### PR TITLE
[Studio] Fix GPU detection for AMD/Intel — add Vulkan VRAM fallback

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -322,14 +322,18 @@ class LlamaCppBackend:
 
     @staticmethod
     def _get_gpu_free_memory() -> list[tuple[int, int]]:
-        """Query free memory per GPU via nvidia-smi.
+        """Query free memory per GPU.
+
+        Tries nvidia-smi first (NVIDIA), then falls back to vulkaninfo
+        (AMD/Intel/any Vulkan-capable GPU).
 
         Returns list of (gpu_index, free_mib) sorted by index.
-        Respects CUDA_VISIBLE_DEVICES if set.
-        Returns empty list if nvidia-smi is not available.
+        Respects CUDA_VISIBLE_DEVICES if set (nvidia-smi path only).
+        Returns empty list if no GPU query method is available.
         """
         import os
 
+        # ── 1. Try nvidia-smi (NVIDIA GPUs) ──────────────────────────
         try:
             result = subprocess.run(
                 [
@@ -341,31 +345,104 @@ class LlamaCppBackend:
                 text = True,
                 timeout = 10,
             )
-            if result.returncode != 0:
-                return []
+            if result.returncode == 0:
+                # Parse which GPUs are allowed by existing CUDA_VISIBLE_DEVICES
+                allowed = None
+                cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+                if cvd is not None and cvd.strip():
+                    try:
+                        allowed = set(int(x.strip()) for x in cvd.split(","))
+                    except ValueError:
+                        pass  # Non-numeric (e.g., "GPU-uuid"), ignore filter
 
-            # Parse which GPUs are allowed by existing CUDA_VISIBLE_DEVICES
-            allowed = None
-            cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-            if cvd is not None and cvd.strip():
-                try:
-                    allowed = set(int(x.strip()) for x in cvd.split(","))
-                except ValueError:
-                    pass  # Non-numeric (e.g., "GPU-uuid"), ignore filter
-
-            gpus = []
-            for line in result.stdout.strip().splitlines():
-                parts = line.split(",")
-                if len(parts) == 2:
-                    idx = int(parts[0].strip())
-                    free_mib = int(parts[1].strip())
-                    if allowed is not None and idx not in allowed:
-                        continue
-                    gpus.append((idx, free_mib))
-            return gpus
+                gpus = []
+                for line in result.stdout.strip().splitlines():
+                    parts = line.split(",")
+                    if len(parts) == 2:
+                        idx = int(parts[0].strip())
+                        free_mib = int(parts[1].strip())
+                        if allowed is not None and idx not in allowed:
+                            continue
+                        gpus.append((idx, free_mib))
+                return gpus
         except Exception as e:
-            logger.debug(f"Failed to query GPU free memory via nvidia-smi: {e}")
+            logger.debug(f"nvidia-smi not available: {e}")
+
+        # ── 2. Fallback: vulkaninfo (AMD / Intel / any Vulkan GPU) ───
+        try:
+            gpus = LlamaCppBackend._get_gpu_free_memory_vulkan()
+            if gpus:
+                return gpus
+        except Exception as e:
+            logger.debug(f"vulkaninfo fallback failed: {e}")
+
+        return []
+
+    @staticmethod
+    def _get_gpu_free_memory_vulkan() -> list[tuple[int, int]]:
+        """Query free VRAM via vulkaninfo memory budget.
+
+        Parses vulkaninfo output to find DEVICE_LOCAL memory heaps and
+        their budget (how much VRAM the OS allows this process to use,
+        already accounting for other applications).
+
+        Handles multi-GPU systems by splitting on ``GPU<N>:`` headers,
+        and handles GPUs with multiple DEVICE_LOCAL heaps by taking the
+        largest budget per physical device.
+
+        Returns list of (gpu_index, free_mib).
+        """
+        import re
+
+        result = subprocess.run(
+            ["vulkaninfo"],
+            capture_output = True,
+            text = True,
+            timeout = 15,
+        )
+        if result.returncode != 0:
             return []
+
+        output = result.stdout
+
+        # Split by physical device.  vulkaninfo prints "GPU0:", "GPU1:", etc.
+        # On single-GPU systems there is only one such section.
+        device_sections = re.split(r"(?=^GPU\d+:)", output, flags = re.MULTILINE)
+        device_sections = [
+            s for s in device_sections if re.match(r"^GPU\d+:", s.strip())
+        ]
+        # If no GPUn headers found, treat the whole output as one device.
+        if not device_sections:
+            device_sections = [output]
+
+        budget_re = re.compile(r"budget\s*=\s*(\d+)")
+        gpus: list[tuple[int, int]] = []
+
+        for gpu_idx, device_section in enumerate(device_sections):
+            # A single GPU can expose multiple DEVICE_LOCAL heaps (e.g.
+            # with resizable BAR).  Take the largest budget across all
+            # device-local heaps for this physical device.
+            max_free_mib = 0
+            heap_sections = re.split(r"(?=\tmemoryHeaps\[\d+\]:)", device_section)
+            for section in heap_sections:
+                if "MEMORY_HEAP_DEVICE_LOCAL_BIT" not in section:
+                    continue
+                budget_m = budget_re.search(section)
+                if not budget_m:
+                    continue
+                budget_bytes = int(budget_m.group(1))
+                free_mib = budget_bytes // (1024 * 1024)
+                if free_mib > max_free_mib:
+                    max_free_mib = free_mib
+
+            if max_free_mib > 0:
+                gpus.append((gpu_idx, max_free_mib))
+
+        if gpus:
+            logger.info(
+                f"Vulkan GPU memory detected: {', '.join(f'GPU{idx}={free}MiB' for idx, free in gpus)}"
+            )
+        return gpus
 
     @staticmethod
     def _select_gpus(
@@ -2622,7 +2699,7 @@ class LlamaCppBackend:
 
                                 except json.JSONDecodeError:
                                     logger.debug(
-                                        f"Skipping malformed SSE line: " f"{line[:100]}"
+                                        f"Skipping malformed SSE line: {line[:100]}"
                                     )
                             if _stream_done:
                                 break  # exit outer for

--- a/studio/backend/tests/test_vulkan_gpu_memory.py
+++ b/studio/backend/tests/test_vulkan_gpu_memory.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Tests for Vulkan GPU memory detection fallback.
+
+Covers _get_gpu_free_memory (orchestrator) and _get_gpu_free_memory_vulkan
+(vulkaninfo parser): single/multi GPU, multi-heap, nvidia-smi priority,
+CUDA_VISIBLE_DEVICES filtering, and graceful failure paths.
+
+Requires no GPU, network, or external libraries beyond pytest.
+Cross-platform: Linux, macOS, Windows, WSL.
+"""
+
+import sys
+import types as _types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy / unavailable external dependencies before importing the
+# module under test.  Same pattern as test_kv_cache_estimation.py.
+# ---------------------------------------------------------------------------
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# loggers
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+
+# structlog
+_structlog_stub = _types.ModuleType("structlog")
+sys.modules.setdefault("structlog", _structlog_stub)
+
+# httpx
+_httpx_stub = _types.ModuleType("httpx")
+for _exc_name in (
+    "ConnectError",
+    "TimeoutException",
+    "ReadTimeout",
+    "ReadError",
+    "RemoteProtocolError",
+    "CloseError",
+):
+    setattr(_httpx_stub, _exc_name, type(_exc_name, (Exception,), {}))
+
+
+class _FakeTimeout:
+    def __init__(self, *a, **kw):
+        pass
+
+
+_httpx_stub.Timeout = _FakeTimeout
+_httpx_stub.Client = type(
+    "Client",
+    (),
+    {
+        "__init__": lambda self, **kw: None,
+        "__enter__": lambda self: self,
+        "__exit__": lambda self, *a: None,
+    },
+)
+sys.modules.setdefault("httpx", _httpx_stub)
+
+from core.inference.llama_cpp import LlamaCppBackend
+
+# ---------------------------------------------------------------------------
+# Vulkaninfo output fixtures
+# ---------------------------------------------------------------------------
+
+VULKANINFO_SINGLE_GPU_SINGLE_HEAP = """\
+GPU0:
+\tdeviceName        = AMD Radeon RX 5700 XT
+memoryHeaps: count = 2
+\tmemoryHeaps[0]:
+\t\tsize   = 34289745920 (0x7fbd40000) (31.93 GiB)
+\t\tbudget = 33484447744 (0x7cbd42000) (31.18 GiB)
+\t\tusage  = 200704 (0x00031000) (196.00 KiB)
+\t\tflags:
+\t\t\tNone
+\tmemoryHeaps[1]:
+\t\tsize   = 8573157376 (0x1ff000000) (7.98 GiB)
+\t\tbudget = 6441484288 (0x17ff14000) (6.00 GiB)
+\t\tusage  = 0 (0x00000000) (0.00 B)
+\t\tflags: count = 2
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+\t\t\tMEMORY_HEAP_MULTI_INSTANCE_BIT
+"""
+
+VULKANINFO_SINGLE_GPU_MULTI_HEAP = """\
+GPU0:
+\tdeviceName        = AMD Radeon RX 7900 XTX
+memoryHeaps: count = 3
+\tmemoryHeaps[0]:
+\t\tsize   = 34289745920
+\t\tbudget = 33484447744
+\t\tflags:
+\t\t\tNone
+\tmemoryHeaps[1]:
+\t\tsize   = 8573157376
+\t\tbudget = 6441484288
+\t\tflags: count = 1
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+\tmemoryHeaps[2]:
+\t\tsize   = 268435456
+\t\tbudget = 268435456
+\t\tflags: count = 1
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+"""
+
+VULKANINFO_MULTI_GPU = """\
+GPU0:
+\tdeviceName        = AMD Radeon RX 5700 XT
+memoryHeaps: count = 2
+\tmemoryHeaps[0]:
+\t\tsize   = 34289745920
+\t\tbudget = 33484447744
+\t\tflags:
+\t\t\tNone
+\tmemoryHeaps[1]:
+\t\tsize   = 8573157376
+\t\tbudget = 6441484288
+\t\tflags: count = 1
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+GPU1:
+\tdeviceName        = AMD Radeon RX 6800
+memoryHeaps: count = 2
+\tmemoryHeaps[0]:
+\t\tsize   = 34289745920
+\t\tbudget = 33484447744
+\t\tflags:
+\t\t\tNone
+\tmemoryHeaps[1]:
+\t\tsize   = 17179869184
+\t\tbudget = 16777216000
+\t\tflags: count = 1
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+"""
+
+VULKANINFO_MULTI_GPU_INLINE_NAME = """\
+GPU0: AMD Radeon RX 5700 XT
+memoryHeaps: count = 2
+\tmemoryHeaps[0]:
+\t\tsize   = 34289745920
+\t\tbudget = 33484447744
+\t\tflags:
+\t\t\tNone
+\tmemoryHeaps[1]:
+\t\tsize   = 8573157376
+\t\tbudget = 6441484288
+\t\tflags: count = 1
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+GPU1: NVIDIA GeForce RTX 3090
+memoryHeaps: count = 2
+\tmemoryHeaps[0]:
+\t\tsize   = 34289745920
+\t\tbudget = 33484447744
+\t\tflags:
+\t\t\tNone
+\tmemoryHeaps[1]:
+\t\tsize   = 25769803776
+\t\tbudget = 25200000000
+\t\tflags: count = 1
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+"""
+
+VULKANINFO_NO_DEVICE_LOCAL = """\
+GPU0:
+\tdeviceName        = llvmpipe (LLVM 15.0.0, 256 bits)
+memoryHeaps: count = 1
+\tmemoryHeaps[0]:
+\t\tsize   = 2147483648
+\t\tbudget = 2147483648
+\t\tflags:
+\t\t\tNone
+"""
+
+VULKANINFO_NO_GPU_HEADERS = """\
+memoryHeaps: count = 2
+\tmemoryHeaps[0]:
+\t\tsize   = 34289745920
+\t\tbudget = 33484447744
+\t\tflags:
+\t\t\tNone
+\tmemoryHeaps[1]:
+\t\tsize   = 8573157376
+\t\tbudget = 6441484288
+\t\tflags: count = 1
+\t\t\tMEMORY_HEAP_DEVICE_LOCAL_BIT
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_gpu_free_memory_vulkan
+# ---------------------------------------------------------------------------
+
+
+class TestVulkanParser:
+    """Tests for _get_gpu_free_memory_vulkan (vulkaninfo parser)."""
+
+    def test_single_gpu_single_heap(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = VULKANINFO_SINGLE_GPU_SINGLE_HEAP
+            )
+            result = LlamaCppBackend._get_gpu_free_memory_vulkan()
+        assert result == [(0, 6441484288 // (1024 * 1024))]
+
+    def test_single_gpu_multi_heap_takes_max(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = VULKANINFO_SINGLE_GPU_MULTI_HEAP
+            )
+            result = LlamaCppBackend._get_gpu_free_memory_vulkan()
+        assert len(result) == 1
+        assert result[0][0] == 0
+        # Should take the larger heap (6441484288), not the smaller (268435456)
+        assert result[0][1] == 6441484288 // (1024 * 1024)
+
+    def test_multi_gpu(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = VULKANINFO_MULTI_GPU
+            )
+            result = LlamaCppBackend._get_gpu_free_memory_vulkan()
+        assert len(result) == 2
+        assert result[0] == (0, 6441484288 // (1024 * 1024))
+        assert result[1] == (1, 16777216000 // (1024 * 1024))
+
+    def test_multi_gpu_inline_device_name(self):
+        """GPU headers like 'GPU0: AMD Radeon...' (not just 'GPU0:')."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = VULKANINFO_MULTI_GPU_INLINE_NAME
+            )
+            result = LlamaCppBackend._get_gpu_free_memory_vulkan()
+        assert len(result) == 2
+        assert result[0] == (0, 6441484288 // (1024 * 1024))
+        assert result[1] == (1, 25200000000 // (1024 * 1024))
+
+    def test_no_device_local_heaps(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = VULKANINFO_NO_DEVICE_LOCAL
+            )
+            result = LlamaCppBackend._get_gpu_free_memory_vulkan()
+        assert result == []
+
+    def test_vulkaninfo_failure(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 1, stdout = "")
+            result = LlamaCppBackend._get_gpu_free_memory_vulkan()
+        assert result == []
+
+    def test_no_gpu_headers_fallback(self):
+        """When vulkaninfo has no GPU0:/GPU1: headers, treat as single device."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = VULKANINFO_NO_GPU_HEADERS
+            )
+            result = LlamaCppBackend._get_gpu_free_memory_vulkan()
+        assert len(result) == 1
+        assert result[0] == (0, 6441484288 // (1024 * 1024))
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_gpu_free_memory (orchestrator)
+# ---------------------------------------------------------------------------
+
+NVIDIA_SMI_OUTPUT = "0, 8000\n1, 4000\n"
+
+
+class TestGpuMemoryOrchestrator:
+    """Tests for _get_gpu_free_memory (nvidia-smi + vulkan fallback)."""
+
+    def test_nvidia_smi_success(self):
+        """nvidia-smi works -> return its results, don't call vulkan."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = NVIDIA_SMI_OUTPUT
+            )
+            result = LlamaCppBackend._get_gpu_free_memory()
+        assert result == [(0, 8000), (1, 4000)]
+        # Only one call (nvidia-smi), no vulkaninfo
+        assert mock_run.call_count == 1
+
+    def test_nvidia_smi_success_empty_no_fallback(self):
+        """nvidia-smi succeeds but returns empty -> return [], no vulkan fallback."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = "")
+            result = LlamaCppBackend._get_gpu_free_memory()
+        assert result == []
+        # Only nvidia-smi called, NOT vulkaninfo
+        assert mock_run.call_count == 1
+
+    def test_nvidia_smi_fail_vulkan_fallback(self):
+        """nvidia-smi not found -> fall back to vulkaninfo."""
+
+        def side_effect(cmd, **kwargs):
+            if "nvidia-smi" in cmd:
+                raise FileNotFoundError("nvidia-smi not found")
+            return SimpleNamespace(
+                returncode = 0, stdout = VULKANINFO_SINGLE_GPU_SINGLE_HEAP
+            )
+
+        with patch("subprocess.run", side_effect = side_effect):
+            result = LlamaCppBackend._get_gpu_free_memory()
+        assert len(result) == 1
+        assert result[0][0] == 0
+
+    def test_both_fail(self):
+        """Both nvidia-smi and vulkaninfo fail -> return []."""
+
+        def side_effect(cmd, **kwargs):
+            if "nvidia-smi" in cmd:
+                raise FileNotFoundError("nvidia-smi not found")
+            return SimpleNamespace(returncode = 1, stdout = "")
+
+        with patch("subprocess.run", side_effect = side_effect):
+            result = LlamaCppBackend._get_gpu_free_memory()
+        assert result == []
+
+    def test_cuda_visible_devices_filtering(self):
+        """CUDA_VISIBLE_DEVICES filters nvidia-smi results."""
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "1"}),
+        ):
+            mock_run.return_value = SimpleNamespace(
+                returncode = 0, stdout = NVIDIA_SMI_OUTPUT
+            )
+            result = LlamaCppBackend._get_gpu_free_memory()
+        assert result == [(1, 4000)]


### PR DESCRIPTION
## Problem

Unsloth Studio doesn't detect GPU on AMD/Intel systems. The VRAM detection (`_get_gpu_free_memory()`) uses only `nvidia-smi`, so on non-NVIDIA hardware it returns an empty list. This means:

- Studio thinks there's no GPU at all
- Context length stays at full native (e.g. 128K) without auto-reduction
- KV cache doesn't fit in VRAM and spills into system RAM
- Inference is slow because data transfers between GPU and RAM

## Fix

Add a `vulkaninfo` fallback that kicks in when `nvidia-smi` is not available:

- Parses Vulkan memory heap budgets (`VK_EXT_memory_budget`)
- Correctly handles multi-GPU systems and GPUs with multiple DEVICE_LOCAL heaps
- nvidia-smi still has priority — zero impact on NVIDIA setups
- When nvidia-smi succeeds (returncode 0), its result is authoritative — empty list means no visible GPUs, no fallback to vulkan

## Before / After

**Before (AMD GPU):**
```
GPUs free: [], selected: None, fit: True
→ 128K context, KV cache in RAM, slow
```

**After (AMD GPU):**
```
Vulkan GPU memory detected: GPU0=7382MiB
GPUs free: [(0, 7382)], selected: [0], fit: False
→ Context auto-reduced to fit VRAM, everything on GPU
```

## Tested on

- AMD Radeon RX 5700 XT (8 GB), Windows 11, Vulkan 1.4.341
- Model: gemma-4-E4B-it Q4_K_XL (4.8 GB)
- Context properly auto-reduced, full GPU offload with `-ngl -1`
- 12 unit tests covering parser + orchestrator edge cases