### PR TITLE
Remove reference to mamba in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ All notebooks are **beginner friendly**! Add your dataset, click "Run All", and 
 ## 💾 Installation Instructions
 
 ### Conda Installation
-`⚠️Only use Conda if you have it. If not, use Pip`. Select either `pytorch-cuda=11.8,12.1` for CUDA 11.8 or CUDA 12.1. If you have `mamba`, use `mamba` instead of `conda` for faster solving. We support `python=3.10,3.11,3.12`.
+`⚠️Only use Conda if you have it. If not, use Pip`. Select either `pytorch-cuda=11.8,12.1` for CUDA 11.8 or CUDA 12.1. We support `python=3.10,3.11,3.12`.
 ```bash
 conda create --name unsloth_env \
     python=3.11 \


### PR DESCRIPTION
Mamba solver was merged into conda. Mamba is not longer actively developed. Removed sentence telling people to use mamba.