### PR TITLE
Add Qwen2.5 Coder model support to registry and chat templates

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -895,6 +895,19 @@ DEFAULT_SYSTEM_MESSAGE["qwen25"] = qwen25_default_system_message # No system mes
 
 CHAT_TEMPLATES["qwen2.5"]  = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
 DEFAULT_SYSTEM_MESSAGE["qwen2.5"] = qwen25_default_system_message # No system message in Qwen 2.5
+
+# Qwen2.5 Coder templates
+CHAT_TEMPLATES["qwen-2.5-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen-2.5-coder"] = qwen25_default_system_message
+
+CHAT_TEMPLATES["qwen2.5-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen2.5-coder"] = qwen25_default_system_message
+
+CHAT_TEMPLATES["qwen25-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen25-coder"] = qwen25_default_system_message
+
+CHAT_TEMPLATES["qwen-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen-coder"] = qwen25_default_system_message
 pass
 
 # =========================================== Phi-4

--- a/unsloth/registry/REGISTRY.md
+++ b/unsloth/registry/REGISTRY.md
@@ -99,7 +99,7 @@ Prints the following (abridged) output:
     - [x] MistralSmall
     - [x] Qwen2.5
     - [x] Qwen2.5-VL
-    - [ ] Qwen2.5 Coder
+    - [x] Qwen2.5 Coder
     - [x] QwenQwQ-32B
     - [x] Deepseek v3
     - [x] Deepseek R1

--- a/unsloth/registry/_qwen.py
+++ b/unsloth/registry/_qwen.py
@@ -3,6 +3,7 @@ from unsloth.registry.registry import ModelInfo, ModelMeta, QuantType, _register
 _IS_QWEN_2_5_REGISTERED = False
 _IS_QWEN_2_5_VL_REGISTERED = False
 _IS_QWEN_QWQ_REGISTERED = False
+_IS_QWEN_2_5_CODER_REGISTERED = False
 class QwenModelInfo(ModelInfo):
     @classmethod
     def construct_model_name(cls, base_name, version, size, quant_type, instruct_tag):
@@ -26,6 +27,12 @@ class QwenQVQPreviewModelInfo(ModelInfo):
     @classmethod
     def construct_model_name(cls, base_name, version, size, quant_type, instruct_tag):
         key = f"{base_name}-{size}B-Preview"
+        return super().construct_model_name(base_name, version, size, quant_type, instruct_tag, key)
+
+class Qwen2_5CoderModelInfo(ModelInfo):
+    @classmethod
+    def construct_model_name(cls, base_name, version, size, quant_type, instruct_tag):
+        key = f"{base_name}{version}-Coder-{size}B"
         return super().construct_model_name(base_name, version, size, quant_type, instruct_tag, key)
     
 # Qwen2.5 Model Meta
@@ -76,6 +83,18 @@ QwenQVQPreviewMeta = ModelMeta(
     quant_types=[QuantType.NONE, QuantType.BNB],
 )
 
+# Qwen2.5 Coder Model Meta
+Qwen_2_5_CoderMeta = ModelMeta(
+    org="Qwen",
+    base_name="Qwen",
+    instruct_tags=[None, "Instruct"],
+    model_version="2.5",
+    model_sizes=["0.5", "1.5", "3", "7", "14", "32"],
+    model_info_cls=Qwen2_5CoderModelInfo,
+    is_multimodal=False,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
+)
+
 def register_qwen_2_5_models(include_original_model: bool = False):
     global _IS_QWEN_2_5_REGISTERED
     if _IS_QWEN_2_5_REGISTERED:
@@ -98,10 +117,18 @@ def register_qwen_qwq_models(include_original_model: bool = False):
     _register_models(QwenQVQPreviewMeta, include_original_model=include_original_model)
     _IS_QWEN_QWQ_REGISTERED = True
 
+def register_qwen_2_5_coder_models(include_original_model: bool = False):
+    global _IS_QWEN_2_5_CODER_REGISTERED
+    if _IS_QWEN_2_5_CODER_REGISTERED:
+        return
+    _register_models(Qwen_2_5_CoderMeta, include_original_model=include_original_model)
+    _IS_QWEN_2_5_CODER_REGISTERED = True
+
 def register_qwen_models(include_original_model: bool = False):
     register_qwen_2_5_models(include_original_model=include_original_model)
     register_qwen_2_5_vl_models(include_original_model=include_original_model)
     register_qwen_qwq_models(include_original_model=include_original_model)
+    register_qwen_2_5_coder_models(include_original_model=include_original_model)
 
 if __name__ == "__main__":
     from unsloth.registry.registry import MODEL_REGISTRY, _check_model_info


### PR DESCRIPTION
- Added model info class and metadata for 0.5B-32B sizes
- Implemented registration function with quantization support
- Added chat template aliases
- Updated registry documentation