### PR TITLE
fix: add inputs_embeds support with correct priority in generation

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -152,6 +152,7 @@ def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
     attention_mask = None,
+    inputs_embeds = None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -227,11 +228,19 @@ def _fast_prepare_inputs_for_generation(
 
     if "cache_position" in kwargs:
         kwargs["position_ids"] = kwargs["cache_position"]
-    return {
-        "input_ids": input_ids,
+
+    # Build return dict with inputs_embeds support for generation
+    result = {
         "attention_mask": attention_mask,
         **kwargs,
     }
+    # Support inputs_embeds for generation (e.g., when using embeddings directly)
+    # Prioritize inputs_embeds when available, as transformers may create dummy input_ids
+    if inputs_embeds is not None:
+        result["inputs_embeds"] = inputs_embeds
+    else:
+        result["input_ids"] = input_ids
+    return result
 
 
 def fix_prepare_inputs_for_generation(module):


### PR DESCRIPTION
## Summary

Add `inputs_embeds` parameter to `_fast_prepare_inputs_for_generation` to enable direct embedding-based generation for Llama models.

## Problem

When calling `model.generate(inputs_embeds=...)` on Unsloth-patched models, users received a ValueError because the function signature lacked the `inputs_embeds` parameter.

## Solution

- Added `inputs_embeds = None` parameter to the function signature
- Implemented logic to correctly prioritize `inputs_embeds` when available

**Important**: When `model.generate(inputs_embeds=...)` is called, `transformers` often creates a dummy `input_ids` tensor, so we check `if inputs_embeds is not None` (not `if inputs_embeds is not None and input_ids is None`) to ensure embeddings are used correctly.

## Changes

```python
# Prioritize inputs_embeds when available
if inputs_embeds is not None:
    result["inputs_embeds"] = inputs_embeds
else:
    result["input_ids"] = input_ids
```

Fixes #3798

🤖 Generated with [Claude Code](https://claude.com/claude-code)