### PR TITLE
Fix editable install scanning 6,500+ node_modules dirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ studio = [
 
 [tool.setuptools.packages.find]
 include = ["unsloth*", "unsloth_cli*", "studio", "studio.backend*"]
-exclude = ["images*", "tests*", "*.node_modules*"]
+exclude = ["images*", "tests*", "*.node_modules", "*.node_modules.*"]
 
 [project.optional-dependencies]
 triton = [


### PR DESCRIPTION
## Summary

- The `[tool.setuptools.packages.find]` section had no `include` filter, so `find_namespace_packages` discovered **all** directories as Python packages -- including the ~6,557 directories inside `studio/frontend/node_modules/` created during the frontend build step
- This caused the editable install (`uv pip install -e . --no-deps`) to run 20,000+ glob operations across 6,619 "packages", taking 7+ minutes on slower machines
- Adding an explicit `include` filter scopes discovery to only the packages we ship: `unsloth*`, `unsloth_cli*`, `studio`, `studio.backend*`

## Changes

```diff
 [tool.setuptools.packages.find]
-exclude = ["images*", "tests*", "kernels/moe*"]
+include = ["unsloth*", "unsloth_cli*", "studio", "studio.backend*"]
+exclude = ["images*", "tests*", "*.node_modules*"]
```

**Removed the old `kernels/moe*` exclude** -- it used `/` instead of `.` notation so it never actually matched anything. The moe packages are included via `unsloth*`.

## Benchmarks (editable install build time)

| | Packages discovered | Build time |
|---|---|---|
| Before | 6,619 | 5.4s |
| After | 58 | 1.2s |

On a user's machine with a slower disk, the before case took ~7 minutes.

## Wheel comparison

All real files are identical between the old and new wheels:

| Category | Before | After |
|---|---|---|
| frontend/dist | 565 | 565 |
| YAML configs | 74 | 74 |
| JSON configs | 23 | 23 |
| PNG assets | 92 | 92 |
| kernels/moe | 27 | 27 |
| Shell scripts | 2 | 2 |

The only files removed from the wheel are `build/lib/` duplicates (setuptools build artifacts that were accidentally included) and a few `.py` files from npm packages inside `node_modules/`.

## Test plan

- [x] Editable install works (`uv pip install -e . --no-deps`)
- [x] `import unsloth` resolves to local editable source
- [x] `import studio.backend` works
- [x] Studio launches and passes `/api/health` check
- [x] Wheel build succeeds with all assets present
- [x] Wheel contents compared against original -- no regressions