### PR TITLE
Fix LM Studio GGUF loading on native Windows (no GPU)

### DIFF
--- a/studio/backend/utils/paths/path_utils.py
+++ b/studio/backend/utils/paths/path_utils.py
@@ -6,6 +6,7 @@ Path utilities for model and dataset handling
 """
 
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 import structlog
@@ -14,12 +15,33 @@ from loggers import get_logger
 logger = get_logger(__name__)
 
 
+def _is_wsl() -> bool:
+    """Detect if we are running inside WSL (Windows Subsystem for Linux)."""
+    if sys.platform == "win32":
+        return False
+    try:
+        with open("/proc/version", "r") as f:
+            return "microsoft" in f.read().lower()
+    except Exception:
+        return False
+
+
+_IS_WSL: bool = _is_wsl()
+
+
 def normalize_path(path: str) -> str:
     """
-    Convert Windows paths to WSL format if needed.
+    Normalize filesystem paths for cross-platform use.
 
-    Examples:
+    On WSL, converts Windows drive-letter paths to ``/mnt/<drive>/...``.
+    On native Windows, keeps the drive letter and normalizes separators.
+    On Linux/macOS (non-WSL), paths are returned with forward slashes.
+
+    Examples (WSL):
         C:\\Users\\... -> /mnt/c/Users/...
+    Examples (native Windows):
+        C:\\Users\\... -> C:/Users/...
+    Examples (Linux/macOS):
         /home/user/... -> /home/user/... (unchanged)
     """
     if not path:
@@ -27,9 +49,13 @@ def normalize_path(path: str) -> str:
 
     # Handle Windows drive letters (C:\\ or c:\\)
     if len(path) >= 3 and path[1] == ":" and path[2] in ("\\", "/"):
-        drive = path[0].lower()
-        rest = path[3:].replace("\\", "/")
-        return f"/mnt/{drive}/{rest}"
+        # Only map to /mnt/<drive>/ when running under WSL;
+        # on native Windows the drive letter must be preserved.
+        if _IS_WSL:
+            drive = path[0].lower()
+            rest = path[3:].replace("\\", "/")
+            return f"/mnt/{drive}/{rest}"
+        return path.replace("\\", "/")
 
     # Already Unix-style or relative
     return path.replace("\\", "/")


### PR DESCRIPTION
## Summary
- `normalize_path()` unconditionally converted Windows drive-letter paths (e.g. `C:\Users\...`) to WSL format (`/mnt/c/Users/...`), even on native Windows where that path does not exist
- This caused `detect_gguf_model()` to return `None` for LM Studio GGUF models (their paths come from `_scan_lmstudio_dir` as absolute Windows paths like `C:\Users\user\.lmstudio\models\publisher\model-name`)
- With GGUF detection failing, the load fell through to the Unsloth/transformers inference path, which imports `from unsloth import FastLanguageModel` at module level, triggering the GPU check and raising "Unsloth cannot find any torch accelerator"
- Non-LM-Studio GGUFs were unaffected because they are either remote HF repos (no path normalization) or relative paths (no drive letter to convert)

The fix adds WSL detection (`/proc/version` check) so the `/mnt/<drive>/` mapping only applies when actually running under WSL. On native Windows, drive letters are preserved and only backslashes are normalized to forward slashes.

## Test plan
- [ ] On native Windows (CPU-only, no GPU): load an LM Studio GGUF model -- should route to llama-server instead of erroring
- [ ] On WSL: load an LM Studio GGUF from the Windows-side path (`C:\Users\...`) -- should still map to `/mnt/c/...` correctly
- [ ] On Linux/macOS: no behavior change for Unix paths