### PR TITLE
Fix: GRPO with Mistral and importing

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -17,6 +17,30 @@ from packaging.version import Version
 import os, re, subprocess, inspect
 import numpy as np
 
+# unsloth/__init__.py
+# (Add this near the top, after other essential imports)
+
+# Check if modules that need patching are already imported
+critical_modules = ['trl', 'transformers', 'peft']
+already_imported = [mod for mod in critical_modules if mod in sys.modules]
+
+# This check is critical because Unsloth optimizes these libraries by modifying
+# their code at import time. If they're imported first, the original (slower, 
+# more memory-intensive) implementations will be used instead of Unsloth's
+# optimized versions, potentially causing OOM errors or slower training.
+
+if already_imported:
+    # stacklevel=2 makes warning point to user's import line rather than this library code,
+    # showing them exactly where to fix the import order in their script
+    warnings.warn(
+        f"WARNING: Unsloth should be imported before {', '.join(already_imported)} "
+        f"to ensure all optimizations are applied. Your code may run slower or encounter "
+        f"memory issues without these optimizations.\n\n"
+        f"Please restructure your imports with 'import unsloth' at the top of your file.",
+        stacklevel=2
+    )
+pass
+
 # Unsloth currently does not work on multi GPU setups - sadly we are a 2 brother team so
 # enabling it will require much more work, so we have to prioritize. Please understand!
 # We do have a beta version, which you can contact us about!

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -34,7 +34,7 @@ if already_imported:
         f"to ensure all optimizations are applied. Your code may run slower or encounter "
         f"memory issues without these optimizations.\n\n"
         f"Please restructure your imports with 'import unsloth' at the top of your file.",
-        stacklevel=2
+        stacklevel = 2,
     )
 pass
 

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -17,9 +17,6 @@ from packaging.version import Version
 import os, re, subprocess, inspect
 import numpy as np
 
-# unsloth/__init__.py
-# (Add this near the top, after other essential imports)
-
 # Check if modules that need patching are already imported
 critical_modules = ['trl', 'transformers', 'peft']
 already_imported = [mod for mod in critical_modules if mod in sys.modules]

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -293,7 +293,7 @@ def MistralForCausalLM_fast_forward(
         shift_logits = logits
         if not hasattr(self, "extra_ignored_labels"):
             # Fixes https://github.com/unslothai/unsloth/issues/10
-            self.extra_ignored_labels = torch.full((self.max_seq_length, 1), -100, device="cuda:0")
+            self.extra_ignored_labels = torch.full((self.max_seq_length, 1), -100, device = "cuda:0")
         pass
 
         shift_labels = torch.hstack((labels[..., 1:], self.extra_ignored_labels[:labels.shape[0]]))

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -257,7 +257,6 @@ def MistralForCausalLM_fast_forward(
     elif num_logits_to_keep != 0:
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :].to(lm_head.dtype))
     else:
-        # --- mirror the llama.py functionality
         RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
         # < 1024 Normal Unsloth uses less VRAM!
         if bsz * q_len <= 1024: RETURN_LOGITS = True

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -35,6 +35,7 @@ except:
     MistralSdpaAttention   = MistralAttention
     MistralFlashAttention2 = MistralAttention
 pass
+from unsloth_zoo.utils import Version, _get_dtype
 
 
 def MistralAttention_fast_forward(
@@ -287,6 +288,7 @@ def MistralForCausalLM_fast_forward(
         pass
         logits = self.lm_head(hidden_states.to(lm_head.dtype))
     pass
+    logits = logits.to(_get_dtype(self.config.torch_dtype))
 
     loss = None
     if labels is not None:

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -18,7 +18,6 @@ from ._utils import __version__
 from .llama import (
     LlamaRotaryEmbedding,
     LlamaLinearScalingRotaryEmbedding,
-    __DTYPE_MAP
 )
 from transformers.models.mistral.modeling_mistral import (
     MistralAttention,
@@ -220,33 +219,34 @@ def MistralForCausalLM_fast_forward(
         )
     else:
         outputs = self.model(
-            input_ids=input_ids,
-            causal_mask=causal_mask,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            inputs_embeds=inputs_embeds,
-            use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            input_ids = input_ids,
+            causal_mask = causal_mask,
+            attention_mask = attention_mask,
+            position_ids = position_ids,
+            past_key_values = past_key_values,
+            inputs_embeds = inputs_embeds,
+            use_cache = use_cache,
+            output_attentions = output_attentions,
+            output_hidden_states = output_hidden_states,
+            return_dict = return_dict,
         )
     pass
 
     hidden_states = outputs[0]
 
-    # --- if we are in GRPO mode, return raw hidden states
+    # If we are in GRPO mode, return raw hidden states
     if os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1":
         num_logits_to_keep = max(num_logits_to_keep, logits_to_keep)
         if num_logits_to_keep != 0:
             hidden_states = hidden_states[:, -num_logits_to_keep:, :]
         return CausalLMOutputWithPast(
-            loss=None,
-            logits=hidden_states,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
+            loss = None,
+            logits = hidden_states,
+            past_key_values = outputs.past_key_values,
+            hidden_states = outputs.hidden_states,
+            attentions = outputs.attentions,
         )
+    pass
 
     bsz, q_len, hd = hidden_states.shape
     lm_head = self.lm_head.weight
@@ -265,11 +265,11 @@ def MistralForCausalLM_fast_forward(
             n_items = kwargs.get("num_items_in_batch", None) or kwargs.get("n_items", None)
             logit_softcapping = getattr(self.config, "final_logit_softcapping", 0)
             loss = fused_linear_cross_entropy(
-                hidden_states=hidden_states,
-                lm_weight=lm_head,
-                labels=labels,
-                num_items_in_batch=n_items,
-                logit_softcapping=logit_softcapping,
+                hidden_states = hidden_states,
+                lm_weight = lm_head,
+                labels = labels,
+                num_items_in_batch = n_items,
+                logit_softcapping = logit_softcapping,
             )
 
             if not return_dict:
@@ -277,22 +277,15 @@ def MistralForCausalLM_fast_forward(
                 return (loss,) + output if loss is not None else output
             
             output = CausalLMOutputWithPast(
-                loss=loss,
-                logits=EMPTY_LOGITS,
-                past_key_values=outputs.past_key_values,
-                hidden_states=outputs.hidden_states,
-                attentions=outputs.attentions,
+                loss = loss,
+                logits = EMPTY_LOGITS,
+                past_key_values = outputs.past_key_values,
+                hidden_states = outputs.hidden_states,
+                attentions = outputs.attentions,
             )
             return output
         pass
         logits = self.lm_head(hidden_states.to(lm_head.dtype))
-    pass
-
-    torch_dtype = __DTYPE_MAP.get(self.config.torch_dtype, None)
-    if torch_dtype is not None:
-        logits = logits.to(torch_dtype)
-    else:
-        raise TypeError("Unsloth: torch_dtype for models is not bfloat16, float16 or float32!")
     pass
 
     loss = None
@@ -316,11 +309,11 @@ def MistralForCausalLM_fast_forward(
         return (loss,) + output if loss is not None else output
 
     return CausalLMOutputWithPast(
-        loss=loss,
-        logits=logits,
-        past_key_values=outputs.past_key_values,
-        hidden_states=outputs.hidden_states,
-        attentions=outputs.attentions,
+        loss = loss,
+        logits = logits,
+        past_key_values = outputs.past_key_values,
+        hidden_states = outputs.hidden_states,
+        attentions = outputs.attentions,
     )
 pass
 

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -18,6 +18,7 @@ from ._utils import __version__
 from .llama import (
     LlamaRotaryEmbedding,
     LlamaLinearScalingRotaryEmbedding,
+    __DTYPE_MAP
 )
 from transformers.models.mistral.modeling_mistral import (
     MistralAttention,
@@ -183,6 +184,7 @@ def MistralForCausalLM_fast_forward(
     output_hidden_states: Optional[bool] = None,
     return_dict: Optional[bool] = None,
     num_logits_to_keep: Optional[int] = 0,
+    logits_to_keep: Optional[int] = 0,
     *args, **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
 
@@ -194,7 +196,6 @@ def MistralForCausalLM_fast_forward(
         elif q_len <= sliding_window:
             causal_mask = xformers.attn_bias.LowerTriangularMask()
         else:
-            # Fix from https://github.com/Rypo
             causal_mask = xformers.attn_bias.BlockDiagonalCausalMask\
                 .from_seqlens([q_len]*bsz)\
                 .make_local_attention(window_size = sliding_window)
@@ -233,6 +234,20 @@ def MistralForCausalLM_fast_forward(
     pass
 
     hidden_states = outputs[0]
+
+    # --- if we are in GRPO mode, return raw hidden states
+    if os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1":
+        num_logits_to_keep = max(num_logits_to_keep, logits_to_keep)
+        if num_logits_to_keep != 0:
+            hidden_states = hidden_states[:, -num_logits_to_keep:, :]
+        return CausalLMOutputWithPast(
+            loss=None,
+            logits=hidden_states,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
     bsz, q_len, hd = hidden_states.shape
     lm_head = self.lm_head.weight
     if bsz == 1 and q_len == 1:
@@ -241,18 +256,53 @@ def MistralForCausalLM_fast_forward(
     elif num_logits_to_keep != 0:
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :].to(lm_head.dtype))
     else:
+        # --- mirror the llama.py functionality
+        RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
+        # < 1024 Normal Unsloth uses less VRAM!
+        if bsz * q_len <= 1024: RETURN_LOGITS = True
+
+        if not RETURN_LOGITS and HAS_CUT_CROSS_ENTROPY and labels is not None:
+            n_items = kwargs.get("num_items_in_batch", None) or kwargs.get("n_items", None)
+            logit_softcapping = getattr(self.config, "final_logit_softcapping", 0)
+            loss = fused_linear_cross_entropy(
+                hidden_states=hidden_states,
+                lm_weight=lm_head,
+                labels=labels,
+                num_items_in_batch=n_items,
+                logit_softcapping=logit_softcapping,
+            )
+
+            if not return_dict:
+                output = (logits,) + outputs[1:]
+                return (loss,) + output if loss is not None else output
+            
+            output = CausalLMOutputWithPast(
+                loss=loss,
+                logits=EMPTY_LOGITS,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
+            )
+            return output
+        pass
         logits = self.lm_head(hidden_states.to(lm_head.dtype))
     pass
-    logits = logits.to(self.config.torch_dtype)
+
+    torch_dtype = __DTYPE_MAP.get(self.config.torch_dtype, None)
+    if torch_dtype is not None:
+        logits = logits.to(torch_dtype)
+    else:
+        raise TypeError("Unsloth: torch_dtype for models is not bfloat16, float16 or float32!")
+    pass
 
     loss = None
     if labels is not None:
         shift_logits = logits
         if not hasattr(self, "extra_ignored_labels"):
             # Fixes https://github.com/unslothai/unsloth/issues/10
-            self.extra_ignored_labels = torch.full((self.max_seq_length, 1), -100, device = "cuda:0")
+            self.extra_ignored_labels = torch.full((self.max_seq_length, 1), -100, device="cuda:0")
         pass
-        
+
         shift_labels = torch.hstack((labels[..., 1:], self.extra_ignored_labels[:labels.shape[0]]))
         loss = fast_cross_entropy_loss(
             logits  = shift_logits,


### PR DESCRIPTION
This pull request solves two issues:
1. `MistralForCausalLM_fast_forward` method does not account for 'UNSLOTH_RETURN_HIDDEN_STATES' env variable causing GRPO trainer to break.
2. unsloth *must* be imported before trl/transformers/peft since it patches their source code (specifically trl). If either of those libraries imported first, the patching won't have any effect and that (a) may break training in some cases and (b) lead to OOM due to absence of some optimizations.

---

### Mistral GRPO

Current implementation of `MistralForCausalLM_fast_forward` method always returns logits which is incompatible with GRPOTrainer. Running training leads to the following exception:
```
TorchRuntimeError: Failed running call_function <built-in method matmul of type object at 0x74393685f240>(*(GradTrackingTensor(lvl=1, value=
    FakeTensor(..., device='cuda:0', size=(1, s0, 32001), dtype=torch.bfloat16,
               requires_grad=True)
), GradTrackingTensor(lvl=1, value=
    FakeTensor(..., device='cuda:0', size=(4096, 32001), dtype=torch.bfloat16)
)), **{}):
a and b must have same reduction dim, but got [s0, 32001] X [4096, 32001].

from user code:
   File "/workspace/research/grpo/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 100, in accumulate_chunk
    (chunk_grad_input,), (chunk_loss, (unscaled_loss, chunk_completion_length, chunk_mean_kl,)) = torch.func.grad_and_value(
  File "/opt/conda/lib/python3.11/site-packages/torch/_functorch/apis.py", line 442, in wrapper
    return eager_transforms.grad_and_value_impl(
  File "/opt/conda/lib/python3.11/site-packages/torch/_functorch/vmap.py", line 48, in fn
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.11/site-packages/torch/_functorch/eager_transforms.py", line 1407, in grad_and_value_impl
    output = func(*args, **kwargs)
  File "/workspace/research/grpo/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 80, in compute_loss
    new_logits = torch.matmul(new_hidden_states, lm_head.t())

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
```

I've implemented the necessary functionality following the example of `CausalLM_fast_forward` in llama.py. With that fix training runs as expected.

---

### Importing order

Importing trl (or any other dependencies with trl) before unsloth makes trainer patching lose its effect. 

I've spend a whole day trying to understand why my code either breaks or OOMs (while colab notebooks with essentially the same functionality work just fine) mid training till I had an AHA! moment to realize importing order is the issue.

To avoid such cases, I've implemented a simple check for imports in the top-level `__init__.py` that warns users if unsloth was imported after trl.