### PR TITLE
fix(loader): add Qwen3.5 model type dispatch to fix LoRA saving

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3263,6 +3263,9 @@ class FastLlamaModel:
             apply_lora_mlp = apply_lora_mlp_swiglu
         elif model_type == "qwen3":
             apply_lora_mlp = apply_lora_mlp_swiglu
+        elif model_type == "qwen3_5":
+            # Qwen3.5 uses the same MLP architecture as Qwen3
+            apply_lora_mlp = apply_lora_mlp_swiglu
         elif model_type == "falcon_h1":
             apply_lora_mlp = apply_lora_mlp_swiglu
         elif model_type == "qwen3moe":

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -633,6 +633,17 @@ class FastLanguageModel(FastLlamaModel):
             dispatch_model = (
                 FastQwen3Model if model_type == "qwen3" else FastQwen3MoeModel
             )
+        elif model_type == "qwen3_5":
+            # Qwen3.5 shares the same architecture as Qwen3
+            # but requires transformers >= 5.2.0
+            if not SUPPORTS_QWEN3:
+                raise ImportError(
+                    f"Unsloth: Your transformers version of {transformers_version} does not support Qwen3.5.\n"
+                    f"The minimum required version is 5.2.0.\n"
+                    f'Try `pip install --upgrade "transformers>=5.2.0"`\n'
+                    f"to obtain the latest transformers build, then restart this session."
+                )
+            dispatch_model = FastQwen3Model
         # elif model_type == "falcon_h1":
         #     dispatch_model = FastFalconH1Model
         #     if not SUPPORTS_FALCON_H1:


### PR DESCRIPTION
## Problem

Qwen3.5 models (model_type='qwen3_5') were falling through to the generic FastModel path in the loader dispatch logic, causing 'Unsloth: Saving LoRA finetune failed since # of LoRAs = 128 does not match # of saved modules = 0' errors when saving LoRA adapters (reported in #4294).

## Root Cause

The `model_type == "qwen3_5"` case was not explicitly handled in:
1. `FastLanguageModel.from_pretrained()` dispatch logic in `loader.py`
2. `FastLlamaModel.patch_peft_model()` in `llama.py`

This caused Qwen3.5 models to use the generic `FastModel` path, which doesn't properly set up the model structure that `unsloth_zoo.saving_utils.merge_and_overwrite_lora` expects.

## Fix

- Added explicit dispatch for `qwen3_5` to `FastQwen3Model` in `loader.py` (Qwen3.5 shares the same architecture as Qwen3)
- Added `qwen3_5` handling in `patch_peft_model` for correct MLP patching with `apply_lora_mlp_swiglu`
- Note: `qwen3_5` was already in the `FORCE_FLOAT32` list for NaN grad norm prevention

## Testing

- Verified the dispatch logic correctly routes qwen3_5 models to FastQwen3Model
- Verified patch_peft_model correctly handles qwen3_5 with apply_lora_mlp_swiglu
- Verified qwen3_5 is in FORCE_FLOAT32 list

Fixes #4294
