### PR TITLE
Bug-fix issue #1435 -  Llama architecture and multi-GPUs setup

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -25,7 +25,6 @@ __all__ = [
     "__version__",
     "HAS_FLASH_ATTENTION",
     "HAS_FLASH_ATTENTION_SOFTCAPPING",
-    "PRE_CHECK",
     "platform_system",
     "patch_tokenizer",
     "get_statistics",
@@ -37,7 +36,7 @@ __all__ = [
     "torch_compile_options",
     "patch_linear_scaling",
     "patch_llama_rope_scaling",
-    "check_nvidia",
+    "check_if_nvidia_is_installed",
     "create_boolean_mask",
     "torch_amp_custom_fwd",
     "torch_amp_custom_bwd",
@@ -957,20 +956,13 @@ def patch_llama_rope_scaling(
     return init_name, function
 pass
 
-
-def check_nvidia():
-    # Unsloth doesn't work yet on AMD devices - we're working on it!
-    output = np.array([0,])
-    try:
-        output = subprocess.check_output("nvidia-smi --query-gpu=memory.used --format=csv", shell = True)
-        output = re.findall(rb'([\d]{1,})[\s]{1,}M', output)
-        output = np.array([int(x.decode('utf-8'))/1024 for x in output])
-    except:
-        if not torch.cuda.is_available():
-            raise RuntimeError("Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!")    
-    return output
+def check_if_nvidia_is_installed():
+    if not torch.cuda.is_available():
+        raise RuntimeError("Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!")
 pass
-PRE_CHECK = check_nvidia()
+
+# We check if Nvidia is installer since we only support Nvidia for now.
+check_if_nvidia_is_installed()
 
 
 def create_boolean_mask(n = 4096, sliding_window = 2048):

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1749,8 +1749,6 @@ class FastLlamaModel:
             # Add to kwargs
             kwargs["rope_scaling"] = rope_scaling
         pass
-        # We currently only support NVIDIA GPUs - AMD / Intel is a work in progress!
-        pre_check = check_nvidia()
 
         bnb_config = None
         if load_in_4bit:
@@ -1818,8 +1816,6 @@ class FastLlamaModel:
         pass
         # Return old flag
         os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = old_hf_transfer
-        # We currently only support NVIDIA GPUs - AMD / Intel is a work in progress!
-        post_check = check_nvidia()
 
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name
@@ -1852,9 +1848,6 @@ class FastLlamaModel:
         except:
             raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
         pass
-
-        if ((post_check - pre_check) >= 1).sum() > 1:
-            raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
 
         import transformers.trainer
         items_in_trainer = dir(transformers.trainer)
@@ -1890,8 +1883,6 @@ class FastLlamaModel:
         except:
             if not torch.cuda.is_available():
                 raise RuntimeError('Unsloth: We do not support AMD / Intel machines yet - it is a work in progress!')
-        if ((a - PRE_CHECK) >= 1).sum() > 1:
-            raise RuntimeError('Unsloth currently does not support multi GPU setups - but we are working on it!')
         for _ in range(3):
             gc.collect()
             torch.cuda.empty_cache()"""

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -123,9 +123,6 @@ class FastBaseVisionModel:
 
         assert(dtype == torch.float16 or dtype == torch.bfloat16 or dtype == torch.float32)
 
-        # We currently only support NVIDIA GPUs - AMD / Intel is a work in progress!
-        pre_check = check_nvidia()
-
         bnb_config = None
         if load_in_4bit:
             bnb_config = BitsAndBytesConfig(
@@ -154,8 +151,6 @@ class FastBaseVisionModel:
         )
         # Return old flag
         os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = old_hf_transfer
-        # We currently only support NVIDIA GPUs - AMD / Intel is a work in progress!
-        post_check = check_nvidia()
 
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name


### PR DESCRIPTION
> See issue #1435 

> Some edits have been made to improve readability,

On a multi-GPUs setup, if one of the GPUs is in use and its memory size usage changes, it is impossible to use a Llama since a check is executed using [`check_nvidia`](https://github.com/unslothai/unsloth/blob/d1d15f1d14f1168837d29b9c08e9b6d63945d469/unsloth/models/_utils.py#L961), even if no other Llama architecture is in memory. The problem is that the check has two responsibilities:

1. It extracts the number of devices by using the memory size.
2. It checks if CUDA is installed on the device. 

According to the function name, I think the second responsibility is appropriate. Thus, I have proposed a new function with a clearer responsibility: it only verifies if CUDA is installed. Since this function is in the [`_utils.py`](unsloth/models/_utils.py) module and is called on every loading, I put the verification in this module and removed the other checks, `llama.py` and `vision.py`.

## The bug

Since the function verifies the memory usage of `N` CUDA devices, if the memory usage differs (increases or decreases) after loading the weights of a Llama architecture, it raises an error since it infers that the Llama model is loaded into multi-GPUs when, in fact, it is not. The bug is not consistent since a memory usage change needs to occur between the [ `pre_check`](https://github.com/unslothai/unsloth/blob/d1d15f1d14f1168837d29b9c08e9b6d63945d469/unsloth/models/llama.py#L1753) and the [`post_check`](https://github.com/unslothai/unsloth/blob/d1d15f1d14f1168837d29b9c08e9b6d63945d469/unsloth/models/llama.py#L1822) in `llama.py`. However, from my experimentation, I have faced this multiple times bug when I tried to train multiple different LLMs on a multi-GPU setup.

### Arguments
1. As an argument, the vision architecture also had the Nvidia check but did not use it.
2. It is not a robust method to check if a model is loaded into multiple GPUs (i.e. [`check_nvidia`](https://github.com/unslothai/unsloth/blob/d1d15f1d14f1168837d29b9c08e9b6d63945d469/unsloth/models/_utils.py#L961)).
3. Behavior and [`check_nvidia`](https://github.com/unslothai/unsloth/blob/d1d15f1d14f1168837d29b9c08e9b6d63945d469/unsloth/models/_utils.py#L961) depend on the setup and out-of-scope process (i.e., another process uses more or less memory).
