### PR TITLE
Throw error when inferencing longer than max_popsition_embeddings

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1381,7 +1381,11 @@ def _wrap_fast_inference(generate, device_type, dtype, model):
         if hasattr(model, "config") and hasattr(model.config, "max_position_embeddings"):
             if "input_ids" in kwargs and kwargs["input_ids"] is not None and "max_new_tokens" in kwargs:
                 if kwargs["input_ids"].shape[-1] + kwargs["max_new_tokens"] > model.config.max_position_embeddings:
-                    raise ValueError(f'Unsloth: input length {kwargs["input_ids"].shape[-1]} + max_new_tokens {kwargs["max_new_tokens"]} exceeds `max_position_embeddings` {model.config.max_position_embeddings}! consider passing max_position_embeddings flag while initializing the model.')
+                    raise ValueError(
+                        f'Unsloth: input length {kwargs["input_ids"].shape[-1]} + max_new_tokens {kwargs["max_new_tokens"]} exceeds the maximum sequence length of {model.config.max_position_embeddings}!\n'\
+                        'You will need to do long context extension by increasing the `max_seq_length` in `FastLanguageModel.from_pretrained`.'
+                    )
+        pass
 
         # Set a flag for generation!
         internal_model = model

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1378,6 +1378,11 @@ def _wrap_fast_inference(generate, device_type, dtype, model):
     @torch.inference_mode
     def _fast_generate(*args, **kwargs):
 
+        if hasattr(model, "config") and hasattr(model.config, "max_position_embeddings"):
+            if "input_ids" in kwargs and kwargs["input_ids"] is not None and "max_new_tokens" in kwargs:
+                if kwargs["input_ids"].shape[-1] + kwargs["max_new_tokens"] > model.config.max_position_embeddings:
+                    raise ValueError(f'Unsloth: input length {kwargs["input_ids"].shape[-1]} + max_new_tokens {kwargs["max_new_tokens"]} exceeds `max_position_embeddings` {model.config.max_position_embeddings}! consider passing max_position_embeddings flag while initializing the model.')
+
         # Set a flag for generation!
         internal_model = model
         while hasattr(internal_model, "model"):


### PR DESCRIPTION
We have RoPE scaling but that only comes into effect when [`max_seq_length > config.max_position_embeddings`](https://github.com/unslothai/unsloth/blob/a2f8db3e7341f983af5814a2c56f54fa29ee548d/unsloth/models/llama.py#L1551).
So if someone created a model with `FastLanguageModel.from_pretrained(max_seq_len=2048)`, if the max_position_embeddings is say **32768**, inference works with RoPE till **32768** but Long Rope is not used. 
If someone initialises with `FastLanguageModel.from_pretrained(max_seq_len=131072)`, Long RoPE kicks in at init and inference would work till `max(max_seq_len, max_position_embeddings)` and then throw the error:

```
Error for input shape torch.Size([1, 25600]) Unsloth: input length 25600 + max_new_tokens 2 exceeds `max_position_embeddings` 16384! consider passing max_position_embeddings flag while initializing the model.
```