### PR TITLE
Handle transformers move to dtype from torch_dtype

### DIFF
--- a/unsloth/models/cohere.py
+++ b/unsloth/models/cohere.py
@@ -14,6 +14,8 @@
 
 from .llama import *
 from ._utils import __version__
+from unsloth_zoo.hf_utils import dtype_from_config
+from unsloth_zoo.utils import _get_dtype
 try:
     from transformers.models.cohere.modeling_cohere import (
         CohereAttention,
@@ -401,7 +403,7 @@ def CohereModel_fast_forward_inference(
     out_weights = tuple(torch.empty_like(self.model.layers[0].input_layernorm.weight, dtype = torch.float32, device = torch.device(x)) for x in range(DEVICE_COUNT))
     input_ids = input_ids[:,:self.max_seq_length]
     hidden_states = self.model.embed_tokens(input_ids)
-    hidden_states = hidden_states.to(self.config.torch_dtype)
+    hidden_states = hidden_states.to(_get_dtype(dtype_from_config(self.config)))
     bsz, q_len, hd = hidden_states.shape
     seq_len = past_key_values[0][0].shape[-2]
     if bsz != 1:

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -16,6 +16,7 @@ from .llama import *
 import os
 from ._utils import __version__
 from unsloth_zoo.utils import Version, _get_dtype
+from unsloth_zoo.hf_utils import dtype_from_config
 from .llama import (
     LlamaRotaryEmbedding,
     LlamaLinearScalingRotaryEmbedding,
@@ -480,7 +481,7 @@ def _FalconH1_fast_forward_inference(attention_fast_forward_inference=FalconH1At
         X = self.model.embed_tokens(input_ids)
         X = X * self.config.embedding_multiplier
 
-        X = X.to(_get_dtype(self.config.torch_dtype))
+        X = X.to(_get_dtype(dtype_from_config(self.config)))
         bsz, q_len, hd = X.shape
         assert(q_len == 1)
         # Get saved buffers to reduce memory movement

--- a/unsloth/models/gemma.py
+++ b/unsloth/models/gemma.py
@@ -14,6 +14,8 @@
 
 from .llama import *
 from ._utils import __version__
+from unsloth_zoo.utils import _get_dtype
+from unsloth_zoo.hf_utils import dtype_from_config
 import math
 
 try:
@@ -152,7 +154,7 @@ def GemmaModel_fast_forward_inference(
     out_weights = tuple(torch.empty_like(self.model.layers[0].input_layernorm.weight, dtype = torch.float32, device = torch.device(x)) for x in range(DEVICE_COUNT))
     input_ids = input_ids[:,:self.max_seq_length]
     hidden_states = self.model.embed_tokens(input_ids)
-    hidden_states = hidden_states.to(self.config.torch_dtype)
+    hidden_states = hidden_states.to(_get_dtype(dtype_from_config(self.config)))
     # 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
     # 2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
     hidden_states *= torch.tensor(math_sqrt(self.config.hidden_size), dtype = hidden_states.dtype)

--- a/unsloth/models/gemma2.py
+++ b/unsloth/models/gemma2.py
@@ -14,6 +14,8 @@
 
 from .llama import *
 from ._utils import __version__
+from unsloth_zoo.utils import _get_dtype
+from unsloth_zoo.hf_utils import dtype_from_config
 from .gemma import (
     GemmaFixedRotaryEmbedding,
     GemmaFixedLinearScalingRotaryEmbedding,
@@ -379,7 +381,7 @@ def Gemma2Model_fast_forward_inference(
     out_weights = tuple(torch.empty_like(self.model.layers[0].input_layernorm.weight, dtype = torch.float32, device = torch.device(x)) for x in range(DEVICE_COUNT))
     input_ids = input_ids[:,:self.max_seq_length]
     hidden_states = self.model.embed_tokens(input_ids)
-    hidden_states = hidden_states.to(self.config.torch_dtype)
+    hidden_states = hidden_states.to(_get_dtype(dtype_from_config(self.config)))
     # 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
     # 2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
     hidden_states *= torch.tensor(math_sqrt(self.config.hidden_size), dtype = hidden_states.dtype)

--- a/unsloth/models/granite.py
+++ b/unsloth/models/granite.py
@@ -15,6 +15,8 @@
 from .llama import *
 import os
 from ._utils import __version__
+from unsloth_zoo.utils import _get_dtype
+from unsloth_zoo.hf_utils import dtype_from_config
 from .llama import (
     LlamaRotaryEmbedding,
     LlamaLinearScalingRotaryEmbedding,
@@ -375,7 +377,7 @@ def GraniteModel_fast_forward_inference(
 ):
     input_ids = input_ids[:,:self.max_seq_length]
     hidden_states = self.model.embed_tokens(input_ids)
-    hidden_states = hidden_states.to(self.config.torch_dtype)
+    hidden_states = hidden_states.to(_get_dtype(dtype_from_config(self.config)))
     hidden_states *= self.model.embedding_multiplier
     residual_multiplier = \
         self.residual_multiplier \

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -47,6 +47,7 @@ import importlib.util
 
 # https://github.com/huggingface/transformers/pull/26037 allows 4 bit loading!
 from unsloth_zoo.utils import Version, _get_dtype
+from unsloth_zoo.hf_utils import dtype_from_config
 transformers_version = Version(transformers_version)
 SUPPORTS_FOURBIT   = transformers_version >= Version("4.37")
 SUPPORTS_GEMMA     = transformers_version >= Version("4.38")
@@ -437,12 +438,11 @@ class FastLanguageModel(FastLlamaModel):
 
         if load_in_4bit:
             # Fix up bitsandbytes config
-            config = model.config.to_dict()
-            torch_dtype = config.get("dtype") or config.get("torch_dtype")
+            compute_dtype = dtype_from_config(model.config)
             quantization_config = \
             {
-                # Sometimes torch_dtype is not a string!!
-                "bnb_4bit_compute_dtype"           : torch_dtype,
+                # Sometimes compute_dtype is not a string!!
+                "bnb_4bit_compute_dtype"           : compute_dtype,
                 "bnb_4bit_quant_type"              : "nf4",
                 "bnb_4bit_use_double_quant"        : True,
                 "llm_int8_enable_fp32_cpu_offload" : False,
@@ -889,12 +889,11 @@ class FastModel(FastBaseModel):
 
         if load_in_4bit:
             # Fix up bitsandbytes config
-            config = model.config.to_dict()
-            torch_dtype = config.get("dtype") or config.get("torch_dtype")
+            compute_dtype = dtype_from_config(model.config)
             quantization_config = \
             {
-                # Sometimes torch_dtype is not a string!!
-                "bnb_4bit_compute_dtype"           : torch_dtype,
+                # Sometimes compute_dtype is not a string!!
+                "bnb_4bit_compute_dtype"           : compute_dtype,
                 "bnb_4bit_quant_type"              : "nf4",
                 "bnb_4bit_use_double_quant"        : True,
                 "llm_int8_enable_fp32_cpu_offload" : False,

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -15,6 +15,8 @@
 from .llama import *
 import os
 from ._utils import __version__
+from unsloth_zoo.utils import _get_dtype
+from unsloth_zoo.hf_utils import dtype_from_config
 from .llama import (
     LlamaRotaryEmbedding,
     LlamaLinearScalingRotaryEmbedding,
@@ -230,7 +232,7 @@ def MistralForCausalLM_fast_forward(
                     attention_mask = attention_mask.expand(bsz, 1, q_len, q_len)
                 attention_mask = attention_mask + causal_mask_values[None, None, :, :]
 
-            attention_mask = attention_mask.to(dtype=_get_dtype(self.config.torch_dtype))
+            attention_mask = attention_mask.to(dtype=_get_dtype(dtype_from_config(self.config)))
 
     output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
     output_hidden_states = (
@@ -324,7 +326,7 @@ def MistralForCausalLM_fast_forward(
         pass
         logits = self.lm_head(hidden_states.to(lm_head.dtype))
     pass
-    logits = logits.to(_get_dtype(self.config.torch_dtype))
+    logits = logits.to(_get_dtype(dtype_from_config(self.config)))
 
     loss = None
     if labels is not None:

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -234,7 +234,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         )
     pass
 
-    # Edit bf16, fp16 by checking model's torch_dtype directly
+    # Edit bf16, fp16 by checking model's dtype/torch_dtype directly
     extra_args = ""
     if "args" in call_args and "model" in call_args:
         mixed_precision = \
@@ -247,7 +247,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         "    print('Unsloth: Switching to float32 training since model cannot work with float16')\n"\
         "    force_float32 = True\n"\
         "mixed_precision_dtype = os.environ.get('UNSLOTH_MIXED_PRECISION', 'float32')\n"\
-        "dtype = getattr(model.config, 'torch_dtype', None)\n"\
+        "dtype = getattr(model.config, 'dtype', None) or getattr(model.config, 'torch_dtype', None)\n"\
         "if dtype is None: dtype = model.get_input_embeddings().dtype\n"\
         "from unsloth_zoo.utils import _get_dtype\n"\
         "dtype = _get_dtype(dtype)\n"\

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -43,6 +43,7 @@ from transformers.models.llama.modeling_llama import logger
 from transformers import __version__ as transformers_version
 from triton import __version__ as triton_version
 from unsloth_zoo.utils import _get_dtype
+from unsloth_zoo.hf_utils import dtype_from_config, add_dtype_kwargs
 from unsloth_zoo.patching_utils import patch_model_and_tokenizer
 from unsloth_zoo.training_utils import prepare_model_for_training
 import types
@@ -73,8 +74,6 @@ global PROMPT_LOOPKUP
 PROMPT_LOOPKUP = dict()
 
 from transformers import GenerationConfig, CompileConfig, HybridCache
-from transformers import PretrainedConfig
-HAS_TORCH_DTYPE = "torch_dtype" in PretrainedConfig.__doc__
 
 _compile_config = CompileConfig(
     fullgraph = False,
@@ -121,7 +120,7 @@ def unsloth_base_fast_generate(
     bsz = input_ids.shape[0]
 
     FastBaseModel.for_inference(self)
-    dtype = _get_dtype(getattr(self.config, "dtype", None) or getattr(self.config, "torch_dtype", None))
+    dtype = _get_dtype(dtype_from_config(self.config))
 
     # Check if VLM
     is_vlm = any(
@@ -444,11 +443,7 @@ class FastBaseModel:
         torch_dtype = dtype
         if do_forced_float32: torch_dtype = torch.bfloat16
 
-        if HAS_TORCH_DTYPE:
-            kwargs["torch_dtype"] = torch_dtype
-        else:
-            # Transformers removed torch_dtype
-            kwargs["dtype"] = torch_dtype
+        kwargs = add_dtype_kwargs(torch_dtype, kwargs)
 
         raise_handler = RaiseUninitialized()
         model = auto_model.from_pretrained(
@@ -705,9 +700,7 @@ class FastBaseModel:
         full_finetuning = os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1"
 
         float32_mixed_precision = True
-        if _get_dtype(
-                getattr(model.config, "dtype", None) or getattr(model.config, "torch_dtype", None)
-            ) == torch.bfloat16 and full_finetuning:
+        if _get_dtype(dtype_from_config(model.config)) == torch.bfloat16 and full_finetuning:
             # Use bfloat16 precision for full finetuning
             float32_mixed_precision = False
 


### PR DESCRIPTION
The latest transformers is now using dtype instead of torch_dtype throughout. This PR handles this move as well as keep it BC for older transformer versions. Depends on https://github.com/unslothai/unsloth-zoo/pull/255

Notebooks tested for training:
qwen3 sft: https://colab.research.google.com/drive/1a3GQf6fgiw8LvkcqUtjawweG-XNZoXsL?usp=sharing
llama 3.2: https://colab.research.google.com/drive/1xmHA144D_7BrXrsOYa4KRNf6Px0PDS_L?usp=sharing
gpt-oss: https://colab.research.google.com/drive/1ZonfSgVbuDBu8ZsbdUYQ1qpC4y5J5KlF?usp=sharing
gemma3n vision: https://colab.research.google.com/drive/1q_oXN7vARKPnV_Tgfn3CFhqIZvfsMa83?usp=sharing
grpo qwen3: https://colab.research.google.com/drive/1B247FF6xQSZhDYCitX90Eytsj2JSBz8X?usp=sharing
qwen 2.5vl: https://colab.research.google.com/drive/1xiGzQONx5J9cKbym-PEcsYY3b61jbjEA?usp=sharing
gemma3 270: https://colab.research.google.com/drive/1lCcO_5Ty32NtTRopZ2mSSk48_BC_YRJf?usp=sharing
orpheus: https://colab.research.google.com/drive/1aaqKA9CFkbkIh6-yFR7fO5mKcf8nVG9A?usp=sharing
grpo deepseek: https://colab.research.google.com/drive/1zbG-CXXT186V_o1cbK--g-f3zJakRwjF?usp=sharing
