### PR TITLE
ROCm: Add gfx950 (MI355X/CDNA4) to is_cdna()

### DIFF
--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -82,6 +82,7 @@ def is_cdna():
         "gfx940",
         "gfx941",
         "gfx942",
+        "gfx950",  # CDNA4 (MI350/MI355X)
     )
 
 


### PR DESCRIPTION
## Summary

Add AMD Instinct MI355X (gfx950 / CDNA4) to `is_cdna()` so Triton kernels use the correct `num_warps`.

### Problem

`is_cdna()` only listed gfx940/941/942 (MI300 series). MI355X (gfx950, CDNA4) has the same 1024-thread workgroup limit and 64-thread wavefront size, but was missing. This caused all Triton kernels to use `num_warps=32` (2048 threads) instead of 16 (1024 threads):

```
triton.runtime.errors.OutOfResources: out of resource: threads,
Required: 2048, Hardware limit: 1024
```

This blocked all training on MI355X.

### Change

```diff
 def is_cdna():
     return is_hip() and triton.runtime.driver.active.get_current_target().arch in (
         "gfx940",
         "gfx941",
         "gfx942",
+        "gfx950",  # CDNA4 (MI350/MI355X)
     )
```

### Hardware verification

```
GPU: AMD Instinct MI355X
gcnArchName: gfx950:sramecc+:xnack-
warp_size: 64
workgroup thread limit: 1024 (same as gfx942)
```

### Tested on 8× AMD Instinct MI355X (gfx950), ROCm 7.1

| Test | Result |
|------|--------|
| Vision RL GRPO (Qwen2.5-VL-7B) | ✅ 5/5 steps |
| Code RL GRPO (gpt-oss-20b BF16) | ✅ 20/20 steps |
| gpt-oss-120b GRPO (8-GPU) | ✅ 5/5 steps |
| MoE expert LoRA + merge | ✅ 46.2M trainable, merge success |

### Note

Full MI355X support also requires PR #4021 (ROCm GPT-OSS MXFP4→BF16 routing) by @danielhanchen, I closed the full change which is PR #4050. This PR is the additional piece needed for CDNA4 Triton kernel compatibility.