### PR TITLE
Pin torch>=2.4,<2.11.0 in Studio installers

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -583,7 +583,7 @@ shell.Run cmd, 0, False
         uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.3.11" unsloth-zoo
     } elseif ($TorchIndexUrl) {
         Write-Host "==> Installing PyTorch ($TorchIndexUrl)..."
-        uv pip install --python $VenvPython torch torchvision torchaudio --index-url $TorchIndexUrl
+        uv pip install --python $VenvPython "torch>=2.4,<2.11.0" torchvision torchaudio --index-url $TorchIndexUrl
         if ($LASTEXITCODE -ne 0) {
             Write-Host "[ERROR] Failed to install PyTorch (exit code $LASTEXITCODE)" -ForegroundColor Red
             return

--- a/install.sh
+++ b/install.sh
@@ -775,7 +775,7 @@ if [ "$_MIGRATED" = true ]; then
 elif [ -n "$TORCH_INDEX_URL" ]; then
     # Fresh: Step 1 - install torch from explicit index
     echo "==> Installing PyTorch ($TORCH_INDEX_URL)..."
-    uv pip install --python "$_VENV_PY" torch torchvision torchaudio \
+    uv pip install --python "$_VENV_PY" "torch>=2.4,<2.11.0" torchvision torchaudio \
         --index-url "$TORCH_INDEX_URL"
     # Fresh: Step 2 - install unsloth, preserving pre-installed torch
     echo "==> Installing unsloth (this may take a few minutes)..."


### PR DESCRIPTION
## Summary
- Pin `torch>=2.4,<2.11.0` in `install.sh` (Linux/macOS) and `install.ps1` (Windows) fresh install paths
- torch 2.11.0 has a `torch.compile`/dynamo bug that causes a `StopIteration` crash in `dict_keys_getitem` when compiling MoE router functions (e.g. `GptOssTopKRouter_forward`)
- Only affects the explicit torch install step for fresh environments -- migration and fallback paths are unchanged

## Test plan
- [ ] Fresh install via `./install.sh --local` resolves torch <2.11.0
- [ ] gpt-oss-20b finetuning completes without StopIteration crash
- [ ] Windows fresh install via `install.ps1` resolves torch <2.11.0