### PR TITLE
fix: remove dead code branch in fast_rms_layernorm_inference

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -643,7 +643,8 @@ torch_mean = torch.mean
 
 def fast_rms_layernorm_inference(self, X, XX = None, XX2 = None, variance = None):
     old_dtype = X.dtype
-    if XX is None:
+    inplace = XX is not None
+    if not inplace:
         XX = X.to(torch.float32)
         variance = XX.square().mean(-1, keepdim = True)
     else:
@@ -652,10 +653,10 @@ def fast_rms_layernorm_inference(self, X, XX = None, XX2 = None, variance = None
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
-    if XX is None:
-        X = XX.to(old_dtype)
-    else:
+    if inplace:
         X.copy_(XX)
+    else:
+        X = XX.to(old_dtype)
 
     X *= self.weight
     return X


### PR DESCRIPTION
## Summary

In `fast_rms_layernorm_inference`, the second `if XX is None:` check (line 655) is dead code. The first branch at line 646 assigns `XX = X.to(torch.float32)` when `XX` is `None`, so by the time we reach the second check, `XX` is always not `None`. This means:

- The `X = XX.to(old_dtype)` path (intended for the non-inplace case) **never executes**
- The `X.copy_(XX)` path (intended for the pre-allocated buffer case) **always executes**

This is a correctness bug when callers don't pass pre-allocated buffers (`XX=None`): the function writes into the original `X` tensor via `copy_` instead of creating a new tensor with `XX.to(old_dtype)`, which may produce wrong results or unexpected in-place mutation.

## Fix

Save the original `XX is not None` state into an `inplace` boolean before the first branch reassigns `XX`, then use that flag to select the correct dtype-conversion path afterward.

## Test plan

- Verified by code inspection that the two branches now correspond to the correct calling conventions (with and without pre-allocated buffers)
- Existing unit/integration tests should continue to pass since the in-place path (the common hot path) is unchanged