### PR TITLE
import undefined transformers_version for falcon model

### DIFF
--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -35,8 +35,8 @@ except:
     if not transformers_version >= Version("4.53.0"): #TODO: Update when transformers is updated
         raise ImportError(
             f"Unsloth: Your transformers version of {transformers_version} does not support FalconH1.\n"\
-            f"The minimum required version is 4.50.3.\n"\
-            f'Try `pip install --upgrade "transformers>=4.50.3"`\n'\
+            f"The minimum required version is 4.53.0.\n"\
+            f'Try `pip install --upgrade "transformers>=4.53.0"`\n'\
             f"to obtain the latest transformers build, then restart this session."\
         )
     pass

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -30,8 +30,9 @@ try:
         FalconHybridMambaAttentionDynamicCache,
     )
 except:
+    from transformers import __version__ as transformers_version
     transformers_version = Version(transformers_version)
-    if not transformers_version >= Version("4.50.3"): #TODO: Update when transformers is updated
+    if not transformers_version >= Version("4.53.0"): #TODO: Update when transformers is updated
         raise ImportError(
             f"Unsloth: Your transformers version of {transformers_version} does not support FalconH1.\n"\
             f"The minimum required version is 4.50.3.\n"\
@@ -48,7 +49,10 @@ try:
         FalconH1Attention,
     )
 except:
-    FalconH1Attention   = FalconH1Attention
+    # if we are on a old version of transformers technically it should fail in the try except above
+    # but if somehow we make it here, we need to raise an error since FalconH1Attention is not available
+    # or renamed
+    raise ImportError("Unsloth: Could not import FalconH1Attention from transformers.models.falcon_h1.modeling_falcon_h1.")
 pass
 
 

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -26,7 +26,6 @@ from .mistral import FastMistralModel
 from .qwen2   import FastQwen2Model
 from .qwen3   import FastQwen3Model
 from .qwen3_moe import FastQwen3MoeModel
-from .falcon_h1 import FastFalconH1Model
 from .cohere  import FastCohereModel
 from transformers import AutoConfig
 from transformers import __version__ as transformers_version
@@ -64,6 +63,9 @@ if SUPPORTS_GEMMA:
     from .gemma  import FastGemmaModel
 if SUPPORTS_GEMMA2:
     from .gemma2 import FastGemma2Model
+pass
+if SUPPORTS_FALCON_H1:
+    from .falcon_h1 import FastFalconH1Model
 pass
 import torch
 from ._utils import (


### PR DESCRIPTION
The falcon model has an undefined transformers_version and is failing on `from unsloth import FastLanguageModel`. This PR is a online definition to make the import work.

![image](https://github.com/user-attachments/assets/e2a0b39a-f035-42b6-bf03-b7fbc2ad0679)


Tested in a colab notebook to show it works.
https://colab.research.google.com/drive/1YjdPa5BUlT2LnGp333Ih18UW48JJIpgN?usp=sharing