### PR TITLE
Add optional datasets metadata support to save/push functions

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1491,7 +1491,7 @@ def create_huggingface_repo(
 ):
     if token is None:
         token = get_token()
-    save_directory, username = _determine_username(save_directory, "", token)
+    save_directory, username = _determine_username(save_directory, None, token)
 
     from huggingface_hub import create_repo
 


### PR DESCRIPTION
## Motivation

Happy to take a different approach, but think it would be nice to make it easier to pass metadata about training datasets to generate dataset cards for unsloth! 

Will do some more testing if the approach in general looks okay. 

When models are pushed to the Hugging Face Hub, linking them to their training datasets makes them significantly more discoverable. The `datasets` field in model card metadata powers the "linked models" section on dataset pages and enables filtering models by training data on the Hub. Currently, Unsloth users have to manually edit their model card or make a separate `metadata_update` call after pushing.

This also simplifies scripts like those in [unsloth/jobs](https://huggingface.co/datasets/unsloth/jobs), which currently need a separate `metadata_update` call after pushing:

```python
# Before: separate import + API call needed
model.push_to_hub_merged(args.output_repo, tokenizer=tokenizer, save_method="merged_16bit")
from huggingface_hub import metadata_update
metadata_update(args.output_repo, {"datasets": [args.dataset]}, overwrite=True)

# After: single call
model.push_to_hub_merged(
    args.output_repo, tokenizer=tokenizer,
    save_method="merged_16bit", datasets=[args.dataset],
)
```

## Summary
- Adds an optional `datasets` parameter to all public save/push functions, allowing users to tag uploaded models with training dataset metadata
- Uses `ModelCard.data.datasets` for standard paths and `metadata_update` for GGUF/generic paths
- Falls back to `metadata_update` when repos already exist so metadata isn't silently skipped

## Usage
```python
model.push_to_hub_merged(
    "my-org/my-model",
    tokenizer,
    save_method="merged_16bit",
    datasets=["my-org/my-dataset", "HuggingFaceFW/fineweb"],
)
```

## Example
Tested with SmolLM2-135M pushed via `push_to_hub_merged` with `datasets=["HuggingFaceFW/fineweb", "allenai/dolma"]`:
https://huggingface.co/davanstrien/test-unsloth-datasets-metadata

## Details
- `datasets` defaults to `None` (no change to existing behavior)
- All `metadata_update` calls pass `token` explicitly so they work without a global HF login
- Metadata failures emit a `logger.warning_once` instead of silently swallowing errors
- Covered paths: `save_pretrained_merged`, `push_to_hub_merged`, `push_to_hub_gguf`, and their generic equivalents
- Not covered: dynamic `push_to_hub` wrapper (mirrors upstream HF signature via `exec`), GGML, torchao — these are niche and can be added in a follow-up

## Test plan
- [x] `push_to_hub_merged` with `datasets=["HuggingFaceFW/fineweb", "allenai/dolma"]` on a new repo — [metadata confirmed on Hub](https://huggingface.co/davanstrien/test-unsloth-datasets-metadata)
- [ ] Same on an existing repo — verify metadata is updated via fallback path
- [ ] `push_to_hub_gguf` with `datasets` — verify metadata appears
- [x] All paths without `datasets` arg — no change in behavior (default is `None`)