### PR TITLE
specify different tokenizer_path/name

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -403,7 +403,7 @@ class FastLanguageModel(FastLlamaModel):
 
             tokenizer_name = old_model_name
         else:
-            tokenizer_name = None
+            tokenizer_name = kwargs.pop("tokenizer_name", None)
         pass
 
         if fast_inference:
@@ -867,7 +867,7 @@ class FastModel(FastBaseModel):
 
             tokenizer_name = old_model_name
         else:
-            tokenizer_name = None
+            tokenizer_name = kwargs.pop("tokenizer_name", None)
         pass
 
         # Check if VLM


### PR DESCRIPTION
This fix addresses #3275 

Works for Llama based models and Fast models.

Llama: https://colab.research.google.com/drive/1_OPBKlw9IH9Dl6qVZOPSFZCSW59C1umK?usp=sharing
Gemma: https://colab.research.google.com/drive/1Oil_lMbKtFwH_nmCzS62TFw6VMh4kpW5?usp=sharing

Also confirmed regular notebooks run and gptoss will work with the changes
gpt: https://colab.research.google.com/drive/1lPGGsp8ksElpAm9hHsKoOwECQnDcKZgU?usp=sharing