### PR TITLE
Fix/studio colab button message: Add fallback message for Colab Studio button when proxy URL fails

### DIFF
--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -66,10 +66,10 @@ def show_link(port: int = 8888):
             <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="white"><polygon points="5,3 19,12 5,21"/></svg>
             Open Unsloth Studio
         </a>
-        <p style="color: #333333; margin: 12px 0 0 0; font-size: 14px;">       
+        <p style="color: #333333; margin: 12px 0 0 0; font-size: 14px; font-weight: bold;">
             If the link doesn't work, you can scroll down to view the UI generated directly in Colab.
         </p>
-        <p style="color: #333333; margin: 16px 0 0 0; font-size: 13px; font-family: monospace;">
+        <p style="color: #333333; margin: 16px 0 0 0; font-size: 13px; font-family: monospace; font-weight: bold;">
             {short_url}
         </p>
     </div>


### PR DESCRIPTION
## Problem
In some cases, the "Open Unsloth Studio" button in the Colab displays localhost:8888 instead of the proper proxy URL (`https://8000-gpu-...`). This appears to be a timing issue where the Colab kernel isn't ready when the URL is requested, causing it to fall back to localhost, which doesn't work in the browser.

## Solution
Added a clear fallback message below the button informing users:
> "If the link doesn't work, you can scroll down to view the UI generated directly in Colab."

This helps users understand what to do if they encounter the localhost issue, since the iframe-based UI below the button always works correctly.

## Changes
- Added fallback message in `studio/backend/colab.py`
- Styled with dark grey color (#333333) and bold text for visibility
- Positioned between the button and the proxy URL

## Testing
Tested in Colab by changing the setup cell to use my fork, verified that the fallback message appears and is easy to read.

<img width="612" height="230" alt="image" src="https://github.com/user-attachments/assets/5bab1b0b-4647-4aa7-a393-28edded629a0" />