### PR TITLE
Inject model reference for dynamic token_type_ids detection in SFTTrainer

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1373,7 +1373,9 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         # token_type_ids detection in sft_prepare_dataset
         _prep_pattern = r"([ \t]*)train_dataset = self\._prepare_dataset\("
         _prep_replacement = r"\1self._unsloth_model_ref = model\n\1train_dataset = self._prepare_dataset("
-        RLTrainer_source = re.sub(_prep_pattern, _prep_replacement, RLTrainer_source, count=1)
+        RLTrainer_source = re.sub(
+            _prep_pattern, _prep_replacement, RLTrainer_source, count = 1
+        )
 
     # Silence TRL's noisy batch_size=1 + padding-free warning (handles both
     # the original "anihilate" typo and the corrected "annihilate" spelling)


### PR DESCRIPTION
## Summary

Injects `self._unsloth_model_ref = model` into the compiled SFTTrainer `__init__` before the first `_prepare_dataset` call. This makes the model object available to `sft_prepare_dataset` for dynamic `token_type_ids` detection.

## Problem

`sft_prepare_dataset` (from unsloth-zoo) runs during `SFTTrainer.__init__`, before `self.model` is set by `super().__init__()`. Without access to the model, it cannot dynamically determine whether the model requires `token_type_ids` (needed by Gemma-3, PaliGemma, ShieldGemma2, and future models that use `create_causal_mask_mapping`).

## Changes

One `.replace()` call in `rl.py` within the `if RLTrainer_name == "SFTTrainer":` block. It inserts `self._unsloth_model_ref = model` on the line before `train_dataset = self._prepare_dataset(` in the compiled SFTTrainer source. This follows the same pattern used by the existing SFTTrainer source transformations in this file.

## Companion PR

Used by unslothai/unsloth-zoo#484 which reads `self._unsloth_model_ref` to dynamically detect models needing `token_type_ids`.

## Testing

Verified on Gemma-3 4B (bf16, 4-bit, 21 steps):
- `trainer._unsloth_model_ref` is set to `PeftModelForCausalLM` after init
- Dynamic detection correctly identifies Gemma-3 as needing `token_type_ids`
- Training completes with zero NaN losses