### PR TITLE
Disable gradient checkpointing when explicitly off for vision

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -264,17 +264,19 @@ def prepare_for_training_mode(f):
     def wrapper(self, *args, **kwargs):
         # Enable training mode
         _was_training = None
+        # Get gradient checkpointing setting from training arguments
+        use_gc = getattr(self.args, 'gradient_checkpointing', True)
         if hasattr(self, 'model') and hasattr(self.model, "training"):
             _was_training = self.model.training
         if hasattr(self, 'model') and hasattr(self.model, "for_training"):
-            self.model.for_training()
+            self.model.for_training(use_gradient_checkpointing=use_gc)
         output = f(self, *args, **kwargs)
         # Restore previous mode when possible
         if hasattr(self, 'model') and hasattr(self.model, "for_inference"):
             if _was_training is False:
                 self.model.for_inference()
             elif _was_training is True and hasattr(self.model, "for_training"):
-                self.model.for_training()
+                self.model.for_training(use_gradient_checkpointing=use_gc)
         # Reset gradient checkpointing buffers to free memory while staying ready for next run
         try:
             reset_unsloth_gradient_checkpointing_buffers()

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1273,7 +1273,7 @@ class FastBaseModel:
         # Since transformers 4.53, must turn on explicitly
         for module in model.modules():
             if hasattr(module, "gradient_checkpointing"):
-                module.gradient_checkpointing = True
+                module.gradient_checkpointing = use_gradient_checkpointing
 
         # Also re-enable training for embeddings for NEFTune
         if hasattr(model, "get_input_embeddings"):


### PR DESCRIPTION
When training Qwen3-VL with `gradient_checkpointing=False`, the process fails with an AttributeError. The error originates from `Qwen3VLVisionBlock` expecting a `_gradient_checkpointing_func` attribute that is not present when checkpointing is disabled.
 
```
AttributeError: 'Qwen3VLVisionBlock' object has no attribute '_gradient_checkpointing_func'. Did you mean: 'gradient_checkpointing'?
``` 

The issue appears to be located in `unsloth_compiled_cache/UnslothSFTTrainer.py`, generated by `rl.py`.

While `FastVisionModel.for_training` is called, it re-enable/configure gradient checkpointing do not properly in `vision.py`:

```python
        m = model
        while hasattr(m, "model"):
            _for_training(m)
            m = m.model
        _for_training(m)
        model.train()  # to turn on training on modules deeper in

        # Since transformers 4.53, must turn on explicitly
        for module in model.modules():
            if hasattr(module, "gradient_checkpointing"):
                module.gradient_checkpointing = True # should be use_gradient_checkpointing
```

Version:
```
unsloth			2026.1.2
unsloth-zoo		2026.1.2
transformers	4.57.3
trl				0.24.0
```

<details>
<summary>Training Script</summary>
```python
    USE_GRAD_CHECKPOINTING = False
    model, tokenizer = FastVisionModel.from_pretrained(
        MODEL_PATH,
        max_seq_length=MAX_LEN,
        load_in_4bit=False,
        load_in_8bit=False,
        load_in_16bit=True,
        use_gradient_checkpointing=USE_GRAD_CHECKPOINTING,
        device_map=device_map,
    )
    ...
    model = FastVisionModel.get_peft_model(
        model,
        finetune_vision_layers=False,
        finetune_language_layers=True,
        finetune_attention_modules=True,
        finetune_mlp_modules=True,
        use_gradient_checkpointing=USE_GRAD_CHECKPOINTING,
        r=LORA_RANK,
        lora_alpha=LORA_RANK,
        lora_dropout=0,
        bias="none",
        random_state=3407,
        use_rslora=False,
        loftq_config=None,
        max_seq_length=MAX_LEN,
    )

    FastVisionModel.for_training(model, use_gradient_checkpointing=USE_GRAD_CHECKPOINTING)  # Enable for training!
    data_collator = UnslothVisionDataCollator(
        model,
        tokenizer,
    )
    trainer = SFTTrainer(
        model=model,
        tokenizer=tokenizer,
        data_collator=data_collator,
        train_dataset=train_conversation_dataset,
        eval_dataset=eval_conversation_dataset,
        args=SFTConfig(
            per_device_train_batch_size=4,
            per_device_eval_batch_size=32,
            gradient_checkpointing=USE_GRAD_CHECKPOINTING,
            gradient_accumulation_steps=1,
            ...
        ),
    )
```
</details>
