### PR TITLE
Fix no-op assert message in chat_templates.py

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -319,9 +319,7 @@ def get_chat_template(
 ):
     old_tokenizer = tokenizer
 
-    if map_eos_token is False:
-        assert("Unsloth: Can only map new tokens to EOS for now. Adding new tokens is not yet supported.")
-    pass
+    assert(map_eos_token, "Unsloth: Can only map new tokens to EOS for now. Adding new tokens is not yet supported.")
 
     IS_GEMMA = False
     if tokenizer.__class__.__name__.startswith("Gemma"):


### PR DESCRIPTION
As is, the `map_eos_token` serves no purpose in `get_chat_template`.

```python
if map_eos_token is False:
        assert("Unsloth: Can only map new tokens to EOS for now. Adding new tokens is not yet supported.")
pass
```

The assert only triggers if its first condition is `false`, but atm the error message is passed in as condition, and as a non-empty string, this will always evaluate to `true` and thus never trigger the assertion.

Therefore, right now the function will execute always the same whether `map_eos_token` is True or not.

In this PR, I have assumed the intention is to raise an error if `map_eos_token` is False.