### PR TITLE
Add support for modules_to_save in FastModel.get_peft_model

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -646,6 +646,7 @@ class FastBaseModel:
             "lora_dropout"      : lora_dropout,
             "bias"              : bias,
             "task_type"         : task_type,
+            "modules_to_save"   : modules_to_save, # why it was missed in unsloth...
             "use_rslora"        : use_rslora,
             "init_lora_weights" : init_lora_weights,
             "loftq_config"      : loftq_config,

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -646,7 +646,7 @@ class FastBaseModel:
             "lora_dropout"      : lora_dropout,
             "bias"              : bias,
             "task_type"         : task_type,
-            "modules_to_save"   : modules_to_save, # why it was missed in unsloth...
+            "modules_to_save"   : modules_to_save,
             "use_rslora"        : use_rslora,
             "init_lora_weights" : init_lora_weights,
             "loftq_config"      : loftq_config,


### PR DESCRIPTION
## Problem Description
Currently, the `FastModel.get_peft_model` method does not support the `modules_to_save` argument.

If a user passes `modules_to_save=["score"]` when training an LLM classifier, the head (`score`) remains a regular `Linear` module and is **not wrapped in `ModulesToSaveWrapper`**.

This results in the head’s weights **not being saved in `adapter_model.safetensors`** along with the LoRA adapters, making reuse or further fine-tuning impossible.

## Solution
- Added support to pass the `modules_to_save` argument into the internal LoRA configuration.
- The head (or any specified modules) is now correctly **wrapped in `ModulesToSaveWrapper`**.