### PR TITLE
chore: Fix Typos

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2862,7 +2862,7 @@ extra_eos_tokens = None,
         jinja_template, flags = re.MULTILINE | re.DOTALL,
     )
 
-    # Check jinja tempate for bos
+    # Check jinja template for bos
     if always_bos_token:
         if not jinja_template.startswith(("{{ bos_token }}", "{{- bos_token }}")):
             jinja_template = "{{ bos_token }}" + jinja_template

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2835,7 +2835,7 @@ class FastLlamaModel:
             for idx, layer in enumerate(model.model.model.layers):
 
                 if model_type != "falcon_h1":
-                    # LoRAMLP.apply doesn't have functionality for gate and down mutlipliers yet.
+                    # LoRAMLP.apply doesn't have functionality for gate and down multipliers yet.
                     # Don't patch falcon h1 for the time being.
 
                     # MLP patching


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `tempate` → `tempate`
  - `mutlipliers` → `multipliers`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.