### PR TITLE
fix: store embedding_learning_rate on self in UnslothTrainingArguments

### DIFF
--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -132,8 +132,8 @@ except:
 
 class UnslothTrainingArguments(TrainingArguments):
     def __init__(self, embedding_learning_rate: float = None, *args, **kwargs):
-        embedding_learning_rate = embedding_learning_rate
         super().__init__(*args, **kwargs)
+        self.embedding_learning_rate = embedding_learning_rate
 
 
 def _create_unsloth_optimizer(


### PR DESCRIPTION
## Summary

Fixes #4492

## Problem

`UnslothTrainingArguments.__init__()` accepts `embedding_learning_rate` but assigns it to a local variable instead of storing it as an instance attribute:

```python
def __init__(self, embedding_learning_rate: float = None, *args, **kwargs):
    embedding_learning_rate = embedding_learning_rate  # ← no-op
    super().__init__(*args, **kwargs)
```

This causes `UnslothTrainer.create_optimizer()` to always get `None` via `getattr(self.args, "embedding_learning_rate", None)`, silently falling back to a single param group. Embeddings then train at the same LR as everything else with no warning.

## Fix

```python
def __init__(self, embedding_learning_rate: float = None, *args, **kwargs):
    super().__init__(*args, **kwargs)
    self.embedding_learning_rate = embedding_learning_rate
```

- Store the parameter as `self.embedding_learning_rate`
- Call `super().__init__()` first to avoid any attribute conflicts

## Verification

```python
from unsloth import UnslothTrainingArguments

args = UnslothTrainingArguments(output_dir="/tmp/test", embedding_learning_rate=2e-5)
print(getattr(args, "embedding_learning_rate", "NOT FOUND"))  # Now prints: 2e-05
```