### PR TITLE
fix: pin unsloth>=2026.3.11 in install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -275,7 +275,7 @@ function Install-UnslothStudio {
     }
 
     Write-Host "==> Installing unsloth (this may take a few minutes)..."
-    uv pip install --python $VenvPython --upgrade-package unsloth unsloth
+    uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.3.11"
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[ERROR] Failed to install unsloth (exit code $LASTEXITCODE)" -ForegroundColor Red
         return

--- a/install.sh
+++ b/install.sh
@@ -235,7 +235,7 @@ fi
 
 # ── Install unsloth directly into the venv (no activation needed) ──
 echo "==> Installing unsloth (this may take a few minutes)..."
-uv pip install --python "$VENV_NAME/bin/python" unsloth --torch-backend=auto
+uv pip install --python "$VENV_NAME/bin/python" "unsloth>=2026.3.11" --torch-backend=auto
 
 # ── Run studio setup ──
 # Ensure the venv's Python is on PATH for setup.sh's Python discovery.


### PR DESCRIPTION
## Summary

- Pin `unsloth>=2026.3.11` in both `install.sh` (Linux/macOS/WSL) and `install.ps1` (Windows)
- Without the pin, stale uv/pip caches can resolve 2026.3.10, which still has `litellm` in `data-designer-deps.txt` and causes `unsloth studio setup` to fail at step 8/11 while PyPI has litellm quarantined
- With the pin, fresh installs always get the fixed version that no longer references litellm

## Changes

**install.sh** (line 238):
```diff
-uv pip install --python "$VENV_NAME/bin/python" unsloth --torch-backend=auto
+uv pip install --python "$VENV_NAME/bin/python" "unsloth>=2026.3.11" --torch-backend=auto
```

**install.ps1** (line 278):
```diff
-uv pip install --python $VenvPython --upgrade-package unsloth unsloth
+uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.3.11"
```

## Test plan

- [x] Verified `unsloth==2026.3.11` is live on PyPI with the litellm fix
- [x] Ran `curl -fsSL https://unsloth.ai/install.sh | sh` from clean state -- all 11/11 setup steps pass
- [x] `bash -n install.sh` passes syntax check

Follows up on #4553 and #4554.