### PR TITLE
Avoid materializing the entire logit matrix for logp calculations.

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -171,38 +171,38 @@ RL_FUNCTIONS["sft_trainer"].append(sft_trainer_compute_loss)
 def grpo_trainer__prepare_inputs(function_name, function):
     if  function_name != "_prepare_inputs": return function
 
-    # import re
-    # # Try to find the function signature and insert after it
-    # # This matches the function signature and any decorators/comments, then finds the first non-empty line after the signature
-    # pattern = r"(def _prepare_inputs\s*\([^\)]*\)\s*(->\s*[^:]+)?\s*:\s*\n)"
-    # match = re.search(pattern, function)
-    # if match:
-    #     sig_end = match.end(1)
-    #     rest = function[sig_end:]
-    #     rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
-    #     rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
-    #     rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
-    #     rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
-    #     insert = (
-    #         "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
-    #         "            self.llm.wake_up()\n"
-    #     )
-    #     function = function[:sig_end] + insert +  rest
-    # else:
-    #     pattern2 = r"(def _prepare_inputs\(.*?\):\n(?:[ ]+#[^\n]*\n)+)"
-    #     match2 = re.search(pattern2, function, flags=re.DOTALL)
-    #     if match2:
-    #         header_and_comments = match2.group(1)
-    #         rest = function[len(header_and_comments):]
-    #         rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
-    #         rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
-    #         rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
-    #         rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
-    #         insert = (
-    #             "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
-    #             "            self.llm.wake_up()\n"
-    #         )
-    #         function = header_and_comments + insert + rest
+    import re
+    # Try to find the function signature and insert after it
+    # This matches the function signature and any decorators/comments, then finds the first non-empty line after the signature
+    pattern = r"(def _prepare_inputs\s*\([^\)]*\)\s*(->\s*[^:]+)?\s*:\s*\n)"
+    match = re.search(pattern, function)
+    if match:
+        sig_end = match.end(1)
+        rest = function[sig_end:]
+        rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
+        rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
+        rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
+        rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
+        insert = (
+            "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
+            "            self.llm.wake_up()\n"
+        )
+        function = function[:sig_end] + insert +  rest
+    else:
+        pattern2 = r"(def _prepare_inputs\(.*?\):\n(?:[ ]+#[^\n]*\n)+)"
+        match2 = re.search(pattern2, function, flags=re.DOTALL)
+        if match2:
+            header_and_comments = match2.group(1)
+            rest = function[len(header_and_comments):]
+            rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
+            rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
+            rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
+            rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
+            insert = (
+                "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
+                "            self.llm.wake_up()\n"
+            )
+            function = header_and_comments + insert + rest
 
     # Add mixed precision training
     function = function.replace(
@@ -217,15 +217,15 @@ def grpo_trainer__prepare_inputs(function_name, function):
         "self.accelerator.unwrap_model(self.model)",
         "self.accelerator.unwrap_model(self.model, keep_fp32_wrapper = False)",
     )
-    # sleep_and_cache = (
-    #     "if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
-    #     "            self.llm.sleep(os.environ.get('VLLM_SLEEP_MODE', 1))\n"
-    #     "        "
-    # )
-    # if re.search(r"\n\s*return ", function):
-    #     function = re.sub(r"(\n\s*)return ", f"\\1{sleep_and_cache}return ", function, count=1)
-    # else:
-    #     function = function.rstrip() + "\n    " + sleep_and_cache
+    sleep_and_cache = (
+        "if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
+        "            self.llm.sleep(os.environ.get('VLLM_SLEEP_MODE', 1))\n"
+        "        "
+    )
+    if re.search(r"\n\s*return ", function):
+        function = re.sub(r"(\n\s*)return ", f"\\1{sleep_and_cache}return ", function, count=1)
+    else:
+        function = function.rstrip() + "\n    " + sleep_and_cache
     return function
 pass
 RL_FUNCTIONS["grpo_trainer"].append(grpo_trainer__prepare_inputs)

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -326,7 +326,7 @@ def grpo_trainer_compute_loss(function_name, function):
         
         if os.environ.get('UNSLOTH_USE_NEW_MODEL', '0') == '1':
             loss, completion_length, mean_kl = grpo_compute_loss_slow(
-                ref_per_token_logps, per_token_logps, old_per_token_logps, input_ids, completion_mask, self.beta, advantages, 
+                ref_per_token_logps, per_token_logps, old_per_token_logps, completion_mask, self.beta, advantages, 
                 loss_type = self.args.loss_type,
                 epsilon_low = self.epsilon_low, epsilon_high = self.epsilon_high,
                 max_completion_length = self.args.max_completion_length,
@@ -335,7 +335,7 @@ def grpo_trainer_compute_loss(function_name, function):
         else:
             if hasattr(self.args, "loss_type"):
                 loss, completion_length, mean_kl = grpo_accumulated_loss(
-                    self, _input_ids, logits_to_keep, completion_mask, advantages, old_per_token_logps,
+                    self, completion_mask, advantages, ref_per_token_logps, per_token_logps, old_per_token_logps,
                     n_chunks = self.args.unsloth_num_chunks,
                     loss_type = self.args.loss_type,
                     epsilon_low = self.epsilon_low, epsilon_high = self.epsilon_high,
@@ -345,7 +345,7 @@ def grpo_trainer_compute_loss(function_name, function):
             else:
                 # to ensure backwards compatibility with trl 0.15.2 and maybe even 0.17
                 loss, completion_length, mean_kl = grpo_accumulated_loss(
-                    self, _input_ids, logits_to_keep, completion_mask, advantages, old_per_token_logps,
+                    self, completion_mask, advantages, ref_per_token_logps, per_token_logps, old_per_token_logps,
                     n_chunks = self.args.unsloth_num_chunks,
                 )    
 

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -171,38 +171,38 @@ RL_FUNCTIONS["sft_trainer"].append(sft_trainer_compute_loss)
 def grpo_trainer__prepare_inputs(function_name, function):
     if  function_name != "_prepare_inputs": return function
 
-    import re
-    # Try to find the function signature and insert after it
-    # This matches the function signature and any decorators/comments, then finds the first non-empty line after the signature
-    pattern = r"(def _prepare_inputs\s*\([^\)]*\)\s*(->\s*[^:]+)?\s*:\s*\n)"
-    match = re.search(pattern, function)
-    if match:
-        sig_end = match.end(1)
-        rest = function[sig_end:]
-        rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
-        rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
-        rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
-        rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
-        insert = (
-            "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
-            "            self.llm.wake_up()\n"
-        )
-        function = function[:sig_end] + insert +  rest
-    else:
-        pattern2 = r"(def _prepare_inputs\(.*?\):\n(?:[ ]+#[^\n]*\n)+)"
-        match2 = re.search(pattern2, function, flags=re.DOTALL)
-        if match2:
-            header_and_comments = match2.group(1)
-            rest = function[len(header_and_comments):]
-            rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
-            rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
-            rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
-            rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
-            insert = (
-                "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
-                "            self.llm.wake_up()\n"
-            )
-            function = header_and_comments + insert + rest
+    # import re
+    # # Try to find the function signature and insert after it
+    # # This matches the function signature and any decorators/comments, then finds the first non-empty line after the signature
+    # pattern = r"(def _prepare_inputs\s*\([^\)]*\)\s*(->\s*[^:]+)?\s*:\s*\n)"
+    # match = re.search(pattern, function)
+    # if match:
+    #     sig_end = match.end(1)
+    #     rest = function[sig_end:]
+    #     rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
+    #     rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
+    #     rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
+    #     rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
+    #     insert = (
+    #         "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
+    #         "            self.llm.wake_up()\n"
+    #     )
+    #     function = function[:sig_end] + insert +  rest
+    # else:
+    #     pattern2 = r"(def _prepare_inputs\(.*?\):\n(?:[ ]+#[^\n]*\n)+)"
+    #     match2 = re.search(pattern2, function, flags=re.DOTALL)
+    #     if match2:
+    #         header_and_comments = match2.group(1)
+    #         rest = function[len(header_and_comments):]
+    #         rest = re.sub(r"^[ \t]*self\.llm\.wake_up\(\)\s*\n", "", rest)
+    #         rest = re.sub(r"^[ \t]*torch\.cuda\.empty_cache\(\)\s*\n", "", rest)
+    #         rest = re.sub(r"^[ \t]*free, total = torch.cuda.mem_get_info\(\)\s*\n", "", rest)
+    #         rest = re.sub(r"^[ \t]*print\(f?\".*cuda.*\"\)\s*\n", "", rest)
+    #         insert = (
+    #             "        if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
+    #             "            self.llm.wake_up()\n"
+    #         )
+    #         function = header_and_comments + insert + rest
 
     # Add mixed precision training
     function = function.replace(
@@ -217,15 +217,15 @@ def grpo_trainer__prepare_inputs(function_name, function):
         "self.accelerator.unwrap_model(self.model)",
         "self.accelerator.unwrap_model(self.model, keep_fp32_wrapper = False)",
     )
-    sleep_and_cache = (
-        "if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
-        "            self.llm.sleep(os.environ.get('VLLM_SLEEP_MODE', 1))\n"
-        "        "
-    )
-    if re.search(r"\n\s*return ", function):
-        function = re.sub(r"(\n\s*)return ", f"\\1{sleep_and_cache}return ", function, count=1)
-    else:
-        function = function.rstrip() + "\n    " + sleep_and_cache
+    # sleep_and_cache = (
+    #     "if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
+    #     "            self.llm.sleep(os.environ.get('VLLM_SLEEP_MODE', 1))\n"
+    #     "        "
+    # )
+    # if re.search(r"\n\s*return ", function):
+    #     function = re.sub(r"(\n\s*)return ", f"\\1{sleep_and_cache}return ", function, count=1)
+    # else:
+    #     function = function.rstrip() + "\n    " + sleep_and_cache
     return function
 pass
 RL_FUNCTIONS["grpo_trainer"].append(grpo_trainer__prepare_inputs)
@@ -255,7 +255,6 @@ def grpo_trainer__get_per_token_logps(function_name, function):
         batch_size = batch_size or input_ids.size(0)
         lm_head = model.get_output_embeddings().weight
 
-        prev_UNSLOTH_RETURN_HIDDEN_STATES = os.environ["UNSLOTH_RETURN_HIDDEN_STATES"]
         os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "1"
         with torch.amp.autocast(device_type = 'cuda', dtype = self._autocast_dtype):
             all_logps = []
@@ -271,7 +270,6 @@ def grpo_trainer__get_per_token_logps(function_name, function):
                 all_logps.append(logps[:, :-1])
             pass
         pass
-        os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = prev_UNSLOTH_RETURN_HIDDEN_STATES
         
         return torch.cat(all_logps, dim=0)
     pass

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -242,40 +242,36 @@ def grpo_trainer__move_model_to_vllm(function_name, function):
 pass
 RL_FUNCTIONS["grpo_trainer"].append(grpo_trainer__move_model_to_vllm)
 
-
-# Edit _get_per_token_logps to handle mixed precision
 def grpo_trainer__get_per_token_logps(function_name, function):
     if  function_name != "_get_per_token_logps": return function
 
-    def _get_per_token_logps(self, model, input_ids, attention_mask, logits_to_keep, calc_logprob_flag = None):
-        if os.environ.get('UNSLOTH_USE_NEW_MODEL', '0') == '0' and  not calc_logprob_flag:
-            return None # Unsloth efficient GRPO
-        # Otherwise, calculate normally:
+    def _get_per_token_logps(self, model, input_ids, attention_mask, logits_to_keep, batch_size=None):
+        from cut_cross_entropy import linear_cross_entropy
+
         if not hasattr(self, '_autocast_dtype'):
             self._autocast_dtype = torch.float16 if os.environ.get('ACCELERATE_MIXED_PRECISION', 'fp16') == 'fp16' else torch.bfloat16
             if os.environ.get('UNSLOTH_FORCE_FLOAT32', '0') == '1': self._autocast_dtype = torch.float16
 
+        batch_size = batch_size or input_ids.size(0)
+        lm_head = model.get_output_embeddings().weight
+
         os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "1"
         with torch.amp.autocast(device_type = 'cuda', dtype = self._autocast_dtype):
-            # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
-            hidden_states = model(input_ids=input_ids, attention_mask=attention_mask, logits_to_keep=logits_to_keep + 1).logits
-            #logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
-            return hidden_states
-            # input_ids = input_ids[:, -logits_to_keep:]
-            # For transformers<=4.48, logits_to_keep argument isn't supported, so here we drop logits ourselves.
-            # See https://github.com/huggingface/trl/issues/2770
-            # logits = logits[:, -logits_to_keep:]
-            # return logits
-            # logps = selective_log_softmax(logits, input_ids)
+            all_logps = []
+            for i in range(0, input_ids.size(0), batch_size):
+                input_ids_batch = input_ids[i : i + batch_size]
+                attention_mask_batch = attention_mask[i : i + batch_size]
 
-            # row_indices, col_indices = torch.where(logps < -20)
-
-            # # Method 1: Check if tensors have elements
-            # if len(row_indices) > 0 and len(col_indices) > 0:
-            #     breakpoint()  # Breakpoint triggered here
-            #     print("Found high values!")
-            # return  logps #  compute logprobs for the input tokens
+                # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
+                hidden_states = model(input_ids=input_ids_batch, attention_mask=attention_mask_batch, logits_to_keep=logits_to_keep + 1).logits
+                # Add dummy input_id at the end. Last logp is exluded.
+                input_ids_batch = torch.cat((input_ids_batch[:, -logits_to_keep:], torch.zeros((batch_size, 1), dtype=input_ids_batch.dtype, device=input_ids_batch.device)), dim=-1)
+                logps = -1 * linear_cross_entropy(hidden_states.to(dtype=lm_head.dtype), lm_head, input_ids_batch, reduction="none", impl="cce")
+                all_logps.append(logps[:, :-1])
+            pass
         pass
+        
+        return torch.cat(all_logps, dim=0)
     pass
 
     function = inspect.getsource(_get_per_token_logps)
@@ -312,16 +308,9 @@ def grpo_trainer_compute_loss(function_name, function):
         _logits_to_keep = logits_to_keep
         
         per_token_logps = self._get_per_token_logps(model, input_ids, attention_mask, logits_to_keep)
-
-        # Compute the KL divergence between the model and the reference model
-        # _prepare_inputs doesn't return reference log probs anymore. We need to calculate it ourselves.
-        # https://github.com/huggingface/trl/blob/05bc43e960396581e458195b8388efe6b82cae1f/trl/trainer/grpo_trainer.py#L1328
-        if self.beta != 0.0:
-            with torch.inference_mode(), model.disable_adapter():
-                ref_per_token_logps = self._get_per_token_logps(model, input_ids, attention_mask, logits_to_keep)
-        else:
-            ref_per_token_logps = None
-        # per_token_kl = torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
+        # ref_per_token_logps is now cached in _buffered_inputs
+        # https://github.com/huggingface/trl/blob/5206c927f6bb161e45114531b0bca8286acfeada/trl/trainer/grpo_trainer.py#L1292
+        ref_per_token_logps = inputs["ref_per_token_logps"]
 
         # x - x.detach() allows for preserving gradients from x
         advantages = inputs["advantages"]
@@ -329,13 +318,13 @@ def grpo_trainer_compute_loss(function_name, function):
         # per_token_loss = -(per_token_loss - self.beta * per_token_kl)
         # loss = ((per_token_loss * completion_mask).sum(dim=1) / completion_mask.sum(dim=1)).mean()
         if "old_per_token_logps" in inputs.keys():
-            old_hidden_states = inputs["old_per_token_logps"]
+            old_per_token_logps = inputs["old_per_token_logps"]
         else: 
-            old_hidden_states = None
-        input_ids = input_ids[:, -logits_to_keep:]
+            old_per_token_logps = None
+        
         if per_token_logps is not None:
             loss, completion_length, mean_kl = grpo_compute_loss_slow(
-                ref_per_token_logps, per_token_logps, old_hidden_states, input_ids, completion_mask, self.beta, advantages, 
+                ref_per_token_logps, per_token_logps, old_per_token_logps, input_ids, completion_mask, self.beta, advantages, 
                 loss_type = self.args.loss_type,
                 epsilon_low = self.epsilon_low, epsilon_high = self.epsilon_high,
                 max_completion_length = self.args.max_completion_length,
@@ -344,7 +333,7 @@ def grpo_trainer_compute_loss(function_name, function):
         else:
             if hasattr(self.args, "loss_type"):
                 loss, completion_length, mean_kl = grpo_accumulated_loss(
-                    self, _input_ids, logits_to_keep, completion_mask, advantages, old_hidden_states,
+                    self, _input_ids, logits_to_keep, completion_mask, advantages, old_per_token_logps,
                     n_chunks = self.args.unsloth_num_chunks,
                     loss_type = self.args.loss_type,
                     epsilon_low = self.epsilon_low, epsilon_high = self.epsilon_high,
@@ -354,7 +343,7 @@ def grpo_trainer_compute_loss(function_name, function):
             else:
                 # to ensure backwards compatibility with trl 0.15.2 and maybe even 0.17
                 loss, completion_length, mean_kl = grpo_accumulated_loss(
-                    self, _input_ids, logits_to_keep, completion_mask, advantages, old_hidden_states,
+                    self, _input_ids, logits_to_keep, completion_mask, advantages, old_per_token_logps,
                     n_chunks = self.args.unsloth_num_chunks,
                 )    
 


### PR DESCRIPTION
Avoids materializing the entire logit matrix for ref, old, and new policy’s log probability calculation using CCE with no reductions.
`selective_log_softmax(e @ c.T, index) == -cce(e, c, index, reduction="none”)`

The default invocation of `linear_cross_entropy` applies gradient filtering, which can be turned off by setting `filter_eps` to `-inf`.

num_generations = 8
num_iterations = 4
batch_size = 8
unsloth_num_chunks = 4
max_prompt_length = 512
max_completion_length = 1024
vocab_size = 128256

<img width="336" alt="Screenshot 2025-06-19 at 7 17 03 PM" src="https://github.com/user-attachments/assets/f12e3536-72aa-40e9-877e-51778350e9e1" />

Runtime baseline: 15m 58s
Runtime CCE: 13m 21s

Reduces VRAM usage by around 15% - 20%, though the memory usage should be lower still with CCE. Moreover, for larger values of batch_size, max_completion_length, and vocab_size, the difference will be much more profound.

Other changes -
1. Modifies `_get_per_token_logps` to accept a batch_size (https://github.com/huggingface/trl/blob/5206c927f6bb161e45114531b0bca8286acfeada/trl/trainer/grpo_trainer.py#L853). Removes calc_logprob_flag.
2. Computes logps in `compute_loss` (before calling into `UnslothEfficientGRPO`), ensuring a consistent interface with HF.
3. Removes explicit computation of ref logps since HF does that now (https://github.com/huggingface/trl/blob/5206c927f6bb161e45114531b0bca8286acfeada/trl/trainer/grpo_trainer.py#L1292).