### PR TITLE
Fix TRL 0.25.1+ GRPO vision crash and reward function TypeError

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1916,6 +1916,7 @@ def _patch_prepare_multimodal_messages():
     # Also patch in grpo_trainer module if imported
     try:
         import trl.trainer.grpo_trainer as _gt
+
         if hasattr(_gt, "prepare_multimodal_messages"):
             _gt.prepare_multimodal_messages = _safe_prepare_multimodal_messages
     except ImportError:

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1888,16 +1888,39 @@ def patch_trl_vllm_generation():
     return
 
 
-def patch_trl_vllm_generation():
-    # trl moved vllm stuff to trl/generation/vllm_generation.py
-    # We need to min_p patch it to not instantiate another vLLM instance if we already have one with fast_inference
-    # Find the instance of self.llm = LLM(..) (multiline) and wrap it around an if clause
-    for function in RL_ADDITIONAL_FUNCTIONS["vllm_generation"]:
-        logger.info(
-            f"Unsloth: Patching trl VLLMGeneration with function: {function.__name__}"
-        )
-        function()
-    return
+def _patch_prepare_multimodal_messages():
+    """Fix 2: TRL >= 0.25.1 calls prepare_multimodal_messages unconditionally for
+    vision models. When notebooks pre-apply chat templates (converting prompts to strings),
+    the function crashes iterating over characters. This patch adds isinstance(messages, str)
+    guard to return strings unchanged."""
+    try:
+        import trl.data_utils as _du
+    except ImportError:
+        return
+
+    _original = getattr(_du, "prepare_multimodal_messages", None)
+    if _original is None:
+        return
+    if getattr(_original, "_unsloth_patched", False):
+        return
+
+    def _safe_prepare_multimodal_messages(messages, *args, **kwargs):
+        # If messages is already a string (pre-applied chat template), return as-is
+        if isinstance(messages, str):
+            return messages
+        return _original(messages, *args, **kwargs)
+
+    _safe_prepare_multimodal_messages._unsloth_patched = True
+    _du.prepare_multimodal_messages = _safe_prepare_multimodal_messages
+
+    # Also patch in grpo_trainer module if imported
+    try:
+        import trl.trainer.grpo_trainer as _gt
+        if hasattr(_gt, "prepare_multimodal_messages"):
+            _gt.prepare_multimodal_messages = _safe_prepare_multimodal_messages
+    except ImportError:
+        pass
+    logger.info("Unsloth: Patched prepare_multimodal_messages with string guard")
 
 
 def PatchFastRL(algorithm = None, FastLanguageModel = None):
@@ -1906,5 +1929,6 @@ def PatchFastRL(algorithm = None, FastLanguageModel = None):
     patch_trl_rl_trainers()
     patch_trl_openenv()
     patch_trl_vllm_generation()
+    _patch_prepare_multimodal_messages()
     if type(algorithm) is str and algorithm.islower():
         PatchRLStatistics(algorithm)

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -537,6 +537,35 @@ def grpo_trainer__generate_and_score_completions(function_name, function):
 RL_FUNCTIONS["grpo_trainer"].append(grpo_trainer__generate_and_score_completions)
 
 
+# Fix 6: TRL 0.25.0+ _calculate_rewards text arguments
+#
+# TRL 0.25.0+ passes `prompts` and `completions` to _calculate_rewards in different formats:
+#   - For conversational inputs: list of dicts [{"role": "assistant", "content": "..."}]
+#   - For non-conversational inputs: plain text strings
+#
+# This inconsistency causes reward functions to fail when they expect one format but get the other.
+# The variables `prompts_text` and `completions_text` always contain plain decoded text strings.
+#
+# Fix: Always pass plain text (prompts_text, completions_text) to _calculate_rewards for consistency.
+# This ensures reward functions receive predictable string format regardless of conversational mode.
+def grpo_trainer__calculate_rewards_text_fix(function_name, function):
+    if function_name != "_generate_and_score_completions":
+        return function
+
+    # Only apply if prompts_text and completions_text exist (TRL 0.25.0+)
+    if "prompts_text" in function and "completions_text" in function:
+        # Replace the _calculate_rewards call to use text versions
+        function = function.replace(
+            "self._calculate_rewards(inputs, prompts, completions, completion_ids_list)",
+            "self._calculate_rewards(inputs, prompts_text, completions_text, completion_ids_list)",
+        )
+
+    return function
+
+
+RL_FUNCTIONS["grpo_trainer"].append(grpo_trainer__calculate_rewards_text_fix)
+
+
 # Fix {"reasoning_effort" : "high"} not applied
 def grpo_trainer_fix_maybe_apply_chat_template(function_name, function):
     spaces = function.find("def ")


### PR DESCRIPTION
Replacement for #3975 due to Studio rebasing

## Summary

- Fix vision GRPO crash on TRL 0.25.1+ when notebooks pre-apply chat templates
- Fix reward function TypeError when expecting plain text but receiving conversation format dicts

## Changes

### Fix 2: Vision GRPO crash (rl.py)

TRL 0.25.1+ calls `prepare_multimodal_messages()` unconditionally for vision models. When notebooks pre-apply `tokenizer.apply_chat_template()` (converting prompts to strings), the function crashes iterating over characters.

**Solution**: Add `_patch_prepare_multimodal_messages()` that wraps the TRL function with an `isinstance(messages, str)` guard. String prompts now pass through unchanged.

### Fix 6: Reward function TypeError (rl_replacements.py)

TRL 0.25.0+ passes `prompts` and `completions` to `_calculate_rewards` in different formats:
- Conversational inputs: list of dicts `[{"role": "assistant", "content": "..."}]`
- Non-conversational inputs: plain strings

This inconsistency causes reward functions to crash when they expect strings but receive dicts (or vice versa).

**Solution**: Add `grpo_trainer__calculate_rewards_text_fix()` that makes `_calculate_rewards` always use `prompts_text` and `completions_text` (plain decoded strings) for consistent behavior.

## Test plan

- [x] Verified Fix 2: `prepare_multimodal_messages("test string", [])` returns string unchanged
- [x] Verified Fix 6: Compiled cache shows `_calculate_rewards` uses `prompts_text, completions_text`
- [x] Smoke tested nb2_gpt_oss_2048 with TRL 0.25.1 - runs without TypeError
- [x] Smoke tested vision model loading with TRL 0.25.1 - works correctly
- [x] Re-applied on latest main and re-confirmed all tests pass
