### PR TITLE
Fall back to parsing model name when HF API has no param count

### DIFF
--- a/studio/frontend/src/features/onboarding/components/steps/model-selection-step.tsx
+++ b/studio/frontend/src/features/onboarding/components/steps/model-selection-step.tsx
@@ -58,6 +58,13 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
+/** Extract param count label from model name (e.g. "Qwen3-0.6B" -> "0.6B"). */
+function extractParamLabel(id: string): string | null {
+  const name = id.split("/").pop() ?? id;
+  const match = name.match(/(?:^|[-_])(\d+(?:\.\d+)?)[Bb](?:[-_]|$)/);
+  return match ? `${match[1]}B` : null;
+}
+
 export function ModelSelectionStep() {
   const gpu = useGpuInfo();
   const {
@@ -119,7 +126,7 @@ export function ModelSelectionStep() {
       const fit = fitMap.get(r.id);
       map.set(r.id, {
         status: fit?.status ?? null,
-        detail: r.totalParams ? formatCompact(r.totalParams) : null,
+        detail: r.totalParams ? formatCompact(r.totalParams) : extractParamLabel(r.id),
       });
     }
     return map;

--- a/studio/frontend/src/features/studio/sections/model-section.tsx
+++ b/studio/frontend/src/features/studio/sections/model-section.tsx
@@ -72,6 +72,13 @@ const DARK_CONTENT =
 const DARK_COMBOBOX_CONTENT =
   "bg-foreground text-background shadow-xl border-background/10 dark:[--accent:rgba(2,6,23,0.08)] dark:[--accent-foreground:rgb(2,6,23)] dark:[&_[data-slot=combobox-item]]:text-slate-900 dark:[&_.text-muted-foreground]:text-slate-500";
 
+/** Extract param count label from model name (e.g. "Qwen3-0.6B" -> "0.6B"). */
+function extractParamLabel(id: string): string | null {
+  const name = id.split("/").pop() ?? id;
+  const match = name.match(/(?:^|[-_])(\d+(?:\.\d+)?)[Bb](?:[-_]|$)/);
+  return match ? `${match[1]}B` : null;
+}
+
 export function ModelSection() {
   const gpu = useGpuInfo();
 
@@ -233,7 +240,7 @@ export function ModelSection() {
       { est: number; status: VramFitStatus | null; detail: string | null }
     >();
     for (const r of hfResults) {
-      const detail = r.totalParams ? formatCompact(r.totalParams) : null;
+      const detail = r.totalParams ? formatCompact(r.totalParams) : extractParamLabel(r.id);
       const fit = fitMap.get(r.id);
       map.set(r.id, {
         est: fit?.est ?? 0,


### PR DESCRIPTION
## Summary

- Models like `unsloth/Qwen3-0.6B` have no `safetensors` metadata on the Hugging Face API (`safetensors: None`), so the training model selector and onboarding wizard showed no parameter size badge next to the model name.
- The chat model picker already had `extractParamLabel()` as a fallback, which parses sizes like `0.6B` from the model name using a regex.
- Added the same fallback to the training model selector (`model-section.tsx`) and the onboarding model selection step (`model-selection-step.tsx`).

## Files changed

- `studio/frontend/src/features/studio/sections/model-section.tsx` -- added `extractParamLabel()`, used as fallback when `totalParams` is missing
- `studio/frontend/src/features/onboarding/components/steps/model-selection-step.tsx` -- same change

## Test plan

- Open the training tab and check that `unsloth/Qwen3-0.6B` now shows "0.6B" next to its name
- Confirm models that do have HF safetensors metadata (e.g. `unsloth/Qwen3.5-4B`) still show their param count from the API as before