### PR TITLE
Add tool calling demo notebook to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All notebooks are **beginner friendly**! Add your dataset, click "Run All", and 
 | **Phi-4 (14B)** | [▶️ Start for free](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Phi_4-Conversational.ipynb)               | 2x faster | 70% less |
 | **Llama 3.2 Vision (11B)**      | [▶️ Start for free](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Llama3.2_(11B)-Vision.ipynb)               | 2x faster | 50% less |
 | **Llama 3.1 (8B)**      | [▶️ Start for free](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Llama3.1_(8B)-Alpaca.ipynb)               | 2x faster | 70% less |
+| **Llama 3.1 (8B) Tool Calling**      | [▶️ Start for free](https://colab.research.google.com/drive/1-1FbzLnx1DWRa8ysx5KUlhvRtaToCbvV?authuser=1#scrollTo=kR3gIAX-SM2q)               | 2x faster | 70% less |
 | **Gemma 2 (9B)**      | [▶️ Start for free](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Gemma2_(9B)-Alpaca.ipynb)               | 2x faster | 70% less |
 | **Qwen 2.5 (7B)**      | [▶️ Start for free](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Qwen2.5_(7B)-Alpaca.ipynb)               | 2x faster | 70% less |
 | **Mistral v0.3 (7B)**    | [▶️ Start for free](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Mistral_v0.3_(7B)-Conversational.ipynb)               | 2.2x faster | 75% less |


### PR DESCRIPTION
Adds a tool calling example notebook. Solves #1400 and partially #1561

Currently I'm linking to a personal colab link, but I can send a PR to unsloth/notebooks as well with the notebook. 

The example uses Llama-3.1-8b and [user-defined custom tools](https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_1/#user-defined-custom-tool-calling).