### PR TITLE
fix: Ctrl+C not terminating backend on Linux

### DIFF
--- a/cli/commands/studio.py
+++ b/cli/commands/studio.py
@@ -147,7 +147,7 @@ def studio_default(
             # NOTE: Event.wait() without a timeout blocks at the C level
             # on Linux, preventing Python from delivering SIGINT (Ctrl+C).
             while not _shutdown_event.is_set():
-                _shutdown_event.wait(timeout=1)
+                _shutdown_event.wait(timeout = 1)
         else:
             while True:
                 time.sleep(1)

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -275,4 +275,4 @@ if __name__ == "__main__":
     # which prevents Python from delivering SIGINT (Ctrl+C).  Using a
     # short timeout in a loop lets the interpreter process pending signals.
     while not _shutdown_event.is_set():
-        _shutdown_event.wait(timeout=1)
+        _shutdown_event.wait(timeout = 1)


### PR DESCRIPTION
## Problem

Pressing Ctrl+C while the backend is running on Linux prints `^C` characters but never actually terminates the process. The user has to resort to `kill -9` to stop it.

## Root Cause

`threading.Event.wait()` **without a timeout** blocks at the C level on Linux, which prevents CPython from delivering the pending `SIGINT` to the registered signal handler. The main thread never returns to Python bytecode, so `KeyboardInterrupt` / the custom `_signal_handler` never fires.

This affects both entry points:
- `studio/backend/run.py` (`__main__` block)
- `cli/commands/studio.py` (CLI `unsloth studio` path)

## Fix

Replace bare `_shutdown_event.wait()` with a loop using a 1-second timeout:

```python
while not _shutdown_event.is_set():
    _shutdown_event.wait(timeout=1)
```

The short timeout lets the interpreter periodically return to Python bytecode, allowing signal handlers to run. No functional change otherwise — the loop exits identically when `_shutdown_event` is set by the signal handler.

## Platform Impact

| Platform | `run.py` | `studio.py` |
|----------|----------|-------------|
| **Linux** | ✅ Fixes Ctrl+C | ✅ Fixes Ctrl+C |
| **Windows** | ✅ No-op (was already interruptible) | ✅ N/A (Windows takes a different `subprocess.Popen` code path) |

## Files Changed
- `studio/backend/run.py`
- `cli/commands/studio.py`
