### PR TITLE
[Studio] Try installing causal-conv1d from prebuilt wheels if avialable

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -325,7 +325,7 @@ def patch_package_file(package_name: str, relative_path: str, url: str) -> None:
 def install_python_stack() -> int:
     global USE_UV, _STEP, _TOTAL
     _STEP = 0
-    _TOTAL = 11 if IS_WINDOWS else 12
+    _TOTAL = 10 if IS_WINDOWS else 11
 
     # 1. Upgrade pip (needed even with uv as fallback and for bootstrapping)
     _progress("pip upgrade")
@@ -334,22 +334,7 @@ def install_python_stack() -> int:
     # Try to use uv for faster installs
     USE_UV = _bootstrap_uv()
 
-    # 2. Pin torch to a range where prebuilt causal-conv1d / mamba-ssm wheels exist.
-    # Wheels are published for torch 2.6 through 2.10 at:
-    #   https://github.com/Dao-AILab/causal-conv1d/releases
-    #   https://github.com/state-spaces/mamba/releases
-    # Bump the upper bound once upstream publishes wheels for newer torch versions.
-    _progress("torch for hybrid model wheel compatibility")
-    pip_install(
-        "Installing pinned torch stack",
-        "--no-cache-dir",
-        "torch>=2.6.0,<2.11.0",
-        "torchvision",
-        "torchaudio",
-        constrain = False,
-    )
-
-    # 3. Core packages: unsloth-zoo + unsloth
+    # 2. Core packages: unsloth-zoo + unsloth
     _progress("base packages")
     pip_install(
         "Installing base packages",
@@ -357,7 +342,7 @@ def install_python_stack() -> int:
         req = REQ_ROOT / "base.txt",
     )
 
-    # 4. Extra dependencies
+    # 3. Extra dependencies
     _progress("unsloth extras")
     pip_install(
         "Installing additional unsloth dependencies",
@@ -383,7 +368,7 @@ def install_python_stack() -> int:
         req = REQ_ROOT / "overrides.txt",
     )
 
-    # 6. Triton kernels (no-deps, from source)
+    # 5. Triton kernels (no-deps, from source)
     if not IS_WINDOWS:
         _progress("triton kernels")
         pip_install(
@@ -415,7 +400,7 @@ def install_python_stack() -> int:
     #     "https://raw.githubusercontent.com/unslothai/unsloth/refs/heads/main/unsloth/save.py",
     # )
 
-    # 9. Studio dependencies
+    # 8. Studio dependencies
     _progress("studio deps")
     pip_install(
         "Installing studio dependencies",
@@ -423,7 +408,7 @@ def install_python_stack() -> int:
         req = REQ_ROOT / "studio.txt",
     )
 
-    # 10. Data-designer dependencies
+    # 9. Data-designer dependencies
     _progress("data designer deps")
     pip_install(
         "Installing data-designer base dependencies",
@@ -431,7 +416,7 @@ def install_python_stack() -> int:
         req = SINGLE_ENV / "data-designer-deps.txt",
     )
 
-    # 11. Data-designer packages (no-deps to avoid conflicts)
+    # 10. Data-designer packages (no-deps to avoid conflicts)
     _progress("data designer")
     pip_install(
         "Installing data-designer",
@@ -440,7 +425,7 @@ def install_python_stack() -> int:
         req = SINGLE_ENV / "data-designer.txt",
     )
 
-    # 12. Local Data Designer seed plugin
+    # 11. Local Data Designer seed plugin
     if not LOCAL_DD_UNSTRUCTURED_PLUGIN.is_dir():
         _safe_print(
             _red(
@@ -457,7 +442,7 @@ def install_python_stack() -> int:
         constrain = False,
     )
 
-    # 13. Patch metadata for single-env compatibility
+    # 12. Patch metadata for single-env compatibility
     _progress("finalizing")
     run(
         "Patching single-env metadata",


### PR DESCRIPTION
Tested on B200 with torch 2.11 (build from pypi) and 2.9 (install from wheel)

1. try to install from wheel on the github releases targeting the current pytorch and cuda version
2. If failed, fall back to pypi which takes quite a while :(


<details>
<summary>Click to view full logs. Install takes few seconds</summary>

```
{"timestamp": "2026-03-24T11:56:07.307901Z", "level": "info", "event": "Dynamic check: unsloth/NVIDIA-Nemotron-3-Nano-4B uses tokenizer_class=TokenizersBackend (requires transformers 5.x)"}
{"timestamp": "2026-03-24T11:56:07.309019Z", "level": "info", "event": "Activated transformers 5.x from /home/datta0/.unsloth/studio/.venv_t5"}
{"timestamp": "2026-03-24T11:56:07.309086Z", "level": "info", "event": "Auto-enabled trust_remote_code for unsloth/* transformers 5.x model: unsloth/NVIDIA-Nemotron-3-Nano-4B"}
{"timestamp": "2026-03-24T11:56:08.238636Z", "level": "info", "event": "request_completed", "method": "GET", "path": "/api/train/progress", "status_code": 200, "process_time_ms": 2.88}
{"timestamp": "2026-03-24T11:56:08.587124Z", "level": "info", "event": "Resolved causal-conv1d environment tuple: python=cp313 torch=2.9 cuda_major=13 cxx11abi=TRUE"}
{"timestamp": "2026-03-24T11:56:08.587207Z", "level": "info", "event": "Checking for published causal-conv1d wheel: https://github.com/Dao-AILab/causal-conv1d/releases/download/v1.6.1.post4/causal_conv1d-1.6.1+cu13torch2.9cxx11abiTRUE-cp313-cp313-linux_x86_64.whl"}
{"timestamp": "2026-03-24T11:56:08.793083Z", "level": "info", "event": "Installing causal-conv1d from direct wheel URL: https://github.com/Dao-AILab/causal-conv1d/releases/download/v1.6.1.post4/causal_conv1d-1.6.1+cu13torch2.9cxx11abiTRUE-cp313-cp313-linux_x86_64.whl"}
{"timestamp": "2026-03-24T11:56:13.433361Z", "level": "info", "event": "Installed prebuilt causal-conv1d wheel successfully"}
{"timestamp": "2026-03-24T11:56:13.433482Z", "level": "info", "event": "SSM model detected; setting up mamba-ssm after causal-conv1d"}
{"timestamp": "2026-03-24T11:56:14.678879Z", "level": "info", "event": "Resolved mamba-ssm environment tuple: python=cp313 torch=2.9 cuda_major=13 cxx11abi=TRUE"}
{"timestamp": "2026-03-24T11:56:14.678964Z", "level": "info", "event": "Checking for published mamba-ssm wheel: https://github.com/state-spaces/mamba/releases/download/v2.3.1/mamba_ssm-2.3.1+cu13torch2.9cxx11abiTRUE-cp313-cp313-linux_x86_64.whl"}
{"timestamp": "2026-03-24T11:56:14.902057Z", "level": "info", "event": "Installing mamba-ssm from direct wheel URL: https://github.com/state-spaces/mamba/releases/download/v2.3.1/mamba_ssm-2.3.1+cu13torch2.9cxx11abiTRUE-cp313-cp313-linux_x86_64.whl"}
{"timestamp": "2026-03-24T11:56:21.988722Z", "level": "info", "event": "Installed prebuilt mamba-ssm wheel successfully"}
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
Unsloth: Your Flash Attention 2 installation seems to be broken. Using Xformers instead. No performance changes will be seen.
🦥 Unsloth Zoo will now patch everything to make training faster!
{"timestamp": "2026-03-24T11:56:39.848999Z", "level": "info", "event": "Subprocess loaded transformers 5.3.0"}
{"timestamp": "2026-03-24T11:56:40.079677Z", "level": "info", "event": "Model 'unsloth/NVIDIA-Nemotron-3-Nano-4B' needs transformers 5.x \u2014 checking vision via subprocess"}
{"timestamp": "2026-03-24T11:56:42.790077Z", "level": "info", "event": "Vision check (subprocess, transformers 5.x) for 'unsloth/NVIDIA-Nemotron-3-Nano-4B': model_type=nemotron_h, architectures=['NemotronHForCausalLM'], is_vision=False"}
{"timestamp": "2026-03-24T11:56:42.790174Z", "level": "info", "event": "pre_detect: audio_type=None, is_audio=False, is_audio_vlm=False, is_vlm=False"}
tokenizer_config.json: 11.2kB [00:00, 31.8MB/s]
tokenizer.json: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17.1M/17.1M [00:00<00:00, 124MB/s]
special_tokens_map.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 420/420 [00:00<00:00, 3.69MB/s]
chat_template.jinja: 10.5kB [00:00, 37.7MB/s]
{"timestamp": "2026-03-24T11:56:45.133175Z", "level": "info", "event": "Pre-loaded tokenizer for unsloth/NVIDIA-Nemotron-3-Nano-4B"}
README.md: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 603/603 [00:00<00:00, 3.87MB/s]
{"timestamp": "2026-03-24T11:56:45.795933Z", "level": "info", "event": "Loaded dataset from Hugging Face: unsloth/OpenMathReasoning-mini (19,252 rows)\n"}
{"timestamp": "2026-03-24T11:56:45.796084Z", "level": "info", "event": "Eval disabled (eval_steps <= 0), skipping eval split detection\n"}
{"timestamp": "2026-03-24T11:56:45.796111Z", "level": "info", "event": "Formatting dataset with format_type='auto'...\n"}
{"timestamp": "2026-03-24T11:56:45.801901Z", "level": "info", "event": "\ud83d\udcdd Using tokenizer's own chat template (no Unsloth template match)"}
{"timestamp": "2026-03-24T11:56:45.802231Z", "level": "info", "event": "Multi-GPU detected (8 visible GPUs) -- capping num_proc 64 -> 4 to avoid fork deadlocks"}
{"timestamp": "2026-03-24T11:56:46.043052Z", "level": "info", "event": "Dataset formatted successfully (19252 samples, user_mapped)\n"}
{"timestamp": "2026-03-24T11:56:46.061382Z", "level": "info", "event": "\nClearing GPU memory before training..."}
Hardware detected: CUDA — NVIDIA B200
{"timestamp": "2026-03-24T11:56:46.421820Z", "level": "info", "event": "Model 'unsloth/NVIDIA-Nemotron-3-Nano-4B' needs transformers 5.x \u2014 checking vision via subprocess"}
{"timestamp": "2026-03-24T11:56:49.062046Z", "level": "info", "event": "Vision check (subprocess, transformers 5.x) for 'unsloth/NVIDIA-Nemotron-3-Nano-4B': model_type=nemotron_h, architectures=['NemotronHForCausalLM'], is_vision=False"}
{"timestamp": "2026-03-24T11:56:49.062130Z", "level": "info", "event": "Audio type: None, is_audio: False, is_audio_vlm: False"}
{"timestamp": "2026-03-24T11:56:49.062155Z", "level": "info", "event": "Dataset has images: False, audio: False"}
{"timestamp": "2026-03-24T11:56:49.062172Z", "level": "info", "event": "Using VLM path: False"}
{"timestamp": "2026-03-24T11:56:49.062216Z", "level": "info", "event": "\nLoading text model: unsloth/NVIDIA-Nemotron-3-Nano-4B"}
Unsloth: WARNING `trust_remote_code` is True.
Are you certain you want to do remote code execution?
==((====))==  Unsloth 2026.3.10: Fast Nemotron_H patching. Transformers: 5.3.0.
   \\   /|    NVIDIA B200. Num GPUs = 8. Max memory: 178.353 GB. Platform: Linux.
O^O/ \_/ \    Torch: 2.9.1+cu130. CUDA: 10.0. CUDA Toolkit: 13.0. Triton: 3.5.1
\        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = False]
 "-____-"     Free license: http://github.com/unslothai/unsloth
Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
Unsloth: Nemotron_H does not support SDPA - switching to fast eager.
Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.
modeling_nemotron_h.py: 78.6kB [00:00, 141MB/s]
A new version of the following files was downloaded from https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-4B:
- modeling_nemotron_h.py
. Make sure to double-check they do not contain any added malicious code. To avoid downloading new versions of the code file, you can pin a revision.
model.safetensors: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.95G/7.95G [00:16<00:00, 486MB/s]
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 263/263 [00:00<00:00, 279.01it/s]
generation_config.json: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 132/132 [00:00<00:00, 926kB/s]
{"timestamp": "2026-03-24T11:57:15.963481Z", "level": "info", "event": "Loaded text model"}
{"timestamp": "2026-03-24T11:57:15.963610Z", "level": "info", "event": "Model loaded successfully"}
{"timestamp": "2026-03-24T11:57:15.963667Z", "level": "info", "event": "Configuring LoRA adapters (r=16, alpha=16)...\n"}
{"timestamp": "2026-03-24T11:57:15.963690Z", "level": "info", "event": "Gradient checkpointing: unsloth (type: str)\n"}
{"timestamp": "2026-03-24T11:57:15.963711Z", "level": "info", "event": "Text model LoRA configuration:"}
{"timestamp": "2026-03-24T11:57:15.963729Z", "level": "info", "event": "  - Target modules: ['q_proj', 'k_proj', 'v_proj', 'o_proj', 'gate_proj', 'up_proj', 'down_proj']\n"}
Unsloth: Making `model.base_model.model.backbone` require gradients
{"timestamp": "2026-03-24T11:57:18.135441Z", "level": "info", "event": "LoRA adapters configured successfully\n"}
{"timestamp": "2026-03-24T11:57:18.136221Z", "level": "info", "event": "Configuring data collator...\n"}
{"timestamp": "2026-03-24T11:57:18.136282Z", "level": "info", "event": "[DEBUG] learning_rate from training_args: 5e-05 (type: float)\n"}
{"timestamp": "2026-03-24T11:57:18.136339Z", "level": "info", "event": "Multi-GPU detected (8 visible GPUs) -- capping num_proc 48 -> 4 to avoid fork deadlocks"}
{"timestamp": "2026-03-24T11:57:18.136360Z", "level": "info", "event": "[DEBUG] dataset_num_proc=4 (is_audio=False, is_audio_vlm=False, _cuda_audio_used=False)"}
{"timestamp": "2026-03-24T11:57:18.136375Z", "level": "info", "event": "Using warmup_steps: 5\n"}
{"timestamp": "2026-03-24T11:57:18.136389Z", "level": "info", "event": "Training for 30 steps\n"}
{"timestamp": "2026-03-24T11:57:18.136402Z", "level": "info", "event": "No eval dataset \u2014 evaluation disabled\n"}
{"timestamp": "2026-03-24T11:57:18.136415Z", "level": "info", "event": "Configuring text model training parameters\n"}
{"timestamp": "2026-03-24T11:57:18.136429Z", "level": "info", "event": "Sequence packing: disabled\n"}
{"timestamp": "2026-03-24T11:57:18.136458Z", "level": "info", "event": "The configuration is: {'per_device_train_batch_size': 2, 'gradient_accumulation_steps': 4, 'learning_rate': 5e-05, 'fp16': False, 'bf16': True, 'logging_steps': 1, 'weight_decay': 0.01, 'seed': 3407, 'output_dir': '/home/datta0/.unsloth/studio/outputs/unsloth_NVIDIA-Nemotron-3-Nano-4B_1774353438', 'report_to': 'none', 'include_num_input_tokens_seen': True, 'dataset_num_proc': 4, 'max_seq_length': 2048, 'warmup_steps': 5, 'save_steps': 30, 'save_strategy': 'steps', 'max_steps': 30, 'optim': 'adamw_8bit', 'lr_scheduler_type': 'linear', 'dataset_text_field': 'text', 'packing': False}"}
{"timestamp": "2026-03-24T11:57:18.136482Z", "level": "info", "event": "Training configuration prepared\n"}
Unsloth: Tokenizing ["text"] (num_proc=4):   0%|                                                                                                                                                           | 0/19252 [00:00<?, ? examples/s]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/multiprocess/popen_fork.py:66: DeprecationWarning: This process (pid=2439231) is multi-threaded, use of fork() may lead to deadlocks in the child.
  self.pid = os.fork()
Unsloth: Tokenizing ["text"] (num_proc=4): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 19252/19252 [00:28<00:00, 673.07 examples/s]
🦥 Unsloth: Padding-free auto-enabled, enabling faster training.
{"timestamp": "2026-03-24T11:57:47.291598Z", "level": "info", "event": "Trainer initialized\n"}
{"timestamp": "2026-03-24T11:57:47.291694Z", "level": "info", "event": "Configuring train on responses only...\n"}
{"timestamp": "2026-03-24T11:57:47.291722Z", "level": "info", "event": "No template mapping found for model: unsloth/NVIDIA-Nemotron-3-Nano-4B\n"}
{"timestamp": "2026-03-24T11:57:47.291742Z", "level": "info", "event": "Training on full sequences (including prompts)\n"}
{"timestamp": "2026-03-24T11:57:47.291853Z", "level": "info", "event": "Starting training...\n"}
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 11, 'pad_token_id': 999}.
  0%|                                                                                                                                                                                                                | 0/30 [00:00<?, ?it/s]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
Unsloth: Will smartly offload gradients to save VRAM!
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '25.19', 'grad_norm': '1.395', 'learning_rate': '0', 'epoch': '0.0004155', 'num_input_tokens_seen': 16029, 'train_runtime': '85.94', 'train_tokens_per_second': '186.5'}
  3%|██████▋                                                                                                                                                                                                 | 1/30 [01:25<41:32, 85.93s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '23.85', 'grad_norm': '1.255', 'learning_rate': '1e-05', 'epoch': '0.0008311', 'num_input_tokens_seen': 31965, 'train_runtime': '87.41', 'train_tokens_per_second': '365.7'}
  7%|█████████████▎                                                                                                                                                                                          | 2/30 [01:27<16:55, 36.25s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '23.97', 'grad_norm': '1.446', 'learning_rate': '2e-05', 'epoch': '0.001247', 'num_input_tokens_seen': 47604, 'train_runtime': '88.98', 'train_tokens_per_second': '535'}
 10%|████████████████████                                                                                                                                                                                    | 3/30 [01:28<09:11, 20.42s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
{'loss': '23.72', 'grad_norm': '1.155', 'learning_rate': '3e-05', 'epoch': '0.001662', 'num_input_tokens_seen': 62972, 'train_runtime': '90.27', 'train_tokens_per_second': '697.6'}
{'loss': '24.98', 'grad_norm': '1.545', 'learning_rate': '4e-05', 'epoch': '0.002078', 'num_input_tokens_seen': 79356, 'train_runtime': '91.17', 'train_tokens_per_second': '870.4'}
{'loss': '23.78', 'grad_norm': '2.518', 'learning_rate': '5e-05', 'epoch': '0.002493', 'num_input_tokens_seen': 95740, 'train_runtime': '92.07', 'train_tokens_per_second': '1040'}
{'loss': '23.28', 'grad_norm': '2.001', 'learning_rate': '4.8e-05', 'epoch': '0.002909', 'num_input_tokens_seen': 111516, 'train_runtime': '93.11', 'train_tokens_per_second': '1198'}
{'loss': '23.3', 'grad_norm': '1.673', 'learning_rate': '4.6e-05', 'epoch': '0.003324', 'num_input_tokens_seen': 127535, 'train_runtime': '94.12', 'train_tokens_per_second': '1355'}
{'loss': '24.95', 'grad_norm': '2.628', 'learning_rate': '4.4e-05', 'epoch': '0.00374', 'num_input_tokens_seen': 143870, 'train_runtime': '95.14', 'train_tokens_per_second': '1512'}
{'loss': '23.69', 'grad_norm': '2.589', 'learning_rate': '4.2e-05', 'epoch': '0.004155', 'num_input_tokens_seen': 159144, 'train_runtime': '96.31', 'train_tokens_per_second': '1652'}
{'loss': '23.77', 'grad_norm': '2.303', 'learning_rate': '4e-05', 'epoch': '0.004571', 'num_input_tokens_seen': 174698, 'train_runtime': '97.33', 'train_tokens_per_second': '1795'}
{'loss': '22.89', 'grad_norm': '2.099', 'learning_rate': '3.8e-05', 'epoch': '0.004986', 'num_input_tokens_seen': 191082, 'train_runtime': '98.23', 'train_tokens_per_second': '1945'}
{'loss': '23.14', 'grad_norm': '5.933', 'learning_rate': '3.6e-05', 'epoch': '0.005402', 'num_input_tokens_seen': 207376, 'train_runtime': '99.23', 'train_tokens_per_second': '2090'}
{'loss': '23.48', 'grad_norm': '3.71', 'learning_rate': '3.4e-05', 'epoch': '0.005818', 'num_input_tokens_seen': 222393, 'train_runtime': '100.4', 'train_tokens_per_second': '2216'}
{'loss': '22.26', 'grad_norm': '3.519', 'learning_rate': '3.2e-05', 'epoch': '0.006233', 'num_input_tokens_seen': 237894, 'train_runtime': '101.4', 'train_tokens_per_second': '2347'}
{'loss': '21.49', 'grad_norm': '2.508', 'learning_rate': '3e-05', 'epoch': '0.006649', 'num_input_tokens_seen': 254278, 'train_runtime': '102.3', 'train_tokens_per_second': '2486'}
{'loss': '23.16', 'grad_norm': '3.333', 'learning_rate': '2.8e-05', 'epoch': '0.007064', 'num_input_tokens_seen': 270419, 'train_runtime': '103.3', 'train_tokens_per_second': '2618'}
{'loss': '21.69', 'grad_norm': '2.597', 'learning_rate': '2.6e-05', 'epoch': '0.00748', 'num_input_tokens_seen': 286019, 'train_runtime': '104.4', 'train_tokens_per_second': '2739'}
{'loss': '22.97', 'grad_norm': '3.773', 'learning_rate': '2.4e-05', 'epoch': '0.007895', 'num_input_tokens_seen': 302403, 'train_runtime': '105.3', 'train_tokens_per_second': '2871'}
{'loss': '21.71', 'grad_norm': '3.814', 'learning_rate': '2.2e-05', 'epoch': '0.008311', 'num_input_tokens_seen': 317490, 'train_runtime': '106.4', 'train_tokens_per_second': '2983'}
 67%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                                                  | 20/30 [01:46<00:10,  1.07s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '21.67', 'grad_norm': '3.249', 'learning_rate': '2e-05', 'epoch': '0.008726', 'num_input_tokens_seen': 332451, 'train_runtime': '107.7', 'train_tokens_per_second': '3086'}
 70%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▎                                                           | 21/30 [01:47<00:10,  1.13s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
{'loss': '21.86', 'grad_norm': '2.798', 'learning_rate': '1.8e-05', 'epoch': '0.009142', 'num_input_tokens_seen': 348255, 'train_runtime': '109', 'train_tokens_per_second': '3196'}
{'loss': '20.41', 'grad_norm': '3.026', 'learning_rate': '1.6e-05', 'epoch': '0.009557', 'num_input_tokens_seen': 364639, 'train_runtime': '109.9', 'train_tokens_per_second': '3318'}
{'loss': '21.36', 'grad_norm': '3.114', 'learning_rate': '1.4e-05', 'epoch': '0.009973', 'num_input_tokens_seen': 380220, 'train_runtime': '111', 'train_tokens_per_second': '3425'}
{'loss': '20.66', 'grad_norm': '3.459', 'learning_rate': '1.2e-05', 'epoch': '0.01039', 'num_input_tokens_seen': 395105, 'train_runtime': '112.1', 'train_tokens_per_second': '3524'}
{'loss': '20.54', 'grad_norm': '2.734', 'learning_rate': '1e-05', 'epoch': '0.0108', 'num_input_tokens_seen': 410768, 'train_runtime': '113.2', 'train_tokens_per_second': '3627'}
{'loss': '22.81', 'grad_norm': '3.747', 'learning_rate': '8e-06', 'epoch': '0.01122', 'num_input_tokens_seen': 425737, 'train_runtime': '114.4', 'train_tokens_per_second': '3722'}
{'loss': '21.29', 'grad_norm': '4.102', 'learning_rate': '6e-06', 'epoch': '0.01164', 'num_input_tokens_seen': 441813, 'train_runtime': '115.4', 'train_tokens_per_second': '3829'}
{'loss': '21.11', 'grad_norm': '2.816', 'learning_rate': '4e-06', 'epoch': '0.01205', 'num_input_tokens_seen': 457399, 'train_runtime': '116.5', 'train_tokens_per_second': '3926'}
{'loss': '20.86', 'grad_norm': '3.542', 'learning_rate': '2e-06', 'epoch': '0.01247', 'num_input_tokens_seen': 473181, 'train_runtime': '117.5', 'train_tokens_per_second': '4027'}
{'train_runtime': '117.9', 'train_samples_per_second': '2.035', 'train_steps_per_second': '0.254', 'train_loss': '22.66', 'epoch': '0.01247', 'num_input_tokens_seen': 473181}
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [01:57<00:00,  3.93s/it]
{"timestamp": "2026-03-24T11:59:46.932270Z", "level": "info", "event": "Patching adapter_config.json with unsloth_training_method='lora'"}
{"timestamp": "2026-03-24T11:59:46.932475Z", "level": "info", "event": "\nTraining completed! Model saved to /home/datta0/.unsloth/studio/outputs/unsloth_NVIDIA-Nemotron-3-Nano-4B_1774353438\n"}

```
</details>




<details>
<summary>H100 logs with new branch</summary>

```

{"timestamp": "2026-03-25T03:55:56.453338Z", "level": "info", "event": "Checking format for dataset: unsloth/OpenMathReasoning-mini"}
{"timestamp": "2026-03-25T03:55:56.538530Z", "level": "info", "event": "Tier 1: loading single file data/cot-00000-of-00001.parquet"}
{"timestamp": "2026-03-25T03:55:57.553459Z", "level": "info", "event": "Format check result: requires_mapping=False, format=custom_heuristic, is_image=False"}
{"timestamp": "2026-03-25T03:55:57.555504Z", "level": "info", "event": "request_completed", "method": "POST", "path": "/api/datasets/check-format", "status_code": 200, "process_time_ms": 1103.7}
{"timestamp": "2026-03-25T03:55:58.113349Z", "level": "info", "event": "Starting training job with model: unsloth/NVIDIA-Nemotron-3-Nano-4B"}
{"timestamp": "2026-03-25T03:55:58.116143Z", "level": "info", "event": "Loaded default model defaults from /home/datta0/unsloth/studio/backend/assets/configs/model_defaults/default.yaml"}
{"timestamp": "2026-03-25T03:55:58.116433Z", "level": "info", "event": "InferenceOrchestrator initialized (subprocess mode)"}
{"timestamp": "2026-03-25T03:55:58.117148Z", "level": "info", "event": "ExportOrchestrator initialized (subprocess mode)"}
{"timestamp": "2026-03-25T03:55:58.121288Z", "level": "info", "event": "Training subprocess started (pid=34893)"}
{"timestamp": "2026-03-25T03:55:58.122814Z", "level": "info", "event": "request_completed", "method": "POST", "path": "/api/train/start", "status_code": 200, "process_time_ms": 11.33}
{"timestamp": "2026-03-25T03:55:58.235684Z", "level": "info", "event": "Top GGUF models: ['unsloth/Qwen3.5-35B-A3B-GGUF', 'unsloth/Qwen3.5-9B-GGUF', 'unsloth/Qwen3.5-27B-GGUF', 'unsloth/Qwen3.5-122B-A10B-GGUF', 'unsloth/Qwen3.5-4B-GGUF', 'unsloth/gpt-oss-20b-GGUF', 'unsloth/Qwen3-Coder-Next-GGUF', 'unsloth/GLM-4.7-Flash-GGUF', 'unsloth/Qwen3.5-0.8B-GGUF', 'unsloth/Qwen3.5-2B-GGUF', 'unsloth/Nemotron-3-Nano-30B-A3B-GGUF', 'unsloth/Qwen3.5-397B-A17B-GGUF', 'unsloth/LTX-2.3-GGUF', 'unsloth/Qwen3-VL-4B-Instruct-GGUF', 'unsloth/Qwen3.5-35B-A3B-Experiments-GGUF', 'unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF', 'unsloth/GLM-4.6V-Flash-GGUF', 'unsloth/gemma-3-27b-it-GGUF', 'unsloth/gpt-oss-120b-GGUF', 'unsloth/gemma-3-12b-it-GGUF', 'unsloth/Qwen-Image-Edit-2511-GGUF', 'unsloth/Llama-3.2-1B-Instruct-GGUF', 'unsloth/Qwen3-4B-Instruct-2507-GGUF', 'unsloth/Qwen3-0.6B-GGUF', 'unsloth/Qwen3-VL-30B-A3B-Instruct-GGUF', 'unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF', 'unsloth/MiniMax-M2.5-GGUF', 'unsloth/gemma-3-270m-it-GGUF', 'unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF', 'unsloth/Qwen3-4B-GGUF', 'unsloth/gemma-3-4b-it-GGUF', 'unsloth/Qwen2.5-VL-7B-Instruct-GGUF', 'unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF', 'unsloth/FLUX.2-klein-9B-GGUF']"}
{"timestamp": "2026-03-25T03:55:58.235763Z", "level": "info", "event": "Top hub models: ['unsloth/GLM-4.7-Flash-FP8-Dynamic', 'unsloth/mistral-7b-v0.3-bnb-4bit', 'unsloth/Meta-Llama-3.1-8B-Instruct', 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit', 'unsloth/DeepSeek-OCR-2', 'unsloth/gpt-oss-20b', 'unsloth/Qwen3-0.6B', 'unsloth/Llama-3.2-1B-Instruct', 'unsloth/Llama-3.1-8B-Instruct', 'unsloth/Qwen3-14B-unsloth-bnb-4bit', 'unsloth/Llama-3.2-3B-Instruct', 'unsloth/Qwen3-4B-Instruct-2507-unsloth-bnb-4bit', 'unsloth/Qwen3-0.6B-unsloth-bnb-4bit', 'unsloth/gpt-oss-20b-unsloth-bnb-4bit', 'unsloth/Qwen2.5-7B-Instruct-bnb-4bit', 'unsloth/GLM-4.7-Flash', 'unsloth/Qwen3.5-9B', 'unsloth/Qwen3-4B-Base', 'unsloth/Qwen2.5-7B', 'unsloth/Qwen3.5-4B', 'unsloth/Qwen2-7B', 'unsloth/Qwen2.5-3B-Instruct-unsloth-bnb-4bit', 'unsloth/gpt-oss-120b-BF16', 'unsloth/gpt-oss-20b-BF16', 'unsloth/Qwen3-8B-unsloth-bnb-4bit', 'unsloth/Qwen3-8B', 'unsloth/Llama-3.2-1B-Instruct-unsloth-bnb-4bit', 'unsloth/Qwen3-4B', 'unsloth/Qwen3.5-2B', 'unsloth/Qwen3-4B-bnb-4bit', 'unsloth/Qwen2.5-7B-Instruct-unsloth-bnb-4bit', 'unsloth/DeepSeek-V3-0324-BF16', 'unsloth/embeddinggemma-300m', 'unsloth/Llama-3.2-3B-Instruct-unsloth-bnb-4bit', 'unsloth/llama-3-8b-bnb-4bit', 'unsloth/Qwen3-1.7B-unsloth-bnb-4bit', 'unsloth/Qwen2.5-7B-Instruct', 'unsloth/Qwen3-4B-unsloth-bnb-4bit', 'unsloth/Qwen3.5-0.8B', 'unsloth/Qwen3-VL-4B-Instruct-unsloth-bnb-4bit']"}
{"timestamp": "2026-03-25T03:55:58.851066Z", "level": "info", "event": "Dynamic check: unsloth/NVIDIA-Nemotron-3-Nano-4B uses tokenizer_class=TokenizersBackend (requires transformers 5.x)"}
{"timestamp": "2026-03-25T03:55:58.852230Z", "level": "info", "event": "Activated transformers 5.x from /home/datta0/.unsloth/studio/.venv_t5"}
{"timestamp": "2026-03-25T03:55:58.852311Z", "level": "info", "event": "Auto-enabled trust_remote_code for unsloth/* transformers 5.x model: unsloth/NVIDIA-Nemotron-3-Nano-4B"}
{"timestamp": "2026-03-25T03:56:01.664356Z", "level": "info", "event": "request_completed", "method": "GET", "path": "/api/train/progress", "status_code": 200, "process_time_ms": 2.96}
{"timestamp": "2026-03-25T03:56:08.792557Z", "level": "info", "event": "Installed prebuilt causal-conv1d wheel"}
{"timestamp": "2026-03-25T03:56:08.792662Z", "level": "info", "event": "SSM model detected; setting up mamba-ssm after causal-conv1d"}
{"timestamp": "2026-03-25T03:56:23.249467Z", "level": "info", "event": "Installed prebuilt mamba-ssm wheel"}
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
Unsloth: Your Flash Attention 2 installation seems to be broken. Using Xformers instead. No performance changes will be seen.
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/triton/runtime/autotuner.py:99: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
  warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "
🦥 Unsloth Zoo will now patch everything to make training faster!
{"timestamp": "2026-03-25T03:56:40.665942Z", "level": "info", "event": "Subprocess loaded transformers 5.3.0"}
{"timestamp": "2026-03-25T03:56:40.884820Z", "level": "info", "event": "Model 'unsloth/NVIDIA-Nemotron-3-Nano-4B' needs transformers 5.x \u2014 checking vision via subprocess"}
{"timestamp": "2026-03-25T03:56:43.614114Z", "level": "info", "event": "Vision check (subprocess, transformers 5.x) for 'unsloth/NVIDIA-Nemotron-3-Nano-4B': model_type=nemotron_h, architectures=['NemotronHForCausalLM'], is_vision=False"}
{"timestamp": "2026-03-25T03:56:43.614237Z", "level": "info", "event": "pre_detect: audio_type=None, is_audio=False, is_audio_vlm=False, is_vlm=False"}
tokenizer_config.json: 11.2kB [00:00, 34.5MB/s]
tokenizer.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17.1M/17.1M [00:00<00:00, 113MB/s]
special_tokens_map.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 420/420 [00:00<00:00, 2.89MB/s]
chat_template.jinja: 10.5kB [00:00, 40.2MB/s]
{"timestamp": "2026-03-25T03:56:46.791801Z", "level": "info", "event": "Pre-loaded tokenizer for unsloth/NVIDIA-Nemotron-3-Nano-4B"}
README.md: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 603/603 [00:00<00:00, 3.87MB/s]
{"timestamp": "2026-03-25T03:56:47.828676Z", "level": "info", "event": "Loaded dataset from Hugging Face: unsloth/OpenMathReasoning-mini (19,252 rows)\n"}
{"timestamp": "2026-03-25T03:56:47.828740Z", "level": "info", "event": "Eval disabled (eval_steps <= 0), skipping eval split detection\n"}
{"timestamp": "2026-03-25T03:56:47.828770Z", "level": "info", "event": "Formatting dataset with format_type='auto'...\n"}
Map: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 19252/19252 [00:01<00:00, 9636.45 examples/s]
{"timestamp": "2026-03-25T03:56:49.830573Z", "level": "info", "event": "\ud83d\udcdd Using tokenizer's own chat template (no Unsloth template match)"}
Applying chat template to chatml_conversations (num_proc=8):   0%|                                                                          | 0/19252 [00:00<?, ? examples/s]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/multiprocess/popen_fork.py:66: DeprecationWarning: This process (pid=34893) is multi-threaded, use of fork() may lead to deadlocks in the child.
  self.pid = os.fork()
Applying chat template to chatml_conversations (num_proc=8): 100%|████████████████████████████████████████████████████████████| 19252/19252 [00:02<00:00, 7303.15 examples/s]
{"timestamp": "2026-03-25T03:56:52.616239Z", "level": "info", "event": "Dataset formatted successfully (19252 samples, user_mapped)\n"}
{"timestamp": "2026-03-25T03:56:52.616821Z", "level": "info", "event": "\nClearing GPU memory before training..."}
Hardware detected: CUDA — NVIDIA H100 80GB HBM3
{"timestamp": "2026-03-25T03:56:53.047438Z", "level": "info", "event": "Model 'unsloth/NVIDIA-Nemotron-3-Nano-4B' needs transformers 5.x \u2014 checking vision via subprocess"}
{"timestamp": "2026-03-25T03:56:55.773669Z", "level": "info", "event": "Vision check (subprocess, transformers 5.x) for 'unsloth/NVIDIA-Nemotron-3-Nano-4B': model_type=nemotron_h, architectures=['NemotronHForCausalLM'], is_vision=False"}
{"timestamp": "2026-03-25T03:56:55.773773Z", "level": "info", "event": "Audio type: None, is_audio: False, is_audio_vlm: False"}
{"timestamp": "2026-03-25T03:56:55.773805Z", "level": "info", "event": "Dataset has images: False, audio: False"}
{"timestamp": "2026-03-25T03:56:55.773829Z", "level": "info", "event": "Using VLM path: False"}
{"timestamp": "2026-03-25T03:56:55.773892Z", "level": "info", "event": "\nLoading text model: unsloth/NVIDIA-Nemotron-3-Nano-4B"}
Unsloth: WARNING `trust_remote_code` is True.
Are you certain you want to do remote code execution?
==((====))==  Unsloth 2026.3.11: Fast Nemotron_H patching. Transformers: 5.3.0.
   \\   /|    NVIDIA H100 80GB HBM3. Num GPUs = 1. Max memory: 79.179 GB. Platform: Linux.
O^O/ \_/ \    Torch: 2.9.1+cu129. CUDA: 9.0. CUDA Toolkit: 12.9. Triton: 3.5.1
\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.33.post2. FA2 = False]
 "-____-"     Free license: http://github.com/unslothai/unsloth
Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
Unsloth: Nemotron_H does not support SDPA - switching to fast eager.
Unsloth: QLoRA and full finetuning all not selected. Switching to 16bit LoRA.
modeling_nemotron_h.py: 78.6kB [00:00, 119MB/s]
A new version of the following files was downloaded from https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-4B:
- modeling_nemotron_h.py
. Make sure to double-check they do not contain any added malicious code. To avoid downloading new versions of the code file, you can pin a revision.
model.safetensors: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.95G/7.95G [00:36<00:00, 216MB/s]
Loading weights: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 263/263 [00:01<00:00, 223.22it/s]
generation_config.json: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 132/132 [00:00<00:00, 1.07MB/s]
{"timestamp": "2026-03-25T03:57:43.599518Z", "level": "info", "event": "Loaded text model"}
{"timestamp": "2026-03-25T03:57:43.599629Z", "level": "info", "event": "Model loaded successfully"}
{"timestamp": "2026-03-25T03:57:43.599795Z", "level": "info", "event": "Configuring LoRA adapters (r=16, alpha=16)...\n"}
{"timestamp": "2026-03-25T03:57:43.599830Z", "level": "info", "event": "Gradient checkpointing: unsloth (type: str)\n"}
{"timestamp": "2026-03-25T03:57:43.599857Z", "level": "info", "event": "Text model LoRA configuration:"}
{"timestamp": "2026-03-25T03:57:43.599882Z", "level": "info", "event": "  - Target modules: ['q_proj', 'k_proj', 'v_proj', 'o_proj', 'gate_proj', 'up_proj', 'down_proj']\n"}
Unsloth: Making `model.base_model.model.backbone` require gradients
{"timestamp": "2026-03-25T03:57:46.840069Z", "level": "info", "event": "LoRA adapters configured successfully\n"}
{"timestamp": "2026-03-25T03:57:46.840535Z", "level": "info", "event": "Configuring data collator...\n"}
{"timestamp": "2026-03-25T03:57:46.840587Z", "level": "info", "event": "[DEBUG] learning_rate from training_args: 0.0003 (type: float)\n"}
{"timestamp": "2026-03-25T03:57:46.840659Z", "level": "info", "event": "[DEBUG] dataset_num_proc=6 (is_audio=False, is_audio_vlm=False, _cuda_audio_used=False)"}
{"timestamp": "2026-03-25T03:57:46.840684Z", "level": "info", "event": "Using warmup_steps: 5\n"}
{"timestamp": "2026-03-25T03:57:46.840705Z", "level": "info", "event": "Training for 30 steps\n"}
{"timestamp": "2026-03-25T03:57:46.840723Z", "level": "info", "event": "No eval dataset \u2014 evaluation disabled\n"}
{"timestamp": "2026-03-25T03:57:46.840742Z", "level": "info", "event": "Configuring text model training parameters\n"}
{"timestamp": "2026-03-25T03:57:46.840762Z", "level": "info", "event": "Sequence packing: disabled\n"}
{"timestamp": "2026-03-25T03:57:46.840790Z", "level": "info", "event": "The configuration is: {'per_device_train_batch_size': 2, 'gradient_accumulation_steps': 4, 'learning_rate': 0.0003, 'fp16': False, 'bf16': True, 'logging_steps': 1, 'weight_decay': 0.01, 'seed': 3407, 'output_dir': '/home/datta0/.unsloth/studio/outputs/unsloth_NVIDIA-Nemotron-3-Nano-4B_1774411066', 'report_to': 'none', 'include_num_input_tokens_seen': True, 'dataset_num_proc': 6, 'max_seq_length': 2048, 'warmup_steps': 5, 'save_steps': 30, 'save_strategy': 'steps', 'max_steps': 30, 'optim': 'adamw_8bit', 'lr_scheduler_type': 'linear', 'dataset_text_field': 'text', 'packing': False}"}
{"timestamp": "2026-03-25T03:57:46.840814Z", "level": "info", "event": "Training configuration prepared\n"}
Unsloth: Tokenizing ["text"] (num_proc=6):   0%|                                                                                            | 0/19252 [00:00<?, ? examples/s]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/multiprocess/popen_fork.py:66: DeprecationWarning: This process (pid=34893) is multi-threaded, use of fork() may lead to deadlocks in the child.
  self.pid = os.fork()
Unsloth: Tokenizing ["text"] (num_proc=6): 100%|███████████████████████████████████████████████████████████████████████████████| 19252/19252 [00:20<00:00, 945.45 examples/s]
🦥 Unsloth: Padding-free auto-enabled, enabling faster training.
{"timestamp": "2026-03-25T03:58:07.643061Z", "level": "info", "event": "Trainer initialized\n"}
{"timestamp": "2026-03-25T03:58:07.643145Z", "level": "info", "event": "Configuring train on responses only...\n"}
{"timestamp": "2026-03-25T03:58:07.643175Z", "level": "info", "event": "No template mapping found for model: unsloth/NVIDIA-Nemotron-3-Nano-4B\n"}
{"timestamp": "2026-03-25T03:58:07.643199Z", "level": "info", "event": "Training on full sequences (including prompts)\n"}
{"timestamp": "2026-03-25T03:58:07.643318Z", "level": "info", "event": "Starting training...\n"}
The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 11, 'pad_token_id': 999}.
  0%|                                                                                                                                                 | 0/30 [00:00<?, ?it/s]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
Unsloth: Will smartly offload gradients to save VRAM!
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '25.32', 'grad_norm': '1.394', 'learning_rate': '0', 'epoch': '0.0004155', 'num_input_tokens_seen': 16029, 'train_runtime': '83.67', 'train_tokens_per_second': '191.6'}
  3%|████▌                                                                                                                                    | 1/30 [01:23<40:26, 83.67s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '24.34', 'grad_norm': '1.488', 'learning_rate': '6e-05', 'epoch': '0.0008311', 'num_input_tokens_seen': 31965, 'train_runtime': '85.49', 'train_tokens_per_second': '373.9'}
  7%|█████████▏                                                                                                                               | 2/30 [01:25<16:34, 35.53s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '24.55', 'grad_norm': '1.501', 'learning_rate': '0.00012', 'epoch': '0.001247', 'num_input_tokens_seen': 47604, 'train_runtime': '87.49', 'train_tokens_per_second': '544.1'}
 10%|█████████████▋                                                                                                                           | 3/30 [01:27<09:05, 20.22s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
{'loss': '23.97', 'grad_norm': '1.557', 'learning_rate': '0.00018', 'epoch': '0.001662', 'num_input_tokens_seen': 62972, 'train_runtime': '89.17', 'train_tokens_per_second': '706.2'}
{'loss': '24.25', 'grad_norm': '2.187', 'learning_rate': '0.00024', 'epoch': '0.002078', 'num_input_tokens_seen': 79356, 'train_runtime': '90.66', 'train_tokens_per_second': '875.3'}
{'loss': '21.9', 'grad_norm': '3.786', 'learning_rate': '0.0003', 'epoch': '0.002493', 'num_input_tokens_seen': 95740, 'train_runtime': '92.15', 'train_tokens_per_second': '1039'}
{'loss': '20.76', 'grad_norm': '3.677', 'learning_rate': '0.000288', 'epoch': '0.002909', 'num_input_tokens_seen': 111516, 'train_runtime': '93.7', 'train_tokens_per_second': '1190'}
{'loss': '20.76', 'grad_norm': '4.749', 'learning_rate': '0.000276', 'epoch': '0.003324', 'num_input_tokens_seen': 127535, 'train_runtime': '95.23', 'train_tokens_per_second': '1339'}
{'loss': '20.02', 'grad_norm': '3.828', 'learning_rate': '0.000264', 'epoch': '0.00374', 'num_input_tokens_seen': 143870, 'train_runtime': '96.78', 'train_tokens_per_second': '1487'}
{'loss': '17.92', 'grad_norm': '3.525', 'learning_rate': '0.000252', 'epoch': '0.004155', 'num_input_tokens_seen': 159144, 'train_runtime': '98.35', 'train_tokens_per_second': '1618'}
{'loss': '17.85', 'grad_norm': '4.834', 'learning_rate': '0.00024', 'epoch': '0.004571', 'num_input_tokens_seen': 174698, 'train_runtime': '99.86', 'train_tokens_per_second': '1749'}
{'loss': '16.48', 'grad_norm': '3.949', 'learning_rate': '0.000228', 'epoch': '0.004986', 'num_input_tokens_seen': 191082, 'train_runtime': '101.4', 'train_tokens_per_second': '1885'}
{'loss': '17.39', 'grad_norm': '7.575', 'learning_rate': '0.000216', 'epoch': '0.005402', 'num_input_tokens_seen': 207376, 'train_runtime': '102.9', 'train_tokens_per_second': '2015'}
{'loss': '15.65', 'grad_norm': '19.21', 'learning_rate': '0.000204', 'epoch': '0.005818', 'num_input_tokens_seen': 222393, 'train_runtime': '104.4', 'train_tokens_per_second': '2129'}
{'loss': '15.87', 'grad_norm': '3.519', 'learning_rate': '0.000192', 'epoch': '0.006233', 'num_input_tokens_seen': 237894, 'train_runtime': '106', 'train_tokens_per_second': '2245'}
{'loss': '14.54', 'grad_norm': '2.168', 'learning_rate': '0.00018', 'epoch': '0.006649', 'num_input_tokens_seen': 254278, 'train_runtime': '107.4', 'train_tokens_per_second': '2366'}
{'loss': '14.73', 'grad_norm': '2.284', 'learning_rate': '0.000168', 'epoch': '0.007064', 'num_input_tokens_seen': 270419, 'train_runtime': '109', 'train_tokens_per_second': '2481'}
 57%|█████████████████████████████████████████████████████████████████████████████                                                           | 17/30 [01:48<00:20,  1.61s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/mamba_ssm/ops/triton/ssd_combined.py:878: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:856.)
  dtype = torch.get_autocast_gpu_dtype()
{'loss': '14.88', 'grad_norm': '2.578', 'learning_rate': '0.000156', 'epoch': '0.00748', 'num_input_tokens_seen': 286019, 'train_runtime': '110.7', 'train_tokens_per_second': '2583'}
 60%|█████████████████████████████████████████████████████████████████████████████████▌                                                      | 18/30 [01:50<00:19,  1.65s/it]/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
  return data.pin_memory(device)
/home/datta0/.unsloth/studio/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning: The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument. (Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:31.)
  return data.pin_memory(device)
{'loss': '14.64', 'grad_norm': '2.938', 'learning_rate': '0.000144', 'epoch': '0.007895', 'num_input_tokens_seen': 302403, 'train_runtime': '112.2', 'train_tokens_per_second': '2695'}
{'loss': '13.4', 'grad_norm': '2.328', 'learning_rate': '0.000132', 'epoch': '0.008311', 'num_input_tokens_seen': 317490, 'train_runtime': '113.8', 'train_tokens_per_second': '2790'}
{'loss': '13.92', 'grad_norm': '2.737', 'learning_rate': '0.00012', 'epoch': '0.008726', 'num_input_tokens_seen': 332451, 'train_runtime': '115.4', 'train_tokens_per_second': '2882'}
{'loss': '13.63', 'grad_norm': '1.724', 'learning_rate': '0.000108', 'epoch': '0.009142', 'num_input_tokens_seen': 348255, 'train_runtime': '117', 'train_tokens_per_second': '2976'}
{'loss': '12.81', 'grad_norm': '1.465', 'learning_rate': '9.6e-05', 'epoch': '0.009557', 'num_input_tokens_seen': 364639, 'train_runtime': '118.5', 'train_tokens_per_second': '3076'}
{'loss': '13.33', 'grad_norm': '2.33', 'learning_rate': '8.4e-05', 'epoch': '0.009973', 'num_input_tokens_seen': 380220, 'train_runtime': '120.1', 'train_tokens_per_second': '3166'}
{'loss': '12.36', 'grad_norm': '1.593', 'learning_rate': '7.2e-05', 'epoch': '0.01039', 'num_input_tokens_seen': 395105, 'train_runtime': '121.6', 'train_tokens_per_second': '3249'}
{'loss': '12.89', 'grad_norm': '2.572', 'learning_rate': '6e-05', 'epoch': '0.0108', 'num_input_tokens_seen': 410768, 'train_runtime': '123.2', 'train_tokens_per_second': '3334'}
{'loss': '13.93', 'grad_norm': '1.639', 'learning_rate': '4.8e-05', 'epoch': '0.01122', 'num_input_tokens_seen': 425737, 'train_runtime': '124.7', 'train_tokens_per_second': '3414'}
{'loss': '11.71', 'grad_norm': '1.855', 'learning_rate': '3.6e-05', 'epoch': '0.01164', 'num_input_tokens_seen': 441813, 'train_runtime': '126.3', 'train_tokens_per_second': '3499'}
{'loss': '12.83', 'grad_norm': '2.204', 'learning_rate': '2.4e-05', 'epoch': '0.01205', 'num_input_tokens_seen': 457399, 'train_runtime': '127.9', 'train_tokens_per_second': '3577'}
{'loss': '12.57', 'grad_norm': '1.359', 'learning_rate': '1.2e-05', 'epoch': '0.01247', 'num_input_tokens_seen': 473181, 'train_runtime': '129.4', 'train_tokens_per_second': '3657'}
{'train_runtime': '129.9', 'train_samples_per_second': '1.848', 'train_steps_per_second': '0.231', 'train_loss': '16.97', 'epoch': '0.01247', 'num_input_tokens_seen': 473181}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [02:09<00:00,  4.33s/it]
{"timestamp": "2026-03-25T04:00:18.897759Z", "level": "info", "event": "Patching adapter_config.json with unsloth_training_method='lora'"}
{"timestamp": "2026-03-25T04:00:18.898044Z", "level": "info", "event": "\nTraining completed! Model saved to /home/datta0/.unsloth/studio/outputs/unsloth_NVIDIA-Nemotron-3-Nano-4B_1774411066\n"}
<sys>:0: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
^C{"timestamp": "2026-03-25T04:03:58.847109Z", "level": "info", "event": "Graceful shutdown initiated \u2014 cleaning up subprocesses..."}
{"timestamp": "2026-03-25T04:03:58.847269Z", "level": "info", "event": "All subprocesses cleaned up"}


```
</details>