### PR TITLE
fix: unsloth fixes for gfx1151

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1930,9 +1930,12 @@ def unsloth_compile_transformers(
                         -1,
                         self.hidden_size,
                     )
-                    next_states = next_states * routing_weights.transpose(
-                        0, 1
-                    ).view(num_experts, batch_size, -1)[..., None]
+                    next_states = (
+                        next_states
+                        * routing_weights.transpose(0, 1).view(
+                            num_experts, batch_size, -1
+                        )[..., None]
+                    )
                     next_states = next_states.sum(dim = 0)
                 return next_states
 

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -710,7 +710,9 @@ def LlamaDecoderLayer_fast_forward(
     # On Strix Halo (HIP), run the MLP in float32 for selected
     # model families (Qwen, Mistral, GPT-OSS) for improved stability.
     layer_config = getattr(self, "config", None)
-    layer_model_type = getattr(layer_config, "model_type", "") if layer_config is not None else ""
+    layer_model_type = (
+        getattr(layer_config, "model_type", "") if layer_config is not None else ""
+    )
     SAFE_MLP_MODEL_TYPES = ("qwen", "mistral", "gpt-oss", "gpt_oss")
     SAFE_STRIX_MLP = STRIX_HALO_SAFE and any(
         layer_model_type.startswith(x) for x in SAFE_MLP_MODEL_TYPES
@@ -763,9 +765,7 @@ def LlamaDecoderLayer_fast_forward(
 
         # Fully Connected
         residual = hidden_states
-        hidden_states = fast_rms_layernorm(
-            self.post_attention_layernorm, hidden_states
-        )
+        hidden_states = fast_rms_layernorm(self.post_attention_layernorm, hidden_states)
         if SAFE_STRIX_MLP:
             mlp_in = hidden_states.to(torch.float32)
             mlp_out = self.mlp(mlp_in)
@@ -883,7 +883,6 @@ def LlamaModel_fast_forward(
     if inputs_embeds is None:
         inputs_embeds = self.embed_tokens(input_ids)
 
-    
     # Normalized from Gemma
     IS_GEMMA = self.config.model_type.startswith("gemma")
     IS_GEMMA2 = self.config.model_type.startswith("gemma2")

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -365,7 +365,6 @@ def MistralForCausalLM_fast_forward(
         logits = self.lm_head(hidden_states.to(lm_head.dtype))
     logits = logits.to(_get_dtype(dtype_from_config(self.config)))
 
-
     # PyTorch CE loss instead of fused kernels for some nans in unsloth_fused_ce_loss on StrixHalo
     if STRIX_HALO_SAFE:
         logits = logits.float()


### PR DESCRIPTION
### Resolves https://github.com/unslothai/unsloth/issues/3385#issue-3462515585


Summary
- Fine-tuning Gemma‑3 on AMD Strix Halo (HIP/ROCm) produced NaN losses
- NaNs came from the first transformer block (forward), not the optimizer.

Root Cause
- On HIP (gfx1151, ROCm 6.4), bfloat16 FlashAttention2 can be numerically unstable.
- Unsloth routed Gemma‑3 attention through FlashAttention2 in bf16, triggering NaN activations.

What We Changed
- Keep FlashAttention2 for performance, but on HIP run its math in float16 (safer), then cast results back.
- Added opt‑in env toggles for adjacent kernels (RoPE, RMSNorm) and for diagnostics only.
- Added a debug log (logger.debug) to confirm the actual paths/dtypes when DEBUG verbosity is enabled.

Validation
```python
import torch, importlib
import os 

mods = ["unsloth","unsloth_zoo","transformers","trl","accelerate","peft","xformers","bitsandbytes","triton"]
for m in mods:
    try:
        print(m, importlib.import_module(m).__version__)
    except Exception as e:
        print(m, "not found")
print("torch:", torch.__version__, "HIP:", torch.version.hip)
print("cuda.is_available:", torch.cuda.is_available(), "bf16_supported:", torch.cuda.is_bf16_supported())
print("device:", torch.cuda.get_device_name(0))
```

    unsloth 2025.11.3
    unsloth_zoo 2025.11.3
    transformers 4.57.1
    trl 0.24.0
    accelerate 1.11.0
    peft 0.17.1
    xformers not found
    bitsandbytes 0.49.0.dev0
    triton 3.5.1
    torch: 2.10.0a0+rocm7.10.0a20251015 HIP: 7.1.25413-7721681424
    cuda.is_available: True bf16_supported: True
    device: Radeon 8060S Graphics



```python
import logging
logger = logging.getLogger(__name__)
logger.setLevel(logging.DEBUG)
```

```python
import os
os.environ['UNSLOTH_FA2_COMPUTE_DTYPE'] = 'float16'
os.environ['UNSLOTH_ROPE_IMPL'] = 'slow'
os.environ['UNSLOTH_DISABLE_TRITON_RMSNORM'] = '1'

import unsloth, inspect
import unsloth.models.llama as L
print("unsloth_file:", unsloth.__file__)
print("llama_file:", L.__file__)

from unsloth import FastModel
from transformers import AutoTokenizer
import torch

tok = AutoTokenizer.from_pretrained("unsloth/gemma-3-4b-it")
m,_ = FastModel.from_pretrained(
"unsloth/gemma-3-4b-it",
load_in_4bit=False, load_in_8bit=False, full_finetuning=False,
)
m.train().cuda()
b = tok(["hello world"]*2, return_tensors="pt", padding=True).to("cuda")
out = m(**b, labels=b["input_ids"])
print("loss_is_nan:", torch.isnan(out.loss).item(), "loss:", float(out.loss))
out.loss.backward()
has_nan = any(p.grad is not None and torch.isnan(p.grad).any() for p in
m.parameters())
print("grad_has_nan:", has_nan)
```

    bitsandbytes library load error: Configured ROCm binary not found at /opt/venv/lib64/python3.13/site-packages/bitsandbytes/libbitsandbytes_rocm71.so
    Traceback (most recent call last):
      File "/opt/venv/lib64/python3.13/site-packages/bitsandbytes/cextension.py", line 313, in <module>
        lib = get_native_library()
      File "/opt/venv/lib64/python3.13/site-packages/bitsandbytes/cextension.py", line 282, in get_native_library
        raise RuntimeError(f"Configured {BNB_BACKEND} binary not found at {cuda_binary_path}")
    RuntimeError: Configured ROCm binary not found at /opt/venv/lib64/python3.13/site-packages/bitsandbytes/libbitsandbytes_rocm71.so


    🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.


    /opt/venv/lib64/python3.13/site-packages/torch/library.py:356: UserWarning: Warning only once for all operators,  other operators may also be overridden.
      Overriding a previously registered kernel for the same operator and the same dispatch key
      operator: flash_attn::_flash_attn_backward(Tensor dout, Tensor q, Tensor k, Tensor v, Tensor out, Tensor softmax_lse, Tensor(a6!)? dq, Tensor(a7!)? dk, Tensor(a8!)? dv, float dropout_p, float softmax_scale, bool causal, SymInt window_size_left, SymInt window_size_right, float softcap, Tensor? alibi_slopes, bool deterministic, Tensor? rng_state=None) -> Tensor
        registered at /opt/venv/lib64/python3.13/site-packages/torch/_library/custom_ops.py:922
      dispatch key: ADInplaceOrView
      previous kernel: no debug info
           new kernel: registered at /opt/venv/lib64/python3.13/site-packages/torch/_library/custom_ops.py:922 (Triggered internally at /__w/TheRock/TheRock/external-builds/pytorch/pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:208.)
      self.m.impl(


    🦥 Unsloth Zoo will now patch everything to make training faster!
    unsloth_file: /opt/venv/lib64/python3.13/site-packages/unsloth/__init__.py
    llama_file: /opt/venv/lib64/python3.13/site-packages/unsloth/models/llama.py


    /opt/venv/lib64/python3.13/site-packages/unsloth_zoo/gradient_checkpointing.py:348: UserWarning: expandable_segments not supported on this platform (Triggered internally at /__w/TheRock/TheRock/external-builds/pytorch/pytorch/c10/hip/HIPAllocatorConfig.h:36.)
      GPU_BUFFERS = tuple([torch.empty(2*256*2048, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])


    ==((====))==  Unsloth 2025.11.3: Fast Gemma3 patching. Transformers: 4.57.1.
       \\   /|    Radeon 8060S Graphics. Num GPUs = 1. Max memory: 128.0 GB. Platform: Linux.
    O^O/ \_/ \    Torch: 2.10.0a0+rocm7.10.0a20251015. ROCm Toolkit: 7.1.25413-7721681424. Triton: 3.5.1
    \        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = True]
     "-____-"     Free license: http://github.com/unslothai/unsloth
    Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
    Unsloth: Gemma3 does not support SDPA - switching to fast eager.
    Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.



    Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]


    /tmp/ipykernel_3852/715560139.py:23: UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
    Consider using tensor.detach() first. (Triggered internally at /__w/TheRock/TheRock/external-builds/pytorch/pytorch/torch/csrc/autograd/generated/python_variable_methods.cpp:836.)
      print("loss_is_nan:", torch.isnan(out.loss).item(), "loss:", float(out.loss))


    loss_is_nan: False loss: 15.633398056030273
    grad_has_nan: False



```python
import unsloth, torch
from unsloth import FastModel
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("unsloth/gemma-3-4b-it")
m,_ = FastModel.from_pretrained("unsloth/gemma-3-4b-it", load_in_4bit=False, load_in_8bit=False, full_finetuning=False)
m.train().cuda()
b = tok(["hello world"]*2, return_tensors="pt", padding=True).to("cuda")
out = m(**b, labels=b["input_ids"])
print("forward_loss_is_nan:", torch.isnan(out.loss).item(), "loss:", float(out.loss))
out.loss.backward()
has_nan = any(p.grad is not None and torch.isnan(p.grad).any() for p in m.parameters())
print("grad_has_nan:", has_nan)
```

    ==((====))==  Unsloth 2025.11.3: Fast Gemma3 patching. Transformers: 4.57.1.
       \\   /|    Radeon 8060S Graphics. Num GPUs = 1. Max memory: 128.0 GB. Platform: Linux.
    O^O/ \_/ \    Torch: 2.10.0a0+rocm7.10.0a20251015. ROCm Toolkit: 7.1.25413-7721681424. Triton: 3.5.1
    \        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = True]
     "-____-"     Free license: http://github.com/unslothai/unsloth
    Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
    Unsloth: Gemma3 does not support SDPA - switching to fast eager.
    Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.



    Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]


    forward_loss_is_nan: False loss: 15.633398056030273
    grad_has_nan: False



```python
import unsloth, torch
from unsloth import FastModel
from transformers import AutoTokenizer
tok = AutoTokenizer.from_pretrained("unsloth/gemma-3-4b-it")
m,_ = FastModel.from_pretrained("unsloth/gemma-3-4b-it", load_in_4bit=False, load_in_8bit=False, full_finetuning=False)
m.train().cuda()
b = tok(["hello world"]*2, return_tensors="pt", padding=True).to("cuda")
out = m(**b, labels=b["input_ids"])
print("FA/xformers disabled -> loss_is_nan:", torch.isnan(out.loss).item(), "loss:", float(out.loss))
```

    ==((====))==  Unsloth 2025.11.3: Fast Gemma3 patching. Transformers: 4.57.1.
       \\   /|    Radeon 8060S Graphics. Num GPUs = 1. Max memory: 128.0 GB. Platform: Linux.
    O^O/ \_/ \    Torch: 2.10.0a0+rocm7.10.0a20251015. ROCm Toolkit: 7.1.25413-7721681424. Triton: 3.5.1
    \        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = True]
     "-____-"     Free license: http://github.com/unslothai/unsloth
    Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
    Unsloth: Gemma3 does not support SDPA - switching to fast eager.
    Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.



    Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]


    FA/xformers disabled -> loss_is_nan: False loss: 15.633398056030273



```python
import unsloth, torch
from unsloth import FastModel
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("unsloth/gemma-3-4b-it")
m,_ = FastModel.from_pretrained("unsloth/gemma-3-4b-it", load_in_4bit=False, load_in_8bit=False, full_finetuning=False)
m = m.to(dtype=torch.float32).cuda()
b = tok(["hello world"]*2, return_tensors="pt", padding=True)
b = {k:(v.to("cuda").to(torch.float32) if v.dtype.is_floating_point else v.to("cuda")) for k,v in b.items()}
with torch.autocast(device_type="cuda", dtype=torch.float32, enabled=False):
    out = m(**b, labels=b["input_ids"])
print("fp32 forced -> loss_is_nan:", torch.isnan(out.loss).item(), "loss:", float(out.loss))
```

    ==((====))==  Unsloth 2025.11.3: Fast Gemma3 patching. Transformers: 4.57.1.
       \\   /|    Radeon 8060S Graphics. Num GPUs = 1. Max memory: 128.0 GB. Platform: Linux.
    O^O/ \_/ \    Torch: 2.10.0a0+rocm7.10.0a20251015. ROCm Toolkit: 7.1.25413-7721681424. Triton: 3.5.1
    \        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = True]
     "-____-"     Free license: http://github.com/unslothai/unsloth
    Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
    Unsloth: Gemma3 does not support SDPA - switching to fast eager.
    Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.



    Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]


    fp32 forced -> loss_is_nan: False loss: 15.536109924316406



```python
import unsloth, torch
from unsloth import FastModel
from transformers import AutoTokenizer
tok = AutoTokenizer.from_pretrained("unsloth/gemma-3-4b-it")
m,_ = FastModel.from_pretrained("unsloth/gemma-3-4b-it", load_in_4bit=False, load_in_8bit=False, full_finetuning=False)
m.eval().cuda()
b = tok(["hello world"]*2, return_tensors="pt", padding=True).to("cuda")
with torch.no_grad():
    out = m(**b, return_dict=True)
logits = out.logits
print("logits_dtype:", logits.dtype, "shape:", tuple(logits.shape))
print("logits_has_nan:", torch.isnan(logits).any().item(), "has_inf:", torch.isinf(logits).any().item())
```

    ==((====))==  Unsloth 2025.11.3: Fast Gemma3 patching. Transformers: 4.57.1.
       \\   /|    Radeon 8060S Graphics. Num GPUs = 1. Max memory: 128.0 GB. Platform: Linux.
    O^O/ \_/ \    Torch: 2.10.0a0+rocm7.10.0a20251015. ROCm Toolkit: 7.1.25413-7721681424. Triton: 3.5.1
    \        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = True]
     "-____-"     Free license: http://github.com/unslothai/unsloth
    Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
    Unsloth: Gemma3 does not support SDPA - switching to fast eager.
    Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.



    Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]


    logits_dtype: torch.bfloat16 shape: (2, 3, 262208)
    logits_has_nan: False has_inf: False


