### PR TITLE
studio: enable training progress stream without JWT when auth disabled

### DIFF
--- a/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
@@ -16,6 +16,7 @@ const STATUS_POLL_INTERVAL_MS = 3000;
 const METRICS_POLL_INTERVAL_MS = 5000;
 const STREAM_RECONNECT_DELAY_MS = 1500;
 const AUTH_STATUS_RETRY_INTERVAL_MS = 3000;
+const AUTH_STATUS_TIMEOUT_MS = 3000;
 const INITIAL_HYDRATE_TIMEOUT_MS = 4000;
 
 function wait(ms: number): Promise<void> {
@@ -57,14 +58,19 @@ export function useTrainingRuntimeLifecycle(): void {
 
       authProbeInFlight = true;
       lastAuthProbeStartedAt = now;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => {
+        controller.abort();
+      }, AUTH_STATUS_TIMEOUT_MS);
       try {
-        const res = await fetch("/api/auth/status");
+        const res = await fetch("/api/auth/status", { signal: controller.signal });
         if (!res.ok) return;
         const data = (await res.json()) as { auth_disabled?: boolean };
         authDisabled = Boolean(data.auth_disabled);
       } catch {
         // Keep previous mode and retry later.
       } finally {
+        clearTimeout(timeout);
         authProbeInFlight = false;
       }
     };


### PR DESCRIPTION
Training lifecycle gated status polling, metrics polling, and the `/api/train/progress` SSE on `hasAuthToken()`.

Users have no JWT but the API already allows anonymous access, so the UI never subscribed to progress and looked stuck on pre-training while training ran on the server.

Fetch `/api/auth/status`, treat `auth_disabled` like “session OK” for train APIs, and start status/metrics intervals after that so we don’t race before the flag is set.
