### PR TITLE
fix(studio): restore scroll lock on reasoning panel collapse

### DIFF
--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -17,6 +17,7 @@ import {
   type ReasoningGroupComponent,
   type ReasoningMessagePartComponent,
   useAuiState,
+  useScrollLock,
 } from "@assistant-ui/react";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { Idea01Icon } from "@hugeicons/core-free-icons";
@@ -66,23 +67,29 @@ function ReasoningRoot({
   children,
   ...props
 }: ReasoningRootProps) {
+  const collapsibleRef = useRef<HTMLDivElement>(null);
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const lockScroll = useScrollLock(collapsibleRef, ANIMATION_DURATION);
 
   const isControlled = controlledOpen !== undefined;
   const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
+      if (!open) {
+        lockScroll();
+      }
       if (!isControlled) {
         setUncontrolledOpen(open);
       }
       controlledOnOpenChange?.(open);
     },
-    [isControlled, controlledOnOpenChange],
+    [lockScroll, isControlled, controlledOnOpenChange],
   );
 
   return (
     <Collapsible
+      ref={collapsibleRef}
       data-slot="reasoning-root"
       data-variant={variant}
       open={isOpen}


### PR DESCRIPTION
## Summary
- Restores `useScrollLock` in `ReasoningRoot` that was removed in PR #4543
- Without the hook, collapsing a reasoning panel causes the thread viewport to jump as the content height changes during the 200ms animation
- The fix freezes `scrollTop` on the nearest scrollable ancestor for the animation duration, matching the identical pattern already used by `tool-fallback.tsx` and `tool-group.tsx`

## Changes
- `studio/frontend/src/components/assistant-ui/reasoning.tsx`: added `useScrollLock` import, `collapsibleRef`, `lockScroll()` call on collapse, and `ref` on `<Collapsible>`

## Test plan
- [ ] Open a chat with reasoning (e.g. a thinking model)
- [ ] Scroll up in the thread so the reasoning panel is partially visible
- [ ] Collapse the reasoning panel and verify the viewport does not jump
- [ ] Verify `npx tsc --noEmit` passes