### PR TITLE
Fix Gemma3 4B training on transformers 5.x (token_type_ids)

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1762,6 +1762,7 @@ def _unsloth_pre_compute_loss(self, model, inputs, *args, **kwargs):
             _inner = getattr(_inner, _attr, _inner)
         if getattr(getattr(_inner, "config", None), "model_type", "") in ("gemma3",):
             import sys as _sys
+
             _mod = _sys.modules.get(type(_inner).__module__)
             _has_ccm = _mod is not None and hasattr(_mod, "create_causal_mask_mapping")
             if _has_ccm and _inner.training:


### PR DESCRIPTION
## Summary

Fixes Gemma3 4B text-only SFT training crash on `transformers>=5.0.0`:

```
torch._dynamo.exc.Unsupported: ... ValueError("token_type_ids is required as a model input when training")
```

In transformers 5.x, `create_causal_mask_mapping()` raises `ValueError` when `is_training=True` and `token_type_ids is None`. The existing detection in `dataset_utils.py` for `_needs_token_type_ids` misses this case because:

1. The model is wrapped in `PeftModel`, so `type(model).__module__` points to `peft.peft_model` instead of the transformers module
2. The `processing_class` is a tokenizer (not `Gemma3Processor`), so the fallback MRO check resolves to a module that does not have `create_causal_mask_mapping`

This adds a fallback in `_unsloth_pre_compute_loss` that injects `token_type_ids = torch.zeros_like(input_ids)` when all of the following are true:
- `token_type_ids` is not already in the inputs
- The inner model config has `model_type == "gemma3"`
- The model's module has `create_causal_mask_mapping` (only exists in transformers 5.x)
- The model is in training mode

For text-only SFT, all-zeros token_type_ids is correct (no image tokens present).

## Backward Compatibility

On transformers 4.x, `create_causal_mask_mapping` does not exist in the module, so the `hasattr` check is False and this code is inert.

## Dependencies

Requires unslothai/unsloth-zoo#488 for the compiler and bitsandbytes fixes.

## Testing

| Test | transformers 5.1.0 | transformers 4.57.6 |
|------|-------------------|-------------------|
| Gemma3 4B training (15 steps) | Pass | Pass |
| Gemma3 270M regression (30 steps) | Pass | Pass |