### PR TITLE
[3/N] Enable intel GPU for unsloth

### DIFF
--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -20,7 +20,7 @@ from .utils import (
     MAX_FUSED_SIZE,
     triton_tanh,
     triton_cast,
-    torch_cuda_device,
+    torch_gpu_device,
 )
 from transformers.models.llama.modeling_llama import logger
 from packaging.version import Version
@@ -301,7 +301,7 @@ class Fast_CrossEntropyLoss(torch.autograd.Function):
             BLOCK_SIZE, num_warps = calculate_settings(vocab_size)
             logsumexp = torch.empty(n_rows, dtype = torch.float32, device = device)
 
-            with torch_cuda_device(device):
+            with torch_gpu_device(device):
                 _cross_entropy_forward[(n_rows,)](
                     logits, logits.stride(0),
                     losses,
@@ -319,7 +319,7 @@ class Fast_CrossEntropyLoss(torch.autograd.Function):
             # For large vocabs > 65336 like Gemma 256K
             logsumexp = torch.empty((n_rows, n_chunks,), dtype = torch.float32, device = device)
 
-            with torch_cuda_device(device):
+            with torch_gpu_device(device):
                 _chunked_cross_entropy_forward[(n_rows, n_chunks,)](
                     logits, logits.stride(0),
                     losses,
@@ -363,7 +363,7 @@ class Fast_CrossEntropyLoss(torch.autograd.Function):
         div, mod = divmod(vocab_size, BLOCK_SIZE)
         n_blocks : int = div + (mod != 0)
 
-        with torch_cuda_device(dlosses.device):
+        with torch_gpu_device(dlosses.device):
             _cross_entropy_backward[(n_rows, n_blocks,)](
                 logits,   logits.stride(0),
                 dlosses, dlosses.stride(0),

--- a/unsloth/kernels/geglu.py
+++ b/unsloth/kernels/geglu.py
@@ -18,7 +18,7 @@ import torch
 from .utils import (
     calculate_settings,
     triton_tanh,
-    torch_cuda_device,
+    torch_gpu_device,
 )
 
 
@@ -48,7 +48,7 @@ def geglu_exact_forward_kernel(gate, up):
     device = gate.device
     out = torch.empty((batch, seq_len, hd), dtype = gate.dtype, device = device)
     grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
-    with torch_cuda_device(device):
+    with torch_gpu_device(device):
         _exact_forward_kernel[grid](gate, up, out, n_elements, BLOCK_SIZE = 1024,)
     return out
 pass
@@ -105,7 +105,7 @@ def geglu_exact_backward_kernel(DW, e, g):
     batch_seq_len, hd = e.shape
     n_elements = e.numel()
     grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
-    with torch_cuda_device(e.device):
+    with torch_gpu_device(e.device):
         _exact_backward_kernel[grid](DW, e, g, n_elements, BLOCK_SIZE = 1024,)
     return DW, e, g
 pass
@@ -143,7 +143,7 @@ def geglu_approx_forward_kernel(gate, up):
     device = gate.device
     out = torch.empty((batch, seq_len, hd), dtype = gate.dtype, device = device)
     grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
-    with torch_cuda_device(device):
+    with torch_gpu_device(device):
         _approx_forward_kernel[grid](gate, up, out, n_elements, BLOCK_SIZE = 1024,)
     return out
 pass
@@ -207,7 +207,7 @@ def geglu_approx_backward_kernel(DW, e, g):
     batch_seq_len, hd = e.shape
     n_elements = e.numel()
     grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
-    with torch_cuda_device(e.device):
+    with torch_gpu_device(e.device):
         _approx_backward_kernel[grid](DW, e, g, n_elements, BLOCK_SIZE = 1024,)
     return DW, e, g
 pass

--- a/unsloth/kernels/layernorm.py
+++ b/unsloth/kernels/layernorm.py
@@ -16,7 +16,7 @@
 import triton
 import triton.language as tl
 import torch
-from .utils import calculate_settings, torch_cuda_device
+from .utils import calculate_settings, torch_gpu_device
 from unsloth_zoo.patching_utils import (
     patch_layernorm,
 )
@@ -113,7 +113,7 @@ class Fast_Layernorm(torch.autograd.Function):
         r  = torch.empty(n_rows, dtype = torch.float32, device = device)
         mu = torch.empty(n_rows, dtype = torch.float32, device = device)
 
-        with torch_cuda_device(device):
+        with torch_gpu_device(device):
             layernorm_forward[(n_rows,)](
                 Y, Y.stride(0),
                 X, X.stride(0),
@@ -140,7 +140,7 @@ class Fast_Layernorm(torch.autograd.Function):
         X, W, b, r, mu = ctx.saved_tensors
         n_rows, n_cols = dY.shape
 
-        with torch_cuda_device(dY.device):
+        with torch_gpu_device(dY.device):
             layernorm_backward[(n_rows,)](
                 dY, dY.stride(0),
                 X,  X .stride(0),

--- a/unsloth/kernels/rms_layernorm.py
+++ b/unsloth/kernels/rms_layernorm.py
@@ -15,7 +15,7 @@
 import triton
 import triton.language as tl
 import torch
-from .utils import calculate_settings, torch_cuda_device
+from .utils import calculate_settings, torch_gpu_device
 
 @triton.jit
 def _rms_layernorm_forward(
@@ -156,7 +156,7 @@ class Fast_RMS_Layernorm(torch.autograd.Function):
         r = torch.empty(n_rows, dtype = torch.float32, device = device)
 
         fx = _gemma_rms_layernorm_forward if gemma else _rms_layernorm_forward
-        with torch_cuda_device(device):
+        with torch_gpu_device(device):
             fx[(n_rows,)](
                 Y, Y.stride(0),
                 X, X.stride(0),
@@ -186,7 +186,7 @@ class Fast_RMS_Layernorm(torch.autograd.Function):
         # dW = X
         dX = torch.empty_like(dY) if ctx.GEMMA else dY
 
-        with torch_cuda_device(dY.device):
+        with torch_gpu_device(dY.device):
             _rms_layernorm_backward[(n_rows,)](
                 dY, dY.stride(0),
                 dX, dX.stride(0),

--- a/unsloth/kernels/rope_embedding.py
+++ b/unsloth/kernels/rope_embedding.py
@@ -15,7 +15,7 @@
 import triton
 import triton.language as tl
 import torch
-from .utils import calculate_settings, torch_cuda_device
+from .utils import calculate_settings, torch_gpu_device
 ROPE_GROUP_SIZE : int = 4
 
 def _rope_embedding(
@@ -100,7 +100,7 @@ class Fast_RoPE_Embedding(torch.autograd.Function):
         div, mod = divmod(n_heads, ROPE_GROUP_SIZE)
         n_groups : int = div + (mod != 0)
 
-        with torch_cuda_device(Q.device):
+        with torch_gpu_device(Q.device):
             _rope_embedding[(n_rows, n_groups, )](
                   Q,   Q.stride(0),
                 cos, cos.stride(0),
@@ -135,7 +135,7 @@ class Fast_RoPE_Embedding(torch.autograd.Function):
         cos = ctx.cos
         sin = ctx.sin
 
-        with torch_cuda_device(dY.device):
+        with torch_gpu_device(dY.device):
             _rope_embedding[(n_rows, ctx.n_groups, )](
                 dY,  dY .stride(0),
                 cos, cos.stride(0),

--- a/unsloth/kernels/swiglu.py
+++ b/unsloth/kernels/swiglu.py
@@ -15,7 +15,7 @@
 import triton
 import triton.language as tl
 import torch
-from .utils import calculate_settings, torch_cuda_device
+from .utils import calculate_settings, torch_gpu_device
 
 
 @triton.jit
@@ -43,7 +43,7 @@ def swiglu_fg_kernel(e, g):
     n_elements = e.numel()
     h = torch.empty((batch, seq_len, hd), dtype = e.dtype, device = e.device)
     grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
-    with torch_cuda_device(e.device):
+    with torch_gpu_device(e.device):
         _fg_kernel[grid](e, g, h, n_elements, BLOCK_SIZE = 1024,)
     return h
 pass
@@ -95,7 +95,7 @@ def swiglu_DWf_DW_dfg_kernel(DW, e, g):
     batch_seq_len, hd = e.shape
     n_elements = e.numel()
     grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
-    with torch_cuda_device(e.device):
+    with torch_gpu_device(e.device):
         _DWf_DW_dfg_kernel[grid](DW, e, g, n_elements, BLOCK_SIZE = 1024,)
     return DW, e, g
 pass

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -35,7 +35,7 @@ else:
     torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cuda")
 pass
 
-if DEVICE_TYPE == "xpu"
+if DEVICE_TYPE == "xpu":
     torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")
     torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "xpu")
 

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -23,20 +23,21 @@ from unsloth import DEVICE_TYPE
 import torch
 torch_Tensor = torch.Tensor
 from packaging.version import Version
-if DEVICE_TYPE == "cuda":
-    if Version(torch.__version__) < Version("2.4.0"):
-        torch_amp_custom_fwd = torch.cuda.amp.custom_fwd
-        torch_amp_custom_bwd = torch.cuda.amp.custom_bwd
-    else:
-        torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "cuda")
-        torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cuda")
-    pass
-elif DEVICE_TYPE == "xpu":
-    if Version(torch.__version__) < Version("2.6.0"):
-        raise RuntimeError("torch.xpu currently only supports torch.version >= 2.6.0")
-    else:
-        torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")
-        torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "xpu")
+
+if DEVICE_TYPE == "xpu" and Version(torch.__version__) < Version("2.6.0"):
+    raise RuntimeError("Intel xpu currently supports unsloth with torch.version >= 2.6.0")
+
+if Version(torch.__version__) < Version("2.4.0"):
+    torch_amp_custom_fwd = torch.cuda.amp.custom_fwd
+    torch_amp_custom_bwd = torch.cuda.amp.custom_bwd
+else:
+    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "cuda")
+    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cuda")
+pass
+
+if DEVICE_TYPE == "xpu"
+    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")
+    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "xpu")
 
 
 # tl.math.tanh now is libdevice.tanh

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -96,7 +96,13 @@ else:
     def torch_gpu_device(device): return nullcontext()
     pass
 
-_gpu_getCurrentRawStream = torch._C._cuda_getCurrentRawStream if DEVICE_TYPE=="cuda" else torch._C._xpu_getCurrentRawStream 
+# INTEL GPU Specific Logic
+if DEVICE_TYPE == "xpu":
+    _gpu_getCurrentRawStream = torch._C._xpu_getCurrentRawStream 
+# NVIDIA GPU Default Logic
+else:
+    _gpu_getCurrentRawStream = torch._C._cuda_getCurrentRawStream
+
 c_void_p = ctypes.c_void_p
 def _get_tensor_stream(tensor: torch_Tensor) -> c_void_p:
     return c_void_p(_gpu_getCurrentRawStream(tensor.device.index))
@@ -121,7 +127,7 @@ if DEVICE_TYPE == "xpu":
         GPU_STREAMS[k] = v
     GPU_STREAMS = tuple(GPU_STREAMS)
     del _XPU_STREAMS
-else DEVICE_TYPE == "cuda":
+else:
     # NVIDIA GPU Default Logic
     _CUDA_STREAMS = {
         (index := torch.cuda.device(i).idx) : ctypes.c_void_p(torch._C._cuda_getCurrentRawStream(index))

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -73,6 +73,7 @@ def calculate_settings(n : int) -> (int, int,):
     return BLOCK_SIZE, num_warps
 pass
 
+HAS_CUDA_STREAM = False
 # INTEL GPU specific logic
 if DEVICE_TYPE == "xpu":
     # TODO: Changed here after adding XPU BNB support

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -111,7 +111,8 @@ pass
 
 
 # Get array of CUDA streams and other buffers
-global GPU_STREAMS
+global CUDA_STREAMS
+global XPU_STREAMS
 global WEIGHT_BUFFERS
 global ABSMAX_BUFFERS
 
@@ -121,12 +122,12 @@ if DEVICE_TYPE == "xpu":
         (index := torch.xpu.device(i).idx) : ctypes.c_void_p(torch._C._xpu_getCurrentRawStream(index))
         for i in range(torch.xpu.device_count())
     }
-    GPU_STREAMS   = [None] * (max(_XPU_STREAMS.keys()) + 1)
+    XPU_STREAMS   = [None] * (max(_XPU_STREAMS.keys()) + 1)
     WEIGHT_BUFFERS = [None] * (max(_XPU_STREAMS.keys()) + 1)
     ABSMAX_BUFFERS = [None] * (max(_XPU_STREAMS.keys()) + 1)
     for k, v in _XPU_STREAMS.items(): 
-        GPU_STREAMS[k] = v
-    GPU_STREAMS = tuple(GPU_STREAMS)
+        XPU_STREAMS[k] = v
+    XPU_STREAMS = tuple(XPU_STREAMS)
     del _XPU_STREAMS
 else:
     # NVIDIA GPU Default Logic
@@ -134,11 +135,11 @@ else:
         (index := torch.cuda.device(i).idx) : ctypes.c_void_p(torch._C._cuda_getCurrentRawStream(index))
         for i in range(torch.cuda.device_count())
     }
-    GPU_STREAMS   = [None] * (max(_CUDA_STREAMS.keys()) + 1)
+    CUDA_STREAMS   = [None] * (max(_CUDA_STREAMS.keys()) + 1)
     WEIGHT_BUFFERS = [None] * (max(_CUDA_STREAMS.keys()) + 1)
     ABSMAX_BUFFERS = [None] * (max(_CUDA_STREAMS.keys()) + 1)
-    for k, v in _CUDA_STREAMS.items(): GPU_STREAMS[k] = v
-    GPU_STREAMS = tuple(CUDA_STREAMS)
+    for k, v in _CUDA_STREAMS.items(): CUDA_STREAMS[k] = v
+    CUDA_STREAMS = tuple(CUDA_STREAMS)
     del _CUDA_STREAMS
 
 

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -33,8 +33,7 @@ if DEVICE_TYPE == "cuda":
     pass
 elif DEVICE_TYPE == "xpu":
     if Version(torch.__version__) < Version("2.4.0"):
-        torch_amp_custom_fwd = torch.xpu.amp.custom_fwd
-        torch_amp_custom_bwd = torch.xpu.amp.custom_bwd
+        raise RuntimeError("torch.xpu currently only supports torch.version >= 2.6.0")
     else:
         torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")
         torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "xpu")

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -32,7 +32,7 @@ if DEVICE_TYPE == "cuda":
         torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cuda")
     pass
 elif DEVICE_TYPE == "xpu":
-    if Version(torch.__version__) < Version("2.4.0"):
+    if Version(torch.__version__) < Version("2.6.0"):
         raise RuntimeError("torch.xpu currently only supports torch.version >= 2.6.0")
     else:
         torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -17,6 +17,7 @@ import ctypes
 MAX_FUSED_SIZE : int = 65536
 next_power_of_2 = triton.next_power_of_2
 import functools
+from typing import Optional
 from unsloth import DEVICE_TYPE
 
 # torch.cuda.amp.custom_fwd is deprecated >= 2.4


### PR DESCRIPTION
Hi unsloth, we are going to support unsloth intel GPU with several prs and this is the third pr.

- [x] add intel dependent packages for PyTorch 2.6 in pyproject.toml
- [x] generalize device types and refactor device-bias code in init.py
- [x] refactor device-bias code in kernels
- [ ] refactor device-bias code for models


For the first step we are aiming to support several models with LoRA, and increase our feature in the future (including BNB, FlashAttention, xformers).

For this PR, we add torch_gpu_device and resolve device specific API for cuda and Intel GPU(XPU).
For cuda specific path, we didn't change the logics, only add check and tab to pass python grammar.

