### PR TITLE
Fix/export mistral

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -32,8 +32,8 @@ import numpy as np
 # We do have a beta version, which you can contact us about!
 # Thank you for your understanding and we appreciate it immensely!
 
-# Fixing https://github.com/unslothai/unsloth/issues/1266
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = 'python'
+# Fixes https://github.com/unslothai/unsloth/issues/1266
+os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 if "CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -31,6 +31,10 @@ import numpy as np
 # enabling it will require much more work, so we have to prioritize. Please understand!
 # We do have a beta version, which you can contact us about!
 # Thank you for your understanding and we appreciate it immensely!
+
+# Fixing https://github.com/unslothai/unsloth/issues/1266
+os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = 'python'
+
 if "CUDA_VISIBLE_DEVICES" in os.environ:
     os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
     devices = os.environ["CUDA_VISIBLE_DEVICES"]

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -889,6 +889,11 @@ def save_to_gguf(
     #     "undergoing some major bug fixes as at 5th of May 2024. This is not an Unsloth issue.\n"\
     #     "Please be patient - GGUF saving should still work, but might not work as well."
     # )
+
+    # Fixes this issue
+    # https://github.com/unslothai/unsloth/issues/1266
+    os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = 'python'
+
     assert(model_dtype == "float16" or model_dtype == "bfloat16")
     model_dtype = "f16" if model_dtype == "float16" else "bf16"
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -889,11 +889,6 @@ def save_to_gguf(
     #     "undergoing some major bug fixes as at 5th of May 2024. This is not an Unsloth issue.\n"\
     #     "Please be patient - GGUF saving should still work, but might not work as well."
     # )
-
-    # Fixes this issue
-    # https://github.com/unslothai/unsloth/issues/1266
-    os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = 'python'
-
     assert(model_dtype == "float16" or model_dtype == "bfloat16")
     model_dtype = "f16" if model_dtype == "float16" else "bf16"
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -772,38 +772,10 @@ def install_llama_cpp_make_non_blocking():
 pass
 
 
-def install_python_non_blocking(packages=[]):
-    processes = []
-    
-    if "protobuf" in packages:
-        # First uninstall protobuf if it exists
-        uninstall_cmd = ["pip", "uninstall", "-y", "protobuf"]
-        processes.append(subprocess.Popen(uninstall_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT))
-        
-        # Install other packages (except protobuf) if any
-        other_packages = [pkg for pkg in packages if pkg != "protobuf"]
-        if other_packages:
-            install_cmd = ["pip", "install"] + other_packages
-            processes.append(subprocess.Popen(install_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT))
-        
-        # Install protobuf with special handling
-        protobuf_cmd = ["pip", "install", "--no-binary=protobuf", "protobuf"]
-        processes.append(subprocess.Popen(protobuf_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT))
-    else:
-        # Regular installation for other packages
-        full_command = ["pip", "install"] + packages
-        processes.append(subprocess.Popen(full_command, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT))
-    
-    # Return a wrapper object that can wait for all processes
-    class ProcessWrapper:
-        def __init__(self, processes):
-            self.processes = processes
-            
-        def wait(self):
-            for process in self.processes:
-                process.wait()
-    
-    return ProcessWrapper(processes)
+def install_python_non_blocking(packages = []):
+    full_command = ["pip", "install"] + packages
+    run_installer = subprocess.Popen(full_command, stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT)
+    return run_installer
 pass
 
 


### PR DESCRIPTION
Fix this issue by adding environment variables at the start of importing unsloth.

Tried adding it inside the `save_gguf` but it doesn't work .-.

![image](https://github.com/user-attachments/assets/33d12481-df41-4efb-a2e3-4af39d40d645)

Where did I find the solution -> https://github.com/protocolbuffers/protobuf/issues/3002#issuecomment-325459597

Will evaluate on other model first, then will open the PR

Need to create separate PR for testing on Kaggle since even `saving_to_gguf` doesn't work on Kaggle because of limited space (we haven't moved that function to `/tmp`)