### PR TITLE
fix UnboundLocalError

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -155,14 +155,14 @@ class FastLanguageModel(FastLlamaModel):
         try:
             model_config = AutoConfig.from_pretrained(model_name, token = token, revision = revision)
             is_model = True
-        except Exception as autoconfig_error:
-            autoconfig_error = str(autoconfig_error)
+        except Exception as e:
+            autoconfig_error = str(e)
             is_model = False
         try:
             peft_config = PeftConfig .from_pretrained(model_name, token = token, revision = revision)
             is_peft = True
-        except Exception as peft_error:
-            peft_error = str(peft_error)
+        except Exception as e:
+            peft_error = str(e)
             is_peft = False
         pass
 

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -155,14 +155,14 @@ class FastLanguageModel(FastLlamaModel):
         try:
             model_config = AutoConfig.from_pretrained(model_name, token = token, revision = revision)
             is_model = True
-        except Exception as e:
-            autoconfig_error = str(e)
+        except Exception as error:
+            autoconfig_error = str(error)
             is_model = False
         try:
             peft_config = PeftConfig .from_pretrained(model_name, token = token, revision = revision)
             is_peft = True
-        except Exception as e:
-            peft_error = str(e)
+        except Exception as error:
+            peft_error = str(error)
             is_peft = False
         pass
 


### PR DESCRIPTION
I'm finetuning LLaMA 3.1 8B using `transformers==4.42.3` and `unsloth==2024.8`. I hit an error because `not is_model and not is_peft` is true (expected with transformers 4.42.3), but the error message seems odd:
```
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
Cell In[4], line 1
----> 1 model, tokenizer = FastLanguageModel.from_pretrained(
      2     model_name = model_name,
      3     max_seq_length = max_seq_length,
      4     dtype = dtype,
      5     load_in_4bit = load_in_4bit,
      6     # token = "hf_...", # use one if using gated models like meta-llama/Llama-2-7b-hf
      7 )

File /data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/loader.py:178, in FastLanguageModel.from_pretrained(model_name, max_seq_length, dtype, load_in_4bit, token, device_map, rope_scaling, fix_tokenizer, trust_remote_code, use_gradient_checkpointing, resize_model_vocab, revision, *args, **kwargs)
    171     raise RuntimeError(
    172         "Unsloth: Your repo has a LoRA adapter and a base model.\n"\
    173         "You have 2 files `config.json` and `adapter_config.json`.\n"\
    174         "We must only allow one config file.\n"\
    175         "Please separate the LoRA and base models to 2 repos."
    176     )
    177 elif not is_model and not is_peft:
--> 178     raise RuntimeError(autoconfig_error or peft_error)
    179 pass
    181 # Get base model for PEFT:

UnboundLocalError: local variable 'autoconfig_error' referenced before assignment
```

This is because:
When an exception has been assigned using as target, it is cleared at the end of the except clause. This is as if
```
except E as N:
    foo
```
was translated to
```
except E as N:
    try:
        foo
    finally:
        del N
```
This means the exception must be assigned to a different name to be able to refer to it after the except clause. Exceptions are cleared because with the traceback attached to them, they form a reference cycle with the stack frame, keeping all locals in that frame alive until the next garbage collection occurs. 

check this [doc](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement)
