### PR TITLE
Fix TRL 0.25.1+ GRPO vision crash and reward function TypeError

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1587,6 +1587,7 @@ def _patch_prepare_multimodal_messages():
     # Also patch in grpo_trainer module if imported
     try:
         import trl.trainer.grpo_trainer as _gt
+
         if hasattr(_gt, "prepare_multimodal_messages"):
             _gt.prepare_multimodal_messages = _safe_prepare_multimodal_messages
     except ImportError:

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -29,16 +29,20 @@ from unsloth_zoo.rl_replacements import RL_REPLACEMENTS, left_pack_padding
 from unsloth_zoo.utils import Version
 from importlib.metadata import version as importlib_version
 from unsloth_zoo.log import logger
+
 # device_synchronize may not exist in older unsloth_zoo versions
 try:
     from unsloth_zoo.device_type import device_synchronize
 except ImportError:
     import torch
+
     def device_synchronize():
         if torch.cuda.is_available():
             torch.cuda.synchronize()
         elif hasattr(torch, "xpu") and torch.xpu.is_available():
             torch.xpu.synchronize()
+
+
 import importlib.util
 from ..device_type import (
     is_hip,


### PR DESCRIPTION
## Summary

- Fix vision GRPO crash on TRL 0.25.1+ when notebooks pre-apply chat templates
- Fix reward function TypeError when expecting plain text but receiving conversation format dicts

## Changes

### Fix 2: Vision GRPO crash (rl.py)

TRL 0.25.1+ calls `prepare_multimodal_messages()` unconditionally for vision models. When notebooks pre-apply `tokenizer.apply_chat_template()` (converting prompts to strings), the function crashes iterating over characters.

**Solution**: Add `_patch_prepare_multimodal_messages()` that wraps the TRL function with an `isinstance(messages, str)` guard. String prompts now pass through unchanged.

### Fix 6: Reward function TypeError (rl_replacements.py)

TRL 0.25.0+ passes `prompts` and `completions` to `_calculate_rewards` in different formats:
- Conversational inputs: list of dicts `[{"role": "assistant", "content": "..."}]`
- Non-conversational inputs: plain strings

This inconsistency causes reward functions to crash when they expect strings but receive dicts (or vice versa).

**Solution**: Add `grpo_trainer__calculate_rewards_text_fix()` that makes `_calculate_rewards` always use `prompts_text` and `completions_text` (plain decoded strings) for consistent behavior.

## Test plan

- [x] Verified Fix 2: `prepare_multimodal_messages("test string", [])` returns string unchanged
- [x] Verified Fix 6: Compiled cache shows `_calculate_rewards` uses `prompts_text, completions_text`
- [x] Smoke tested nb2_gpt_oss_2048 with TRL 0.25.1 - runs without TypeError
- [x] Smoke tested vision model loading with TRL 0.25.1 - works correctly