### PR TITLE
feat(chat): screen wake lock during generation

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -515,6 +515,16 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         return;
       }
 
+      // Screen wake lock: keep screen on during long generations
+      let wakeLock: WakeLockSentinel | null = null;
+      try {
+        if ("wakeLock" in navigator) {
+          wakeLock = await navigator.wakeLock.request("screen");
+        }
+      } catch {
+        // Wake lock not available or denied -- continue without it
+      }
+
       const threadKey = unstable_threadId || "__default";
       let waitingFirstChunk = true;
       let firstTokenSettled = false;
@@ -768,6 +778,11 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           }
         }
         runtime.setThreadRunning(threadKey, false);
+        // Release screen wake lock
+        if (wakeLock) {
+          void wakeLock.release().catch(() => {});
+          wakeLock = null;
+        }
       }
     },
   };


### PR DESCRIPTION
## Summary

Prevent screen sleep during long model inference by requesting a Screen Wake Lock when text streaming begins and releasing it when generation completes (in the `finally` block).

This is useful for large model inference or extended reasoning chains that can run 30+ minutes, where a screen timeout would be disruptive.

Uses the [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) (`navigator.wakeLock`). If the API is unavailable or the request is denied, generation proceeds normally with no user-facing error.

## Dependencies

None. This PR branches from `main` and only touches `chat-adapter.ts`.

## Merge order

Independent -- can merge in any order relative to other chat feature PRs. If it merges after the Session Memory PR (which also modifies `chat-adapter.ts`), a rebase will be needed to resolve the conflict in the system prompt construction section.

## Test plan

- [ ] Start a generation, check DevTools console for wake lock acquisition (no errors)
- [ ] Verify generation completes normally
- [ ] Verify wake lock is released after generation ends (check `navigator.wakeLock` state)
- [ ] Verify `npx tsc --noEmit` passes