### PR TITLE
Fix qwen3 GRPO QKNorm causing issues

### DIFF
--- a/unsloth/kernels/rms_layernorm.py
+++ b/unsloth/kernels/rms_layernorm.py
@@ -170,7 +170,7 @@ class Fast_RMS_Layernorm(torch.autograd.Function):
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.num_warps  = num_warps
         ctx.GEMMA = gemma
-        ctx.save_for_backward(X, W, r)
+        ctx.save_for_backward(X, W.clone(), r)
         return Y.view(*shape)
     pass
 

--- a/unsloth/models/qwen3.py
+++ b/unsloth/models/qwen3.py
@@ -91,7 +91,7 @@ def Qwen3Attention_fast_forward(
     K = K.view(bsz, q_len, n_kv_heads, head_dim)#.transpose(1, 2) # we will transpose after normalisation
     V = V.view(bsz, q_len, n_kv_heads, head_dim).transpose(1, 2)
 
-    #Qwen3 has QKNorm. This seems to be the only difference from Qwen2.
+    # Qwen3 has QKNorm. This seems to be the only difference from Qwen2.
     # Note that using fast_layernorm_compiled causes issues as the dimensions don't match up.
     # I tried to add a compiled version of the new norm but the numbers don't match up with Transformers
     # TODO: Check on the differences here.


### PR DESCRIPTION
Without doing this change, when I run the GRPOTrainer, on doing backward pass (gradient accumulation itself, not even optimiser step) throws the following error. I'm still trying to understand why this is the case.

This only effects GRPO and SFT was and is working fine. 
My guess is when we do generation, we're somehow unknowingly passing through `fast_rms_layernorm` instead of `fast_rms_layernorm_inference`?

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/datta0/codes/unsloth_grpo.py", line 310, in <module>
[rank0]:     trainer.train(resume_from_checkpoint=False)
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/transformers/trainer.py", line 2236, in train
[rank0]:     return inner_training_loop(
[rank0]:            ^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "<string>", line 314, in _fast_inner_training_loop
[rank0]:   File "<string>", line 77, in _unsloth_training_step
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/accelerate/accelerator.py", line 2359, in backward
[rank0]:     loss.backward(**kwargs)
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/_tensor.py", line 648, in backward
[rank0]:     torch.autograd.backward(
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/autograd/__init__.py", line 353, in backward
[rank0]:     _engine_run_backward(
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/autograd/graph.py", line 824, in _engine_run_backward
[rank0]:     return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/autograd/function.py", line 307, in apply
[rank0]:     return user_fn(self, *args)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/repos/unsloth_zoo/unsloth_zoo/gradient_checkpointing.py", line 554, in backward
[rank0]:     outputs = ctx.run_function(*detached_inputs)
[rank0]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/repos/unsloth/unsloth/models/llama.py", line 856, in custom_forward
[rank0]:     return module(*inputs, past_key_value, output_attentions, padding_mask = padding_mask, position_embeddings = position_embeddings)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/repos/unsloth/unsloth/models/llama.py", line 544, in LlamaDecoderLayer_fast_forward
[rank0]:     hidden_states, self_attn_weights, present_key_value = self.self_attn(
[rank0]:                                                           ^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/repos/unsloth/unsloth/models/qwen3.py", line 98, in Qwen3Attention_fast_forward
[rank0]:     Q = fast_rms_layernorm(self.q_norm, Q)
[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 838, in _fn
[rank0]:     return fn(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/repos/unsloth/unsloth/kernels/rms_layernorm.py", line 215, in fast_rms_layernorm
[rank0]:     out = Fast_RMS_Layernorm.apply(X, W, eps, gemma)
[rank0]:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/datta0/.venvs/unsloth/lib/python3.12/site-packages/torch/autograd/function.py", line 575, in apply
[rank0]:     return super().apply(*args, **kwargs)  # type: ignore[misc]
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: RuntimeError: Inference tensors cannot be saved for backward. To work around you can make a clone to get a normal tensor and use it in autograd.
```