### PR TITLE
studio: fix chat CPU spike

### DIFF
--- a/studio/frontend/src/features/chat/db.ts
+++ b/studio/frontend/src/features/chat/db.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import Dexie, { type EntityTable, liveQuery } from "dexie";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { MessageRecord, ThreadRecord } from "./types";
 
 const db = new Dexie("unsloth-chat") as Dexie & {
@@ -38,18 +38,29 @@ db.version(3)
 
 export { db };
 
+/**
+ * Wraps Dexie liveQuery for React state updates.
+ *
+ * Important: include every semantic query input in `deps` (filters, sort keys,
+ * IDs, etc). `querier` identity is intentionally ignored to avoid re-subscribing
+ * on every render when callers pass inline functions.
+ */
 export function useLiveQuery<T>(
   querier: () => Promise<T>,
   deps: unknown[] = [],
 ): T | undefined {
   const [value, setValue] = useState<T>();
+  const querierRef = useRef(querier);
+  querierRef.current = querier;
+
   useEffect(() => {
-    const sub = liveQuery(querier).subscribe({
+    const sub = liveQuery(() => querierRef.current()).subscribe({
       next: setValue,
       error: (err) => console.error("useLiveQuery:", err),
     });
     return () => sub.unsubscribe();
+    // Intentionally omit `querier` from deps: inline functions would re-subscribe every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [querier, ...deps]);
+  }, deps);
   return value;
 }


### PR DESCRIPTION
Inline querier identity changed every render, forcing useLiveQuery to resubscribe continuously causing CPU spikes.

On my machine, idle /chat dropped from `~9%` to `~0.1%` CPU with chrome and edge using the same repro.
(absolute % varies by hardware). 
 
Prevented resubscribing on every render (even with inline functions)
Subscriptions now only update when defined inputs (deps) actually change
Added docs to clarify that all relevant inputs (filters, IDs, etc.) must be included in deps

ThreadSidebar uses a static query with deps: []; behavior matches intent. 
Future call sites that close over changing values must include those values in deps, same as any hook that intentionally omits function identity from the dependency list.

Before:
<img width="1300" height="48" alt="image" src="https://github.com/user-attachments/assets/6efb54c2-d039-4fe4-86b8-4dc6feaa2a0a" />

After:
<img width="1292" height="45" alt="image" src="https://github.com/user-attachments/assets/092ed419-865b-4cc2-a1d1-5629a61a91b3" />