### PR TITLE
Fix studio frontend build producing empty Tailwind CSS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,24 @@ version = {attr = "unsloth.models._utils.__version__"}
 include-package-data = true
 
 [tool.setuptools.package-data]
-studio = ["frontend/dist/**/*"]
+studio = [
+    "*.sh",
+    "*.ps1",
+    "*.bat",
+    "frontend/dist/**/*",
+    "frontend/public/**/*",
+    "frontend/src/**/*",
+    "frontend/*.json",
+    "frontend/*.ts",
+    "frontend/*.js",
+    "frontend/*.lock",
+    "frontend/*.html",
+    "frontend/*.yaml",
+    "frontend/.git*",
+    "backend/requirements/**/*",
+    "backend/core/data_recipe/oxc-validator/*.json",
+    "backend/core/data_recipe/oxc-validator/*.mjs",
+]
 
 [tool.setuptools.packages.find]
 exclude = ["images*", "tests*", "kernels/moe*"]

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -255,6 +255,22 @@ async def get_hardware_info():
 # ============ Serve Frontend (Optional) ============
 
 
+def _strip_crossorigin(html_bytes: bytes) -> bytes:
+    """Remove ``crossorigin`` attributes from script/link tags.
+
+    Vite adds ``crossorigin`` by default which forces CORS mode on font
+    subresource loads.  When Studio is served over plain HTTP, Firefox
+    HTTPS-Only Mode does not exempt CORS font requests -- causing all
+    @font-face downloads to fail silently.  Stripping the attribute
+    makes them regular same-origin fetches that work on any protocol.
+    """
+    import re as _re
+
+    html = html_bytes.decode("utf-8")
+    html = _re.sub(r'\s+crossorigin(?:="[^"]*")?', "", html)
+    return html.encode("utf-8")
+
+
 def _inject_bootstrap(html_bytes: bytes, app: FastAPI) -> bytes:
     """Inject bootstrap credentials into HTML when password change is required.
 
@@ -296,6 +312,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
     @app.get("/")
     async def serve_root():
         content = (build_path / "index.html").read_bytes()
+        content = _strip_crossorigin(content)
         content = _inject_bootstrap(content, app)
         return Response(
             content = content,
@@ -319,6 +336,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
 
         # Serve index.html as bytes — avoids Content-Length mismatch
         content = (build_path / "index.html").read_bytes()
+        content = _strip_crossorigin(content)
         content = _inject_bootstrap(content, app)
         return Response(
             content = content,

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -121,8 +121,33 @@ echo "✅ Node $(node -v) | npm $(npm -v)"
 echo ""
 echo "Building frontend..."
 cd "$SCRIPT_DIR/frontend"
+
+# Tailwind v4's oxide scanner respects .gitignore in parent directories.
+# Python venvs create a .gitignore with "*" (ignore everything), which
+# prevents Tailwind from scanning .tsx source files for class names.
+# Temporarily hide any such .gitignore during the build, then restore it.
+_HIDDEN_GITIGNORES=()
+_dir="$(pwd)"
+while [ "$_dir" != "/" ]; do
+    _dir="$(dirname "$_dir")"
+    if [ -f "$_dir/.gitignore" ] && grep -qx '\*' "$_dir/.gitignore" 2>/dev/null; then
+        mv "$_dir/.gitignore" "$_dir/.gitignore._twbuild"
+        _HIDDEN_GITIGNORES+=("$_dir/.gitignore")
+    fi
+done
+
+_restore_gitignores() {
+    for _gi in "${_HIDDEN_GITIGNORES[@]}"; do
+        mv "${_gi}._twbuild" "$_gi" 2>/dev/null || true
+    done
+}
+trap _restore_gitignores EXIT
+
 run_quiet "npm install" npm install
 run_quiet "npm run build" npm run build
+
+_restore_gitignores
+trap - EXIT
 cd "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator"
 run_quiet "npm install (oxc validator runtime)" npm install
 cd "$SCRIPT_DIR"


### PR DESCRIPTION
## Summary

- Fix `pip install` (non-editable) producing a broken studio frontend with no Tailwind CSS utility classes
- Fix Firefox HTTPS-Only Mode blocking all font downloads when studio is served over HTTP

## Problem

When installing via `pip install git+https://github.com/unslothai/unsloth.git` and running `unsloth studio setup`, the frontend renders with no styling -- images fill the entire page, layouts are broken, and fonts fail to load.

**Root cause 1 -- missing source files in pip package:**
`pyproject.toml` only had `package-data = ["frontend/dist/**/*"]`. The `include-package-data = true` setting relies on `git ls-files`, which fails in pip/uv isolated builds (source is copied to a temp dir without `.git`). Result: `frontend/src/`, `package.json`, `vite.config.ts`, etc. are all absent from the installed package.

**Root cause 2 -- venv `.gitignore` breaks Tailwind scanning:**
Python venvs auto-create a `.gitignore` containing just `*`. Tailwind v4's oxide scanner walks parent directories and respects `.gitignore`, so the venv's `*` pattern causes it to skip all `.tsx` source files. Result: 34KB CSS skeleton with zero utility classes instead of the expected 265KB.

**Root cause 3 -- `crossorigin` attribute blocks fonts on HTTP:**
Vite adds `crossorigin` to `<script>` and `<link>` tags by default. This forces CORS mode on font subresource loads. Firefox HTTPS-Only Mode does not exempt CORS font requests even when the page itself is exempted, causing all `@font-face` downloads to fail with `NS_ERROR_ABORT`.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Expand `package-data` to include frontend source files, config files, setup scripts, and backend requirements using glob patterns. Avoids `node_modules` by using targeted subdirectory globs instead of `frontend/**/*`. |
| `studio/setup.sh` | Before `npm run build`, walk parent directories and temporarily rename any `.gitignore` containing a bare `*`. Restore after build via explicit call + `trap EXIT` for error safety. |
| `studio/backend/main.py` | Add `_strip_crossorigin()` to remove the `crossorigin` attribute from the served HTML at runtime. Fonts then load as regular same-origin requests on any protocol. |

## Test plan

- [ ] `pip install git+https://github.com/unslothai/unsloth.git` (non-editable, fresh venv)
- [ ] `unsloth studio setup` completes, frontend CSS is 265KB+
- [ ] `unsloth studio` serves pages with correct styling
- [ ] Fonts load in Firefox with HTTPS-Only Mode enabled
- [ ] Editable install (`pip install -e .`) still works
- [ ] Wheel does not contain `node_modules`