### PR TITLE
Fix/save torchao model loading logic

### DIFF
--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -928,7 +928,6 @@ __INT_TO_FLOAT_MAPPER = \
     ),
     "unsloth/gpt-oss-20b-unsloth-bnb-4bit" : (
         "unsloth/gpt-oss-20b",
-        "unsloth/gpt-oss-20b-BF16",
         "openai/gpt-oss-20b",
         "unsloth/gpt-oss-20b-unsloth-bnb-4bit",
     ),


### PR DESCRIPTION
## Problem 

**1- AutoModel:** We previously used `AutoModel` from pretrained to load models in our implementation of the `save_pretrained_torchao` method. However AutoModel loads the base model without a specific task-head.

**2-Merged model directory**: `save_pretrained_torchao` merges the model (if necessary) before converting and does not delete the merged model directory after the process is done which consumes unnecessary disk space and potentially confuses users a

## Solution

**1-AutoModel:**
- We test if the model is a vlm or a text model
- We set auto_model to either `AutoModelForCausalLM` or `AutoModelForImageTextToText` based on the test result
- We also set auto_processor to either `AutoProcessor` or `AutoTokenizer` based on the above test
This loads the model properly
```
is_vlm = False
    if hasattr(self, "config") and hasattr(self.config, "architectures"):
        is_vlm = any(
            x.endswith(("ForConditionalGeneration", "ForVisionText2Text"))
            for x in self.config.architectures
        )
        is_vlm = is_vlm or hasattr(self.config, "vision_config")
    auto_model = AutoModelForImageTextToText if is_vlm else AutoModelForCausalLM
    auto_processor = AutoProcessor if is_vlm else AutoTokenizer

    tokenizer = auto_processor.from_pretrained(arguments["save_directory"])
...
 model = auto_model.from_pretrained(
        arguments["save_directory"],
        device_map = "auto",
        quantization_config = quantization_config,
        **kwargs,
    )
```

**2 - Merged model directory:** We remove the `save_directory` directory tree after the conversion process is complete. The torchao converted model is saved to the `torchao_save_directory` instead.
```
if os.path.exists(save_directory):
        try:
            import shutil
            shutil.rmtree(save_directory)
        except:
            pass
            
```

## solves

https://github.com/unslothai/unsloth/issues/3599
