### PR TITLE
[bugs] fix for casual mask

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -319,8 +319,8 @@ def LlamaAttention_fast_forward_inference(
     # pass
 
     # when qlen==vlen and attn_mask is None, we should use causal attention
-    Q_len = Q.shape[-2]
-    K_len = K.shape[-2]
+    Q_len = Qn.shape[-2]
+    K_len = Knn.shape[-2]
     if attention_mask is None and Q_len == K_len:
         is_causal = True
     else:


### PR DESCRIPTION
In Unsloth, when flash_attn and xformers optimizations are not used, is_causal=False is always passed into scaled_dot_product_attention even when attention_mask is None (e.g. [code here](https://github.com/unslothai/unsloth/blob/main/unsloth/models/llama.py#L509-L532)), which leads to bug in results for finetuning and inference, especially for inference using FastLanguageModel.

is_causal should be True when attention_mask is None and seq_len == kv_seq_len.