### PR TITLE
Add ROCm support to llama.cpp prebuilt installer

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -1746,8 +1746,10 @@ def resolve_upstream_asset_choice(host: HostInfo, llama_tag: str) -> AssetChoice
             rocm_name = f"llama-{llama_tag}-bin-ubuntu-rocm-7.2-x64.tar.gz"
             if rocm_name in upstream_assets:
                 log(f"AMD ROCm detected -- trying upstream prebuilt {rocm_name}")
-                log("Note: prebuilt is compiled for ROCm 7.2; if your ROCm version differs, "
-                    "this may fail preflight and fall back to a source build (safe)")
+                log(
+                    "Note: prebuilt is compiled for ROCm 7.2; if your ROCm version differs, "
+                    "this may fail preflight and fall back to a source build (safe)"
+                )
                 return AssetChoice(
                     repo = UPSTREAM_REPO,
                     tag = llama_tag,
@@ -1785,7 +1787,9 @@ def resolve_upstream_asset_choice(host: HostInfo, llama_tag: str) -> AssetChoice
         if host.has_rocm:
             hip_name = f"llama-{llama_tag}-bin-win-hip-radeon-x64.zip"
             if hip_name in upstream_assets:
-                log(f"AMD ROCm detected on Windows -- trying upstream HIP prebuilt {hip_name}")
+                log(
+                    f"AMD ROCm detected on Windows -- trying upstream HIP prebuilt {hip_name}"
+                )
                 return AssetChoice(
                     repo = UPSTREAM_REPO,
                     tag = llama_tag,
@@ -1794,7 +1798,9 @@ def resolve_upstream_asset_choice(host: HostInfo, llama_tag: str) -> AssetChoice
                     source_label = "upstream",
                     install_kind = "windows-hip",
                 )
-            log("AMD ROCm detected on Windows but no HIP prebuilt found -- falling back to CPU")
+            log(
+                "AMD ROCm detected on Windows but no HIP prebuilt found -- falling back to CPU"
+            )
 
         upstream_name = f"llama-{llama_tag}-bin-win-cpu-x64.zip"
         if upstream_name not in upstream_assets:


### PR DESCRIPTION
## Summary

- Extend `detect_host()` to detect AMD ROCm GPUs via hipcc/amd-smi/rocm-smi and `/opt/rocm`
- Add `has_rocm` field to `HostInfo` dataclass
- Route Linux ROCm hosts to the upstream ROCm 7.2 prebuilt (with source build fallback)
- Route Windows ROCm hosts to the HIP prebuilt (with CPU fallback and log message)
- Add `linux-rocm` and `windows-hip` install kinds with correct runtime file patterns

## How it works

### Host detection

`detect_host()` now checks for ROCm presence (skipped on macOS) by looking for:
- `hipcc`, `amd-smi`, or `rocm-smi` on PATH
- `/opt/rocm` directory or `ROCM_PATH` env var

### Asset selection

In `resolve_upstream_asset_choice()`:

| Host | Condition | Behavior |
|------|-----------|----------|
| Linux x86_64 | ROCm detected, no NVIDIA | Try `llama-{tag}-bin-ubuntu-rocm-7.2-x64.tar.gz`, fall back to source build |
| Windows x86_64 | ROCm detected, no NVIDIA | Try `llama-{tag}-bin-win-hip-radeon-x64.zip`, fall back to CPU with log |
| Any | NVIDIA present | Normal CUDA path (ROCm ignored) |

A log warning notes that the prebuilt is compiled for ROCm 7.2 and may fail preflight on other versions, in which case the source build fallback compiles with `-DGGML_HIP=ON` and auto-detects the exact GPU target via `rocminfo`.

### Runtime patterns

`runtime_patterns_for_choice()` now handles `linux-rocm` (includes `libggml-hip.so*`) and `windows-hip` (includes `*.exe`, `*.dll`).

## Test plan

- [x] `python -m py_compile studio/install_llama_prebuilt.py` passes
- [x] Mocked unit tests for asset selection, runtime patterns, and HostInfo all pass (see companion PR for test suite)
- [x] On B200 host (NVIDIA), `has_rocm=False` and CUDA path is unchanged