### PR TITLE
fix(ROCm): prevent false TMA support detection on AMD GPUs

### DIFF
--- a/unsloth/kernels/moe/grouped_gemm/interface.py
+++ b/unsloth/kernels/moe/grouped_gemm/interface.py
@@ -39,10 +39,10 @@ logger.addHandler(ch)
 
 # Precompute TMA support to avoid graph breaks
 # TMA requires both:
-# 1. GPU capability >= 9 (Hopper+)
+# 1. NVIDIA GPU with capability >= 9 (Hopper+)
 # 2. Triton version with TMA API (make_tensor_descriptor or _experimental_make_tensor_descriptor)
 def _check_tma_support():
-    if DEVICE_TYPE == "xpu":
+    if DEVICE_TYPE in ("xpu", "hip"):
         return False
     import triton.language as tl
 


### PR DESCRIPTION
## Problem

`_check_tma_support()` in `unsloth/kernels/moe/grouped_gemm/interface.py` incorrectly returns `True` on AMD ROCm GPUs.

TMA (Tensor Memory Accelerator) is an **NVIDIA Hopper+ exclusive** hardware feature. However, both checks in the function pass on AMD:

| Check | AMD gfx1100 (W7900) | Expected |
|---|---|---|
| `torch.cuda.get_device_capability()[0] >= 9` | `11 >= 9` → **True** ❌ | False |
| `hasattr(tl, "make_tensor_descriptor")` | **True** (symbol exists in ROCm Triton) | N/A |
| `_SUPPORTS_TMA` (final) | **True** ❌ | **False** |

The capability value `11` comes from gfx**11**00, not from NVIDIA's sm_90 (Hopper). This false positive would cause MoE grouped GEMM to attempt TMA operations on AMD, leading to runtime failures.

## Fix

Early-return `False` for HIP devices, matching the existing XPU guard:

```python
def _check_tma_support():
    if DEVICE_TYPE in ("xpu", "hip"):  # TMA is NVIDIA Hopper+ only
        return False
    ...
```

## Verification

Tested on AMD Radeon PRO W7900 (gfx1100, ROCm 6.3.4):

```
Original _SUPPORTS_TMA: True   ← BUG
Fixed    _SUPPORTS_TMA: False  ← Correct
```

## Changes

- `unsloth/kernels/moe/grouped_gemm/interface.py`: 1 file, +2 −2