### PR TITLE
fix: add Qwen3.5 version gate in loader dispatch

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -442,6 +442,13 @@ class FastLanguageModel(FastLlamaModel):
         except Exception as error:
             autoconfig_error = str(error)
             if "architecture" in autoconfig_error:
+                if "qwen3_5" in autoconfig_error:
+                    raise ImportError(
+                        f"Unsloth: Your transformers version of {transformers_version} does not support Qwen3.5.\n"
+                        f"The minimum required version is 5.2.0.\n"
+                        f'Try `pip install --upgrade "transformers>=5.2.0"`\n'
+                        f"to obtain the latest transformers build, then restart this session."
+                    )
                 raise ValueError(
                     f"`{model_name}` is not supported yet in `transformers=={transformers_version}`.\n"
                     f"Please update transformers via `pip install --upgrade transformers` and try again."
@@ -558,17 +565,6 @@ class FastLanguageModel(FastLlamaModel):
 
         if not was_disabled:
             enable_progress_bars()
-
-        # Qwen3.5 only exists in transformers >= 5.2.0. Give a clear error on
-        # older versions; on 5.2+ let it fall through to the generic FastModel
-        # path where the compiler applies fused CE automatically.
-        if model_type == "qwen3_5" and transformers_version < Version("5.2.0"):
-            raise ImportError(
-                f"Unsloth: Your transformers version of {transformers_version} does not support Qwen3.5.\n"
-                f"The minimum required version is 5.2.0.\n"
-                f'Try `pip install --upgrade "transformers>=5.2.0"`\n'
-                f"to obtain the latest transformers build, then restart this session."
-            )
 
         if model_type == "llama":
             scaling_type = None
@@ -1062,6 +1058,13 @@ class FastModel(FastBaseModel):
         except Exception as error:
             autoconfig_error = str(error)
             if "architecture" in autoconfig_error:
+                if "qwen3_5" in autoconfig_error:
+                    raise ImportError(
+                        f"Unsloth: Your transformers version of {transformers_version} does not support Qwen3.5.\n"
+                        f"The minimum required version is 5.2.0.\n"
+                        f'Try `pip install --upgrade "transformers>=5.2.0"`\n'
+                        f"to obtain the latest transformers build, then restart this session."
+                    )
                 raise ValueError(
                     f"`{model_name}` is not supported yet in `transformers=={transformers_version}`.\n"
                     f"Please update transformers via `pip install --upgrade transformers` and try again."


### PR DESCRIPTION
## Summary

Fixes #4188. Adds a Qwen3.5-specific error message when users try to load Qwen3.5 models on unsupported transformers versions, and corrects the FORCE_FLOAT32 comment.

Qwen3.5 requires transformers >= 5.2.0. Previously, users on older versions got a generic "does not recognize this architecture" error with no guidance. This intercepts that error in the `AutoConfig` exception handler and provides a clear upgrade path.

No dedicated `FastQwen3_5Model` class is needed -- the unsloth compiler already applies fused CE automatically via `apply_fused_lm_head` for both `Qwen3_5ForCausalLM` and `Qwen3_5ForConditionalGeneration` through the generic `FastModel` fallback path.

## Changes

`unsloth/models/loader.py`:

- Add `qwen3_5` check in `AutoConfig.from_pretrained` error handler (both `FastLanguageModel` and `FastModel` paths) to show a specific error message pointing users to `transformers>=5.2.0`
- Update FORCE_FLOAT32 comment for `qwen3_5`: the `(1+w)` RMSNorm pattern does not overflow float16 (it computes in float32 internally), the real reason is GDN layers produce NaN grad norms during float16 training

## Test results

| Environment | Result |
|-------------|--------|
| transformers 4.57.6: load Qwen3.5 | Clear error: "minimum required version is 5.2.0" |
| transformers 5.3.0: Qwen3.5-0.8B 4bit training 200 steps | 1.55 GB peak, loss 1.50, no NaN |
| transformers 5.3.0: import unsloth | works |

Supersedes #4331. Companion PR: unslothai/unsloth-zoo#552 (Conv dtype fix in compiler).