### PR TITLE
Export Model to ollama.com 

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1638,7 +1638,7 @@ def create_ollama_model(
         print(f"\nMODEL CREATED FAILED WITH RETURN CODE {return_code}")
     else:
         print("\nMODEL CREATED SUCCESSFULLY")
-    pass
+pass
 
 
 def push_to_ollama_hub(username: str, model_name: str, tag: str):
@@ -1672,6 +1672,41 @@ def push_to_ollama_hub(username: str, model_name: str, tag: str):
         print(f"\nMODEL PUBLISHED FAILED WITH RETURN CODE {return_code}")
     else:
         print("\nMODEL PUBLISHED SUCCESSFULLY")
+
+
+def push_to_ollama(
+    tokenizer,
+    gguf_location,
+    username: str,
+    model_name: str,
+    tag: str
+):
+    model_file = create_ollama_modelfile(
+        tokenizer=tokenizer,
+        gguf_location=gguf_location
+    )
+
+    with open(f"Modelfile_{model_name}", "w") as f:
+        f.write(model_file)
+        f.close()
+    
+    create_ollama_model(
+        username=username,
+        model_name=model_name,
+        tag=tag,
+        modelfile_path=f"Modelfile_{model_name}"
+    )
+
+    push_to_ollama_hub(
+        username=username,
+        model_name=model_name,
+        tag=tag
+    )
+
+    print("Succesfully pushed to ollama")
+
+
+
 
 
 def unsloth_save_pretrained_gguf(

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1602,6 +1602,44 @@ def create_ollama_modelfile(tokenizer, gguf_location):
     return modelfile
 pass
 
+def create_ollama_model(
+    username: str, 
+    model_name: str, 
+    tag: str, 
+    modelfile_path: str
+):
+    try:
+        init_check = subprocess.run(
+            ['curl', 'http://localhost:11434'], capture_output=True, text=True,  timeout=3
+        )
+        if init_check.returncode == 0:
+            print(init_check.stdout.strip())
+        else:
+            print("Ollama Server is not Running")
+    except subprocess.TimeoutExpired:
+        return "Ollama Request Timeout"
+
+    process = subprocess.Popen(
+            ['ollama', 'create', f'{username}/{model_name}:{tag}', '-f', f'{modelfile_path}'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True
+    )
+
+    for line in iter(process.stdout.readline, ''):
+        print(line, end='')
+        sys.stdout.flush()
+
+    return_code = process.wait()
+
+    if return_code != 0:
+        print(f"\nMODEL PUBLISHED FAILED WITH RETURN CODE {return_code}")
+    else:
+        print("\nMODEL PUBLISHED SUCCESSFULLY")
+    pass
+
 
 def push_to_ollama_hub(username: str, model_name: str, tag: str):
     try:

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -17,6 +17,7 @@ from bitsandbytes.nn import Linear4bit as Bnb_Linear4bit
 from peft.tuners.lora import Linear4bit as Peft_Linear4bit
 from peft.tuners.lora import Linear as Peft_Linear
 from typing import Optional, Callable, Union, List
+import requests
 import torch
 import os
 import shutil
@@ -1599,6 +1600,21 @@ def create_ollama_modelfile(tokenizer, gguf_location):
 
     return modelfile
 pass
+
+
+def push_to_ollama_hub(
+    model_name: str,
+    tag: str
+) -> str:  
+    print("Make sure to add the public key from ~/.ollama/id_ed22519.pub (in colab) to ollama.com")
+    response = requests.post(
+        "http://localhost:11434/api/push",
+        json={
+            "model": f"{model_name}:{tag}"
+        }
+    )
+
+    return response.status_code
 
 
 def unsloth_save_pretrained_gguf(

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1604,9 +1604,13 @@ pass
 
 def push_to_ollama_hub(
     model_name: str,
-    tag: str
+    tag: str,
+    username: str
 ) -> str:  
-    print("Make sure to add the public key from ~/.ollama/id_ed22519.pub (in colab) to ollama.com")
+    print(
+        "Make sure to add the public key from ~/.ollama/id_ed22519.pub (in colab) to ollama.com"
+    )
+    assert model_name.split("/")[0] == username, "Rename the model to <username>/<model_name>"
     response = requests.post(
         "http://localhost:11434/api/push",
         json={

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1635,9 +1635,9 @@ def create_ollama_model(
     return_code = process.wait()
 
     if return_code != 0:
-        print(f"\nMODEL PUBLISHED FAILED WITH RETURN CODE {return_code}")
+        print(f"\nMODEL CREATED FAILED WITH RETURN CODE {return_code}")
     else:
-        print("\nMODEL PUBLISHED SUCCESSFULLY")
+        print("\nMODEL CREATED SUCCESSFULLY")
     pass
 
 


### PR DESCRIPTION
## Fix for Download Issues from Colab

Many users faced issues downloading `.gguf` files while setting up Ollama servers. Follow these steps as an alternative:  
1. **Install Ollama:**  
   ```sh
   curl -fsSL https://ollama.com/install.sh | sh
   ```  

2. **Retrieve your Colab public key:**  
   ```sh
   !cat ~/.ollama/id_ed25519.pub
   ```  

3. **Add the key to your account** for authentication and seamless downloads.  

Additionally, with the contributed `push_to_ollama_hub` function, users can now **push models to [[ollama.com](https://ollama.com/)](https://ollama.com) directly from Colab**.  

This keeps it clean, direct, and easy to follow. 🚀