### PR TITLE
Fix: pin transformers==4.57.6 in main Studio venv

### DIFF
--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -11,6 +11,6 @@ git+https://github.com/meta-pytorch/OpenEnv.git
 # executorch>=1.0.1               # 41.5 MB - no imports in unsloth/zoo/studio
 torch-c-dlpack-ext
 sentence_transformers==5.2.0
-transformers>=4.57.6
+transformers==4.57.6
 pytorch_tokenizers
 kernels

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -1,8 +1,8 @@
 # Single-env pins for unsloth + studio + data-designer
 # Keep compatible with unsloth transformers bounds.
-transformers>=4.57.6
+transformers==4.57.6
 trl==0.23.1
-huggingface-hub>=0.36.2
+huggingface-hub==0.36.2
 
 # Studio stack
 datasets==4.3.0


### PR DESCRIPTION
## Summary
- Revert `transformers>=4.57.6` back to `transformers==4.57.6` in `extras-no-deps.txt`
- Revert `transformers>=4.57.6` and `huggingface-hub>=0.36.2` back to exact pins in `constraints.txt`

## Problem
Commit f9c4b08 loosened `==` pins to `>=` in the main Studio venv requirements. This allowed pip to upgrade transformers to 5.x in the main venv, which then fails with:
```
ImportError: cannot import name 'is_offline_mode' from 'huggingface_hub'
```
because transformers 5.x needs huggingface_hub>=1.5.0 but the main venv has 0.36.2.

## Fix
The main Studio venv must stay on `transformers==4.57.6` and `huggingface-hub==0.36.2`. The 5.x version lives only in `.venv_t5/` and is switched in via `sys.path` at runtime for models that need it (Gemma-4, GLM-4.7, etc.).

## Files changed
- `studio/backend/requirements/extras-no-deps.txt`
- `studio/backend/requirements/single-env/constraints.txt`