### PR TITLE
Fix `UnslothTrainingArguments` not patching `trl.Config` properly

### DIFF
--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -61,13 +61,9 @@ else:
     pass
 pass
 
-try:
-    from trl import SFTConfig as TrainingArguments
-except:
-    from transformers import TrainingArguments
-pass
+from trl import SFTConfig
 @dataclass
-class UnslothTrainingArguments(TrainingArguments):
+class UnslothTrainingArguments(SFTConfig):
     embedding_learning_rate : Optional[float] = field(
         default = None,
         metadata = {"help" : "Different learning rates for embeddings and lm_head."}

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -68,10 +68,11 @@ except:
 pass
 
 class UnslothTrainingArguments(TrainingArguments):
-    embedding_learning_rate : Optional[float] = field(
-        default = None,
-        metadata = {"help" : "Different learning rates for embeddings and lm_head."}
-    )
+    def __init__(self, embedding_learning_rate: float = None, *args, **kwargs):
+        embedding_learning_rate : Optional[float] = field(
+            default = embedding_learning_rate,
+            metadata = {"help" : "Different learning rates for embeddings and lm_head."}
+        )
 pass
 
 

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -61,9 +61,13 @@ else:
     pass
 pass
 
-from trl import SFTConfig
-@dataclass
-class UnslothTrainingArguments(SFTConfig):
+try:
+    from trl import SFTConfig as TrainingArguments
+except:
+    from transformers import TrainingArguments
+pass
+
+class UnslothTrainingArguments(TrainingArguments):
     embedding_learning_rate : Optional[float] = field(
         default = None,
         metadata = {"help" : "Different learning rates for embeddings and lm_head."}

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -69,10 +69,8 @@ pass
 
 class UnslothTrainingArguments(TrainingArguments):
     def __init__(self, embedding_learning_rate: float = None, *args, **kwargs):
-        embedding_learning_rate : Optional[float] = field(
-            default = embedding_learning_rate,
-            metadata = {"help" : "Different learning rates for embeddings and lm_head."}
-        )
+        embedding_learning_rate = embedding_learning_rate
+        super().__init__(*args, **kwargs)
 pass
 
 


### PR DESCRIPTION
Few updates ago, we patch `trl.Config` especially in the `bf16` and `fp16` args to bypass the `Ampere` GPU error -> https://github.com/unslothai/unsloth/blob/main/unsloth/models/rl.py#L235-L267

But the patching is not propagate to the inheritance class that is using `dataclass`. Therefore, we should inherit it using Python Class instead to propagate the patching.

This fixes training error on `Mistral CPT`