### PR TITLE
studio: fix export HF model dropdown clearing on enter/click-away

### DIFF
--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -75,6 +75,8 @@ import {
 import { GuidedTour, useGuidedTourController } from "@/features/tour";
 import { exportTourSteps } from "./tour";
 
+const SEARCH_INPUT_REASONS = new Set(["input-change", "input-paste", "input-clear"]);
+
 export function ExportPage() {
   const { hfToken, setHfToken } = useTrainingConfigStore(
     useShallow((s) => ({
@@ -122,6 +124,9 @@ export function ExportPage() {
 
   const hfComboboxAnchorRef = useRef<HTMLDivElement>(null);
   const localComboboxAnchorRef = useRef<HTMLDivElement>(null);
+  const selectingHfModelRef = useRef(false);
+  const hfModelInputRef = useRef("");
+  const localModelInputRef = useRef("");
 
   const tour = useGuidedTourController({
     id: "export",
@@ -310,6 +315,14 @@ export function ExportPage() {
     setModelInput("");
   }, [modelSource]);
 
+  useEffect(() => {
+    hfModelInputRef.current = modelInput;
+  }, [modelInput]);
+
+  useEffect(() => {
+    localModelInputRef.current = localModelInput;
+  }, [localModelInput]);
+
   const handleMethodChange = (method: ExportMethod) => {
     setExportMethod(method);
     if (method !== "gguf") {
@@ -324,6 +337,58 @@ export function ExportPage() {
     selectedExportSource &&
     exportMethod &&
     (exportMethod !== "gguf" || quantLevels.length > 0)
+  );
+
+  const applyHfSourceModel = useCallback((value: string) => {
+    const next = value.trim();
+    setModelInput(next);
+    setSelectedSourceModel(next || null);
+  }, []);
+
+  const handleHfSourceModelSelect = useCallback((id: string | null) => {
+    selectingHfModelRef.current = true;
+    const next = id ?? "";
+    hfModelInputRef.current = next;
+    setModelInput(next);
+    setSelectedSourceModel(id);
+  }, []);
+
+  const handleHfSourceInputChange = useCallback(
+    (value: string, eventDetails?: { reason?: string }) => {
+      hfModelInputRef.current = value;
+      if (selectingHfModelRef.current) {
+        selectingHfModelRef.current = false;
+        return;
+      }
+      if (!SEARCH_INPUT_REASONS.has(eventDetails?.reason ?? "")) {
+        return;
+      }
+      setModelInput(value);
+      if (value.trim() === "") {
+        setSelectedSourceModel(null);
+      }
+    },
+    [],
+  );
+
+  const applyLocalSourceModel = useCallback((value: string) => {
+    const next = value.trim();
+    setLocalModelInput(next);
+    setSelectedSourceModel(next || null);
+  }, []);
+
+  const handleLocalSourceInputChange = useCallback(
+    (value: string, eventDetails?: { reason?: string }) => {
+      localModelInputRef.current = value;
+      if (!SEARCH_INPUT_REASONS.has(eventDetails?.reason ?? "")) {
+        return;
+      }
+      setLocalModelInput(value);
+      if (value.trim() === "") {
+        setSelectedSourceModel(null);
+      }
+    },
+    [],
   );
 
   // ---- Export handler ----
@@ -680,16 +745,24 @@ export function ExportPage() {
                                 items={hfResultIds}
                                 filteredItems={hfResultIds}
                                 filter={null}
-                                value={selectedSourceModel}
-                                onValueChange={setSelectedSourceModel}
-                                onInputValueChange={(val) => {
-                                  setModelInput(val);
-                                  setSelectedSourceModel(null);
-                                }}
+                                value={modelInput || selectedSourceModel || null}
+                                onValueChange={handleHfSourceModelSelect}
+                                onInputValueChange={handleHfSourceInputChange}
                                 itemToStringValue={(id) => id}
                                 autoHighlight={true}
                               >
-                                <ComboboxInput placeholder="Search models..." className="w-full">
+                                <ComboboxInput
+                                  placeholder="Search models..."
+                                  className="w-full"
+                                  onBlur={() =>
+                                    applyHfSourceModel(hfModelInputRef.current)
+                                  }
+                                  onKeyDown={(event) => {
+                                    if (event.key !== "Enter") return;
+                                    event.preventDefault();
+                                    applyHfSourceModel(hfModelInputRef.current);
+                                  }}
+                                >
                                   <InputGroupAddon>
                                     <HugeiconsIcon icon={Search01Icon} className="size-4" />
                                   </InputGroupAddon>
@@ -792,10 +865,11 @@ export function ExportPage() {
                               value={localModelInput || null}
                               onValueChange={(id) => {
                                 const next = id ?? "";
+                                localModelInputRef.current = next;
                                 setLocalModelInput(next);
                                 setSelectedSourceModel(next || null);
                               }}
-                              onInputValueChange={setLocalModelInput}
+                              onInputValueChange={handleLocalSourceInputChange}
                               itemToStringValue={(id) => id}
                               autoHighlight={true}
                             >
@@ -806,13 +880,11 @@ export function ExportPage() {
                                     : "./models/my-model"
                                 }
                                 className="w-full"
-                                onBlur={() =>
-                                  setSelectedSourceModel(localModelInput.trim() || null)
-                                }
+                                onBlur={() => applyLocalSourceModel(localModelInputRef.current)}
                                 onKeyDown={(event) => {
                                   if (event.key !== "Enter") return;
                                   event.preventDefault();
-                                  setSelectedSourceModel(localModelInput.trim() || null);
+                                  applyLocalSourceModel(localModelInputRef.current);
                                 }}
                               >
                                 <InputGroupAddon>


### PR DESCRIPTION
Fixes a regression in Export where Hugging Face/local model input could clear after pressing Enter or clicking away.
Updates combobox input handling to only react to real typing events, preventing reset events from wiping selection.
Adds explicit commit behavior on Enter/blur so manual model IDs/paths persist reliably.

New:
![UNSLOTH GIF TEST](https://github.com/user-attachments/assets/a5026362-7a23-4ebe-80f5-e9bd84818b99)

**Cause:**
Export combobox mixed selected value and typed input without guarding non-user input-change reasons.
Enter/blur paths did not consistently commit the current typed value.
Selection/update events could race and null out the source model.