### PR TITLE
Fix torch CUDA symbol errors from LD_LIBRARY_PATH conflicts

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -26,8 +26,8 @@ def _fix_torch_cuda_ld_path():
     Fix: detect torch's lib dirs (without importing torch) and prepend them
     so they take priority.  Returns True if LD_LIBRARY_PATH was changed.
     """
-    if sys.platform == "win32":
-        return False  # Windows uses PATH, not LD_LIBRARY_PATH
+    if sys.platform != "linux":
+        return False
     ld_path = os.environ.get("LD_LIBRARY_PATH", "")
     if not ld_path:
         return False
@@ -67,12 +67,24 @@ def _fix_torch_cuda_ld_path():
         return False
 
 
-# Fix LD_LIBRARY_PATH before any torch/CUDA libs get loaded.
-# If we changed it, re-exec so the dynamic linker sees the new value.
 _LD_FIXED_SENTINEL = "_UNSLOTH_STUDIO_LD_FIXED"
-if _LD_FIXED_SENTINEL not in os.environ and _fix_torch_cuda_ld_path():
+
+
+def _maybe_reexec_for_cuda_ld_path():
+    """Re-exec once so the dynamic linker sees corrected LD_LIBRARY_PATH.
+
+    Must only be called from a true entry point (``if __name__ == "__main__"``
+    or an explicit startup function), never at module import time, because
+    os.execv replaces the entire process.
+    """
+    if _LD_FIXED_SENTINEL in os.environ:
+        return
+    if not _fix_torch_cuda_ld_path():
+        return
     os.environ[_LD_FIXED_SENTINEL] = "1"
-    os.execv(sys.executable, [sys.executable] + sys.argv)
+    argv = getattr(sys, "orig_argv", None) or [sys.executable] + sys.argv
+    os.execv(sys.executable, argv)
+
 
 from pathlib import Path
 
@@ -237,6 +249,8 @@ def run_server(
     """
     global _server, _shutdown_event
 
+    _maybe_reexec_for_cuda_ld_path()
+
     import nest_asyncio
 
     nest_asyncio.apply()
@@ -300,6 +314,8 @@ def run_server(
 
 # For direct execution (also invoked by CLI via os.execvp / subprocess)
 if __name__ == "__main__":
+    _maybe_reexec_for_cuda_ld_path()
+
     import argparse
     import signal
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -33,6 +33,7 @@ def _fix_torch_cuda_ld_path():
         return False
     try:
         import importlib.util
+
         spec = importlib.util.find_spec("torch")
         if not spec or not spec.origin:
             return False
@@ -54,7 +55,7 @@ def _fix_torch_cuda_ld_path():
 
         # Already at the front -- nothing to do
         existing = ld_path.split(":")
-        if existing[:len(lib_dirs)] == lib_dirs:
+        if existing[: len(lib_dirs)] == lib_dirs:
             return False
 
         # Prepend torch dirs, deduplicate

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -12,6 +12,67 @@ import sys
 # Suppress annoying C-level dependency warnings globally (e.g. SwigPyPacked)
 os.environ["PYTHONWARNINGS"] = "ignore"
 
+
+def _fix_torch_cuda_ld_path():
+    """Prepend torch's bundled CUDA libs to LD_LIBRARY_PATH.
+
+    PyTorch wheels ship their own CUDA runtime (libcudart, libcublas, etc.)
+    inside ``site-packages/nvidia/*/lib/``.  On Linux the dynamic linker
+    checks LD_LIBRARY_PATH **before** the RUNPATH baked into the .so files,
+    so a user's pre-existing LD_LIBRARY_PATH pointing at a different system
+    CUDA (e.g. /usr/local/cuda-13/lib64) will shadow torch's libs and cause
+    symbol-version errors at import time.
+
+    Fix: detect torch's lib dirs (without importing torch) and prepend them
+    so they take priority.  Returns True if LD_LIBRARY_PATH was changed.
+    """
+    if sys.platform == "win32":
+        return False  # Windows uses PATH, not LD_LIBRARY_PATH
+    ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+    if not ld_path:
+        return False
+    try:
+        import importlib.util
+        spec = importlib.util.find_spec("torch")
+        if not spec or not spec.origin:
+            return False
+        torch_dir = os.path.dirname(spec.origin)
+        site_pkgs = os.path.dirname(torch_dir)
+        nvidia_dir = os.path.join(site_pkgs, "nvidia")
+
+        lib_dirs = []
+        torch_lib = os.path.join(torch_dir, "lib")
+        if os.path.isdir(torch_lib):
+            lib_dirs.append(torch_lib)
+        if os.path.isdir(nvidia_dir):
+            for sub in sorted(os.listdir(nvidia_dir)):
+                lib = os.path.join(nvidia_dir, sub, "lib")
+                if os.path.isdir(lib):
+                    lib_dirs.append(lib)
+        if not lib_dirs:
+            return False
+
+        # Already at the front -- nothing to do
+        existing = ld_path.split(":")
+        if existing[:len(lib_dirs)] == lib_dirs:
+            return False
+
+        # Prepend torch dirs, deduplicate
+        torch_set = set(lib_dirs)
+        cleaned = [p for p in existing if p not in torch_set]
+        os.environ["LD_LIBRARY_PATH"] = ":".join(lib_dirs + cleaned)
+        return True
+    except Exception:
+        return False
+
+
+# Fix LD_LIBRARY_PATH before any torch/CUDA libs get loaded.
+# If we changed it, re-exec so the dynamic linker sees the new value.
+_LD_FIXED_SENTINEL = "_UNSLOTH_STUDIO_LD_FIXED"
+if _LD_FIXED_SENTINEL not in os.environ and _fix_torch_cuda_ld_path():
+    os.environ[_LD_FIXED_SENTINEL] = "1"
+    os.execv(sys.executable, [sys.executable] + sys.argv)
+
 from pathlib import Path
 
 # Add the backend directory to Python path

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -232,6 +232,7 @@ def run_server(
     port: int = 8000,
     frontend_path: Path = Path(__file__).resolve().parent.parent / "frontend" / "dist",
     silent: bool = False,
+    allow_reexec: bool = False,
 ):
     """
     Start the FastAPI server.
@@ -241,6 +242,11 @@ def run_server(
         port: Port to bind to (auto-increments if in use)
         frontend_path: Path to frontend build directory (optional)
         silent: Suppress startup messages
+        allow_reexec: Re-exec the process (os.execv) to apply the torch CUDA
+            LD_LIBRARY_PATH fix. Enable ONLY from true CLI/process entrypoints.
+            Embedders (e.g. Colab via colab.start) must leave this False,
+            otherwise the re-exec replaces the notebook kernel and drops
+            in-memory state.
 
     Note:
         Signal handlers are NOT registered here so that embedders
@@ -249,7 +255,13 @@ def run_server(
     """
     global _server, _shutdown_event
 
-    _maybe_reexec_for_cuda_ld_path()
+    # Only re-exec when invoked as a real CLI/process entrypoint. Embedders
+    # (e.g. Colab via colab.start -> run_server) keep allow_reexec=False,
+    # because os.execv would replace the live notebook kernel and drop
+    # in-memory state. CLI entrypoints (run.py __main__, unsloth_cli in-venv
+    # fallback) opt in explicitly.
+    if allow_reexec:
+        _maybe_reexec_for_cuda_ld_path()
 
     import nest_asyncio
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -138,6 +138,8 @@ def studio_default(
         port = port,
         frontend_path = frontend,
         silent = silent,
+        # CLI entrypoint: apply the torch CUDA LD_LIBRARY_PATH fix via re-exec.
+        allow_reexec = True,
     )
 
     from studio.backend.run import _shutdown_event

--- a/unsloth_cli/commands/ui.py
+++ b/unsloth_cli/commands/ui.py
@@ -85,6 +85,8 @@ def ui(
         port = port,
         frontend_path = frontend,
         silent = silent,
+        # CLI entrypoint: apply the torch CUDA LD_LIBRARY_PATH fix via re-exec.
+        allow_reexec = True,
     )
 
     from studio.backend.run import _shutdown_event


### PR DESCRIPTION
## Problem

Users who have `LD_LIBRARY_PATH` set with system CUDA lib paths (e.g. from conda, manual CUDA installs, or Docker base images) get torch symbol errors when launching Studio:

```
ImportError: /usr/local/cuda-13/lib64/libcudart.so.13: undefined symbol: ...
```

This happens because on Linux, the dynamic linker checks `LD_LIBRARY_PATH` **before** the `RUNPATH` embedded in torch's `.so` files. So system CUDA libs get loaded instead of the ones torch was built against (`site-packages/nvidia/*/lib/`).

The workaround today is for the user to manually `unset LD_LIBRARY_PATH` before launching Studio. Most users will not figure this out on their own.

## Fix

Add `_fix_torch_cuda_ld_path()` and `_maybe_reexec_for_cuda_ld_path()` to `run.py`:

1. **Linux-only** -- `LD_LIBRARY_PATH` is a Linux-specific linker mechanism
2. Locate torch's bundled CUDA lib dirs (`torch/lib/` and `nvidia/*/lib/`) using `importlib.util.find_spec` (does not import torch)
3. Prepend them to `LD_LIBRARY_PATH` so they take priority over system CUDA
4. Re-exec the process using `sys.orig_argv` (preserves `python -m`, `-c`, etc.) so the dynamic linker sees the updated path
5. A sentinel env var (`_UNSLOTH_STUDIO_LD_FIXED`) prevents infinite re-exec

The re-exec is called from `run_server()` and the `__main__` block -- **not** at module import time. Importing `run.py` (e.g. from the CLI or notebooks) is safe and will not replace the host process.

The user's original paths are preserved (just deprioritized), so non-torch tools that need system CUDA still work. If `LD_LIBRARY_PATH` is empty or torch is not installed, the fix is a no-op.

## Test plan

- [ ] Launch Studio with `LD_LIBRARY_PATH=/usr/local/cuda-13/lib64` set -- should work without symbol errors
- [ ] Launch Studio without `LD_LIBRARY_PATH` set -- should behave identically to before (no re-exec)
- [ ] `python -c "from studio.backend.run import run_server"` with `LD_LIBRARY_PATH` set -- should NOT trigger re-exec (import safety)
- [ ] `unsloth studio -H 0.0.0.0 -p 8888` with `LD_LIBRARY_PATH` set -- should work (CLI path)
- [ ] Launch on macOS/Windows -- should be a complete no-op
- [ ] Run a training job after launch to confirm CUDA works end-to-end