### PR TITLE
Fix LlamaModel_fast_forward signature to match HF Transformers (Support inputs_embeds)

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -766,7 +766,7 @@ __DTYPE_MAP = {
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L825
 def LlamaModel_fast_forward(
     self,
-    input_ids: torch.LongTensor,
+    input_ids: Optional[torch.LongTensor] = None,
     causal_mask: Optional[BlockDiagonalCausalMask] = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,


### PR DESCRIPTION
### Summary
This PR updates the `LlamaModel_fast_forward` function signature in `unsloth/models/llama.py` to make `input_ids` optional, defaulting to `None`.

### Motivation
Currently, Unsloth requires `input_ids` to be present, which prevents the model from accepting `inputs_embeds` only. This change aligns the Unsloth implementation with the original Hugging Face Transformers source code, where `input_ids` is optional.

This fixes an issue where missing `input_ids` would raise a `TypeError` even if embeddings were provided.

### Reference
This restores parity with the upstream implementation referenced in the code comments:
https://github.com/huggingface/transformers/blob/f7650253c477dd48c3cf3ff3d7b4f44f93ee62b9/src/transformers/models/llama/modeling_llama.py#L382