### PR TITLE
Fix Kaggle telemetry misclassification when COLAB_ keys exist

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1160,7 +1160,7 @@ def _get_statistics(statistics = None, force_download = True):
                             elif "google" in file_content:
                                 return "gcp"
                     return "other"
-                
+
                 try:
                     statistics = try_vllm_check()
                 except Exception:


### PR DESCRIPTION
**Problem**
Kaggle notebook environments can expose both KAGGLE_* and COLAB_* environment keys. _get_statistics currently checks COLAB_ before KAGGLE_, causing Kaggle sessions to be labeled colab/colabpro.

**Fix**
Prefer filesystem markers (e.g. /kaggle/working, /content + /opt/colab) before env-key heuristics, then fall back to the existing env-key checks. This avoids misclassification when providers leak overlapping env vars.

**Repro**
Kaggle test notebook: https://www.kaggle.com/code/hnxnq07/kaggle-stats-gathering-test