### PR TITLE
GptAttention turn training off during inference

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2986,6 +2986,7 @@ class FastLlamaModel:
             _for_inference(m)
             m = m.model
         _for_inference(m)
+        model.eval() # to turn off training on modules deeper in
 
         # Since transformers 4.53, must turn off explicitly
         for module in model.modules():
@@ -3030,6 +3031,7 @@ class FastLlamaModel:
             _for_training(m)
             m = m.model
         _for_training(m)
+        model.train() # to turn on training on modules deeper in
 
         # Since transformers 4.53, must turn on explicitly
         for module in model.modules():

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -772,6 +772,7 @@ class FastBaseModel:
             _for_inference(m)
             m = m.model
         _for_inference(m)
+        model.eval() # to turn off training on modules deeper in
 
         # Since transformers 4.53, must turn off explicitly
         for module in model.modules():
@@ -823,6 +824,7 @@ class FastBaseModel:
             _for_training(m)
             m = m.model
         _for_training(m)
+        model.train() # to turn on training on modules deeper in
 
         # Since transformers 4.53, must turn on explicitly
         for module in model.modules():


### PR DESCRIPTION
GptAttention is deeper inside modules for_inference and for_training go. To be sure we turn off those modules for inference or on for inference we call model.train and model.eval respectively.

Gpt oss inference now works with use_cache=True

https://colab.research.google.com/drive/11qS1-C86hr8twvo-y_Po4-pYYBRepT_l?usp=sharing