### PR TITLE
chore: Fix Typos

### DIFF
--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -582,7 +582,7 @@ def _fast_prepare_inputs_for_generation(
     position_ids=None,
     use_cache=True,
     **kwargs,):
-    # Overwitten -- has a unique cache type, `FalconHybridMambaAttentionDynamicCache`
+    # Overwritten -- has a unique cache type, `FalconHybridMambaAttentionDynamicCache`
     empty_past_kv = past_key_values is None
 
     # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/unsloth/models/gemma.py
+++ b/unsloth/models/gemma.py
@@ -246,7 +246,7 @@ class GemmaFixedRotaryEmbedding(torch.nn.Module):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
 
-        # The difference is we do division explicity instead of t * (1/x) ie we do t/x.
+        # The difference is we do division explicitly instead of t * (1/x) ie we do t/x.
         freq_exponents = (2.0 / self.dim) * (
             torch.arange(self.dim // 2, dtype = torch.int64, device = "cpu").float()
         )
@@ -310,7 +310,7 @@ class GemmaFixedLinearScalingRotaryEmbedding(GemmaFixedRotaryEmbedding):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
 
-        # The difference is we do division explicity instead of t * (1/x) ie we do t/x.
+        # The difference is we do division explicitly instead of t * (1/x) ie we do t/x.
         freq_exponents = (2.0 / self.dim) * (
             torch.arange(self.dim // 2, dtype = torch.int64, device = "cpu").float()
         )


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `Overwitten` → `Overwritten`
  - `explicity` → `explicitly`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.