### PR TITLE
feat: Support custom `auto_model` for wider model compatibility (Whisper, Bert,etc) & `attn_implementation` support

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -468,14 +468,15 @@ class FastModel(FastBaseModel):
         revision                   = None,
         return_logits              = False, # Return logits
         fullgraph                  = True, # No graph breaks
+        use_exact_model_name       = False,
         auto_model                 = None,
         whisper_language           = None,
         whisper_task               = None,
-        use_exact_model_name       = False,
         *args, **kwargs,
     ):
         if token is None: token = get_token()
-
+        if whisper_language is not None: assert(type(whisper_language) is str)
+        if whisper_task is not None: assert(type(whisper_task) is str)
         SUPPORTS_BFLOAT16 = is_bfloat16_supported()
         if dtype is None:
             dtype = torch.float16 if not SUPPORTS_BFLOAT16 else torch.bfloat16
@@ -712,7 +713,7 @@ class FastModel(FastBaseModel):
         # Check if VLM
         is_vlm = any(x.endswith("ForConditionalGeneration") for x in model_config.architectures)
         is_vlm = is_vlm or hasattr(model_config, "vision_config")
-        if not auto_model:
+        if auto_model is None:
             auto_model = AutoModelForVision2Seq if is_vlm else AutoModelForCausalLM
 
         model, tokenizer = FastBaseModel.from_pretrained(

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -468,6 +468,9 @@ class FastModel(FastBaseModel):
         revision                   = None,
         return_logits              = False, # Return logits
         fullgraph                  = True, # No graph breaks
+        auto_model                 = None,
+        whisper_language           = None,
+        whisper_task               = None,
         use_exact_model_name       = False,
         *args, **kwargs,
     ):
@@ -709,7 +712,8 @@ class FastModel(FastBaseModel):
         # Check if VLM
         is_vlm = any(x.endswith("ForConditionalGeneration") for x in model_config.architectures)
         is_vlm = is_vlm or hasattr(model_config, "vision_config")
-        auto_model = AutoModelForVision2Seq if is_vlm else AutoModelForCausalLM
+        if not auto_model:
+            auto_model = AutoModelForVision2Seq if is_vlm else AutoModelForCausalLM
 
         model, tokenizer = FastBaseModel.from_pretrained(
             model_name        = model_name,
@@ -727,6 +731,8 @@ class FastModel(FastBaseModel):
             auto_model        = auto_model,
             use_gradient_checkpointing = use_gradient_checkpointing,
             supports_sdpa     = supports_sdpa,
+            whisper_language  = whisper_language,
+            whisper_task      = whisper_task,            
             *args, **kwargs,
         )
 

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -371,7 +371,9 @@ class FastBaseModel:
 
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name
-        auto_processor = AutoProcessor if (auto_model is AutoModelForVision2Seq ) or (whisper_language and whisper_task) else AutoTokenizer
+        is_vlm = (auto_model is AutoModelForVision2Seq)
+        is_whisper = (whisper_language is not None and whisper_task is not None)
+        auto_processor = AutoProcessor if (is_vlm or is_whisper) else AutoTokenizer
         if whisper_language and whisper_task:
            tokenizer = auto_processor.from_pretrained(
                 tokenizer_name,
@@ -482,7 +484,7 @@ class FastBaseModel:
         modules_to_save            = None,
         init_lora_weights          = True,
         loftq_config               = {},
-        task_type                = TaskType.CAUSAL_LM,
+        task_type                  = TaskType.CAUSAL_LM,
         temporary_location         = "_unsloth_temporary_saved_buffers",
         **kwargs,
     ):

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -306,7 +306,8 @@ class FastBaseModel:
             do_forced_float32 = True
         pass
         # Stop SDPA for some archs like Pixtral / Mistral3
-        kwargs["attn_implementation"] = "sdpa"
+        if not ("attn_implementation" in kwargs):
+            kwargs["attn_implementation"] = "sdpa"
         if not supports_sdpa:
             print(f"Unsloth: {model_type_arch.title()} does not support SDPA - switching to eager!")
             del kwargs["attn_implementation"]
@@ -505,7 +506,7 @@ class FastBaseModel:
             finetune_attention_modules = True
             finetune_mlp_modules       = True
         pass
-        if target_modules is None:
+        if target_modules is None or target_modules == "all-linear":
             target_modules = get_peft_regex(
                 model,
                 finetune_vision_layers     = finetune_vision_layers,
@@ -516,7 +517,7 @@ class FastBaseModel:
         else:
             assert(type(target_modules) in (list, tuple,))
         pass
-
+        
         # Clear deleted GPU items
         for _ in range(3):
             gc.collect()


### PR DESCRIPTION


feat: Support custom auto_model, Whisper params, and attn_implementation

This PR enhances FastModel.from_pretrained to support a broader range of models:

Custom auto_model: Allows specifying the exact Hugging Face model class (e.g., WhisperForConditionalGeneration , RobertaForSequenceClassification), enabling loading of non-default casual llm types.

Whisper Integration: Adds whisper_language and whisper_task parameters for correct Whisper AutoProcessor setup when using a custom auto_model.

attn_implementation: Enables passing attn_implementation (e.g., "eager"), required for models like Mamba.



Usage Example:

```py
from unsloth import FastModel
from transformers import WhisperForConditionalGeneration
import torch

# Load Whisper specifying class and language/task
model, processor = FastModel.from_pretrained(
    model_name = "openai/whisper-small",
    auto_model = WhisperForConditionalGeneration,
    whisper_language = "Arabic",
    whisper_task = "transcribe",
    # attn_implementation = "eager", # Also supported now
)
```