### PR TITLE
Fix TypeScript build errors in studio frontend

### DIFF
--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -17,7 +17,7 @@ import {
 
 const MAX_DISPLAY = 10_000;
 const COPY_RESET_MS = 2000;
-const SHIKI_THEME = ["github-light", "github-dark"] as const;
+const SHIKI_THEME = ["github-light", "github-dark"] as ["github-light", "github-dark"];
 
 function truncate(text: string): string {
   return text.length <= MAX_DISPLAY

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import type { ChatModelAdapter } from "@assistant-ui/react";
-import type { MessageTiming } from "@assistant-ui/core";
+import type { MessageTiming, ToolCallMessagePart } from "@assistant-ui/core";
 import { toast } from "sonner";
 import {
   generateAudio,
@@ -527,7 +527,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       let reasoningDuration = 0;
       // Tool call content parts — accumulated and yielded cumulatively.
       // result is set directly on the tool-call part when tool_end arrives.
-      const toolCallParts: { type: "tool-call"; toolCallId: string; toolName: string; args: Record<string, unknown>; result?: unknown }[] = [];
+      const toolCallParts: ToolCallMessagePart[] = [];
 
       try {
         const { supportsReasoning, reasoningEnabled } = runtime;
@@ -582,11 +582,13 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           if (toolEvent !== undefined) {
             if (toolEvent.type === "tool_start") {
               const id = (toolEvent.tool_call_id as string) || `${toolEvent.tool_name}_${Date.now()}`;
+              const toolArgs = (toolEvent.arguments ?? {}) as ToolCallMessagePart["args"];
               toolCallParts.push({
                 type: "tool-call" as const,
                 toolCallId: id,
                 toolName: toolEvent.tool_name as string,
-                args: (toolEvent.arguments as Record<string, unknown>) ?? {},
+                argsText: JSON.stringify(toolArgs),
+                args: toolArgs,
               });
             } else if (toolEvent.type === "tool_end") {
               const id = (toolEvent.tool_call_id as string) ||


### PR DESCRIPTION
## Summary
- Fix `tool-ui-python.tsx`: the `SHIKI_THEME` array used `as const` which produced a `readonly` tuple incompatible with the mutable `[BundledTheme, BundledTheme]` type expected by the `Streamdown` component. Changed to an explicit tuple assertion.
- Fix `chat-adapter.ts`: the `toolCallParts` array was missing the `argsText` field required by `ToolCallMessagePart` from `@assistant-ui/core`, and `args` was typed as `Record<string, unknown>` instead of `ReadonlyJSONObject`. Used the `ToolCallMessagePart` type directly and added `argsText: JSON.stringify(toolArgs)` at the push site.
- Fix `tools.py`: moved `from unsloth_zoo.rl_environments import check_signal_escape_patterns` from module-level to inside `_check_code_safety()` with a try/except fallback. The top-level import triggers `unsloth_zoo.__init__` which calls `get_device_type()` at module scope, raising `NotImplementedError` on Apple Silicon Macs and crashing the `/v1/chat/completions` endpoint. On Mac the safety check now gracefully skips, while GGUF inference via llama.cpp continues to work.

## Test plan
- [x] `npm run build` in `studio/frontend` completes successfully
- [x] Vite build produces dist output without errors
- [ ] Verify `unsloth studio` chat completions endpoint works on Mac (Apple Silicon)
- [ ] Verify tool-calling code execution works on GPU platforms (safety check still runs)