### PR TITLE
fix: install data-designer plugin non-editable for Colab compatibility

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -270,7 +270,6 @@ def install_python_stack() -> int:
         "Installing local data-designer unstructured plugin",
         "--no-cache-dir",
         "--no-deps",
-        "-e",
         str(LOCAL_DD_UNSTRUCTURED_PLUGIN),
         constrain = False,
     )


### PR DESCRIPTION
# fix: install data-designer plugin non-editable for Colab compatibility

## What

Remove the `-e` (editable) flag from the `data-designer-unstructured-seed` local plugin install in `install_python_stack.py`.

**Before:**
```python
pip_install(
    "Installing local data-designer unstructured plugin",
    "--no-cache-dir", "--no-deps",
    "-e", str(LOCAL_DD_UNSTRUCTURED_PLUGIN),
    constrain=False,
)
```

**After:**
```python
pip_install(
    "Installing local data-designer unstructured plugin",
    "--no-cache-dir", "--no-deps",
    str(LOCAL_DD_UNSTRUCTURED_PLUGIN),
    constrain=False,
)
```

## Why

Running the Colab notebook caused the server to crash on startup with:

```
ModuleNotFoundError: No module named 'data_designer_unstructured_seed'
```

Even though the setup log showed the plugin installed successfully:

```
Installing local data-designer unstructured plugin...
✅ Python dependencies installed
```

The root cause: editable installs (`-e`) work by dropping a `.pth` file into site-packages that points Python at the source directory. That `.pth` file is only processed at **Python startup**. In Colab, the kernel is already running when `setup.sh` installs the plugin, so the `.pth` file is never read and the package is invisible to the live kernel.

A regular (non-editable) install copies the package files directly into site-packages, which the already-running kernel can find immediately.

## Impact

- **Colab**: fixes the startup crash
- **Local (Linux/Windows)**: no change in behaviour — the venv is always wiped and recreated fresh before install, so Python starts clean and would have picked up the `.pth` file either way