### PR TITLE
revert: always rebuild frontend, override caching with _NEED_FRONTEND_BUILD=true

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -823,11 +823,39 @@ Write-Host ""
 # ==========================================================================
 #  PHASE 2: Frontend build (skip if pip-installed -- already bundled)
 # ==========================================================================
+$DistDir = Join-Path $FrontendDir "dist"
+# Skip build if dist/ exists and no tracked input is newer than dist/.
+# Checks src/, public/, package.json, config files -- not just src/.
 $NeedFrontendBuild = $true
 if ($IsPipInstall) {
     $NeedFrontendBuild = $false
     Write-Host "[OK] Running from pip install - frontend already bundled, skipping build" -ForegroundColor Green
+} elseif (Test-Path $DistDir) {
+    $DistTime = (Get-Item $DistDir).LastWriteTime
+    $NewerFile = $null
+    # Check src/ and public/ recursively (probe paths directly, not via -Include)
+    foreach ($subDir in @("src", "public")) {
+        $subPath = Join-Path $FrontendDir $subDir
+        if (Test-Path $subPath) {
+            $NewerFile = Get-ChildItem -Path $subPath -Recurse -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.LastWriteTime -gt $DistTime } | Select-Object -First 1
+            if ($NewerFile) { break }
+        }
+    }
+    # Also check all top-level files (package.json, bun.lock, vite.config.ts, index.html, etc.)
+    if (-not $NewerFile) {
+        $NewerFile = Get-ChildItem -Path $FrontendDir -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTime -gt $DistTime } |
+            Select-Object -First 1
+    }
+    if (-not $NewerFile) {
+        $NeedFrontendBuild = $false
+        Write-Host "[OK] Frontend already built and up to date -- skipping build" -ForegroundColor Green
+    } else {
+        Write-Host "[INFO] Frontend source changed since last build -- rebuilding..." -ForegroundColor Yellow
+    }
 }
+$NeedFrontendBuild = $true
 if ($NeedFrontendBuild -and -not $IsPipInstall) {
     Write-Host ""
     Write-Host "Building frontend..." -ForegroundColor Cyan

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -41,6 +41,24 @@ if [[ "$keynames" == *$'\nCOLAB_'* ]]; then
 fi
 
 # ── Detect whether frontend needs building ──
+# Skip if dist/ exists AND no tracked input is newer than dist/.
+# Checks top-level config/entry files and src/, public/ recursively.
+# This handles: PyPI installs (dist/ bundled), repeat runs (no changes),
+# and upgrades/pulls (source newer than dist/ triggers rebuild).
+_NEED_FRONTEND_BUILD=true
+if [ -d "$SCRIPT_DIR/frontend/dist" ]; then
+    # Check all top-level files (package.json, bun.lock, vite.config.ts, index.html, etc.)
+    _changed=$(find "$SCRIPT_DIR/frontend" -maxdepth 1 -type f \
+        -newer "$SCRIPT_DIR/frontend/dist" -print -quit 2>/dev/null)
+    # Check src/ and public/ recursively (|| true guards against set -e when dirs are missing)
+    if [ -z "$_changed" ]; then
+        _changed=$(find "$SCRIPT_DIR/frontend/src" "$SCRIPT_DIR/frontend/public" \
+            -type f -newer "$SCRIPT_DIR/frontend/dist" -print -quit 2>/dev/null) || true
+    fi
+    if [ -z "$_changed" ]; then
+        _NEED_FRONTEND_BUILD=false
+    fi
+fi
 _NEED_FRONTEND_BUILD=true
 if [ "$_NEED_FRONTEND_BUILD" = false ]; then
     echo "✅ Frontend already built and up to date -- skipping Node/npm check."


### PR DESCRIPTION
## Summary

Adds a single `_NEED_FRONTEND_BUILD=true` line after the mtime-based caching block in `setup.sh` and `setup.ps1`, overriding whatever the cache check decided.

The caching logic itself is left intact for future re-enabling -- just remove the override line.

## Why

Mtime-based caching is unreliable in the current setup:
- Git does not preserve file timestamps on clone/pull
- Tailwind v4 requires hiding `site-packages/.gitignore` before `vite build`; the cache path can bypass this, producing broken CSS