### PR TITLE
Add falcon h1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ triton = [
 ]
 
 huggingface = [
-    "unsloth_zoo>=2025.6.5",
+    "unsloth_zoo>=2025.6.6",
     "packaging",
     "tyro",
     "transformers>=4.51.3,!=4.47.0,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3",
@@ -381,7 +381,7 @@ colab-ampere-torch220 = [
     "flash-attn>=2.6.3",
 ]
 colab-new = [
-    "unsloth_zoo>=2025.6.5",
+    "unsloth_zoo>=2025.6.6",
     "packaging",
     "tyro",
     "transformers>=4.51.3,!=4.47.0,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3",

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2025.6.6"
+__version__ = "2025.6.8"
 
 __all__ = [
     "SUPPORTS_BFLOAT16",
@@ -153,6 +153,8 @@ from transformers.training_args import logger as transformers_training_args_logg
 transformers_training_args_logger.addFilter(HideLoggingMessage("The speedups"))
 # torch.distributed process group is initialized, but parallel_mode != ParallelMode.DISTRIBUTED.
 transformers_training_args_logger.addFilter(HideLoggingMessage("torch.distributed"))
+# average_tokens_across_devices is set to True but it is invalid when world size is1
+transformers_training_args_logger.addFilter(HideLoggingMessage("average_tokens_across_devices"))
 del transformers_training_args_logger
 
 # No label_names provided for model class

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -49,15 +49,17 @@ import importlib.util
 # https://github.com/huggingface/transformers/pull/26037 allows 4 bit loading!
 from unsloth_zoo.utils import Version, _get_dtype
 transformers_version = Version(transformers_version)
-SUPPORTS_FOURBIT = transformers_version >= Version("4.37")
-SUPPORTS_GEMMA   = transformers_version >= Version("4.38")
-SUPPORTS_GEMMA2  = transformers_version >= Version("4.42")
-SUPPORTS_LLAMA31 = transformers_version >= Version("4.43.2")
-SUPPORTS_LLAMA32 = transformers_version  > Version("4.45.0")
-SUPPORTS_GRANITE = transformers_version >= Version("4.46.0")
-SUPPORTS_QWEN3   = transformers_version >= Version("4.50.3")
+SUPPORTS_FOURBIT   = transformers_version >= Version("4.37")
+SUPPORTS_GEMMA     = transformers_version >= Version("4.38")
+SUPPORTS_GEMMA2    = transformers_version >= Version("4.42")
+SUPPORTS_LLAMA31   = transformers_version >= Version("4.43.2")
+SUPPORTS_LLAMA32   = transformers_version  > Version("4.45.0")
+SUPPORTS_GRANITE   = transformers_version >= Version("4.46.0")
+SUPPORTS_QWEN3     = transformers_version >= Version("4.50.3")
 SUPPORTS_QWEN3_MOE = transformers_version >= Version("4.50.3")
-SUPPORTS_FALCON_H1 = transformers_version >= Version("4.50.3")
+SUPPORTS_FALCON_H1 = transformers_version >= Version("4.53.0")
+SUPPORTS_GEMMA3N   = transformers_version >= Version("4.53.0")
+
 if SUPPORTS_GEMMA:
     from .gemma  import FastGemmaModel
 if SUPPORTS_GEMMA2:
@@ -556,6 +558,10 @@ class FastModel(FastBaseModel):
             os.environ["UNSLOTH_FORCE_CUSTOM_DTYPE"] = "torch.float16;if name.endswith(('_proj', 'fc1', 'fc2', 'codebook', 'head')): module.to(torch.float16)"
         elif "olmo-2" in lowered_model_name and transformers_version < Version("4.50.0.dev0"):
             raise RuntimeError("Unsloth: OLMo-2 only works on transformers >= 4.50.0." + NIGHTLY)
+        elif "gemma-3n" in lowered_model_name:
+            os.environ["UNSLOTH_DISABLE_STATIC_GENERATION"] = "1"
+            if transformers_version < Version("4.53.0"):
+                raise RuntimeError("Unsloth: Gemma 3N only works on transformers >= 4.53.0" + LATEST)
         else:
             for check_model_name in DISABLE_COMPILE_MODEL_NAMES:
                 if check_model_name in lowered_model_name:
@@ -739,6 +745,10 @@ class FastModel(FastBaseModel):
                 trust_remote_code       = trust_remote_code,
                 unsloth_force_compile   = unsloth_force_compile,
             )
+        pass
+        # Fix SDPA
+        if "gemma-3n" in lowered_model_name:
+            supports_sdpa = False
         pass
 
         # Check if this is local model since the tokenizer gets overwritten

--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -879,6 +879,26 @@ __INT_TO_FLOAT_MAPPER = \
         "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
         "unsloth/Mistral-Small-3.2-24B-Instruct-2506-bnb-4bit",
     ),
+    "unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit" : (
+        "unsloth/gemma-3n-E4B-it",
+        "google/gemma-3n-E4B-it",
+        "unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit",
+    ),
+    "unsloth/gemma-3n-E2B-it-unsloth-bnb-4bit" : (
+        "unsloth/gemma-3n-E2B-it",
+        "google/gemma-3n-E2B-it",
+        "unsloth/gemma-3n-E2B-it-unsloth-bnb-4bit",
+    ),
+    "unsloth/gemma-3n-E4B-unsloth-bnb-4bit" : (
+        "unsloth/gemma-3n-E4B",
+        "google/gemma-3n-E4B",
+        "unsloth/gemma-3n-E4B-unsloth-bnb-4bit",
+    ),
+    "unsloth/gemma-3n-E2B-unsloth-bnb-4bit" : (
+        "unsloth/gemma-3n-E2B",
+        "google/gemma-3n-E2B",
+        "unsloth/gemma-3n-E2B-unsloth-bnb-4bit",
+    ),
 }
 
 INT_TO_FLOAT_MAPPER  = {}

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -722,6 +722,8 @@ class FastBaseModel:
         pass
         # Must disable returning hidden states in the case for GRPO
         os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "0"
+        # Must enable returning logits
+        os.environ["UNSLOTH_RETURN_LOGITS"] = "1"
         return model
     pass
 
@@ -760,6 +762,8 @@ class FastBaseModel:
             embeddings = model.get_output_embeddings()
             if hasattr(embeddings, "training"): embeddings.training = True
         pass
+        # Can re-enable not returning logits
+        os.environ["UNSLOTH_RETURN_LOGITS"] = "0"
         return model
     pass
 pass


### PR DESCRIPTION
This **PR** introduces support for the **FalconH1** model family within the **Unsloth** library.

It addresses the following [issue](https://github.com/unslothai/unsloth/issues/2622).

Training integration has been validated using the following command:
```
python unsloth-cli.py --model_name "tiiuae/Falcon-H1-0.5B-Base" \
  --max_seq_length 2048 --dtype bfloat16 --load_in_4bit \
  --r 64 --lora_alpha 32 --lora_dropout 0.1 --bias "none" \
  --per_device_train_batch_size 1
```

**Note**: Inference support is currently under active development and is being debugged. 
@danielhanchen , do you think we can first have FalconH1 training supported for the community in unsloth and then raise a separate PR to fix inference?