### PR TITLE
[transformers] [v5]remove unused hybridcache

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -117,8 +117,6 @@ except:
 
 HAS_TORCH_DTYPE = "torch_dtype" in PretrainedConfig.__doc__
 
-from transformers import GenerationConfig, CompileConfig
-
 _compile_config = CompileConfig(
     fullgraph = False,
     dynamic = None,


### PR DESCRIPTION
This is unused and causes issues in [transformers v5](https://github.com/huggingface/transformers/pull/43168/changes#diff-7723156f6b075b1bf1525f769d90a7cc0b5f233becdcbe28707aaa753960d897L366-L374)
Remove it 