### PR TITLE
Improve torchvision mismatch ImportError guidance

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -689,6 +689,7 @@ def torchvision_compatibility_check():
         f"Unsloth: torch=={torch_version_raw} requires "
         f"torchvision>={required_tv_str}, "
         f"but found torchvision=={torchvision_version_raw}. "
+        f'Try updating torchvision via `pip install --upgrade "torchvision>={required_tv_str}"`. '
         f"Please refer to https://pytorch.org/get-started/previous-versions/ "
         f"for more information."
     )


### PR DESCRIPTION
## Summary
- improve the torch/torchvision mismatch error message with an actionable upgrade command
- include `pip install --upgrade "torchvision>=<required_version>"` directly in the message
- keep compatibility-check behavior unchanged (stable mismatches still raise, prerelease/custom builds still warn)

## Why
The previous message correctly explained the mismatch but did not provide a direct remediation command. This update makes the error immediately actionable.

## Validation
- local runtime sanity check in current environment (`torch==2.10.0+cu130`, `torchvision==0.24.1`) confirms the raised `ImportError` now includes this command hint:
```bash
pip install --upgrade "torchvision>=0.25.0"
```
