### PR TITLE
fixup rope sync for everything

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -499,8 +499,6 @@ def LlamaAttention_fast_forward(
     #     else inplace_rope_embedding(Q, K, cos, sin, position_ids)
     # )
     Q, K = fast_rope_embedding(Q, K, cos, sin)
-    # synchronize before cat to avoid race condition
-    torch.cuda.current_stream(Q.device).synchronize()
 
     if past_key_value is not None:
         K = torch.cat([past_key_value[0], K], dim = 2)


### PR DESCRIPTION
Move sync back to `fast_rope_embedding` to make it apply for all models.