### PR TITLE
if mlp doesn't exist in layer module check for feed_forward

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2718,10 +2718,21 @@ class FastLlamaModel:
         if lora_dropout == 0 and bias == "none":
             for idx, layer in enumerate(model.model.model.layers):
 
+                # Determine MLP module name (falcon_h1 has feed_forward, llama style has mlp)
+                if hasattr(layer, "mlp"):
+                    mlp_module_name = "mlp"
+                elif hasattr(layer, "feed_forward"):
+                    mlp_module_name = "feed_forward"
+                else:
+                    logger.warning_once(f"Unsloth: No MLP module found in layer {idx} so skipping peft mlp patching")
+                    continue
+
+                mlp_module = getattr(layer, mlp_module_name)
+
                 # MLP patching
-                gate_proj = layer.mlp.gate_proj
-                up_proj   = layer.mlp.  up_proj
-                down_proj = layer.mlp.down_proj
+                gate_proj = mlp_module.gate_proj
+                up_proj   = mlp_module.  up_proj
+                down_proj = mlp_module.down_proj
 
                 if  hasattr(gate_proj, "lora_A") and \
                     hasattr(  up_proj, "lora_A") and \
@@ -2734,7 +2745,7 @@ class FastLlamaModel:
                     (len(getattr(down_proj, "lora_magnitude_vector", []) or []) == 0):
 
                     # https://stackoverflow.com/questions/50599045/python-replacing-a-function-within-a-class-of-a-module
-                    layer.mlp.forward = types.MethodType(_apply_lora_mlp, layer.mlp)
+                    mlp_module.forward = types.MethodType(_apply_lora_mlp, mlp_module)
                     n_mlp += 1
                 else:
                     logger.warning_once(


### PR DESCRIPTION
falcon h1 decoder layer names the mlp module feed_forward, and the patch_peft_model method of FastLlamaModel fails because it expects it to be named mlp. This change checks for the feed_forward name if mlp does not exist, and will silently skip the layer if neither mlp or feed_forward is not found.

tested on falcon and llama

falcon: https://colab.research.google.com/drive/19gPGPs-9p6IVfSpoflJOmFqGoCwRpvtW?usp=sharing
llama: https://colab.research.google.com/drive/1WObymQsiB8ki9_kcd2eMMmYXGYqqI0fP?usp=sharing