### PR TITLE
Fix: prevent load_in_fp8 kwarg from reaching Qwen3MoeForCausalLM constructor (Fix #3649)

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -654,7 +654,7 @@ class FastBaseModel:
 
         raise_handler = RaiseUninitialized()
         if not fast_inference:
-            #Prevent load_in_fp8 from being forwarded into HF internal model loading
+            # Prevent load_in_fp8 from being forwarded into HF internal model loading
             load_in_fp8 = kwargs.pop("load_in_fp8", None)
             model = auto_model.from_pretrained(
                 model_name,


### PR DESCRIPTION
### PR Description

This PR fixes the issue reported in #3649 where calling:
```
FastModel.from_pretrained(
    "unsloth/Qwen3-30B-A3B-Instruct-2507-FP8",
    load_in_fp8=True,
)
```
TypeError: Qwen3MoeForCausalLM.__init__() got an unexpected keyword argument 'load_in_fp8'
The problem was that load_in_fp8 was an internal flag for Unsloth, but it was still being passed to the Hugging Face model constructor and models like Qwen3MoeForCausalLM do not accept that argument -->which caused the crash.

---

### What I changed

The parameter is now removed from the location where the model is passed to the HF loader:

`load_in_fp8 = kwargs.pop("load_in_fp8", None)`

I kept the value around if it's needed later, but it no longer gets to the HF constructor.

---

### Notes

I don’t have FP8 hardware to perform a full training run, so the fix is based on the reading the execution path and matching it with the similar logic that’s already implemented in the codebase fixes (like the change in PR #3621).
if additional adjustments are needed, I’m happy to update the PR.

Fixes​‍​‌‍​‍‌​‍​‌‍​‍‌ #3649