### PR TITLE
fix/sft-trainer

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -174,4 +174,4 @@ from .tokenizer_utils import *
 from .trainer import *
 
 # patch sft trainer
-_patch_sft_trainer()
+_patch_trl_trainer()

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -172,3 +172,6 @@ from .save import *
 from .chat_templates import *
 from .tokenizer_utils import *
 from .trainer import *
+
+# patch sft trainer
+_patch_sft_trainer()

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -200,11 +200,13 @@ if Version(trl.__version__) >= Version("0.13.0.dev0"):
     def _patch_trl_trainer():
         import trl.trainer
         trl_classes = dir(trl.trainer)
-        trl_trainers = set(x[:-len("Trainer")] for x in trl_classes if x.endswith("Trainer"))
-        trl_configs  = set(x[:-len("Config")]  for x in trl_classes if x.endswith("Config"))
+
+        non_convertable_trainer = set(["PPOv2", "AlignProp"])
+        trl_trainers = set(x[:-len("Trainer")] for x in trl_classes if x.endswith("Trainer")) - non_convertable_trainer
+        trl_configs  = set(x[:-len("Config")]  for x in trl_classes if x.endswith("Config")) - non_convertable_trainer
         trl_classes = list(trl_trainers & trl_configs)
         for x in trl_classes:
-            exec(f"{x}Trainer.__init__ = create_backwards_compatible_trainer({x}Trainer, trl.{x}Config)", globals())
+            exec(f"trl.{x}Trainer.__init__ = create_backwards_compatible_trainer(trl.{x}Trainer, trl.{x}Config)", globals())
     pass
 else:
     def _patch_trl_trainer(): return


### PR DESCRIPTION
Since trl>=0.13.0.dev0, we need to move `['max_seq_length', 'dataset_num_proc', 'packing', 'dataset_text_field']` to `SFTConfig` .

Hence, we need to implement patch into `SFTTrainer` for backward compatibility. Here's an example of using old API on newest `trl`. Note that I give warning if it possible to user to move to `SFTConfig` instead.

![image](https://github.com/user-attachments/assets/bcfb61ff-0995-4825-8049-713f262075e4)

And here's using the new API :

![image](https://github.com/user-attachments/assets/4c175229-31ad-4426-bcd4-d2758574bce0)
