### PR TITLE
Fix/phi-longrope

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1126,8 +1126,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        div, mod = divmod(seq_len, 8192)
-        self.current_rope_size = (div + (mod != 0)) * 8192
+        self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass
@@ -1253,8 +1252,7 @@ class LlamaExtendedRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        div, mod = divmod(seq_len, 8192)
-        self.current_rope_size = (div + (mod != 0)) * 8192
+        self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass
@@ -1369,8 +1367,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        div, mod = divmod(seq_len, 8192)
-        self.current_rope_size = (div + (mod != 0)) * 8192
+        self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -194,6 +194,8 @@ def LlamaAttention_fast_forward_inference(
     # cos, sin = self.rotary_emb(Vn, seq_len = kv_seq_len)
     # Qn, Kn = inplace_rope_embedding(Qn, Kn, cos, sin, position_ids)
 
+    # Need to do it prior 2 steps before hitting full on short KV cache
+    # or else error
     self.rotary_emb.extend_rope_embedding(Vn, seq_len + 2)
     cos, sin = self.rotary_emb.get_cached(kv_seq_len)
     cos = cos[position_ids].unsqueeze(1)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -193,6 +193,8 @@ def LlamaAttention_fast_forward_inference(
 
     # cos, sin = self.rotary_emb(Vn, seq_len = kv_seq_len)
     # Qn, Kn = inplace_rope_embedding(Qn, Kn, cos, sin, position_ids)
+
+    self.rotary_emb.extend_rope_embedding(Vn, seq_len + 1)
     cos, sin = self.rotary_emb.get_cached(kv_seq_len)
     cos = cos[position_ids].unsqueeze(1)
     sin = sin[position_ids].unsqueeze(1)
@@ -1361,7 +1363,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     pass
 
     def extend_rope_embedding(self, x, seq_len):
-        if seq_len <= self.current_rope_size: return
+        if seq_len < self.current_rope_size: return
         # Iteratively grow by increments of 8192
         self.current_rope_size = math.ceil(seq_len / 8192) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -194,7 +194,7 @@ def LlamaAttention_fast_forward_inference(
     # cos, sin = self.rotary_emb(Vn, seq_len = kv_seq_len)
     # Qn, Kn = inplace_rope_embedding(Qn, Kn, cos, sin, position_ids)
 
-    self.rotary_emb.extend_rope_embedding(Vn, seq_len + 1)
+    self.rotary_emb.extend_rope_embedding(Vn, seq_len + 2)
     cos, sin = self.rotary_emb.get_cached(kv_seq_len)
     cos = cos[position_ids].unsqueeze(1)
     sin = sin[position_ids].unsqueeze(1)
@@ -1363,7 +1363,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     pass
 
     def extend_rope_embedding(self, x, seq_len):
-        if seq_len < self.current_rope_size: return
+        if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
         self.current_rope_size = math.ceil(seq_len / 8192) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1126,7 +1126,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        self.current_rope_size = math.ceil(seq_len / 8192) * 8192
+        div, mod = divmod(seq_len, 8192)
+        self.current_rope_size = (div + (mod != 0)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass
@@ -1252,7 +1253,8 @@ class LlamaExtendedRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        self.current_rope_size = math.ceil(seq_len / 8192) * 8192
+        div, mod = divmod(seq_len, 8192)
+        self.current_rope_size = (div + (mod != 0)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass
@@ -1367,7 +1369,8 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     def extend_rope_embedding(self, x, seq_len):
         if seq_len <= self.current_rope_size: return
         # Iteratively grow by increments of 8192
-        self.current_rope_size = math.ceil(seq_len / 8192) * 8192
+        div, mod = divmod(seq_len, 8192)
+        self.current_rope_size = (div + (mod != 0)) * 8192
         self._set_cos_sin_cache(self.current_rope_size, device = "cuda:0", dtype = x.dtype)
     pass
 pass


### PR DESCRIPTION
#1189 mentioned that we can't generate beyond 4096 tokens

After investigation, Unsloth do not extend longrope dynamically on generation. Hence I added this and now it "works" but output after 4096 is still gibberish.

but if input token is beyond 4096 already, then the output will be good.