### PR TITLE
fix(tokenizer): add add_generation_prompt to templates with whitespace after endfor

### DIFF
--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -662,7 +662,9 @@ def _fix_chat_template(chat_template):
     after_endfor_raw = chat_template[where + len(chosen_end) :]
     after_endfor = after_endfor_raw.strip()
     dash = "-" if chosen_end.startswith("{%-") else ""
-    prefix_ws = after_endfor_raw[: len(after_endfor_raw) - len(after_endfor_raw.lstrip())]
+    prefix_ws = after_endfor_raw[
+        : len(after_endfor_raw) - len(after_endfor_raw.lstrip())
+    ]
     suffix_ws = after_endfor_raw[len(after_endfor_raw.rstrip()) :]
 
     if (
@@ -673,14 +675,9 @@ def _fix_chat_template(chat_template):
         and after_endfor.count("{{") == 1
         and after_endfor.count("}}") == 1
     ):
-        wrapped = (
-            "{%" + dash + " if add_generation_prompt %}" + after_endfor + endif
-        )
+        wrapped = "{%" + dash + " if add_generation_prompt %}" + after_endfor + endif
         chat_template = (
-            chat_template[: where + len(chosen_end)]
-            + prefix_ws
-            + wrapped
-            + suffix_ws
+            chat_template[: where + len(chosen_end)] + prefix_ws + wrapped + suffix_ws
         )
     return chat_template
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -642,6 +642,12 @@ def _find_end_position(template, endfor, endif):
 
 
 def _fix_chat_template(chat_template):
+    """Add {% if add_generation_prompt %} to templates that have a single {{ ... }} after endfor/endif.
+
+    Handles ChatML-style and similar templates where the assistant prompt is a single
+    placeholder after the loop. Supports leading/trailing whitespace (e.g. newlines).
+    See: https://github.com/unslothai/unsloth/issues/4150
+    """
     endfor = "{% endfor %}"
     endif = "{% endif %}"
     chosen_end = _find_end_position(chat_template, endfor, endif)
@@ -653,10 +659,11 @@ def _fix_chat_template(chat_template):
         return chat_template
 
     where = chat_template.find(chosen_end)
-
-    after_endfor = chat_template[where + len(chosen_end) :]
-
+    after_endfor_raw = chat_template[where + len(chosen_end) :]
+    after_endfor = after_endfor_raw.strip()
     dash = "-" if chosen_end.startswith("{%-") else ""
+    prefix_ws = after_endfor_raw[: len(after_endfor_raw) - len(after_endfor_raw.lstrip())]
+    suffix_ws = after_endfor_raw[len(after_endfor_raw.rstrip()) :]
 
     if (
         "{%" + dash + " if" not in after_endfor
@@ -666,11 +673,15 @@ def _fix_chat_template(chat_template):
         and after_endfor.count("{{") == 1
         and after_endfor.count("}}") == 1
     ):
-        after_endfor = (
+        wrapped = (
             "{%" + dash + " if add_generation_prompt %}" + after_endfor + endif
         )
-
-        chat_template = chat_template[: where + len(chosen_end)] + after_endfor
+        chat_template = (
+            chat_template[: where + len(chosen_end)]
+            + prefix_ws
+            + wrapped
+            + suffix_ws
+        )
     return chat_template
 
 


### PR DESCRIPTION
Fixes #4150

  ## What

  In `_fix_chat_template`, the substring after `{% endfor %}` or `{% endif %}` is now normalized by stripping leading/trailing whitespace for the condition check. When we insert the `{% if add_generation_prompt %}...{% endif %}` wrapper, we preserve the original prefix and suffix whitespace so the patched template string keeps the same formatting.

  **Before:** We required `after_endfor.startswith("{{")`. Templates like `{% endfor %}\n{{ '<|im_start|>assistant\n' }}` failed the check and were not patched → `RuntimeError` when loading LoRA for chat.

  **After:** We use `after_endfor = after_endfor_raw.strip()` for the condition and reassemble as `chosen_end + prefix_ws + wrapped + suffix_ws`, so ChatML-style templates with newlines or spaces after the loop are correctly patched.

  ## Why

  When loading a LoRA adapter (e.g. Hermes fine-tuned with Llama Factory) from a local path, the saved tokenizer's chat template can have a single `{{ ... }}` block after `{% endfor %}` with leading/trailing whitespace. The previous logic only patched when the content immediately after the loop started with `{{`, so these templates were left without `add_generation_prompt` and `fix_chat_template` raised:

  RuntimeError: Unsloth: The tokenizer ... does not have a {% if add_generation_prompt %} for generation purposes.

  Stripping for the check and preserving whitespace when rebuilding the template fixes this without changing behaviour for templates that already have no surrounding whitespace.

  ## Impact

  - **Users loading Hermes (or similar ChatML) LoRA for chat/inference:** No more `RuntimeError` when the saved tokenizer template has newlines or spaces after
  `{% endfor %}`.
  - **Existing templates without surrounding whitespace:** Behaviour unchanged; the condition and the inserted block are the same as before.