### PR TITLE
removing redundant chat template for gemma 3

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1010,9 +1010,6 @@ PARAMETER num_predict 32768
 gemma3_template_eos_token = "<end_of_turn>"
 CHAT_TEMPLATES["gemma-3"] = (gemma3_template, gemma3_template_eos_token, False, gemma3_ollama,)
 DEFAULT_SYSTEM_MESSAGE["gemma-3"] = None # No system message in Gemma-3
-
-CHAT_TEMPLATES["gemma3"] = (gemma3_template, gemma3_template_eos_token, False, gemma3_ollama,)
-DEFAULT_SYSTEM_MESSAGE["gemma3"] = None # No system message in Gemma-3
 pass
 
 # =========================================== Qwen-3


### PR DESCRIPTION
Fixes #3138 

Removes the duplicate entry for Gemma 3 in the chat template.

Regards,