### PR TITLE
Adding launch command to install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -107,11 +107,24 @@ function Install-UnslothStudio {
     Write-Host ""
     Write-Host "========================================="
     Write-Host "   Unsloth Studio installed!"
-    Write-Host "   Launching Unsloth Studio..."
     Write-Host "========================================="
     Write-Host ""
-    $UnslothExe = Join-Path $VenvName "Scripts\unsloth.exe"
-    & $UnslothExe studio -H 0.0.0.0 -p 8888
+
+    # Launch studio automatically in interactive terminals;
+    # in non-interactive environments (CI, Docker) just print instructions.
+    $IsInteractive = [Environment]::UserInteractive -and (-not [Console]::IsInputRedirected)
+    if ($IsInteractive) {
+        Write-Host "==> Launching Unsloth Studio..."
+        Write-Host ""
+        $UnslothExe = Join-Path $VenvName "Scripts\unsloth.exe"
+        & $UnslothExe studio -H 0.0.0.0 -p 8888
+    } else {
+        Write-Host "  To launch, run:"
+        Write-Host ""
+        Write-Host "    .\${VenvName}\Scripts\activate"
+        Write-Host "    unsloth studio -H 0.0.0.0 -p 8888"
+        Write-Host ""
+    }
 }
 
 Install-UnslothStudio

--- a/install.sh
+++ b/install.sh
@@ -212,7 +212,19 @@ echo "==> Running unsloth studio setup..."
 echo ""
 echo "========================================="
 echo "   Unsloth Studio installed!"
-echo "   Launching Unsloth Studio..."
 echo "========================================="
 echo ""
-exec "$VENV_NAME/bin/unsloth" studio -H 0.0.0.0 -p 8888
+
+# Launch studio automatically in interactive terminals;
+# in non-interactive environments (Docker, CI, cloud-init) just print instructions.
+if [ -t 0 ]; then
+    echo "==> Launching Unsloth Studio..."
+    echo ""
+    exec "$VENV_NAME/bin/unsloth" studio -H 0.0.0.0 -p 8888
+else
+    echo "  To launch, run:"
+    echo ""
+    echo "    source ${VENV_NAME}/bin/activate"
+    echo "    unsloth studio -H 0.0.0.0 -p 8888"
+    echo ""
+fi


### PR DESCRIPTION
Adding the launch command in the one liner install script.
Both install.sh and install.ps1 now automatically launch Unsloth Studio after installation completes when running in an interactive terminal, but gracefully fall back to printing manual launch instructions in non-interactive environments (Docker, CI, cloud-init) to avoid blocking the process.