### PR TITLE
grpo_compute_loss_slow called with wrong positional args

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -1131,6 +1131,7 @@ def grpo_trainer_compute_loss(function_name, function):
                 ref_logps,
                 per_token_logps,
                 old_logps,
+                sampling_per_token_logps,
                 input_ids,
                 completion_mask,
                 self.beta,
@@ -1151,7 +1152,6 @@ def grpo_trainer_compute_loss(function_name, function):
                 num_items_in_batch = num_items_in_batch,
                 current_gradient_accumulation_steps = current_gradient_accumulation_steps,
                 num_processes = num_processes,
-                sampling_per_token_logps = sampling_per_token_logps,
             )
         else:
             if hasattr(self.args, "loss_type"):


### PR DESCRIPTION
fixes #4885 

Simple fix to make `sampling_per_token_logps` a positional arg not a kwarg