### PR TITLE
Remove `dataset_text_field` from `SFTConfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,6 @@ trainer = SFTTrainer(
     train_dataset = dataset,
     tokenizer = tokenizer,
     args = SFTConfig(
-        dataset_text_field = "text",
         max_seq_length = max_seq_length,
         per_device_train_batch_size = 2,
         gradient_accumulation_steps = 4,


### PR DESCRIPTION
Hey unsloth!

I suggest removing this line, as `"text"` is the default value.

Cheers from Upper Bound (live on stage)