### PR TITLE
fix: system prompt ignored in unsloth inference

### DIFF
--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -1020,11 +1020,11 @@ class InferenceBackend:
                 input_text = processor.apply_chat_template(
                     vision_messages, add_generation_prompt = True, tokenize = False
                 )
-            except Exception:
+            except Exception as e:
                 if system_prompt:
                     logger.warning(
-                        f"Vision processor for '{self.active_model_name}' does not support "
-                        f"system messages — dropping system prompt for this request."
+                        f"Vision processor for '{self.active_model_name}' may not support "
+                        f"system messages; retrying without. Original error: {e}"
                     )
                     vision_messages = [user_msg]
                     input_text = processor.apply_chat_template(


### PR DESCRIPTION
## Summary
- The system prompt from the chat sidebar was being stripped out of messages by `_extract_content_parts()` but never added back before calling `tokenizer.apply_chat_template()` in the non-GGUF text and vision paths
- GGUF and audio paths were fine, only affected unsloth/transformers models
- Now prepends the system message back into the messages list before formatting

## Test plan
- [x] Load a non-GGUF model, set a system prompt, send a message and check the model follows it
- [x] Same with a vision model and an image
- [x] Verify GGUF models still work as before