### PR TITLE
Fix macOS install.sh: stdin consumption and Python discovery

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -202,7 +202,9 @@ uv pip install --python "$VENV_NAME/bin/python" unsloth --torch-backend=auto
 # setup.sh requires, but uv already installed a compatible interpreter
 # inside the venv.
 VENV_ABS_BIN="$(cd "$VENV_NAME/bin" && pwd)"
-export PATH="$VENV_ABS_BIN:$PATH"
+if [ -n "$VENV_ABS_BIN" ]; then
+    export PATH="$VENV_ABS_BIN:$PATH"
+fi
 
 echo "==> Running unsloth studio setup..."
 "$VENV_NAME/bin/unsloth" studio setup </dev/null


### PR DESCRIPTION
## Summary

Fixes two issues that break the macOS `curl | sh` installer:

- **First run fails, second run works.** Commands like `brew install` and `sh <uv-installer>` read from stdin, consuming bytes from the piped script. The shell loses sync and prints the remaining source code as text instead of executing it. Fixed by redirecting stdin from `/dev/null` for all subprocess calls that may read stdin (`brew install`, `apt-get`, `xcode-select --install`, uv installer).

- **"No Python version between 3.11 and 3.13 found" on macOS.** `setup.sh` discovers Python via `compgen -c` on the system PATH. On Macs with only Python 3.9.6 (system) and 3.14.3 (Homebrew), this fails -- even though `uv` already installed Python 3.13 into the `unsloth_studio` venv. Fixed by adding the venv's `bin/` directory to PATH before invoking `unsloth studio setup`, so `setup.sh` finds the venv's Python 3.13.

## Reproduction

On a Mac with only Python 3.9 and 3.14 installed:
```
curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh | sh
```

Before this fix:
1. First run: `brew install cmake` consumes stdin, script source code gets printed as text
2. Second run: gets past brew, but `setup.sh` fails with "No Python version between 3.11 and 3.13 found"

After this fix: single run completes successfully.

## Changes

- `install.sh`: Add `</dev/null` to `brew install`, `apt-get`, `xcode-select --install`, and `sh "$_uv_tmp"` to prevent stdin consumption when piped
- `install.sh`: Export `PATH` with the venv's `bin/` directory before calling `unsloth studio setup` so `setup.sh` can discover the venv's Python 3.13

## Test plan

- [ ] Verify `curl -fsSL .../install.sh | sh` works on macOS in a single run (no re-run needed)
- [ ] Verify Linux install still works (no regression from `</dev/null` redirects)
- [ ] Verify WSL install still works