### PR TITLE
Fix single gpu limit code overriding the wrong cuda gpu id via env

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -17,22 +17,16 @@ import importlib
 
 # Currently only supports 1 GPU, or else seg faults will occur.
 if "CUDA_VISIBLE_DEVICES" in os.environ:
-    device = os.environ["CUDA_VISIBLE_DEVICES"]
-    if not device.isdigit():
+    devices = os.environ["CUDA_VISIBLE_DEVICES"]
+    # check if there are multiple cuda devices set in env
+    if not devices.isdigit():
+        first_id = devices.split(',')[0]
         warnings.warn(
-            f"Unsloth: 'CUDA_VISIBLE_DEVICES' is currently {device} "\
-             "but we require 'CUDA_VISIBLE_DEVICES=0'\n"\
-             "We shall set it ourselves."
+            f"Unsloth: 'CUDA_VISIBLE_DEVICES' is currently {devices} \n"\
+            "Multiple CUDA devices detected but we require a single device.\n"\
+            f"We will override CUDA_VISIBLE_DEVICES to first device: {first_id}."
         )
-        os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-    elif "CUDA_DEVICE_ORDER" not in os.environ:
-        warnings.warn(
-            f"Unsloth: 'CUDA_DEVICE_ORDER' is not set "\
-             "but we require 'CUDA_DEVICE_ORDER=PCI_BUS_ID'\n"\
-             "We shall set it ourselves."
-        )
-        os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(first_id)
 else:
     # warnings.warn("Unsloth: 'CUDA_VISIBLE_DEVICES' is not set. We shall set it ourselves.")
     os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"


### PR DESCRIPTION
PR fixes the following scenario:

1. There are multiple gpu devices
2. User already launched unsloth code with CUDA_VISIBLE_DEVICES=13,14
3. CUDA_DEVICE_ORDER=PCI_BUS_ID can be set or not
4. Current code will set CUDA_VISIBLE_DEVICES=0 which is not in the set of [13,14] specified by the user. 

PR will not override CUDA_DEVICE_ORDER when CUDA_VISIBLE_DEVICES is set, inherit whatever order is used, and correctly limit single device to first device specified by end-user. 

Ran into this issue since we have multiple containers sharing multiple gpus amongst several devs and have to be careful that python programs honors the range set by CUDA_VISIBLE_DEVICES or else we may oom another dev's gpu. 

Will also fix scenario where CUDA_DEVICE_ORDER is not set and user already set CUDA_VISIBLE_DEVICES=0 as current code will force CUDA_DEVICE_ORDER to PCI_BUS_ID causing 0 to be a different gpu than what end-user expected.

@danielhanchen I don't think unsloth needs to have CUDA_DEVICE_ORDER set right? It only needs to limit to single visible device if I am not mistaken. 
