### PR TITLE
Fix Hermes chat template validation error

### DIFF
--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -604,7 +604,7 @@ def load_correct_tokenizer(
     # Ignore mistral type models since they don't have an add_generation_prompt
     if any(
         s in str(getattr(tokenizer, "name_or_path", "")).lower()
-        for s in ["mistral", "qwen3guard"]
+        for s in ["mistral", "qwen3guard", "hermes"]
     ):
         chat_template = old_chat_template
 


### PR DESCRIPTION
Replacement for #4183 due to Studio rebasing

Fixes #4150

## Summary
Hermes models use ChatML-style templates that don't require the `{% if add_generation_prompt %}` validation check. This PR adds `hermes` to the list of models that bypass this check, similar to how `mistral` and `qwen3guard` are already handled.

## Changes
- Added `hermes` to the model bypass list in `load_correct_tokenizer` function in `unsloth/tokenizer_utils.py`

## Root Cause
When loading a Hermes model (or a LoRA adapter trained with Hermes/ChatML template), the `fix_chat_template` function was raising a `RuntimeError` because:
1. The ChatML template doesn't have `{% if add_generation_prompt %}` in a format the auto-fixer expects
2. The auto-fixer `_fix_chat_template` couldn't patch it automatically
3. This caused the error: "does not have a {% if add_generation_prompt %} for generation purposes"

## Testing
The fix follows the existing pattern used for mistral and qwen3guard models, which have similar template structures that don't require this validation.

## Diff Stats
```
 unsloth/tokenizer_utils.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```