### PR TITLE
Pass attention mask when doing GRPO

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -798,7 +798,8 @@ def LlamaModel_fast_forward(
     # Ignore attention_mask
     if attention_mask is None:
         padding_mask = None
-    elif self.training:
+    elif self.training and os.getenv("UNSLOTH_GRPO", "0") != "1":
+        # GRPO uses left padding so we might want to persist attention mask
         attention_mask = None
         padding_mask = None
     else:

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -738,7 +738,9 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
         if len(replacer) != 0:
             replacer = replacer[0]
             vllm_setter = "\n" + " "*8 + \
-            "if hasattr(model, 'vllm_engine') and hasattr(args, 'use_vllm'):\n" + \
+            "os.environ['UNSLOTH_GRPO'] = '1'\n" + \
+            " " * 8  + "print('Setting unsloth grpo to True')\n" + \
+            " " * 8  + "if hasattr(model, 'vllm_engine') and hasattr(args, 'use_vllm'):\n" + \
             " " * 12 + "if (getattr(args, 'use_vllm', False) == False):\n" + \
             " " * 16 + "args.use_vllm = True\n"
 


### PR DESCRIPTION
GRPO has left padding for generation. This causes issues with FA as it doesn't support left padding. If we do not pass the attention mask, tokens pay attention to the initial padding tokens causing the gradients to blow up to NaN. 
For now, this works around that. 

Maybe for later, unpad the inputs and pass for training. 