### PR TITLE
Fix feature_request ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
-about: Suggest an idea: new algorithm, model, kernel, etc.
+about: "Suggest an idea: new algorithm, model, kernel, etc."
 title: "[FEAT]"
-labels: feature request
+labels: "feature request"
 assignees: ''
 
 ---


### PR DESCRIPTION
Previous `feature request` template was not displaying due to a formatting error in one of the template fields, and was therefore not showing up when a user clicked on "New Issue".

This patch should fix this.