### PR TITLE
Fix loading saved model with a different name

### DIFF
--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -77,7 +77,7 @@ def __get_model_name(
         return new_model_name
     pass
 
-    return None
+    return model_name
 pass
 
 


### PR DESCRIPTION
Problematic
Currently it is impossible to load a previously saved model because the returned model name turns to None and then breaks afterwards.

Solution
Return the model name passed by argument if it doesn't match any of the mapping