### PR TITLE
Wrap models import with ROCm amdgpu ids fd2 filter

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -305,8 +305,10 @@ elif DEVICE_TYPE == "xpu":
     # TODO: check triton for intel installed properly.
     pass
 
-from .models import *
-from .models import __version__
+# Filter native fd=2 amdgpu.ids noise during model import startup.
+with _filter_rocm_amdgpu_ids_fd2_noise():
+    from .models import *
+    from .models import __version__
 from .save import *
 from .chat_templates import *
 from .tokenizer_utils import *


### PR DESCRIPTION
## Summary
- wrap `from .models import *` and `from .models import __version__` with `_filter_rocm_amdgpu_ids_fd2_noise()` during startup

## Why
`main` already wraps early ROCm startup imports (`unsloth_zoo`, `torch`, `unsloth_zoo.device_type`) from PR #4056.

However, logs show `/opt/amdgpu/share/libdrm/amdgpu.ids: No such file or directory` can still be emitted later during model import startup. This change applies the same selective fd=2 filtering to that segment.

## Validation
- `python -m py_compile unsloth/__init__.py unsloth/import_fixes.py`
