### PR TITLE
studio: prevent false multimodal warning during model loading

### DIFF
--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -45,10 +45,8 @@ const placeholderData = [
 export function TrainingSection() {
   const store = useTrainingConfigStore();
   const { isStarting, startError, startTrainingRun } = useTrainingActions();
-  const isModelCapabilitiesSettled =
-    !!store.selectedModel &&
-    !store.isCheckingVision &&
-    !store.isLoadingModelDefaults;
+  const isLoadingModel = store.isLoadingModelDefaults || store.isCheckingVision;
+  const isModelCapabilitiesSettled = !!store.selectedModel && !isLoadingModel;
   const isIncompatible =
     isModelCapabilitiesSettled &&
     ((!store.isVisionModel && store.isDatasetImage === true) ||
@@ -162,10 +160,10 @@ export function TrainingSection() {
           data-tour="studio-start"
           className="w-full cursor-pointer bg-gradient-to-r from-emerald-500 to-teal-500 text-white hover:from-emerald-600 hover:to-teal-600"
           onClick={() => void startTrainingRun()}
-          disabled={isStarting || isIncompatible || store.isCheckingDataset || store.isCheckingVision || store.isLoadingModelDefaults || !configValidation.ok}
+          disabled={isStarting || isIncompatible || store.isCheckingDataset || isLoadingModel || !configValidation.ok}
         >
           <HugeiconsIcon icon={Rocket01Icon} className="size-4" />
-          {isStarting ? "Starting..." : store.isLoadingModelDefaults || store.isCheckingVision ? "Loading model..." : store.isCheckingDataset ? "Checking dataset..." : "Start Training"}
+          {isStarting ? "Starting..." : isLoadingModel ? "Loading model..." : store.isCheckingDataset ? "Checking dataset..." : "Start Training"}
         </Button>
         {startError && (
           <p className="text-xs text-red-500 leading-relaxed">{startError}</p>


### PR DESCRIPTION
Fixes #4641 

This was caused by a UI timing issue in Studio where the Training panel could briefly show an incorrect incompatibility warning:
**“Text model is not compatible with a multimodal dataset”**

Could happen when a dataset is detected as multimodal before the selected model’s capabilities have finished loading (e.g. local uploads + quick model changes).

The warning is now only shown after model capability checks have settled, guarded by:

model selected
not checking vision
not loading model defaults


