### PR TITLE
Feat/kaggle-gguf-on-tmp

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -228,7 +228,7 @@ class FastLanguageModel(FastLlamaModel):
                 exist_config         = os.path.exists(os.path.join(model_name, "config.json"))
                 both_exist = exist_adapter_config and exist_config
             else:
-                files = HfFileSystem(token = token).glob(os.path.join(model_name, "*.json"))
+                files = HfFileSystem(token = token).glob(f"{model_name}/*.json")
                 files = (os.path.split(x)[-1] for x in files)
                 if sum(x == "adapter_config.json" or x == "config.json" for x in files) >= 2:
                     both_exist = True

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1806,6 +1806,9 @@ def unsloth_push_to_hub_gguf(
     del arguments["quantization_method"]
     del arguments["first_conversion"]
 
+    if IS_KAGGLE_ENVIRONMENT:
+        arguments["save_directory"] = os.path.join(KAGGLE_TMP, arguments["save_directory"])
+
     # Fix tokenizer adding an extra BOS token at the front
     fix_bos_token, old_chat_template = fix_tokenizer_bos_token(tokenizer)
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1906,6 +1906,10 @@ def unsloth_push_to_hub_gguf(
             if username not in new_save_directory else \
             new_save_directory.lstrip('/.')
 
+        if IS_KAGGLE_ENVIRONMENT:
+            # Take last 2 parts of the link
+            link = "/".join(link.split("/")[-2:])
+
         print(f"Saved GGUF to https://huggingface.co/{link}")
     pass
 
@@ -1915,6 +1919,10 @@ def unsloth_push_to_hub_gguf(
             self, repo_id, token,
             "GGUF converted", "gguf", modelfile_location, old_username, private,
         )
+        if IS_KAGGLE_ENVIRONMENT:
+            # Take last 2 parts of the link
+            link = "/".join(link.split("/")[-2:])
+
         print(f"Saved Ollama Modelfile to https://huggingface.co/{link}")
     pass
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1707,27 +1707,17 @@ def unsloth_save_pretrained_gguf(
     pass
 
     if IS_KAGGLE_ENVIRONMENT:
-        print(
-            "Unsloth: We zipped the file for you to download since we store it in the Kaggle",
-            f"{KAGGLE_TMP} directory.\n"\
-        )
-        from zipfile import ZipFile, ZIP_DEFLATED
-
         list_of_files = list(all_file_locations)
         if modelfile_location is not None:
             list_of_files.append(modelfile_location)
-        print(f"Unsloth: Zipping {list_of_files}...")
-        with ZipFile(os.path.join(KAGGLE_TMP, "unsloth_gguf.zip"), "w", compression=ZIP_DEFLATED) as zip_file:
-            for file in list_of_files:
-                try:
-                    zip_file.write(file)
-                except FileNotFoundError as _:
-                    logger.warning(f"Unsloth: file {file} not found. Skipping...")
-            pass
 
-        # Now expose the zipfile to user
-        from IPython.display import FileLink
-        FileLink(os.path.join(KAGGLE_TMP, "unsloth_gguf.zip"))
+        from IPython.display import FileLink, display
+
+        for file_location in list_of_files:
+            if file_location is not None:
+                display(FileLink(file_location))
+
+        logger.info("Unsloth: Click the above links to download the files.")
 
     if push_to_hub:
         print("Unsloth: Uploading GGUF to Huggingface Hub...")


### PR DESCRIPTION
Now we move all GGUF Process to `/tmp` so user can convert GGUF using Kaggle

We manage to save the GGUF on `/tmp` but now the problem is how user will download the GGUF since you can't access `/tmp` through GUI and [FileLink](https://www.kaggle.com/discussions/general/174345) seems not working .-.

Also fixing https://github.com/unslothai/unsloth/issues/1222 since  `HFFileSystem` is hardcoded to use linux format of forward slash instead of adapting to the user's OS

Here's my run for GGUF on Mistral 7b (I already fix the wrong name on the print, I am to lazy to rerun it again LOL)

![image](https://github.com/user-attachments/assets/482e6904-e739-4c41-8af5-ed73906d0e61)

Because the `save_pretrained_gguf` still not "solved" (need to discuss how to approach the download process). I put it as draft first
