### PR TITLE
Update torchao save

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -2856,7 +2856,7 @@ def _unsloth_save_torchao_with_given_config(
     if os.path.exists(save_directory):
         try:
             shutil.rmtree(save_directory)
-        except Exception:
+        except:
             pass
 
 


### PR DESCRIPTION
This updates unsloth_save_pretrained_torchao.

With this change, after QAT, we can do this to save the model:

```
# Save locally
model.save_pretrained_torchao(save_to, tokenizer=tokenizer)

# Or push to hub
from huggingface_hub import get_token, whoami
def _get_username():
    token = get_token()
    username = whoami(token=token)["name"]
    return username
username = _get_username()
model.save_pretrained_torchao(f"{username}/{save_to}", tokenizer=tokenizer, push_to_hub=True)
```

Previously we had to manually convert with something like this:

```
from unsloth.models._utils import _convert_torchao_model
_convert_torchao_model(model)

# Save locally
model.save_pretrained(save_to, safe_serialization=False)
tokenizer.save_pretrained(save_to)

# Or save to hub
from huggingface_hub import get_token, whoami
def _get_username():
    token = get_token()
    username = whoami(token=token)["name"]
    return username
username = _get_username()
model.push_to_hub(f"{username}/{save_to}", safe_serialization=False)
tokenizer.push_to_hub(f"{username}/{save_to}")
```

unsloth_save_pretrained_torchao now either calls _unsloth_save_torchao_with_given_config (previous behavior) or _unsloth_save_torchao_with_attached_config.

As the name suggests, _unsloth_save_torchao_with_given_config requires a torchao config is provided and starts from a floating point model.

_unsloth_save_torchao_with_given_config uses the config on the model (_torchao_config) that gets attached when a qat_scheme is provided to FastLanguageModel.

The save_directory is always appended with "-torchao" to preserve the previous behavior, but from an API perspective I think this is a bit odd. cc @danielhanchen for thoughts 
