### PR TITLE
Remove Blackwell flex attention disable workaround from studio

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -61,21 +61,6 @@ async def lifespan(app: FastAPI):
     # Detect hardware first — sets DEVICE global used everywhere
     detect_hardware()
 
-    # Disable flex attention on Blackwell+ GPUs (sm_120 and above)
-    if get_device() == DeviceType.CUDA:
-        import torch
-
-        props = torch.cuda.get_device_properties(0)
-        sm_version = props.major * 10 + props.minor
-        if sm_version >= 120:
-            os.environ["UNSLOTH_ENABLE_FLEX_ATTENTION"] = "0"
-            import structlog
-            from loggers import get_logger
-
-            get_logger(__name__).info(
-                f"GPU sm_{sm_version} detected — setting UNSLOTH_FLEX_ATTENTION=0"
-            )
-
     # Pre-cache the helper GGUF model for LLM-assisted dataset detection.
     # Runs in a background thread so it doesn't block server startup.
     import threading


### PR DESCRIPTION
## Summary

Removes the workaround in `studio/backend/main.py` that disabled flex attention on all Blackwell+ GPUs (sm_120 and above) by setting `UNSLOTH_ENABLE_FLEX_ATTENTION=0` at startup.

This workaround was added because the flex_attention backward kernel exceeded shared memory limits on Blackwell GPUs (~101KB per SM), causing `InductorError: No valid triton configs. OutOfMemoryError` during training with models that have large head_dims (e.g., 256 in Gemma3).

The root cause is now fixed in unsloth-zoo PR https://github.com/unslothai/unsloth-zoo/pull/542, which patches the backward kernel config selection to dynamically generate safe fallback configs that fit within the GPU's shared memory limit. With that fix merged, flex attention works correctly on Blackwell GPUs.

Keeping flex attention enabled provides a measured ~1.3x speedup over the SDPA fallback (716ms/step vs 920ms/step on RTX PRO 6000 Blackwell with Gemma3-4B).

**Depends on:** https://github.com/unslothai/unsloth-zoo/pull/542

## Files Changed

- `studio/backend/main.py` -- removed 15 lines (the sm_120 flex attention disable block)

## Test plan

- [x] Verified flex attention works on RTX PRO 6000 Blackwell with the unsloth-zoo fix
- [x] Verified no NaN/Inf grad norms across 61 training steps with flex attention on Blackwell
- [x] Verified 1.3x speedup vs SDPA (flex: 716ms/step, SDPA: 920ms/step)
- [x] Verified `get_device` and `DeviceType` imports are still used elsewhere in main.py (lines 156, 177)