### PR TITLE
upload tensorboard training stats to hub if available

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1359,6 +1359,20 @@ def upload_to_huggingface(
             uploaded_location = file_location
         pass
 
+        # find ftevent file from tensorboard and upload it
+        import glob
+        ftevent_files = glob.glob("*out.tfevents*", recursive = True)
+        if len(ftevent_files) > 0:
+            print("Unsloth: Uploading tensorboard files... Please wait...", file_location + "*out.tfevents*")
+            for ftevent_file in ftevent_files:
+                hf_api.upload_file(
+                    path_or_fileobj = ftevent_file,
+                    path_in_repo    = ftevent_file.replace(file_location, ""),
+                    repo_id         = save_directory,
+                    repo_type       = "model",
+                    commit_message  = "(Trained with Unsloth)",
+                )
+
         hf_api.upload_file(
             path_or_fileobj = file_location,
             path_in_repo    = uploaded_location,


### PR DESCRIPTION
## Uploading Training Metrics to your HuggingFace

Using the Notebooks, CLI or future Gradio UI it is possible to have the 'report_to' parameter of the trainer set to tensorboard.

This will produce tensorboard ftevents files that can then be pushed to Hugging Face for adding to the metrics tab.

![image](https://github.com/user-attachments/assets/6145b27c-24fc-4461-b6eb-0ad062c8c491)

![image](https://github.com/user-attachments/assets/e1d5cc96-f19f-4fa7-94ae-d14c63c0cf41)
