### PR TITLE
Fix/add gpt oss bf16 to mapper

### DIFF
--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -934,6 +934,7 @@ __INT_TO_FLOAT_MAPPER = \
     ),
     "unsloth/gpt-oss-120b-unsloth-bnb-4bit" : (
         "unsloth/gpt-oss-120b",
+        "unsloth/gpt-oss-120b-BF16",
         "openai/gpt-oss-120b",
         "unsloth/gpt-oss-120b-unsloth-bnb-4bit",
     ),


### PR DESCRIPTION
add BF16 gpt-oss variant to model mapper . works with unsloth-zoo https://github.com/unslothai/unsloth-zoo/pull/314