### PR TITLE
Fix triton 3.6.0 + torch 2.9.x torch.compile crash (missing cluster_dims)

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -128,6 +128,7 @@ from .import_fixes import (
     check_vllm_torch_sm100_compatibility,
     fix_vllm_guided_decoding_params,
     fix_vllm_pdl_blackwell,
+    fix_triton_compiled_kernel_missing_attrs,
     fix_rocm_triton_key_error,
     ignore_logger_messages,
     patch_ipykernel_hf_xet,
@@ -148,6 +149,7 @@ fix_vllm_aimv2_issue()
 check_vllm_torch_sm100_compatibility()
 fix_vllm_guided_decoding_params()
 fix_vllm_pdl_blackwell()
+fix_triton_compiled_kernel_missing_attrs()
 fix_rocm_triton_key_error()
 ignore_logger_messages()
 patch_ipykernel_hf_xet()
@@ -166,6 +168,7 @@ del fix_vllm_aimv2_issue
 del check_vllm_torch_sm100_compatibility
 del fix_vllm_guided_decoding_params
 del fix_vllm_pdl_blackwell
+del fix_triton_compiled_kernel_missing_attrs
 del fix_rocm_triton_key_error
 del ignore_logger_messages
 del patch_ipykernel_hf_xet


### PR DESCRIPTION
## Summary

- Fixes `InductorError: 'KernelMetadata' object has no attribute 'cluster_dims'` when using `torch.compile` with triton 3.6.0 and torch 2.9.x
- Adds `fix_triton_compiled_kernel_missing_attrs()` to `import_fixes.py` following existing patterns (like `fix_rocm_triton_key_error`)
- Monkey-patches `triton.compiler.compiler.CompiledKernel.__init__` to inject `num_ctas` and `cluster_dims` as direct attributes on the kernel object

## Problem

In triton 3.6.0, `CompiledKernel` no longer exposes `num_ctas` and `cluster_dims` as direct attributes -- they moved behind `packed_metadata`. However, torch 2.9.x Inductor (`torch/_inductor/runtime/triton_heuristics.py` line ~1757) still eagerly accesses `binary.metadata.cluster_dims` when constructing the scope dict for `make_launcher()`. Since triton 3.6.0's metadata namedtuple does not contain `cluster_dims`, this crashes before the code reaches the newer launch path that does not need `cta_args` at all.

This breaks any code path that triggers `torch.compile`, including the Unsloth compiled GRPO trainer cache (`UnslothGRPOTrainer.py` lines 100, 145, 544, 991).

PyTorch fixed this upstream in commit `97bd4db` by adding `hasattr` guards. Since we cannot edit installed packages at runtime, we instead inject the missing attributes onto `CompiledKernel` instances so the older `hasattr(binary, "num_ctas")` branch succeeds.

## Fix

The patch runs during `import unsloth` (before any `torch.compile` call):

1. Checks if `CompiledKernel` already has `num_ctas` as a class-level attribute (old triton) -- if so, returns early
2. Wraps `CompiledKernel.__init__` to add `num_ctas` (from `metadata.num_ctas`, default 1) and `cluster_dims` (default `(1, 1, 1)`) after the original init
3. These attributes are unused by triton 3.6.0's new launch path (`launch_metadata` / `packed_metadata`), so the values do not affect behavior

## Testing

Validated with gpt-oss-20b BnB 4-bit GRPO training (3 notebooks, 30 steps each) on:
- transformers 4.57.6 + torch 2.9.1 + triton 3.6.0 -- all pass (no patch needed, but patch is a no-op)
- transformers 5.0.0 + torch 2.9.1 + triton 3.6.0 -- all pass with patch (previously crashed at step 0)

## References

- Upstream PyTorch fix: https://github.com/pytorch/pytorch/blob/97bd4db/torch/_inductor/runtime/triton_heuristics.py#L1974
- Related issue: https://github.com/pytorch/pytorch/issues/117185