### PR TITLE
Fix/gemma4 install script

### DIFF
--- a/install_gemma4_mlx.sh
+++ b/install_gemma4_mlx.sh
@@ -133,8 +133,17 @@ uv pip install --python "$_VENV_PY" -q mlx mlx-lm 2>/dev/null
 substep "done"
 
 step "install" "installing transformers>=5.5.0..."
-uv pip install --python "$_VENV_PY" -q "transformers>=5.5.0" 2>/dev/null
-substep "done"
+if uv pip install --python "$_VENV_PY" -q "transformers>=5.5.0" 2>/dev/null; then
+    substep "installed from PyPI"
+else
+    substep "PyPI install failed (Python <3.10?), trying GitHub..."
+    if uv pip install --python "$_VENV_PY" -q "git+https://github.com/huggingface/transformers.git@v5.5-release" 2>/dev/null; then
+        substep "installed from huggingface/transformers v5.5-release"
+    else
+        step "warning" "could not install transformers>=5.5.0" "$C_WARN"
+        substep "tried: PyPI, huggingface/transformers v5.5-release"
+    fi
+fi
 
 # ── Find mlx-lm models directory ─────────────────────────────
 MLX_MODELS=$("$_VENV_PY" -c "import mlx_lm; print(mlx_lm.__path__[0])")/models


### PR DESCRIPTION
This just simplifies the transformer installation for users.
mlx-lm installs a transformer version 4.57.6 by default as its dependency. If the user has a python version >=3.10 it will install transformer version 5.5.0 or else keep the 4.57.6. Works in both cases.