### PR TITLE
Fix repetition_penalty default causing 24% TPS drop in GGUF inference

### DIFF
--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -291,7 +291,7 @@ class ChatCompletionRequest(BaseModel):
         0.01, ge = 0.0, le = 1.0, description = "[x-unsloth] Min-p sampling threshold"
     )
     repetition_penalty: float = Field(
-        1.1, ge = 1.0, le = 2.0, description = "[x-unsloth] Repetition penalty"
+        1.0, ge = 1.0, le = 2.0, description = "[x-unsloth] Repetition penalty"
     )
     image_base64: Optional[str] = Field(
         None, description = "[x-unsloth] Base64-encoded image for vision models"


### PR DESCRIPTION
## Summary

- `ChatCompletionRequest.repetition_penalty` was defaulting to `1.1` when API clients omitted the field
- This silently forced llama-server to perform per-token repetition scanning on every request
- Drops streaming throughput from ~225 TPS to ~172 TPS (a 24% penalty)

The Studio frontend always sends `repetition_penalty=1.0` explicitly, so the UI was unaffected. But any API client hitting `/v1/chat/completions` without setting the field (curl, third-party integrations, Open WebUI, etc.) would get the slower path.

This was the root cause behind user reports of Unsloth Studio being "slower than LM Studio" -- LM Studio applies `repeat_penalty` internally and also runs at ~171 TPS. With `repetition_penalty=1.0`, Unsloth is actually 32% faster.

## Benchmark

Qwen3.5-4B Q4_K_XL, 256 max tokens, 10 runs each:

| Configuration | Mean TPS |
|---|---|
| Direct llama-server (no repeat_penalty) | 224.7 |
| Direct llama-server (repeat_penalty=1.1) | 171.8 |
| Studio /v1 (omit rp, Pydantic default=1.1) | 171.9 |
| **Studio /v1 (explicit rp=1.0)** | **225.2** |
| LM Studio (default) | 170.8 |

## Change

One-line fix: change the Pydantic `Field` default from `1.1` to `1.0` in `ChatCompletionRequest`. This aligns with:
- The frontend default (`repetitionPenalty: 1.0` in `runtime.ts`)
- `generate_chat_completion()`'s function signature default (`1.0`)
- llama-server's own default (`1.0`)

## Test plan

- [ ] `POST /v1/chat/completions` without `repetition_penalty` field should now run at full speed (~225 TPS)
- [ ] `POST /v1/chat/completions` with `repetition_penalty: 1.1` should still work (172 TPS, expected)
- [ ] Frontend chat should be unaffected (already sends `1.0` explicitly)