### PR TITLE
fix: exclude .ipynb from ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
         args:
           - --fix
           - --exit-non-zero-on-fix
+        exclude: '\.ipynb$'
   - repo: local
     hooks:
       - id: ruff-format-with-kwargs


### PR DESCRIPTION
## Summary

- Add `exclude: '\.ipynb$'` to the ruff hook in `.pre-commit-config.yaml` so notebooks are not linted by ruff during pre-commit runs

## Context

The ruff pre-commit hook runs on all file types by default, including `.ipynb`. Colab notebooks are authored in Colab's editor where ruff does not run, and they can contain IPython magics (`%cd`, `!git`) that ruff cannot parse. This was causing `pre-commit.ci` to fail on unrelated PRs (e.g. #4501) due to a syntax issue in the Colab notebook on `main`.

## Test plan

- pre-commit.ci will skip `.ipynb` files going forward
- No functional changes to any Python or notebook code