### PR TITLE
fix cross entropy loss issue for small vocab size on amd gpu

### DIFF
--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -300,6 +300,7 @@ class Fast_CrossEntropyLoss(torch.autograd.Function):
         if n_chunks == 1:
             # For small vocabs <= 65336 like Llama, Mistral
             BLOCK_SIZE, num_warps = calculate_settings(vocab_size)
+            if is_cdna(): num_warps = num_warps // 2
             logsumexp = torch.empty(n_rows, dtype = torch.float32, device = device)
 
             with torch_gpu_device(device):

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -298,12 +298,7 @@ def MistralForCausalLM_fast_forward(
     else:
         RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
         # < 1024 Normal Unsloth uses less VRAM!
-        if DEVICE_TYPE == "hip":
-            # [TODO] AMD GPUs fail on chunked_cross_entropy loss!
-            # RuntimeError: Triton Error [HIP]:  Code: 1, Messsage: invalid argument
-            RETURN_LOGITS = False
-        elif bsz*q_len <= 1024:
-            RETURN_LOGITS = True
+        if bsz * q_len <= 1024: RETURN_LOGITS = True
 
         if not RETURN_LOGITS and labels is not None:
             n_items = kwargs.get("num_items_in_batch", None) or kwargs.get("n_items", None)


### PR DESCRIPTION
# Summary
This PR fixes cross entropy loss issue when fine tune models with small vocab sizes such as Mistral v0.3 7B on AMD MI300 gpu.

# Context / Motivation
- As AMD GPU with CDNA3 arch has different hardware resource with Nvidia's gpu, the default settings of cross_entropy_loss kernel produces illegal launch parameters and cause training failure like: RuntimeError: Triton Error [HIP]: Code: 1, Messsage: invalid argument
- For models with small vocab sizes, like mistral, we could halve num_warps to reduce resource usage and this can keep the logits return unchanged.
- This PR reduces num warps to reasonable values, to enable mistral sft on AMD MI300, while keeping RETURN_LOGITS logic unchanged.

# Changes
- Halve num_warps for single chunk case for amd cdna arch.

# Testing
- [x] Qwen3-14B / Mistral_0.3-7B / Llama3.2_1B_and_3B sft on MI300
- [x] Qwen3-14B / Mistral_0.3-7B / Llama3.2_1B_and_3B sft on RTX 4090


