### PR TITLE
fix: add python-json-logger to data-designer-deps

### DIFF
--- a/studio/backend/requirements/single-env/data-designer-deps.txt
+++ b/studio/backend/requirements/single-env/data-designer-deps.txt
@@ -14,6 +14,7 @@ lxml<7,>=6.0.2
 marko<3,>=2.1.2
 mcp<2,>=1.26.0
 networkx<4,>=3.0
+python-json-logger>=3,<4
 ruff<1,>=0.14.10
 scipy<2,>=1.11.0
 sqlfluff<4,>=3.2.0


### PR DESCRIPTION
Adds `python-json-logger>=3,<4` to `studio/backend/requirements/single-env/data-designer-deps.txt`.

Missing dependency needed by data-designer-config.