### PR TITLE
fix(studio): disable Recipes nav

### DIFF
--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -17,12 +17,15 @@ const CHAT_ONLY_ALLOWED = new Set(["/", "/chat", "/login", "/signup", "/change-p
 
 function isChatOnlyAllowed(pathname: string): boolean {
   if (CHAT_ONLY_ALLOWED.has(pathname)) return true;
-  if (pathname === "/data-recipes" || pathname.startsWith("/data-recipes/")) return true;
   return false;
 }
 
 export const Route = createRootRoute({
   beforeLoad: ({ location }) => {
+    // Recipes disabled while litellm is quarantined on PyPI
+    if (location.pathname.startsWith("/data-recipes")) {
+      throw redirect({ to: "/studio" });
+    }
     const chatOnly = usePlatformStore.getState().isChatOnly();
     if (chatOnly && !isChatOnlyAllowed(location.pathname)) {
       throw redirect({ to: "/chat" });

--- a/studio/frontend/src/components/navbar.tsx
+++ b/studio/frontend/src/components/navbar.tsx
@@ -34,7 +34,7 @@ import { TOUR_OPEN_EVENT } from "@/features/tour";
 
 const NAV_ITEMS = [
   { label: "Studio", href: "/studio", icon: ZapIcon, enabled: true },
-  { label: "Recipes", href: "/data-recipes", icon: ChefHatIcon, enabled: true },
+  { label: "Recipes", href: "/data-recipes", icon: ChefHatIcon, enabled: false },
   { label: "Export", href: "/export", icon: PackageIcon, enabled: true },
   { label: "Chat", href: "/chat", icon: BubbleChatIcon, enabled: true },
 ];
@@ -93,7 +93,7 @@ export function Navbar() {
             const disabledByTraining =
               isTrainingRunning && item.href !== "/studio";
             const disabledByDevice =
-              chatOnly && item.href !== "/chat" && item.href !== "/data-recipes";
+              chatOnly && item.href !== "/chat";
             if (!item.enabled || disabledByTraining || disabledByDevice) {
               return (
                 <span
@@ -240,7 +240,7 @@ export function Navbar() {
                   const disabledByTraining =
                     isTrainingRunning && item.href !== "/studio";
                   const disabledByDevice =
-                    chatOnly && item.href !== "/chat" && item.href !== "/data-recipes";
+                    chatOnly && item.href !== "/chat";
                   if (disabledByTraining || disabledByDevice) {
                     return (
                       <span


### PR DESCRIPTION
## Unsloth is NOT affected by the litellm supply chain attack

Unsloth does not bundle or vendor litellm. Our pinned version range (`<1.80.12`) never included the compromised `1.82.8` release. However, PyPI has quarantined the entire `litellm` project (all versions), which prevents Data Designer from running.

## Summary

As a precaution, disable the **Recipes** tab in the navbar since the backend dependency it relies on (Data Designer) cannot function while litellm is unavailable on PyPI.

- `navbar.tsx`: Set `enabled: false` on the Recipes nav item, remove `/data-recipes` from chat-only exceptions
- `__root.tsx`: Remove `/data-recipes` from `isChatOnlyAllowed`

Easy to re-enable once the quarantine is lifted flip `enabled` back to `true`.

