### PR TITLE
Fix beam search for Llama models by adding reorder_cache method

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1683,6 +1683,24 @@ class FastLlamaModel:
         LlamaForCausalLM    .forward = CausalLM_fast_forward(LlamaModel_fast_forward_inference)
         PeftModelForCausalLM.forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(LlamaForCausalLM)
+        
+        # Fix beam search by ensuring reorder_cache method exists
+        if not hasattr(LlamaForCausalLM, 'reorder_cache'):
+            @staticmethod
+            def reorder_cache(past_key_values, beam_idx):
+                """
+                This function is used to re-order the `past_key_values` cache if
+                [`~PreTrainedModel.beam_search`] or [`~PreTrainedModel.beam_sample`] is called.
+                This is required to match `past_key_values` with the correct beam_idx at every generation step.
+                """
+                reordered_past = ()
+                for layer_past in past_key_values:
+                    reordered_past += (
+                        tuple(past_state.index_select(0, beam_idx.to(past_state.device)) for past_state in layer_past),
+                    )
+                return reordered_past
+            
+            LlamaForCausalLM.reorder_cache = reorder_cache
 
         # Solves https://github.com/unslothai/unsloth/issues/168
         # Static KV Cache was introduced in 4.38.0, causing training to be much slower.


### PR DESCRIPTION
When using beam search with Unsloth-optimized Llama models, users encounter: NotImplementedError: Make sure that a `reorder_cache` function is correctly implemented in transformers.models.llama.modeling_llama

This occurs because Unsloth patches LlamaForCausalLM but doesn't preserve the reorder_cache static method required for beam search operations.

The fix adds the missing reorder_cache method after Unsloth's patching, ensuring compatibility with transformers' beam search functionality. This allows users to use generation methods like model.generate(num_beams=N) without errors.