### PR TITLE
Add PyTorch 2.10 and xformers 0.0.34 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ pip install unsloth
 </details>
 
 ### Advanced Pip Installation
-`⚠️Do **NOT** use this if you have Conda.` Pip is a bit more complex since there are dependency issues. The pip command is different for `torch 2.2,2.3,2.4,2.5,2.6,2.7,2.8,2.9` and CUDA versions.
+`⚠️Do **NOT** use this if you have Conda.` Pip is a bit more complex since there are dependency issues. The pip command is different for `torch 2.2,2.3,2.4,2.5,2.6,2.7,2.8,2.9,2.10` and CUDA versions.
 
-For other torch versions, we support `torch211`, `torch212`, `torch220`, `torch230`, `torch240`, `torch250`, `torch260`, `torch270`, `torch280`, `torch290` and for CUDA versions, we support `cu118` and `cu121` and `cu124`. For Ampere devices (A100, H100, RTX3090) and above, use `cu118-ampere` or `cu121-ampere` or `cu124-ampere`.
+For other torch versions, we support `torch211`, `torch212`, `torch220`, `torch230`, `torch240`, `torch250`, `torch260`, `torch270`, `torch280`, `torch290`, `torch2100` and for CUDA versions, we support `cu118` and `cu121` and `cu124`. For Ampere devices (A100, H100, RTX3090) and above, use `cu118-ampere` or `cu121-ampere` or `cu124-ampere`. Note: torch 2.10 only supports CUDA 12.6, 12.8, and 13.0.
 
 For example, if you have `torch 2.4` and `CUDA 12.1`, use:
 ```bash
@@ -208,6 +208,12 @@ Another example, if you have `torch 2.9` and `CUDA 13.0`, use:
 ```bash
 pip install --upgrade pip
 pip install "unsloth[cu130-torch290] @ git+https://github.com/unslothai/unsloth.git"
+```
+
+Another example, if you have `torch 2.10` and `CUDA 12.6`, use:
+```bash
+pip install --upgrade pip
+pip install "unsloth[cu126-torch2100] @ git+https://github.com/unslothai/unsloth.git"
 ```
 
 And other examples:
@@ -254,8 +260,10 @@ elif v  < V('2.8.0'): x = 'cu{}{}-torch271'
 elif v  < V('2.8.9'): x = 'cu{}{}-torch280'
 elif v  < V('2.9.1'): x = 'cu{}{}-torch290'
 elif v  < V('2.9.2'): x = 'cu{}{}-torch291'
+elif v  < V('2.10.1'): x = 'cu{}{}-torch2100'
 else: raise RuntimeError(f"Torch = {v} too new!")
 if v > V('2.6.9') and cuda not in ("11.8", "12.6", "12.8", "13.0"): raise RuntimeError(f"CUDA = {cuda} not supported!")
+if v >= V('2.10.0') and cuda not in ("12.6", "12.8", "13.0"): raise RuntimeError(f"Torch 2.10 requires CUDA 12.6, 12.8, or 13.0! Got CUDA = {cuda}")
 x = x.format(cuda.replace(".", ""), "-ampere" if False else "") # is_ampere is broken due to flash-attn
 print(f'pip install --upgrade pip && pip install --no-deps git+https://github.com/unslothai/unsloth-zoo.git && pip install "unsloth[{x}] @ git+https://github.com/unslothai/unsloth.git" --no-build-isolation')
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,18 @@ cu130onlytorch291 = [
     "xformers @ https://download.pytorch.org/whl/cu130/xformers-0.0.33.post2-cp39-abi3-manylinux_2_28_x86_64.whl ; ('linux' in sys_platform)",
     "xformers @ https://download.pytorch.org/whl/cu130/xformers-0.0.33.post2-cp39-abi3-win_amd64.whl ; (sys_platform == 'win32')",
 ]
+cu126onlytorch2100 = [
+    "xformers @ https://download.pytorch.org/whl/cu126/xformers-0.0.34-cp39-abi3-manylinux_2_28_x86_64.whl ; ('linux' in sys_platform)",
+    "xformers @ https://download.pytorch.org/whl/cu126/xformers-0.0.34-cp39-abi3-win_amd64.whl ; (sys_platform == 'win32')",
+]
+cu128onlytorch2100 = [
+    "xformers @ https://download.pytorch.org/whl/cu128/xformers-0.0.34-cp39-abi3-manylinux_2_28_x86_64.whl ; ('linux' in sys_platform)",
+    "xformers @ https://download.pytorch.org/whl/cu128/xformers-0.0.34-cp39-abi3-win_amd64.whl ; (sys_platform == 'win32')",
+]
+cu130onlytorch2100 = [
+    "xformers @ https://download.pytorch.org/whl/cu130/xformers-0.0.34-cp39-abi3-manylinux_2_28_x86_64.whl ; ('linux' in sys_platform)",
+    "xformers @ https://download.pytorch.org/whl/cu130/xformers-0.0.34-cp39-abi3-win_amd64.whl ; (sys_platform == 'win32')",
+]
 cu118 = [
     "unsloth[huggingface]",
     "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
@@ -486,6 +498,21 @@ cu130-torch291 = [
     "unsloth[huggingface]",
     "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
     "unsloth[cu130onlytorch291]",
+]
+cu126-torch2100 = [
+    "unsloth[huggingface]",
+    "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
+    "unsloth[cu126onlytorch2100]",
+]
+cu128-torch2100 = [
+    "unsloth[huggingface]",
+    "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
+    "unsloth[cu128onlytorch2100]",
+]
+cu130-torch2100 = [
+    "unsloth[huggingface]",
+    "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
+    "unsloth[cu130onlytorch2100]",
 ]
 kaggle = [
     "unsloth[huggingface]",
@@ -770,6 +797,21 @@ cu130-ampere-torch291 = [
     "unsloth[huggingface]",
     "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
     "unsloth[cu130onlytorch291]",
+]
+cu126-ampere-torch2100 = [
+    "unsloth[huggingface]",
+    "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
+    "unsloth[cu126onlytorch2100]",
+]
+cu128-ampere-torch2100 = [
+    "unsloth[huggingface]",
+    "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
+    "unsloth[cu128onlytorch2100]",
+]
+cu130-ampere-torch2100 = [
+    "unsloth[huggingface]",
+    "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",
+    "unsloth[cu130onlytorch2100]",
 ]
 flashattentiontorch260abiFALSEcu12x = [
     "flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp39-cp39-linux_x86_64.whl ; ('linux' in sys_platform) and python_version == '3.9'",

--- a/unsloth/_auto_install.py
+++ b/unsloth/_auto_install.py
@@ -35,7 +35,9 @@ elif v  < V('2.8.0'): x = 'cu{}{}-torch271'
 elif v  < V('2.8.9'): x = 'cu{}{}-torch280'
 elif v  < V('2.9.1'): x = 'cu{}{}-torch290'
 elif v  < V('2.9.2'): x = 'cu{}{}-torch291'
+elif v  < V('2.10.1'): x = 'cu{}{}-torch2100'
 else: raise RuntimeError(f"Torch = {v} too new!")
 if v > V('2.6.9') and cuda not in ("11.8", "12.6", "12.8", "13.0"): raise RuntimeError(f"CUDA = {cuda} not supported!")
+if v >= V('2.10.0') and cuda not in ("12.6", "12.8", "13.0"): raise RuntimeError(f"Torch 2.10 requires CUDA 12.6, 12.8, or 13.0! Got CUDA = {cuda}")
 x = x.format(cuda.replace(".", ""), "-ampere" if False else "") # is_ampere is broken due to flash-attn
 print(f'pip install --upgrade pip && pip install --no-deps git+https://github.com/unslothai/unsloth-zoo.git && pip install "unsloth[{x}] @ git+https://github.com/unslothai/unsloth.git" --no-build-isolation')


### PR DESCRIPTION
## Summary

Adds support for PyTorch 2.10 with xformers 0.0.34.

### Changes

**pyproject.toml:**
- Added `cu126onlytorch2100`, `cu128onlytorch2100`, `cu130onlytorch2100` xformers 0.0.34 wheel dependencies
- Added `cu126-torch2100`, `cu128-torch2100`, `cu130-torch2100` meta-dependencies
- Added `cu126-ampere-torch2100`, `cu128-ampere-torch2100`, `cu130-ampere-torch2100` ampere variants

**unsloth/_auto_install.py:**
- Added version detection: `elif v < V('2.10.1'): x = 'cu{}{}-torch2100'`
- Added CUDA check for torch 2.10 (only CUDA 12.6, 12.8, 13.0 have xformers 0.0.34 wheels)

**README.md:**
- Updated supported torch versions list to include `torch2100`
- Added installation example for torch 2.10 with CUDA 12.6
- Updated Python REPL code block with torch 2.10 version detection

### xformers 0.0.34 Wheel Availability

| CUDA Version | Linux | Windows |
|--------------|-------|---------|
| cu126 | xformers-0.0.34-cp39-abi3-manylinux_2_28_x86_64.whl | xformers-0.0.34-cp39-abi3-win_amd64.whl |
| cu128 | xformers-0.0.34-cp39-abi3-manylinux_2_28_x86_64.whl | xformers-0.0.34-cp39-abi3-win_amd64.whl |
| cu130 | xformers-0.0.34-cp39-abi3-manylinux_2_28_x86_64.whl | xformers-0.0.34-cp39-abi3-win_amd64.whl |

Note: xformers 0.0.34 uses `cp39-abi3` (Python stable ABI), which works with Python 3.9+.

## Test plan

- [ ] Verify pyproject.toml syntax is valid
- [ ] Test version detection with torch 2.9.1 (should select torch291)
- [ ] Test version detection with torch 2.9.2/2.10.0 (should select torch2100)
- [ ] Verify CUDA 11.8/12.1/12.4 are blocked for torch 2.10
- [ ] Verify CUDA 12.6/12.8/13.0 work for torch 2.10
- [ ] Confirm wheel URLs are accessible