### PR TITLE
fix: Windows installer fails on _yaml.pyd Access Denied (os error 5)

### DIFF
--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -12,3 +12,5 @@ git+https://github.com/meta-pytorch/OpenEnv.git
 torch-c-dlpack-ext
 sentence_transformers==5.2.0
 transformers==4.57.6
+pytorch_tokenizers
+kernels

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -461,25 +461,13 @@ def install_python_stack() -> int:
         req = REQ_ROOT / "extras-no-deps.txt",
     )
 
-    # 4. Overrides (torchao) -- force-reinstall
+    # 4. Overrides (torchao, transformers) -- force-reinstall
     _progress("dependency overrides")
     pip_install(
         "Installing dependency overrides",
         "--force-reinstall",
         "--no-cache-dir",
         req = REQ_ROOT / "overrides.txt",
-    )
-
-    # 4b. pytorch_tokenizers & kernels -- --no-deps to avoid cascading into
-    # huggingface_hub -> pyyaml whose _yaml.pyd is locked on Windows (os error 5).
-    # Their deps (huggingface_hub, tokenizers, pyyaml, etc.) are already installed.
-    pip_install(
-        "Installing pytorch_tokenizers and kernels",
-        "--force-reinstall",
-        "--no-deps",
-        "--no-cache-dir",
-        "pytorch_tokenizers",
-        "kernels",
     )
 
     # 5. Triton kernels (no-deps, from source)


### PR DESCRIPTION
  Description:
  ## Summary
  - On Windows, step 4 (dependency overrides) uses `--force-reinstall` which
    cascades into transitive deps: `pytorch_tokenizers` → `tokenizers` →
    `huggingface_hub` → `pyyaml`. The `_yaml.cp312-win_amd64.pyd` DLL is
    already loaded in memory by the running Python process, so Windows blocks
    replacement with "Access is denied" (os error 5).
  - Move `pytorch_tokenizers` and `kernels` out of `overrides.txt` into a
    separate `--force-reinstall --no-deps` step. Their deps (huggingface_hub,
    tokenizers, pyyaml, etc.) are already installed from earlier steps.