### PR TITLE
Fix DDP "marked ready twice" for VLMs with CPU offload + TiledMLP

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1295,12 +1295,12 @@ class FastBaseModel:
 
                 def _pack(x):
                     if isinstance(x, torch.Tensor) and x.device.type != "cpu":
-                        return ("offload", x.device, x.to("cpu", non_blocking=True))
+                        return ("offload", x.device, x.to("cpu", non_blocking = True))
                     return ("pass", x)
 
                 def _unpack(packed):
                     if packed[0] == "offload":
-                        return packed[2].to(packed[1], non_blocking=True)
+                        return packed[2].to(packed[1], non_blocking = True)
                     return packed[1]
 
                 with torch.autograd.graph.saved_tensors_hooks(_pack, _unpack):


### PR DESCRIPTION
Improves the existing DDP compatibility block (from PR #3751) with two targeted fixes that preserve Unsloth's memory optimizations:

1. Non-reentrant checkpointing with CPU activation offloading via saved_tensors_hooks. PR #3751 switched to non-reentrant but dropped CPU offloading entirely.

2. DDP-safe TiledMLP backward: uses functional torch.autograd.grad() for all-but-last sequence chunk (no DDP hooks fired), then .backward() for the final chunk (fires hooks exactly once).

Both fixes are gated behind is_distributed(), so single-GPU training is completely unaffected.

Tested on Qwen3-VL-4B + LoRA with 8x L40S GPUs. These changes successfully enabled multi-GPU training.