### PR TITLE
Fix case where GGUF saving fails when model_dtype is torch.float16 ("f16")

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -930,7 +930,7 @@ def save_to_gguf(
 
     # Check first_conversion format
     if   first_conversion == "f16"  : pass
-    if   first_conversion == "bf16" : pass
+    elif first_conversion == "bf16" : pass
     elif first_conversion == "f32"  : pass
     elif first_conversion == "q8_0" : pass
     else:


### PR DESCRIPTION
This PR addresses #626 

When a model is loaded on a non-ampere GPU (ie colab T4), it will normally be dispatched to fp16. However, this leads to errors when saving to GGUF. Originally, the code had an extra if instead of an elif. This PR fixes that.