### PR TITLE
[Fix] Respect llm_int8_skip_modules for VLM

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2833,9 +2833,11 @@ def make_fast_generate_wrapper(original_generate):
 # Ref: https://github.com/unslothai/unsloth/issues/4208
 import transformers.quantizers.quantizers_utils as _quantizers_utils
 
-if hasattr(_quantizers_utils, "should_convert_module") and \
-    getattr(_quantizers_utils.should_convert_module, "__name__", "") != "patched_should_convert_module":
-
+if (
+    hasattr(_quantizers_utils, "should_convert_module")
+    and getattr(_quantizers_utils.should_convert_module, "__name__", "")
+    != "patched_should_convert_module"
+):
     _original_should_convert_module = _quantizers_utils.should_convert_module
 
     def _get_full_name_aliases(full_name):
@@ -2893,4 +2895,3 @@ if hasattr(_quantizers_utils, "should_convert_module") and \
         )
     except Exception:
         pass
-pass


### PR DESCRIPTION
Replacement for #4209 due to Studio rebasing

Some (vision) models like gemma3 seem to have issues with this when using dyanmic quants (llm_int8_skip_modules)

Ref: https://github.com/unslothai/unsloth/issues/4208 due to mismatch in model.language_model.model vs model.language_model

This has been addressed in https://github.com/unslothai/unsloth/pull/4018/changes/e5944ffe18b756c46dd389a4e00b7226bfac6c46
But for reasons unknown was reverted in the same PR :( 
Reintroduce the fix here
Without this, transformers/peft seems to wrap these in peft.Linear4bit but the underlying weight is 16bit lol