### PR TITLE
fix issue with qwen3 template double quote escapes

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1029,7 +1029,7 @@ qwen3_template = \
         {{- "\n" }}
         {{- tool | tojson }}
     {%- endfor %}
-    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\\"name\\": <function-name>, \\"arguments\\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
 {%- else %}
     {%- if messages[0].role == 'system' %}
         {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}


### PR DESCRIPTION
This fixes a minor issue noted in https://github.com/unslothai/unsloth/pull/2537#issue-3064585262, which was in response to https://github.com/unslothai/unsloth/issues/2521.

Specifically, the existing version was causing an error when processing the template:

```python
TemplateSyntaxError: expected token 'end of print statement', got 'name'
```

This is now fixed by double escaping the double quotes (which matches a similar alteration in the `qwen25_template` in the same file). As an aside, this qwen3 template looks current based on the discussion [here](https://www.reddit.com/r/LocalLLaMA/comments/1klltt4/the_qwen3_chat_template_is_still_bugged/) where Daniel has been involved with trying to sort out various Qwen3 template issues (the only change being the extra escape of the double quotes compared to the template in the GGUF [here](https://huggingface.co/unsloth/Qwen3-1.7B-GGUF) at time of writing).