### PR TITLE
Fix too sensitive "Unsloth currently does not support multi GPU setups" when training with a single GPU in a multi-GPU environment.

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1646,11 +1646,11 @@ class FastLlamaModel:
             else:
                 inner_training_loop = Trainer._original_training_loop
         except:
-            raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
+            raise RuntimeError('llama.py:1649 Unsloth currently does not support multi GPU setups - but we are working on it!')
         pass
 
         if ((post_check - pre_check) >= 1).sum() > 1:
-            raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
+            raise RuntimeError('llama.py:1653 Unsloth currently does not support multi GPU setups - but we are working on it!')
 
         import transformers.trainer
         items_in_trainer = dir(transformers.trainer)
@@ -1675,17 +1675,23 @@ class FastLlamaModel:
         f"\\        /    Total batch size = {total_train_batch_size:,} | Total steps = {max_steps:,}\\n"\\
         f' "-____-"     Number of trainable parameters = {get_model_param_count(model, trainable_only=True):,}'
         logger.warning(debug_info)
-        import subprocess, re, gc, numpy as np
+        import subprocess, os, re, gc, numpy as np
+        index_for_cuda = os.environ.get("CUDA_VISIBLE_DEVICES", -1)
+        if "," in index_for_cuda:
+            raise RuntimeError("llama.py:1681 Unsloth currently does not support multi GPU setups - but we are working on it!")
+        index_for_cuda = int(index_for_cuda)
         a = np.array([0,])
         try:
             a = subprocess.check_output('nvidia-smi --query-gpu=memory.used --format=csv', shell = True)
             a = re.findall(rb'([\\d]{1,})[\\s]{1,}M', a)
             a = np.array([int(x.decode('utf-8'))/1024 for x in a])
+            if index_for_cuda != -1:
+                a = np.array([a[index_for_cuda],])
         except:
             if not torch.cuda.is_available():
                 raise RuntimeError('Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!')
         if ((a - PRE_CHECK) >= 1).sum() > 1:
-            raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
+            raise RuntimeError('llama.py:1694 Unsloth currently does not support multi GPU setups - but we are working on it!')
         for _ in range(3):
             gc.collect()
             torch.cuda.empty_cache()"""

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -964,7 +964,11 @@ def patch_sft_trainer_tokenizer():
 
         check_text = \
         "\n"\
-        "import subprocess, re, gc, numpy as np\n"\
+        "import subprocess, os, re, gc, numpy as np\n"\
+        "index_for_cuda = os.environ.get(\"CUDA_VISIBLE_DEVICES\", -1)\n"\
+        "if \",\" in index_for_cuda:\n"\
+        "    raise RuntimeError(\"tokenizer_utils.py:958 Unsloth currently does not support multi GPU setups - but we are working on it!\")\n"\
+        "index_for_cuda = int(index_for_cuda)\n"\
         "a = np.array([0,])\n"\
         "try:\n"\
         "    a = subprocess.check_output('nvidia-smi --query-gpu=memory.used --format=csv', shell = True)\n"\
@@ -974,7 +978,7 @@ def patch_sft_trainer_tokenizer():
         "    if not torch.cuda.is_available():\n"\
         "        raise RuntimeError('Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!')\n"\
         "if ((a - PRE_CHECK) >= 1).sum() > 1:\n"\
-        "    raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')\n"\
+        "    raise RuntimeError('tokenizer_utils.py:971 Unsloth currently does not support multi GPU setups - but we are working on it!')\n"\
         "for _ in range(3):\n"\
         "    gc.collect()\n"\
         "    torch.cuda.empty_cache()\n"\

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -830,12 +830,18 @@ pass
 
 
 def check_nvidia():
+    index_for_cuda = os.environ.get("CUDA_VISIBLE_DEVICES", -1)
+    if "," in index_for_cuda:
+        raise RuntimeError("Unsloth currently does not support multi GPU setups - but we are working on it!")
+    index_for_cuda = int(index_for_cuda)
     # Unsloth doesn't work yet on AMD devices - we're working on it!
     output = np.array([0,])
     try:
         output = subprocess.check_output("nvidia-smi --query-gpu=memory.used --format=csv", shell = True)
         output = re.findall(rb'([\d]{1,})[\s]{1,}M', output)
         output = np.array([int(x.decode('utf-8'))/1024 for x in output])
+        if index_for_cuda != -1:
+            output = np.array([output[index_for_cuda],])
     except:
         if not torch.cuda.is_available():
             raise RuntimeError("Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!")


### PR DESCRIPTION
Hi there,

this PR has the changes requested in #974. I unfortunately don't have a system where I can test this myself, but I have been testing it with other people on a cluster that has multiple GPUs. 

The only problem is that I think that the fix at [llama.py:1694](https://github.com/unslothai/unsloth/compare/main...giuliabaldini:unsloth:main#diff-a45b72bb533eda979990bd79cde5fe9c9fde424779a4f1fc1195b75853d93b45R1694) does not seem to work, as we are still getting the error. So to make it run we have actually removed this check. Any ideas of how to fix that? Is it problematic to remove that check there?

@hife-ai @Datta0 @Sehyo