### PR TITLE
fix: add revision parameter support and escape quotes in chat templates

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -341,6 +341,7 @@ class FastBaseModel:
         auto_config = None,
         offload_embedding = False,
         float32_mixed_precision = None,  # Forces float32 mixed precision
+        revision = None,
         # vLLM parameters
         fast_inference = False,
         gpu_memory_utilization = 0.5,
@@ -603,6 +604,7 @@ class FastBaseModel:
                     model_name,
                     token = token,
                     trust_remote_code = trust_remote_code,
+                    revision = revision,
                 )
             if hasattr(auto_config, "quantization_config"):
                 from transformers.quantizers.auto import (
@@ -655,6 +657,7 @@ class FastBaseModel:
             token = token,
             attn_implementation = "sdpa" if supports_sdpa else "eager",
             trust_remote_code = trust_remote_code,
+            revision = revision,
         )
         verify_fp8_support_if_applicable(model_config)
 
@@ -669,6 +672,7 @@ class FastBaseModel:
                 # quantization_config   = bnb_config,
                 token = token,
                 trust_remote_code = trust_remote_code,
+                revision = revision,
                 # attn_implementation   = attn_implementation,
                 **kwargs,
             )


### PR DESCRIPTION
## Summary

This PR addresses two bugs:

### Fix #3544: Add `revision` parameter support

The `revision` parameter in `FastLlamaModel.from_pretrained` was defined in the function signature but never passed to the underlying HuggingFace calls. This prevented users from loading specific model revisions/branches.

**Changes:**
- Added `revision` parameter to `AutoConfig.from_pretrained`
- Added `revision` parameter to `AutoModelForCausalLM.from_pretrained`
- Added `revision` parameter to `AutoModelForSequenceClassification.from_pretrained`
- Added `revision` parameter to `load_correct_tokenizer` and `_load_correct_tokenizer` functions

### Fix #3667: Escape single quotes in Vicuna chat template

When using the Vicuna chat template with `get_chat_template()`, Jinja2 throws a `TemplateSyntaxError` because the default system message contains apostrophes (e.g., "user's questions") that break the single-quoted string in the template.

**Changes:**
- Added single quote escaping (`'` → `\'`) in `_change_system_message` function before substituting system messages into templates

## Test Plan

- [x] Verified Python syntax check passes for all modified files
- [x] Created and ran a test script to verify the Jinja2 template fix:
  - Original (buggy) version fails with `expected token 'end of print statement', got 's'`
  - Fixed version compiles and renders successfully