### PR TITLE
fixed indentation error in models/_utils.py:209

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -197,17 +197,21 @@ if hasattr(transformers.cache_utils, "DynamicCache") and \
 
     source = inspect.getsource(transformers.cache_utils.DynamicCache.__getitem__)
     start = source.find("def")
-    spaces = start*" "
     source = source.split("\n")
     source = "\n".join(x[start:] for x in source)
+
     where = source.find("raise KeyError")
-    source = source[:where] + \
-        f"if len(self) == 0:\n{spaces}{spaces}"\
-        "    raise RuntimeError('Unsloth: You must call `FastLanguageModel.for_inference(model)` before doing inference for Unsloth models.')\n" + \
-        f"{spaces}{spaces}else:\n{spaces}{spaces}{spaces}" + source[where:]
+    source = (
+        source[:where] +
+        "if len(self) == 0:\n" +
+        "            raise RuntimeError('Unsloth: You must call `FastLanguageModel.for_inference(model)` before doing inference for Unsloth models.')\n" +
+        "        else:\n" +
+        source[where:]
+    )
     source = source.replace("__getitem__", "__cache_utils_getitem__", 1)
     exec(source)
     transformers.cache_utils.DynamicCache.__getitem__ = __cache_utils_getitem__
+
 pass
 # =============================================
 


### PR DESCRIPTION
Fixed this error I was getting while using FastInference
Traceback (most recent call last):

  File /opt/conda/lib/python3.10/site-packages/IPython/core/interactiveshell.py:3553 in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  Cell In[16], line 1
    from unsloth import FastLanguageModel

  File /opt/conda/lib/python3.10/site-packages/unsloth/__init__.py:170
    from .models import *

  File /opt/conda/lib/python3.10/site-packages/unsloth/models/__init__.py:15
    from .loader  import FastLanguageModel

  File /opt/conda/lib/python3.10/site-packages/unsloth/models/loader.py:15
    from ._utils import is_bfloat16_supported, HAS_FLASH_ATTENTION, HAS_FLASH_ATTENTION_SOFTCAPPING

  File /opt/conda/lib/python3.10/site-packages/unsloth/models/_utils.py:209
    exec(source)

  File <string>:25
    )if len(self) == 0:
                      ^
SyntaxError: invalid syntax