### PR TITLE
DOC Update - Update README.md with os.environ in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ import torch
 from transformers import TrainingArguments
 from trl import DPOTrainer
 
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = '0' # TO SELECT DIFFERENT DEVICES YOU CAN USE COMMA SEPARATED LIST - '1,2,3' or SINGLE DEVICE USE - '1'
+
 model, tokenizer = FastLanguageModel.from_pretrained(
     model_name = "unsloth/zephyr-sft-bnb-4bit",
     max_seq_length = max_seq_length,


### PR DESCRIPTION
Added OS Environ in example to avoid device conflicts , for a user at least in jupyter notebook this allows to select GPU in a multi GPU setup.  As currently the  unsloth init checks all GPU's and takes the first in the order which can be a issue when some GPU's are in use and the list still shows them. So to manually avoid this, this os config is required. Small change but a bit time saver for those who straight away copies the tutorials

I have seen one change similar to this changing throughout the code using a check method but I feel mentioning in tutorials or on ReadMe is more than enough, I can also try to change the whole code to leverage this, but adding new models 