### PR TITLE
Update key from "from" to "user"

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1068,8 +1068,8 @@ def to_sharegpt(
         assistants = examples[output_column_name]
         texts = [
             [
-                {"from" : "user",      "content" : str(user)     },
-                {"from" : "assistant", "content" : str(assistant)},
+                {"role" : "user",      "content" : str(user)     },
+                {"role" : "assistant", "content" : str(assistant)},
             ] \
             for user, assistant in zip(users, assistants)
         ]


### PR DESCRIPTION
When use [tokenizer.apply_chat_template](https://huggingface.co/docs/transformers/main/en/chat_templating), the key should be "role" rather than "from", this is liknk to [this issue](https://github.com/unslothai/unsloth/issues/994)

I don't know it is suitable for all situation, I also can add a dedicated parameter of the key if you think it is better.