### PR TITLE
Added k_norm & q_norm to merged Qwen3 layers

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -70,6 +70,7 @@ LLAMA_WEIGHTS = (
 LLAMA_LAYERNORMS = (
     "input_layernorm", "post_attention_layernorm",
     "pre_feedforward_layernorm", "post_feedforward_layernorm",
+    "self_attn.q_norm", "self_attn.k_norm",
 )
 
 # https://github.com/ggerganov/llama.cpp/blob/master/examples/quantize/quantize.cpp#L19


### PR DESCRIPTION
Ensures to include self_attn.q_norm and self_attn.k_norm layers when merging & saving Qwen3 weights.