### PR TITLE
Fix: ModernBERT sequence classification num_labels support

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -784,16 +784,10 @@ class FastBaseModel:
 
         # Handle sequence classification parameters (num_labels, id2label, label2id)
         # These need to be set in the config before model instantiation
-        num_labels = kwargs.pop("num_labels", None)
-        id2label = kwargs.pop("id2label", None)
-        label2id = kwargs.pop("label2id", None)
-
-        if num_labels is not None:
-            model_config.num_labels = num_labels
-        if id2label is not None:
-            model_config.id2label = id2label
-        if label2id is not None:
-            model_config.label2id = label2id
+        for param in ("num_labels", "id2label", "label2id"):
+            value = kwargs.pop(param, None)
+            if value is not None:
+                setattr(model_config, param, value)
 
         verify_fp8_support_if_applicable(model_config)
 

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -782,6 +782,19 @@ class FastBaseModel:
             setattr(auto_config, "attn_implementation", config_attn_impl)
         model_config = auto_config
 
+        # Handle sequence classification parameters (num_labels, id2label, label2id)
+        # These need to be set in the config before model instantiation
+        num_labels = kwargs.pop("num_labels", None)
+        id2label = kwargs.pop("id2label", None)
+        label2id = kwargs.pop("label2id", None)
+        
+        if num_labels is not None:
+            model_config.num_labels = num_labels
+        if id2label is not None:
+            model_config.id2label = id2label
+        if label2id is not None:
+            model_config.label2id = label2id
+
         verify_fp8_support_if_applicable(model_config)
 
         raise_handler = RaiseUninitialized()

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -787,7 +787,7 @@ class FastBaseModel:
         num_labels = kwargs.pop("num_labels", None)
         id2label = kwargs.pop("id2label", None)
         label2id = kwargs.pop("label2id", None)
-        
+
         if num_labels is not None:
             model_config.num_labels = num_labels
         if id2label is not None:


### PR DESCRIPTION
Replacement for #4177 due to Studio rebasing

# Fix: Add support for sequence classification parameters in FastModel

## Issue #4163 
## Problem

When using `FastModel.from_pretrained()` with `AutoModelForSequenceClassification` for BERT-based models (including ModernBERT), users encountered a `TypeError`:

```python
TypeError: ModernBertForSequenceClassification.__init__() got an unexpected keyword argument 'num_labels'
```

This prevented users from loading sequence classification models with custom label configurations, making it impossible to use unsloth for fine-tuning BERT models on classification tasks.

### Reproduction

```python
from unsloth import FastModel
from transformers import AutoModelForSequenceClassification

model, tokenizer = FastModel.from_pretrained(
    model_name="unsloth/ModernBERT-large",
    auto_model=AutoModelForSequenceClassification,
    num_labels=6,  #  This caused TypeError
    id2label={0: "sadness", 1: "joy", 2: "love", 3: "anger", 4: "fear", 5: "surprise"},
    label2id={"sadness": 0, "joy": 1, "love": 2, "anger": 3, "fear": 4, "surprise": 5},
)
```

##  Solution

The issue was in `unsloth/models/vision.py` in the `FastBaseModel.from_pretrained()` method. The parameters `num_labels`, `id2label`, and `label2id` were being passed directly to `auto_model.from_pretrained()` via `**kwargs`, but for sequence classification models, these parameters must be set in the model's **config** before instantiation.

### Changes Made

**File:** `unsloth/models/vision.py` (lines ~784-800)

Added code to extract sequence classification parameters from kwargs and set them on the config before model loading:

```python
# Handle sequence classification parameters (num_labels, id2label, label2id)
# These need to be set in the config before model instantiation
num_labels = kwargs.pop("num_labels", None)
id2label = kwargs.pop("id2label", None)
label2id = kwargs.pop("label2id", None)

if num_labels is not None:
    model_config.num_labels = num_labels
if id2label is not None:
    model_config.id2label = id2label
if label2id is not None:
    model_config.label2id = label2id
```

This ensures the parameters are in the config when `auto_model.from_pretrained()` is called, preventing them from being passed as unexpected keyword arguments to the model's `__init__` method.

##  Testing

### Validation Tests
-  Python syntax validation passes
-  Config parameter extraction works correctly
-  None parameter handling (backward compatibility)
-  Module imports successfully

### Backward Compatibility
-  Models without `num_labels` continue to work (existing use cases unaffected)
-  Models with `num_labels` now work correctly (new functionality)
-  Partial parameters (only `num_labels` without `id2label`/`label2id`) handled correctly
-  No breaking changes to existing API

### Usage After Fix

```python
from unsloth import FastModel
from transformers import AutoModelForSequenceClassification
import os

os.environ["UNSLOTH_DISABLE_FAST_GENERATION"] = "1"

# Now works! 
model, tokenizer = FastModel.from_pretrained(
    model_name="unsloth/ModernBERT-large",
    auto_model=AutoModelForSequenceClassification,
    max_seq_length=2048,
    dtype=None,
    load_in_4bit=False,
    load_in_16bit=True,
    num_labels=6,
    id2label={0: "sadness", 1: "joy", 2: "love", 3: "anger", 4: "fear", 5: "surprise"},
    label2id={"sadness": 0, "joy": 1, "love": 2, "anger": 3, "fear": 4, "surprise": 5},
)

```

##  Additional Notes

- This fix follows the same pattern used in `unsloth/models/llama.py` for handling `num_labels` in LLaMA-based models
- The fix is minimal and surgical - only affects models that explicitly pass these parameters
- Applies to all transformer models using `AutoModelForSequenceClassification` through `FastModel.from_pretrained()`
- Works with both full finetuning and LoRA/QLoRA



##  Related

- Issue: https://github.com/unslothai/unsloth/issues/4163


##  Checklist

- [x] Code follows the project's style guidelines
- [x] Changes are backward compatible
- [x] No breaking changes to existing functionality
- [x] Tested with ModernBERT sequence classification

---

Thank you for reviewing! This fix enables ModernBERT sequence classification while maintaining full backward compatibility. 🦥