### PR TITLE
Architecture-aware KV cache VRAM estimation (5-path)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -403,13 +403,16 @@ class LlamaCppBackend:
         }.get(cache_type_kv or "f16", 2.0)
 
         # Path 1: MLA (DeepSeek-V2/V3, GLM-4.7, GLM-5, Kimi-K2.5)
-        # MLA stores only the compressed KV latent + RoPE in the K cache.
+        # MLA stores one compressed KV latent per token/layer (shared across heads).
         # V is reconstructed from the latent on the fly -- no separate V cache.
         # key_length = kv_lora_rank + rope_dim (the full compressed representation).
+        # MLA GGUFs set head_count_kv=1; default to 1 if absent to avoid
+        # falling back to n_heads (e.g., 128 for DeepSeek-V3) which would 128x.
         if self._kv_lora_rank is not None:
+            n_kv_mla = self._n_kv_heads or 1
             rope_dim = self._key_length_mla or 64
             key_len = self._kv_key_length or (self._kv_lora_rank + rope_dim)
-            return int(n_layers * n_ctx * n_kv * key_len * bpe)
+            return int(n_layers * n_ctx * n_kv_mla * key_len * bpe)
 
         key_len = self._kv_key_length
         val_len = self._kv_value_length
@@ -421,7 +424,7 @@ class LlamaCppBackend:
             and self._full_attention_interval is not None
         ):
             fai = self._full_attention_interval
-            n_attn = n_layers // fai if fai > 0 else n_layers
+            n_attn = -(-n_layers // fai) if fai > 0 else n_layers  # ceiling division
             if key_len is not None and val_len is not None:
                 return int(n_attn * n_ctx * n_kv * (key_len + val_len) * bpe)
             head_dim = self._embedding_length // self._n_heads if self._n_heads else 128  # type: ignore[operator]


### PR DESCRIPTION
## Summary

- Replace the single legacy KV cache formula with 5 architecture-aware estimation paths
- Parse 8 additional GGUF metadata fields for accurate sizing across modern architectures
- Backwards compatible: old GGUFs without the new fields fall through to the legacy formula

## Problem

The current estimator uses `2 * n_kv_heads * (embed // n_heads) * n_layers * n_ctx * bpe` for all models. This is wrong for most modern architectures:

| Model | Architecture | Current Estimate | Correct Estimate | Error |
|-------|-------------|-----------------|-----------------|-------|
| Gemma-3 27B | Sliding Window | 81.38 GB | 10.41 GB | +682% over |
| Qwen3.5 27B | Hybrid Mamba | 53.25 GB | 16.00 GB | +233% over |
| DeepSeek-V3.1 | MLA | 2.08 GB | 10.72 GB | -81% under |
| GLM-5 | MLA | 5.73 GB | 17.18 GB | -67% under |
| Kimi-K2.5 | MLA | 6.67 GB | 17.16 GB | -61% under |
| Qwen3-0.6B | Standard GQA | 2.19 GB | 4.38 GB | -50% under |

Overestimates cause the context slider to cap too low (users told they can only fit 16K when 128K would fit). Underestimates cause OOM crashes when the estimated context is too large.

## 5 Estimation Paths

1. **MLA** (DeepSeek-V2/V3, GLM-4.7, GLM-5, Kimi-K2.5) -- K-only cache using compressed KV latent + RoPE; no separate V allocation. Uses `kv_lora_rank` field.
2. **Hybrid Mamba** (Qwen3.5-27B, Qwen3.5-35B-A3B) -- only 1 in N layers is attention (rest are Mamba with no KV cache). Uses `full_attention_interval` and `ssm.inner_size` fields.
3. **Sliding Window** (Gemma-3, gpt-oss) -- SWA layers cache `min(ctx, window)` tokens instead of the full context. Uses `sliding_window` field.
4. **Standard GQA** (Qwen3, Llama-3) -- uses explicit `key_length`/`value_length` from GGUF instead of `embed // n_heads` (which gives wrong answers for many models).
5. **Legacy fallback** -- identical to the old formula, for old GGUFs that lack the new fields.

## New GGUF Fields Parsed (8)

`attention.key_length`, `attention.value_length`, `attention.sliding_window`, `full_attention_interval`, `attention.kv_lora_rank`, `attention.key_length_mla`, `ssm.inner_size`, `ssm.state_size`

## Changes

Single file: `studio/backend/core/inference/llama_cpp.py` (+93, -6)

- 8 new `Optional[int]` instance fields in `__init__`
- Extended `arch_keys` dict in `_read_gguf_metadata` (5 -> 13 keys)
- Reset block in `_read_gguf_metadata` clears all new fields
- Broadened `_can_estimate_kv` gate (accepts MLA, explicit dims, or legacy)
- Rewrote `_estimate_kv_cache_bytes` with 5-path selection
- `unload_model` resets all new fields

## Test plan

- [ ] Verify Python syntax check passes
- [ ] Verify existing `test_vram_estimation.py` tests still pass
- [ ] Validate all 8 new fields are correctly parsed from 9 real GGUF files (Qwen3.5-27B, Gemma-3-27b-it, Qwen3-0.6B, GLM-4.7-Flash, Qwen3.5-35B-A3B, gpt-oss-20b, GLM-5, DeepSeek-V3.1, Kimi-K2.5)
- [ ] Confirm legacy GGUFs (without new fields) still produce the same estimate as before
- [ ] Load a Gemma-3 GGUF and confirm the context slider allows higher context than before
- [ ] Load a DeepSeek-V3 GGUF and confirm no OOM at the estimated context