### PR TITLE
vLLM Windows CUDA support [tested]

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1654,10 +1654,11 @@ class FastLlamaModel:
             )
         pass
         if fast_inference:
-            import platform
-            if platform.system().lower() == 'windows':
-                print("Unsloth: vLLM does not work in Windows! Will use Unsloth inference!")
-                fast_inference = False
+            from transformers.utils.import_utils import _is_package_available
+            _vllm_available = _is_package_available("vllm")
+            if _vllm_available == False:
+                  print("Unsloth: vLLM is not installed! Will use Unsloth inference!")
+                  fast_inference = False
             major_version, minor_version = torch.cuda.get_device_capability()
             if major_version < 7:
                 print("Unsloth: vLLM does not work on older GPUs - will switch to Unsloth inference!")

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -339,10 +339,12 @@ class FastLanguageModel(FastLlamaModel):
 
         if fast_inference:
             import platform
-            if platform.system().lower() == 'windows':
-                print("Unsloth: vLLM does not work in Windows! Will use Unsloth inference!")
-                fast_inference = False
-            pass
+            from transformers.utils.import_utils import _is_package_available
+            _vllm_available = _is_package_available("vllm")
+            if _vllm_available == False:
+                  print("Unsloth: vLLM is not installed! Will use Unsloth inference!")
+                  fast_inference = False
+                  pass
             from unsloth_zoo.vllm_utils import (
                 patch_vllm, 
                 vllm_dynamic_quant_supported,


### PR DESCRIPTION
[vLLM Windows CUDA support ](https://github.com/vllm-project/vllm/issues/14981)

[vllm-windows](https://github.com/SystemPanic/vllm-windows) Windows wheels by [SystemPanic](https://github.com/SystemPanic)

install 
```bash
conda create -n vllm python=3.12
conda activate vllm
pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
pip install https://github.com/SystemPanic/vllm-windows/releases/download/v0.8.1/vllm-0.8.1+cu124-cp312-cp312-win_amd64.whl
pip install https://github.com/SystemPanic/flashinfer-windows/releases/download/v0.2.3/flashinfer_python-0.2.3+cu124torch2.6-cp312-cp312-win_amd64.whl
pip install --upgrade pillow
pip install --upgrade pandas
pip install --upgrade triton-windows
pip install grpcio==1.71.0
pip install "unsloth[windows] @ git+https://github.com/fenglui/unsloth.git"
pip install --no-deps git+https://github.com/huggingface/transformers.git
pip install trl==0.15.2
```
training test

download https://github.com/unslothai/notebooks/blob/main/nb/Qwen2.5_(3B)-GRPO.ipynb

remove the installation code block

add code block at top

```
import torch
print('PyTorch version:', torch.__version__)
import vllm
print('vllm version:', vllm.__version__)
from transformers.utils.import_utils import _is_package_available
_vllm_available = _is_package_available("vllm")
print(_vllm_available)

import os
os.environ['UNSLOTH_DISABLE_AUTO_UPDATES'] = '1'
os.environ["VLLM_USE_V1"] = "0"

import platform
if platform.system() == "Windows":
    # Disable libuv on Windows by default
    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")
else:
    # https://www.kaggle.com/competitions/ai-mathematical-olympiad-progress-prize-2/discussion/560682#3113134
    os.environ["TRITON_PTXAS_PATH"] = "/usr/local/cuda/bin/ptxas"
```

then you can run the rest of the training code.

if the vllm serve faild, add env var "USE_LIBUV" and set value "0" to your windows system var

and that's it, we can run unsloth training with vllm support with Windows.
