### PR TITLE
Extend amdgpu.ids filtering to models import startup

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -301,8 +301,9 @@ elif DEVICE_TYPE == "xpu":
     # TODO: check triton for intel installed properly.
     pass
 
-from .models import *
-from .models import __version__
+with _suppress_hip_libdrm_ids_noise():
+    from .models import *
+    from .models import __version__
 from .save import *
 from .chat_templates import *
 from .tokenizer_utils import *


### PR DESCRIPTION
## Summary
- extend existing HIP fd2 line-filtering to cover the `from .models import *` startup block
- keep filtering scope targeted to `amdgpu.ids: No such file or directory` only

## Why
The warning still appears on some ROCm environments after earlier startup fixes, indicating the message is emitted later in import startup than the already wrapped blocks.

Upstream references indicate this warning is related to libdrm path resolution in ROCm torch wheels and venv path behavior:
- https://github.com/pytorch/pytorch/issues/144203
- https://github.com/ROCm/ROCm/issues/2961
- https://github.com/ROCm/ROCm/issues/5943
- https://discuss.pytorch.org/t/cantt-find-amdgpu-ids-when-running-in-venv/214980

## Changes
- in `unsloth/__init__.py`, wrap:
  - `from .models import *`
  - `from .models import __version__`
  with `_suppress_hip_libdrm_ids_noise()`.

## Validation
- `python -m py_compile unsloth/__init__.py unsloth/import_fixes.py`
