### PR TITLE
fix(studio): don't set trust_remote_code for Gemma 4 training

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -390,11 +390,16 @@ def run_training_process(
     # Some newer architectures (e.g. NemotronH) have config parsing bugs in
     # transformers that require trust_remote_code=True as a workaround.
     # Only auto-enable for unsloth/* prefixed models (trusted source).
+    # Exclude Gemma 4 since it is a native transformers 5.5 model and
+    # trust_remote_code=True would bypass the compiler (disabling fused CE).
     from utils.transformers_version import needs_transformers_5
 
+    _lowered = model_name.lower()
+    _is_native_t5 = any(x in _lowered for x in ("gemma-4", "gemma4"))
     if (
         needs_transformers_5(model_name)
-        and model_name.lower().startswith("unsloth/")
+        and _lowered.startswith("unsloth/")
+        and not _is_native_t5
         and not config.get("trust_remote_code", False)
     ):
         config["trust_remote_code"] = True


### PR DESCRIPTION
## Summary

- Exclude Gemma 4 from the `trust_remote_code=True` auto-enable in the training worker
- This was the root cause of the inflated training loss (~50 instead of ~13 with GA=4)

## Problem

The training worker (worker.py:395-400) auto-enables `trust_remote_code=True` for all `unsloth/*` models that need transformers 5.x. This was added for NemotronH which has config parsing bugs requiring it as a workaround.

However, Gemma 4 is a native transformers 5.5 model that does NOT need `trust_remote_code`. When `trust_remote_code=True` is set, `unsloth_compile_transformers()` returns early at line 2176 of `_utils.py`:

```python
if trust_remote_code and unsloth_force_compile == False:
    print("Unsloth: We can't trace models if `trust_remote_code = True`, "
          "so turning off some optimizations!")
    return model_types, False
```

This bypasses the entire compiler, including the fused cross entropy patch. Without fused CE, the logged training loss is inflated by `gradient_accumulation_steps` (Issue #1 from gemma-4-details findings).

## Fix

Add an exclusion for models matching `gemma-4` or `gemma4` in the auto-enable condition. The compiler then runs normally and applies the fused cross entropy patch.

Requires unslothai/unsloth-zoo#575 for the `fixup_fused_lm_head()` source normalization that makes pattern 3 match Gemma 4's forward.

## Test plan

- [ ] Finetune Gemma 4 E2B-it in Studio with GA=4: loss should be ~13, not ~52
- [ ] Verify NemotronH and other trust_remote_code models still get it auto-enabled
- [ ] Verify compiler output shows "Fast fused linear cross entropy patch for Gemma4ForConditionalGeneration"