### PR TITLE
fix: add inputs_embeds support to prepare_inputs_for_generation

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -152,6 +152,7 @@ def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
     attention_mask = None,
+    inputs_embeds = None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -227,11 +228,18 @@ def _fast_prepare_inputs_for_generation(
 
     if "cache_position" in kwargs:
         kwargs["position_ids"] = kwargs["cache_position"]
-    return {
-        "input_ids": input_ids,
+
+    # Build return dict with inputs_embeds support for generation
+    result = {
         "attention_mask": attention_mask,
         **kwargs,
     }
+    # Support inputs_embeds for generation (e.g., when using embeddings directly)
+    if inputs_embeds is not None and input_ids is None:
+        result["inputs_embeds"] = inputs_embeds
+    else:
+        result["input_ids"] = input_ids
+    return result
 
 
 def fix_prepare_inputs_for_generation(module):


### PR DESCRIPTION
## Summary

Add `inputs_embeds` parameter support to `_fast_prepare_inputs_for_generation` to enable generation with embeddings directly.

## Problem

When calling `model.generate(inputs_embeds=...)` on Unsloth-patched models, users get:

```
ValueError: You passed `inputs_embeds` to `.generate()`, but the model class LlamaForCausalLM doesn't have its forwarding implemented.
```

This happens because Unsloth's `_fast_prepare_inputs_for_generation` function didn't include `inputs_embeds` in its signature, causing transformers to think the model doesn't support embedding-based generation.

## Solution

1. Added `inputs_embeds = None` parameter to the function signature
2. Modified the return dict to include either `inputs_embeds` or `input_ids` based on what was provided

## Test Plan

- [x] Python syntax check passes

Fixes #3779