### PR TITLE
clears any selected_adapters before calling internal_model.save_pretr…

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -642,7 +642,8 @@ def unsloth_save_model(
     model.config = new_config
 
     # Save!
-
+    
+    save_pretrained_settings["selected_adapters"] = None
     # Check if pushing to an organization
     if save_pretrained_settings["push_to_hub"] and (username != actual_username):
         print(f"Unsloth: Saving to organization with address {new_save_directory}")


### PR DESCRIPTION
…ained

I have a script that downloads the adapter from hf, merges it with the base model and uploads the result. It worked a month ago (or so), but failed now. Tried it both on colab, kaggle and locally. It would only save the adapter.

After some digging, I tried setting `save_pretrained_settings["selected_adapters"] = None` before the peft call, and that seemed to do the trick.

The fix for my use case was on line 672, but I figure this is the correct place. Although I'm not sure this is a proper fix at all. Most likely there's a place somewhere that incorrectly sets selected_adapters to "lora", or something similar, when loading an adapter `from_pretrained`.