### PR TITLE
Move print logging in save.py to transformers logger

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -161,7 +161,7 @@ pass
 
 def fast_save_pickle(shard, name):
     # Use this if # CPUs is <= 2
-    print(f"Unsloth: Saving {name}...")
+    logger.info(f"Unsloth: Saving {name}...")
     torch.save(
         shard,
         name,
@@ -268,7 +268,7 @@ def unsloth_save_model(
 
     if save_method == "merged_4bit":
 
-        print("Unsloth: Merging 4bit and LoRA weights to 4bit...")
+        logger.info("Unsloth: Merging 4bit and LoRA weights to 4bit...")
         print("This might take 5 minutes...")
 
         # Counteract no LoRA adapters!


### PR DESCRIPTION
In a few different places, the transformers logger is used in log warnings. However, throughout the remainder of the `save.py` code print statements are provided to show the user additional progress context. 

For systems in which logs are visible but the console isn't, it is not possible to get this additional printed context. As such, this PR converts all the print statements in `save.py` to use the transformers logger, similar to warnings. This will allow systems without the console to get the full logged context.