### PR TITLE
Fix indefinite article usage in comments and docstrings

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2593,7 +2593,7 @@ default_system_message = \
 extra_eos_tokens = None,
 ):
     """
-    Creates a Ollama modelfile and a HF Jinja template from a custom
+    Creates an Ollama modelfile and a HF Jinja template from a custom
     template. You must provide 2x examples of an input & output.
     There is an optional system message as well.
 
@@ -2930,7 +2930,7 @@ extra_eos_tokens = None,
 
 ):
     """
-    Creates a Ollama modelfile and a HF Jinja template from a custom
+    Creates an Ollama modelfile and a HF Jinja template from a custom
     template. You must provide 2x examples of an input & output.
     There is an optional system message as well.
 

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -57,7 +57,7 @@ try:
         FalconH1Attention,
     )
 except ModuleNotFoundError:
-    # if we are on a old version of transformers technically it should fail in the try except above
+    # if we are on an old version of transformers technically it should fail in the try except above
     # but if somehow we make it here, we need to raise an error since FalconH1Attention is not available
     # or renamed
     raise ImportError(

--- a/unsloth/ollama_template_mappers.py
+++ b/unsloth/ollama_template_mappers.py
@@ -1520,7 +1520,7 @@ Loop over messages and look for a user-provided system message and documents
 
     {{- /*
     NOTE: Since Ollama collates consecutive roles, for control and documents, we
-        work around this by allowing the role to contain an qualifier after the
+        work around this by allowing the role to contain a qualifier after the
         role string.
     */ -}}
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -600,7 +600,7 @@ def load_correct_tokenizer(
     ### 1. Fixup tokenizer's chat_template
     old_chat_template = getattr(tokenizer, "chat_template", None)
 
-    # Ignore mistral type models since they don't have a add_generation_prompt
+    # Ignore mistral type models since they don't have an add_generation_prompt
     if "mistral" in str(getattr(tokenizer, "name_or_path", "")).lower():
         chat_template = old_chat_template
 


### PR DESCRIPTION
 Corrects 5 instances of incorrect a/an usage across 4 files:

  - `chat_templates.py` (2×): "a Ollama" → "an Ollama"
  - `falcon_h1.py`: "a old version" → "an old version"
  - `ollama_template_mappers.py`: "an qualifier" → "a qualifier"
  - `tokenizer_utils.py`: "a add_generation_prompt" → "an add_generation_prompt"