### PR TITLE
studio: add speculative decoding support (ngram-mod, on by default)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -109,6 +109,7 @@ class LlamaCppBackend:
         self._supports_tools: bool = False
         self._cache_type_kv: Optional[str] = None
         self._reasoning_default: bool = True
+        self._speculative_type: Optional[str] = None
         # KV-cache estimation fields (populated by _read_gguf_metadata)
         self._n_layers: Optional[int] = None
         self._n_kv_heads: Optional[int] = None
@@ -197,6 +198,10 @@ class LlamaCppBackend:
     @property
     def cache_type_kv(self) -> Optional[str]:
         return self._cache_type_kv
+
+    @property
+    def speculative_type(self) -> Optional[str]:
+        return self._speculative_type
 
     # ── Binary discovery ──────────────────────────────────────────
 
@@ -1055,6 +1060,7 @@ class LlamaCppBackend:
         n_ctx: int = 4096,
         chat_template_override: Optional[str] = None,
         cache_type_kv: Optional[str] = None,
+        speculative_type: Optional[str] = None,
         n_threads: Optional[int] = None,
         n_gpu_layers: Optional[int] = None,  # Accepted for caller compat, unused
     ) -> bool:
@@ -1315,6 +1321,27 @@ class LlamaCppBackend:
             else:
                 self._cache_type_kv = None
 
+            # Speculative decoding (n-gram self-speculation, zero VRAM cost)
+            # ngram-mod is recommended: 4MB fixed hash, auto-resets on low
+            # acceptance, zero VRAM overhead.  Defaults tuned for mixed use
+            # (chat + code + reasoning):
+            #   --spec-ngram-size-n 16  (source warns if <16 for ngram-mod)
+            #   --draft-max 24          (middle ground: chat=16, code=32)
+            _valid_spec_types = {"ngram-simple", "ngram-mod"}
+            if speculative_type and speculative_type in _valid_spec_types:
+                if not is_vision:  # spec decoding disabled for vision models
+                    cmd.extend(["--spec-type", speculative_type])
+                    if speculative_type == "ngram-mod":
+                        cmd.extend([
+                            "--spec-ngram-size-n", "16",
+                            "--draft-max", "24",
+                        ])
+                    self._speculative_type = speculative_type
+                else:
+                    self._speculative_type = None
+            else:
+                self._speculative_type = None
+
             # Apply custom chat template override if provided
             if chat_template_override:
                 import tempfile
@@ -1553,6 +1580,7 @@ class LlamaCppBackend:
             self._reasoning_always_on = False
             self._supports_tools = False
             self._cache_type_kv = None
+            self._speculative_type = None
             self._n_layers = None
             self._n_kv_heads = None
             self._n_heads = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1332,10 +1332,14 @@ class LlamaCppBackend:
                 if not is_vision:  # spec decoding disabled for vision models
                     cmd.extend(["--spec-type", speculative_type])
                     if speculative_type == "ngram-mod":
-                        cmd.extend([
-                            "--spec-ngram-size-n", "16",
-                            "--draft-max", "24",
-                        ])
+                        cmd.extend(
+                            [
+                                "--spec-ngram-size-n",
+                                "16",
+                                "--draft-max",
+                                "24",
+                            ]
+                        )
                     self._speculative_type = speculative_type
                 else:
                     self._speculative_type = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1322,24 +1322,22 @@ class LlamaCppBackend:
                 self._cache_type_kv = None
 
             # Speculative decoding (n-gram self-speculation, zero VRAM cost)
-            # ngram-mod is recommended: 4MB fixed hash, auto-resets on low
-            # acceptance, zero VRAM overhead.  Defaults tuned for mixed use
-            # (chat + code + reasoning):
-            #   --spec-ngram-size-n 16  (source warns if <16 for ngram-mod)
-            #   --draft-max 24          (middle ground: chat=16, code=32)
+            # ngram-mod: ~16 MB shared hash pool, constant memory/complexity,
+            # variable draft lengths.  Params from llama.cpp docs:
+            #   --spec-ngram-size-n 24  (small n not recommended)
+            #   --draft-min 48 --draft-max 64 (MoEs need long drafts;
+            #     dense models can reduce these)
+            # ref: https://github.com/ggml-org/llama.cpp/blob/master/docs/speculative.md
             _valid_spec_types = {"ngram-simple", "ngram-mod"}
             if speculative_type and speculative_type in _valid_spec_types:
                 if not is_vision:  # spec decoding disabled for vision models
                     cmd.extend(["--spec-type", speculative_type])
                     if speculative_type == "ngram-mod":
-                        cmd.extend(
-                            [
-                                "--spec-ngram-size-n",
-                                "16",
-                                "--draft-max",
-                                "24",
-                            ]
-                        )
+                        cmd.extend([
+                            "--spec-ngram-size-n", "24",
+                            "--draft-min", "48",
+                            "--draft-max", "64",
+                        ])
                     self._speculative_type = speculative_type
                 else:
                     self._speculative_type = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1333,11 +1333,16 @@ class LlamaCppBackend:
                 if not is_vision:  # spec decoding disabled for vision models
                     cmd.extend(["--spec-type", speculative_type])
                     if speculative_type == "ngram-mod":
-                        cmd.extend([
-                            "--spec-ngram-size-n", "24",
-                            "--draft-min", "48",
-                            "--draft-max", "64",
-                        ])
+                        cmd.extend(
+                            [
+                                "--spec-ngram-size-n",
+                                "24",
+                                "--draft-min",
+                                "48",
+                                "--draft-max",
+                                "64",
+                            ]
+                        )
                     self._speculative_type = speculative_type
                 else:
                     self._speculative_type = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1323,11 +1323,23 @@ class LlamaCppBackend:
 
             # Speculative decoding (n-gram self-speculation, zero VRAM cost)
             # ngram-mod: ~16 MB shared hash pool, constant memory/complexity,
-            # variable draft lengths.  Params from llama.cpp docs:
+            # variable draft lengths.  Helps most when the model repeats
+            # existing text (code refactoring, summarization, reasoning).
+            # For general chat with low repetition, overhead is ~5 ms.
+            #
+            # Benchmarks from llama.cpp PRs #18471, #19164:
+            #   Scenario                        | Without | With    | Speedup
+            #   gpt-oss-120b code refactor      | 181 t/s | 446 t/s | 2.5x
+            #   Qwen3-235B offloaded            |  12 t/s |  21 t/s | 1.8x
+            #   gpt-oss-120b repeat (92% accept)| 181 t/s | 814 t/s | 4.5x
+            #
+            # Params from llama.cpp docs (docs/speculative.md):
             #   --spec-ngram-size-n 24  (small n not recommended)
             #   --draft-min 48 --draft-max 64 (MoEs need long drafts;
             #     dense models can reduce these)
             # ref: https://github.com/ggml-org/llama.cpp/blob/master/docs/speculative.md
+            # ref: https://github.com/ggml-org/llama.cpp/pull/19164
+            # ref: https://github.com/ggml-org/llama.cpp/pull/18471
             _valid_spec_types = {"ngram-simple", "ngram-mod"}
             if speculative_type and speculative_type in _valid_spec_types:
                 if not is_vision:  # spec decoding disabled for vision models

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -48,6 +48,10 @@ class LoadRequest(BaseModel):
         None,
         description = "Physical GPU indices to use, for example [0, 1]. Omit or pass [] to use automatic selection. Explicit gpu_ids are unsupported when the parent CUDA_VISIBLE_DEVICES uses UUID/MIG entries. Not supported for GGUF models.",
     )
+    speculative_type: Optional[str] = Field(
+        None,
+        description = "Speculative decoding mode for GGUF models (e.g. 'ngram-simple', 'ngram-mod'). Ignored for non-GGUF and vision models.",
+    )
 
 
 class UnloadRequest(BaseModel):
@@ -163,6 +167,10 @@ class LoadResponse(BaseModel):
         None,
         description = "Jinja2 chat template string (from GGUF metadata or tokenizer)",
     )
+    speculative_type: Optional[str] = Field(
+        None,
+        description = "Active speculative decoding mode (e.g. 'ngram-simple', 'ngram-mod'), or None if disabled",
+    )
 
 
 class UnloadResponse(BaseModel):
@@ -224,6 +232,10 @@ class InferenceStatusResponse(BaseModel):
     native_context_length: Optional[int] = Field(
         None,
         description = "Model's native context length from GGUF metadata (not capped by VRAM)",
+    )
+    speculative_type: Optional[str] = Field(
+        None,
+        description = "Active speculative decoding mode (e.g. 'ngram-simple', 'ngram-mod'), or None if disabled",
     )
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -179,6 +179,7 @@ async def load_model(
                     supports_reasoning = llama_backend.supports_reasoning,
                     reasoning_always_on = llama_backend.reasoning_always_on,
                     chat_template = llama_backend.chat_template,
+                    speculative_type = llama_backend.speculative_type,
                 )
         else:
             if (
@@ -247,6 +248,12 @@ async def load_model(
                 )
                 unsloth_backend.unload_model(unsloth_backend.active_model_name)
 
+            # Default to ngram-mod speculative decoding for non-vision GGUF
+            # models.  Zero VRAM cost, 10-40% speedup on structured text.
+            effective_spec_type = request.speculative_type
+            if effective_spec_type is None and not config.is_vision:
+                effective_spec_type = "ngram-mod"
+
             # Route to HF mode or local mode based on config
             # Run in a thread so the event loop stays free for progress
             # polling and other requests during the (potentially long)
@@ -263,6 +270,7 @@ async def load_model(
                     n_ctx = request.max_seq_length,
                     chat_template_override = request.chat_template_override,
                     cache_type_kv = request.cache_type_kv,
+                    speculative_type = effective_spec_type,
                 )
             else:
                 # Local mode: llama-server loads via -m <path>
@@ -275,6 +283,7 @@ async def load_model(
                     n_ctx = request.max_seq_length,
                     chat_template_override = request.chat_template_override,
                     cache_type_kv = request.cache_type_kv,
+                    speculative_type = effective_spec_type,
                 )
 
             if not success:
@@ -317,6 +326,7 @@ async def load_model(
                 supports_tools = llama_backend.supports_tools,
                 cache_type_kv = llama_backend.cache_type_kv,
                 chat_template = llama_backend.chat_template,
+                speculative_type = llama_backend.speculative_type,
             )
 
         # ── Standard path: load via Unsloth/transformers ──────────
@@ -652,6 +662,7 @@ async def get_status(
                 context_length = llama_backend.context_length,
                 max_context_length = llama_backend.max_context_length,
                 native_context_length = llama_backend.native_context_length,
+                speculative_type = llama_backend.speculative_type,
             )
 
         # Otherwise, report Unsloth backend status

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -248,12 +248,6 @@ async def load_model(
                 )
                 unsloth_backend.unload_model(unsloth_backend.active_model_name)
 
-            # Default to ngram-mod speculative decoding for non-vision GGUF
-            # models.  Zero VRAM cost, 10-40% speedup on structured text.
-            effective_spec_type = request.speculative_type
-            if effective_spec_type is None and not config.is_vision:
-                effective_spec_type = "ngram-mod"
-
             # Route to HF mode or local mode based on config
             # Run in a thread so the event loop stays free for progress
             # polling and other requests during the (potentially long)
@@ -270,7 +264,7 @@ async def load_model(
                     n_ctx = request.max_seq_length,
                     chat_template_override = request.chat_template_override,
                     cache_type_kv = request.cache_type_kv,
-                    speculative_type = effective_spec_type,
+                    speculative_type = request.speculative_type,
                 )
             else:
                 # Local mode: llama-server loads via -m <path>
@@ -283,7 +277,7 @@ async def load_model(
                     n_ctx = request.max_seq_length,
                     chat_template_override = request.chat_template_override,
                     cache_type_kv = request.cache_type_kv,
-                    speculative_type = effective_spec_type,
+                    speculative_type = request.speculative_type,
                 )
 
             if not success:

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -280,6 +280,15 @@ export function ChatSettingsPanel({
 }: ChatSettingsPanelProps) {
   const isMobile = useIsMobile();
   const isGguf = useChatRuntimeStore((s) => s.activeGgufVariant) != null;
+  const speculativeType = useChatRuntimeStore((s) => s.speculativeType);
+  const setSpeculativeType = useChatRuntimeStore((s) => s.setSpeculativeType);
+  const loadedSpeculativeType = useChatRuntimeStore(
+    (s) => s.loadedSpeculativeType,
+  );
+  const currentModels = useChatRuntimeStore((s) => s.models);
+  const currentCheckpoint = params.checkpoint;
+  const currentModelIsVision =
+    currentModels.find((m) => m.id === currentCheckpoint)?.isVision ?? false;
   const ggufContextLength = useChatRuntimeStore((s) => s.ggufContextLength);
   const ggufMaxContextLength = useChatRuntimeStore(
     (s) => s.ggufMaxContextLength,
@@ -299,7 +308,8 @@ export function ChatSettingsPanel({
   const ctxMaxValue = ggufNativeContextLength ?? ggufContextLength ?? null;
   const kvDirty = kvCacheDtype !== loadedKvCacheDtype;
   const ctxDirty = customContextLength !== null;
-  const modelSettingsDirty = kvDirty || ctxDirty;
+  const specDirty = speculativeType !== loadedSpeculativeType;
+  const modelSettingsDirty = kvDirty || ctxDirty || specDirty;
   const [customPresets, setCustomPresets] = useState<Preset[]>(() =>
     loadSavedCustomPresets(),
   );
@@ -580,6 +590,32 @@ export function ChatSettingsPanel({
                     </SelectContent>
                   </Select>
                 </div>
+                {!currentModelIsVision && (
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-xs font-medium">
+                        Speculative Decoding
+                      </div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Speed up generation with no VRAM cost.
+                      </div>
+                    </div>
+                    <Select
+                      value={speculativeType ?? "off"}
+                      onValueChange={(v) => {
+                        setSpeculativeType(v === "off" ? null : v);
+                      }}
+                    >
+                      <SelectTrigger className="h-7 w-[120px] text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="ngram-mod">On</SelectItem>
+                        <SelectItem value="off">Off</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
                 {modelSettingsDirty && (
                   <div className="flex flex-wrap gap-1.5 pt-1">
                     <button
@@ -594,6 +630,7 @@ export function ChatSettingsPanel({
                       onClick={() => {
                         setCustomContextLength(null);
                         setKvCacheDtype(loadedKvCacheDtype);
+                        setSpeculativeType(loadedSpeculativeType);
                       }}
                       className="rounded-md border px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent"
                     >

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -250,6 +250,7 @@ export function useChatModelRuntime() {
         const ggufNativeContextLength = statusRes.is_gguf
           ? (statusRes.native_context_length ?? null)
           : null;
+        const currentSpecType = statusRes.speculative_type ?? null;
         useChatRuntimeStore.setState({
           supportsReasoning,
           reasoningAlwaysOn,
@@ -257,6 +258,8 @@ export function useChatModelRuntime() {
           ggufContextLength: currentGgufContextLength,
           ggufMaxContextLength,
           ggufNativeContextLength,
+          speculativeType: currentSpecType,
+          loadedSpeculativeType: currentSpecType,
         });
 
         // Set reasoning default for Qwen3.5 small models
@@ -393,7 +396,7 @@ export function useChatModelRuntime() {
               previousWasUnloaded = true;
             }
 
-            const { chatTemplateOverride, kvCacheDtype, customContextLength, ggufContextLength } = useChatRuntimeStore.getState();
+            const { chatTemplateOverride, kvCacheDtype, customContextLength, ggufContextLength, speculativeType } = useChatRuntimeStore.getState();
             // GGUF: use custom context length, or 0 = model's native context
             // Non-GGUF: use the Max Seq Length slider value
             const effectiveMaxSeqLength = customContextLength != null
@@ -409,6 +412,7 @@ export function useChatModelRuntime() {
               trust_remote_code: paramsBeforeLoad.trustRemoteCode ?? false,
               chat_template_override: chatTemplateOverride,
               cache_type_kv: kvCacheDtype,
+              speculative_type: speculativeType,
             });
 
             // If cancelled while loading, don't update UI to show
@@ -431,6 +435,7 @@ export function useChatModelRuntime() {
               }
             }
             const loadedKv = loadResponse.cache_type_kv ?? null;
+            const loadedSpec = loadResponse.speculative_type ?? null;
             const nativeCtx = loadResponse.is_gguf
               ? (loadResponse.context_length ?? 131072)
               : null;
@@ -457,6 +462,8 @@ export function useChatModelRuntime() {
               codeToolsEnabled: loadResponse.supports_tools ?? false,
               kvCacheDtype: loadedKv,
               loadedKvCacheDtype: loadedKv,
+              speculativeType: loadedSpec,
+              loadedSpeculativeType: loadedSpec,
               customContextLength: keepCustomCtx,
               defaultChatTemplate: loadResponse.chat_template ?? null,
               chatTemplateOverride: null,

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -165,6 +165,8 @@ type ChatRuntimeStore = {
   toolCallTimeout: number;
   kvCacheDtype: string | null;
   loadedKvCacheDtype: string | null;
+  speculativeType: string | null;
+  loadedSpeculativeType: string | null;
   customContextLength: number | null;
   defaultChatTemplate: string | null;
   chatTemplateOverride: string | null;
@@ -198,6 +200,7 @@ type ChatRuntimeStore = {
   setMaxToolCallsPerMessage: (value: number) => void;
   setToolCallTimeout: (value: number) => void;
   setKvCacheDtype: (dtype: string | null) => void;
+  setSpeculativeType: (type: string | null) => void;
   setCustomContextLength: (v: number | null) => void;
   setChatTemplateOverride: (template: string | null) => void;
   setPendingAudio: (base64: string, name: string) => void;
@@ -230,6 +233,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
   toolCallTimeout: loadInt(TOOL_CALL_TIMEOUT_KEY, 5),
   kvCacheDtype: null,
   loadedKvCacheDtype: null,
+  speculativeType: "ngram-mod",
+  loadedSpeculativeType: null,
   customContextLength: null,
   defaultChatTemplate: null,
   chatTemplateOverride: null,
@@ -302,6 +307,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
       toolStatus: null,
       kvCacheDtype: null,
       loadedKvCacheDtype: null,
+      speculativeType: "ngram-mod",
+      loadedSpeculativeType: null,
       customContextLength: null,
       defaultChatTemplate: null,
       chatTemplateOverride: null,
@@ -327,6 +334,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
       return { toolCallTimeout };
     }),
   setKvCacheDtype: (kvCacheDtype) => set({ kvCacheDtype }),
+  setSpeculativeType: (speculativeType) => set({ speculativeType }),
   setCustomContextLength: (customContextLength) => set({ customContextLength }),
   setChatTemplateOverride: (chatTemplateOverride) => set({ chatTemplateOverride }),
   setPendingAudio: (base64, name) =>

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -41,6 +41,7 @@ export interface LoadModelRequest {
   trust_remote_code?: boolean;
   chat_template_override?: string | null;
   cache_type_kv?: string | null;
+  speculative_type?: string | null;
 }
 
 export interface ValidateModelResponse {
@@ -93,6 +94,7 @@ export interface LoadModelResponse {
   supports_tools?: boolean;
   cache_type_kv?: string | null;
   chat_template?: string | null;
+  speculative_type?: string | null;
 }
 
 export interface UnloadModelRequest {
@@ -123,6 +125,7 @@ export interface InferenceStatusResponse {
   context_length?: number | null;
   max_context_length?: number | null;
   native_context_length?: number | null;
+  speculative_type?: string | null;
 }
 
 export interface AudioGenerationResponse {


### PR DESCRIPTION
## Summary
- Enables n-gram speculative decoding for all GGUF models in Unsloth Studio, on by default
- Uses llama.cpp's `ngram-mod` mode ([PR #19164](https://github.com/ggml-org/llama.cpp/pull/19164)): ~16 MB shared hash pool, zero VRAM cost, variable speedup depending on content repetition
- llama.cpp author [recommends enabling this by default](https://github.com/ggml-org/llama.cpp/pull/19164#issuecomment-3828097600): "Overall, I think this speculator can become enabled by default in llama-server"
- Params from [llama.cpp docs](https://github.com/ggml-org/llama.cpp/blob/master/docs/speculative.md): `--spec-ngram-size-n 24 --draft-min 48 --draft-max 64`
- Auto-disabled for vision models (unsupported in llama.cpp)
- On/Off toggle in Chat Settings > Model section with Apply/Reset support

### Performance (from llama.cpp PRs [#18471](https://github.com/ggml-org/llama.cpp/pull/18471), [#19164](https://github.com/ggml-org/llama.cpp/pull/19164))

Speculative decoding helps most when the model repeats existing text (code refactoring, summarization, reasoning that restates earlier thinking):

| Scenario | Without | With ngram-mod | Speedup |
|----------|---------|----------------|---------|
| gpt-oss-120b code refactor ([#18471](https://github.com/ggml-org/llama.cpp/pull/18471)) | 181 t/s | 446 t/s | 2.5x |
| Qwen3-235B offloaded ([#18471](https://github.com/ggml-org/llama.cpp/pull/18471)) | 11.8 t/s | 21.0 t/s | 1.8x |
| gpt-oss-120b code repeat, 92% acceptance ([#19164](https://github.com/ggml-org/llama.cpp/pull/19164)) | 181 t/s | 814 t/s | 4.5x |

For general chat with low repetition, acceptance rate is near zero with negligible overhead (~5 ms per request).

## Changes

**Backend (3 files):**
- `studio/backend/models/inference.py` -- `speculative_type` field on `LoadRequest`, `LoadResponse`, `InferenceStatusResponse`
- `studio/backend/core/inference/llama_cpp.py` -- `speculative_type` param on `load_model()`, passes `--spec-type ngram-mod --spec-ngram-size-n 24 --draft-min 48 --draft-max 64` to llama-server, silently skips for vision models
- `studio/backend/routes/inference.py` -- Passes speculative_type through to load/status responses

**Frontend (4 files):**
- `studio/frontend/src/features/chat/types/api.ts` -- `speculative_type` on request/response types
- `studio/frontend/src/features/chat/stores/chat-runtime-store.ts` -- `speculativeType` state (default `"ngram-mod"`), setter, reset
- `studio/frontend/src/features/chat/chat-settings-sheet.tsx` -- On/Off dropdown in Model section, GGUF only, hidden for vision
- `studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts` -- Wires speculative_type through load request/response and reconnect

## Test plan
- [ ] Load a GGUF model, confirm llama-server logs show `--spec-type ngram-mod --spec-ngram-size-n 24 --draft-min 48 --draft-max 64`
- [ ] Send chat messages, confirm responses work correctly
- [ ] Toggle speculative decoding Off in settings, click Apply, confirm logs show no spec flags
- [ ] Toggle back On, click Apply, confirm spec flags reappear
- [ ] Load a vision model (e.g. Gemma-3 with mmproj), confirm spec decoding toggle is hidden
- [ ] Refresh the page with a GGUF model loaded, confirm spec decoding state is restored