### PR TITLE
Fix gpt temporary patch for grpo to happen after compile

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -256,15 +256,17 @@ def prefer_flex_attn_if_supported(model_class, config):
 
 def _run_temporary_patches(phase):
     import inspect
+
     for temporary_patch in TEMPORARY_PATCHES:
         try:
             sig = inspect.signature(temporary_patch)
             if "phase" in sig.parameters:
-                temporary_patch(phase=phase)
+                temporary_patch(phase = phase)
             else:
                 temporary_patch()
         except (ValueError, TypeError):
             temporary_patch()
+
 
 _run_temporary_patches("init")
 


### PR DESCRIPTION
Fixes #4175 

The gpt oss grpo patch in temporary_patches runs 3 times. Since it runs before compiler, compiler doesnt match the causallm pattern so we lose the connection to unsloth fused loss. This PR proposes phases for temporary patches so patches can determine when they want to run.

Depends on https://github.com/unslothai/unsloth-zoo/pull/536

Notebooks Tested:
gpt finetuning
https://colab.research.google.com/drive/11Hi8srn79s5gGoVbOhtw09LCkq6wfJnb?usp=sharing

gpt long context
https://colab.research.google.com/drive/1jcMg3xQ5c1C1Vxd-6DcZjIuzgfEBh56R?usp=sharing

gpt grpo
https://colab.research.google.com/drive/1JwlBpfg-cpnUDtlIdtziSfDxKP_YlMwW?usp=sharing