### PR TITLE
Silence TRL's batch_size=1 padding-free warning in compiled trainer source

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1357,6 +1357,32 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         )
         RLTrainer_source = RLTrainer_source.replace(_sig_vlm_old, _sig_vlm_new)
 
+    # Silence TRL's noisy batch_size=1 + padding-free warning (handles both
+    # the original "anihilate" typo and the corrected "annihilate" spelling)
+    for _typo in ("anihilate", "annihilate"):
+        _idx = RLTrainer_source.find(_typo)
+        if _idx == -1:
+            continue
+        # Walk backwards to find "if args.per_device_train_batch_size"
+        _block_start = RLTrainer_source.rfind(
+            "if args.per_device_train_batch_size == 1", 0, _idx
+        )
+        if _block_start == -1:
+            continue
+        # Walk backwards to the newline before the if
+        _line_start = RLTrainer_source.rfind("\n", 0, _block_start)
+        # Walk forwards past the closing paren to the end of the block
+        _close = RLTrainer_source.find(")", _idx)
+        if _close == -1:
+            continue
+        _block_end = RLTrainer_source.find("\n", _close)
+        if _block_end == -1:
+            continue
+        RLTrainer_source = (
+            RLTrainer_source[:_line_start] + RLTrainer_source[_block_end:]
+        )
+        break
+
     # Remove multiple doc strings
     if __RLConfig_doc__ != "" and RLTrainer_source.count(__RLTrainer_doc__) == 2:
         RLTrainer_source = RLTrainer_source.replace(__RLTrainer_doc__, "", 1)


### PR DESCRIPTION
## Summary
- Strip TRL's `per_device_train_batch_size == 1` padding-free warning from compiled trainer source. The warning fires whenever Unsloth auto-enables padding-free mode with batch size 1, which is the common single-GPU case. Handles both the original "anihilate" typo and the corrected "annihilate" spelling.

## Test plan
- [x] Verified TRL batch_size warning absent in SFT training output (Llama-3.2-1B, 4-bit LoRA, batch_size=1)
- [x] Verified training completes normally with correct loss values
- [x] Tested across TRL 0.22.2 through 0.27.2