### PR TITLE
fix/enable flex_attention

### DIFF
--- a/unsloth/kernels/flex_attention.py
+++ b/unsloth/kernels/flex_attention.py
@@ -32,7 +32,7 @@ try:
         create_block_mask as _create_block_mask,
     )
     _flex_attention = torch.compile(_flex_attention, dynamic = True, options = torch_compile_options)
-    HAS_FLEX_ATTENTION = False
+    HAS_FLEX_ATTENTION = True
 except:
     HAS_FLEX_ATTENTION = False
 pass


### PR DESCRIPTION
this line weirdly have two paths false for flex attention, is it a bug?:
```
try:
    from torch.nn.attention.flex_attention import (
        flex_attention as _flex_attention,
        create_block_mask as _create_block_mask,
    )
    _flex_attention = torch.compile(_flex_attention, dynamic = True, options = torch_compile_options)
    HAS_FLEX_ATTENTION = False
except:
    HAS_FLEX_ATTENTION = False
pass
```

first one should have

`HAS_FLEX_ATTENTION = True`