### PR TITLE
Extend TRL experimental patching and vLLM readiness

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -568,7 +568,10 @@ class FastLanguageModel(FastLlamaModel):
         if (
             os.path.exists(os.path.join(old_model_name, "tokenizer_config.json"))
             and os.path.exists(os.path.join(old_model_name, "tokenizer.json"))
-            and os.path.exists(os.path.join(old_model_name, "special_tokens_map.json"))
+            and (
+                os.path.exists(os.path.join(old_model_name, "special_tokens_map.json"))
+                or os.path.exists(os.path.join(old_model_name, "chat_template.jinja"))
+            )
         ):
             tokenizer_name = old_model_name
         else:
@@ -1237,7 +1240,10 @@ class FastModel(FastBaseModel):
         if (
             os.path.exists(os.path.join(old_model_name, "tokenizer_config.json"))
             and os.path.exists(os.path.join(old_model_name, "tokenizer.json"))
-            and os.path.exists(os.path.join(old_model_name, "special_tokens_map.json"))
+            and (
+                os.path.exists(os.path.join(old_model_name, "special_tokens_map.json"))
+                or os.path.exists(os.path.join(old_model_name, "chat_template.jinja"))
+            )
         ):
             tokenizer_name = old_model_name
         else:


### PR DESCRIPTION
## Summary
1. Patch TRL experimental trainers and already-imported experimental modules for backward compatibility.
2. Make RL trainer patching safer with optional logging and DataCollatorForPreference handling.
3. Add a vLLM readiness fallback using the metrics endpoint.

## Testing
1. Ran Llama3 8B ORPO notebook with transformers 4.57.6 and 5.0.0 using trl 0.27.1.
2. Ran Meta Synthetic Data Llama3 2 3B notebook with transformers 4.57.6 and 5.0.0 using trl 0.27.1.