### PR TITLE
silenty skip falcon h1 import if transformers_version < 4.53.0

### DIFF
--- a/unsloth/models/__init__.py
+++ b/unsloth/models/__init__.py
@@ -19,7 +19,11 @@ from .qwen2     import FastQwen2Model
 from .qwen3     import FastQwen3Model
 from .qwen3_moe import FastQwen3MoeModel
 from .granite   import FastGraniteModel
-from .falcon_h1 import FastFalconH1Model
+try:
+    from .falcon_h1 import FastFalconH1Model
+except:
+    # transformers_version < 4.53.0 does not have falcon_h1 so silenty skip it for now
+    pass
 from .dpo       import PatchDPOTrainer, PatchKTOTrainer
 from ._utils import is_bfloat16_supported, is_vLLM_available, __version__
 from .rl        import PatchFastRL, vLLMSamplingParams


### PR DESCRIPTION
small fix to allow transformers<4.53.0 to run without raising an import error for falcon even when not running falcon model.