### PR TITLE
Fix broken link for advanced pip installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pip install unsloth
 ```
 pip install --upgrade --force-reinstall --no-cache-dir unsloth unsloth_zoo
 ```
-See [here](https://github.com/unslothai/unsloth/edit/main/README.md#advanced-pip-installation) for advanced pip install instructions.
+See [here](#advanced-pip-installation) for advanced pip install instructions.
 ### Windows Installation
 
 1. **Install NVIDIA Video Driver:**


### PR DESCRIPTION
The link to "advanced pip install instructions" in the `Pip Installation` section was pointing to the `edit` page URL (`.../edit/main/README.md...`), which is incorrect for viewing.

I updated it to a relative anchor link (`#advanced-pip-installation`) so it correctly jumps to the relevant section within the README.