### PR TITLE
allow torch.float32 dtype in FastLanguageModel

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -145,7 +145,8 @@ class FastLanguageModel(FastLlamaModel):
         if token is None: token = get_token()
         if isinstance(dtype, str) and dtype in ["float16", "bfloat16"]:
             dtype = getattr(torch, dtype)
-        assert (dtype is None or dtype == torch.float16 or dtype == torch.bfloat16)
+        assert (dtype is None or dtype == torch.float16 or dtype == torch.bfloat16
+                or dtype == torch.float32)
 
         if use_gradient_checkpointing == "unsloth":
             patch_unsloth_smart_gradient_checkpointing(dtype = dtype)


### PR DESCRIPTION
FastLanguageModel checks for dtype, but will raise an AssertionError if torch.float32 is passed. This PR relaxes this constraint.

Notebook to test with gpt-oss:
https://colab.research.google.com/drive/1qHZQwdHypb8j-5ww_okkLlWvQ86NwEK1?usp=sharing

We print out all the parameter dtypes and see they are only float32, or uint8. And assert the same for good measure.
