### PR TITLE
fix(studio): add pip nvidia CUDA libs to LD_LIBRARY_PATH for llama-server

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -969,6 +969,46 @@ class LlamaCppBackend:
 
                 lib_dirs = [binary_dir]
                 _arch = platform.machine()  # x86_64, aarch64, etc.
+
+                # Pip-installed nvidia CUDA runtime libs (e.g. torch's
+                # bundled cuda-bindings).  The prebuilt llama.cpp binary
+                # links against libcudart.so.13 / libcublas.so.13 which
+                # live here, not in /usr/local/cuda.
+                import glob as _glob
+
+                for _nv_pattern in [
+                    os.path.join(
+                        sys.prefix,
+                        "lib",
+                        "python*",
+                        "site-packages",
+                        "nvidia",
+                        "cu*",
+                        "lib",
+                    ),
+                    os.path.join(
+                        sys.prefix,
+                        "lib",
+                        "python*",
+                        "site-packages",
+                        "nvidia",
+                        "cudnn",
+                        "lib",
+                    ),
+                    os.path.join(
+                        sys.prefix,
+                        "lib",
+                        "python*",
+                        "site-packages",
+                        "nvidia",
+                        "nvjitlink",
+                        "lib",
+                    ),
+                ]:
+                    for _nv_dir in _glob.glob(_nv_pattern):
+                        if os.path.isdir(_nv_dir):
+                            lib_dirs.append(_nv_dir)
+
                 for cuda_lib in [
                     "/usr/local/cuda/lib64",
                     f"/usr/local/cuda/targets/{_arch}-linux/lib",


### PR DESCRIPTION
## Summary

Companion fix to #4588. The `-ngl -1` flag alone was not enough -- the prebuilt llama.cpp binary (`cuda13-newer`) links against `libcudart.so.13` and `libcublas.so.13`, but those only exist in the pip-installed nvidia package inside the venv:

```
/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cu13/lib/libcudart.so.13
/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cu13/lib/libcublas.so.13
```

The existing `LD_LIBRARY_PATH` code only searched `/usr/local/cuda*` paths, which on Colab contain CUDA 12.8 (`libcudart.so.12`). The CUDA backend failed to load silently and llama-server fell back to CPU even with `-ngl -1`.

## What changed

In `studio/backend/core/inference/llama_cpp.py`, added a glob scan of the venv's nvidia package directories before the existing `/usr/local/cuda*` paths:

- `nvidia/cu*/lib` -- catches cu12, cu13, and future CUDA major versions
- `nvidia/cudnn/lib` -- cuDNN shared libs
- `nvidia/nvjitlink/lib` -- JIT link libs

Uses `sys.prefix` to find the active venv root, so it works for both the Studio venv and any other venv layout.

## How to reproduce

1. Install Unsloth Studio on Colab or any system where CUDA 13 comes from pip (not `/usr/local/cuda`)
2. Load any GGUF model
3. Run `ldd /root/.unsloth/llama.cpp/build/bin/libggml-cuda.so` and observe `libcudart.so.13 => not found`
4. `nvidia-smi` shows 0% GPU utilization despite `-ngl -1`

## Verification

Before fix:
```
libcudart.so.13 => not found
libcublas.so.13 => not found
GPU Memory: 3 MiB, GPU-Util: 0%
```

After fix:
```
GPU Memory: 13317 MiB, GPU-Util: 77%, Power: 309W
llama-server process: 13308 MiB GPU memory
```

## Test plan

- [x] Tested on Colab with RTX PRO 6000 Blackwell, CUDA 13.0, pip-installed torch
- [ ] Verify systems with `/usr/local/cuda` CUDA 13 still work (paths are additive, not replacing)
- [ ] Verify CPU-only systems still start without errors (glob returns empty, no dirs added)