### PR TITLE
Studio: show all GPUs in GPU monitor

### DIFF
--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -129,9 +129,9 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
     def test_visible_gpu_utilization_filters_to_parent_visible_ids(self):
         smi_output = "\n".join(
             [
-                "0, 10, 30, 1000, 10000, 50, 100",
-                "1, 20, 40, 2000, 10000, 60, 120",
-                "3, 30, 50, 3000, 10000, 70, 140",
+                "0, GPU Zero, 10, 30, 1000, 10000, 50, 100",
+                "1, GPU One, 20, 40, 2000, 10000, 60, 120",
+                "3, GPU Three, 30, 50, 3000, 10000, 70, 140",
             ]
         )
 
@@ -152,6 +152,7 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
         self.assertEqual([device["index"] for device in result["devices"]], [1, 3])
         self.assertEqual(result["devices"][0]["visible_ordinal"], 0)
         self.assertEqual(result["devices"][1]["visible_ordinal"], 1)
+        self.assertEqual(result["devices"][0]["name"], "GPU One")
         self.assertEqual(result["devices"][0]["gpu_utilization_pct"], 20.0)
         self.assertEqual(result["devices"][1]["power_utilization_pct"], 50.0)
 
@@ -222,6 +223,7 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
         self.assertEqual(result["parent_visible_gpu_ids"], [])
         self.assertEqual(len(result["devices"]), 2)
         self.assertEqual(result["index_kind"], "relative")
+        self.assertEqual(result["devices"][0]["name"], "GPU-A")
 
     def test_mlx_visible_gpu_info_is_best_effort_relative(self):
         with (
@@ -242,6 +244,7 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
         self.assertTrue(result["available"])
         self.assertEqual(result["index_kind"], "relative")
         self.assertEqual(result["devices"][0]["index"], 0)
+        self.assertEqual(result["devices"][0]["name"], "Apple Silicon")
         self.assertEqual(result["devices"][0]["visible_ordinal"], 0)
 
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -524,6 +524,7 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
                     {
                         "index": td["index"],
                         "index_kind": index_kind,
+                        "name": td["name"],
                         "visible_ordinal": td["visible_ordinal"],
                         "gpu_utilization_pct": None,
                         "temperature_c": None,
@@ -563,6 +564,7 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
                 {
                     "index": 0,
                     "index_kind": "relative",
+                    "name": mem.get("device_name", "MLX"),
                     "visible_ordinal": 0,
                     "gpu_utilization_pct": None,
                     "temperature_c": None,

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -128,7 +128,7 @@ def get_visible_gpu_utilization(
         result = subprocess.run(
             [
                 "nvidia-smi",
-                "--query-gpu=index,utilization.gpu,temperature.gpu,"
+                "--query-gpu=index,name,utilization.gpu,temperature.gpu,"
                 "memory.used,memory.total,power.draw,power.limit",
                 "--format=csv,noheader,nounits",
             ],
@@ -157,7 +157,7 @@ def get_visible_gpu_utilization(
     devices = []
     for line in result.stdout.strip().splitlines():
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) < 7:
+        if len(parts) < 8:
             continue
 
         try:
@@ -168,21 +168,24 @@ def get_visible_gpu_utilization(
         if visible_ordinals is not None and idx not in visible_ordinals:
             continue
 
+        name = ", ".join(parts[1:-6]).strip() or None
+
         devices.append(
             _build_gpu_metrics(
-                vram_used_mb = _parse_smi_value(parts[3]),
-                vram_total_mb = _parse_smi_value(parts[4]),
-                power_draw = _parse_smi_value(parts[5]),
-                power_limit = _parse_smi_value(parts[6]),
+                vram_used_mb = _parse_smi_value(parts[-4]),
+                vram_total_mb = _parse_smi_value(parts[-3]),
+                power_draw = _parse_smi_value(parts[-2]),
+                power_limit = _parse_smi_value(parts[-1]),
                 index = idx,
                 index_kind = "physical",
+                name = name,
                 visible_ordinal = (
                     visible_ordinals[idx]
                     if visible_ordinals is not None
                     else len(devices)
                 ),
-                gpu_utilization_pct = _parse_smi_value(parts[1]),
-                temperature_c = _parse_smi_value(parts[2]),
+                gpu_utilization_pct = _parse_smi_value(parts[-6]),
+                temperature_c = _parse_smi_value(parts[-5]),
             )
         )
 

--- a/studio/frontend/src/features/studio/sections/progress-section.tsx
+++ b/studio/frontend/src/features/studio/sections/progress-section.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/features/training";
 import type { TrainingViewData } from "@/features/training";
 import { useGpuUtilization } from "@/hooks";
+import type { GpuUtilizationDevice } from "@/hooks/use-gpu-utilization";
 import { cn } from "@/lib/utils";
 import {
   ChartAverageIcon,
@@ -113,10 +114,7 @@ export function ProgressSection({
     data.totalSteps > 0
       ? Math.min(
           100,
-          Math.max(
-            0,
-            Math.round((data.currentStep / data.totalSteps) * 100),
-          ),
+          Math.max(0, Math.round((data.currentStep / data.totalSteps) * 100)),
         )
       : Math.round(data.progressPercent);
 
@@ -129,8 +127,7 @@ export function ProgressSection({
 
   const stepsPerSecond =
     elapsed != null && elapsed > 0 ? data.currentStep / elapsed : null;
-  const showHalfwayHint =
-    data.phase === "training" && pct >= 50 && pct < 100;
+  const showHalfwayHint = data.phase === "training" && pct >= 50 && pct < 100;
   const showCompletedHint = data.phase === "completed";
   const handleCompareInChat = async () => {
     setTrainingCompareHandoff(data.modelName);
@@ -152,16 +149,32 @@ export function ProgressSection({
     : (lastValue(data.gradNormHistory) ?? data.currentGradNorm);
 
   const cfgEpochs = isHistorical ? configOverride?.epochs : config.epochs;
-  const cfgBatchSize = isHistorical ? configOverride?.batchSize : config.batchSize;
-  const cfgLearningRate = isHistorical ? configOverride?.learningRate : config.learningRate;
+  const cfgBatchSize = isHistorical
+    ? configOverride?.batchSize
+    : config.batchSize;
+  const cfgLearningRate = isHistorical
+    ? configOverride?.learningRate
+    : config.learningRate;
   const cfgMaxSteps = isHistorical ? configOverride?.maxSteps : config.maxSteps;
-  const cfgContextLength = isHistorical ? configOverride?.contextLength : config.contextLength;
-  const cfgWarmupSteps = isHistorical ? configOverride?.warmupSteps : config.warmupSteps;
-  const cfgOptimizerType = isHistorical ? configOverride?.optimizerType : config.optimizerType;
+  const cfgContextLength = isHistorical
+    ? configOverride?.contextLength
+    : config.contextLength;
+  const cfgWarmupSteps = isHistorical
+    ? configOverride?.warmupSteps
+    : config.warmupSteps;
+  const cfgOptimizerType = isHistorical
+    ? configOverride?.optimizerType
+    : config.optimizerType;
   const cfgLoraRank = isHistorical ? configOverride?.loraRank : config.loraRank;
-  const cfgLoraAlpha = isHistorical ? configOverride?.loraAlpha : config.loraAlpha;
-  const cfgLoraDropout = isHistorical ? configOverride?.loraDropout : config.loraDropout;
-  const cfgLoraVariant = isHistorical ? configOverride?.loraVariant : config.loraVariant;
+  const cfgLoraAlpha = isHistorical
+    ? configOverride?.loraAlpha
+    : config.loraAlpha;
+  const cfgLoraDropout = isHistorical
+    ? configOverride?.loraDropout
+    : config.loraDropout;
+  const cfgLoraVariant = isHistorical
+    ? configOverride?.loraVariant
+    : config.loraVariant;
 
   const optimizerLabel =
     OPTIMIZER_OPTIONS.find((o) => o.value === cfgOptimizerType)?.label ??
@@ -264,7 +277,9 @@ export function ProgressSection({
             >
               {stoppedLoss != null ? stoppedLoss.toFixed(4) : "--"}
             </MetricStat>
-            <MetricStat label="LR">{stoppedLr != null ? stoppedLr.toExponential(2) : "--"}</MetricStat>
+            <MetricStat label="LR">
+              {stoppedLr != null ? stoppedLr.toExponential(2) : "--"}
+            </MetricStat>
             <MetricStat label="Grad Norm">
               {formatNumber(stoppedGradNorm, 3)}
             </MetricStat>
@@ -272,7 +287,11 @@ export function ProgressSection({
               {data.modelName || "--"}
             </MetricStat>
             <MetricStat label="Method">
-              {data.trainingMethod === "qlora" ? "QLoRA" : data.trainingMethod === "lora" ? "LoRA" : "Full"}
+              {data.trainingMethod === "qlora"
+                ? "QLoRA"
+                : data.trainingMethod === "lora"
+                  ? "LoRA"
+                  : "Full"}
             </MetricStat>
           </div>
 
@@ -304,65 +323,42 @@ function LiveGpuPanel({
   isTrainingRunning: boolean;
 }): ReactElement {
   const gpu = useGpuUtilization(isTrainingRunning);
+  const gpuEntries = gpu.devices;
+  const gpuCountLabel =
+    gpuEntries.length > 0
+      ? `${gpuEntries.length} visible GPU${gpuEntries.length === 1 ? "" : "s"}`
+      : "No visible GPU";
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <p className="text-xs font-medium text-muted-foreground">
-          GPU Monitor
-        </p>
-        <span className="text-[11px] text-muted-foreground">Live</span>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs font-medium text-muted-foreground">GPU Monitor</p>
+        <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+          <span>{gpuCountLabel}</span>
+          <span>Live</span>
+        </div>
       </div>
-      <div className="grid grid-cols-2 gap-2.5">
-        <GpuStat
-          label="Utilization"
-          icon={
-            <HugeiconsIcon
-              icon={DashboardSpeed01Icon}
-              className="size-3.5"
+      {gpuEntries.length > 0 ? (
+        <div
+          className={cn(
+            "grid gap-3",
+            gpuEntries.length > 1
+              ? "grid-cols-1 sm:grid-cols-2 xl:grid-cols-3"
+              : "grid-cols-1",
+          )}
+        >
+          {gpuEntries.map((entry) => (
+            <GpuMonitorCard
+              key={`${entry.index}-${entry.visible_ordinal ?? "na"}`}
+              gpu={entry}
             />
-          }
-          value={
-            gpu.gpu_utilization_pct != null
-              ? `${gpu.gpu_utilization_pct}%`
-              : "--"
-          }
-          pct={gpu.gpu_utilization_pct ?? 0}
-        />
-        <GpuStat
-          label="Temperature"
-          icon={
-            <HugeiconsIcon icon={TemperatureIcon} className="size-3.5" />
-          }
-          value={
-            gpu.temperature_c != null ? `${gpu.temperature_c}°C` : "--"
-          }
-          pct={gpu.temperature_c ?? 0}
-          max={100}
-        />
-        <GpuStat
-          label="VRAM"
-          icon={<HugeiconsIcon icon={RamMemoryIcon} className="size-3.5" />}
-          value={
-            gpu.vram_used_gb != null && gpu.vram_total_gb != null
-              ? `${gpu.vram_used_gb} / ${gpu.vram_total_gb} GB`
-              : "--"
-          }
-          pct={gpu.vram_utilization_pct ?? 0}
-        />
-        <GpuStat
-          label="Power"
-          icon={<HugeiconsIcon icon={ZapIcon} className="size-3.5" />}
-          value={
-            gpu.power_draw_w != null
-              ? gpu.power_limit_w != null
-                ? `${gpu.power_draw_w} / ${gpu.power_limit_w} W`
-                : `${gpu.power_draw_w} W`
-              : "--"
-          }
-          pct={gpu.power_utilization_pct ?? 0}
-        />
-      </div>
+          ))}
+        </div>
+      ) : (
+        <div className="corner-squircle rounded-2xl border border-dashed border-border/60 bg-background/30 px-3 py-5 text-sm text-muted-foreground">
+          No visible GPU telemetry yet.
+        </div>
+      )}
     </div>
   );
 }
@@ -606,12 +602,14 @@ function GpuStat({
   label,
   icon,
   value,
+  detail,
   pct,
   max,
 }: {
   label: string;
   icon: ReactNode;
   value: string;
+  detail?: string;
   pct: number;
   max?: number;
 }): ReactElement {
@@ -624,18 +622,96 @@ function GpuStat({
   }
 
   return (
-    <div className="corner-squircle flex flex-col gap-2 rounded-2xl border border-border/50 bg-background/60 p-3">
-      <div className="flex items-center justify-between text-xs">
-        <span className="flex items-center gap-1.5 text-muted-foreground">
-          {icon}
-          {label}
-        </span>
-        <span className="font-medium tabular-nums">{value}</span>
+    <div className="corner-squircle min-w-0 rounded-2xl border border-border/50 bg-background/60 p-3">
+      <div className="flex min-w-0 items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        <span className="shrink-0">{icon}</span>
+        <span className="truncate">{label}</span>
       </div>
-      <div className="h-2 w-full overflow-hidden rounded-full bg-muted/80">
+      <div className="mt-2 min-w-0">
+        <p className="truncate text-sm font-semibold leading-none tabular-nums text-foreground">
+          {value}
+        </p>
+        {detail ? (
+          <p className="mt-1 truncate text-[11px] text-muted-foreground">
+            {detail}
+          </p>
+        ) : null}
+      </div>
+      <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted/80">
         <div
           className={`h-full rounded-full ${barColor} transition-all duration-300`}
           style={{ width: `${clamped}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function GpuMonitorCard({ gpu }: { gpu: GpuUtilizationDevice }): ReactElement {
+  const title =
+    gpu.visible_ordinal != null
+      ? `GPU ${gpu.visible_ordinal}`
+      : `GPU ${gpu.index}`;
+  const subtitle =
+    gpu.index_kind === "physical" &&
+    gpu.visible_ordinal != null &&
+    gpu.visible_ordinal !== gpu.index
+      ? `${gpu.name ?? "GPU device"} • physical ${gpu.index}`
+      : (gpu.name ?? "GPU device");
+
+  return (
+    <div className="corner-squircle min-w-0 rounded-2xl border border-border/50 bg-background/40 p-3">
+      <div className="mb-3 flex min-w-0 items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium">{title}</p>
+          <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-muted-foreground">
+            {subtitle}
+          </p>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+        <GpuStat
+          label="Utilization"
+          icon={
+            <HugeiconsIcon icon={DashboardSpeed01Icon} className="size-3.5" />
+          }
+          value={
+            gpu.gpu_utilization_pct != null
+              ? `${gpu.gpu_utilization_pct}%`
+              : "--"
+          }
+          pct={gpu.gpu_utilization_pct ?? 0}
+        />
+        <GpuStat
+          label="Temperature"
+          icon={<HugeiconsIcon icon={TemperatureIcon} className="size-3.5" />}
+          value={gpu.temperature_c != null ? `${gpu.temperature_c}°C` : "--"}
+          pct={gpu.temperature_c ?? 0}
+          max={100}
+        />
+        <GpuStat
+          label="VRAM"
+          icon={<HugeiconsIcon icon={RamMemoryIcon} className="size-3.5" />}
+          value={
+            gpu.vram_used_gb != null ? `${gpu.vram_used_gb} GB used` : "--"
+          }
+          detail={
+            gpu.vram_total_gb != null
+              ? `${gpu.vram_total_gb} GB total`
+              : undefined
+          }
+          pct={gpu.vram_utilization_pct ?? 0}
+        />
+        <GpuStat
+          label="Power"
+          icon={<HugeiconsIcon icon={ZapIcon} className="size-3.5" />}
+          value={gpu.power_draw_w != null ? `${gpu.power_draw_w} W draw` : "--"}
+          detail={
+            gpu.power_limit_w != null
+              ? `${gpu.power_limit_w} W limit`
+              : undefined
+          }
+          pct={gpu.power_utilization_pct ?? 0}
         />
       </div>
     </div>

--- a/studio/frontend/src/hooks/use-gpu-utilization.ts
+++ b/studio/frontend/src/hooks/use-gpu-utilization.ts
@@ -4,74 +4,227 @@
 import { authFetch } from "@/features/auth";
 import { useEffect, useRef, useState } from "react";
 
-export interface GpuUtilization {
-    available: boolean;
-    backend: string | null;
-    gpu_utilization_pct: number | null;
-    temperature_c: number | null;
-    vram_used_gb: number | null;
-    vram_total_gb: number | null;
-    vram_utilization_pct: number | null;
-    power_draw_w: number | null;
-    power_limit_w: number | null;
-    power_utilization_pct: number | null;
+export interface GpuUtilizationDevice {
+  index: number;
+  index_kind: string | null;
+  visible_ordinal: number | null;
+  name: string | null;
+  gpu_utilization_pct: number | null;
+  temperature_c: number | null;
+  vram_used_gb: number | null;
+  vram_total_gb: number | null;
+  vram_utilization_pct: number | null;
+  power_draw_w: number | null;
+  power_limit_w: number | null;
+  power_utilization_pct: number | null;
 }
 
-const DEFAULT: GpuUtilization = {
-    available: false,
-    backend: null,
-    gpu_utilization_pct: null,
-    temperature_c: null,
-    vram_used_gb: null,
-    vram_total_gb: null,
-    vram_utilization_pct: null,
-    power_draw_w: null,
-    power_limit_w: null,
-    power_utilization_pct: null,
+export interface GpuUtilization {
+  available: boolean;
+  backend: string | null;
+  backend_cuda_visible_devices: string | null;
+  parent_visible_gpu_ids: number[];
+  index_kind: string | null;
+  devices: GpuUtilizationDevice[];
+  gpu_utilization_pct: number | null;
+  temperature_c: number | null;
+  vram_used_gb: number | null;
+  vram_total_gb: number | null;
+  vram_utilization_pct: number | null;
+  power_draw_w: number | null;
+  power_limit_w: number | null;
+  power_utilization_pct: number | null;
+}
+
+const DEFAULT_DEVICE: GpuUtilizationDevice = {
+  index: 0,
+  index_kind: null,
+  visible_ordinal: null,
+  name: null,
+  gpu_utilization_pct: null,
+  temperature_c: null,
+  vram_used_gb: null,
+  vram_total_gb: null,
+  vram_utilization_pct: null,
+  power_draw_w: null,
+  power_limit_w: null,
+  power_utilization_pct: null,
 };
 
+const DEFAULT: GpuUtilization = {
+  available: false,
+  backend: null,
+  backend_cuda_visible_devices: null,
+  parent_visible_gpu_ids: [],
+  index_kind: null,
+  devices: [],
+  gpu_utilization_pct: null,
+  temperature_c: null,
+  vram_used_gb: null,
+  vram_total_gb: null,
+  vram_utilization_pct: null,
+  power_draw_w: null,
+  power_limit_w: null,
+  power_utilization_pct: null,
+};
+
+function toNumberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeDevice(
+  device: unknown,
+  fallbackIndex: number,
+): GpuUtilizationDevice | null {
+  if (!device || typeof device !== "object") {
+    return null;
+  }
+
+  const entry = device as Record<string, unknown>;
+  return {
+    ...DEFAULT_DEVICE,
+    index: typeof entry.index === "number" ? entry.index : fallbackIndex,
+    index_kind: typeof entry.index_kind === "string" ? entry.index_kind : null,
+    visible_ordinal:
+      typeof entry.visible_ordinal === "number" ? entry.visible_ordinal : null,
+    name: typeof entry.name === "string" ? entry.name : null,
+    gpu_utilization_pct: toNumberOrNull(entry.gpu_utilization_pct),
+    temperature_c: toNumberOrNull(entry.temperature_c),
+    vram_used_gb: toNumberOrNull(entry.vram_used_gb),
+    vram_total_gb: toNumberOrNull(entry.vram_total_gb),
+    vram_utilization_pct: toNumberOrNull(entry.vram_utilization_pct),
+    power_draw_w: toNumberOrNull(entry.power_draw_w),
+    power_limit_w: toNumberOrNull(entry.power_limit_w),
+    power_utilization_pct: toNumberOrNull(entry.power_utilization_pct),
+  };
+}
+
+function normalizeGpuUtilization(payload: unknown): GpuUtilization {
+  if (!payload || typeof payload !== "object") {
+    return DEFAULT;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const rawDevices = Array.isArray(record.devices)
+    ? record.devices
+    : Array.isArray(record.gpus)
+      ? record.gpus
+      : [];
+  const devices = rawDevices
+    .map((device, index) => normalizeDevice(device, index))
+    .filter((device): device is GpuUtilizationDevice => device !== null);
+
+  const normalized: GpuUtilization = {
+    ...DEFAULT,
+    available: record.available === true,
+    backend: typeof record.backend === "string" ? record.backend : null,
+    backend_cuda_visible_devices:
+      typeof record.backend_cuda_visible_devices === "string"
+        ? record.backend_cuda_visible_devices
+        : null,
+    parent_visible_gpu_ids: Array.isArray(record.parent_visible_gpu_ids)
+      ? record.parent_visible_gpu_ids.filter(
+          (gpuId): gpuId is number =>
+            typeof gpuId === "number" && Number.isFinite(gpuId),
+        )
+      : [],
+    index_kind:
+      typeof record.index_kind === "string" ? record.index_kind : null,
+    devices,
+    gpu_utilization_pct: toNumberOrNull(record.gpu_utilization_pct),
+    temperature_c: toNumberOrNull(record.temperature_c),
+    vram_used_gb: toNumberOrNull(record.vram_used_gb),
+    vram_total_gb: toNumberOrNull(record.vram_total_gb),
+    vram_utilization_pct: toNumberOrNull(record.vram_utilization_pct),
+    power_draw_w: toNumberOrNull(record.power_draw_w),
+    power_limit_w: toNumberOrNull(record.power_limit_w),
+    power_utilization_pct: toNumberOrNull(record.power_utilization_pct),
+  };
+
+  const hasLegacyMetrics = [
+    normalized.gpu_utilization_pct,
+    normalized.temperature_c,
+    normalized.vram_used_gb,
+    normalized.power_draw_w,
+  ].some((value) => value != null);
+
+  if (
+    normalized.devices.length === 0 &&
+    (normalized.available || hasLegacyMetrics)
+  ) {
+    normalized.devices = [
+      {
+        ...DEFAULT_DEVICE,
+        index: 0,
+        gpu_utilization_pct: normalized.gpu_utilization_pct,
+        temperature_c: normalized.temperature_c,
+        vram_used_gb: normalized.vram_used_gb,
+        vram_total_gb: normalized.vram_total_gb,
+        vram_utilization_pct: normalized.vram_utilization_pct,
+        power_draw_w: normalized.power_draw_w,
+        power_limit_w: normalized.power_limit_w,
+        power_utilization_pct: normalized.power_utilization_pct,
+      },
+    ];
+  }
+
+  return normalized;
+}
+
+async function fetchGpuUtilization(
+  endpoint: string,
+): Promise<GpuUtilization | null> {
+  const response = await authFetch(endpoint);
+  if (!response.ok) {
+    return null;
+  }
+  return normalizeGpuUtilization(await response.json());
+}
+
 /**
- * Poll `GET /api/train/hardware` for live GPU utilization stats.
+ * Poll `GET /api/train/hardware/visible` for live GPU utilization stats.
  *
  * Only polls while `enabled` is true (i.e. training is running).
  * Polling interval defaults to 10 000 ms.
  */
 export function useGpuUtilization(
-    enabled: boolean,
-    intervalMs = 10_000,
+  enabled: boolean,
+  intervalMs = 10_000,
 ): GpuUtilization {
-    const [data, setData] = useState<GpuUtilization>(DEFAULT);
-    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [data, setData] = useState<GpuUtilization>(DEFAULT);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    useEffect(() => {
-        if (!enabled) {
-            // Reset when training stops so the cards show "--" again
-            setData(DEFAULT);
-            return;
+  useEffect(() => {
+    if (!enabled) {
+      // Reset when training stops so the cards show "--" again
+      setData(DEFAULT);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const payload =
+          (await fetchGpuUtilization("/api/train/hardware/visible")) ??
+          (await fetchGpuUtilization("/api/train/hardware"));
+        if (!cancelled && payload) {
+          setData(payload);
         }
+      } catch {
+        // Silently ignore — next poll will retry
+      }
+    }
 
-        let cancelled = false;
+    // Fetch immediately, then set up interval
+    void poll();
+    timerRef.current = setInterval(() => void poll(), intervalMs);
 
-        async function poll() {
-            try {
-                const res = await authFetch("/api/train/hardware");
-                if (!res.ok || cancelled) return;
-                const json = (await res.json()) as GpuUtilization;
-                if (!cancelled) setData(json);
-            } catch {
-                // Silently ignore — next poll will retry
-            }
-        }
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [enabled, intervalMs]);
 
-        // Fetch immediately, then set up interval
-        void poll();
-        timerRef.current = setInterval(() => void poll(), intervalMs);
-
-        return () => {
-            cancelled = true;
-            if (timerRef.current) clearInterval(timerRef.current);
-        };
-    }, [enabled, intervalMs]);
-
-    return data;
+  return data;
 }

--- a/studio/frontend/src/hooks/use-gpu-utilization.ts
+++ b/studio/frontend/src/hooks/use-gpu-utilization.ts
@@ -196,8 +196,6 @@ export function useGpuUtilization(
 
   useEffect(() => {
     if (!enabled) {
-      // Reset when training stops so the cards show "--" again
-      setData(DEFAULT);
       return;
     }
 
@@ -226,5 +224,5 @@ export function useGpuUtilization(
     };
   }, [enabled, intervalMs]);
 
-  return data;
+  return enabled ? data : DEFAULT;
 }

--- a/studio/frontend/src/hooks/use-gpu-utilization.ts
+++ b/studio/frontend/src/hooks/use-gpu-utilization.ts
@@ -171,14 +171,22 @@ function normalizeGpuUtilization(payload: unknown): GpuUtilization {
   return normalized;
 }
 
+interface FetchGpuUtilizationResult {
+  status: number;
+  payload: GpuUtilization | null;
+}
+
 async function fetchGpuUtilization(
   endpoint: string,
-): Promise<GpuUtilization | null> {
+): Promise<FetchGpuUtilizationResult> {
   const response = await authFetch(endpoint);
   if (!response.ok) {
-    return null;
+    return { status: response.status, payload: null };
   }
-  return normalizeGpuUtilization(await response.json());
+  return {
+    status: response.status,
+    payload: normalizeGpuUtilization(await response.json()),
+  };
 }
 
 /**
@@ -193,6 +201,7 @@ export function useGpuUtilization(
 ): GpuUtilization {
   const [data, setData] = useState<GpuUtilization>(DEFAULT);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const visibleEndpointMissingRef = useRef(false);
 
   useEffect(() => {
     if (!enabled) {
@@ -203,9 +212,25 @@ export function useGpuUtilization(
 
     async function poll() {
       try {
-        const payload =
-          (await fetchGpuUtilization("/api/train/hardware/visible")) ??
-          (await fetchGpuUtilization("/api/train/hardware"));
+        let payload: GpuUtilization | null = null;
+
+        if (!visibleEndpointMissingRef.current) {
+          const visibleResult = await fetchGpuUtilization(
+            "/api/train/hardware/visible",
+          );
+          payload = visibleResult.payload;
+          if (
+            !payload &&
+            [404, 405, 501].includes(visibleResult.status)
+          ) {
+            visibleEndpointMissingRef.current = true;
+          }
+        }
+
+        if (!payload) {
+          payload = (await fetchGpuUtilization("/api/train/hardware")).payload;
+        }
+
         if (!cancelled && payload) {
           setData(payload);
         }


### PR DESCRIPTION
## Summary
This updates Studio's GPU Monitor to show every visible GPU instead of only mirroring GPU 0.

Closes #4440.

## What changed
- return `gpus[]` plus GPU counts from the backend hardware utilization endpoint
- keep the legacy top-level GPU 0 fields for backwards compatibility
- add backend coverage for multi-GPU parsing
- update the frontend hook to accept the multi-GPU payload
- render one responsive card per GPU in the training progress panel
- tighten the card layout so long GPU names and metric strings do not overflow

## Validation
- `~/.unsloth/studio/.venv/bin/pytest studio/backend/tests/test_gpu_utilization.py -q`
- `npm run typecheck`
- `npm run build`
