### PR TITLE
the pixtral vision notebook fails during inference

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -112,6 +112,11 @@ def unsloth_base_fast_generate(
     arch = self.config.architectures[0]
 
     # Remove token_type_ids - WRONG for Gemma 3 since bidirectional attention
+    if hasattr(self, "generate") and hasattr(self, "forward"):
+        # did not combine with below since self might not have model
+        keys = inspect.signature(self.forward).parameters.keys()
+        if "token_type_ids" not in keys:
+            kwargs.pop("token_type_ids", None)
     # kwargs.pop("token_type_ids", None)
 
     # VLMs do not allow logits_to_keep


### PR DESCRIPTION
The pixtral vision notebook currently fails during inference with unused kwargs token_type_ids.


![image](https://github.com/user-attachments/assets/0a781a6c-eb5d-46b4-b581-867a6402d2a3)


And also fixes #2392. Initially there was code to pop out the token_type_ids for VLM's but this failed for Gemma3 so it was commented out. But now fails for Pixtral. Instead of checking directly for gemma3 vlm architecture, we can inspect the forward method for valid kwargs and check for token_type_ids, and pop if it doesn't exist. 

I also tested the Pixtral notebook and inference now works. https://colab.research.google.com/drive/137uUFLRKzoZ5S2ao95eSWUghgFV6OAb1?usp=sharing

