### PR TITLE
handle updated gradient checkpointing in transformers 4.53.0

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2830,6 +2830,8 @@ class FastLlamaModel:
 
         def _for_inference(m):
             if hasattr(m, "gradient_checkpointing"): m.gradient_checkpointing = False
+            # Transformers >= 4.53.0 need gradient_checkpointing_disable() instead of setting gradient_checkpointing to False
+            if hasattr(m, "gradient_checkpointing_disable"): m.gradient_checkpointing_disable()
             if hasattr(m, "training"): m.training = False
             # Pad tokenizer to the left
             if hasattr(m, "_saved_temp_tokenizer"): m._saved_temp_tokenizer.padding_side = "left"
@@ -2868,6 +2870,8 @@ class FastLlamaModel:
 
         def _for_training(m):
             if hasattr(m, "gradient_checkpointing"): m.gradient_checkpointing = use_gradient_checkpointing
+            # Transformers >= 4.53.0 need gradient_checkpointing_enable() instead of setting gradient_checkpointing to True
+            if hasattr(m, "gradient_checkpointing_enable"): m.gradient_checkpointing_enable()
             if hasattr(m, "training"): m.training = True
             # Pad tokenizer to the left
             if hasattr(m, "_saved_temp_tokenizer"): m._saved_temp_tokenizer.padding_side = "right"

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -699,6 +699,8 @@ class FastBaseModel:
 
         def _for_inference(m):
             if hasattr(m, "gradient_checkpointing"): m.gradient_checkpointing = False
+            # Transformers >= 4.53.0 need gradient_checkpointing_disable() instead of setting gradient_checkpointing to False
+            if hasattr(m, "gradient_checkpointing_disable"): m.gradient_checkpointing_disable()
             if hasattr(m, "training"): m.training = False
             # Pad tokenizer to the left
             if hasattr(m, "_saved_temp_tokenizer"): m._saved_temp_tokenizer.padding_side = "left"
@@ -741,6 +743,8 @@ class FastBaseModel:
 
         def _for_training(m):
             if hasattr(m, "gradient_checkpointing"): m.gradient_checkpointing = use_gradient_checkpointing
+            # Transformers >= 4.53.0 need gradient_checkpointing_enable() instead of setting gradient_checkpointing to True
+            if hasattr(m, "gradient_checkpointing_enable"): m.gradient_checkpointing_enable()
             if hasattr(m, "training"): m.training = True
             # Pad tokenizer to the left
             if hasattr(m, "_saved_temp_tokenizer"): m._saved_temp_tokenizer.padding_side = "right"


### PR DESCRIPTION
The way to handle enabling and disabling gradient checkpointing has changed in transformers==4.53.0

Instead of setting `model.gradient_checkpointing = True/False` there are now convenience functions `gradient_checkpointing_enable` and `gradient_checkpointing_disable`. We check for these attributes and run them alongside the old way for backwards compatibility. This change affects both the FastModel and FastLlamaModel paths. So I include 4 tests with FastVisionModel/FastLanguageModel paths and 4.52.4 and 4.53.0.

The tests show in all cases the the model offloads gradients to vram during training. And that model.is_gradient_checkpointing is off before inference, and on afterwards. In addition when setting use_cache there is no longer a failure in 4.53.0 inference.

FastVisionModel 4.52.4: https://colab.research.google.com/drive/1fO7IGFNx9xOMTBHmQkq8U7FB7BElBEbg?usp=sharing
FastVisionModel 4.53.0: https://colab.research.google.com/drive/1fAkb3UVoDDMBQeZCO1YlUdnwXQOSg5MS?usp=sharing
FastLanguageModel 4.52.4: https://colab.research.google.com/drive/1Txg2462k7o9LGjXWlucp_5cUGljHRXOE?usp=sharing
FastLanguageModel 4.53.0: https://colab.research.google.com/drive/12ddhzl0XDHLY49Js_7rLeCm78bnrwb--?usp=sharing