### PR TITLE
Harden vLLM notebook stdout patch

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -134,6 +134,7 @@ from .import_fixes import (
     patch_enable_input_require_grads,
     fix_openenv_no_vllm,
     fix_executorch,
+    patch_vllm_for_notebooks,
 )
 
 fix_xformers_performance_issue()
@@ -147,6 +148,7 @@ patch_datasets()
 patch_enable_input_require_grads()
 fix_openenv_no_vllm()
 fix_executorch()
+patch_vllm_for_notebooks()
 
 del fix_xformers_performance_issue
 del fix_vllm_aimv2_issue
@@ -159,6 +161,7 @@ del patch_datasets
 del patch_enable_input_require_grads
 del fix_openenv_no_vllm
 del fix_executorch
+del patch_vllm_for_notebooks
 
 # Torch 2.4 has including_emulation
 if DEVICE_TYPE == "cuda":

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -204,6 +204,63 @@ def fix_xformers_performance_issue():
             logger.info(f"Unsloth: Failed patching Xformers with error = {str(e)}")
 
 
+def patch_vllm_for_notebooks():
+    import sys
+
+    ipython = None
+    try:
+        from IPython import get_ipython as _get_ipython
+    except Exception:
+        _get_ipython = None
+
+    if _get_ipython is not None:
+        try:
+            ipython = _get_ipython()
+        except Exception:
+            ipython = None
+
+    if ipython is None:
+        try:
+            import builtins
+
+            _get_ipython = getattr(builtins, "get_ipython", None)
+            if callable(_get_ipython):
+                ipython = _get_ipython()
+        except Exception:
+            ipython = None
+
+    if ipython is None:
+        return
+
+    try:
+        shell = ipython.__class__.__name__
+        is_notebook = shell == "ZMQInteractiveShell" or "google.colab" in str(
+            type(ipython)
+        )
+    except Exception:
+        return
+
+    if not is_notebook:
+        return
+
+    if not hasattr(sys.stdout, "fileno"):
+        return
+
+    needs_patch = False
+    try:
+        fd = sys.stdout.fileno()
+        if not isinstance(fd, int) or fd < 0:
+            needs_patch = True
+    except Exception:
+        needs_patch = True
+
+    if not needs_patch:
+        return
+
+    print("Notebook detected: Patching sys.stdout.fileno for vLLM compatibility...")
+    sys.stdout.fileno = lambda: 1
+
+
 # ValueError: 'aimv2' is already used by a Transformers config, pick another name.
 def fix_vllm_aimv2_issue():
     spec = importlib.util.find_spec("vllm")


### PR DESCRIPTION
## Summary
- detect notebooks using IPython or builtins get_ipython and handle empty returns safely
- only override sys.stdout.fileno when it is missing or unusable

## Testing
- not run (import-only change)