### PR TITLE
Add load_in_16bit Parameter and Fix 8-bit Quantization Config

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -294,7 +294,8 @@ class FastBaseModel:
         kwargs.pop("attn_implementation", None); # No need since we auto call it
 
         # Cannot be None, since HF now checks for the config
-        if load_in_4bit: kwargs["quantization_config"] = bnb_config
+        if load_in_4bit or load_in_8bit: 
+            kwargs["quantization_config"] = bnb_config
 
         model = auto_model.from_pretrained(
             model_name,

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -296,6 +296,9 @@ class FastBaseModel:
         # Cannot be None, since HF now checks for the config
         if load_in_4bit or load_in_8bit: 
             kwargs["quantization_config"] = bnb_config
+            
+        # Remove load_in_16bit from kwargs as it's not a valid parameter for transformers
+        kwargs.pop("load_in_16bit", None)
 
         model = auto_model.from_pretrained(
             model_name,


### PR DESCRIPTION
This pull request introduces a new parameter, `load_in_16bit`, across our model loading functions and fixes an issue with 8-bit quantization configuration. 

**Current Issues Addressed:**

1. **No 16-bit LoRA Support:** Currently, there is no way to train a model with 16-bit precision using the FastModel class because the code automatically falls back to QLoRA (4-bit) if none of the following arguments are set to True: `load_in_4bit`, `load_in_8bit`, or `full_finetuning`. This creates a significant limitation for users who want to use 16-bit LoRA finetuning.

2. **8-bit Quantization Config Bug:** The code was only checking for `load_in_4bit` when setting the `quantization_config` parameter, which meant that proper 8-bit finetuning wasn't being configured correctly even when `load_in_8bit=True` was specified.

**Key Changes:**

• Added `load_in_16bit` parameter to FastBaseModel.from_pretrained, FastModel.from_pretrained, and FastLanguageModel.from_pretrained with a default value of False.

• Fixed the quantization config logic to properly set `kwargs["quantization_config"] = bnb_config` when either `load_in_4bit` OR `load_in_8bit` is True. Before it only checked for `load_in_4bit` value.

• Implemented logic to check for conflicting loading options (load_in_4bit, load_in_8bit, load_in_16bit, and full_finetuning) so that only one can be enabled at a time.

• Added code to remove load_in_16bit from kwargs before calling the Transformers library's from_pretrained to avoid passing an invalid parameter to Transformers.

• Updated the fallback logic to consider the new load_in_16bit parameter before defaulting to QLoRA.

**Benefits:**

• Enables explicit 16-bit LoRA finetuning without falling back to 4-bit quantization.

• Fixes 8-bit quantization configuration, ensuring proper setup when users select 8-bit training.

• Provides a clearer and flexible API for users who wish to load models in different precision formats.
