### PR TITLE
comparative tests for saving and merging logic

### DIFF
--- a/tests/saving/save_merge_comparative_tests/test_transformers_trl_peft_finetuning_save_merge_notebook.ipynb
+++ b/tests/saving/save_merge_comparative_tests/test_transformers_trl_peft_finetuning_save_merge_notebook.ipynb
@@ -1,0 +1,1267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b9927875-939b-42e0-ab75-a0d2e873e917",
+   "metadata": {},
+   "source": [
+    "# OCR lora finetuning and merging using Transformers + Peft + TRL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70441539-db2e-411d-9583-85ba8e1591eb",
+   "metadata": {},
+   "source": [
+    "## import libs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a98dfb7b-5438-4389-9635-b9a31df3dff5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig,Qwen2VLProcessor\n",
+    "from peft import LoraConfig\n",
+    "from qwen_vl_utils import process_vision_info\n",
+    "import torch\n",
+    "from torch.utils.data import Dataset\n",
+    "import os\n",
+    "from PIL import Image\n",
+    "import glob\n",
+    "from datasets import load_dataset\n",
+    "from trl import SFTTrainer, SFTConfig\n",
+    "import random"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb7404ed-08ce-4950-8610-5c355953e211",
+   "metadata": {},
+   "source": [
+    "# Dataset Preparation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "237c4e5c-c876-4b21-bba4-6e99e9d5e5da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "24da7f84877e4007a3194a420f1eab7d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Resolving data files:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7cb83a0092df4b1aa59117a2748b9900",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Resolving data files:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9356a50d878343539b2f132645505616",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading dataset shards:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "dataset = load_dataset(\"lbourdois/OCR-liboaccn-OPUS-MIT-5M-clean\", 'en', split=\"train\")\n",
+    "# To select the first 2000 examples\n",
+    "train_dataset = dataset.select(range(2000))\n",
+    "\n",
+    "# To select the next 200 examples for evaluation\n",
+    "eval_dataset = dataset.select(range(2000, 2200))\n",
+    "\n",
+    "# Convert dataset to OAI messages       \n",
+    "def format_data(sample):\n",
+    "    return {\"messages\": [\n",
+    "                {\n",
+    "                    \"role\": \"system\",\n",
+    "                    \"content\": [{\"type\": \"text\", \"text\": system_message}],\n",
+    "                },\n",
+    "                {\n",
+    "                    \"role\": \"user\",\n",
+    "                    \"content\": [\n",
+    "                        {\n",
+    "                            \"type\": \"text\",\n",
+    "                            \"text\": sample[\"question\"],\n",
+    "                        },{\n",
+    "                            \"type\": \"image\",\n",
+    "                            \"image\": sample[\"image\"],\n",
+    "                        }\n",
+    "                    ],\n",
+    "                },\n",
+    "                {\n",
+    "                    \"role\": \"assistant\",\n",
+    "                    \"content\": [{\"type\": \"text\", \"text\": sample[\"answer\"]}],\n",
+    "                },\n",
+    "            ],\n",
+    "        }\n",
+    "\n",
+    "system_message = \"You are an expert french ocr system.\"\n",
+    "# Convert dataset to OAI messages\n",
+    "# need to use list comprehension to keep Pil.Image type, .mape convert image to bytes\n",
+    "train_dataset = [format_data(sample) for sample in train_dataset]\n",
+    "eval_dataset = [format_data(sample) for sample in eval_dataset]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f531014-b0e8-40f5-b093-0e159c02cb0c",
+   "metadata": {},
+   "source": [
+    "# Setup OCR main evaluation and help functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d071bcd9-5fe5-450e-908e-57c7011a0602",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import torch\n",
+    "from tqdm import tqdm\n",
+    "import pandas as pd\n",
+    "from jiwer import wer, cer\n",
+    "from qwen_vl_utils import process_vision_info\n",
+    "\n",
+    "def evaluate_ocr_model(model, processor, dataset, output_dir=\"ocr_evaluation_results\"):\n",
+    "    \"\"\"\n",
+    "    Evaluate a Qwen VL model on an OCR dataset with specific structure.\n",
+    "    \n",
+    "    Args:\n",
+    "        model: The loaded Qwen VL model\n",
+    "        processor: The Qwen processor/tokenizer\n",
+    "        dataset: List of items with 'messages' field containing conversation exchanges\n",
+    "        output_dir: Directory to save results\n",
+    "    \n",
+    "    Returns:\n",
+    "        tuple: (average WER, average CER)\n",
+    "    \"\"\"\n",
+    "    # Create output directory if it doesn't exist\n",
+    "    os.makedirs(output_dir, exist_ok=True)\n",
+    "    \n",
+    "    # Initialize results storage\n",
+    "    results = []\n",
+    "    \n",
+    "    # Process each sample in the dataset\n",
+    "    for i, sample in enumerate(tqdm(dataset, desc=\"Evaluating OCR performance\")):\n",
+    "        try:\n",
+    "            # Extract the messages from the sample\n",
+    "            messages = sample['messages']\n",
+    "            \n",
+    "            # Extract system message (if present)\n",
+    "            system_message = next((msg for msg in messages if msg['role'] == 'system'), None)\n",
+    "            \n",
+    "            # Extract user message with the image and question\n",
+    "            user_message = next((msg for msg in messages if msg['role'] == 'user'), None)\n",
+    "            if not user_message:\n",
+    "                print(f\"Skipping sample {i}: No user message found\")\n",
+    "                continue\n",
+    "                \n",
+    "            # Extract assistant message with ground truth\n",
+    "            assistant_message = next((msg for msg in messages if msg['role'] == 'assistant'), None)\n",
+    "            if not assistant_message:\n",
+    "                print(f\"Skipping sample {i}: No assistant message (ground truth) found\")\n",
+    "                continue\n",
+    "            \n",
+    "            # Extract ground truth text\n",
+    "            ground_truth = None\n",
+    "            for content_item in assistant_message['content']:\n",
+    "                if content_item['type'] == 'text':\n",
+    "                    ground_truth = content_item['text']\n",
+    "                    break\n",
+    "                    \n",
+    "            if not ground_truth:\n",
+    "                print(f\"Skipping sample {i}: No text found in assistant message\")\n",
+    "                continue\n",
+    "            \n",
+    "            # Extract image and question from user message\n",
+    "            image = None\n",
+    "            question = None\n",
+    "            \n",
+    "            for content_item in user_message['content']:\n",
+    "                if content_item['type'] == 'image':\n",
+    "                    image = content_item['image']\n",
+    "                elif content_item['type'] == 'text':\n",
+    "                    question = content_item['text']\n",
+    "            \n",
+    "            if not image:\n",
+    "                print(f\"Skipping sample {i}: No image found in user message\")\n",
+    "                continue\n",
+    "                \n",
+    "            if not question:\n",
+    "                print(f\"Skipping sample {i}: No question found in user message\")\n",
+    "                continue\n",
+    "            \n",
+    "            # Construct messages for the model input (excluding assistant message)\n",
+    "            input_messages = []\n",
+    "            \n",
+    "            # Add system message if it exists\n",
+    "            if system_message:\n",
+    "                input_messages.append(system_message)\n",
+    "            \n",
+    "            # Add user message\n",
+    "            input_messages.append(user_message)\n",
+    "            \n",
+    "            # Preparation for inference using Qwen's specific processing\n",
+    "            text = processor.apply_chat_template(\n",
+    "                input_messages, tokenize=False, add_generation_prompt=True\n",
+    "            )\n",
+    "            \n",
+    "            # Process vision info (images/videos) from messages\n",
+    "            image_inputs, video_inputs = process_vision_info(input_messages)\n",
+    "            \n",
+    "            # Create model inputs\n",
+    "            inputs = processor(\n",
+    "                text=[text],\n",
+    "                images=image_inputs,\n",
+    "                videos=video_inputs,\n",
+    "                padding=True,\n",
+    "                return_tensors=\"pt\"\n",
+    "            )\n",
+    "            inputs = inputs.to(model.device)\n",
+    "            \n",
+    "            # Generate response\n",
+    "            with torch.no_grad():\n",
+    "                generated_ids = model.generate(\n",
+    "                    **inputs, \n",
+    "                    max_new_tokens=1024,\n",
+    "                    temperature=1.5, \n",
+    "                    min_p=0.1,\n",
+    "                    use_cache=True\n",
+    "                )\n",
+    "            \n",
+    "            # Extract only the generated part (not the input)\n",
+    "            generated_ids_trimmed = [\n",
+    "                out_ids[len(in_ids):] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)\n",
+    "            ]\n",
+    "            \n",
+    "            # Decode the generated text\n",
+    "            generated_response = processor.batch_decode(\n",
+    "                generated_ids_trimmed, \n",
+    "                skip_special_tokens=True, \n",
+    "                clean_up_tokenization_spaces=False\n",
+    "            )[0]\n",
+    "            \n",
+    "            # Calculate metrics\n",
+    "            word_error = wer(ground_truth, generated_response)\n",
+    "            char_error = cer(ground_truth, generated_response)\n",
+    "            \n",
+    "            # Save individual result\n",
+    "            output_file = os.path.join(output_dir, f\"sample_{i}.txt\")\n",
+    "            with open(output_file, 'w', encoding='utf-8') as f:\n",
+    "                f.write(f\"Sample {i}\\n\")\n",
+    "                f.write(f\"Question: {question}\\n\\n\")\n",
+    "                f.write(f\"Model output:\\n{generated_response.strip()}\\n\\n\")\n",
+    "                f.write(f\"Ground truth:\\n{ground_truth}\\n\\n\")\n",
+    "                f.write(f\"WER: {word_error:.4f}, CER: {char_error:.4f}\")\n",
+    "            \n",
+    "            # Store results for summary\n",
+    "            results.append({\n",
+    "                'sample_id': i,\n",
+    "                'wer': word_error,\n",
+    "                'cer': char_error,\n",
+    "                'model_output': generated_response.strip(),\n",
+    "                'ground_truth': ground_truth,\n",
+    "                'question': question\n",
+    "            })\n",
+    "            \n",
+    "        except Exception as e:\n",
+    "            print(f\"Error processing sample {i}: {str(e)}\")\n",
+    "            import traceback\n",
+    "            traceback.print_exc()\n",
+    "            \n",
+    "    # Create summary report\n",
+    "    if results:\n",
+    "        df = pd.DataFrame(results)\n",
+    "        \n",
+    "        # Calculate overall averages\n",
+    "        avg_wer = df['wer'].mean()\n",
+    "        avg_cer = df['cer'].mean()\n",
+    "        \n",
+    "        # Save average metrics\n",
+    "        with open(os.path.join(output_dir, \"avg_metrics.txt\"), 'w') as f:\n",
+    "            f.write(f\"Average WER: {avg_wer:.4f}\\n\")\n",
+    "            f.write(f\"Average CER: {avg_cer:.4f}\\n\")\n",
+    "        \n",
+    "        # Save detailed results\n",
+    "        df.to_csv(os.path.join(output_dir, \"detailed_results.csv\"), index=False)\n",
+    "        \n",
+    "        print(\"\\nResults Summary:\")\n",
+    "        print(f\"Average WER: {avg_wer:.4f}\")\n",
+    "        print(f\"Average CER: {avg_cer:.4f}\")\n",
+    "        print(f\"\\nDetailed results saved to {output_dir}/\")\n",
+    "        \n",
+    "        return avg_wer, avg_cer\n",
+    "    else:\n",
+    "        print(\"No results to summarize.\")\n",
+    "        return None, None\n",
+    "\n",
+    "\n",
+    "# At the beginning of your notebook, define a variable to collect results\n",
+    "model_comparison_results = {}\n",
+    "\n",
+    "# Create a simple function to add results to the comparison\n",
+    "def add_to_comparison(model_name, wer, cer):\n",
+    "    \"\"\"Add model results to the comparison tracker\"\"\"\n",
+    "    model_comparison_results[model_name] = {\n",
+    "        \"wer\": wer,\n",
+    "        \"cer\": cer\n",
+    "    }\n",
+    "    #return model_comparison_results\n",
+    "\n",
+    "# Create a function to print the comparison report whenever needed\n",
+    "def print_model_comparison(save_csv=True, save_plot=True):\n",
+    "    \"\"\"Print a comparison of all models evaluated so far\"\"\"\n",
+    "    if not model_comparison_results:\n",
+    "        print(\"No model results available for comparison\")\n",
+    "        return\n",
+    "        \n",
+    "    print(\"\\n==== MODEL COMPARISON REPORT ====\")\n",
+    "    \n",
+    "    # Create a comparison dataframe\n",
+    "    comparison_df = pd.DataFrame({\n",
+    "        \"Model\": list(model_comparison_results.keys()),\n",
+    "        \"WER\": [results[\"wer\"] for results in model_comparison_results.values()],\n",
+    "        \"CER\": [results[\"cer\"] for results in model_comparison_results.values()]\n",
+    "    })\n",
+    "    \n",
+    "    # Sort by WER (best performance first)\n",
+    "    comparison_df = comparison_df.sort_values(\"WER\")\n",
+    "    \n",
+    "    # Display the comparison table\n",
+    "    print(\"\\nComparison Table (sorted by WER):\")\n",
+    "    print(comparison_df.to_string(index=False))\n",
+    "    \n",
+    "    # Save the comparison table\n",
+    "    if save_csv:\n",
+    "        comparison_file = \"model_comparison_results.csv\"\n",
+    "        comparison_df.to_csv(comparison_file, index=False)\n",
+    "        print(f\"\\nComparison table saved to {comparison_file}\")\n",
+    "    \n",
+    "    # Generate a bar chart visualization\n",
+    "    if save_plot:\n",
+    "        import matplotlib.pyplot as plt\n",
+    "        plt.figure(figsize=(12, 6))\n",
+    "        \n",
+    "        # Plot WER\n",
+    "        plt.subplot(1, 2, 1)\n",
+    "        plt.bar(comparison_df[\"Model\"], comparison_df[\"WER\"], color='skyblue')\n",
+    "        plt.title('Word Error Rate Comparison')\n",
+    "        plt.ylabel('WER (lower is better)')\n",
+    "        plt.ylim(bottom=0)\n",
+    "        plt.xticks(rotation=45, ha='right')\n",
+    "        \n",
+    "        # Plot CER\n",
+    "        plt.subplot(1, 2, 2)\n",
+    "        plt.bar(comparison_df[\"Model\"], comparison_df[\"CER\"], color='lightgreen')\n",
+    "        plt.title('Character Error Rate Comparison')\n",
+    "        plt.ylabel('CER (lower is better)')\n",
+    "        plt.ylim(bottom=0)\n",
+    "        plt.xticks(rotation=45, ha='right')\n",
+    "        \n",
+    "        plt.tight_layout()\n",
+    "        plt.savefig('ocr_model_comparison.png')\n",
+    "        plt.show()\n",
+    "        \n",
+    "        print(f\"\\nVisualization saved to ocr_model_comparison.png\")\n",
+    "    \n",
+    "    return comparison_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fee2633-5d45-4e2b-a737-94578eeae5f4",
+   "metadata": {},
+   "source": [
+    "# Finetuning setup and run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c1ab7f6-c324-41d5-b6eb-1c81135a42e8",
+   "metadata": {},
+   "source": [
+    "## Load base model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a7c25437-5321-4a7d-84b9-0bd14806e844",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8922b934b4684fceaa20f8697b58cc64",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Hugging Face model id\n",
+    "model_id = \"unsloth/Qwen2-VL-7B-Instruct\" \n",
+    "\n",
+    "# BitsAndBytesConfig int-4 config\n",
+    "bnb_config = BitsAndBytesConfig(\n",
+    "    load_in_4bit=True, bnb_4bit_use_double_quant=True, bnb_4bit_quant_type=\"nf4\", bnb_4bit_compute_dtype=torch.bfloat16\n",
+    ")\n",
+    "\n",
+    "# Load model and tokenizer\n",
+    "model = AutoModelForVision2Seq.from_pretrained(\n",
+    "    model_id,\n",
+    "    device_map=\"auto\",\n",
+    "    # attn_implementation=\"flash_attention_2\", # not supported for training\n",
+    "    torch_dtype=torch.bfloat16,\n",
+    "    quantization_config=bnb_config\n",
+    ")\n",
+    "processor = AutoProcessor.from_pretrained(model_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4024857e-4490-46d8-b916-0d3dff9ba519",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [10:06<00:00,  3.03s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 3.6077\n",
+      "Average CER: 2.7190\n",
+      "\n",
+      "Detailed results saved to peft_base_model_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark base model performance\n",
+    "model_name = \"Base model\" \n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, processor, eval_dataset, output_dir=\"peft_base_model_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98b6b6c5-7db1-4363-b5b3-6223831d70ed",
+   "metadata": {},
+   "source": [
+    "## Lora Finetuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b6a7095d-b42a-43e8-96bb-9ef8461455de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from peft import LoraConfig\n",
+    "\n",
+    "# LoRA config based on QLoRA paper & Sebastian Raschka experiment\n",
+    "peft_config = LoraConfig(\n",
+    "        lora_alpha=16,\n",
+    "        lora_dropout=0.05,\n",
+    "        r=8,\n",
+    "        bias=\"none\",\n",
+    "        target_modules=[\"q_proj\", \"v_proj\"],\n",
+    "        task_type=\"CAUSAL_LM\", \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "293e1b35-886f-4094-8e56-a6dc04608050",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trl import SFTConfig\n",
+    "from transformers import Qwen2VLProcessor\n",
+    "from qwen_vl_utils import process_vision_info\n",
+    "\n",
+    "args = SFTConfig(\n",
+    "    output_dir=\"peft-qwen2-7vl-french-ocr-checkpoints\", # directory to save and repository id\n",
+    "    num_train_epochs=2,                     # number of training epochs\n",
+    "    #max_steps = 60,\n",
+    "    per_device_train_batch_size=4,          # batch size per device during training\n",
+    "    gradient_accumulation_steps=8,          # number of steps before performing a backward/update pass\n",
+    "    gradient_checkpointing=True,            # use gradient checkpointing to save memory\n",
+    "    optim=\"adamw_torch_fused\",              # use fused adamw optimizer\n",
+    "    logging_steps=5,                       # log every 10 steps\n",
+    "    save_strategy=\"epoch\",                  # save checkpoint every epoch\n",
+    "    learning_rate=2e-4,                     # learning rate, based on QLoRA paper\n",
+    "    bf16=True,                              # use bfloat16 precision\n",
+    "    max_grad_norm=0.3,                      # max gradient norm based on QLoRA paper\n",
+    "    warmup_ratio=0.03,                      # warmup ratio based on QLoRA paper\n",
+    "    lr_scheduler_type=\"constant\",           # use constant learning rate scheduler\n",
+    "    report_to=\"none\",                # report metrics to tensorboard\n",
+    "    gradient_checkpointing_kwargs = {\"use_reentrant\": False}, # use reentrant checkpointing\n",
+    "    dataset_text_field=\"\", # need a dummy field for collator\n",
+    "    dataset_kwargs = {\"skip_prepare_dataset\": True} # important for collator\n",
+    ")\n",
+    "args.remove_unused_columns=False\n",
+    "\n",
+    "# Create a data collator to encode text and image pairs\n",
+    "def collate_fn(examples):\n",
+    "    # Get the texts and images, and apply the chat template\n",
+    "    texts = [processor.apply_chat_template(example[\"messages\"], tokenize=False) for example in examples]\n",
+    "    image_inputs = [process_vision_info(example[\"messages\"])[0] for example in examples]\n",
+    "\n",
+    "    # Tokenize the texts and process the images\n",
+    "    batch = processor(text=texts, images=image_inputs, return_tensors=\"pt\", padding=True)\n",
+    "\n",
+    "    # The labels are the input_ids, and we mask the padding tokens in the loss computation\n",
+    "    labels = batch[\"input_ids\"].clone()\n",
+    "    labels[labels == processor.tokenizer.pad_token_id] = -100  #\n",
+    "    # Ignore the image token index in the loss computation (model specific)\n",
+    "    if isinstance(processor, Qwen2VLProcessor):\n",
+    "        image_tokens = [151652,151653,151655]\n",
+    "    else: \n",
+    "        image_tokens = [processor.tokenizer.convert_tokens_to_ids(processor.image_token)]\n",
+    "    for image_token_id in image_tokens:\n",
+    "        labels[labels == image_token_id] = -100\n",
+    "    batch[\"labels\"] = labels\n",
+    "\n",
+    "    return batch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "93ac2238-f462-4390-b890-d75dfab777c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "No label_names provided for model class `PeftModelForCausalLM`. Since `PeftModel` hides base models input arguments, if label_names is not given, label_names can't be set automatically within `Trainer`. Note that empty label_names list will be used instead.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from trl import SFTTrainer\n",
+    "\n",
+    "trainer = SFTTrainer(\n",
+    "    model=model,\n",
+    "    args=args,\n",
+    "    train_dataset=train_dataset,\n",
+    "    data_collator=collate_fn,\n",
+    "    #dataset_text_field=\"\", # needs dummy value\n",
+    "    peft_config=peft_config,\n",
+    "    processing_class=processor,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6bf6df81-b162-4f06-b2f7-8152e7ff975b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='124' max='124' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [124/124 07:07, Epoch 1/2]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Step</th>\n",
+       "      <th>Training Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>3.416800</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>2.926000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>15</td>\n",
+       "      <td>2.373200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>20</td>\n",
+       "      <td>1.943900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>25</td>\n",
+       "      <td>1.659600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>30</td>\n",
+       "      <td>1.636300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>35</td>\n",
+       "      <td>1.498500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>40</td>\n",
+       "      <td>1.376600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>45</td>\n",
+       "      <td>1.463900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>50</td>\n",
+       "      <td>1.384300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>55</td>\n",
+       "      <td>1.340000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>60</td>\n",
+       "      <td>1.365000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>65</td>\n",
+       "      <td>1.163800</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>70</td>\n",
+       "      <td>1.186800</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>75</td>\n",
+       "      <td>1.192800</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>80</td>\n",
+       "      <td>1.113200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>85</td>\n",
+       "      <td>1.140700</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>90</td>\n",
+       "      <td>1.153800</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>95</td>\n",
+       "      <td>1.122200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>100</td>\n",
+       "      <td>1.105200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>105</td>\n",
+       "      <td>1.142200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>110</td>\n",
+       "      <td>1.129300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>115</td>\n",
+       "      <td>1.142600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>120</td>\n",
+       "      <td>1.137100</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# start training, the model will be automatically saved to the hub and the output directory\n",
+    "trainer.train()\n",
+    "\n",
+    "# save model \n",
+    "trainer.save_model(\"peft-qwen2-7vl-french-ocr-adapter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3115afb9-6f9a-4c8b-99da-c9dbd1721928",
+   "metadata": {},
+   "source": [
+    "# Load adapter model and measure adapter performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "55f7da1c-e8d4-4ae8-871e-e63359e7ab8c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ef61cf9fdff044a0a3276c3e6011665d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Load Base_Model\n",
+    "\n",
+    "\n",
+    "model_id = \"Qwen/Qwen2-VL-7B-Instruct\" \n",
+    "# Load Model base model\n",
+    "model = AutoModelForVision2Seq.from_pretrained(\n",
+    "  model_id,\n",
+    "  device_map=\"auto\",\n",
+    "  torch_dtype=torch.bfloat16\n",
+    ")\n",
+    "processor = AutoProcessor.from_pretrained(model_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3d152ff9-a1bb-4b7c-a3b3-784fa3a05c10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load adapter on top of base model\n",
+    "adapter_path = \"./peft-qwen2-7vl-french-ocr-adapter\"\n",
+    "model.load_adapter(adapter_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "39a869b3-9b7c-40aa-bf60-a431f2bb2899",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [02:38<00:00,  1.26it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 0.0386\n",
+      "Average CER: 0.0160\n",
+      "\n",
+      "Detailed results saved to peft_lora_model_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark lora model performance\n",
+    "model_name = \"Peft lora model\" \n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, processor, eval_dataset, output_dir=\"peft_lora_model_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2ce4774-bb0d-4ed5-b8f6-5ce10367553c",
+   "metadata": {},
+   "source": [
+    "# Merge Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "801d00f2-1711-4cc3-ac1a-d2eb4bcd3a83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e3bb67822462403bb66dfa0f34a9d30d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from peft import PeftModel\n",
+    "from transformers import AutoProcessor, AutoModelForVision2Seq\n",
+    "\n",
+    "adapter_path = \"./peft-qwen2-7vl-french-ocr-adapter\"\n",
+    "base_model_id = \"unsloth/Qwen2-VL-7B-Instruct\"\n",
+    "merged_path = \"peft_merged_model_french_ocr_qwen7-vl\"\n",
+    "\n",
+    "# Load Model base model\n",
+    "model = AutoModelForVision2Seq.from_pretrained(model_id, low_cpu_mem_usage=True)\n",
+    "\n",
+    "# Path to save the merged model\n",
+    "\n",
+    "# Merge LoRA and base model and save\n",
+    "peft_model = PeftModel.from_pretrained(model, adapter_path)\n",
+    "merged_model = peft_model.merge_and_unload()\n",
+    "merged_model.save_pretrained(merged_path,safe_serialization=True, max_shard_size=\"2GB\")\n",
+    "\n",
+    "processor = AutoProcessor.from_pretrained(base_model_id)\n",
+    "processor.save_pretrained(merged_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8a99b40-3716-4b02-8f69-96c67ab3cf32",
+   "metadata": {},
+   "source": [
+    "# Benchmark merged model performance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae0d4732-125f-4bbb-9e96-b28b5adc14b6",
+   "metadata": {},
+   "source": [
+    "## load merged model in 4 bits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "03c5c6c7-2e70-473c-92ac-a1e4a6566f05",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "580e58ae770347429a4e54f393cec082",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/18 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# model = AutoModelForVision2Seq.from_pretrained(\n",
+    "#   \"./merged_model_french_ocr_qwen7-vl\",\n",
+    "#   torch_dtype=torch.bfloat16\n",
+    "# )\n",
+    "from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig,Qwen2VLProcessor\n",
+    "from peft import LoraConfig\n",
+    "from qwen_vl_utils import process_vision_info\n",
+    "merged_path = \"peft_merged_model_french_ocr_qwen7-vl\"\n",
+    "\n",
+    "# BitsAndBytesConfig int-4 config\n",
+    "bnb_config = BitsAndBytesConfig(\n",
+    "    load_in_4bit=True, bnb_4bit_use_double_quant=True, bnb_4bit_quant_type=\"nf4\", bnb_4bit_compute_dtype=torch.bfloat16\n",
+    ")\n",
+    "\n",
+    "# Load model and tokenizer\n",
+    "merged_model = AutoModelForVision2Seq.from_pretrained(\n",
+    "    merged_path,\n",
+    "    device_map=\"auto\",\n",
+    "    # attn_implementation=\"flash_attention_2\", # not supported for training\n",
+    "    torch_dtype=torch.bfloat16,\n",
+    "    quantization_config=bnb_config\n",
+    ")\n",
+    "merged_processor = AutoProcessor.from_pretrained(merged_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f9afcd72-8d81-4fd3-9ce7-0a5516ea7ed9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [03:33<00:00,  1.07s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 1.8805\n",
+      "Average CER: 1.3268\n",
+      "\n",
+      "Detailed results saved to peft_merged_model_4bit_ocr_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark 4bits lora model performance\n",
+    "model_name = \"Merged model 4bits\" \n",
+    "avg_wer, avg_cer = evaluate_ocr_model(merged_model, merged_processor, eval_dataset, output_dir=\"peft_merged_model_4bit_ocr_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16791257-6a20-4a78-8c13-04277bc497a8",
+   "metadata": {},
+   "source": [
+    "## load merged model in 8 bits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d1e6ce2b-3148-4849-9af5-88fa3ae3db74",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8a6ca5985b97441abeba30c8d0a498fb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/18 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig,Qwen2VLProcessor\n",
+    "from peft import LoraConfig\n",
+    "from qwen_vl_utils import process_vision_info\n",
+    "\n",
+    "\n",
+    "quantization_config = BitsAndBytesConfig(load_in_8bit=True)\n",
+    "\n",
+    "merged_model = AutoModelForVision2Seq.from_pretrained(\n",
+    "    merged_path,\n",
+    "    device_map=\"auto\",\n",
+    "    quantization_config=quantization_config\n",
+    ")\n",
+    "\n",
+    "merged_processor = AutoProcessor.from_pretrained(merged_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "af7fe047-ed82-4b05-a430-3df674011276",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [06:53<00:00,  2.07s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 0.0381\n",
+      "Average CER: 0.0136\n",
+      "\n",
+      "Detailed results saved to peft_merged_model_4bit_ocr_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark 8 bits lora model performance\n",
+    "model_name = \"Merged model 8bits\" \n",
+    "avg_wer, avg_cer = evaluate_ocr_model(merged_model, merged_processor, eval_dataset, output_dir=\"peft_merged_model_4bit_ocr_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f51cab5-9e3f-496b-a987-86248a3d02cf",
+   "metadata": {},
+   "source": [
+    "# Model performance comparison report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "067fa460-dd39-4540-add5-3e106ed28bcb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "==== MODEL COMPARISON REPORT ====\n",
+      "\n",
+      "Comparison Table (sorted by WER):\n",
+      "             Model      WER      CER\n",
+      "Merged model 8bits 0.038061 0.013620\n",
+      "   Peft lora model 0.038568 0.015985\n",
+      "Merged model 4bits 1.880497 1.326828\n",
+      "        Base model 3.607724 2.718979\n",
+      "\n",
+      "Comparison table saved to model_comparison_results.csv\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAJOCAYAAABm7rQwAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmDtJREFUeJzs3XlcVGX7x/Hv4MKibC7ghorL474vCS5gqYiWWo+WZQ9quWNqVhZqbmVUZmqaW6aWZeaaZWWuaK654a5loZiJWwqCggrn90c/JkdAQWFGmM/79ZpXzH3uc+Y6czozl9e55z4mwzAMAQAAAAAAAFbkYOsAAAAAAAAAYH8oSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAXlMRESETCaTIiIibB0KIEkqX768evToYeswAABWYjKZNHDgQFuHAeA2gYGBCgwMtHUYQBoUpYD7sHjxYplMJq1YsSLNsjp16shkMmnjxo1plpUtW1b+/v7WCPGe5s+fL5PJlOFjx44dtg4xXT169LCI09HRUf/5z380atQoJSYm3tc2jxw5ojFjxujkyZPZG+z/O3funF599VVVrVpVLi4uKlSokBo0aKC3335bV65cyZHXBAAgu/3+++/q27evKlSoICcnJ7m5ualp06aaMmWKrl+/buvwHthff/2lMWPGKDIy0mqvmXoxMaPHokWLrBZLVowZM8YizgIFCqh8+fIaNGjQfec2Of3+x8XFaezYsapTp44KFy4sZ2dn1axZU6+//rr++uuvHHlNAPeW39YBALlRs2bNJElbtmzRk08+aW6Pi4vToUOHlD9/fm3dulUtW7Y0Lzt9+rROnz6trl27Wj3euxk3bpx8fX3TtFeqVMkG0WSOo6Oj5syZI0mKjY3VypUr9dZbb+n333/Xl19+meXtHTlyRGPHjlVgYKDKly+frbHu2rVL7dq1U3x8vJ5//nk1aNBAkrR79269++672rx5s9asWZOtr/mwOX78uBwcuAYCALnZ999/ry5dusjR0VEhISGqWbOmbty4oS1btui1117T4cOHNXv2bFuH+UD++usvjR07VuXLl1fdunWt+tqDBg1So0aN0rT7+flZNY6smjFjhgoXLqyEhAStX79eU6dO1d69e7Vly5Ysbysn3/8//vhDrVq1UnR0tLp06aI+ffqoYMGCOnDggD799FOtWLFCv/76a7a+5sMmr+ebyL0oSgH3oVSpUvL19U3zhbt9+3YZhqEuXbqkWZb6PLWgdb8Mw1BiYqKcnZ0faDupgoOD1bBhwyytc+vWLaWkpKhgwYJpliUkJKhQoUL3HU9m9i9//vx6/vnnzc8HDBggf39/ffXVV/rwww/l7e1936+fna5cuaInn3xS+fLl0759+1S1alWL5ePHj9cnn3xio+hy1u3H0dHR0dbhAAAeQFRUlLp27apy5cppw4YNKlmypHlZaGioTpw4oe+//96qMT1ovmFNmYm1efPm6ty5c5a2m5KSohs3bsjJyem+XvNerl27JhcXl7v26dy5s4oVKyZJ6tu3r7p27aqvv/5av/zyixo3bvxAr59dbt26paeeekrnzp1TREREmlx8/Pjxeu+992wUXc5LPY7p5e3Aw4BL18B9atasmfbt22cxXH3r1q2qUaOGgoODtWPHDqWkpFgsM5lMatq0qaR/viDfeustVaxYUY6OjipfvryGDx+upKQki9cpX768Hn/8cf30009q2LChnJ2dNWvWLEnSn3/+qU6dOqlQoULy8vLSyy+/nGb9B3Xy5EmZTCZ98MEHmjx5sjne1J+8mUwmHTlyRM8995w8PT3NX/TZsX+ZZTKZ1KxZMxmGoT/++MPcfurUKQ0YMEBVqlSRs7OzihYtqi5dulj8TG/+/Pnq0qWLJKlly5bmYei3z8n1448/qnnz5ipUqJBcXV3Vvn17HT58+J5xzZo1S2fOnNGHH36YpiAlSd7e3ho5cqRF2/Tp01WjRg05OjqqVKlSCg0NTTMMPjAwUDVr1tSBAwcUEBAgFxcXVapUSUuXLpUkbdq0SY888oicnZ1VpUoVrVu3zmL91ON27NgxPf3003Jzc1PRokU1ePDgND+BnDdvnh599FF5eXnJ0dFR1atX14wZM9Lsy92O451zSt28eVNjx45V5cqV5eTkpKJFi6pZs2Zau3atxTY3bNhgft89PDzUsWNHHT16NN19OXHihHr06CEPDw+5u7urZ8+eunbtWjpHBQCQVe+//77i4+P16aefWhSkUlWqVEmDBw9O0/7NN9+oZs2acnR0VI0aNbR69WqL5Zn5npb+nXJg06ZNGjBggLy8vFSmTJksbUP652LRyy+/rPLly8vR0VFlypRRSEiILl68qIiICPNIpZ49e5rzgfnz55vX37lzp9q2bSt3d3e5uLgoICBAW7dutXiNu+VGDyp1rq4vv/zSnCusXr36ru+PlLXcYs+ePWrRooVcXFw0fPjwLMfYvHlzSf/81DPV33//rVdffVW1atVS4cKF5ebmpuDgYO3fv9/cJ7ve//QsW7ZM+/fv14gRI9I9Fm5ubho/frxF25IlS9SgQQM5OzurWLFiev7553XmzBmLPj169FDhwoUVHR2txx9/XIULF1bp0qX18ccfS5IOHjyoRx99VIUKFVK5cuW0cOFCi/VTj9vmzZvVt29fFS1aVG5ubgoJCdHly5ct+q5cuVLt27dXqVKl5OjoqIoVK+qtt95ScnKyRb+7Hcf05pSaOnWqatSoIRcXF3l6eqphw4Zp4ty3b5+Cg4Pl5uamwoUL67HHHkszzUfqvmzdulVDhw5V8eLFVahQIT355JO6cOFCeocFMGOkFHCfmjVrpgULFmjnzp3mD/itW7fK399f/v7+io2N1aFDh1S7dm3zsqpVq6po0aKSpF69eumzzz5T586d9corr2jnzp0KDw/X0aNH08xVdfz4cT377LPq27evevfurSpVquj69et67LHHFB0drUGDBqlUqVJasGCBNmzYkKX9iI2N1cWLFy3aTCaTOc5U8+bNU2Jiovr06SNHR0cVKVLEvKxLly6qXLmy3nnnHRmGkS37l1Wpyaenp6e5bdeuXdq2bZu6du2qMmXK6OTJk5oxY4YCAwN15MgRubi4qEWLFho0aJA++ugjDR8+XNWqVZMk838XLFig7t27KygoSO+9956uXbumGTNmmIuSd/u537fffitnZ+dMX/kcM2aMxo4dq1atWql///46fvy4ZsyYoV27dmnr1q0qUKCAue/ly5f1+OOPq2vXrurSpYtmzJihrl276ssvv9SQIUPUr18/Pffcc5owYYI6d+6s06dPy9XV1eL1nn76aZUvX17h4eHasWOHPvroI12+fFmff/65uc+MGTNUo0YNdejQQfnz59d3332nAQMGKCUlRaGhoRbby+xxHDNmjMLDw9WrVy81btxYcXFx2r17t/bu3avWrVtLktatW6fg4GBVqFBBY8aM0fXr1zV16lQ1bdpUe/fuTfO+P/300/L19VV4eLj27t2rOXPmyMvLK09f+QQAa/nuu+9UoUKFLM2LuWXLFi1fvlwDBgyQq6urPvroI/33v/9VdHS0OcfIzPf07QYMGKDixYtr1KhRSkhIyNI24uPj1bx5cx09elQvvPCC6tevr4sXL+rbb7/Vn3/+qWrVqmncuHEaNWqU+vTpYy6upO7zhg0bFBwcrAYNGmj06NFycHAwX7j5+eef04wKSi83upurV6+mycckqWjRojKZTObnGzZs0OLFizVw4EAVK1ZM5cuXN8/BlN77k5Xc4tKlSwoODlbXrl31/PPP39fI8/TysT/++EPffPONunTpIl9fX507d06zZs1SQECAjhw5olKlSmX7+3+7b7/9VpL0v//9L1P7MH/+fPXs2VONGjVSeHi4zp07pylTpmjr1q3at2+fPDw8zH2Tk5MVHBysFi1a6P3339eXX36pgQMHqlChQhoxYoS6deump556SjNnzlRISIj8/PzSTJsxcOBAeXh4aMyYMebjc+rUKfN8Y6kxFS5cWEOHDlXhwoW1YcMGjRo1SnFxcZowYYLF9jJ7HD/55BMNGjRInTt3Nl+YPHDggHbu3KnnnntOknT48GE1b95cbm5uGjZsmAoUKKBZs2YpMDDQfBH0di+99JI8PT01evRonTx5UpMnT9bAgQP19ddfZ+q9h50yANyXw4cPG5KMt956yzAMw7h586ZRqFAh47PPPjMMwzC8vb2Njz/+2DAMw4iLizPy5ctn9O7d2zAMw4iMjDQkGb169bLY5quvvmpIMjZs2GBuK1eunCHJWL16tUXfyZMnG5KMxYsXm9sSEhKMSpUqGZKMjRs33jX+efPmGZLSfTg6Opr7RUVFGZIMNzc34/z58xbbGD16tCHJePbZZy3as2P/MtK9e3ejUKFCxoULF4wLFy4YJ06cMD744APDZDIZNWvWNFJSUsx9r127lmb97du3G5KMzz//3Ny2ZMmSdN+zq1evGh4eHubjliomJsZwd3dP034nT09Po06dOpnar/PnzxsFCxY02rRpYyQnJ5vbp02bZkgy5s6da24LCAgwJBkLFy40tx07dsyQZDg4OBg7duwwt//000+GJGPevHnmttTj1qFDB4sYBgwYYEgy9u/fb25L7z0MCgoyKlSoYNF2t+NYrlw5o3v37ubnderUMdq3b3+Xd8Mw6tata3h5eRmXLl0yt+3fv99wcHAwQkJC0uzLCy+8YLH+k08+aRQtWvSurwEAuLfY2FhDktGxY8dMryPJKFiwoHHixAlz2/79+w1JxtSpU81tmf2eTs1ZmjVrZty6dcuif2a3MWrUKEOSsXz58jT9U3OHXbt2pfnOTF1euXJlIygoKE2e4evra7Ru3drcllFulJGNGzdmmI9JMs6ePWvum/o9f/jwYYttZPT+3E9uMXPmzEzFnbqfx48fNy5cuGCcPHnSmDt3ruHs7GwUL17cSEhIMPdNTEy0eH3D+Ce/dHR0NMaNG2duy473Pz316tUz3N3dM7VfN27cMLy8vIyaNWsa169fN7evWrXKkGSMGjXK3Na9e3dDkvHOO++Y2y5fvmw4OzsbJpPJWLRokbk9NU8bPXq0uS31uDVo0MC4ceOGuf399983JBkrV6602Nc79e3b13BxcTESExPNbXc7jgEBAUZAQID5eceOHY0aNWrc9f3o1KmTUbBgQeP33383t/3111+Gq6ur0aJFizT70qpVK4tj9PLLLxv58uUzrly5ctfXgX3j53vAfapWrZqKFi1qnitq//79SkhIMF/R8ff3Nw8p3r59u5KTk81Dhn/44QdJ0tChQy22+corr0hSmnkZfH19FRQUZNH2ww8/qGTJkhajcFxcXNSnT58s7cfHH3+stWvXWjx+/PHHNP3++9//qnjx4uluo1+/fmlikx5s/+4mISFBxYsXV/HixVWpUiW9+uqratq0qVauXGlxNfH2ealu3rypS5cuqVKlSvLw8NDevXvv+Tpr167VlStX9Oyzz+rixYvmR758+fTII4+ke4fF28XFxaUZnZSRdevW6caNGxoyZIjFpOC9e/eWm5tbmvescOHCFpPmV6lSRR4eHqpWrZrFVavUv2//WWOqO0c6vfTSS5L+PX6S5XuYOqouICBAf/zxh2JjYy3Wz+xx9PDw0OHDh/Xbb7+lu/zs2bOKjIxUjx49LEbk1a5dW61bt7aIL9Wd/w82b95cly5dUlxc3D3jAQBkLPVzNLPfZ6latWqlihUrmp/Xrl1bbm5uFt9HWf2e7t27t/Lly2fRltltLFu2THXq1LG4QU2q23OH9ERGRuq3337Tc889p0uXLpnzgYSEBD322GPavHmzxZQNUtrvpXsZNWpUmnxs7dq1Ft+DkhQQEKDq1aunu40735+s5haOjo7q2bNnluKuUqWKihcvrvLly+uFF15QpUqV9OOPP1qMcnN0dDS/fnJysi5duqTChQurSpUqmcrH7uf9v11W8rHdu3fr/PnzGjBggMVcXe3bt1fVqlXTnTutV69e5r89PDxUpUoVFSpUSE8//bS5PTVPSy8f69Onj8WItf79+yt//vwZ5mOpo+qaN2+ua9eu6dixYxbby+xx9PDw0J9//qldu3aluzw5OVlr1qxRp06dVKFCBXN7yZIl9dxzz2nLli1p8qw+ffpYnE/NmzdXcnKyTp06dc94YL/4+R5wn0wmk/z9/c1fhFu3bpWXl5f5rnX+/v6aNm2aJJmLU6lFqVOnTsnBwSHNHe5KlCghDw+PNB/c6d0d79SpU6pUqVKaRCqrP31r3LhxpiY6Ty+GjJZlx/7djZOTk7777jtJ/8yr9f777+v8+fNpJke/fv26wsPDNW/ePJ05c8Zi+PydBZX0pBZNHn300XSXu7m53XV9Nzc3Xb169Z6vI8n8ntx5/AoWLKgKFSqkec/KlCmT5ti7u7vLx8cnTZukNHMTSFLlypUtnlesWFEODg4W83Bs3bpVo0eP1vbt29PM0RQbG2vevpT54zhu3Dh17NhR//nPf1SzZk21bdtW//vf/8w/dc3ovZD+KQb/9NNPaSZwLVu2rEW/1J8NXL58+Z7HCQCQsdTP0Mx+n6W683NZ+uez+fbvo6x+T6f3PZPZbfz+++/673//m6V9SJWaD3Tv3j3DPrGxsRY/WctqblOrVi21atXqnv2ymo9Jmc8tSpcuneXJsJctWyY3NzdduHBBH330kaKiotLkYykpKZoyZYqmT5+uqKgoi3mQ7pwuIj338/7f7s5i6N3cLQepWrVqmhsZOTk5pblo6+7unmGelpl8rHDhwipZsqRFPnb48GGNHDlSGzZsSFMIuvNcyexxfP3117Vu3To1btxYlSpVUps2bfTcc8+Z57+9cOGCrl27lmE+lpKSotOnT6tGjRrm9rvlY0BGKEoBD6BZs2b67rvvdPDgQfN8Uqn8/f312muv6cyZM9qyZYtKlSplcZVBuveVuVTZdae9B3G3GDJallP7ly9fPovELSgoSFWrVlXfvn3N8wZI/4z8mTdvnoYMGSI/Pz+5u7vLZDKpa9eud72iliq1z4IFC1SiRIk0y/Pnv/tHaNWqVRUZGakbN25k+x1P7rxSfK92IxPzWdx5vH7//Xc99thjqlq1qj788EP5+PioYMGC+uGHHzRp0qQ072Fmj2OLFi30+++/a+XKlVqzZo3mzJmjSZMmaebMmRZXG7PiQfYbAJAxNzc3lSpVSocOHcrSepn5XM7q93R63zMP+l2fGanbmTBhgurWrZtun8KFC98z1uxwP/lYdmw7Iy1atDDffe+JJ55QrVq11K1bN+3Zs8c8Ouqdd97Rm2++qRdeeEFvvfWWihQpIgcHBw0ZMiRL+VhW3v/bVa1aVfv27dPp06fTXLx7UDmRj93pypUrCggIkJubm8aNG6eKFSvKyclJe/fu1euvv37f+Vi1atV0/PhxrVq1SqtXr9ayZcs0ffp0jRo1SmPHjs1ynBL5GO4PRSngAaSOfNqyZYu2bt2qIUOGmJc1aNBAjo6OioiI0M6dO9WuXTvzsnLlyiklJUW//fabeUJtSTp37pyuXLmicuXK3fO1y5Urp0OHDskwDItiwvHjx7Nhzx5MduxfVpQsWVIvv/yyxo4dqx07dqhJkyaSpKVLl6p79+6aOHGiuW9iYmKaO85kVDxL/dmBl5dXpq5e3umJJ57Q9u3btWzZMj377LN37Zv6nhw/ftyieHnjxg1FRUXd1+vfy2+//WZxVfXEiRNKSUkxTyL+3XffKSkpSd9++63Fla97/WwxM4oUKaKePXuqZ8+eio+PV4sWLTRmzBj16tXL4r2407Fjx1SsWLFccxtwAMgLHn/8cc2ePVvbt2+Xn59ftm03s9/T2bGNihUr3rOwdq98wM3NLUe+j3OKtXOLwoULa/To0erZs6cWL15snmZg6dKlatmypT799FOL/leuXDEXtKSce/+feOIJffXVV/riiy8UFhZ21763v2d3jpQ/fvx4tuew0j/5WMuWLc3P4+PjdfbsWfO/HSIiInTp0iUtX75cLVq0MPeLiop64NcuVKiQnnnmGT3zzDO6ceOGnnrqKY0fP15hYWEqXry4XFxcMszHHBwcsr3IB/vEnFLAA2jYsKGcnJz05Zdf6syZMxYjpRwdHVW/fn19/PHHSkhIsLgFbeqXzOTJky229+GHH0r653fr99KuXTv99ddfWrp0qbnt2rVrmj179oPsUrbIjv3LqpdeekkuLi569913zW358uVLc2Vm6tSpaW6fm1rguDOBDQoKkpubm9555x3dvHkzzWve6xa3/fr1U8mSJfXKK6/o119/TbP8/PnzevvttyX9M/dGwYIF9dFHH1nE/Omnnyo2NjZH3rPUWxanmjp1qiQpODhY0r9Xu+78KcS8efMe6HUvXbpk8bxw4cKqVKmSkpKSJP1TZKxbt64+++wzi2Ny6NAhrVmzxqLACwDIecOGDVOhQoXUq1cvnTt3Ls3y33//XVOmTMnydjP7PZ0d2/jvf/+r/fv3p7kDsPTv91xG+UCDBg1UsWJFffDBB4qPj0+z/sN6y3tb5BbdunVTmTJlLO5+m94xWrJkic6cOWPRllPvf+fOnVWrVi2NHz9e27dvT7P86tWrGjFihKR/cnsvLy/NnDnTnJdI0o8//qijR4/myHs2e/ZsizxzxowZunXr1l3zsRs3bmj69OkP9Lp35mMFCxZU9erVZRiGbt68qXz58qlNmzZauXKlxU8Jz507p4ULF6pZs2ZMkYBswUgp4AEULFhQjRo10s8//yxHR0c1aNDAYrm/v7/5yt3tRak6deqoe/fumj17tnlI7i+//KLPPvtMnTp1srhakpHevXtr2rRpCgkJ0Z49e1SyZEktWLAgze2T7+XHH39MM0Fiaux3/twws7Jj/7KqaNGi6tmzp6ZPn66jR4+qWrVqevzxx7VgwQK5u7urevXq2r59u9atW5dm/oK6desqX758eu+99xQbGytHR0c9+uij8vLy0owZM/S///1P9evXV9euXVW8eHFFR0fr+++/V9OmTc3zhqXH09NTK1asULt27VS3bl09//zz5v9H9u7dq6+++sp8xbl48eIKCwvT2LFj1bZtW3Xo0EHHjx/X9OnT1ahRIz3//PPZ/p5FRUWpQ4cOatu2rbZv364vvvhCzz33nOrUqSNJatOmjQoWLKgnnnhCffv2VXx8vD755BN5eXnp7Nmz9/261atXV2BgoBo0aKAiRYpo9+7dWrp0qQYOHGjuM2HCBAUHB8vPz08vvviirl+/rqlTp8rd3V1jxox50F0HAGRBxYoVtXDhQj3zzDOqVq2aQkJCVLNmTd24cUPbtm3TkiVL1KNHjyxvN7Pf09mxjddee01Lly5Vly5d9MILL6hBgwb6+++/9e2332rmzJmqU6eOKlasKA8PD82cOVOurq4qVKiQHnnkEfn6+mrOnDkKDg5WjRo11LNnT5UuXVpnzpzRxo0b5ebmZp7r8n79/PPPSkxMTNNeu3Zt85yLWWWL3KJAgQIaPHiwXnvtNa1evVpt27bV448/rnHjxqlnz57y9/fXwYMH9eWXX6bJM3Pq/S9QoICWL1+uVq1aqUWLFnr66afVtGlTFShQQIcPH9bChQvl6emp8ePHq0CBAnrvvffUs2dPBQQE6Nlnn9W5c+c0ZcoUlS9fXi+//HK2v2c3btzQY489pqefftp8fJo1a6YOHTpI+icn9/T0VPfu3TVo0CCZTCYtWLDggX8S16ZNG5UoUUJNmzaVt7e3jh49qmnTpql9+/bmieHffvttrV27Vs2aNdOAAQOUP39+zZo1S0lJSXr//fcfeN8BSZJ1b/YH5D1hYWGGJMPf3z/NsuXLlxuSDFdX1zS3ML5586YxduxYw9fX1yhQoIDh4+NjhIWFWdzW1TAMo1y5ckb79u3Tfe1Tp04ZHTp0MFxcXIxixYoZgwcPNlavXm1IMjZu3HjXuFNv3ZrRI/V2vFFRUYYkY8KECWm2kXo74AsXLqRZlh37l57u3bsbhQoVSnfZ77//buTLl8/o3r27YRj/3Ja3Z8+eRrFixYzChQsbQUFBxrFjx4xy5cqZ+6T65JNPjAoVKhj58uVL8/5t3LjRCAoKMtzd3Q0nJyejYsWKRo8ePYzdu3dnKua//vrLePnll43//Oc/hpOTk+Hi4mI0aNDAGD9+vBEbG2vRd9q0aUbVqlWNAgUKGN7e3kb//v2Ny5cvW/QJCAhI9xa+Gb2XkozQ0FDz89TjduTIEaNz586Gq6ur4enpaQwcONDi9seGYRjffvutUbt2bcPJyckoX7688d577xlz5841JBlRUVH3fO3UZbe/32+//bbRuHFjw8PDw3B2djaqVq1qjB8/3uJ2yIZhGOvWrTOaNm1qODs7G25ubsYTTzxhHDlyxKJPRv8Ppv7/fXuMAIAH8+uvvxq9e/c2ypcvbxQsWNBwdXU1mjZtakydOtXi+/3O751Ud34fZPZ7OvUzfdeuXWm2mZXv+kuXLhkDBw40SpcubRQsWNAoU6aM0b17d+PixYvmPitXrjSqV69u5M+f3yIfMgzD2Ldvn/HUU08ZRYsWNRwdHY1y5coZTz/9tLF+/Xpzn7vlRunZuHHjXfOx0aNH3/N9vdv7YxgPlltk5G77GRsba7i7uxsBAQGGYRhGYmKi8corrxglS5Y0nJ2djaZNmxrbt283AgICzH1SPej7fzeXL182Ro0aZdSqVctwcXExnJycjJo1axphYWHG2bNnLfp+/fXXRr169QxHR0ejSJEiRrdu3Yw///zTok9GOWlm87TU47Zp0yajT58+hqenp1G4cGGjW7duxqVLlyzW3bp1q9GkSRPD2dnZKFWqlDFs2DDjp59+SpOz3u043vl+z5o1y2jRooX5/axYsaLx2muvpclN9+7dawQFBRmFCxc2XFxcjJYtWxrbtm2z6JPR/4Op/3/f698lsG8mw2DWMQCwJ2PGjNHYsWN14cIFi7kcAAAAYB3z589Xz549tWvXrkzdCRvIq5hTCgAAAAAAAFZHUQoAAAAAAABWR1EKAAAAAAAAVsecUgAAAAAAALA6RkoBAAAAAADA6ihKAQAAAAAAwOry2zoAa0tJSdFff/0lV1dXmUwmW4cDAAAecoZh6OrVqypVqpQcHOz3eh45FAAAyKzM5k92V5T666+/5OPjY+swAABALnP69GmVKVPG1mHYDDkUAADIqnvlT3ZXlHJ1dZX0zxvj5uZm42gAAMDDLi4uTj4+PuYcwl6RQwEAgMzKbP5kd0Wp1OHmbm5uJFQAACDT7P0na+RQAAAgq+6VP9nvxAgAAAAAAACwGYpSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALC6/LYOAACA3ObdfRdtHQLu8Ea9YrYOAQAA3MWUy1NsHQLuMNhzsK1DYKQUAAAAAAAArI+iFAAAAAAAAKyOohQAAAAAAACsjqIUAAAAAAAArI6iFAAAAAAAAKyOohQAAAAAAACsjqIUAAAAAAAArM6mRakZM2aodu3acnNzk5ubm/z8/PTjjz9m2H/+/PkymUwWDycnJytGDAAAAAAAgOyQ35YvXqZMGb377ruqXLmyDMPQZ599po4dO2rfvn2qUaNGuuu4ubnp+PHj5ucmk8la4QIAAAAAACCb2LQo9cQTT1g8Hz9+vGbMmKEdO3ZkWJQymUwqUaKENcIDAAAAAABADnlo5pRKTk7WokWLlJCQID8/vwz7xcfHq1y5cvLx8VHHjh11+PDhu243KSlJcXFxFg8AAAAAAADYls2LUgcPHlThwoXl6Oiofv36acWKFapevXq6fatUqaK5c+dq5cqV+uKLL5SSkiJ/f3/9+eefGW4/PDxc7u7u5oePj09O7QoAAAAAAAAyyeZFqSpVqigyMlI7d+5U//791b17dx05ciTdvn5+fgoJCVHdunUVEBCg5cuXq3jx4po1a1aG2w8LC1NsbKz5cfr06ZzaFQAAAAAAAGSSTeeUkqSCBQuqUqVKkqQGDRpo165dmjJlyl0LTakKFCigevXq6cSJExn2cXR0lKOjY7bFCwAAAAAAgAdn85FSd0pJSVFSUlKm+iYnJ+vgwYMqWbJkDkcFAAAAAACA7GTTkVJhYWEKDg5W2bJldfXqVS1cuFARERH66aefJEkhISEqXbq0wsPDJUnjxo1TkyZNVKlSJV25ckUTJkzQqVOn1KtXL1vuBgAAAAAAALLIpkWp8+fPKyQkRGfPnpW7u7tq166tn376Sa1bt5YkRUdHy8Hh38Fcly9fVu/evRUTEyNPT081aNBA27Zty3BidAAAAAAAADycbFqU+vTTT++6PCIiwuL5pEmTNGnSpByMCAAAAAAAANbw0M0pBQAAAAAAgLyPohQAAAAAAACsjqIUAAAAAAAArI6iFAAAAAAAAKyOohQAAAAAAACsjqIUAAAAAAAArI6iFAAAAAAAAKyOohQAAAAAAACsjqIUAAAAAAAArI6iFAAAQC4SHh6uRo0aydXVVV5eXurUqZOOHz9+13Xmz58vk8lk8XBycrJSxAAAAOmjKAUAAJCLbNq0SaGhodqxY4fWrl2rmzdvqk2bNkpISLjrem5ubjp79qz5cerUKStFDAAAkL78tg4AAAAAmbd69WqL5/Pnz5eXl5f27NmjFi1aZLieyWRSiRIlcjo8AACATGOkFAAAQC4WGxsrSSpSpMhd+8XHx6tcuXLy8fFRx44ddfjwYWuEBwAAkCGKUgAAALlUSkqKhgwZoqZNm6pmzZoZ9qtSpYrmzp2rlStX6osvvlBKSor8/f31559/ZrhOUlKS4uLiLB4AAADZiZ/vAQAA5FKhoaE6dOiQtmzZctd+fn5+8vPzMz/39/dXtWrVNGvWLL311lvprhMeHq6xY8dma7wAAAC3Y6QUAABALjRw4ECtWrVKGzduVJkyZbK0boECBVSvXj2dOHEiwz5hYWGKjY01P06fPv2gIQMAAFhgpBQAAEAuYhiGXnrpJa1YsUIRERHy9fXN8jaSk5N18OBBtWvXLsM+jo6OcnR0fJBQAQAA7oqiFAAAQC4SGhqqhQsXauXKlXJ1dVVMTIwkyd3dXc7OzpKkkJAQlS5dWuHh4ZKkcePGqUmTJqpUqZKuXLmiCRMm6NSpU+rVq5fN9gMAAICiFAAAQC4yY8YMSVJgYKBF+7x589SjRw9JUnR0tBwc/p2l4fLly+rdu7diYmLk6empBg0aaNu2bapevbq1wgYAAEiDohQAAEAuYhjGPftERERYPJ80aZImTZqUQxEBAADcHyY6BwAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNXZtCg1Y8YM1a5dW25ubnJzc5Ofn59+/PHHu66zZMkSVa1aVU5OTqpVq5Z++OEHK0ULAAAAAACA7GLTolSZMmX07rvvas+ePdq9e7ceffRRdezYUYcPH063/7Zt2/Tss8/qxRdf1L59+9SpUyd16tRJhw4dsnLkAAAAAAAAeBA2LUo98cQTateunSpXrqz//Oc/Gj9+vAoXLqwdO3ak23/KlClq27atXnvtNVWrVk1vvfWW6tevr2nTplk5cgAAAAAAADyIh2ZOqeTkZC1atEgJCQny8/NLt8/27dvVqlUri7agoCBt377dGiECAAAAAAAgm+S3dQAHDx6Un5+fEhMTVbhwYa1YsULVq1dPt29MTIy8vb0t2ry9vRUTE5Ph9pOSkpSUlGR+HhcXlz2BAwAAAAAA4L7ZfKRUlSpVFBkZqZ07d6p///7q3r27jhw5km3bDw8Pl7u7u/nh4+OTbdsGAAAAAADA/bF5UapgwYKqVKmSGjRooPDwcNWpU0dTpkxJt2+JEiV07tw5i7Zz586pRIkSGW4/LCxMsbGx5sfp06ezNX4AAAAAAABknc2LUndKSUmx+Lnd7fz8/LR+/XqLtrVr12Y4B5UkOTo6ys3NzeIBAAAAAAAA27LpnFJhYWEKDg5W2bJldfXqVS1cuFARERH66aefJEkhISEqXbq0wsPDJUmDBw9WQECAJk6cqPbt22vRokXavXu3Zs+ebcvdAAAAAAAAQBbZtCh1/vx5hYSE6OzZs3J3d1ft2rX1008/qXXr1pKk6OhoOTj8O5jL399fCxcu1MiRIzV8+HBVrlxZ33zzjWrWrGmrXQAAAAAAAMB9sGlR6tNPP73r8oiIiDRtXbp0UZcuXXIoIgAAAAAAAFjDQzenFAAAAAAAAPI+ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAAAAAsDqKUgAAAAAAALA6ilIAAAAAAACwOopSAAAAuUh4eLgaNWokV1dXeXl5qVOnTjp+/Pg911uyZImqVq0qJycn1apVSz/88IMVogUAAMgYRSkAAIBcZNOmTQoNDdWOHTu0du1a3bx5U23atFFCQkKG62zbtk3PPvusXnzxRe3bt0+dOnVSp06ddOjQIStGDgAAYCm/rQMAAABA5q1evdri+fz58+Xl5aU9e/aoRYsW6a4zZcoUtW3bVq+99pok6a233tLatWs1bdo0zZw5M8djBgAASA8jpQAAAHKx2NhYSVKRIkUy7LN9+3a1atXKoi0oKEjbt2/PcJ2kpCTFxcVZPAAAALITRSkAAIBcKiUlRUOGDFHTpk1Vs2bNDPvFxMTI29vbos3b21sxMTEZrhMeHi53d3fzw8fHJ9viBgAAkChKAQAA5FqhoaE6dOiQFi1alO3bDgsLU2xsrPlx+vTpbH8NAABg35hTCgAAIBcaOHCgVq1apc2bN6tMmTJ37VuiRAmdO3fOou3cuXMqUaJEhus4OjrK0dExW2IFAABIDyOlAAAAchHDMDRw4ECtWLFCGzZskK+v7z3X8fPz0/r16y3a1q5dKz8/v5wKEwAA4J4YKQUAAJCLhIaGauHChVq5cqVcXV3N80K5u7vL2dlZkhQSEqLSpUsrPDxckjR48GAFBARo4sSJat++vRYtWqTdu3dr9uzZNtsPAAAARkoBAADkIjNmzFBsbKwCAwNVsmRJ8+Prr78294mOjtbZs2fNz/39/bVw4ULNnj1bderU0dKlS/XNN9/cdXJ0AACAnMZIKQAAgFzEMIx79omIiEjT1qVLF3Xp0iUHIgIAALg/jJQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDVUZQCAAAAAACA1VGUAgAAAAAAgNVRlAIAAAAAAIDV2bQoFR4erkaNGsnV1VVeXl7q1KmTjh8/ftd15s+fL5PJZPFwcnKyUsQAAAAAAADIDvmzukJUVJR+/vlnnTp1SteuXVPx4sVVr149+fn5Zbk4tGnTJoWGhqpRo0a6deuWhg8frjZt2ujIkSMqVKhQhuu5ublZFK9MJlNWdwMAAAAAAAA2lOmi1JdffqkpU6Zo9+7d8vb2VqlSpeTs7Ky///5bv//+u5ycnNStWze9/vrrKleuXKa2uXr1aovn8+fPl5eXl/bs2aMWLVpkuJ7JZFKJEiUyGzoAAAAAAAAeMpkqStWrV08FCxZUjx49tGzZMvn4+FgsT0pK0vbt27Vo0SI1bNhQ06dPV5cuXbIcTGxsrCSpSJEid+0XHx+vcuXKKSUlRfXr19c777yjGjVqZPn1AAAArCU7R5sDAADkBZkqSr377rsKCgrKcLmjo6MCAwMVGBio8ePH6+TJk1kOJCUlRUOGDFHTpk1Vs2bNDPtVqVJFc+fOVe3atRUbG6sPPvhA/v7+Onz4sMqUKZOmf1JSkpKSkszP4+LishwbAADA/cqJ0eYAAAB5QaaKUqkFqVu3bmnhwoUKCgqSt7d3un2LFi2qokWLZjmQ0NBQHTp0SFu2bLlrPz8/P/n5+Zmf+/v7q1q1apo1a5beeuutNP3Dw8M1duzYLMcDAADwoKw12hwAACA3ytLd9/Lnz69+/fopMTExW4MYOHCgVq1apY0bN6Y72uluChQooHr16unEiRPpLg8LC1NsbKz5cfr06ewIGQAA4J7effdd7dy5UwMGDEhTkJL+HW0+c+ZMHTt2TBUqVLBBlAAAALaRpaKUJDVu3FiRkZHZ8uKGYWjgwIFasWKFNmzYIF9f3yxvIzk5WQcPHlTJkiXTXe7o6Cg3NzeLBwAAgDXcPtr8888/17lz5zLsW7RoUTVo0MBaoQEAANhcpu++l2rAgAEaOnSoTp8+rQYNGqhQoUIWy2vXrp3pbYWGhmrhwoVauXKlXF1dFRMTI0lyd3eXs7OzJCkkJESlS5dWeHi4JGncuHFq0qSJKlWqpCtXrmjChAk6deqUevXqldVdAQAAsIrU0eZHjx61dSgAAAAPjSwXpbp27SpJGjRokLnNZDLJMAyZTCYlJydnelszZsyQJAUGBlq0z5s3Tz169JAkRUdHy8Hh3wFdly9fVu/evRUTEyNPT081aNBA27ZtU/Xq1bO6KwAAAFaTOtqcycwBAAD+keWiVFRUVLa9uGEY9+wTERFh8XzSpEmaNGlStsUAAABgDdk52hwAACAvyHJRiqt7AAAAWZedo80BAADygiwXpSRpwYIFmjlzpqKiorR9+3aVK1dOkydPlq+vrzp27JjdMQIAAOR62TnaHAAAIC/I8t33ZsyYoaFDh6pdu3a6cuWK+aqeh4eHJk+enN3xAQAA5AnlypW76wMAAMDeZLkoNXXqVH3yyScaMWKE8uXLZ25v2LChDh48mK3BAQAA5CULFixQ06ZNVapUKZ06dUqSNHnyZK1cudLGkQEAAFhflotSUVFRqlevXpp2R0dHJSQkZEtQAAAAeQ2jzQEAACxluSjl6+uryMjINO2rV69WtWrVsiMmAACAPIfR5gAAAJayPNH50KFDFRoaqsTERBmGoV9++UVfffWVwsPDNWfOnJyIEQAAINdjtDkAAIClLBelevXqJWdnZ40cOVLXrl3Tc889p1KlSmnKlCnmWx0DAADAUupo8zsnNWe0OQAAsFdZLkpJUrdu3dStWzddu3ZN8fHx8vLyyu64AAAA8hRGmwMAAFjKclHq0Ucf1fLly+Xh4SEXFxe5uLhIkuLi4tSpUydt2LAh24MEAADI7RhtDgAAYCnLRamIiAjduHEjTXtiYqJ+/vnnbAkKAAAgL2K0OQAAwL8yXZQ6cOCA+e8jR44oJibG/Dw5OVmrV69W6dKlszc6AACAPILR5gAAAJYyXZSqW7euTCaTTCaTHn300TTLnZ2dNXXq1GwNDgAAIK9gtDkAAIClTBeloqKiZBiGKlSooF9++UXFixc3LytYsKC8vLyUL1++HAkSAAAgt2K0OQAAQPoyXZRKvX3xxo0bVbduXeXPb7lqcnKyNm/erBYtWmRvhAAAALkYo80BAADSd1933zt79myaiTmvXLmili1bKjk5OduCAwAAyO0YbQ4AAJC+LBelDMOQyWRK037p0iUVKlQoW4ICAADIKxhtDgAAkL5MF6WeeuopSZLJZFKPHj3k6OhoXpacnKwDBw7I398/+yMEAADIAxhtDgAAYCnTRSl3d3dJ/4yUcnV1lbOzs3lZwYIF1aRJE/Xu3Tv7IwQAAMgDGG0OAABgKdNFqXnz5kmSypcvr1dffZXkCQAAIBMYbQ4AAJC+LM8pNXr0aN26dUvr1q3T77//rueee06urq7666+/5ObmpsKFC+dEnAAAALkSo80BAADSl+Wi1KlTp9S2bVtFR0crKSlJrVu3lqurq9577z0lJSVp5syZOREnAABArsRocwAAgPQ5ZHWFwYMHq2HDhrp8+bLFlb4nn3xS69evz9bgAAAA8orRo0fL0dFR69at06xZs3T16lVJ0l9//aX4+HgbRwcAAGB9WR4p9fPPP2vbtm0qWLCgRXv58uV15syZbAsMAAAgL2G0OQAAgKUsj5RKSUlJ95bFf/75p1xdXbMlKAAAgLyG0eYAAACWslyUatOmjSZPnmx+bjKZFB8fr9GjR6tdu3bZGRsAAECe8fPPP2vkyJGMNgcAAPh/Wf753sSJExUUFKTq1asrMTFRzz33nH777TcVK1ZMX331VU7ECAAAkOsx2hwAAMBSlotSZcqU0f79+7Vo0SIdOHBA8fHxevHFF9WtWzeLoegAAAD4V+po89mzZ0titDkAAECWi1KSlD9/fj3//PPZHQsAAECexWhzAAAAS/dVlDp+/LimTp2qo0ePSpKqVaumgQMHqmrVqtkaHAAAQF7BaHMAAABLWS5KLVu2TF27dlXDhg3l5+cnSdqxY4dq1aqlRYsW6b///W+2BwkAAJAXMNocAADgX1kuSg0bNkxhYWEaN26cRfvo0aM1bNgwilIAAAAZYLQ5AADAvxyyusLZs2cVEhKSpv3555/X2bNnsyUoAACAvGbZsmWqWbOm9uzZozp16qhOnTrau3evatWqpWXLltk6PAAAAKvL8kipwMBA/fzzz6pUqZJF+5YtW9S8efNsCwwAACAvYbQ5AACApUwVpb799lvz3x06dNDrr7+uPXv2qEmTJpL+mVNqyZIlGjt2bM5ECQAAkMvdbbT5hAkTbBARAACAbWWqKNWpU6c0bdOnT9f06dMt2kJDQ9WvX79sCQwAACAvYbQ5AACApUwVpVJSUnI6DgAAgDyH0eYAAAAZy/KcUgAAAMgcRpsDAABkjKIUAABADmG0OQAAQMYcbB0AAAAAAAAA7A9FKQAAAAAAAFgdRSkAAAAAAABYXZaLUnv37tXBgwfNz1euXKlOnTpp+PDhunHjRrYGBwAAAAAAgLwpy0Wpvn376tdff5Uk/fHHH+ratatcXFy0ZMkSDRs2LNsDBAAAAAAAQN6T5aLUr7/+qrp160qSlixZohYtWmjhwoWaP3++li1blt3xAQAA5AmMNgcAALCU5aKUYRjm2xuvW7dO7dq1kyT5+Pjo4sWL2RsdAABAHsFocwAAAEtZLko1bNhQb7/9thYsWKBNmzapffv2kqSoqCh5e3tnaVvh4eFq1KiRXF1d5eXlpU6dOun48eP3XG/JkiWqWrWqnJycVKtWLf3www9Z3Q0AAACrYrQ5AACApSwXpSZPnqy9e/dq4MCBGjFihCpVqiRJWrp0qfz9/bO0rU2bNik0NFQ7duzQ2rVrdfPmTbVp00YJCQkZrrNt2zY9++yzevHFF7Vv3z516tRJnTp10qFDh7K6KwAAAFaTnaPNN2/erCeeeEKlSpWSyWTSN998c9f+ERERMplMaR4xMTH3tS8AAADZIX9WV6hdu7bFfAipJkyYoHz58mVpW6tXr7Z4Pn/+fHl5eWnPnj1q0aJFuutMmTJFbdu21WuvvSZJeuutt7R27VpNmzZNM2fOzNLrAwAAWEvqaPNWrVpp06ZNmjFjhqT7G22ekJCgOnXq6IUXXtBTTz2V6fWOHz8uNzc383MvL68svS4AAEB2ynJRKiNOTk4PvI3Y2FhJUpEiRTLss337dg0dOtSiLSgoKMMrhElJSUpKSjI/j4uLe+A4AQAAsmry5Mnq1q2bvvnmmwcebR4cHKzg4OAsx+Dl5SUPD48srwcAAJATMlWUKlKkiH799VcVK1ZMnp6eMplMGfb9+++/7yuQlJQUDRkyRE2bNlXNmjUz7BcTE5PmaqK3t3eGw8/Dw8M1duzY+4oJAAAgu2TnaPP7VbduXSUlJalmzZoaM2aMmjZtmmFfLuwBAICclqmi1KRJk+Tq6irpn6t8OSE0NFSHDh3Sli1bsnW7YWFhFiOr4uLi5OPjk62vAQAAcL+yY7T5vZQsWVIzZ85Uw4YNlZSUpDlz5igwMFA7d+5U/fr1012HC3sAACCnZaoo1b1793T/zi4DBw7UqlWrtHnzZpUpU+aufUuUKKFz585ZtJ07d04lSpRIt7+jo6McHR2zLVYAAIDMssZo88yoUqWKqlSpYn7u7++v33//XZMmTdKCBQvSXYcLewAAIKdl25xS98MwDL300ktasWKFIiIi5Ovre891/Pz8tH79eg0ZMsTctnbtWvn5+eVgpAAAAFlnjdHm96tx48Z3HaHOhT0AAJDTbFqUCg0N1cKFC7Vy5Uq5urqa54Vyd3eXs7OzJCkkJESlS5dWeHi4JGnw4MEKCAjQxIkT1b59ey1atEi7d+/W7NmzbbYfAAAA6cnp0eYPIjIyUiVLlrR1GAAAwI7ZtCiVeivkwMBAi/Z58+apR48ekqTo6Gg5ODiYl/n7+2vhwoUaOXKkhg8frsqVK+ubb7656+ToAAAAeUl8fLxOnDhhfh4VFaXIyEgVKVJEZcuWVVhYmM6cOaPPP/9c0j+jtHx9fVWjRg0lJiZqzpw52rBhg9asWWOrXQAAALD9z/fuJSIiIk1bly5d1KVLlxyICAAA4OG3e/dutWzZ0vw8de6n7t27a/78+Tp79qyio6PNy2/cuKFXXnlFZ86ckYuLi2rXrq1169ZZbAMAAMDaslSUunnzppydnRUZGcnIJAAAABsJDAy868W9+fPnWzwfNmyYhg0blsNRAQAAZI3Dvbv8q0CBAipbtqySk5NzKh4AAAAAAADYgSwVpSRpxIgRGj58eI7ethgAACAvuXnzpvLnz69Dhw7ZOhQAAICHRpbnlJo2bZpOnDihUqVKqVy5cipUqJDF8r1792ZbcAAAAHkBo80BAADSynJRqlOnTjkQBgAAQN6WOtp8wYIFKlKkiK3DAQAAsLksF6VGjx6dE3EAAADkaYw2BwAAsJTlopQkXblyRUuXLtXvv/+u1157TUWKFNHevXvl7e2t0qVLZ3eMAAAAuR6jzQEAACxluSh14MABtWrVSu7u7jp58qR69+6tIkWKaPny5YqOjtbnn3+eE3ECwEPp3X0XbR0C7vBGvWK2DgFIF6PNAQAALGX57ntDhw5Vjx499Ntvv8nJycnc3q5dO23evDlbgwMAAMhLrly5ojlz5igsLMx8J+O9e/fqzJkzNo4MAADA+rI8UmrXrl2aNWtWmvbSpUsrJiYmW4ICAADIaxhtDgAAYCnLI6UcHR0VFxeXpv3XX39V8eLFsyUoAACAvIbR5gAAAJayXJTq0KGDxo0bp5s3b0qSTCaToqOj9frrr+u///1vtgcIAACQF+zatUt9+/ZN085ocwAAYK+yXJSaOHGi4uPj5eXlpevXrysgIECVKlWSq6urxo8fnxMxAgAA5HqMNgcAALCU5Tml3N3dtXbtWm3ZskUHDhxQfHy86tevr1atWuVEfAAAAHlC6mjzxYsXS2K0OQAAQJaLUomJiXJyclKzZs3UrFmznIgJAAAgz5k4caI6d+5sMdo8JiZGfn5+jDYHAAB2KctFKQ8PDzVu3FgBAQFq2bKl/Pz85OzsnBOxAQAA5BmMNgcAALCU5aLUunXrtHnzZkVERGjSpEm6deuWGjZsqICAAAUGBqp169Y5EScAAECuxmhzAAAAS1me6LxZs2YaPny41qxZoytXrmjjxo2qVKmS3n//fbVt2zYnYgQAAMj1PDw81KJFC7355pvasGGDrl+/buuQAAAAbCrLI6Wkf+4SExERYX4kJSXp8ccfV2BgYDaHBwAAkDcw2hwAAMBSlotSpUuX1vXr1xUYGKjAwEC9/vrrql27tkwmU07EBwAAkCek/mxv+PDhunXrlnbt2qVZs2bp/fff17vvvqvk5GRbhwgAAGBVWS5KFS9eXMeOHVNMTIxiYmJ07tw5Xb9+XS4uLjkRHwAAQJ7BaHMAAIB/ZbkoFRkZqStXrmjz5s3atGmThg8friNHjqhu3bpq2bIltzQGAABIB6PNAeAfUy5PsXUIuMNgz8G2DgF2KssTnUv/TNTZoUMHDR8+XGFhYercubN27dqld999N7vjAwAAyBOKFy+ua9eupRltDgAAYK+yXJRavny5Bg0apNq1a8vb21v9+/dXfHy8Jk6cqL179+ZEjAAAALleZGSkYmJi9MYbbygpKUnDhw9XsWLF5O/vrxEjRtg6PAAAAKvL8s/3+vXrpxYtWqhPnz4KCAhQrVq1ciIuAACAPCd1tHnTpk3l7++vlStX6quvvtLOnTuZAgEAANidLBelzp8/nxNxAAAA5GnLly83T3B+5MgRFSlSRM2aNdPEiRMVEBBg6/AAAACsLstFKUlKTk7WN998o6NHj0qSqlevro4dOypfvnzZGhwAAEBewWhzAAAAS1kuSp04cULt2rXTmTNnVKVKFUlSeHi4fHx89P3336tixYrZHiQAAEBux2hzAAAAS1kuSg0aNEgVK1bUjh07VKRIEUnSpUuX9Pzzz2vQoEH6/vvvsz1IAACAvIDR5gAAAP/KclFq06ZNFgUpSSpatKjeffddNW3aNFuDAwAAyCsYbQ4AAGDJIasrODo66urVq2na4+PjVbBgwWwJCgAAIK9JHW1++vRp7d27V3v37lV0dLR8fX01aNAgW4cHAABgdVkuSj3++OPq06ePdu7cKcMwZBiGduzYoX79+qlDhw45ESMAAECut2nTJr3//vvpjjbftGmTDSMDAACwjSwXpT766CNVrFhRfn5+cnJykpOTk5o2bapKlSppypQpOREjAABArsdocwAAAEtZnlPKw8NDK1eu1G+//aZjx45JkqpVq6ZKlSple3AAAAB5Repo808//VSNGzeWJO3cuZPR5gAAwG5luSiVqnLlyqpcuXJ2xgIAAJBnffTRR+revbv8/PxUoEABSdKtW7fUoUMHRpsDAAC7lKmi1NChQzO9wQ8//PC+gwEAAMirGG0OAABgKVNFqX379mVqYyaT6YGCAQAAyOsYbQ4AAPCPTBWlNm7cmNNxAAAA5DmMNgcAAMjYfc8pBQAAgLtjtDkAAEDGMlWU6tevn0aOHKkyZcrcs+/XX3+tW7duqVu3bg8cHAAAQG7GaHMAAICMZaooVbx4cdWoUUNNmzbVE088oYYNG6pUqVJycnLS5cuXdeTIEW3ZskWLFi1SqVKlNHv27JyOGwAAAAAAALmYQ2Y6vfXWW/r111/VtGlTTZ8+XU2aNFHZsmXl5eWlKlWqKCQkRH/88Ydmz56tHTt2qHbt2jkdNwAAwEOvX79++vPPPzPV9+uvv9aXX36ZwxEBAAA8PDI9p5S3t7dGjBihESNG6PLly4qOjtb169dVrFgxVaxYkbkQAAAA7sBocwAAgIzd10Tnnp6e8vT0zO5YAAAA8pS33npLAwcO1Jw5czR9+nQdOXLEYrmrq6tatWql2bNnq23btjaKEgAAwDa4+x4AAEAOYrQ5AABA+ihKAQAAWAmjzQEAAP6VqYnOc8rmzZv1xBNPqFSpUjKZTPrmm2/u2j8iIkImkynNIyYmxjoBAwAAAAAAIFvYtCiVkJCgOnXq6OOPP87SesePH9fZs2fNDy8vrxyKEAAAAAAAADkh236+l5iYqGnTpunVV1/N9DrBwcEKDg7O8mt5eXnJw8Mjy+sBAAAAAADg4ZClkVIXLlzQqlWrtGbNGiUnJ0uSbt68qSlTpqh8+fJ69913cyTIO9WtW1clS5ZU69attXXr1rv2TUpKUlxcnMUDAAAAAAAAtpXpotSWLVtUuXJldejQQcHBwfL399eRI0dUo0YNzZo1S2PGjNHp06dzMlaVLFlSM2fO1LJly7Rs2TL5+PgoMDBQe/fuzXCd8PBwubu7mx8+Pj45GiMAAEBWJCYm6oMPPrB1GAAAAFaX6aLUyJEj1a5dOx04cEBDhw7Vrl279OSTT+qdd97RkSNH1K9fPzk7O+dkrKpSpYr69u2rBg0ayN/fX3PnzpW/v78mTZqU4TphYWGKjY01P3K6cAYAAHCnh2W0OQAAwMMk00WpgwcPauTIkapZs6bGjRsnk8mk999/X507d87J+O6pcePGOnHiRIbLHR0d5ebmZvEAAACwlodhtDkAAMDDKNNFqcuXL6tYsWKSJGdnZ7m4uKhmzZo5FlhmRUZGqmTJkrYOAwAAIF0Pw2hzAACAh1GW7r535MgRxcTESJIMw9Dx48eVkJBg0ad27dqZ3l58fLzFKKeoqChFRkaqSJEiKlu2rMLCwnTmzBl9/vnnkqTJkyfL19dXNWrUUGJioubMmaMNGzZozZo1WdkNAAAAqzl48KCmT5+u6tWra9y4cfrwww/1/vvvq2PHjrYODQAAwKayVJR67LHHZBiG+fnjjz8uSTKZTDIMQyaTyTxPQmbs3r1bLVu2ND8fOnSoJKl79+6aP3++zp49q+joaPPyGzdu6JVXXtGZM2fk4uKi2rVra926dRbbAAAAeJg8rKPNAQAAbC3TRamoqKhsf/HAwECLIted5s+fb/F82LBhGjZsWLbHAQAAkJOye7Q5AABAXpDpolS5cuVyMg4AAIA8K7tHmwMAAOQFmS5Kvf/++3rppZfME3Fu3bpVDRs2lKOjoyTp6tWrev311zV9+vSciRQAACAXyonR5gAAAHlBpotSYWFh6tGjh7koFRwcrMjISFWoUEGSdO3aNc2aNYuiFAAAwG0YbQ4AAJA+h8x2vHPup7vNBQUAAIB/vP/++7p+/br5+datW5WUlGR+fvXqVQ0YMMAWoQEAANhUpotSAAAAyLqwsDBdvXrV/Dw4OFhnzpwxP08dbQ4AAGBvKEoBAADkIEabAwAApC/Tc0pJ0pw5c1S4cGFJ0q1btzR//nwVK1ZMkiyuAAIAAAAAAAB3k+miVNmyZfXJJ5+Yn5coUUILFixI0wcAAAAAAAC4l0wXpU6ePJmDYQAAAORd2T3afPPmzZowYYL27Nmjs2fPasWKFerUqdNd14mIiNDQoUN1+PBh+fj4aOTIkerRo0eWXxsAACC7ZLooFRUVJV9f35yMBQAAIM/JidHmCQkJqlOnjl544QU99dRT9+wfFRWl9u3bq1+/fvryyy+1fv169erVSyVLllRQUFCWXhsAACC7ZLooVbFiRZUrV04tW7Y0P8qUKZOTsQEAAOR6OTHaPDg4WMHBwZnuP3PmTPn6+mrixImSpGrVqmnLli2aNGkSRSkAAGAzmb773oYNG9S9e3f98ccf6tOnj8qVK6fKlSurb9++WrRokc6dO5eTcQIAAOA+bd++Xa1atbJoCwoK0vbt220UEQAAQBaKUoGBgRozZowiIiJ0+fJlrV27Vs8++6yOHj2qHj16qFSpUqpRo0ZOxgoAAJDrbNiwQdWrV1dcXFyaZbGxsapRo4Y2b96cozHExMTI29vbos3b21txcXG6fv16uuskJSUpLi7O4gEAAJCdMl2Uup2Tk5MeffRRjRw5UmPHjtWgQYNUuHBhHTt2LLvjAwAAyNUmT56s3r17y83NLc0yd3d39e3bV5MmTbJBZHcXHh4ud3d388PHx8fWIQEAgDwmS0WpGzduaPPmzRo7dqxatmwpDw8P9evXT5cvX9a0adMUFRWVU3ECAADkSvv371fbtm0zXN6mTRvt2bMnR2MoUaJEmqkWzp07Jzc3Nzk7O6e7TlhYmGJjY82P06dP52iMAADA/mR6ovNHH31UO3fulK+vrwICAtS3b18tXLhQJUuWzMn4AAAAcrVz586pQIECGS7Pnz+/Lly4kKMx+Pn56YcffrBoW7t2rfz8/DJcx9HRUY6OjjkaFwAAsG+ZHin1888/q2jRonr00Uf12GOPqXXr1hSkAAAA7qF06dI6dOhQhssPHDiQ5ZwqPj5ekZGRioyMlCRFRUUpMjJS0dHRkv4Z5RQSEmLu369fP/3xxx8aNmyYjh07punTp2vx4sV6+eWXs75DAAAA2STTRakrV65o9uzZcnFx0XvvvadSpUqpVq1aGjhwoJYuXZrjV/gAAAByo3bt2unNN99UYmJimmXXr1/X6NGj9fjjj2dpm7t371a9evVUr149SdLQoUNVr149jRo1SpJ09uxZc4FKknx9ffX9999r7dq1qlOnjiZOnKg5c+YoKCjoAfYMAADgwWT653uFChVS27ZtzXMiXL16VVu2bNHGjRv1/vvvq1u3bqpcufJdrwQCAADYm5EjR2r58uX6z3/+o4EDB6pKlSqSpGPHjunjjz9WcnKyRowYkaVtBgYGyjCMDJfPnz8/3XX27duXpdcBAADISZkuSt2pUKFCKlKkiIoUKSJPT0/lz59fR48ezc7YAAAAcj1vb29t27ZN/fv3V1hYmLmYZDKZFBQUpI8//lje3t42jhIAAMD6Ml2USklJ0e7duxUREaGNGzdq69atSkhIUOnSpdWyZUt9/PHHatmyZU7GCgAAkCuVK1dOP/zwgy5fvqwTJ07IMAxVrlxZnp6etg4NAADAZjJdlPLw8FBCQoJKlCihli1batKkSQoMDFTFihVzMj4AAIA8w9PTU40aNbJ1GAAAAA+FTBelJkyYoJYtW+o///lPTsYDAAAAAAAAO5DpolTfvn1zMg4AAAAAAADYEQdbBwAAAAAAAAD7Q1EKAAAAAAAAVkdRCgAAAAAAAFZHUQoAAAAAAABWR1EKAAAAAAAAVkdRCgAAAAAAAFZHUQoAAAAAAABWR1EKAAAAAAAAVkdRCgAAAAAAAFZHUQoAAAAAAABWR1EKAAAAAAAAVkdRCgAAAAAAAFZHUQoAAAAAAABWR1EKAAAAAAAAVkdRCgAAAAAAAFZHUQoAAAAAAABWR1EKAAAAAAAAVkdRCgAAAAAAAFZHUQoAAAAAAABWR1EKAAAAAAAAVkdRCgAAAAAAAFZn06LU5s2b9cQTT6hUqVIymUz65ptv7rlORESE6tevL0dHR1WqVEnz58/P8TgBAAAAAACQvWxalEpISFCdOnX08ccfZ6p/VFSU2rdvr5YtWyoyMlJDhgxRr1699NNPP+VwpAAAAAAAAMhO+W354sHBwQoODs50/5kzZ8rX11cTJ06UJFWrVk1btmzRpEmTFBQUlFNhAgAAAAAAIJvlqjmltm/frlatWlm0BQUFafv27TaKCAAAAAAAAPfDpiOlsiomJkbe3t4Wbd7e3oqLi9P169fl7OycZp2kpCQlJSWZn8fFxeV4nAAAAAAAALi7XDVS6n6Eh4fL3d3d/PDx8bF1SAAAAAAAAHYvVxWlSpQooXPnzlm0nTt3Tm5ubumOkpKksLAwxcbGmh+nT5+2RqgAAAAAAAC4i1z18z0/Pz/98MMPFm1r166Vn59fhus4OjrK0dExp0MDAAAAAABAFth0pFR8fLwiIyMVGRkpSYqKilJkZKSio6Ml/TPKKSQkxNy/X79++uOPPzRs2DAdO3ZM06dP1+LFi/Xyyy/bInwAAAAAAADcJ5sWpXbv3q169eqpXr16kqShQ4eqXr16GjVqlCTp7Nmz5gKVJPn6+ur777/X2rVrVadOHU2cOFFz5sxRUFCQTeIHAAAAAADA/bHpz/cCAwNlGEaGy+fPn5/uOvv27cvBqAAAAAAAAJDTctVE5wAAAAAAAMgbKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAADkQh9//LHKly8vJycnPfLII/rll18y7Dt//nyZTCaLh5OTkxWjBQAASIuiFAAAQC7z9ddfa+jQoRo9erT27t2rOnXqKCgoSOfPn89wHTc3N509e9b8OHXqlBUjBgAASIuiFAAAQC7z4Ycfqnfv3urZs6eqV6+umTNnysXFRXPnzs1wHZPJpBIlSpgf3t7eVowYAAAgLYpSAAAAuciNGze0Z88etWrVytzm4OCgVq1aafv27RmuFx8fr3LlysnHx0cdO3bU4cOH7/o6SUlJiouLs3gAAABkJ4pSAAAAucjFixeVnJycZqSTt7e3YmJi0l2nSpUqmjt3rlauXKkvvvhCKSkp8vf3159//pnh64SHh8vd3d388PHxydb9AAAAoCgFAACQx/n5+SkkJER169ZVQECAli9fruLFi2vWrFkZrhMWFqbY2Fjz4/Tp01aMGAAA2IP8tg4AAAAAmVesWDHly5dP586ds2g/d+6cSpQokaltFChQQPXq1dOJEycy7OPo6ChHR8cHihUAAOBuGCkFAACQixQsWFANGjTQ+vXrzW0pKSlav369/Pz8MrWN5ORkHTx4UCVLlsypMAEAAO6JkVIAAAC5zNChQ9W9e3c1bNhQjRs31uTJk5WQkKCePXtKkkJCQlS6dGmFh4dLksaNG6cmTZqoUqVKunLliiZMmKBTp06pV69ettwNAABg5yhKAQAA5DLPPPOMLly4oFGjRikmJkZ169bV6tWrzZOfR0dHy8Hh3wHxly9fVu/evRUTEyNPT081aNBA27ZtU/Xq1W21CwAAABSlAAAAcqOBAwdq4MCB6S6LiIiweD5p0iRNmjTJClEBAABkHnNKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOooSgEAAAAAAMDqKEoBAAAAAADA6ihKAQAAAAAAwOoeiqLUxx9/rPLly8vJyUmPPPKIfvnllwz7zp8/XyaTyeLh5ORkxWgBAAAAAADwoGxelPr66681dOhQjR49Wnv37lWdOnUUFBSk8+fPZ7iOm5ubzp49a36cOnXKihEDAAAAAADgQdm8KPXhhx+qd+/e6tmzp6pXr66ZM2fKxcVFc+fOzXAdk8mkEiVKmB/e3t5WjBgAAAAAAAAPyqZFqRs3bmjPnj1q1aqVuc3BwUGtWrXS9u3bM1wvPj5e5cqVk4+Pjzp27KjDhw9bI1wAAAAAAABkE5sWpS5evKjk5OQ0I528vb0VExOT7jpVqlTR3LlztXLlSn3xxRdKSUmRv7+//vzzz3T7JyUlKS4uzuIBAAAAAAAA27L5z/eyys/PTyEhIapbt64CAgK0fPlyFS9eXLNmzUq3f3h4uNzd3c0PHx8fK0cMAAAAAACAO9m0KFWsWDHly5dP586ds2g/d+6cSpQokaltFChQQPXq1dOJEyfSXR4WFqbY2Fjz4/Tp0w8cNwAAAAAAAB6MTYtSBQsWVIMGDbR+/XpzW0pKitavXy8/P79MbSM5OVkHDx5UyZIl013u6OgoNzc3iwcAAAAAAABsK7+tAxg6dKi6d++uhg0bqnHjxpo8ebISEhLUs2dPSVJISIhKly6t8PBwSdK4cePUpEkTVapUSVeuXNGECRN06tQp9erVy5a7AQAAAAAAgCyweVHqmWee0YULFzRq1CjFxMSobt26Wr16tXny8+joaDk4/Dug6/Lly+rdu7diYmLk6empBg0aaNu2bapevbqtdgEAAAAAAABZZPOilCQNHDhQAwcOTHdZRESExfNJkyZp0qRJVogKAAAAAAAAOSXX3X0PAAAAAAAAuR9FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWB1FKQAAAAAAAFgdRSkAAAAAAABYHUUpAAAAAAAAWF1+WwcgSR9//LEmTJigmJgY1alTR1OnTlXjxo0z7L9kyRK9+eabOnnypCpXrqz33ntP7dq1s2LEd/fuvou2DgF3eKNesRx/DY77w8caxx0AbCWv5U8AAMD+2Hyk1Ndff62hQ4dq9OjR2rt3r+rUqaOgoCCdP38+3f7btm3Ts88+qxdffFH79u1Tp06d1KlTJx06dMjKkQMAANgG+RMAAMgLTIZhGLYM4JFHHlGjRo00bdo0SVJKSop8fHz00ksv6Y033kjT/5lnnlFCQoJWrVplbmvSpInq1q2rmTNn3vP14uLi5O7urtjYWLm5uWXfjtyGETMPH0ZK2SeOu33iuNunnDzu1sgdssra+ZNknfdhyuUpObJd3J/BnoOt8joc94eLNY47x/zhw3G3Tzl53DObN9j053s3btzQnj17FBYWZm5zcHBQq1attH379nTX2b59u4YOHWrRFhQUpG+++Sbd/klJSUpKSjI/j42NlfTPG5RTEuOv5ti2cX/i4grm+Gtw3B8+HHf7xHG3Tzl53FNzBhtfxzOzRv4k2SiHikvMsW0j6+Ly5dyxvh3H/eFijePOMX/4cNztU04e98zmTzYtSl28eFHJycny9va2aPf29taxY8fSXScmJibd/jExMen2Dw8P19ixY9O0+/j43GfUyI3S/h8Ae8Bxt08cd/tkjeN+9epVubu7W+GV7s4a+ZNEDgXpDaUddYe8j+Nunzju9skax/1e+dNDMdF5TgoLC7O4MpiSkqK///5bRYsWlclksmFkD7+4uDj5+Pjo9OnTD83PFZCzOOb2ieNunzjumWcYhq5evapSpUrZOhSrIoe6P5xb9onjbp847vaJ4545mc2fbFqUKlasmPLly6dz585ZtJ87d04lSpRId50SJUpkqb+jo6McHR0t2jw8PO4/aDvk5ubGyWZnOOb2ieNunzjumfMwjJBKZY38SSKHelCcW/aJ426fOO72ieN+b5nJn2x6972CBQuqQYMGWr9+vbktJSVF69evl5+fX7rr+Pn5WfSXpLVr12bYHwAAIC8hfwIAAHmFzX++N3ToUHXv3l0NGzZU48aNNXnyZCUkJKhnz56SpJCQEJUuXVrh4eGSpMGDBysgIEATJ05U+/bttWjRIu3evVuzZ8+25W4AAABYDfkTAADIC2xelHrmmWd04cIFjRo1SjExMapbt65Wr15tnowzOjpaDg7/Dujy9/fXwoULNXLkSA0fPlyVK1fWN998o5o1a9pqF/IsR0dHjR49Os3QfeRdHHP7xHG3Txz33I386eHFuWWfOO72ieNunzju2ctkPCz3NwYAAAAAAIDdsOmcUgAAAAAAALBPFKUAAAAAAABgdRSlAAAAAAAAYHUUpQAAAAAAAGB1FKWAPG7SpElq166drcMAYAVXr161dQgAkCeQPwH2hRzKdihK2ZmUlBRbhwArq1y5srZs2aJu3brZOhRYEee6/Zk1a5YaNWqk06dP2zoUIM/hM9X+kD/ZL853+0MOZVsUpexISkqKHBz+OeRbt27ViRMnbBwRrKF9+/ZatmyZVq9era5du9o6HFjB7ed6ZGSkLl26ZOOIYA1BQUG6deuWnn32Wf3555+2DgfIM8if7BP5k30ih7JP5FC2RVHKTtz+ATt8+HD16dNHkZGRiouLs3FkyGkmk0mPPfaYvvrqK61du5bEKo+7/Vx/88031aNHD+3atUvXr1+3cWTIaeXLl9fGjRt16dIlde7cmaQKyAbkT/aL/Mn+kEPZL3Io2zIZhmHYOghYz5gxYzRz5kx9+eWXatKkiQoVKmTrkGAlhmFo7dq1euaZZxQUFKRFixbZOiTkoJEjR+rTTz/V3Llz1aRJE3l6eto6JOQwwzBkMpl0+vRptW7dWh4eHlq6dKnKlClj69CAXI/8yX6RP9kfcij7Qw5lWxSl8rjUir9hGIqKilKnTp00ZswYPfXUU7pw4YJOnz6t1atXq0yZMgoJCbF1uMgmqR+sv/32m86ePSsXFxeVLVtWXl5e+umnn/Tss8+qTZs25sQqtT9yr9uP4ZEjR/TUU0/pww8/VLt27XTlyhWdO3dOmzdvlq+vr1q1amXjaJHTTp8+rccee0xFihQhqQLuA/mTfSJ/sk/kULgdOZT15bd1AMg5t27dUv78/xxik8mkYsWKKX/+/Pr777/1008/adGiRTpw4IASExN1/fp1/f333xoyZIhtg8YDS/1iXb58uV5++WV5enrqxo0bKlmypMLCwsxX+Z599ll169ZNX375JQlVLpecnKx8+fKZn7u4uMgwDLm4uCgiIkKLFy/Wli1b9Pfff6t48eIaPny4unTpYsOIkV1Sz/cDBw7o2LFjcnBwkK+vrxo0aKD169erVatW6ty5M0kVkAXkT/aJ/Mk+kUPZL3KohwdzSuVR69at06pVqyRJvXv3VteuXeXm5iZfX19Nnz5d7dq1U5EiRfTuu+9q586dqlKlCrfBzOVS7xRiMpm0bds2vfDCCxo2bJgiIyM1atQoRUREKDIyUpLUunVrLVq0SF999ZVefPFFG0aNB7Vu3TodOXJEkjRkyBC9/PLLKleunAoVKqR+/fqpTZs2yp8/v8LDw7V7926lpKTowoULNo4a2cVkMmnZsmUKCgrS1KlTNWnSJD3zzDOaM2eOfHx8tG7dOsXGxqpr166Kjo62dbjAQ4/8yf6QP9kvcij7Rg718GCkVB6UlJSkMWPG6Pr16/rss8+0efNmrVu3TpK0dOlS7dixQ87Ozqpbt655nfj4eIurBMg99u/frzp16sjBwcF8dXfLli0KCgpSaGioTp8+rbCwMPXt21evvvqqJOnSpUtq3bq11q9fr1KlStl4D3C/EhMT1b17d3l7e6tmzZr67rvvtHHjRplMJu3evVvffvutvL295efnZ16ncOHC4lfbudvtV3X37dunfv36ady4cerfv782b96sRx991Hx3MB8fH61du1b169fXiy++qNWrV/NZD2SA/Mm+kD/ZN3Io+0QO9ZAykGdMmDDBiIqKMj+vUKGC4eDgYEyePDnd/levXjV+/fVXo23btkbt2rWNmzdvWilSZJfvvvvOqFatmjFr1iyL9rffftt45ZVXjLNnzxqlS5c2+vTpYyQnJxuGYRg//PCDMW3aNCMxMdEWISMbLFiwwLh48aL5uaenp1GwYEFj8eLFhmEY5mOdKj4+3oiOjjaCg4ONunXrcq7nUhs2bDD/nXoMFyxYYLRt29YwDMM4efKkUbZsWaN///7mfidOnDAMwzD+/PNP898ALJE/2R/yJ/tFDmWfyKEebvx8L49YsWKFdu3aJR8fHxmGob///ls+Pj5q0KCBvv76a61YsUK3bt2SJPN/v/rqK4WEhOjmzZvavXu38ufPr+TkZFvuBrIo9XfPn3/+uWbPnm1u9/Dw0Pz581W/fn09+eSTmjVrlhwcHJSSkqJly5bp4MGD5uHqyF3mzJmjBQsWyNPTU7du3dKZM2fk4eGhYsWK6cMPP9S+ffvMtzNOPZ8/++wzPfHEE0pISNAvv/zCuZ4Lbdu2Tc8995xee+01STLPd5OSkqJChQrpt99+U7NmzdS2bVtNmzZNkrRp0ybNmzdPFy5cUOnSpVWxYkWbxQ88rMif7BP5k30ih7JP5FC5gK2rYsg+t1/JiYmJMbcFBgYajRs3NpYvX27cuHHDYp2NGzcat27dMgzDoPKfy6Qe71OnThm9evUyAgMDjblz55qXd+3a1ShYsKCxf/9+49q1a8bVq1eNN954w/D29jaOHj1qq7CRDVLP2a1bt5r/vnXrluHr62s0atTI2Ldvn5GSkmLuf/36dWP58uWc67nY2bNnjXHjxhk1a9Y0hg0bZm5ftWqVUbJkSaNIkSJGv379LNYZMGCA0bVrVyMuLs7a4QK5CvmTfSF/sm/kUPaHHOrhR1EqD7j9g3P37t1G2bJljT59+hiHDh0yDMMw4uLijMDAQMPPz89YtGiRERcXZ/j7+xuhoaHm9VI/aJF7pCZVx44dM0aMGGH4+voalStXNubNm2cYxj9DTQMCAgx3d3ejZs2aRkBAgFG6dGlj7969NowaDyL1mKekpBgRERGGk5OTMX78eCM6OtowDMO4cuWK4evra/j5+Rm//PKLkZiYaLRr184YO3aseRuc67lP6nFPSEgw3n//faNu3brG6NGjzctfffVVw2QyGV999ZXx559/GjExMcawYcOMokWLGocPH7ZR1MDDj/zJPpE/2SdyKPtEDpU7mAyD2dpyM+P/b2V5u48++khffPGFGjZsqIEDB6p69eq6evWqunTpolOnTunmzZtydXXVzp07VbBgQRtFjuywfPlyde/eXf369VNSUpJ++OEHubu7KzQ0VC+88IKkf4YdX7lyRcWLF1fTpk1Vrlw5G0eN+5HeuT58+HAtWrRIffv2Vbdu3VSmTBnFxsbqkUceUUpKivLnzy8HBwft27dPBQoUsFHkeFApKSlycHDQrl27tGTJEq1cuVKnTp3Sq6++qrfffluS1KNHD61atUr58+dX+fLldeHCBS1dulT16tWzcfTAw4n8yb6RP9kXcij7RQ6VO1CUysVu3LhhTopS7xqSaurUqZo7d678/PzMidW1a9f0ww8/KDExUV27dlX+/PnTrIfc49KlSwoODlbHjh01YsQISdLhw4c1fvx4HT16VEOGDFH37t1tHCWyw82bN80J0Z2J1fDhw/XFF18oNDTUnFRdvXpV8+bNU758+dS3b1/O9Tzg22+/VZcuXTRixAi5uLho3bp1+u2339S5c2e99957kqSNGzfq77//VpEiRVS1alWVLFnSxlEDDyfyJ/tG/mRfyKFADvXwoyiVC23evFktWrQwP584caI2btwoV1dXValSRWPGjJEkTZ8+XXPmzDEnVtWqVbPYzu23xETuk5iYqPr166t79+56/fXXze1HjhxRu3btVKhQIQ0YMEChoaE2jBIP4uDBg6pVq5b5+fTp07Vz504VKVJE1apVU58+fST9m1QNHDhQ3bp1U+nSpS22w7meuyUkJOiZZ55RtWrVNGHCBElSTEyMZs6cqfnz5+t///uf3nrrLRtHCTz8yJ8gkT/ZC3IoSORQuQV338tlJk2apD59+mjhwoWSpPfee09jx45VpUqVVKBAAU2bNk2PPvqorl27pgEDBqhnz5765Zdf9Pbbb+v06dMW2+IDNvdJrSGnpKQoKSlJ5cqVU3R0tBITE83LqlevrpYtWyo+Pl5r1qzRlStXbBgx7teIESMUGhqqDRs2SJLGjRtnTp4PHDigMWPG6Omnn5YkvfPOO/rf//6nGTNmaObMmfr7778ttsW5nru5uLjo0qVLiouLM7eVKFFC/fv3l6+vryZNmqRXXnnFhhECDz/yJ/tG/mRfyKGQihwqd2AcYi7TokUL7d69W9OnT1dsbKxOnDihJUuWKCgoSNI/H7RPPvmknnrqKa1evVovvfSSEhMTdeTIkTSVf+QeqcONExMT5ezsLJPJJHd3d4WEhKhbt26qUqWKevfuLWdnZ0mSo6OjOan28PCwbfC4L4GBgdq8ebM++ugjXbhwQfv379d3332nwMBAXbt2TevWrdOLL76okJAQff755xo/frwSEhJ0+PBheXp62jp8PKDUc94wDN26dUv+/v46ceKE/vjjD1WoUEGS5O3trYCAAMXExGjv3r06d+6cvL29bRw58HAif7JP5E/2iRzKvpFD5T78fC+XSJ2kTZL27dunDz74QGfOnNGpU6f07bffqlatWuYTcNu2berYsaNmzJihzp07S/r35Lx9O8gdUo/djz/+qBkzZujatWtydXXVO++8o2rVqmnatGkaNGiQevbsKW9vb/39999avHixIiMjVbZsWVuHjyy6/Rz9+eefNXz4cHl4eOj06dP6/vvvzf84unHjhpYsWaKxY8dq3rx5atq0qSTLL+I7J/XEwy/1uMXGxsrR0VEFChRQvnz5tHXrVnXo0EHdunXT4MGDVbFiRUnSkCFD5OnpqcGDB/MPKCAd5E/2i/zJ/pBD2TdyqNyLb9dc4urVq7p27Zpu3rypevXq6eWXX1bJkiUVHR2tNWvWSJL5w7NixYpyd3e3GHac+gFLQpX7mEwmrVq1Sp06dVLVqlVVr149XblyRY888ohWrFihgQMH6uuvv9bVq1e1bt06/f7779qwYQMJVS515swZ89/NmzfX22+/rYsXL+rAgQOKiIgwLytYsKAaNWqkS5cu6fz58+Z2kqncK/W4fffdd2rXrp2aNGmi+vXra+nSpWratKkWLVqkRYsWKTQ0VF27dtXzzz+vuXPnqlu3biRTQAbIn+wX+ZP9IYeyX+RQuRs/38sFFi9erE8++URxcXEqVqyYFi9erIYNG+rNN9+UYRj64osv5Onpab6FrYeHhwoUKKCkpCSL7fABmztdu3ZNH374oV555RW988475vbevXure/fuqlWrlrp06aL27dvLyclJ169fV6FChWwYMe7XggUL1K9fP/PcJ5IUEBCgKVOmaPDgwZo/f76KFCmi4OBgSZKXl5eKFy/OuZ5HmEwmrV69Wp07d9abb74pLy8v7dq1Sy+88IJ+++03hYWF6dtvv9Xq1au1c+dOFS1aVFu2bFGlSpVsHTrwUCJ/sm/kT/aFHMq+kUPlbvx87yH32WefaeDAgRo5cqRu3Lihb775RsHBwXr77bcl/TMUfcKECfr555/VoUMH+fj4aOfOnTpy5IgOHz7M7UvzgKtXr+qRRx7R0KFD1atXL4tb2zZr1kwVKlTQ559/zt1B8oCBAwdq3bp1cnZ2Vp8+fdS/f3/zsp9//llvvPGGrl27pqeeekply5bV8uXL9euvv+rQoUMc+1zOMAwlJyera9eu8vLy0vTp083L3n33Xb399ttatGiRHn/8cfPPE26/rT0AS+RPIH+yL+RQ9oscKvdjLPJD7OTJk/rggw80depUvf7663rzzTdVt25dFStWTImJiUpKSlK9evUUFhampk2b6osvvtDKlSvVtm1bc0KVnJxs693AA3J1dVWpUqW0YsUKSVKBAgV08+ZNSVKVKlV0/fp1SdwdJC9wcnKSr6+vgoKCNHnyZIsv1ebNm2vixIlycnLS2LFj9eWXX6p+/fo6ePCg8uXLx7mey5lMJjk4OOjixYvmYeSpV2/feOMNPfnkk3rnnXeUkpJivlMUyRSQPvInSORP9oYcyn6RQ+V+FKUeYpcvX9bFixfVpEkTc1tUVJQ+/fRTNWrUSI0aNdLBgwdVq1YtDR8+XP7+/mrevLn69OljTqj4os1dUj8o4+LiLG5d2rt3b/3111964403JMl8pe/mzZtycXHRrVu3xKDH3K9p06aqU6eOXn31VbVq1UrTpk3T9OnT1b59e23dulVNmjTRlClTVLFiRbVs2VKjRo3iXM9DHBwcVKFCBa1YsUI3btyQo6Ojbty4IemfW5Xnz59fDg4OHGvgHsif7A/5E8ih7Bs5VO7Gz/ceYufPn9ejjz4qX19fhYWFady4cfrtt9/04YcfysnJSTNmzFBkZKQOHjwoV1dX/fbbb6pYsaIcHBy4S0wu9s0332jy5Mm6ePGiXnjhBT3//PNyd3fXhAkTtGTJEhUrVkxt2rTR0aNHtWzZMu3YsUM1atSwddjIBlu3blX//v21e/duXbp0SeHh4fr000/l5uamv/76yzzPwd69e1WnTh3ly5ePCTlzqdTjFhMTI8MwVKJECZlMJh08eFDdu3eXj4+Pli5dav4HVP/+/RUdHa1ly5bJ0dGRYw7cBfmTfSJ/sm/kUPaDHCoPMvDQunnzprFw4UKjUaNGRkhIiFGqVClj9+7d5uUHDx40PD09jZ9++sliveTkZGuHimyyZ88ew8vLy3jjjTeMl19+2XBzczN69uxpnDx50khKSjJWrlxptG/f3mjatKnx5JNPGgcOHLB1yMhGp0+fNmrXrm1+/p///McoU6aMUblyZeOTTz5J0//WrVvWDA/ZbNmyZUbNmjUNb29vo3///sa2bdvM7XXr1jUqVqxo9OnTx/jvf/9rFC5c2Ni/f7+NIwZyB/In+0P+BHIo+0IOlbcwi+NDxLijWp8/f349++yz6ty5sw4cOKDNmzfLx8fHvPzWrVsqWbKkihQpYrEdrvDlHsb/D1RMPe63bt1Sz549FR4eLklq3bq1+vXrp5SUFI0YMUIdOnRQhw4dlJSUJAcHB/MVAOQud57rqcqUKaMKFSpow4YNevnll1WqVCm9++67Wrx4sV577TUVK1ZMnTp1MvdnCHLu9euvv+qVV17RoEGDVLBgQX3yySc6efKkhg4dqqeeeko1a9bURx99pJiYGHl6emrnzp2qXr26rcMGHkrkT/aH/Ml+kUOBHCrvoSj1EDhy5IiqV68uk8mU7gdtgQIFVLp0aXl7e+vbb79Vt27dlJiYqDFjxqhUqVKqX7++jSJHdjCZTNq6dat27dqlw4cPq2jRouZlwcHBmjFjhvr166cCBQqoX79+atCggRwdHW0YMe7X3c711MkX4+Li1KpVK7Vq1UoLFy5UsWLF5ObmprJly+qJJ56wYfR4EHf+A6pAgQJq06aNhgwZIpPJJH9/f73yyiv64IMPdPPmTQUHB2vatGnmdRlqDqRF/mTfyJ/sCzmU/SKHyvuYU8rGwsLCtHPnTo0dO1bNmzeXlP7JEx8fr/79++vQoUO6cuWKSpUqpaSkJG3fvl0FChRgDoRcbNWqVerQoYOaNGmiHTt2qEqVKpoxY4YCAwPNfX788Ud16dJFPXv21MSJE7ljRC6U2XN9//79mj59usaOHasSJUqk2Q4TcuZOqcd6/fr1WrVqleLi4nTjxg0tWLDA3Gfv3r169dVXVbhwYf3vf/9Tly5dbBgx8HAjfwL5k/0gh7Jv5FB5H0UpG1u1apXCw8NVunRpDRw4UC1atJBk+UGb+vfly5e1Zs0a/frrrypdurS6d++ufPny6datW8qfn0FvuVF0dLSmTJmiKlWqqE+fPlqzZo1GjhypChUqKDQ01PzFK0lr165V+fLlVblyZRtGjPuVmXM99R9Ht/8jiSs8eceaNWvUtm1bBQUFadeuXUpOTtakSZPUo0cPc599+/bpxRdfVKVKlTRv3jwVKlTIdgEDDzHyJ/tG/mRfyKFADpW3UZR6CKxbt05vvvmmypQpo5deeumuH7R3ouKfe0VGRmrYsGH6+++/NWfOHNWtW1eStHr1ao0ZM0Y+Pj4aMmSImjZtattAkW0yc64jbzp58qS+/fZbFSxYUP369dOBAwcUHh6uv/76S71799bzzz9v7rt//355eHioXLlyNowYePiRP9kn8if7RA5lv8ih8j7GK9tQaj2wVatWGjt2rP7880999NFH2rx5sySZfzMtyaLifzsSqtzr8uXLSk5O1rFjx3T06FFze9u2bTV27FjFxMTorbfe0vbt220YJbJDVs515D3Hjx9X+/btNWnSJPNky7Vr19Ybb7yh0qVLa+bMmVq4cKG5f506dUimgLsgf7Jv5E/2hRzKvpFD2QeKUjaQkpIiSRZV/TZt2mjMmDE6c+bMXT9ouRKQd7Rs2VLvvPOOmjdvro8++kg//PCDeVlQUJBef/11paSkqGzZsjaMEg/iQc515C0BAQG6fPmyIiMjzW116tTRG2+8oQoVKuidd97R4sWLbRcgkAuQP0Eif7IX5FBIRQ6V9/HzPSu7fRj50qVLdfbsWZ0/f14DBgxQyZIlFRERobCwMJUuXVqDBg0yD01F3nL7UOOff/5ZEydOVFxcnF577TUFBweb+yUkJPB76FyKcx23i4qK0qRJk7Ry5UqFhYWpX79+5mX79u3TjBkzNHz4cJUvX952QQIPMT5TIZE/2QvOd9yOHCrvoyhlI8OGDdPixYtVo0YNJSYmavv27Vq0aJE6dOigdevWafTo0SpdurR69+6t1q1b2zpc5IDbE6vNmzfrww8/1LVr1xQaGqqOHTvaODpkF851pDpx4oQ+/vhj/fjjjxoyZIhFUnXjxg3uCgVkAp+pIH+yH5zvSEUOlbdxyxEbWLhwoRYsWKDVq1erTp06Wr9+vVq3bq3k5GRJ//xmOiUlRaGhodq0aRMfsnnI7Vd+Uocam0wmtWjRQg4ODho1apTmzp2rVq1acYUvD+Bcx+0qVaqkAQMGSJKmTZumxMREDRkyRJJIpoBM4DPVfpE/2R/Od9yOHCqPM5Cj1qxZk6ZtwoQJRmhoqGEYhrFo0SLD1dXVmDFjhmEYhnH58mUjKSnJMAzD2Llzp3Hr1i3rBYtslZKSYhjGP8f04sWL9+xnGIaxbds24/Tp0zkeG7If5zrulJycnG77b7/9ZvTq1cto1KiRcfnyZesGBeQSfKbaL/In+8P5jjuRQ9kXJjrPQcuWLVNQUJA++eQTi/ZTp07pwoULWr9+vXr37q333nvPPARxzpw5euONN5SSkqLGjRsrX7585isCyD2M/7+C99133yk4OFhNmzZVkyZNtGbNGiUkJFj0vX1yRj8/P5UpU8YWIeMBcK7bt9Tzd/fu3ZozZ46mTp2qffv2pXsbeumfq31hYWH67rvv5OHhYcVIgdyBz1T7Rf5kfzjf7Rs5FCQxUiqnjR8/3ihQoIAxa9Ysc8V306ZNRv369Y38+fMbH3/8sbnv1atXjSeeeMIYPHiwjaJFdvruu+8MV1dXY8yYMUZkZKTRunVro0aNGsann35qxMfH2zo8ZDPOdfu2dOlSo2TJkkZAQIDx+OOPGyaTyZg7d67FlXwAmcdnqv0if7I/nO/2jRwKzCmVQ5KTk5UvXz4NHz5c+fPnV2hoqFxcXPT888+rVq1aaty4sRITExUfH69Lly4pKipKo0eP1tmzZ7V8+XJJlhM5IneJjo7W+PHjNXr0aL3yyiu6cuWKTpw4oZSUFI0ePVqS9PTTT6tw4cI2jhQPinMdBw4c0IABAzRu3Dj17dtXJ0+e1Pfff68TJ05wXIEs4jPVvpE/2RfOd5BDQZL4+V4OMAxD+fLlkyRNmjRJ0j8fur1799bs2bPl6empUaNGqVmzZpo7d67KlCmjvn37KikpSTt37lT+/PmVnJzMiZjLGP8//DQhIUEuLi7q1q2bevTooZiYGDVu3Fht27bVyZMn5evrqw8++EDz589XfHy8jaPGg+BchyT99ddfatSokfr27auoqCg1b95cffv21fjx483LAdwbn6n2ifzJPnG+QyKHwv+z1RAtezBq1CijWLFixtdff23MnDnTePHFF418+fIZ06dPNwzDMBISEozz588bP/30k/F/7d15dIz3/gfw95OEJJZIJGmC4trTeyiqajlJY0ltx5JWUZwS9EqLkESLEHKL2BNbFVctt0pxoxWSiobGWqmGoHWVFq0SSbiJRBKSWT6/P9yZX1y0lpFnZp736y9nMuN8xnh/8jnfeZ7v99y5c+bLVXU6nZpl01P49NNPxd/fX/Ly8uTy5csiIhIZGSmvv/66FBQUiIjI2LFjpVq1atKxY0e5efOmmuWShTDr2vbZZ59J69at5fTp01K/fn0ZPXq0+TNOTU2V4cOH/+FmvUR0L/ZU7eH8pF3Mu7ZxhiIR3r73zBQWFiI5ORkzZszAwIEDAQCjRo1C7dq1ERYWBmdnZ4SEhKBKlSro1q2b+XVGoxFOTvxYbIn897LhW7duYd26dQgODoaHhwc8PDwAADk5OahZsyZcXV0BAM7Ozti+fTtatGiBGjVqqFk6WQCzri2mvF+4cAGurq6oXbs2Xn75ZdSoUQOvvvoq+vbti9WrV5u/+U9JSUF+fr7522Ai+mPsqdrB+YmYd23hDEUPw9v3npGysjJcvXrV/IvUaDTC0dERkydPhr+/P8LDw7Fy5cr7XvewkwbIeimKgrS0NPztb3+Dr68v3n777Xt+7uzsjCNHjmDRokUIDQ3FmjVr0LRpU9SqVUulismSmHXtMA1TiYmJ6NGjB1JSUlBQUIBmzZqhY8eOqFSpEpo2bYqrV6/i4sWLmDJlCtavX4/Y2FieEEP0iNhTtYPzEzHv2sEZiv4IE20BptXc8ry8vNCtWzesXr0aV69eNTfPqlWrolGjRqhbty62bNnywNeSbTEYDPjpp5+QmpqKQ4cOoWbNmgDu/qIFgLVr16JJkybYtWsXTp48iUOHDuEvf/mLihXTk2LWtU1RFCQlJWHo0KEICwtD9+7dzd/Wx8bGYujQodi2bRsaNGiAwYMHIzExEfv27UPz5s1VrpzIOrGnahvnJ21h3rWNMxT9EUWY8qdiNBrNDTQ7OxslJSVo2LAhAODgwYOYNm0a6tati6VLl8Lb2xulpaUYOHAgIiIiEBgYCEVReGqEHcjNzUViYiLGjx+PkSNHYsWKFQCAO3fuwMXFBQBw69YtKIrCE2NsFLNOhYWF6NOnDwIDAzFz5kzcuXMHhYWFSExMxAsvvAB/f3/k5OTg2LFjqFevHnx9feHj46N22URWiT2VAM5PWsG8E2co+iO8GfcpiIi5wc6YMQPJycn46aef0KFDB/Ts2RMTJ07E+PHjsWTJErRo0QIBAQE4d+4cjEYj/P39oSjKPU2abIPpl2JeXh6MRiPc3d3x3HPPYdiwYdDpdJg6dSpcXFwQFxcHFxcXlJWVoXLlyqhevbrapdMTYtYJuPv/wGAwwMfHBxcvXsQ//vEPHDt2DBkZGWjQoAHeeustREVFoU+fPmqXSmTV2FO1ifOTNjHvBHCGoj/GK6UsYM6cOYiPj8dHH30ENzc3fPnllzhx4gSCgoIwf/58/PLLL0hISMClS5fg7u6O2NhY8zGm3LjNtpS/H3rmzJkoKipCWVkZJk6ciAEDBsDb2xurV69GdHQ0Ro0ahQULFqhdMlkQs05Dhw7F/v37UVBQgB49eqBHjx7o378/Ro0aBU9PT6xZs0btEolsBnuqdnB+IuadOEPRQz3r4/3smdFolBs3bkhgYKCsWbPG/PjNmzdl0aJF0rJlS0lISHjga3mMqW0xGo3mP6empoqzs7PMnTtXduzYIRMnTpRGjRpJZGSk5ObmSklJiaxevVoURZFp06apWDVZCrOuPabMZ2VlyZUrV8xHlIuIJCQkSGJiouj1etHr9SIiMmLECAkNDRW9Xn9PvyCi+7GnagfnJ2LetYczFD0u3r73FEz3t+fl5SErK8v8eI0aNTBu3Dhs374de/fuRf/+/e97LY8xtQ2XLl1CgwYNoCgK9Ho9HBwcsHHjRgwZMgRTpkwBAPTr1w8NGjTAokWL8MILL+Cdd97BG2+8AScnJ/j7+6v8DsgSmHVtkf9+o79z507MnTsXV69eRdOmTdGlSxdMnTr1ns85NzcXS5cuxZdffokjR47w21yiR8Ceav84P5EJ864tnKHoSfDm3MdgNBrve0yv16N+/fo4deoU8vPzzadDODs745VXXkFOTs4DX0fWb+PGjQgJCUFKSgqAu78YHRwcUFxcbN5o0XRCzNixY9GrVy/ExcXBaDTCy8sLI0aMQNOmTVWrn54cs65tiqIgOTkZQ4YMwaBBg7Blyxa0b98e06dPx4wZM8zP++qrrzBw4EAkJCQgLS0Nf/3rX1Wsmsh6sadqC+cnbWPetY0zFD0JLko9ovIb7P3444/4/fffkZeXh6pVq2LatGlISkpCdHQ0rl27BuDuqSHff/896tWrx435bFT9+vWh0+mwevVq7Nmzx/x43bp18fXXX+POnTuoXLmyebBq06YNqlatitLSUgDgCSE2ilmnK1euIC4uDnPnzkV4eDiaNm2KTz/9FB07dsTSpUsRHR0NAOjVqxdGjhyJlJQUtGrVSt2iiawUe6r2cH7SLuadOEPRk+BG548pKioKGzZsQLVq1dCgQQPEx8ejefPmSElJwZtvvokXX3wRlSpVgtFoRH5+Pk6ePMlLT21Yeno6Jk2aBHd3d7z77rvo1asXbt68iYCAAFStWhXffPMNqlSpAuDut33//ve/kZycbH6MbBezbv8edprPnTt3MG/ePAwbNgyurq7o2rUrAgMDMWvWLERGRuKzzz7DhAkTsHjxYhWqJrJN7KnawvlJ25h3+8cZiiyJi1KPIS0tDaGhoVi1ahXOnz+PlJQUHD9+HMnJyXjxxRdx5swZJCUlISsrCz4+Ppg0aRKcnJyg1+vZaG3Y0aNHMXnyZLi7u2Ps2LHo3r070tPTMXr0aNy4cQPt27eHXq9HWloaDh8+jJYtW6pdMj0lZt3+mYapy5cvIz09HdnZ2Rg9ejRcXFwAwHwU+Zw5c5Ceno7169fD09MTsbGx2LRpE4xGI/bv3w8fHx9+q0/0J9hTtYnzkzYx7/aPMxRZGhel/sD/rgDv3bsXR44cQUxMDADg5MmTiImJQUZGBr766iu0bNnyvmNLeYypfTANVm5uboiMjESXLl1QVFSE+fPn4/r163B1dUVoaCj8/PzULpWeALOuLabP+/Tp0wgODoaHhwcuXrwIX19fnDhxAq6urubnDho0CAUFBea9USIjI1G7dm2EhoaievXqar0FIqvGnkomnJ/sH/OuLZyh6FngotQjiIuLw/nz53HhwgU0btwYq1atMv/s1KlTiImJQWZmJhITE3lPrB0zDVam00K6d++udklkYcy6/TMNU6dOnUKHDh0QGRmJsLAw3Lp1C507d0Z8fDwGDBhgfv4nn3yCDz/8EH369IFOp8P27dvx3XffoUmTJiq+CyLbwJ5KAOcnrWDe7R9nKHpWuCj1AOVX/GfPno0lS5YgICAAWVlZOHPmDNLS0tC2bVvz80+fPo0xY8bAy8sLO3bsUKlqehIPuh/adMnpg5gGKy8vLwwfPhz9+vUD8P/Hn5JtYda16ZdffkGLFi3w/vvvY9asWebH/f390alTJ1y5cgXdu3dHp06d4OLigpUrV2LHjh1wd3fHwoULeYsJ0UOwp2oH5ydi3rWJMxQ9E0IP9dtvv0l4eLh8++23IiLy66+/Sv/+/cXd3V1OnDhxz3N//vlnMRgMapRJTykrK0t2794tIiJbt26VmJgYuXPnzkOfn56eLi1atJDBgwdLUVFRRZVJzxCzrh0Gg0GioqLE29tbFi9ebH587ty54uDgIIMHD5Z27dpJpUqVJDw8XPR6vYiI6PV65p3oEbGnagPnJxJh3rWEMxQ9K1yUeojExERRFEXq1asnhw8fNj+elZUl/fv3Fw8PD8nMzLzvdWy0tmPFihWSmJgow4YNk/bt28vUqVNFURRZv379n7722LFj8uuvvz77IumZY9a15+rVqzJhwgRp166drFy5UubPny/e3t6ye/duMRqNIiIybtw4qVatmly6dEndYolsDHuq/eP8RCbMu/ZwhqJngYtSD2EwGCQsLEwURZGNGzfe87Nr167JoEGDRFEUOXfunEoV0tOIjo4Wd3d3yc/Plx9++EHatWsniqJIZGSk+Tmmxkr2jVnXpmvXrsm4ceOkWbNm4ujoKPv27RMRkZKSEhERSU5OloYNG8pPP/2kZplENoc91b5xfqLymHdt4gxFlsZzN4EHHkHq4OCAxYsXo7i4GGPGjIGPjw9ee+01AICvry/i4uLQuHFjNGzYUI2S6SncvHkT6enpiI6Ohru7O86cOYOSkhK0bNkSP/zwA5KSktC7d28oivLAPRPIdjHrZOLr64vo6Gg4ODjA2dkZmZmZ6NKli/nUmK+//hre3t547rnnVK6UyHqxp2oL5ydtY97JhDMUWZzaq2JqWrFihfnPpnte/5fRaJThw4eLm5ubpKamPvA5Op3umdRHz0ZRUZG89NJLMnDgQFmzZo04ODjIwYMH5fjx4xIcHCydOnWSnTt33vMa08o/2SZmnR7G9G1fu3btZN68eSIiMmvWLKlWrZqcOnVK5eqIrBN7qjZxftIm5p0ehjMUWYpmF6XS0tJEURR55513zI/9UaMNCQmRmjVryq5duyqqRHoGTJeU5+TkiLOzs1SuXFni4+PNPz948KAEBwdLly5dJDExUUREYmJiZObMmQ/9/0HWjVmnP2MaqgICAuSVV14RFxcXycjIULssIqvEnqpNnJ+0iXmnP8MZiixBs9fVtm7dGhs2bEBycjJGjhwJAHB0dITBYLjvuYqiYN26dfD398eyZcsqulSyINOxw3l5eSgrKwNw94ja7OxsAEBAQAAiIyPh5eWFiIgIBAUFYc6cOejZsyccHR1Vq5ueHLNOf8bX1xfTpk1D48aNkZeXh6NHj6JNmzZql0VkldhTtYnzkzYx7/RnOEORJSgiImoXUdHK3xO9efNmhIeH4+2330ZcXBwAwGAwPPQXKO+Rtw+XL1/Gf/7zHzg5OaFDhw4IDg5GXFwcfHx8AAAnT55Eeno6zp49i/feew9+fn4qV0xPglmnx3H9+nUYjUZzHyCie7GnEucn7WDe6XFwhqKnobmNzkXE3GCXLVuG06dPmzfpu337Nj7++GPzNwAParQODg5stDZIRKAoCnJzc1FaWgpPT0/UqlULlSpVQkpKCnr06AEA5sGqVatWaNWqlbpF01Nh1ulxeXt7q10CkdViT9Umzk/axLzT4+IMRU9Dc4tSpsuPZ86ciSVLlmDt2rXo27cvDhw4gH/+85/Q6XRYs2bNnzZash2mgWrHjh348MMPUVBQAA8PD3Tt2hXvvfce/P39kZqaitdeew1OTk6YN28efH191S6bnhKzTkRkOeyp2sP5SbuYdyKqUGptZqWmwsJC6dq1qyxevNj8WF5enqxatUqqV68uEyZMMD9uMBgqvkCyuNTUVKlatarEx8dLfn6+fPDBB1KlShXZunWrefPOb7/9VhRFkdGjR/NztxPMOhGR5bCnag/nJ+1i3omoomjuSikAqFy5Mq5evYoLFy6YH/Pw8MDgwYOxa9cuLFu2DLm5udi8eTNX+W2M/PdbvfJKS0uxZcsWjB49GhEREcjNzcW//vUvhISEYODAgQCA4uJidOjQAenp6XBzc+PnbieYdSIiy2FPtV+cn+h/Me9EVFHsflHqQfczOzs7o3///khPT8exY8fwyiuvAADc3NzQqlUr6HQ66PV63gttY0yf182bN5GXlwcAaNiwIZydnXHz5k1069YN169fR+vWrdG7d2+sWLECALBz5064urqic+fO5v8LZHuYdSIiy2FP1Q7OT8S8E5Ga7LqDlG+SGRkZSElJwdmzZ1FaWoohQ4YgJycHK1euxOHDhwEARUVFOHPmDPr27Ytt27aZN+kj62f6rH/88Uf06dMHgYGBCAoKQlhYGIC7m+8tXrwY7dq1Q3BwsHmgKi4uxueff44TJ07c9w0h2Q5mnYjIcthTtYPzEzHvRKQ2RURE7SKehfKXIUdFRWHbtm2oVKkSHB0d4efnh48++gjnzp3D5MmTUVJSgsqVK8NgMMBgMCAzMxNOTk4PvJSZrI/pl+mpU6fg7++PYcOGwd/fH3v27MHXX3+NcePGYfDgwejTpw9u3bqF3377zfzaadOmYdOmTdi7dy8aN26s4rugJ8WsExFZDnuqdnB+IuadiKyCOltZVZzly5eLr6+vHDx4UEREIiIipFq1apKamioiImfPnpUvvvhCwsPDZf78+aLT6URERK/Xq1YzPb6ff/5ZXFxcZPr06ebHSkpKpHPnztKxY0e5ffu2bN26Vby8vKRNmzYyYMAAeeONN6RmzZpy4sQJFSsnS2HWiYgshz1VGzg/kQjzTkTqsts9peS/F4AdPXoUY8eORUBAAHbu3Im1a9di0aJFCAoKwu3bt1G7dm34+fnh9ddfN79Wr9fDyclu/2nsjtFoxLp161C9enV4eXmZHzftc5CUlAQA6NevH1566SXExcVBp9Ohbt26mDdvHpo0aaJW6WQBzDoRkeWwp2oH5ydi3onIGthVJ5Fyl48qigKDwYDbt2+jffv22L9/P4YOHYpFixYhNDQUOp0OGzduRK1atdCrVy84Ojqa/x42WNvi4OCAcePGoaSkBJs3b0ZRURGmTp2KGzduYMGCBYiOjoaLiwsAoHHjxli5cqXKFdPTYtaJiCyHPVWbOD9pE/NORNbGrjY6NzVY09Gljo6O8PT0xKBBg9C7d2+sXLkSoaGhAICCggJs2bIFFy5cuKfBkm2qXbs2pkyZgrZt2yI5ORmTJk1C69atMWLECEyePBnA3V/CUm4LNbHP7dQ0gVknIrIc9lTt4vykPcw7EVkbu9jovPypEVu3bsWaNWswceJE9OzZE3l5eRg4cCDOnTuH8+fPw2AwoKSkBMOHD0dBQQEOHTrEJmtHrl27hjlz5mD79u2oU6cOvv/+ewC8xNheMOtERJbDnkomnJ/sH/NORNbK5q+UKt9g9+7di2+++QbHjx9HfHw80tLSULNmTUyfPh01atRA/fr10aFDB/Tp0wc3btzAgQMH4OjoCIPBoPK7IEupVasWoqOj8eabb8LR0RHz588HcPcSYx5Xa9uYdSIiy2FPpfI4P9k35p2IrJldXCkFAB988AG2bNmCUaNGobCwEJ9++inatm2LSZMmoXPnztDpdPjkk0+gKAq8vb0RHBwMR0dHfgNkp7KzsxEbG4vMzEx07doVH374odolkYUw60RElsOeSuVxfrJvzDsRWSO7WJTKzMxEr169sHnzZnTu3BkAcPDgQbz//vuoXr06pk2bhi5dutz3OoPBwEtR7Vh2djaioqJw5coVbNmyBZ6enmqXRE+JWScishz2VHoQzk/2iXknImtlk0ve5S9B1ev1cHV1NW/aB9zdgPHVV19FXFwcgoKCsHDhQuh0OnTv3t38c0VR2GDtnK+vL+bNmwcAHKhsFLNORGQ57Kn0KDg/2QfmnYhshU3uKWVqsJGRkViwYAGKi4shIjh//jwAmO95DggIQKtWrXD58mVs2LABP//8MwDc05DJvvn4+MDHx0ftMugJMetERJbDnkqPivOT7WPeichW2NSiVPk7DTMyMvD555+jU6dOaNOmDcLCwjB+/HgkJyeb73kuKiqCn58fIiIikJKSgm+++Uat0onoMTDrRESWw55KpB3MOxHZGpvcUyo+Ph7FxcUoLS3F7NmzAQBlZWX44IMPsHz5coSFhcHDwwMHDx5EUVERjh07hu7du8PT0xObN29WuXoielTMOhGR5bCnEmkH805EtsLm9pQqLi7GgQMHsGvXLrz55pvmxytXroylS5eiefPm2LZtG0pKSvD8889j9+7dAO424WbNmqlVNhE9JmadiMhy2FOJtIN5JyJbYvVXSpk22SsvKysLf//73/HZZ59h9+7dCAwMvGczv5KSElSpUgUAUFpaipkzZ2LdunU4cOAAmjZtWuHvgYj+HLNORGQ57KlE2sG8E5Ets+pFqfKN8/LlyygsLES9evXg5uaG4uJihISEYM+ePdi3bx/atm1rPrLU9LoLFy5g2bJlSEhIQFJSElq3bq3yOyKiB2HWiYgshz2VSDuYdyKydVa7KFV+xT86Ohqpqak4e/YsAgMD4efnh4ULFyIvLw9jxoxBSkoK9u7di5dffvme1xUXF+PMmTPw8fFB/fr11Xw7RPQQzDoRkeWwpxJpB/NORHZBrFxsbKx4eXlJamqqXLt2TQYMGCA1atSQ48ePi4hIbm6uvPXWW6Ioipw9e1blaonoSTHrRESWw55KpB3MOxHZMqvc6NxoNEJRFOTn5yMtLQ0ff/wxgoKCkJqaiq+++gpLly7FSy+9BJ1OB29vbyxfvhxNmjRB48aN1S6diB4Ds05EZDnsqUTawbwTkb2wqtv3Tp8+jTp16sDT0xPA3Q34OnXqhHXr1uHSpUsYMmQIFi5ciHfffRelpaXYuHEjWrRogXbt2pn/Dr1eDycnq1xrI6L/YtaJiCyHPZVIO5h3IrI3DmoXYLJjxw60b98eMTExuH79OoC7x5IqioIZM2YgJCQECxYswLvvvgvg7kZ+CQkJ+P333+/5e9hgiawbs05EZDnsqUTawbwTkT2yikWp0tJSJCUl4c6dO7h48SJmz56NnJwcuLu7IyYmBnv27IG/vz/ee+89iAgKCwsRHh6OsrIyvP7662qXT0SPiFknIrIc9lQi7WDeicheWc3te9999x169+6N9u3b4/bt22jevDmioqLg4+OD5cuXY8KECejWrRtEBKWlpcjPz0dGRgYqVapkPtqUiKwfs05EZDnsqUTawbwTkT1SfVHKaDRCRODg4ID3338fnp6eMBqN+PLLL/Hqq68iOjoanp6eOHToEL744guICBo2bIgxY8bAycmJ90QT2QhmnYjIcthTibSDeScie6Zadzp79izc3NxQp04d82PPP/88Nm3ahG+//RZVq1bF5s2bMXv2bEyZMgUBAQHo0KHDPQ3VYDCwwRJZOWadiMhy2FOJtIN5JyItUGVPqe3bt6Nly5bw9/fH559/joyMDABAREQE3NzcsHjxYkRERKBv375IT0/HggULkJ2dfV9D5SWoRNaNWScishz2VCLtYN6JSCsqfNm8rKwM+/btw3PPPQdHR0esWrUKbm5u8PDwwOzZsxEUFIRLly4BAKZPnw4HBwesW7cO9evXx/jx4yu6XCJ6Qsw6EZHlsKcSaQfzTkRaosqeUtnZ2Zg7dy4uX76MWrVqYeTIkZg4cSK8vLxw8eJFnDp1CgkJCXjjjTcAABs2bMDbb7/NlX4iG8OsExFZDnsqkXYw70SkFarcvufr64vJkyejTp06yMzMxPHjx3HgwAFMnDgRPXv2RN26deHn52d+fkhICBwdHWEwGNQol4ieELNORGQ57KlE2sG8E5FWqHr63rVr1zBnzhwcPXoUQ4cORUREBAAgLy8PNWvWhNFohIODKutmRGRBzDoRkeWwpxJpB/NORPZO1UUp4O6lqbGxsTh27BiCg4MRFRUF4O5JEbz8lMh+MOtERJbDnkqkHcw7Edkz1RelgLuNds6cOTh+/Di6dOmCWbNmqV0SET0DzDoRkeWwpxJpB/NORPbKKq719PX1xdSpU9GoUSPk5OTACtbJiOgZYNaJiCyHPZVIO5h3IrJXVnGllEleXh7c3d3h4OAAEYGiKGqXRETPALNORGQ57KlE2sG8E5G9sapFKRNu2EekDcw6EZHlsKcSaQfzTkT2wioXpYiIiIiIiIiIyL5xeZ2IiIiIiIiIiCocF6WIiIiIiIiIiKjCcVGKiIiIiIiIiIgqHBeliIiIiIiIiIiownFRioiIiIiIiIiIKhwXpYiIiIiIiIiIqMJxUYqIiIiIiIiIiCocF6WIiIiIiIiIiKjCcVGKiIiIiIiIiIgqHBeliIiIiIiIiIiowv0fWS3YBMFhCuwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Visualization saved to ocr_model_comparison.png\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Model</th>\n",
+       "      <th>WER</th>\n",
+       "      <th>CER</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Merged model 8bits</td>\n",
+       "      <td>0.038061</td>\n",
+       "      <td>0.013620</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Peft lora model</td>\n",
+       "      <td>0.038568</td>\n",
+       "      <td>0.015985</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Merged model 4bits</td>\n",
+       "      <td>1.880497</td>\n",
+       "      <td>1.326828</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Base model</td>\n",
+       "      <td>3.607724</td>\n",
+       "      <td>2.718979</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                Model       WER       CER\n",
+       "3  Merged model 8bits  0.038061  0.013620\n",
+       "1     Peft lora model  0.038568  0.015985\n",
+       "2  Merged model 4bits  1.880497  1.326828\n",
+       "0          Base model  3.607724  2.718979"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import matplotlib\n",
+    "#print model comparison\n",
+    "print_model_comparison()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7472d75a-eff5-4177-8bac-4f112e8b735a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/saving/save_merge_comparative_tests/test_unsloth_finetuning_save_merge_notebook.ipynb
+++ b/tests/saving/save_merge_comparative_tests/test_unsloth_finetuning_save_merge_notebook.ipynb
@@ -1,0 +1,1526 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e8047c22-0d71-4b2d-b491-3a1fa3538d5c",
+   "metadata": {},
+   "source": [
+    "# OCR lora finetuning and merging using Unsloth"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f9a8c1b-34ba-4087-a523-33024c606b19",
+   "metadata": {},
+   "source": [
+    "## Import required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cca84808-92aa-4347-adab-fedbd970afd1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.\n",
+      "🦥 Unsloth Zoo will now patch everything to make training faster!\n"
+     ]
+    }
+   ],
+   "source": [
+    "from unsloth import FastVisionModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ee2b80d4-e8a0-4818-b804-08abeb232cbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig,Qwen2VLProcessor\n",
+    "from peft import LoraConfig\n",
+    "from qwen_vl_utils import process_vision_info\n",
+    "import torch\n",
+    "from torch.utils.data import Dataset\n",
+    "import os\n",
+    "from PIL import Image\n",
+    "import glob\n",
+    "from datasets import load_dataset\n",
+    "from trl import SFTTrainer, SFTConfig\n",
+    "import random"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b4dbc54-87b1-4dee-9ada-4e6a081a9747",
+   "metadata": {},
+   "source": [
+    "## Dataset Preparation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "318fd0ae-3d3f-4dee-94d3-598aa8a3d9a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ec94804d4ee4509863d147ae9993bee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Resolving data files:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3cc38b0912f5417eb400609495412261",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Resolving data files:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a112932ceeb545cc8492db5f423051c1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading dataset shards:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "dataset = load_dataset(\"lbourdois/OCR-liboaccn-OPUS-MIT-5M-clean\", 'en', split=\"train\")\n",
+    "# To select the first 2000 examples\n",
+    "train_dataset = dataset.select(range(2000))\n",
+    "\n",
+    "# To select the next 200 examples for evaluation\n",
+    "eval_dataset = dataset.select(range(2000, 2200))\n",
+    "\n",
+    "# Convert dataset to OAI messages       \n",
+    "def format_data(sample):\n",
+    "    return {\"messages\": [\n",
+    "                {\n",
+    "                    \"role\": \"system\",\n",
+    "                    \"content\": [{\"type\": \"text\", \"text\": system_message}],\n",
+    "                },\n",
+    "                {\n",
+    "                    \"role\": \"user\",\n",
+    "                    \"content\": [\n",
+    "                        {\n",
+    "                            \"type\": \"text\",\n",
+    "                            \"text\": sample[\"question\"],\n",
+    "                        },{\n",
+    "                            \"type\": \"image\",\n",
+    "                            \"image\": sample[\"image\"],\n",
+    "                        }\n",
+    "                    ],\n",
+    "                },\n",
+    "                {\n",
+    "                    \"role\": \"assistant\",\n",
+    "                    \"content\": [{\"type\": \"text\", \"text\": sample[\"answer\"]}],\n",
+    "                },\n",
+    "            ],\n",
+    "        }\n",
+    "\n",
+    "system_message = \"You are an expert french ocr system.\"\n",
+    "# Convert dataset to OAI messages\n",
+    "# need to use list comprehension to keep Pil.Image type, .mape convert image to bytes\n",
+    "train_dataset = [format_data(sample) for sample in train_dataset]\n",
+    "eval_dataset = [format_data(sample) for sample in eval_dataset]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e856f92a-559a-4ad8-9b57-19d24b1b3b6a",
+   "metadata": {},
+   "source": [
+    "## Setup OCR main evaluation function and helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fe86acab-20ae-434f-a89c-cd1202c82083",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import torch\n",
+    "from tqdm import tqdm\n",
+    "import pandas as pd\n",
+    "from jiwer import wer, cer\n",
+    "from qwen_vl_utils import process_vision_info\n",
+    "\n",
+    "def evaluate_ocr_model(model, processor, dataset, output_dir=\"ocr_evaluation_results\"):\n",
+    "    \"\"\"\n",
+    "    Evaluate a Qwen VL model on an OCR dataset with specific structure.\n",
+    "    \n",
+    "    Args:\n",
+    "        model: The loaded Qwen VL model\n",
+    "        processor: The Qwen processor/tokenizer\n",
+    "        dataset: List of items with 'messages' field containing conversation exchanges\n",
+    "        output_dir: Directory to save results\n",
+    "    \n",
+    "    Returns:\n",
+    "        tuple: (average WER, average CER)\n",
+    "    \"\"\"\n",
+    "    # Create output directory if it doesn't exist\n",
+    "    os.makedirs(output_dir, exist_ok=True)\n",
+    "    \n",
+    "    # Initialize results storage\n",
+    "    results = []\n",
+    "    \n",
+    "    # Process each sample in the dataset\n",
+    "    for i, sample in enumerate(tqdm(dataset, desc=\"Evaluating OCR performance\")):\n",
+    "        try:\n",
+    "            # Extract the messages from the sample\n",
+    "            messages = sample['messages']\n",
+    "            \n",
+    "            # Extract system message (if present)\n",
+    "            system_message = next((msg for msg in messages if msg['role'] == 'system'), None)\n",
+    "            \n",
+    "            # Extract user message with the image and question\n",
+    "            user_message = next((msg for msg in messages if msg['role'] == 'user'), None)\n",
+    "            if not user_message:\n",
+    "                print(f\"Skipping sample {i}: No user message found\")\n",
+    "                continue\n",
+    "                \n",
+    "            # Extract assistant message with ground truth\n",
+    "            assistant_message = next((msg for msg in messages if msg['role'] == 'assistant'), None)\n",
+    "            if not assistant_message:\n",
+    "                print(f\"Skipping sample {i}: No assistant message (ground truth) found\")\n",
+    "                continue\n",
+    "            \n",
+    "            # Extract ground truth text\n",
+    "            ground_truth = None\n",
+    "            for content_item in assistant_message['content']:\n",
+    "                if content_item['type'] == 'text':\n",
+    "                    ground_truth = content_item['text']\n",
+    "                    break\n",
+    "                    \n",
+    "            if not ground_truth:\n",
+    "                print(f\"Skipping sample {i}: No text found in assistant message\")\n",
+    "                continue\n",
+    "            \n",
+    "            # Extract image and question from user message\n",
+    "            image = None\n",
+    "            question = None\n",
+    "            \n",
+    "            for content_item in user_message['content']:\n",
+    "                if content_item['type'] == 'image':\n",
+    "                    image = content_item['image']\n",
+    "                elif content_item['type'] == 'text':\n",
+    "                    question = content_item['text']\n",
+    "            \n",
+    "            if not image:\n",
+    "                print(f\"Skipping sample {i}: No image found in user message\")\n",
+    "                continue\n",
+    "                \n",
+    "            if not question:\n",
+    "                print(f\"Skipping sample {i}: No question found in user message\")\n",
+    "                continue\n",
+    "            \n",
+    "            # Construct messages for the model input (excluding assistant message)\n",
+    "            input_messages = []\n",
+    "            \n",
+    "            # Add system message if it exists\n",
+    "            if system_message:\n",
+    "                input_messages.append(system_message)\n",
+    "            \n",
+    "            # Add user message\n",
+    "            input_messages.append(user_message)\n",
+    "            \n",
+    "            # Preparation for inference using Qwen's specific processing\n",
+    "            text = processor.apply_chat_template(\n",
+    "                input_messages, tokenize=False, add_generation_prompt=True\n",
+    "            )\n",
+    "            \n",
+    "            # Process vision info (images/videos) from messages\n",
+    "            image_inputs, video_inputs = process_vision_info(input_messages)\n",
+    "            \n",
+    "            # Create model inputs\n",
+    "            inputs = processor(\n",
+    "                text=[text],\n",
+    "                images=image_inputs,\n",
+    "                videos=video_inputs,\n",
+    "                padding=True,\n",
+    "                return_tensors=\"pt\"\n",
+    "            )\n",
+    "            inputs = inputs.to(model.device)\n",
+    "            \n",
+    "            # Generate response\n",
+    "            with torch.no_grad():\n",
+    "                generated_ids = model.generate(\n",
+    "                    **inputs, \n",
+    "                    max_new_tokens=1024, \n",
+    "                    # top_p=0.9, \n",
+    "                    # temperature=1.0\n",
+    "                    temperature=1.5, \n",
+    "                    min_p=0.1,\n",
+    "                    use_cache=True\n",
+    "                )\n",
+    "            \n",
+    "            # Extract only the generated part (not the input)\n",
+    "            generated_ids_trimmed = [\n",
+    "                out_ids[len(in_ids):] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)\n",
+    "            ]\n",
+    "            \n",
+    "            # Decode the generated text\n",
+    "            generated_response = processor.batch_decode(\n",
+    "                generated_ids_trimmed, \n",
+    "                skip_special_tokens=True, \n",
+    "                clean_up_tokenization_spaces=False\n",
+    "            )[0]\n",
+    "            \n",
+    "            # Calculate metrics\n",
+    "            word_error = wer(ground_truth, generated_response)\n",
+    "            char_error = cer(ground_truth, generated_response)\n",
+    "            \n",
+    "            # Save individual result\n",
+    "            output_file = os.path.join(output_dir, f\"sample_{i}.txt\")\n",
+    "            with open(output_file, 'w', encoding='utf-8') as f:\n",
+    "                f.write(f\"Sample {i}\\n\")\n",
+    "                f.write(f\"Question: {question}\\n\\n\")\n",
+    "                f.write(f\"Model output:\\n{generated_response.strip()}\\n\\n\")\n",
+    "                f.write(f\"Ground truth:\\n{ground_truth}\\n\\n\")\n",
+    "                f.write(f\"WER: {word_error:.4f}, CER: {char_error:.4f}\")\n",
+    "            \n",
+    "            # Store results for summary\n",
+    "            results.append({\n",
+    "                'sample_id': i,\n",
+    "                'wer': word_error,\n",
+    "                'cer': char_error,\n",
+    "                'model_output': generated_response.strip(),\n",
+    "                'ground_truth': ground_truth,\n",
+    "                'question': question\n",
+    "            })\n",
+    "            \n",
+    "        except Exception as e:\n",
+    "            print(f\"Error processing sample {i}: {str(e)}\")\n",
+    "            import traceback\n",
+    "            traceback.print_exc()\n",
+    "            \n",
+    "    # Create summary report\n",
+    "    if results:\n",
+    "        df = pd.DataFrame(results)\n",
+    "        \n",
+    "        # Calculate overall averages\n",
+    "        avg_wer = df['wer'].mean()\n",
+    "        avg_cer = df['cer'].mean()\n",
+    "        \n",
+    "        # Save average metrics\n",
+    "        with open(os.path.join(output_dir, \"avg_metrics.txt\"), 'w') as f:\n",
+    "            f.write(f\"Average WER: {avg_wer:.4f}\\n\")\n",
+    "            f.write(f\"Average CER: {avg_cer:.4f}\\n\")\n",
+    "        \n",
+    "        # Save detailed results\n",
+    "        df.to_csv(os.path.join(output_dir, \"detailed_results.csv\"), index=False)\n",
+    "        \n",
+    "        print(\"\\nResults Summary:\")\n",
+    "        print(f\"Average WER: {avg_wer:.4f}\")\n",
+    "        print(f\"Average CER: {avg_cer:.4f}\")\n",
+    "        print(f\"\\nDetailed results saved to {output_dir}/\")\n",
+    "        \n",
+    "        return avg_wer, avg_cer\n",
+    "    else:\n",
+    "        print(\"No results to summarize.\")\n",
+    "        return None, None\n",
+    "\n",
+    "\n",
+    "# At the beginning of your notebook, define a variable to collect results\n",
+    "model_comparison_results = {}\n",
+    "\n",
+    "# Create a simple function to add results to the comparison\n",
+    "def add_to_comparison(model_name, wer, cer):\n",
+    "    \"\"\"Add model results to the comparison tracker\"\"\"\n",
+    "    model_comparison_results[model_name] = {\n",
+    "        \"wer\": wer,\n",
+    "        \"cer\": cer\n",
+    "    }\n",
+    "    #return model_comparison_results\n",
+    "\n",
+    "# Create a function to print the comparison report whenever needed\n",
+    "def print_model_comparison(save_csv=True, save_plot=True):\n",
+    "    \"\"\"Print a comparison of all models evaluated so far\"\"\"\n",
+    "    if not model_comparison_results:\n",
+    "        print(\"No model results available for comparison\")\n",
+    "        return\n",
+    "        \n",
+    "    print(\"\\n==== MODEL COMPARISON REPORT ====\")\n",
+    "    \n",
+    "    # Create a comparison dataframe\n",
+    "    comparison_df = pd.DataFrame({\n",
+    "        \"Model\": list(model_comparison_results.keys()),\n",
+    "        \"WER\": [results[\"wer\"] for results in model_comparison_results.values()],\n",
+    "        \"CER\": [results[\"cer\"] for results in model_comparison_results.values()]\n",
+    "    })\n",
+    "    \n",
+    "    # Sort by WER (best performance first)\n",
+    "    comparison_df = comparison_df.sort_values(\"WER\")\n",
+    "    \n",
+    "    # Display the comparison table\n",
+    "    print(\"\\nComparison Table (sorted by WER):\")\n",
+    "    print(comparison_df.to_string(index=False))\n",
+    "    \n",
+    "    # Save the comparison table\n",
+    "    if save_csv:\n",
+    "        comparison_file = \"model_comparison_results.csv\"\n",
+    "        comparison_df.to_csv(comparison_file, index=False)\n",
+    "        print(f\"\\nComparison table saved to {comparison_file}\")\n",
+    "    \n",
+    "    # Generate a bar chart visualization\n",
+    "    if save_plot:\n",
+    "        import matplotlib.pyplot as plt\n",
+    "        plt.figure(figsize=(12, 6))\n",
+    "        \n",
+    "        # Plot WER\n",
+    "        plt.subplot(1, 2, 1)\n",
+    "        plt.bar(comparison_df[\"Model\"], comparison_df[\"WER\"], color='skyblue')\n",
+    "        plt.title('Word Error Rate Comparison')\n",
+    "        plt.ylabel('WER (lower is better)')\n",
+    "        plt.ylim(bottom=0)\n",
+    "        plt.xticks(rotation=45, ha='right')\n",
+    "        \n",
+    "        # Plot CER\n",
+    "        plt.subplot(1, 2, 2)\n",
+    "        plt.bar(comparison_df[\"Model\"], comparison_df[\"CER\"], color='lightgreen')\n",
+    "        plt.title('Character Error Rate Comparison')\n",
+    "        plt.ylabel('CER (lower is better)')\n",
+    "        plt.ylim(bottom=0)\n",
+    "        plt.xticks(rotation=45, ha='right')\n",
+    "        \n",
+    "        plt.tight_layout()\n",
+    "        plt.savefig('ocr_model_comparison.png')\n",
+    "        plt.show()\n",
+    "        \n",
+    "        print(f\"\\nVisualization saved to ocr_model_comparison.png\")\n",
+    "    \n",
+    "    return comparison_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5907eb2-cdd6-422b-ae22-b403cb0787fb",
+   "metadata": {},
+   "source": [
+    "## Finetuning Setup and Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dd535c06-d2a3-4acc-8044-6ec4eae3fb51",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==((====))==  Unsloth 2025.5.6: Fast Qwen2 patching. Transformers: 4.51.3.\n",
+      "   \\\\   /|    NVIDIA A100-SXM4-80GB. Num GPUs = 1. Max memory: 79.254 GB. Platform: Linux.\n",
+      "O^O/ \\_/ \\    Torch: 2.7.0+cu126. CUDA: 8.0. CUDA Toolkit: 12.6. Triton: 3.3.0\n",
+      "\\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.30. FA2 = True]\n",
+      " \"-____-\"     Free license: http://github.com/unslothai/unsloth\n",
+      "Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load Base Model\n",
+    "\n",
+    "model, tokenizer = FastVisionModel.from_pretrained(\n",
+    "    model_name = \"unsloth/Qwen2-VL-7B-Instruct\",\n",
+    "    max_seq_length = 2048, # Choose any for long context!\n",
+    "    load_in_4bit = True,  # 4 bit quantization to reduce memory\n",
+    "    load_in_8bit = False, # [NEW!] A bit more accurate, uses 2x memory\n",
+    "    full_finetuning = False, # [NEW!] We have full finetuning now!\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a2c20bdc-fce5-48f9-86b2-a3cda70fedf1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [03:18<00:00,  1.01it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 0.1707\n",
+      "Average CER: 0.0899\n",
+      "\n",
+      "Detailed results saved to unsloth_base_model_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark base model performance\n",
+    "model_name = \"Unsloth Base model\" \n",
+    "FastVisionModel.for_inference(model)\n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, tokenizer, eval_dataset, output_dir=\"unsloth_base_model_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bd230c0-e335-41a6-9f6a-531e224d3176",
+   "metadata": {},
+   "source": [
+    "## Lora Finetuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "69efdf0e-9acd-4813-9b54-2c592a55f58b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Making `model.base_model.model.model` require gradients\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = FastVisionModel.get_peft_model(\n",
+    "    model,\n",
+    "    finetune_vision_layers     = True, # Turn off for just text!\n",
+    "    finetune_language_layers   = True,  # Should leave on!\n",
+    "    finetune_attention_modules = True,  # Attention good for GRPO\n",
+    "    finetune_mlp_modules       = True,  # SHould leave on always!\n",
+    "\n",
+    "    r = 16, # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128\n",
+    "    target_modules = [\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\",\n",
+    "                      \"gate_proj\", \"up_proj\", \"down_proj\",],\n",
+    "    lora_alpha = 32,\n",
+    "    lora_dropout = 0, # Supports any, but = 0 is optimized\n",
+    "    bias = \"none\",    # Supports any, but = \"none\" is optimized\n",
+    "    # [NEW] \"unsloth\" uses 30% less VRAM, fits 2x larger batch sizes!\n",
+    "    use_gradient_checkpointing = \"unsloth\", # True or \"unsloth\" for very long context\n",
+    "    random_state = 3407,\n",
+    "    use_rslora = False,  # We support rank stabilized LoRA\n",
+    "    loftq_config = None, # And LoftQ\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "2065fd3e-046c-4abc-b09b-4c5955ecd828",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Model does not have a default image size - using 512\n"
+     ]
+    }
+   ],
+   "source": [
+    "from unsloth import is_bf16_supported\n",
+    "from unsloth.trainer import UnslothVisionDataCollator\n",
+    "FastVisionModel.for_training(model) # Enable for training!\n",
+    "model.config.use_cache = False\n",
+    "\n",
+    "\n",
+    "trainer = SFTTrainer(\n",
+    "    model = model,\n",
+    "    tokenizer = tokenizer,\n",
+    "    data_collator = UnslothVisionDataCollator(model, tokenizer),\n",
+    "    train_dataset = train_dataset,\n",
+    "    args = SFTConfig(\n",
+    "        per_device_train_batch_size = 4,\n",
+    "        gradient_accumulation_steps = 8,\n",
+    "        gradient_checkpointing=True,\n",
+    "        gradient_checkpointing_kwargs = {\"use_reentrant\": False}, # use reentrant checkpointing\n",
+    "        max_grad_norm=0.3,                      # max gradient norm based on QLoRA paper\n",
+    "        warmup_ratio=0.03,\n",
+    "        num_train_epochs = 2, # Set this instead of max_steps for full training runs\n",
+    "        learning_rate = 2e-4,\n",
+    "        fp16 = not is_bf16_supported(),\n",
+    "        bf16 = is_bf16_supported(),\n",
+    "        logging_steps = 5,\n",
+    "        save_strategy=\"epoch\",\n",
+    "        optim = \"adamw_torch_fused\",\n",
+    "        weight_decay = 0.01,\n",
+    "        lr_scheduler_type = \"linear\",\n",
+    "        seed = 3407,\n",
+    "        output_dir = \"unsloth-qwen2-7vl-french-ocr-checkpoints\",\n",
+    "        report_to = \"none\",     # For Weights and Biases\n",
+    "\n",
+    "        # You MUST put the below items for vision finetuning:\n",
+    "        remove_unused_columns = False,\n",
+    "        dataset_text_field = \"\",\n",
+    "        dataset_kwargs = {\"skip_prepare_dataset\": True},\n",
+    "        dataset_num_proc = 4,\n",
+    "        max_seq_length = 2048,\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "2f6a6c1b-c467-4c83-9fe7-82b599b0fed5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "==((====))==  Unsloth - 2x faster free finetuning | Num GPUs used = 1\n",
+      "   \\\\   /|    Num examples = 2,000 | Num Epochs = 2 | Total steps = 124\n",
+      "O^O/ \\_/ \\    Batch size per device = 4 | Gradient accumulation steps = 8\n",
+      "\\        /    Data Parallel GPUs = 1 | Total batch size (4 x 8 x 1) = 32\n",
+      " \"-____-\"     Trainable parameters = 40,370,176/7,000,000,000 (0.58% trained)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='124' max='124' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [124/124 06:43, Epoch 1/2]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Step</th>\n",
+       "      <th>Training Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>1.925900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>0.400700</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>15</td>\n",
+       "      <td>0.097200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>20</td>\n",
+       "      <td>0.071300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>25</td>\n",
+       "      <td>0.076500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>30</td>\n",
+       "      <td>0.071400</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>35</td>\n",
+       "      <td>0.071600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>40</td>\n",
+       "      <td>0.069200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>45</td>\n",
+       "      <td>0.065900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>50</td>\n",
+       "      <td>0.068000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>55</td>\n",
+       "      <td>0.067500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>60</td>\n",
+       "      <td>0.063200</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>65</td>\n",
+       "      <td>0.063400</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>70</td>\n",
+       "      <td>0.059700</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>75</td>\n",
+       "      <td>0.060100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>80</td>\n",
+       "      <td>0.060500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>85</td>\n",
+       "      <td>0.061000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>90</td>\n",
+       "      <td>0.060400</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>95</td>\n",
+       "      <td>0.058000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>100</td>\n",
+       "      <td>0.059600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>105</td>\n",
+       "      <td>0.058900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>110</td>\n",
+       "      <td>0.059300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>115</td>\n",
+       "      <td>0.056900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>120</td>\n",
+       "      <td>0.058500</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# run training\n",
+    "trainer_stats = trainer.train()\n",
+    "\n",
+    "model.save_pretrained(\"unsloth-qwen2-7vl-french-ocr-adapter\", tokenizer)\n",
+    "tokenizer.save_pretrained(\"unsloth-qwen2-7vl-french-ocr-adapter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1867d58b-290e-4716-9d7e-fe2c55fb3bdb",
+   "metadata": {},
+   "source": [
+    "## Measure Adapter Performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3bd3aa9c-d058-47d4-bab7-cd342041cd41",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [05:27<00:00,  1.64s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 0.0059\n",
+      "Average CER: 0.0010\n",
+      "\n",
+      "Detailed results saved to unsloth_lora_model_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark lora model performance\n",
+    "model_name = \"Unsloth lora adapter model\" \n",
+    "FastVisionModel.for_inference(model)\n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, tokenizer, eval_dataset, output_dir=\"unsloth_lora_model_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afe505b0-987d-4696-9d45-13b41491fa89",
+   "metadata": {},
+   "source": [
+    "## Merge Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "7ca527a3-231e-487d-b46b-330c406479bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found HuggingFace hub cache directory: /home/mlengineer/.cache/huggingface/hub\n",
+      "Checking cache directory for required files...\n",
+      "Cache check failed: model-00001-of-00004.safetensors not found in local cache.\n",
+      "Not all required files found in cache. Will proceed with downloading.\n",
+      "Downloading safetensors index for unsloth/qwen2-vl-7b-instruct...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b0c244d0e1df48ebbdd7d2573d6d5971",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors.index.json:   0%|          | 0.00/56.5k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Merging weights into 16bit:   0%|                                                                                               | 0/4 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "573962eaabc543e1ad06d2af9600b40d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model-00001-of-00004.safetensors:   0%|          | 0.00/4.97G [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Merging weights into 16bit:  25%|█████████████████████▊                                                                 | 1/4 [00:27<01:23, 27.67s/it]"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1a62a14c6163478eb0c152274224ea12",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model-00002-of-00004.safetensors:   0%|          | 0.00/4.99G [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Merging weights into 16bit:  50%|███████████████████████████████████████████▌                                           | 2/4 [01:00<01:01, 30.85s/it]"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "15b190b780db45e1861ed659449156ff",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model-00003-of-00004.safetensors:   0%|          | 0.00/4.93G [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Merging weights into 16bit:  75%|█████████████████████████████████████████████████████████████████▎                     | 3/4 [01:29<00:29, 29.92s/it]"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d761a8a6a9c24b1bbc41ffea57d4df1e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model-00004-of-00004.safetensors:   0%|          | 0.00/1.69G [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Merging weights into 16bit: 100%|███████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:37<00:00, 24.40s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# merge default 16 bits\n",
+    "model.save_pretrained_merged(save_directory=\"qwen2-ocr-merged-finetune-merge-16bit\", tokenizer=tokenizer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "cde6bd60-59ae-4184-aafe-874c91888f04",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Merging LoRA weights into 4bit model...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/conda/envs/unsloth_latest/lib/python3.11/site-packages/peft/tuners/lora/bnb.py:351: UserWarning: Merge lora module to 4-bit linear may get different generations due to rounding errors.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unsloth: Merging finished.\n",
+      "Unsloth: Found skipped modules: ['visual.blocks.0.attn.qkv', 'visual.blocks.0.attn.proj', 'visual.blocks.0.mlp.fc1', 'visual.blocks.0.mlp.fc2', 'visual.blocks.1.attn.qkv', 'visual.blocks.1.attn.proj', 'visual.blocks.1.mlp.fc1', 'visual.blocks.1.mlp.fc2', 'visual.blocks.2.attn.qkv', 'visual.blocks.2.attn.proj', 'visual.blocks.2.mlp.fc1', 'visual.blocks.2.mlp.fc2', 'visual.blocks.3.attn.qkv', 'visual.blocks.3.attn.proj', 'visual.blocks.3.mlp.fc1', 'visual.blocks.3.mlp.fc2', 'visual.blocks.4.attn.qkv', 'visual.blocks.4.attn.proj', 'visual.blocks.4.mlp.fc1', 'visual.blocks.4.mlp.fc2', 'visual.blocks.5.attn.qkv', 'visual.blocks.5.attn.proj', 'visual.blocks.5.mlp.fc1', 'visual.blocks.5.mlp.fc2', 'visual.blocks.6.attn.qkv', 'visual.blocks.6.attn.proj', 'visual.blocks.6.mlp.fc1', 'visual.blocks.6.mlp.fc2', 'visual.blocks.7.attn.qkv', 'visual.blocks.7.attn.proj', 'visual.blocks.7.mlp.fc1', 'visual.blocks.7.mlp.fc2', 'visual.blocks.8.attn.qkv', 'visual.blocks.8.attn.proj', 'visual.blocks.8.mlp.fc1', 'visual.blocks.8.mlp.fc2', 'visual.blocks.9.attn.qkv', 'visual.blocks.9.attn.proj', 'visual.blocks.9.mlp.fc1', 'visual.blocks.9.mlp.fc2', 'visual.blocks.10.attn.qkv', 'visual.blocks.10.attn.proj', 'visual.blocks.10.mlp.fc1', 'visual.blocks.10.mlp.fc2', 'visual.blocks.11.attn.qkv', 'visual.blocks.11.attn.proj', 'visual.blocks.11.mlp.fc1', 'visual.blocks.11.mlp.fc2', 'visual.blocks.12.attn.qkv', 'visual.blocks.12.attn.proj', 'visual.blocks.12.mlp.fc1', 'visual.blocks.12.mlp.fc2', 'visual.blocks.13.attn.qkv', 'visual.blocks.13.attn.proj', 'visual.blocks.13.mlp.fc1', 'visual.blocks.13.mlp.fc2', 'visual.blocks.14.attn.qkv', 'visual.blocks.14.attn.proj', 'visual.blocks.14.mlp.fc1', 'visual.blocks.14.mlp.fc2', 'visual.blocks.15.attn.qkv', 'visual.blocks.15.attn.proj', 'visual.blocks.15.mlp.fc1', 'visual.blocks.15.mlp.fc2', 'visual.blocks.16.attn.qkv', 'visual.blocks.16.attn.proj', 'visual.blocks.16.mlp.fc1', 'visual.blocks.16.mlp.fc2', 'visual.blocks.17.attn.qkv', 'visual.blocks.17.attn.proj', 'visual.blocks.17.mlp.fc1', 'visual.blocks.17.mlp.fc2', 'visual.blocks.18.attn.qkv', 'visual.blocks.18.attn.proj', 'visual.blocks.18.mlp.fc1', 'visual.blocks.18.mlp.fc2', 'visual.blocks.19.attn.qkv', 'visual.blocks.19.attn.proj', 'visual.blocks.20.attn.qkv', 'visual.blocks.20.attn.proj', 'visual.blocks.20.mlp.fc1', 'visual.blocks.20.mlp.fc2', 'visual.blocks.21.attn.qkv', 'visual.blocks.21.attn.proj', 'visual.blocks.21.mlp.fc1', 'visual.blocks.21.mlp.fc2', 'visual.blocks.22.mlp.fc1', 'visual.blocks.22.mlp.fc2', 'visual.blocks.23.attn.qkv', 'visual.blocks.23.attn.proj', 'visual.blocks.23.mlp.fc1', 'visual.blocks.23.mlp.fc2', 'visual.blocks.24.attn.qkv', 'visual.blocks.24.attn.proj', 'visual.blocks.24.mlp.fc1', 'visual.blocks.24.mlp.fc2', 'visual.blocks.25.attn.qkv', 'visual.blocks.25.attn.proj', 'visual.blocks.25.mlp.fc1', 'visual.blocks.25.mlp.fc2', 'visual.blocks.26.attn.qkv', 'visual.blocks.26.attn.proj', 'visual.blocks.26.mlp.fc1', 'visual.blocks.26.mlp.fc2', 'visual.blocks.27.attn.qkv', 'visual.blocks.27.attn.proj', 'visual.blocks.27.mlp.fc1', 'visual.blocks.27.mlp.fc2', 'visual.blocks.28.attn.qkv', 'visual.blocks.28.attn.proj', 'visual.blocks.28.mlp.fc1', 'visual.blocks.28.mlp.fc2', 'visual.blocks.29.attn.qkv', 'visual.blocks.29.attn.proj', 'visual.blocks.30.attn.qkv', 'visual.blocks.30.attn.proj', 'visual.blocks.30.mlp.fc1', 'visual.blocks.30.mlp.fc2', 'visual.blocks.31.attn.qkv', 'visual.blocks.31.attn.proj', 'visual.blocks.31.mlp.fc1', 'visual.blocks.31.mlp.fc2', 'visual.merger.mlp.0', 'visual.merger.mlp.2', 'lm_head']. Updating config.\n",
+      "Unsloth: Saving merged 4bit model to qwen2-ocr-merged-finetune-merge-4bit...\n",
+      "Unsloth: Merged 4bit model saved.\n",
+      "Unsloth: Merged 4bit model process completed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# merge 4 bits\n",
+    "model.save_pretrained_merged(save_directory=\"qwen2-ocr-merged-finetune-merge-4bit\", tokenizer=tokenizer, save_method=\"merged_4bit_forced\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af5d1e1f-d0d5-4f83-a7c0-67586d29cada",
+   "metadata": {},
+   "source": [
+    "## Benchmark merged model performance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e1ea8f0-b2d8-45d6-b275-b9815314bc68",
+   "metadata": {},
+   "source": [
+    "### 16 bits merged model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c3dce45b-89fa-423a-a626-d957102d2f86",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==((====))==  Unsloth 2025.5.6: Fast Qwen2 patching. Transformers: 4.51.3.\n",
+      "   \\\\   /|    NVIDIA A100-SXM4-80GB. Num GPUs = 1. Max memory: 79.254 GB. Platform: Linux.\n",
+      "O^O/ \\_/ \\    Torch: 2.7.0+cu126. CUDA: 8.0. CUDA Toolkit: 12.6. Triton: 3.3.0\n",
+      "\\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.30. FA2 = True]\n",
+      " \"-____-\"     Free license: http://github.com/unslothai/unsloth\n",
+      "Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "41f6c8f2c9664c04bb586b805562fe6f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load 16bits-merged model in 4 bits\n",
+    "model, tokenizer = FastVisionModel.from_pretrained(\"./qwen2-ocr-merged-finetune-merge-16bit\",load_in_4bit=True, load_in_8bit=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "dcf9ef6a-90bd-4441-a600-39dd44445aa6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [18:09<00:00,  5.45s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 3.5484\n",
+      "Average CER: 3.6879\n",
+      "\n",
+      "Detailed results saved to unsloth_16bits_merged_model_load_4bits_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark 4bit loaded, 16bits merged model performance\n",
+    "model_name = \"Unsloth 16bits-merged model load-4bits\" \n",
+    "model.config.use_cache = True\n",
+    "\n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, tokenizer, eval_dataset, output_dir=\"unsloth_16bits_merged_model_load_4bits_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "56089faa-e159-485b-b825-39c0e38fc5ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==((====))==  Unsloth 2025.5.6: Fast Qwen2 patching. Transformers: 4.51.3.\n",
+      "   \\\\   /|    NVIDIA A100-SXM4-80GB. Num GPUs = 1. Max memory: 79.254 GB. Platform: Linux.\n",
+      "O^O/ \\_/ \\    Torch: 2.7.0+cu126. CUDA: 8.0. CUDA Toolkit: 12.6. Triton: 3.3.0\n",
+      "\\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.30. FA2 = True]\n",
+      " \"-____-\"     Free license: http://github.com/unslothai/unsloth\n",
+      "Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d8f871b645934b359139d8f73f4075b8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# load model in 8 bits\n",
+    "model, tokenizer = FastVisionModel.from_pretrained(\"./qwen2-ocr-merged-finetune-merge-16bit\",load_in_4bit=False, load_in_8bit=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e15c1397-7c3c-4583-922b-562a74fa2405",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [01:48<00:00,  1.84it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 0.0050\n",
+      "Average CER: 0.0009\n",
+      "\n",
+      "Detailed results saved to unsloth_16bits_merged_model_load_8bits_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark 4bit loaded, 16bits merged model performance\n",
+    "model_name = \"Unsloth 16bits-merged model load-8bits\" \n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, tokenizer, eval_dataset, output_dir=\"unsloth_16bits_merged_model_load_8bits_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3216e6eb-12ff-44a4-9c06-d00d9d67a346",
+   "metadata": {},
+   "source": [
+    "### 4 bits merged model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b6c34c03-ceb2-4569-8879-1fb8d13dc66f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==((====))==  Unsloth 2025.5.6: Fast Qwen2 patching. Transformers: 4.51.3.\n",
+      "   \\\\   /|    NVIDIA A100-SXM4-80GB. Num GPUs = 1. Max memory: 79.254 GB. Platform: Linux.\n",
+      "O^O/ \\_/ \\    Torch: 2.7.0+cu126. CUDA: 8.0. CUDA Toolkit: 12.6. Triton: 3.3.0\n",
+      "\\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.30. FA2 = True]\n",
+      " \"-____-\"     Free license: http://github.com/unslothai/unsloth\n",
+      "Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18fdba92a64e43509229050f2d96436b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# load 4bits-merged model in 4 bits\n",
+    "model, tokenizer = FastVisionModel.from_pretrained(\"./qwen2-ocr-merged-finetune-merge-4bit\",load_in_4bit=True, load_in_8bit=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8b0ecfb7-7d0a-4cfc-a710-b51de7e5ffc9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [03:16<00:00,  1.02it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 0.1499\n",
+      "Average CER: 0.0745\n",
+      "\n",
+      "Detailed results saved to unsloth_4bits_merged_model_load_4bits_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark 4bit loaded, 4bits merged model performance\n",
+    "model_name = \"Unsloth 4bits-merged model load-4bits\" \n",
+    "\n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, tokenizer, eval_dataset, output_dir=\"unsloth_4bits_merged_model_load_4bits_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "39dde9ba-01f5-4ce4-9614-970fe12d0d9b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==((====))==  Unsloth 2025.5.6: Fast Qwen2 patching. Transformers: 4.51.3.\n",
+      "   \\\\   /|    NVIDIA A100-SXM4-80GB. Num GPUs = 1. Max memory: 79.254 GB. Platform: Linux.\n",
+      "O^O/ \\_/ \\    Torch: 2.7.0+cu126. CUDA: 8.0. CUDA Toolkit: 12.6. Triton: 3.3.0\n",
+      "\\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.30. FA2 = True]\n",
+      " \"-____-\"     Free license: http://github.com/unslothai/unsloth\n",
+      "Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4e7acfabe92c4cc49a86969df68b4b02",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# load model in 8 bits\n",
+    "model, tokenizer = FastVisionModel.from_pretrained(\"./qwen2-ocr-merged-finetune-merge-4bit\",load_in_4bit=False, load_in_8bit=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "223b2cf0-6dc9-485e-8848-d3a075b591fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating OCR performance: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [03:16<00:00,  1.02it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Results Summary:\n",
+      "Average WER: 0.1499\n",
+      "Average CER: 0.0745\n",
+      "\n",
+      "Detailed results saved to unsloth_4bits_merged_model_load_8bits_results/\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# benchmark 8bit loaded, 4bits merged model performance\n",
+    "model_name = \"Unsloth 4bits-merged model load-8bits\" \n",
+    "\n",
+    "avg_wer, avg_cer = evaluate_ocr_model(model, tokenizer, eval_dataset, output_dir=\"unsloth_4bits_merged_model_load_8bits_results\")\n",
+    "add_to_comparison(model_name, avg_wer, avg_cer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "892ecfc3-c004-4109-9807-798628e7c95c",
+   "metadata": {},
+   "source": [
+    "# Model comparison report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "3252b42b-406f-4e7e-bacb-6ef7176188cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "==== MODEL COMPARISON REPORT ====\n",
+      "\n",
+      "Comparison Table (sorted by WER):\n",
+      "                                 Model      WER      CER\n",
+      "Unsloth 16bits-merged model load-8bits 0.005011 0.000896\n",
+      "            Unsloth lora adapter model 0.005900 0.001000\n",
+      " Unsloth 4bits-merged model load-8bits 0.149930 0.074493\n",
+      " Unsloth 4bits-merged model load-4bits 0.149930 0.074493\n",
+      "                    Unsloth Base model 0.170700 0.089900\n",
+      "Unsloth 16bits-merged model load-4bits 3.548406 3.687869\n",
+      "\n",
+      "Comparison table saved to model_comparison_results.csv\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKYAAAJOCAYAAACN2Q8zAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAA5fRJREFUeJzs3Xd4FNX79/HPAimQTkuooUpvUiQBCSC9W7B/AyhNmoiKvyBSxSiIgCJNRBRFFAFRUJEWkCpVOkgNNSBCAgECJOf5gycrSxJqkkmy79d17SU7c2b2nrOb2dt7zp6xGWOMAAAAAAAAgHSWzeoAAAAAAAAA4JwoTAEAAAAAAMASFKYAAAAAAABgCQpTAAAAAAAAsASFKQAAAAAAAFiCwhQAAAAAAAAsQWEKAAAAAAAAlqAwBQAAAAAAAEtQmAIAAAAAAIAlKEwByFQiIiJks9kUERFhdSiAJKlYsWLq2LGj1WEAANKJzWZTr169rA4DwE3q16+v+vXrWx0G7hOFKQBJfP/997LZbJo3b16SdVWqVJHNZtPy5cuTrCtatKiCg4PTI8Q7mj59umw2W4qPdevWWR1isjp27OgQp5ubmx566CENGjRIV65cua997tq1S0OGDNHhw4dTN9j/LyoqSm+88YbKli2rXLlyycPDQ9WrV9e7776r8+fPp8lrAgCQ2g4cOKBu3bqpRIkScnd3l7e3t+rUqaNx48bp8uXLVof3wE6cOKEhQ4Zo69at6faaiRcUU3rMmjUr3WK5F0OGDHGI08XFRcWKFVOfPn3uO7dJ6/6PiYnR0KFDVaVKFXl6eipnzpyqWLGi3nrrLZ04cSJNXhNILTmsDgBAxlO3bl1J0qpVq/T444/bl8fExGjHjh3KkSOHVq9erQYNGtjXHT16VEePHtWzzz6b7vHezrBhw1S8ePEky0uVKmVBNHfHzc1NU6dOlSRFR0dr/vz5Gj58uA4cOKBvvvnmnve3a9cuDR06VPXr11exYsVSNdYNGzaoRYsWunjxol588UVVr15dkrRx40a9//77WrlypX7//fdUfc2MZu/evcqWjes8AJCZLVy4UO3bt5ebm5tCQ0NVsWJFXb16VatWrdKbb76pnTt3asqUKVaH+UBOnDihoUOHqlixYqpatWq6vnafPn1Us2bNJMuDgoLSNY57NXHiRHl6eio2NlZLly7VJ598os2bN2vVqlX3vK+07P+DBw+qUaNGioyMVPv27dW1a1e5urpq27Zt+vzzzzVv3jzt27cvVV8zo8nq+WZWR2EKQBIFCxZU8eLFk3zprl27VsYYtW/fPsm6xOeJRa37ZYzRlStXlDNnzgfaT6LmzZurRo0a97TN9evXlZCQIFdX1yTrYmNj5eHhcd/x3M3x5ciRQy+++KL9eY8ePRQcHKxvv/1WH330kfz9/e/79VPT+fPn9fjjjyt79uzasmWLypYt67B+xIgR+uyzzyyKLm3d/D66ublZHQ4A4AEcOnRIzz77rAIDA7Vs2TIVKFDAvq5nz57av3+/Fi5cmK4xPWi+kZ7uJtZHH31UTz311D3tNyEhQVevXpW7u/t9veadXLp0Sbly5bptm6eeekp58+aVJHXr1k3PPvusvvvuO/3555+qVavWA71+arl+/bqeeOIJRUVFKSIiIkkuPmLECH3wwQcWRZf2Et/H5PJ2ZB5c4gWQrLp162rLli0OQ9dXr16tChUqqHnz5lq3bp0SEhIc1tlsNtWpU0fSjS/J4cOHq2TJknJzc1OxYsU0YMAAxcXFObxOsWLF1KpVKy1atEg1atRQzpw5NXnyZEnSsWPH1K5dO3l4eCh//vx67bXXkmz/oA4fPiybzaYPP/xQY8eOtceb+PM3m82mXbt26fnnn5efn5/9yz41ju9u2Ww21a1bV8YYHTx40L78yJEj6tGjh8qUKaOcOXMqT548at++vcNP9qZPn6727dtLkho0aGAfkn7zHF2//vqrHn30UXl4eMjLy0stW7bUzp077xjX5MmTdfz4cX300UdJilKS5O/vr4EDBzosmzBhgipUqCA3NzcVLFhQPXv2TDIkvn79+qpYsaK2bdumkJAQ5cqVS6VKldIPP/wgSVqxYoUeeeQR5cyZU2XKlNGSJUsctk983/bs2aOnn35a3t7eypMnj1599dUkP4f84osv1LBhQ+XPn19ubm4qX768Jk6cmORYbvc+3jrH1LVr1zR06FCVLl1a7u7uypMnj+rWravFixc77HPZsmX2fvf19VXbtm21e/fuZI9l//796tixo3x9feXj46NOnTrp0qVLybwrAIB7NXLkSF28eFGff/65Q1EqUalSpfTqq68mWf7jjz+qYsWKcnNzU4UKFfTbb785rL+b72npv+kHVqxYoR49eih//vwqXLjwPe1DunHB6LXXXlOxYsXk5uamwoULKzQ0VP/8848iIiLsI5Y6depkzwemT59u3379+vVq1qyZfHx8lCtXLoWEhGj16tUOr3G73OhBJc7d9c0339hzhd9+++22/SPdW26xadMm1atXT7ly5dKAAQPuOcZHH31U0o2ffSb6999/9cYbb6hSpUry9PSUt7e3mjdvrr/++sveJrX6Pzlz5szRX3/9pbfffjvZ98Lb21sjRoxwWDZ79mxVr15dOXPmVN68efXiiy/q+PHjDm06duwoT09PRUZGqlWrVvL09FShQoX06aefSpK2b9+uhg0bysPDQ4GBgZo5c6bD9onv28qVK9WtWzflyZNH3t7eCg0N1blz5xzazp8/Xy1btlTBggXl5uamkiVLavjw4YqPj3dod7v3Mbk5pj755BNVqFBBuXLlkp+fn2rUqJEkzi1btqh58+by9vaWp6enHnvssSRTfiQey+rVq9WvXz/ly5dPHh4eevzxx3XmzJnk3hbcI0ZMAUhW3bp1NWPGDK1fv95+kl+9erWCg4MVHBys6Oho7dixQ5UrV7avK1u2rPLkySNJ6ty5s7788ks99dRTev3117V+/XqFh4dr9+7dSeau2rt3r5577jl169ZNXbp0UZkyZXT58mU99thjioyMVJ8+fVSwYEHNmDFDy5Ytu6fjiI6O1j///OOwzGaz2eNM9MUXX+jKlSvq2rWr3NzclDt3bvu69u3bq3Tp0nrvvfdkjEmV47tXiQmon5+ffdmGDRu0Zs0aPfvssypcuLAOHz6siRMnqn79+tq1a5dy5cqlevXqqU+fPvr44481YMAAlStXTpLs/50xY4Y6dOigpk2b6oMPPtClS5c0ceJEe2Hydj/9++mnn5QzZ867vgI6ZMgQDR06VI0aNdIrr7yivXv3auLEidqwYYNWr14tFxcXe9tz586pVatWevbZZ9W+fXtNnDhRzz77rL755hv17dtX3bt31/PPP69Ro0bpqaee0tGjR+Xl5eXwek8//bSKFSum8PBwrVu3Th9//LHOnTunr776yt5m4sSJqlChgtq0aaMcOXLo559/Vo8ePZSQkKCePXs67O9u38chQ4YoPDxcnTt3Vq1atRQTE6ONGzdq8+bNaty4sSRpyZIlat68uUqUKKEhQ4bo8uXL+uSTT1SnTh1t3rw5Sb8//fTTKl68uMLDw7V582ZNnTpV+fPnz9JXQAEgvfz8888qUaLEPc2TuWrVKs2dO1c9evSQl5eXPv74Yz355JOKjIy05xh38z19sx49eihfvnwaNGiQYmNj72kfFy9e1KOPPqrdu3frpZde0sMPP6x//vlHP/30k44dO6Zy5cpp2LBhGjRokLp27WovsCQe87Jly9S8eXNVr15dgwcPVrZs2ewXb/74448ko4OSy41u58KFC0nyMUnKkyePbDab/fmyZcv0/fffq1evXsqbN6+KFStmn5Mpuf65l9zi7Nmzat68uZ599lm9+OKL9zUCPbl87ODBg/rxxx/Vvn17FS9eXFFRUZo8ebJCQkK0a9cuFSxYMNX7/2Y//fSTJOl///vfXR3D9OnT1alTJ9WsWVPh4eGKiorSuHHjtHr1am3ZskW+vr72tvHx8WrevLnq1aunkSNH6ptvvlGvXr3k4eGht99+Wy+88IKeeOIJTZo0SaGhoQoKCkoyhUavXr3k6+urIUOG2N+fI0eO2OcfS4zJ09NT/fr1k6enp5YtW6ZBgwYpJiZGo0aNctjf3b6Pn332mfr06aOnnnrKfnFy27ZtWr9+vZ5//nlJ0s6dO/Xoo4/K29tb/fv3l4uLiyZPnqz69evbL4TerHfv3vLz89PgwYN1+PBhjR07Vr169dJ33313V32P2zAAkIydO3caSWb48OHGGGOuXbtmPDw8zJdffmmMMcbf3998+umnxhhjYmJiTPbs2U2XLl2MMcZs3brVSDKdO3d22Ocbb7xhJJlly5bZlwUGBhpJ5rfffnNoO3bsWCPJfP/99/ZlsbGxplSpUkaSWb58+W3j/+KLL4ykZB9ubm72docOHTKSjLe3tzl9+rTDPgYPHmwkmeeee85heWocX0o6dOhgPDw8zJkzZ8yZM2fM/v37zYcffmhsNpupWLGiSUhIsLe9dOlSku3Xrl1rJJmvvvrKvmz27NnJ9tmFCxeMr6+v/X1LdOrUKePj45Nk+a38/PxMlSpV7uq4Tp8+bVxdXU2TJk1MfHy8ffn48eONJDNt2jT7spCQECPJzJw5075sz549RpLJli2bWbdunX35okWLjCTzxRdf2Jclvm9t2rRxiKFHjx5Gkvnrr7/sy5Lrw6ZNm5oSJUo4LLvd+xgYGGg6dOhgf16lShXTsmXL2/SGMVWrVjX58+c3Z8+etS/766+/TLZs2UxoaGiSY3nppZcctn/88cdNnjx5bvsaAIA7i46ONpJM27Zt73obScbV1dXs37/fvuyvv/4ykswnn3xiX3a339OJOUvdunXN9evXHdrf7T4GDRpkJJm5c+cmaZ+YO2zYsCHJd2bi+tKlS5umTZsmyTOKFy9uGjdubF+WUm6UkuXLl6eYj0kyJ0+etLdN/J7fuXOnwz5S6p/7yS0mTZp0V3EnHufevXvNmTNnzOHDh820adNMzpw5Tb58+UxsbKy97ZUrVxxe35gb+aWbm5sZNmyYfVlq9H9yqlWrZnx8fO7quK5evWry589vKlasaC5fvmxfvmDBAiPJDBo0yL6sQ4cORpJ577337MvOnTtncubMaWw2m5k1a5Z9eWKeNnjwYPuyxPetevXq5urVq/blI0eONJLM/PnzHY71Vt26dTO5cuUyV65csS+73fsYEhJiQkJC7M/btm1rKlSocNv+aNeunXF1dTUHDhywLztx4oTx8vIy9erVS3IsjRo1cniPXnvtNZM9e3Zz/vz5274O7oyf8gFIVrly5ZQnTx773FF//fWXYmNj7Vd2goOD7cOL165dq/j4ePvw4V9++UWS1K9fP4d9vv7665KUZJ6G4sWLq2nTpg7LfvnlFxUoUMBhNE6uXLnUtWvXezqOTz/9VIsXL3Z4/Prrr0naPfnkk8qXL1+y++jevXuS2KQHO77biY2NVb58+ZQvXz6VKlVKb7zxhurUqaP58+c7XFW8eZ6qa9eu6ezZsypVqpR8fX21efPmO77O4sWLdf78eT333HP6559/7I/s2bPrkUceSfbOizeLiYlJMkopJUuWLNHVq1fVt29fh4nCu3TpIm9v7yR95unp6TCRfpkyZeTr66ty5co5XL1K/PfNP3FMdOuIp969e0v67/2THPswcXRdSEiIDh48qOjoaIft7/Z99PX11c6dO/X3338nu/7kyZPaunWrOnbs6DAyr3LlymrcuLFDfIlu/Qw++uijOnv2rGJiYu4YDwAgZYnn0bv9PkvUqFEjlSxZ0v68cuXK8vb2dvg+utfv6S5duih79uwOy+52H3PmzFGVKlUcblqT6ObcITlbt27V33//reeff15nz5615wOxsbF67LHHtHLlSofpG6Sk30t3MmjQoCT52OLFix2+ByUpJCRE5cuXT3Yft/bPveYWbm5u6tSp0z3FXaZMGeXLl0/FihXTSy+9pFKlSunXX391GO3m5uZmf/34+HidPXtWnp6eKlOmzF3lY/fT/ze7l3xs48aNOn36tHr06OEwd1fLli1VtmzZZOdS69y5s/3fvr6+KlOmjDw8PPT000/blyfmacnlY127dnUYufbKK68oR44cKeZjiaPrHn30UV26dEl79uxx2N/dvo++vr46duyYNmzYkOz6+Ph4/f7772rXrp1KlChhX16gQAE9//zzWrVqVZI8q2vXrg5/T48++qji4+N15MiRO8aD2+OnfACSZbPZFBwcbP8yXL16tfLnz2+/m11wcLDGjx8vSfYCVWJh6siRI8qWLVuSO98FBATI19c3yck7ubvmHTlyRKVKlUqSTN3rz+Bq1ap1V5OfJxdDSutS4/hux93dXT///LOkG/NsjRw5UqdPn04yYfrly5cVHh6uL774QsePH3cYSn9rUSU5iYWThg0bJrve29v7ttt7e3vrwoULd3wdSfY+ufX9c3V1VYkSJZL0WeHChZO89z4+PipSpEiSZZKSzFUgSaVLl3Z4XrJkSWXLls1hXo7Vq1dr8ODBWrt2bZI5m6Kjo+37l+7+fRw2bJjatm2rhx56SBUrVlSzZs30v//9z/6z15T6QrpREF60aFGSSV2LFi3q0C7xJwTnzp274/sEAEhZ4jn0br/PEt16XpZunJtv/j661+/p5L5n7nYfBw4c0JNPPnlPx5AoMR/o0KFDim2io6Mdfr52r7lNpUqV1KhRozu2u9d8TLr73KJQoUL3PEH2nDlz5O3trTNnzujjjz/WoUOHkuRjCQkJGjdunCZMmKBDhw45zIt069QRybmf/r/ZrQXR27ldDlK2bNkkNzdyd3dPcuHWx8cnxTztbvIxT09PFShQwCEf27lzpwYOHKhly5YlKQbd+rdyt+/jW2+9pSVLlqhWrVoqVaqUmjRpoueff94+H+6ZM2d06dKlFPOxhIQEHT16VBUqVLAvv10+hgdDYQpAiurWrauff/5Z27dvt88vlSg4OFhvvvmmjh8/rlWrVqlgwYIOVxukO1+hS5Rad+B7ELeLIaV1aXV82bNnd0jemjZtqrJly6pbt272eQSkGyOAvvjiC/Xt21dBQUHy8fGRzWbTs88+e9sra4kS28yYMUMBAQFJ1ufIcfuviLJly2rr1q26evVqqt8J5dYrxndabu5ifotb368DBw7oscceU9myZfXRRx+pSJEicnV11S+//KIxY8Yk6cO7fR/r1aunAwcOaP78+fr99981depUjRkzRpMmTXK46ngvHuS4AQAp8/b2VsGCBbVjx4572u5uzsv3+j2d3PfMg37X343E/YwaNUpVq1ZNto2np+cdY00N95OPpca+U1KvXj37Xflat26tSpUq6YUXXtCmTZvso6Tee+89vfPOO3rppZc0fPhw5c6dW9myZVPfvn3vKR+7l/6/WdmyZbVlyxYdPXo0yQW8B5UW+ditzp8/r5CQEHl7e2vYsGEqWbKk3N3dtXnzZr311lv3nY+VK1dOe/fu1YIFC/Tbb79pzpw5mjBhggYNGqShQ4fec5wS+VhaojAFIEWJI6BWrVql1atXq2/fvvZ11atXl5ubmyIiIrR+/Xq1aNHCvi4wMFAJCQn6+++/7ZNsS1JUVJTOnz+vwMDAO752YGCgduzYIWOMQ0Fh7969qXBkDyY1ju9eFChQQK+99pqGDh2qdevWqXbt2pKkH374QR06dNDo0aPtba9cuZLkTjQpFdASf4KQP3/+u7qKeavWrVtr7dq1mjNnjp577rnbtk3sk7179zoUMK9evapDhw7d1+vfyd9//+1wdXX//v1KSEiwTyz+888/Ky4uTj/99JPDFbA7/YTxbuTOnVudOnVSp06ddPHiRdWrV09DhgxR586dHfriVnv27FHevHkzzS3CASAraNWqlaZMmaK1a9cqKCgo1fZ7t9/TqbGPkiVL3rG4dqd8wNvbO02+j9NKeucWnp6eGjx4sDp16qTvv//ePuXADz/8oAYNGujzzz93aH/+/Hl7UUtKu/5v3bq1vv32W3399dcKCwu7bdub++zWEfN79+5N9RxWupGPNWjQwP784sWLOnnypP3/HSIiInT27FnNnTtX9erVs7c7dOjQA7+2h4eHnnnmGT3zzDO6evWqnnjiCY0YMUJhYWHKly+fcuXKlWI+li1btlQv9CFlzDEFIEU1atSQu7u7vvnmGx0/ftxhxJSbm5sefvhhffrpp4qNjXW4PW3iF83YsWMd9vfRRx9JuvE79jtp0aKFTpw4oR9++MG+7NKlS5oyZcqDHFKqSI3ju1e9e/dWrly59P7779uXZc+ePckVmk8++STJrXUTixy3JrFNmzaVt7e33nvvPV27di3Ja97p9rfdu3dXgQIF9Prrr2vfvn1J1p8+fVrvvvuupBtzcbi6uurjjz92iPnzzz9XdHR0mvRZ4u2ME33yySeSpObNm0v676rXrT+L+OKLLx7odc+ePevw3NPTU6VKlVJcXJykG4XGqlWr6ssvv3R4T3bs2KHff//docgLAEh7/fv3l4eHhzp37qyoqKgk6w8cOKBx48bd837v9ns6Nfbx5JNP6q+//kpyZ2Dpv++5lPKB6tWrq2TJkvrwww918eLFJNvfKR+wihW5xQsvvKDChQs73BU3ufdo9uzZOn78uMOytOr/p556SpUqVdKIESO0du3aJOsvXLigt99+W9KN3D5//vyaNGmSPS+RpF9//VW7d+9Okz6bMmWKQ545ceJEXb9+/bb52NWrVzVhwoQHet1b8zFXV1eVL19exhhdu3ZN2bNnV5MmTTR//nyHnxVGRUVp5syZqlu3LtMlpCNGTAFIkaurq2rWrKk//vhDbm5uql69usP64OBg+xW8mwtTVapUUYcOHTRlyhT78Nw///xTX375pdq1a+dw1SQlXbp00fjx4xUaGqpNmzapQIECmjFjRpJbK9/Jr7/+mmTSxMTYb/3p4d1KjeO7V3ny5FGnTp00YcIE7d69W+XKlVOrVq00Y8YM+fj4qHz58lq7dq2WLFmSZD6DqlWrKnv27Prggw8UHR0tNzc3NWzYUPnz59fEiRP1v//9Tw8//LCeffZZ5cuXT5GRkVq4cKHq1Kljn0csOX5+fpo3b55atGihqlWr6sUXX7R/RjZv3qxvv/3WfuU5X758CgsL09ChQ9WsWTO1adNGe/fu1YQJE1SzZk29+OKLqd5nhw4dUps2bdSsWTOtXbtWX3/9tZ5//nlVqVJFktSkSRO5urqqdevW6tatmy5evKjPPvtM+fPn18mTJ+/7dcuXL6/69eurevXqyp07tzZu3KgffvhBvXr1srcZNWqUmjdvrqCgIL388su6fPmyPvnkE/n4+GjIkCEPeugAgHtQsmRJzZw5U88884zKlSun0NBQVaxYUVevXtWaNWs0e/ZsdezY8Z73e7ff06mxjzfffFM//PCD2rdvr5deeknVq1fXv//+q59++kmTJk1SlSpVVLJkSfn6+mrSpEny8vKSh4eHHnnkERUvXlxTp05V8+bNVaFCBXXq1EmFChXS8ePHtXz5cnl7e9vnvrxff/zxh65cuZJkeeXKle1zMN4rK3ILFxcXvfrqq3rzzTf122+/qVmzZmrVqpWGDRumTp06KTg4WNu3b9c333yTJM9Mq/53cXHR3Llz1ahRI9WrV09PP/206tSpIxcXF+3cuVMzZ86Un5+fRowYIRcXF33wwQfq1KmTQkJC9NxzzykqKkrjxo1TsWLF9Nprr6V6n129elWPPfaYnn76afv7U7duXbVp00bSjZzcz89PHTp0UJ8+fWSz2TRjxowH/nlckyZNFBAQoDp16sjf31+7d+/W+PHj1bJlS/tk8e+++64WL16sunXrqkePHsqRI4cmT56suLg4jRw58oGPHfcgfW8CCCCzCQsLM5JMcHBwknVz5841koyXl1eS2xtfu3bNDB061BQvXty4uLiYIkWKmLCwMIdbvhpjTGBgoGnZsmWyr33kyBHTpk0bkytXLpM3b17z6quvmt9++81IMsuXL79t3Im3dU3pkXir3kOHDhlJZtSoUUn2kXir4DNnziRZlxrHl5wOHToYDw+PZNcdOHDAZM+e3XTo0MEYc+OWvZ06dTJ58+Y1np6epmnTpmbPnj0mMDDQ3ibRZ599ZkqUKGGyZ8+epP+WL19umjZtanx8fIy7u7spWbKk6dixo9m4ceNdxXzixAnz2muvmYceesi4u7ubXLlymerVq5sRI0aY6Ohoh7bjx483ZcuWNS4uLsbf39+88sor5ty5cw5tQkJCkr29b0p9Kcn07NnT/jzxfdu1a5d56qmnjJeXl/Hz8zO9evVyuDWyMcb89NNPpnLlysbd3d0UK1bMfPDBB2batGlGkjl06NAdXztx3c39/e6775patWoZX19fkzNnTlO2bFkzYsQIh1slG2PMkiVLTJ06dUzOnDmNt7e3ad26tdm1a5dDm5Q+g4mf75tjBAA8mH379pkuXbqYYsWKGVdXV+Pl5WXq1KljPvnkE4fv91u/dxLd+n1wt9/Tief0DRs2JNnnvXzXnz171vTq1csUKlTIuLq6msKFC5sOHTqYf/75x95m/vz5pnz58iZHjhwO+ZAxxmzZssU88cQTJk+ePMbNzc0EBgaap59+2ixdutTe5na5UXKWL19+23xs8ODBd+zX2/WPMQ+WW6TkdscZHR1tfHx8TEhIiDHGmCtXrpjXX3/dFChQwOTMmdPUqVPHrF271oSEhNjbJHrQ/r+dc+fOmUGDBplKlSqZXLlyGXd3d1OxYkUTFhZmTp486dD2u+++M9WqVTNubm4md+7c5oUXXjDHjh1zaJNSTnq3eVri+7ZixQrTtWtX4+fnZzw9Pc0LL7xgzp4967Dt6tWrTe3atU3OnDlNwYIFTf/+/c2iRYuS5Ky3ex9v7e/JkyebevXq2fuzZMmS5s0330ySm27evNk0bdrUeHp6mly5cpkGDRqYNWvWOLRJ6TOY+Pm+0/+X4M5sxjBTFwAg6xgyZIiGDh2qM2fOOMztAAAAgPQxffp0derUSRs2bLirO2TDuTHHFAAAAAAAACxBYQoAAAAAAACWoDAFAAAAAAAASzDHFAAAAAAAACzBiCkAAAAAAABYgsIUAAAAAAAALJHD6gCAe5GQkKATJ07Iy8tLNpvN6nAAAE7AGKMLFy6oYMGCypaNa3rIfMifAABWuNscisIUMpUTJ06oSJEiVocBAHBCR48eVeHCha0OA7hn5E8AACvdKYeiMIVMxcvLS9KND7a3t7fF0QAAnEFMTIyKFCli/w4CMhvyJwCAFe42h6IwhUwlcfi5t7c3iRUAIF3xEyhkVuRPAAAr3SmHYqIEAAAAAAAAWILCFAAAAAAAACxBYQoAAAAAAACWoDAFAAAAAAAAS1CYAgAAAAAAgCUoTAEAAAAAAMASFKYAAAAAAABgCQpTAAAAAAAAsASFKQAAAAAAAFiCwhQAAAAAAAAsQWEKAAAAAAAAlqAwBQAAAAAAAEtQmAIAAAAAAIAlclgdADKniRMnauLEiTp8+LAkqUKFCho0aJCaN2+ebPvp06erU6dODsvc3Nx05cqVtA4VAHCX3t/yj9UhpKr/q5bX6hAAAIATGHdunNUhpKpX/V5N19ejMIX7UrhwYb3//vsqXbq0jDH68ssv1bZtW23ZskUVKlRIdhtvb2/t3bvX/txms6VXuAAAAAAAIAOiMIX70rp1a4fnI0aM0MSJE7Vu3boUC1M2m00BAQHpER4AAAAAAMgEmGMKDyw+Pl6zZs1SbGysgoKCUmx38eJFBQYGqkiRImrbtq127tx5x33HxcUpJibG4QEAAAAAALIGClO4b9u3b5enp6fc3NzUvXt3zZs3T+XLl0+2bZkyZTRt2jTNnz9fX3/9tRISEhQcHKxjx47d9jXCw8Pl4+NjfxQpUiQtDgUAAAAAAFiAwhTuW5kyZbR161atX79er7zyijp06KBdu3Yl2zYoKEihoaGqWrWqQkJCNHfuXOXLl0+TJ0++7WuEhYUpOjra/jh69GhaHAoAAAAAALAAc0zhvrm6uqpUqVKSpOrVq2vDhg0aN27cHYtNkuTi4qJq1app//79t23n5uYmNze3VIkXAAAAAABkLIyYQqpJSEhQXFzcXbWNj4/X9u3bVaBAgTSOCgAAAAAAZFSMmMJ9CQsLU/PmzVW0aFFduHBBM2fOVEREhBYtWiRJCg0NVaFChRQeHi5JGjZsmGrXrq1SpUrp/PnzGjVqlI4cOaLOnTtbeRgAAAAAAMBCFKZwX06fPq3Q0FCdPHlSPj4+qly5shYtWqTGjRtLkiIjI5Ut238D8s6dO6cuXbro1KlT8vPzU/Xq1bVmzZoUJ0sHAAAAAABZH4Up3JfPP//8tusjIiIcno8ZM0ZjxoxJw4gAAAAAAEBmwxxTAAAAAAAAsASFKQAAACCdTJw4UZUrV5a3t7e8vb0VFBSkX3/9NcX206dPl81mc3i4u7unY8QAAKQtfsoHAAAApJPChQvr/fffV+nSpWWM0Zdffqm2bdtqy5YtqlChQrLbeHt7a+/evfbnNpstvcIFACDNUZgCAAAA0knr1q0dno8YMUITJ07UunXrUixM2Ww2BQQEpEd4AACkO37KBwAAAFggPj5es2bNUmxsrIKCglJsd/HiRQUGBqpIkSJq27atdu7cedv9xsXFKSYmxuEBAEBGRWEKAAAASEfbt2+Xp6en3Nzc1L17d82bN0/ly5dPtm2ZMmU0bdo0zZ8/X19//bUSEhIUHBysY8eOpbj/8PBw+fj42B9FihRJq0MBAOCBUZgCAAAA0lGZMmW0detWrV+/Xq+88oo6dOigXbt2Jds2KChIoaGhqlq1qkJCQjR37lzly5dPkydPTnH/YWFhio6Otj+OHj2aVocCAMADY44pAAAAIB25urqqVKlSkqTq1atrw4YNGjdu3G2LTYlcXFxUrVo17d+/P8U2bm5ucnNzS7V4AQBIS4yYAgAAACyUkJCguLi4u2obHx+v7du3q0CBAmkcFQAA6YMRUwAAAEA6CQsLU/PmzVW0aFFduHBBM2fOVEREhBYtWiRJCg0NVaFChRQeHi5JGjZsmGrXrq1SpUrp/PnzGjVqlI4cOaLOnTtbeRgAAKQaClMAAABAOjl9+rRCQ0N18uRJ+fj4qHLlylq0aJEaN24sSYqMjFS2bP/9qOHcuXPq0qWLTp06JT8/P1WvXl1r1qxJcbJ0AAAyGwpTAAAAQDr5/PPPb7s+IiLC4fmYMWM0ZsyYNIwIAABrMccUAAAAAAAALEFhCgAAAAAAAJagMAUAAAAAAABLUJgCAAAAAACAJShMAQAAAAAAwBIUpgAAAAAAAGAJClMAAAAAAACwBIUpAAAAAAAAWILCFAAAAAAAACxBYQoAAAAAAACWoDAFAAAAAAAAS1CYAgAAAAAAgCUoTAEAAAAAAMASFKYAAAAAAABgCQpTAAAAAAAAsASFKQAAAAAAAFiCwhQAAAAAAAAsQWEKAAAAAAAAlqAwBQAAAAAAAEtQmAIAAAAAAIAlKEwBAAAAAADAEhSmcF8mTpyoypUry9vbW97e3goKCtKvv/56221mz56tsmXLyt3dXZUqVdIvv/ySTtECAAAAAICMiMIU7kvhwoX1/vvva9OmTdq4caMaNmyotm3baufOncm2X7NmjZ577jm9/PLL2rJli9q1a6d27dppx44d6Rw5AAAAAADIKChM4b60bt1aLVq0UOnSpfXQQw9pxIgR8vT01Lp165JtP27cODVr1kxvvvmmypUrp+HDh+vhhx/W+PHj0zlyAAAAAACQUVCYwgOLj4/XrFmzFBsbq6CgoGTbrF27Vo0aNXJY1rRpU61duzY9QgQAAAAAABlQDqsDQOa1fft2BQUF6cqVK/L09NS8efNUvnz5ZNueOnVK/v7+Dsv8/f116tSp275GXFyc4uLi7M9jYmIePHAAAAAAAJAhMGIK961MmTLaunWr1q9fr1deeUUdOnTQrl27UvU1wsPD5ePjY38UKVIkVfcPAAAAAACsQ2EK983V1VWlSpVS9erVFR4eripVqmjcuHHJtg0ICFBUVJTDsqioKAUEBNz2NcLCwhQdHW1/HD16NNXiBwAAAAAA1qIwhVSTkJDg8LO7mwUFBWnp0qUOyxYvXpzinFSJ3Nzc5O3t7fAAAAAAAABZA3NM4b6EhYWpefPmKlq0qC5cuKCZM2cqIiJCixYtkiSFhoaqUKFCCg8PlyS9+uqrCgkJ0ejRo9WyZUvNmjVLGzdu1JQpU6w8DAAAAAAAYCEKU7gvp0+fVmhoqE6ePCkfHx9VrlxZixYtUuPGjSVJkZGRypbtvwF5wcHBmjlzpgYOHKgBAwaodOnS+vHHH1WxYkWrDgEAAAAAAFiMn/Lhvnz++ec6fPiw4uLidPr0aS1ZssRelJKkiIgITZ8+3WGb9u3ba+/evYqLi9OOHTvUokWLdI4aAADAWhMnTlTlypXtUxQEBQXp119/ve02s2fPVtmyZeXu7q5KlSrpl19+SadoAQBIexSmAAAAgHRSuHBhvf/++9q0aZM2btyohg0bqm3bttq5c2ey7desWaPnnntOL7/8srZs2aJ27dqpXbt22rFjRzpHDgBA2qAwBQAAAKST1q1bq0WLFipdurQeeughjRgxQp6enlq3bl2y7ceNG6dmzZrpzTffVLly5TR8+HA9/PDDGj9+fDpHDgBA2qAwBQAAAFggPj5es2bNUmxsbIp3Kl67dq0aNWrksKxp06Zau3ZteoQIAECaY/JzAAAAIB1t375dQUFBunLlijw9PTVv3jyVL18+2banTp2Sv7+/wzJ/f3+dOnUqxf3HxcUpLi7O/jwmJiZ1AgcAIA0wYgoAAABIR2XKlNHWrVu1fv16vfLKK+rQoYN27dqVavsPDw+Xj4+P/VGkSJFU2zcAAKmNwhQAAACQjlxdXVWqVClVr15d4eHhqlKlisaNG5ds24CAAEVFRTksi4qKUkBAQIr7DwsLU3R0tP1x9OjRVI0fAIDURGEKAAAAsFBCQoLDT+9uFhQUpKVLlzosW7x4cYpzUkmSm5ubvL29HR4AAGRUzDEFAAAApJOwsDA1b95cRYsW1YULFzRz5kxFRERo0aJFkqTQ0FAVKlRI4eHhkqRXX31VISEhGj16tFq2bKlZs2Zp48aNmjJlipWHAQBAqqEwBQAAAKST06dPKzQ0VCdPnpSPj48qV66sRYsWqXHjxpKkyMhIZcv2348agoODNXPmTA0cOFADBgxQ6dKl9eOPP6pixYpWHQIAAKmKwhQAAACQTj7//PPbro+IiEiyrH379mrfvn0aRQQAgLWYYwoAAAAAAACWoDAFAAAAAAAAS1CYAgAAAAAAgCUoTAEAAAAAAMASFKYAAAAAAABgCQpTAAAAAAAAsASFKQAAAAAAAFiCwhQAAAAAAAAsQWEKAAAAAAAAlqAwBQAAAAAAAEtQmAIAAAAAAIAlKEwBAAAAAADAEjmsDgDp69ChQ/rjjz905MgRXbp0Sfny5VO1atUUFBQkd3d3q8MDAAAAAABOhMKUk/jmm280btw4bdy4Uf7+/ipYsKBy5sypf//9VwcOHJC7u7teeOEFvfXWWwoMDLQ6XAAAAAAA4AQoTDmBatWqydXVVR07dtScOXNUpEgRh/VxcXFau3atZs2apRo1amjChAlq3769RdECAABkLIw4BwAg7VCYcgLvv/++mjZtmuJ6Nzc31a9fX/Xr19eIESN0+PDh9AsOAAAgg2LEOQAAaY/ClBNILEpdv35dM2fOVNOmTeXv759s2zx58ihPnjzpGR4AAECGw4hzAADSB4UpJ5IjRw51795du3fvtjoUAACADI0R5wAApI9sVgeA9FWrVi1t3brV6jAAAAAytJtHnH/11VeKiopKsW2ePHlUvXr19AoNAIAshRFTTqZHjx7q16+fjh49qurVq8vDw8NhfeXKlS2KDAAAIONhxDkAAGmLwpSTefbZZyVJffr0sS+z2Wwyxshmsyk+Pt6q0AAAADKkxBHnTHAOAEDqozDlZA4dOmR1CAAAAJkKI84BAEg7FKacDFf6AAAA7g0jzgEASDtMfu6EZsyYoTp16qhgwYI6cuSIJGns2LGaP3/+Xe8jPDxcNWvWlJeXl/Lnz6927dpp7969t91m+vTpstlsDg93d/cHOhYAAIC0dujQoSSPgwcP2v8LAADuH4UpJzNx4kT169dPLVq00Pnz5+1X+Hx9fTV27Ni73s+KFSvUs2dPrVu3TosXL9a1a9fUpEkTxcbG3nY7b29vnTx50v5ILIwBAABkVIGBgbd9AACA+0dhysl88skn+uyzz/T2228re/bs9uU1atTQ9u3b73o/v/32mzp27KgKFSqoSpUqmj59uiIjI7Vp06bbbmez2RQQEGB/+Pv73/exAAAApJfUGHEOAACSojDlZA4dOqRq1aolWe7m5nbH0U63Ex0dLUnKnTv3bdtdvHhRgYGBKlKkiNq2baudO3fe92sCAACkh9QacQ4AAJKiMOVkihcvrq1btyZZ/ttvv6lcuXL3tc+EhAT17dtXderUUcWKFVNsV6ZMGU2bNk3z58/X119/rYSEBAUHB+vYsWMpbhMXF6eYmBiHBwAAQHpKrRHnAAAgKe7K52T69eunnj176sqVKzLG6M8//9S3336r8PBwTZ069b722bNnT+3YsUOrVq26bbugoCAFBQXZnwcHB6tcuXKaPHmyhg8fnuw24eHhGjp06H3FBQAAkBrSasQ5AACgMOV0OnfurJw5c2rgwIG6dOmSnn/+eRUsWFDjxo2z3wr5XvTq1UsLFizQypUrVbhw4Xva1sXFRdWqVdP+/ftTbBMWFqZ+/frZn8fExKhIkSL3HCcAAMD9ShxxfutE5w8y4hwAANxAYcoJvfDCC3rhhRd06dIlXbx4Ufnz57/nfRhj1Lt3b82bN08REREqXrz4Pe8jPj5e27dvV4sWLVJs4+bmJjc3t3veNwAAQGpJixHnAADgBgpTTqZhw4aaO3eufH19lStXLuXKlUvSjZFI7dq107Jly+5qPz179tTMmTM1f/58eXl56dSpU5IkHx8f5cyZU5IUGhqqQoUKKTw8XJI0bNgw1a5dW6VKldL58+c1atQoHTlyRJ07d06DIwUAAEgdqT3iHAAA/IfJz51MRESErl69mmT5lStX9Mcff9z1fiZOnKjo6GjVr19fBQoUsD++++47e5vIyEidPHnS/vzcuXPq0qWLypUrpxYtWigmJkZr1qxR+fLlH+ygAAAA0tgLL7ygv//+WxcvXtSpU6d07Ngxvfzyy/e8n/DwcNWsWVNeXl7Knz+/2rVrp7179952m+nTp8tmszk83N3d7/dQAADIUBgx5SS2bdtm//euXbvsI5ykGz+p++2331SoUKG73p8x5o5tIiIiHJ6PGTNGY8aMuevXAAAAyAhSa8S5JK1YsUI9e/ZUzZo1df36dQ0YMEBNmjTRrl275OHhkeJ23t7eDgUsm812/wcEAEAGQmHKSVStWtV+ha1hw4ZJ1ufMmVOffPKJBZEBAABkbKk14ly6MWH6zaZPn678+fNr06ZNqlevXorb2Ww2BQQE3NNrAQCQGVCYchKHDh2SMUYlSpTQn3/+qXz58tnXubq6Kn/+/MqePbuFEQIAAGQsqT3iPDnR0dGSpNy5c9+23cWLFxUYGKiEhAQ9/PDDeu+991ShQoVk28bFxSkuLs7+PCYm5oFiBAAgLVGYchKJtzdevny5qlatqhw5HN/6+Ph4rVy58rZX6gAAAJxJWo84T0hIUN++fVWnTh1VrFgxxXZlypTRtGnTVLlyZUVHR+vDDz9UcHCwdu7cqcKFCydpHx4erqFDh953XAAApCcKU06mYcOGOnnypPLnz++w/Pz582rQoIHi4+MtigwAACBjSesR5z179tSOHTu0atWq27YLCgpSUFCQ/XlwcLDKlSunyZMna/jw4Unah4WFqV+/fvbnMTExKlKkyH3HCQBAWqIw5WSMMclOlnn27NnbTrgJAADgbNJyxHmvXr20YMECrVy5MtlRT7fj4uKiatWqaf/+/cmud3Nzk5ub2z3HBACAFShMOYknnnhC0o2JMzt27OiQrMTHx2vbtm0KDg62KjwAAIAMKzVHnBtj1Lt3b82bN08REREqXrz4PccTHx+v7du3q0WLFve8LQAAGQ2FKSfh4+Mj6UYy5OXlpZw5c9rXubq6qnbt2urSpYtV4QEAAGRYqTnivGfPnpo5c6bmz58vLy8v+4TqPj4+9vwsNDRUhQoVUnh4uCRp2LBhql27tkqVKqXz589r1KhROnLkiDp37vyARwYAgPUoTDmJL774QpJUrFgxvfHGG/xsDwAA4A7SYsT5xIkTJUn169d3WP7FF1+oY8eOkqTIyEhly5bNvu7cuXPq0qWLTp06JT8/P1WvXl1r1qxR+fLl7+OoAADIWChMOZnBgwfr+vXrWrJkiQ4cOKDnn39eXl5eOnHihLy9veXp6Wl1iAAAABlCWow4N8bcsU1ERITD8zFjxmjMmDH39DoAAGQWFKaczJEjR9SsWTNFRkYqLi5OjRs3lpeXlz744APFxcVp0qRJVocIAACQITDiHACAtJftzk2Qlbz66quqUaOGzp0753DV7/HHH9fSpUstjAwAACBjGjx4sNzc3LRkyRJNnjxZFy5ckCSdOHFCFy9etDg6AAAyN0ZMOZk//vhDa9askaurq8PyYsWK6fjx4xZFBQAAkHEx4hwAgLTDiCknk5CQkOwtjY8dOyYvLy8LIgIAAMjYGHEOAEDaoTDlZJo0aaKxY8fan9tsNl28eFGDBw9WixYtrAsMAAAgg/rjjz80cOBARpwDAJAG+Cmfkxk9erSaNm2q8uXL68qVK3r++ef1999/K2/evPr222+tDg8AACDDYcQ5AABph8KUkylcuLD++usvzZo1S9u2bdPFixf18ssv64UXXnAYmg4AAIAbEkecT5kyRRIjzgEASE0UppxQjhw59OKLL1odBgAAQKbAiHMAANIOhSkntHfvXn3yySfavXu3JKlcuXLq1auXypYta3FkAAAAGQ8jzgEASDsUppzMnDlz9Oyzz6pGjRoKCgqSJK1bt06VKlXSrFmz9OSTT1ocIQAAQMbDiHMAANIGhSkn079/f4WFhWnYsGEOywcPHqz+/ftTmAIAAEgGI84BAEgb2awOAOnr5MmTCg0NTbL8xRdf1MmTJy2ICAAAIGObM2eOKlasqE2bNqlKlSqqUqWKNm/erEqVKmnOnDlWhwcAQKbGiCknU79+ff3xxx8qVaqUw/JVq1bp0UcftSgqAACAjIsR5wAApB0KU07gp59+sv+7TZs2euutt7Rp0ybVrl1b0o05pmbPnq2hQ4daFSIAAECGdbsR56NGjbIgIgAAsg4KU06gXbt2SZZNmDBBEyZMcFjWs2dPde/ePZ2iAgAAyBwYcQ4AQNqhMOUEEhISrA4BAAAgU2HEOQAA6YPCFAAAAHALRpwDAJA+KEwBAAAAt2DEOQAA6SOb1QEAAAAAAADAOVGYAgAAAAAAgCUoTAEAAAAAAMASFKaczObNm7V9+3b78/nz56tdu3YaMGCArl69amFkAAAAAADA2VCYcjLdunXTvn37JEkHDx7Us88+q1y5cmn27Nnq37+/xdEBAAAAAABnQmHKyezbt09Vq1aVJM2ePVv16tXTzJkzNX36dM2ZM8fa4AAAADIgRpwDAJB2KEw5GWOM/fbHS5YsUYsWLSRJRYoU0T///GNlaAAAABkSI84BAEg7FKacTI0aNfTuu+9qxowZWrFihVq2bClJOnTokPz9/e96P+Hh4apZs6a8vLyUP39+tWvXTnv37r3jdrNnz1bZsmXl7u6uSpUq6ZdffrnvYwEAAEgPjDgHACDtUJhyMmPHjtXmzZvVq1cvvf322ypVqpQk6YcfflBwcPBd72fFihXq2bOn1q1bp8WLF+vatWtq0qSJYmNjU9xmzZo1eu655/Tyyy9ry5Ytateundq1a6cdO3Y88HEBAACkFUacAwCQdmzGGGN1ELDelStXlD17drm4uNzX9mfOnFH+/Pm1YsUK1atXL9k2zzzzjGJjY7VgwQL7stq1a6tq1aqaNGnSXb1OTEyMfHx8FB0dLW9v7/uKFQCQvPe3ZK3/wf6/anlTZT9896Bhw4YqUqSIGjVqpJdfflm7du1SqVKltGLFCnXo0EGHDx+2OsTb4jMMAGlr3LlxVoeQql71ezVV9nO33z+MmIIkyd3d/b6LUpIUHR0tScqdO3eKbdauXatGjRo5LGvatKnWrl2b4jZxcXGKiYlxeAAAAKSn1BpxDgAAksphdQBIe7lz59a+ffuUN29e+fn5yWazpdj233//vef9JyQkqG/fvqpTp44qVqyYYrtTp04lmcfK399fp06dSnGb8PBwDR069J5jAgAASC2VK1d2uCtfolGjRil79uwWRAQAQNZBYcoJjBkzRl5eXpJuXPFLbT179tSOHTu0atWqVN93WFiY+vXrZ38eExOjIkWKpPrrAAAA3Ct3d3erQwAAINOjMOUEOnTokOy/U0OvXr20YMECrVy5UoULF75t24CAAEVFRTksi4qKUkBAQIrbuLm5yc3NLVViBQAAuFtpPeIcAADcQGEK98UYo969e2vevHmKiIhQ8eLF77hNUFCQli5dqr59+9qXLV68WEFBQWkYKQAAwL1LqxHn4eHhmjt3rvbs2aOcOXMqODhYH3zwgcqUKXPb7WbPnq133nlHhw8fVunSpfXBBx/Y7w4IAEBmRmEK96Vnz56aOXOm5s+fLy8vL/s8UT4+PsqZM6ckKTQ0VIUKFVJ4eLgk6dVXX1VISIhGjx6tli1batasWdq4caOmTJli2XEAAAAkJ61GnK9YsUI9e/ZUzZo1df36dQ0YMEBNmjTRrl275OHhkew2a9as0XPPPafw8HC1atVKM2fOVLt27bR58+bbzu8JAEBmYDPGGKuDQOaT0nD2L774Qh07dpQk1a9fX8WKFdP06dPt62fPnq2BAwfar/aNHDnynq72cbtjAEg772/5x+oQUtX/VcubKvvhuwdp6cyZM8qfP79WrFihevXqJdvmmWeeUWxsrBYsWGBfVrt2bVWtWlWTJk2642vwGQaAtDXu3DirQ0hVr/q9mir7udvvH0ZM4b7cTT0zIiIiybL27durffv2aRARAABA5hMdHS3pxpxWKVm7dq3DzWAkqWnTpvrxxx+TbR8XF6e4uDj785iYmAcPFACANJLN6gCQfq5du6YcOXJox44dVocCAADg9BISEtS3b1/VqVPntj/JO3XqlPz9/R2W+fv726dSuFV4eLh8fHzsD+5oDADIyChMOREXFxcVLVpU8fHxVocCAADg9Hr27KkdO3Zo1qxZqbrfsLAwRUdH2x9Hjx5N1f0DAJCaKEw5mbffflsDBgzgtsYAAAB3Ia1GnPfq1UsLFizQ8uXLVbhw4du2DQgIUFRUlMOyqKgoBQQEJNvezc1N3t7eDg8AADIq5phyMuPHj9f+/ftVsGBBBQYGJrn7y+bNmy2KDAAAIONJ7RHnxhj17t1b8+bNU0REhIoXL37HbYKCgrR06VL17dvXvmzx4sUKCgpKlZgAALAShSkn065dO6tDAAAAyFQSR5zPmDHjtpOU342ePXtq5syZmj9/vry8vOzzRPn4+ChnzpySpNDQUBUqVEjh4eGSpFdffVUhISEaPXq0WrZsqVmzZmnjxo2aMmXKgx0YAAAZAIUpJzN48GCrQwAAAMhUUnPE+cSJEyVJ9evXd1j+xRdfqGPHjpKkyMhIZcv234wbwcHBmjlzpgYOHKgBAwaodOnS+vHHH287YToAAJkFhSkndP78ef3www86cOCA3nzzTeXOnVubN2+Wv7+/ChUqZHV4AAAAGUpqjjg3xtyxTURERJJl7du3V/v27VMtDgAAMgoKU05m27ZtatSokXx8fHT48GF16dJFuXPn1ty5cxUZGamvvvrK6hABAAAyFEacAwCQdrgrn5Pp16+fOnbsqL///lvu7u725S1atNDKlSstjAwAACDjOn/+vKZOnaqwsDD73Y03b96s48ePWxwZAACZGyOmnMyGDRs0efLkJMsLFSpkn3wTAAAA/2HEOQAAaYcRU07Gzc1NMTExSZbv27dP+fLlsyAiAACAjI0R5wAApB0KU06mTZs2GjZsmK5duyZJstlsioyM1FtvvaUnn3zS4ugAAAAyng0bNqhbt25JljPiHACAB0dhysmMHj1aFy9eVP78+XX58mWFhISoVKlS8vLy0ogRI6wODwAAIMNhxDkAAGmHOaacjI+PjxYvXqxVq1Zp27Ztunjxoh5++GE1atTI6tAAAAAypMQR599//70kRpwDAJCaKEw5mStXrsjd3V1169ZV3bp1rQ4HAAAgwxs9erSeeuophxHnp06dUlBQECPOAQB4QBSmnIyvr69q1aqlkJAQNWjQQEFBQcqZM6fVYQEAAGRYjDgHACDtUJhyMkuWLNHKlSsVERGhMWPG6Pr166pRo4ZCQkJUv359NW7c2OoQAQAAMhRGnAMAkHaY/NzJ1K1bVwMGDNDvv/+u8+fPa/ny5SpVqpRGjhypZs2aWR0eAABAhuPr66t69erpnXfe0bJly3T58mWrQwIAIMtgxJQT2rdvnyIiIuyPuLg4tWrVSvXr17c6NAAAgAyHEecAAKQdClNOplChQrp8+bLq16+v+vXr66233lLlypVls9msDg0AACBDSvwJ34ABA3T9+nVt2LBBkydP1siRI/X+++8rPj7e6hABAMi0KEw5mXz58mnPnj06deqUTp06paioKF2+fFm5cuWyOjQAAIAMixHnAACkDQpTTmbr1q06f/68Vq5cqRUrVmjAgAHatWuXqlatqgYNGnDLYwAAgFsw4hwAgLTD5OdOyNfXV23atNGAAQMUFhamp556Shs2bND7779vdWgAAAAZTr58+XTp0qUkI84BAMCDozDlZObOnas+ffqocuXK8vf31yuvvKKLFy9q9OjR2rx5s9XhAQAAZDhbt27VqVOn9H//93+Ki4vTgAEDlDdvXgUHB+vtt9+2OjwAADI1fsrnZLp376569eqpa9euCgkJUaVKlawOCQAAIMNLHHFep04dBQcHa/78+fr222+1fv16pkIAAOABUJhyMqdPn7Y6BAAAgExl7ty59knPd+3apdy5c6tu3boaPXq0QkJCrA4PAIBMjcKUE4qPj9ePP/6o3bt3S5LKly+vtm3bKnv27BZHBgAAkPEw4hwAgLRDYcrJ7N+/Xy1atNDx48dVpkwZSVJ4eLiKFCmihQsXqmTJkhZHCAAAkLEw4hwAgLRDYcrJ9OnTRyVLltS6deuUO3duSdLZs2f14osvqk+fPlq4cKHFEQIAAGQ8jDgHACBtUJhyMitWrHAoSklSnjx59P7776tOnToWRgYAAJAxMeIcAIC0k83qAJC+3NzcdOHChSTLL168KFdXVwsiAgAAyNgSR5wfPXpUmzdv1ubNmxUZGanixYurT58+VocHAECmRmHKybRq1Updu3bV+vXrZYyRMUbr1q1T9+7d1aZNG6vDAwAAyHBWrFihkSNHJjvifMWKFRZGBgBA5kdhysl8/PHHKlmypIKCguTu7i53d3fVqVNHpUqV0rhx46wODwAAIMNhxDkAAGmHwpST8fX11fz587V371798MMP+uGHH7R3717NmzdPPj4+97SvlStXqnXr1ipYsKBsNpt+/PHH27aPiIiQzWZL8jh16tQDHBEAAEDaYsQ5AABph8nPnVTp0qVVunTpB9pHbGysqlSpopdeeklPPPHEXW+3d+9eeXt725/nz5//geIAAABISx9//LE6dOigoKAgubi4SJKuX7+uNm3aMOIcAIAHRGHKCfTr1++u23700Ud33bZ58+Zq3rz5PceTP39++fr63vN2AAAAVkgccf73339rz549kqRy5cqpVKlSFkcGAEDmR2HKCWzZsuWu2tlstjSO5IaqVasqLi5OFStW1JAhQ1SnTp10eV0AAIAHkRojzgEAgCMKU05g+fLlVocgSSpQoIAmTZqkGjVqKC4uTlOnTlX9+vW1fv16Pfzww8luExcXp7i4OPvzmJiY9AoXAAA4sbQacQ4AABxRmEK6KVOmjMqUKWN/HhwcrAMHDmjMmDGaMWNGstuEh4dr6NCh6RUiAACApLQbcb5y5UqNGjVKmzZt0smTJzVv3jy1a9cuxfYRERFq0KBBkuUnT55UQEDAPb02AAAZEYUpJ9C9e3cNHDhQhQsXvmPb7777TtevX9cLL7yQDpFJtWrV0qpVq1JcHxYW5nDFMiYmRkWKFEmP0AAAgBNLqxHn3DwGAABHFKacQL58+VShQgXVqVNHrVu3Vo0aNVSwYEG5u7vr3Llz2rVrl1atWqVZs2apYMGCmjJlSrrFtnXrVhUoUCDF9W5ubnJzc0u3eAAAANISN48BAMBRNqsDQNobPny49u3bpzp16mjChAmqXbu2ihYtqvz586tMmTIKDQ3VwYMHNWXKFK1bt06VK1e+q/1evHhRW7du1datWyVJhw4d0tatWxUZGSnpxmin0NBQe/uxY8dq/vz52r9/v3bs2KG+fftq2bJl6tmzZ6ofMwAAwIPo3r27jh07dldtv/vuO33zzTdpGk/VqlVVoEABNW7cWKtXr07T1wIAID0xYspJ+Pv76+2339bbb7+tc+fOKTIyUpcvX1bevHlVsmTJ+7oj38aNGx3mPEj8yV2HDh00ffp0nTx50l6kkqSrV6/q9ddf1/Hjx5UrVy5VrlxZS5YsSXbeBAAAACtllBHn3DwGAJDV2YwxxuoggLsVExMjHx8fRUdHO8yzAAB4cO9v+cfqEFLV/1XLmyr74bvHeUVFRWnq1KmaNWuWdu3a5bDOy8tLjRo1UufOndWsWbP72r/NZrvj5OfJCQkJUdGiRVO8ecyQIUOSvXkMn2EASBvjzo2zOoRU9arfq6myn7vNoRgxBQAAACQjLUacpwZuHgMAyEooTAEAAAB34OfnJz8/P6vDkMTNYwAAWQuFKQAAACCdXLx4Ufv377c/T7x5TO7cuVW0aFGFhYXp+PHj+uqrryTduHlM8eLFVaFCBV25ckVTp07VsmXL9Pvvv1t1CAAApCoKUwAAAEA64eYxAAA4ojAFSdKVK1c0fvx4vfHGG1aHAgAAkGXVr19ft7v30PTp0x2e9+/fX/3790/jqAAAsE42qwNA+jlz5owWLFig33//XfHx8ZKka9euady4cSpWrJjef/99iyMEAAAAAADOhMKUk1i1apVKly6tNm3aqHnz5goODtauXbtUoUIFTZ48WUOGDNHRo0etDhMAACDTuHLlij788EOrwwAAIFOjMOUkBg4cqBYtWmjbtm3q16+fNmzYoMcff1zvvfeedu3ape7duytnzpxWhwkAAJChMOIcAIC0RWHKSWzfvl0DBw5UxYoVNWzYMNlsNo0cOVJPPfWU1aEBAABkSIw4BwAg7VGYchLnzp1T3rx5JUk5c+ZUrly5VLFiRYujAgAAyLgYcQ4AQNrjrnxOZNeuXTp16pQkyRijvXv3KjY21qFN5cqVrQgNAAAgw9m+fbsmTJig8uXLa9iwYfroo480cuRItW3b1urQAADIMihMOZHHHnvM4fbErVq1kiTZbDYZY2Sz2exzJwAAADg7RpwDAJD2KEw5iUOHDlkdAgAAQKbDiHMAANIWhSknERgYaHUIAAAAmQ4jzgEASFsUppzEyJEj1bt3b/sEnatXr1aNGjXk5uYmSbpw4YLeeustTZgwwcowAQAAMgxGnAMAkPYoTDmJsLAwdezY0V6Yat68ubZu3aoSJUpIki5duqTJkydTmAIAAPj/GHEOAEDay2Z1AEgfNw9BT+45AAAAHI0cOVKXL1+2P1+9erXi4uLszy9cuKAePXpYERoAAFkGhSkAAAAgGWFhYbpw4YL9efPmzXX8+HH788QR5wAA4P5RmAIAAACSwYhzAADSHnNMOZGpU6fK09NTknT9+nVNnz5defPmlSSHq4EAAAAAAADpgcKUkyhatKg+++wz+/OAgADNmDEjSRsAAAAAAID0QmHKSRw+fNjqEAAAADIdRpwDAJC2KEw5iUOHDql48eJWhwEAAJBpMOIcAIC0R2HKSZQsWVKBgYFq0KCB/VG4cGGrwwIAAMiwGHEOAEDaozDlJJYtW6aIiAhFRETo22+/1dWrV1WiRAk1bNjQXqjy9/e3OkwAAAAAAOBEslkdANJH/fr1NWTIEEVEROjcuXNavHixnnvuOe3evVsdO3ZUwYIFVaFCBavDBAAAyDCWLVum8uXLKyYmJsm66OhoVahQQStXrrQgMgAAsg5GTDkhd3d3NWzYUHXr1lWDBg3066+/avLkydqzZ4/VoQEAAGQYY8eOVZcuXeTt7Z1knY+Pj7p166YxY8aoXr16FkQHAEDWwIgpJ3L16lWtXLlSQ4cOVYMGDeTr66vu3bvr3LlzGj9+vA4dOmR1iAAAABnGX3/9pWbNmqW4vkmTJtq0aVM6RgQAQNbDiCkn0bBhQ61fv17FixdXSEiIunXrppkzZ6pAgQJWhwYAAJAhRUVFycXFJcX1OXLk0JkzZ9IxIgAAsh5GTDmJP/74Q3ny5FHDhg312GOPqXHjxhSlAAAAbqNQoULasWNHiuu3bdtGPgUAwAOiMOUkzp8/rylTpihXrlz64IMPVLBgQVWqVEm9evXSDz/8wNU+AACAW7Ro0ULvvPOOrly5kmTd5cuXNXjwYLVq1cqCyAAAyDr4KZ+T8PDwULNmzezzJFy4cEGrVq3S8uXLNXLkSL3wwgsqXbr0ba8KAgAAOJOBAwdq7ty5euihh9SrVy+VKVNGkrRnzx59+umnio+P19tvv21xlAAAZG4UppyUh4eHcufOrdy5c8vPz085cuTQ7t27rQ4LAAAgw/D399eaNWv0yiuvKCwsTMYYSZLNZlPTpk316aefyt/f3+IoAQDI3Pgpn5NISEjQn3/+qZEjR6p58+by9fVVcHCwJkyYoICAAH366ac6ePDgPe1z5cqVat26tQoWLCibzaYff/zxjttERETo4Ycflpubm0qVKqXp06ff3wEBAACkg8DAQP3yyy/6559/tH79eq1bt07//POPfvnlFxUvXtzq8AAAyPQYMeUkfH19FRsbq4CAADVo0EBjxoxR/fr1VbJkyfveZ2xsrKpUqaKXXnpJTzzxxB3bHzp0SC1btlT37t31zTffaOnSpercubMKFCigpk2b3nccAAAAac3Pz081a9a0OgwAALIcClNOYtSoUWrQoIEeeuihVNtn8+bN1bx587tuP2nSJBUvXlyjR4+WJJUrV06rVq3SmDFjKEwBAAAAAOCE+Cmfk+jWrVuqFqXux9q1a9WoUSOHZU2bNtXatWstiggAAAAAAFiJwhTSzalTp5JMEOrv76+YmBhdvnw52W3i4uIUExPj8AAAAMismKMTAABHFKaQoYWHh8vHx8f+KFKkiNUhAQAA3LfEOTo//fTTu2qfOEdngwYNtHXrVvXt21edO3fWokWL0jhSAADSB3NMId0EBAQoKirKYVlUVJS8vb2VM2fOZLcJCwtTv3797M9jYmIoTgEAgEyLOToBAHBEYQrpJigoSL/88ovDssWLFysoKCjFbdzc3OTm5pbWoQEAAGRIKc3R2bdv3xS3iYuLU1xcnP05UyEAADIyfsqH+3bx4kVt3bpVW7dulXRjqPnWrVsVGRkp6cZop9DQUHv77t276+DBg+rfv7/27NmjCRMm6Pvvv9drr71mRfgAAAAZ3v3M0clUCACAzITCFO7bxo0bVa1aNVWrVk2S1K9fP1WrVk2DBg2SJJ08edJepJKk4sWLa+HChVq8eLGqVKmi0aNHa+rUqQxDBwAASEVhYWGKjo62P44ePWp1SAAApIif8uG+1a9fX8aYFNcnd8eY+vXra8uWLWkYFQAAQNZxP3N0MhUCACAzYcQUAAAAkEEFBQVp6dKlDsvuNEcnAACZCYUpAAAAIJ0wRycAAI4oTAEAAADphDk6AQBwxBxTAAAAQDphjk4AABwxYgoAAAAAAACWoDAFAAAAAAAAS1CYAgAAAAAAgCUoTAEAAAAAAMASFKYAAAAAAABgCQpTAAAAAAAAsASFKQAAAAAAAFiCwhQAAAAAAAAsQWEKAAAAAAAAlqAwBQAAAAAAAEtQmAIAAAAAAIAlKEwBAAAAAADAEhSmAAAAAAAAYAkKUwAAAAAAALAEhSkAAAAAAABYgsIUAAAAAAAALEFhCgAAAAAAAJagMAUAAAAAAABLUJgCAAAAAACAJShMAQAAAAAAwBIUpgAAAAAAAGAJClMAAAAAAACwBIUpAAAAAAAAWILCFAAAAAAAACxBYQoAAAAAAACWoDAFAAAAAAAAS1CYAgAAAAAAgCUoTAEAAAAAAMASFKYAAAAAAABgCQpTAAAAAAAAsASFKTyQTz/9VMWKFZO7u7seeeQR/fnnnym2nT59umw2m8PD3d09HaMFAAAAAAAZCYUp3LfvvvtO/fr10+DBg7V582ZVqVJFTZs21enTp1PcxtvbWydPnrQ/jhw5ko4RAwAAZAxc3AMA4AYKU7hvH330kbp06aJOnTqpfPnymjRpknLlyqVp06aluI3NZlNAQID94e/vn44RAwAAWI+LewAA/IfCFO7L1atXtWnTJjVq1Mi+LFu2bGrUqJHWrl2b4nYXL15UYGCgihQporZt22rnzp23fZ24uDjFxMQ4PAAAADIzLu4BAPAfClO4L//884/i4+OTJEX+/v46depUstuUKVNG06ZN0/z58/X1118rISFBwcHBOnbsWIqvEx4eLh8fH/ujSJEiqXocAAAA6Sm9Lu4BAJBZUJhCugkKClJoaKiqVq2qkJAQzZ07V/ny5dPkyZNT3CYsLEzR0dH2x9GjR9MxYgAAgNSVHhf3GHEOAMhMclgdADKnvHnzKnv27IqKinJYHhUVpYCAgLvah4uLi6pVq6b9+/en2MbNzU1ubm4PFCsAAEBmFhQUpKCgIPvz4OBglStXTpMnT9bw4cOTtA8PD9fQoUPTM0QAAO4bI6ZwX1xdXVW9enUtXbrUviwhIUFLly51SJxuJz4+Xtu3b1eBAgXSKkwAAIAMJT0u7jHiHACQmVCYwn3r16+fPvvsM3355ZfavXu3XnnlFcXGxqpTp06SpNDQUIWFhdnbDxs2TL///rsOHjyozZs368UXX9SRI0fUuXNnqw4BAAAgXaXHxT03Nzd5e3s7PAAAyKj4KR/u2zPPPKMzZ85o0KBBOnXqlKpWrarffvvNPmdCZGSksmX7r/Z57tw5denSRadOnZKfn5+qV6+uNWvWqHz58lYdAgAAQLrr16+fOnTooBo1aqhWrVoaO3Zskot7hQoVUnh4uKQbF/dq166tUqVK6fz58xo1ahQX9wAAWQaFKTyQXr16qVevXsmui4iIcHg+ZswYjRkzJh2iAgAAyLi4uAcAwH8oTAEAAADpjIt7AADcwBxTAAAAAAAAsASFKQAAAAAAAFiCwhQAAAAAAAAsQWEKAAAAAAAAlqAwBQAAAAAAAEtQmAIAAAAAAIAlKEwBAAAAAADAEhSmAAAAAAAAYAkKUwAAAAAAALAEhSkAAAAAAABYgsIUAAAAAAAALEFhCgAAAAAAAJagMAUAAAAAAABLUJgCAAAAAACAJShMAQAAAAAAwBIUpgAAAAAAAGAJClMAAAAAAACwBIUpAAAAAAAAWILCFAAAAAAAACxBYQoAAAAAAACWoDAFAAAAAAAAS+SwOgAAADKC97f8Y3UIqer/quW1OgQAAADgjhgxBQAAAAAAAEswYgqA02OkDH0AAAAAwBqMmAIAAAAAAIAlKEwBAAAAAADAEhSmAAAAAAAAYAkKUwAAAAAAALAEhSkAAAAAAABYgrvyAQAAAACA+zLu3DirQ0hVr/q9anUITofCFAAAAADgnmS1YoR0fwWJrNYPFGVgBX7KBwAAAAAAAEtQmMID+fTTT1WsWDG5u7vrkUce0Z9//nnb9rNnz1bZsmXl7u6uSpUq6ZdffkmnSAEAADIOcigAAG6gMIX79t1336lfv34aPHiwNm/erCpVqqhp06Y6ffp0su3XrFmj5557Ti+//LK2bNmidu3aqV27dtqxY0c6Rw4AAGAdcigAAP5DYQr37aOPPlKXLl3UqVMnlS9fXpMmTVKuXLk0bdq0ZNuPGzdOzZo105tvvqly5cpp+PDhevjhhzV+/Ph0jhwAAMA65FAAAPyHwhTuy9WrV7Vp0yY1atTIvixbtmxq1KiR1q5dm+w2a9eudWgvSU2bNk2xPQAAQFZDDgUAgCPuyof78s8//yg+Pl7+/v4Oy/39/bVnz55ktzl16lSy7U+dOpXi68TFxSkuLs7+PDo6WpIUExNzv6E7+Oivs6myn4yiX5U897wNfSBduXghDSKxTkyM6z1vQx/QBxJ9kPJ+bnznGGNSZX9wbumRQ6V1/jTx3MRU2U9G8YrfK/e8DX0gXYm5kgaRWCsm+73/jWS1fqAP6APp/vog2f3cZQ5FYQoZWnh4uIYOHZpkeZEiRSyIJuNL2lPOhz6gDyT6QKIPpNTvgwsXLsjHxyeV9wqkPvKne/N/+j+rQ7AcfXAD/UAfSPSBlPp9cKccisIU7kvevHmVPXt2RUVFOSyPiopSQEBAstsEBATcU3tJCgsLU79+/ezPExIS9O+//ypPnjyy2WwPcATpJyYmRkWKFNHRo0fl7e1tdTiWoA/oA4k+kOgDKXP2gTFGFy5cUMGCBa0OBVlAeuRQ5E9ZA31AHySiH+gDKXP2wd3mUBSmcF9cXV1VvXp1LV26VO3atZN0I+lZunSpevXqlew2QUFBWrp0qfr27WtftnjxYgUFBaX4Om5ubnJzc3NY5uvr+6DhW8Lb2zvTnEDSCn1AH0j0gUQfSJmvDxgphdSSHjkU+VPWQh/QB4noB/pAynx9cDc5FIUp3Ld+/fqpQ4cOqlGjhmrVqqWxY8cqNjZWnTp1kiSFhoaqUKFCCg8PlyS9+uqrCgkJ0ejRo9WyZUvNmjVLGzdu1JQpU6w8DAAAgHRFDgUAwH8oTOG+PfPMMzpz5owGDRqkU6dOqWrVqvrtt9/sk3NGRkYqW7b/bvwYHBysmTNnauDAgRowYIBKly6tH3/8URUrVrTqEAAAANIdORQAAP+hMIUH0qtXrxSHnUdERCRZ1r59e7Vv3z6No8pY3NzcNHjw4CRD6p0JfUAfSPSBRB9I9AGQiBzq9jhX0AcSfZCIfqAPpKzdBzbDvY8BAAAAAABggWx3bgIAAAAAAACkPgpTAAAAAAAAsASFKQAAAAAAAFiCwhSA+xIZGWl1CECGsGrVKiUkJFgdBgAgkyCHAm4gh0IiClPAfbj1ngHOdg+BwYMHq2zZstq+fbvVoVjO2d57ONq2bZvq1aunYcOGOX1ixd8CgDtx9vxJIodK5IzvPRyRQ93A38INFKaAe5SQkCCbzSZJ2rx5s6Kjo+3PncXrr7+uoKAgtWvXzqkTq5s/C9HR0RZHY42bE4lLly5ZGIk1KleurClTpig8PFzvvvuu0yZWN/8t7Nu3zyk/CwBuj/zpBnIo8ieJ/Ekih5LIn25GYQq4BwkJCcqW7cafzcCBA/Xaa69p4cKFun79ulNVu729vTV//nwFBgaqTZs2TplY3fxZGDt2rIYPH64DBw5YHFX6urkPJk6cqIkTJ+rYsWMWR5X+OnfurIkTJ2ro0KFOmVjd/DkYPHiwXn/9dS1btkzx8fEWRwYgoyB/+o+z51DkT+RPN3PmHIr8yRGFKeAeJJ483n77bU2ePFnvvPOOmjdvrhw5ctir3c5wQjXGyNPT06kTq8TPQv/+/fXee++pevXqypEjh8VRpa+b+2Dw4MHy9/e3OKL0l/g/VC+99JKmTJnilIlV4ucgLCxMEyZMULdu3VS7dm1lz57d3saZ+gNAUuRP/3H2HIr8ifwpkbPnUORPtzAA7ighIcH+782bN5uHHnrIrF692hhjzPnz582ePXvMp59+anbs2GGMMSY+Pt6SONNSSsd06dIl8+ijj5pixYqZbdu2pXNU1vr6669NoUKFzKZNm+zLrl27Zg4ePGhhVOnrs88+MwULFjSbN2+2L7t+/bo5deqUhVGlvcRzwvXr1x2eT5482WTLls0MHTo0S54HUrJy5UpTrFgxs2HDBmPMjfPC4cOHzdy5c01kZKQxJmueFwHcHvnTDeRQjsifnDd/MoYc6mbkT/9xrvI0cJ9ungPB09NTV69eVUxMjLZv367Jkydr8eLFio+P16uvvqrNmzerUqVKFkab+m4eajpr1izt2LFDrq6uqlSpkh5//HH9/vvvatasmdq0aaOffvopyx1/ImOMw2chMjJS5cqV08MPP6y9e/dq0aJFmjJlis6ePas+ffooLCzMwmjTxq19sGfPHj366KOqVq2a/v77b61YsUITJkxQQkKC+vTpo5deesnCaNNGYh8sW7ZMCxcu1PHjx/Xwww/rf//7n7p27aps2bKpW7dukm78ZCXxbycrc3FxUc6cOZU9e3bt2LFDX3zxhebNmydjjGJjY7Vu3TqVKFHC6jABpDNnz58kciiJ/Ekif0pEDuWI/Ok/WfudBh7QihUr9Mcff0i6MVnlp59+quzZs6tatWp6/fXX9cgjjyghIUHvvvuuNm7cqPLly2vx4sUWR536bh5y/Prrr+vo0aPat2+fOnXqpPDwcLm7u+vnn39WiRIl9Pjjj2vz5s0WR5z6Dhw4YE8oZs6cqRMnTsjf319Hjx7Vs88+qyeffFJr165V+/bt1b9/f73zzjvat2+fxVGnruPHj9v74KefflJCQoI8PT118OBB9e7dWy+88IIWLVqkevXqqWHDhho8eHCWnDPBZrNp3rx5at26tSTJ399f8+fPV4MGDRQTE6POnTvr888/13vvvaewsLAsNwz7zz//1K5duyTdOC/Onz9fOXPmlJeXl3r06KGgoCBduHBBw4cP188//6zcuXNr/fr1FkcNID2RP/3H2XMo8ifyp5s5cw5F/nQH1g3WAjK2yMhI89hjj5nGjRub5557zri4uNiHWe/atcv88ssvZsWKFfZhqJcvXzY1a9Y0X331lZVhp6rEYzPGmAULFpiiRYuatWvXGmOMmTFjhnFzczPTpk2zt4mNjTUVKlQwTz75ZLrHmpbWrVtnqlevbmbOnGn69etnsmfPbqKioszx48fNqFGjTMuWLc2UKVPM/v377e2DgoLMsWPHLI489Sxbtsw0btzYrFq1yvTt29fYbDYTExNj9uzZY3r37m2Cg4PNxx9/bHbu3GmMMWb+/PmmXr165ty5c9YGngaOHz9uqlatasaPH2+MMebo0aMmf/78pkePHg7txo8fb/LkyWPOnDljRZhp4u+//zYVKlQwXbt2NZ06dTLZsmWznxdXrVplvvjiC/Prr7+a2NhYY4wxFy5cMNWqVTPz5s2zMGoA6Yn86QZyKPInY8ifbuWsORT5051RmAJukXiiNMaYFStWmMDAQJMjRw7zxRdfGGMc50sw5kZCdeDAAdOiRQtTvXp1h0Qks/r444/t/7527Zp9WYsWLYwxxsyZM8d4eXmZyZMnG2OMiYmJMevWrTPG3PhtdFboA2NufCkYY8yePXtMp06dTMGCBY2vr6/Zu3evQ7urV68aY278Bjw2Nta0atXKNGnSJEv8JvzSpUvGGGM2bNhgHn30UVOyZEnj5+dndu3aZW9z7do1c/HiRfvzuLg406pVK9OmTZskfy+ZzZQpU8wvv/zisGzPnj2mRIkS5ty5cyYyMtIULlzYdO3a1b7+l19+sX92zp8/n67xppXvv//e/u/vvvvOBAQEGFdXVzNnzpxk28fFxZkTJ06Yli1bmkceeSTLnBMApIz86QZyKPInY8ifjCGHMob86V7wUz7gJjNmzNDSpUt19epVSVLevHlVoEAB1apVSz/88INWrFhhH4obHx+v69eva/r06erdu7fOnz+vtWvXKnv27Jn6Np+//fabPvjgA3Xq1EmS7HdK8fLyUqFChTRnzhx16NBBo0aNUteuXSVJy5cv15w5c3TmzBn776Qzcx9IUrdu3RQWFiZjjMqUKaNy5crpn3/+UdGiRfXnn3/a28XHx8vFxUWxsbH67rvv1Lp1ax07dkwLFixQtmzZMvUQ5K5du2rcuHEyxqhGjRoKCgrSkSNHVLFiRUVFRdnbZcuWTR4eHrpw4YK+//57tW7dWpGRkfrhhx9ks9kybR+cOHFC8+fPV79+/bRs2TL7cnd3d5UoUULr169X3bp11aJFC3366aeSpL1792ru3Ln2Oyz5+PhYEntqGjlypH766Sddu3ZNklSkSBF5eXmpRIkSWrJkibZt22ZvGx8fr6tXr+qTTz5Rp06d9M8//+iPP/7IEucEACkjf7qBHIr8SSJ/ksihJPKne2ZtXQzIWM6dO2evTC9fvty+fNGiRaZZs2amSZMmZsWKFQ7b/PHHH2bWrFn27RKvjmVW0dHRZsKECaZatWrmf//7n335b7/9ZnLlymVsNpuZMGGCfXlsbKxp2rSpeeWVV7LE1R1jbly5W7hwof1K3tWrV82ePXvM77//bjp37myCgoLMZ5995rBNVFSUGTFihHnjjTfsn4HM/Fm4fv26+eyzzxyuZi5fvtzMnj3bPPbYY6ZFixZm4cKFDtscP37c9OnTx3Tt2jVL9IExxqxevdo899xzplKlSub33383xhhz5coV88gjjxibzWY6duzo0P6NN94wNWvWNCdPnrQi3DRx4sQJ+/u4ZcsW+/IZM2aYhx9+2Lz88stJ7ia1evVqM378+CxzXgRwe+RPNzh7DkX+RP50M2fPocif7g2FKSAZq1evNvnz5zevvfaafdlPP/1kmjdvblq0aGFPutq2bWu+/vpre5vMPtwy8UvUGGNPrLp3725fNm7cOGOz2czo0aPNihUrzLp160zjxo1NlSpV7CfOzJ5Y3Rr/tGnTTEhIiPn333+NMcZs27bNdOjQwQQFBZnPP//c3u7zzz83+/btsz/PzJ+FW/tg6tSppnPnziYmJsYYY8yaNWtMSEiIadGihfn111/t7ebNm2fOnj2b5DbAmdHNsf/+++8mNDTUlC9f3v4/VlFRUaZEiRKmbt265rvvvjPz5883vXv3Nt7e3uavv/6yKuw0tXDhQlOqVCnz0Ucf2ZdNnTrVPPzww6Zbt272427btq1ZtmyZvU1m/hwAuDfOmj8ZQw5F/kT+lIgcyhH5092xGWOM1aO2gIwmKipKU6dO1XfffafGjRtr9OjRkqQFCxZoypQp2rZtm/z8/PTvv/9q//79cnFxsTjiB2duuo3txIkTtX79ei1dulQnTpxQx44d9fnnn0uS3n33XU2dOlXnz59XmTJl5Ofnp59//lkuLi6Kj49X9uzZrTyMVGWM0bRp0zR58mQFBARo+vTpyp07t3bu3KkPP/xQO3bs0KOPPqp9+/Zp8+bNOnbsmLJly5bklsCZWUJCgt555x0tWrRIwcHBGj58uHx8fLRu3ToNGDBALi4uaty4sSIiIrRhwwadPHkyS/RBYvwLFy7U9OnTFRUVpVWrVqlcuXIaM2aMmjRpooMHD+p///uf/v33XxljVLRoUY0aNUpVqlSxOvw0cfDgQb333nvas2ePnnzySb322muSZP8bkW702/Hjx3X48OEscV4EcG+cMX+SyKFuRf7kvPmTRA51K/Knu0NhCk4t8bfbibfylf47mZ45c0aff/65vvrqKzVv3tyeXK1bt067d+/W0aNHNWDAAOXIkUPXr1+3zyOQ2b377rv68MMPNXXqVHl5eWnevHlauXKlatasqS+//FKStH//fl25ckUeHh4qVqyYbDZbluiDhIQEh8+CJF2/fl2zZ8/Wxx9/rNy5c2vGjBnKnTu39uzZoxkzZmjVqlXKnTu3vv/+e7m4uCS7j8wkufivXr2qDz/8UD/99JNq1KihESNGyMfHRxs2bNCYMWN08OBB+fr62pPrrJBUSdKqVasUEhKiTz75RI8++qi2bdumr776SidOnNCYMWPUqFEjXbt2TadPn5aLi4s8PDzk4eFhddgPzNwYTZ3s5/jgwYP64IMP9Ndff+npp59Wv379JN24/fXOnTt19uxZvf/++1nuvAjAEflT8pw1hyJ/In+6lTPmUORPD4bCFJxWTEyMvL297c8nTpyoPXv26MKFCwoNDVX9+vUVExOjCRMm6KuvvlKLFi304YcfJtlPVrrCdf78eT3++ONq27at+vbtK0m6cOGCpk6dqrFjx6p58+aaNGlSku0yezIhSdeuXbNfoVi1apUSEhLk7u6uWrVqKSEhQbNnz9bYsWMdkqtLly4pR44ccnFxyRKJ5c19sGnTJuXMmVOSVL58eV27dk0ffvih5s+f75Bc/fvvv5IkPz+/LNEHN3vvvfe0dOlSLV261L5s5cqVGjJkiKKiojRp0iQ9+uijFkaY+mJjYx0Sw+nTp+vw4cOy2Wx66qmnVKFCBR09elTvvvuu/vrrLz3zzDP2K383y0rnRQCOyJ+S56w5FPkT+VNynC2HIn9KBenzi0EgYxkwYIDJkyePOXPmjDHGmNdff934+fmZtm3bmvr165scOXKYQYMGmejoaHP+/HkTHh5uKlWqZLp06WJx5GkrPj7e1KpVy/To0cNheVxcnGncuLHJkSOHefzxxy2KLm28+OKLZt68efbn/fr1M7lz5zZFihQxrq6u5qWXXjIHDhwwxhjz7bffmuDgYNO6dWvzzz//OOwnM88L0a9fP4fftL/++usmICDAFCxY0OTNm9cMHDjQXLt2zVy7ds2MGDHCBAUFmd69eye5jW9WuL3zzcaOHWtKlixpoqKiHJZPnTrV2Gw2U7BgQYd+y+zCwsJM7dq1zblz54wxxrz22mvGz8/P1KlTx1SrVs3kyJHDTJkyxRhjzJEjR0y3bt1MnTp1zPDhwy2MGkB6In9KmbPlUORP5E+340w5FPlT6sg6ZVngHjRu3Fh//PGHGjRooLlz5+r8+fNatGiRatasKUkaP368Bg0aJE9PT7355pvq1KmTLly4oCNHjmSZYbYpDbuuXbu2du3apZ07d6pChQqSJFdXV9WqVUvXrl1TwYIFM/3VvURRUVG6fPmyXn75ZXl4eKh06dKaN2+eFi5cqHz58unQoUP63//+p/Pnz2vixIlq37694uPjNXToUL3//vsaNWqUfV+Z9TOxe/dubdmyRcuXL9ekSZOUI0cOff/995o1a5ayZ8+uv//+W927d9fJkyc1depUvfHGG5Ju/C6+ePHiDld7ssJn4mZlypSRzWbTr7/+qieffFKenp6SpLJly6pevXqqUqWKAgMDLY4ydRhjVKJECa1cuVKhoaEaPny4jhw5oqVLl6py5cqy2WwaOnSoevbsKR8fHz399NPq37+/wsLCdPTo0SxzXgRwe+RPNzh7DkX+RP50J86SQ5E/pSIrq2JAeku8KpOQkGBWrVpl6tatawoXLmzKli1r9uzZ43DVZtSoUSZXrlzm4MGDxhhjzp8/77B9ZnbzlZk9e/aYvXv3mhMnThhjjPn7779NoUKFzJNPPmnWr19vEhISzKVLl8wTTzxhxo0bZz/2rHJ15++//zZdunQxfn5+pm/fvqZ3797GmP/e402bNhkvLy8zYMAAY8yN27b+/vvvWepOGStXrjRPPfWUqV69uunVq5d56623HNYvWbLE2Gw288knnxhjblz9/fLLL7NMHyS+13v27DF//vmnWbp0qX1djx49jL+/v5k6daqJjIw08fHxJiwszLz44ov2K2OZXeLf8vXr183MmTNNvXr1TK1atUz16tVNVFSUw996v379TP78+e3ni1OnTtnXZ/bzIoCUkT/9hxzqBvIn8idjnDuHIn9KXRSm4FSuX79uYmNjjTE3TgJ//PGHadWqlXF1dTXbtm0zxhhz6dIlY4wx//zzjylUqJCZO3euwz4y+8nj5vgHDBhgSpUqZQoXLmz8/PxMeHi4McaY3bt3m4ceeshUr17dVKlSxVSrVs2ULVs2S9zOODl79+413bt3N+7u7qZly5bGmBtfNnFxccaYG8ORixUrlmQ4clZKLCIiIsyzzz5rfH197T+5iI+Pt9/++vXXXzd169ZNMvw8s/dB4md59uzZplChQqZEiRLGy8vL1KlTx2zcuNEYY0yvXr1M2bJlTUBAgKlVq5bJlStXlrqd8ZUrV+z/vn79upkxY4apW7eu8fLysn/mE9ts3brVFCpUyKxevdphH1nhf7IApIz86QZyKEfkT86bPxlDDkX+lLr4KR+cxty5czVv3jzt2bNHzz77rF5//XUFBwfrrbfe0unTp9WmTRtt2LBBefPmlSRduXJFNpstyUSEmX24ZWL8H374oaZMmaKvv/5aPj4+Wrt2rYYMGaJTp05p7NixWrx4sVatWqVt27bJ19dXb7zxhnLkyJElJuVbs2aNjhw5on///Vc9e/bUQw89pN69e0uSpkyZogULFqhVq1ZydXWVJOXKlUu+vr5J7haSmfthzpw58vLyUpMmTSRJISEhstlsunDhgr799lu98MIL9mWS5OPjI2OMfSh2oszcB9KNv4d169bp5Zdf1rhx4/TII4/IxcVFzz77rF5++WV9+eWX+uSTT7Ry5UodOHBAly9fVtOmTVWyZEmrQ08V06ZN0+jRo7V48WIVLFhQ2bNn13PPPScXFxcNGjRITz/9tObOnavcuXNLuvG3IN2Y6PVmWfFnCABuIH/6j7PnUORP5E83c+YcivwpDVhdGQPSw7Rp04yPj4/p3bu36dGjh7HZbOa7774zxtyo9q9evdrUqFHDFC5c2EybNs188803pmXLlqZKlSpZ4orGra5du2ZatGhh3nnnHYfl33zzjXFxcTFfffVVittldp9//rkJCAgwtWvXNtmzZ7df4TPGmP3795uOHTsaV1dXM3v2bHPy5Elz5swZ07hxY9O0adMscZUzISHBbNu2zdhsNmOz2czChQsd1q9evdq0bdvWlClTxixfvtxcu3bNxMTEmAYNGpgnnngiS/TBrSZMmGBq165trly5Yr9ydeXKFVO1alVTv359i6NLG4nvY+3atY3NZjNlypQxx44ds69PHJZevXp18/DDD5slS5aYBQsWmBYtWphq1aplyfMigKTIn5Jy1hyK/In8KTnOlkORP6UdClPI8rZv324CAwPNDz/8YF/21FNPmdmzZzsMwfzzzz9NnTp1jM1mM88//7wZPXq0fRhuVjqJxMfHm0uXLpkqVarY7wYRFxdn/zLp1q2bCQoKMnFxcZk+ibrVwoULTe7cuc3ChQvNv//+a9atW2fy5ctnjhw5Ym9z+PBhExoaarJnz24CAgJM7969TZ06deyfhaww5Pb8+fOmUaNGpmPHjiZ79uxm/vz5Duv//PNP06xZM5M9e3ZToUIF89JLL5kaNWrY+yCrJFeJxzF48GBTtmxZ+/LEn6Ns2bLF+Pj4mD///DPLHHOixM9xly5dzIgRI8zjjz9uAgMDzaFDhxza/fDDD+ahhx4yOXPmNE8++aQZMGBAljwvAkiK/CkpZ82hyJ9uIH/6j7PmUORPaYexY8jy/v33X3l6eiooKMi+7MiRI5owYYIqVKigHj16aNeuXapZs6bef/99Va9eXZLUr18/ubi46Pr165l6uG1CQoLD82zZsilnzpyqV6+eJk2apKNHj8rV1VXx8fGSpDx58sjPz0+urq5JhuFndmvXrlWzZs3UokUL+fn5qUiRIipdurQWLVqkoUOHau/evQoMDNTw4cPVu3dvRUVF2e9AlPhZyCpDbs+cOaMXXnhBffr00ZNPPqmIiAhJN36yUbNmTQ0ZMkRPPPGEjhw5ohYtWujPP/+090FW+DmG9N9PMh5//HFFRkbqww8/lCTlzJlTknT16lXlzZtX3t7eWeaYEyV+jkuVKqVjx45p7NixCggIUKNGjRQZGanu3btr69atevzxxzV06FCVKlVKgYGBGjFiRJY4LwK4M2fPnyRyqETkT/8hf7rBWXMo8qe0k3XOmEAK3N3dtWvXLs2dO1f16tXTO++8o7Nnz6pDhw7KmTOnwsLCdPHiRX311VcKDg7W559/br/Fr6RMnVjcfEviDRs2KCEhQRUqVJCnp6d69+6tHTt26JlnntF3332nIkWK6Nq1a/rzzz9VuHBhiyNPfcYY/f333zpy5Ih9We/evbV//3799ttv2rJli2bOnKmvv/5aNWvWVOfOnVWwYEG1aNFCNptNxphM/VlIlJCQIB8fH1WtWlUeHh4KDw+Xi4uLGjdurLx586pFixZq1aqVHnnkEXXp0kXly5dXu3btskQfmP9/S95t27bp77//VuXKlVWwYEFVqVJFb731liZMmKCEhAT1799fMTExWrhwoXLkyCE/Pz+rQ091iX0REBCgVatWqWjRovr111/Vpk0blShRQg8//LAqV66sbNmyqX379vLz81Pjxo3t22bmzwGAu+PM+ZNEDpWI/OkGZ86fJHKoRORPaciagVpA+kgcOhoeHm7c3d1N69atTZ48eczu3bvtbRYsWGBsNpv9rjKJstIwyzfeeMMULlzYuLq6mpYtW9qHHq9YscI0bNjQeHh4mDp16pjKlSubChUqZMkhx8YYs379euPh4WHKly9vatWqZYoUKWIOHz5sX1+hQgXzzDPPJNkuKw3HT9S9e3cTFhZmjDHm9OnTJn/+/MZms6U4N0ZW+XuYN2+e8fb2NoGBgSZPnjxmyJAh5tSpU+bcuXNm+PDhxsPDwwQGBpoqVaqY/Pnzm02bNlkdcpo6duyYCQkJMcYYc/XqVVOmTBnj5+dnihYtak6ePJmkfVb5HAC4PfKn/5BDkT/dzFnzJ2PIoW5G/pT6KNkhS0scOvp///d/6tq1q7Zt26aYmBiVLVvWfmcUV1dXVa1aVb6+vg7bZuZhlub/V/Mlad26dfr999/17bffyhijYcOGafTo0bp8+bKeeeYZzZ8/X998843OnDkjb29v9ejRQzly5ND169ezXFW/Vq1a2rZtm/bt26effvpJefLkUWBgoGJjY+Xh4aGGDRvq1KlTDldJpcx/1fdmiZ+NIkWKKDo6WpLUqFEjlSpVSo8//ri6dOkiNzc3Pf300w7bZea/B+nGlc5Lly7ps88+00cffaSnn35a48aN0w8//KB///1X//d//6eBAwfq6aef1qJFi5QvXz498sgjKl68uNWhp7mLFy/qr7/+UpcuXeTv768ZM2aof//+KlGihI4cOaJ8+fLZ22b2zwGAu+Os+ZNEDpUc8ifnzZ8kcqiUkD+lrqxztgCSYYyRdCPBSrxd544dO7Rjxw5VrFhRsbGxmjBhggoUKJBlhl7fmhR4enrq0UcfVd26dSXduL1p79699emnn+ratWt68cUX1a1bN4d9xMfHZ6lkIlFCQoJKlCihEiVKaMqUKbp+/bokycPDQwkJCfrrr79Us2bNLDMPQnISk+1GjRpp4MCBCgwMVNGiRfXjjz/Kzc1NcXFxGj9+fJLEKrNKTCRjY2OVK1cuFS5cWI899pi8vLw0cOBAeXh46Msvv5Qk9enTRw899JAeeughi6NOe4n9UqhQIRUsWFC1a9dW7dq1NWfOHOXOnVuTJ0/W2LFj7edNAM7FGfMniRwqJeRPzpc/SeRQySF/SkPWDNQCUldYWJjZvHlzkuWJw6hXrlxpTp8+bc6fP2+efPJJkydPHtO0aVNTq1YtU7169Sx1x5BE4eHhpnHjxqZmzZrmqaeeclgXGRlp2rZtaxo2bGgmTJhgUYRpY+PGjfb382aJn4XTp08bY4yZMWOGyZs3r+nfv7+ZMWOGadasmalatWqWGHZ+pz44e/asOXHihClYsKBp166dOXXqlL3NhQsXstTfgTE3hp7XrFnTlCtXzpQuXdrs2rXLYf2YMWNMzZo1zUsvveTw04TM7k7nxT/++MPExsaaDz/80Lz44osmKioq2f0w/BzIusifkueMORT5E/lTcpwxhyJ/sgaFKWR6Fy5cMG5ubiY4ONhs377dvjzxy2Hu3LnGzc3NLFiwwBhjzO7du82YMWNM165dzahRo+xfpJn9C/XmL8NPPvnEeHp6mv79+5tq1aqZ/Pnzm5EjRzq0P3r0qKlbt67p2bNneoeaZj744ANjs9nMwoULHeZ4SOybOXPmmDJlypgzZ86YyMhI88EHH5j8+fOboKAg0759e/tnIDN/kdypDxJvXxsfH2+2bNlizp49m+x+MntylZg87Ny503h4eJhBgwaZl19+2RQvXty0bNnS7Nmzx6H9iBEjTL169RySzMzsbs6LLi4u5vfffzfG/Hd7ZwDOg/zpP86eQ5E/kT/dzJlzKPIn61CYQqaWeJL4999/TfHixU1QUJD566+/7OsXLFhgPD09zeTJk2+7n8z8RXqrJUuWmBEjRphffvnFGGPMyZMnTbdu3UxQUJAZPXq0Q9uoqCh7H2aVSTqfeOIJkz9/frNgwQITFxdnXz537lzj4eGR5Orm2bNnzdmzZ+3HnxUS7Dv1waeffmphdOnnzz//NOPGjTNDhgyxL5s+fbqpX7++ad++vdm3b59D+5SSzMwmtc6LALIu8qfkOXMORf5E/nQzZ8yhyJ+sRWEKmdrNVyWOHDlicufObdq2bWu2bNlijDFm/Pjx5ssvv7QouvT3xx9/mCJFipi8efOaVatW2ZdHRkaa7t27m9q1a5sxY8Yk2S4rXN25fPmy/d9PPPGEKVy4sFmwYIG5fPmyOXv2rKlZs2aSL5JbE8nMnljeTx9kVadPnzbNmzc3uXLlMr169XJY98UXX5iQkBDz3HPPOdxhKqvgvAjgTjhPJOWsORT5E/nTrZw1h+K8aC0KU8gS3njjDfPKK6+YcuXKmWzZspm6des6VPIz+xfm3Tp27JgZPHiwyZ07t+ndu7fDuqNHj5oePXqYEiVKmFmzZlkUYdq4+Yvku+++M9OmTTM2m82ULl3a/hOE5G7dmpXQB0nNmzfPNGzY0BQsWNDs37/fYd2XX35pqlSpYjp27JjsfBJZAedFAHfCeeI/zphDkTvQBylx5hyK86I1KEwh0/v444+Nn5+fWbdundm+fbtZs2aNKVy4sKldu7bZtm2bvZ2znEROnz5thg4dakqXLm3eeecdh3WHDh0yo0aNynJD7xO9/fbbJnfu3Obzzz834eHhpl69eiZPnjxmwYIFWfKLMzn0gePf+m+//WYaNmxo6tSpY/bu3evQbubMmVlmos5bcV4EcCecJ5Jy1hyK3IE+SOTsORTnRetQmEKm161bN/Pcc885LDt69KgpUKCAady4sdm6datFkaWdW4eN35oknTx50gwdOtSULVs2SWKV0jaZ3bFjx0zJkiXNjBkzHJa3atXK+Pv7mwULFpgrV65YFF36oA/+c3PCsGDBAtOkSRMTHBycZE6ErMoZz4sA7o2znifIoRyRO9AHt3LmHMpZz4sZQTYBmZQxRpJ07tw5nT171r48Li5OhQsXVlhYmJYsWaKXXnpJBw4csCrMVGeMUbZsN/50Z8+eLUnKnj27Q5uAgAB17dpVzz//vObNm6e+ffsm2c+t22QFcXFxyps3ryTp6tWrkm70ka+vr95++20tWLBA169ftzLENOeMfZB4Lrj53zabzf7vli1bqk+fPvL19VW7du2y1PngVs56XgRw95z5PEEOlTxnzB1u5ax9QA51gzOfFzMKClPINBISEhye22w2SdLLL7+s1atXa/LkyZIkNzc3SZKvr69eeuklBQYGqlixYukaa1oxxtiPOzw8XB07dtSOHTuSbRsQEKAuXbqoWbNmOnPmjMMXT2aX3LEUKlRIAQEB9s+Bq6urrl+/LpvNppIlS2rfvn364osvlCNHjvQON03QB//1wc2Jos1ms58rbk2sOnfurLJly2ap/6HgvAjgTjhP3EAORe4g0QeJnD2H4ryYAaXf4Czg/t087Hr//v1m27Zt9t97X7x40fTv398UL17cfPzxx+by5cvmxIkTpnnz5ubjjz+2b5eVhl2vX7/edO/e3SxduvSObW++lW9W+D30rUPwb/7d/08//WRKly5tXnnlFfuy69evmxdeeMHs3bs30985JxF98N9nefHixSY0NNQ88cQT5uWXXzaXLl1Ksa0xN84XWQXnRQB3wnkiKWfNocgd6INEzp5DcV7MmGzGZJFLAMiyzE1XuAYNGqTvvvtOMTEx8vT01Hvvvac2bdro33//1ZQpU/TBBx8ob968stls8vX11caNG+Xi4mLxEaSuH3/8UUOGDNGlS5f066+/qmTJkg59lJK7aZPRJSQk2Ifgjxs3Ths3btTff/+tV199Vc3/X3v3GRhVtX4NfE0KhN6JlEjvNfTQAwjSRGn+URAEBFQQQemC9KZIDUU6SBFBQIoU6dIEKQIqUgUB6SUkJCSZ9X6Ydw4zEBy8Jhlmzvp9MZycyd3zZLLOc/cpu359pEiRAnPmzMGYMWOQJUsWlCtXDocOHcLdu3dx4sQJ+Pr6Ii4uzqPP9qgGj6xatQqtW7dGly5dkDt3bkycOBHJkiXDtm3bkDVrVqd9veHz70i5KCKuKCeeZNYeSr2DavA4s/ZQysXnmHvmw0T+vSFDhjBbtmxcvXo1Y2JiGBoaynz58jEsLIwPHjwgaZv1/uqrr7hixQpjJjsmJsadw05wO3fu5CuvvMLkyZNz1qxZxnZPP5P3b/Tr14+BgYHs27cv+/btyzRp0rBv3768dOkS4+LieOjQIb7xxhts1aoVO3bsaJwF8aazXWavwY0bN1i+fHmOGzeOpO3BpUFBQezcubPTft7yfp9GuSgirignHjF7D2X23oFUDUj1UKRy8XmkiSnxCEeOHGHlypW5bt06kuTGjRuZNm1ahoSEMEOGDAwLC+P169efeJ2nX2b5tAPCkSNH2KRJE5YrV47Lly83tpuhsVqyZAnz5MnDgwcPkiR//vlnWiwWZsqUiV27duWff/4Z7+u86UCiGpAXLlxg/vz5eefOHV65coU5cuRwaqi+/fZbN44uaZg1F0Xk2Zk5J9RDOVPvoBrYmb2HMnMuPs80MSUe4cKFC1ywYAFjYmK4fft2BgYGcsaMGSTJatWqsWDBghw9ejTv3bvn5pEmHMeGasGCBRwxYgQ7duzIY8eOkSR/+eUXNm/enNWrV+eKFSuMfb25sYqLi+OKFSuMe7xXr17NdOnScfHixZw9ezYtFgt79+5t1Mgbmb0G9s93dHQ0q1atyilTpjBXrlzs3LmzcVbzwoULfOWVV7hhwwZ3DjXRmTEXReTfMWtOqIdyZvbegVQNSPVQdmbNxeedJqbkufO0M1z2mes333yT77//vjFr/cYbbzAoKIitWrXyyobi448/Zo4cOdimTRs2atSIKVKk4JQpU0jaHuDZokUL1qxZk1999ZWbR5rw4nvg6IULF3jp0iVeuXKF5cqV4+eff06SvHPnDl944QX6+flx8uTJbhlvYlANHr333bt3c82aNbxx4wYfPnzIdu3aMXXq1HzllVec9u/Tpw+Dg4N56dIldww3USgXRcQV5cSTzNpDqXdQDezM3kMpFz2H96x5KV7B8cGEBw4cMLZVrFgRmTNnBklcvXoV2bNnd3oI38qVKxEcHGwsbeotD+hbuXIllixZgvXr16NkyZLYv38/1q1bhxdeeAEAUKFCBfTu3Rt9+vTBnj178Oabb7p5xAnH8bPw4MED+Pr6Inny5AgKCgIAnDhxAhEREShTpgwA4Pbt22jRogUqVaqE119/3W3jTkiqwaOHVH777bfo2LEjunbtiuLFiyNTpkzo378/jh07hjt37mDMmDHImzcvtmzZgiVLlmDnzp3Inj27u4efIJSLIuKKcuJJZu2h1DuoBnZm76GUi55FE1PyXLGHR58+ffDNN98gKioK0dHRaNy4MUaOHIns2bPjxRdfxNKlS3Hnzh0cO3YM9+7dQ+nSpeHj4+MUQJ7o8fHfuHEDVatWRcmSJbF48WJ06dIFYWFhaNasGe7du4fw8HCUK1cOkydPRuHChd048oTlWIexY8di48aNiIqKQq5cufD5558je/bsiIqKwrVr13DgwAHExcVh4sSJsFqtmDRpEgB4/MopqoGNxWLBtm3b0K5dO0yaNAlvvPEGkiVLBgAoUKAAvv76a4waNQqzZ89GqlSpkCNHDvz4448oUaKEm0eecMyeiyLimnJCPRSg3gFQDRyZvYdSLnoYd12qJfI0kyZNYqZMmbhnzx4eOnSImzdvZubMmfnyyy8b+3Ts2JEtW7Zk69atvXK1jGvXrpEkhw4dyjp16nDbtm1MmzYtp06dauwzY8YMduvWjREREcY2b6oBSQ4YMICZM2fmmDFjOGTIEBYvXpx58uTh3r17SdpW1MicOTPz5s3LkJAQ47PgTZfeqga2Grz++uskyYiICP744498++23+cEHH3DHjh0kycjISIaHhxsrqXgb5aKIuKKcsFEPpd6BVA3szN5DKRc9hyamxK2OHDnyxEoX7dq1Y9euXZ22nTp1iqlTp2bPnj2NbY4HDk9fLWPz5s3Gkq3vvfce27VrR5L8/fffWbJkSVosFqeGKjIyko0aNWKnTp285gDqeDC0Wq08f/48CxUq5LQySFxcHOvUqcO8efMyOjqaJHn8+HH+9ttvxgHEkz8LqsGTrFYr3333XVaoUIHr16/n66+/znr16rFSpUqsX78+q1ev7jXPQbBTLoqIK8qJR8zeQ6l3UA2exmw9lHLRs+naNHGbYcOGITg4GNu2bUNsbCwAICYmBqdOncKtW7eM/aKjo5E/f34MHDgQO3fuxK1bt5zu9yUJPz/PvSs1IiICS5cuxdKlS/HSSy/hq6++Qq9evQAAOXPmxOuvv46iRYvi119/xcWLF7Ft2zY0a9YMFy9eRFhYmHH/sydr3rw5vvjiC9y/fx+A7dLjyMhI3LhxA7ly5QIAPHz4ED4+Pvj2228RGxuLL774AgBQrFgxFC5c2Ljk1lM/C6pB/CwWC3r06IG7d++iS5cu8PX1Rbdu3bB371507NgR4eHhSJkypbuHmWCUiyLiinLiEbP3UOodVIN/YqYeSrno+TQxJW4zcOBAvPzyy3j77bexbds2xMTEwN/fH23btsX27duxdu1aAEDy5MkBAAEBAfD19UWqVKmcHkLn6Q+kS5UqFT777DPExcVhy5Yt6NKlC4oWLWp8r1OnTnjzzTexdetWFC5cGD179gRge4ifn58f4uLiPL4G+fLlw6effoq5c+cajUWhQoWQNm1aLFq0CACQLFkyxMbGws/PDzly5EBMTMwTP8eT7wNXDWD8n4Njx47hm2++wbp163D69GkUKFAAe/bswQ8//IBFixahYcOGAGx/A6lTp3bnkBOcclFEXFFOPGL2Hkq9g2pgZ/YeSrnoBdxzoZaYneMlkvXq1WO2bNm4adMmWq1Wnjp1iq1atWL16tW5cuVKkuSNGzdYv359tmzZ0isuu3YUGxvLS5cusV27dmzevDmrVKnCL774wmmfmJgYRkdH86effuLFixe95pJjx9/liBEj6OPjwwkTJvD27dskyc8//5xlypThZ599ZuwXFxfHChUqcOzYsUk93EShGtjY67BixQoGBQWxWLFirFChAoODg3nw4EGnfbds2cLevXszbdq0PHLkiDuGmyiUiyLiinLCmVl7KPUOqoEjs/dQykXvoIkpcZvHQ+SFF17g5s2bSZL79+9n27ZtmTJlSubPn59FihRhqVKlvObBhE97oN7ly5fZqVMnVqxY0amxslqtvHbtmtP79paH8jm+j+HDh9PHx4fjx49nXFwc//77b/bs2ZMFChRgw4YN+cknn7BatWosWrSoRzeUj1MNbLZu3cqMGTNy2rRpJMk1a9bQz8+PL7zwgvGw0itXrrBly5asUKECjx496s7hJgoz56KIPBuz54R6KBv1DqqBI7P3UGbPRW9gIT34xmrxOHS4hxeAcVktALz88ss4fPgwFi1ahDp16uDOnTs4efIk9u/fj8DAQDRv3hy+vr5Or/FEjjWYN28ezpw5Az8/PzRt2hQlSpTApUuXMGzYMBw7dgyvvPIKevbsifr166NEiRIYP368m0efMB7/HDguxzpixAgMHDgQ48aNQ48ePXDr1i1s27YNU6dORZo0aZAlSxZMmzbNuATfU5fzVQ0esVqtiIqKQq9evZApUyYMHToUly9fRkhICEJCQhAREYGffvoJGzZsQHBwMK5cuQIfHx8EBga6e+gJQrkoIq4oJ2zM3kOpd1ANHmfmHkq56GXcMx8mZrNo0SLj68dnpR+f4Q4MDOTmzZuNFTMcxcbGJt4gk4Dje//oo4+YIUMGVq1alWXKlKGvry+nT59Okrxw4QI/+OAD5s2bl7ly5WKJEiXirYcnstfg8bOVj5/1slgs/OKLL576vj35bJeZa2B/j3FxcU+8/71793LXrl28c+cOy5Yty06dOpG0XZpusVjo5+fHPXv2JPmYE4tyUURcUU48YvYeysy9g53Za6Aeyka56J00MSWJbsuWLbRYLBwwYICx7Z9CpH79+syZMye/++47rw2MP/74gy1atOChQ4cYGxtLq9XKwYMH08/Pj4sXLyZJ/v3339y7dy8XLVpk1MFTD6R2nTt3ZokSJZwOrI7iuyR74sSJvHXrltN+nnzJrZlrYH9vJ0+e5HvvvccmTZpw1KhRT+y3ceNGhoSE8Pz58yRtzVaDBg3YtWtXnjx5MknHnFiUiyLiinIifmbsoczcO9iZvQbqoWyUi95LE1OS6B4+fMi5c+cyefLk7N+/v7H9n0KkXLlybNy4cZKNMSktWrSIBQsWZJkyZfj33387HUg//vhjZsmShZcuXXridd4Qpjt37mSePHlYu3btZ2osRo4cSYvFwmXLliXpOBOTWWtgf09Hjhxh5syZ+dprr7F169ZMliwZR44c6bTvokWL6Ovry99//50k2b9/f77xxhsMDw9P8nEnFuWiiLiinHiSWXsos/YOjsxcA/VQjygXvZcmpiRJxMTEcO7cufT392e/fv2M7f8UIt7wYMr4zJo1iyEhIUyXLh3//vtvkmRUVBRJ8ujRo8yRIwd3797tziEmqv379zNXrlwMDQ19psZi/vz5Hn2WMz5mq4H9vRw9epQpUqQwGgmr1coPP/yQH3zwASMjI439r169yrp16zJDhgwMDQ1lqlSp+Msvv7hl7IlJuSgirignnJm5hzJb7xAfM9ZAPdSTlIveSRNTkmgeD4fo6GjOmTOHfn5+/xgijsHh6SES3+XCsbGx/Prrr1moUCFWq1aN169fN7536tQp5siRg9u2bUvCUSYtq9XKffv2/avGgvTsS/AfZ8YaXLx4kVmyZGHz5s2dtrdq1YolSpRgoUKFWKdOHc6bN4+krQEbM2YM+/bta5z18wbKRRFxRTlhox7KmRl7h8eZtQbqoZSLZqCJKUkUjn/40dHRTpdQz5o1y2WIeAPHGpw7d46XL1/m5cuXSdoaq0WLFrFChQoMDg7mpk2buGbNGjZs2JDBwcEef8m5o6cdBPbv38+goKB/bCy8hWpA7tixgxUrVmSjRo24Y8cOkuSoUaOYMmVKjhgxgvPmzWPx4sWZO3dupzN73pQNykURcUU5YaMeSr0DqRrYmb2HUi6agyamJME5hse4ceP45ptvsly5chw1ahR//fVXkuScOXPo7+/vdG+wN3GswZAhQ1i+fHm++OKLrFevHletWkXSdvZmyZIlLFiwIJMlS8YWLVpw8ODBxuW43tBYOdbh+++/5/Tp07ls2TIeP36cJPnTTz/xxRdf9OrGQjV4ZOPGjaxfvz4bN27MDh06MGvWrNy4caPx/UuXLtFisTAsLMyNo0wcykURcUU5YaMeSr0DqRo8zqw9lHLRPDQxJYmmT58+zJw5M2fMmMERI0awePHirF69OsPDwxkdHc25c+cyICCA77//vruHmqAcZ+kHDhzIzJkz87vvvuO2bdv4yiuvME2aNFy6dCnJR2f9atWqxXr16vHGjRskyQcPHrhl7Imld+/eDAoKYq1atVilShUWK1aM3377LUly3759zJ07N+vUqePVDYWZa+D4N7FhwwbWq1ePKVKk4JgxY4zvP3z4kJcvX2bp0qX59ddfu2uoic6suSgiz87MOaEeypmZewc7s9dAPZSNmXPRLDQxJQnKHp4HDx5k0aJFuWfPHpLkpk2bGBAQwDlz5jjtP3nyZFavXt0rLrk8ffq00/vYsWMHy5Urxx9//JGk7WxPmjRpWKNGDaZOnZrffPMNSdtZvwULFrBKlSps3Lgxr1696pbxJyTH5mDhwoXMnj278TDS8ePHM3ny5Mb7J21nvZInT85u3bol+VgTi2rgzPFv44cffuDLL7/MevXqcevWrcb2gQMHMnfu3Pzzzz/dMcREY+ZcFJFnY/acUA9lo95BNYiPWXsos+ei2WhiSv6zgQMHOh0gSPLHH39koUKFSJLLly9nmjRpOG3aNJLk/fv3uWLFCoaHh9NqtRrh4ckh0r17dwYGBvLAgQPG+zhz5gz79+9Pq9XKjRs3MmvWrJw+fTrPnTvHkiVLMmXKlJw7dy5J20F46dKlLFasGFu2bOmxZ31Wr15tfG1/0GTv3r35zjvvkCRXrFjBNGnScPr06STJ8PBwnj17liR54sQJj7/0nlQN/snjZ/0aNGjAl156iT/99BPHjBnDgIAAHjp0yI0jTDjKRRFxRTlhox5KvQOpGrhilh5KuWhempiS/+S3335j9erVGRoayrVr1xrbd+7cyUqVKnHBggVMmzYtp06danxv69atfOutt5xWifD08IiKimKJEiVYqlQp/vTTT8bB8d69eyTJFi1asHfv3sb7bNmyJYsWLcq6desa+8bFxXH58uU8d+6cW97DfzVjxgzmzZuX48aNc9rep08fjhkzhps2bWLq1KmNhiIuLo4LFy7kxIkTjaWeSc9+LoRq4NrjjdUrr7zCrFmz0t/fnwcPHnTjyBKOclFEXFFOPGL2Hkq9g2rwrLy9h1IumpsmpuQ/2717N1999VXWrl3b6WxHhQoVaLFYOHHiRGPbgwcP2KBBAzZr1swjz2jFx/4sg7i4OJYoUYLly5fn3r17jfd369Yt5suXjyNHjiRpa7RatGjB1atXG8HpDQfSc+fO8b333mOlSpU4duxYY/vkyZNpsViYPHlyYxlbkrx79y7r1KnjtIqGpzN7DWJjY43P9ONLMzs2CY5fr1u3jq+++qrxMFNvYfZcFBHXlBPqoUj1DqRqQKqHslMumpeFJCHyP4iJiYG/vz8A4JtvvsGCBQtw69YtDBw4EC+//DLOnj2LJk2awM/PD++99x5iYmKwcuVKXLlyBUeOHIGfnx+sVit8fHzc/E7+d47j37FjB06ePIkuXbqgWrVq+Pzzz1G2bFn4+Piga9euWL9+Pd566y1s27YNUVFR2LNnD3x9fT2+BsCjz8LNmzcxbNgw/Pzzz2jevDm6d+8OAHjvvfcwd+5cbNiwAUFBQYiLi0PXrl1x8+ZN7Nu3D35+fm5+B/+dmWtw8uRJ5M6dG8mTJwcA/PDDD1i7di1iYmLQqVMnFCpUCAEBASAJi8UCAE5fR0ZGImXKlG4bf0JSLoqIK8oJG/VQ5u4d7MxeA/VQNspF0RVT8p8NHDiQzZs3Z+nSpenr68uKFSty3bp1JMmLFy+yYcOGLF26NKtVq8YOHTrw4cOHJJ88G+DJ+vbty6xZs3LcuHHs3r07c+fOzVKlSvHAgQMkyaNHj/K9995j+fLl2bJlS6MG3jC773jm5ptvvmHnzp2ZJUsWZs+enRMmTCBJ3r59my1btmTatGkZGBjIcuXKsWrVqkYdPP1sp5lrsGTJEubJk4fLli0jSW7bto2+vr5s2bIlc+bMyaJFi3LatGkMDw8n+fSzft5GuSgirignbMzaQ5m5d7Azew3UQz1JuWhempiS/2T69OlMkyYNd+7cyStXrnDt2rWsVasWq1evzvXr1xv73bhxw2n5Xm8Kj99++43ZsmXjmjVrjG3Xr19nkSJFWLJkSf7888/G9vv37z/1Ml1P179/f2bOnJlhYWGcPn06Q0JCWLp0aX7xxRfGPlu3buXGjRu5Z88eo6H0pjqYsQYPHjxg7dq1Wa5cOS5fvpzdunUzngFBku3atWNwcDCnTJkSb2PljZSLIuKKcsJGPZQ5e4fHmbUG6qGcKRfNTRNT8p907NiRzZs3d9q2ZcsWlixZkhUqVOCGDRueeI23Baq9qbKf2YuOjiZJnj9/npkyZWLdunW5a9cupzN73laDP//8k0WLFuXSpUuNbefPn2f79u1ZqFAhTpo0Kd7XefrZTkdmrIH9sx4VFcV69eqxYsWKLF++PDdu3GjsY7Va+fbbb7NUqVKcOnWq8TBbb6ZcFBFXlBM2Zu+hzNg7PM6sNVAP9STlornpJkz5n1itVgBA5syZcfv2bURERBjfq1WrFjp06IBjx47h448/xq5du5xea78n2lvkypULALBixQoAQLJkyWC1WpE+fXrkzZsXmzdvxsyZM53uefa2GqRPnx7R0dG4ceMGANu977ly5cLw4cMRHR2NCRMmYMiQIU+8zpvuAzdLDex/+4Dtsw7YPs9r165Fjhw5cPDgQRw+fBhxcXHG9+bMmYMKFSpgzJgx+Prrr0EvfbShclFEXFFOODN7D2WW3uGfmKkG6qHip1wUAPC8v2hxC8cgBR4dDIoXL469e/di/fr1TvtkypQJVapUQatWrVClSpUkHWtiebwGdilSpMDAgQOxaNEijBs3DoCtPilSpEDp0qXx22+/Yc6cOUk51ERlPyA6HhhjY2ORM2dOHDlyxDiYkES2bNlQsWJFpEqVCrdv3/aag6mZa+Dj44PTp09j7NixAGwPqGzQoAEePnyIJUuWoEGDBli8eDFWrVqFmJgY43VffvklGjdujFq1anlNE6FcFBFXlBM26qHM3TvYmb0G6qFslIsSr6S8PEs8k+Olsps3b+a3335rPKSPJHv06MGAgADOnj2bx48f582bN9moUSMOGTLEuLzS0y+3dRz/9OnT2b17d7722mvcs2cPo6KiePPmTQ4aNIiZMmViixYtOHDgQFarVo3FihUzXuvJD2e0c6zDlStXeOvWLd6/f58k+f3339PHx4cDBgzgzZs3SdouT27RogXnz59vfBY8/ZJbs9cgNjbWWL75jTfeoMVicVrC2X5JepkyZbh8+XLjoZTeRrkoIq4oJ2zUQ6l3IFUDUj0UqVyUp9PElDyzjz76iDlz5mSePHn4wgsvsGjRojx8+DBJsnfv3syRIwcDAwOZL18+FilSxAhTTz+IOOrTpw8DAwPZuXNnNm3alIGBgRw/fjzDw8MZERHB7777jlWrVuXLL7/sVSvHkM6/xyFDhrBMmTIsVKgQS5cuzc2bN5Mkly1bRn9/f9atW5fNmjVjSEgIixUrZjSUnl4H1cDm4cOHbN26NS0WC5s1a2Zsj4qKMv5rf17CokWLvLKxslMuiogrygkbs/ZQ6h1UA0fqoWyUi/I4TUzJM5kzZw4zZcrEQ4cO8a+//uKFCxdYrVo15s6dm+fOnSNJ7tu3jxs2bODy5cuNg4g3rZIwZ84c5sqVi4cOHSJJ7t+/nxaLhdmzZ+fo0aN569ateF/nTTUgbQ1FpkyZ+NVXX3HOnDls06YNkyVLxjlz5pAkd+/ezT59+rBVq1bs1q2b1zSWjsxeg5iYGPbo0YPNmzdnhgwZOHjwYON79lVSoqKiWLlyZVarVs1rH9apXBQRV5QTNuqh1DuQqgGpHopULkr8NDElz2TAgAHGKgmOB4cyZcqwVq1a8b7G0y+7dvTw4UN++eWXnDx5Mkny22+/Zbp06bhgwQJ+/PHHDAgI4Oeff86LFy86vc7bZvVv377NihUrcsaMGU7b+/XrRz8/Px45coTkkw2ENx1IzFqD+D7L4eHhHDt2LNOmTevUWJHkrVu3GBMTwwsXLiTVEJOc2XNRRFxTTqiHIs3bOzgycw3UQzlTLkp89PBzeSaXL1/G6dOnAdgeUBcVFQUA6N+/P/78809cuHDhidf4+vom6RgTk7+/P0JDQ9GsWTP8+eefGDx4MD799FO0adMG3bt3R7JkyTBkyBDs3LnT6XXe8IBCO5KIiorCuXPnkDFjRgAwHsw4cuRIVK1aFWFhYSDp9MBCkvDz83PLmBOaWWtAEhaLBfv378esWbMwfPhw/PHHH0iWLBm6deuGTz75BOPHj8fgwYMBAIMHD0arVq0QHR2NoKAg9w4+EZk9F0XENeWEeiiz9g6OzFwD9VBPUi5KfDQxJU6etmpK+/btcfPmTWMViYCAAABA8uTJkSxZMo8/aDyL/PnzI1u2bPjrr78QFxeHmjVrAgBu3LiBt956C8OGDcPrr7/u3kEmoMc/CxaLBS+88ALKli2LGTNmICIiAv7+/oiNjQVJZM6cGVarFRaLxenz4MmNpWpgY7FYsHz5ctStWxezZ8/GrFmzULVqVYwZMwb37t1Dt27dMGTIEIwcORKlSpXC+PHjMXz4cKRKlcrdQ08QykURcUU58c/M1EOpd1ANHJm5h1Iuyr+hiSkxkDSW6/zuu+8wffp0HD16FFarFaVKlcLrr7+OFStWYPDgwYiMjMTZs2cxffp05MqVC9myZXPz6JPO7du3cfXqVfz22284cuQIBg0ahLt376J79+7w9fVFXFycu4f4n1mtVuOzcO7cOZw/f974XocOHRAeHo6PPvoIcXFx8PPzA0lcu3bNOAvmDVSDR8s5//777+jRowcmTpyIrVu34vz583j//fexfPlyzJo1C/7+/ujUqRP27duHzp074/DhwyhXrpybR58wlIsi4opy4tl5ew+l3kE1sDN7D6VclH8tae4YFE/Sv39/pk6dmkWKFKGvry+HDBnC27dv89q1a/z000+ZLVs2pk2bloUKFWK5cuW88sGErrRu3ZoZMmRgUFCQUw28TZ8+fVioUCGmSZOGH3zwAU+fPs24uDhOmjSJwcHBzJcvH1u3bs3y5cuzaNGiXvEcgMeZrQYrVqwwVsix2717N3Pnzs3ffvvN6TkJgwYNYpYsWZ54Log3Ui6KiCvKiWdjhh7KbL1DfMxYA/VQT1IuyrPSxJQYf/hWq5WXL19mnTp1uGfPHpLk5MmTmS1bNvbu3Zs3btwgaXsg3/Lly7lz506vWSXhWcPP8cF7P/74I/fs2eM1NXjc6tWrmT9/fi5fvpwzZ85ktmzZ2LRpUx4/fpxWq5UHDx5kjx492LFjR/bv3994/970cEKz1eDcuXMsXLgwX331Ve7YscPYvmHDBmbKlIlnzpwhSUZERBjfe+GFFxgWFpbkY01sykURcUU5YaMeypnZeof4mLEG6qFslIvyv9LElMk5NhOXL1/muXPn+MEHHzAyMtLYPmXKFGbLlo19+/bl2bNnn/gZnnwQIZ1rsGLFCk6dOpWTJk3i7du3je2OZzjie7+eXgPyycZy+/btHDVqlPHv/fv3s0CBAnzttdeM5Z4f5+kHEtWA3LRpE6tWrcpmzZpx+/btxvbg4GBWqVLFad9bt26xVKlSXLFiRVIPM1EpF0XEFeWEjXoo9Q6kamBn9h5KuSj/hSamhKTtctuiRYsyZcqUzJcvn7Fkq11YWBhffPFFvvfee7xy5YqbRpnwHJulPn36MDAwkC+99BKzZMnCOnXqcOPGjcY+3rRs8eMc39uUKVP4zjvvsHLlyuzTp4/TfvbGomXLlk5ng7yB2Wvg2Exs2rSJISEhbNasGbds2ULS9r7z5MnDkJAQHjlyhAcPHuSgQYOYNWtWnjt3zk2jTlxmzUUReXZmzgn1UOodSNWAVA/1ODPnovzvNDFlUo4HkTVr1jBHjhz86quv2K9fP+bKlYtt27blsWPHnF7z2WefsUmTJl7ZXEyYMIE5c+bkzz//TJJctmwZLRYLq1evzg0bNnh1Y+X4nkaOHMmAgAC2atWKadKkYeHChblmzRqn/X/66SemSZOGAwYMSOqhJhrVgE98xjds2MCQkBA2bdqUP/74I0ny559/ZoUKFZglSxbmyZOHBQsWNP5mvIFyUURcUU48yaw9lHoH1cDO7D2UclESgiamTG716tV89913OWXKFGPbnDlzWLZsWXbo0IHHjx932t9bmgvHy0Tv3bvHnj17cubMmSTJ5cuXM3369BwzZgyLFSvG0qVLc/369V7/EL69e/eyW7duxlmsw4cPs3r16mzcuDHXrVvntO+vv/7qlZfamrUG9r/nLVu28JNPPjHe1+bNm1mpUiWnxook9+zZw2PHjvHvv/92y3gTm1lzUUSenZlzQj2UM7P2Do7MXAP1UI+YORflv9PElIn9+uuvrFSpEtOlS8eRI0c6fc8eIp06deLhw4edvudN4bF06VLevXuXu3fv5vXr13ns2DEWKFCAEyZMIEmuX7+e/v7+DA4O5u7du9082sSzatUqlihRgkWKFOH58+eN7fv372f16tXZqFEjfv/990+8zpsaC7PWwP73vHz5cmbKlIldu3Z1OoO3ceNGo7HaunWru4aZZJSLIuKKcsJGPZR5ewdHZq6BeqhHlIvyX2liyuRWrlzJkJAQFitWjAcOHHD63rx58xgUFMTRo0e7aXQJz/GM3ahRo2ixWHj69GnjgYuzZs1i5cqVefXqVZK2puvNN99kp06dvOIA+jT79+9ns2bNmCpVKn755ZdO3/vpp59Yq1YtVqpUiXv37nXTCBOfmWuwd+9epkuXzjjjbWf/u9i+fTurVq3Kl156yemsn7cyWy6KyL9nxpxQD/UkM/cOdmavgXqoR8yYi5JwNDFlAo7Ldj6+jbRddlm7dm02btz4iXud161b55XNxKFDhzhu3DiuX7+e5KPajBo1isWKFeORI0d4+/ZtvvLKKxw3bpzxOm+shd2JEyfYsmVLVqpUiYsXL3b63o8//sj333/fqy/FJ81bg0mTJrFRo0YkbavErFq1is2aNWNwcLBRh3Xr1rFu3bq8ePGiO4eaYJSLIuKKciJ+6qGcmbV3cGTmGpith1IuSmLRxJSX69WrFxcvXmzM2juGiOPXy5cvZ506deINEdK7moktW7bQYrEwQ4YMxmW19kD9888/mSNHDubOnZsvvvgiS5UqxYcPH7pzuAlm7dq1vHbt2j/uc/jwYf7f//0fq1atyiVLlsS7jyc3FqrBI45///Pnz6fFYuGsWbP40ksvsWHDhmzTpg3btm3LgIAA/vXXXyTJiIgIdw03QSkXRcQV5UT8zNhDqXdQDR5n1h5KuSiJSRNTXiw6OpqlSpVihQoVuHLlSpchsmLFCtarV4+VK1fmyZMnk3y8SeXMmTPs27cvU6RIYTwHwWq1Gs3TxYsXOWfOHM6ZM8eomf2/nmru3LkMCAjgxIkTefPmzX/c9/Dhw2zVqhVr1KjB2bNnJ9EIE59qYGP/m7c3SFarlREREfzwww+ZM2dOduzY0bjU/Pbt2yxVqhR/+eUXp9d6MuWiiLiinHg6s/VQ6h1UA0dm7qGUi5LYNDHlpexnJCIjI/nSSy+xYsWKXLFihcsQWbhwIbt37+41ZzSe9j7++usvdu/enX5+fly4cKGxPb4ze94yq//RRx8xT548nDBhAq9fv/6P+x4+fJh169blu+++m0SjSxqqgc26devYsGFDNmnShNOmTTMarMdXiOnTpw+LFSvmslaeQrkoIq4oJx5RD2Wj3kE1cGTGHkq5KElBE1NeyjEATp06xZIlS7JGjRpctWqV0SQ8LUTi+xmeyHH8X3/9NSdMmMBPP/2UZ8+eZWxsLG/fvs0ePXowbdq0To2Vp5/ReFxUVJTx9QcffMDChQtzwoQJvHXr1j++7o8//vD4z4CdavDI7t27mSxZMvbo0YO1a9dmxYoV2aZNG96+fdvYZ8uWLezUqRMzZsz4xOopnky5KCKuKCds1EOpdyBVg8eZtYdSLkpS8IN4JR8fHwBAjx49cOnSJfj5+eHQoUPo1asXAKBhw4bw8/MDSVgsFlgsFuPrx3+Gp7KP/6OPPsLChQtRrFgxnDp1Cl999RW6d++ODh06YMCAAfDx8UG3bt0QGRmJTp06OdXA05FE8uTJAQCzZs1CtmzZcP78eQwbNgwA8NZbbyFDhgzxvrZAgQIAAKvV6tGfBTPXwP43bR//qVOnsHfvXowaNQo9e/aE1WrFtGnTsHjxYnTt2hVhYWHw9fXFwYMHcfHiRezYsQPFixd399tIMMpFEXFFOWFj9h7KzL2DndlroB7qEeWiJAl3zIZJ0pg9ezYzZMjAw4cP89KlS7x69SorVKjAEiVKcPXq1fFefultVq5cyWzZsvHIkSPG+3333XcZHBzMuXPnkiTPnz/Pd955hy+99JIbR5q4Bg8ezPTp0/Prr7/m4sWL2apVK2bKlOmZznp5CzPV4PFnIJDk77//zurVqzNnzpycNWuWsf3hw4cMCwtjSEgI27Vrx3v37jE2NpZ37txJ8nEnBeWiiLiinLBRD2Wu3uFpzFYD9VDxUy5KYtPElBcbOHAgQ0NDGRsb63RvcKlSpVikSBGuXLnSK1ZLsQsLC3ti5Yfp06ezdOnSvHv3rtPDN1u3bs2iRYsa/7569apXBqnVauWtW7dYqlQpTpw40el77733HtOkScMJEybwxo0bbhph4jNrDf7++2/mzZuXq1evJknevXuXvXr1Yo4cOfjaa685XVIdGxvLadOmsXDhwuzcubNX/i3YmS0XReTfM2NOqIdyZtbewZGZa6Ae6klmzEVJWrqmzgvFxcUBAB4+fIi7d+/C19cXPj4+ePDgAVKkSIHRo0fj9OnTGDBgAPbs2ePm0SaMHTt2YPTo0Zg6dSqOHTtmbI+IiMDdu3eROnVq+Pn54cGDBwCA4cOH4/z589i1axcAIGvWrMZlp97EYrHAz892x66vry8AICoqCgAQFhaG4OBgTJkyBdOnT8fdu3fdNs7EZNYaPHjwABUqVEDHjh2xdu1apE2bFoMGDULHjh1x7tw59O3bFw8fPgRgq0vHjh3x8ccfo2/fvl5zK4YjM+aiiPw7Zs0J9VBPMmvv4MjMNVAP9YhZc1GSniamvIDVanX6t/3g0bp1axw/fhwDBw4EAKRIkQIAEBsbi5YtWyI0NBRVq1ZN2sEmkho1amDEiBE4evQoJkyYgF9++QWArQbh4eFo3749gEc1uHXrFnLmzImMGTM6/RxPP5g8/lkAgDRp0iAoKAhz5swBAAQEBCAmJgYAkCtXLkRHR+P48eNImzZtko41sagGNrlz58aIESPw6quvok2bNli7di1Sp06Njz76CA0bNsTOnTsxYMAAo7Hy8/NDhw4dkDt3bvcOPIEoF0XEFeWEjXoo9Q6AauDIzD2UclHcxt2XbMl/43gp6VdffcV+/fqxR48e3Lx5M0ly2rRpTJEiBXv27MlTp07x1KlTbNCgAT/55BPjdZ6+lK9jDebPn88yZcqwffv2xkoYK1asYIYMGdi8eXPu37+f+/btY6NGjVi5cmWvWiHC8b0cOHCA+/fv544dO0jaVtDInTs369WrR6vVavzOX3/9de7cudN4radffmzWGjz+OXa85eL06dN85513mC5dOq5Zs4Ykee/ePQ4YMIBVqlThu+++y+jo6CQdb2JTLoqIK8oJG/VQ5u0dHJm5BuqhHlEuijtpYspL9OrViy+++CJbtWrFzp0702KxcO7cubx9+zYXL17MrFmzMkeOHMyZMyeDg4ONe4A99SDyOMf3sWDBApYpU4Zvv/02f/31V5K2pVsLFy7MbNmysUCBAqxRo4ZRA29orBzff79+/Vi0aFEWLFiQQUFBbNeuHW/dusVNmzYxf/78zJMnDxs0aMDg4GAWKFDAOIB4eh3MXoMLFy5w+fLlxr8dGwN7YxUYGMgffviBJHn//n327NmTderU4dWrV5N8vEnB7LkoIq4pJ8zdQ5m9dyBVA1I91OOUi+IOmpjyAmvWrGHOnDm5f/9+kuT69etpsVi4YMECY59r165x69at3LZtmxG2jmcEvMHTGqvjx4+TtL3fI0eO8LfffjMOoN5Wg88++4yZMmXivn37GBMTwyFDhtBisfDQoUMkyZs3b7J///7s2bMne/XqZbx/bzq7YcYaxMTEsFWrVgwODuaSJUuM7Y7v6ddff+Xrr7/O0NBQXrt2jaRtxRn7195GuSgirignHjF7D2XG3uFxZq2BeihnykVxF01MeYEZM2awZcuWJMlvvvmGqVOn5owZM0iSd+7cMc54OfL0g8jTxNdYtW/f3jioOvL0szuPs1qtbN26tbGM7YoVK5g+fXpOnz6dpG3ljPh404HEzDU4deoUmzRpwtDQUC5atMjY7vi3/s033zAwMJCnT592xxCTlHJRRFxRTjgzaw9l5t7Bzuw1UA/1iHJR3EUPP/cw8T2Y0GKx4O7du1i8eDHat2+Pzz77DJ06dQIAbNiwAWPHjsXt27edXmN/kJ0n4mOrvjj+23FVmDZt2qBHjx44duwYhg0bhjNnzji9zsfHsz/+j38WoqOjsW/fPqRIkQLbt29H27ZtMWrUKHTu3BmxsbEYNWoU1q5d+8TPsa+44olUg0fy58+P8ePHI2XKlJg1axaWLFkCwPa3bn9QacGCBZE1a1avWjkJUC6KiGvKCRv1UOodANXgcWbtoZSL8jzx3KOKCZE0GoHvv//e2F6kSBHcvHkTHTp0wKBBg9ClSxcAQGRkJBYuXIiAgACkT5/eHUNOcDExMcaqL5GRkQAerQJjP1A4NlatW7dGhw4dkD59euTJk8cNI0489s9CbGwsANtKKa1atcK8efPQsGFDjB8/3vgs3Lp1CwcPHsSff/7ptvEmBtXAWZ48eTB58mSkTJkSM2fOxPz58wEA/v7+AIBFixYhZcqUyJw5szuHmaCUiyLiinLCRj2UjXoH1SA+ZuuhlIvyvNHElIewWq1G83DmzBk0bNgQffr0AQBUrVoVDRo0QMaMGXH79m3s27cPO3bsQNOmTfHXX39h8uTJTo2GJ9q3bx+ioqKMg8O4cePQtm1btGjRAnv27MGDBw+c3qPj1507d8acOXPg4+MT75kBT+P4HhYsWICiRYsiIiICAFC+fHmcOXMGlSpVQrVq1QAAV65cwdtvv407d+4YBxdPpxo8nb2xSp8+PaZOnYru3bvj66+/RteuXTFv3jx8+eWXXtNQmD0XRcQ15YR6KDv1DqqBK2bpoZSL8lxKursG5X/leM//qFGj2K1bN2bKlIkWi4Xvv/++8b1evXqxatWqtFgsDAkJYf369Y1VEjz53t+hQ4cyKCiIK1asIEmOHz+eadOmZe/evVmkSBEWK1aMYWFhDA8PJ+lcr6d97akcn+mwatUqjh49mhaLhbVr12ZERARJcu7cuSxcuDCLFi3K4OBgVqhQgeXKlfOKzwKpGjyrixcvcvDgwSxZsiSDg4P5yiuvGA+x9QZmz0URcU05oR7KTr2DavBveHMPpVyU55WF1HSnpxg6dCgmTpyIr776ClarFYcPH8bw4cPRtm1bzJgxAwBw8+ZNXLhwAdmyZUNgYCAsFgtiY2M9+h7wqKgovPbaa7h+/Tr69u2L77//Hq1bt0ZoaCgAoH379jh8+DA6duyItm3bInXq1CBpnAnwRr1798Y333yDDh064LfffsOWLVuQI0cO/Pjjj0iRIgX27t2Lc+fO4fTp0yhcuDCaNWsGX19fj/8sOFINno3VasWDBw/g6+uLgIAAdw8nwZk1F0Xk2Zk5J9RDOVPvoBr8G97cQ5k5F+U55d55Mfknjmc2oqKiGBoaytGjRxvbIiMjuXDhQvr5+fHDDz80tjvOhHv6qikPHjwgaXv/9erVY4kSJVi4cOEnVoh5++23GRwczLCwMN67d88dQ00yBw4cYNasWblx40aStt/3jz/+yEKFCrFs2bLGWa/HedPZDdXg2Xj6Ge74KBdFxBXlhI16KGfqHVSDf8Pbeijlojzv9Iyp5xQdHki3b98+JE+eHH/99ReuXLli7JMiRQo0bdoULVq0wMSJE9GrVy8AtmcD2O8h9+RVUwAYZyfu3r2LtWvXomDBgjh16hR2796Nhw8fGvvNmTMHZcuWxYgRI7Bp0yZ3DTdRPP5MB4vFgqioKBQpUsT4d6VKlTBx4kT88ssvePXVVxEdHQ0AiIuLM17nyStmqAb/G287461cFBFXlBOPmL2HUu+gGvwX3tRDKRfFE+jT9RyiwyXUn3zyCdq1a4dr167hrbfewu7du7Fr1y5j35QpU6JIkSJo0qQJpk+fjrFjxwLw/OBYuXIlPv30UwDAhx9+iI4dO8LPzw+LFy9GvXr1MHv2bKxZs8ZYwhUAZs6cia5du+LVV19106gTh/132bdvX/Tv3x+5c+dGxowZsXTpUmMfX19fBAcHo1ChQvjxxx9Rs2ZNY7s3UA1EuSgirignbNRD2ah3UA1EuSieQ5+y55A9PA4ePIhjx45hzpw5yJo1K2rVqoV06dIhLCwM27dvBwDcu3cPBw8eRP369dG1a1esXLkS169f9+iVEqKjo3H69GmMHj0aNWvWxOzZszFy5EgAQLJkyfDtt98iMDAQI0eOfKKx6tevH3x9fZ3O8ngqx9/h999/j1WrVqFRo0ZIkSIFGjZsiPXr12PhwoXGPsmSJUOJEiWwdOlSXL9+HRMmTHDDqBOWaiB2Zs9FEXFNOaEeClDvAKgG8ohyUTyFJqaeUwsWLMCgQYNw7949lChRAgBQuXJl9OzZE3fv3kWbNm1Qvnx5hISE4OzZs+jUqRNy5syJe/fuIUWKFB59+Wny5MnxwQcfoFy5cti5cyfatm2L4sWLA7A1XMmTJ8fq1auRNWtWjB49Gl9//TViY2OdfoY3nOWx/w7Xr1+PlStXonnz5qhcuTJSpkyJHj16IHPmzJg8eTI6dOiAuXPnokmTJrh8+TJq1qyJdOnS4a+//nLzO/jvVANxZOZcFJFnY/acUA+l3gFQDcSZ2XNRPIMeqf+cevDgAU6ePInbt2/jt99+Q4UKFQAADRo0QP78+fHHH39g69atyJUrF959910AwPHjx1GgQAGvCI+YmBhUq1YNFSpUwLx585AlSxZ8+umnSJ48OR48eIAUKVJg1apVqFGjBn744Qe0bt3a3UNOFFeuXMGAAQPw+++/o2XLlsb2fPny4fPPP8eKFSuwcOFCHDt2DFmzZsWKFSuQPHlyZMmSBZkyZQIAj19dRzUQO7Pnooi4ppxQDwWodwBUA3lEuSgeIWmftS7xedoKB8uWLWPhwoX5f//3fzx69OhTX3/mzBl+9NFHTJcuHX/55ZfEGmaieloN7t+/z7FjxzJt2rQcPHiwsd1qtfL8+fOMjY31qhUi7CtfOK6A8fPPP7N27drMnz8/ly9fHu/rHFdR6d27NwMDA3n69OnEHWwiUQ2EVC6KiGvKCRv1UOodSNVAbJSL4qk0MeVmjuGxZs0afvXVV5w4caKxLOvixYtZpkwZtm/f3ikc7AedBw8ecOjQoaxevTqPHDmStINPII41mD9/PgcNGsROnTrxp59+YkREBKOiovjZZ58xffr0HDBgACMiIli/fn2+9dZb8f4MT+X4Hi5cuMCLFy/y7t27JMmjR4+yZs2abNCgAdeuXWvsFxMTY3z9888/s127dnzxxRefWAraU6gGQioXRcQ15YSNeij1DqRqIDbKRfFkmph6TvTq1Yu5c+dmjRo1WLx4cebOnZt79uwhaWs0ypYty44dO/Lnn39+4rX379/njRs3knrICe6jjz5i5syZ2bhxY5YuXZqBgYH89NNPee3aNUZGRnLy5MkMCAhg/vz5WaJECT58+NDdQ04wjme3hgwZwuDgYBYuXJh58uQxznAdOnSINWvWZMOGDblu3bp4f86KFSt49uzZJBlzQlMN5HHKRRFxRTlhY9YeSr2DaiBPUi6KJ9LE1HNg1qxZzJo1qzEzvXr1alosFqcDx7x58xgUFMSRI0c6vdbxYOSJ7OPfsGEDs2fPzsOHDxvfGzZsGEuUKMGxY8eSJKOiovjHH39w5cqVxsy/49kebzBkyBBmyZKFa9as4Y0bN1izZk1my5aNf/zxB0ny4MGDrF27NitWrMjdu3cbr/P0s52OVAMhzZ2LIvJszJ4T6qEeUe+gGoiN2XNRPJcmpp4Dn3zyCfv160eSXLp0KdOmTctp06aRJO/cuWPst27dOqOZ8GRjx47lpk2bnLZ98803LFiwIK9cueL0Hvv168fAwECnOth5Qy0c3blzh6GhoVy2bBlJ8rvvvmP69Ok5depUko/e765du9i1a1evbCRUA7EzWy6KyL9nxpxQD/Uk9Q6qgTxixlwU76CJqedA06ZN+cEHH3Dnzp1MkyaNcRCxWq0cPHjwE7PZnhwiR48eZf78+dm8eXPu2LHD2D5//nxmyZLFuHQ0MjKSpC1AM2TIwDVr1rhlvEnp4sWLDAwM5JUrV7hlyxamTp3aOJBERERwyJAhT1xa622NhWogdmbKRRH535gtJ9RDxU+9g2ogj5gtF8V7+Lh7VUAzsVqt8W5/6623sGPHDtSqVQvjxo0zlum8f/8+Dh48iLt37zrt7+vrm+hjTSwlS5bE9OnTceXKFUyaNAnbt28HALRu3RpZsmRBs2bNAAApUqQAAFy/fh2ZM2dGxowZ3TXkREHyiW05c+ZE5cqV8e677+KVV17BxIkT0aVLFwDAjRs3sGnTJmzdutXp9T4+nvsnrBoIoFwUEdeUEzbqodQ7AKqB2CgXxdv4uXsAZmG1Wo0DwLZt2xAeHo5y5cohe/bsKFOmDAoUKACSSJEiBWJjY/HHH3+gV69euHr1KlauXOnm0SeMuLg4+Pr6onbt2oiLi8PgwYMxZcoUkERoaCi+/PJLtGnTBuXLl8ewYcNgtVoxdepUpE+fHhUrVnT38BOM42fh5s2bAIBMmTLBarWiSpUqGDduHF5++WW0b98eABAREYEuXbogICAATZs2BQBYLBb3DD6BqAYCKBdFxDXlhI16KPUOgGogNspF8UruuEzLzPr06cPUqVMzV65cTJ06NRcsWECS/PXXX9miRQsGBQUxY8aMLF26NKtVq2asmuLpl1k6Xi7s+LDOkJAQNm3a1HgI47Fjx1izZk0GBQWxSJEirFu3rtfU4HEDBgxg2bJlmStXLn7++eeMjY3lgwcP2KVLFxYvXpxVq1bl22+/zcqVK7NkyZJeWQfVQEjz5qKIPDsz54R6KGfqHVQDsTFzLor30cRUIrM3EFarlb///jsrVqzIH3/8kZcuXWKfPn3o6+vLKVOmkCRv377NkydPcunSpTxw4IDRiHj6qimODdX48ePZq1cvIxB/+OEHVqpUiU2bNuWuXbuM/f744w/+9ddfXlODxy1YsIBBQUGcOnUqP/nkE/r5+fGdd95hZGQkIyMjuWzZMrZr146dOnXiiBEjjPfvTXVQDcxLuSgirignbNRDOVPvoBqYmXJRvJkmphKRYzMRHh7OU6dOccCAAU77DBgwgD4+Ppw6dSrv37//jz/D0/Xq1Ys5c+bkuHHjePbsWWP7hg0bWKlSJTZr1oxbt2594nXeUIPH38PKlSs5c+ZM498bNmygr68vO3TowNu3b8f7Mzz97IZqIKRyUURcU048yaw9lHoH1UBslIvi7fSMqURkv/d30KBB2L59O06cOIFChQrh4sWLCAoKAgAMHz4cFosFPXr0QEREBLp27YqAgIAnfoanmz9/PubPn49169ahXLlyAIDY2FjExsaiXr16SJEiBfr3749hw4YhQ4YMKF26tPFaT68BSeM9zJ8/H+fPn8eWLVvQvHlzY5969eph3bp1aNSoEfz9/dG/f3/jM2LnyQ8nVA3ETrkoIq4oJ5yZtYdS76AayCPKRfF67p0X806Os9ELFixglixZOHbsWL711ltMmTIlBw8ezMuXLzu95oMPPmC1atWMSzS9Te/evdmuXTuS5PHjxxkWFsaSJUsyX758XLhwIUlyzZo17Ny5s1fN5jv+Pj/99FP6+/vzpZdeosViYc2aNXn48GGn/Tdt2kSLxcKxY8cm8UgTj2ogpHJRRFxTTsTPjD2UegfVQGyUi2IWmphKRLt27eJ7773HpUuXGtuGDh3KoKAgDh8+nFeuXHHa3/G+YU8W3/jHjx9PX19f9u/fnyVLlmTTpk05ZswYtm/fnhkzZuTNmzed9veWxsruwIEDbNWqFffs2UOS3LJlC4OCgti+fXv+8ssvTvvu37/fK+//Vg2ENG8uisizM3NOqIdypt5BNRAbM+eimINu5Usk+/btQ9u2bXHr1i3jsmsAGDhwIADgyy+/hI+PD9566y3kyJEDgG35VpIevYyr4/Kl169fR8aMGWGxWNChQwfcuHED69atQ4cOHVC3bl0ULlwYR44cwcmTJxEZGYmMGTMaP8ebLjVduHAh5syZg9jYWBQpUgQAUKtWLcyYMQNdunQBSfTs2RPFixcHAFSoUAGA7TJ9Pz/v+BNVDQQwby6KyLMzc06oh3Km3kE1EBsz56KYiPvmxLxfWFgYc+XKxVdeeYWnT592+t7w4cPp7+/P+fPnu2l0iWvYsGEsV64cq1atys8++4zh4eEkyXv37hn7xMTE8OWXX2b9+vW9ejZ/7dq1LF26NDNkyMD169c7fe/7779nnjx5+Oqrr/LMmTNuGmHiUw3Ezsy5KCLPxuw5oR7KRr2DaiCPmD0XxftpYioROF5Ca38OQPfu3Z1WUSHJuXPnes0qGY5N0ezZs5kpUyZOnTqVLVq0YEhICFu3bm2sFHLv3j0uWbKEoaGhLF26NB8+fEjSuy49f9zOnTtZvnx5NmnShDt27HD63sqVK9m0aVOvfv+kamB2ZsxFEfl3zJoT6qGeTr2DamB2Zs1FMR8LSbr7qi1vw/9/2eSdO3eQPn16TJo0CfPmzUP16tXx4YcfInfu3E77x8XFeexqGXzsEtGtW7di8+bNKFu2rLFiSFhYGBYtWoS8efMiLCwMsbGxmDlzJs6dO4ewsDD4+fl55SXHJGG1Wo3f7a5du9C7d2/kyJEDH3zwAapXr/7Eaxwv4/cGqoHYmSkXReR/Y7acUA8VP/UOqoE8YrZcFBNzz3yYd3j87ERcXJxx1mvZsmWsU6cOr127RtL24Mpy5cqxbdu2T6yc4MkcH7S3detWFi9enIGBgdy0aZOxPSYmhmFhYaxcuTLbtWvHu3fv0mq1GrXyhtn9xy+jd3x/69ev55w5c0iSmzdvZuXKldmiRQunGnkD1UBI5aKIuKacsFEPpd6BVA3ERrkoZqdp9f+R41mJX375BYDtYZMWiwXLli1D+/bt8eqrryJLliwAgA8//BBNmjSBxWJBYGCg28adkA4ePIhcuXJh7dq1AICyZcuiSZMm8PHxwbx58xAdHQ0A8PPzQ+fOndGmTRvs2rULEyZMgMViMR7K5+mz+lar1TjjGRcXZ2y3WCz49ttv0ahRI/j7+wMA6tSpg6FDh+Lw4cPYsWOHW8abGFQDAZSLIuKacsJGPZR6B0A1EBvlogh0xdT/wnFGe9CgQSxcuDC///57kuSdO3dYv359Tpo0Kd797TPf3nAv+KlTp9imTRtmyZKFa9asIUmGh4dz0KBBLFeuHHv16sXo6Ghj/5iYGH777bcef3bPkePvcezYsezZsycjIiJIkkeOHKGPjw+nTZtG0vmM2IEDB7ymDqqBkMpFEXFNOfGI2Xso9Q6qgdgoF0VsNDH1H/Tr14+BgYH8/vvv+ddff5G0BcTNmzeNr+2e9rWnO3PmDN955x2mT5/eaKzu3bvHAQMGsGLFik80VnbedkDt1asXc+TIwS+++IIXL14kSV66dIk7d+502u/x37031UE1EFK5KCKuKSds1EOpdyBVA7FRLorZaWLqX3D8w//ll19YuHBh/vDDDyRtjcSZM2c4d+5c/vrrr15/sHB8f6dPn+Y777zDdOnSOTVWn3zyCStXrsxOnTo5rSjhbb766itmzZqVhw4dMrbFxMTw7t27Xv2+HakG5qVcFBFXlBPO1EPZqHdQDcxMuSjizHuW8EgC9nvAHz58CF9fX/z999/Ily8fDh48iIULF2Lz5s24ePEi8ufPj5kzZ6JcuXJuHnHC2r59Oy5evIg2bdrA19fXWPUhX7586Nu3LwCgc+fOWLhwIWrVqoW+ffsiPDwckZGRHv0MhMc9vtrFuXPnEBoaiuDgYBw7dgxbt27F9OnTQRKdO3fGe++9h+TJk7txxAlPNRA7s+eiiLimnFAPBah3AFQDeUS5KOJMDz9/Bps2bcKDBw8AAAMHDsTo0aNRqFAhFClSBJUqVUKtWrUQFxeHkSNH4ubNm7h8+TIOHDjg5lEnHJKIjIzEiBEjMHXqVCxduhQAjMYKAPLmzYvu3bsjJCQEU6ZMwb1795AqVSqMHj0aM2bMMB7S6emuX79uNBTz58/HuXPnkC1bNixbtgx9+vRBy5YtsXv3bnTq1AkvvfQSxo4di9u3b7t51AlLNRBAuSgirikn1EPZqXdQDcRGuSjyFO67WMsz3Lp1iwULFmTRokX53nvvMWXKlDx69ChJ2wPp5s2bx+3btxvPALBaraxWrRoXLlzozmEnitOnT7NJkyYMDQ3lokWLjO2Ol5dOnTqVL7zwgrGcqZ033P+8Z88e+vj48Pfff+fHH3/MbNmy8fz58yTJUaNGsXr16gwLC+OpU6dIkn/88QfLly9v/NsbqAZCKhdFxDXlhDMz91DqHVQDsVEuijydJqaeYtWqVcbXly5dYtq0aZkyZUru2bOHJJ+47zsyMpJ//vknGzVqxNKlS3vtvcBnz55lw4YNGRoaysWLFxvb7QG6ceNGVqtWjTdu3HDXEBNcVFQUSfLGjRts164dU6dOzXTp0vHcuXPx7kfa6vHyyy+zbt26Ht9QkqqB2CgXRcQV5cTTma2HUu+gGoiNclHENd3KF4/58+dj8ODBxiXWERERSJ8+PbJmzYquXbvi7t278PPzM74fFxeH1atX4/XXX8edO3fw008/OV2i7U3y5MmDyZMnI2XKlJg5cybmzp0LAEiWLBmioqIwceJEvPDCC8iYMaObR5owateujdGjRwMAMmXKhMKFCyMiIgIxMTG4d+8eABi/5+TJk+PBgweYPXs26tWrh7///htr166FxWKB1Wp123v4r1QDAZSLIuKacuKfmamHUu+gGoiNclHk2VhID79pPZHYH0546NAhlClTBhEREbh27RoaN24Mf39/7NixA2nTpgVge37A4cOHcfHiRTRq1Ai+vr6IjY2Fn5/3Plv+3Llz6N27N86ePYvChQujTJky2LRpE27evIl9+/bBz88PJI0H+3mqffv2ITg42Hjw5KVLl3D58mVMmzYNy5Ytw+bNmxESEmL8vq9cuYLNmzdj7969mDx5Mvz8/Dz+s6AaiJ1yUURcUU64ZoYeSr2DaiCPKBdFnoH7LtZ6/u3atYsWi4VTp041th07dozFixdn2bJleePGDcbFxbFDhw4cO3assY9ZLre8dOkSJ0yYwMqVK/OVV15h165djUtRvW2J29GjR7Nly5bGpdZXr17lG2+8wVSpUnH//v3GfmPHjjXuFSe967OgGgipXBQR15QTrpmlh1LvoBqIjXJR5J9pYsqFIUOGMHny5Jw+fbqx7dixYyxVqhQzZcrEChUqMG/evF7VRPxX3higa9eupb+/P9955x2jsbh27RrffPNNJk+enF988QVr1KjBUqVKeeX7J1UDeUS5KCKuKCf+N952/FTvoBrII8pFkafTxNT/908BMGTIEPr4+DiFyL179zhixAiOGTPGeK0ZDyaPP5TRGx7SGBcXF+/2TZs2MUWKFOzQoQMfPHhA0vY5+Pjjj1m2bFk2bdqUDx8+/Mef4SlUAyGViyLimnLif+dtPZR6B9VAbJSLIv+e6Z8x9ffffyMwMNC4j3/GjBk4efIkLBYL6tWrh9DQUPj7+2PIkCEYOnQopk2bhk6dOj3xc+z3Dovn4mPPczhw4ABu376NEiVKIFWqVEibNi02btyI1157DW+88QamTJmCgIAAAMC1a9eQJUsWWCwWj74PXDUQQLkoIq4pJ8ROvYNqIDbKRZH/wJ2zYu7Wpk0bVqxYkadPnyZJDho0iKlSpWKrVq1YoEABlipVyumy26FDhzJZsmT84osv3DlsSQRdunThpk2bjH9/9NFHzJIlCzNkyMAXX3yRb775Jk+cOEGS3LBhA1OlSsVOnToxPDzc6ed48tlO1UBI5aKIuKacEDv1DqqB2CgXRf4bU09M/frrr8yYMSMbNGjAffv2sU6dOty1axdJ28Hhiy++YEhICD/88EPjcso+ffqwatWqOnh4mUKFCjFv3rzctWsX16xZwwIFCnDLli28cuUKp06dyrp167J27do8efIkSXLz5s20WCwcPXq0m0eecFQDIZWLIuKackLs1DuoBmKjXBT5b0x7K5/9EslTp06hfPnyKFasGABg2bJlyJEjBwDg/v37+Oyzz7Bu3TqsW7cOgYGBAB5drksPX8pXnC+VrVGjBq5du4bWrVsjPDwco0ePNvb77rvvMGbMGLz00ksYPHgwANtl2sHBwR5/ybVqIHbKRRFxRTkhgHoHQDWQR5SLIgnAXTNi7rR//35evnzZeLjcqVOnmCNHDlosFm7cuNFp34sXL9JisXDlypVO2zWz7R0ef7Bg9erVabFYWL9+/Se+17VrVxYpUuSJBxp6+soZqoGQykURcU05IXbqHVQDsVEuiiQMH3dPjCW1OXPmoGHDhti8eTNiYmIQFxeH/PnzY9euXciUKRNGjx6NEydOOL2mQIECSJUqldM2zWh7vpUrV2LMmDG4d++esW3Hjh2oX78+du3ahQ0bNiA6Otr4XpUqVZAiRQrcvXvX6ed48tku1UAA5aKIuKacEDv1DqqB2CgXRRKOqW7lW7FiBdq2bYuZM2fi9ddfh4+P87zcyZMnUalSJRQoUABvvvkm8ubNi5kzZ+Ls2bM4evSoVkfwIn/++SeKFCmCwoULo2XLlnj//feRJk0a4/vVq1fH+fPnMXr0aNSoUQN+fn74v//7PyRLlgwbNmzwigOIaiCAclFEXFNOiJ16B9VAbJSLIgnLVBNTb7/9Nl588UUMGTIEZ86cwfr163HixAnUrFkTZcuWRYECBXDy5EnUrFkTV69eRZs2bZAmTRqMHz8e/v7+WrrTi1y+fBmVK1dG4cKFcevWLTRt2hSdOnVCxowZjX2qV6+OH3/8EXnz5kW5cuVw9epVbNq0Cf7+/l5xH7hqIIByUURcU06InXoH1UBslIsiCcx9dxEmrQcPHrBIkSJcvnw5b9y4waCgIL722mssVaoUy5Urx9DQUB49epQkee7cOVosFg4aNMh4ve4B9z5t27blr7/+yl69ejE4OJgTJ07krVu3OH/+fGOfV199lRaLhTt27GBcXBxJ7/osqAbmplwUEVeUE/I49Q6qgdkpF0USnqmumHrjjTdQsGBBXL9+HQDw+eefI0WKFFi7di2mTJmCggULYuzYsQgICMDFixeRLVs2+Pn56cyGl2rSpAleffVVtGnTBr1798bOnTtx7tw55MiRA0eOHDEuye3cuTOmTp0KX19fWK3WJy7V9WSqgSgXRcQV5YQ4Uu+gGohyUSShmSodc+XKha+//hpHjhxBcHAwUqRIAQBo1KgRQkJCsH79esTGxgIAgoKC4Ofnh9jYWIWHl4mLiwMAlCxZEseOHYOfnx9Gjx6N8+fPw2q1okmTJoiKijL2nzFjBnx9fREXF+c1DYVqIHbKRRFxRTkhgHoHQDWQR5SLIgnLaxPS8aBgtVoBAKNGjUL27Nmxd+9eHDt2zGmfkJAQZM+e3djXTqtleB/7/dwVKlTA7du3ERsbi/Lly6No0aJo3rw5Nm/ejOHDhyMiIiLe13kD1cCclIsi4opyQp5GvYNqYFbKRZHE55UTU8uXL8fQoUNx5coVAICPjw9iYmIAAEuWLEHVqlUxd+5czJw5E+fOncONGzcwfvx4ZM6c2WlVDfFuGTJkwPbt21GkSBGkS5cOmzZtwsyZM1GoUCFcvXoVKVOmdPcQE51qYB7KRRFxRTkhz0K9g2pgJspFkaThdc+YWr16NV577TUAwEcffYTevXsjS5YsAGDc2x0TE4MWLVrgjz/+wJ9//omiRYvCarVi3759Wi3DREji5Zdfhr+/P+bOnWt8TkiCJHx8fLz+s6AamINyUURcUU7Is1LvoBqYhXJRJOl41cTUlStX8P777yM4OBh58uTBW2+9hQ8//BD9+vUzQiQ2Nta4jPLQoUM4f/480qZNi9DQUPj6+jp9XzzX4weBpx0UTp8+jSxZsiBdunQA4PRgSk9/SKVqIIByUURcU06InXoH1UBslIsiScur/lL8/f1Rv359FCpUCNWrV0fKlCnRvHlzADBCxM/PD3FxcfD19UWZMmVQpkwZ4/VxcXEKDy8QExMDf39/AEBkZCRSpkxpNBSPNxf58+d3eq1jE+HJDYVqIHbKRRFxRTkhgHoHQDWQR5SLIknLq66YAoB79+4hbdq0xr9XrFiBFi1aoHv37hgwYAAyZ86Me/fu4fz58yhZsqQbRyoJbd++fShdujQCAgIAAOPGjcO+ffsAAD169DBWzPDmS2pVA4mPclFEXFFOmJd6B9VA4qdcFEk6Xjedbw8Pq9UKkmjWrBmWL1+OiRMnYuTIkThx4gRee+01hIWFuXmkkpCGDRuGli1bYv369QCACRMmYOjQocibNy9OnDiBTp06Ye7cubh//z4sFgu8bD4WgGogT6dcFBFXlBPmpN5BNZCnUy6KJB2vu2LKkeMDCFetWoUWLVogZcqUCAwMxIkTJ4xLdcXzRUVF4bXXXsP169fRt29ffP/992jdujVCQ0MBAO3bt8fhw4fRsWNHtG3bFqlTp/a6s16qgTwL5aKIuKKcMA/1DqqBPBvlokji8uqJqccVKFAAL7zwArZt2wY/Pz89kM5LREVFISAgANHR0WjSpAkuX76MmJgYLF68GMHBwcZ+7du3x5EjR9CxY0e0adPGq5ZwVQ3kf6VcFBFXlBPeSb2DaiD/O+WiSMLyyFv5Hp9LczW3FhkZiXr16iEyMlLh4YXszwO4e/cu1q5di4IFC+LUqVPYvXs3Hj58aOw3Z84clC1bFiNGjMCmTZvcNdxEoRqIclFEXFFOiCP1DqqBKBdFnhceNzEVExNjXDobGRkJAE6rZcTHx8cHnTt3xvnz5xUeXmTlypX49NNPAQAffvghOnbsCD8/PyxevBj16tXD7NmzsWbNGsTExBivmTlzJrp27YpXX33VTaNOWKqBAMpFEXFNOSF26h1UA7FRLoo8PzzmVr6EWi1D4eEdoqOjMWnSJHzyyScICQnBzz//jL1796J48eLG95s0aYLr169jwIABaNy48RP3ftuXd/VUqoEoF0XEFeWEOFLvoBqIclHkuUQPMHToUAYFBXHFihUkyfHjxzNt2rTs3bs3ixQpwmLFijEsLIzh4eEkSavV6s7hShKJiopi5cqVabFY+P777zttt//35ZdfZvny5blw4ULGxMS4a6iJRjUwL+WiiLiinJD4qHdQDcxMuSjyfPKIW/l69eqFYsWKYeTIkVi+fDmOHTuGVatWYcyYMfj1119RoUIFzJw5E/Pnz9dSriYSExODatWqoXv37li0aBGGDBkCAEiePDkePHiA5MmTY9WqVfDx8cEPP/zglWc0VAPzUi6KiCvKCYmPegfVwMyUiyLPp+f+Vj6tliF2VqsVPj5PzqVGRERg6tSpGD58OHr27Gk8M4AkLly4gJw5c8JiscT7Wk+jGgigXBQR15QTYqfeQTUQG+WiyHPMXZdq/VtXr15lTEwMmzVrRl9fX06ePJnR0dFO+3Ts2JHZs2fn8uXL3TRKSSxxcXHG1/Pnz+egQYPYqVMn/vTTT4yIiGBUVBQ/++wzpk+fngMGDGBERATr16/Pt956K96f4YlUA3mcclFEXFFOmJt6B9VAnqRcFHn+PLcTU99++y0HDRpEkuzevTsbN25MkoyOjmaDBg1YunRpLl++nA8fPnR63ciRIxkbG5vk45Wk8dFHHzFz5sxs3LgxS5cuzcDAQH766ae8du0aIyMjOXnyZAYEBDB//vwsUaLEE58Pb6AamJdyUURcUU5IfNQ7qAZmplwUef49lxNTUVFRHDt2LJMlS8YaNWowderUPHbsmNP369WrxzJlynDFihXxHjgUIt7D/tDBDRs2MHv27Dx8+LDxvWHDhrFEiRIcO3YsSdtn448//uDKlSuNz4A3PLBSNRDlooi4opwQR+odVANRLop4iudyYorUahlmN3bsWG7atMlp2zfffMOCBQvyypUrTgeIfv36MTAwkHfu3Hni53jygUQ1kMcpF0XEFeWEual3UA3kScpFkeffc/skP62WYV6//PILvvzyS3z55ZfYuXOnsT0yMhK3b9+Gv78/fH198eDBAwBAnz598PDhQ+zateuJn+Xr65tk405IqoHER7koIq4oJ8xLvYNqIPFTLop4AHfPjNk97aGC9+/f59ixY5k2bVoOHjzY2G61Wnn+/HnGxsbqgYRe6IcffmCVKlXYrFkzbtu2jaTtM1K0aFHWqFHDad9Tp06xQIEC3L17d9IPNBGpBqJcFBFXlBPiSL2DaiDKRRFP9FxMBzsu4bpgwQKcOXMGf//9Nzp27IhixYrhgw8+gMViwYgRIxATE4P+/fujefPmyJIlC+bPn//EzxDPFRcXB19fX9SuXRtxcXEYPHgwpkyZApIIDQ3Fl19+iTZt2qB8+fIYNmwYrFYrpk6divTp06NixYruHn6CUA0EUC6KiGvKCbFT76AaiI1yUcRDuXdezJlWyzA3xzMUjg+rDAkJYdOmTY2zWceOHWPNmjUZFBTEIkWKsG7dusZnwdOfB6AayOOUiyLiinLC3NQ7qAbyJOWiiGdx+8SUVssQ0rmhGD9+PHv16mX8jn/44QdWqlSJTZs25a5du4z9/vjjD/7111/Gaz39s6AaiJ1yUURcUU4Iqd6BVA3kEeWiiOdyy8SUVsuQp+nVqxdz5szJcePG8ezZs8b2DRs2sFKlSmzWrBm3bt36xOu86X5w1cCclIsi4opyQp5GvYNqYFbKRRHvkOQTU0ePHmX+/PnZvHlz7tixw9g+f/58ZsmShTdu3CBJRkZGkiTv3LnDDBkycM2aNUk9VEli8+bNY9asWXngwAFjW0xMDB88eECS3LFjB6tUqcLQ0FCnMyDeRDUwJ+WiiLiinJCnUe+gGpiVclHEeyT5U91KliyJ6dOn48qVK5g0aRK2b98OAGjdujWyZMmCZs2aAQBSpEgBALh+/ToyZ86MjBkzJvVQJYn9+uuvaNCgAcqVK4cTJ05g6tSpKFu2LIoXL46vvvoK1atXR9++fVGwYEGULFnS3cNNFKqBOSkXRcQV5YQ8jXoH1cCslIsi3sNCkkn1P2ZfLQMANm3ahMGDByN79ux4//33ERoait27d6NNmzbIlCmT02oZ165dw969e43XiucjCYvF4rRtwoQJ+Pjjj9GnTx+sXbsW+fPnR8WKFXHy5EmsWrUKp06dcjqQePqKGaqBAMpFEXFNOSF26h1UA7FRLop4F7+k+h+yWq1GAJBE3bp1QRJDhgzBlClTkDx5clSpUgXfffcdunXrhk6dOiF16tQICgrC7t274evr6xRA4rkcm4Hr168jY8aMsFgs6NChA27cuIF169ahQ4cOqFu3LgoXLowjR47g5MmTiIyMdGoqPLmhUA0EUC6KiGvKCbFT76AaiI1yUcT7JMkVU44HkQkTJuDy5csYNWoUfH19sWXLFnzyySfInj07evTogapVqwIATp06hZQpUyJbtmzw8fFBbGws/PySbB5NksDw4cOxevVqBAQEoEmTJujSpQtSp06N8PBwpEmTBgAQGxuLxo0bw2KxYN26dU+cIfN0qoF5KRdFxBXlhMRHvYNqYGbKRRHvlCSnC+zh0bt3b4wbNw4vvPACLly4AACoXbs2Bg8ejMuXL2PChAnYtm0bAKBAgQLIkSMHfHx8YLVaFR5ewHEOdM6cOZgwYQLat2+PbNmy4dtvv8W7776LO3fuIE2aNAgPD8fSpUtRt25d/P3331i9ejUsFgusVqsb38F/pxqInXJRRFxRTgig3gFQDeQR5aKId0qyZ0zNnz8fvXv3xrp161CuXDkAtjMZsbGxCAgIwM6dO9G/f38kS5YMX3zxBUqXLp0Uw5Ik8PizALZu3YrNmzejbNmyaN68OQAgLCwMixYtQt68eREWFobY2FjMnDkT586dQ1hYGPz8/Dz67IZqIPFRLoqIK8oJ81LvoBpI/JSLIl4oqZb/6927N9u1a0eSPH78OMPCwliyZEnmy5ePCxcuJEmuWbOGnTt3ZlxcXFINS5LAlStXjK+3bt3K4sWLMzAwkJs2bTK2x8TEMCwsjJUrV2a7du149+5dWq1WWq1WkmRsbGySjzshqQYSH+WiiLiinDAv9Q6qgcRPuSjifRLlVj7GcxFWtmzZsHDhQgwYMABvvPEGtmzZgjfffBM1atRA9+7dcevWLTRq1AjTp083LrMUz3fw4EHkypULa9euBQCULVsWTZo0gY+PD+bNm4fo6GgAgJ+fHzp37ow2bdpg165dmDBhAiwWCywWC0h69MMJVQMBlIsi4ppyQuzUO6gGYqNcFDGJhJ7pcpyVvnbtGmNjYxkXF8d79+5xwIABLF26NCdOnMjffvuNJHn48GFWqVKFFy9eTOihyHPg1KlTbNOmDbNkycI1a9aQJMPDwzlo0CCWK1eOvXr1YnR0tLF/TEwMv/32W686u6UaiHJRRFxRTogj9Q6qgSgXRcwk0Z4xpdUyxO7s2bMYPXo0vvnmGyxcuBCNGjVCeHg4xowZgx9++AHVq1fH8OHDkSxZMqfXedMyrqqBAMpFEXFNOSF26h1UA7FRLoqYQELNcNnv4ybJ2bNnM1OmTJw6dSpbtGjBkJAQtm7dmrdv3yZJ3rt3j0uWLGFoaChLly7Nhw8fkqTuAfYyjmesTp8+zXfeeYfp0qUzznrdu3ePn3zyCStXrsxOnToxJibGXUNNNKqBuSkXRcQV5YQ8Tr2DamB2ykUR8/nPz5ji/7/gyj4rvXXrVpw6dQrTp0/Hu+++i2XLluHNN9/EmTNn0LVrV9y9excPHz7E+fPnUaBAARw4cAD+/v6IjY01lv8Uz7V9+3YsXLgQAODr64u4uDgAQL58+dC3b1+0bNkSnTt3xtatW5EmTRr07dsX5cuX96pnAKgGolwUEVeUE+JIvYNqIMpFEVP7rzNbWi1DSNuZjYiICNapU4eVKlXikiVLjO85/n6PHz/OZs2a8bXXXuPdu3dJkg8ePDA+C45nSDyNaiB2ykURcUU5IaR6B1I1kEeUiyLm9Z+mkrVahthZLBakTJkS06dPR2BgIL788kssXrwYgPNZr2LFiqF27drYu3ev8fkICAgwPguefD+4aiCAclFEXFNOiJ16B9VAbJSLIib3X2a1tFqGxOfs2bNs2LAhQ0NDuXjxYmO7/bOwceNGVqtWjTdu3HDXEBOdamBeykURcUU5IfFR76AamJlyUcTc/vOqfFotQ+Jz7tw5dOvWDZGRkWjTpg3efvttAEBUVBSaNWuGVKlS4euvv/bqs1uqgXkpF0XEFeWExEe9g2pgZspFEfP6nyemHAPgzJkzGDNmDJYtW4avvvrKCJGxY8di69atKF68OMLCwuDn55egg5fn27lz59C7d2+cPXsWhQsXRpkyZbBp0ybcvHkT+/btg5+fn9dfeq0amItyUURcUU6IK+odVAOzUS6KyL96xpRWy5B/I0+ePJg4cSLeeustnD9/Hjt37kTBggWNhiI2NtbrGwrVwPspF0XEFeWE/BvqHVQDM1AuioijZ7piiiQePHiAJk2a4P79++jevTv+7//+D4DzDPeJEyfw6aefwmq1Yt68eUibNi2ioqKQPHlyPZhQnOiSW9XA0ykXRcQV5YQkNPUOqoGnUy6KSHye6YoprZYh/8Xjc59mPNOhGngf5aKIuKKckP9CvYNq4I2UiyISn391K1++fPkwfvx4pEyZErNmzcKSJUsA2ELk4cOHxj4FChSAj4/zj1Z4mNfjv3szfhZUA++lXBQRV5QT8r9Q76AaeDPloog4+lcTU4Dtnu/JkycjZcqUmDlzJubOnQsASJYsGaKiojBx4kS88MILyJgxY4IPVkTkeaRcFBFXlBMiIs6UiyJi9z+vyqfVMkREnCkXRcQV5YSIiDPlooj8zxNTAHD58mV88803WLZsGTJnzowXX3wR48ePN1bL0DKeImI2ykURcUU5ISLiTLkoYm7/aWLqabRahoiIM+WiiLiinBARcaZcFDGH/zwx9fhllbrMUkTMTrkoIq4oJ0REnCkXRcwrUa6YEhERERERERERceVfr8onIiIiIiIiIiKSEDQxJSIiIiIiIiIibqGJKRERERERERERcQtNTImIiIiIiIiIiFtoYkpERERERERERNxCE1MiIiIiIiIiIuIWmpgSERERERERERG30MSUiIiIiIiIiIi4hSamRERERERERETELTQxJSIiIiIiIiIibqGJKRERERERERERcYv/B4as62pWApq0AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Visualization saved to ocr_model_comparison.png\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Model</th>\n",
+       "      <th>WER</th>\n",
+       "      <th>CER</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Unsloth 16bits-merged model load-8bits</td>\n",
+       "      <td>0.005011</td>\n",
+       "      <td>0.000896</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Unsloth lora adapter model</td>\n",
+       "      <td>0.005900</td>\n",
+       "      <td>0.001000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Unsloth 4bits-merged model load-8bits</td>\n",
+       "      <td>0.149930</td>\n",
+       "      <td>0.074493</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Unsloth 4bits-merged model load-4bits</td>\n",
+       "      <td>0.149930</td>\n",
+       "      <td>0.074493</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Unsloth Base model</td>\n",
+       "      <td>0.170700</td>\n",
+       "      <td>0.089900</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Unsloth 16bits-merged model load-4bits</td>\n",
+       "      <td>3.548406</td>\n",
+       "      <td>3.687869</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                    Model       WER       CER\n",
+       "1  Unsloth 16bits-merged model load-8bits  0.005011  0.000896\n",
+       "5              Unsloth lora adapter model  0.005900  0.001000\n",
+       "3   Unsloth 4bits-merged model load-8bits  0.149930  0.074493\n",
+       "2   Unsloth 4bits-merged model load-4bits  0.149930  0.074493\n",
+       "4                      Unsloth Base model  0.170700  0.089900\n",
+       "0  Unsloth 16bits-merged model load-4bits  3.548406  3.687869"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import matplotlib\n",
+    "#print model comparison\n",
+    "print_model_comparison()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e23d37a3-3bb8-45f2-8a5a-4b41c5f12540",
+   "metadata": {},
+   "source": [
+    "<!-- # Load adapter model and measure adapter performance\n",
+    "\n",
+    "# # Load model and tokenizer\n",
+    "# model = AutoModelForVision2Seq.from_pretrained(\n",
+    "#     \"./merged_model_french_ocr_qwen7-vl\",\n",
+    "#     device_map=\"auto\",\n",
+    "#     # attn_implementation=\"flash_attention_2\", # not supported for training\n",
+    "#     torch_dtype=torch.bfloat16,\n",
+    "#     #quantization_config=bnb_config\n",
+    "# )\n",
+    "\n",
+    "model, tokenizer = FastVisionModel.from_pretrained(\"./merged_model_french_ocr_qwen7-vl\",load_in_8bit=True, load_in_4bit=False)\n",
+    "FastVisionModel.for_inference(model) -->"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
comparative tests showcasing saving and merging lora adapters.
Uses Qwen-2-7b-vl-Instruct as a base model , with the use case being OCR.
Uses wer and cer to measure model performance on OCR task.
Included are two notebooks:
- Baseline using pure transformers + trl + peft
- Unsloth notebook version