### PR TITLE
DeepseekOCR: add trust_remote_code kwarg

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -640,6 +640,7 @@ class FastBaseModel:
             model_name,
             token = token,
             attn_implementation = "sdpa" if supports_sdpa else "eager",
+            trust_remote_code = trust_remote_code,
         )
         verify_fp8_support_if_applicable(model_config)
 


### PR DESCRIPTION
add trust_remote_code kwarg so that we don't get prompted to accept remote code.

Running with this branch fixes the issue:
https://colab.research.google.com/drive/1o1pVBsG50Jo61k7MtNSKBasSwc-MbhuG?usp=sharing

