### PR TITLE
removing redundant chat template for gpt oss

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1794,9 +1794,6 @@ type {{ .Function.Name }} = () => any;
 gptoss_template_template_eos_token = "<|return|>"
 CHAT_TEMPLATES["gpt-oss"] = (gptoss_template, gptoss_template_template_eos_token, False, gptoss_ollama,)
 DEFAULT_SYSTEM_MESSAGE["gpt-oss"] = None # No system message in GPT-oss
-
-CHAT_TEMPLATES["gptoss"] = (gptoss_template, gptoss_template_template_eos_token, False, gptoss_ollama,)
-DEFAULT_SYSTEM_MESSAGE["gptoss"] = None # No system message in GPT-oss
 pass
 
 # =========================================== Qwen3-Instruct


### PR DESCRIPTION
Fixes #3136 

The chat template has duplicate entry for gpt-oss.

Removing duplicate entry.

Regards,