### PR TITLE
Convert torch.bfloat16, torch.float16, etc. to vLLM valid dtypes

### DIFF
--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -78,10 +78,6 @@ class SyntheticDataKit:
             use_bitsandbytes       = False,
             **kwargs,
         )
-
-
-
-
         if "dtype" in engine_args:
             dtype_val = engine_args["dtype"]
             # Convert torch.bfloat16, torch.float16, etc. to valid CLI string
@@ -93,8 +89,6 @@ class SyntheticDataKit:
             valid_dtypes = {"auto", "bfloat16", "float", "float16", "float32", "half"}
             if engine_args["dtype"] not in valid_dtypes:
                 engine_args["dtype"] = "auto"
-
-        
         if "device" in engine_args: del engine_args["device"]
         if "model"  in engine_args: del engine_args["model"]
         if "compilation_config" in engine_args:

--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -79,6 +79,22 @@ class SyntheticDataKit:
             **kwargs,
         )
 
+
+
+
+        if "dtype" in engine_args:
+            dtype_val = engine_args["dtype"]
+            # Convert torch.bfloat16, torch.float16, etc. to valid CLI string
+            if hasattr(dtype_val, "name"):
+                engine_args["dtype"] = dtype_val.name
+            elif isinstance(dtype_val, str) and dtype_val.startswith("torch."):
+                engine_args["dtype"] = dtype_val.split(".")[-1]
+            # Only allow valid vLLM choices
+            valid_dtypes = {"auto", "bfloat16", "float", "float16", "float32", "half"}
+            if engine_args["dtype"] not in valid_dtypes:
+                engine_args["dtype"] = "auto"
+
+        
         if "device" in engine_args: del engine_args["device"]
         if "model"  in engine_args: del engine_args["model"]
         if "compilation_config" in engine_args:


### PR DESCRIPTION
# Convert torch.bfloat16, torch.float16, etc. to valid CLI string


Checks `dtype`  params when building the subprocess_command for vllm.

Passing `torch.bfloat16` values seems to stop vllm from deploying properly, and result in 

```
vllm serve: error: argument --dtype: invalid choice: 'torch.bfloat16' (choose from 'auto', 'bfloat16', 'float', 'float16', 'float32', 'half')
```
The update makes it such that vLLM will deploy even when the correct `dtype` isn't specified isn't specified in the model name
