### PR TITLE
fix: correct gpt-oss Ollama generation prompt and add quantization wa…

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1926,8 +1926,11 @@ def unsloth_save_pretrained_gguf(
     # GPT-OSS needs mxfp4 save method
     if is_gpt_oss:
         if quantization_method is not None:
-            _qm = quantization_method if isinstance(quantization_method, (list, tuple)) \
+            _qm = (
+                quantization_method
+                if isinstance(quantization_method, (list, tuple))
                 else [quantization_method]
+            )
             _ignored = [q for q in _qm if str(q).lower() != "mxfp4"]
             if _ignored:
                 logger.warning_once(


### PR DESCRIPTION
## Summary
Fixes two bugs related to the gpt-oss model.

**Issue 2 — Incorrect Ollama Modelfile generation prompt**
`create_ollama_modelfile()` was emitting `<|start|>assistant` as the
generation prompt. The correct form (matching how every other assistant
message is rendered in the template) is
`<|start|>assistant<|channel|>final<|message|>`.
Also adds the missing `PARAMETER stop <|return|>` line.

**Issue 4 — Silent quantization override for gpt-oss**
`save_pretrained_gguf()` silently overrode any user-supplied
`quantization_method` to MXFP4 with no feedback. A `UserWarning` is
now raised naming the ignored method(s) and explaining how to suppress it.

## Tests
Added `tests/saving/test_gpt_oss_fixes.py`:
- 4 template assertion tests (no heavy deps, always run)
- 7 warning behaviour tests (skip gracefully without full ML stack)

- Fix create_ollama_modelfile() generation prompt for gpt-oss: '<|start|>assistant' → '<|start|>assistant<|channel|>final<|message|>'
- Add missing 'PARAMETER stop <|return|>' to gpt-oss Modelfile
- Emit UserWarning when save_pretrained_gguf() silently overrides a user-supplied quantization_method to MXFP4 for gpt-oss models
- Add unit tests covering both fixes