### PR TITLE
Fix xformers Blackwell guard: broader coverage and root cause docs

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -973,6 +973,25 @@ except:
 try:
     from xformers import __version__ as xformers_version
 
+    # Xformers <= 0.0.32.post2 has a broken FA3 dispatch on Blackwell/RTX 50x GPUs.
+    # The FA3 check used `capability >= (9, 0)` which matches SM 10.0/11.0/12.0,
+    # causing sm_90a kernels to be attempted on non-Hopper GPUs (CUDA error in
+    # flash_fwd_launch_template.h:188). Fixed in 0.0.33 with `<= (9, 0)`.
+    # See https://github.com/facebookresearch/xformers/issues/1329
+    if DEVICE_TYPE == "cuda":
+        major_version, minor_version = torch.cuda.get_device_capability()
+        if (f"{major_version}.{minor_version}" in ("10.0", "11.0", "12.0")) and (
+            Version(xformers_version) <= Version("0.0.32.post2")
+        ):
+            raise NotImplementedError(
+                f"Unsloth: Xformers {xformers_version} has a broken FA3 dispatch on "
+                f"SM {major_version}.{minor_version} GPUs. Please upgrade to >= 0.0.33 or build from source via\n"
+                "```\n"
+                "pip install ninja\n"
+                "pip install -v --no-build-isolation -U git+https://github.com/facebookresearch/xformers.git@main#egg=xformers\n"
+                "```\n"
+            )
+
     # Temporarily disable 0.0.27 and higher - inference issues
     if False:  # Version(xformers_version) >= Version("0.0.27"):
         raise ImportError(


### PR DESCRIPTION
## Summary

Updates the xformers version guard for Blackwell/RTX 50x/Jetson GPUs (SM 10.0/11.0/12.0) with the correct root cause and broader version coverage.

**Root cause:** xformers <= 0.0.32.post2 had a broken FA3 dispatch check -- it used `capability >= (9, 0)` which matched Blackwell SM 12.0, causing sm_90a Hopper kernels to be attempted on non-Hopper GPUs. This produced the CUDA error in `flash_fwd_launch_template.h:188` reported in [facebookresearch/xformers#1329](https://github.com/facebookresearch/xformers/issues/1329). Fixed upstream in 0.0.33 where the check was changed to `(8, 0) <= capability <= (9, 0)`.

**Changes:**

- **Broaden version check** from `in (Version("0.0.32.post2"),)` to `<= Version("0.0.32.post2")` to cover all versions with the broken FA3 dispatch, not just one specific version.
- **Add `DEVICE_TYPE == "cuda"` guard** to avoid calling `torch.cuda.get_device_capability()` on non-CUDA devices (XPU, etc.).
- **Document the root cause** in comments -- the FA3 dispatch bug, the upstream fix, and the issue link.
- **Update error message** to include the installed version and recommend upgrading to >= 0.0.33 as the primary fix, with build-from-source as fallback. The `raise NotImplementedError` is caught by the existing `except Exception` handler, which prints the message when `UNSLOTH_ENABLE_LOGGING` is set and falls back to SDPA.

## Testing

Verified on NVIDIA RTX PRO 6000 Blackwell Server Edition (SM 12.0), PyTorch 2.9.1+cu128:

| xformers version | Guard result | Runtime | Numerical diff vs SDPA |
|---|---|---|---|
| 0.0.33.post2 (pre-built wheel) | passes (> 0.0.32.post2) | works (FA2 via PTX) | 0.0 |
| 0.0.34+41531ce (source build) | passes | works (FA2 native) | 0.0 |

The pre-built 0.0.33.post2 wheel works on Blackwell because:
1. The FA3 dispatch is capped at SM <= 9.0, so FA3 is never attempted
2. FA2 (`fa2F@2.5.7-pt`) is auto-dispatched and works via PTX forward compatibility from the wheel's `8.0+PTX` in `TORCH_CUDA_ARCH_LIST`