### PR TITLE
Fix GPT-OSS BlockMask error during inference

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -197,6 +197,12 @@ def prefer_flex_attn_if_supported(model_class, config):
             model_class, "_supports_flex_attn", False
         ):
             return None
+        # GPT-OSS uses eager attention during inference since flex attention
+        # returns incorrect results (likely due to left padding issues).
+        # Skip setting flex_attention to avoid BlockMask type errors.
+        model_type = getattr(config, "model_type", "") if config else ""
+        if model_type == "gpt_oss":
+            return None
         if config is not None:
             setattr(config, "_attn_implementation", "flex_attention")
             if hasattr(config, "attn_implementation"):


### PR DESCRIPTION
## Summary

- Exclude GPT-OSS models from using `flex_attention` in `prefer_flex_attn_if_supported()`
- Prevents `TypeError: unsupported operand type(s) for +=: 'Tensor' and 'BlockMask'` during inference/generation

## Problem

GPT-OSS models use eager attention during inference because flex attention returns incorrect results (likely due to left padding issues). See the comment in `gpt_oss.py`:

```python
# Weirdly for inference, flex attention returns gibberish
# Most likely due to left padding
```

However, when `_attn_implementation` is set to `"flex_attention"`, transformers creates `BlockMask` objects. When these are passed to the eager attention path during inference, it causes:

```
TypeError: unsupported operand type(s) for +=: 'Tensor' and 'BlockMask'
```

## Fix

Check `config.model_type` and skip setting `flex_attention` for `gpt_oss` models, keeping them on the eager path.

## Testing

- Verified GPT-OSS now shows `_attn_implementation: eager`
- Inference generation works correctly
- GRPO training completes without errors