### PR TITLE
fix: compute_loss bug

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1166,7 +1166,7 @@ def _unsloth_pre_compute_loss(self, model, inputs, *args, **kwargs):
             inputs["num_items_in_batch"] = kwargs["num_items_in_batch"]
         pass
     pass
-    return self._old_compute_loss(model, inputs, args, kwargs)
+    return self._old_compute_loss(model, inputs, *args, **kwargs)
 pass
 
 


### PR DESCRIPTION
Currently, Unsloth doesn't properly pass additional parameters to Trainer.compute_loss such as return_outputs because of a typo. This leads to errors when calling trainer.evaluate(). This change fixes the bug.