### PR TITLE
Fix bug in save.py with interpreting quantization_method as a string when saving to gguf

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -853,8 +853,12 @@ def save_to_gguf(
     model_dtype = "f16" if model_dtype == "float16" else "bf16"
 
     # Convert quantization_method to list
-    quantization_method = \
-        quantization_method if type(quantization_method) is list else list(quantization_method)
+    if isinstance(quantization_method, list):
+        quantization_method_list = quantization_method
+    elif isinstance(quantization_method, str):
+        quantization_method_list = [quantization_method]
+    else:
+        quantization_method_list = list(quantization_method)
 
     # Check if bfloat16 is supported
     if model_dtype == "bf16" and not torch.cuda.is_bf16_supported():


### PR DESCRIPTION
## Context
Upon attempting to save my fine-tuned models as gguf I encountered a new error. Upon investigation I discovered the issue to be some code that incorrectly broke strings passed for quantization_method argument to save_pretrained_gguf.

## Description
The new code correctly converts a given to a list as well as preserving the functionality of directly receiving lists. It validates that a string or a list are actually being passed, and as a fallback will attempt to convert whatever remains as a list and move on.

Thanks for all your hard work and consideration of my code! Happy to make changes as required, wasn't sure if it should just break if not string or list or proceed to the next step and potentially error out. 