### PR TITLE
fix(studio): harden sandbox security for terminal and python tools

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -883,8 +883,7 @@ def _check_signal_escape_patterns(code: str):
                         has_opaque_kwargs = True
 
                 cmd_kw_values = [
-                    v for k, v in expanded_kwargs.items()
-                    if k in _CMD_KWARGS
+                    v for k, v in expanded_kwargs.items() if k in _CMD_KWARGS
                 ]
                 all_call_args = list(node.args) + cmd_kw_values
                 blocked_in_args = _check_args_for_blocked(all_call_args)
@@ -928,12 +927,9 @@ def _check_signal_escape_patterns(code: str):
                         }
                     )
                     shell_node = expanded_kwargs.get("shell")
-                    shell_safe = (
-                        shell_node is None
-                        or (
-                            isinstance(shell_node, ast.Constant)
-                            and shell_node.value is False
-                        )
+                    shell_safe = shell_node is None or (
+                        isinstance(shell_node, ast.Constant)
+                        and shell_node.value is False
                     )
                     if shell_func in _STRING_SHELL_FUNCS or not shell_safe:
 


### PR DESCRIPTION
## Summary

Fixes #4818. The terminal and python tool sandboxing in Studio could be bypassed to run privileged commands like sudo and chmod (as reported and verified by the issue author).

The root cause is the command blocklist using naive str.split(), which is trivially bypassed via quoting, full paths, nested shells, shell metacharacters, subshells, process substitution, and cross-tool pivoting through Python os.system/subprocess.

This PR hardens sandbox security with multiple independent defense layers, all cross-platform (Linux, macOS, Windows) and with zero measurable performance overhead.

## Changes

1. Better command tokenization -- shlex.split + os.path.basename + regex scanning at shell command boundaries (subshells, process substitution, optional path prefixes). Targeted nested shell detection for bash/sh/zsh -c arguments.

2. Sanitized subprocess environment -- _build_safe_env strips all credentials (HF_TOKEN, WANDB_API_KEY, GH_TOKEN, AWS_*, LD_PRELOAD, DYLD_*) while preserving the active Python interpreter and virtualenv directories in PATH.

3. OS-level privilege restriction -- PR_SET_NO_NEW_PRIVS via prctl on Linux makes sudo/su/pkexec fail at the kernel level. RLIMIT_NPROC (256) prevents fork bombs. RLIMIT_FSIZE (100MB) prevents disk filling.

4. Extended AST safety checker -- Detects os.system, os.popen, subprocess.run/Popen/call, os.exec*, os.spawn*, os.posix_spawn* with blocked commands or dynamic args. Tracks aliased imports (import os as myos) and from-imports (from subprocess import run as r). Inspects keyword arguments. Handles list and tuple literals. Includes exception_catching detection for timeout evasion.

5. Cross-platform shell support -- cmd /c on Windows, bash -c on Unix. CREATE_NO_WINDOW on Windows. Windows-specific blocked commands (rmdir, takeown, icacls, runas, powershell, pwsh).

6. Expanded blocklist -- From 7 to 14+ commands.

## Test plan

- 151 tests covering all bypass vectors, normal command pass-through, env isolation, resource limits, and false positive prevention
- Normal commands work: ls, pwd, cat, echo, python, pip, git
- No false positives on quoted text, filenames with blocked words, pip install
- Environment variables not leaked to subprocesses
- Active Python interpreter and virtualenv remain accessible in sandbox PATH
- 3 rounds of parallel reviews (7x reviewer.py + 3x Sonnet subagents + Gemini Code Assist), all findings addressed