### PR TITLE
Disable flex-attention defaults for Gemma3N variants

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -235,14 +235,16 @@ def prefer_flex_attn_if_supported(model_class, config):
             model_class, "_supports_flex_attn", False
         ):
             return None
-        # GPT-OSS and Mllama use eager/sdpa attention during inference since
-        # flex attention returns incorrect results or errors out.
+        # GPT-OSS, Mllama and Gemma3N use eager/sdpa attention during
+        # inference since flex attention returns incorrect results or errors out.
         # GPT-OSS: left padding issues cause incorrect outputs.
         # Mllama: _update_causal_mask uses make_flex_block_causal_mask which
         # creates BlockMask with Q_LEN=KV_LEN=total_seq_len, but during
         # decode q_len=1, causing ValueError. Needs transformers update.
+        # Gemma3N: timm vision wrappers (eg Gemma3nVisionConfig) do not
+        # support flex_attention.
         model_type = getattr(config, "model_type", "") if config else ""
-        if model_type in ("gpt_oss", "mllama"):
+        if model_type in ("gpt_oss", "mllama") or str(model_type).startswith("gemma3n"):
             return None
         if config is not None:
             setattr(config, "_attn_implementation", "flex_attention")

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -630,7 +630,13 @@ class FastBaseModel:
         except KeyError:
             pass
 
-        default_attn_impl = "flex_attention" if flex_attn_impl else "sdpa"
+        model_type = str(getattr(auto_config, "model_type", "")).lower()
+        if model_type.startswith("gemma3n"):
+            # Gemma3N variants initialize timm-based vision towers which do
+            # not support flex_attention, so default to eager unless overridden.
+            default_attn_impl = "eager"
+        else:
+            default_attn_impl = "flex_attention" if flex_attn_impl else "sdpa"
         if not ("attn_implementation" in kwargs):
             kwargs["attn_implementation"] = default_attn_impl
         if not supports_sdpa and kwargs.get("attn_implementation") == "sdpa":


### PR DESCRIPTION
## Summary
- Prevent `prefer_flex_attn_if_supported(...)` from selecting flex attention for all Gemma3N model type variants using a `startswith("gemma3n")` guard.
- In `FastVisionModel.from_pretrained(...)`, set default attention implementation to `"eager"` for all Gemma3N variants when the user does not explicitly pass `attn_implementation`.
- Preserve user override behavior by only assigning defaults when `attn_implementation` is absent.

## Root cause
Gemma3N includes timm-based vision wrappers (including `gemma3n_vision`) that are not compatible with `flex_attention`. Guarding only exact `model_type == "gemma3n"` is not sufficient.

## Files changed
- `unsloth/models/_utils.py`
- `unsloth/models/vision.py`

## Validation
- `python -m compileall unsloth/models/_utils.py unsloth/models/vision.py`
- Runtime probe with `PYTHONPATH` set to this branch:
  - `gemma3n -> None`
  - `gemma3n_vision -> None`
  - `gemma3n_audio -> None`
  - `gpt_oss -> None`
  - `llama -> flex_attention`
