### PR TITLE
loader.py: when dispatching to FastModel, use original model name

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -306,7 +306,7 @@ class FastLanguageModel(FastLlamaModel):
         #     dispatch_model = FastGraniteModel
         else:
             return FastModel.from_pretrained(
-                model_name                 = model_name,
+                model_name                 = old_model_name,
                 max_seq_length             = max_seq_length,
                 dtype                      = dtype,
                 load_in_4bit               = load_in_4bit,


### PR DESCRIPTION
When the original model_name refers to a saved LoRA checkpoint, we rewrite it to point to the base model on line 233 here -- and as a result, FastModel loads from the base model, ignoring the LoRA.