### PR TITLE
fix: improved error handling when llama.cpp build fails

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -887,11 +887,15 @@ def install_llama_cpp_old(version = -10):
         os.path.exists("llama.cpp/llama-quantize.exe") or
         os.path.exists("llama.cpp/llama-quantize") or
         os.path.exists("llama.cpp/quantize.exe") or
-        os.path.exists("llama.cpp/quantize")
+        os.path.exists("llama.cpp/quantize") or
+        os.path.exists("llama.cpp/build/bin/llama-quantize") or
+        os.path.exists("llama.cpp/build/bin/quantize") or
+        os.path.exists()
     ):
         raise RuntimeError(
             "Unsloth: The file 'llama.cpp/llama-quantize' or `llama.cpp/quantize` does not exist.\n"\
-            "But we expect this file to exist! Maybe the llama.cpp developers changed the name or check extension of the llama-quantize file."
+            "We've also double checked the building directory under 'llama.cpp/build/bin/'.\n"\
+            "But we expect this file to exist! Check if the file exists under llama.cp and investigate the building process of llama.cpp (make/cmake)"
         )
     pass
 pass
@@ -1081,11 +1085,16 @@ def save_to_gguf(
             quantize_location = "llama.cpp/llama-quantize.exe"
         elif os.path.exists("llama.cpp/llama-quantize"):
             quantize_location = "llama.cpp/llama-quantize"
+        elif os.path.exists("llama.cpp/build/bin/llama-quantize"):
+            quantize_location = "llama.cpp/build/bin/llama-quantize"
+        elif os.path.exists("llama.cpp/build/bin/quantize"):
+            quantize_location = "llama.cpp/build/bin/quantize"
         else:
-            raise RuntimeError(
-                "Unsloth: The file ('llama.cpp/llama-quantize' or 'llama.cpp/llama-quantize.exe' if you are on Windows WSL) or 'llama.cpp/quantize' does not exist.\n"\
-                "But we expect this file to exist! Maybe the llama.cpp developers changed the name or check extension of the llama-quantize file."
-            )
+        raise RuntimeError(
+            "Unsloth: The file 'llama.cpp/llama-quantize' or `llama.cpp/quantize` does not exist.\n"\
+            "We've also double checked the building directory under 'llama.cpp/build/bin/'.\n"\
+            "But we expect this file to exist! Check if the file exists under llama.cp and investigate the building process of llama.cpp (make/cmake)"
+        )
         pass
 
         # See https://github.com/unslothai/unsloth/pull/730


### PR DESCRIPTION
Hi!

When I tried to run _save_pretrained_gguf()_ I had multiple different errors. All problems were related to a failing LLama.cpp build. As you can see unter [this pull request ](https://github.com/ggml-org/llama.cpp/commit/bd3f59f81289b920bcc597a208c14f55e39ed37e), curl for llama cpp is now activated by default, which is resulting for me in:

```
CMake Error at common/CMakeLists.txt:90 (message):
  Could NOT find CURL.  Hint: to disable this feature, set -DLLAMA_CURL=OFF
```

(System is a Ubuntu 24.04 with newest version of unsloth and llama.cpp. Curl is installed.)

So then I installed llama.cpp manually, but then got the error:
```

Unsloth: The file 'llama.cpp/llama-quantize' or `llama.cpp/quantize` does not exist.\n"\
            "But we expect this file to exist! Maybe the llama.cpp developers changed the name or check extension of the llama-quantize file."

```
Thats right, because is it still under /llama.cpp/build/bin. As the save.py shows, all llama-* files gets copied to llama.cpp, when the build runs successfully. But in my case that dont happend and I had some misleading error messages. I hope that pull request decreases the amount of people having these issues or a clearer direction for debugging! 