### PR TITLE
Pin Gemma-4 transformers requirement to 5.5.0 stable

### DIFF
--- a/install_gemma4_mlx.sh
+++ b/install_gemma4_mlx.sh
@@ -132,8 +132,8 @@ step "install" "installing mlx, mlx-lm..."
 uv pip install --python "$_VENV_PY" -q mlx mlx-lm 2>/dev/null
 substep "done"
 
-TRANSFORMERS_WHL="transformers-5.5.0.dev0-py3-none-any.whl"
-TRANSFORMERS_GH="git+https://github.com/huggingface/transformers.git@v5.5-release"
+TRANSFORMERS_WHL="transformers-5.5.0-py3-none-any.whl"
+TRANSFORMERS_GH="git+https://github.com/huggingface/transformers.git@91b1ab1fdfa81a552644a92fbe3e8d88de40e167"
 
 step "install" "installing transformers>=5.5.0..."
 if uv pip install --python "$_VENV_PY" -q "$TRANSFORMERS_GH" 2>/dev/null; then

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -60,7 +60,7 @@ _TRANSFORMERS_5_TOKENIZER_CLASSES: set[str] = {
 _tokenizer_class_cache: dict[str, bool] = {}
 
 # Versions
-TRANSFORMERS_5_VERSION = "5.5.0.dev0"
+TRANSFORMERS_5_VERSION = "5.5.0"
 TRANSFORMERS_DEFAULT_VERSION = "4.57.6"
 
 # Pre-installed directory for transformers 5.x — created by setup.sh / setup.ps1

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -78,7 +78,7 @@ SUPPORTS_QWEN3_MOE = transformers_version >= Version("4.50.3")
 SUPPORTS_FALCON_H1 = transformers_version >= Version("4.53.0")
 SUPPORTS_GEMMA3N = transformers_version >= Version("4.53.0")
 SUPPORTS_GPTOSS = transformers_version >= Version("4.55.0")
-SUPPORTS_GEMMA4 = transformers_version >= Version("5.5.0.dev0")
+SUPPORTS_GEMMA4 = transformers_version >= Version("5.5.0")
 # Transformers v5 meta-device loading corrupts non-persistent buffers (inv_freq).
 # See _fix_rope_inv_freq() below for details.
 _NEEDS_ROPE_FIX = transformers_version >= Version("5.0.0")


### PR DESCRIPTION
## Summary
- Update Gemma-4 transformers version pin from `5.5.0.dev0` to `5.5.0` in `unsloth/models/loader.py`, `studio/backend/utils/transformers_version.py`, and `install_gemma4_mlx.sh`
- Fix `install_gemma4_mlx.sh` which referenced a non-existent `v5.5-release` branch -- pin to commit `91b1ab1fdfa81a552644a92fbe3e8d88de40e167` instead

## Context
Gemma-4 support has landed in transformers main (huggingface/transformers#45192). The dev0 pre-release pin is no longer needed now that 5.5.0 stable is available.

## Files changed
- `unsloth/models/loader.py` -- `SUPPORTS_GEMMA4` version check
- `studio/backend/utils/transformers_version.py` -- `TRANSFORMERS_5_VERSION` constant
- `install_gemma4_mlx.sh` -- wheel filename and git install URL