### PR TITLE
Fix/load lora save lora

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2080,6 +2080,22 @@ class FastLlamaModel:
         if r <= 0:
             raise TypeError(f"Unsloth: Rank of {str(r)} must be larger than 0.")
 
+        vllm_engine = None
+        if hasattr(model, "vllm_engine"):
+            # Fast inference!
+            vllm_engine = model.vllm_engine
+            vllm_fast_generate = model.fast_generate
+            vllm_fast_generate_batches = model.fast_generate_batches
+
+            import pdb; pdb.set_trace()
+
+            if modules_to_save is not None:
+                raise NotImplementedError("Unsloth: Currently fast inference does not work with training embeddings or lm_head.")
+
+            if bias != "none":
+                raise NotImplementedError("Unsloth: Currently fast inference does not work with using biases for LoRA.")
+        pass
+
         if isinstance(model, PeftModelForCausalLM):
             # Check if exactly the same and then pass through!
             assert(hasattr(model, "peft_config"))
@@ -2163,6 +2179,21 @@ class FastLlamaModel:
                     model.get_output_embeddings().original_module\
                         .to(device = "cpu", non_blocking = True)
                     model.get_output_embeddings().original_module.requires_grad_(False)
+                pass
+
+                # Now pass the vllm method to loaded model
+
+                # Patch for fast inference
+                if vllm_engine is not None:
+                    model.vllm_engine = vllm_engine
+                    model.fast_generate = vllm_fast_generate
+                    model.fast_generate_batches = vllm_fast_generate_batches
+
+                    # Also saving and loading LoRA
+                    from functools import partial
+                    from unsloth_zoo.vllm_utils import save_lora, load_lora
+                    model.save_lora = partial(save_lora, model)
+                    model.load_lora = partial(load_lora, model)
                 pass
 
                 return model
@@ -2331,19 +2362,6 @@ class FastLlamaModel:
             modules_to_save = list(set(modules_to_save))
         pass
 
-        vllm_engine = None
-        if hasattr(model, "vllm_engine"):
-            # Fast inference!
-            vllm_engine = model.vllm_engine
-            vllm_fast_generate = model.fast_generate
-            vllm_fast_generate_batches = model.fast_generate_batches
-
-            if modules_to_save is not None:
-                raise NotImplementedError("Unsloth: Currently fast inference does not work with training embeddings or lm_head.")
-
-            if bias != "none":
-                raise NotImplementedError("Unsloth: Currently fast inference does not work with using biases for LoRA.")
-        pass
 
         # Get LoRA
         arguments = dict(

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2087,8 +2087,6 @@ class FastLlamaModel:
             vllm_fast_generate = model.fast_generate
             vllm_fast_generate_batches = model.fast_generate_batches
 
-            import pdb; pdb.set_trace()
-
             if modules_to_save is not None:
                 raise NotImplementedError("Unsloth: Currently fast inference does not work with training embeddings or lm_head.")
 


### PR DESCRIPTION
People complaining that they can't use the LoRA with VLLM because `load_lora` method is not available. This is because when loading a LoRA model, `get_peft_model` goes into the  `Unsloth: Already have LoRA adapters! We shall skip this step.` patching. 

This PR is simply putting the patching inside that stage as well. We can't just move the patching to the beginning on the function or else when doing inference while training (like training GRPO), it'll do the inference only on the base model

This PR still has a flaw that the inference of vLLM has to be run once first before it's able to do inference on the loaded lora. Which maybe related of this part in the unsloth-zoo? 

https://github.com/unslothai/unsloth-zoo/blob/a9857088bdaf412bef36800d837a3a37657555c8/unsloth_zoo/vllm_utils.py#L1206-L1212

Related issue -> https://github.com/unslothai/unsloth/issues/1670#issuecomment-2671409852