### PR TITLE
Fix Layernorm when num_cols not a power of 2

### DIFF
--- a/unsloth/kernels/layernorm.py
+++ b/unsloth/kernels/layernorm.py
@@ -49,6 +49,7 @@ def layernorm_forward(
     b_row = tl.load(b + col_offsets, mask = mask, other = 0).to(tl.float32)
 
     mean_X  = tl.sum(X_row,   axis = 0) / n_cols
+    # (X[0] - mean) == -mean so we need to mask it out
     XX = tl.where(mask, X_row - mean_X, 0)
     row_var = tl.sum(XX * XX, axis = 0) / n_cols
     inv_var = tl.math.rsqrt(row_var + eps)

--- a/unsloth/kernels/layernorm.py
+++ b/unsloth/kernels/layernorm.py
@@ -49,7 +49,7 @@ def layernorm_forward(
     b_row = tl.load(b + col_offsets, mask = mask, other = 0).to(tl.float32)
 
     mean_X  = tl.sum(X_row,   axis = 0) / n_cols
-    XX      = X_row - mean_X
+    XX = tl.where(mask, X_row - mean_X, 0)
     row_var = tl.sum(XX * XX, axis = 0) / n_cols
     inv_var = tl.math.rsqrt(row_var + eps)
     tl.store (r, inv_var)


### PR DESCRIPTION
### Handling Non-Power-of-Two Input Dimensions in the Forward Pass  

During the forward pass, if the number of columns in the input matrix is **not** a power of two, it gets **padded with zeros** to the nearest power-of-two value.  

However, this introduces an issue when computing:  

```math
XX = X_{\text{row}} - \text{mean}_X
```

For the padded columns, `XX` contains `-mean_X` instead of zero. This incorrectly affects the computation of `inv_var`, which should **only consider the original (non-padded) values**.  

### Why This Issue Was Overlooked  
The existing tests do not cover this case since they only use input dimensions that are already powers of two.  

### Solution  
To fix this, we should apply a **mask** when computing `XX` to ensure that padded values do not interfere with `inv_var`.  