### PR TITLE
Add Idefics3 support (Granite Docling VLM)

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -100,6 +100,7 @@ VLLM_SUPPORTED_VLM = [
     "mistral3",
     "qwen3_vl",
     "qwen3_vl_moe",
+    "idefics3",
 ]
 VLLM_NON_LORA_VLM = [
     "mllama",
@@ -459,7 +460,7 @@ class FastBaseModel:
         if is_vlm and fast_inference:
             if not any(arch in VLLM_SUPPORTED_VLM for arch in model_types):
                 raise RuntimeError(
-                    f"Unsloth: Fast inference is only supported for Language models and Qwen2.5-VL, Gemma3 among vision models. "
+                    f"Unsloth: Fast inference is only supported for Language models and Qwen2.5-VL, Gemma3, Idefics3 among vision models. "
                     f"Found architectures: {', '.join(model_types)}!"
                 )
 


### PR DESCRIPTION
Closes #4079

Adds Idefics3 architecture support to `FastVisionModel`, enabling fine-tuning of `ibm-granite/granite-docling-258M` and other Idefics3-based models.

## Changes

`unsloth/models/vision.py` — 1 file, 39 insertions:

1. Add `"idefics3"` to `VLLM_SUPPORTED_VLM`
2. Add `_fix_requires_grad_hooks_for_kwargs()` — replaces `requires_grad_pre_hook` on modules after registration to handle kwargs-only forward signatures (Idefics3's vision encoder passes all args via kwargs → empty positional args tuple → `RuntimeError: Failed to make input require gradients`)

## Test results

`ibm-granite/granite-docling-258M` (257.5M params), RTX 5080 16GB:

**SFT** — `unsloth/LaTeX_OCR` dataset (68K samples), LoRA r=32 + DoRA:
```
Loss:  3.11 → 1.29 (30 steps)
VRAM:  3.7 GB peak (24%)
Time:  107s
```

**GRPO** — TRL `GRPOTrainer`, text prompts, custom reward:
```
Loss:  -0.12 → -0.27 (3 steps, policy gradient)
Grad:  0.66 → 1.45 (non-zero, flowing)
```

**Pipeline**: load → LoRA/DoRA → forward → backward → train → generate → save — all pass.

The hook fix is a no-op for models with non-empty positional args (all existing VLMs).