### PR TITLE
Fix self.temp_O buffer shape for batched inference

### DIFF
--- a/unsloth/models/cohere.py
+++ b/unsloth/models/cohere.py
@@ -296,7 +296,7 @@ def CohereAttention_fast_forward_inference(
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
             self.temp_O = torch.empty(
-                (1, bsz, hidden_size), dtype = dtype, device = "cuda:0"
+                (bsz, 1, hidden_size), dtype = dtype, device = "cuda:0"
             )
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -265,7 +265,7 @@ def FalconH1Attention_fast_forward_inference(
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((1, bsz, hidden_size), dtype = dtype, device = device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 

--- a/unsloth/models/gemma2.py
+++ b/unsloth/models/gemma2.py
@@ -352,7 +352,7 @@ def Gemma2Attention_fast_forward_inference(
         )
         self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
         # Only for Gemma2
-        self.temp_O = torch.empty((1, bsz, hidden_size), dtype = dtype, device = device)
+        self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
         self.attention = torch.empty(
             (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
         )

--- a/unsloth/models/granite.py
+++ b/unsloth/models/granite.py
@@ -324,7 +324,7 @@ def GraniteAttention_fast_forward_inference(
         )
         self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
         # Only for Gemma2
-        self.temp_O = torch.empty((1, bsz, hidden_size), dtype = dtype, device = device)
+        self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
         self.attention = torch.empty(
             (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
         )

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -397,7 +397,7 @@ def LlamaAttention_fast_forward_inference(
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((1, bsz, hidden_size), dtype = dtype, device = device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 

--- a/unsloth/models/qwen3.py
+++ b/unsloth/models/qwen3.py
@@ -249,7 +249,7 @@ def Qwen3Attention_fast_forward_inference(
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((1, bsz, hidden_size), dtype = dtype, device = device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 


### PR DESCRIPTION
## Summary

- Fix `self.temp_O` allocation shape from `(1, bsz, hidden_size)` to `(bsz, 1, hidden_size)` in 6 model files
- The wrong shape caused `torch.matmul` to silently resize the output tensor when `bsz > 1`, producing `UserWarning: An output with one or more elements was resized`
- This will become a hard error in a future PyTorch release

## Details

The Pattern A allocation path (triggered when `attention_size != hidden_size`, e.g. Mistral Nemo 12b) allocated `self.temp_O` as `(1, bsz, hidden_size)`. However, `fast_linear_forward` calls `torch.matmul(X, W.t(), out=self.temp_O)` where `X` has shape `(bsz, 1, in_features)`, so the output should be `(bsz, 1, hidden_size)`.

The Pattern B alias path (`self.temp_O = self.temp_QA[1][:, :, :hidden_size]`) already produces the correct `(bsz, 1, hidden_size)` shape. When `bsz == 1`, both shapes are identical `(1, 1, hidden_size)`, so this only manifests with batched inference.

### Files changed

| File | Function |
|------|----------|
| `unsloth/models/llama.py` | `LlamaAttention_fast_forward_inference` |
| `unsloth/models/gemma2.py` | `Gemma2Attention_fast_forward_inference` |
| `unsloth/models/granite.py` | `GraniteAttention_fast_forward_inference` |
| `unsloth/models/cohere.py` | `CohereAttention_fast_forward_inference` |
| `unsloth/models/qwen3.py` | `Qwen3Attention_fast_forward_inference` |
| `unsloth/models/falcon_h1.py` | `FalconH1Attention_fast_forward_inference` |

## Test plan

- [x] Batched left-padded generation tested on 20 models across 6 architectures -- all produce coherent output, zero resize warnings
- [x] Single-sequence (bsz=1) generation still works for all models
- [x] SFT training sanity check (5 steps on Llama-3.2-1B) passes with no regressions
- [x] Baseline confirmed: old (1, bsz, hidden_size) produces 26 resize warnings on gemma-2-2b-it (bsz=3)

### Test results: 20 models, batched generation (bsz=3), zero resize warnings

| # | Model | Architecture | bsz=1 warnings | bsz=3 warnings | Status |
|---|-------|-------------|-----------------|-----------------|--------|
| 1 | HuggingFaceTB/SmolLM-135M-Instruct | Llama | 0 | 0 | PASS |
| 2 | HuggingFaceTB/SmolLM-360M-Instruct | Llama | 0 | 0 | PASS |
| 3 | HuggingFaceTB/SmolLM-1.7B-Instruct | Llama | 0 | 0 | PASS |
| 4 | TinyLlama/TinyLlama-1.1B-Chat-v1.0 | Llama | 0 | 0 | PASS |
| 5 | unsloth/Llama-3.2-1B-Instruct | Llama | 0 | 0 | PASS |
| 6 | meta-llama/Llama-3.2-3B-Instruct | Llama | 0 | 0 | PASS |
| 7 | Qwen/Qwen2-0.5B-Instruct | Qwen2 | 0 | 0 | PASS |
| 8 | Qwen/Qwen2.5-0.5B-Instruct | Qwen2 | 0 | 0 | PASS |
| 9 | Qwen/Qwen2.5-Coder-0.5B-Instruct | Qwen2 | 0 | 0 | PASS |
| 10 | Qwen/Qwen2.5-1.5B-Instruct | Qwen2 | 0 | 0 | PASS |
| 11 | Qwen/Qwen2.5-Math-1.5B-Instruct | Qwen2 | 0 | 0 | PASS |
| 12 | deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | Qwen2 | 0 | 0 | PASS |
| 13 | unsloth/mistral-7b-instruct-v0.3-bnb-4bit | Mistral | 0 | 0 | PASS |
| 14 | google/gemma-2b-it | Gemma | 0 | 0 | PASS |
| 15 | google/gemma-1.1-2b-it | Gemma | 0 | 0 | PASS |
| 16 | google/gemma-2-2b-it | Gemma2 | 0 | 0 | PASS |
| 17 | Qwen/Qwen3-0.6B | Qwen3 | 0 | 0 | PASS |
| 18 | Qwen/Qwen3-1.7B | Qwen3 | 0 | 0 | PASS |
| 19 | Qwen/Qwen2.5-Coder-1.5B-Instruct | Qwen2 | 0 | 0 | PASS |
| 20 | Qwen/Qwen2.5-Math-1.5B | Qwen2 | 0 | 0 | PASS |

Note: This fix is independent of #4083 (batched left-padded generation). The shape bug pre-dates that PR and affects any batched inference path.