### PR TITLE
Add vLLM + torch < 2.9.0 + SM100 compatibility check

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -125,6 +125,7 @@ from unsloth_zoo.device_type import (
 from .import_fixes import (
     fix_xformers_performance_issue,
     fix_vllm_aimv2_issue,
+    check_vllm_torch_sm100_compatibility,
     fix_vllm_guided_decoding_params,
     fix_vllm_pdl_blackwell,
     fix_rocm_triton_key_error,
@@ -142,6 +143,8 @@ from .import_fixes import (
 
 fix_xformers_performance_issue()
 fix_vllm_aimv2_issue()
+# Check vLLM + torch < 2.9.0 + SM100 compatibility BEFORE importing vLLM
+check_vllm_torch_sm100_compatibility()
 fix_vllm_guided_decoding_params()
 fix_vllm_pdl_blackwell()
 fix_rocm_triton_key_error()
@@ -158,6 +161,7 @@ patch_torchcodec_audio_decoder()
 
 del fix_xformers_performance_issue
 del fix_vllm_aimv2_issue
+del check_vllm_torch_sm100_compatibility
 del fix_vllm_guided_decoding_params
 del fix_vllm_pdl_blackwell
 del fix_rocm_triton_key_error

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -699,6 +699,72 @@ def fix_rocm_triton_key_error():
     )
 
 
+def check_vllm_torch_sm100_compatibility():
+    """
+    Check for incompatible vLLM + torch < 2.9.0 + SM100 (Blackwell) combination.
+
+    vLLM's distributed module (device_communicators) crashes with std::bad_alloc
+    when imported on SM100 GPUs (B200/B100) with torch < 2.9.0. This is due to
+    C++ code in vLLM's NCCL/distributed layer being incompatible with older
+    torch versions on the newer Blackwell architecture.
+
+    This check runs early (before vLLM import) to provide a helpful error message
+    instead of a cryptic std::bad_alloc crash.
+    """
+    # Check if vLLM is installed (without importing it)
+    if importlib.util.find_spec("vllm") is None:
+        return
+
+    # Check torch version
+    try:
+        torch_version = Version(importlib_version("torch"))
+        if torch_version >= Version("2.9.0"):
+            return  # torch >= 2.9.0 is compatible
+    except Exception:
+        return  # Can't determine torch version, skip check
+
+    # Check if any CUDA GPU is SM100 (Blackwell)
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return
+
+        has_sm100 = False
+        sm100_gpu_name = None
+        for i in range(torch.cuda.device_count()):
+            major, minor = torch.cuda.get_device_capability(i)
+            if major == 10:
+                has_sm100 = True
+                sm100_gpu_name = torch.cuda.get_device_name(i)
+                break
+
+        if not has_sm100:
+            return
+    except Exception:
+        return
+
+    # Get vLLM version for the error message
+    try:
+        vllm_version = importlib_version("vllm")
+    except Exception:
+        vllm_version = "unknown"
+
+    # Incompatible combination detected - raise helpful error
+    raise RuntimeError(
+        f"Unsloth: Incompatible configuration detected.\n\n"
+        f"  GPU: {sm100_gpu_name} (SM100 / Blackwell architecture)\n"
+        f"  torch version: {torch_version}\n"
+        f"  vLLM version: {vllm_version}\n\n"
+        f"vLLM's distributed module crashes with std::bad_alloc on SM100 GPUs "
+        f"(B200/B100/Blackwell) when using torch < 2.9.0.\n\n"
+        f"To fix this, please upgrade torch:\n"
+        f"  pip install --upgrade torch>=2.9.0\n\n"
+        f"Alternatively, if you don't need vLLM:\n"
+        f"  pip uninstall vllm"
+    )
+
+
 def fix_vllm_pdl_blackwell():
     """
     Fix vLLM PDL (Programmatic Dependent Launch) bug on Blackwell GPUs (SM100).


### PR DESCRIPTION
## Summary

vLLM's distributed module (`device_communicators`) crashes with `std::bad_alloc` when imported on SM100 GPUs (B200/B100/Blackwell) with torch < 2.9.0. This is due to C++ code in vLLM's NCCL/distributed layer being incompatible with older torch versions on Blackwell architecture.

This PR adds an early compatibility check that runs before vLLM is imported, providing a helpful error message instead of a cryptic C++ exception.

## Changes

- `import_fixes.py`: Added `check_vllm_torch_sm100_compatibility()` function
- `__init__.py`: Import and call the check before any vLLM imports

## The Check

1. Detects if vLLM is installed (without importing it)
2. Checks if torch version is < 2.9.0
3. Checks if any GPU is SM100 (Blackwell)
4. If all conditions are met, raises `RuntimeError` with clear upgrade instructions

## Error Message Example

```
Unsloth: Incompatible configuration detected.

  GPU: NVIDIA B200 (SM100 / Blackwell architecture)
  torch version: 2.8.0
  vLLM version: 0.15.0

vLLM's distributed module crashes with std::bad_alloc on SM100 GPUs
(B200/B100/Blackwell) when using torch < 2.9.0.

To fix this, please upgrade torch:
  pip install --upgrade torch>=2.9.0

Alternatively, if you don't need vLLM:
  pip uninstall vllm
```

## Test

Verified on B200 GPU with torch 2.8.0 + vLLM - the check correctly detects the incompatible combination and provides a helpful error before the crash would occur.