### PR TITLE
Direct windows support for unsloth

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,25 @@ You should install the latest version of your GPUs driver. You can download driv
  - [NVIDIA GPU Drive Download](https://www.nvidia.com/Download/index.aspx)
 
 ### Step 2: Visual Studio C++
-
 You will need Visual Studio, with C++ installed. By default, C++ is not installed with Visual Studio, so make sure you select all of the C++ options. Also select options for Windows 10/11 SDK.
- - [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/)
+  - [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/)
+<table>
+  <tr>
+    <td>
+      <img src="https://github.com/user-attachments/assets/d3e6ca95-85bb-442a-8c6f-81944300598e" alt="VSCode C++ Ref Image" width="400" height="350"/>
+    </td>
+    <td>
+      <div align="center">
+        <h1>Steps to configure VS C++</h1>
+      </div>
+      <ol>
+        <li>Launch the Installer downloaded from the link above.</li>
+        <li>In the installer, navigate to Individual components and select all the options mentioned in the image.</li>
+        <li>Click on install now.</li>
+      </ol>
+    </td>
+  </tr>
+</table>
 
 ### Step 3: CUDA Toolkit
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,32 @@ x = x.format(cuda.replace(".", ""), "-ampere" if is_ampere else "")
 print(f'pip install --upgrade pip && pip install "unsloth[{x}] @ git+https://github.com/unslothai/unsloth.git"')
 ```
 
-### Windows Installation
+## Windows Installation
+### Step 1: NVIDIA Video Driver
 
+You should install the latest version of your GPUs driver. You can download drivers here:
+ - [NVIDIA GPU Drive Download](https://www.nvidia.com/Download/index.aspx)
+
+### Step 2: Visual Studio C++
+
+You will need Visual Studio, with C++ installed. By default, C++ is not installed with Visual Studio, so make sure you select all of the C++ options. Also select options for Windows 10/11 SDK.
+ - [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/)
+
+### Step 3: CUDA Toolkit
+
+ - [Download CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive)
+
+### Step 4: Install PyTorch 
+
+You will need the correct version of PyTorch that is compatibile with your CUDA drivers, so make sure to select them carefully
+ - [Install PyTorch](https://pytorch.org/get-started/locally/)
+
+### Step 5: Install Unsloth
+```python
+pip install "unsloth[windows] @ git+https://github.com/unslothai/unsloth.git"
+```
+
+### Side note
 To run Unsloth directly on Windows:
 - Install Triton from this Windows fork and follow the instructions: https://github.com/woct0rdho/triton-windows (be aware that the Windows fork requires PyTorch >= 2.4 and CUDA 12)
 - In the SFTTrainer, set `dataset_num_proc=1` to avoid a crashing issue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ exclude = ["images*"]
 
 [project.optional-dependencies]
 triton = [
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post5/triton-3.1.0-cp312-cp312-win_amd64.whl ; python_version=='3.12' and platform_system == 'Windows'",
     "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp39-cp39-win_amd64.whl ; python_version=='3.9' and platform_system == 'Windows'",
     "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp310-cp310-win_amd64.whl ; python_version=='3.10' and platform_system == 'Windows'",
     "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp311-cp311-win_amd64.whl ; python_version=='3.11' and platform_system == 'Windows'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,33 @@ exclude = ["images*"]
 
 [project.optional-dependencies]
 triton = [
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post5/triton-3.1.0-cp39-cp39-win_amd64.whl ; python_version=='3.9' and platform_system == 'Windows'",
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post5/triton-3.1.0-cp310-cp310-win_amd64.whl ; python_version=='3.10' and platform_system == 'Windows'",
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post5/triton-3.1.0-cp311-cp311-win_amd64.whl ; python_version=='3.11' and platform_system == 'Windows'",
     "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post5/triton-3.1.0-cp312-cp312-win_amd64.whl ; python_version=='3.12' and platform_system == 'Windows'",
+    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp39-cp39-win_amd64.whl ; python_version=='3.9' and platform_system == 'Windows'",
+    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp310-cp310-win_amd64.whl ; python_version=='3.10' and platform_system == 'Windows'",
+    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp311-cp311-win_amd64.whl ; python_version=='3.11' and platform_system == 'Windows'",
+    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp312-cp312-win_amd64.whl ; python_version=='3.12' and platform_system == 'Windows'"
+]
+
+windows=[
+    "unsloth_zoo>=2025.2.7",
+    "packaging",
+    "tyro",
+    "transformers>=4.46.1,!=4.47.0",
+    "datasets>=2.16.0",
+    "sentencepiece>=0.2.0",
+    "tqdm",
+    "psutil",
+    "wheel>=0.42.0",
+    "numpy",
+    "accelerate>=0.34.1",
+    "trl>=0.7.9,!=0.9.0,!=0.9.1,!=0.9.2,!=0.9.3,!=0.15.0",
+    "peft>=0.7.1,!=0.11.0",
+    "protobuf<4.0.0",
+    "huggingface_hub",
+    "hf_transfer",
+    "unsloth[triton]",
+    "bitsandbytes>=0.41.1 ; platform_system == 'Windows'",
+    "xformers>=0.0.22.post7 ; platform_system == 'Windows'",
 ]
 huggingface = [
     "unsloth_zoo>=2025.2.7",


### PR DESCRIPTION
This PR is a continuation of #1821 

# Direct Windows support for Unsloth
## Feature Overview
These changes allow user to install unsloth on windows directly without any dependency issues using a simple command:
```python
pip install "unsloth[windows] @ git+https://github.com/unslothai/unsloth.git"
```
## Implementation Details
- Updated pyproject.toml to allow installation of unsloth and all its dependencies directly without manual work.
## Reasoning
- First issue was to configure GPU by installing GPU drivers and CUDA drivers. This is a necessary prerequisite for PyTorch to utilize GPU acceleration.
- As the PyTorch version depends on the versions of CUDA drivers used, we need to install PyTorch specific to the CUDA drivers installed previously. Mismatched versions often cause compatibility issues.
- On Windows, we need Windows SDK and a compatible C/C++ compiler to run some dependencies, so using Microsoft Visual C++ (MSVC) we can easily install those required components for proper compilation.
- Finally, we updated **pyproject.toml** to support direct installation of all dependencies and **unsloth**, ensuring the package can be installed with a **single command** without manual intervention.
## Testing Details
- Tested on 4 python versions: 3.9, 3.10, 3.11, 3.12.
- Tested for 3 different CUDA versions - 11.8, 12.4, 12.6
- Tested on 2 windows machines with different GPUs to test support across different drivers - GTX 1650, RTX 3050
## Contributors
This feature was developed in collaboration with [@Captain-T2004](https://github.com/Captain-T2004).