### PR TITLE
Ignore None Values when building vllm subprocess_command

### DIFF
--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -97,6 +97,9 @@ class SyntheticDataKit:
             elif which == "False":
                 # Ignore flag
                 pass
+            elif which == "None":
+                # Ignore flag
+                pass
             else:
                 subprocess_commands += ["--" + flag, which,]
         pass


### PR DESCRIPTION
Ignores `None` params when building the `subprocess_command` for vllm. 

Passing none values seems to stop vllm from deploying properly, and result in `RuntimeError: Unsloth: vllm_process failed to load! ` error message as --quantize will be passed with none if quantization type isn't specified in the model name, when vllm expects a technique with the --quantize.

This makes it so that vllm will deploy even when the quantization isn't specified in the model name, resolving #2676 