### PR TITLE
Use transformers v5.5-release branch, pin to 5.5.0

### DIFF
--- a/install_gemma4_mlx.sh
+++ b/install_gemma4_mlx.sh
@@ -133,7 +133,7 @@ uv pip install --python "$_VENV_PY" -q mlx mlx-lm 2>/dev/null
 substep "done"
 
 TRANSFORMERS_WHL="transformers-5.5.0-py3-none-any.whl"
-TRANSFORMERS_GH="git+https://github.com/huggingface/transformers.git@91b1ab1fdfa81a552644a92fbe3e8d88de40e167"
+TRANSFORMERS_GH="git+https://github.com/huggingface/transformers.git@v5.5-release"
 
 step "install" "installing transformers>=5.5.0..."
 if uv pip install --python "$_VENV_PY" -q "$TRANSFORMERS_GH" 2>/dev/null; then

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1551,7 +1551,7 @@ if (Test-Path $VenvT5Dir) { Remove-Item -Recurse -Force $VenvT5Dir }
 New-Item -ItemType Directory -Path $VenvT5Dir -Force | Out-Null
 $prevEAP_t5 = $ErrorActionPreference
 $ErrorActionPreference = "Continue"
-foreach ($pkg in @("transformers==5.3.0", "huggingface_hub==1.7.1", "hf_xet==1.4.2")) {
+foreach ($pkg in @("transformers==5.5.0", "huggingface_hub==1.8.0", "hf_xet==1.4.2")) {
     if ($script:UnslothVerbose) {
         Fast-Install --target $VenvT5Dir --no-deps $pkg
         $t5PkgExit = $LASTEXITCODE

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -459,8 +459,8 @@ if [ "$_SKIP_PYTHON_DEPS" = false ]; then
     # at runtime (slow, ~10-15s), we pre-install into a separate directory.
     # The training subprocess just prepends .venv_t5/ to sys.path -- instant switch.
     mkdir -p "$VENV_T5_DIR"
-    run_quiet "install transformers 5.x" fast_install --target "$VENV_T5_DIR" --no-deps "transformers==5.3.0"
-    run_quiet "install huggingface_hub for t5" fast_install --target "$VENV_T5_DIR" --no-deps "huggingface_hub==1.7.1"
+    run_quiet "install transformers 5.x" fast_install --target "$VENV_T5_DIR" --no-deps "transformers==5.5.0"
+    run_quiet "install huggingface_hub for t5" fast_install --target "$VENV_T5_DIR" --no-deps "huggingface_hub==1.8.0"
     run_quiet "install hf_xet for t5" fast_install --target "$VENV_T5_DIR" --no-deps "hf_xet==1.4.2"
     run_quiet "install tiktoken for t5" fast_install --target "$VENV_T5_DIR" "tiktoken"
     step "transformers" "5.x pre-installed"


### PR DESCRIPTION
## Summary
- The \`v5.5-release\` branch now exists on huggingface/transformers, so we can use it directly
- Use \`transformers==5.5.0\` for Studio setup (setup.sh, setup.ps1) and the runtime venv_t5 switcher
- Use \`git+transformers.git@v5.5-release\` for the MLX installer fallback
- Bump \`huggingface_hub\` from 1.7.1 to 1.8.0 in setup.sh and setup.ps1 to stay consistent

## Files changed
- \`studio/setup.sh\` -- \`transformers==5.5.0\`, \`huggingface_hub==1.8.0\`
- \`studio/setup.ps1\` -- same
- \`install_gemma4_mlx.sh\` -- \`@v5.5-release\` branch ref