### PR TITLE
Updated pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [here](https://github.com/unslothai/unsloth/edit/main/README.md#advanced-pip
 7. **Install Unsloth:**
    
 ```python
-pip install "unsloth[windows] @ git+https://github.com/unslothai/unsloth.git"
+pip install unsloth
 ```
 
 #### Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "xformers>=0.0.27.post2",
     "bitsandbytes",
     "triton>=3.0.0 ; platform_system == 'Linux'",
+    "triton-windows ; platform_system == 'Windows'",
     "packaging",
     "tyro",
     "transformers>=4.46.1,!=4.47.0",


### PR DESCRIPTION
Triton can directly be installed using pip
``` python
pip install triton-windows
```

Unnecessary links have been removed, allowing: ```pip install unsloth ``` to work seamlessly after setting up Torch and CUDA. 