### PR TITLE
[FIX] Move loss and n_items to logits device in fast_cross_entropy_loss loss for multi-GPU support

### DIFF
--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -447,8 +447,8 @@ def fast_cross_entropy_loss(
     )
     if n_items is None:
         n_items = torch.count_nonzero(labels != -100)
-    loss = loss.to(device)
-    n_items = n_items.to(device)
+    if torch.is_tensor(n_items):
+        n_items = n_items.to(device)
     return loss.sum() / n_items
 
 


### PR DESCRIPTION
Continuation of @devchilll 's PR #4059 . PR 4059 resolves the RuntimeError at the `masked_fill_` call in the chunked cross-entropy forward path but similar error continues in `return loss.sum() / n_items` call downstream.

Fix: explicitly move loss and n_items to the same device as logits at the end of `fast_cross_entropy_loss`

Completes final fix of #4041 