### PR TITLE
Fix num_train_epochs=None causing TypeError in GRPOConfig

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -891,6 +891,15 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         )
         extra_args += learning_rate_check
 
+    # Fix num_train_epochs = None causing TypeError in Trainer.__init__
+    # Trainer does `args.num_train_epochs > 0` which fails when None
+    if "num_train_epochs" in call_args:
+        num_train_epochs_check = (
+            "if num_train_epochs is None:\n"
+            "    num_train_epochs = 3.0  # Default to 3 epochs if None, max_steps will override\n"
+        )
+        extra_args += num_train_epochs_check
+
     # Check if max_seq_length is NOT defined (max_length is now default)
     if "max_seq_length" not in call_args and "max_length" in call_args:
         max_seq_length_pre = """max_seq_length : Optional[int] = field(


### PR DESCRIPTION
## Summary
- Fix TypeError when `num_train_epochs=None` is passed to GRPOConfig
- Converts None to 3.0 (the default) before Trainer init (max_steps still controls actual duration)

## Problem
When users pass `num_train_epochs=None` to GRPOConfig, the Trainer initialization fails with:

```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

This happens at `transformers/training_args.py:290` where Trainer does:
```python
if args.num_train_epochs > 0:  # Fails when None
```

## Solution
Add a check in the generated RLConfig code to convert None to 3.0:
```python
if num_train_epochs is None:
    num_train_epochs = 3.0  # Default to 3 epochs if None, max_steps will override
```

The actual training duration is still controlled by `max_steps` since it takes precedence when both are set.

## Test
```python
from trl import GRPOConfig, GRPOTrainer

config = GRPOConfig(
    num_train_epochs=None,  # Previously caused TypeError
    max_steps=500,          # This controls actual duration
    ...
)
# Now works - num_train_epochs converted to 3.0, training runs for 500 steps
```

Tested with TRL 0.27.1 and Unsloth main.