### PR TITLE
Changing lstrip -> strip to address trailing spaces/newlines in chat formatting for Ollama (#992)

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1281,7 +1281,7 @@ extra_eos_tokens = None,
     You must use {INPUT}, {OUTPUT} twice, and {SYSTEM} is optional.
     """
     # Strip only the left
-    chat_template = chat_template.lstrip()
+    chat_template = chat_template.strip()
 
     assert(tokenizer is not None)
 


### PR DESCRIPTION
This is related to #992 