### PR TITLE
Silence non-actionable TRL trainer import failures

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -420,7 +420,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
     try:
         trainer = eval(f"trl.trainer.{trainer_file}")
     except Exception as error:
-        print(f"Unsloth: Could not import trl.trainer.{trainer_file}: {error}")
+        logger.info(f"Unsloth: Could not import trl.trainer.{trainer_file}: {error}")
         return
 
     # Get SFTTrainer and SFTConfig names


### PR DESCRIPTION
## Summary

- `_patch_trl_rl_trainers()` in `rl.py` enumerates all trainer modules from `dir(trl.trainer)` and dynamically imports each one. Some modules like `alignprop_trainer` (in trl 0.22.2) fail because they depend on optional packages like `diffusers` that may not be installed.
- The failure is caught and handled gracefully (`return`), but the `print()` call on line 423 produces noise on every `from unsloth import FastLanguageModel`:
  ```
  Unsloth: Could not import trl.trainer.alignprop_trainer: Failed to import
  trl.trainer.alignprop_trainer because of the following error: cannot import
  name 'DDPOStableDiffusionPipeline' from 'trl.models'
  ```
- This message is not actionable by the user -- `alignprop_trainer` is not needed for LLM fine-tuning.

## Changes

Change `print()` to `logger.info()` so these messages only appear when `UNSLOTH_ENABLE_LOGGING=1`. The `logger` import already exists (`from unsloth_zoo.log import logger` on line 26), and other similar messages in the same function already use `logger.info()` (lines 442, 447, 458, 465).

## Test plan

- [ ] Verify `from unsloth import FastLanguageModel` no longer prints alignprop noise with trl 0.22.2
- [ ] Verify setting `UNSLOTH_ENABLE_LOGGING=1` still shows the message for debugging