### PR TITLE
Studio: SVG preview, fix streaming and model selector bugs

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1277,12 +1277,13 @@ class LlamaCppBackend:
         the next token.  Without this, iter_text() blocks until the next
         chunk arrives and cancellation can take many seconds on large models.
         """
+        text_iter = response.iter_text()
         while True:
             if cancel_event is not None and cancel_event.is_set():
                 response.close()
                 return
             try:
-                chunk = next(response.iter_text())
+                chunk = next(text_iter)
                 yield chunk
             except StopIteration:
                 return

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -64,6 +64,7 @@ function getCodeFilename(language: string | null) {
     ts: "ts",
     tsx: "tsx",
     typescript: "ts",
+    svg: "svg",
     yaml: "yml",
     yml: "yml",
   };
@@ -74,6 +75,33 @@ function getCodeFilename(language: string | null) {
     ? extByLanguage[normalized] || fallbackExt || "txt"
     : "txt";
   return `snippet.${ext}`;
+}
+
+function isSvgFence(codeFence: CodeFence): boolean {
+  const lang = codeFence.language?.toLowerCase() ?? "";
+  if (lang === "svg") return true;
+  if ((lang === "xml" || lang === "html") && codeFence.source.trimStart().startsWith("<svg")) return true;
+  return false;
+}
+
+const UNSAFE_SVG_RE = /<script[\s>]|on\w+\s*=|javascript:|<foreignObject[\s>]|<iframe[\s>]|<embed[\s>]|<object[\s>]/i;
+
+function sanitizeSvg(source: string): string | null {
+  if (UNSAFE_SVG_RE.test(source)) return null;
+  return source;
+}
+
+function SvgPreview({ source }: { source: string }) {
+  const dataUri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(source)}`;
+  return (
+    <div className="mt-2 flex justify-center rounded-lg border border-border bg-white p-4 dark:bg-neutral-100">
+      <img
+        src={dataUri}
+        alt="SVG preview"
+        style={{ maxWidth: "100%", maxHeight: 512 }}
+      />
+    </div>
+  );
 }
 
 function downloadTextFile(filename: string, text: string): void {
@@ -207,15 +235,19 @@ function StreamdownBlock(props: BlockProps) {
   }
 
   if (codeFence) {
+    const svgSource = !props.isIncomplete && isSvgFence(codeFence) ? sanitizeSvg(codeFence.source) : null;
     return (
-      <div className="relative isolate">
-        <Block {...props} />
-        <CodeBlockActions
-          disabled={props.isIncomplete}
-          language={codeFence.language}
-          source={codeFence.source}
-        />
-      </div>
+      <>
+        <div className="relative isolate">
+          <Block {...props} />
+          <CodeBlockActions
+            disabled={props.isIncomplete}
+            language={codeFence.language}
+            source={codeFence.source}
+          />
+        </div>
+        {svgSource && <SvgPreview source={svgSource} />}
+      </>
     );
   }
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -232,8 +232,8 @@ async function autoLoadSmallestModel(): Promise<boolean> {
               gguf_variant: variant.quant,
               trust_remote_code: false,
             });
+            useChatRuntimeStore.getState().setCheckpoint(repo.repo_id, variant.quant);
             const store = useChatRuntimeStore.getState();
-            store.setCheckpoint(repo.repo_id, variant.quant);
             store.setParams({ ...store.params, maxTokens: loadResp.context_length ?? 131072 });
             // Add model to store so the selector shows the name
             const autoModel: ChatModelSummary = {
@@ -282,8 +282,8 @@ async function autoLoadSmallestModel(): Promise<boolean> {
             gguf_variant: null,
             trust_remote_code: false,
           });
+          useChatRuntimeStore.getState().setCheckpoint(repo.repo_id);
           const store = useChatRuntimeStore.getState();
-          store.setCheckpoint(repo.repo_id);
           store.setParams({ ...store.params, maxTokens: 4096 });
           const sfModel: ChatModelSummary = {
             id: repo.repo_id,
@@ -319,8 +319,8 @@ async function autoLoadSmallestModel(): Promise<boolean> {
         gguf_variant: "UD-Q4_K_XL",
         trust_remote_code: false,
       });
+      useChatRuntimeStore.getState().setCheckpoint("unsloth/Qwen3.5-4B-GGUF", "UD-Q4_K_XL");
       const store = useChatRuntimeStore.getState();
-      store.setCheckpoint("unsloth/Qwen3.5-4B-GGUF", "UD-Q4_K_XL");
       store.setParams({ ...store.params, maxTokens: loadResp.context_length ?? 131072 });
       const defaultModel: ChatModelSummary = {
         id: "unsloth/Qwen3.5-4B-GGUF",

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -31,7 +31,7 @@ import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import type { MessageRecord, ModelType } from "./types";
 
 const DEFAULT_SUGGESTIONS = [
-  "Draw an ASCII art of a cute sloth",
+  "Draw an SVG of a cute sloth",
   "Solve the integral of x²·sin(x) step by step",
   "Write a Python function that finds the longest palindrome in a string",
   "Format a comparison of 3 databases as a markdown table with pros and cons",


### PR DESCRIPTION
## Summary

- **SVG preview in chat**: When the model generates SVG code, a rendered preview now appears below the code block using a safe `data:image/svg+xml` URI in an `<img>` tag. SVGs containing `<script>`, event handlers, `javascript:` URIs, `<foreignObject>`, `<iframe>`, `<embed>`, or `<object>` are not rendered. Preview only appears after generation completes.
- **Fix GGUF streaming crash**: `response.iter_text()` was being called on every loop iteration, creating a new iterator each time. The second call fails because httpx detects the stream was already consumed. Fixed by caching the iterator once.
- **Fix model selector showing "Select model..." after auto-load**: `autoLoadSmallestModel()` called `setCheckpoint()` then `setParams({ ...store.params, ... })` using a stale state snapshot, which overwrote the checkpoint back to empty. Fixed by re-reading state after `setCheckpoint` before calling `setParams`.
- **Fix TS6133 build error**: Remove unused `warmupToastShown` variable that broke `tsc -b` due to `noUnusedLocals: true`.
- **Update default suggestion**: "Draw an ASCII art of a cute sloth" to "Draw an SVG of a cute sloth".

## Test plan
- [ ] Click "Draw an SVG of a cute sloth" suggestion card
- [ ] Confirm model auto-loads and model selector shows the model name (not "Select model...")
- [ ] Confirm SVG code block streams, then preview image appears below it after generation completes
- [ ] Confirm Copy/Download buttons work on the SVG code block
- [ ] Confirm SVG with `<script>` or `onclick` does NOT render a preview
- [ ] Confirm non-SVG code blocks and mermaid diagrams are unaffected
- [ ] Confirm `tsc -b && vite build` passes cleanly
- [ ] Confirm Docker build (`unsloth studio setup`) succeeds