### PR TITLE
Update RMS LayerNorm implementation, and list compr. change in chat templates

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1506,10 +1506,7 @@ def get_ollama_eos_tokens(tokenizer, extra_eos_tokens = []):
 
     # Remove duplicates
     splitted = joined_text.split("\x01\x00")
-    final_eos_tokens = []
-    for old, new in zip(added_tokens_decoder, splitted):
-        if old == new: final_eos_tokens.append(old)
-    pass
+    final_eos_tokens = [old for old, new in zip(added_tokens_decoder, splitted) if old == new]
     final_eos_tokens += extra_eos_tokens
     final_eos_tokens += repeatted_tokens
 

--- a/unsloth/kernels/rms_layernorm.py
+++ b/unsloth/kernels/rms_layernorm.py
@@ -253,7 +253,6 @@ def unpatch_rms_layernorm():
     except:
         pass
     return
-    return
 pass
 
 


### PR DESCRIPTION
I think we dont need the double return?

also, replaced a for loop with list comp in chat_templates