### PR TITLE
fix: propagate revision to vLLM fast_inference

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -881,6 +881,7 @@ class FastBaseModel:
                 disable_log_stats = disable_log_stats,
                 use_bitsandbytes = load_in_4bit,
                 unsloth_vllm_standby = unsloth_vllm_standby,
+                revision = revision,
                 is_vision_model = is_vlm,
                 fp8_mode = fp8_mode,
             )


### PR DESCRIPTION
Replacement for #3816 due to Studio rebasing

## Summary
- Pass revision into vLLM fast_inference loader in `llama.py`

## Test Plan
- Not run (no supported GPU in local env)
