### PR TITLE
Fix: Add support for TRL native dataset formats

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -132,7 +132,7 @@ def sft_trainer_prepare_dataset(function_name, function):
         "    if 'formatting_func'    not in locals(): raise RuntimeError('Unsloth: Please file a bug report - `formatting_func` does not exist!')\n"
         "    if 'dataset_text_field' not in locals() and 'args' in locals(): dataset_text_field = args.dataset_text_field\n"
         "    if 'dataset_text_field' not in locals(): raise RuntimeError('Unsloth: Please file a bug report - `dataset_text_field` does not exist!')\n"
-         "try:\n"
+        "try:\n"
         "    _first_item = dataset[0]\n"
         "except:\n"
         "    _first_item = next(iter(dataset))\n"


### PR DESCRIPTION
## Title 
not sure if this aligns with repo's ideology 
Unsloth's fast `_prepare_dataset` doesn't support TRL's native formats. 
just detects native formats early and uses TRL's original implementation instead, which has proper tokenization support.

EDIT: works for streaming datasets too now : ) 
Fixes #3399