### PR TITLE
 fix(llm_assist): disable thinking mode for helper model JSON output

### DIFF
--- a/studio/backend/utils/datasets/llm_assist.py
+++ b/studio/backend/utils/datasets/llm_assist.py
@@ -143,7 +143,9 @@ def _run_with_helper(prompt: str, max_tokens: int = 256) -> Optional[str]:
             return None
 
         messages = [{"role": "user", "content": prompt}]
-        logger.info("Helper model request: enable_thinking=False (per-request override)")
+        logger.info(
+            "Helper model request: enable_thinking=False (per-request override)"
+        )
         cumulative = ""
         for text in backend.generate_chat_completion(
             messages = messages,


### PR DESCRIPTION
## Problem

The LLM helper model (`unsloth/Qwen3.5-4B-GGUF`) used for dataset analysis is a reasoning model. When loaded via `LlamaCppBackend.load_model()`, the server starts with `--chat-template-kwargs {"enable_thinking": true}` by default, causing all responses not align with expected output format.

This strips the structured JSON from the output the helper model needs to produce for dataset classification, column mapping, and system prompt generation. The existing `_strip_think_tags()` workaround is fragile — JSON can get split across think blocks, or the model may reason in natural language instead of producing structured output.

## Fix

- Pass `enable_thinking=False` to `generate_chat_completion()` in both `_run_with_helper()` and `_generate_with_backend()`, using the existing per-request override mechanism in `LlamaCppBackend`
- Add info-level log lines so the per-request override is visible alongside the server-level default

## Changes

- **`studio/backend/utils/datasets/llm_assist.py`**
  - `_run_with_helper()`: added `enable_thinking=False` + log line
  - `_generate_with_backend()`: added `enable_thinking=False` + log line

## Log Output

```
Reasoning model: enable_thinking=True by default                        ← server starts
Helper model request: enable_thinking=False (per-request override)      ← each request overrides
```

## Screenshots

<img width="1512" height="43" alt="Screenshot 2026-03-17 at 3 50 03 PM" src="https://github.com/user-attachments/assets/5dc996ff-74c2-4909-9089-40f44ea50041" />
<img width="1512" height="43" alt="Screenshot 2026-03-17 at 3 50 03 PM" src="https://github.com/user-attachments/assets/5dc996ff-74c2-4909-9089-40f44ea50041" />
<img width="928" height="752" alt="Screenshot 2026-03-17 at 3 51 37 PM" src="https://github.com/user-attachments/assets/5101e732-4e23-4e1f-b40a-8994dad5874d" />
<img width="928" height="752" alt="Screenshot 2026-03-17 at 3 51 37 PM" src="https://github.com/user-attachments/assets/5101e732-4e23-4e1f-b40a-8994dad5874d" />
