### PR TITLE
Fix torchvision compatibility check for source builds and future torch versions

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -612,9 +612,8 @@ def torchvision_compatibility_check():
     # Detect nightly/dev/alpha/beta/rc builds from the raw version string.
     # These often have version mismatches that are expected.
     _pre_tags = (".dev", "a0", "b0", "rc", "alpha", "beta", "nightly")
-    is_prerelease = (
-        any(t in torch_version_raw for t in _pre_tags)
-        or any(t in torchvision_version_raw for t in _pre_tags)
+    is_prerelease = any(t in torch_version_raw for t in _pre_tags) or any(
+        t in torchvision_version_raw for t in _pre_tags
     )
 
     # Downgrade to warning for custom/source/pre-release builds or formula-predicted


### PR DESCRIPTION
## Summary

- On AMD machines with source-built PyTorch (`torch==2.7.0+gitf717b2a`, `torchvision==0.21.0+7af6987`), `torchvision_compatibility_check()` raised a hard `ImportError` that blocked `from unsloth import FastLanguageModel` entirely, even though the build was functional.
- The hardcoded compatibility table also silently skipped any torch version not already listed, giving zero feedback for future releases like torch 2.10+.

## Changes

**Custom/source build detection** -- Detects source builds by checking the raw version string's local identifier (the part after `+`) against known standard prefixes (`cu\d`, `rocm\d`, `cpu`, `xpu`). This must operate on the raw string from `importlib_version()` because our custom `Version()` wrapper strips local identifiers via regex before parsing. The regex requires `cu`/`rocm` to be followed by a digit (avoiding false negatives on suffixes like `+custom_build`), is case-insensitive (handles `+ROCM6.3`), and matches `cpu`/`xpu` as exact strings.

**Pre-release/nightly detection** -- Detects `.dev`, `a0`, `b0`, `rc`, `alpha`, `beta`, `nightly` tags in the raw torch version string. Nightly/dev/rc builds with standard CUDA or ROCm suffixes (e.g. `2.7.0.dev20250301+cu124`) now produce a warning instead of a hard `ImportError`, since these builds commonly have version mismatches that are expected during development.

**Formula-based forward compatibility** -- The torch-to-torchvision minor version mapping follows a consistent formula that has held for every release from torch 1.7 through 2.9:
  - `torch 1.x` -> `torchvision 0.(x + 1)` (verified: 1.7 through 1.13)
  - `torch 2.x` -> `torchvision 0.(x + 15)` (verified: 2.0 through 2.9)

  For versions not in the known table, the formula is used as a fallback. Mismatches from formula-predicted versions produce a warning rather than a hard error, since the formula could in theory change.

**Graceful degradation** -- Wraps `importlib_version()` and `Version()` calls in try/except so broken package metadata never crashes the import.

**Environment variable override** -- `UNSLOTH_SKIP_TORCHVISION_CHECK=1` skips the check entirely for environments where the user knows the build is correct.

**Behavior matrix:**

| Scenario | Old behavior | New behavior |
|----------|-------------|-------------|
| Standard release mismatch (e.g. `+cu124`) | ImportError | ImportError (unchanged) |
| Source/custom build mismatch (e.g. `+git*`) | ImportError | Warning only |
| Nightly/dev/rc build mismatch (e.g. `.dev*+cu124`) | ImportError | Warning only |
| Future torch version, correct torchvision | Silent skip | Logs compatible |
| Future torch version, wrong torchvision | Silent skip | Warning |
| `UNSLOTH_SKIP_TORCHVISION_CHECK=1` | N/A | Skips check |

Validated with 384 standard-table backwards-compat tests (100% match with old behavior), plus 50+ additional tests covering custom builds, pre-releases, forward compat, edge cases, and adversarial inputs.

## Test plan

- [x] Verify standard CUDA/ROCm release mismatches still raise ImportError (384 tests, 100% match)
- [x] Verify source-built versions (`+gitXXX`, `+HEXHASH`) produce a warning instead of ImportError
- [x] Verify nightly/dev/rc builds with standard suffixes produce a warning instead of ImportError
- [x] Verify formula correctly predicts torchvision requirements for future torch 2.10+
- [x] Verify `UNSLOTH_SKIP_TORCHVISION_CHECK=1` bypasses the check
- [x] Verify all other version checks in import_fixes.py (xformers, vllm, datasets, fbgemm_gpu, etc.) are unaffected
- [x] Verify regex handles case insensitivity (`+ROCM6.3`, `+CPU`)
- [x] Verify regex precision (no false negatives on `+custom_build`, `+cust`, etc.)