### PR TITLE
Add vLLM fallback and GRPO completion normalization

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -217,7 +217,10 @@ def fix_deepseek_v2_moe_alias():
 
     deepseek_v2.DeepseekV2MoE = deepseek_v2.DeepseekV2Moe
     try:
-        if hasattr(deepseek_v2, "__all__") and "DeepseekV2MoE" not in deepseek_v2.__all__:
+        if (
+            hasattr(deepseek_v2, "__all__")
+            and "DeepseekV2MoE" not in deepseek_v2.__all__
+        ):
             deepseek_v2.__all__.append("DeepseekV2MoE")
     except Exception:
         pass
@@ -236,10 +239,14 @@ def fix_qwen2_vl_max_pixels_none():
     original = qwen2_vl.smart_resize
     default_max_pixels = 14 * 14 * 4 * 1280
 
-    def smart_resize(height, width, factor=28, min_pixels=56 * 56, max_pixels=default_max_pixels):
+    def smart_resize(
+        height, width, factor = 28, min_pixels = 56 * 56, max_pixels = default_max_pixels
+    ):
         if max_pixels is None:
             max_pixels = default_max_pixels
-        return original(height, width, factor=factor, min_pixels=min_pixels, max_pixels=max_pixels)
+        return original(
+            height, width, factor = factor, min_pixels = min_pixels, max_pixels = max_pixels
+        )
 
     smart_resize._unsloth_max_pixels_patch = True
     qwen2_vl.smart_resize = smart_resize
@@ -247,7 +254,9 @@ def fix_qwen2_vl_max_pixels_none():
 
 def fix_qwen2_5_vl_tie_word_embeddings():
     try:
-        from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLTextConfig
+        from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
+            Qwen2_5_VLTextConfig,
+        )
     except Exception:
         return
 

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1141,7 +1141,9 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         )
     except Exception as exc:
         if os.environ.get("UNSLOTH_LOGGING_ENABLED", "0") == "1":
-            print(f"Unsloth: Failed to compile {RLTrainer_name} ({exc}), falling back to original trainer.")
+            print(
+                f"Unsloth: Failed to compile {RLTrainer_name} ({exc}), falling back to original trainer."
+            )
         return
 
     # Patch Trainer

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -457,14 +457,14 @@ def grpo_trainer__calculate_rewards(function_name, function):
         "                return ''.join(_unsloth_completion_to_text(item) for item in completion)\n"
         "            return str(completion)\n"
         "        completion_texts = [_unsloth_completion_to_text(c) for c in completions]\n"
-        "        completions_are_text = all(isinstance(c, str) for c in completions)\n"
+        "        completions_are_text = all(isinstance(c, str) for c in completions)\n",
     )
 
     function = function.replace(
-        "        reward_kwargs[\"trainer_state\"] = self.state\n",
-        "        reward_kwargs[\"trainer_state\"] = self.state\n"
-        "        reward_kwargs[\"completion_texts\"] = completion_texts\n"
-        "        reward_kwargs[\"completion_raw\"] = completions\n",
+        '        reward_kwargs["trainer_state"] = self.state\n',
+        '        reward_kwargs["trainer_state"] = self.state\n'
+        '        reward_kwargs["completion_texts"] = completion_texts\n'
+        '        reward_kwargs["completion_raw"] = completions\n',
     )
 
     function = function.replace(
@@ -473,7 +473,10 @@ def grpo_trainer__calculate_rewards(function_name, function):
     )
 
     # Add a robust try/except wrapper for reward funcs expecting dict completions.
-    if "string indices must be integers" not in function and "output_reward_func = reward_func(" in function:
+    if (
+        "string indices must be integers" not in function
+        and "output_reward_func = reward_func(" in function
+    ):
         base_try = (
             "                    # UNSLOTH_REWARD_FUNC_TRY\n"
             "                    try:\n"
@@ -481,11 +484,11 @@ def grpo_trainer__calculate_rewards(function_name, function):
             "                            prompts=prompts, completions=(completions if completions_are_text else completion_texts), completion_ids=completion_ids_list, **reward_kwargs\n"
             "                        )\n"
             "                    except TypeError as e:\n"
-            "                        if \"string indices must be integers\" in str(e):\n"
+            '                        if "string indices must be integers" in str(e):\n'
             "                            def _wrap_completion_list(_comps):\n"
             "                                if isinstance(_comps, list):\n"
-            "                                    return [c if isinstance(c, dict) else {\"content\": c} for c in _comps]\n"
-            "                                return [{\"content\": _comps}]\n"
+            '                                    return [c if isinstance(c, dict) else {"content": c} for c in _comps]\n'
+            '                                return [{"content": _comps}]\n'
             "                            _wrapped = [_wrap_completion_list(c) for c in completions]\n"
             "                            output_reward_func = reward_func(\n"
             "                                prompts=prompts, completions=_wrapped, completion_ids=completion_ids_list, **reward_kwargs\n"


### PR DESCRIPTION
## Summary
- add safe vLLM import guard for guided decoding patch
- normalize GRPO completions and retry reward funcs on string vs dict mismatch
- wrap vLLM fast_generate with HF fallback and disable vLLM inference for FP8 models
- attach HF model and tokenizer to vLLM engine for fallback
- add DeepSeek v2 MoE alias and Qwen VL compatibility helpers
- guard RL trainer compilation to fall back to original trainer on failure

## Testing
- python -m py_compile unsloth/import_fixes.py unsloth/__init__.py unsloth/models/rl_replacements.py unsloth/models/_utils.py unsloth/models/llama.py unsloth/models/vision.py unsloth/models/rl.py