### PR TITLE
Fix `check_nvidia` to support running multiple single GPU training / inference at the same time

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -933,15 +933,25 @@ pass
 
 
 def check_nvidia():
-    # Unsloth doesn't work yet on AMD devices - we're working on it!
+    cuda_visible_devices = os.environ.get('CUDA_VISIBLE_DEVICES')
+
     output = np.array([0,])
     try:
-        output = subprocess.check_output("nvidia-smi --query-gpu=memory.used --format=csv", shell = True)
-        output = re.findall(rb'([\d]{1,})[\s]{1,}M', output)
-        output = np.array([int(x.decode('utf-8'))/1024 for x in output])
-    except:
+        if cuda_visible_devices is not None:
+            gpu_ids = cuda_visible_devices.split(',')
+            query_gpus = ','.join(gpu_ids)
+            command = f"nvidia-smi --query-gpu=index,memory.used --format=csv -i {query_gpus}"
+        else:
+            command = "nvidia-smi --query-gpu=index,memory.used --format=csv"
+
+        output = subprocess.check_output(command, shell=True)
+        output = re.findall(rb'(\d+),\s*(\d+)\s*MiB', output)
+        output = np.array([int(x[1].decode('utf-8'))/1024 for x in output])
+    except subprocess.CalledProcessError:
         if not torch.cuda.is_available():
-            raise RuntimeError("Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!")    
+            raise RuntimeError("Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!")
+        raise
+
     return output
 pass
 PRE_CHECK = check_nvidia()

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1410,14 +1410,14 @@ class FastLlamaModel:
 
         # Patch Trainer
         from transformers.trainer import Trainer
-        try:
-            if Trainer._inner_training_loop.__name__ != "_fast_inner_training_loop":
-                inner_training_loop = inspect.getsource(Trainer._inner_training_loop)
-                Trainer._original_training_loop = inner_training_loop
-            else:
-                inner_training_loop = Trainer._original_training_loop
-        except:
-            raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
+        # try:
+        if Trainer._inner_training_loop.__name__ != "_fast_inner_training_loop":
+            inner_training_loop = inspect.getsource(Trainer._inner_training_loop)
+            Trainer._original_training_loop = inner_training_loop
+        else:
+            inner_training_loop = Trainer._original_training_loop
+        # except:
+        #    raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
         pass
 
         if ((post_check - pre_check) >= 1).sum() > 1:


### PR DESCRIPTION
I know multi-gpu is work in progress but in the meantime we could allow people to use single gpu multiple times in different python processes by specifying the GPU on which it should run with `CUDA_VISIBLE_DEVICES` for each process.

This patch fix `check_nvidia` to allow that use case.