### PR TITLE
Regroup chat settings sidebar into focused sections

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -478,7 +478,7 @@ export function ChatSettingsPanel({
                       value={ggufContextLength ?? ""}
                       placeholder="Loading..."
                       disabled={true}
-                      className="h-7 w-[90px] text-xs opacity-50 cursor-not-allowed"
+                      className="h-7 w-[90px] text-xs"
                     />
                   </div>
                   <div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
Breaks the old catch-all Settings panel into Model, Sampling, Tools, and Preferences sections with icons. GGUF models get context length and KV cache dtype controls, non-GGUF gets trust remote code. Collapsible open/closed state now persists across sessions.