### PR TITLE
[Studio] Add --with-llama-cpp-dir option to setup command.

### DIFF
--- a/cli/commands/studio.py
+++ b/cli/commands/studio.py
@@ -181,7 +181,7 @@ def setup(
         if not resolved.is_dir():
             typer.echo(f"Error: --with-llama-cpp-dir path does not exist: {resolved}")
             raise typer.Exit(1)
-        env["UNSLOTH_LLAMA_CPP_DIR"] = str(resolved)
+        env["UNSLOTH_LLAMA_CPP_PATH"] = str(resolved)
 
     if platform.system() == "Windows":
         result = subprocess.run(

--- a/cli/commands/studio.py
+++ b/cli/commands/studio.py
@@ -162,19 +162,34 @@ def studio_default(
 
 
 @studio_app.command()
-def setup():
+def setup(
+    with_llama_cpp_dir: Optional[Path] = typer.Option(
+        None,
+        "--with-llama-cpp-dir",
+        help = "Path to a local llama.cpp directory to use instead of cloning from GitHub.",
+    ),
+):
     """Run one-time Studio environment setup."""
     script = _find_setup_script()
     if not script:
         typer.echo("Error: Could not find setup script (setup.sh / setup.ps1).")
         raise typer.Exit(1)
 
+    env = os.environ.copy()
+    if with_llama_cpp_dir is not None:
+        resolved = with_llama_cpp_dir.resolve()
+        if not resolved.is_dir():
+            typer.echo(f"Error: --with-llama-cpp-dir path does not exist: {resolved}")
+            raise typer.Exit(1)
+        env["UNSLOTH_LLAMA_CPP_DIR"] = str(resolved)
+
     if platform.system() == "Windows":
         result = subprocess.run(
             ["powershell", "-ExecutionPolicy", "Bypass", "-File", str(script)],
+            env = env,
         )
     else:
-        result = subprocess.run(["bash", str(script)])
+        result = subprocess.run(["bash", str(script)], env = env)
 
     if result.returncode != 0:
         raise typer.Exit(result.returncode)

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1022,7 +1022,11 @@ if (Test-Path $LlamaServerBin) {
     # -- Step A: Clone or pull llama.cpp (or use a local directory) --
 
     $LocalLlamaCppPath = [Environment]::GetEnvironmentVariable('UNSLOTH_LLAMA_CPP_PATH', 'Process')
-    if ($LocalLlamaCppPath -and (Test-Path $LocalLlamaCppPath -PathType Container)) {
+    if ($LocalLlamaCppPath -and -not (Test-Path $LocalLlamaCppPath -PathType Container)) {
+        Write-Host "   [WARN] UNSLOTH_LLAMA_CPP_PATH='$LocalLlamaCppPath' does not exist; falling back to cloning" -ForegroundColor Yellow
+        $LocalLlamaCppPath = $null
+    }
+    if ($LocalLlamaCppPath) {
         # Use the user-supplied directory; create a junction so downstream code
         # finds everything at the canonical $LlamaCppDir path.
         $resolvedLocal = (Resolve-Path $LocalLlamaCppPath).Path

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1019,21 +1019,41 @@ if (Test-Path $LlamaServerBin) {
     [Environment]::SetEnvironmentVariable('CUDA_PATH', $CudaToolkitRoot, 'Process')
     [Environment]::SetEnvironmentVariable('CudaToolkitDir', "$CudaToolkitRoot\", 'Process')
 
-    # -- Step A: Clone or pull llama.cpp --
+    # -- Step A: Clone or pull llama.cpp (or use a local directory) --
 
-    if (Test-Path (Join-Path $LlamaCppDir ".git")) {
-        Write-Host "   llama.cpp repo already cloned, pulling latest..." -ForegroundColor Gray
-        git -C $LlamaCppDir pull 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "   [WARN] git pull failed -- using existing source" -ForegroundColor Yellow
+    $LocalLlamaCppPath = [Environment]::GetEnvironmentVariable('UNSLOTH_LLAMA_CPP_PATH', 'Process')
+    if ($LocalLlamaCppPath -and (Test-Path $LocalLlamaCppPath -PathType Container)) {
+        # Use the user-supplied directory; create a junction so downstream code
+        # finds everything at the canonical $LlamaCppDir path.
+        $resolvedLocal = (Resolve-Path $LocalLlamaCppPath).Path
+        if ($resolvedLocal -eq $LlamaCppDir) {
+            Write-Host "   [WARN] --with-llama-cpp-dir points to the canonical build location; ignoring (will clone fresh)" -ForegroundColor Yellow
+            $LocalLlamaCppPath = $null
+        } else {
+            Write-Host "   Using local llama.cpp directory: $resolvedLocal" -ForegroundColor Gray
+            if (Test-Path $LlamaCppDir) { Remove-Item -Recurse -Force $LlamaCppDir }
+            cmd /c "mklink /J `"$LlamaCppDir`" `"$resolvedLocal`"" 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "   [WARN] Could not create junction; copying instead..." -ForegroundColor Yellow
+                Copy-Item -Recurse -Path $resolvedLocal -Destination $LlamaCppDir
+            }
         }
-    } else {
-        Write-Host "   Cloning llama.cpp..." -ForegroundColor Gray
-        if (Test-Path $LlamaCppDir) { Remove-Item -Recurse -Force $LlamaCppDir }
-        git clone --depth 1 https://github.com/ggml-org/llama.cpp.git $LlamaCppDir 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            $BuildOk = $false
-            $FailedStep = "git clone"
+    }
+    if (-not $LocalLlamaCppPath) {
+        if (Test-Path (Join-Path $LlamaCppDir ".git")) {
+            Write-Host "   llama.cpp repo already cloned, pulling latest..." -ForegroundColor Gray
+            git -C $LlamaCppDir pull 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "   [WARN] git pull failed -- using existing source" -ForegroundColor Yellow
+            }
+        } else {
+            Write-Host "   Cloning llama.cpp..." -ForegroundColor Gray
+            if (Test-Path $LlamaCppDir) { Remove-Item -Recurse -Force $LlamaCppDir }
+            git clone --depth 1 https://github.com/ggml-org/llama.cpp.git $LlamaCppDir 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                $BuildOk = $false
+                $FailedStep = "git clone"
+            }
         }
     }
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -279,14 +279,26 @@ UNSLOTH_HOME="$HOME/.unsloth"
 mkdir -p "$UNSLOTH_HOME"
 LLAMA_CPP_DIR="$UNSLOTH_HOME/llama.cpp"
 LLAMA_SERVER_BIN="$LLAMA_CPP_DIR/build/bin/llama-server"
-rm -rf "$LLAMA_CPP_DIR"
+# Allow using a custom local llama.cpp directory via UNSLOTH_LLAMA_CPP_DIR
+# (set by `unsloth studio setup --with-llama-cpp-dir /path/to/llama.cpp`)
+USE_LOCAL_LLAMA_CPP=false
+if [ -n "${UNSLOTH_LLAMA_CPP_DIR:-}" ] && [ -d "$UNSLOTH_LLAMA_CPP_DIR" ]; then
+    USE_LOCAL_LLAMA_CPP=true
+    # Symlink (or copy) the user-provided directory so the rest of the build
+    # and runtime code finds it at the canonical location.
+    rm -rf "$LLAMA_CPP_DIR"
+    ln -sfn "$UNSLOTH_LLAMA_CPP_DIR" "$LLAMA_CPP_DIR"
+    echo "   Using local llama.cpp directory: $UNSLOTH_LLAMA_CPP_DIR"
+else
+    rm -rf "$LLAMA_CPP_DIR"
+fi
 {
     # Check prerequisites
     if ! command -v cmake &>/dev/null; then
         echo ""
         echo "⚠️  cmake not found — skipping llama-server build (GGUF inference won't be available)"
         echo "   Install cmake and re-run setup.sh to enable GGUF inference."
-    elif ! command -v git &>/dev/null; then
+    elif ! command -v git &>/dev/null && [ "$USE_LOCAL_LLAMA_CPP" = false ]; then
         echo ""
         echo "⚠️  git not found — skipping llama-server build (GGUF inference won't be available)"
     else
@@ -294,7 +306,9 @@ rm -rf "$LLAMA_CPP_DIR"
         echo "Building llama-server for GGUF inference..."
 
         BUILD_OK=true
-        run_quiet "clone llama.cpp" git clone --depth 1 https://github.com/ggml-org/llama.cpp.git "$LLAMA_CPP_DIR" || BUILD_OK=false
+        if [ "$USE_LOCAL_LLAMA_CPP" = false ]; then
+            run_quiet "clone llama.cpp" git clone --depth 1 https://github.com/ggml-org/llama.cpp.git "$LLAMA_CPP_DIR" || BUILD_OK=false
+        fi
 
         if [ "$BUILD_OK" = true ]; then
             # Skip tests/examples we don't need (faster build)

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -279,18 +279,22 @@ UNSLOTH_HOME="$HOME/.unsloth"
 mkdir -p "$UNSLOTH_HOME"
 LLAMA_CPP_DIR="$UNSLOTH_HOME/llama.cpp"
 LLAMA_SERVER_BIN="$LLAMA_CPP_DIR/build/bin/llama-server"
-# Allow using a custom local llama.cpp directory via UNSLOTH_LLAMA_CPP_DIR
+# Allow using a custom local llama.cpp directory via UNSLOTH_LLAMA_CPP_PATH
 # (set by `unsloth studio setup --with-llama-cpp-dir /path/to/llama.cpp`)
 USE_LOCAL_LLAMA_CPP=false
-if [ -n "${UNSLOTH_LLAMA_CPP_DIR:-}" ] && [ -d "$UNSLOTH_LLAMA_CPP_DIR" ]; then
-    USE_LOCAL_LLAMA_CPP=true
-    # Symlink (or copy) the user-provided directory so the rest of the build
-    # and runtime code finds it at the canonical location.
-    rm -rf "$LLAMA_CPP_DIR"
-    ln -sfn "$UNSLOTH_LLAMA_CPP_DIR" "$LLAMA_CPP_DIR"
-    echo "   Using local llama.cpp directory: $UNSLOTH_LLAMA_CPP_DIR"
-else
-    rm -rf "$LLAMA_CPP_DIR"
+rm -rf "$LLAMA_CPP_DIR"
+if [ -n "${UNSLOTH_LLAMA_CPP_PATH:-}" ] && [ -d "$UNSLOTH_LLAMA_CPP_PATH" ]; then
+    # Resolve to an absolute path so the symlink target is stable
+    _LOCAL_PATH="$(cd "$UNSLOTH_LLAMA_CPP_PATH" && pwd)"
+    if [ "$_LOCAL_PATH" = "$LLAMA_CPP_DIR" ]; then
+        echo "⚠️  --with-llama-cpp-dir points to the canonical build location; ignoring (will clone fresh)"
+    else
+        USE_LOCAL_LLAMA_CPP=true
+        # Symlink the user-provided directory so the rest of the build
+        # and runtime code finds it at the canonical location.
+        ln -sfn "$_LOCAL_PATH" "$LLAMA_CPP_DIR"
+        echo "   Using local llama.cpp directory: $_LOCAL_PATH"
+    fi
 fi
 {
     # Check prerequisites


### PR DESCRIPTION
This patch implements the --with-llama-cpp-dir mentioned in #4379. 

Tested and can confirm that training works fine.  Open to alternatives if you guys think this is not the right approach.

<img width="1497" height="1072" alt="image" src="https://github.com/user-attachments/assets/383a79e1-4fa6-4750-a9f5-b13ae29ace7c" />

And inference

<img width="1497" height="1072" alt="image" src="https://github.com/user-attachments/assets/7cab9b5c-cfd8-4798-9b3d-fde897fa9159" />

