### PR TITLE
Fix renaming on other model than Llama

### DIFF
--- a/unsloth/models/cohere.py
+++ b/unsloth/models/cohere.py
@@ -466,7 +466,7 @@ class FastCohereModel(FastLlamaModel):
         CohereDecoderLayer   .forward = CohereDecoderLayer_fast_forward
         CohereModel          .forward = LlamaModel_fast_forward
         CohereForCausalLM    .forward = CausalLM_fast_forward(CohereModel_fast_forward_inference)
-        PeftModelForCausalLM .forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM .forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(CohereForCausalLM)
         
         import transformers.models.cohere.modeling_cohere

--- a/unsloth/models/gemma.py
+++ b/unsloth/models/gemma.py
@@ -332,7 +332,7 @@ class FastGemmaModel(FastLlamaModel):
         GemmaDecoderLayer   .forward = GemmaDecoderLayer_fast_forward
         GemmaModel          .forward = LlamaModel_fast_forward
         GemmaForCausalLM    .forward = CausalLM_fast_forward(GemmaModel_fast_forward_inference)
-        PeftModelForCausalLM.forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM.forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(GemmaForCausalLM)
 
         # Solves https://github.com/unslothai/unsloth/issues/168

--- a/unsloth/models/gemma2.py
+++ b/unsloth/models/gemma2.py
@@ -477,7 +477,7 @@ class FastGemma2Model(FastLlamaModel):
         Gemma2DecoderLayer   .forward = Gemma2DecoderLayer_fast_forward
         Gemma2Model          .forward = LlamaModel_fast_forward
         Gemma2ForCausalLM    .forward = CausalLM_fast_forward(Gemma2Model_fast_forward_inference)
-        PeftModelForCausalLM .forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM .forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(Gemma2ForCausalLM)
         
         # Solves https://github.com/unslothai/unsloth/issues/168

--- a/unsloth/models/granite.py
+++ b/unsloth/models/granite.py
@@ -468,7 +468,7 @@ class FastGraniteModel(FastLlamaModel):
         GraniteModel          .forward  = LlamaModel_fast_forward
         GraniteForCausalLM    .forward  = CausalLM_fast_forward(GraniteModel_fast_forward_inference)
         GraniteForCausalLM    .__init__ = patched_init(GraniteForCausalLM.__init__)
-        PeftModelForCausalLM .forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM .forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(GraniteForCausalLM)
 
         import transformers.models.granite.modeling_granite

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -368,7 +368,7 @@ class FastMistralModel(FastLlamaModel):
         MistralDecoderLayer   .forward = LlamaDecoderLayer_fast_forward
         MistralModel          .forward = LlamaModel_fast_forward
         MistralForCausalLM    .forward = MistralForCausalLM_fast_forward
-        PeftModelForCausalLM  .forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM  .forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(MistralForCausalLM)
         
         # Solves https://github.com/unslothai/unsloth/issues/168

--- a/unsloth/models/qwen2.py
+++ b/unsloth/models/qwen2.py
@@ -55,7 +55,7 @@ class FastQwen2Model(FastLlamaModel):
         Qwen2DecoderLayer   .forward = LlamaDecoderLayer_fast_forward
         Qwen2Model          .forward = LlamaModel_fast_forward
         Qwen2ForCausalLM    .forward = CausalLM_fast_forward(LlamaModel_fast_forward_inference)
-        PeftModelForCausalLM.forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM.forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(Qwen2ForCausalLM)
 
         # Solves https://github.com/unslothai/unsloth/issues/168

--- a/unsloth/models/qwen3.py
+++ b/unsloth/models/qwen3.py
@@ -387,7 +387,7 @@ class FastQwen3Model(FastLlamaModel):
         Qwen3DecoderLayer   .forward = LlamaDecoderLayer_fast_forward
         Qwen3Model          .forward = LlamaModel_fast_forward
         Qwen3ForCausalLM    .forward = CausalLM_fast_forward(_LlamaModel_fast_forward_inference(Qwen3Attention_fast_forward_inference))
-        PeftModelForCausalLM.forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM.forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(Qwen3ForCausalLM)
 
         # Solves https://github.com/unslothai/unsloth/issues/168

--- a/unsloth/models/qwen3_moe.py
+++ b/unsloth/models/qwen3_moe.py
@@ -177,7 +177,7 @@ class FastQwen3MoeModel(FastQwen3Model):
         Qwen3MoeDecoderLayer   .forward = Qwen3MoeDecoderLayer_fast_forward
         Qwen3MoeModel          .forward = LlamaModel_fast_forward
         Qwen3MoeForCausalLM    .forward = CausalLM_fast_forward(LlamaModel_fast_forward_inference)
-        PeftModelForCausalLM.forward = PeftModelForCausalLM_fast_forward
+        PeftModelForCausalLM.forward = PeftModel_fast_forward
         fix_prepare_inputs_for_generation(Qwen3MoeForCausalLM)
 
         # Solves https://github.com/unslothai/unsloth/issues/168


### PR DESCRIPTION
In this [commit](https://github.com/unslothai/unsloth/commit/ca839d8bc8cef4b443e5b878b29e5be5d74d20e0#diff-a45b72bb533eda979990bd79cde5fe9c9fde424779a4f1fc1195b75853d93b45R1245), we change the name from `PeftModelForCausalLM_fast_forward` to `PeftModel_fast_forward`

but we forgot to rename other model than Llama. 


Mentioned in this https://github.com/unslothai/unsloth/issues/2759 

Tested on Mistral model