### PR TITLE
fix(ROCm): remove dead code fix_rocm_triton_key_error

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -139,7 +139,6 @@ from .import_fixes import (
     fix_vllm_guided_decoding_params,
     fix_vllm_pdl_blackwell,
     fix_triton_compiled_kernel_missing_attrs,
-    fix_rocm_triton_key_error,
     patch_trunc_normal_precision_issue,
     ignore_logger_messages,
     patch_ipykernel_hf_xet,
@@ -161,7 +160,6 @@ check_vllm_torch_sm100_compatibility()
 fix_vllm_guided_decoding_params()
 fix_vllm_pdl_blackwell()
 fix_triton_compiled_kernel_missing_attrs()
-fix_rocm_triton_key_error()
 patch_trunc_normal_precision_issue()
 ignore_logger_messages()
 patch_ipykernel_hf_xet()
@@ -181,7 +179,6 @@ del check_vllm_torch_sm100_compatibility
 del fix_vllm_guided_decoding_params
 del fix_vllm_pdl_blackwell
 del fix_triton_compiled_kernel_missing_attrs
-del fix_rocm_triton_key_error
 del patch_trunc_normal_precision_issue
 del ignore_logger_messages
 del patch_ipykernel_hf_xet

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -941,39 +941,6 @@ def fix_triton_compiled_kernel_missing_attrs():
     )
 
 
-def fix_rocm_triton_key_error():
-    """
-    ROCm + torch.compile can fail if Triton lacks `triton_key`.
-    Disable Inductor/compile only on ROCm when that symbol is missing.
-    """
-    try:
-        import torch
-    except (ImportError, ModuleNotFoundError):
-        return
-
-    if not getattr(torch.version, "hip", None):
-        return
-
-    try:
-        import triton
-    except (ImportError, ModuleNotFoundError):
-        return
-
-    try:
-        from triton.runtime import triton_key  # noqa: F401
-
-        return
-    except ImportError:
-        pass
-
-    os.environ.setdefault("TORCHINDUCTOR_DISABLE", "1")
-    os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
-    logger.info(
-        "Unsloth: ROCm detected and Triton lacks triton_key; "
-        "disabling torch.compile/Inductor to avoid backend crash."
-    )
-
-
 def patch_trunc_normal_precision_issue():
     """
     Patch torch.nn.init.trunc_normal_ for low precision tensors to run init in fp32.


### PR DESCRIPTION
Remove `fix_rocm_triton_key_error()` from #3923 — the function is dead code with multiple issues:

1. **Checks wrong path**: function checks `triton.runtime.triton_key` (missing on ROCm), but `torch._inductor` uses `triton.compiler.compiler.triton_key` which **exists and works** on ROCm.
2. **Invalid env var**: sets `TORCHINDUCTOR_DISABLE` which does not exist in PyTorch (102 `TORCHINDUCTOR_*` vars exist, this is not one of them).
3. **Set too late**: `TORCH_COMPILE_DISABLE` is set after `import torch`; `torch._dynamo` reads it only once at import time, so it has no effect.
4. **Harmful side-effect**: the env var is inherited by subprocesses where it _does_ take effect, needlessly disabling `torch.compile` on working ROCm setups.

`torch.compile` works correctly on Triton 3.4.0 / gfx1100 — verified with matmul, CE loss, RMSNorm, transformer forward+backward, and LoRA backward.

cc @danielhanchen