### PR TITLE
Display peft error

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -561,6 +561,7 @@ class FastModel(FastBaseModel):
         except Exception as error:
             peft_error = str(error)
             is_peft = False
+            print("Unsloth: Failed to get peft config: {peft_error}.")
         pass
 
         # Both config.json and adapter_config.json should not exist!


### PR DESCRIPTION
My script was starting and stopping without displaying any errors or showing any signs something was wrong, it just refused to run.
I did some debugging and found that a 404 is thrown when trying to fetch adapter_config.json. This error is caught but after that, nothing is done with the error. Maybe in some cases it's supposed to continue working despite a peft error but in this my case it's supposed to throw the peft error or at least display it in the console:

https://github.com/unslothai/unsloth/blob/05f4875aff111bf3801f6e740cc03cb7a8594c9b/unsloth/models/loader.py#L176

I added a print so that if any error occurs fetching the config it at least lets the user know so they know what's going on.