### PR TITLE
studio: update Creative/Precise presets, show "Off" for disabled samplers

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -44,9 +44,10 @@ const BUILTIN_PRESETS: Preset[] = [
     name: "Creative",
     params: {
       ...defaultInferenceParams,
-      temperature: 1.2,
-      topP: 0.95,
-      topK: 80,
+      temperature: 1.5,
+      topP: 1.0,
+      topK: 0,
+      minP: 0.1,
       repetitionPenalty: 1.0,
     },
   },
@@ -54,9 +55,10 @@ const BUILTIN_PRESETS: Preset[] = [
     name: "Precise",
     params: {
       ...defaultInferenceParams,
-      temperature: 0.2,
-      topP: 0.7,
-      topK: 20,
+      temperature: 0.1,
+      topP: 0.95,
+      topK: 80,
+      minP: 0.01,
       repetitionPenalty: 1.0,
     },
   },
@@ -307,14 +309,16 @@ export function ChatSettingsPanel({
                 max={1}
                 step={0.05}
                 onChange={set("topP")}
+                displayValue={params.topP === 1 ? "Off" : undefined}
               />
               <ParamSlider
                 label="Top K"
                 value={params.topK}
-                min={-1}
+                min={0}
                 max={100}
                 step={1}
                 onChange={set("topK")}
+                displayValue={params.topK === 0 ? "Off" : undefined}
               />
               <ParamSlider
                 label="Min P"


### PR DESCRIPTION
## Summary

- **Creative preset**: temperature=1.5, min_p=0.1, top_p=1.0 (disabled), top_k=0 (disabled). Uses min_p as the primary truncation sampler with high temperature for diverse output.
- **Precise preset**: temperature=0.1, top_p=0.95, top_k=80, min_p=0.01. Low temperature for deterministic output.
- **Show "Off" labels** for sampler values that disable them: top_p=1.0, top_k=0, repetition_penalty=1.0. Per llama.cpp docs these values mean the sampler has no effect.
- **Top K slider min** changed from -1 to 0 since 0 = disabled.

## Test plan

- [ ] Select Creative preset, confirm sliders show temperature=1.5, Top P=Off, Top K=Off, Min P=0.1
- [ ] Select Precise preset, confirm sliders show temperature=0.1, Top P=0.95, Top K=80, Min P=0.01
- [ ] Move Top P slider to 1.0, confirm label shows "Off"
- [ ] Move Top K slider to 0, confirm label shows "Off"