### PR TITLE
Add a .gitignore and make HF deps fully optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -57,7 +57,10 @@ pass
 
 
 # Try loading bitsandbytes and triton
-import bitsandbytes as bnb
+from .utils.imports import is_bnb_available
+
+if is_bnb_available():
+    import bitsandbytes as bnb
 import triton
 from triton.common.build import libcuda_dirs
 import os
@@ -65,49 +68,50 @@ import re
 import numpy as np
 import subprocess
 
-try:
-    cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
-    libcuda_dirs()
-except:
-    warnings.warn(
-        "Unsloth: Running `ldconfig /usr/lib64-nvidia` to link CUDA."\
-    )
-
-    if os.path.exists("/usr/lib64-nvidia"):
-        os.system("ldconfig /usr/lib64-nvidia")
-    elif os.path.exists("/usr/local"):
-        # Sometimes bitsandbytes cannot be linked properly in Runpod for example
-        possible_cudas = subprocess.check_output(["ls", "-al", "/usr/local"]).decode("utf-8").split("\n")
-        find_cuda = re.compile(r"[\s](cuda\-[\d\.]{2,})$")
-        possible_cudas = [find_cuda.search(x) for x in possible_cudas]
-        possible_cudas = [x.group(1) for x in possible_cudas if x is not None]
-
-        # Try linking cuda folder, or everything in local
-        if len(possible_cudas) == 0:
-            os.system(f"ldconfig /usr/local/")
-        else:
-            find_number = re.compile(r"([\d\.]{2,})")
-            latest_cuda = np.argsort([float(find_number.search(x).group(1)) for x in possible_cudas])[::-1][0]
-            latest_cuda = possible_cudas[latest_cuda]
-            os.system(f"ldconfig /usr/local/{latest_cuda}")
-    pass
-
-    importlib.reload(bnb)
-    importlib.reload(triton)
+if is_bnb_available():
     try:
-        import bitsandbytes as bnb
-        from triton.common.build import libcuda_dirs
         cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
         libcuda_dirs()
     except:
         warnings.warn(
-            "Unsloth: CUDA is not linked properly.\n"\
-            "Try running `python -m bitsandbytes` then `python -m xformers.info`\n"\
-            "We tried running `ldconfig /usr/lib64-nvidia` ourselves, but it didn't work.\n"\
-            "You need to run in your terminal `sudo ldconfig /usr/lib64-nvidia` yourself, then import Unsloth.\n"\
-            "Also try `sudo ldconfig /usr/local/cuda-xx.x` - find the latest cuda version.\n"\
-            "Unsloth will still run for now, but maybe it might crash - let's hope it works!"
+            "Unsloth: Running `ldconfig /usr/lib64-nvidia` to link CUDA."\
         )
+
+        if os.path.exists("/usr/lib64-nvidia"):
+            os.system("ldconfig /usr/lib64-nvidia")
+        elif os.path.exists("/usr/local"):
+            # Sometimes bitsandbytes cannot be linked properly in Runpod for example
+            possible_cudas = subprocess.check_output(["ls", "-al", "/usr/local"]).decode("utf-8").split("\n")
+            find_cuda = re.compile(r"[\s](cuda\-[\d\.]{2,})$")
+            possible_cudas = [find_cuda.search(x) for x in possible_cudas]
+            possible_cudas = [x.group(1) for x in possible_cudas if x is not None]
+
+            # Try linking cuda folder, or everything in local
+            if len(possible_cudas) == 0:
+                os.system(f"ldconfig /usr/local/")
+            else:
+                find_number = re.compile(r"([\d\.]{2,})")
+                latest_cuda = np.argsort([float(find_number.search(x).group(1)) for x in possible_cudas])[::-1][0]
+                latest_cuda = possible_cudas[latest_cuda]
+                os.system(f"ldconfig /usr/local/{latest_cuda}")
+        pass
+
+        importlib.reload(bnb)
+        importlib.reload(triton)
+        try:
+            import bitsandbytes as bnb
+            from triton.common.build import libcuda_dirs
+            cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
+            libcuda_dirs()
+        except:
+            warnings.warn(
+                "Unsloth: CUDA is not linked properly.\n"\
+                "Try running `python -m bitsandbytes` then `python -m xformers.info`\n"\
+                "We tried running `ldconfig /usr/lib64-nvidia` ourselves, but it didn't work.\n"\
+                "You need to run in your terminal `sudo ldconfig /usr/lib64-nvidia` yourself, then import Unsloth.\n"\
+                "Also try `sudo ldconfig /usr/local/cuda-xx.x` - find the latest cuda version.\n"\
+                "Unsloth will still run for now, but maybe it might crash - let's hope it works!"
+            )
 pass
 
 from .models import *

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -17,9 +17,11 @@ __all__ = [
     "test_chat_templates",
 ]
 
-from transformers import StoppingCriteria, StoppingCriteriaList
+from .utils.imports import is_transformers_available
+if is_transformers_available():
+    from transformers import StoppingCriteria, StoppingCriteriaList
+    from transformers.models.llama.modeling_llama import logger
 from torch import LongTensor, FloatTensor
-from transformers.models.llama.modeling_llama import logger
 from .save import patch_saving_functions
 import os
 import shutil

--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -16,7 +16,9 @@ import triton
 import triton.language as tl
 import torch
 from .utils import calculate_settings, MAX_FUSED_SIZE
-from transformers.models.llama.modeling_llama import logger
+from ..utils.imports import is_transformers_available
+if is_transformers_available():
+    from transformers.models.llama.modeling_llama import logger
 
 
 @triton.jit

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ..utils.imports import is_bnb_available
+
 import triton
 MAX_FUSED_SIZE = 65536
 next_power_of_2 = triton.next_power_of_2
@@ -29,15 +31,16 @@ def calculate_settings(n):
 pass
 
 
-import bitsandbytes as bnb
-get_ptr = bnb.functional.get_ptr
-import ctypes
-import torch
-cdequantize_blockwise_fp32      = bnb.functional.lib.cdequantize_blockwise_fp32
-cdequantize_blockwise_fp16_nf4  = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
-cdequantize_blockwise_bf16_nf4  = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
-cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
-cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
+if is_bnb_available():
+    import bitsandbytes as bnb
+    get_ptr = bnb.functional.get_ptr
+    import ctypes
+    import torch
+    cdequantize_blockwise_fp32      = bnb.functional.lib.cdequantize_blockwise_fp32
+    cdequantize_blockwise_fp16_nf4  = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
+    cdequantize_blockwise_bf16_nf4  = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
+    cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
+    cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
 
 
 def QUANT_STATE(W):

--- a/unsloth/models/dpo.py
+++ b/unsloth/models/dpo.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from ..utils.imports import is_transformers_available
 
-try:
-    from transformers.utils.notebook import (
-        IntervalStrategy,
-        NotebookTrainingTracker,
-        NotebookProgressCallback,
-    )
-    HAS_NOTEBOOK = True
-except:
-    HAS_NOTEBOOK = False
+HAS_NOTEBOOK = False
+if is_transformers_available():
+    try:
+        from transformers.utils.notebook import (
+            IntervalStrategy,
+            NotebookTrainingTracker,
+            NotebookProgressCallback,
+        )
+        HAS_NOTEBOOK = True
+    except:
+        pass
 pass
 
 DPOTrainer_metrics = [

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -478,7 +478,7 @@ def LlamaModel_fast_forward(
     output_hidden_states: Optional[bool] = None,
     return_dict:          Optional[bool] = None,
     *args, **kwargs,
-) -> Union[Tuple, BaseModelOutputWithPast]:
+) -> Union[Tuple, "transformers.models.llama.modeling_llama.BaseModelOutputWithPast"]:
 
     output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
     assert(output_attentions is False)

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -14,9 +14,12 @@
 
 from .llama import FastLlamaModel, logger
 from .mistral import FastMistralModel
-from transformers import AutoConfig
-from transformers import __version__ as transformers_version
-from peft import PeftConfig, PeftModel
+from ..utils.imports import is_transformers_available, is_peft_available
+if is_transformers_available():
+    from transformers import AutoConfig
+    from transformers import __version__ as transformers_version
+if is_peft_available():
+    from peft import PeftConfig, PeftModel
 from .mapper import INT_TO_FLOAT_MAPPER, FLOAT_TO_INT_MAPPER
 import os
 

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -12,25 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .llama import FastLlamaModel, logger
+from .llama import FastLlamaModel
 from .mistral import FastMistralModel
 from ..utils.imports import is_transformers_available, is_peft_available
 if is_transformers_available():
     from transformers import AutoConfig
     from transformers import __version__ as transformers_version
+    from .llama import logger
 if is_peft_available():
     from peft import PeftConfig, PeftModel
 from .mapper import INT_TO_FLOAT_MAPPER, FLOAT_TO_INT_MAPPER
 import os
 
-# https://github.com/huggingface/transformers/pull/26037 allows 4 bit loading!
-major, minor = transformers_version.split(".")[:2]
-major, minor = int(major), int(minor)
-SUPPORTS_FOURBIT = (major > 4) or (major == 4 and minor >= 37)
-SUPPORTS_GEMMA   = (major > 4) or (major == 4 and minor >= 38)
-if SUPPORTS_GEMMA:
-    from .gemma import FastGemmaModel
-del major, minor
+if is_transformers_available():
+    # https://github.com/huggingface/transformers/pull/26037 allows 4 bit loading!
+    major, minor = transformers_version.split(".")[:2]
+    major, minor = int(major), int(minor)
+    SUPPORTS_FOURBIT = (major > 4) or (major == 4 and minor >= 37)
+    SUPPORTS_GEMMA   = (major > 4) or (major == 4 and minor >= 38)
+    if SUPPORTS_GEMMA:
+        from .gemma import FastGemmaModel
+    del major, minor
 
 
 def _get_model_name(model_name, load_in_4bit = True):

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -14,23 +14,25 @@
 
 from .llama import *
 from ._utils import __version__
+from ..utils.imports import is_transformers_available
 
-from transformers.models.mistral.modeling_mistral import (
-    MistralAttention,
-    MistralDecoderLayer,
-    MistralModel,
-    MistralForCausalLM,
-)
-# For Pytorch 2.1.1
-try:
+if is_transformers_available():
     from transformers.models.mistral.modeling_mistral import (
-        MistralSdpaAttention,
-        MistralFlashAttention2,
+        MistralAttention,
+        MistralDecoderLayer,
+        MistralModel,
+        MistralForCausalLM,
     )
-except:
-    MistralSdpaAttention   = MistralAttention
-    MistralFlashAttention2 = MistralAttention
-pass
+    # For Pytorch 2.1.1
+    try:
+        from transformers.models.mistral.modeling_mistral import (
+            MistralSdpaAttention,
+            MistralFlashAttention2,
+        )
+    except:
+        MistralSdpaAttention   = MistralAttention
+        MistralFlashAttention2 = MistralAttention
+    pass
 
 
 def MistralAttention_fast_forward(

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -177,7 +177,7 @@ def MistralForCausalLM_fast_forward(
     output_hidden_states: Optional[bool] = None,
     return_dict: Optional[bool] = None,
     *args, **kwargs,
-) -> Union[Tuple, CausalLMOutputWithPast]:
+) -> Union[Tuple, "transformers.modeling_outputs.CausalLMOutputWithPast"]:
 
     if causal_mask is None and past_key_values is None:
         bsz, q_len = input_ids.shape

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -12,15 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from bitsandbytes.nn import Linear4bit as Bnb_Linear4bit
-from peft.tuners.lora import Linear4bit as Peft_Linear4bit
-from peft.tuners.lora import Linear as Peft_Linear
+from .utils.imports import is_bnb_available, is_peft_available, is_transformers_available
+
+if is_bnb_available():
+    from bitsandbytes.nn import Linear4bit as Bnb_Linear4bit
+if is_peft_available():
+    from peft.tuners.lora import Linear4bit as Peft_Linear4bit
+    from peft.tuners.lora import Linear as Peft_Linear
 from typing import Optional, Callable, Union, List
 import torch
 import os
 import pickle
 import gc
-from transformers.models.llama.modeling_llama import logger
+if is_transformers_available():
+    from transformers.models.llama.modeling_llama import logger
 from .kernels import fast_dequantize, QUANT_STATE, get_lora_parameters
 import subprocess
 import psutil

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from transformers import AutoTokenizer
-from transformers.convert_slow_tokenizer import convert_slow_tokenizer
-from transformers import PreTrainedTokenizerFast
+from .utils.imports import is_transformers_available
+if is_transformers_available():
+    from transformers import AutoTokenizer
+    from transformers.convert_slow_tokenizer import convert_slow_tokenizer
+    from transformers.models.llama.modeling_llama import logger
+    from transformers import AutoTokenizer, convert_slow_tokenizer, PreTrainedTokenizerFast
 import re
 import os
-from transformers.models.llama.modeling_llama import logger
 
 __all__ = [
     "load_correct_tokenizer",

--- a/unsloth/utils/imports.py
+++ b/unsloth/utils/imports.py
@@ -1,0 +1,43 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import importlib
+import importlib.metadata
+
+
+def _is_package_available(pkg_name, metadata_name=None):
+    # Check we're not importing a "pkg_name" directory somewhere but the actual library by trying to grab the version
+    package_exists = importlib.util.find_spec(pkg_name) is not None
+    if package_exists:
+        try:
+            # Some libraries have different names in the metadata
+            _ = importlib.metadata.metadata(pkg_name if metadata_name is None else metadata_name)
+            return True
+        except importlib.metadata.PackageNotFoundError:
+            return False
+        
+def is_bnb_available():
+    return _is_package_available("bitsandbytes")
+
+def is_peft_available():
+    return _is_package_available("peft")
+
+def is_transformers_available():
+    return _is_package_available("transformers")
+
+def is_flash_attn_available():
+    if not torch.version.cuda:
+        return False
+    return _is_package_available("flashattn")


### PR DESCRIPTION
# Enable `Accelerate` integration by fully making HF deps optional

## What does this add?

This PR adds import guards across `unsloth` for the various integration libs, making sure that core imports are still possible without triggering external lib imports.

It does so by following an `is_x_available` workflow, similar to what we use at HF. 

This PR also adds in a `.gitignore` relative to working with a python file, as I found it a bit cumbersome not being able to do `git add .`. If we want to remove it, that's quite alright 😉 

## Who is it for?

Users of `unsloth` who want to try out the cool gradient offloading mechanism, while only having the core parts of `unsloth` installed.

## Why is it needed?

There are areas in the code that do a large deal of patching to `transformers` and `peft`. This simply guards said patching so its only done if the lib is available.

## What parts of the API does this impact?

### User-facing:

None

### Internal structure:

Adds new library imports checks for:

* bitsandbytes
* peft
* transformers
* flash_attn