### PR TITLE
Streaming tool detection: guard late tool_calls, filter incomplete fragments

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2372,8 +2372,12 @@ class LlamaCppBackend:
                         tool_calls = [
                             tool_calls_acc[i]
                             for i in sorted(tool_calls_acc)
-                            if (tool_calls_acc[i].get("function", {})
-                                .get("name", "").strip())
+                            if (
+                                tool_calls_acc[i]
+                                .get("function", {})
+                                .get("name", "")
+                                .strip()
+                            )
                         ] or None
                     if (
                         not tool_calls


### PR DESCRIPTION
## Summary

Follow-up to #4639 (merged). Two defensive hardening fixes for the streaming tool detection state machine:

- If visible content was already emitted to the user when `delta.tool_calls` arrives later in the same stream, ignore the tool_calls instead of reclassifying the turn as a tool call. llama-server never interleaves content and tool_calls (they are mutually exclusive per the SSE protocol), but this guard protects against other OpenAI-compatible backends that might.
- Filter out incomplete structured tool_calls fragments (empty `function.name`) before passing them to `execute_tool()`. These can appear when a streaming response is truncated by `max_tokens`, client disconnect, or interruption mid-argument.

## Test plan

- [ ] Verify normal tool calls (structured `delta.tool_calls`) still execute correctly
- [ ] Verify XML fallback tool calls still parse and execute
- [ ] Verify no-tool plain text responses stream at full speed
- [ ] Verify truncated tool call streams do not crash or execute empty-name tools