### PR TITLE
fix: prevent UnicodeEncodeError on Windows CP1252 consoles in studio setup

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -22,20 +22,20 @@ from pathlib import Path
 
 IS_WINDOWS = sys.platform == "win32"
 
-# ── Verbosity control ──────────────────────────────────────────────────────────
+# -- Verbosity control ----------------------------------------------------------
 # By default the installer shows a minimal progress bar (one line, in-place).
 # Set UNSLOTH_VERBOSE=1 in the environment to restore full per-step output:
 #   Linux/Mac:  UNSLOTH_VERBOSE=1 ./studio/setup.sh
 #   Windows:    $env:UNSLOTH_VERBOSE="1" ; .\studio\setup.ps1
 VERBOSE: bool = os.environ.get("UNSLOTH_VERBOSE", "0") == "1"
 
-# Progress bar state — updated by _progress() as each install step runs.
+# Progress bar state -- updated by _progress() as each install step runs.
 # _TOTAL counts: pip-upgrade + 7 shared steps + triton (non-Windows) + local-plugin + finalize
 # Update _TOTAL here if you add or remove install steps in install_python_stack().
 _STEP: int = 0
 _TOTAL: int = 0  # set at runtime in install_python_stack() based on platform
 
-# ── Paths ──────────────────────────────────────────────────────────────
+# -- Paths --------------------------------------------------------------
 SCRIPT_DIR = Path(__file__).resolve().parent
 REQ_ROOT = SCRIPT_DIR / "backend" / "requirements"
 SINGLE_ENV = REQ_ROOT / "single-env"
@@ -44,7 +44,7 @@ LOCAL_DD_UNSTRUCTURED_PLUGIN = (
     SCRIPT_DIR / "backend" / "plugins" / "data-designer-unstructured-seed"
 )
 
-# ── Unicode-safe printing ─────────────────────────────────────────────
+# -- Unicode-safe printing ---------------------------------------------
 # On Windows the default console encoding can be a legacy code page
 # (e.g. CP1252) that cannot represent Unicode glyphs such as ✅ or ❌.
 # _safe_print() gracefully degrades to ASCII equivalents so the
@@ -76,7 +76,7 @@ def _safe_print(*args: object, **kwargs: object) -> None:
         )
 
 
-# ── Color support ──────────────────────────────────────────────────────
+# -- Color support ------------------------------------------------------
 
 
 def _enable_colors() -> bool:
@@ -104,7 +104,7 @@ def _enable_colors() -> bool:
     return True  # Unix terminals support ANSI by default
 
 
-# Colors disabled — Colab and most CI runners render ANSI fine, but plain output
+# Colors disabled -- Colab and most CI runners render ANSI fine, but plain output
 # is cleaner in the notebook cell. Re-enable by setting _HAS_COLOR = _enable_colors()
 _HAS_COLOR = False
 
@@ -124,7 +124,7 @@ def _red(msg: str) -> str:
 def _progress(label: str) -> None:
     """Print an in-place progress bar for the current install step.
 
-    Uses only stdlib (sys.stdout) — no extra packages required.
+    Uses only stdlib (sys.stdout) -- no extra packages required.
     In VERBOSE mode this is a no-op; per-step labels are printed by run() instead.
     """
     global _STEP
@@ -161,7 +161,7 @@ def run(
 # Packages to skip on Windows (require special build steps)
 WINDOWS_SKIP_PACKAGES = {"open_spiel", "triton_kernels"}
 
-# ── uv bootstrap ──────────────────────────────────────────────────────
+# -- uv bootstrap ------------------------------------------------------
 
 USE_UV = False  # Set by _bootstrap_uv() at the start of install_python_stack()
 UV_NEEDS_SYSTEM = False  # Set by _bootstrap_uv() via probe
@@ -319,7 +319,7 @@ def patch_package_file(package_name: str, relative_path: str, url: str) -> None:
     download_file(url, dest)
 
 
-# ── Main install sequence ─────────────────────────────────────────────
+# -- Main install sequence ---------------------------------------------
 
 
 def install_python_stack() -> int:
@@ -350,7 +350,7 @@ def install_python_stack() -> int:
         req = REQ_ROOT / "extras.txt",
     )
 
-    # 3b. Extra dependencies (no-deps) — audio model support etc.
+    # 3b. Extra dependencies (no-deps) -- audio model support etc.
     _progress("extra codecs")
     pip_install(
         "Installing extras (no-deps)",
@@ -359,7 +359,7 @@ def install_python_stack() -> int:
         req = REQ_ROOT / "extras-no-deps.txt",
     )
 
-    # 4. Overrides (torchao, transformers) — force-reinstall
+    # 4. Overrides (torchao, transformers) -- force-reinstall
     _progress("dependency overrides")
     pip_install(
         "Installing dependency overrides",


### PR DESCRIPTION
## Summary

Fixes #4509

On Windows, `unsloth studio setup` can complete all dependency installation and then crash with a `UnicodeEncodeError` when `studio/install_python_stack.py` prints Unicode status glyphs (`✅`, `❌`, `⚠️`) to a console using a legacy code page such as CP1252.

This affects any Windows user running Studio setup from a non-UTF-8 PowerShell or console host, which is the default on stock Windows setups.

### Root cause

`print()` calls in `install_python_stack.py` emit Unicode emoji directly. CP1252 (and other legacy Windows code pages) cannot encode characters like `\u2705` (✅), causing:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2705' in position 0:
  character maps to <undefined>
```

### Changes

- Add a `_safe_print()` helper that wraps `print()` and catches `UnicodeEncodeError`
- On encode failure, swap emoji for ASCII equivalents (`✅` → `[OK]`, `❌` → `[FAIL]`, `⚠️` → `[!]`) via a lookup table
- Any remaining unencodable characters are replaced using Python's `errors="replace"` codec fallback
- Replace all 5 `print()` calls that emit Unicode glyphs with `_safe_print()`
- UTF-8 terminals (Linux, macOS, modern Windows Terminal) are completely unaffected — `_safe_print()` only activates its fallback path when `print()` raises `UnicodeEncodeError`

## Test plan

- [x] `python3 -m py_compile studio/install_python_stack.py` passes
- [x] On a UTF-8 terminal, output is identical to before (the `try` path succeeds, emoji render normally)
- [ ] On a Windows CP1252 console, setup completes without `UnicodeEncodeError` — emoji degrade to `[OK]`/`[FAIL]`/`[!]`