### PR TITLE
Support `revision` parameter in `FastLanguageModel.from_pretrained`

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -81,6 +81,7 @@ class FastLanguageModel(FastLlamaModel):
         trust_remote_code = False,
         use_gradient_checkpointing = True,
         resize_model_vocab = None,
+        revision = None,
         *args, **kwargs,
     ):
         if token is None and "HF_TOKEN" in os.environ:
@@ -95,12 +96,12 @@ class FastLanguageModel(FastLlamaModel):
         # First check if it's a normal model via AutoConfig
         is_peft = False
         try:
-            model_config = AutoConfig.from_pretrained(model_name, token = token)
+            model_config = AutoConfig.from_pretrained(model_name, token = token, revision=revision)
             is_peft = False
         except:
             try:
                 # Most likely a PEFT model
-                peft_config = PeftConfig.from_pretrained(model_name, token = token)
+                peft_config = PeftConfig.from_pretrained(model_name, token = token, revision=revision)
             except:
                 raise RuntimeError(f"Unsloth: `{model_name}` is not a full model or a PEFT model.")
             
@@ -154,6 +155,7 @@ class FastLanguageModel(FastLlamaModel):
             model_patcher  = dispatch_model,
             tokenizer_name = tokenizer_name,
             trust_remote_code = trust_remote_code,
+            revision = revision if not is_peft else None,
             *args, **kwargs,
         )
         
@@ -189,7 +191,7 @@ class FastLanguageModel(FastLlamaModel):
 
         if is_peft:
             # Now add PEFT adapters
-            model = PeftModel.from_pretrained(model, old_model_name, token = token)
+            model = PeftModel.from_pretrained(model, old_model_name, token = token, revision = revision)
             # Patch it as well!
             model = dispatch_model.patch_peft_model(model, use_gradient_checkpointing)
         pass

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -96,12 +96,12 @@ class FastLanguageModel(FastLlamaModel):
         # First check if it's a normal model via AutoConfig
         is_peft = False
         try:
-            model_config = AutoConfig.from_pretrained(model_name, token = token, revision=revision)
+            model_config = AutoConfig.from_pretrained(model_name, token = token, revision = revision)
             is_peft = False
         except:
             try:
                 # Most likely a PEFT model
-                peft_config = PeftConfig.from_pretrained(model_name, token = token, revision=revision)
+                peft_config = PeftConfig.from_pretrained(model_name, token = token, revision = revision)
             except:
                 raise RuntimeError(f"Unsloth: `{model_name}` is not a full model or a PEFT model.")
             

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -930,7 +930,7 @@ def save_to_gguf(
 
     # Check first_conversion format
     if   first_conversion == "f16"  : pass
-    if   first_conversion == "bf16" : pass
+    elif first_conversion == "bf16" : pass
     elif first_conversion == "f32"  : pass
     elif first_conversion == "q8_0" : pass
     else:


### PR DESCRIPTION
This pull request addresses #624 

Instead of always passing the revision parameter to be used by the base model, the revision parameter is now:
* passed to PeftConfig and PeftModel if the model is a PEFT model
* passed to AutoConfig and the base model dispatcher if the model isn't a PEFT model