### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # The message to post on stale issues.
           # This message will ping the issue author.


### PR DESCRIPTION
This PR updates an outdated GitHub Action version.

- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/stale.yml`
