### PR TITLE
Fix for grpo_compute_loss_slow

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -223,7 +223,6 @@ def grpo_trainer__get_per_token_logps(function_name, function):
             # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
             hidden_states = model(input_ids=input_ids, attention_mask=attention_mask, logits_to_keep=logits_to_keep + 1).logits
             #logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
-            hidden_states = hidden_states[:, :-1, :]
             return hidden_states
             # input_ids = input_ids[:, -logits_to_keep:]
             # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves.
@@ -298,6 +297,8 @@ def grpo_trainer_compute_loss(function_name, function):
             old_hidden_states = None
         input_ids = input_ids[:, -logits_to_keep:]
         if per_token_logps is not None:
+            ref_per_token_logps = ref_per_token_logps[:, :-1, :]
+            per_token_logps = per_token_logps[:, :-1, :]
             loss, completion_length, mean_kl = grpo_compute_loss_slow(
                 ref_per_token_logps, per_token_logps, old_hidden_states, input_ids, completion_mask, self.beta, advantages, 
                 loss_type = self.args.loss_type,

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -223,6 +223,7 @@ def grpo_trainer__get_per_token_logps(function_name, function):
             # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
             hidden_states = model(input_ids=input_ids, attention_mask=attention_mask, logits_to_keep=logits_to_keep + 1).logits
             #logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
+            hidden_states = hidden_states[:, :-1, :]
             return hidden_states
             # input_ids = input_ids[:, -logits_to_keep:]
             # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves.


### PR DESCRIPTION
Not sure how much this matters since the default is UNSLOTH_USE_NEW_MODEL=0, but when UNSLOTH_USE_NEW_MODEL=1, this error happens in `grpo_compute_loss_slow()`:

`TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <built-in function sub>(*(FakeTensor(..., device='cuda:0', size=(s1, s5)), FakeTensor(..., device='cuda:0', size=(s1, s2))), **{}): got RuntimeError('The size of tensor a (s5) must match the size of tensor b (s2) at non-singleton dimension 1)')`

`from user code:
   File "/home/simpissa/unsloth/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 323, in grpo_compute_loss_slow
    ref = ref_x - torch.logsumexp(ref_logits, dim = -1)`

since the last logits aren't being sliced off by `_get_per_token_logps()` before being handed to `grpo_compute_loss_slow()`