### PR TITLE
Remove Gemma-4 from FORCE_FLOAT32

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -108,8 +108,6 @@ FORCE_FLOAT32 = [
     "gemma3n",
     "gpt_oss",
     "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
-    "gemma4,",  # Add comma bc gemma4 will match gemma4_text
-    "gemma4_text",
 ]
 
 global DISABLE_COMPILE_MODEL_NAMES


### PR DESCRIPTION
## Summary
- Remove `gemma4,` and `gemma4_text` from the `FORCE_FLOAT32` list in `loader.py`
- Gemma-4 works correctly in both float16 and bfloat16 without forcing float32

## Background

The `FORCE_FLOAT32` override was forcing Gemma-4 to load in bfloat16/float32 when the user requested float16. This prevented float16 from working on Tesla T4 and other GPUs without bfloat16 support.

Testing shows that Gemma-4's activation magnitudes stay well within float16 range (max ~2080 vs fp16 max 65504). The forced float32 path was actually causing training divergence -- with it enabled, the compiled run diverged at step ~28 with grad norms collapsing to near zero and loss plateauing at ~12.4.

## Test results

**Training** (Gemma-4 E2B, 4-bit LoRA, SFT on FineTome-100k, 100 steps, no patches):

| Metric | float16 | bfloat16 |
|--------|---------|----------|
| Final loss (step 100) | 3.048 | 3.065 |
| Min loss | 2.389 (step 76) | 2.396 (step 76) |
| Avg loss (last 20 steps) | 3.198 | 3.211 |
| Grad norms | Healthy (~3.0) | Healthy (~3.0) |

**Inference**: float16 and bfloat16 produce identical outputs.

## Companion PR
- unslothai/unsloth-zoo#576 -- removes all Gemma-4 temporary patches from `gemma4.py`

## Test plan
- [x] Verify float16 inference produces correct output
- [x] Verify bfloat16 inference produces correct output
- [x] Verify float16 training converges (100 steps)
- [x] Verify bfloat16 training converges (100 steps)
- [x] Verify losses match between float16 and bfloat16
- [ ] Test on Tesla T4 (float16-only GPU)