### PR TITLE
fix: handle missing add_generation_prompt in saved LoRA tokenizers

### DIFF
--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -666,7 +666,7 @@ def _fix_chat_template(chat_template):
     ):
         after_endfor = (
             "{%" + dash + " if add_generation_prompt %}"
-            + "{{ '<|im_start|>assistant\\n' }}"
+            + "{{ '<|im_start|>assistant\n' }}"
             + "{%" + dash + " endif %}"
         )
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -658,6 +658,21 @@ def _fix_chat_template(chat_template):
 
     dash = "-" if chosen_end.startswith("{%-") else ""
 
+    # Case 1: nothing after endfor - template was saved without generation prompt
+    if (
+        not after_endfor.strip()
+        and "add_generation_prompt" not in chat_template
+        and "<|im_start|>" in chat_template
+    ):
+        after_endfor = (
+            "{%" + dash + " if add_generation_prompt %}"
+            + "{{ '<|im_start|>assistant\\n' }}"
+            + "{%" + dash + " endif %}"
+        )
+        chat_template = chat_template[: where + len(chosen_end)] + after_endfor
+        return chat_template
+
+    # Case 2: original logic - something after endfor starting with {{
     if (
         "{%" + dash + " if" not in after_endfor
         and "{%" + dash + " set " not in after_endfor
@@ -731,11 +746,14 @@ def fix_chat_template(tokenizer):
                 "{% if add_generation_prompt %}" not in new_chat_template
                 and "{%- if add_generation_prompt %}" not in new_chat_template
             ):
-                raise RuntimeError(
+                # Could not auto-fix - warn but don't crash so user can still
+                # load their saved LoRA adapter for inference/chat
+                logger.warning_once(
                     f"Unsloth: The tokenizer `{tokenizer.name_or_path}`\n"
-                    "does not have a {% if add_generation_prompt %} for generation purposes.\n"
-                    f"Please file a bug report to the maintainers of `{tokenizer.name_or_path}` - thanks!"
+                    "does not have a {{% if add_generation_prompt %}} for generation purposes.\n"
+                    "Generation may not work correctly. Please notify the model maintainers."
                 )
+                return chat_template
             else:
                 logger.warning_once(
                     "Unsloth: We successfully patched the tokenizer to add a {% if add_generation_prompt %} to the chat_template.\n"

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -665,9 +665,13 @@ def _fix_chat_template(chat_template):
         and "<|im_start|>" in chat_template
     ):
         after_endfor = (
-            "{%" + dash + " if add_generation_prompt %}"
+            "{%"
+            + dash
+            + " if add_generation_prompt %}"
             + "{{ '<|im_start|>assistant\n' }}"
-            + "{%" + dash + " endif %}"
+            + "{%"
+            + dash
+            + " endif %}"
         )
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor
         return chat_template


### PR DESCRIPTION
Replacement for #4179 due to Studio rebasing

## Problem
When a LoRA adapter is trained with a ChatML template (e.g., Hermes-3, 
Magnum-v2) via LlamaFactory and saved, the saved tokenizer's chat_template 
loses the `{% if add_generation_prompt %}` block. Loading this LoRA for 
inference then crashes immediately:

RuntimeError: The tokenizer does not have a 
{% if add_generation_prompt %} for generation purposes.

Fixes #4150

## Root Cause
`_fix_chat_template` only handled templates ending with `{{ something }}` — 
not empty endings, which is exactly what LlamaFactory saves.

## Fix
1. **`_fix_chat_template`**: Added handler for empty `after_endfor` — appends 
   correct ChatML generation prompt block when missing.
2. **`fix_chat_template`**: Changed final fallback from `RuntimeError` to 
   `logger.warning_once` so users can still load their adapter if auto-fix fails.