### PR TITLE
Fix Gemma3N audio training stride assertion with non-reentrant checkpointing

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1377,11 +1377,13 @@ class FastBaseModel:
         _model_type = getattr(getattr(model, "config", None), "model_type", "") or ""
         if "gemma3n" in _model_type.lower():
             _original_gc_enable = model.gradient_checkpointing_enable
+
             def _gc_enable_reentrant(**kwargs):
                 gc_kwargs = kwargs.get("gradient_checkpointing_kwargs", {}) or {}
                 gc_kwargs["use_reentrant"] = True
                 kwargs["gradient_checkpointing_kwargs"] = gc_kwargs
                 return _original_gc_enable(**kwargs)
+
             model.gradient_checkpointing_enable = _gc_enable_reentrant
 
         from transformers.trainer import Trainer


### PR DESCRIPTION
## Summary

Gemma3N audio conformer processes variable-length audio tensors that cause stride mismatches in AOT autograd's compiled backward pass when non-reentrant gradient checkpointing is used:

```
AssertionError: expected size 2==2, stride 1928==1936 at dim=0
This error most often comes from a incorrect fake (aka meta) kernel for a custom op.
```

The audio conformer's conv/norm layers produce tensors whose strides vary with audio clip duration (e.g. 241 vs 242 mel frames), but AOT autograd traces the backward graph assuming fixed strides from the first batch. On subsequent batches with slightly different audio lengths, the stride assertion fires.

## Root cause

1. The Gemma3N Audio notebook sets `gradient_checkpointing_kwargs={"use_reentrant": False}` in `SFTConfig`
2. TRL 0.27.0+ also forces `use_reentrant=False` by default
3. Transformers Trainer calls `model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=...)` during training, which overrides Unsloth's own `use_reentrant=True` set during `prepare_model_for_training`
4. Non-reentrant checkpointing triggers AOT autograd compilation of the backward pass
5. The compiled backward graph has hardcoded stride expectations that break on variable-length audio batches

## Fix

Intercept `gradient_checkpointing_enable` on Gemma3N models to always force `use_reentrant=True`, regardless of what the notebook or TRL passes. This prevents AOT autograd from compiling the backward pass with rigid stride assumptions.

## Test plan

- [x] Gemma3N audio training with `use_reentrant=False` in SFTConfig: previously crashed at step 1, now trains successfully (loss 12.9 -> 0.56 over 100 steps on librispeech)
- [x] Gemma3N text-only training: still works (loss 12.0 -> 3.3 over 10 steps)
- [x] Other model types (Llama, Qwen, Mistral, Phi, Gemma3, etc.): no regressions, verified on 16 notebooks