### PR TITLE
Fix VLM GRPO matmul shape mismatch in _get_per_token_logps_and_entropies

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -908,7 +908,11 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
                                 )
                             else:
                                 # Model returned logits directly - scaling/softcapping already applied by model forward
-                                logprobs_chunk = chunked_selective_log_softmax(logits_chunk, completion_input_ids_chunk, temperature)
+                                logprobs_chunk = chunked_selective_log_softmax(
+                                    logits_chunk,
+                                    completion_input_ids_chunk,
+                                    temperature,
+                                )
                     # This is needed to avoid race conditions with GPT OSS offload_embbed=True
                     # However, it seems that this line does not slow down or disrupt models.
                     device_synchronize()


### PR DESCRIPTION
## Summary

- VLM models (e.g. Qwen2.5-VL) can return logits `[B*T, vocab_size]` instead of hidden states `[B*T, hidden_dim]` from their forward pass during GRPO training. When this happens, `chunked_hidden_states_selective_log_softmax` tries `logits @ lm_head.t()` which crashes with `RuntimeError: mat1 and mat2 shapes cannot be multiplied (72x152064 and 3584x152064)`.
- Add a shape guard in the VLM branch of `_get_per_token_logps_and_entropies`: check `output.shape[-1]` against `lm_head.shape[1]` (hidden_dim). When hidden states are returned, the existing `chunked_hidden_states_selective_log_softmax` path is taken. When logits are returned, scaling/softcapping/temperature are applied manually and `chunked_selective_log_softmax` (which takes logits directly) is used instead.
- Add `chunked_selective_log_softmax` to the import from `unsloth_zoo.rl_replacements`.
- The text-only branch (`pixel_values is None`) is unchanged.

Companion PR: unslothai/unsloth-zoo#546 (same fix for `grpo_accumulated_loss`).

## Test plan

- [x] Shape guard unit test: hidden_states vs logits routing both produce valid `[B, T]` log probabilities
- [x] VLM GRPO smoke test: Qwen2.5-VL-7B with `max_steps=3`, no matmul crash
- [x] Text-only GRPO regression: Llama-3.2-1B with `max_steps=10`, no regression