### PR TITLE
BUG: fix _fix_chat_template for ChatML templates missing add_generation_prompt (#4150)

### DIFF
--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -672,9 +672,7 @@ def _fix_chat_template(chat_template):
 
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor
 
-    elif (
-        re.sub(r"\{#.*?#\}", "", after_endfor, flags=re.DOTALL).strip() == ""
-    ):
+    elif re.sub(r"\{#.*?#\}", "", after_endfor, flags = re.DOTALL).strip() == "":
         # GH#4150: ChatML-style templates (Hermes, Magnum, Phi-4, etc.) that
         # end with {% endfor %} (optionally followed by only whitespace
         # and/or Jinja comments) and have no add_generation_prompt block.
@@ -682,7 +680,7 @@ def _fix_chat_template(chat_template):
         # so that neither the guard nor the separator inference can be fooled
         # by ChatML tokens or `add_generation_prompt` mentions that appear
         # only inside a comment.
-        scrubbed = re.sub(r"\{#.*?#\}", "", chat_template, flags=re.DOTALL)
+        scrubbed = re.sub(r"\{#.*?#\}", "", chat_template, flags = re.DOTALL)
         if (
             "<|im_start|>" in scrubbed
             and "<|im_end|>" in scrubbed
@@ -743,9 +741,7 @@ def _fix_chat_template(chat_template):
             # after `endfor`. Jinja comments are also dropped for the same
             # reason: they have no runtime effect but their surrounding
             # whitespace would be preserved if we kept them.
-            chat_template = (
-                chat_template[: where + len(chosen_end)] + generation_block
-            )
+            chat_template = chat_template[: where + len(chosen_end)] + generation_block
 
     return chat_template
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -673,31 +673,20 @@ def _fix_chat_template(chat_template):
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor
 
     elif re.sub(r"\{#.*?#\}", "", after_endfor, flags = re.DOTALL).strip() == "":
-        # GH#4150: ChatML-style templates (Hermes, Magnum, Phi-4, etc.) that
-        # end with {% endfor %} (optionally followed by only whitespace
-        # and/or Jinja comments) and have no add_generation_prompt block.
-        # Strip Jinja `{# ... #}` comments before any regex / substring check
-        # so that neither the guard nor the separator inference can be fooled
-        # by ChatML tokens or `add_generation_prompt` mentions that appear
-        # only inside a comment.
+        # GH#4150: ChatML templates ending at {% endfor %} without an
+        # add_generation_prompt block. Scrub Jinja `{# ... #}` comments so
+        # tokens inside comments cannot fool the guard below.
         scrubbed = re.sub(r"\{#.*?#\}", "", chat_template, flags = re.DOTALL)
         if (
             "<|im_start|>" in scrubbed
             and "<|im_end|>" in scrubbed
             and "add_generation_prompt" not in scrubbed
         ):
-            # Infer the model-specific separator after "assistant" from the
-            # template itself. Strategy:
-            #   1. Prefer an explicit assistant literal
-            #      ('<|im_start|>assistant<sep>') if the template contains one.
-            #   2. Otherwise scan all role-concatenation separators
-            #      (message['role'] + '<sep>'). If they all agree, use that
-            #      single separator.
-            #   3. If multiple different role separators are present (e.g. a
-            #      Phi-4-mini style template that uses '\n' for system and
-            #      '<|im_sep|>' for user/assistant), prefer '<|im_sep|>' when
-            #      it appears in the template, otherwise fall back to the
-            #      ChatML newline default.
+            # Infer the assistant-turn separator. Prefer an explicit
+            # '<|im_start|>assistant<sep>' literal; else the unique
+            # `message['role'] + '<sep>'` from role concatenations; else
+            # '<|im_sep|>' if present (Phi-4-mini uses '\n' for system and
+            # '<|im_sep|>' for user/assistant); else '\n'.
             assistant_match = re.search(
                 r"""(['"])<\|im_start\|>assistant([^'"]*)\1""",
                 scrubbed,
@@ -709,38 +698,25 @@ def _fix_chat_template(chat_template):
                     scrubbed,
                 )
             ]
-            unique_role_seps = list(dict.fromkeys(role_seps))  # preserves order
+            unique_role_seps = list(dict.fromkeys(role_seps))
             if assistant_match is not None and assistant_match.group(2):
-                # Non-empty captured separator (e.g. '<|im_start|>assistant\n').
                 separator = assistant_match.group(2)
             elif len(unique_role_seps) == 1:
                 separator = unique_role_seps[0]
             elif "<|im_sep|>" in scrubbed:
                 separator = "<|im_sep|>"
             else:
-                # Fallback for both the no-match case and the degenerate
-                # `'<|im_start|>assistant'` bare-literal case, so the
-                # injected Jinja block always produces a usable ChatML
-                # generation prefix.
                 separator = "\\n"
-            # Use a double-quoted Jinja string literal so a single quote in
-            # the separator (should one ever appear) cannot break the
-            # generated block.
+            # Emit a double-quoted Jinja literal so a single quote in the
+            # separator cannot break the block. Drop trailing whitespace/
+            # comments after endfor: they would render as stray output
+            # after the generation prefix.
             assistant_prefix = "<|im_start|>assistant" + separator
             generation_block = (
                 "{%" + dash + " if add_generation_prompt %}"
                 '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
                 "{%" + dash + " endif %}"
             )
-            # `after_endfor` contains only whitespace and/or Jinja comments
-            # at this point (verified by the scrubbed emptiness check
-            # above). Whitespace would render as stray trailing output
-            # after the generation prefix when
-            # `apply_chat_template(add_generation_prompt=True)` is called,
-            # so drop it entirely and place the generation block directly
-            # after `endfor`. Jinja comments are also dropped for the same
-            # reason: they have no runtime effect but their surrounding
-            # whitespace would be preserved if we kept them.
             chat_template = chat_template[: where + len(chosen_end)] + generation_block
 
     return chat_template

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -672,9 +672,12 @@ def _fix_chat_template(chat_template):
 
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor
 
-    elif after_endfor.strip() == "":
+    elif (
+        re.sub(r"\{#.*?#\}", "", after_endfor, flags=re.DOTALL).strip() == ""
+    ):
         # GH#4150: ChatML-style templates (Hermes, Magnum, Phi-4, etc.) that
-        # end with {% endfor %} and have no add_generation_prompt block.
+        # end with {% endfor %} (optionally followed by only whitespace
+        # and/or Jinja comments) and have no add_generation_prompt block.
         # Strip Jinja `{# ... #}` comments before any regex / substring check
         # so that neither the guard nor the separator inference can be fooled
         # by ChatML tokens or `add_generation_prompt` mentions that appear
@@ -726,6 +729,11 @@ def _fix_chat_template(chat_template):
                 '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
                 "{%" + dash + " endif %}"
             )
+            # `after_endfor` contains only whitespace and/or Jinja comments
+            # at this point (verified above), so it carries no semantic
+            # content for rendering. Drop it and append the generation
+            # block directly after `endfor`, matching the behavior of the
+            # first repair branch.
             chat_template = (
                 chat_template[: where + len(chosen_end)] + generation_block
             )

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -672,19 +672,39 @@ def _fix_chat_template(chat_template):
 
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor
 
-    elif after_endfor.strip() == "" and "<|im_start|>" in chat_template:
-        # GH#4150: ChatML-style templates (Hermes, etc.) that end with
-        # {% endfor %} and have no add_generation_prompt block.
-        # Extract the model-specific separator after role (e.g. '\n' for
-        # Hermes, '<|im_sep|>' for Phi-4) to avoid hard-coding.
-        import re
-
-        sep_match = re.search(r"message\['role'\]\s*\+\s*'([^']*)'", chat_template)
-        separator = sep_match.group(1) if sep_match else "\\n"
+    elif (
+        after_endfor.strip() == ""
+        and "<|im_start|>" in chat_template
+        and "<|im_end|>" in chat_template
+        and "add_generation_prompt" not in chat_template
+    ):
+        # GH#4150: ChatML-style templates (Hermes, Magnum, Phi-4, etc.) that
+        # end with {% endfor %} and have no add_generation_prompt block.
+        # Infer the model-specific separator after "assistant" from the
+        # template itself. Prefer an explicit assistant literal
+        # (`'<|im_start|>assistant<sep>'`), then role-concatenation in either
+        # quote style and with either `message['role']` or `message.role`
+        # access, then fall back to the common ChatML newline separator.
+        assistant_match = re.search(
+            r"""(['"])<\|im_start\|>assistant([^'"]*)\1""",
+            chat_template,
+        )
+        role_match = re.search(
+            r"""message(?:\[['"]role['"]\]|\.role)\s*\+\s*(['"])([^'"]*)\1""",
+            chat_template,
+        )
+        if assistant_match is not None:
+            separator = assistant_match.group(2)
+        elif role_match is not None:
+            separator = role_match.group(2)
+        else:
+            separator = "\\n"
+        # Use a double-quoted Jinja string literal so a single quote in the
+        # separator (should one ever appear) cannot break the generated block.
         assistant_prefix = "<|im_start|>assistant" + separator
         generation_block = (
             "{%" + dash + " if add_generation_prompt %}"
-            "{{ '" + assistant_prefix + "' }}"
+            '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
             "{%" + dash + " endif %}"
         )
         chat_template = chat_template[: where + len(chosen_end)] + generation_block

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -712,13 +712,18 @@ def _fix_chat_template(chat_template):
                 )
             ]
             unique_role_seps = list(dict.fromkeys(role_seps))  # preserves order
-            if assistant_match is not None:
+            if assistant_match is not None and assistant_match.group(2):
+                # Non-empty captured separator (e.g. '<|im_start|>assistant\n').
                 separator = assistant_match.group(2)
             elif len(unique_role_seps) == 1:
                 separator = unique_role_seps[0]
             elif "<|im_sep|>" in scrubbed:
                 separator = "<|im_sep|>"
             else:
+                # Fallback for both the no-match case and the degenerate
+                # `'<|im_start|>assistant'` bare-literal case, so the
+                # injected Jinja block always produces a usable ChatML
+                # generation prefix.
                 separator = "\\n"
             # Use a double-quoted Jinja string literal so a single quote in
             # the separator (should one ever appear) cannot break the
@@ -730,10 +735,14 @@ def _fix_chat_template(chat_template):
                 "{%" + dash + " endif %}"
             )
             # `after_endfor` contains only whitespace and/or Jinja comments
-            # at this point (verified above), so it carries no semantic
-            # content for rendering. Drop it and append the generation
-            # block directly after `endfor`, matching the behavior of the
-            # first repair branch.
+            # at this point (verified by the scrubbed emptiness check
+            # above). Whitespace would render as stray trailing output
+            # after the generation prefix when
+            # `apply_chat_template(add_generation_prompt=True)` is called,
+            # so drop it entirely and place the generation block directly
+            # after `endfor`. Jinja comments are also dropped for the same
+            # reason: they have no runtime effect but their surrounding
+            # whitespace would be preserved if we kept them.
             chat_template = (
                 chat_template[: where + len(chosen_end)] + generation_block
             )

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -672,42 +672,63 @@ def _fix_chat_template(chat_template):
 
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor
 
-    elif (
-        after_endfor.strip() == ""
-        and "<|im_start|>" in chat_template
-        and "<|im_end|>" in chat_template
-        and "add_generation_prompt" not in chat_template
-    ):
+    elif after_endfor.strip() == "":
         # GH#4150: ChatML-style templates (Hermes, Magnum, Phi-4, etc.) that
         # end with {% endfor %} and have no add_generation_prompt block.
-        # Infer the model-specific separator after "assistant" from the
-        # template itself. Prefer an explicit assistant literal
-        # (`'<|im_start|>assistant<sep>'`), then role-concatenation in either
-        # quote style and with either `message['role']` or `message.role`
-        # access, then fall back to the common ChatML newline separator.
-        assistant_match = re.search(
-            r"""(['"])<\|im_start\|>assistant([^'"]*)\1""",
-            chat_template,
-        )
-        role_match = re.search(
-            r"""message(?:\[['"]role['"]\]|\.role)\s*\+\s*(['"])([^'"]*)\1""",
-            chat_template,
-        )
-        if assistant_match is not None:
-            separator = assistant_match.group(2)
-        elif role_match is not None:
-            separator = role_match.group(2)
-        else:
-            separator = "\\n"
-        # Use a double-quoted Jinja string literal so a single quote in the
-        # separator (should one ever appear) cannot break the generated block.
-        assistant_prefix = "<|im_start|>assistant" + separator
-        generation_block = (
-            "{%" + dash + " if add_generation_prompt %}"
-            '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
-            "{%" + dash + " endif %}"
-        )
-        chat_template = chat_template[: where + len(chosen_end)] + generation_block
+        # Strip Jinja `{# ... #}` comments before any regex / substring check
+        # so that neither the guard nor the separator inference can be fooled
+        # by ChatML tokens or `add_generation_prompt` mentions that appear
+        # only inside a comment.
+        scrubbed = re.sub(r"\{#.*?#\}", "", chat_template, flags=re.DOTALL)
+        if (
+            "<|im_start|>" in scrubbed
+            and "<|im_end|>" in scrubbed
+            and "add_generation_prompt" not in scrubbed
+        ):
+            # Infer the model-specific separator after "assistant" from the
+            # template itself. Strategy:
+            #   1. Prefer an explicit assistant literal
+            #      ('<|im_start|>assistant<sep>') if the template contains one.
+            #   2. Otherwise scan all role-concatenation separators
+            #      (message['role'] + '<sep>'). If they all agree, use that
+            #      single separator.
+            #   3. If multiple different role separators are present (e.g. a
+            #      Phi-4-mini style template that uses '\n' for system and
+            #      '<|im_sep|>' for user/assistant), prefer '<|im_sep|>' when
+            #      it appears in the template, otherwise fall back to the
+            #      ChatML newline default.
+            assistant_match = re.search(
+                r"""(['"])<\|im_start\|>assistant([^'"]*)\1""",
+                scrubbed,
+            )
+            role_seps = [
+                m.group(2)
+                for m in re.finditer(
+                    r"""message(?:\[['"]role['"]\]|\.role)\s*\+\s*(['"])([^'"]*)\1""",
+                    scrubbed,
+                )
+            ]
+            unique_role_seps = list(dict.fromkeys(role_seps))  # preserves order
+            if assistant_match is not None:
+                separator = assistant_match.group(2)
+            elif len(unique_role_seps) == 1:
+                separator = unique_role_seps[0]
+            elif "<|im_sep|>" in scrubbed:
+                separator = "<|im_sep|>"
+            else:
+                separator = "\\n"
+            # Use a double-quoted Jinja string literal so a single quote in
+            # the separator (should one ever appear) cannot break the
+            # generated block.
+            assistant_prefix = "<|im_start|>assistant" + separator
+            generation_block = (
+                "{%" + dash + " if add_generation_prompt %}"
+                '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
+                "{%" + dash + " endif %}"
+            )
+            chat_template = (
+                chat_template[: where + len(chosen_end)] + generation_block
+            )
 
     return chat_template
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -675,10 +675,17 @@ def _fix_chat_template(chat_template):
     elif after_endfor.strip() == "" and "<|im_start|>" in chat_template:
         # GH#4150: ChatML-style templates (Hermes, etc.) that end with
         # {% endfor %} and have no add_generation_prompt block.
-        # Append the standard ChatML generation prompt.
+        # Extract the model-specific separator after role (e.g. '\n' for
+        # Hermes, '<|im_sep|>' for Phi-4) to avoid hard-coding.
+        import re
+        sep_match = re.search(
+            r"message\['role'\]\s*\+\s*'([^']*)'", chat_template
+        )
+        separator = sep_match.group(1) if sep_match else "\\n"
+        assistant_prefix = "<|im_start|>assistant" + separator
         generation_block = (
             "{%" + dash + " if add_generation_prompt %}"
-            "{{ '<|im_start|>assistant\n' }}"
+            "{{ '" + assistant_prefix + "' }}"
             "{%" + dash + " endif %}"
         )
         chat_template = (

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -671,6 +671,20 @@ def _fix_chat_template(chat_template):
         )
 
         chat_template = chat_template[: where + len(chosen_end)] + after_endfor
+
+    elif after_endfor.strip() == "" and "<|im_start|>" in chat_template:
+        # GH#4150: ChatML-style templates (Hermes, etc.) that end with
+        # {% endfor %} and have no add_generation_prompt block.
+        # Append the standard ChatML generation prompt.
+        generation_block = (
+            "{%" + dash + " if add_generation_prompt %}"
+            "{{ '<|im_start|>assistant\n' }}"
+            "{%" + dash + " endif %}"
+        )
+        chat_template = (
+            chat_template[: where + len(chosen_end)] + generation_block
+        )
+
     return chat_template
 
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -678,9 +678,8 @@ def _fix_chat_template(chat_template):
         # Extract the model-specific separator after role (e.g. '\n' for
         # Hermes, '<|im_sep|>' for Phi-4) to avoid hard-coding.
         import re
-        sep_match = re.search(
-            r"message\['role'\]\s*\+\s*'([^']*)'", chat_template
-        )
+
+        sep_match = re.search(r"message\['role'\]\s*\+\s*'([^']*)'", chat_template)
         separator = sep_match.group(1) if sep_match else "\\n"
         assistant_prefix = "<|im_start|>assistant" + separator
         generation_block = (
@@ -688,9 +687,7 @@ def _fix_chat_template(chat_template):
             "{{ '" + assistant_prefix + "' }}"
             "{%" + dash + " endif %}"
         )
-        chat_template = (
-            chat_template[: where + len(chosen_end)] + generation_block
-        )
+        chat_template = chat_template[: where + len(chosen_end)] + generation_block
 
     return chat_template
 


### PR DESCRIPTION
Fixes #4150

## Problem

ChatML-style templates (Hermes-3, Magnum-v2, etc.) saved after LoRA training may end
with `{% endfor %}` and have no `{% if add_generation_prompt %}` block. This causes
`fix_chat_template()` to raise:

```
RuntimeError: Unsloth: The tokenizer `...` does not have a
{% if add_generation_prompt %} for generation purposes.
```

## Root Cause

`_fix_chat_template()` only patches templates where content (`{{ ... }}`) follows
`{% endfor %}`. When the template simply ends after `{% endfor %}` (empty suffix),
the function returns the template unchanged, and the caller raises RuntimeError.

## Fix

Add an `elif` branch in `_fix_chat_template()` that detects ChatML templates
(containing `<|im_start|>`) with an empty suffix after `endfor`, and appends
the standard ChatML generation prompt block:

```jinja2
{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}
```

This is a general fix (not model-name-based bypass) that handles any ChatML-style
template missing the generation prompt block.