### PR TITLE
Sets overwrite back to false

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -777,7 +777,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         RLTrainer_source,
         f"trl.trainer.{trainer_file}",
         imports,
-        overwrite = True,
+        overwrite=False,
     )
 
     # Patch Trainer


### PR DESCRIPTION
Related to: https://github.com/unslothai/unsloth-zoo/pull/297

Sets overwrite back to false so cache isn't rewritten unnecessarily any more due to above fix.