### PR TITLE
fix: [Studio] setup.ps1 update-flow for windows 

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1351,8 +1351,6 @@ function Fast-Install {
     & python -m pip install @Args_ 2>&1
 }
 
-Fast-Install --upgrade pip | Out-Null
-
 # ── Check if Python deps need updating ──
 # Compare installed package version against PyPI latest.
 # Skip all Python dependency work if versions match (fast update path).
@@ -1361,11 +1359,11 @@ $SkipPythonDeps = $false
 
 if ($env:SKIP_STUDIO_BASE -ne "1" -and $env:STUDIO_LOCAL_INSTALL -ne "1") {
     # Only check when NOT called from install.ps1 (which just installed the package)
-    $InstalledVer = try { & python -c "from importlib.metadata import version; print(version('$_PkgName'))" 2>$null } catch { "" }
+    $InstalledVer = try { (& python -c "from importlib.metadata import version; print(version('$_PkgName'))" 2>$null | Out-String).Trim() } catch { "" }
     $LatestVer = ""
     try {
         $pypiJson = Invoke-RestMethod -Uri "https://pypi.org/pypi/$_PkgName/json" -TimeoutSec 5 -ErrorAction Stop
-        $LatestVer = $pypiJson.info.version
+        $LatestVer = "$($pypiJson.info.version)".Trim()
     } catch { }
 
     if ($InstalledVer -and $LatestVer -and ($InstalledVer -eq $LatestVer)) {
@@ -1397,6 +1395,8 @@ if ($env:SKIP_STUDIO_BASE -ne "1" -and $env:STUDIO_LOCAL_INSTALL -ne "1") {
 # }
 
 if (-not $SkipPythonDeps) {
+
+Fast-Install --upgrade pip | Out-Null
 
 # Pre-install PyTorch with CUDA support.
 # On Windows, the default PyPI torch wheel is CPU-only.

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -292,13 +292,16 @@ def update(
     """Update Unsloth Studio dependencies and rebuild."""
     # Ensure SKIP_STUDIO_BASE is not inherited from a parent install.ps1 session
     os.environ.pop("SKIP_STUDIO_BASE", None)
-    os.environ["STUDIO_LOCAL_INSTALL"] = "1" if local else "0"
     os.environ["STUDIO_PACKAGE_NAME"] = package
     if local:
+        os.environ["STUDIO_LOCAL_INSTALL"] = "1"
         # Pass the repo root explicitly so install_python_stack.py doesn't
         # have to guess from SCRIPT_DIR (which may be inside site-packages).
         repo_root = Path(__file__).resolve().parents[2]
         os.environ["STUDIO_LOCAL_REPO"] = str(repo_root)
+    else:
+        os.environ["STUDIO_LOCAL_INSTALL"] = "0"
+        os.environ.pop("STUDIO_LOCAL_REPO", None)
     _run_setup_script(verbose = verbose)
 
 


### PR DESCRIPTION
## Summary

- Ports the update-flow logic from `setup.sh` (introduced in #4530) to `setup.ps1`
- `unsloth studio update` on Windows now checks installed version against PyPI latest and skips all Python dependency work (PyTorch, `install_python_stack.py`, transformers 5.x) when already up-to-date
- Falls through to full install if PyPI is unreachable (safe default)
- Footer banner shows "Unsloth Studio Updated" vs "Unsloth Studio Setup Complete" depending on context

## Test plan

Requires a Windows machine with an existing `unsloth studio` install (`~\.unsloth\studio\unsloth_studio` venv).

### Fast path (versions match)
- [ ] Run `unsloth studio update` when installed unsloth version matches PyPI latest
- [ ] Verify output shows `unsloth X.Y.Z is up to date` and `dependencies up to date`
- [ ] Verify PyTorch is NOT re-downloaded (~2.8 GB saved)
- [ ] Verify footer says "Unsloth Studio Updated"

### Update path (new version available)

Since downgrading unsloth also replaces `setup.ps1` in site-packages with the old version (no version check), use this workaround:

\`\`\`powershell
# 1. Install from this branch
./install.ps1 --local

# 2. Downgrade unsloth inside the venv
& "$env:USERPROFILE\.unsloth\studio\unsloth_studio\Scripts\pip" install unsloth==2026.3.16

# 3. Replace setup.ps1 with the new version from this branch
$setupPath = & "$env:USERPROFILE\.unsloth\studio\unsloth_studio\Scripts\python" -c "import studio; import pathlib; print(pathlib.Path(studio.__file__).parent / 'setup.ps1')"
Invoke-WebRequest -Uri "https://raw.githubusercontent.com/unslothai/unsloth/fix/setup-ps1-update-flow/studio/setup.ps1" -OutFile $setupPath

# 4. Run update — should detect version mismatch and do a full install
unsloth studio update
\`\`\`

- [ ] Verify output shows `unsloth 2026.3.14 -> X.Y.Z available, updating...`
- [ ] Verify full dependency install runs

### Install path (called from install.ps1)
- [ ] Set `$env:SKIP_STUDIO_BASE = "1"` and run `setup.ps1`
- [ ] Verify version check is skipped, full install runs as before
- [ ] Verify footer says "Unsloth Studio Setup Complete"

### Offline/unreachable PyPI
- [ ] Disconnect network or set a bogus proxy, run `unsloth studio update`
- [ ] Verify output shows `could not reach PyPI, updating to be safe...`
- [ ] Verify full dependency install runs (safe fallback)