### PR TITLE
Fix: Added specific check for Gemma so models like BERT properly init…

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -221,7 +221,7 @@ class _RaiseUninitialized(logging.Handler):
     def __init__(self):
         super().__init__()
     def emit(self, record):
-        if "some weights of" in str(record).lower():
+        if "some weights of" in str(record).lower() and "gemma" in str(record).lower():
             raise Exception(
                 f"Unsloth: Critical error since some weights are not initialized.\n"\
                 f"Please try updating Unsloth, transformers and timm via:\n"\

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -226,7 +226,7 @@ class _RaiseUninitialized(logging.Handler):
                 f"Unsloth: Critical error since some weights are not initialized.\n"\
                 f"Please try updating Unsloth, transformers and timm via:\n"\
                 f"`pip install --upgrade --force-reinstall --no-cache-dir --no-deps unsloth unsloth_zoo transformers timm`\n"\
-                f"".str(record))
+                f"{record}")
 pass
 class RaiseUninitialized:
     def __init__(self):


### PR DESCRIPTION
…ialize

ModernBERT doesn't initialize due to some of its weights not being initialized, but this doesn't represent a critical error and should be just a warning just like in the original google colab notebook #3048:
<img width="1726" height="76" alt="image" src="https://github.com/user-attachments/assets/58e69a6a-a073-477a-b6e2-953e0036d6f4" />
source: https://colab.research.google.com/github/timothelaborie/text_classification_scripts/blob/main/bert_classification.ipynb#scrollTo=e5uSZBwQCfWP

However, it should be a critical error for Gemma3nForConditionalGeneration. The solution is a simple specific check for Gemma in the record variable.