### PR TITLE
Fix out of resources issue for llama3.2 sft on amd gpu

### DIFF
--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -21,6 +21,7 @@ from .utils import (
     triton_tanh,
     triton_cast,
     torch_gpu_device,
+    is_cdna,
 )
 from transformers.models.llama.modeling_llama import logger
 from packaging.version import Version
@@ -332,7 +333,7 @@ class Fast_CrossEntropyLoss(torch.autograd.Function):
                     SOFTCAP          = logit_softcapping,
                     DO_LOGIT_SCALING = DO_LOGIT_SCALING,
                     LOGIT_SCALE      = logit_scaling,
-                    num_warps        = 32,
+                    num_warps        = 32 if not is_cdna() else 16,
                 )
             # logsumexp(chunked_logsumexp) - x
             # Do the -x separately

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -62,6 +62,14 @@ else:
 pass
 
 
+def is_hip():
+    return triton.runtime.driver.active.get_current_target().backend == "hip"
+
+
+def is_cdna():
+    return is_hip() and triton.runtime.driver.active.get_current_target().arch in ('gfx940', 'gfx941', 'gfx942')
+
+
 def calculate_settings(n : int) -> (int, int,):
     BLOCK_SIZE : int = next_power_of_2(n)
     if BLOCK_SIZE > MAX_FUSED_SIZE:


### PR DESCRIPTION
##  Summary
This PR fixes the out of resource issue when fine tune llama3.2 on AMD MI300 gpu.

##  Context / Motivation
As AMD GPU with CDNA3 arch has different hardware resource with Nvidia's gpu, the default settings of cross_entropy_loss kernel  produces illegal launch parameters and cause training failure, for Llama and Qwen3 models. 
This PR reduces num warps to reasonable values, to enable llm sft on AMD MI300.

##  Changes
- Add AMD arch detection utility functions
- For AMD's CDNA3 arch, reduced num_warps to 16

## Testing
- [x] llama3.2 and qwen3 sft pass on AMD MI300
- [x] llama3.2 and qwen3 sft pass on Nvidia's 4090

## Related Issues
None
