### PR TITLE
removed bidirectional check for 31b

### DIFF
--- a/unsloth/models/gemma4_text.py
+++ b/unsloth/models/gemma4_text.py
@@ -54,10 +54,6 @@ class ModelArgs(BaseModelArgs):
     use_bidirectional_attention: Optional[str] = None
 
     def __post_init__(self):
-        if self.use_bidirectional_attention is not None:
-            raise NotImplementedError(
-                "Gemma4 bidirectional attention modes are not implemented in mlx-lm."
-            )
         if self.layer_types is None:
             self.layer_types = [
                 "sliding_attention" if (i + 1) % 6 else "full_attention"


### PR DESCRIPTION
The bidirectional attention is for vision encoding, not for text. so we dont need this check.