### PR TITLE
Fix Gemma3 QAT training instability with int8-int4 scheme

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2198,6 +2198,18 @@ def _prepare_model_for_qat(
     from torchao.quantization.granularity import PerGroup, PerAxis
     from torchao.quantization.qat import QATConfig
 
+    # Gemma3 models have issues with int8 embedding quantization due to their
+    # large vocabulary size (262144). Auto-switch to int4 weight-only instead.
+    if qat_scheme == "int8-int4":
+        model_types = get_transformers_model_type(model.config)
+        is_gemma3 = any("gemma3" in mt or "gemma_3" in mt for mt in model_types)
+        if is_gemma3:
+            print(
+                "Unsloth: Gemma3 has a large vocabulary causing int8 embedding issues. "
+                "Switching to int4 weight-only QAT for training stability."
+            )
+            qat_scheme = "int4"
+
     if not isinstance(qat_scheme, TorchAOConfig):
         torchao_config: Optional[TorchAOConfig] = None
         if qat_scheme == "fp8-int4":


### PR DESCRIPTION
## Summary

Gemma3 models have a large vocabulary (262144 tokens) which causes training loss to explode (~17 instead of ~2.7) when using int8 embedding quantization with the `int8-int4` (phone-deployment) QAT scheme.

This fix auto-detects Gemma3 models using `get_transformers_model_type` and switches to `int4` weight-only QAT for stable training.

## Changes

- Added Gemma3 detection in `_prepare_model_for_qat` function
- Auto-switches from `int8-int4` to `int4` scheme for Gemma3 models
- Prints informative message when switching

## Testing

Verified that training loss converges properly (~2.7) with the fix applied.