### PR TITLE
fix(studio): improve tool-calling re-prompt for small models

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -45,8 +45,8 @@ _INTENT_SIGNAL = re.compile(
     r"\b(?:now i|next i)\b"
     r")"
 )
-_MAX_REPROMPTS = 1
-_REPROMPT_MAX_CHARS = 500
+_MAX_REPROMPTS = 3
+_REPROMPT_MAX_CHARS = 2000
 
 # ── Pre-compiled patterns for GGUF shard detection ───────────
 _SHARD_FULL_RE = re.compile(r"^(.*)-(\d{5})-of-(\d{5})\.gguf$")
@@ -810,7 +810,9 @@ class LlamaCppBackend:
                 # Detect tool calling support from chat template
                 tool_markers = [
                     "{%- if tools %}",
+                    "{%- if tools -%}",
                     "{% if tools %}",
+                    "{% if tools -%}",
                     '"role" == "tool"',
                     "'role' == 'tool'",
                     'message.role == "tool"',
@@ -2657,8 +2659,9 @@ class LlamaCppBackend:
                                 {
                                     "role": "user",
                                     "content": (
-                                        "Please use the available tools to complete "
-                                        "the task instead of describing what to do."
+                                        "STOP. Do NOT write code or explain. "
+                                        "You MUST call a tool NOW. "
+                                        "Call web_search or python immediately."
                                     ),
                                 }
                             )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -96,8 +96,10 @@ router = APIRouter()
 
 # Appended to tool-use nudge to discourage plan-without-action
 _TOOL_ACTION_NUDGE = (
-    " Always call tools directly."
+    " IMPORTANT: Always call tools directly -- never write code yourself."
     " Never describe what you plan to do -- just call the tool immediately."
+    " For any code request, call the python tool. For any factual question, call web_search."
+    " Do NOT output code blocks -- use the python tool instead."
 )
 
 # Regex for stripping leaked tool-call XML from assistant messages/stream


### PR DESCRIPTION
## Summary

- Raise `_REPROMPT_MAX_CHARS` from 500 to 2000 so longer responses (full code blocks, multi-paragraph plans) still trigger the plan-without-action re-prompt
- Raise `_MAX_REPROMPTS` from 1 to 3 to give small models more chances to switch from narrating to actually calling tools
- Use direct, imperative re-prompt language that small models follow more reliably
- Strengthen the system prompt tool nudge to explicitly redirect code generation to the python tool
- Fix tool-calling detection for chat templates that use Jinja whitespace-trimming syntax (`{%- if tools -%}`)

## Context

PR #4769 added the plan-without-action re-prompt to prevent small models from stalling on tool-calling tasks. However, two gaps remained:

1. **Char limit too low**: Models that generate full HTML/code responses (1000+ chars) never triggered the re-prompt because `_REPROMPT_MAX_CHARS=500` filtered them out. The model would write an entire weather dashboard in HTML instead of calling `python` to execute code.

2. **One retry not enough**: With `_MAX_REPROMPTS=1`, small models got a single nudge. They would acknowledge the nudge but still respond with text instead of a tool call on the second attempt.

3. **Template detection gap**: Some chat templates use `{%- if tools -%}` (with trailing dash for whitespace trimming) which wasn't matched by the existing `tool_markers` list, causing `supports_tools` to be incorrectly set to `False`.

## Test plan

- [ ] Load a small GGUF model (e.g. Qwen3.5-4B) with tool calling enabled
- [ ] Send "Create a live weather dashboard in HTML" -- verify the model calls `web_search` or `python` instead of writing code directly
- [ ] Send "What are current exchange rates for USD to EUR?" -- verify `web_search` is called
- [ ] Load a model whose chat template uses `{%- if tools -%}` syntax -- verify `supports_tools` is detected as `True`
- [ ] Verify large models (>9B) are unaffected by the changes