### PR TITLE
Fix Deepseek OCR Lora Model Load

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -849,10 +849,8 @@ class FastModel(FastBaseModel):
                 trust_remote_code = trust_remote_code,
             )
             is_peft = True
-        except ImportError as error:
-            peft_error = str(error)
-            is_peft = False
-            raise error
+        except ImportError:
+            raise
         except Exception as error:
             peft_error = str(error)
             if "architecture" in peft_error:


### PR DESCRIPTION
Most models types have logic to load the model directly from a peft_config (only saved lora adapters and tokenizer). Deepseek OCR since it requires `trust_remote_code=True` fails in `AutoConfig.from_pretrained` since trust_remote_code isn't passed (unsloth_zoo.hf_utils). This depends on https://github.com/unslothai/unsloth-zoo/pull/386, which creates a trust_remote_code kwarg. Once accepted this PR can successfully pass `trust_remote_code=True` when specified by user.

Additionally, a common failure mode is missing package, but that error get swallowed up. This will explicitly raise if an ImportError happens.

This notebook: https://colab.research.google.com/drive/1rQcpPJzFpTId-7KGSvU2zDIg2-emUJTd?usp=sharing
shows regular deepseek ocr works with new code.

Thie notebook: https://colab.research.google.com/drive/1bADSkRQuLQ7VkAV1XlCOH_38nqPhMPye?usp=sharing
shows that direct loading of a save lora_model now works with new code.