### PR TITLE
fix(studio): build llama.cpp from master for Gemma 4 support

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -59,7 +59,7 @@ def env_int(name: str, default: int, *, minimum: int | None = None) -> int:
     return value
 
 
-DEFAULT_LLAMA_TAG = os.environ.get("UNSLOTH_LLAMA_TAG", "latest")
+DEFAULT_LLAMA_TAG = os.environ.get("UNSLOTH_LLAMA_TAG", "master")
 # Force all installs to use mainline llama.cpp from ggml-org.
 # Previously: DEFAULT_PUBLISHED_REPO = os.environ.get("UNSLOTH_LLAMA_RELEASE_REPO", "unslothai/llama.cpp")
 DEFAULT_PUBLISHED_REPO = "ggml-org/llama.cpp"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -29,6 +29,7 @@ $PackageDir = Split-Path -Parent $ScriptDir
 # --------------------------------------------------------------------------
 $DefaultLlamaPrForce = ""
 $DefaultLlamaSource = "https://github.com/ggml-org/llama.cpp"
+$DefaultLlamaTag = "master"
 
 # Verbose can be enabled either by CLI flag or by UNSLOTH_VERBOSE=1.
 $script:UnslothVerbose = ($env:UNSLOTH_VERBOSE -eq '1')
@@ -1597,7 +1598,7 @@ if (-not (Test-Path $UnslothHome)) { New-Item -ItemType Directory -Force $Unslot
 $LlamaCppDir = Join-Path $UnslothHome "llama.cpp"
 $NeedLlamaSourceBuild = $false
 $SkipPrebuiltInstall = $false
-$RequestedLlamaTag = if ($env:UNSLOTH_LLAMA_TAG) { $env:UNSLOTH_LLAMA_TAG } else { "latest" }
+$RequestedLlamaTag = if ($env:UNSLOTH_LLAMA_TAG) { $env:UNSLOTH_LLAMA_TAG } else { $DefaultLlamaTag }
 # Force all installs to use mainline llama.cpp from ggml-org.
 # Previously: $HelperReleaseRepo = if ($env:UNSLOTH_LLAMA_RELEASE_REPO) { $env:UNSLOTH_LLAMA_RELEASE_REPO } else { "unslothai/llama.cpp" }
 $HelperReleaseRepo = "ggml-org/llama.cpp"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -14,9 +14,12 @@ RULE=$(printf '\342\224\200%.0s' {1..52})
 #
 #   _DEFAULT_LLAMA_PR_FORCE : PR number to build by default ("" = normal path)
 #   _DEFAULT_LLAMA_SOURCE   : git clone URL for source builds
+#   _DEFAULT_LLAMA_TAG      : llama.cpp ref to build ("latest" = newest release,
+#                             "master" = bleeding-edge, "bNNNN" = specific tag)
 # ──────────────────────────────────────────────────────────────────────────
 _DEFAULT_LLAMA_PR_FORCE=""
 _DEFAULT_LLAMA_SOURCE="https://github.com/ggml-org/llama.cpp"
+_DEFAULT_LLAMA_TAG="master"
 
 # ── Colors (same palette as startup_banner / install_python_stack) ──
 if [ -n "${NO_COLOR:-}" ]; then
@@ -478,7 +481,7 @@ LLAMA_SERVER_BIN="$LLAMA_CPP_DIR/build/bin/llama-server"
 _NEED_LLAMA_SOURCE_BUILD=false
 _LLAMA_CPP_DEGRADED=false
 _LLAMA_FORCE_COMPILE="${UNSLOTH_LLAMA_FORCE_COMPILE:-0}"
-_REQUESTED_LLAMA_TAG="${UNSLOTH_LLAMA_TAG:-latest}"
+_REQUESTED_LLAMA_TAG="${UNSLOTH_LLAMA_TAG:-${_DEFAULT_LLAMA_TAG}}"
 # Force all installs to use mainline llama.cpp from ggml-org.
 # Previously: _HELPER_RELEASE_REPO="${UNSLOTH_LLAMA_RELEASE_REPO:-unslothai/llama.cpp}"
 _HELPER_RELEASE_REPO="ggml-org/llama.cpp"


### PR DESCRIPTION
## Summary

- Default llama.cpp build target from `latest` release tag to `master` branch
- The latest ggml-org/llama.cpp release (b8635) does not include Gemma 4 support -- ggml-org/llama.cpp#21309 merged after the release was cut
- This causes `llama-server` to fail with `unknown model architecture: 'gemma4'` when loading any Gemma 4 GGUF
- Temporary fix until the next upstream release includes Gemma 4

## Changes

- `setup.sh`: add `_DEFAULT_LLAMA_TAG="master"` maintainer-editable default
- `setup.ps1`: add `$DefaultLlamaTag="master"` maintainer-editable default  
- `install_llama_prebuilt.py`: change `DEFAULT_LLAMA_TAG` fallback from `"latest"` to `"master"`

Users can still override via `UNSLOTH_LLAMA_TAG` env var. Once a new upstream release is cut with Gemma 4 support, revert these back to `"latest"`.

## Test plan

- [ ] Fresh install via `install.sh --local` builds llama.cpp from master HEAD
- [ ] Load Gemma 4 E2B GGUF in Studio -- verify it works (was failing with b8635)
- [ ] Load Qwen3.5-4B GGUF -- verify non-Gemma models still work
- [ ] `UNSLOTH_LLAMA_TAG=b8635` override still works (builds from that tag)