### PR TITLE
fix: disable OCR in pymupdf4llm PDF extraction

### DIFF
--- a/studio/backend/routes/data_recipe/seed.py
+++ b/studio/backend/routes/data_recipe/seed.py
@@ -388,7 +388,7 @@ def _extract_text_from_file(file_path: Path, ext: str) -> str:
         import pymupdf4llm
 
         raw = pymupdf4llm.to_markdown(
-            str(file_path), write_images = False, show_progress = False
+            str(file_path), write_images = False, show_progress = False, use_ocr = False
         )
     elif ext == ".docx":
         import mammoth


### PR DESCRIPTION
Add use_ocr=False to pymupdf4llm.to_markdown(). The existing write_images=False only controls image output, not Tesseract OCR, causing failures when tessdata is missing.