### PR TITLE
Use blobless clone in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsl
 
 You can also install directly from source:
 ```
-git clone https://github.com/unslothai/unsloth.git
+git clone --filter=blob:none https://github.com/unslothai/unsloth.git
 cd unsloth
 pip install -e .
 unsloth studio setup


### PR DESCRIPTION
## Summary

- Changes `git clone` to `git clone --filter=blob:none` in the README install instructions
- Reduces clone download from ~50MB to ~5MB by fetching blobs on demand instead of upfront
- The repo has ~45MB of deleted tokenizer files (`gemma_3_lora/`, `exports/`) still in git history that are no longer needed

## Test plan

- [x] Verified `git clone --filter=blob:none` produces a working checkout
- [x] `pip install -e .` and `unsloth studio setup` work as before