### PR TITLE
Sync chat_template from tokenizer to vLLM

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -701,7 +701,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
             "if hasattr(self, 'llm') and self.llm is not None and hasattr(self.llm, 'get_tokenizer'):\n"
             "    _vllm_tok = self.llm.get_tokenizer()\n"
             "    _pc = getattr(self, 'processing_class', None) or getattr(self, 'tokenizer', None)\n"
-            "    if _pc is not None and getattr(_pc, 'chat_template', None) is not None and _vllm_tok.chat_template is None:\n"
+            "    if _vllm_tok is not None and _pc is not None and getattr(_pc, 'chat_template', None) is not None and getattr(_vllm_tok, 'chat_template', None) is None:\n"
             "        _vllm_tok.chat_template = _pc.chat_template\n"
             "pass\n"
         )


### PR DESCRIPTION
## Summary

When using base models with custom chat templates applied after loading, vLLM's internal tokenizer may not have the `chat_template` set. This causes issues during RL training with vLLM inference because vLLM uses its own tokenizer copy that is missing the custom template.

## Changes

Added automatic `chat_template` sync in RL trainer initialization:

- Checks if vLLM's tokenizer exists (`self.llm.get_tokenizer()`)
- Gets the `processing_class` (the tokenizer you loaded and configured)
- If `processing_class` has a `chat_template` and vLLM's tokenizer does not, copies it over

This ensures that custom chat templates applied to base models are correctly propagated to vLLM's internal tokenizer.

## Example Use Case

```python
model, tokenizer = FastLanguageModel.from_pretrained("unsloth/Qwen3-4B")

# Apply custom chat template to base model
tokenizer.chat_template = my_custom_template

trainer = GRPOTrainer(
    model=model,
    processing_class=tokenizer,
    ...
    use_vllm=True,
)
# vLLM's tokenizer now automatically gets the custom chat_template
```

## Testing

Tested with Qwen3-4B base model + custom chat template + GRPO trainer with vLLM. The chat template is correctly applied to vLLM's tokenizer.