### PR TITLE
remove dead code from fast_rms_layernorm_inference

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -303,7 +303,6 @@ pass
 torch_square = torch.square
 torch_mean   = torch.mean
 def fast_rms_layernorm_inference(self, X, XX = None, XX2 = None, variance = None):
-    old_dtype = X.dtype
     if XX is None:
         XX = X.to(torch.float32)
         variance = XX.square().mean(-1, keepdim = True)
@@ -314,8 +313,7 @@ def fast_rms_layernorm_inference(self, X, XX = None, XX2 = None, variance = None
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
-    if XX is None: X = XX.to(old_dtype)
-    else: X.copy_(XX)
+    X.copy_(XX)
 
     X *= self.weight
     return X


### PR DESCRIPTION
If XX is None it will error out on 
```python
XX *= variance.rsqrt_()
```
also I'd like to know:
1) why `X.copy_(XX)` over `X[:] = XX`
2) what is the purposed of doing `torch_square = torch.square` outside the function?

Thank you for your work on unsloth!