### PR TITLE
Fix multiprocessing crash on Windows/macOS and unify num_proc logic

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -932,14 +932,15 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
     # Edit dataset_num_proc
     if "dataset_num_proc" in call_args:
         num_proc_check = (
-            "if dataset_num_proc is None:\n"
+            "import multiprocessing as _mp\n"
+            "if _mp.get_start_method() != 'fork':\n"
+            "    dataset_num_proc = None\n"
+            "elif dataset_num_proc is None:\n"
             "    import psutil\n"
             "    dataset_num_proc = min(max((psutil.cpu_count() or 1)+4, 2), 64)\n"
             "    memory_gb_left = psutil.virtual_memory().available / (1024**3)\n"
-            "    if   memory_gb_left <=  4: dataset_num_proc = 1 # Too risky, so set to 1\n"
-            "    elif memory_gb_left <=  6: dataset_num_proc = min(2, dataset_num_proc)\n"
-            "    elif memory_gb_left <= 10: dataset_num_proc = min(4, dataset_num_proc)\n"
-            "    elif memory_gb_left <= 14: dataset_num_proc = min(6, dataset_num_proc)\n"
+            "    if memory_gb_left <= 2: dataset_num_proc = 1\n"
+            "    else: dataset_num_proc = min(dataset_num_proc, int(memory_gb_left))\n"
         )
         extra_args += num_proc_check
 


### PR DESCRIPTION
## Summary

- On Windows and macOS (Python 3.8+), `multiprocessing` uses the `spawn` start method instead of `fork`. When HuggingFace `datasets` calls `.map(num_proc=N)`, it creates a `Pool(N)` which re-imports `__main__` in each spawned worker, causing infinite recursion and a `RuntimeError` during bootstrapping.
- The generated Config `__init__` (for `UnslothSFTConfig`, `UnslothGRPOConfig`, etc.) auto-computes `dataset_num_proc` from `psutil.cpu_count()` without guarding against non-fork start methods.
- This adds a guard using `multiprocessing.get_start_method() != 'fork'`. When the start method is `spawn` or `forkserver`, force `dataset_num_proc = None` so HuggingFace datasets takes the single-process path. Linux `fork` behavior is unchanged.
- Also replaces the fixed memory threshold logic with the simpler adaptive approach already used in `train_on_responses_only`: cap at 64, then `min(num_proc, int(available_gb))`, with a safety floor of 1 when available memory is at or below 2GB.

Companion PR: https://github.com/unslothai/unsloth-zoo/pull/473

## Changes

`unsloth/models/rl.py` -- in the code-gen block that builds Config `__init__` methods:

Before (fixed thresholds, no spawn guard):
```python
"if dataset_num_proc is None:\n"
"    import psutil\n"
"    dataset_num_proc = min(max((psutil.cpu_count() or 1)+4, 2), 64)\n"
"    memory_gb_left = psutil.virtual_memory().available / (1024**3)\n"
"    if   memory_gb_left <=  4: dataset_num_proc = 1\n"
"    elif memory_gb_left <=  6: dataset_num_proc = min(2, dataset_num_proc)\n"
"    elif memory_gb_left <= 10: dataset_num_proc = min(4, dataset_num_proc)\n"
"    elif memory_gb_left <= 14: dataset_num_proc = min(6, dataset_num_proc)\n"
```

After (adaptive memory clamp, cross-platform spawn guard):
```python
"import multiprocessing as _mp\n"
"if _mp.get_start_method() != 'fork':\n"
"    dataset_num_proc = None\n"
"elif dataset_num_proc is None:\n"
"    import psutil\n"
"    dataset_num_proc = min(max((psutil.cpu_count() or 1)+4, 2), 64)\n"
"    memory_gb_left = psutil.virtual_memory().available / (1024**3)\n"
"    if memory_gb_left <= 2: dataset_num_proc = 1\n"
"    else: dataset_num_proc = min(dataset_num_proc, int(memory_gb_left))\n"
```

## Why `get_start_method()` instead of `os.name == 'nt'`

Checking the actual multiprocessing start method is more correct and future-proof:
- **Windows**: always `spawn`, correctly guarded
- **macOS**: default changed from `fork` to `spawn` in Python 3.8+, so macOS users are protected too
- **Linux**: default is `fork`, so multiprocessing works as before
- Handles any config where someone explicitly sets the start method to `spawn` or `forkserver`

## Test plan

- [x] Verified on Linux (fork) that `dataset_num_proc` still auto-computes to 64 (no regression)
- [x] Verified the regenerated `UnslothSFTTrainer.py` cache contains the `get_start_method() != 'fork'` guard
- [x] Ran full SFT training (21 steps) with eval and inference, all passed, loss = 1.4998
- [ ] User verifies on Windows that the `RuntimeError` is gone after reinstalling from patched source