### PR TITLE
feat: Native CGGR support for SFTTrainer (closes #3884)

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -283,6 +283,7 @@ from .trainer import *
 # CGGR (Confidence-Gated Gradient Routing) integration
 # Optional: requires `pip install cggr` for full functionality
 from .cggr import CGGR_AVAILABLE
+
 if CGGR_AVAILABLE:
     from .cggr import CGGRUnslothBridge, patch_trainer_for_cggr, create_truncated_router
 
@@ -299,4 +300,3 @@ from unsloth_zoo.rl_environments import (
 
 # Patch TRL trainers for backwards compatibility
 _patch_trl_trainer()
-

--- a/unsloth/cggr/__init__.py
+++ b/unsloth/cggr/__init__.py
@@ -20,7 +20,7 @@ This module provides selective backpropagation via label masking, enabling
 
 Usage:
     from unsloth.cggr import CGGRUnslothBridge
-    
+
     trainer = SFTTrainer(...)
     CGGRUnslothBridge.patch_trainer(trainer, min_tokens_ratio=0.25)
     trainer.train()
@@ -42,6 +42,7 @@ __all__ = [
 # Check if CGGR package is available
 try:
     import cggr
+
     CGGR_AVAILABLE = True
 except ImportError:
     CGGR_AVAILABLE = False
@@ -58,13 +59,17 @@ else:
             "CGGR is not installed. Install with: pip install cggr\n"
             "For CUDA acceleration: pip install cggr[cuda]"
         )
-    
+
     create_truncated_router = _cggr_not_available
-    CGGRUnslothBridge = type("CGGRUnslothBridge", (), {
-        "patch_trainer": staticmethod(_cggr_not_available),
-    })
+    CGGRUnslothBridge = type(
+        "CGGRUnslothBridge",
+        (),
+        {
+            "patch_trainer": staticmethod(_cggr_not_available),
+        },
+    )
     patch_trainer_for_cggr = _cggr_not_available
-    
+
     class TruncatedRouter:
         def __init__(self, *args, **kwargs):
             _cggr_not_available()

--- a/unsloth/cggr/router.py
+++ b/unsloth/cggr/router.py
@@ -32,37 +32,37 @@ __all__ = ["TruncatedRouter", "create_truncated_router"]
 class TruncatedRouter(nn.Module):
     """
     A truncated version of a language model using only the first N layers.
-    
+
     Used for fast difficulty scoring in CGGR. Shares weights with the parent
     model, so uses zero additional memory.
-    
+
     Args:
         model: The parent HuggingFace model
         num_layers: Number of decoder layers to use (default: 2)
     """
-    
+
     def __init__(self, model: nn.Module, num_layers: int = 2):
         super().__init__()
         self.num_layers = num_layers
-        
+
         # Get the base model (handle PEFT wrapping)
         base_model = model
         if hasattr(model, "base_model"):
             base_model = model.base_model
         if hasattr(base_model, "model"):
             base_model = base_model.model
-        
+
         # Store reference to model components (shares weights, no copy)
         self.embed_tokens = self._get_embed_tokens(base_model)
         self.layers = self._get_layers(base_model, num_layers)
         self.norm = self._get_norm(base_model)
         self.lm_head = self._get_lm_head(model, base_model)
-        
+
         # Store config for reference
         self.config = getattr(base_model, "config", None)
         self.dtype = next(model.parameters()).dtype
         self.device = next(model.parameters()).device
-        
+
     def _get_embed_tokens(self, model: nn.Module) -> nn.Module:
         """Extract embedding layer from model."""
         if hasattr(model, "embed_tokens"):
@@ -72,7 +72,7 @@ class TruncatedRouter(nn.Module):
         if hasattr(model, "transformer") and hasattr(model.transformer, "wte"):
             return model.transformer.wte  # GPT-2 style
         raise ValueError(f"Cannot find embedding layer in model: {type(model)}")
-    
+
     def _get_layers(self, model: nn.Module, num_layers: int) -> nn.ModuleList:
         """Extract first N decoder layers."""
         layers = None
@@ -84,13 +84,13 @@ class TruncatedRouter(nn.Module):
             layers = model.transformer.h  # GPT-2 style
         elif hasattr(model, "encoder") and hasattr(model.encoder, "layer"):
             layers = model.encoder.layer  # BERT style
-        
+
         if layers is None:
             raise ValueError(f"Cannot find decoder layers in model: {type(model)}")
-        
+
         # Return reference to first N layers (shares weights)
         return nn.ModuleList([layers[i] for i in range(min(num_layers, len(layers)))])
-    
+
     def _get_norm(self, model: nn.Module) -> Optional[nn.Module]:
         """Extract final normalization layer."""
         if hasattr(model, "norm"):
@@ -100,17 +100,21 @@ class TruncatedRouter(nn.Module):
         if hasattr(model, "transformer") and hasattr(model.transformer, "ln_f"):
             return model.transformer.ln_f  # GPT-2 style
         return None
-    
-    def _get_lm_head(self, original_model: nn.Module, base_model: nn.Module) -> nn.Module:
+
+    def _get_lm_head(
+        self, original_model: nn.Module, base_model: nn.Module
+    ) -> nn.Module:
         """Extract language model head."""
         if hasattr(original_model, "lm_head"):
             return original_model.lm_head
         if hasattr(base_model, "lm_head"):
             return base_model.lm_head
-        if hasattr(original_model, "base_model") and hasattr(original_model.base_model, "lm_head"):
+        if hasattr(original_model, "base_model") and hasattr(
+            original_model.base_model, "lm_head"
+        ):
             return original_model.base_model.lm_head
         raise ValueError(f"Cannot find lm_head in model: {type(original_model)}")
-    
+
     @torch.inference_mode()
     def forward(
         self,
@@ -121,49 +125,53 @@ class TruncatedRouter(nn.Module):
     ) -> torch.Tensor:
         """
         Forward pass through truncated model to get logits for scoring.
-        
+
         Args:
             input_ids: Input token IDs [batch, seq_len]
             attention_mask: Attention mask [batch, seq_len]
             position_ids: Position IDs [batch, seq_len]
-            
+
         Returns:
             logits: Output logits [batch, seq_len, vocab_size]
         """
         # Embeddings
         hidden_states = self.embed_tokens(input_ids)
-        
+
         # Generate position_ids if not provided (needed for RoPE)
         if position_ids is None:
-            position_ids = torch.arange(
-                input_ids.size(1), device=input_ids.device
-            ).unsqueeze(0).expand(input_ids.size(0), -1)
-        
+            position_ids = (
+                torch.arange(input_ids.size(1), device = input_ids.device)
+                .unsqueeze(0)
+                .expand(input_ids.size(0), -1)
+            )
+
         # Simple expansion for 2D mask to 4D if needed by layers
         mask_input = attention_mask
         if attention_mask is not None and attention_mask.dim() == 2:
             # Convert [batch, seq] to [batch, 1, 1, seq]
             mask_input = attention_mask[:, None, None, :]
-            mask_input = mask_input.to(dtype=hidden_states.dtype)
+            mask_input = mask_input.to(dtype = hidden_states.dtype)
             mask_input = (1.0 - mask_input) * torch.finfo(hidden_states.dtype).min
-        
+
         # Pass through truncated layers
         for layer in self.layers:
             layer_outputs = layer(
                 hidden_states,
-                attention_mask=mask_input,
-                position_ids=position_ids,
-                use_cache=False,
+                attention_mask = mask_input,
+                position_ids = position_ids,
+                use_cache = False,
             )
-            hidden_states = layer_outputs[0] if isinstance(layer_outputs, tuple) else layer_outputs
-        
+            hidden_states = (
+                layer_outputs[0] if isinstance(layer_outputs, tuple) else layer_outputs
+            )
+
         # Apply final norm if available
         if self.norm is not None:
             hidden_states = self.norm(hidden_states)
-        
+
         # Get logits
         logits = self.lm_head(hidden_states)
-        
+
         return logits
 
 
@@ -173,23 +181,23 @@ def create_truncated_router(
 ) -> TruncatedRouter:
     """
     Create a truncated router from a model for CGGR difficulty scoring.
-    
+
     The router shares weights with the parent model, so uses zero additional
     GPU memory. It only runs the first N layers to quickly estimate token
     difficulty.
-    
+
     Args:
         model: HuggingFace model (can be PEFT-wrapped)
         num_layers: Number of decoder layers to use (default: 2)
-        
+
     Returns:
         TruncatedRouter instance
-        
+
     Example:
         >>> from unsloth import FastLanguageModel
         >>> model, tokenizer = FastLanguageModel.from_pretrained(...)
         >>> router = create_truncated_router(model, num_layers=2)
     """
-    router = TruncatedRouter(model, num_layers=num_layers)
+    router = TruncatedRouter(model, num_layers = num_layers)
     logger.info(f"Created truncated router with {num_layers} layers for CGGR scoring")
     return router


### PR DESCRIPTION
Summary
This PR implements native support for Confidence-Gated Gradient Routing (CGGR). This technique enables a selective backward pass by identifying "easy" tokens early in the model and masking their labels, allowing the backward pass to focus only on informative tokens.

By leveraging CGGR, users can achieve significant throughput increases (tested up to 1.59x) on consumer hardware by utilizing the saved memory to scale batch sizes beyond what is normally possible.

Key Features
Efficiency: Keeps only the top N% hardest tokens for gradient computation based on entropy or margin scoring.
Zero Kernel Changes: Directly compatible with Unsloth's optimized Fast_CrossEntropyLoss. By setting easy tokens to ignore_index=-100, the existing kernels naturally skip gradient computation for those tokens.
Zero Extra Memory: The TruncatedRouter uses the first few layers of the existing model and shares weights with the parent, consuming no additional VRAM.
GPU-Native Optimization: All statistics and masking logic are vectorized on the GPU to avoid CPU-GPU synchronization bottlenecks during the training loop.
Performance (Validated on RTX 3060 12GB)
Tested using SmolLM2-135M at an equal memory budget (~10GB VRAM):

Baseline (Batch 8): 8.3k tokens/sec at 9.13 GB
CGGR (Batch 32): 10.5k tokens/sec at 10.23 GB
Result: +27% Throughput increase by enabling 4x larger batch size.
Note: Higher gains are expected with larger models and longer sequence lengths where memory is the primary bottleneck.

Usage
CGGR can be enabled with a single line after SFTTrainer initialization:

python
from unsloth.cggr import CGGRUnslothBridge
trainer = SFTTrainer(model=model, ...)
CGGRUnslothBridge.patch_trainer(
    trainer,
    min_tokens_ratio=0.25, # Keep 25% hardest tokens
    num_router_layers=2,   # Use first 2 layers for routing
    warmup_steps=10        # Train normally for 10 steps first
)