### PR TITLE
fix: chat_templates.py bug

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1842,9 +1842,9 @@ def train_on_responses_only(
         return { "labels" : all_labels }
     pass
 
-    if hasattr(trainer, "train_dataset"):
+    if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
         trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True)
-    if hasattr(trainer, "eval_dataset"):
+    if hasattr(trainer, "eval_dataset") and trainer.eval_dataset is not None:
         trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True)
     return trainer
 pass

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1845,7 +1845,7 @@ def train_on_responses_only(
     if hasattr(trainer, "train_dataset"):
         trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True)
     if hasattr(trainer, "eval_dataset"):
-        trainer.eval_dataset  = trainer.eval_dataset .map(_train_on_responses_only, batched = True)
+        trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True)
     return trainer
 pass
 


### PR DESCRIPTION
Fixes chat template bug, noticed there's an extra space from [issue](https://github.com/unslothai/unsloth/issues/1047)


```python
from unsloth.chat_templates import train_on_responses_only
trainer = train_on_responses_only(
    trainer,
    instruction_part = "<|start_header_id|>user<|end_header_id|>\n\n",
    response_part = "<|start_header_id|>assistant<|end_header_id|>\n\n",
)

---------------------------------------------------------------------------

AttributeError                            Traceback (most recent call last)

[<ipython-input-9-4f9c74a86b96>](https://localhost:8080/#) in <cell line: 2>()
      1 from unsloth.chat_templates import train_on_responses_only
----> 2 trainer = train_on_responses_only(
      3     trainer,
      4     instruction_part = "<|start_header_id|>user<|end_header_id|>\n\n",
      5     response_part = "<|start_header_id|>assistant<|end_header_id|>\n\n",

[/usr/local/lib/python3.10/dist-packages/unsloth/chat_templates.py](https://localhost:8080/#) in train_on_responses_only(trainer, instruction_part, response_part)
   1846         trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True)
   1847     if hasattr(trainer, "eval_dataset"):
-> 1848         trainer.eval_dataset  = trainer.eval_dataset .map(_train_on_responses_only, batched = True)
   1849     return trainer
   1850 pass

AttributeError: 'NoneType' object has no attribute 'map'
```