### PR TITLE
fix(studio): add bun cache validation to Windows setup.ps1

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -919,11 +919,37 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
 
     $UseBun = $null -ne (Get-Command bun -ErrorAction SilentlyContinue)
 
+    # bun's package cache can become corrupt -- packages get stored with only
+    # metadata but no actual content (bin/, lib/). When this happens bun install
+    # exits 0 but leaves binaries missing. We validate after install and clear
+    # the cache + retry once before falling back to npm.
     if ($UseBun) {
         Write-Host "   Using bun for package install (faster)" -ForegroundColor DarkGray
         & bun install *> $null
         $bunExit = $LASTEXITCODE
-        if ($bunExit -ne 0) {
+        # On Windows, .bin/ entries can be tsc, tsc.cmd, or tsc.ps1
+        $hasTsc = (Test-Path "node_modules\.bin\tsc") -or (Test-Path "node_modules\.bin\tsc.cmd")
+        $hasVite = (Test-Path "node_modules\.bin\vite") -or (Test-Path "node_modules\.bin\vite.cmd")
+        if ($bunExit -eq 0 -and $hasTsc -and $hasVite) {
+            # bun install succeeded and critical binaries are present
+        } elseif ($bunExit -eq 0) {
+            Write-Host "   bun install exited 0 but critical binaries are missing, clearing cache and retrying..." -ForegroundColor Yellow
+            if (Test-Path "node_modules") {
+                Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue
+            }
+            & bun pm cache rm *> $null
+            & bun install *> $null
+            $bunExit = $LASTEXITCODE
+            $hasTsc = (Test-Path "node_modules\.bin\tsc") -or (Test-Path "node_modules\.bin\tsc.cmd")
+            $hasVite = (Test-Path "node_modules\.bin\vite") -or (Test-Path "node_modules\.bin\vite.cmd")
+            if ($bunExit -ne 0 -or -not $hasTsc -or -not $hasVite) {
+                Write-Host "   bun retry failed, falling back to npm" -ForegroundColor Yellow
+                if (Test-Path "node_modules") {
+                    Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue
+                }
+                $UseBun = $false
+            }
+        } else {
             Write-Host "   [WARN] bun install failed (exit $bunExit), falling back to npm" -ForegroundColor Yellow
             if (Test-Path "node_modules") {
                 Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

Ports the bun cache corruption fix from setup.sh (#4594) to setup.ps1 (Windows).

The same bug affects Windows: bun's package cache can become corrupt, storing only package metadata without actual content. bun install exits 0 but leaves binaries like tsc missing from `node_modules\.bin\`.

## Changes

- After `bun install`, verify `tsc` and `vite` exist in `node_modules\.bin\`
- Check for both bare names and `.cmd` wrappers (Windows npm/bun create both forms)
- If missing, clear the bun cache with `bun pm cache rm` and retry once
- Only fall back to npm if the retry also fails

## Test plan

- [ ] On Windows, corrupt the bun cache for typescript, run setup.ps1, confirm cache gets cleared and retry succeeds
- [ ] On Windows, fresh install with clean cache, confirm bun works on first attempt without retry
- [ ] Confirm npm fallback works if bun fails after cache clear