### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "2-5X faster LLM finetuning"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 keywords = ["ai", "llm",]
 authors = [
     {email = "info@unsloth.ai"},


### PR DESCRIPTION
Switched pyproject license to dictionary type to address:


```
Getting requirements to build wheel: finished with status 'error'
error: subprocess-exited-with-error
× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> [95 lines of output]
configuration error: `project.license` must be valid exactly by one definition (2 matches found):
    - keys:
        'file': {type: string}
        required: ['file']
    - keys:
        'text': {type: string}
        required: ['text']

DESCRIPTION:
`Project license <https://peps.python.org/pep-0621/#license>`_.

GIVEN VALUE:
"Apache-2.0"

OFFENDING RULE: 'oneOf'
```
which was preventing installation via `pip install git+https://github.com/unslothai/unsloth.git`