### PR TITLE
Fix global dequantize buffer dtype mismatch across mixed-precision loads

### DIFF
--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -388,7 +388,7 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
             global ABSMAX_BUFFERS
             WEIGHT_BUFFER = WEIGHT_BUFFERS[device_index]
             ABSMAX_BUFFER = ABSMAX_BUFFERS[device_index]
-            if WEIGHT_BUFFER is None:
+            if WEIGHT_BUFFER is None or WEIGHT_BUFFER.dtype != dtype:
                 WEIGHT_BUFFERS[device_index] = WEIGHT_BUFFER = torch_empty(
                     size, dtype = dtype, device = device, requires_grad = False
                 )
@@ -498,7 +498,7 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
             global ABSMAX_BUFFERS
             WEIGHT_BUFFER = WEIGHT_BUFFERS[device_index]
             ABSMAX_BUFFER = ABSMAX_BUFFERS[device_index]
-            if WEIGHT_BUFFER is None:
+            if WEIGHT_BUFFER is None or WEIGHT_BUFFER.dtype != dtype:
                 WEIGHT_BUFFERS[device_index] = WEIGHT_BUFFER = torch_empty(
                     size, dtype = dtype, device = device, requires_grad = False
                 )


### PR DESCRIPTION
## Summary

Fix `WEIGHT_BUFFERS` dtype going stale when multiple 4-bit models are loaded with different dtypes in the same process. The global dequantize buffer checks whether its **size** is sufficient (`resize_`), but never whether its **dtype** still matches the current model — so loading a bfloat16 model followed by a float16 model causes `torch.matmul` to crash.

Related: #4005 (fixed backward-path dtype casts; this fixes the root cause in the shared buffer layer).

## Reproduction

```python
from unsloth import FastLanguageModel
import torch

# Step 1: load bf16
m1, t1 = FastLanguageModel.from_pretrained(
    "unsloth/Llama-3.2-1B", dtype=None, load_in_4bit=True,  # auto → bf16
)
m1 = FastLanguageModel.get_peft_model(m1, r=8,
    target_modules=["q_proj","k_proj","v_proj","o_proj"],
    use_gradient_checkpointing="unsloth",
)
m1.train()
inp = t1("hi", return_tensors="pt").to("cuda")
inp["labels"] = inp["input_ids"].clone()
m1(**inp).loss.backward()   # OK — buffer allocated as bf16
del m1; torch.cuda.empty_cache()

# Step 2: load fp16 in the same process
m2, t2 = FastLanguageModel.from_pretrained(
    "unsloth/Llama-3.2-1B", dtype=torch.float16, load_in_4bit=True,
)
m2 = FastLanguageModel.get_peft_model(m2, r=8,
    target_modules=["q_proj","k_proj","v_proj","o_proj"],
    use_gradient_checkpointing="unsloth",
)
m2.train()
inp = t2("hi", return_tensors="pt").to("cuda")
inp["labels"] = inp["input_ids"].clone()
m2(**inp).loss.backward()   # CRASH — buffer is still bf16
# RuntimeError: expected mat1 and mat2 to have the same dtype,
#   but got: c10::Half != c10::BFloat16
```

## Root Cause

`fast_dequantize(..., use_global_buffer=True)` in `kernels/utils.py` caches a `WEIGHT_BUFFER` per device. The buffer is allocated once on first use and reused thereafter. When the requested `dtype` changes (e.g. bf16 → fp16), the stale buffer dtype propagates into the dequantized weight, creating a mismatch with the activation tensor.

## Fix

Add a dtype check alongside the existing `None` check:

```python
- if WEIGHT_BUFFER is None:
+ if WEIGHT_BUFFER is None or WEIGHT_BUFFER.dtype != dtype:
```

Applied to both the CUDA/HIP and XPU buffer paths.

## Testing

Tested on AMD Radeon PRO W7900 (gfx1100, ROCm 7.1, PyTorch 2.8.0):

| Scenario | Before | After |
|----------|--------|-------|
| bf16 → fp16 sequential load + backward | ❌ RuntimeError | ✅ |
| fp16 → bf16 sequential load + backward | ❌ RuntimeError | ✅ |
| Single dtype (bf16 or fp16) | ✅ | ✅ |
| SFTTrainer bf16 + 4bit | ✅ | ✅ |
| 16-bit no-quant inference | ✅ | ✅ |
| Sampling inference | ✅ | ✅ |

> Co-authored-by: billishyahao <bill.he@amd.com>
> Co-authored-by: yueyuan <yueyuan@amd.com>

cc @danielhanchen