### PR TITLE
Fix GGUF GPU fit check to account for KV cache VRAM

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -370,7 +370,7 @@ class LlamaCppBackend:
         available_mib: int,
         model_size_bytes: int,
         cache_type_kv: Optional[str] = None,
-        min_ctx: int = 2048,
+        min_ctx: int = 4096,
     ) -> int:
         """Return the largest context length that fits in GPU VRAM.
 


### PR DESCRIPTION
## Summary

The GPU fit check in Studio's llama-server backend only compared the GGUF file size against free VRAM, completely ignoring KV cache memory. For models with large native context lengths (e.g. Qwen3.5-9B at 262k), the GGUF file is 5.6 GB which easily passes the 70% threshold on a 24 GB GPU, but the actual runtime footprint with KV cache at 262k context is north of 40 GB at f16. This caused llama-server to silently fall back to CPU inference, resulting in very slow responses even though the GPU was correctly detected.

Reported scenario: RTX 3090 with 22415 MiB free, Qwen3.5-9B-UD-Q4_K_XL (5.6 GB GGUF). Log showed `fit: False` (which confusingly means `use_fit=False`, i.e. "model fits") and `-ngl -1` was passed, but the 262k default context made the KV cache blow past VRAM.

## Changes

- **GGUF metadata parsing**: `_read_gguf_metadata` now also reads `block_count`, `head_count_kv`, `head_count`, and `embedding_length` from the GGUF header. These are needed to estimate KV cache size. No extra I/O since we already parse the header for `context_length` and `chat_template`.

- **KV cache estimation** (`_estimate_kv_cache_bytes`): Computes `2 * n_kv_heads * head_dim * n_layers * n_ctx * bytes_per_element` with proper mapping for each supported `cache_type_kv` (f16, q8_0, q4_0, etc.). Returns 0 if metadata is unavailable, so old behavior is preserved as a fallback.

- **Context auto-capping** (`_fit_context_to_vram`): When the model's native context length would cause model + KV cache to exceed 70% of available GPU VRAM, binary-searches for the largest context that fits. Minimum context is 2048. Result is rounded to 256 for alignment.

- **Updated GPU selection in `load_model`**: Resolves `n_ctx=0` to the model's native context, runs the auto-cap, then passes `model_size + kv_cache_estimate` to `_select_gpus` so the fit decision reflects actual runtime memory. Logs context reduction when it happens.

## Effect on the reported scenario

| | Context | Est. KV Cache | Total VRAM | Fits 22.4 GB? |
|---|---|---|---|---|
| Before | 262,144 | ~40 GB (f16, not estimated) | ~45.6 GB | No, CPU fallback |
| After | 63,488 (auto-capped) | ~9.7 GB | ~15.3 GB | Yes, full GPU offload |
| After (q4_0 KV) | 226,304 (auto-capped) | ~2.7 GB | ~8.3 GB | Yes, nearly full native ctx |

Models that already fit at their native context length are unaffected. If GGUF metadata is missing the architecture fields, the code falls back to the previous file-size-only check.