### PR TITLE
Fix: Ensure patch_tokenizer does not crash (#5)

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -148,7 +148,7 @@ def patch_tokenizer(model, tokenizer):
         model.config.update({"unsloth_version" : __version__})
     if not hasattr(tokenizer, "pad_token") or tokenizer.pad_token is None:
         # Fixes https://github.com/unslothai/unsloth/issues/5
-        if hasattr(tokenizer, "unk_token"):
+        if hasattr(tokenizer, "unk_token") and tokenizer.unk_token is not None:
             tokenizer.add_special_tokens({"pad_token" : tokenizer.unk_token})
             tokenizer.pad_token = tokenizer.unk_token
         else:


### PR DESCRIPTION
**Issue**
The patch_tokenizer function assumes that if the tokenizer has attribute unk_token, the value of this token is not null. However, with models like DeepSeek Math, the unk_token is None. When we try to set the pad token as None, this causes the tokenizer.add_special_tokens to raise an exception, which propagates all the way to FastLanguageModel.from_pretrained function call. 

**Solution**
The fix is incredibly simple. We just add the following None check inside the patch_tokenizer function:
`
if hasattr(tokenizer, "unk_token") and tokenizer.unk_token is not None:
            tokenizer.add_special_tokens({"pad_token" : tokenizer.unk_token})
            tokenizer.pad_token = tokenizer.unk_token
`

**Context**
This issue is first mentioned in #5. [Redix8](https://github.com/Redix8) has just brought this issue up again and I have faced the same problem too. 
