### PR TITLE
Fixed duplicate tokenizer_name parameter in FastVisionModel.from_pretrained

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -400,7 +400,9 @@ class FastLanguageModel(FastLlamaModel):
                 pass
             pass
         pass
-
+        
+        tokenizer_name = kwargs.pop('tokenizer_name', tokenizer_name)
+        
         model, tokenizer = dispatch_model.from_pretrained(
             model_name        = model_name,
             max_seq_length    = max_seq_length,


### PR DESCRIPTION
Fixes #3275

- Adds `tokenizer_name = kwargs.pop('tokenizer_name', tokenizer_name)` before calling FastBaseModel.from_pretrained()
- Prevents TypeError: got multiple values for keyword argument 'tokenizer_name'
- Tested with Qwen2.5-VL-3B-Instruct model

```
from unsloth import FastVisionModel

model, processor = FastVisionModel.from_pretrained(
    "unsloth/Qwen2.5-VL-3B-Instruct",
    load_in_4bit=False,
    use_gradient_checkpointing="unsloth",
    tokenizer_name="unsloth/Qwen2.5-VL-3B-Instruct"
)

```


`
/home/nvidia/project/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
  from .autonotebook import tqdm as notebook_tqdm
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
🦥 Unsloth Zoo will now patch everything to make training faster!
==((====))==  Unsloth 2025.9.1: Fast Qwen2_5_Vl patching. Transformers: 4.56.1.
   \\   /|    NVIDIA H100 NVL. Num GPUs = 8. Max memory: 93.086 GB. Platform: Linux.
O^O/ \_/ \    Torch: 2.8.0+cu128. CUDA: 9.0. CUDA Toolkit: 12.8. Triton: 3.4.0
\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.32.post2. FA2 = False]
 "-____-"     Free license: http://github.com/unslothai/unsloth
Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.
Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.33it/s]
Fetching 1 files: 100%|██████████| 1/1 [00:00<00:00, 8224.13it/s]
Fetching 1 files: 100%|██████████| 1/1 [00:00<00:00, 6502.80it/s]
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
Fetching 1 files: 100%|██████████| 1/1 [00:00<00:00, 19691.57it/s]
`