### PR TITLE
Fix ROPE extension issue and device mismatch

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1032,7 +1032,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        self.current_rope_size = int(math.ceil(seq_len / 8192)) * 8192
+        self.current_rope_size = math.ceil(seq_len / 8192) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass
@@ -1105,7 +1105,7 @@ class LlamaExtendedRotaryEmbedding(torch.nn.Module):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
         
-        t = torch.arange(self.current_rope_size, device="cpu", dtype=torch.int64).float()
+        t = torch.arange(self.current_rope_size, device=self.inv_freq.device, dtype=torch.int64).float()
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
@@ -1154,7 +1154,7 @@ class LlamaExtendedRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        self.current_rope_size = int(math.ceil(seq_len / 8192)) * 8192
+        self.current_rope_size = math.ceil(seq_len / 8192) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -14,6 +14,7 @@
 
 import torch
 import gc
+import math
 from typing import Optional, Tuple, List, Union
 from ._utils import *
 from ._utils import __version__
@@ -1031,7 +1032,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        self.current_rope_size = int(round(seq_len / 8192)) * 8192
+        self.current_rope_size = int(math.ceil(seq_len / 8192)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass
@@ -1153,7 +1154,7 @@ class LlamaExtendedRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        self.current_rope_size = int(round(seq_len / 8192)) * 8192
+        self.current_rope_size = int(math.ceil(seq_len / 8192)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -155,14 +155,14 @@ class FastLanguageModel(FastLlamaModel):
         try:
             model_config = AutoConfig.from_pretrained(model_name, token = token, revision = revision)
             is_model = True
-        except Exception as autoconfig_error:
-            autoconfig_error = str(autoconfig_error)
+        except Exception as e:
+            autoconfig_error = str(e)
             is_model = False
         try:
             peft_config = PeftConfig .from_pretrained(model_name, token = token, revision = revision)
             is_peft = True
-        except Exception as peft_error:
-            peft_error = str(peft_error)
+        except Exception as e:
+            peft_error = str(e)
             is_peft = False
         pass
 

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -155,14 +155,14 @@ class FastLanguageModel(FastLlamaModel):
         try:
             model_config = AutoConfig.from_pretrained(model_name, token = token, revision = revision)
             is_model = True
-        except Exception as e:
-            autoconfig_error = str(e)
+        except Exception as error:
+            autoconfig_error = str(error)
             is_model = False
         try:
             peft_config = PeftConfig .from_pretrained(model_name, token = token, revision = revision)
             is_peft = True
-        except Exception as e:
-            peft_error = str(e)
+        except Exception as error:
+            peft_error = str(error)
             is_peft = False
         pass
 


### PR DESCRIPTION
Environment:
```
==((====))==  Unsloth 2024.8: Fast Llama patching. Transformers = 4.43.3.
   \\   /|    GPU: NVIDIA A40. Max memory: 44.352 GB. Platform = Linux.
O^O/ \_/ \    Pytorch: 2.3.0+cu121. CUDA = 8.6. CUDA Toolkit = 12.1.
\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.26.post1. FA2 = True]
 "-____-"     Free Apache license: http://github.com/unslothai/unsloth
```
Initial error:
```
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/transformers/trainer.py", line 3318, in training_step
    loss = self.compute_loss(model, inputs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/transformers/trainer.py", line 3363, in compute_loss
    outputs = model(**inputs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/utils/operations.py", line 819, in forward
    return model_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/utils/operations.py", line 807, in __call__
    return convert_to_fp32(self.model_forward(*args, **kwargs))
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/amp/autocast_mode.py", line 16, in decorate_autocast
    return func(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 959, in PeftModelForCausalLM_fast_forward
    return self.base_model(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/peft/tuners/tuners_utils.py", line 179, in forward
    return self.model.forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 169, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 878, in _CausalLM_fast_forward
    outputs = self.model(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 169, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 715, in LlamaModel_fast_forward
    hidden_states = Unsloth_Offloaded_Gradient_Checkpointer.apply(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/autograd/function.py", line 598, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/cuda/amp/autocast_mode.py", line 115, in decorate_fwd
    return fwd(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/_utils.py", line 645, in forward
    output = forward_function(hidden_states, *args)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 169, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 467, in LlamaDecoderLayer_fast_forward
    hidden_states, self_attn_weights, present_key_value = self.self_attn(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 169, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 349, in LlamaAttention_fast_forward
    self.rotary_emb.extend_rope_embedding(V, seq_len = kv_seq_len)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 1158, in extend_rope_embedding
    self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 1110, in _set_cos_sin_cache
    freqs = torch.outer(t, self.inv_freq)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```
I examined `self.inv_freq` and found that although it was initialized on the CPU, it's now on the GPU, which caused this error:
![CleanShot 2024-07-31 at 15 22 36@2x](https://github.com/user-attachments/assets/5e885708-a694-4463-86fc-d8cfef25c62f)


To resolve this, I modified `t` to be on the same device as `self.inv_freq`, which solved the initial problem.

However, a new error then occurred:
```
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/transformers/trainer.py", line 3318, in training_step
    loss = self.compute_loss(model, inputs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/transformers/trainer.py", line 3363, in compute_loss
    outputs = model(**inputs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/utils/operations.py", line 822, in forward
    return model_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/utils/operations.py", line 810, in __call__
    return convert_to_fp32(self.model_forward(*args, **kwargs))
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/amp/autocast_mode.py", line 16, in decorate_autocast
    return func(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 958, in PeftModelForCausalLM_fast_forward
    return self.base_model(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/peft/tuners/tuners_utils.py", line 179, in forward
    return self.model.forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 166, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 877, in _CausalLM_fast_forward
    outputs = self.model(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 166, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 714, in LlamaModel_fast_forward
    hidden_states = Unsloth_Offloaded_Gradient_Checkpointer.apply(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/autograd/function.py", line 598, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/cuda/amp/autocast_mode.py", line 115, in decorate_fwd
    return fwd(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/_utils.py", line 645, in forward
    output = forward_function(hidden_states, *args)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 166, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 466, in LlamaDecoderLayer_fast_forward
    hidden_states, self_attn_weights, present_key_value = self.self_attn(
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/accelerate/hooks.py", line 166, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/models/llama.py", line 353, in LlamaAttention_fast_forward
    Q, K = fast_rope_embedding(Q, K, cos, sin)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/kernels/rope_embedding.py", line 135, in fast_rope_embedding
    Q = Fast_RoPE_Embedding.apply(Q.transpose(1, 2), cos, sin).transpose(1, 2)
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/torch/autograd/function.py", line 598, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
  File "/data/miniconda3/envs/py310/lib/python3.10/site-packages/unsloth/kernels/rope_embedding.py", line 81, in forward
    assert(seq_len <= cos.shape[0])
AssertionError
```

Upon checking the output, I discovered that my input sequence length is 34k, which exceeds the initial `current_rope_size`. It appears that `extend_rope_embedding` was not effective. The reason for this is that `round()` was used for rounding, preventing the rope size from increasing. To address this, I changed it to use ceiling rounding instead.
