### PR TITLE
Fix/kaggle pytorch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,12 +108,6 @@ cu118onlytorch240 = [
 cu121onlytorch240 = [
     "xformers==0.0.27.post2",
 ]
-cu121onlytorch250 = [
-    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp39-cp39-manylinux_2_28_x86_64.whl ; python_version=='3.9'",
-    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version=='3.10'",
-    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version=='3.11'",
-    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version=='3.12'"
-]
 cu118 = [
     "unsloth[huggingface]",
     "bitsandbytes>=0.43.3",
@@ -182,7 +176,7 @@ kaggle-new = [
     "bitsandbytes>=0.43.3",
 ]
 kaggle-cu121 = [
-    "unsloth[cu121onlytorch250]"
+    "torch @ https://download.pytorch.org/whl/cu121/torch-2.5.0%2Bcu121-cp310-cp310-linux_x86_64.whl"
 ]
 conda = [
     "unsloth[huggingface]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,9 @@ kaggle-new = [
     "unsloth[huggingface]",
     "bitsandbytes>=0.43.3",
 ]
+kaggle-cu121 = [
+    "torch>=2.4.0+cu121"
+]
 conda = [
     "unsloth[huggingface]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ cu118onlytorch240 = [
 cu121onlytorch240 = [
     "xformers==0.0.27.post2",
 ]
+cu121onlytorch250 = [
+    "xformers==0.0.28.post2",
+]
 cu118 = [
     "unsloth[huggingface]",
     "bitsandbytes>=0.43.3",
@@ -176,7 +179,7 @@ kaggle-new = [
     "bitsandbytes>=0.43.3",
 ]
 kaggle-cu121 = [
-    "torch>=2.4.0+cu121"
+    "unsloth[cu121onlytorch250]"
 ]
 conda = [
     "unsloth[huggingface]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,11 @@ cu118onlytorch240 = [
 cu121onlytorch240 = [
     "xformers==0.0.27.post2",
 ]
-cu121onlytorch250 = [
-    "xformers==0.0.28.post2",
+cu121onlytorch240 = [
+    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp39-cp39-manylinux_2_28_x86_64.whl ; python_version=='3.9'",
+    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version=='3.10'",
+    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version=='3.11'",
+    "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version=='3.12'"
 ]
 cu118 = [
     "unsloth[huggingface]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ cu118onlytorch240 = [
 cu121onlytorch240 = [
     "xformers==0.0.27.post2",
 ]
-cu121onlytorch240 = [
+cu121onlytorch250 = [
     "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp39-cp39-manylinux_2_28_x86_64.whl ; python_version=='3.9'",
     "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version=='3.10'",
     "xformers @ https://download.pytorch.org/whl/cu121/xformers-0.0.28.post2-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version=='3.11'",


### PR DESCRIPTION
Following this error in Kaggle : 

`ImportError: /opt/conda/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12: undefined symbol: __nvJitLinkComplete_12_4, version libnvJitLink.so.12`

We need to reduce the pytorch version to use `cu121` instead. It's a known problem solely for [kaggle](https://github.com/pytorch/pytorch/issues/134929) 

Since in Kaggle, by default it's using pypi version (`pip install unsloth`). I cannot think any better solution than extend it for Kaggle only and add optional dependencies from there.

Then, in Kaggle, the installation step is 

```python
%%capture
!pip install pip3-autoremove
!pip-autoremove torch torchvision torchaudio -y
!pip install "unsloth[kaggle-cu121] @ git+https://github.com/unslothai/unsloth.git@pip"

import os
os.environ["WANDB_DISABLED"] = "true"
```