### PR TITLE
FEAT: add HF tagging in unsloth

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -118,6 +118,10 @@ class FastLanguageModel(FastLlamaModel):
             *args, **kwargs,
         )
 
+        # in case the model supports tagging, add the unsloth tag.
+        if hasattr(model, "add_model_tags"):
+            model.add_model_tags(["unsloth"])
+
         if load_in_4bit:
             # Fix up bitsandbytes config
             quantization_config = \


### PR DESCRIPTION
Hi @danielhanchen 👋 !

This PR adds the model tagging feature so that you can easily filter all models that use unsloth that have been pushed on the Hub through a simple filter search on the Hub, e.g.: https://huggingface.co/models?other=unsloth

We do add the tag `"unsloth"` on SFTTrainer but this PR makes it possible to add the tags for all Trainer / non-Trainer usage for the FastLanguageModel from unsloth. 

As this feature is only available from transformers >= 4.37.0 I guarded the call with a 

```python
if hasattr(model, "add_model_tags"):
```

Let me know what do you think !