### PR TITLE
fix(studio): pin llama.cpp to b8637 (Gemma 4 support)

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -59,7 +59,7 @@ def env_int(name: str, default: int, *, minimum: int | None = None) -> int:
     return value
 
 
-DEFAULT_LLAMA_TAG = os.environ.get("UNSLOTH_LLAMA_TAG", "master")
+DEFAULT_LLAMA_TAG = os.environ.get("UNSLOTH_LLAMA_TAG", "b8637")
 # Force all installs to use mainline llama.cpp from ggml-org.
 # Previously: DEFAULT_PUBLISHED_REPO = os.environ.get("UNSLOTH_LLAMA_RELEASE_REPO", "unslothai/llama.cpp")
 DEFAULT_PUBLISHED_REPO = "ggml-org/llama.cpp"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -29,7 +29,7 @@ $PackageDir = Split-Path -Parent $ScriptDir
 # --------------------------------------------------------------------------
 $DefaultLlamaPrForce = ""
 $DefaultLlamaSource = "https://github.com/ggml-org/llama.cpp"
-$DefaultLlamaTag = "master"
+$DefaultLlamaTag = "b8637"
 
 # Verbose can be enabled either by CLI flag or by UNSLOTH_VERBOSE=1.
 $script:UnslothVerbose = ($env:UNSLOTH_VERBOSE -eq '1')

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -19,7 +19,7 @@ RULE=$(printf '\342\224\200%.0s' {1..52})
 # ──────────────────────────────────────────────────────────────────────────
 _DEFAULT_LLAMA_PR_FORCE=""
 _DEFAULT_LLAMA_SOURCE="https://github.com/ggml-org/llama.cpp"
-_DEFAULT_LLAMA_TAG="master"
+_DEFAULT_LLAMA_TAG="b8637"
 
 # ── Colors (same palette as startup_banner / install_python_stack) ──
 if [ -n "${NO_COLOR:-}" ]; then


### PR DESCRIPTION
## Summary

- ggml-org/llama.cpp `b8637` is now released with Gemma 4 support (ggml-org/llama.cpp#21309)
- Reverts the temporary `"master"` default from #4790 back to a pinned release tag
- Eliminates the HTTP 422 errors from the prebuilt resolver (which could not match "master" against the GitHub releases API)
- Restores prebuilt binary downloads on all platforms instead of forcing source builds

## Changes

- `setup.sh`: `_DEFAULT_LLAMA_TAG="master"` -> `"b8637"`
- `setup.ps1`: `$DefaultLlamaTag = "master"` -> `"b8637"`
- `install_llama_prebuilt.py`: `DEFAULT_LLAMA_TAG` fallback `"master"` -> `"b8637"`

## Test plan

- [ ] Fresh install resolves prebuilt bundle from b8637 (no source build needed)
- [ ] Load Gemma 4 E2B GGUF in Studio -- works with b8637 binary
- [ ] `UNSLOTH_LLAMA_TAG` env var override still works
- [ ] `unsloth studio update` picks up the new tag and downloads the prebuilt