### PR TITLE
fix/transformers-unpack

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -62,9 +62,13 @@ os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 try:
     import torch
-except:
-    raise ImportError("Pytorch is not installed. Go to https://pytorch.org/.\n"\
-                      "We have some installation instructions on our Github page.")
+except ModuleNotFoundError:
+    raise ImportError(
+        "Unsloth: Pytorch is not installed. Go to https://pytorch.org/.\n"\
+        "We have some installation instructions on our Github page."
+    )
+except Exception as exception:
+    raise exception
 pass
 
 # Hugging Face Hub faster downloads (only enable during Colab and Kaggle sessions)

--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -388,6 +388,13 @@ from transformers.models.llama.modeling_llama import (
     List,
     Tuple,
 )
+
+try:
+    from transformers.models.llama.modeling_llama import Unpack, KwargsForCausalLM
+except ImportError:
+    logger.warning("Unsloth: Could not find Unpack, KwargsForCausalLM in LlamaForCausalLM. "
+    "This is expected if you are using an older version of Transformers (<4.46.0). ")
+
 import inspect, re
 function = inspect.getsource(LlamaForCausalLM.forward)
 function = function.split("\n")

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -145,7 +145,7 @@ pass
 
 def _merge_lora(layer, name):
 
-    bias = None
+    bias = getattr(layer, "bias", None)
     if isinstance(layer, (Bnb_Linear4bit, Peft_Linear4bit, Peft_Linear)):
         # Is LoRA so we need to merge!
         W, quant_state, A, B, s, bias = get_lora_parameters_bias(layer)

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -914,7 +914,9 @@ def patch_sft_trainer_tokenizer():
 
         check_text = \
         "\n"\
-        "if 'tokenizer' not in locals(): tokenizer = processing_class\n"\
+        "if 'tokenizer'          not in locals(): tokenizer = processing_class\n"\
+        "if 'formatting_func'    not in locals(): raise RuntimeError('Unsloth: Please file a bug report - `formatting_func` does not exist!')\n"\
+        "if 'dataset_text_field' not in locals(): raise RuntimeError('Unsloth: Please file a bug report - `dataset_text_field` does not exist!')\n"\
         "test_text = dataset[0][dataset_text_field] if (formatting_func is None and dataset_text_field is not None) else formatting_func(dataset[0])[0]\n"\
         "chat_template = getattr(tokenizer, 'chat_template', None)\n"\
         "chat_template = '' if chat_template is None else chat_template\n"\
@@ -1017,7 +1019,10 @@ pass
 for trainer_name in ("SFTTrainer", "DPOTrainer", "KTOTrainer"):
     trainer_text = patch_trl_tokenizer_processing_class(trainer_name)
     if trainer_text is None: continue
-    exec(trainer_text, globals())
+    try:
+        exec(trainer_text, globals())
+    except:
+        raise RuntimeError(f"Unsloth: Please file a bug report! Error patching {trainer_name}")
     exec(f"trl.trainer.{trainer_name} = Unsloth{trainer_name}", globals())
 pass
 


### PR DESCRIPTION
Multiple user reported that they got an error if using latest version of transformers (in my case, it's `4.47.0dev`)

After investigation, it's because we need to import `Unpack` and `KwargsForCausalLM` for that

I am still not sure what to do if it's actually not found (the purpose of `Unpack` and `KwargsForCausalLM` is only for typehinting. But still.....). So now I just put logger warning but it's kinda ugly in colab (where the transformers version is still 4.44.2

![image](https://github.com/user-attachments/assets/ea069577-5967-4152-bc46-63b9acdc6e64)
