### PR TITLE
fixed save_pretrained_torchao and associated tests

### DIFF
--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -812,6 +812,11 @@ __INT_TO_FLOAT_MAPPER = \
         "microsoft/Phi-4-mini-reasoning",
         "unsloth/phi-4-mini-reasoning-bnb-4bit",
     ),
+    "unsloth/Phi-4-mini-instruct-unsloth-bnb-4bit" : (
+        "unsloth/Phi-4-mini-instruct",
+        "microsoft/Phi-4-mini-instruct",
+        "unsloth/Phi-4-mini-instruct-bnb-4bit",
+    ),
     "unsloth/orpheus-3b-0.1-pretrained-unsloth-bnb-4bit" : (
         "unsloth/orpheus-3b-0.1-pretrained",
         "canopylabs/orpheus-3b-0.1-pretrained",


### PR DESCRIPTION
Additional fixes for save_pretrained_torchao method

**mapping.py:**
Added Phi-4-mini-instruct to the unsloth model map as it's part of the test_model list used or else model will fail when tested.

**save.py:**
- Added support for vision models by routing `save_pretrained_torchao` to `unsloth_save_pretrained_torchao` for vision models as well
- Replaced `AutoModelForCausalLM` with `AutoModel` in `save_pretrained_torchao` since we also want to support vision models (AutoModelForCausalLM is for language models only)
- Fixed and re-arranged save_directory logic: Introduced separate save directory logic to ensure that 16bit merged model generated by call to `unsloth_generic_save` inside `save_pretrained_torchao` is not saved in the same directory as the `torchao` quantized model or else model directory is not readable and results in exception. 16 bit model generated by `unsloth_generic_save` is saved to default `save_directory` while `torchao` quantized model is saved to separate `save_directory`+torchao prefix directory

**test_unsloth_save:**
- replaced `Gemma3-1b` with `Gemma3-4b` , under vision models, since `Gemma3-1b` is a language model
- Introduced separate save directory logic to ensure that 16bit merged model generated by call to `unsloth_generic_save` inside `save_pretrained_torchao` is not saved in the same directory as the `torchao` quantized model or else model directory is not readable and results in exception.
- Reinstated 16bit model calculations and assertion:  we calculate the 16-bits weight for assertion tests, from the 16bit merged model saved in `save_path`


**Tests**:
- `test_save_merged_16bit` were testing to be working with the latest unsloth version.  Ensure to update package versions with the `--force-reinstall` flag before testing. (check below screenshot)
<img width="2555" height="628" alt="Screen Shot 2025-09-04 at 5 49 01 AM" src="https://github.com/user-attachments/assets/ce766f16-c319-40f4-b27f-fa80c753099f" />

- updated `test_save_torchao` pass for the 10 models (check below screenshot)
<img width="2553" height="606" alt="Screen Shot 2025-09-04 at 5 22 48 AM" src="https://github.com/user-attachments/assets/26ec2ff9-9874-4755-9e5b-9024ca0d8be8" />
