### PR TITLE
Fix model training state restoration in GRPO trainer

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -393,7 +393,14 @@ def grpo_trainer__generate_and_score_completions(function_name, function):
 
     if match:
         indent = match.group(1)
-        new_code = indent + "if not _was_training:\n" + indent + "    self.model.for_inference()\n" + indent + "return output"
+        new_code = (
+            indent
+            + "if not _was_training:\n"
+            + indent
+            + "    self.model.for_inference()\n"
+            + indent
+            + "return output"
+        )
         function = function.replace(f"{indent}return output", new_code)
 
     return function


### PR DESCRIPTION
Fixes #3744



@danielhanchen @shimmyshimmer 

I did some debugging and found that during evaluation, `Trainer.evaluate()` correctly calls `model.eval()` to set model.training=False. However, Unsloth's patched `_generate_and_score_completions` function calls `self.model.for_training()` ([rl_replacements.py#L267](https://github.com/unslothai/unsloth/blob/main/unsloth/models/rl_replacements.py#L267), [L273](https://github.com/unslothai/unsloth/blob/main/unsloth/models/rl_replacements.py#L273)) but never restores the original mode afterward. This leaves `model.training=True` even during evaluation.

When TRL's [log()](https://github.com/huggingface/trl/blob/main/trl/trainer/grpo_trainer.py#L2327) method runs, it checks `self.model.training` to determine which metrics bucket to use. Since `model.training=True`, eval metrics get logged to the "train" bucket instead of "eval".

**Proposed Fix:**

Save the original training state (`_was_training = self.model.training`) before calling for_training() ([around L260](https://github.com/unslothai/unsloth/blob/main/unsloth/models/rl_replacements.py#L260))
Restore it at the end of `_generate_and_score_completions` before return output.

Example:

Modify the existing replacement_lines to save the mode
```
replacement_lines = """
    batch_size = self.args.per_device_train_batch_size if mode == "train" else self.args.per_device_eval_batch_size
    _was_training = self.model.training
    try:
        # TRL 0.23.1 and below path
        if not has_images:
            # Left pad prompt before calculation old and ref hidden states
            prompt_completion_ids = left_pack_padding(prompt_completion_ids, self.processing_class.pad_token_id)
        self.model.for_training()
    except:
        # TRL 0.24.0 and below path
        if images is None:
            # Left pad prompt before calculation old and ref hidden states
            prompt_completion_ids = left_pack_padding(prompt_completion_ids, self.processing_class.pad_token_id)
        self.model.for_training()"""
```

Add this new replacement near the end of the function (before return function):
```
function = function.replace(
    "        return output",  # 8 spaces before 'return'
    """        if not _was_training:
            self.model.for_inference()
        return output"""
)
```

I've tested this fix locally and confirmed eval metrics now appear correctly in wandb's evaluation panel. Would you like me to open a PR?

<img width="1200" height="638" alt="Image" src="https://github.com/user-attachments/assets/de3930ac-eb7a-4b4f-a317-41210d2f7cba" />

@Datta0 I have raised a PR and sharing a [Colab Notebook ](https://colab.research.google.com/drive/1csYmgSZNmyMQD5IqqReWb77ZwIwgXUP3?usp=sharing)to validate results. Attaching a screenshot of wandb panel and link to the [workspace](https://wandb.ai/numb3r33/huggingface?nw=nwusernumb3r33). Please take a look and let me know if any more info or changes are required

<img width="1201" height="702" alt="Image" src="https://github.com/user-attachments/assets/f156d44c-6bc4-484d-9714-3f2040bbcfb5" />

Here is the screenshot of the trainer after replacement

<img width="1170" height="435" alt="image" src="https://github.com/user-attachments/assets/eb085007-5f61-453b-a756-10f3d22705c6" />

