### PR TITLE
Pass position embeddings explicitly from decoder layer.

### DIFF
--- a/unsloth/models/cohere.py
+++ b/unsloth/models/cohere.py
@@ -75,6 +75,7 @@ def CohereAttention_fast_forward(
     output_attentions:    bool = False,
     use_cache:            bool = False,
     padding_mask:         Optional[torch.LongTensor] = None,
+    position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     *args, **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
     
@@ -112,12 +113,11 @@ def CohereAttention_fast_forward(
     if past_key_value is not None:
         kv_seq_len += past_key_value[0].shape[-2]
 
+    cos, sin = position_embeddings
     if position_ids is None:
-        cos = self.rotary_emb.cos_cached
-        sin = self.rotary_emb.sin_cached
         Q, K = fast_rope_embedding(Q, K, cos, sin)
     else:
-        cos, sin = self.rotary_emb(V, seq_len = kv_seq_len)
+        cos, sin = cos[position_ids], sin[position_ids]
         Q, K = inplace_rope_embedding(Q, K, cos, sin, position_ids)
     pass
 
@@ -190,6 +190,7 @@ def CohereDecoderLayer_fast_forward(
     output_attentions:    Optional[bool] = False,
     use_cache:            Optional[bool] = False,
     padding_mask:         Optional[torch.LongTensor] = None,
+    position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     *args, **kwargs,
 ):
     if use_cache and hasattr(self, "_flag_for_generation"): #past_key_value is not None:

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -47,6 +47,7 @@ def MistralAttention_fast_forward(
     output_attentions:    bool = False,
     use_cache:            bool = False,
     padding_mask:         Optional[torch.LongTensor] = None,
+    position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     *args, **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
     


### PR DESCRIPTION
With [transformers master (probably 4.47.1)(or later)](https://github.com/huggingface/transformers/pull/34858), llama and derivatives expect position embeddings to be passed explicitly from decoder layer forward call. Update unsloth code to cater to that.