### PR TITLE
fix: use unsloth[huggingfacenotorch] instead of --no-deps in no-torch mode

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -620,8 +620,14 @@ shell.Run cmd, 0, False
         # Migrated env: force-reinstall unsloth+unsloth-zoo to ensure clean state
         # in the new venv location, while preserving existing torch/CUDA
         Write-Host "==> Upgrading unsloth in migrated environment..."
-        $noDepsArg = if ($SkipTorch) { "--no-deps" } else { $null }
-        uv pip install --python $VenvPython $noDepsArg --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.3.14" unsloth-zoo
+        if ($SkipTorch) {
+            # No-torch: install runtime deps via [huggingfacenotorch] extras,
+            # then unsloth-zoo with --no-deps to avoid pulling torch.
+            uv pip install --python $VenvPython --reinstall-package unsloth "unsloth[huggingfacenotorch]>=2026.3.14"
+            uv pip install --python $VenvPython --no-deps --reinstall-package unsloth-zoo unsloth-zoo
+        } else {
+            uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.3.14" unsloth-zoo
+        }
         if ($StudioLocalInstall) {
             Write-Host "==> Overlaying local repo (editable)..."
             uv pip install --python $VenvPython -e $RepoRoot --no-deps
@@ -639,13 +645,21 @@ shell.Run cmd, 0, False
         }
 
         Write-Host "==> Installing unsloth (this may take a few minutes)..."
-        $noDepsArg = if ($SkipTorch) { "--no-deps" } else { $null }
-        if ($StudioLocalInstall) {
-            uv pip install --python $VenvPython $noDepsArg --upgrade-package unsloth "unsloth>=2026.3.14" unsloth-zoo
+        if ($SkipTorch) {
+            # No-torch: install runtime deps via [huggingfacenotorch] extras,
+            # then unsloth-zoo with --no-deps to avoid pulling torch.
+            uv pip install --python $VenvPython --upgrade-package unsloth "unsloth[huggingfacenotorch]>=2026.3.14"
+            uv pip install --python $VenvPython --no-deps --upgrade-package unsloth-zoo unsloth-zoo
+            if ($StudioLocalInstall) {
+                Write-Host "==> Overlaying local repo (editable)..."
+                uv pip install --python $VenvPython -e $RepoRoot --no-deps
+            }
+        } elseif ($StudioLocalInstall) {
+            uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.3.14" unsloth-zoo
             Write-Host "==> Overlaying local repo (editable)..."
             uv pip install --python $VenvPython -e $RepoRoot --no-deps
         } else {
-            uv pip install --python $VenvPython $noDepsArg --upgrade-package unsloth "$PackageName"
+            uv pip install --python $VenvPython --upgrade-package unsloth "$PackageName"
         }
     } else {
         # Fallback: GPU detection failed to produce a URL -- let uv resolve torch

--- a/install.sh
+++ b/install.sh
@@ -863,13 +863,19 @@ if [ "$_MIGRATED" = true ]; then
     # Migrated env: force-reinstall unsloth+unsloth-zoo to ensure clean state
     # in the new venv location, while preserving existing torch/CUDA
     echo "==> Upgrading unsloth in migrated environment..."
-    _no_deps_arg=""
     if [ "$SKIP_TORCH" = true ]; then
-        _no_deps_arg="--no-deps"
+        # No-torch: install runtime deps via [huggingfacenotorch] extras,
+        # then unsloth-zoo with --no-deps to avoid pulling torch.
+        uv pip install --python "$_VENV_PY" \
+            --reinstall-package unsloth \
+            "unsloth[huggingfacenotorch]>=2026.3.14"
+        uv pip install --python "$_VENV_PY" --no-deps \
+            --reinstall-package unsloth-zoo unsloth-zoo
+    else
+        uv pip install --python "$_VENV_PY" \
+            --reinstall-package unsloth --reinstall-package unsloth-zoo \
+            "unsloth>=2026.3.14" unsloth-zoo
     fi
-    uv pip install --python "$_VENV_PY" $_no_deps_arg \
-        --reinstall-package unsloth --reinstall-package unsloth-zoo \
-        "unsloth>=2026.3.14" unsloth-zoo
     if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
         echo "==> Overlaying local repo (editable)..."
         uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
@@ -885,17 +891,25 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
     fi
     # Fresh: Step 2 - install unsloth, preserving pre-installed torch
     echo "==> Installing unsloth (this may take a few minutes)..."
-    _no_deps_arg=""
     if [ "$SKIP_TORCH" = true ]; then
-        _no_deps_arg="--no-deps"
-    fi
-    if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
-        uv pip install --python "$_VENV_PY" $_no_deps_arg \
+        # No-torch: install runtime deps via [huggingfacenotorch] extras,
+        # then unsloth-zoo with --no-deps to avoid pulling torch.
+        uv pip install --python "$_VENV_PY" \
+            --upgrade-package unsloth \
+            "unsloth[huggingfacenotorch]>=2026.3.14"
+        uv pip install --python "$_VENV_PY" --no-deps \
+            --upgrade-package unsloth-zoo unsloth-zoo
+        if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
+            echo "==> Overlaying local repo (editable)..."
+            uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
+        fi
+    elif [ "$STUDIO_LOCAL_INSTALL" = true ]; then
+        uv pip install --python "$_VENV_PY" \
             --upgrade-package unsloth "unsloth>=2026.3.14" unsloth-zoo
         echo "==> Overlaying local repo (editable)..."
         uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
     else
-        uv pip install --python "$_VENV_PY" $_no_deps_arg \
+        uv pip install --python "$_VENV_PY" \
             --upgrade-package unsloth "$PACKAGE_NAME"
     fi
 else

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -440,17 +440,24 @@ def install_python_stack() -> int:
     if skip_base:
         print(_green(f"✅ {package_name} already installed — skipping base packages"))
     elif NO_TORCH:
-        # No-torch mode: install unsloth + unsloth-zoo without torch deps
+        # No-torch mode: install runtime deps via [huggingfacenotorch] extras
+        # (safetensors, transformers, datasets, etc.), then unsloth-zoo with
+        # --no-deps to avoid pulling torch.
         _progress("base packages (no torch)")
         pip_install(
-            "Updating base packages (no-torch mode)",
+            "Installing unsloth runtime deps (no-torch mode)",
+            "--no-cache-dir",
+            "--upgrade-package",
+            "unsloth",
+            "unsloth[huggingfacenotorch]>=2026.3.14",
+        )
+        pip_install(
+            "Installing unsloth-zoo (no-torch mode)",
             "--no-cache-dir",
             "--no-deps",
             "--upgrade-package",
-            "unsloth",
-            "--upgrade-package",
             "unsloth-zoo",
-            req = REQ_ROOT / "base.txt",
+            "unsloth-zoo",
         )
         if local_repo:
             pip_install(


### PR DESCRIPTION
## Summary
- Fixes `PackageNotFoundError: safetensors` (and other missing deps) when using `--no-torch` mode
- The previous `--no-deps` approach skipped ALL dependencies, not just torch
- Now uses `unsloth[huggingfacenotorch]` extras to install runtime deps (safetensors, transformers, datasets, accelerate, etc.) without pulling torch
- `unsloth-zoo` is still installed with `--no-deps` since its PyPI metadata declares `torch>=2.4.0`

## What changed
All three installer files updated:
- `install.sh`: migrated-env + fresh install paths
- `install.ps1`: same paths mirrored
- `studio/install_python_stack.py`: `unsloth studio update` path

## Before (broken)
```
uv pip install --no-deps unsloth unsloth-zoo
# Missing: safetensors, transformers, datasets, accelerate, peft, ...
```

## After (fixed)
```
uv pip install "unsloth[huggingfacenotorch]>=2026.3.14"   # gets runtime deps
uv pip install --no-deps unsloth-zoo                       # gets zoo without torch
```

## Test plan
- [x] `sh -n install.sh` passes
- [x] `python -m py_compile studio/install_python_stack.py` passes
- [ ] Manual test: `./install.sh --no-torch` on a fresh venv should install safetensors, transformers, etc.