### PR TITLE
Add functionality to update model vocabulary with new tokenizer tokens

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -21,6 +21,7 @@ from transformers import AutoConfig
 from transformers import __version__ as transformers_version
 from peft import PeftConfig, PeftModel
 from .mapper import INT_TO_FLOAT_MAPPER, FLOAT_TO_INT_MAPPER, MAP_TO_UNSLOTH_16bit
+from ..tokenizer_utils import add_new_tokens
 import os
 try:
     from huggingface_hub.utils import get_token
@@ -348,6 +349,16 @@ class FastLanguageModel(FastLlamaModel):
         if resize_model_vocab is not None:
             model.resize_token_embeddings(resize_model_vocab)
         pass
+
+        # Check if tokenizer is updated -> Add tokens in process
+        # Only for PEFT -> Assume it's checkpoint since checkpoit only saves adapter
+        if is_peft and model_config.vocab_size < len(tokenizer.vocab):
+            logger.warning_once(
+                "Unsloth: Your model's vocab size is less than the tokenizer's vocab size.\n"\
+                "We shall add the new tokens to the model's vocab."
+            )
+            add_new_tokens(model, tokenizer, resize_tokenizer = False)
+
 
         # In case the model supports tagging, add the unsloth tag.
         if hasattr(model, "add_model_tags"):


### PR DESCRIPTION
https://github.com/unslothai/unsloth/issues/1215

Given this issue where we can't immediately use the changed vocab size because the difference size between the adapter and base model, we need to resize the base model before merging the LoRA into base model.

Note this need changes to the `unsloth-zoo` since we need a modification of it. which I also create a PR of it 

https://github.com/unslothai/unsloth-zoo/pull/9