### PR TITLE
perf(ROCm): add is_rdna() detection and optimize CE loss for RDNA GPUs

### DIFF
--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -22,6 +22,7 @@ from .utils import (
     triton_cast,
     torch_gpu_device,
     is_cdna,
+    is_rdna,
 )
 from transformers.models.llama.modeling_llama import logger
 from unsloth_zoo.utils import Version
@@ -364,7 +365,7 @@ class Fast_CrossEntropyLoss(torch.autograd.Function):
                     SOFTCAP = logit_softcapping,
                     DO_LOGIT_SCALING = DO_LOGIT_SCALING,
                     LOGIT_SCALE = logit_scaling,
-                    num_warps = 32 if not is_cdna() else 16,
+                    num_warps = 16 if is_cdna() or is_rdna() else 32,
                 )
             # logsumexp(chunked_logsumexp) - x
             # Do the -x separately


### PR DESCRIPTION
## Summary

Apply targeted Triton kernel tuning for the chunked cross-entropy forward path on AMD RDNA consumer/workstation GPUs (RDNA3/RDNA4).

> **Note:** `is_rdna()` scope restriction is tracked in PR #4136.

## Changes

**`unsloth/kernels/cross_entropy_loss.py`**
- Chunked CE forward (large vocab > 65536): set `num_warps=16` for RDNA
- Refactored condition from `32 if not is_cdna() else 16` → `16 if is_cdna() or is_rdna() else 32`

> **Correction (post-merge):** The benchmark "Speedup" column compared `warps=16` against `warps=8`, but the previous code path for RDNA already used `warps=32`. The actual change vs. old behavior is ~0.4%, within measurement noise. The warp change has been reverted in PR #TODO — `is_rdna()` remains available in `utils.py` for future RDNA-specific tuning.

## Benchmark Results

**Hardware**: AMD Radeon PRO W7900 (gfx1100, RDNA3, 48GB)
**Method**: 5 independent trials × 300 iterations each, median reported

### Chunked CE Forward (large vocab, BS=65536)

| Model | vocab | warps=8 | warps=16 (RDNA) | warps=32 (old code) | Δ vs old code |
|-------|-------|---------|-----------------|---------------------|---------------|
| Llama-3.1-8B | 128K | 0.450ms | **0.193ms** | 0.194ms | ~0.4% |
| Qwen2.5-7B | 152K | 0.603ms | **0.242ms** | 0.244ms | ~0.6% |
| Gemma-3-4B | 256K | 0.911ms | **0.379ms** | 0.381ms | ~0.4% |

### Other kernels — no modification needed

| Kernel | BLOCK_SIZE | Default warps | Doubled warps | Verdict |
|--------|-----------|--------------|--------------|---------|
| RMS LayerNorm fwd | 2048–8192 | 8 | 16 (−10~25%) | ❌ Keep default |
| RMS LayerNorm bwd | 2048–4096 | 8 | 16 (−12~20%) | ❌ Keep default |
| LayerNorm fwd | 2048–4096 | 8 | 16 (−6~27%) | ❌ Keep default |
| RoPE legacy | 64 | 4 | 8 (−5~22%) | ❌ Keep default |
| RoPE QK (GQA) | 128 | 4 | 8 (−45~47%) | ❌ Keep default |
| CE fwd (small vocab) | 32768 | 32 | — | ❌ Keep default |
| CE backward | 4096 | 8 | — | ❌ Keep default |

## Testing

- Verified `is_rdna()` returns `True` on W7900 (gfx1100)
- Verified `is_rdna()` returns `False` on NVIDIA GPUs and CDNA GPUs
- Confirmed no functional regression — only the chunked CE forward path is affected

cc @danielhanchen