### PR TITLE
Silence peft target_parameters RuntimeWarning for MoE models

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3073,8 +3073,12 @@ class FastLlamaModel:
                 clean_gpu_cache()
 
         import warnings as _w
+
         with _w.catch_warnings():
-            _w.filterwarnings("ignore", message=".*target_parameters.*were set but no parameter was matched.*")
+            _w.filterwarnings(
+                "ignore",
+                message = ".*target_parameters.*were set but no parameter was matched.*",
+            )
             model = _get_peft_model(model, lora_config)
         # Fix LoraConfig.auto_mapping is None
         fix_lora_auto_mapping(model)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1210,8 +1210,12 @@ class FastBaseModel:
             use_gradient_checkpointing = use_gradient_checkpointing,
         )
         import warnings as _w
+
         with _w.catch_warnings():
-            _w.filterwarnings("ignore", message=".*target_parameters.*were set but no parameter was matched.*")
+            _w.filterwarnings(
+                "ignore",
+                message = ".*target_parameters.*were set but no parameter was matched.*",
+            )
             model = _get_peft_model(model, lora_config)
         # Apply QAT + LoRA if specified
         if qat_scheme is not None:


### PR DESCRIPTION
## Summary
- Wrap `_get_peft_model` calls in `llama.py` and `vision.py` with `warnings.catch_warnings()` to suppress the `target_parameters were set but no parameter was matched` RuntimeWarning.
- This warning fires on MoE models (e.g. Qwen3-MoE, DeepSeek) where expert layers use `nn.Parameter` naming that peft warns about but handles correctly. The warning is harmless noise that confuses users.

## Test plan
- [x] Verified warning no longer appears when loading MoE models with LoRA
- [x] Verified LoRA adapter still applies correctly to both regular and expert layers