### PR TITLE
Fix/colab plugin editable install

### DIFF
--- a/studio/Unsloth_Studio_Colab.ipynb
+++ b/studio/Unsloth_Studio_Colab.ipynb
@@ -42,7 +42,7 @@
    "id": "92d28e3c",
    "metadata": {},
    "source": [
-    "### Setup"
+    "### ⚠️ GPU Check - Run This First!"
    ]
   },
   {
@@ -52,9 +52,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ===========================================\n",
-    "# ⚠️  GPU Check - Run This First!\n",
-    "# ===========================================\n",
     "import torch\n",
     "\n",
     "print(\"🔍 Checking for GPU...\")\n",
@@ -73,16 +70,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "27da2957",
+   "metadata": {},
+   "source": [
+    "### Setup: Clone repo and run setup"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "27e68f91",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ===========================================\n",
-    "# Setup: Clone repo and run setup\n",
-    "# ===========================================\n",
-    "\n",
     "!git clone --depth 1 --branch main https://github.com/unslothai/unsloth.git\n",
     "%cd /content/unsloth\n",
     "\n",
@@ -96,7 +97,7 @@
    "id": "3e1771a9",
    "metadata": {},
    "source": [
-    "### Launch Studio"
+    "### Start Unsloth Studio"
    ]
   },
   {
@@ -106,9 +107,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ===========================================\n",
-    "# Start Unsloth Studio\n",
-    "# ===========================================\n",
     "import sys\n",
     "sys.path.insert(0, '/content/unsloth/studio/backend')\n",
     "\n",


### PR DESCRIPTION
# fix: Colab-compatible plugin install + Studio setup simplification

## Problem

Installing the `data-designer` plugin with `-e` (editable) mode fails in Google Colab because Colab's environment doesn't support editable installs of packages at arbitrary paths. This caused Unsloth Studio to break entirely when launched from the Colab notebook.

Additionally, the Colab notebook was pointing at a private internal repo (`new-ui-prototype`) with a required GitHub token, making it inaccessible to external users.

## Changes

- **Fix editable install for Colab** — install `data-designer` plugin non-editably so it works in both Colab and standard environments
- **Update Colab notebook** — clone from the public `unslothai/unsloth` repo instead of the private `new-ui-prototype` repo; remove the GitHub token auth cell; fix all paths to match the new repo structure (`studio/setup.sh`, `/content/unsloth/...`)
- **Simplify `unsloth studio setup`** — remove the `_dev_setup` / `_pip_setup` / `_build_llama_cpp` / `_get_repo_root` / `_find_install_script` split; the command now just locates and runs `setup.sh` / `setup.ps1` directly, regardless of install method
- **Security fixes** — prevent RCE via untrusted Hugging Face repo configs in AI-assist model config and seed dataset loads
- **ROCm wheels** — add `rocm702-torch280` and `rocm72-torch291` extras to `pyproject.toml`; restrict `rocm711-torch291` to Linux

## Testing

- [ ] Colab notebook runs end-to-end without a GitHub token
- [ ] `unsloth studio setup` works from a pip install
- [ ] `unsloth studio setup` works from an editable/git-clone install