### PR TITLE
Fix isinstance guard in _backwards_compatible_trainer (fixes #4155)

### DIFF
--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -302,11 +302,14 @@ def _backwards_compatible_trainer(trainer_class, config_class):
             # Reinitialising config class with parameters (that were none initially but populated on first init)
             # causes the 2nd init to fail as there are mutual exclusive checks on pairs of parameters.
             # Refer: https://github.com/huggingface/trl/blob/main/trl/trainer/grpo_config.py#L499-L502 for example
-            # So we only create config class if the previous init was not TrainingArguments
-            if not isinstance(training_args, TrainingArguments):
-                config = config_class(**config_dict)
-            else:
+            # So we only create config class if training_args is not already the correct type.
+            # We check against config_class (not TrainingArguments) because all TRL configs
+            # (DPOConfig, GRPOConfig, etc.) are subclasses of TrainingArguments, so isinstance
+            # against TrainingArguments is always True and never triggers conversion.
+            if isinstance(training_args, config_class):
                 config = training_args
+            else:
+                config = config_class(**config_dict)
 
             # Reconstruct kwargs for Trainer
             kwargs = trainer_kwargs


### PR DESCRIPTION
## Summary

- Fix the `isinstance` guard in `_backwards_compatible_trainer` that prevented plain `TrainingArguments` from being converted to the correct TRL config class (e.g. `DPOConfig`), causing `AttributeError` on trainer-specific attributes like `padding_value`
- The old guard checked `isinstance(training_args, TrainingArguments)`, which is always `True` for every TRL config class since they all inherit from `TrainingArguments` -- the conversion branch was dead code
- The new guard checks `isinstance(training_args, config_class)` instead, which correctly distinguishes "already the right config type" from "plain TrainingArguments that needs conversion"

## Problem

When a user passes `TrainingArguments` to `DPOTrainer` (instead of `DPOConfig`), the trainer crashes:

```
AttributeError: 'TrainingArguments' object has no attribute 'padding_value'
```

This happens because the compatibility wrapper at `trainer.py:306` checks:

```python
if not isinstance(training_args, TrainingArguments):
    config = config_class(**config_dict)   # never reached
else:
    config = training_args                 # always taken
```

Since `DPOConfig`, `GRPOConfig`, `SFTConfig`, and all other TRL config classes are subclasses of `TrainingArguments`, the `isinstance` check is `True` for everything. The conversion branch is effectively dead code.

## Fix

```python
if isinstance(training_args, config_class):
    config = training_args                 # already correct type, pass through
else:
    config = config_class(**config_dict)   # plain TA or wrong type, convert
```

This correctly handles all cases:

| Input | `isinstance(input, config_class)` | Action |
|---|---|---|
| Plain `TrainingArguments` | `False` | Convert to `DPOConfig` / `GRPOConfig` / etc. |
| `DPOConfig` to `DPOTrainer` | `True` | Pass through unchanged |
| `GRPOConfig` to `GRPOTrainer` | `True` | Pass through (avoids mutual-exclusivity re-init error) |
| Subclass of `DPOConfig` | `True` | Pass through unchanged |

The GRPO/RLOO mutual-exclusivity guard is preserved because configs that are already the correct type are never re-initialized.

## Tested

- `DPOTrainer` with plain `TrainingArguments` -- no longer crashes, trains successfully
- `DPOTrainer` with `DPOConfig` -- still works, no regression
- `SFTTrainer` with `SFTConfig` -- still works, no regression
- `GRPOConfig` re-initialization correctly prevented (mutual-exclusivity guard intact)
- All 15 TRL trainer/config pairs patched correctly
- Verified `GRPOConfig` and `RLOOConfig` are the only configs with mutual-exclusivity constraints; plain `TrainingArguments` conversion to either works fine since the conflicting fields are not present on `TrainingArguments`

Fixes #4155