### PR TITLE
Change UnslothTrainingArguments base class to SFTConfig, fix https://github.com/unslothai/unsloth/issues/936 

### DIFF
--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -14,8 +14,7 @@
 
 from dataclasses import dataclass, field
 from typing import Optional
-from transformers import TrainingArguments
-from trl import SFTTrainer
+from trl import SFTTrainer, SFTConfig
 from . import is_bfloat16_supported
 
 __all__ = [
@@ -25,7 +24,7 @@ __all__ = [
 
 
 @dataclass
-class UnslothTrainingArguments(TrainingArguments):
+class UnslothTrainingArguments(SFTConfig):
     embedding_learning_rate : Optional[float] = field(
         default = None,
         metadata = {"help" : "Different learning rates for embeddings and lm_head."}


### PR DESCRIPTION
Recent modified of pyproject.toml with trl:
From ```"trl>=0.7.9,<0.9.0"``` to ```"trl>=0.7.9,!=0.9.0,!=0.9.1,!=0.9.2,!=0.9.3"```


The new trl version add a hardcoded check for ```args.packing```.
https://github.com/huggingface/trl/pull/1530

![image](https://github.com/user-attachments/assets/a6e21b61-c1e8-4af5-86d9-5d8e42ec8312)
But since UnslothTrainingArguments inherited from TrainingArguments which has no ```args.packing``` and we need UnslothTrainingArguments to pass in embedding_learning_rate.

![image](https://github.com/user-attachments/assets/8ef4e6c0-d683-4561-a69a-4f8e1e2d0158)

Simple solution is to pass straight into the UnslothTrainer and let it override the SFTConfig and set the ```args.packing``` but they also set  ```packing: Optional[bool] = False``` and check by ```if packing``` so we can't really pass any value other than ```True``` to override and actually set ```args.packing```.

Long term solution here is to inherited from trl's SFTConfig. The issue seem to be from trl side though as we can still pass in TrainingArguments class type to the SFTTrainer config even though we don't have the necessary args to pass the sanity check.