### PR TITLE
Fix trl.experimental thin wrapper compilation and OOM from peft_config overwrite

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1627,12 +1627,15 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
     for function in functions:
         if not hasattr(RLTrainer, function):
             continue
-        fx = getattr(RLTrainer, function)
-        try:
-            source = inspect.getsource(fx)
-        except:
-            continue
-        original_source = source
+        if function in changed:
+            original_source, source = changed[function]
+        else:
+            fx = getattr(RLTrainer, function)
+            try:
+                source = inspect.getsource(fx)
+            except:
+                continue
+            original_source = source
 
         # Check for function
         for edit_function in edit_functions:


### PR DESCRIPTION
## Summary

Two fixes to `unsloth/models/rl.py`:

### 1. Trainer compilation failures from `trl.experimental` thin wrappers

Starting in TRL 0.24.0, trainers began moving to `trl.experimental` with `trl/trainer/*_trainer.py` becoming thin deprecation wrappers. This causes compilation failures in `_patch_trl_rl_trainers` because the Config class cannot be found/imported from the thin wrapper module, and because there is no try/except in the loop, one failure kills ALL subsequent trainers -- including SFT and GRPO.

**Affected TRL versions:**
- **0.24.0**: AlignProp, DDPO, IterativeSFT removed entirely
- **0.25.x**: BCO moved to experimental
- **0.26.x**: CPO, GKD, KTO, NashMD, OnlineDPO, ORPO, PPO, PRM, XPO (9 trainers) moved
- **0.27.x**: Same thin wrappers plus utility class moves

**Changes:**

1. **Defensive try/except in `patch_trl_rl_trainers`** -- One trainer failure no longer blocks all subsequent trainers. Critical for keeping SFT/GRPO working regardless of experimental trainer issues.

2. **MRO fallback for Config name discovery** -- When Config name is not in `dir(trainer_module)` and the `_config.py` module fallback also fails, walks the Trainer class MRO to find Config in the parent module (e.g., `trl.experimental.bco` has both `BCOTrainer` and `BCOConfig`).

3. **MRO fallback for Config class loading** -- Same MRO walk for actually loading the Config class. Tracks `_config_resolved_module` so the correct module is used for imports downstream.

4. **Thin wrapper detection fix** -- The previous detection checked for "trl.experimental" in the class source, then resolved to the first MRO parent whose source did NOT contain "trl.experimental". This was too aggressive: in TRL 0.24.0-0.25.x, real implementations reference `trl.experimental` without being thin wrappers, causing incorrect resolution to `BaseTrainer`. Now only resolves to parents whose module name contains `trl.experimental`. Also checks module-level source (some thin wrappers only have the experimental reference in module-level imports, not the class body).

5. **`_config_resolved_module` for imports and model location** -- `all_imports` and `_model_location` now fall back to `_config_resolved_module` when `_trainer_resolved_module` is None.

### 2. OOM from `prepare_model_for_kbit_training` overwriting peft_config patching

In `patch_functions`, the function loop iterates over all Trainer methods and re-fetches their source via `inspect.getsource`. When `__init__` is encountered again (e.g., by an edit function like `sft_trainer_push_to_hub_token`), the original unpatched source overwrites the patched version, undoing the `peft_config` removal. This causes `prepare_model_for_kbit_training` to run and OOM on T4 GPUs.

**Fix:** Check if a function is already in the `changed` dict before fetching source. If it is, start from the already-patched source so earlier patches (peft_config removal) are preserved.

## Verified across 6 TRL versions

| TRL | Compiled Trainers | Notes |
|-----|-------------------|-------|
| 0.22.2 | 18 | Baseline, all trainers |
| 0.23.1 | 18 | All trainers |
| 0.24.0 | 15 | 3 removed (AlignProp/DDPO/IterativeSFT) -- correct |
| 0.25.1 | 15 | BCO resolved via MRO to `trl.experimental.bco` |
| 0.26.2 | 15 | All 10 thin wrappers resolved via MRO |
| 0.27.2 | 15 | Same as 0.26.2 |

Memory fix verified: `prepare_peft_model`/`prepare_model_for_kbit_training` absent from compiled SFTTrainer, `peft_config` patching (`if False:`) preserved, `push_to_hub_token` fix present.

SFT regression test passes (5 steps, Llama-3.2-1B 4-bit LoRA, TRL 0.22.2).