### PR TITLE
Fix breaking bug in save.py with interpreting quantization_method as a string when saving to gguf

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -528,6 +528,7 @@ def get_chat_template(
         chat_template, stop_word = chat_template
         assert(type(chat_template) is str)
         assert(type(stop_word) is str)
+        ollama_modelfile = None
 
     elif type(chat_template) is str:
 

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1423,9 +1423,38 @@ class FastLlamaModel:
         transformers_set_seed(random_state)
 
         if isinstance(model, PeftModelForCausalLM):
-            raise TypeError(
-                "Unsloth: Your model already has LoRA adapters. No need to run this again!"
+            # Check if exactly the same and then pass through!
+            assert(hasattr(model, "peft_config"))
+
+            peft_config = model.peft_config["default"].to_dict()
+            check_parameters = [
+                "r", "lora_alpha", "lora_dropout",
+                "bias", "layers_to_transform", "layers_pattern",
+                "use_rslora", "modules_to_save", "init_lora_weights",
+            ]
+            check_all = True
+            for param in check_parameters:
+                check_all = check_all and (peft_config[param] == eval(param))
+            pass
+            check_all = check_all and (
+                len(set(peft_config["target_modules"]) ^ set(target_modules)) == 0
             )
+            check_all = check_all and (
+                (loftq_config == {} or loftq_config is None) and \
+                (peft_config["loftq_config"] == {} or peft_config["loftq_config"] is None)
+            )
+
+            if check_all:
+                # Simply pass through!
+                logger.warning(
+                    "Unsloth: Already have LoRA adapters! We shall skip this step."
+                )
+                return model
+            else:
+                raise TypeError(
+                    "Unsloth: Your model already has LoRA adapters. Your new parameters are different."
+                )
+            pass
         pass
 
         if loftq_config is None: loftq_config = {}

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -853,13 +853,13 @@ def save_to_gguf(
     model_dtype = "f16" if model_dtype == "float16" else "bf16"
 
     # Convert quantization_method to list
-    if isinstance(quantization_method, list):
-        quantization_method_list = quantization_method
-    elif isinstance(quantization_method, str):
-        quantization_method_list = [quantization_method]
+    if   isinstance(quantization_method, list):  pass
+    elif isinstance(quantization_method, str):   quantization_method = [ quantization_method, ]
+    elif isinstance(quantization_method, tuple): quantization_method = list(quantization_method)
     else:
-        raise TypeError("quantization_method should be either a string or a list")
-
+        raise TypeError("Unsloth: quantization_method can only be a string or a list of strings")
+    pass
+    
     # Check if bfloat16 is supported
     if model_dtype == "bf16" and not torch.cuda.is_bf16_supported():
         logger.warning(
@@ -875,7 +875,7 @@ def save_to_gguf(
     pass
 
     # Check I quants
-    for quant_method in quantization_method_list:
+    for quant_method in quantization_method: 
         if quant_method.startswith("iq2"):
             raise RuntimeError("Unsloth: Currently iq2 type quantizations aren't supported yet - sorry!")
     pass
@@ -890,7 +890,7 @@ def save_to_gguf(
 
     # Map quant methods
     new_quantization_method = []
-    for quant_method in quantization_method_list:
+    for quant_method in quantization_method:
         if   quant_method == "not_quantized":  quantization_method = model_dtype
         elif quant_method == "fast_quantized": quantization_method = "q8_0"
         elif quant_method == "quantized":      quantization_method = "q4_k_m"

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -858,7 +858,7 @@ def save_to_gguf(
     elif isinstance(quantization_method, str):
         quantization_method_list = [quantization_method]
     else:
-        quantization_method_list = list(quantization_method)
+        raise TypeError("quantization_method should be either a string or a list")
 
     # Check if bfloat16 is supported
     if model_dtype == "bf16" and not torch.cuda.is_bf16_supported():

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -875,7 +875,7 @@ def save_to_gguf(
     pass
 
     # Check I quants
-    for quant_method in quantization_method: 
+    for quant_method in quantization_method_list:
         if quant_method.startswith("iq2"):
             raise RuntimeError("Unsloth: Currently iq2 type quantizations aren't supported yet - sorry!")
     pass
@@ -890,7 +890,7 @@ def save_to_gguf(
 
     # Map quant methods
     new_quantization_method = []
-    for quant_method in quantization_method:
+    for quant_method in quantization_method_list:
         if   quant_method == "not_quantized":  quantization_method = model_dtype
         elif quant_method == "fast_quantized": quantization_method = "q8_0"
         elif quant_method == "quantized":      quantization_method = "q4_k_m"

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -853,8 +853,12 @@ def save_to_gguf(
     model_dtype = "f16" if model_dtype == "float16" else "bf16"
 
     # Convert quantization_method to list
-    quantization_method = \
-        quantization_method if type(quantization_method) is list else list(quantization_method)
+    if isinstance(quantization_method, list):
+        quantization_method_list = quantization_method
+    elif isinstance(quantization_method, str):
+        quantization_method_list = [quantization_method]
+    else:
+        quantization_method_list = list(quantization_method)
 
     # Check if bfloat16 is supported
     if model_dtype == "bf16" and not torch.cuda.is_bf16_supported():


### PR DESCRIPTION
## Context
Upon attempting to save my fine-tuned models as gguf I encountered a new error as of today. Upon investigation I discovered the issue to be some code that incorrectly broke strings passed for quantization_method argument to save_pretrained_gguf.

## Description
The new code correctly converts a given string to a list as well as preserving the functionality of directly receiving lists. It validates that a string or a list are actually being passed, and in the case of a non-string or list being passed raises a type error.

## Additional Notes

This is a resubmission that fixes a few issues present with my initial pull request as well as implements better error handling.

Thanks for all your hard work and consideration of my code! Happy to make changes as required.