### PR TITLE
Add use_rslora reference to LoraConfig inititalisation

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -538,6 +538,7 @@ class FastBaseModel:
             lora_dropout    = lora_dropout,
             bias            = bias,
             task_type       = task_type,
+            use_rslora      = use_rslora,
         )
         model = prepare_model_for_kbit_training(
             model,


### PR DESCRIPTION
Fixes #2531 via passing `use_rslora` kwarg to `LoraConfig` initialisation in `get_peft_model`.