### PR TITLE
Fix Colab training failing with 'Please install unsloth_zoo'

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -304,15 +304,24 @@ if [ ! -x "$VENV_DIR/bin/python" ]; then
             | grep -v '^#' | grep -v '^$' \
             | pip install -q -r /dev/stdin 2>/dev/null || true
 
-        # Install core ML packages (unsloth + unsloth-zoo) and training
-        # extras (trl, transformers, etc.) into system Python.  Without
-        # these the training/inference/export workers fail at import time
-        # with "Failed to import ML libraries: Please install unsloth_zoo".
+        # Install the same ML package groups that install_python_stack.py
+        # uses for the normal (venv) path.  Without these the training,
+        # inference, and export workers fail at import time with:
+        #   "Failed to import ML libraries: Please install unsloth_zoo"
+        # base.txt must succeed -- it has unsloth + unsloth-zoo.
         echo "   Installing core ML packages for training..."
-        pip install -q -r "$SCRIPT_DIR/backend/requirements/base.txt" 2>/dev/null || true
+        pip install -q -r "$SCRIPT_DIR/backend/requirements/base.txt" || {
+            echo "Failed to install base ML packages (unsloth + unsloth-zoo)"
+            exit 1
+        }
         sed 's/[><=!~;].*//' "$SCRIPT_DIR/backend/requirements/extras.txt" \
             | grep -v '^#' | grep -v '^$' \
             | pip install -q -r /dev/stdin 2>/dev/null || true
+        # trl, transformers, sentence_transformers live in extras-no-deps.txt
+        pip install -q --no-deps \
+            -r "$SCRIPT_DIR/backend/requirements/extras-no-deps.txt" 2>/dev/null || true
+        pip install -q --force-reinstall \
+            -r "$SCRIPT_DIR/backend/requirements/overrides.txt" 2>/dev/null || true
 
         _COLAB_NO_VENV=true
     else


### PR DESCRIPTION
## Summary

- The Colab no-venv path in `setup.sh` (added in #4601, modified in #4618) only installs `studio.txt` (fastapi, uvicorn, structlog) into system Python. It sets `_SKIP_PYTHON_DEPS=true`, which skips `install_python_stack()` entirely -- so `base.txt` (unsloth + unsloth-zoo), `extras.txt`, `extras-no-deps.txt` (trl, transformers, sentence_transformers), and `overrides.txt` (torchao) are never installed.
- When training starts, the worker subprocess tries to `import unsloth`, which checks `importlib.metadata.version("unsloth_zoo")` and raises `PackageNotFoundError`, surfaced as `Failed to import ML libraries: Please install unsloth_zoo`. Even past that, `trl` (imported at `trainer.py:63`) would also be missing since it lives in `extras-no-deps.txt`.
- This adds all four requirement groups to the Colab block, matching what `install_python_stack.py` does for the normal venv path. `base.txt` fails fast on error; `extras.txt` gets version-constraint stripping to avoid Colab conflicts; `extras-no-deps.txt` is installed with `--no-deps`; `overrides.txt` is installed with `--force-reinstall`.

## What changed

Only the Colab `if` block in `studio/setup.sh` (lines 297-306). Non-Colab paths are completely untouched.

## How it broke

1. Before #4530, `setup.sh` created a fresh venv and unconditionally called `install_python_stack()` which installed everything. Colab worked.
2. #4530 refactored `setup.sh` to assume a venv exists (created by `install.sh`). No venv = hard error. Colab has no `install.sh` step.
3. #4601 hotfixed Colab by installing only `studio.txt` (enough to launch the UI) and exiting early. Training was never tested.
4. #4618 removed the early exit so llama.cpp could build, but kept `_SKIP_PYTHON_DEPS=true` for Colab, so `install_python_stack()` is still never called.

## Test plan

- [ ] Run the [Unsloth Studio Colab notebook](https://colab.research.google.com/github/unslothai/unsloth/blob/main/studio/Unsloth_Studio_Colab.ipynb) on a free T4
- [ ] Verify Studio launches and training starts without import errors (`unsloth_zoo`, `trl`, `transformers`, `sentence_transformers`)
- [ ] Verify non-Colab `setup.sh` path is unchanged (run `unsloth studio update` locally)