### PR TITLE
studio: add spacing before beta badge

### DIFF
--- a/studio/frontend/src/components/navbar.tsx
+++ b/studio/frontend/src/components/navbar.tsx
@@ -77,7 +77,7 @@ export function Navbar() {
             alt="Unsloth"
             className="hidden h-9 w-auto dark:block"
           />
-          <span className="text-[10px] font-extrabold tracking-[0.12em] text-primary">
+          <span className="ml-1.5 text-[10px] font-extrabold tracking-[0.12em] text-primary">
             BETA
           </span>
         </Link>


### PR DESCRIPTION
Add horizontal spacing between the Studio logo wordmark and the `BETA` label in the navbar.

Before:
<img width="612" height="196" alt="image" src="https://github.com/user-attachments/assets/d01c7da8-4329-41fa-818d-589fa709a5e5" />

After:
<img width="450" height="105" alt="image" src="https://github.com/user-attachments/assets/b936a4e1-a89e-4a78-a280-419a68daf260" />
