### PR TITLE
Fix loftq None config for FastBaseModel

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -65,6 +65,7 @@ __all__ = [
     "process_vision_info",
     "unsloth_compile_transformers",
     "patch_fast_lora",
+    "validate_loftq_config",
 ]
 
 import torch
@@ -1307,3 +1308,63 @@ if USE_MODELSCOPE:
         raise ImportError(f'You are using the modelscope hub, please install modelscope by `pip install modelscope -U`')
     pass
 pass
+
+
+def validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, model):
+    from peft import LoraConfig
+
+    if loftq_config is None: loftq_config = {}
+
+    signature = str(inspect.signature(LoraConfig))
+    SUPPORTS_LOFTQ  = "loftq_config" in signature
+
+    if lora_dropout != 0:
+        logger.warning_once(
+            f"Unsloth: Dropout = 0 is supported for fast patching. You are using dropout = {lora_dropout}.\n"\
+            f"Unsloth will patch all other layers, except LoRA matrices, causing a performance hit."
+        )
+    pass
+
+    if bias != "none":
+        logger.warning_once(
+            f"Unsloth: bias = `none` is supported for fast patching. You are using bias = {bias}.\n"\
+            f"Unsloth will patch all other layers, except LoRA matrices, causing a performance hit."
+        )
+    pass
+
+    if not (type(init_lora_weights) is bool or \
+        init_lora_weights == "gaussian" or init_lora_weights == "loftq"):
+        raise ValueError(
+            'Unsloth: `init_lora_weights` must be either [True, False, "gaussian", "loftq"].'
+        )
+    pass
+
+    if init_lora_weights == "loftq":
+
+        if not SUPPORTS_LOFTQ:
+            import peft
+            raise RuntimeError(
+                f"Unsloth: Your PEFT version of {peft.__version__} does not support LoftQ init.\n"\
+                "Please install PEFT 0.7.2 or higher.\n"\
+                "You can also install from source: `pip install git+https://github.com/huggingface/peft.git"
+            )
+        pass
+
+        if loftq_config == {}:
+            from peft import LoftQConfig
+            logger.warning_once(
+                "Unsloth: init_lora_weights = `loftq` is set, but `loftq_config` is None.\n"\
+                "We shall use `loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)`."
+            )
+            loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)
+        pass
+        
+        if hasattr(model.config, "quantization_config"):
+            raise ValueError(
+                "Unsloth: You are using `loftq` init, yet `load_in_4bit = True` was set.\n"\
+                "Reload your model without any quantization by setting `load_in_4bit = False`."
+            )
+        pass
+    pass
+
+    return loftq_config

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -612,6 +612,8 @@ class FastBaseModel:
                 torch.xpu.empty_cache()
         pass
         max_seq_length = model.max_seq_length
+        # if we pass loftq_config = None we will get an error
+        loftq_config = validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, model)
         lora_config = LoraConfig(
             r                 = r,
             lora_alpha        = lora_alpha,


### PR DESCRIPTION
Many notebooks explicitly pass None into loftq where the default is set to {}. When we passed the `loftq_config` to `FastBaseModel.get_peft_model` those notebooks would fail becuase peft expects a dict or LoftQConfig. To fix I used the same loftq logic from llama.py and set a default loftq_config for FastBaseModel.

https://github.com/unslothai/unsloth/issues/2845

Tested that the notebook in question now works.

https://colab.research.google.com/drive/1rl30wn1VRI1HQ20rdhRr0YF0zMxhwUYb?usp=sharing