### PR TITLE
[WIP] Apple Silicon (MPS/Metal) Support

### DIFF
--- a/benchmarks/mlx/reproduce_loss_curves.py
+++ b/benchmarks/mlx/reproduce_loss_curves.py
@@ -189,7 +189,11 @@ def run_worker(model_name, display_name, use_lora, use_cce, wandb_project=None):
     if wandb_project:
         try:
             import wandb
-            label = "CCE+compile" if use_cce else "Baseline+compile"
+            import mlx.core as mx
+            # Add suffix to distinguish mlx-cce vs regular mlx in W&B
+            has_fast_cce = hasattr(mx, "fast") and hasattr(mx.fast, "cce_loss")
+            cce_suffix = " (mlx-cce)" if has_fast_cce else " (mlx)"
+            label = ("CCE+compile" if use_cce else "Baseline+compile") + cce_suffix
             run = wandb.init(
                 project=wandb_project,
                 name=f"{display_name} ({label})",

--- a/test_embedding.py
+++ b/test_embedding.py
@@ -1,0 +1,23 @@
+import torch
+import mlx.core as mx
+from unsloth.kernels.mlx.bridge import mlx_to_torch
+
+arr = mx.array([[1, 2, 3], [4, 5, 6]], dtype=mx.int32)
+tensor = mlx_to_torch(arr)
+print("Tensor:", tensor)
+print("Tensor device:", tensor.device)
+
+emb = torch.nn.Embedding(10, 5).to("mps")
+try:
+    res = emb(tensor.to("mps"))
+    print("Success")
+except Exception as e:
+    print("Error:", e)
+
+# Test with a clone
+tensor2 = tensor.clone()
+try:
+    res = emb(tensor2.to("mps"))
+    print("Success with clone")
+except Exception as e:
+    print("Error with clone:", e)


### PR DESCRIPTION
This PR introduces high-performance Apple Silicon support for Unsloth. The goal is to allow Mac users (M1/M2/M3/M4) to fine-tune and run inference on 7B+ models with performance parity to entry-level CUDA hardware, leveraging Apple's Unified Memory and Metal architecture.

