### PR TITLE
Fix warmup_ratio deprecation for transformers >= 5.0

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -79,6 +79,7 @@ except Exception:
 # Get transformers version for feature detection
 try:
     from transformers import __version__ as _transformers_version_raw
+
     transformers_version = Version(_transformers_version_raw)
 except Exception:
     transformers_version = Version("0.0.0")


### PR DESCRIPTION
## Summary

- In transformers 5.0, `warmup_ratio` is deprecated and will be removed in v5.2
- `warmup_steps` now accepts float values: values < 1 are treated as a ratio of total training steps (same semantics as `warmup_ratio`), values >= 1 are absolute step counts
- The Unsloth trainer compiler in `rl.py` sets `warmup_ratio = 0.1` as a default for all compiled trainers, which triggers the deprecation warning on transformers >= 5.0

## Changes

- Add `transformers_version` detection in `rl.py` (same pattern as existing `trl_version` and `torch_version`)
- On transformers >= 5.0: set `warmup_steps = 0.1` instead (same behavior, no warning)
- On transformers < 5.0: keep `warmup_ratio = 0.1` (backward compatible, since `warmup_steps` only accepts int in older versions)

## Test plan

- [ ] Verify no deprecation warning on transformers >= 5.0
- [ ] Verify warmup behavior unchanged on transformers < 5.0