### PR TITLE
fix(studio): revert llama.cpp default tag to latest

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -60,6 +60,10 @@ def env_int(name: str, default: int, *, minimum: int | None = None) -> int:
     return value
 
 
+# Prefer "latest" over "master" -- "master" bypasses the prebuilt resolver
+# (no matching GitHub release), forces a source build, and causes HTTP 422
+# errors. Only use "master" temporarily when the latest release is missing
+# support for a new model architecture.
 DEFAULT_LLAMA_TAG = os.environ.get("UNSLOTH_LLAMA_TAG", "latest")
 # Force all installs to use mainline llama.cpp from ggml-org.
 # Previously: DEFAULT_PUBLISHED_REPO = os.environ.get("UNSLOTH_LLAMA_RELEASE_REPO", "unslothai/llama.cpp")

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -27,6 +27,10 @@ $PackageDir = Split-Path -Parent $ScriptDir
 #  Change these in the GitHub-hosted script so users get updated defaults.
 #  User env vars always override these baked-in values.
 # --------------------------------------------------------------------------
+# Prefer "latest" over "master" -- "master" bypasses the prebuilt resolver
+# (no matching GitHub release), forces a source build, and causes HTTP 422
+# errors. Only use "master" temporarily when the latest release is missing
+# support for a new model architecture.
 $DefaultLlamaPrForce = ""
 $DefaultLlamaSource = "https://github.com/ggml-org/llama.cpp"
 $DefaultLlamaTag = "latest"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -16,6 +16,11 @@ RULE=$(printf '\342\224\200%.0s' {1..52})
 #   _DEFAULT_LLAMA_SOURCE   : git clone URL for source builds
 #   _DEFAULT_LLAMA_TAG      : llama.cpp ref to build ("latest" = newest release,
 #                             "master" = bleeding-edge, "bNNNN" = specific tag)
+#                             Prefer "latest" over "master" -- "master" bypasses
+#                             the prebuilt resolver (no matching GitHub release),
+#                             forces a source build, and causes HTTP 422 errors.
+#                             Only use "master" temporarily when the latest release
+#                             is missing support for a new model architecture.
 # ──────────────────────────────────────────────────────────────────────────
 _DEFAULT_LLAMA_PR_FORCE=""
 _DEFAULT_LLAMA_SOURCE="https://github.com/ggml-org/llama.cpp"


### PR DESCRIPTION
## Summary

- Follow-up to #4796 which pinned the tag to `b8637`
- Change from `"b8637"` to `"latest"` so the prebuilt resolver always picks the newest ggml-org/llama.cpp release automatically
- No manual tag bumps needed for future releases

## Changes

- `setup.sh`: `_DEFAULT_LLAMA_TAG="b8637"` -> `"latest"`
- `setup.ps1`: `$DefaultLlamaTag = "b8637"` -> `"latest"`
- `install_llama_prebuilt.py`: `DEFAULT_LLAMA_TAG` fallback `"b8637"` -> `"latest"`