### PR TITLE
fix/load-checkpoint-add-new-tokens 

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -32,6 +32,7 @@ from .cohere import FastCohereModel
 from transformers import AutoConfig
 from transformers import __version__ as transformers_version
 from peft import PeftConfig, PeftModel
+from ..tokenizer_utils import add_new_tokens
 from .loader_utils import (
     _get_fp8_mode_and_check_settings,
     _offline_quantize_to_fp8,
@@ -727,6 +728,16 @@ class FastLanguageModel(FastLlamaModel):
 
         if resize_model_vocab is not None:
             model.resize_token_embeddings(resize_model_vocab)
+
+        # PEFT checkpoints can carry tokenizer-added tokens that are not yet
+        # reflected in the base model vocab. Resize before merge/load so the
+        # adapter and base model stay shape-compatible.
+        if is_peft and model_config.vocab_size < len(tokenizer.vocab):
+            logger.warning_once(
+                "Unsloth: Your model's vocab size is less than the tokenizer's vocab size.\n"
+                "We shall add the new tokens to the model's vocab."
+            )
+            add_new_tokens(model, tokenizer, resize_tokenizer = False)
 
         # In case the model supports tagging, add the unsloth tag.
         if hasattr(model, "add_model_tags"):


### PR DESCRIPTION
Replacement for #1225 due to Studio rebasing

https://github.com/unslothai/unsloth/issues/1215

Given this issue where we can't immediately use the changed vocab size because the difference size between the adapter and base model, we need to resize the base model before merging the LoRA into base model.

Note this need changes to the `unsloth-zoo` since we need a modification of it. which I also create a PR of it 

https://github.com/unslothai/unsloth-zoo/pull/9