### PR TITLE
Add Gemma 4 26B MoE support (MLX)

### DIFF
--- a/unsloth/models/gemma4_text.py
+++ b/unsloth/models/gemma4_text.py
@@ -130,11 +130,13 @@ class Router(nn.Module):
     def __init__(self, args: ModelArgs):
         super().__init__()
         self.args = args
-        self.norm = Gemma4RMSNorm(args.hidden_size, eps = args.rms_norm_eps, with_scale = False)
+        self.norm = Gemma4RMSNorm(
+            args.hidden_size, eps = args.rms_norm_eps, with_scale = False
+        )
         self.proj = nn.Linear(args.hidden_size, args.num_experts, bias = False)
         self.scale = mx.ones((args.hidden_size,))
         self.per_expert_scale = mx.ones((args.num_experts,))
-        self._root_size = args.hidden_size ** -0.5
+        self._root_size = args.hidden_size**-0.5
 
     def __call__(self, x: mx.array):
         x = self.norm(x)
@@ -178,7 +180,10 @@ class Experts(nn.Module):
         )
 
     def __call__(
-        self, x: mx.array, top_k_indices: mx.array, top_k_weights: mx.array,
+        self,
+        x: mx.array,
+        top_k_indices: mx.array,
+        top_k_weights: mx.array,
     ) -> mx.array:
         B, S, H = x.shape
         K = top_k_indices.shape[-1]
@@ -711,7 +716,9 @@ class Model(nn.Module):
                 continue
 
             if k.endswith(".experts.down_proj"):
-                k = k.replace(".experts.down_proj", ".experts.switch_glu.down_proj.weight")
+                k = k.replace(
+                    ".experts.down_proj", ".experts.switch_glu.down_proj.weight"
+                )
                 sanitized[k] = v
                 continue
 


### PR DESCRIPTION
Add Gemma 4 26B MoE support with Router, GeGLU, and Experts classes backed by mlx_lm's SwitchGLU, MoE forward path in TransformerBlock running shared MLP and expert MoE in parallel, weight remapping in sanitize for SwitchGLU format, new ModelArgs fields (num_experts, top_k_experts, moe_intermediate_size), and a clear error for mlx_lm < 0.31 which lacks switch_layers