### PR TITLE
Fix gemma-3n

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -611,7 +611,6 @@ class FastModel(FastBaseModel):
         # Olmo 2
         elif "olmo-2" in lowered_model_name and transformers_version < Version("4.50.0.dev0"):
             raise RuntimeError("Unsloth: OLMo-2 only works on transformers >= 4.50.0." + NIGHTLY)
-        # Gemma 3N
         elif "falcon-h1" in lowered_model_name:
             # Falcon must use float32 Triton ie TRITON_F32_DEFAULT = 'ieee'
             # since Mamba kernels error out on using lower precision

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -575,9 +575,22 @@ class FastModel(FastBaseModel):
             raise RuntimeError("Unsloth: Qwen 2.5 only works on transformers >= 4.49.0." + LATEST)
         # Gemma 3
         elif "gemma-3" in lowered_model_name:
-            if transformers_version < Version("4.50.0.dev0"):
-                raise RuntimeError("Unsloth: Gemma 3 only works on transformers >= 4.50.0." + NIGHTLY)
+            if "gemma-3n" in lowered_model_name:
+                if transformers_version < Version("4.53.0"):
+                    raise RuntimeError("Unsloth: Gemma 3N only works on transformers >= 4.53.0" + LATEST)
+                os.environ["UNSLOTH_DISABLE_STATIC_GENERATION"] = "1"
+                os.environ["UNSLOTH_FORCE_CUSTOM_DTYPE"] = \
+                    "float16;torch.float16;torch.float16;"\
+                    "if name.endswith('norm'): "\
+                    "module._pre_set_compute_dtype = torch.float32\n"\
+                    ";"\
+                    "from unsloth_zoo.temporary_patches.gemma3n import patch_Gemma3nConvNormAct_forward; patch_Gemma3nConvNormAct_forward()"
+            else:
+                if transformers_version < Version("4.50.0.dev0"):
+                    raise RuntimeError("Unsloth: Gemma 3 only works on transformers >= 4.50.0." + NIGHTLY)
+
             # Set norms to float32 since anyways they get upcasted to float32
+            # common in both gemma-3 and gemma-3n
             os.environ["UNSLOTH_HIGH_PRECISION_LAYERNORM"] = "1"
         # Cohere
         elif "c4ai-command-a-03-2025" in lowered_model_name and transformers_version < Version("4.50.0.dev0"):
@@ -599,18 +612,6 @@ class FastModel(FastBaseModel):
         elif "olmo-2" in lowered_model_name and transformers_version < Version("4.50.0.dev0"):
             raise RuntimeError("Unsloth: OLMo-2 only works on transformers >= 4.50.0." + NIGHTLY)
         # Gemma 3N
-        elif "gemma-3n" in lowered_model_name:
-            if transformers_version < Version("4.53.0"):
-                raise RuntimeError("Unsloth: Gemma 3N only works on transformers >= 4.53.0" + LATEST)
-            os.environ["UNSLOTH_DISABLE_STATIC_GENERATION"] = "1"
-            os.environ["UNSLOTH_FORCE_CUSTOM_DTYPE"] = \
-                "float16;torch.float16;torch.float16;"\
-                "if name.endswith('norm'): "\
-                "module._pre_set_compute_dtype = torch.float32\n"\
-                ";"\
-                "from unsloth_zoo.temporary_patches.gemma3n import patch_Gemma3nConvNormAct_forward; patch_Gemma3nConvNormAct_forward()"
-            # Set norms to float32 since anyways they get upcasted to float32
-            os.environ["UNSLOTH_HIGH_PRECISION_LAYERNORM"] = "1"
         elif "falcon-h1" in lowered_model_name:
             # Falcon must use float32 Triton ie TRITON_F32_DEFAULT = 'ieee'
             # since Mamba kernels error out on using lower precision


### PR DESCRIPTION
the gemma-3n logic in loader.py is no longer being executed after https://github.com/unslothai/unsloth/commit/9c8735ae4af8d4cbd26d12d02e2c294b8227579f since it will fall into the gemma-3 elif statement. The PR moves gemma-3n inside the gemma-3 logic so that the 3n patch gets applied.

With this change gemma3n vision finetuning works without pinning unsloth and transformers.

Conversational: https://colab.research.google.com/drive/1j-x9oBNu4MUX7bpKjZgozafUDUwgPWGv?usp=sharing
Audio: https://colab.research.google.com/drive/1Roqj8Fb1SA9IOCARBft6l-LZzGiNzdCJ?usp=sharing
**Vision**: https://colab.research.google.com/drive/1YYBeW1bLsJwK6Ion0DVeMRk2ZuSCTqeU?usp=sharing

