### PR TITLE
Fix incorrect function call in test_qwen3_grpo.py

### DIFF
--- a/blackwell/test_qwen3_grpo.py
+++ b/blackwell/test_qwen3_grpo.py
@@ -415,7 +415,9 @@ sampling_params = SamplingParams(
     top_k=50,
     max_tokens=1024,
 )
-model.disable_gradient_checkpointing()
+
+model.gradient_checkpointing_disable() # This is required if using transformers >= 4.53.0 and `use_cache=True`
+
 output = (
     model.fast_generate(
         [text],

--- a/blackwell/test_qwen3_grpo.py
+++ b/blackwell/test_qwen3_grpo.py
@@ -416,7 +416,6 @@ sampling_params = SamplingParams(
     max_tokens=1024,
 )
 
-model.gradient_checkpointing_disable() # This is required if using transformers >= 4.53.0 and `use_cache=True`
 
 output = (
     model.fast_generate(


### PR DESCRIPTION
This test file uses the incorrect name for the function, which is **gradient_checkpointing_disable()**, not disable_gradient_checkpointing(): https://github.com/huggingface/transformers/blob/4f9b4e62bc52a52b19a6a4a1a6bfc61a3f5b65b1/src/transformers/modeling_utils.py#L3848

I copied the line verbatim from test_llama32_sft.py - I'm not sure if this actually is required as stated, just wanted it consistent for when other people like me attempt to this and have no clue what they're doing when it throws an exception.