### PR TITLE
Support for out-of-source quantizers

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3013,8 +3013,7 @@ class FastLlamaModel:
         if qat_scheme is not None:
             print("Unsloth: Applying QAT to mitigate quantization degradation")
             model = FastLlamaModel._prepare_for_qat(model, qat_scheme)
-            
-        pass
+
 
         model._saved_temp_tokenizer = _saved_temp_tokenizer
 

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -587,7 +587,6 @@ except:
 
 
 class FastModel(FastBaseModel):
-
     @staticmethod
     def _prepare_for_qat(model, qat_scheme):
         model = _prepare_model_for_qat(model, qat_scheme)
@@ -1143,7 +1142,6 @@ class FastModel(FastBaseModel):
         if qat_scheme is not None:
             print("Unsloth: Applying QAT to mitigate quantization degradation")
             model = FastModel._prepare_for_qat(model, qat_scheme)
-        pass
 
         return model, tokenizer
 


### PR DESCRIPTION
The goal of this PR is to allow any user to easily change how quantization is applied during the fine tuning process.
A longer description of the issue can be found in #3521 

By making `_prepare_for_qat` a staticmethod, it is possible to replace it like so:

```python
def my_quant_func(...):
    ...
    return model

FastLlamaModel._prepare_for_qat = my_quant_func
```

As mentioned in the issue above, even allowing for a custom quantization function (and thus, custom quantizer like Brevitas), does not solve all the issues, since Unsloth makes a strong assumption about the names of the quantization functions for [weights](https://github.com/unslothai/unsloth/blob/2267b5c5532957141a33bfa5bb9f0b220a4b3efe/unsloth/kernels/utils.py#L197) and  [activations](https://github.com/unslothai/unsloth/blob/2267b5c5532957141a33bfa5bb9f0b220a4b3efe/unsloth/kernels/utils.py#L291).

This can be patched without necessarily changing anything within Unsloth, but I believe it might be worth thinking about a more general implementation for the naming conventions (either a task for this or another PR, you tell me).

cc @Datta0
