### PR TITLE
Transformers Fix v4.57 rename from PretrainedConfig to PreTrainedConfig

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -432,7 +432,12 @@ try:
 except:
     pass
 from transformers import __version__ as transformers_version
-from transformers import PretrainedConfig
+
+try:
+    from transformers import PreTrainedConfig
+except:
+    from transformers import PretrainedConfig
+
 model_architectures = ["llama", "mistral", "gemma", "gemma2", "qwen2", "granite", "qwen3", "qwen3_moe", "falcon_h1"]
 
 for model_name in model_architectures:

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -92,7 +92,13 @@ PRE_COMPILE_INFERENCE = [
     "gpt_oss",
 ]
 
-from transformers import GenerationConfig, CompileConfig, HybridCache, AutoConfig, PretrainedConfig
+from transformers import GenerationConfig, CompileConfig, HybridCache, AutoConfig
+try:
+    from transformers import PreTrainedConfig
+    PretrainedConfig = PreTrainedConfig
+except:
+    from transformers import PretrainedConfig
+
 HAS_TORCH_DTYPE = "torch_dtype" in PretrainedConfig.__doc__
 
 from transformers import GenerationConfig, CompileConfig, HybridCache


### PR DESCRIPTION
Fixes https://github.com/unslothai/unsloth/issues/3415

Users also report it fixes the issue for them. The change is needed due to transformers renaming PretrainedConfig to PreTrainedConfig in the main version of transformers.

