### PR TITLE
fix: patch PEFT for Gemma4ClippableLinear in loader checkpoint path (fixes export)

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1585,18 +1585,19 @@ class FastModel(FastBaseModel):
 
                 _LoraModel._create_and_replace = _patched_car
 
-            model = PeftModel.from_pretrained(
-                model,
-                old_model_name,
-                token = token,
-                revision = revision,
-                is_trainable = True,
-                trust_remote_code = trust_remote_code,
-            )
-
-            # Restore original PEFT method
-            if _clippable_linear_cls is not None:
-                _LoraModel._create_and_replace = _original_car
+            try:
+                model = PeftModel.from_pretrained(
+                    model,
+                    old_model_name,
+                    token = token,
+                    revision = revision,
+                    is_trainable = True,
+                    trust_remote_code = trust_remote_code,
+                )
+            finally:
+                # Always restore original PEFT method, even if loading fails
+                if _clippable_linear_cls is not None:
+                    _LoraModel._create_and_replace = _original_car
 
             # Patch it as well!
             model = FastBaseModel.post_patch_model(


### PR DESCRIPTION
## Problem

Exporting or loading a Gemma-4 LoRA checkpoint fails with:

```
ValueError: Target module Gemma4ClippableLinear(
  (linear): Linear(in_features=768, out_features=768, bias=False)
) is not supported. Currently, only the following modules are supported:
`torch.nn.Linear`, `torch.nn.Embedding`, `torch.nn.Conv1d`, ...
```

PEFT doesn't support `Gemma4ClippableLinear` yet — it wraps `nn.Linear` but doesn't subclass it, so PEFT's LoRA injection doesn't recognize it as a valid target.

Tracked upstream:
- https://github.com/huggingface/peft/issues/3130
- https://github.com/huggingface/peft/issues/3129

## Why training works but export/inference doesn't

Training works because `unsloth/models/vision.py` (lines 1301-1353) already has a monkey-patch that intercepts `LoraModel._create_and_replace` and redirects `Gemma4ClippableLinear` to its inner `.linear` child:

```python
# vision.py — training path (already exists)
_clippable_linear_cls = None
try:
    from transformers.models.gemma4.modeling_gemma4 import (
        Gemma4ClippableLinear as _clippable_linear_cls,
    )
except ImportError:
    pass
if _clippable_linear_cls is not None:
    from peft.tuners.lora.model import LoraModel as _LoraModel
    _original_car = _LoraModel._create_and_replace

    def _patched_car(self, peft_config, adapter_name, target,
                     target_name, parent, current_key=None, **kwargs):
        if isinstance(target, _clippable_linear_cls):
            return _original_car(
                self, peft_config, adapter_name,
                target.linear, "linear", target,  # redirect to inner nn.Linear
                current_key=current_key, **kwargs,
            )
        return _original_car(
            self, peft_config, adapter_name,
            target, target_name, parent,
            current_key=current_key, **kwargs,
        )

    _LoraModel._create_and_replace = _patched_car

model = _get_peft_model(model, lora_config)

# Restore original PEFT method
if _clippable_linear_cls is not None:
    _LoraModel._create_and_replace = _original_car
```

But when **loading an existing checkpoint** (export, inference), the code goes through `loader.py` → `PeftModel.from_pretrained()` which is a completely separate code path. The monkey-patch from `vision.py` is not active there.

## Fix

Apply the same monkey-patch pattern from `vision.py` around the `PeftModel.from_pretrained()` call in `loader.py`'s vision model loading path. The patch:

1. Saves the original `_create_and_replace` method
2. Installs a wrapper that checks if the target is `Gemma4ClippableLinear` — if so, redirects to its inner `.linear` attribute
3. Calls `PeftModel.from_pretrained()` with the patch active
4. Restores the original method immediately after

This is a temporary workaround until PEFT adds native support for `Gemma4ClippableLinear`.

## Test plan

- [ ] Export a Gemma-4 LoRA checkpoint (previously crashed with ValueError)
- [ ] Load a Gemma-4 LoRA checkpoint for inference
- [ ] Verify Gemma-4 training still works (unchanged path in vision.py)
- [ ] Verify non-Gemma-4 models are unaffected (patch is guarded by ImportError + isinstance check)




https://github.com/user-attachments/assets/7f37517d-8f8f-4ea8-b346-35ca93c563ce


