### PR TITLE
add code for intel qlora

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -233,7 +233,7 @@ elif DEVICE_TYPE == "hip":
     # NO-OP for rocm device
     pass
 elif DEVICE_TYPE == "xpu":
-    # currently intel xpu will not support bnb, will add support in the future
+    import bitsandbytes as bnb
     # TODO: check triton for intel installed properly.
     pass
 

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -75,19 +75,13 @@ def calculate_settings(n : int) -> (int, int,):
 pass
 
 HAS_CUDA_STREAM = False
-# INTEL GPU specific logic
-if DEVICE_TYPE == "xpu":
-    # TODO: Changed here after adding XPU BNB support
-    HAS_XPU_STREAM = True
-    def get_ptr(x: Optional[torch.Tensor]):
-        raise RuntimeError("XPU BNB support is not implemented yet. This function should not be called.")
-else:
-    # NVIDIA-GPU logic here as default
-    import bitsandbytes as bnb
-    # https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1330/files
-    HAS_CUDA_STREAM = Version(bnb.__version__) > Version("0.43.3")
-    get_ptr = bnb.functional.get_ptr
+import bitsandbytes as bnb
+# https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1330/files
+HAS_CUDA_STREAM = Version(bnb.__version__) > Version("0.43.3")
+get_ptr = bnb.functional.get_ptr
 
+if DEVICE_TYPE == "xpu":
+    HAS_XPU_STREAM = True
 
 if DEVICE_COUNT > 1:
     if DEVICE_TYPE in ("cuda", "hip"):
@@ -148,31 +142,11 @@ pass
 # Bitsandbytes operations
 ctypes_c_int   = ctypes.c_int
 ctypes_c_int32 = ctypes.c_int32
-# INTEL GPU Specific Logic
-if DEVICE_TYPE == "xpu":
-    # TODO: After adding XPU BNB support, this function should be implemented
-    def cdequantize_blockwise_fp32(*args, **kwargs):
-        raise RuntimeError("XPU BNB support is not implemented yet. cdequantize_blockwise_fp32 should not be called now.")
-
-    def cdequantize_blockwise_fp16_nf4(*args, **kwargs):
-        raise RuntimeError("XPU BNB support is not implemented yet. cdequantize_blockwise_fp16_nf4 should not be called now.")
-
-    def cdequantize_blockwise_bf16_nf4(*args, **kwargs):
-        raise RuntimeError("XPU BNB support is not implemented yet. cdequantize_blockwise_bf16_nf4 should not be called now.")
-
-    def cgemm_4bit_inference_naive_fp16(*args, **kwargs):
-        raise RuntimeError("XPU BNB support is not implemented yet. cgemm_4bit_inference_naive_fp16 should not be called now.")
-
-    def cgemm_4bit_inference_naive_bf16(*args, **kwargs):
-        raise RuntimeError("XPU BNB support is not implemented yet. cgemm_4bit_inference_naive_bf16 should not be called now.")
-else:
-    # NVIDIA GPU Default Logic
-    cdequantize_blockwise_fp32      = bnb.functional.lib.cdequantize_blockwise_fp32
-    cdequantize_blockwise_fp16_nf4  = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
-    cdequantize_blockwise_bf16_nf4  = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
-    cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
-    cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
-pass
+cdequantize_blockwise_fp32      = bnb.functional.lib.cdequantize_blockwise_fp32
+cdequantize_blockwise_fp16_nf4  = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
+cdequantize_blockwise_bf16_nf4  = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
+cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
+cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
 
 torch_device_stream = torch.xpu.current_stream if DEVICE_TYPE == "xpu" else torch.cuda.current_stream
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -517,8 +517,7 @@ pass
 
 # =============================================
 # Get Flash Attention v2 if Ampere (RTX 30xx, A100)
-if DEVICE_TYPE in ("cuda", "hip"):
-    import bitsandbytes as bnb
+import bitsandbytes as bnb
 
 from transformers import AutoTokenizer
 from transformers.utils.import_utils import _is_package_available


### PR DESCRIPTION
Tested with llama3.2 1B

(/workspace1/conda_env/lzy_unsloth) gta@DUT7357PVC:/workspace2/zhenyuan/unsloth_28/unsloth_validation$ python 
run.py --sft --qlora --model_name unsloth/Llama-3.2-1B-Instruct --dtype bfloat16 --max_steps 10
The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers and GPU quantization are unavailable.
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
INFO:datasets:PyTorch version 2.9.0a0+git61a7b09 available.
🦥 Unsloth Zoo will now patch everything to make training faster!
==((====))==  Unsloth 2025.9.6: Fast Llama patching. Transformers: 4.56.2.
   \\   /|    Intel(R) Data Center GPU Max 1100. Num GPUs = 8. Max memory: 47.984 GB. Platform: Linux.
O^O/ \_/ \    Torch: 2.9.0a0+git61a7b09. Intel Toolkit: 20250300. Triton: 3.3.1
\        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = False]
 "-____-"     Free license: http://github.com/unslothai/unsloth
Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
Unsloth 2025.9.6 patched 16 layers with 16 QKV layers, 16 O layers and 16 MLP layers.
Unsloth: Tokenizing ["text"] (num_proc=196): 100%|█████████████| 51760/51760 [00:40<00:00, 1289.85 examples/s]
==((====))==  Unsloth - 2x faster free finetuning | Num GPUs used = 1
   \\   /|    Num examples = 51,760 | Num Epochs = 1 | Total steps = 10
O^O/ \_/ \    Batch size per device = 2 | Gradient accumulation steps = 4
\        /    Data Parallel GPUs = 1 | Total batch size (2 x 4 x 1) = 8
 "-____-"     Trainable parameters = 11,272,192 of 1,247,086,592 (0.90% trained)
  0%|                                                                                  | 0/10 [00:00<?, ?it/s]Unsloth: Will smartly offload gradients to save VRAM!
{'loss': 1.7823, 'grad_norm': 0.7197486758232117, 'learning_rate': 0.0, 'epoch': 0.0}                         
{'loss': 2.2414, 'grad_norm': 1.1325058937072754, 'learning_rate': 4e-05, 'epoch': 0.0}                       
{'loss': 1.9271, 'grad_norm': 0.7045528292655945, 'learning_rate': 8e-05, 'epoch': 0.0}                       
{'loss': 2.1657, 'grad_norm': 0.9182726740837097, 'learning_rate': 0.00012, 'epoch': 0.0}                     
{'loss': 2.0065, 'grad_norm': 0.8175152540206909, 'learning_rate': 0.00016, 'epoch': 0.0}                     
{'loss': 1.8588, 'grad_norm': 0.696787416934967, 'learning_rate': 0.0002, 'epoch': 0.0}                       
{'loss': 1.4615, 'grad_norm': 0.7219595909118652, 'learning_rate': 0.00016, 'epoch': 0.0}                     
{'loss': 1.6534, 'grad_norm': 0.8075016736984253, 'learning_rate': 0.00012, 'epoch': 0.0}                     
{'loss': 1.5285, 'grad_norm': 0.820014476776123, 'learning_rate': 8e-05, 'epoch': 0.0}                        
{'loss': 1.5361, 'grad_norm': 0.9512497782707214, 'learning_rate': 4e-05, 'epoch': 0.0}                       
{'train_runtime': 18.7188, 'train_samples_per_second': 4.274, 'train_steps_per_second': 0.534, 'train_loss': 1.8161260485649109, 'epoch': 0.0}
100%|█████████████████████████████████████████████████████████████████████████| 10/10 [00:18<00:00,  1.87s/it]


Below is my test env:
(/workspace1/conda_env/lzy_unsloth)
Package                  Version                Editable project location
------------------------ ---------------------- -------------------------------------
absl-py                  2.3.0
accelerate               1.7.0
aiohappyeyeballs         2.6.1
aiohttp                  3.12.12
aiosignal                1.3.2
alembic                  1.16.1
annotated-types          0.7.0
antlr4-python3-runtime   4.9.3
asteroid-filterbanks     0.4.0
astunparse               1.6.3
async-timeout            5.0.1
attrs                    25.3.0
audioread                3.0.1
autocommand              2.2.2
av                       14.4.0
backports.tarfile        1.2.0
bitsandbytes             0.47.0.dev0            /workspace1/xiaoli/bitsandbytes-clean
blobfile                 3.0.0
build                    1.2.2.post1
certifi                  2025.4.26
cffi                     1.17.1
charset-normalizer       3.4.2
check-wheel-contents     0.6.2
click                    8.2.1
cmake                    4.0.2
colorlog                 6.9.0
contourpy                1.3.2
cycler                   0.12.1
datasets                 3.6.0
decorator                5.2.1
decord                   0.6.0
diffusers                0.33.1
dill                     0.3.8
docopt                   0.6.2
docstring_parser         0.16
docutils                 0.21.2
dpcpp-cpp-rt             2025.1.1
einops                   0.8.1
evaluate                 0.4.3
exceptiongroup           1.3.0
expecttest               0.3.0
filelock                 3.13.1
fire                     0.7.0
flake8                   7.2.0
fonttools                4.58.3
frozenlist               1.7.0
fsspec                   2024.6.1
fvcore                   0.1.5.post20221221
greenlet                 3.2.3
hf_transfer              0.1.9
hf-xet                   1.1.5
huggingface-hub          0.35.1
HyperPyYAML              1.2.2
hypothesis               6.135.7
id                       1.5.0
idna                     3.10
impi-devel               2021.14.1
impi-rt                  2021.15.0
importlib_metadata       8.7.0
inflect                  7.3.1
iniconfig                2.1.0
intel-cmplr-lib-rt       2025.1.1
intel-cmplr-lib-ur       2025.1.1
intel-cmplr-lic-rt       2025.1.1
intel-opencl-rt          2025.1.1
intel-openmp             2025.1.1
intel-pti                0.12.3
intel-sycl-rt            2025.1.1
iopath                   0.1.10
jaraco.collections       5.1.0
jaraco.context           5.3.0
jaraco.functools         4.0.1
jaraco.text              3.12.1
Jinja2                   3.1.4
joblib                   1.5.1
julius                   0.2.7
kagglehub                0.3.12
kenlm                    0.3.0
kiwisolver               1.4.8
lazy_loader              0.4
librosa                  0.11.0
lightning                2.5.1.post0
lightning-utilities      0.14.3
lintrunner               0.12.7
lion-pytorch             0.2.3
llvmlite                 0.44.0
lxml                     5.4.0
Mako                     1.3.10
markdown-it-py           3.0.0
MarkupSafe               2.1.5
matplotlib               3.10.3
mccabe                   0.7.0
mdurl                    0.1.2
mkl                      2025.1.0
mkl-dpcpp                2025.0.1
mkl-include              2025.2.0
mkl-static               2025.2.0
more-itertools           10.3.0
mpmath                   1.3.0
msgpack                  1.1.1
multidict                6.4.4
multiprocess             0.70.16
networkx                 3.3
nh3                      0.2.21
ninja                    1.11.1.4
nltk                     3.9.1
numba                    0.61.2
numpy                    1.26.4
nvidia-cublas-cu12       12.6.4.1
nvidia-cuda-cupti-cu12   12.6.80
nvidia-cuda-nvrtc-cu12   12.6.77
nvidia-cuda-runtime-cu12 12.6.77
nvidia-cudnn-cu12        9.5.1.17
nvidia-cufft-cu12        11.3.0.4
nvidia-cufile-cu12       1.11.1.6
nvidia-curand-cu12       10.3.7.77
nvidia-cusolver-cu12     11.7.1.2
nvidia-cusparse-cu12     12.5.4.2
nvidia-cusparselt-cu12   0.6.3
nvidia-nccl-cu12         2.26.2
nvidia-nvjitlink-cu12    12.6.85
nvidia-nvtx-cu12         12.6.77
omegaconf                2.3.0
oneccl                   2021.15.2
oneccl-devel             2021.15.2
onemkl-sycl-blas         2025.1.0
onemkl-sycl-datafitting  2025.0.1
onemkl-sycl-dft          2025.1.0
onemkl-sycl-lapack       2025.1.0
onemkl-sycl-rng          2025.1.0
onemkl-sycl-sparse       2025.1.0
onemkl-sycl-stats        2025.0.1
onemkl-sycl-vm           2025.0.1
opencv-python            4.11.0.86
optree                   0.16.0
optuna                   4.3.0
packaging                24.2
pandas                   2.3.0
parameterized            0.9.0
peft                     0.15.2
pillow                   11.2.1
pip                      25.1.1
platformdirs             4.3.8
pluggy                   1.6.0
pooch                    1.8.2
portalocker              3.1.1
primePy                  1.3
propcache                0.3.2
protobuf                 6.31.1
psutil                   7.0.0
pyannote.audio           3.3.2
pyannote.core            5.0.0
pyannote.database        5.1.3
pyannote.metrics         3.2.1
pyannote.pipeline        3.0.1
pyarrow                  20.0.0
pycodestyle              2.13.0
pycparser                2.22
pycryptodomex            3.23.0
pyctcdecode              0.5.0
pydantic                 2.11.7
pydantic_core            2.33.2
pyflakes                 3.3.2
Pygments                 2.19.1
pygtrie                  2.5.0
pyparsing                3.2.3
pyproject_hooks          1.2.0
pytesseract              0.3.13
pytest                   8.4.0
python-dateutil          2.9.0.post0
pytorch-lightning        2.5.1.post0
pytorch-metric-learning  2.8.1
pytorch-msssim           1.0.0
pytorch-triton-xpu       3.3.1+gitb0e26b73
pytorchvideo             0.1.5
pytz                     2025.2
PyYAML                   6.0.2
readme_renderer          44.0
regex                    2024.11.6
requests                 2.32.4
requests-toolbelt        1.0.0
rfc3986                  2.0.0
rich                     14.0.0
rouge_score              0.1.2
ruamel.yaml              0.18.14
ruamel.yaml.clib         0.2.12
safetensors              0.5.3
scikit-learn             1.7.0
scipy                    1.15.3
semver                   3.0.4
sentence-transformers    4.1.0
sentencepiece            0.2.0
setuptools               79.0.1
shellingham              1.5.4
shtab                    1.7.2
six                      1.17.0
sortedcontainers         2.4.0
soundfile                0.13.1
soxr                     0.5.0.post1
speechbrain              1.0.3
SQLAlchemy               2.0.41
sympy                    1.13.3
tabulate                 0.9.0
tbb                      2022.1.0
tbb-devel                2022.2.0
tcmlib                   1.3.0
tensorboardX             2.6.4
termcolor                3.1.0
threadpoolctl            3.6.0
tiktoken                 0.9.0
timm                     1.0.15
tokenizers               0.22.1
tomli                    2.2.1
torch                    2.9.0a0+git61a7b09
torch-audiomentations    0.12.0
torch_pitch_shift        1.2.5
torchao                  0.11.0+gitdf46e7ac
torchaudio               2.8.0.dev20250615+xpu
torchdata                0.11.0
torchmetrics             1.7.2
torchtune                0.0.0                  /workspace2/majing/torchtune
torchvision              0.23.0.dev20250615+xpu
tqdm                     4.67.1
transformers             4.56.2
triton                   3.3.1
trl                      0.23.0
twine                    6.1.0
typeguard                4.4.3
typer                    0.16.0
types-dataclasses        0.6.6
typing_extensions        4.12.2
typing-inspection        0.4.1
tyro                     0.9.24
tzdata                   2025.2
umf                      0.10.0
UNKNOWN                  0.0.0
unsloth                  2025.9.6
unsloth_zoo              2025.9.8
urllib3                  2.4.0
uv                       0.7.19
wheel                    0.45.1
wheel-filename           1.4.2
xxhash                   3.5.0
yacs                     0.1.8
yarl                     1.20.1
zipp                     3.23.0
