### PR TITLE
Give GGUF the same filename as project name

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1149,7 +1149,14 @@ def save_to_gguf(
     n_cpus *= 2
     # Concurrency from https://rentry.org/llama-cpp-conversions#merging-loras-into-a-model
 
-    final_location = str((Path(model_directory) / f"unsloth.{first_conversion.upper()}.gguf").absolute())
+    # Give GGUF the same filename as project name
+    if "/" not in model_directory:
+        gguf_filename = model_directory
+    else:
+        gguf_filename = model_directory.split('/')[-1]
+    pass
+    
+    final_location = str((Path(model_directory) / f"{gguf_filename}.{first_conversion.upper()}.gguf").absolute())
     
     print(f"Unsloth: [1] Converting model at {model_directory} into {first_conversion} GGUF format.\n"\
           f"The output location will be {final_location}\n"\
@@ -1213,7 +1220,7 @@ def save_to_gguf(
     for quant_method in quantization_method:
         if quant_method != first_conversion:
             print(f"Unsloth: [2] Converting GGUF 16bit into {quant_method}. This might take 20 minutes...")
-            final_location = str((Path(model_directory) / f"unsloth.{quant_method.upper()}.gguf").absolute())
+            final_location = str((Path(model_directory) / f"{gguf_filename}.{quant_method.upper()}.gguf").absolute())
 
             command = f"./{quantize_location} {full_precision_location} "\
                 f"{final_location} {quant_method} {n_cpus}"


### PR DESCRIPTION
Why?
Default filename is "unsloth" - and that's nice, but when you have multiple models on HF and try to download them to OpenWebUI - they all have the same name like "unsloth.8.0.gguf".

Tested in colab with local and HF saving of gguf.

Local save
```
INFO:hf-to-gguf:Set model quantization version
INFO:gguf.gguf_writer:Writing the following files:
INFO:gguf.gguf_writer:/content/test-llama-3.2-1B/test-llama-3.2-1B.Q8_0.gguf: n_tensors = 147, total_size = 1.3G
Writing: 100%|██████████| 1.31G/1.31G [00:25<00:00, 51.9Mbyte/s]
INFO:hf-to-gguf:Model successfully exported to /content/test-llama-3.2-1B/test-llama-3.2-1B.Q8_0.gguf
```

HF save
```
Unsloth: Conversion completed! Output location: /content/sebaxakerhtc/test-llama-3.2-1B-GGUF/test-llama-3.2-1B-GGUF.Q2_K.gguf
Unsloth: Saved Ollama Modelfile to sebaxakerhtc/test-llama-3.2-1B-GGUF/Modelfile
Unsloth: Uploading GGUF to Huggingface Hub...
100%
 1/1 [00:05<00:00,  5.84s/it]
test-llama-3.2-1B-GGUF.Q2_K.gguf: 
 592M/? [00:05<00:00, 371MB/s]
Saved GGUF to https://huggingface.co/sebaxakerhtc/test-llama-3.2-1B-GGUF
```