### PR TITLE
pin llama.cpp commit

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -729,7 +729,7 @@ pass
 
 
 def install_llama_cpp_clone_non_blocking():
-    full_command = ["git", "clone", "--recursive", "https://github.com/ggerganov/llama.cpp"]
+    full_command = ["git", "clone", "--recursive", "https://github.com/ggerganov/llama.cpp#b3345"]
     run_installer = subprocess.Popen(full_command, stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT)
     return run_installer
 pass


### PR DESCRIPTION
As llama.cpp does not work with the latest commit as indicated by this issue: https://github.com/unslothai/unsloth/issues/748#issuecomment-2238395604 and it is good practice to pin dependencies, I have pinned the commit as suggested by the mentioned issue.