### PR TITLE
Fix Whisper concrete auto_model fallback in FastBaseModel.from_pretrained

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -627,8 +627,8 @@ class FastBaseModel:
         # Re-resolve model_class after potential config change
         try:
             model_class = auto_model._model_mapping[auto_config.__class__]
-        except KeyError:
-            pass
+        except Exception:
+            model_class = None
 
         default_attn_impl = "flex_attention" if flex_attn_impl else "sdpa"
         if not ("attn_implementation" in kwargs):


### PR DESCRIPTION
## Summary
This fixes a Whisper loading crash when users pass a concrete model class as `auto_model`, for example:

```python
auto_model = WhisperForConditionalGeneration
```

In `FastBaseModel.from_pretrained`, model class re-resolution after FP8 redirection accessed:

```python
auto_model._model_mapping[auto_config.__class__]
```

The second lookup only handled `KeyError`, so concrete classes without `_model_mapping` raised `AttributeError` and crashed.

## What changed
- Updated the second post-FP8 model-class re-resolution fallback in `unsloth/models/vision.py`.
- Changed:
  - `except KeyError: pass`
- To:
  - `except Exception: model_class = None`

This matches the defensive behavior already used in the first lookup and keeps control flow safe for both AutoModel classes and concrete model classes.

## Validation
- `python -m py_compile unsloth/models/vision.py`
- Runtime smoke for concrete-class path (`WhisperForConditionalGeneration`) with sentinel marker after mapping section.
  - Result marker: `PASS ... survived _model_mapping access`
- Runtime smoke for AutoModel path (`AutoModelForSpeechSeq2Seq`) completed successfully.

## Compatibility
- No API changes.
- Existing AutoModel usage is unchanged.
- Concrete-class `auto_model` usage no longer crashes in this code path.
