### PR TITLE
Add missing import of inspect

### DIFF
--- a/unsloth/device_type.py
+++ b/unsloth/device_type.py
@@ -27,6 +27,7 @@ import functools
 import inspect
 from unsloth_zoo.utils import Version
 
+
 @functools.cache
 def is_hip():
     return bool(getattr(getattr(torch, "version", None), "hip", None))


### PR DESCRIPTION
During the review of #3748 an import of inspect was missed as noticed in #3279
cc @danielhanchen 
