### PR TITLE
Fix Windows local GGUF model loading crash

### DIFF
--- a/studio/backend/utils/inference/inference_config.py
+++ b/studio/backend/utils/inference/inference_config.py
@@ -17,7 +17,7 @@ import structlog
 from loggers import get_logger
 
 from utils.models.model_config import load_model_defaults
-from utils.paths import is_local_path
+from utils.paths import is_local_path, normalize_path
 
 logger = get_logger(__name__)
 
@@ -94,12 +94,27 @@ def _has_specific_yaml(model_identifier: str) -> bool:
     if model_identifier.lower() in _REVERSE_MODEL_MAPPING:
         return True
 
-    # Check for exact filename match.
     # For local filesystem paths (e.g. C:\Users\...\model on Windows),
-    # use only the basename to avoid passing absolute paths into rglob
-    # which raises "Non-relative patterns are unsupported".
+    # normalize backslashes so Path().parts splits correctly on POSIX/WSL,
+    # then try matching the last 1-2 path components against the registry
+    # (mirrors the logic in load_model_defaults).
     _is_local = is_local_path(model_identifier)
-    _lookup = Path(model_identifier).name if _is_local else model_identifier
+    _normalized = normalize_path(model_identifier) if _is_local else model_identifier
+
+    if _is_local:
+        parts = Path(_normalized).parts
+        for depth in (2, 1):
+            if len(parts) >= depth:
+                suffix = "/".join(parts[-depth:])
+                if suffix.lower() in _REVERSE_MODEL_MAPPING:
+                    return True
+        _lookup = Path(_normalized).name
+    else:
+        _lookup = model_identifier
+
+    # Check for exact filename match (basename for local paths to avoid
+    # passing absolute paths into rglob which raises
+    # "Non-relative patterns are unsupported" on Windows).
     model_filename = _lookup.replace("/", "_") + ".yaml"
     for config_path in defaults_dir.rglob(model_filename):
         if config_path.is_file():

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1424,8 +1424,11 @@ def load_model_defaults(model_name: str) -> Dict[str, Any]:
         # the last 1-2 path components against the registry
         # (e.g. "Spark-TTS-0.5B/LLM").
         _is_local_path = is_local_path(model_name)
+        # Normalize Windows backslash paths so Path().parts splits correctly
+        # on POSIX/WSL hosts (pathlib treats backslashes as literals on Linux).
+        _normalized = normalize_path(model_name) if _is_local_path else model_name
         if model_name.lower() not in _REVERSE_MODEL_MAPPING and _is_local_path:
-            parts = Path(model_name).parts
+            parts = Path(_normalized).parts
             for depth in [2, 1]:
                 if len(parts) >= depth:
                     suffix = "/".join(parts[-depth:])
@@ -1444,10 +1447,7 @@ def load_model_defaults(model_name: str) -> Dict[str, Any]:
         # For local filesystem paths, use only the directory basename to
         # avoid passing absolute paths (e.g. C:\...) into rglob which
         # raises "Non-relative patterns are unsupported" on Windows.
-        if _is_local_path:
-            _lookup_name = Path(model_name).name
-        else:
-            _lookup_name = model_name
+        _lookup_name = Path(_normalized).name if _is_local_path else model_name
         model_filename = _lookup_name.replace("/", "_") + ".yaml"
         # Search in subfolders and root
         for config_path in defaults_dir.rglob(model_filename):


### PR DESCRIPTION
## Summary
- Fixes "Non-relative patterns are unsupported" error when loading a local GGUF model on Windows (e.g. from LM Studio's model directory)
- The root cause: `load_model_defaults()` and `_has_specific_yaml()` passed full Windows absolute paths (like `C:\Users\...\model`) into `Path.rglob()`, which rejects non-relative patterns
- The local-path detection only checked for `/` and `.` prefixes (Unix paths), missing Windows drive letters (`C:\`), UNC paths (`\\server\share`), and backslash separators

## Changes
- `studio/backend/utils/models/model_config.py`: Extended local-path detection to cover Windows paths; use directory basename instead of full path for YAML filename lookup
- `studio/backend/utils/inference/inference_config.py`: Same fix in `_has_specific_yaml()`

## Repro
1. On Windows, have a local GGUF model (e.g. in LM Studio's models directory)
2. Open Unsloth Studio, select the local model, click Load
3. llama-server starts successfully, but the load endpoint returns 500 with "Failed to load model: Non-relative patterns are unsupported"