### PR TITLE
fix: skip redundant HfFileSystem().glob() calls in loader.py

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -49,7 +49,6 @@ except:
     except:
         # For older versions of huggingface_hub
         from huggingface_hub.utils._token import get_token
-from huggingface_hub import HfFileSystem
 import importlib.util
 from ..device_type import (
     is_hip,


### PR DESCRIPTION
## Summary
- Guard `SUPPORTS_LLAMA32` glob blocks in `FastLanguageModel.from_pretrained` and `FastModel.from_pretrained` with `is_model and is_peft` so the `HfFileSystem` HTTP call is only made when both configs could actually exist
- Prevents indefinite hangs on slow/unreliable networks since the glob result is redundant when either `AutoConfig` or `PeftConfig` already failed to load
- Adds 7 unit tests verifying glob is skipped/called in the correct scenarios

## Test plan
- [x] `pytest tests/test_loader_glob_skip.py -v` — all 7 tests pass
- [ ] Train any HF model (e.g. `unsloth/Qwen3.5-2B`) — should no longer hang on slow networks
- [ ] Train a LoRA adapter repo — should still detect conflicting configs correctly
- [ ] Train a local model path — behavior unchanged