### PR TITLE
fix: skip download progress polling for exported GGUF models

### DIFF
--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -1003,7 +1003,7 @@ export function LoraModelPicker({
                             onSelect(adapter.id, {
                               source: isLocal ? "local" : isExported ? "exported" : "lora",
                               isLora: !isLocal && !isMerged && !isGguf,
-                              isDownloaded: isLocal || isGguf,
+                              isDownloaded: true,
                             });
                           }
                         }}


### PR DESCRIPTION
## Summary

- Exported GGUF models selected from the Fine-tuned tab incorrectly triggered download progress polling (`/api/models/download-progress` every 2s), showing "Downloading model..." even though the file is already local
- Root cause: `isLocalGgufDir` was gated on `isLocal` (source === "local"), which excluded exported GGUFs (source === "exported"), so `isDownloaded` was never passed
- Fix: include exported GGUFs in the `isLocalGgufDir` check so they get the variant expander, and pass `isDownloaded: true` in the fallback branch as a safety net

Reported by **@GudeAndi** on Discord (30 March 2026).

## Test plan

- [ ] Export a GGUF model from training
- [ ] In the chat page, select the exported GGUF from the Fine-tuned tab
- [ ] Verify toast says "Starting model..." (not "Downloading model...")
- [ ] Verify no `/api/models/download-progress` requests in backend logs
- [ ] Verify model loads via llama-server normally