### PR TITLE
Add unsloth to User PATH on Windows after install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -623,6 +623,19 @@ shell.Run cmd, 0, False
 
     New-StudioShortcuts -UnslothExePath $UnslothExe
 
+    # ── Add venv Scripts dir to User PATH so `unsloth studio` works from any terminal ──
+    $ScriptsDir = Join-Path $VenvDir "Scripts"
+    $UserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+    if (-not $UserPath -or $UserPath -notlike "*$ScriptsDir*") {
+        if ($UserPath) {
+            [System.Environment]::SetEnvironmentVariable("Path", "$ScriptsDir;$UserPath", "User")
+        } else {
+            [System.Environment]::SetEnvironmentVariable("Path", "$ScriptsDir", "User")
+        }
+        Refresh-SessionPath
+        Write-Host "[OK] Added unsloth to PATH" -ForegroundColor Green
+    }
+
     Write-Host ""
     Write-Host "========================================="
     Write-Host "   Unsloth Studio installed!"


### PR DESCRIPTION
## Summary
- After `install.ps1` completes, `unsloth studio` only works if the user activates the Studio venv first or uses the full absolute path to `unsloth.exe`. The Desktop and Start Menu shortcuts work, but typing `unsloth studio` in a fresh PowerShell or cmd window does not.
- This adds the Studio venv's `Scripts\` directory to the persistent **User** `Path` environment variable (if not already present), so `unsloth studio` works from any new terminal window without activation.
- The current installer session is also refreshed via the existing `Refresh-SessionPath` helper.

## Changes
`install.ps1`: After `New-StudioShortcuts`, register `$VenvDir\Scripts` in the User PATH. Skips if already present. Handles the edge case where User PATH is empty.

## Test plan
- [ ] Run `install.ps1` on a fresh Windows machine, confirm `[OK] Added unsloth to PATH` appears
- [ ] Open a new PowerShell window (without activating venv), run `unsloth studio -H 0.0.0.0 -p 8888`, confirm it launches
- [ ] Re-run `install.ps1`, confirm it does not duplicate the PATH entry
- [ ] Check `[Environment]::GetEnvironmentVariable("Path", "User")` contains the Scripts dir