### PR TITLE
Replace back ticks with single quotes

### DIFF
--- a/blackwell/README.md
+++ b/blackwell/README.md
@@ -30,7 +30,7 @@ The installation order is important, since we want the overwrite bundled depende
     Create a project dir and venv:
 
     ```bash
-    mkdir `unsloth-blackwell` && cd `unsloth-blackwell`
+    mkdir 'unsloth-blackwell' && cd 'unsloth-blackwell'
     uv venv .venv --python=3.12 --seed
     source .venv/bin/activate
     ```


### PR DESCRIPTION
Back ticks attempt to execute program and capture output.  Should be using single quote marks.