### PR TITLE
Docs: Add WSL Installation Guide for Blackwell / RTX 5090 GPU

### DIFF
--- a/blackwell/README.md
+++ b/blackwell/README.md
@@ -169,6 +169,40 @@ The installation order is important, since we want the overwrite bundled depende
 If you are using mamba as your package just replace conda with mamba for all commands shown above.
 
 
+## WSL-Specific Notes
+
+If you're using WSL (Windows Subsystem for Linux) and encounter issues during xformers compilation, follow these additional steps:
+
+1. **Increase WSL Memory Limit**
+   Create or edit the WSL configuration file:
+   ```bash
+   # Create or edit .wslconfig in your Windows user directory
+   # (typically C:\Users\YourUsername\.wslconfig)
+   
+   # Add these lines to the file
+   [wsl2]
+   memory=16GB  # Minimum 16GB recommended for xformers compilation
+   processors=4  # Adjust based on your CPU cores
+   swap=2GB
+   localhostForwarding=true
+   ```
+   After making these changes, restart WSL:
+   ```powershell
+   wsl --shutdown
+   ```
+
+2. **Install xformers**
+   Use the following command to install xformers with optimized compilation for WSL:
+   ```bash
+   # Set CUDA architecture for Blackwell GPUs
+   export TORCH_CUDA_ARCH_LIST="12.0"
+   
+   # Install xformers from source with optimized build flags
+   pip install -v --no-build-isolation -U git+https://github.com/facebookresearch/xformers.git@main#egg=xformers
+   ```
+   
+   The `--no-build-isolation` flag helps avoid potential build issues in WSL environments.
+
 ## Post Installation notes:
 
 After installation, your environment should look similar to `blackwell.requirements.txt`.


### PR DESCRIPTION
Hi there,

I've added a dedicated guide for installing on Windows Subsystem for Linux (WSL) to help users get set up with Blackwell GPUs like the RTX 5090.

I ran into a couple of key issues on my WSL setup and wanted to share the solutions.

First, the xformers build process is very memory-intensive. Without increasing WSL's default memory limit, the build would consistently fail and cause my WSL instance to shut down unexpectedly. The guide now includes a crucial step to create a .wslconfig file to allocate at least 16GB of memory, which completely resolves this crashing issue.

Second, the original instructions to clone and build the repository didn't seem to work smoothly in my environment. While I haven't tested that method on a standard Linux installation, I found that installing xformers using the command from their official documentation worked perfectly on WSL. This PR adds those steps as a reliable alternative.

Hope this helps other WSL users have a smoother experience!

<img width="699" height="311" alt="image" src="https://github.com/user-attachments/assets/1cbb8dbe-abb4-4823-b8a3-d8d8b09c6295" />
