### PR TITLE
Enable Python 3.14 in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "unsloth"
 dynamic = ["version"]
 description = "2-5X faster training, reinforcement learning & finetuning"
 readme = "README.md"
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 license = "Apache-2.0"
 keywords = ["ai", "llm", "reinforcement learning", "machine learning", "artificial intelligence", "pytorch"]
 authors = [


### PR DESCRIPTION
## Summary
Enable Python 3.14 in package metadata by widening `requires-python`.

## Changes
- `pyproject.toml`
  - `requires-python` changed from `>=3.9,<3.14` to `>=3.9,<3.15`

## Validation
- Parsed `pyproject.toml` with `tomllib`
- Verified `project.requires-python` is now `>=3.9,<3.15`
