### PR TITLE
Update Model Conversion Command in `save.py` to `convert_hf_to_gguf.py`

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1035,7 +1035,7 @@ def save_to_gguf(
             f"--outfile {final_location} --vocab-type {vocab_type} "\
             f"--outtype {first_conversion} --concurrency {n_cpus} --pad-vocab"
     else:
-        command = f"python llama.cpp/convert-hf-to-gguf.py {model_directory} "\
+        command = f"python llama.cpp/convert_hf_to_gguf.py {model_directory} "\
             f"--outfile {final_location} "\
             f"--outtype {first_conversion}"
     pass

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -800,8 +800,8 @@ def install_llama_cpp_old(version = -10):
     # Check if successful
     if not os.path.exists("llama.cpp/quantize") and not os.path.exists("llama.cpp/llama-quantize"):
         raise RuntimeError(
-            "Unsloth: llama.cpp GGUF seems to be too buggy to install.\n"\
-            "File a report to llama.cpp's main repo since this is not an Unsloth issue."
+            "Unsloth: The file 'llama.cpp/llama-quantize' or `llama.cpp/quantize` does not exist.\n"\
+            "But we expect this file to exist! Maybe the llama.cpp developers changed the name?"
         )
     pass
 pass
@@ -945,9 +945,28 @@ def save_to_gguf(
         quantize_location = "llama.cpp/quantize"
     elif os.path.exists("llama.cpp/llama-quantize"):
         quantize_location = "llama.cpp/llama-quantize"
+    else:
+        raise RuntimeError(
+            "Unsloth: The file 'llama.cpp/llama-quantize' or 'llama.cpp/quantize' does not exist.\n"\
+            "But we expect this file to exist! Maybe the llama.cpp developers changed the name?"
+        )
     pass
 
-    if error != 0 or quantize_location is None:
+    # See https://github.com/unslothai/unsloth/pull/730
+    # Filenames changed again!
+    convert_location = None
+    if os.path.exists("llama.cpp/convert-hf-to-gguf.py"):
+        convert_location = "llama.cpp/convert-hf-to-gguf.py"
+    elif os.path.exists("llama.cpp/convert_hf_to_gguf.py"):
+        convert_location = "llama.cpp/convert_hf_to_gguf.py"
+    else:
+        raise RuntimeError(
+            "Unsloth: The file 'llama.cpp/convert-hf-to-gguf.py' or 'llama.cpp/convert_hf_to_gguf.py' does not exist.\n"\
+            "But we expect this file to exist! Maybe the llama.cpp developers changed the name?"
+        )
+    pass
+
+    if error != 0 or quantize_location is None or convert_location is None:
         print(f"Unsloth: llama.cpp error code = {error}.")
         install_llama_cpp_old(-10)
     pass
@@ -1035,7 +1054,7 @@ def save_to_gguf(
             f"--outfile {final_location} --vocab-type {vocab_type} "\
             f"--outtype {first_conversion} --concurrency {n_cpus} --pad-vocab"
     else:
-        command = f"python llama.cpp/convert_hf_to_gguf.py {model_directory} "\
+        command = f"python {convert_location} {model_directory} "\
             f"--outfile {final_location} "\
             f"--outtype {first_conversion}"
     pass

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -376,7 +376,7 @@ def fix_sentencepiece_gguf(saved_location):
     """
         Fixes sentencepiece tokenizers which did not extend the vocabulary with
         user defined tokens.
-        Inspiration from https://github.com/ggerganov/llama.cpp/blob/master/convert-hf-to-gguf.py
+        Inspiration from https://github.com/ggerganov/llama.cpp/blob/master/convert_hf_to_gguf.py
     """
     from copy import deepcopy
     from transformers.utils import sentencepiece_model_pb2


### PR DESCRIPTION
### Update Model Conversion Command in `save.py` to `convert_hf_to_gguf.py`

### Description:

This PR updates the model conversion command in [`save.py`](unsloth/save.py) to use `convert_hf_to_gguf.py`, aligning with the latest tools and practices from the `llama.cpp` repository. This change ensures that the conversion process benefits from the latest efficiency and compatibility improvements.

### Changes Made:

- Replaced the previous model conversion command in `save.py` with `convert_hf_to_gguf.py`.

### Reason for Change:

- The file name for the conversion script has been updated in the original `llama.cpp` repository.
- Ensures the conversion process is up-to-date with the latest enhancements and compatibility fixes.

### Notes:

- This change requires users to pull the latest changes from the `llama.cpp` repository to have the `convert_hf_to_gguf.py` script available.