### PR TITLE
⚠️Remove quarantined `litellm` for precaution -- Unsloth Studio **NOT** affected

### DIFF
--- a/studio/backend/requirements/single-env/data-designer-deps.txt
+++ b/studio/backend/requirements/single-env/data-designer-deps.txt
@@ -8,7 +8,6 @@ httpx-retries<1,>=0.4.2
 json-repair<1,>=0.48.0
 jsonpath-rust-bindings<2,>=1.0
 jsonschema<5,>=4.0.0
-litellm<1.80.12,>=1.73.6
 lxml<7,>=6.0.2
 marko<3,>=2.1.2
 networkx<4,>=3.0


### PR DESCRIPTION
## Unsloth Studio is **NOT** affected by the litellm supply chain attack

Unsloth Studio does not bundle or vendor litellm. The `litellm` package is only listed as an optional runtime dependency for NVIDIA's Data Designer integration.

**Our pinned version range was `litellm>=1.73.6,<1.80.12`. The compromised version is `litellm==1.82.8`. Since 1.82.8 is above our <1.80.12 upper bound, Unsloth Studio was NEVER able to install the malicious version.**

However, PyPI has quarantined the entire `litellm` project (all versions, not just 1.82.8), so no version resolves right now. This breaks `unsloth studio setup` at step 8/11 (data-designer deps).

## Summary

- Remove `litellm` from `studio/backend/requirements/single-env/data-designer-deps.txt`
- `litellm` is currently quarantined on PyPI due to a supply chain attack in version 1.82.8, which injected a malicious `.pth` credential stealer into the wheel
- No version of `litellm` is installable via pip right now
- The litellm GitHub source itself is clean -- the compromise was only in the PyPI distribution

## Context

PyPI quarantine notice: https://pypi.org/project/litellm/

The upstream constraint comes from [data-designer-engine's pyproject.toml](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/packages/data-designer-engine/pyproject.toml#L47). Once PyPI lifts the quarantine, `litellm` can be re-added.

## Test plan

- [x] Ran `unsloth studio setup` after removing litellm -- all 11/11 steps pass
- [x] Ran `unsloth studio -H 0.0.0.0 -p 8888` -- studio launches and serves correctly