### PR TITLE
Triton windows update

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [here](https://github.com/unslothai/unsloth/edit/main/README.md#advanced-pip
 7. **Install Unsloth:**
    
 ```python
-pip install "unsloth[windows] @ git+https://github.com/unslothai/unsloth.git"
+pip install unsloth
 ```
 
 #### Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,7 @@ exclude = ["images*"]
 
 [project.optional-dependencies]
 triton = [
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp39-cp39-win_amd64.whl ; python_version=='3.9' and platform_system == 'Windows'",
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp310-cp310-win_amd64.whl ; python_version=='3.10' and platform_system == 'Windows'",
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp311-cp311-win_amd64.whl ; python_version=='3.11' and platform_system == 'Windows'",
-    "triton @ https://github.com/woct0rdho/triton-windows/releases/download/v3.2.0-windows.post10/triton-3.2.0-cp312-cp312-win_amd64.whl ; python_version=='3.12' and platform_system == 'Windows'"
+    "triton-windows ; platform_system == 'Windows'",
 ]
 
 huggingface = [


### PR DESCRIPTION
Triton can be installed directly on windows using 
```python
pip install triton-windows
```
So, this patch along with #1975 will replace unnecessary links from pyproject.toml and to make windows installation easier