### PR TITLE
fix(studio): disable noUnusedLocals in tsconfig.node.json for Windows build

### DIFF
--- a/studio/frontend/tsconfig.node.json
+++ b/studio/frontend/tsconfig.node.json
@@ -16,7 +16,7 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
TypeScript build was failing on Windows because `tsconfig.node.json` had `noUnusedLocals: true` while `tsconfig.app.json` had it set to `false`. This inconsistency caused `npm run build` to fail with exit code 2 during the Studio setup on Windows.

Aligns the node config with the app config to ensure consistent behavior across platforms.

Fixes #4386