### PR TITLE
fix: properly handle inputs_embeds in _fast_prepare_inputs_for_generation

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -152,6 +152,7 @@ def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
     attention_mask = None,
+    inputs_embeds = None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -227,11 +228,20 @@ def _fast_prepare_inputs_for_generation(
 
     if "cache_position" in kwargs:
         kwargs["position_ids"] = kwargs["cache_position"]
-    return {
-        "input_ids": input_ids,
+
+    # Build return dict with inputs_embeds support for generation
+    result = {
         "attention_mask": attention_mask,
         **kwargs,
     }
+    # Support inputs_embeds for generation (e.g., when using embeddings directly)
+    # Use inputs_embeds if provided, regardless of input_ids presence
+    # (transformers may auto-generate dummy input_ids even when inputs_embeds is passed)
+    if inputs_embeds is not None:
+        result["inputs_embeds"] = inputs_embeds
+    else:
+        result["input_ids"] = input_ids
+    return result
 
 
 def fix_prepare_inputs_for_generation(module):


### PR DESCRIPTION
## Summary

- Fixes #3798: `inputs_embeds` was ignored when `input_ids` was present
- Adds proper `inputs_embeds` parameter to `_fast_prepare_inputs_for_generation` function
- Prioritizes `inputs_embeds` when provided, regardless of `input_ids` presence

## Problem

When calling `model.generate(inputs_embeds=...)`, the transformers library often auto-generates a dummy `input_ids` tensor. The previous condition:

```python
if inputs_embeds is not None and input_ids is None:
    result["inputs_embeds"] = inputs_embeds
```

would always be `False` because `input_ids` was never `None`, causing `inputs_embeds` to be silently ignored.

## Solution

Changed the logic to:

```python
if inputs_embeds is not None:
    result["inputs_embeds"] = inputs_embeds
else:
    result["input_ids"] = input_ids
```

This properly handles the case where both are provided, prioritizing `inputs_embeds` which matches the expected behavior when users explicitly pass embeddings for generation.

## Test plan

- [x] Code follows the existing style in the repository
- [ ] Tested with `model.generate(inputs_embeds=...)` to confirm embeddings are properly used

🤖 Generated with [Claude Code](https://claude.com/claude-code)