### PR TITLE
Quick fix on the CompileConfig error 

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -200,12 +200,14 @@ def unsloth_base_fast_generate(
             cache_implementation = "static"
         else:
             cache_implementation = "hybrid"
+
     if "generation_config" in kwargs:
         kwargs["generation_config"].cache_implementation = cache_implementation
         kwargs["generation_config"].compile_config = _compile_config if cache_implementation is not None else None
     else:
         kwargs["cache_implementation"] = cache_implementation
-        kwargs["compile_config"] = _compile_config if cache_implementation is not None else None
+        if cache_implementation:
+            kwargs["compile_config"] = _compile_config
     pass
 
     try:


### PR DESCRIPTION
https://github.com/unslothai/unsloth/issues/2547

This issue mentioned that there's compiling error because of None type.

I believe this is more Transformers bug especially in this line https://github.com/huggingface/transformers/blob/main/src/transformers/generation/configuration_utils.py#L816-L820
 clearly do a checking on it

Tested on Llama Vision Instruct code