### PR TITLE
Ensure trust_remote_code propagates down to unsloth_compile_transformers

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -644,6 +644,7 @@ class FastModel(FastBaseModel):
                 import_from_cache       = False,
                 disable                 = False,
                 return_logits           = return_logits,
+                trust_remote_code       = trust_remote_code,
             )
         pass
 


### PR DESCRIPTION
While attempting to run GRPO over `phi4-mini-instruct` yesterday, I hit persistent failures trying to start the training run due to `trust-remote_code` being False, even if I set it in my call to `from_pretrained`.

Walking the stack trace, I noticed that this variable wasn't making it into the call into `unsloth_compile_transformers` - it seems to get me past this error, though I've been unable to start training the model for other reasons.