### PR TITLE
Now permitting use of pre-installed llama.cpp

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -839,54 +839,19 @@ def install_llama_cpp_blocking(use_cuda = False):
     pass
 pass
 
-def _command_path(command):
-    """
-    Check if a command is valid and executable.
+def get_executable(executables):
+    # Get system locations (System Path).split(system separator)
+    system_directories = os.environ.get("PATH").split(os.pathsep)
 
-    Args:
-        command (str): The command to check.
-
-    Returns:
-        str or None: The full path to the command if it is valid and executable, 
-                     None otherwise.
-    """
-    # Get the system path
-    system_path = os.environ.get("PATH")
-
-    # Split the system path into individual directories
-    directories = system_path.split(os.pathsep)
-
-    # Check if the command is in any of the directories
-    for directory in directories:
-        # Construct the full path to the command
-        command_path = os.path.join(directory, command)
-
-        # Check if the command path exists and is executable
-        if os.path.exists(command_path) and os.access(command_path, os.X_OK):
-            return command_path
+    for directory in system_directories:
+        for executable in executables:
+            path = os.path.join(directory, command)
+            # Check if the executable exists and is executable
+            if os.path.exists(path) and os.access(path, os.X_OK): return path
         pass
     pass
-
     return None
 pass
-
-def _find_valid_command(*commands):
-    """
-    Finds the first valid command in a list of commands.
-
-    Args:
-        *commands (str): The commands to check.
-
-    Returns:
-        str: The first valid command found, or None if no valid command is found.
-    """
-    for command in commands:
-        if _command_path(command):
-            return command
-        pass
-    pass
-
-    return None
 
 def save_to_gguf(
     model_type           : str,
@@ -980,18 +945,16 @@ def save_to_gguf(
         )
     pass
 
-    # determine whether the system already has llama.cpp installed and the scripts are executable
-    # NOTE: although the executable python scripts have shebang and therefore can be executed directly,
-    # prepending the python interpreter works, too.
-    quantize_location = _find_valid_command("llama-quantize", "quantize")
-    convert_location = _find_valid_command("convert-hf-to-gguf.py", "convert_hf_to_gguf.py")
+    # Determine whether the system already has llama.cpp installed and the scripts are executable
+    quantize_location = get_executable(["llama-quantize", "quantize"])
+    convert_location  = get_executable(["convert-hf-to-gguf.py", "convert_hf_to_gguf.py"])
     
     if quantize_location is not None and convert_location is not None:
         print("Unsloth: llama.cpp found in the system. We shall skip installation.")
     else:
         print("Unsloth: llama.cpp not installed. We shall install it now.")
         quantize_location = None
-        convert_location = None
+        convert_location  = None
     pass
     
     if quantize_location is None or convert_location is None:


### PR DESCRIPTION
Hello, and thank you for your great work!
I'm addressing a problem affecting Unsloth when deployed in an isolated network: saving in GGUF performs a git pull for llama.cpp, which is bound to fail in those environments. The implemented solution is to first check for the necessary programs in the system first, and only download/compile llama.cpp if required. NOTE: llama.cpp python scripts can be executables, given that they contain the appropriate shebang, and they are looked up as such.
Thanks again, have a great one
pepi