### PR TITLE
Fix/casting continue pretraining

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2222,7 +2222,7 @@ class FastLlamaModel:
             print("Unsloth: Training lm_head in mixed precision to save VRAM")
             assert(hasattr(model.model.lm_head, "modules_to_save"))
 
-            dtype = model.model.lm_head.modules_to_save.weight.default
+            dtype = model.model.lm_head.modules_to_save.default.weight.dtype
             model.model.lm_head.modules_to_save.default\
                 .to(device = "cuda:0", dtype=(dtype if (dtype != torch.float16) else torch.float32), non_blocking = True)
             model.model.lm_head.modules_to_save.default.requires_grad_(True)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1958,7 +1958,7 @@ class FastLlamaModel:
                 if "embed_tokens" in new_target_modules:
                     print("Unsloth: Training embed_tokens in mixed precision to save VRAM")
 
-                    dtype = model.model.model.embed_tokens.dtype
+                    dtype = model.model.model.embed_tokens.modules_to_save.default.dtype
                     model.model.model.embed_tokens.modules_to_save.default\
                         .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
                     model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
@@ -1972,7 +1972,7 @@ class FastLlamaModel:
                 if "lm_head" in new_target_modules:
                     print("Unsloth: Training lm_head in mixed precision to save VRAM")
 
-                    dtype = model.model.model.embed_tokens.dtype
+                    dtype = model.model.model.lm_head.modules_to_save.default.dtype
                     model.model.lm_head.modules_to_save.default\
                         .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
                     model.model.lm_head.modules_to_save.default.requires_grad_(True)
@@ -2212,7 +2212,7 @@ class FastLlamaModel:
             print("Unsloth: Training embed_tokens in mixed precision to save VRAM")
             assert(hasattr(model.model.model.embed_tokens, "modules_to_save"))
 
-            dtype = model.model.model.embed_tokens.dtype
+            dtype = model.model.model.embed_tokens.modules_to_save.default.dtype
             model.model.model.embed_tokens.modules_to_save.default\
                 .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
@@ -2222,7 +2222,7 @@ class FastLlamaModel:
             print("Unsloth: Training lm_head in mixed precision to save VRAM")
             assert(hasattr(model.model.lm_head, "modules_to_save"))
 
-            dtype = model.model.model.embed_tokens.dtype
+            dtype = model.model.lm_head.modules_to_save.default
             model.model.lm_head.modules_to_save.default\
                 .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.lm_head.modules_to_save.default.requires_grad_(True)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1972,6 +1972,7 @@ class FastLlamaModel:
                 if "lm_head" in new_target_modules:
                     print("Unsloth: Training lm_head in mixed precision to save VRAM")
 
+                    dtype = model.model.model.embed_tokens.dtype
                     model.model.lm_head.modules_to_save.default\
                         .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
                     model.model.lm_head.modules_to_save.default.requires_grad_(True)
@@ -2210,6 +2211,8 @@ class FastLlamaModel:
         if train_embed_tokens:
             print("Unsloth: Training embed_tokens in mixed precision to save VRAM")
             assert(hasattr(model.model.model.embed_tokens, "modules_to_save"))
+
+            dtype = model.model.model.embed_tokens.dtype
             model.model.model.embed_tokens.modules_to_save.default\
                 .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
@@ -2218,6 +2221,8 @@ class FastLlamaModel:
         if train_lm_head:
             print("Unsloth: Training lm_head in mixed precision to save VRAM")
             assert(hasattr(model.model.lm_head, "modules_to_save"))
+
+            dtype = model.model.model.embed_tokens.dtype
             model.model.lm_head.modules_to_save.default\
                 .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.lm_head.modules_to_save.default.requires_grad_(True)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1958,7 +1958,7 @@ class FastLlamaModel:
                 if "embed_tokens" in new_target_modules:
                     print("Unsloth: Training embed_tokens in mixed precision to save VRAM")
 
-                    dtype = model.model.model.embed_tokens.modules_to_save.default.dtype
+                    dtype = model.model.model.embed_tokens.modules_to_save.default.weight.dtype
                     model.model.model.embed_tokens.modules_to_save.default\
                         .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
                     model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
@@ -1972,7 +1972,7 @@ class FastLlamaModel:
                 if "lm_head" in new_target_modules:
                     print("Unsloth: Training lm_head in mixed precision to save VRAM")
 
-                    dtype = model.model.model.lm_head.modules_to_save.default.dtype
+                    dtype = model.model.model.lm_head.modules_to_save.default.weight.dtype
                     model.model.lm_head.modules_to_save.default\
                         .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
                     model.model.lm_head.modules_to_save.default.requires_grad_(True)
@@ -2212,7 +2212,7 @@ class FastLlamaModel:
             print("Unsloth: Training embed_tokens in mixed precision to save VRAM")
             assert(hasattr(model.model.model.embed_tokens, "modules_to_save"))
 
-            dtype = model.model.model.embed_tokens.modules_to_save.default.dtype
+            dtype = model.model.model.embed_tokens.modules_to_save.default.weight.dtype
             model.model.model.embed_tokens.modules_to_save.default\
                 .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
@@ -2222,7 +2222,7 @@ class FastLlamaModel:
             print("Unsloth: Training lm_head in mixed precision to save VRAM")
             assert(hasattr(model.model.lm_head, "modules_to_save"))
 
-            dtype = model.model.lm_head.modules_to_save.default
+            dtype = model.model.lm_head.modules_to_save.weight.default
             model.model.lm_head.modules_to_save.default\
                 .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.lm_head.modules_to_save.default.requires_grad_(True)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1960,7 +1960,7 @@ class FastLlamaModel:
 
                     dtype = model.model.model.embed_tokens.modules_to_save.default.weight.dtype
                     model.model.model.embed_tokens.modules_to_save.default\
-                        .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
+                        .to(device = "cuda:0", dtype=(dtype if (dtype != torch.float16) else torch.float32), non_blocking = True)
                     model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
 
                     # [TODO] Move old embed_tokens to CPU - should be disk!
@@ -1974,7 +1974,7 @@ class FastLlamaModel:
 
                     dtype = model.model.model.lm_head.modules_to_save.default.weight.dtype
                     model.model.lm_head.modules_to_save.default\
-                        .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
+                        .to(device = "cuda:0", dtype=(dtype if (dtype != torch.float16) else torch.float32), non_blocking = True)
                     model.model.lm_head.modules_to_save.default.requires_grad_(True)
 
                     # [TODO] Move old lm_head to CPU - should be disk!
@@ -2214,7 +2214,7 @@ class FastLlamaModel:
 
             dtype = model.model.model.embed_tokens.modules_to_save.default.weight.dtype
             model.model.model.embed_tokens.modules_to_save.default\
-                .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
+                .to(device = "cuda:0", dtype=(dtype if (dtype != torch.float16) else torch.float32), non_blocking = True)
             model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
         pass
 
@@ -2224,7 +2224,7 @@ class FastLlamaModel:
 
             dtype = model.model.lm_head.modules_to_save.weight.default
             model.model.lm_head.modules_to_save.default\
-                .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
+                .to(device = "cuda:0", dtype=(dtype if (dtype != torch.float16) else torch.float32), non_blocking = True)
             model.model.lm_head.modules_to_save.default.requires_grad_(True)
         pass
 

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1958,8 +1958,9 @@ class FastLlamaModel:
                 if "embed_tokens" in new_target_modules:
                     print("Unsloth: Training embed_tokens in mixed precision to save VRAM")
 
+                    dtype = model.model.model.embed_tokens.dtype
                     model.model.model.embed_tokens.modules_to_save.default\
-                        .to(device = "cuda:0", non_blocking = True)
+                        .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
                     model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
 
                     # [TODO] Move old embed_tokens to CPU - should be disk!
@@ -1972,7 +1973,7 @@ class FastLlamaModel:
                     print("Unsloth: Training lm_head in mixed precision to save VRAM")
 
                     model.model.lm_head.modules_to_save.default\
-                        .to(device = "cuda:0", non_blocking = True)
+                        .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
                     model.model.lm_head.modules_to_save.default.requires_grad_(True)
 
                     # [TODO] Move old lm_head to CPU - should be disk!
@@ -2210,7 +2211,7 @@ class FastLlamaModel:
             print("Unsloth: Training embed_tokens in mixed precision to save VRAM")
             assert(hasattr(model.model.model.embed_tokens, "modules_to_save"))
             model.model.model.embed_tokens.modules_to_save.default\
-                .to(device = "cuda:0", non_blocking = True)
+                .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.model.embed_tokens.modules_to_save.default.requires_grad_(True)
         pass
 
@@ -2218,7 +2219,7 @@ class FastLlamaModel:
             print("Unsloth: Training lm_head in mixed precision to save VRAM")
             assert(hasattr(model.model.lm_head, "modules_to_save"))
             model.model.lm_head.modules_to_save.default\
-                .to(device = "cuda:0", non_blocking = True)
+                .to(device = "cuda:0", dtype=(dtype if (not isinstance(dtype, torch.float16)) else torch.float32), non_blocking = True)
             model.model.lm_head.modules_to_save.default.requires_grad_(True)
         pass
 


### PR DESCRIPTION
Theres' this issue of attempting unscale FP16 gradients

![image](https://github.com/user-attachments/assets/c31a59c4-5f91-4ffa-9d2f-fd127461ae6a)

After investigation, this is because of global dtype, which is when we use it on colab, we will use `torch.float16` instead of `torch.bfloat16`. This error does not happened if we use `torch.bfloat16` (my own RTX4090 for example). So we need to use `torch.float32` on device that is still using `torch.float16` 

Here is the result on bfloat16
![image](https://github.com/user-attachments/assets/0579b6b7-9f3b-4017-9366-3c214b720ff7)

Abd here's the result on float32 (colab)
![image](https://github.com/user-attachments/assets/8121fec6-5ac9-4c4b-80d5-33eef6a82023)




