### PR TITLE
feat(chat): db v4 migration -- folders, prompts, memory tables

### DIFF
--- a/studio/frontend/src/features/chat/db.ts
+++ b/studio/frontend/src/features/chat/db.ts
@@ -3,11 +3,20 @@
 
 import Dexie, { type EntityTable, liveQuery } from "dexie";
 import { useEffect, useState } from "react";
-import type { MessageRecord, ThreadRecord } from "./types";
+import type {
+  FolderRecord,
+  MemoryRecord,
+  MessageRecord,
+  PromptRecord,
+  ThreadRecord,
+} from "./types";
 
 const db = new Dexie("unsloth-chat") as Dexie & {
   threads: EntityTable<ThreadRecord, "id">;
   messages: EntityTable<MessageRecord, "id">;
+  folders: EntityTable<FolderRecord, "id">;
+  prompts: EntityTable<PromptRecord, "id">;
+  memory: EntityTable<MemoryRecord, "id">;
 };
 
 db.version(1).stores({
@@ -35,6 +44,40 @@ db.version(3)
         if (!thread.modelId) thread.modelId = "";
       }),
   );
+
+db.version(4)
+  .stores({
+    threads: "id, modelType, pairId, archived, createdAt, folderId, pinned",
+    messages: "id, threadId, createdAt",
+    folders: "id, createdAt",
+    prompts: "id, createdAt",
+    memory: "id, createdAt",
+  })
+  .upgrade(async (tx) => {
+    // Backfill searchText from first user message in each thread
+    const threads = await tx.table("threads").toArray();
+    for (const thread of threads) {
+      const msgs = await tx
+        .table("messages")
+        .where("threadId")
+        .equals(thread.id)
+        .toArray();
+      const firstUser = msgs
+        .sort((a: MessageRecord, b: MessageRecord) => a.createdAt - b.createdAt)
+        .find((m: MessageRecord) => m.role === "user");
+      if (firstUser) {
+        const textParts = Array.isArray(firstUser.content)
+          ? firstUser.content
+              .filter((p: { type: string }) => p.type === "text")
+              .map((p: { text: string }) => p.text)
+              .join(" ")
+          : "";
+        await tx
+          .table("threads")
+          .update(thread.id, { searchText: textParts.slice(0, 500) });
+      }
+    }
+  });
 
 export { db };
 

--- a/studio/frontend/src/features/chat/types.ts
+++ b/studio/frontend/src/features/chat/types.ts
@@ -15,6 +15,12 @@ export interface ThreadRecord {
   pairId?: string;
   archived: boolean;
   createdAt: number;
+  /** First ~500 chars of first user message for search indexing */
+  searchText?: string;
+  /** Folder this thread belongs to */
+  folderId?: string;
+  /** Pin thread to top of sidebar */
+  pinned?: boolean;
 }
 
 export interface MessageRecord {
@@ -25,4 +31,29 @@ export interface MessageRecord {
   attachments?: import("@assistant-ui/react").ThreadMessage["attachments"];
   metadata?: Record<string, unknown>;
   createdAt: number;
+  /** User feedback on assistant messages */
+  feedback?: "thumbs_up" | "thumbs_down";
+}
+
+export interface FolderRecord {
+  id: string;
+  name: string;
+  createdAt: number;
+}
+
+export interface PromptRecord {
+  id: string;
+  name: string;
+  content: string;
+  variables: string[];
+  tags: string[];
+  createdAt: number;
+}
+
+export interface MemoryRecord {
+  id: string;
+  content: string;
+  enabled: boolean;
+  createdAt: number;
+  updatedAt: number;
 }

--- a/studio/frontend/src/lib/download.ts
+++ b/studio/frontend/src/lib/download.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export function downloadTextFile(
+  filename: string,
+  content: string,
+  mimeType = "text/plain",
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

- Add new Dexie tables for upcoming chat features: `folders`, `prompts`, `memory`
- Extend `ThreadRecord` with `searchText`, `folderId`, `pinned` fields
- Extend `MessageRecord` with `feedback` field for thumbs up/down ratings
- Add new type definitions: `FolderRecord`, `PromptRecord`, `MemoryRecord`
- DB version 4 migration backfills `searchText` from the first user message in each existing thread
- Extract `downloadTextFile` utility to `src/lib/download.ts` for reuse across export features

This is a foundation PR. The following PRs depend on these types and the v4 schema:

1. Sidebar enhancements (search, folders, pinning, export)
2. Message feedback (thumbs up/down)
3. Keyboard shortcuts and command palette
4. Prompt library
5. Session memory
6. Artifacts panel

The wake lock PR (#5 below) is independent and can merge in any order.

## Merge order

**This PR must merge first.** All other chat feature PRs (except wake lock) branch from this one.

## Test plan

- [ ] Verify `npx tsc --noEmit` passes
- [ ] Open the chat page on a fresh browser (no existing IndexedDB) and confirm no console errors
- [ ] Open the chat page on a browser with existing chat data and confirm the v4 migration runs without errors (check DevTools > Application > IndexedDB > unsloth-chat)
- [ ] Confirm existing threads still load correctly after migration