### PR TITLE
Fix batched padded generation

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -707,7 +707,9 @@ def LlamaAttention_fast_forward(
     # If a dense padding mask is provided (e.g. left-padded batched decode),
     # force SDPA since this fast path does not thread that mask through
     # flash/xFormers kernels.
-    backend = "sdpa" if attention_mask is not None else select_attention_backend(use_varlen)
+    backend = (
+        "sdpa" if attention_mask is not None else select_attention_backend(use_varlen)
+    )
     config = AttentionConfig(
         backend = backend,
         n_kv_heads = n_kv_heads,


### PR DESCRIPTION
Fixes #3699 

Using the script 
```
import torch
from unsloth import FastLanguageModel

model, tokenizer = FastLanguageModel.from_pretrained(
    model_name="Qwen/Qwen2.5-0.5B",
    max_seq_length=2048,
    load_in_4bit=True,
)
FastLanguageModel.for_inference(model)

examples = [
    "Short prompt",
    "This is a longer prompt with more tokens",
]

# Single sequence generation works correctly
for ex in examples:
    enc = tokenizer.encode(ex, add_special_tokens=True)
    out = model.generate(torch.tensor([enc]).to(model.device), max_new_tokens=30)
    print(tokenizer.decode(out[0][len(enc):]))  # Correct output

# Batched generation with left-padding produces garbage for shorter sequences
tokenizer.padding_side = 'left'
tokenizer.pad_token = tokenizer.eos_token

batch = tokenizer(examples, padding=True, return_tensors='pt', add_special_tokens=True)
out_batch = model.generate(
    batch['input_ids'].to(model.device),
    attention_mask=batch['attention_mask'].to(model.device),
    max_new_tokens=30,
)
# Shorter sequence (index 0) produces garbage, longer sequence (index 1) is correct
```
posted by @afspies

we no longer get gibberish characters and the batched output matches the single generation.

Notebook: https://colab.research.google.com/drive/1TlcaWlzsc1uuoCxwuNycR_BbMRlcgch6?usp=sharing