### PR TITLE
Fix Windows installer Python detection and winget error handling

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -56,12 +56,15 @@ function Install-UnslothStudio {
             }
         }
         # Try python3 / python via Get-Command -All to look past stubs that
-        # might shadow a real Python further down PATH. Each candidate is
-        # probed with --version; non-functional entries (including App
-        # Execution Alias stubs) simply fail the try-catch and are skipped.
+        # might shadow a real Python further down PATH.
+        # Skip WindowsApps entries: the App Execution Alias stubs live there
+        # and can open the Microsoft Store as a side effect. Legitimate Store
+        # Python is already detected via the py launcher above (Store packages
+        # include py since Python 3.11).
         foreach ($name in @("python3", "python")) {
             foreach ($cmd in @(Get-Command $name -All -ErrorAction SilentlyContinue)) {
                 if (-not $cmd.Source) { continue }
+                if ($cmd.Source -like "*\WindowsApps\*") { continue }
                 try {
                     $out = & $cmd.Source --version 2>&1 | Out-String
                     if ($out -match "Python (3\.1[1-3])\.\d+") { return $Matches[1] }


### PR DESCRIPTION
## Summary

Fixes the PowerShell installer (`install.ps1`) crashing on Windows due to:

- **Windows Store App Execution Alias stubs** -- `Get-Command python` finds the stub at `WindowsApps\python.exe`, then `python --version` writes to stderr. With `$ErrorActionPreference = "Stop"` on PowerShell 5.1, stderr from native commands becomes a terminating error, killing the script before it even tries to install Python.
- **winget "already installed" exit code** -- winget exit code `-1978335189` (`APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE`) means the package is already at the latest version, which is non-fatal. But the script treated any non-zero exit as failure. The fallback `Get-Command python` check could also find the Store stub or fail if Python was partially uninstalled.

## Changes

### 1. New `Find-CompatiblePython` helper function
Replaces the inline `Get-Command python` + `python --version` check:
- Tries the `py` launcher first (`py -3.13`, `py -3.12`, `py -3.11`) since it uses its own registry and is the most reliable way to find Python on Windows
- Falls back to `python3` / `python` using `Get-Command -All` to iterate past a WindowsApps stub that might shadow real Python on PATH
- Explicitly skips any exe with path matching `*\WindowsApps\*`
- Wraps every invocation in `try-catch` so stderr never triggers `$ErrorActionPreference = "Stop"`

### 2. Outcome-based winget install flow
Replaces exit-code-based error handling:
- After `winget install`, saves `$LASTEXITCODE` immediately (before `Refresh-SessionPath` can clobber it)
- Re-detects Python via `Find-CompatiblePython` -- does not care what winget returned
- If Python is still not functional, retries with `winget install --force` (handles both real failures and stale "already installed" state)
- On final failure, shows actionable manual install instructions (python.org URL + "check Add to PATH")

### 3. PATH deduplication in `Refresh-SessionPath`
Each call was prepending machine+user paths without deduplication, causing PATH to grow unboundedly. Now splits on `;`, deduplicates case-insensitively (with trailing backslash normalization), and reassembles.

## Test plan

- [ ] Windows machine with only the Store stub (no real Python): `Find-CompatiblePython` skips `WindowsApps\*`, returns `""`, winget installs Python, re-detect succeeds
- [ ] Windows machine where winget returns `-1978335189`: winget install, re-detect fails, retry with `--force`, re-detect succeeds
- [ ] Windows machine with working Python already installed: `Find-CompatiblePython` returns version immediately, no winget needed
- [ ] Windows machine with `py` launcher installed: detected via `py -3.13` before even checking `python` on PATH
- [ ] Confirm `Refresh-SessionPath` does not grow PATH unboundedly across multiple calls