### PR TITLE
Fix SFTtraining for new trl

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -107,7 +107,8 @@ import torch
 import numpy as np
 from contextlib import nullcontext
 from torch.nn import functional as F
-from transformers import DataCollatorForSeq2Seq, DataCollatorForLanguageModeling
+from transformers import DataCollatorForSeq2Seq
+from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
 
 torch_compile_options = {{
     "epilogue_fusion"   : True,

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -107,8 +107,7 @@ import torch
 import numpy as np
 from contextlib import nullcontext
 from torch.nn import functional as F
-from transformers import DataCollatorForSeq2Seq
-from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
+from transformers import DataCollatorForSeq2Seq, DataCollatorForLanguageModeling as TransformersDataCollatorForLanguageModeling
 
 torch_compile_options = {{
     "epilogue_fusion"   : True,
@@ -359,8 +358,8 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         "from unsloth_zoo.vision_utils import UnslothVisionDataCollator\n"\
         "if not isinstance(data_collator, UnslothVisionDataCollator):\n"\
         "    if isinstance(data_collator, DataCollatorForSeq2Seq) and 'labels' not in train_dataset.column_names:\n"\
-        "        data_collator = DataCollatorForLanguageModeling(__tokenizer, mlm = False)\n"\
-        "    elif isinstance(data_collator, DataCollatorForLanguageModeling) and 'labels' in train_dataset.column_names:\n"\
+        "        data_collator = TransformersDataCollatorForLanguageModeling(__tokenizer, mlm = False)\n"\
+        "    elif isinstance(data_collator, TransformersDataCollatorForLanguageModeling) and 'labels' in train_dataset.column_names:\n"\
         "        data_collator = DataCollatorForSeq2Seq(__tokenizer)\n"\
         "else:\n"\
         "    if hasattr(args, 'remove_unused_columns'): args.remove_unused_columns = False\n"\
@@ -375,7 +374,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         "        if isinstance(data_collator, DataCollatorForSeq2Seq):\n"\
         "            data_collator = DataCollatorForSeq2Seq(__tokenizer.tokenizer)\n"\
         "        else:\n"\
-        "            data_collator = DataCollatorForLanguageModeling(__tokenizer.tokenizer, mlm = False)\n"
+        "            data_collator = TransformersDataCollatorForLanguageModeling(__tokenizer.tokenizer, mlm = False)\n"
         extra_args += pad_check
     pass
 


### PR DESCRIPTION
Latest TRL redefines DataCollatorForLanguageModeling and uses that internally. We actually import it, but that override the name since we later import the same name from transformers. 

https://github.com/huggingface/trl/blob/v0.18.0/trl/trainer/sft_trainer.py#L75
vs 
https://github.com/huggingface/transformers/blob/v4.52.3/src/transformers/data/data_collator.py#L764

Since the signature changes unsloth sfttrainer fails becuase we initialize the transformers version with arguments expected for the sft_trainer version. My fix imports the transformers version as a different name so they don't clobber each other.

I've successfully verified that the fix works for SFT and DPO. 

Failed original runs:
llama: https://colab.research.google.com/drive/1UGMaG2NQMho1z9i7ZDC9J_HYMW0S3L9k?usp=sharing
qwen: https://colab.research.google.com/drive/1w83mQOzSL6T8sbBA2GjJO8n1ycA6kzoj?usp=sharing

fixed:
qwen: https://colab.research.google.com/drive/1MmZJFz6VSHKnyPknUxDa-TDjKI1hd-1U?usp=sharing
dpo: https://colab.research.google.com/drive/1psXyPg9RFJIPUPjoeHQrUDdJA5aTT1XX?usp=sharing

**Please note**: With new trl 0.18.0 non completion tokens are masked by default if prompt is a valid key in the dataset