### PR TITLE
Fix setup.sh crash on Mac with empty gitignore array

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -137,7 +137,7 @@ while [ "$_dir" != "/" ]; do
 done
 
 _restore_gitignores() {
-    for _gi in "${_HIDDEN_GITIGNORES[@]}"; do
+    for _gi in "${_HIDDEN_GITIGNORES[@]+"${_HIDDEN_GITIGNORES[@]}"}"; do
         mv "${_gi}._twbuild" "$_gi" 2>/dev/null || true
     done
 }


### PR DESCRIPTION
## Summary

Fix `unsloth studio setup` crashing on Mac (and any environment where the install directory is not inside a Python venv).

## Problem

The `.gitignore` workaround from #4311 uses a bash array `_HIDDEN_GITIGNORES`. When no parent `.gitignore` containing `*` is found, the array stays empty. The script has `set -euo pipefail` at the top, and `set -u` (nounset) treats `${empty_array[@]}` as an unbound variable, causing:

```
_HIDDEN_GITIGNORES[@]: unbound variable
```

This happens on Mac installs where the package lives in a regular venv (not one created by Python's `venv` module with the auto-generated `*` gitignore).

## Fix

Use `${arr[@]+"${arr[@]}"}` in the `_restore_gitignores` function. This is the standard bash idiom for safely expanding arrays under `set -u` -- it expands to nothing when the array is empty.

## Test plan

- [ ] `unsloth studio setup` on Mac (no parent `*` gitignore)
- [ ] `unsloth studio setup` in a Python venv on Linux (parent `*` gitignore exists)