### PR TITLE
Ensure Temporary Files (input_embeddings.pt or output_embeddings.pt) Are Saved in Relative Directory

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -736,7 +736,8 @@ transformers.utils.quantization_config.BitsAndBytesConfig.__init__ = _BitsAndByt
 import pickle
 
 def offload_to_disk(W, model, name, temporary_location : str = "_unsloth_temporary_saved_buffers"):
-    file_location = os.path.join(temporary_location, model.config._name_or_path)
+    model_name = os.path.basename(model.config._name_or_path) or model.config._name_or_path
+    file_location = os.path.join(temporary_location, model_name)
     if not os.path.exists(file_location):
         os.makedirs(file_location)
     pass


### PR DESCRIPTION
This PR modifies how temporary files (e.g., input_embeddings.pt and output_embeddings.pt) are stored, addressing the issue mentioned in #905. Specifically, it ensures that these files are saved in a relative directory (_unsloth_temporary_saved_buffers) based on the basename of model.config._name_or_path when it is an absolute path.

This issue has been a challenge for me because the model paths on my server are read-only, and modifications to the original directory were not feasible.

Let me know if there’s anything else to improve!