### PR TITLE
Guard TRL estimate_tokens warnings_issued writes in patched RL trainers

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -773,6 +773,18 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
             "    os.environ['UNSLOTH_RETURN_LOGITS'] = '1'\n"
         )
         extra_args += logits_check
+        warnings_issued_check = (
+            "if model is not None:\n"
+            "    _warnings_issued = getattr(model, 'warnings_issued', None)\n"
+            "    if _warnings_issued is None:\n"
+            "        model.warnings_issued = {}\n"
+            "    elif not isinstance(_warnings_issued, dict):\n"
+            "        try:\n"
+            "            model.warnings_issued = dict(_warnings_issued)\n"
+            "        except Exception:\n"
+            "            model.warnings_issued = {}\n"
+        )
+        extra_args += warnings_issued_check
 
     # Check max_seq_length
     if "model" in call_args:


### PR DESCRIPTION
## Summary
- adds a defensive `warnings_issued` initializer in the generated Unsloth RL trainer init path
- runs before TRL writes `model.warnings_issued["estimate_tokens"] = True`
- normalizes non-dict `warnings_issued` values into a dict fallback

## Root Cause
On Transformers 5.1.0 with some PEFT/model wrappers, `model.warnings_issued` may be missing or not a dict during trainer initialization. TRL later writes the `estimate_tokens` key unconditionally, which can raise `AttributeError`.

## Changes
- `unsloth/models/rl.py`
  - in `_patch_trl_rl_trainers`, after logits checks, inject:
    - `getattr(model, "warnings_issued", None)` guard
    - create `{}` when missing
    - coerce/fallback to dict when non-dict

## Validation
- `python -m compileall unsloth/models/rl.py`
- regenerate patched RL trainers and verify compiled GRPO trainer contains the new guard
  - output log: `temp/validate_unsloth_warnings_patch.log`

## Notes
- this keeps behavior unchanged when `warnings_issued` is already valid
- the fix is centralized in the shared RL trainer generation path, so it applies consistently to patched RL trainers
