### PR TITLE
Sleep trl patch

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -277,12 +277,10 @@ def grpo_trainer__generate_and_score_completions(function_name, function):
                 f"{indent}if hasattr(self, 'llm'):\n"
                 f"{indent}    if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
                 f"{indent}        self.llm.wake_up()\n"
-                f"{indent}        torch.cuda.empty_cache()\n\n"
                 f"{line}\n\n"
                 f"{indent}if hasattr(self, 'llm'):\n"
                 f"{indent}    if getattr(self.llm.llm_engine.vllm_config.model_config, 'enable_sleep_mode', False):\n"
                 f"{indent}        self.llm.sleep(os.environ.get('VLLM_SLEEP_MODE', 1))\n"
-                f"{indent}        torch.cuda.empty_cache()"
             )
 
             patched = patched[:match.start()] + wrapped + patched[match.end():]


### PR DESCRIPTION
Previously we were performing sleep and wakeup in `_prepare_inputs`. 
Now that we're doing it in `_generate_and_score_completions` as of #3492 , we do not need to do it in `_prepare_inputs` anymore. 
In fact, doing so would cause double copy of memory resulting in OOM. 

Caveat: This might not work for older versions of trl (0.16.0 and 0.17.0 mostly. v0.18 and above should work fine)