### PR TITLE
Add tests for is_vision_model() caching behaviour

### DIFF
--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -155,8 +155,8 @@ class TestVisionCacheDirectPath:
     @patch("utils.transformers_version.needs_transformers_5", return_value = False)
     @patch("utils.models.model_config.load_model_config")
     def test_direct_vlm_detection_cached(self, mock_load_config, mock_needs_t5):
-        """A standard VLM detected via vision_config should be cached."""
-        cfg = MagicMock()
+        """A standard VLM detected via architecture suffix should be cached."""
+        cfg = MagicMock(spec = [])  # strict: only explicitly set attrs exist
         cfg.model_type = "gemma3"
         cfg.architectures = ["Gemma3ForConditionalGeneration"]
         mock_load_config.return_value = cfg
@@ -186,7 +186,7 @@ class TestVisionCacheDirectPath:
         self, mock_load_config, mock_needs_t5
     ):
         """Models with vision_config (LLaVA, Qwen2-VL, etc.) should be cached as True."""
-        cfg = MagicMock()
+        cfg = MagicMock(spec = [])  # strict: only explicitly set attrs exist
         cfg.model_type = "qwen2_vl"
         cfg.architectures = ["Qwen2VLForCausalLM"]  # Doesn't match VLM suffixes
         cfg.vision_config = {"hidden_size": 1024}
@@ -201,7 +201,7 @@ class TestVisionCacheDirectPath:
     def test_audio_model_excluded_and_cached(self, mock_load_config, mock_needs_t5):
         """Audio-only models (csm, whisper) with ForConditionalGeneration
         should be excluded from VLM detection and cached as False."""
-        cfg = MagicMock()
+        cfg = MagicMock(spec = [])  # strict: only explicitly set attrs exist
         cfg.model_type = "whisper"
         cfg.architectures = ["WhisperForConditionalGeneration"]
         mock_load_config.return_value = cfg


### PR DESCRIPTION
## Summary
- Adds 11 pytest tests for the `is_vision_model()` caching layer introduced in #4853
- Tests cover cache hits/misses, False caching, subprocess path, exception handling, direct detection path, audio exclusion, and token handling
- Separated from #4853 to keep the main PR focused on the implementation change

## Test plan
- Run `pytest studio/backend/tests/test_vision_cache.py -v` after merging #4853
- These tests depend on the `_vision_detection_cache` and `_is_vision_model_uncached` exports from #4853