### PR TITLE
Make ROCm suppression detection robust for custom torch builds

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -25,6 +25,7 @@ import logging
 import textwrap
 import warnings
 import sys
+import functools
 
 # We cannot do from unsloth_zoo.log import logger since FBGEMM might cause seg faults.
 UNSLOTH_ENABLE_LOGGING = os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") in (
@@ -1176,12 +1177,17 @@ _CAUSAL_CONV1D_PREFIX = "causal_conv1d"
 _CAUSAL_CONV1D_BLOCKER_SENTINEL = "_unsloth_causal_conv1d_blocker"
 
 
+@functools.lru_cache(1)
 def _is_rocm_torch_build() -> bool:
     # Most official ROCm wheels include a local version suffix like +rocmX.Y.
     # Some custom/source builds do not, so we fall back to runtime hints.
     try:
         torch_version_raw = str(importlib_version("torch")).lower()
         if "rocm" in torch_version_raw:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.info(
+                    "Unsloth: ROCm detection matched torch version tag (+rocm)."
+                )
             return True
     except Exception:
         pass
@@ -1197,6 +1203,8 @@ def _is_rocm_torch_build() -> bool:
     ):
         value = os.environ.get(key, "")
         if isinstance(value, str) and value.strip():
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.info(f"Unsloth: ROCm detection matched environment key `{key}`.")
             return True
 
     # Filesystem / driver hints for ROCm stacks.
@@ -1207,10 +1215,16 @@ def _is_rocm_torch_build() -> bool:
     ):
         try:
             if path.exists():
+                if UNSLOTH_ENABLE_LOGGING:
+                    logger.info(
+                        f"Unsloth: ROCm detection matched filesystem hint `{path}`."
+                    )
                 return True
         except Exception:
             continue
 
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: ROCm detection did not match any known hints.")
     return False
 
 


### PR DESCRIPTION
## Summary
- make `_is_rocm_torch_build()` robust for custom ROCm torch builds that do not expose a `+rocm` local version suffix
- keep current fd-level stderr suppression path unchanged

## Why
`/opt/amdgpu/share/libdrm/amdgpu.ids: No such file or directory` can still appear on ROCm when the suppression gate incorrectly returns false.

The current gate only checks:
- `"rocm" in importlib_version("torch")`

Some ROCm torch builds report custom version strings without `rocm`, causing false negatives.

## Changes
- retain existing `+rocm` metadata detection
- add fallback checks for ROCm environment hints:
  - `ROCM_PATH`, `ROCM_HOME`, `HIP_PATH`, `HSA_PATH`, `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`
- add fallback checks for ROCm filesystem/driver hints:
  - `/opt/rocm`, `/dev/kfd`, `/sys/module/amdgpu`

## Validation
- `python -m py_compile unsloth/import_fixes.py`
- local smoke test confirms fallback gate returns `True` when ROCm env hints are present
