### PR TITLE
studio: show "Off" for repetition penalty = 1

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -331,6 +331,7 @@ export function ChatSettingsPanel({
                 max={2}
                 step={0.05}
                 onChange={set("repetitionPenalty")}
+                displayValue={params.repetitionPenalty === 1 ? "Off" : undefined}
               />
               {!isGguf && (
                 <ParamSlider


### PR DESCRIPTION
## Summary

- Display "Off" instead of "1" for the repetition penalty slider when the value is 1 (which means no penalty is applied).

## Test plan

- [ ] Open chat settings, confirm repetition penalty shows "Off" at the leftmost position
- [ ] Move slider to 1.05 or above, confirm it shows the numeric value