### PR TITLE
Do not override vllm_mode with colocate

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -666,12 +666,7 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
             "if hasattr(model, 'vllm_engine') and hasattr(args, 'use_vllm'):\n" + \
             " " * 12 + "if (getattr(args, 'use_vllm', False) == False):\n" + \
             " " * 16 + "args.use_vllm = True\n"
-
-            if "grpo" in trainer_file and trl_version >= "0.18":
-                # If model has vllm_engine, then use vllm in colocate mode. Donot wait for server
-                vllm_setter += \
-                " " * 12 + "args.vllm_mode='colocate'\n"
-
+            
             init = init.replace(replacer, replacer + vllm_setter)
         pass
     pass


### PR DESCRIPTION
This PR removes logic in rl.py that overrides vllm_mode to colocate for GRPO job. User should be able to run it in "server" mode if he/she wants to. I have tested it with server mode with my change and it works.