### PR TITLE
fix(models): Update Flash Attention detection for version 2.7+

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -876,6 +876,7 @@ if DEVICE_TYPE == "cuda":
                 # See https://github.com/unslothai/unsloth/issues/4270
                 try:
                     from flash_attn import flash_attn_func
+
                     _ = flash_attn_func  # Ensure import is valid
                 except:
                     # Fall back to legacy import check (for older flash-attn versions)
@@ -932,6 +933,7 @@ elif DEVICE_TYPE == "hip":
             # See https://github.com/unslothai/unsloth/issues/4270
             try:
                 from flash_attn import flash_attn_func
+
                 _ = flash_attn_func  # Ensure import is valid
             except:
                 # Fall back to legacy import check (for older flash-attn versions)


### PR DESCRIPTION
The Flash Attention availability check tried to import internal functions (flash_attn_gpu/flash_attn_cuda) from flash_attn.flash_attn_interface, which may not exist in flash-attn 2.7+.

Changed to first try importing the public API (flash_attn_func) from flash_attn, which is the actual function used by Unsloth throughout the codebase. Falls back to legacy imports for older flash-attn versions.

This fixes false negatives where flash-attn 2.7+ was incorrectly detected as broken, causing unnecessary fallback to XFormers and reduced GPU utilization.

Fixes #4270