### PR TITLE
Relax frontend unused local check

### DIFF
--- a/studio/frontend/tsconfig.app.json
+++ b/studio/frontend/tsconfig.app.json
@@ -18,7 +18,7 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Relax frontend TypeScript unused local checks to prevent `tsc` build failures on unused bindings. Unused vars can still be caught by the existing ESLint setup.