### PR TITLE
Fix: Remove unused `warmupToastShown` variable (TS6133)

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -484,12 +484,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         rejectFirstToken?.(err);
       }
 
-      let warmupToastShown = false;
       const warmupDelayMs = 450;
       const warmupTimer = setTimeout(() => {
         if (!waitingFirstChunk) return;
         if (abortSignal.aborted) return;
-        warmupToastShown = true;
         runtime.setGeneratingStatus("waiting");
       }, warmupDelayMs);
       runtime.setThreadRunning(threadKey, true);


### PR DESCRIPTION

## Summary

Removes the unused `warmupToastShown` variable in `chat-adapter.ts` that was causing the TypeScript compiler to fail with error **TS6133**, breaking Docker builds.

## Changes

- **`studio/frontend/src/features/chat/api/chat-adapter.ts`**: Removed the `warmupToastShown` declaration (line 487) and its assignment inside the `setTimeout` callback. The variable was set but never read — the meaningful side effect (`runtime.setGeneratingStatus("waiting")`) is preserved.

## Context

The Docker build (`unsloth studio setup`) runs `tsc -b && vite build`, which treats unused locals as errors. This two-line deletion unblocks the build with no behavioral change.
