### PR TITLE
Fix: Move RoPE tensors to right devices

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -773,6 +773,26 @@ if torch.cuda.device_count() == 1:
     accelerate.accelerator.Accelerator.distributed_type = lambda *args, **kwargs: DistributedType.NO
 pass
 
+# to move multiple tensors to the same device
+def move_to_device(target_device, *tensors):
+    """
+    Move multiple tensors to target device if they're not already there.
+    
+    Args:
+        target_device: The target device to move tensors to
+        *tensors: Variable number of tensors to potentially move
+        
+    Returns:
+        tuple: The tensors on the target device (same objects if already on device, new if moved)
+    """
+    moved_tensors = []
+    for tensor in tensors:
+        if tensor.device != target_device:
+            moved_tensors.append(tensor.to(target_device))
+        else:
+            moved_tensors.append(tensor)
+    return tuple(moved_tensors) if len(moved_tensors) > 1 else moved_tensors[0]
+
 import transformers.utils.quantization_config
 transformers.utils.quantization_config.BitsAndBytesConfig.__init__ = _BitsAndBytesConfig__init__
 # =============================================

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -773,25 +773,6 @@ if torch.cuda.device_count() == 1:
     accelerate.accelerator.Accelerator.distributed_type = lambda *args, **kwargs: DistributedType.NO
 pass
 
-# to move multiple tensors to the same device
-def move_to_device(target_device, *tensors):
-    """
-    Move multiple tensors to target device if they're not already there.
-    
-    Args:
-        target_device: The target device to move tensors to
-        *tensors: Variable number of tensors to potentially move
-        
-    Returns:
-        tuple: The tensors on the target device (same objects if already on device, new if moved)
-    """
-    moved_tensors = []
-    for tensor in tensors:
-        if tensor.device != target_device:
-            moved_tensors.append(tensor.to(target_device))
-        else:
-            moved_tensors.append(tensor)
-    return tuple(moved_tensors) if len(moved_tensors) > 1 else moved_tensors[0]
 
 import transformers.utils.quantization_config
 transformers.utils.quantization_config.BitsAndBytesConfig.__init__ = _BitsAndBytesConfig__init__

--- a/unsloth/models/cohere.py
+++ b/unsloth/models/cohere.py
@@ -254,8 +254,7 @@ def CohereAttention_fast_forward_inference(
     do_prefill = False,
     attention_mask = None,
 ):
-    if position_ids is not None:
-        position_ids = position_ids.to('cpu')
+
     Xn = hidden_states
     bsz, _, hd = hidden_states.size()
     K1, V1 = past_key_value

--- a/unsloth/models/cohere.py
+++ b/unsloth/models/cohere.py
@@ -254,6 +254,8 @@ def CohereAttention_fast_forward_inference(
     do_prefill = False,
     attention_mask = None,
 ):
+    if position_ids is not None:
+        position_ids = position_ids.to('cpu')
     Xn = hidden_states
     bsz, _, hd = hidden_states.size()
     K1, V1 = past_key_value
@@ -321,8 +323,8 @@ def CohereAttention_fast_forward_inference(
     # cos, sin = self.rotary_emb(Vn, seq_len = kv_seq_len)
     # Qn, Kn = inplace_rope_embedding(Qn, Kn, cos, sin, position_ids)
     cos, sin = self.rotary_emb.get_cached(kv_seq_len)
-    cos = cos[position_ids].unsqueeze(1)
-    sin = sin[position_ids].unsqueeze(1)
+    cos = cos[position_ids].unsqueeze(1).to(Qn.device)
+    sin = sin[position_ids].unsqueeze(1).to(Qn.device)
     h = self.half_head_dim
 
     RH_Q = self.RH_Q

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -113,11 +113,9 @@ def FalconH1Attention_fast_forward(
 
         if position_ids is None:
             # Useful for LongRoPE
-            cos, sin = rotary_emb.get_cached(kv_seq_len)
+            cos, sin = rotary_emb.get_cached(kv_seq_len, device=Q.device)
         else:
-            cos, sin = rotary_emb(V, seq_len = kv_seq_len)
-    cos = cos.to(Q.device)
-    sin = sin.to(Q.device)
+            cos, sin = rotary_emb.get_cached(seq_len = kv_seq_len, device=Q.device)
     Q, K = fast_rope_embedding(Q, K, cos, sin)
 
     if past_key_value is not None:
@@ -282,9 +280,9 @@ def FalconH1Attention_fast_forward_inference(
     # Need to do it prior 2 steps before hitting full on short KV cache
     # or else error
     self.rotary_emb.extend_rope_embedding(Vn, seq_len + 2)
-    cos, sin = self.rotary_emb.get_cached(kv_seq_len)
-    cos = cos[position_ids].unsqueeze(1).to(Qn.device)
-    sin = sin[position_ids].unsqueeze(1).to(Qn.device)
+    cos, sin = self.rotary_emb.get_cached(kv_seq_len, device = Qn.device)
+    cos = cos[position_ids].unsqueeze(1)
+    sin = sin[position_ids].unsqueeze(1)
     h = self.half_head_dim
 
     RH_Q = self.RH_Q

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -116,6 +116,8 @@ def FalconH1Attention_fast_forward(
             cos, sin = rotary_emb.get_cached(kv_seq_len)
         else:
             cos, sin = rotary_emb(V, seq_len = kv_seq_len)
+    cos = cos.to(Q.device)
+    sin = sin.to(Q.device)
     Q, K = fast_rope_embedding(Q, K, cos, sin)
 
     if past_key_value is not None:
@@ -281,8 +283,8 @@ def FalconH1Attention_fast_forward_inference(
     # or else error
     self.rotary_emb.extend_rope_embedding(Vn, seq_len + 2)
     cos, sin = self.rotary_emb.get_cached(kv_seq_len)
-    cos = cos[position_ids].unsqueeze(1)
-    sin = sin[position_ids].unsqueeze(1)
+    cos = cos[position_ids].unsqueeze(1).to(Qn.device)
+    sin = sin[position_ids].unsqueeze(1).to(Qn.device)
     h = self.half_head_dim
 
     RH_Q = self.RH_Q

--- a/unsloth/models/gemma.py
+++ b/unsloth/models/gemma.py
@@ -170,12 +170,6 @@ def GemmaModel_fast_forward_inference(
 
     next_decoder_cache = []
     for idx, decoder_layer in enumerate(self.model.layers):
-
-        decoder_device = decoder_layer.self_attn.q_proj.weight.device
-        hidden_states, out_weight, position_ids = move_to_device(
-            decoder_device, hidden_states, out_weight, position_ids
-        )
-
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference_gemma(decoder_layer.input_layernorm, hidden_states, out_weight)
         hidden_states, present_key_value = LlamaAttention_fast_forward_inference(
@@ -236,7 +230,7 @@ class GemmaFixedRotaryEmbedding(torch.nn.Module):
         # Build here to make `torch.jit.trace` work.
         for device in range(torch.cuda.device_count()):
             self._set_cos_sin_cache(seq_len=self.current_rope_size, device=torch.device(device), dtype=torch.get_default_dtype())
-        
+
         # dummy so that patch_utils doesn't fail for now
         self.cos_cached = torch.empty(1, device=torch.cuda.current_device(), dtype=torch.get_default_dtype())
         self.sin_cached = torch.empty(1, device=torch.cuda.current_device(), dtype=torch.get_default_dtype())

--- a/unsloth/models/gemma2.py
+++ b/unsloth/models/gemma2.py
@@ -426,13 +426,9 @@ def Gemma2Model_fast_forward_inference(
         # For pipeline parallelism, we need to move all tensors to the same device
         # note that this movement is once per GPU in PP
         layer_device = decoder_layer.self_attn.q_proj.weight.device
-        if hidden_states.device != layer_device:
-            hidden_states = hidden_states.to(layer_device)
-        if out_weight.device != layer_device:
-            out_weight = out_weight.to(layer_device)
-        if position_ids.device != layer_device:
-            position_ids = position_ids.to(layer_device)
-        pass
+        hidden_states, out_weight, position_ids = move_to_device(
+            layer_device, hidden_states, out_weight, position_ids
+        )
 
         use_sliding_window = idx % 2 == 0
 

--- a/unsloth/models/gemma2.py
+++ b/unsloth/models/gemma2.py
@@ -307,8 +307,8 @@ def Gemma2Attention_fast_forward_inference(
 
     # cos, sin = self.rotary_emb(Vn, seq_len = kv_seq_len)
     # Qn, Kn = inplace_rope_embedding(Qn, Kn, cos, sin, position_ids)
-    cos = self.rotary_emb.cos_cached[position_ids].unsqueeze(1)
-    sin = self.rotary_emb.sin_cached[position_ids].unsqueeze(1)
+    cos = self.rotary_emb.cos_cached[position_ids].unsqueeze(1).to(Qn.device)
+    sin = self.rotary_emb.sin_cached[position_ids].unsqueeze(1).to(Qn.device)
     h = self.half_head_dim
 
     RH_Q = self.RH_Q

--- a/unsloth/models/gemma2.py
+++ b/unsloth/models/gemma2.py
@@ -114,8 +114,8 @@ def Gemma2Attention_fast_forward(
         kv_seq_len += past_key_value[0].shape[-2]
 
     if position_ids is None:
-        cos = self.rotary_emb.multi_gpu_cos_cached[Q.device]
-        sin = self.rotary_emb.multi_gpu_sin_cached[Q.device]
+        cos = self.rotary_emb.multi_gpu_cos_cached[Q.device.index]
+        sin = self.rotary_emb.multi_gpu_sin_cached[Q.device.index]
         Q, K = fast_rope_embedding(Q, K, cos, sin)
     else:
         cos, sin = self.rotary_emb.get_cached(seq_len = kv_seq_len, device = Q.device)

--- a/unsloth/models/granite.py
+++ b/unsloth/models/granite.py
@@ -395,10 +395,15 @@ def GraniteModel_fast_forward_inference(
         attention_mask = None
     pass
 
-    position_embeddings = self.model.rotary_emb(hidden_states, position_ids, self.max_seq_length)
+    position_embeddings = self.model.rotary_emb.get_cached(seq_len = self.max_seq_length, device = hidden_states.device)
 
     next_decoder_cache = []
     for idx, decoder_layer in enumerate(self.model.layers):
+
+        decoder_device = decoder_layer.self_attn.q_proj.weight.device
+        hidden_states, position_ids = move_to_device(
+            decoder_device, hidden_states, position_ids
+        )
 
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference(decoder_layer.input_layernorm, hidden_states)

--- a/unsloth/models/granite.py
+++ b/unsloth/models/granite.py
@@ -71,7 +71,7 @@ def GraniteAttention_fast_forward(
     position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     *args, **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-    
+
     # Clear inference
     if hasattr(self, "paged_attention"):
         del self.paged_attention_K
@@ -162,7 +162,7 @@ def GraniteAttention_fast_forward(
         # Go back to (batch_size, seq_len, n_heads, head_dim)
         A = A.transpose(1, 2).contiguous()
     pass
-    
+
     attn_output = A.reshape(bsz, q_len, n_heads*head_dim)
     attn_output = self.apply_o(self, attn_output)
     attn_weights = None
@@ -256,7 +256,7 @@ def GraniteAttention_fast_forward_inference(
     use_sliding_window = False,
     position_embeddings : Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
 ):
-    
+
     assert position_embeddings is not None, f"Granite model requires position embeddings to be specified"
 
     Xn = hidden_states
@@ -326,7 +326,7 @@ def GraniteAttention_fast_forward_inference(
     torch.neg(RH_K[:,:,:,:h], out = RH_K[:,:,:,:h])
     Kn *= cos
     Kn.addcmul_(RH_K, sin)
-    
+
     # New KV cache
     # Kn = torch.cat([K1, Kn], dim = 2)
     # Vn = torch.cat([V1, Vn], dim = 2)
@@ -349,7 +349,7 @@ def GraniteAttention_fast_forward_inference(
 
     Qn *= self.scaling
     A = torch_matmul(Qn, Kn.transpose(2, 3), out = self.attention[:,:,:,:cached_len])
-    
+
     # if attention_mask is not None: A += attention_mask # Must add attention_mask for batched
 
     A[:] = torch_nn_functional_softmax(A, dim = -1, dtype = torch.float32)#.to(A.dtype)
@@ -399,11 +399,6 @@ def GraniteModel_fast_forward_inference(
 
     next_decoder_cache = []
     for idx, decoder_layer in enumerate(self.model.layers):
-
-        decoder_device = decoder_layer.self_attn.q_proj.weight.device
-        hidden_states, position_ids = move_to_device(
-            decoder_device, hidden_states, position_ids
-        )
 
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference(decoder_layer.input_layernorm, hidden_states)
@@ -537,7 +532,7 @@ class FastGraniteModel(FastLlamaModel):
 
                 elif hasattr(module, "short_cos_cached") and \
                     (module.short_cos_cached.dtype != correct_dtype):
-                    
+
                     module.short_cos_cached = module.short_cos_cached.to(correct_dtype)
                     module.short_sin_cached = module.short_sin_cached.to(correct_dtype)
                 pass
@@ -552,4 +547,3 @@ class FastGraniteModel(FastLlamaModel):
         return model, tokenizer
     pass
 pass
-

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1021,7 +1021,6 @@ def _LlamaModel_fast_forward_inference(attention_fast_forward_inference=LlamaAtt
         next_decoder_cache = []
 
         for idx, decoder_layer in enumerate(self.model.layers):
-            print(f'Inference through layer {idx}')
             decoder_device = decoder_layer.self_attn.q_proj.weight.device
             if X.device != decoder_device:
                 X = X.to(decoder_device)
@@ -1031,6 +1030,8 @@ def _LlamaModel_fast_forward_inference(attention_fast_forward_inference=LlamaAtt
                 temp_gate = temp_gate.to(decoder_device)
             if temp_up.device != decoder_device:
                 temp_up = temp_up.to(decoder_device)
+            if position_ids.device != decoder_device:
+                position_ids = position_ids.to(decoder_device)
             residual.copy_(X) # residual = X
             X = fast_rms_layernorm_inference(
                 decoder_layer.input_layernorm,

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -210,8 +210,6 @@ def LlamaAttention_fast_forward_inference(
         This means we can pass in a row of Q, but we need to
         remember K and V, which are called the KV cache.
     """
-    if position_ids is not None:
-        position_ids = position_ids.to('cpu')
     Xn = hidden_states
     bsz, _, hd = hidden_states.size()
     K1, V1 = past_key_value

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -90,10 +90,11 @@ def MistralAttention_fast_forward(
     else:
         cos, sin = self.rotary_emb(V, seq_len = kv_seq_len)
         if cos.device != Q.device:
+            # without this, even though V is on GPU0, by the time we reach the foward function
+            # the argument x is on GPU1, and hence cos, sin end up on GPU1
+            # this is a hack to get around this quirk
             cos = cos.to(Q.device)
             sin = sin.to(Q.device)
-        if Q.device != K.device:
-            raise ValueError("Q and K must be on the same device")
         Q, K = inplace_rope_embedding(Q, K, cos, sin, position_ids)
     pass
 

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -89,6 +89,11 @@ def MistralAttention_fast_forward(
         Q, K = fast_rope_embedding(Q, K, cos, sin)
     else:
         cos, sin = self.rotary_emb(V, seq_len = kv_seq_len)
+        if cos.device != Q.device:
+            cos = cos.to(Q.device)
+            sin = sin.to(Q.device)
+        if Q.device != K.device:
+            raise ValueError("Q and K must be on the same device")
         Q, K = inplace_rope_embedding(Q, K, cos, sin, position_ids)
     pass
 

--- a/unsloth/models/qwen3.py
+++ b/unsloth/models/qwen3.py
@@ -116,7 +116,7 @@ def Qwen3Attention_fast_forward(
             # Useful for LongRoPE
             cos, sin = rotary_emb.get_cached(kv_seq_len)
         else:
-            cos, sin = rotary_emb(V, seq_len = kv_seq_len)
+            cos, sin = rotary_emb.get_cached(seq_len = kv_seq_len, device = Q.device)
     Q, K = fast_rope_embedding(Q, K, cos, sin)
 
     if past_key_value is not None:
@@ -299,9 +299,9 @@ def Qwen3Attention_fast_forward_inference(
     # Need to do it prior 2 steps before hitting full on short KV cache
     # or else error
     self.rotary_emb.extend_rope_embedding(Vn, seq_len + 2)
-    cos, sin = self.rotary_emb.get_cached(kv_seq_len)
-    cos = cos[position_ids].unsqueeze(1).to(Qn.device)
-    sin = sin[position_ids].unsqueeze(1).to(Qn.device)
+    cos, sin = self.rotary_emb.get_cached(kv_seq_len, device = Qn.device)
+    cos = cos[position_ids].unsqueeze(1)
+    sin = sin[position_ids].unsqueeze(1)
     h = self.half_head_dim
 
     RH_Q = self.RH_Q

--- a/unsloth/models/qwen3.py
+++ b/unsloth/models/qwen3.py
@@ -66,7 +66,7 @@ def Qwen3Attention_fast_forward(
     position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     *args, **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-    
+
     # Clear inference
     if hasattr(self, "paged_attention"):
         del self.paged_attention_K
@@ -232,8 +232,6 @@ def Qwen3Attention_fast_forward_inference(
         This means we can pass in a row of Q, but we need to
         remember K and V, which are called the KV cache.
     """
-    if position_ids is not None:
-        position_ids = position_ids.to('cpu')
     Xn = hidden_states
     bsz, _, hd = hidden_states.size()
     K1, V1 = past_key_value
@@ -262,14 +260,14 @@ def Qwen3Attention_fast_forward_inference(
         self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype = dtype, device = device)
         self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads*head_dim), dtype = dtype, device = device)
         self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
-        
+
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
             self.temp_O = torch.empty((1, bsz, hidden_size), dtype = dtype, device = device)
         else:
             self.temp_O = self.temp_QA[1][:,:,:hidden_size]
         pass
-        
+
         self.attention = torch.empty((bsz, n_heads, 1, KV_CACHE_INCREMENT+seq_len), dtype = dtype, device = device)
         self.scalar = 1.0 / math_sqrt(self.head_dim)
         self.half_head_dim = head_dim // 2
@@ -317,7 +315,7 @@ def Qwen3Attention_fast_forward_inference(
     RH_K[:,:,:,:h].neg_() #torch.neg(RH_K[:,:,:,:h], out = RH_K[:,:,:,:h])
     Kn *= cos
     Kn.addcmul_(RH_K, sin)
-    
+
     # New KV cache
     # Kn = torch.cat([K1, Kn], dim = 2)
     # Vn = torch.cat([V1, Vn], dim = 2)

--- a/unsloth/models/qwen3.py
+++ b/unsloth/models/qwen3.py
@@ -232,6 +232,8 @@ def Qwen3Attention_fast_forward_inference(
         This means we can pass in a row of Q, but we need to
         remember K and V, which are called the KV cache.
     """
+    if position_ids is not None:
+        position_ids = position_ids.to('cpu')
     Xn = hidden_states
     bsz, _, hd = hidden_states.size()
     K1, V1 = past_key_value
@@ -298,8 +300,8 @@ def Qwen3Attention_fast_forward_inference(
     # or else error
     self.rotary_emb.extend_rope_embedding(Vn, seq_len + 2)
     cos, sin = self.rotary_emb.get_cached(kv_seq_len)
-    cos = cos[position_ids].unsqueeze(1)
-    sin = sin[position_ids].unsqueeze(1)
+    cos = cos[position_ids].unsqueeze(1).to(Qn.device)
+    sin = sin[position_ids].unsqueeze(1).to(Qn.device)
     h = self.half_head_dim
 
     RH_Q = self.RH_Q


### PR DESCRIPTION
Multi GPU inference fails as some tensors are explicitly set to GPU 0 and sometimes RoPE values end up on the wrong GPU. This PR fixes that.