### PR TITLE
Cache frontend build across setup runs

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -749,11 +749,24 @@ Write-Host ""
 #  PHASE 2: Frontend build (skip if pip-installed -- already bundled)
 # ==========================================================================
 $DistDir = Join-Path $FrontendDir "dist"
+$SrcDir = Join-Path $FrontendDir "src"
+# Skip build if dist/ exists and no source file is newer than dist/
+$NeedFrontendBuild = $true
 if ($IsPipInstall) {
+    $NeedFrontendBuild = $false
     Write-Host "[OK] Running from pip install - frontend already bundled, skipping build" -ForegroundColor Green
 } elseif (Test-Path $DistDir) {
-    Write-Host "[OK] Frontend already built (frontend/dist exists). To rebuild, delete frontend/dist and re-run setup." -ForegroundColor Green
-} else {
+    $DistTime = (Get-Item $DistDir).LastWriteTime
+    $NewerSrc = Get-ChildItem -Path $SrcDir -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -gt $DistTime } | Select-Object -First 1
+    if (-not $NewerSrc) {
+        $NeedFrontendBuild = $false
+        Write-Host "[OK] Frontend already built and up to date -- skipping build" -ForegroundColor Green
+    } else {
+        Write-Host "[INFO] Frontend source changed since last build -- rebuilding..." -ForegroundColor Yellow
+    }
+}
+if ($NeedFrontendBuild -and -not $IsPipInstall) {
     Write-Host ""
     Write-Host "Building frontend..." -ForegroundColor Cyan
     # npm writes warnings to stderr; lower ErrorActionPreference so PS doesn't

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -749,17 +749,25 @@ Write-Host ""
 #  PHASE 2: Frontend build (skip if pip-installed -- already bundled)
 # ==========================================================================
 $DistDir = Join-Path $FrontendDir "dist"
-$SrcDir = Join-Path $FrontendDir "src"
-# Skip build if dist/ exists and no source file is newer than dist/
+# Skip build if dist/ exists and no tracked input is newer than dist/.
+# Checks src/, public/, package.json, config files -- not just src/.
 $NeedFrontendBuild = $true
 if ($IsPipInstall) {
     $NeedFrontendBuild = $false
     Write-Host "[OK] Running from pip install - frontend already bundled, skipping build" -ForegroundColor Green
 } elseif (Test-Path $DistDir) {
     $DistTime = (Get-Item $DistDir).LastWriteTime
-    $NewerSrc = Get-ChildItem -Path $SrcDir -Recurse -File -ErrorAction SilentlyContinue |
+    # Check src/ and public/ recursively
+    $NewerFile = Get-ChildItem -Path $FrontendDir -Include "src","public" -Directory -ErrorAction SilentlyContinue |
+        ForEach-Object { Get-ChildItem -Path $_.FullName -Recurse -File -ErrorAction SilentlyContinue } |
         Where-Object { $_.LastWriteTime -gt $DistTime } | Select-Object -First 1
-    if (-not $NewerSrc) {
+    # Also check top-level config files (package.json, vite.config.ts, etc.)
+    if (-not $NewerFile) {
+        $NewerFile = Get-ChildItem -Path $FrontendDir -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '\.(json|ts|js|mjs)$' -and $_.LastWriteTime -gt $DistTime } |
+            Select-Object -First 1
+    }
+    if (-not $NewerFile) {
         $NeedFrontendBuild = $false
         Write-Host "[OK] Frontend already built and up to date -- skipping build" -ForegroundColor Green
     } else {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -748,8 +748,11 @@ Write-Host ""
 # ==========================================================================
 #  PHASE 2: Frontend build (skip if pip-installed -- already bundled)
 # ==========================================================================
+$DistDir = Join-Path $FrontendDir "dist"
 if ($IsPipInstall) {
     Write-Host "[OK] Running from pip install - frontend already bundled, skipping build" -ForegroundColor Green
+} elseif (Test-Path $DistDir) {
+    Write-Host "[OK] Frontend already built (frontend/dist exists). To rebuild, delete frontend/dist and re-run setup." -ForegroundColor Green
 } else {
     Write-Host ""
     Write-Host "Building frontend..." -ForegroundColor Cyan
@@ -758,9 +761,6 @@ if ($IsPipInstall) {
     $prevEAP_npm = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     Push-Location $FrontendDir
-    # Remove stale node_modules and package-lock.json to avoid version conflicts
-    if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-    if (Test-Path "package-lock.json") { Remove-Item -Force "package-lock.json" }
     npm install 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) {
         Pop-Location

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -757,14 +757,20 @@ if ($IsPipInstall) {
     Write-Host "[OK] Running from pip install - frontend already bundled, skipping build" -ForegroundColor Green
 } elseif (Test-Path $DistDir) {
     $DistTime = (Get-Item $DistDir).LastWriteTime
-    # Check src/ and public/ recursively
-    $NewerFile = Get-ChildItem -Path $FrontendDir -Include "src","public" -Directory -ErrorAction SilentlyContinue |
-        ForEach-Object { Get-ChildItem -Path $_.FullName -Recurse -File -ErrorAction SilentlyContinue } |
-        Where-Object { $_.LastWriteTime -gt $DistTime } | Select-Object -First 1
-    # Also check top-level config files (package.json, vite.config.ts, etc.)
+    # Check src/ and public/ recursively using explicit paths
+    $TrackedDirs = @("src", "public") |
+        ForEach-Object { Join-Path $FrontendDir $_ } |
+        Where-Object { Test-Path $_ }
+    $NewerFile = $null
+    if ($TrackedDirs.Count -gt 0) {
+        $NewerFile = $TrackedDirs |
+            ForEach-Object { Get-ChildItem -Path $_ -Recurse -File -ErrorAction SilentlyContinue } |
+            Where-Object { $_.LastWriteTime -gt $DistTime } | Select-Object -First 1
+    }
+    # Also check top-level config and entry files (package.json, vite.config.ts, index.html, etc.)
     if (-not $NewerFile) {
         $NewerFile = Get-ChildItem -Path $FrontendDir -File -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -match '\.(json|ts|js|mjs)$' -and $_.LastWriteTime -gt $DistTime } |
+            Where-Object { $_.Name -match '\.(json|ts|js|mjs|html)$' -and $_.LastWriteTime -gt $DistTime } |
             Select-Object -First 1
     }
     if (-not $NewerFile) {

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -41,10 +41,19 @@ if [[ "$keynames" == *$'\nCOLAB_'* ]]; then
 fi
 
 # ── Detect whether frontend needs building ──
-# Skip frontend build if dist/ already exists (PyPI wheel, previous build, etc.)
-# To force a rebuild, delete frontend/dist and re-run setup.
+# Skip if dist/ exists AND no source file is newer than dist/.
+# This handles: PyPI installs (dist/ bundled), repeat runs (no changes),
+# and upgrades/pulls (source newer than dist/ triggers rebuild).
+_NEED_FRONTEND_BUILD=true
 if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
-    echo "✅ Frontend already built (frontend/dist exists) -- skipping Node/npm check."
+    # Check if any src/ file is newer than dist/
+    _newest_src=$(find "$SCRIPT_DIR/frontend/src" -type f -newer "$SCRIPT_DIR/frontend/dist" 2>/dev/null | head -1)
+    if [ -z "$_newest_src" ]; then
+        _NEED_FRONTEND_BUILD=false
+    fi
+fi
+if [ "$_NEED_FRONTEND_BUILD" = false ]; then
+    echo "✅ Frontend already built and up to date -- skipping Node/npm check."
 else
 NEED_NODE=true
 if command -v node &>/dev/null && command -v npm &>/dev/null; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -41,13 +41,10 @@ if [[ "$keynames" == *$'\nCOLAB_'* ]]; then
 fi
 
 # ── Detect whether frontend needs building ──
-# Only skip when BOTH conditions are true:
-#   1. We're inside site-packages (PyPI / pip install, not editable)
-#   2. dist/ already exists (pre-built in the wheel)
-# Otherwise always (re)build — handles upgrades, editable installs, and
-# pip-from-source where dist/ was never built.
-if [[ "$SCRIPT_DIR" == */site-packages/* ]] && [ -d "$SCRIPT_DIR/frontend/dist" ]; then
-    echo "✅ Frontend pre-built (PyPI) — skipping Node/npm check."
+# Skip frontend build if dist/ already exists (PyPI wheel, previous build, etc.)
+# To force a rebuild, delete frontend/dist and re-run setup.
+if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
+    echo "✅ Frontend already built (frontend/dist exists) -- skipping Node/npm check."
 else
 NEED_NODE=true
 if command -v node &>/dev/null && command -v npm &>/dev/null; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -41,14 +41,19 @@ if [[ "$keynames" == *$'\nCOLAB_'* ]]; then
 fi
 
 # ── Detect whether frontend needs building ──
-# Skip if dist/ exists AND no source file is newer than dist/.
+# Skip if dist/ exists AND no tracked input is newer than dist/.
+# Checks src/, public/, package.json, config files -- not just src/.
 # This handles: PyPI installs (dist/ bundled), repeat runs (no changes),
 # and upgrades/pulls (source newer than dist/ triggers rebuild).
 _NEED_FRONTEND_BUILD=true
 if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
-    # Check if any src/ file is newer than dist/
-    _newest_src=$(find "$SCRIPT_DIR/frontend/src" -type f -newer "$SCRIPT_DIR/frontend/dist" 2>/dev/null | head -1)
-    if [ -z "$_newest_src" ]; then
+    _changed=$(find "$SCRIPT_DIR/frontend" -maxdepth 1 -name "*.json" -o -name "*.ts" -o -name "*.js" -o -name "*.mjs" | \
+        xargs -r find -newer "$SCRIPT_DIR/frontend/dist" 2>/dev/null | head -1)
+    if [ -z "$_changed" ]; then
+        _changed=$(find "$SCRIPT_DIR/frontend/src" "$SCRIPT_DIR/frontend/public" \
+            -type f -newer "$SCRIPT_DIR/frontend/dist" 2>/dev/null | head -1)
+    fi
+    if [ -z "$_changed" ]; then
         _NEED_FRONTEND_BUILD=false
     fi
 fi
@@ -152,12 +157,17 @@ run_quiet "npm run build" npm run build
 
 _restore_gitignores
 trap - EXIT
-cd "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator"
-run_quiet "npm install (oxc validator runtime)" npm install
 cd "$SCRIPT_DIR"
 echo "✅ Frontend built to frontend/dist"
 
-fi  # end frontend dist check
+fi  # end frontend build check
+
+# ── oxc-validator runtime (always install, independent of frontend build) ──
+if [ -d "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator" ]; then
+    cd "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator"
+    run_quiet "npm install (oxc validator runtime)" npm install
+    cd "$SCRIPT_DIR"
+fi
 
 # ── 6. Python venv + deps ──
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -42,16 +42,19 @@ fi
 
 # ── Detect whether frontend needs building ──
 # Skip if dist/ exists AND no tracked input is newer than dist/.
-# Checks src/, public/, package.json, config files -- not just src/.
+# Checks top-level config/entry files and src/, public/ recursively.
 # This handles: PyPI installs (dist/ bundled), repeat runs (no changes),
 # and upgrades/pulls (source newer than dist/ triggers rebuild).
 _NEED_FRONTEND_BUILD=true
 if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
-    _changed=$(find "$SCRIPT_DIR/frontend" -maxdepth 1 -name "*.json" -o -name "*.ts" -o -name "*.js" -o -name "*.mjs" | \
-        xargs -r find -newer "$SCRIPT_DIR/frontend/dist" 2>/dev/null | head -1)
+    # Check top-level config and entry files (package.json, vite.config.ts, index.html, etc.)
+    _changed=$(find "$SCRIPT_DIR/frontend" -maxdepth 1 \
+        \( -name "*.json" -o -name "*.ts" -o -name "*.js" -o -name "*.mjs" -o -name "*.html" \) \
+        -newer "$SCRIPT_DIR/frontend/dist" -print -quit 2>/dev/null)
+    # Check src/ and public/ recursively
     if [ -z "$_changed" ]; then
         _changed=$(find "$SCRIPT_DIR/frontend/src" "$SCRIPT_DIR/frontend/public" \
-            -type f -newer "$SCRIPT_DIR/frontend/dist" 2>/dev/null | head -1)
+            -type f -newer "$SCRIPT_DIR/frontend/dist" -print -quit 2>/dev/null)
     fi
     if [ -z "$_changed" ]; then
         _NEED_FRONTEND_BUILD=false
@@ -163,7 +166,7 @@ echo "✅ Frontend built to frontend/dist"
 fi  # end frontend build check
 
 # ── oxc-validator runtime (always install, independent of frontend build) ──
-if [ -d "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator" ]; then
+if [ -d "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator" ] && command -v npm &>/dev/null; then
     cd "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator"
     run_quiet "npm install (oxc validator runtime)" npm install
     cd "$SCRIPT_DIR"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -51,10 +51,16 @@ if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
     _changed=$(find "$SCRIPT_DIR/frontend" -maxdepth 1 \
         \( -name "*.json" -o -name "*.ts" -o -name "*.js" -o -name "*.mjs" -o -name "*.html" \) \
         -newer "$SCRIPT_DIR/frontend/dist" -print -quit 2>/dev/null)
-    # Check src/ and public/ recursively
+    # Check src/ and public/ recursively (only dirs that exist; a slimmed
+    # layout that ships dist/ without src/ or public/ must not abort under set -e)
     if [ -z "$_changed" ]; then
-        _changed=$(find "$SCRIPT_DIR/frontend/src" "$SCRIPT_DIR/frontend/public" \
-            -type f -newer "$SCRIPT_DIR/frontend/dist" -print -quit 2>/dev/null)
+        _src_dirs=()
+        [ -d "$SCRIPT_DIR/frontend/src" ] && _src_dirs+=("$SCRIPT_DIR/frontend/src")
+        [ -d "$SCRIPT_DIR/frontend/public" ] && _src_dirs+=("$SCRIPT_DIR/frontend/public")
+        if [ "${#_src_dirs[@]}" -gt 0 ]; then
+            _changed=$(find "${_src_dirs[@]}" \
+                -type f -newer "$SCRIPT_DIR/frontend/dist" -print -quit 2>/dev/null)
+        fi
     fi
     if [ -z "$_changed" ]; then
         _NEED_FRONTEND_BUILD=false


### PR DESCRIPTION
## Summary

- Skip frontend `npm install` + `npm run build` if `frontend/dist/` already exists
- Previously `setup.ps1` deleted `node_modules` and `package-lock.json` on every run, forcing a full rebuild every time `unsloth studio setup` was called
- `setup.sh` also always rebuilt even when `dist/` was present from a previous run (it only skipped for non-editable pip installs inside `site-packages/`)
- To force a rebuild, users can delete `frontend/dist/` and re-run setup

## Changes

**`setup.ps1`:**
- Add `elseif (Test-Path $DistDir)` check to skip build when `dist/` exists
- Remove the `node_modules` and `package-lock.json` deletion on every run

**`setup.sh`:**
- Simplify the skip condition from `site-packages/* && dist/ exists` to just `dist/ exists`
- Works for all install paths: PyPI, editable, git clone with prior build

## Test plan

- [ ] First `unsloth studio setup` on a fresh git clone builds frontend as before
- [ ] Second `unsloth studio setup` skips the frontend build with a message
- [ ] Deleting `frontend/dist/` and re-running triggers a fresh build
- [ ] `pip install unsloth` (non-editable) still skips correctly