### PR TITLE
fix: exclude nemotron_h from flex_attention

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -245,7 +245,9 @@ def prefer_flex_attn_if_supported(model_class, config):
         # NemotronH: hybrid Mamba-2 + Transformer model that does not
         # support flex_attention (raises NotImplementedError from transformers).
         model_type = getattr(config, "model_type", "") if config else ""
-        if model_type in ("gpt_oss", "mllama", "nemotron_h") or str(model_type).startswith("gemma3n"):
+        if model_type in ("gpt_oss", "mllama", "nemotron_h") or str(
+            model_type
+        ).startswith("gemma3n"):
             return None
         if config is not None:
             setattr(config, "_attn_implementation", "flex_attention")


### PR DESCRIPTION
## Summary

`NemotronHForCausalLM` (NVIDIA Nemotron-H models) does not support `flex_attention` and raises:

```
NemotronHForCausalLM does not support an attention implementation through torch's flex_attention.
Please request the support for this architecture: https://github.com/huggingface/transformers/issues/34809.
If you believe this error is a bug, please open an issue in Transformers GitHub repository and load
your model with the argument `attn_implementation="eager"` meanwhile.
```

## Change

Add `nemotron_h` to the exclusion list in `_utils.py` alongside the existing exclusions for `gpt_oss`, `mllama`, and `gemma3n`. Unsloth then falls back to the default attention implementation for these models.

## Test plan

- [ ] Load `unsloth/NVIDIA-Nemotron-3-Nano-4B` in Studio and verify training starts without the flex_attention error