### PR TITLE
Add `target_parameters` support for MoE models and fix trainer bugs

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2800,8 +2800,10 @@ class FastLlamaModel:
                 )
             # Validate that embed_tokens/lm_head are not in target_parameters
             invalid_params = [
-                p for p in target_parameters
-                if p in ("lm_head.weight", "lm_head", "embed_tokens.weight", "embed_tokens")
+                p
+                for p in target_parameters
+                if p
+                in ("lm_head.weight", "lm_head", "embed_tokens.weight", "embed_tokens")
             ]
             if invalid_params:
                 raise ValueError(

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1037,8 +1037,10 @@ class FastBaseModel:
 
             # Validate that embed_tokens/lm_head are not in target_parameters
             invalid_params = [
-                p for p in target_parameters
-                if p in ("lm_head.weight", "lm_head", "embed_tokens.weight", "embed_tokens")
+                p
+                for p in target_parameters
+                if p
+                in ("lm_head.weight", "lm_head", "embed_tokens.weight", "embed_tokens")
             ]
             if invalid_params:
                 raise ValueError(


### PR DESCRIPTION

This PR adds full support for `target_parameters` in LoRA/PEFT for MoE (Mixture of Experts) models like `gpt-oss-20b`, and fixes critical bugs in the trainer that were causing `NameError` exceptions.

## Changes

### 1. Bug Fixes in `trainer.py`

Fixed critical typos that were causing `NameError` exceptions during training:

- **Line 309**: Fixed `PADDING_FREE_BLOCKLIST` → `_PADDING_FREE_BLOCK_LIST` (variable was defined with underscores but referenced without)
- **Lines 352, 358**: Fixed `is_unsupported_gemma` → `is_unsupported_model` (variable `is_unsupported_gemma` was never defined)
- **Line 360**: Updated log message from Gemma 2-specific to generic "unsupported model type" since the blocklist now includes `gemma2`, `gpt_oss`, and `mistral`

**Before (broken):**
```python
is_unsupported_model = any(
    x in PADDING_FREE_BLOCKLIST for x in model_types  # NameError!
)
# ...
elif not is_unsupported_gemma and _should_auto_padding_free(config_arg):  # NameError!
```

**After (fixed):**
```python
is_unsupported_model = any(
    x in _PADDING_FREE_BLOCK_LIST for x in model_types
)
# ...
elif not is_unsupported_model and _should_auto_padding_free(config_arg):
```

### 2. `target_parameters` support for `embed_tokens` and `lm_head` in `llama.py`

Added automatic handling for `embed_tokens.weight` and `lm_head.weight` when specified in `target_parameters`:

- Detects these parameters in the `target_parameters` list
- Automatically moves them to `modules_to_save` for full fine-tuning (not LoRA, since PEFT's `ParamWrapper` doesn't support embedding layers)
- Removes them from `target_parameters` to avoid conflicts
- Prints informative messages to notify the user

**Example usage:**
```python
model = FastLanguageModel.get_peft_model(
    model,
    r = 32,
    target_modules=[],
    target_parameters=[
        'down_proj', 'down_proj_bias', 'gate_up_proj', 'gate_up_proj_bias',
        'k_proj.weight', 'q_proj.weight', 'v_proj.weight', 'o_proj.weight',
        'embed_tokens.weight', 'lm_head.weight'  # Now works!
    ],
    lora_alpha = 64,
    ...
)
```

**Output:**
```
Unsloth: Detected embed_tokens in target_parameters - moving to modules_to_save for full training
Unsloth: Detected lm_head in target_parameters - moving to modules_to_save for full training
```

### 3. Same `target_parameters` support added to `vision.py`

Added identical handling for consistency across all model types.

## Files Changed

| File | Changes |
|------|---------|
| `unsloth/trainer.py` | Fixed 3 variable name typos causing `NameError` |
| `unsloth/models/llama.py` | Added `embed_tokens`/`lm_head` handling in `target_parameters` |
| `unsloth/models/vision.py` | Added same handling for vision models |

## Testing

Tested with `unsloth/gpt-oss-20b` MoE model:

1. ✅ Trainer no longer throws `NameError: name 'PADDING_FREE_BLOCKLIST' is not defined`
2. ✅ `target_parameters` with `embed_tokens.weight` and `lm_head.weight` works correctly
3. ✅ Embeddings are properly trained via `modules_to_save`
