### PR TITLE
Model name

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1149,7 +1149,7 @@ def save_to_gguf(
     n_cpus *= 2
     # Concurrency from https://rentry.org/llama-cpp-conversions#merging-loras-into-a-model
 
-    final_location = str((Path(model_directory) / f"unsloth.{first_conversion.upper()}.gguf").absolute())
+    final_location = str((Path(model_directory) / f"{model_directory}.{first_conversion.upper()}.gguf").absolute())
     
     print(f"Unsloth: [1] Converting model at {model_directory} into {first_conversion} GGUF format.\n"\
           f"The output location will be {final_location}\n"\
@@ -1213,7 +1213,7 @@ def save_to_gguf(
     for quant_method in quantization_method:
         if quant_method != first_conversion:
             print(f"Unsloth: [2] Converting GGUF 16bit into {quant_method}. This might take 20 minutes...")
-            final_location = str((Path(model_directory) / f"unsloth.{quant_method.upper()}.gguf").absolute())
+            final_location = str((Path(model_directory) / f"{model_directory}.{quant_method.upper()}.gguf").absolute())
 
             command = f"./{quantize_location} {full_precision_location} "\
                 f"{final_location} {quant_method} {n_cpus}"


### PR DESCRIPTION
Thank you for this AWESOME project!

This PR change the default model name from unsloth to the same name as directory name. Reason: When we train many different models - they all have name like "unsloth.Q8_0.gguf" And we can't understand which model it is

But this way it looks great at HF! The model name is the same as directory name.
A little perfectionism if you like