### PR TITLE
patch sftrainer to disable _is_vlm

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -727,6 +727,13 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         new_text = 'self._signature_columns = ["input_ids", "attention_mask", "completion_mask","labels"]'
         RLTrainer_source = RLTrainer_source.replace(original_text, new_text)
 
+        # Temporary patch _is_vlm to False
+        # as of 0.22 it only exists in sfttrainer
+        oriignal_is_vlm_text = 'self._is_vlm = True'
+        new_is_vlm_text = 'self._is_vlm = False'
+        RLTrainer_source = RLTrainer_source.replace(oriignal_is_vlm_text, new_is_vlm_text)
+
+
     # Remove multiple doc strings
     if __RLConfig_doc__ != "" and RLTrainer_source.count(__RLTrainer_doc__) == 2:
         RLTrainer_source = RLTrainer_source.replace(__RLTrainer_doc__, "", 1)


### PR DESCRIPTION
TRL now supports VLM models natively through SFTTrainer, but it breaks training models that can serve as both VLM and LM's. For instance gemma 3-4b conversational notebook fails because it starts to expect what trl considers VLM style datasets and it breaks our logic.

For the time being we patch _is_vlm to be False so that our existing notebooks/workflow does not fail. Integrating some of the VLM changes is on the roadmap.

Notebooks to test:
gemma 3 text: https://colab.research.google.com/drive/1QWgBMrSb_KIMaRfz6wh96CmpOVKoa-Ia?usp=sharing
gemma 3 vision still works: https://colab.research.google.com/drive/1IHG4tI_uiu9ZsMyh0Ot_mMJjn3k0Nha3?usp=sharing
