### PR TITLE
[Feature] VLMs support for GRPO

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -479,7 +479,7 @@ def grpo_trainer_compute_loss(function_name, function):
 
         get_logps_func = \
             lambda model, input_ids, attention_mask, logits_to_keep, batch_size=None, compute_entropy=False: \
-            self._get_per_token_logps(model, input_ids, attention_mask, logits_to_keep) \
+            self._get_per_token_logps(model, input_ids, attention_mask, pixel_values, image_grid_thw, logits_to_keep) \
             if hasattr(self, "_get_per_token_logps") else \
             self._get_per_token_logps_and_entropies(model, input_ids, attention_mask, logits_to_keep, batch_size, compute_entropy)['logps']
 


### PR DESCRIPTION
This PR aims to add support for VLMs in GRPO, which is currently not supported by HF.

I've implemented a working version that does not yet include VLLM or video input support (mainly due to limited resources for testing video inputs haha).
I added a new variable, use_vision, to the GRPO config. Setting use_vision = True enables vision inputs, while use_vision = False keeps the default GRPO behavior. Default is False.
I also had to change a function in unsloth_zoo.peft_utils (requires_grad_post_hook) to make it work.
I've tested the implementation with Qwen 2.5 VL 7B for 250 steps, and training appears to proceed correctly (see TensorBoard screenshots for reference).


<img src="https://github.com/user-attachments/assets/e6ed1a6a-82a6-46c8-ae6d-52b0091df280" width="400"/>
<img src="https://github.com/user-attachments/assets/284c5a8f-020c-4dbe-a19f-46ea4f5983b9" width="400"/>
<img src="https://github.com/user-attachments/assets/b4e6b441-a486-463b-bab1-dacbe77bc43b" width="400"/>
<img src="https://github.com/user-attachments/assets/e2e4814f-15dc-4290-a18d-14a25e6d75c5" width="400"/>





