### PR TITLE
studio: preserve save_steps when toggling to epochs mode

### DIFF
--- a/studio/frontend/src/features/training/hooks/use-max-steps-epochs-toggle.ts
+++ b/studio/frontend/src/features/training/hooks/use-max-steps-epochs-toggle.ts
@@ -97,7 +97,6 @@ export function useMaxStepsEpochsToggle({
 
     setMaxSteps(0);
     setEpochs(epochs || defaultEpochs);
-    setSaveSteps(0);
   }, [
     defaultEpochs,
     epochs,


### PR DESCRIPTION
Follow up to #4296
Removed `setSaveSteps(0)` from use-max-steps-epochs-toggle when enabling epochs mode.
Toggling stop criterion now only updates maxSteps/epochs.

Reason: Switching from max-steps to epochs should not silently disable checkpointing.
save_steps is still included in training payload, so zeroing it changes behavior unrelated to the user’s action.