### PR TITLE
Fix VLM processor load degradation and vLLM CUDA version detection

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1470,9 +1470,8 @@ def _is_broken_vllm_error(error) -> bool:
         # Also catch CUDA shared library mismatches during vllm import
         # e.g. "libcudart.so.12: cannot open shared object file"
         if (
-            ("libcudart" in message or "libcublas" in message or "libnvrtc" in message)
-            and "cannot open shared object file" in message
-        ):
+            "libcudart" in message or "libcublas" in message or "libnvrtc" in message
+        ) and "cannot open shared object file" in message:
             return True
         current = getattr(current, "__cause__", None) or getattr(
             current, "__context__", None
@@ -1483,6 +1482,7 @@ def _is_broken_vllm_error(error) -> bool:
 def _get_vllm_cuda_mismatch_message(error):
     """If the error is a CUDA version mismatch, return a helpful install message."""
     import re as _re
+
     checked = set()
     current = error
     wanted_cuda = None
@@ -1502,9 +1502,10 @@ def _get_vllm_cuda_mismatch_message(error):
 
     # Detect what CUDA version is actually available on the system
     system_cuda_display = None  # Human-readable, e.g. "13.0"
-    system_cuda_tag = None      # For wheel URL, e.g. "130"
+    system_cuda_tag = None  # For wheel URL, e.g. "130"
     try:
         import torch
+
         cuda_version = torch.version.cuda  # e.g. "13.0" or "12.8"
         if cuda_version:
             system_cuda_display = cuda_version
@@ -1523,6 +1524,7 @@ def _get_vllm_cuda_mismatch_message(error):
     cpu_arch = "x86_64"
     try:
         import platform
+
         cpu_arch = platform.machine()
     except Exception:
         pass

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -920,16 +920,25 @@ class FastBaseModel:
         # Fix _Unsloth_Patched_ prefix in local config files from old saves (issue #4085)
         if os.path.isdir(tokenizer_name):
             import json as _json
-            for _cfg_name in ("processor_config.json", "preprocessor_config.json", "tokenizer_config.json"):
+
+            for _cfg_name in (
+                "processor_config.json",
+                "preprocessor_config.json",
+                "tokenizer_config.json",
+            ):
                 _cfg_path = os.path.join(tokenizer_name, _cfg_name)
                 if os.path.exists(_cfg_path):
                     try:
-                        with open(_cfg_path, "r", encoding="utf-8") as _f:
+                        with open(_cfg_path, "r", encoding = "utf-8") as _f:
                             _cfg = _json.load(_f)
-                        if _cfg.get("processor_class", "").startswith("_Unsloth_Patched_"):
-                            _cfg["processor_class"] = _cfg["processor_class"][len("_Unsloth_Patched_"):]
-                            with open(_cfg_path, "w", encoding="utf-8") as _f:
-                                _json.dump(_cfg, _f, indent=2, ensure_ascii=False)
+                        if _cfg.get("processor_class", "").startswith(
+                            "_Unsloth_Patched_"
+                        ):
+                            _cfg["processor_class"] = _cfg["processor_class"][
+                                len("_Unsloth_Patched_") :
+                            ]
+                            with open(_cfg_path, "w", encoding = "utf-8") as _f:
+                                _json.dump(_cfg, _f, indent = 2, ensure_ascii = False)
                     except Exception:
                         pass
 


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. VLM processor load degradation (issue #4085)

Companion to unslothai/unsloth-zoo#508. The root cause fix (save path) is in unsloth-zoo. This PR handles the load path in `vision.py`:

**Config sanitization before loading:** Before calling `AutoProcessor.from_pretrained`, scan local config files and strip the `_Unsloth_Patched_` prefix. This is needed because `AutoProcessor.from_pretrained` silently degrades to a text-only tokenizer when it encounters an unrecognized class name -- it does not raise an exception, so the existing `get_auto_processor` fallback in the except block never triggers.

**Degraded processor detection:** After loading, check if the returned processor is missing `image_processor` for a VLM model. If so, trigger `_construct_vlm_processor_fallback` to attempt manual construction.

### 2. vLLM CUDA version mismatch detection

`_is_broken_vllm_error` now also matches CUDA shared library errors (`libcudart`, `libcublas`, `libnvrtc` with "cannot open shared object file"). Previously it only matched errors containing `vllm._c` in the message text, which missed the common case where vllm is built for CUDA 12 but the system has CUDA 13 -- the error message says `libcudart.so.12: cannot open shared object file` without mentioning `vllm._c`.

When a CUDA version mismatch is detected, `disable_broken_vllm` now prints a targeted message with the exact GitHub releases wheel URL:

```
Unsloth: vLLM was built for CUDA 12 but this system has CUDA 13.0.
Please reinstall vLLM with the correct CUDA version:

  uv pip install https://github.com/vllm-project/vllm/releases/download/v0.15.1/vllm-0.15.1+cu130-cp38-abi3-manylinux_2_35_x86_64.whl
```

## Test plan

### Issue #4085
- [x] Trained Qwen2-VL-7B-Instruct (20 steps), saved, reloaded -- processor is `Qwen2VLProcessor` with `image_processor`
- [x] Manually corrupted config with `_Unsloth_Patched_Qwen2VLProcessor` -- sanitization fixes it before loading
- [x] Text model (Llama-3.1-8B) save/load/inference works (no regression)

### vLLM CUDA detection
- [x] Installed CUDA 12 vllm on CUDA 13 system -- detected, disabled, correct install URL printed
- [x] Installed CUDA 13 vllm on CUDA 13 system -- no warning, imports cleanly
- [x] Model load + inference works with wrong vllm gracefully disabled