### PR TITLE
Add Qwen2.5 Coder model support to registry and chat templates

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -609,6 +609,18 @@ DEFAULT_SYSTEM_MESSAGE["qwen25"] = qwen25_default_system_message # No system mes
 CHAT_TEMPLATES["qwen2.5"]  = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
 DEFAULT_SYSTEM_MESSAGE["qwen2.5"] = qwen25_default_system_message # No system message in Qwen 2.5
 
+CHAT_TEMPLATES["qwen-2.5-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen-2.5-coder"] = qwen25_default_system_message
+
+CHAT_TEMPLATES["qwen2.5-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen2.5-coder"] = qwen25_default_system_message
+
+CHAT_TEMPLATES["qwen25-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen25-coder"] = qwen25_default_system_message
+
+CHAT_TEMPLATES["qwen-coder"] = (qwen25_template, qwen25_template_eos_token, False, qwen25_ollama,)
+DEFAULT_SYSTEM_MESSAGE["qwen-coder"] = qwen25_default_system_message
+
 # =========================================== Phi-4
 # "{{ bos_token }}"\ # Phi-4 removes BOS?
 phi4_template = \

--- a/unsloth/registry/_qwen.py
+++ b/unsloth/registry/_qwen.py
@@ -3,6 +3,7 @@ from unsloth.registry.registry import ModelInfo, ModelMeta, QuantType, _register
 _IS_QWEN_2_5_REGISTERED = False
 _IS_QWEN_2_5_VL_REGISTERED = False
 _IS_QWEN_QWQ_REGISTERED = False
+_IS_QWEN_2_5_CODER_REGISTERED = False
 
 
 class QwenModelInfo(ModelInfo):
@@ -36,6 +37,15 @@ class QwenQVQPreviewModelInfo(ModelInfo):
     @classmethod
     def construct_model_name(cls, base_name, version, size, quant_type, instruct_tag):
         key = f"{base_name}-{size}B-Preview"
+        return super().construct_model_name(
+            base_name, version, size, quant_type, instruct_tag, key
+        )
+
+
+class Qwen2_5CoderModelInfo(ModelInfo):
+    @classmethod
+    def construct_model_name(cls, base_name, version, size, quant_type, instruct_tag):
+        key = f"{base_name}{version}-Coder-{size}B"
         return super().construct_model_name(
             base_name, version, size, quant_type, instruct_tag, key
         )
@@ -89,6 +99,18 @@ QwenQVQPreviewMeta = ModelMeta(
     quant_types = [QuantType.NONE, QuantType.BNB],
 )
 
+# Qwen2.5 Coder Model Meta
+Qwen_2_5_CoderMeta = ModelMeta(
+    org = "Qwen",
+    base_name = "Qwen",
+    instruct_tags = [None, "Instruct"],
+    model_version = "2.5",
+    model_sizes = ["0.5", "1.5", "3", "7", "14", "32"],
+    model_info_cls = Qwen2_5CoderModelInfo,
+    is_multimodal = False,
+    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
+)
+
 
 def register_qwen_2_5_models(include_original_model: bool = False):
     global _IS_QWEN_2_5_REGISTERED
@@ -115,10 +137,19 @@ def register_qwen_qwq_models(include_original_model: bool = False):
     _IS_QWEN_QWQ_REGISTERED = True
 
 
+def register_qwen_2_5_coder_models(include_original_model: bool = False):
+    global _IS_QWEN_2_5_CODER_REGISTERED
+    if _IS_QWEN_2_5_CODER_REGISTERED:
+        return
+    _register_models(Qwen_2_5_CoderMeta, include_original_model = include_original_model)
+    _IS_QWEN_2_5_CODER_REGISTERED = True
+
+
 def register_qwen_models(include_original_model: bool = False):
     register_qwen_2_5_models(include_original_model = include_original_model)
     register_qwen_2_5_vl_models(include_original_model = include_original_model)
     register_qwen_qwq_models(include_original_model = include_original_model)
+    register_qwen_2_5_coder_models(include_original_model = include_original_model)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replacement for #3436 due to Studio rebasing

- Added model info class and metadata for 0.5B-32B sizes
- Implemented registration function with quantization support
- Added chat template aliases
- Updated registry documentation
