### PR TITLE
Fix full-finetuning fp32 precision fallback for issue #4082

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -733,6 +733,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
             "    force_float32 = True\n"
             "if force_float32:\n"
             "    # Forced float32 training\n"
+            "    os.environ['UNSLOTH_FORCE_FLOAT32'] = '1'\n"
             "    args.fp16 = False\n"
             "    args.bf16 = False\n"
             "    os.environ['ACCELERATE_MIXED_PRECISION'] = 'no'\n"


### PR DESCRIPTION
## Summary
Fix full-finetuning precision handling when model params are float32 so SFTTrainer does not raise a false fp16/bf16 mismatch.

This addresses issue #4082 behavior where `dtype=torch.float16` during full finetuning can upcast model params to float32, then trip the "model is bfloat16 but fp16 requested" guard.

## Changes
- `unsloth/models/rl.py`
  - Honor `UNSLOTH_FORCE_FLOAT32=1` regardless of `full_finetuning` mode.
  - Split dtype checks into explicit buckets: `is_float16`, `is_bfloat16`, `is_float32`.
  - Keep true fp16<->bf16 mismatch errors.
  - Add float32 + fp16 fallback path: auto switch to float32 training instead of raising mismatch.
  - Fix auto mixed-precision defaults so float32 models do not get forced to bf16 when both `fp16` and `bf16` are false.
- `unsloth/models/loader.py`
  - Preserve user-provided `UNSLOTH_FORCE_FLOAT32=1` instead of unconditionally resetting to `0`.

## Validation
Using `temp/issue_4082_replication/repro_4082_fp16.py` with `unsloth==2026.2.1` editable install from this branch:

Post-patch results:
- `A_float16_fp16_force0`: pass
- `B_float16_fp16_force1`: pass
- `C_bfloat16_fp16_force0`: fail (expected true mismatch)
- `D_bfloat16_bf16_force0`: pass
- `E_float16_noamp_force0`: pass
- `F_float16_noamp_force1`: pass

Logs are in:
- `logs/issue_4082_replication/postpatch/`
