### PR TITLE
fix(studio): suppress fatal error when ggml-org has no prebuilt manifest

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4733,6 +4733,12 @@ if __name__ == "__main__":
             f"fatal helper busy conflict: {textwrap.shorten(str(exc), width = 400, placeholder = '...')}"
         )
         raise SystemExit(EXIT_BUSY)
+    except PrebuiltFallback as exc:
+        # Expected when the published repo (e.g. ggml-org/llama.cpp) has no
+        # prebuilt manifest.  Exit quietly with EXIT_FALLBACK so the caller
+        # falls back to source build without a noisy "fatal helper error".
+        log(textwrap.shorten(str(exc), width = 400, placeholder = "..."))
+        raise SystemExit(EXIT_FALLBACK)
     except Exception as exc:
         message = textwrap.shorten(str(exc), width = 400, placeholder = "...")
         log(f"fatal helper error: {message}")


### PR DESCRIPTION
## Summary

- When `DEFAULT_PUBLISHED_REPO` is `ggml-org/llama.cpp`, the prebuilt resolver raises `PrebuiltFallback` because ggml-org releases do not include a `llama-prebuilt-manifest.json` asset
- This was caught by the generic `Exception` handler in `__main__` and printed as `"fatal helper error"` to stderr
- On PowerShell, this stderr output triggers a `NativeCommandError` that looks alarming (even though setup continues and falls back to source build)

## Fix

- Catch `PrebuiltFallback` separately in the top-level `__main__` handler before the generic `Exception` catch
- Exit with `EXIT_FALLBACK` (code 2) instead of `EXIT_ERROR` (code 1)
- The message is still logged but without the `"fatal helper error"` prefix
- The shell scripts already handle non-zero exits and fall back to source builds gracefully

## Before

```
[llama-prebuilt] fatal helper error: no published llama.cpp releases were available in ggml-org/llama.cpp
```

## After

```
[llama-prebuilt] no published llama.cpp releases were available in ggml-org/llama.cpp
```