### PR TITLE
Combine GRPO mixed precision fixes from #4197 and #4114

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -698,14 +698,17 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
                 if not hasattr(self, "_autocast_dtype"):
                     self._autocast_dtype = (
                         torch.float16
-                        if os.environ.get("ACCELERATE_MIXED_PRECISION", "fp16") == "fp16"
+                        if os.environ.get("ACCELERATE_MIXED_PRECISION", "fp16")
+                        == "fp16"
                         else torch.bfloat16
                     )
                 autocaster = torch.amp.autocast(
                     device_type = DEVICE_TYPE, dtype = self._autocast_dtype
                 )
                 dtype_bytes = (
-                    16 if self._autocast_dtype in [torch.float16, torch.bfloat16] else 32
+                    16
+                    if self._autocast_dtype in [torch.float16, torch.bfloat16]
+                    else 32
                 )
 
             pixel_values, image_grid_thw = (


### PR DESCRIPTION
## Summary
This combines the GRPO precision-state changes from #4197 and #4114 into one branch.

It keeps the explicit `bf16` / `fp16` propagation from #4197, keeps the float32 and full-finetuning safety work from #4114, and fixes one remaining force-float32 autocast mismatch in the GRPO replacement helpers that showed up when validating the combined behavior.

## What changed
- preserve explicit force-float32 requests in `loader.py` without leaking an auto-detected force state into later model loads in the same process
- resolve GRPO mixed precision in `rl.py` using the original requested dtype when full finetuning has upcast parameters, so `fp16` full-finetuning and true `float32` models do not collapse into the same branch
- propagate explicit `bf16` / `fp16` requests into `ACCELERATE_MIXED_PRECISION` and `args.mixed_precision`
- disable the GRPO helper autocast override when `UNSLOTH_FORCE_FLOAT32=1`, so force-float32 really means no mixed precision during the GRPO helper forwards

## Validation
I validated this with a notebook-derived GRPO matrix using `unsloth/Llama-3.2-1B-Instruct`.

- 16 Cartesian combinations were checked across `precision x full_finetuning x force_float32 x use_vllm`
- supported LoRA paths ran `trainer.train()` for 1 step
- full-finetuning paths validated model load plus `GRPOTrainer(...)` construction and the pre-train precision state, which is where this bug is decided
- unsupported `full_finetuning=True` plus `fast_inference=True` combinations were checked as expected failures

Final matrix summary:
- 16 total combinations
- 0 unexpected failures
- 4 expected failures for unsupported `full_finetuning + fast_inference`

## Attribution
This keeps the original intent from both PRs:
- #4197 by @BenjaminBruenau
- #4114

The combined commit also carries Benjamin's co-author attribution.
