### PR TITLE
fix: install no-torch runtime deps via requirements file

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -668,10 +668,9 @@ shell.Run cmd, 0, False
         # in the new venv location, while preserving existing torch/CUDA
         Write-Host "==> Upgrading unsloth in migrated environment..."
         if ($SkipTorch) {
-            # No-torch: install runtime deps via [huggingfacenotorch] extras,
-            # then unsloth-zoo with --no-deps to avoid pulling torch.
-            uv pip install --python $VenvPython --reinstall-package unsloth "unsloth[huggingfacenotorch]>=2026.3.14"
-            uv pip install --python $VenvPython --no-deps --reinstall-package unsloth-zoo unsloth-zoo
+            # No-torch: install packages without deps to avoid pulling torch.
+            # Runtime deps are installed by install_python_stack.py via no-torch-runtime.txt.
+            uv pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.3.14" unsloth-zoo
         } else {
             uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.3.14" unsloth-zoo
         }
@@ -693,10 +692,9 @@ shell.Run cmd, 0, False
 
         Write-Host "==> Installing unsloth (this may take a few minutes)..."
         if ($SkipTorch) {
-            # No-torch: install runtime deps via [huggingfacenotorch] extras,
-            # then unsloth-zoo with --no-deps to avoid pulling torch.
-            uv pip install --python $VenvPython --upgrade-package unsloth "unsloth[huggingfacenotorch]>=2026.3.14"
-            uv pip install --python $VenvPython --no-deps --upgrade-package unsloth-zoo unsloth-zoo
+            # No-torch: install packages without deps to avoid pulling torch.
+            # Runtime deps are installed by install_python_stack.py via no-torch-runtime.txt.
+            uv pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.3.14" unsloth-zoo
             if ($StudioLocalInstall) {
                 Write-Host "==> Overlaying local repo (editable)..."
                 uv pip install --python $VenvPython -e $RepoRoot --no-deps
@@ -737,7 +735,9 @@ shell.Run cmd, 0, False
         return
     }
     # Tell setup.ps1 to skip base package installation (install.ps1 already did it)
-    $env:SKIP_STUDIO_BASE = "1"
+    # When no-torch, don't skip base so install_python_stack installs
+    # no-torch-runtime.txt (the runtime deps that --no-deps skipped).
+    $env:SKIP_STUDIO_BASE = if ($SkipTorch) { "0" } else { "1" }
     $env:STUDIO_PACKAGE_NAME = $PackageName
     $env:UNSLOTH_NO_TORCH = if ($SkipTorch) { "true" } else { "false" }
     if ($StudioLocalInstall) {

--- a/install.sh
+++ b/install.sh
@@ -947,13 +947,12 @@ if [ "$_MIGRATED" = true ]; then
     # in the new venv location, while preserving existing torch/CUDA
     echo "==> Upgrading unsloth in migrated environment..."
     if [ "$SKIP_TORCH" = true ]; then
-        # No-torch: install runtime deps via [huggingfacenotorch] extras,
-        # then unsloth-zoo with --no-deps to avoid pulling torch.
-        uv pip install --python "$_VENV_PY" \
-            --reinstall-package unsloth \
-            "unsloth[huggingfacenotorch]>=2026.3.14"
+        # No-torch: install packages without deps to avoid pulling torch.
+        # Runtime deps (safetensors, transformers, etc.) are installed by
+        # install_python_stack.py via no-torch-runtime.txt.
         uv pip install --python "$_VENV_PY" --no-deps \
-            --reinstall-package unsloth-zoo unsloth-zoo
+            --reinstall-package unsloth --reinstall-package unsloth-zoo \
+            "unsloth>=2026.3.14" unsloth-zoo
     else
         uv pip install --python "$_VENV_PY" \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
@@ -975,13 +974,11 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
     # Fresh: Step 2 - install unsloth, preserving pre-installed torch
     echo "==> Installing unsloth (this may take a few minutes)..."
     if [ "$SKIP_TORCH" = true ]; then
-        # No-torch: install runtime deps via [huggingfacenotorch] extras,
-        # then unsloth-zoo with --no-deps to avoid pulling torch.
-        uv pip install --python "$_VENV_PY" \
-            --upgrade-package unsloth \
-            "unsloth[huggingfacenotorch]>=2026.3.14"
+        # No-torch: install packages without deps to avoid pulling torch.
+        # Runtime deps are installed by install_python_stack.py via no-torch-runtime.txt.
         uv pip install --python "$_VENV_PY" --no-deps \
-            --upgrade-package unsloth-zoo unsloth-zoo
+            --upgrade-package unsloth --upgrade-package unsloth-zoo \
+            "unsloth>=2026.3.14" unsloth-zoo
         if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
             echo "==> Overlaying local repo (editable)..."
             uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
@@ -1039,15 +1036,21 @@ if [ -n "$VENV_ABS_BIN" ]; then
 fi
 
 echo "==> Running unsloth setup..."
+# When no-torch, don't skip base so install_python_stack installs
+# no-torch-runtime.txt (the runtime deps that --no-deps skipped).
+_SKIP_BASE=1
+if [ "$SKIP_TORCH" = true ]; then
+    _SKIP_BASE=0
+fi
 if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
-    SKIP_STUDIO_BASE=1 \
+    SKIP_STUDIO_BASE="$_SKIP_BASE" \
     STUDIO_PACKAGE_NAME="$PACKAGE_NAME" \
     STUDIO_LOCAL_INSTALL=1 \
     STUDIO_LOCAL_REPO="$_REPO_ROOT" \
     UNSLOTH_NO_TORCH="$SKIP_TORCH" \
     bash "$SETUP_SH" </dev/null
 else
-    SKIP_STUDIO_BASE=1 \
+    SKIP_STUDIO_BASE="$_SKIP_BASE" \
     STUDIO_PACKAGE_NAME="$PACKAGE_NAME" \
     UNSLOTH_NO_TORCH="$SKIP_TORCH" \
     bash "$SETUP_SH" </dev/null

--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -1,0 +1,24 @@
+# Runtime dependencies for no-torch (GGUF-only) mode.
+# These are normally pulled in transitively by unsloth-zoo, but
+# --no-deps skips them to avoid torch. Install these explicitly.
+# Mirrors the [huggingfacenotorch] extras from pyproject.toml.
+wheel>=0.42.0
+packaging
+numpy
+tqdm
+psutil
+tyro
+protobuf
+sentencepiece>=0.2.0
+safetensors>=0.4.3
+datasets>=3.4.1,!=4.0.*,!=4.1.0,<4.4.0
+accelerate>=0.34.1
+peft>=0.18.0,!=0.11.0
+huggingface_hub>=0.34.0
+hf_transfer
+diffusers
+transformers>=4.51.3,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3,!=4.53.0,!=4.54.0,!=4.55.0,!=4.55.1,!=4.57.0,!=4.57.4,!=4.57.5,!=5.0.0,!=5.1.0,<=5.3.0
+trl>=0.18.2,!=0.19.0,<=0.24.0
+sentence-transformers
+cut_cross_entropy
+pillow

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -462,24 +462,14 @@ def install_python_stack() -> int:
     if skip_base:
         print(_green(f"✅ {package_name} already installed — skipping base packages"))
     elif NO_TORCH:
-        # No-torch mode: install runtime deps via [huggingfacenotorch] extras
-        # (safetensors, transformers, datasets, etc.), then unsloth-zoo with
-        # --no-deps to avoid pulling torch.
+        # No-torch mode: unsloth + unsloth-zoo are already installed with
+        # --no-deps by install.sh/install.ps1. Install the runtime deps
+        # (safetensors, transformers, datasets, etc.) from no-torch-runtime.txt.
         _progress("base packages (no torch)")
         pip_install(
-            "Installing unsloth runtime deps (no-torch mode)",
+            "Installing no-torch runtime deps",
             "--no-cache-dir",
-            "--upgrade-package",
-            "unsloth",
-            "unsloth[huggingfacenotorch]>=2026.3.14",
-        )
-        pip_install(
-            "Installing unsloth-zoo (no-torch mode)",
-            "--no-cache-dir",
-            "--no-deps",
-            "--upgrade-package",
-            "unsloth-zoo",
-            "unsloth-zoo",
+            req = REQ_ROOT / "no-torch-runtime.txt",
         )
         if local_repo:
             pip_install(


### PR DESCRIPTION
## Summary
- Fixes `PackageNotFoundError: safetensors` when using `--no-torch` mode
- The previous fix (#4647) used `unsloth[huggingfacenotorch]` extras, but that extra is **not published on PyPI** -- only exists in the repo's pyproject.toml
- Adds `studio/backend/requirements/no-torch-runtime.txt` with the runtime deps (mirrors `[huggingfacenotorch]` from pyproject.toml)

## Root cause
`--no-deps` skips ALL dependencies, not just torch. The `[huggingfacenotorch]` extras that #4647 tried to use don't exist on PyPI (`provides_extra` on PyPI has no `huggingfacenotorch`).

## Fix
1. `install.sh`/`install.ps1`: install `unsloth` + `unsloth-zoo` with `--no-deps` (unchanged)
2. New: `studio/backend/requirements/no-torch-runtime.txt` lists the runtime deps (safetensors, transformers, datasets, accelerate, peft, etc.)
3. `install_python_stack.py`: NO_TORCH branch installs `no-torch-runtime.txt`
4. `SKIP_STUDIO_BASE` is set to `0` (not `1`) in no-torch mode so `install_python_stack.py`'s NO_TORCH branch actually runs

## Test plan
- [x] `sh -n install.sh` passes
- [x] `python -m py_compile studio/install_python_stack.py` passes
- [ ] Manual: `./install.sh --no-torch` on fresh venv should install safetensors, transformers, etc.