### PR TITLE
Add ROCm (AMD GPU) support to studio setup

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -542,10 +542,10 @@ rm -rf "$LLAMA_CPP_DIR"
                 # Detect AMD GPU architecture (gfx target)
                 GPU_TARGETS=""
                 if command -v rocminfo &>/dev/null; then
-                    _gfx_list=$(rocminfo 2>/dev/null | grep -oE 'gfx[0-9]{3,4}[a-z]?' | sort -u || true)
+                    _gfx_list=$(rocminfo 2>/dev/null | grep -oE 'gfx[0-9]{2,4}[a-z]?' | sort -u || true)
                     _valid_gfx=""
                     for _gfx in $_gfx_list; do
-                        if [[ "$_gfx" =~ ^gfx[0-9]{3,4}[a-z]?$ ]]; then
+                        if [[ "$_gfx" =~ ^gfx[0-9]{2,4}[a-z]?$ ]]; then
                             _valid_gfx="${_valid_gfx}${_valid_gfx:+;}$_gfx"
                         fi
                     done


### PR DESCRIPTION
## Summary

Adds AMD ROCm GPU detection to the llama.cpp build step in `studio/setup.sh`.

Based on the original work by @edamamez in #4390 (commit preserved in git history), with bug fixes applied on top.

- Detects ROCm via `hipcc` (PATH, `/opt/rocm/bin`, `/opt/rocm-*/bin`) only when no CUDA toolchain is present
- Resolves the real ROCm root via `readlink -f` on hipcc and `hipconfig -R` (fixes symlink/variable-collision bug)
- Sets `ROCM_PATH` and `HIP_PATH` for cmake
- Uses `HIPCXX` via `hipconfig -l` instead of legacy `CMAKE_C_COMPILER=hipcc`
- Auto-detects gfx architecture via `rocminfo` with portable `grep -oE`
- Adds ROCm-specific driver-only and CPU-only fallback messages
- CUDA detection is unchanged and takes priority on mixed-toolchain hosts

Changes are limited to the GPU detection block in `studio/setup.sh` (71 lines added, 4 lines modified).

## Bugs fixed vs #4390

1. **ROCM_PATH symlink bug [8/8 reviewers]**: Original set `ROCM_PATH` to the hipcc binary path instead of the ROCm root directory
2. **GPU_BACKEND=cuda never set**: CUDA path was unreachable after the GPU_BACKEND refactor
3. **No CUDA guard on ROCm detection**: Mixed-toolchain hosts could silently flip from CUDA to ROCm
4. **Legacy hipcc compiler [7/8 reviewers]**: Used `-DCMAKE_C_COMPILER=hipcc` which is deprecated upstream
5. **HIP_PATH not set [2/8 reviewers]**: Some ROCm builds need `HIP_PATH` exported alongside `ROCM_PATH`
6. **grep -oP not portable**: Switched to `grep -oE` (ERE) for cross-distro compatibility
7. **Stale hardcoded fallback targets**: Removed; let cmake auto-detect instead

## Test plan

- [x] All 6 GPU detection code paths pass (CUDA-only, ROCm-only, both/CUDA-wins, CPU-only, CUDA-driver-only, ROCm-driver-only)
- [x] `git diff origin/main` touches only `studio/setup.sh`
- [x] Main features preserved (run_quiet_no_exit, _SKIP_GGUF_BUILD, uv/fast_install, WSL handling)
- [x] Contributor's original commit preserved in git history with proper authorship