### PR TITLE
[trl] use non lora model as base for RL

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1173,30 +1173,33 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
     # When "ref" is not in peft_config, GRPO/RLOO fallback uses disable_adapter()
     # which gives the base model logits - exactly what we want
     add_adapter_block_pattern = (
-        r'([ \t]*)'  # Capture leading indentation
-        r'if\s+is_peft_available\(\)\s+and\s+is_peft_model\(model\)\s+and\s+args\.beta\s*!=\s*0\.0\s*:'
-        r'(.*?)'  # Match the entire block until ref_param.data.copy_
-        r'ref_param\.data\.copy_\(param\.data\)'
+        r"([ \t]*)"  # Capture leading indentation
+        r"if\s+is_peft_available\(\)\s+and\s+is_peft_model\(model\)\s+and\s+args\.beta\s*!=\s*0\.0\s*:"
+        r"(.*?)"  # Match the entire block until ref_param.data.copy_
+        r"ref_param\.data\.copy_\(param\.data\)"
     )
+
     def comment_out_block(match):
         """Comment out each line in the matched block, preserving indentation."""
         full_match = match.group(0)
         indent = match.group(1)
-        lines = full_match.split('\n')
+        lines = full_match.split("\n")
         commented_lines = []
         # Add explanation comment first
-        commented_lines.append(f"{indent}# Unsloth: Commented out - use base model as reference, not SFT/LoRA model")
+        commented_lines.append(
+            f"{indent}# Unsloth: Commented out - use base model as reference, not SFT/LoRA model"
+        )
         # Comment out each line - insert # after leading whitespace to preserve indentation
         for line in lines:
             if line.strip():
                 stripped = line.lstrip()
-                leading_ws = line[:len(line) - len(stripped)]
+                leading_ws = line[: len(line) - len(stripped)]
                 commented_lines.append(f"{leading_ws}# {stripped}")
             else:
                 commented_lines.append(line)
-        return '\n'.join(commented_lines)
-    init = re.sub(add_adapter_block_pattern, comment_out_block, init, flags=re.DOTALL)
+        return "\n".join(commented_lines)
 
+    init = re.sub(add_adapter_block_pattern, comment_out_block, init, flags = re.DOTALL)
 
     # Set use_vllm if not set
     if "args.use_vllm" in init and "model" in init and "args" in init:


### PR DESCRIPTION
[TRL updated](https://github.com/huggingface/trl/pull/4723/changes#diff-964e6fd373aa93037604064cb2b822d7f8e2735e33f791065acf2c4c3552d393R332-R341) the RL trainers to use Lora weights as `reference model` when loading a PEFT model. We would ideally want to avoid that and use the base model. If in case someone wants to use the SFT model as the reference model for RL, they might want to merge the weights back to the base model and use it.


UnslothGRPOTrainer After the fix: 
<img width="957" height="333" alt="image" src="https://github.com/user-attachments/assets/2548fb6c-8dcf-434a-ad53-a6196b229a05" />

Side Note that having two adapters with target_parameters, especially for MoE models, is problematic because peft doesn't allow it. 