### PR TITLE
Apply use_reentrant removal to all TRL trainer configs

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1232,7 +1232,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
     # Unsloth gradient checkpointing requires use_reentrant=True, so we remove
     # the setting after super().__init__() when it gets auto-applied.
     RLConfig_post = ""
-    if trl_version >= Version("0.27.0") and RLConfig_name == "GRPOConfig":
+    if trl_version >= Version("0.27.0"):
         RLConfig_post = (
             "        # Unsloth: Remove use_reentrant=False forced by TRL 0.27.0+\n"
             "        if getattr(self, 'gradient_checkpointing_kwargs', None) is not None:\n"


### PR DESCRIPTION
## Summary

The existing fix in `rl.py` that removes `use_reentrant=False` from `gradient_checkpointing_kwargs` (added for TRL 0.27.0+) was gated behind `RLConfig_name == "GRPOConfig"`. This meant only GRPOConfig was protected from the VRAM regression, while SFTConfig, DPOConfig, KTOConfig, CPOConfig, ORPOConfig and all other trainer configs were still affected.

### Change

Remove the `GRPOConfig` guard so the `use_reentrant` removal applies to all compiled trainer configs when TRL >= 0.27.0.

```python
# Before:
if trl_version >= Version("0.27.0") and RLConfig_name == "GRPOConfig":
# After:
if trl_version >= Version("0.27.0"):
```

### Why this is safe

- The version guard `trl_version >= Version("0.27.0")` is preserved, so TRL < 0.27.0 is unaffected
- The removal code only deletes `use_reentrant` from `gradient_checkpointing_kwargs` if it exists, using `getattr` and `in` checks
- This is defense-in-depth alongside the primary fix in unsloth-zoo (https://github.com/unslothai/unsloth-zoo/pull/549) which forces `use_reentrant=True` in `unsloth_checkpoint()` itself

### Compatibility

- TRL 0.22.2 through 0.26.x: unaffected (version guard prevents execution)
- TRL 0.27.0+: now applies to all trainer configs, not just GRPO
- Transformers 4.57.x through 5.3+: compatible (the removal is a no-op if `use_reentrant` is not set)