### PR TITLE
Skip flex_attention on pre-Ampere GPUs (T4, V100)

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -234,6 +234,17 @@ def prefer_flex_attn_if_supported(model_class, config):
             model_class, "_supports_flex_attn", False
         ):
             return None
+        # flex_attention Triton kernels require sm80+ (Ampere and above).
+        # On older GPUs (T4/sm75, V100/sm70) the dense Python fallback runs
+        # instead, but sdpa_dense_backward has a dtype mismatch under fp16
+        # autocast (Half @ Float matmul). Skip flex_attention there.
+        import torch
+        if torch.cuda.is_available():
+            major, _ = torch.cuda.get_device_capability()
+            if major < 8:
+                return None
+        else:
+            return None
         # GPT-OSS, Mllama and Gemma3N use eager/sdpa attention during
         # inference since flex attention returns incorrect results or errors out.
         # GPT-OSS: left padding issues cause incorrect outputs.

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -239,6 +239,7 @@ def prefer_flex_attn_if_supported(model_class, config):
         # instead, but sdpa_dense_backward has a dtype mismatch under fp16
         # autocast (Half @ Float matmul). Skip flex_attention there.
         import torch
+
         if torch.cuda.is_available():
             major, _ = torch.cuda.get_device_capability()
             if major < 8:


### PR DESCRIPTION
## Summary

- Skip `flex_attention` on GPUs with compute capability < 8.0 (pre-Ampere: T4/sm75, V100/sm70)
- On these GPUs the Triton flex_attention kernel cannot run, so PyTorch falls back to `sdpa_dense_backward` which has a dtype mismatch under fp16 autocast (`Half @ Float` matmul at line 904 of `flex_attention.py`)
- Falls back to `sdpa` instead, which works correctly on all GPU architectures

## Root cause

`prefer_flex_attn_if_supported()` only checks `torch >= 2.5.0` and the model's `_supports_flex_attn` flag, but not GPU compute capability. The flex_attention Triton kernels require sm80+.

## Reproduction

Ministral-3B on T4 with `transformers >= 5.0`:

```python
from unsloth import FastModel
model, tokenizer = FastModel.from_pretrained(
    model_name="unsloth/Ministral-3-3B-Instruct-2512-unsloth-bnb-4bit",
    max_seq_length=2048, load_in_4bit=True,
)
```

Crashes during backward with:
```
RuntimeError: expected scalar type Float but found Half
```
at `torch/_higher_order_ops/flex_attention.py:904` in `sdpa_dense_backward`.

## Test plan

- [x] Verified `prefer_flex_attn_if_supported` returns `None` on T4 (sm75)
- [x] Model loads with `sdpa` attention instead of `flex_attention`
- [x] Ministral-3B SFT training completes on T4 with transformers 5.2.0

Fixes #4295