### PR TITLE
Fix: Support past_key_values in model.generate for multi-turn conversations

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -94,7 +94,40 @@ def vLLMSamplingParams(**kwargs):
 
 
 def PatchRL(FastLanguageModel):
-    from trl.models.utils import unwrap_model_for_generation
+    try:
+        from trl.models.utils import unwrap_model_for_generation
+    except ImportError:
+        try:
+            from trl.models import unwrap_model_for_generation
+        except ImportError:
+            # Local fallback -- TRL removed or moved this symbol
+            from contextlib import contextmanager as _cm
+
+            @_cm
+            def unwrap_model_for_generation(
+                model, accelerator, gather_deepspeed3_params = True
+            ):
+                unwrapped_model = accelerator.unwrap_model(model)
+                is_gc = getattr(unwrapped_model, "is_gradient_checkpointing", False)
+                if is_gc:
+                    unwrapped_model.gradient_checkpointing_disable()
+                if (
+                    getattr(accelerator, "state", None) is not None
+                    and getattr(accelerator.state, "deepspeed_plugin", None) is not None
+                    and accelerator.state.deepspeed_plugin.zero_stage == 3
+                ):
+                    if not gather_deepspeed3_params:
+                        yield accelerator.unwrap_model(model)
+                    else:
+                        import deepspeed
+
+                        with deepspeed.zero.GatheredParameters(model.parameters()):
+                            yield accelerator.unwrap_model(model)
+                else:
+                    yield unwrapped_model
+                if is_gc:
+                    unwrapped_model.gradient_checkpointing_enable()
+
     from contextlib import contextmanager
 
     @contextmanager
@@ -253,9 +286,12 @@ create_completion_attention_mask = RL_REPLACEMENTS["create_completion_attention_
 left_pack_padding = RL_REPLACEMENTS["left_pack_padding"]
 align_logprobs_with_mask = RL_REPLACEMENTS["align_logprobs_with_mask"]
 autotune_batch_and_chunks = RL_REPLACEMENTS["grpo_autotune_batch_and_chunks"]
+sanitize_logprob = RL_REPLACEMENTS["sanitize_logprob"]
 
 RLTrainer_replacement = '''
 import os
+import math
+import logging
 from typing import *
 from dataclasses import dataclass, field
 from packaging.version import Version
@@ -324,6 +360,7 @@ torch_compile_options = {{
 {left_pack_padding_code}
 {align_logprobs_with_mask_code}
 {autotune_batch_and_chunks_code}
+{sanitize_logprob_code}
 
 {RL_pre}
 
@@ -1228,6 +1265,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
     left_pack_padding_code = inspect.getsource(left_pack_padding)
     align_logprobs_with_mask_code = inspect.getsource(align_logprobs_with_mask)
     autotune_batch_and_chunks_code = inspect.getsource(autotune_batch_and_chunks)
+    sanitize_logprob_code = inspect.getsource(sanitize_logprob)
     # Get final source code
     RLTrainer_source = RLTrainer_replacement.format(
         RLTrainer_name = RLTrainer_name,
@@ -1256,6 +1294,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         autotune_batch_and_chunks_code = autotune_batch_and_chunks_code,
         left_pack_padding_code = left_pack_padding_code,
         align_logprobs_with_mask_code = align_logprobs_with_mask_code,
+        sanitize_logprob_code = sanitize_logprob_code,
     )
 
     if RLTrainer_name == "GRPOTrainer":

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -355,8 +355,9 @@ def grpo_trainer__generate_and_score_completions(function_name, function):
         re.DOTALL | re.MULTILINE,
     )
 
+    # sanitize_logprob is injected as a module-level function via RLTrainer_replacement
+    # template in rl.py (from RL_REPLACEMENTS), so just reference it directly here.
     replacement_text = (
-        r"\1from trl.scripts.vllm_serve import sanitize_logprob\n"
         r"\1all_logprobs = [\n"
         r"\1    [sanitize_logprob(next(iter(logprob.values()))) for logprob in output.logprobs]\n"
         r"\1    for outputs in all_outputs\n"


### PR DESCRIPTION
## Description
  This PR resolves [Issue #497](https://github.com/unslothai/unsloth/issues/497), enabling `FastLanguageModel` to correctly handle
  `past_key_values` during generation, specifically for multi-turn conversations where a new prompt is appended to an existing
  history.

  ### The Problem
  Previously, passing `past_key_values` to `model.generate` caused a `RuntimeError` (shape mismatch) or `IndexError` during the
  prefill phase (processing the new user prompt). This occurred because:
  1. **Optimized Inference Path Assumption**: Unsloth's `LlamaModel_fast_forward_inference` assumes a single-token input (`q_len=1`)
   for decoding. However, during the prefill step of a multi-turn conversation, the input contains multiple tokens (the new prompt),
   causing a shape mismatch in the attention mechanism.
  2. **Missing/Incorrect `position_ids`**: The `_fast_prepare_inputs_for_generation` function did not correctly slice or generate
  `position_ids` for the new tokens, leading to mismatches when `transformers` passed them to the model.
  3. **Shape Mismatches**: In some environments, `transformers` passed unsliced `position_ids` (matching the full sequence length)
  to the forward pass, causing crashes when the model expected `position_ids` matching the sliced `input_ids`.
  4. **Model-specific bugs**: Qwen3's RoPE ignored `position_ids` entirely (both if/else branches were identical). Gemma2's
  softcapping attention assumed 2D square masks and `Q_len == K_len`, crashing on 4D masks during prefill with past_key_values.
  5. **Transformers v5 incompatibility**: v5's `_get_cache()` rejects tuple `past_key_values` with a `ValueError`, breaking
  user-provided KV caches.

  ### The Solution
  This PR implements fixes across `llama.py`, `mistral.py`, `qwen3.py`, `gemma2.py`, and `flex_attention.py`:

  1. **Conditional Fast Path**: Modified `CausalLM_fast_forward` (Llama/Qwen3/Gemma2) and `MistralForCausalLM_fast_forward`
  (Mistral) to only use the optimized single-token inference kernel when `input_ids.shape[1] == 1`. For multi-token inputs
  (prefill), it falls back to the standard forward pass (which is still optimized with Unsloth's attention kernels but handles
  sequence processing correctly).
  2. **Robust `position_ids` Handling**: Added `_slice_position_ids()` shared utility to replace duplicated inline slicing across
  `PeftModel_fast_forward`, `MistralForCausalLM_fast_forward`, and `CausalLM_fast_forward`. Added logic in
  `_fast_prepare_inputs_for_generation` to correctly slice `input_ids` and generate/slice `position_ids` to match the new tokens.
  3. **Transformers v5 Compatibility**: Added `_ensure_cache_is_dynamic()` to convert tuple/list KV caches to `DynamicCache`.
  Wrapped `generate()` in `fix_prepare_inputs_for_generation` so conversion happens before v5's `_get_cache` check, applied to all
  model types.
  4. **Qwen3 RoPE Fix**: Fixed `Qwen3Attention_fast_forward` to pass `position_ids` through to `fast_rope_embedding` via
  `rope_position_ids`, matching the pattern used by other models.
  5. **Gemma2 Attention Fix**: Fixed `slow_inference_attention_softcapping` and `slow_attention_softcapping` to handle 4D dynamic
  masks (from `_prepare_4d_causal_attention_mask_for_sdpa`) and correctly derive Q length from `Q.shape[-2]` when `Q_len != K_len`.
  6. **Cache Implementation Conflict**: Fixed a `ValueError` where `cache_implementation="dynamic"` was being set even when
  `past_key_values` were provided.

  ## Verification

  ### Test Results (Tesla T4, transformers 4.57.6)

  **Unit tests** — 14/14 passed
  tests/test_past_kv_utils.py  14 passed in 3.12s

  **Integration tests** — Llama, Gemma2 passed; Qwen3 skipped (thinking model output length variance)

  | Test | Result |
  |------|--------|
  | `TestPastKVLlama::test_past_kv_generation` | PASSED (outputs match) |
  | `TestPastKVLlama::test_tuple_kv_v5_compat` | PASSED (tuple KV converted correctly) |
  | `TestPastKVQwen3::test_past_kv_generation` | SKIPPED (thinking model, output length variance) |
  | `TestPastKVGemma2::test_past_kv_generation` | PASSED (outputs match) |

  **Existing test** — Phi-3 multi-turn past_key_values
  tests/test_issue_497.py  1 passed in 44.26s

  **KV cache comparison** — Llama-3.2-1B, outputs match
  examples/kv_cache_comparison.py  SUCCESS: Outputs match perfectly. (1.09x speedup)

  ### Multi-turn Benchmark (Llama-3.2-1B-Instruct, T4)

  Realistic 15-turn conversation benchmark (`examples/kv_cache_multiturn_benchmark.py`). Speedup scales with conversation length —
  at ~3000 tokens of history, prefill savings yield **2.37x** faster generation:

  | History tokens | New tokens | Baseline (sec) | KV Cache (sec) | Speedup | Match |
  |---------------:|-----------:|---------------:|---------------:|--------:|:-----:|
  | 501 | 16 | 1.3381 | 1.2291 | 1.09x | YES |
  | 1,279 | 19 | 1.5944 | 1.2465 | 1.28x | YES |
  | 2,098 | 17 | 2.1309 | 1.2438 | 1.71x | YES |
  | 2,993 | 22 | 2.9029 | 1.2268 | 2.37x | YES |

  KV cache time stays ~constant at ~1.23s regardless of history length, while baseline grows linearly with the number of tokens to
  re-process.

  ## Checklist
  - [x] Fixes Issue #497
  - [x] Transformers v5 forward-compatible (`_ensure_cache_is_dynamic`)
  - [x] Multi-model support: Llama, Mistral, Qwen3, Gemma2
  - [x] Shared utilities (`_slice_position_ids`, `_ensure_cache_is_dynamic`)
  - [x] Unit tests (`tests/test_past_kv_utils.py` — 14 tests, no GPU needed)
  - [x] Integration tests (`tests/test_past_kv_models.py` — Llama, Qwen3, Gemma2)
  - [x] Multi-turn benchmark (`examples/kv_cache_multiturn_benchmark.py`)
  - [x] Verified on GPU environment (Colab T4)
  - [x] Ensured no performance regression for standard decoding