### PR TITLE
llama vision inference fix

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -218,6 +218,9 @@ def unsloth_base_fast_generate(
         if (swa == 0 or type(swa) is not int) \
             and (getattr(self, "_can_compile_fullgraph", True) is True):
             cache_implementation = "static"
+        elif (swa == 0 or type(swa) is not int):
+            # llama vision doesn't have swa and not compatible with static
+            cache_implementation = None
         else:
             cache_implementation = "hybrid"
 


### PR DESCRIPTION
Llama vision inference has a cache issue. It seems we set a cache_implementation of hybrid where only swa attention models work with hybrid. 

Notebooks:
Llama vision working with pypi transformers/trl: https://colab.research.google.com/drive/1A-mm-1pvDb6e5CGtpeRtVkGYUAtFMGv0?usp=sharing
llama vision working with main transformers/trl: https://colab.research.google.com/drive/1EqH1E7lB5PvaeNwhPkNNpzrlaxMWvrb2?usp=sharing
gemma notebook as sanity test: https://colab.research.google.com/drive/1b4vDYgKv_ZIurVSGIfBPSZQbpVJjseRX?usp=sharing