### PR TITLE
Support for Seq2Seq Models (T5, T5Gemma, etc.)

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -824,12 +824,13 @@ class FastModel(FastBaseModel):
         # Check if VLM
         is_vlm = any(x.endswith("ForConditionalGeneration") for x in model_config.architectures)
         is_vlm = is_vlm or hasattr(model_config, "vision_config")
-        if AutoModelForSeq2SeqLM._model_mapping.get(type(model_config), None) is not None:
-            auto_model = AutoModelForSeq2SeqLM
-        elif is_vlm:
-            auto_model = AutoModelForVision2Seq
-        else:
-            auto_model = AutoModelForCausalLM
+        if auto_model is None:
+            if AutoModelForSeq2SeqLM._model_mapping.get(type(model_config), None) is not None:
+                auto_model = AutoModelForSeq2SeqLM
+            elif is_vlm:
+                auto_model = AutoModelForVision2Seq
+            else:
+                auto_model = AutoModelForCausalLM
 
         model, tokenizer = FastBaseModel.from_pretrained(
             model_name        = model_name,

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -479,6 +479,7 @@ from ..kernels import (
 from .vision import FastBaseModel
 from transformers import (
     AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
 )
 try:
     from transformers import AutoModelForImageTextToText
@@ -823,8 +824,12 @@ class FastModel(FastBaseModel):
         # Check if VLM
         is_vlm = any(x.endswith("ForConditionalGeneration") for x in model_config.architectures)
         is_vlm = is_vlm or hasattr(model_config, "vision_config")
-        if auto_model is None:
-            auto_model = AutoModelForVision2Seq if is_vlm else AutoModelForCausalLM
+        if AutoModelForSeq2SeqLM._model_mapping.get(type(model_config), None) is not None:
+            auto_model = AutoModelForSeq2SeqLM
+        elif is_vlm:
+            auto_model = AutoModelForVision2Seq
+        else:
+            auto_model = AutoModelForCausalLM
 
         model, tokenizer = FastBaseModel.from_pretrained(
             model_name        = model_name,


### PR DESCRIPTION
## PR Description
Adds support for Seq2Seq models: `AutoModelForSeq2SeqLM`.

### Why
Seq2Seq models are not directly supported, despite support for all model architectures. This is because `FastModel.from_pretrained` sets the `auto_model` parameter to either `AutoModelForCausalLM` or `AutoModelForVision2Seq`/`AutoModelForImageTextToText`.

Further, since models like T5 have class names ending in `ForConditionalGeneration`, unsloth registers this as a VLM and tries to load it as such.

I use `AutoModelForSeq2SeqLM._model_mapping` to check if a model config is registered as a Seq2Seq model. This logic can be extended to other auto models (e.g., `AutoModelForSequenceClassification`) if desired.


### Links
Support for T5 has some community interest:
* Resolves #719
* Resolves #643