### PR TITLE
Replace GitHub API check with vLLM version check for PDL fix

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -620,7 +620,9 @@ def fix_vllm_pdl_blackwell():
             )
             return
     except Exception as e:
-        logger.debug(f"Unsloth: vLLM version check failed ({e}), applying PDL workaround.")
+        logger.debug(
+            f"Unsloth: vLLM version check failed ({e}), applying PDL workaround."
+        )
 
     # Apply the PDL fix
     os.environ["TRITON_DISABLE_PDL"] = "1"


### PR DESCRIPTION
## Summary

Replaces the GitHub API check with a simpler vLLM version check for the PDL workaround.

## Problem

The GitHub issue check had two issues:
1. Added network latency on every import (0.5s connectivity check + up to 3s API call)
2. Issue being closed does not mean the fix is in the user's installed vLLM version

## Solution

Skip the PDL workaround if vLLM version > 0.13.2, which is when the upstream fix is expected to be included. This is:
- Faster (no network calls)
- More accurate (checks the actual installed version)
- Simpler code