### PR TITLE
Fix unnecessary warning for transformers >= 4.53.0

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -152,12 +152,13 @@ def _fast_prepare_inputs_for_generation(self, input_ids, attention_mask=None, **
                 )
             else:
                 attention_mask = attention_mask[:,[-1]]
-                logger.warning_once(
-                    f"{self.__class__.__name__} has no `_prepare_4d_causal_attention_mask_with_cache_position` method "
-                    "defined in its base modeling class. Compiled forward passes will be sub-optimal. If you're "
-                    "writing code, see Llama for an example implementation. If you're a user, please report this "
-                    "issue on GitHub."
-                )
+                if transformers_version <= Version("4.52.4"):
+                    logger.warning_once(
+                        f"{self.__class__.__name__} has no `_prepare_4d_causal_attention_mask_with_cache_position` method "
+                        "defined in its base modeling class. Compiled forward passes will be sub-optimal. If you're "
+                        "writing code, see Llama for an example implementation. If you're a user, please report this "
+                        "issue on GitHub."
+                    )
 
     if "cache_position" in kwargs:
         kwargs["position_ids"] = kwargs["cache_position"]


### PR DESCRIPTION
Transformers 4.53.0 removed most (maybe all) calls to `_prepare_4d_causal_attention_mask_with_cache_position` from CausalLM classes as part of the new causal masking interface updates. Unsloth currently warns about this, but the warning is no longer needed for newer transformers versions.

This adds a version check to only show the warning when `transformers_version <= Version("4.52.4")`.

Tested with Llama3.2 and warning no longer appears.
https://colab.research.google.com/drive/1dh7DVwXORXt2sYlte56MiAWKzymZprGN?usp=sharing