### PR TITLE
Allow fp8 for non fast inference

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -870,13 +870,6 @@ class FastModel(FastBaseModel):
                         fast_inference = False
                         break
 
-        # [TODO] For now fast_inference only works with fast_inference ie vLLM
-        # if load_in_fp8 != False:
-        #     if not fast_inference:
-        #         raise NotImplementedError(
-        #             "Unsloth: set `fast_inference = True` when doing `load_in_fp8`."
-        #         )
-
         # Find FP8, BnB 4bit, other mapped names
         old_model_name = model_name
         fp8_mode = None

--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -350,10 +350,6 @@ def _get_fp8_mode_and_check_settings(
         raise ValueError(
             f"Unsloth: `load_in_fp8` can only be 'row' or 'block', got '{fp8_mode}'"
         )
-    # if not fast_inference:
-    #     raise ValueError(
-    #         "Unsloth: `load_in_fp8` is only supported for `fast_inference` for now"
-    #     )
     if full_finetuning:
         raise ValueError(
             "Unsloth: `load_in_fp8` is not compatible with full finetuning"

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -120,8 +120,6 @@ except:
 
 HAS_TORCH_DTYPE = "torch_dtype" in PretrainedConfig.__doc__
 
-from transformers import GenerationConfig, CompileConfig
-
 _compile_config = CompileConfig(
     fullgraph = False,
     dynamic = None,

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -255,7 +255,7 @@ def _backwards_compatible_trainer(trainer_class, config_class):
         if "processing_class" in trainer_params and "tokenizer" in kwargs:
             kwargs["processing_class"] = kwargs.pop("tokenizer")
 
-        if ("args" in kwargs) and (Version(trl.__version__) >= Version("0.13.0.dev0")):
+        if ("args" in kwargs) and (Version(trl) >= Version("0.13.0.dev0")):
             training_args = kwargs.pop("args", None)
 
             # Get parameters that Trainer.__init__ actually expects
@@ -456,7 +456,7 @@ def _patch_trl_trainer():
 
     if hasattr(trl, "__UNSLOTH_BACKWARDS_COMPATIBLE__"):
         return
-    if Version(trl.__version__) <= Version("0.11.0"):
+    if Version(trl) <= Version("0.11.0"):
         return
 
     import trl.trainer


### PR DESCRIPTION
Tested on Qwen3-8B with load_in_fp8=True and fast_inference=False