### PR TITLE
Fix vision model GGUF quantization_method error type

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -2240,6 +2240,7 @@ from unsloth_zoo.llama_cpp import (
 def save_to_gguf_generic(
     model,
     save_directory,
+    tokenizer,
     quantization_method = None,
     quantization_type = "Q8_0",
     repo_id = None,


### PR DESCRIPTION
## RELATED ISSUES/PRs
https://github.com/unslothai/unsloth/commit/194d237b99240183279231b9fd25b0f4da67bad4
https://github.com/unslothai/unsloth/issues/3050
https://github.com/unslothai/unsloth/issues/1504#issuecomment-3130246477
https://discord.com/channels/1179035537009545276/1400212019482722384/1400212767440633979
https://github.com/unslothai/unsloth/issues/2209


## PROBLEM
Quantization_method function argument was recently introduced to `save_to_gguf_generic` method in order to resolve an issue users were previously having when calling `save_to_gguf_generic` directly. However this fix caused a typeError for vision models.
When calling `model.save_pretrained_gguf("dir", tokenizer, quantization_method="q4_k_m")` on vision models, users encounter a `TypeError: Unsloth: quantization_method can only be a string or a list of strings`. 

This happens because:
1. Vision models use `save_to_gguf_generic` for GGUF saving
2. `save_to_gguf_generic` doesn't accept a `tokenizer` parameter in its signature
3. The tokenizer (actually a processor like `PixtralProcessor`) gets passed as the `quantization_method` parameter due to positional argument shifting
4. This causes a type mismatch error since processors are objects, not strings

## SOLUTION
- Added `tokenizer` parameter to `save_to_gguf_generic` function signature
- No other changes needed - existing parameter handling logic remains intact


## TESTS
- [x] Tested with vision models (Gemma3-4b) - no more TypeError