### PR TITLE
Spectrum finetuing draft 

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -269,6 +269,39 @@ if is_openai_available():
 pass 
 
 # =============================================
+# git cloning spectrum
+def install_spectrum_clone_non_blocking():
+    import subprocess
+    full_command = ["git", "clone", "--recursive", "https://github.com/cognitivecomputations/spectrum"]
+    run_installer = subprocess.Popen(full_command, stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT)
+    return run_installer
+pass 
+
+# =============================================
+# run spectrum 
+def run_spectrum_script(model_name,top_percent=0.25):
+    # Ensure the repository has been cloned
+    clone_process = install_spectrum_clone_non_blocking()
+    clone_process.wait()  # Wait for cloning to complete
+    
+    # Navigate to the cloned directory
+    os.chdir("spectrum")
+    
+    # Run `spectrum.py` with the desired arguments
+    full_command = [
+        "python", 
+        "spectrum.py", 
+        "--model-name", str(model_name), 
+        "--top-percent", str(top_percent)
+    ]
+    
+    try:
+        result = subprocess.run(full_command, check=True, text=True, capture_output=True)
+        print("Spectrum output:", result.stdout)
+    except subprocess.CalledProcessError as e:
+        print("Error running spectrum.py:", e.stderr)
+
+# =============================================
 # Get Flash Attention v2 if Ampere (RTX 30xx, A100)
 import bitsandbytes as bnb
 from transformers import AutoTokenizer

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._utils import is_bfloat16_supported, HAS_FLASH_ATTENTION, HAS_FLASH_ATTENTION_SOFTCAPPING
+from ._utils import is_bfloat16_supported, HAS_FLASH_ATTENTION, HAS_FLASH_ATTENTION_SOFTCAPPING, install_spectrum_clone_non_blocking
 from .llama   import FastLlamaModel, logger
 from .mistral import FastMistralModel
 from .qwen2   import FastQwen2Model
@@ -159,6 +159,8 @@ class FastLanguageModel(FastLlamaModel):
             raise RuntimeError(autoconfig_error or peft_error)
         pass
 
+        if is_spectrum:
+            
         # Get base model for PEFT:
         if is_peft:
             # Check base model again for PEFT


### PR DESCRIPTION
# Feature request 
#1360  

### Issue 
The current implementation of the Spectrum library has issues when running in notebook environments (e.g., Jupyter or Colab) due to the use of terminal-specific interactive features. This leads to errors or non-functional behavior in notebooks, as the following code segments rely on terminal input:
```python 
def interactive_select_weights(self):
        weight_types = self.get_weight_types()
        sorted_weight_types = self.sort_weight_types(weight_types)
        selected_types = checkboxlist_dialog(
            title="Select Weight Types", 
            text="Deselect the weight types you do not want to scan for SNR:",
            values=[(wt, wt) for wt in sorted_weight_types],
            default_values=sorted_weight_types
        ).run()
        self.layer_types = selected_types
        return selected_types
```
and  
```python
batch_size = input_dialog(title="Batch Size", text="Enter the batch size:").run()
```

Tasks:
 -[ ] Refactor interactive sections to provide alternative non-interactive options, such as:
Allowing weight types and batch size to be passed as arguments or environment variables.
- [ ] Defaulting to sensible values when inputs are not explicitly provided.
- [ ] add spectrum to unsloth 
- [ ] benchmark against lora and qloar 

