### PR TITLE
Fix Studio port conflict detection for loopback addresses

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -98,7 +98,6 @@ def _get_pid_on_port(port: int) -> "tuple[int, str] | None":
     except (psutil.AccessDenied, OSError) as e:
         # psutil.net_connections() needs elevated privileges on some platforms
         logger.debug("Failed to scan network connections for port %s: %s", port, e)
-        pass
     return None
 
 


### PR DESCRIPTION
## Summary

- Fix `_is_port_free()` to detect when localhost (`127.0.0.1` / `::1`) is already held by another process (e.g. an SSH `-L` tunnel) even though the wildcard `0.0.0.0` bind succeeds. Without this check, Unsloth Studio reports it is running on `localhost:PORT` but the port is actually unreachable because the other process wins the loopback routing.
- Add `_get_pid_on_port()` helper that uses `psutil` (when available) to identify which process is blocking the port, so the warning message is actionable.
- Improve the port-conflict warning to clearly show the new port and what to open in the browser.

## Problem

When an SSH tunnel (or any other process) is listening on `127.0.0.1:8888`, binding to `0.0.0.0:8888` still succeeds on all major platforms. The old code only checked the wildcard bind, so it would happily start on port 8888 and print `localhost:8888` in the startup banner, but all localhost traffic was being routed to the SSH tunnel instead.

## Changes

`_is_port_free(host, port)` now does an additional TCP connect probe against `127.0.0.1` and `::1` (when IPv6 is available) whenever the bind host is `0.0.0.0` or `::`. If the connect succeeds, something else is already listening there and we treat the port as taken.

`_get_pid_on_port(port)` is a new optional helper (gracefully degrades when `psutil` is not installed or when elevated privileges are required) that returns the PID and process name occupying the port.

The startup warning now shows a clear block:

```
==================================================
Port 8888 is already in use by ssh.exe (PID 7572).
Unsloth Studio will use port 8889 instead.
Open http://localhost:8889 in your browser.
==================================================
```

## Compatibility

- Uses only stdlib `socket` for the core detection (works on Windows, macOS, Linux).
- `psutil` usage is wrapped in try/except so the fix works even without it.
- IPv6 `::1` check is skipped gracefully when IPv6 is disabled.

## Test plan

- [ ] Start an SSH tunnel on port 8888 (`ssh -L 8888:localhost:8888 ...`), then launch Studio with `-p 8888`. Verify it auto-switches to 8889 and prints the warning with process info.
- [ ] Launch Studio on a free port. Verify no warning is printed and it starts normally.
- [ ] Test on Windows, macOS, and Linux.
