### PR TITLE
Bump installer min version to 2026.3.12

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -607,7 +607,7 @@ shell.Run cmd, 0, False
         # Migrated env: force-reinstall unsloth+unsloth-zoo to ensure clean state
         # in the new venv location, while preserving existing torch/CUDA
         Write-Host "==> Upgrading unsloth in migrated environment..."
-        uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.3.11" unsloth-zoo
+        uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.3.12" unsloth-zoo
         if ($StudioLocalInstall) {
             Write-Host "==> Overlaying local repo (editable)..."
             uv pip install --python $VenvPython -e $RepoRoot --no-deps
@@ -622,7 +622,7 @@ shell.Run cmd, 0, False
 
         Write-Host "==> Installing unsloth (this may take a few minutes)..."
         if ($StudioLocalInstall) {
-            uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.3.11" unsloth-zoo
+            uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.3.12" unsloth-zoo
             Write-Host "==> Overlaying local repo (editable)..."
             uv pip install --python $VenvPython -e $RepoRoot --no-deps
         } else {
@@ -632,7 +632,7 @@ shell.Run cmd, 0, False
         # Fallback: GPU detection failed to produce a URL -- let uv resolve torch
         Write-Host "==> Installing unsloth (this may take a few minutes)..."
         if ($StudioLocalInstall) {
-            uv pip install --python $VenvPython unsloth-zoo "unsloth>=2026.3.11" --torch-backend=auto
+            uv pip install --python $VenvPython unsloth-zoo "unsloth>=2026.3.12" --torch-backend=auto
             Write-Host "==> Overlaying local repo (editable)..."
             uv pip install --python $VenvPython -e $RepoRoot --no-deps
         } else {

--- a/install.sh
+++ b/install.sh
@@ -767,7 +767,7 @@ if [ "$_MIGRATED" = true ]; then
     echo "==> Upgrading unsloth in migrated environment..."
     uv pip install --python "$_VENV_PY" \
         --reinstall-package unsloth --reinstall-package unsloth-zoo \
-        "unsloth>=2026.3.11" unsloth-zoo
+        "unsloth>=2026.3.12" unsloth-zoo
     if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
         echo "==> Overlaying local repo (editable)..."
         uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
@@ -781,7 +781,7 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
     echo "==> Installing unsloth (this may take a few minutes)..."
     if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
         uv pip install --python "$_VENV_PY" \
-            --upgrade-package unsloth "unsloth>=2026.3.11" unsloth-zoo
+            --upgrade-package unsloth "unsloth>=2026.3.12" unsloth-zoo
         echo "==> Overlaying local repo (editable)..."
         uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
     else
@@ -792,7 +792,7 @@ else
     # Fallback: GPU detection failed to produce a URL -- let uv resolve torch
     echo "==> Installing unsloth (this may take a few minutes)..."
     if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
-        uv pip install --python "$_VENV_PY" unsloth-zoo "unsloth>=2026.3.11" --torch-backend=auto
+        uv pip install --python "$_VENV_PY" unsloth-zoo "unsloth>=2026.3.12" --torch-backend=auto
         echo "==> Overlaying local repo (editable)..."
         uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
     else


### PR DESCRIPTION
## Summary
- Bump the minimum `unsloth` version pin from `2026.3.11` to `2026.3.12` in both `install.sh` and `install.ps1`
- Ensures new Studio installs pull the latest PyPI release (2026.3.12)

## Changed files
- `install.sh` -- 3 occurrences of `unsloth>=2026.3.11` updated
- `install.ps1` -- 3 occurrences of `unsloth>=2026.3.11` updated