### PR TITLE
fix rope_theta -> rope_parameters['rope_theta']

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -562,6 +562,12 @@ for model_name in model_architectures:
         config = inspect.getsource(eval(config_filename))
     except:
         continue
+    if "RopeParameters" in config:
+        try:
+            exec(f"from {config_filepath} import RopeParameters", globals())
+        except:
+            continue
+
     if "rope_scaling" in config:
         continue
     config = re.sub(

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1551,7 +1551,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         super().__init__()
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = config.rope_theta
+            try:
+                base = config.rope_theta
+            except:
+                base = getattr(config, "rope_parameters", {})
+                base = base["rope_theta"]
             partial_rotary_factor = (
                 config.partial_rotary_factor
                 if hasattr(config, "partial_rotary_factor")


### PR DESCRIPTION
Transformers v5 refactored rope theta. It now sits inside a RopeParameters object. This PR both fixes the issue for the transformers v5 refactor and keep it backwards compatible.

@danielhanchen the llama.py code has a comment `# [TODO] Hack to pass in config - need to remove later`. Is that still relevant?