### PR TITLE
feat: add support for multiple column shareGPT

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -22,6 +22,7 @@ __all__ = [
     "standardize_sharegpt",
     "apply_chat_template",
     "train_on_responses_only",
+    "parse_multicolumn_output",
 
     "test_construct_chat_template",
 ]
@@ -33,6 +34,7 @@ from .save import patch_saving_functions
 import os
 import shutil
 from .tokenizer_utils import *
+from functools import partial
 from .models._utils import patch_tokenizer
 import re
 from unsloth_zoo.dataset_utils import (
@@ -1087,6 +1089,21 @@ def remove_special_tokens(tokenizer, prompt):
     return prompt
 pass
 
+def extract_add_generation_prompt(tokenizer):
+    if not hasattr(tokenizer, "_generation_prompt"):
+        w_generation_prompt = tokenizer.apply_chat_template(conversation=[{"role" : "user", "content" : "Dummy"}], tokenize = False, add_generation_prompt = True)
+        wo_generation_prompt = tokenizer.apply_chat_template(conversation=[{"role" : "user", "content" : "Dummy"}], tokenize = False, add_generation_prompt = False)
+        tokenizer._generation_prompt = w_generation_prompt[len(wo_generation_prompt):]
+    pass
+
+    return tokenizer._generation_prompt
+pass
+
+def parse_multicolumn_output(tokenizer, output):
+    generation_prompt = extract_add_generation_prompt(tokenizer)
+    return eval(output.lstrip(generation_prompt).rstrip(tokenizer.eos_token))
+pass
+
 
 def _parse_combined_prompt(combined_prompt, dataset):
     # Find {...}
@@ -1189,7 +1206,7 @@ def to_sharegpt(
     """
     Converts a dataset to ShareGPT style.
     ShareGPT requires only 1 input and 1 output field.
-    This means one has to merge multiple columns into 1 for 1 input field.
+    You can pass a multiple columns in the output field and they will be merged into 1 column in JSON format.
     Use `conversation_extension` to increase the length of each conversation by randomnly
     selecting a few and packing them into 1.
 
@@ -1206,6 +1223,17 @@ def to_sharegpt(
             raise TypeError("Unsloth: Your dataset is probably already in ShareGPT format!")
         pass
     pass
+
+    if isinstance(output_column_name, list):
+        def format_to_merge_output_columns(example, columns: list):
+            merged_dict = {}
+            for column in columns:
+                merged_dict[column] = example[column]
+            example["🔥merged😅"] = str(merged_dict)
+            return example
+
+        dataset = dataset.map(partial(format_to_merge_output_columns, columns=output_column_name), desc="Merging output columns")
+        output_column_name = "🔥merged😅"
 
     possible_columns, final_optional_prompts = _parse_combined_prompt(merged_prompt, dataset)
     function = _create_formatter(possible_columns, final_optional_prompts, merged_column_name)


### PR DESCRIPTION
Given this problem from user on discord : https://discord.com/channels/1179035537009545276/1297912272596897833

I am thinking maybe we can support multiple column shareGPT by convert the multiple column into JSON string. Later, we can parse it back to Python so user can retrieve the result. The function behavior will not change at all if user only give one column

Here's the example :

![image](https://github.com/user-attachments/assets/527afbb5-5331-44a1-aefd-26ad78d8d312)

Notice in this one column example, we do not use any JSON format here (behavior unchanged)

![image](https://github.com/user-attachments/assets/9393e007-e024-47a3-bb6f-bc94d7654246)
![image](https://github.com/user-attachments/assets/0c4cc53e-dd76-4833-a00a-68cf861c5d36)

I also created `parse_multicolumn_output` so the user can immediately take the output into dictionary (JSON). Because we need to cut the `.eos_token` and the generation_prompt (the one that `tokenizer` add if we use `add_generation_prompt=True`) before we can `eval`

Here's also the whole colab example which is using Titanic [Kaggle dataset](https://colab.research.google.com/drive/1ktD85YsyJ9tkv1_fZSsO7zFX3NgUOlKC?usp=sharing)