### PR TITLE
ROCm: default GPT-OSS to BF16 and disable AITER

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -782,14 +782,6 @@ class FastBaseModel:
                 # attn_implementation   = attn_implementation,
                 **kwargs,
             )
-            try:
-                from unsloth_zoo.temporary_patches.misc import (
-                    patch_deepseek_ocr_masked_scatter,
-                )
-
-                patch_deepseek_ocr_masked_scatter()
-            except Exception:
-                pass
             if hasattr(model, "generate"):
                 model.fast_generate = make_fast_generate_wrapper(model.generate)
                 model.fast_generate_batches = error_out_no_vllm


### PR DESCRIPTION
## Summary
- Default GPT-OSS model selection to BF16 on HIP to avoid MXFP4 and prequantized blocksize issues
- Disable AITER and ROCm RoPE backend by default on HIP to avoid build locks and runtime faults

## Testing
- gpt-oss-(20B)-GRPO.ipynb (30 steps)
- gpt-oss-(20B)-Fine-tuning.ipynb (30 steps)
- Gemma3_(4B)-Vision.ipynb (30 steps)
- Llama3.2_(1B_and_3B)-Conversational.ipynb (60 steps)