### PR TITLE
pre-commit CI config

### DIFF
--- a/.pre-commit-ci.yaml
+++ b/.pre-commit-ci.yaml
@@ -1,0 +1,6 @@
+ci:
+  autofix_prs: true
+  autofix_prs_limit: 5
+  autoupdate_schedule: monthly
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  skip: []


### PR DESCRIPTION
Config for https://pre-commit.ci/. This will run our pre-commit hooks and create a commit with any changes (ruff format, etc.).

I've requested to enable the corresponding pre-commit CI GitHub app. We should merge this PR, then enable the app so it respects this config.