### PR TITLE
fix: handle zero-strided tensors in fast_rope_embedding (#3781)

### DIFF
--- a/unsloth/kernels/rope_embedding.py
+++ b/unsloth/kernels/rope_embedding.py
@@ -312,8 +312,9 @@ class Fast_RoPE_Embedding_QK(torch.autograd.Function):
         _, n_heads_K, _, _ = K.shape
 
         # Inplace rotary embedding is generally fine
-        Q_out = Q.clone() if not Q.is_contiguous() else Q
-        K_out = K.clone() if not K.is_contiguous() else K
+        # Clone if not contiguous or has zero strides (e.g., from expanded/broadcast tensors)
+        Q_out = Q.clone() if not Q.is_contiguous() or 0 in Q.stride() else Q
+        K_out = K.clone() if not K.is_contiguous() or 0 in K.stride() else K
 
         if has_indices:
             # TRL's rotary indices are always in int32, so casting is just for safety
@@ -384,8 +385,9 @@ class Fast_RoPE_Embedding_QK(torch.autograd.Function):
         )
 
         # Inplace rotary embedding is generally fine
-        dQ_out = dQ.clone() if not dQ.is_contiguous() else dQ
-        dK_out = dK.clone() if not dK.is_contiguous() else dK
+        # Clone if not contiguous or has zero strides (e.g., from expanded/broadcast tensors)
+        dQ_out = dQ.clone() if not dQ.is_contiguous() or 0 in dQ.stride() else dQ
+        dK_out = dK.clone() if not dK.is_contiguous() or 0 in dK.stride() else dK
 
         Q_batch_stride, Q_head_stride, Q_seq_stride = (
             dQ_out.stride(0),


### PR DESCRIPTION
## Summary
Fix #3781: Handle zero-strided tensors in `fast_rope_embedding` forward and backward passes.

When gradient tensors (`dQ`, `dK`) have zero strides (e.g., from expanded/broadcast tensors during debugging scenarios like `(out[0].sum() + out[1].sum()).backward()`), the triton kernel fails because all stride values become zero, causing incorrect memory access patterns.

## Changes
- Add zero-stride check alongside contiguity check in both forward and backward passes
- Clone tensors that have any zero stride to ensure proper memory layout for triton kernel

## Code Changes
```python
# Before
Q_out = Q.clone() if not Q.is_contiguous() else Q

# After  
Q_out = Q.clone() if not Q.is_contiguous() or 0 in Q.stride() else Q
```

## Test plan
- [ ] Run the reproduction case from issue #3781:
  ```python
  out = fast_rope_embedding(x.clone(), x.clone(), cos, sin)
  (out[0].sum() + out[1].sum()).backward()
  ```
- [ ] Verify normal forward/backward passes still work correctly
- [ ] Verify performance is not significantly impacted (zero-stride check is O(4))

🤖 Generated with [Claude Code](https://claude.com/claude-code)