### PR TITLE
Causes all models used in other tooling to be re-downloaded because it wrongly forces it to lowercase

### DIFF
--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1519,11 +1519,9 @@ class ModelConfig:
             identifier = f"unsloth/{identifier}"
             path = identifier
 
-        # Enforce lowercase for remote Hugging Face identifiers to prevent cache duplication
-        # Hugging Face Hub APIs are case-insensitive remotely, but case-sensitive locally (repo_folder_name).
-        if not is_local:
-            identifier = identifier.lower()
-            path = path.lower()
+        # Preserve the user/canonical repo casing for downstream HF calls.
+        # Cache lookups normalize separately so we do not rewrite the repo ID
+        # into a different local cache key than the one already downloaded.
 
         # Auto-detect GGUF models (check before LoRA/vision detection)
         if is_local:

--- a/studio/backend/utils/paths/path_utils.py
+++ b/studio/backend/utils/paths/path_utils.py
@@ -67,12 +67,28 @@ def is_local_path(path: str) -> bool:
 
 
 def get_cache_path(model_name: str) -> Optional[Path]:
-    """Get HuggingFace cache path for a model if it exists."""
+    """Get HuggingFace cache path for a model if it exists.
+
+    Hugging Face repo IDs are case-insensitive remotely, but cache folders keep
+    the case that was used at download time. Resolve the cache dir
+    case-insensitively so callers can preserve the canonical repo ID.
+    """
     cache_dir = Path.home() / ".cache" / "huggingface" / "hub"
     model_cache_name = model_name.replace("/", "--")
     model_cache_path = cache_dir / f"models--{model_cache_name}"
 
-    return model_cache_path if model_cache_path.exists() else None
+    if model_cache_path.exists():
+        return model_cache_path
+
+    target_name = model_cache_path.name.lower()
+    try:
+        for entry in cache_dir.iterdir():
+            if entry.name.lower() == target_name:
+                return entry
+    except OSError:
+        return None
+
+    return None
 
 
 def is_model_cached(model_name: str) -> bool:

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -363,7 +363,7 @@ export function SharedComposer({
         // Side 1: load → generate → wait
         if (handle1 && model1?.id) {
           toast("Loading Model 1…", { id: toastId, description: name1, duration: Infinity });
-          const status = await ensureModelLoaded(model1);
+          await ensureModelLoaded(model1);
           toast("Generating with Model 1…", { id: toastId, description: name1, duration: Infinity });
           const done = handle1.waitForRunEnd();
           handle1.startRun();

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -363,8 +363,8 @@ export function SharedComposer({
         // Side 1: load → generate → wait
         if (handle1 && model1?.id) {
           toast("Loading Model 1…", { id: toastId, description: name1, duration: Infinity });
-          await ensureModelLoaded(model1);
-          toast("Generating with Model 1…", { id: toastId, description: name1, duration: Infinity });
+          const status1 = await ensureModelLoaded(model1);
+          toast("Generating with Model 1…", { id: toastId, description: `${name1} (${status1})`, duration: Infinity });
           const done = handle1.waitForRunEnd();
           handle1.startRun();
           await done;
@@ -377,8 +377,8 @@ export function SharedComposer({
           if (needsLoad) {
             toast("Loading Model 2…", { id: toastId, description: name2, duration: Infinity });
           }
-          await ensureModelLoaded(model2);
-          toast("Generating with Model 2…", { id: toastId, description: name2, duration: Infinity });
+          const status2 = await ensureModelLoaded(model2);
+          toast("Generating with Model 2…", { id: toastId, description: `${name2} (${status2})`, duration: Infinity });
           const done = handle2.waitForRunEnd();
           handle2.startRun();
           await done;


### PR DESCRIPTION
This will break caching of models that have been downloaded with this framework only, but it will fix caching for everyone else who has a lot of models locally downloaded through Python or other tools using HF. 

Fixes https://github.com/unslothai/unsloth/issues/1798

There's more work to be done here but this fixes the immediate problem for everyone who already has a local model cache that works outside of unsloth. 