### PR TITLE
fix(studio): prioritize curated defaults in Recommended model list

### DIFF
--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -109,12 +109,13 @@ class InferenceOrchestrator:
         self._top_models_ready.wait(timeout = 5)
         top_gguf = self._top_gguf_cache or []
         top_hub = self._top_hub_cache or []
-        # GGUFs first, then hub models, then static fallbacks.
+        # Curated static defaults first (editorial picks like new models),
+        # then HF download-ranked models to backfill.
         # Send extras so the frontend still has 4 per category
         # after removing already-downloaded models.
         result: list[str] = []
         seen: set[str] = set()
-        for m in top_gguf + top_hub + self._static_models:
+        for m in self._static_models + top_gguf + top_hub:
             if m not in seen:
                 result.append(m)
                 seen.add(m)


### PR DESCRIPTION
## Summary

- Gemma 4 models were not appearing in the Recommended section of the model picker despite being at the top of `defaults.py`
- The merge order in `orchestrator.py` was `top_gguf + top_hub + static_models`, so HF download-ranked models always came first
- Gemma 4 is new with low download counts, so it was not in the HF API top-40 results and got buried after 80 other models
- Flipped merge order to `static_models + top_gguf + top_hub` so curated editorial picks always appear first, with HF popularity backfilling after
- Deduplication via `seen` set ensures no duplicates when a model appears in both lists

## Test plan

- [x] Verified via `/api/models/list` that Gemma 4 GGUF models now appear at positions 0-3 and Gemma 4 hub models at positions 8-11
- [x] Confirmed 83 total default_models returned (no models lost)
- [x] Non-Gemma models still appear in the list (backfilled from HF download ranking)
- [ ] Visual check: Recommended section in Studio UI shows Gemma 4 on the first page