### PR TITLE
Fix raw text paragraph break normalization

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -149,6 +149,10 @@ def test_raw_text_loader():
         preprocessor = TextPreprocessor()
         clean_text = preprocessor.clean_text("  messy   text  \n\n\n  ")
         assert "messy text" in clean_text, "Should clean text properly"
+        paragraph_text = preprocessor.clean_text("Line 1\r\n\r\n\r\nLine 2")
+        assert paragraph_text == "Line 1\n\nLine 2", (
+            "Should preserve paragraph breaks while normalizing newlines"
+        )
 
         # Test validation
         stats = preprocessor.validate_dataset(text_dataset)

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -150,9 +150,9 @@ def test_raw_text_loader():
         clean_text = preprocessor.clean_text("  messy   text  \n\n\n  ")
         assert "messy text" in clean_text, "Should clean text properly"
         paragraph_text = preprocessor.clean_text("Line 1\r\n\r\n\r\nLine 2")
-        assert paragraph_text == "Line 1\n\nLine 2", (
-            "Should preserve paragraph breaks while normalizing newlines"
-        )
+        assert (
+            paragraph_text == "Line 1\n\nLine 2"
+        ), "Should preserve paragraph breaks while normalizing newlines"
 
         # Test validation
         stats = preprocessor.validate_dataset(text_dataset)

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -154,6 +154,73 @@ def test_raw_text_loader():
             paragraph_text == "Line 1\n\nLine 2"
         ), "Should preserve paragraph breaks while normalizing newlines"
 
+        # Non-ASCII horizontal whitespace separators (NBSP, thin space,
+        # ideographic space, narrow NBSP, em space, vertical tab, form feed)
+        # should be normalized to a single ASCII space, not deleted, otherwise
+        # adjacent words get silently fused together on HTML/PDF/OCR inputs.
+        unicode_whitespace_cases = [
+            ("hello\u00a0world", "hello world"),
+            ("hello\u202fworld", "hello world"),
+            ("hello\u2009world", "hello world"),
+            ("hello\u3000world", "hello world"),
+            ("hello\u2002world", "hello world"),
+            ("hello\x0bworld", "hello world"),
+            ("hello\x0cworld", "hello world"),
+        ]
+        for raw, expected in unicode_whitespace_cases:
+            assert preprocessor.clean_text(raw) == expected, (
+                f"Should normalize Unicode/control whitespace to a single space "
+                f"for {raw!r}"
+            )
+
+        # Mixed paragraph + Unicode whitespace realistic input
+        mixed = preprocessor.clean_text(
+            "Section\u00a01\r\n\r\nBody\ftext\u202Fhere"
+        )
+        assert mixed == "Section 1\n\nBody text here", (
+            "Should preserve paragraph breaks and normalize Unicode "
+            "whitespace simultaneously"
+        )
+
+        # Tabs should collapse to a single space
+        assert preprocessor.clean_text("a\tb") == "a b"
+        assert preprocessor.clean_text("a\t\tb") == "a b"
+
+        # Spaces around newlines should be trimmed on both sides, even with
+        # multiple consecutive newlines
+        assert preprocessor.clean_text("foo \n\n bar") == "foo\n\nbar"
+
+        # Non-whitespace non-ASCII characters sitting between spaces should
+        # not leave an interior double space after being stripped. This
+        # guards the idempotence invariant too: without the extra collapse
+        # pass, "word1 (c) word2" first reduces to "word1  word2" and only
+        # becomes "word1 word2" on a second call.
+        assert preprocessor.clean_text("word1 \u00a9 word2") == "word1 word2"
+        assert preprocessor.clean_text("a \u00e9 b") == "a b"
+        assert preprocessor.clean_text("prefix \U0001F600 suffix") == "prefix suffix"
+
+        # Stripping a non-ASCII character adjacent to a newline must not
+        # leave a stray leading/trailing space on the neighbouring line.
+        assert preprocessor.clean_text("foo \u00e9\nbar") == "foo\nbar"
+        assert preprocessor.clean_text("foo\n\u00e9 bar") == "foo\nbar"
+        # The double-space collapse pass must not swallow a legitimate
+        # paragraph break when a non-ASCII char sits near it.
+        assert preprocessor.clean_text("a \u00a9\n\nb") == "a\n\nb"
+
+        # Idempotence: running clean_text twice should give the same result
+        idempotent_inputs = [
+            "  messy   text  \n\n\n  ",
+            "Line 1\r\n\r\n\r\nLine 2",
+            "hello\u00a0world",
+            "Section\u00a01\r\n\r\nBody\ftext\u202Fhere",
+            "word1 \u00a9 word2",
+            "a \u00e9 b",
+        ]
+        for raw in idempotent_inputs:
+            once = preprocessor.clean_text(raw)
+            twice = preprocessor.clean_text(once)
+            assert once == twice, f"clean_text should be idempotent for {raw!r}"
+
         # Test validation
         stats = preprocessor.validate_dataset(text_dataset)
         assert stats["total_samples"] > 0, "Should count samples"

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -244,9 +244,10 @@ class RawTextDataLoader:
 class TextPreprocessor:
     def clean_text(self, text):
         """Remove unwanted characters, normalize whitespace"""
-        text = re.sub(r"\s+", " ", text)
-        text = re.sub(r"[^\x20-\x7E\n\t]", "", text)
         text = text.replace("\r\n", "\n").replace("\r", "\n")
+        text = re.sub(r"[^\x20-\x7E\n\t]", "", text)
+        text = re.sub(r"[^\S\n]+", " ", text)
+        text = re.sub(r" *\n *", "\n", text)
         text = re.sub(r"\n{3,}", "\n\n", text)
         return text.strip()
 

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -245,8 +245,9 @@ class TextPreprocessor:
     def clean_text(self, text):
         """Remove unwanted characters, normalize whitespace"""
         text = text.replace("\r\n", "\n").replace("\r", "\n")
-        text = re.sub(r"[^\x20-\x7E\n\t]", "", text)
         text = re.sub(r"[^\S\n]+", " ", text)
+        text = re.sub(r"[^\x20-\x7E\n]", "", text)
+        text = re.sub(r"[ ]{2,}", " ", text)
         text = re.sub(r" *\n *", "\n", text)
         text = re.sub(r"\n{3,}", "\n\n", text)
         return text.strip()


### PR DESCRIPTION
## Summary
- preserve paragraph breaks when cleaning raw text
- normalize horizontal whitespace without collapsing newlines
- add a regression check for repeated CRLF paragraph separators

## Testing
- python3 tests/test_raw_text.py