### PR TITLE
fix(tokenizer): add add_generation_prompt (fixes #4150)

### DIFF
--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -655,19 +655,27 @@ def _fix_chat_template(chat_template):
     where = chat_template.find(chosen_end)
 
     after_endfor = chat_template[where + len(chosen_end) :]
+    after_stripped = after_endfor.strip()
 
     dash = "-" if chosen_end.startswith("{%-") else ""
 
     if (
-        "{%" + dash + " if" not in after_endfor
-        and "{%" + dash + " set " not in after_endfor
-        and after_endfor.startswith("{{")
-        and after_endfor.endswith("}}")
-        and after_endfor.count("{{") == 1
-        and after_endfor.count("}}") == 1
+        "{%" + dash + " if" not in after_stripped
+        and "{%" + dash + " set " not in after_stripped
+        and after_stripped.startswith("{{")
+        and after_stripped.endswith("}}")
+        and after_stripped.count("{{") == 1
+        and after_stripped.count("}}") == 1
     ):
+        prefix = after_endfor[: len(after_endfor) - len(after_endfor.lstrip())]
+        suffix = after_endfor[len(after_endfor.rstrip()) :]
+        inner = after_stripped
         after_endfor = (
-            "{%" + dash + " if add_generation_prompt %}" + after_endfor + endif
+            prefix
+            + "{%" + dash + " if add_generation_prompt %}"
+            + inner
+            + endif
+            + suffix
         )
 
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -672,7 +672,9 @@ def _fix_chat_template(chat_template):
         inner = after_stripped
         after_endfor = (
             prefix
-            + "{%" + dash + " if add_generation_prompt %}"
+            + "{%"
+            + dash
+            + " if add_generation_prompt %}"
             + inner
             + endif
             + suffix


### PR DESCRIPTION
# fix(tokenizer): add add_generation_prompt to templates with whitespace after endfor

Fixes #4150

## What

In `_fix_chat_template`, the substring after `{% endfor %}` or `{% endif %}` is now normalized by stripping leading/trailing whitespace for the condition check. When we insert the `{% if add_generation_prompt %}...{% endif %}` wrapper, we preserve the original prefix and suffix whitespace so the patched template string keeps the same formatting.

**Before:** We required `after_endfor.startswith("{{")`. Templates like `{% endfor %}\n{{ '<|im_start|>assistant\n' }}` failed the check and were not patched → `RuntimeError` when loading LoRA for chat.

**After:** We use `after_endfor = after_endfor_raw.strip()` for the condition and reassemble as `chosen_end + prefix_ws + wrapped + suffix_ws`, so ChatML-style templates with newlines or spaces after the loop are correctly patched.

## Why

When loading a LoRA adapter (e.g. Hermes fine-tuned with Llama Factory) from a local path, the saved tokenizer's chat template can have a single `{{ ... }}` block after `{% endfor %}` with leading/trailing whitespace. The previous logic only patched when the content immediately after the loop started with `{{`, so these templates were left without `add_generation_prompt` and `fix_chat_template` raised:

```
RuntimeError: Unsloth: The tokenizer `...` does not have a {% if add_generation_prompt %} for generation purposes.
```

Stripping for the check and preserving whitespace when rebuilding the template fixes this without changing behaviour for templates that already have no surrounding whitespace.

## Impact

- **Users loading Hermes (or similar ChatML) LoRA for chat/inference:** No more `RuntimeError` when the saved tokenizer template has newlines or spaces after `{% endfor %}`.
- **Existing templates without surrounding whitespace:** Behaviour unchanged; the condition and the inserted block are the same as before.
