### PR TITLE
Fix EmbeddingGemma float16 NaN via FORCE_FLOAT32 for gemma3_text

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -99,8 +99,8 @@ from ._utils import (
 global FORCE_FLOAT32
 # Forces float32 precision since float16 goes to infinity
 FORCE_FLOAT32 = [
-    "gemma3,",      # Add comma bc gemma3 will match gemma3n
-    "gemma3text",   # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
+    "gemma3,",  # Add comma bc gemma3 will match gemma3n
+    "gemma3text",  # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
     "gemma3n",
     "gpt_oss",
 ]
@@ -116,8 +116,8 @@ DISABLE_COMPILE_MODEL_NAMES = [
 global DISABLE_SDPA_MODEL_NAMES
 # Disables some SDPA modules since it's wrong
 DISABLE_SDPA_MODEL_NAMES = [
-    "gemma3,",       # Add comma bc gemma3 will match gemma3n
-    "gemma3_text",   # Gemma3TextModel (EmbeddingGemma) - substring match, keep underscore
+    "gemma3,",  # Add comma bc gemma3 will match gemma3n
+    "gemma3_text",  # Gemma3TextModel (EmbeddingGemma) - substring match, keep underscore
 ]
 
 

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -2093,11 +2093,15 @@ def _patch_sentence_transformer_trainer():
         if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "1":
             if hasattr(self, "args") and self.args is not None:
                 if self.args.fp16 or self.args.bf16:
-                    print("Unsloth: Switching to float32 training since model cannot work with float16")
+                    print(
+                        "Unsloth: Switching to float32 training since model cannot work with float16"
+                    )
                     self.args.fp16 = False
                     self.args.bf16 = False
-                    if hasattr(self.args, 'bf16_full_eval'): self.args.bf16_full_eval = False
-                    if hasattr(self.args, 'fp16_full_eval'): self.args.fp16_full_eval = False
+                    if hasattr(self.args, "bf16_full_eval"):
+                        self.args.bf16_full_eval = False
+                    if hasattr(self.args, "fp16_full_eval"):
+                        self.args.fp16_full_eval = False
 
     SentenceTransformerTrainer.__init__ = _patched_init
     SentenceTransformerTrainer._unsloth_auto_compile_patched = True


### PR DESCRIPTION
## Summary

- Add `"gemma3text"` to `FORCE_FLOAT32` in `loader.py` so EmbeddingGemma (model_type `gemma3_text`) explicitly triggers float32 fallback on float16/non-bfloat16 hardware
- Add `"gemma3_text"` to `DISABLE_SDPA_MODEL_NAMES` for the same reason (this list uses substring matching without stripping underscores, so needs the underscore variant)
- Add FORCE_FLOAT32 mixed precision handling in `SentenceTransformerTrainer.__init__` patch so that `fp16`/`bf16` training args get disabled when `UNSLOTH_FORCE_FLOAT32=1`, matching what `rl.py` already does for SFTTrainer/GRPOTrainer

## Problem

EmbeddingGemma (300M) uses the `gemma3_text` architecture which has known float16 overflow (activations reach ~800k, exceeding float16 max of 65,504). On Tesla T4 or when `dtype=torch.float16` is set, this causes NaN gradients during training.

Currently `get_transformers_model_type()` truncates `gemma3_text` to `gemma3` because `gemma3_text` is not in `dir(transformers.models)`, so the existing `"gemma3,"` entry in `FORCE_FLOAT32` happens to match. But if a future transformers version adds a `gemma3_text` module, the truncation stops and FORCE_FLOAT32 silently breaks for these models.

Additionally, `SentenceTransformerTrainer` was missing the FORCE_FLOAT32 training args override that `rl.py` already applies to SFTTrainer/GRPOTrainer.

## Changes

**`unsloth/models/loader.py`**
- `FORCE_FLOAT32`: added `"gemma3text"` -- the matching logic at line 1208 does `model_type_arch.lower().replace("-", "").replace("_", "")`, so `gemma3_text` becomes `gemma3text` and matches directly
- `DISABLE_SDPA_MODEL_NAMES`: added `"gemma3_text"` -- this list uses plain `in` substring matching (line 1257), so the underscore must be kept

**`unsloth/models/sentence_transformer.py`**
- After `_original_init(self, *args, **kwargs)` in `_patch_sentence_transformer_trainer()`, check `UNSLOTH_FORCE_FLOAT32` env var and disable `fp16`/`bf16`/`*_full_eval` training args when active

## Test plan

- [x] Verify FORCE_FLOAT32 triggers for EmbeddingGemma with `dtype=torch.float16`
- [x] Verify matching works for both current behavior (truncated `gemma3`) and future behavior (non-truncated `gemma3_text`)
- [x] Verify standard Gemma3 and Gemma3n still match correctly
- [x] Verify non-gemma models do not false-match
- [x] Full EmbeddingGemma notebook run (30 steps): loss=0.1377, no NaN, valid eval and inference scores