### PR TITLE
Update weather dashboard suggestion prompt

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -116,7 +116,7 @@ const ThreadScrollToBottom: FC = () => {
 
 const SUGGESTION_TOOLS: Record<string, Array<"thinking" | "search" | "code">> = {
   "How do you fine-tune an audio model with Unsloth?": ["thinking", "search"],
-  "Show me a live weather dashboard, no API key needed": ["thinking", "code", "search"],
+  "Create a live weather dashboard in HTML using no API key. Show me the code": ["thinking", "code", "search"],
   "Solve the integral of x·sin(x), and verify it step by step": ["thinking", "code"],
   "Draw an SVG of a cute sloth": ["thinking", "code", "search"],
 };

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -37,9 +37,9 @@ const DEFAULT_SUGGESTIONS = [
     prompt: "How do you fine-tune an audio model with Unsloth?",
   },
   {
-    title: "Show me a live weather dashboard, no API key needed",
+    title: "Create a live weather dashboard in HTML using no API key. Show me the code",
     label: "Weather dashboard",
-    prompt: "Show me a live weather dashboard, no API key needed",
+    prompt: "Create a live weather dashboard in HTML using no API key. Show me the code",
   },
   {
     title: "Solve the integral of x·sin(x), and verify it",


### PR DESCRIPTION
## Summary
- Updated the weather dashboard suggestion text from "Show me a live weather dashboard, no API key needed" to "Create a live weather dashboard in HTML using no API key. Show me the code"
- The new wording explicitly requests HTML code output, producing more useful responses

## Changed files
- `studio/frontend/src/components/assistant-ui/thread.tsx` -- suggestion tools mapping key
- `studio/frontend/src/features/chat/runtime-provider.tsx` -- suggestion title and prompt