### PR TITLE
peft_config before model_config

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -213,7 +213,7 @@ class FastLanguageModel(FastLlamaModel):
             peft_error = str(error)
             is_peft = False
         pass
-        model_types = get_transformers_model_type(model_config or peft_config)
+        model_types = get_transformers_model_type(peft_config or model_config)
         if len(model_types) == 1:
             model_type = model_types[0]
         else:
@@ -626,7 +626,7 @@ class FastModel(FastBaseModel):
             peft_error = str(error)
             is_peft = False
         pass
-        model_types = get_transformers_model_type(model_config or peft_config)
+        model_types = get_transformers_model_type(peft_config or model_config)
         model_types_all = ",".join(model_types)
 
         # Check versions


### PR DESCRIPTION
When loading a lora adapter a model config can still get processed even though there's is only an adapter config files. if the file is a gemma model but saved with a llama name, it will come back with a llama config, or if gemma3 was saved as gemma-3 it will load a Gemma config. then `model_config or peft_config` will return the model_config to get_transformers_model_type causing an incorrect model load. placing peft_config first will return the peft_config if not None and should only return truthy if it's an actual peft config.

This should address #3338 

gemma-3 270 notebook was failing and now works. Also tested on Llama and gpt oss.

gemma 270: https://colab.research.google.com/drive/1Dkn7zGpAfiXK_qzkgBF8xoa6O32niAks?usp=sharing
llama: https://colab.research.google.com/drive/1WrAUtHucfbEj3oBXA9rD4X3jDogP1xB0?usp=sharing
gpt: https://colab.research.google.com/drive/1Zfh6Fp0tHuc_dQi4ElE_SL4InbNHlEc8?usp=sharing