### PR TITLE
studio(fix): use explicit Cancel for model load toast

### DIFF
--- a/studio/frontend/src/features/chat/components/model-load-status.tsx
+++ b/studio/frontend/src/features/chat/components/model-load-status.tsx
@@ -4,7 +4,6 @@
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
-import { XIcon } from "lucide-react";
 
 type ModelLoadDescriptionProps = {
   title?: string | null;
@@ -28,11 +27,11 @@ export function ModelLoadDescription({
   const hasProgress = typeof progressPercent === "number";
 
   return (
-    <div className="flex min-h-12 w-full items-stretch gap-2">
+    <div className="relative flex min-h-12 w-full items-stretch gap-2">
       <div className="flex h-full shrink-0 items-center self-center">
         <Spinner className="size-4 text-foreground" />
       </div>
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 pr-5">
         {title ? <p className="text-foreground leading-5 font-semibold">{title}</p> : null}
         {hasProgress ? (
           <div className="w-full pt-1">
@@ -49,13 +48,13 @@ export function ModelLoadDescription({
       {onStop ? (
         <Button
           type="button"
-          size="icon-sm"
+          size="xs"
           variant="ghost"
           aria-label="Stop model loading"
-          className="h-auto w-10 self-stretch shrink-0 rounded-xl text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:text-destructive"
+          className="h-auto self-stretch shrink-0 !rounded-none !border-0 bg-transparent px-1 text-[10px] text-muted-foreground hover:bg-transparent hover:text-destructive focus-visible:text-destructive"
           onClick={onStop}
         >
-          <XIcon className="size-3.5" />
+          Cancel
         </Button>
       ) : null}
     </div>


### PR DESCRIPTION
The “X” button in this toast was used to cancel the download. This created a UX issue, as users attempting to dismiss the toast could unintentionally cancel the model download.

Before:
<img width="631" height="144" alt="image" src="https://github.com/user-attachments/assets/48cd4579-cf48-4fb0-aed6-09c74a25b849" />

After:
<img width="600" height="174" alt="image" src="https://github.com/user-attachments/assets/2b55c9b5-7737-4fd4-9114-161796fd4405" />

Model load toast: replace the small X-style control with an explicit **Cancel** label (same behavior: stops loading).
Minor layout tweaks so text and the action don’t collide (`relative` wrapper, padding on the description column).

Clearer affordance than an icon-only control on a long-running operation toast.

