### PR TITLE
fix(studio): add -ngl flag for GPU offloading in llama-server

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -857,6 +857,9 @@ class LlamaCppBackend:
 
             if use_fit:
                 cmd.extend(["--fit", "on"])
+            elif gpu_indices is not None:
+                # Model fits on selected GPU(s) -- offload all layers
+                cmd.extend(["-ngl", "-1"])
 
             if n_threads is not None:
                 cmd.extend(["--threads", str(n_threads)])


### PR DESCRIPTION
## Summary

When `_select_gpus` in `llama_cpp.py` determines a GGUF model fits on the selected GPU(s), the orchestrator sets `CUDA_VISIBLE_DEVICES` but never passes `-ngl` (number of GPU layers) to `llama-server`. Without either `-ngl` or `--fit on`, llama-server defaults to **0 GPU layers** and runs the entire model on CPU.

This is observable on any machine with a GPU -- `nvidia-smi` shows near-zero GPU memory usage and 0% utilization while the llama-server process consumes 10+ GB of system RAM for a 2.7 GB model.

## What changed

In `studio/backend/core/inference/llama_cpp.py`, added an `elif` branch after the existing `--fit on` logic:

```python
if use_fit:
    cmd.extend(["--fit", "on"])
elif gpu_indices is not None:
    # Model fits on selected GPU(s) -- offload all layers
    cmd.extend(["-ngl", "-1"])
```

The three code paths are now:

| Condition | Action |
|-----------|--------|
| Model too large for all GPUs (`use_fit=True`) | `--fit on` lets llama.cpp auto-decide layer placement |
| Model fits on selected GPU(s) (`gpu_indices` set, `use_fit=False`) | `-ngl -1` offloads all layers to GPU **(new)** |
| No GPUs available (`gpu_indices=None`, `use_fit=False`) | No GPU flags, runs on CPU |

## How to reproduce

1. Install Unsloth Studio on a machine with a GPU
2. Load any GGUF model (e.g. Qwen3.5-4B) in the chat UI
3. Check `nvidia-smi` -- GPU shows near-zero usage
4. Check the llama-server process args -- no `-ngl` flag present

## Test plan

- [ ] Load a small GGUF model (e.g. Qwen3.5-4B) and confirm `nvidia-smi` shows GPU memory usage after the fix
- [ ] Load a model that exceeds GPU VRAM and confirm `--fit on` path still works
- [ ] Confirm CPU-only systems (no GPU) still work without errors