### PR TITLE
Cache packed sequence metadata to reduce D2H syncs across layers

### DIFF
--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -389,6 +389,13 @@ def mask_packed_sequence_boundaries(
     return True
 
 
+def clear_packed_caches():
+    """Release cached masks/metadata to free device memory."""
+    _PACKED_INFO_CACHE.clear()
+    _SDPA_MASK_CACHE.clear()
+    _XFORMERS_BLOCK_MASK_CACHE.clear()
+
+
 __all__ = [
     "configure_sample_packing",
     "configure_padding_free",
@@ -399,4 +406,5 @@ __all__ = [
     "build_xformers_block_causal_mask",
     "build_sdpa_packed_attention_mask",
     "mask_packed_sequence_boundaries",
+    "clear_packed_caches",
 ]


### PR DESCRIPTION
Replacement for #4173 due to Studio rebasing

Added per-forward-pass caching  to eliminate redundant D2H copies and `cudaStreamSynchronize` calls across layers.


When packing (padding-free) is enabled, three functions are called on every layer of the model during the forward pass:
* `get_packed_info_from_kwargs`: calls `lengths.max().item()` — triggers D2H copy + sync
* `build_sdpa_packed_attention_mask` (SDPA backend): calls `seq_lengths.sum().item()` and `seq_lengths.tolist()` — triggers 2 D2H copies + syncs
* `build_xformers_block_causal_mask` (XFormers backend): calls `seq_lengths.to("cpu")` — triggers D2H copy + sync

For a model with N layers, this results in N unnecessary D2H synchronizations per function, even though the packed sequence metadata (`seq_lengths`) is identical across all layers within the same forward pass.

### Solution
Cache the output of each function using Python object identity (is) comparison on the `seq_lengths` tensor. Since the same `seq_lengths` tensor object is passed to all layers within a single forward pass, subsequent layers hit the cache and skip the D2H operations entirely. A new batch produces a new `seq_lengths` tensor object, which naturally invalidates the cache.

This reduces D2H synchronizations per forward pass:
| Function | Before | After |
|----------|--------|-------|
| `get_packed_info_from_kwargs` | N | 1 |
| `build_sdpa_packed_attention_mask` | 2N | 2 |
| `build_xformers_block_causal_mask` | N | 1 |

Nsys profiling traces:

* Without this PR:
<img width="1157" height="387" alt="image" src="https://github.com/user-attachments/assets/0f490169-b7f2-4c88-be31-b5eac19cec5f" />

* With this PR:
<img width="1164" height="456" alt="image" src="https://github.com/user-attachments/assets/4e5024d5-f9e5-485f-adb0-0e595573b365" />

### Performance
With the caching strategy, CudaStreamSync only appears in the first layer and in the following layers it disappears. We achieve around 43.3% speedup for forward, 5.8% speedup for backward, 14.3% speedup for each batch for Qwen3 14B QLoRA SFT.