### PR TITLE
[intel] use DeviceProperties instead of torch.xxx.deviceproperties

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -556,10 +556,10 @@ from unsloth import DEVICE_TYPE
 def is_big_gpu(index) -> bool:
 
     if DEVICE_TYPE == "xpu":
-        prop = torch.xpu.get_device_properties(index)
+        prop = DeviceProperties.create(torch.device("xpu", index) if type(index) is int else index)
         min_sms = 16
     else:
-        prop = torch.cuda.get_device_properties(index)
+        prop = DeviceProperties.create(torch.device("cuda", index) if type(index) is int else index)
         min_sms = 80
 
     avail_sms = prop.multi_processor_count


### PR DESCRIPTION
Fix issue like below:
  File "unsloth\unsloth\models_utils.py", line 565, in is_big_gpu
    avail_sms = prop.multi_processor_count
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
torch._inductor.exc.InductorError: LoweringException: AttributeError: 'torch._C._XpuDeviceProperties' object has no attribute 'multi_processor_count'

Currently usage is aligned with torch code