### PR TITLE
studio: BETA text alignment and spacing adjustment

### DIFF
--- a/studio/frontend/src/components/navbar.tsx
+++ b/studio/frontend/src/components/navbar.tsx
@@ -77,7 +77,7 @@ export function Navbar() {
             alt="Unsloth"
             className="hidden h-9 w-auto dark:block"
           />
-          <span className="relative -top-[1px] ml-1.4 inline-flex items-center text-[10px] font-extrabold leading-none tracking-[0.12em] text-primary">
+          <span className="relative -top-[1px] inline-flex items-center text-[10px] font-extrabold leading-none tracking-[0.12em] text-primary">
             BETA
           </span>
         </Link>


### PR DESCRIPTION
Follow up to #4326

Adjusted `BETA` badge sizing/positioning for cleaner spacing and centered alignment.
<img width="657" height="138" alt="image" src="https://github.com/user-attachments/assets/434c3037-6944-4ba6-9438-7d84ca7a4147" />

<img width="1824" height="669" alt="image" src="https://github.com/user-attachments/assets/a2c9b50c-204f-49ef-8743-93f8e129b5ef" />
<img width="1819" height="618" alt="image" src="https://github.com/user-attachments/assets/6feb8ff9-b5c5-448d-bd93-be7a2e8e3525" />

