### PR TITLE
studio: show HF model download progress in training start overlay

### DIFF
--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -59,6 +59,7 @@ def _resolve_hf_cache_realpath(repo_dir: Path) -> Optional[str]:
     except Exception:
         return None
 
+
 # Add backend directory to path
 backend_path = Path(__file__).parent.parent.parent
 if str(backend_path) not in sys.path:
@@ -354,7 +355,9 @@ def list_local_datasets(
 
 @router.get("/download-progress")
 async def get_dataset_download_progress(
-    repo_id: str = Query(..., description = "HuggingFace dataset repo ID, e.g. 'unsloth/LaTeX_OCR'"),
+    repo_id: str = Query(
+        ..., description = "HuggingFace dataset repo ID, e.g. 'unsloth/LaTeX_OCR'"
+    ),
     current_subject: str = Depends(get_current_subject),
 ):
     """Return download progress for a HuggingFace dataset repo.

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -11,9 +11,53 @@ import json
 import sys
 from pathlib import Path
 from uuid import uuid4
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
+import re as _re
 import structlog
 from loggers import get_logger
+
+_VALID_REPO_ID = _re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+def _is_valid_repo_id(repo_id: str) -> bool:
+    return bool(_VALID_REPO_ID.fullmatch(repo_id))
+
+
+_dataset_size_cache: dict[str, int] = {}
+
+
+def _get_dataset_size_cached(repo_id: str) -> int:
+    if repo_id in _dataset_size_cache:
+        return _dataset_size_cache[repo_id]
+    try:
+        from huggingface_hub import dataset_info as hf_dataset_info
+
+        info = hf_dataset_info(repo_id, token = None, files_metadata = True)
+        total = sum(s.size for s in info.siblings if getattr(s, "size", None))
+        _dataset_size_cache[repo_id] = total
+        return total
+    except Exception:
+        return 0
+
+
+def _resolve_hf_cache_realpath(repo_dir: Path) -> Optional[str]:
+    """Pick the most useful on-disk path for a HF cache repo dir.
+
+    Mirrors the helper in routes/models.py: prefer the most-recent
+    snapshot dir, fall back to the cache repo root, return resolved
+    realpath. Duplicated here to keep routes/datasets.py self-contained.
+    """
+    try:
+        snapshots_dir = repo_dir / "snapshots"
+        if snapshots_dir.is_dir():
+            snaps = [s for s in snapshots_dir.iterdir() if s.is_dir()]
+            if snaps:
+                latest = max(snaps, key = lambda s: s.stat().st_mtime)
+                return str(latest.resolve())
+        return str(repo_dir.resolve())
+    except Exception:
+        return None
 
 # Add backend directory to path
 backend_path = Path(__file__).parent.parent.parent
@@ -306,6 +350,87 @@ def list_local_datasets(
     current_subject: str = Depends(get_current_subject),
 ) -> LocalDatasetsResponse:
     return LocalDatasetsResponse(datasets = _build_local_dataset_items())
+
+
+@router.get("/download-progress")
+async def get_dataset_download_progress(
+    repo_id: str = Query(..., description = "HuggingFace dataset repo ID, e.g. 'unsloth/LaTeX_OCR'"),
+    current_subject: str = Depends(get_current_subject),
+):
+    """Return download progress for a HuggingFace dataset repo.
+
+    Mirrors ``GET /api/models/download-progress`` but scans the
+    ``datasets--owner--name`` cache directory under HF_HUB_CACHE.
+    Modern ``datasets``/``huggingface_hub`` caches both raw model and
+    raw dataset blobs in HF_HUB_CACHE; the ``datasets`` library writes
+    its processed Arrow shards elsewhere, but the in-progress *download*
+    bytes are observable here. Returns ``cache_path`` so the UI can
+    show users where the dataset blobs landed on disk.
+    """
+    _empty = {
+        "downloaded_bytes": 0,
+        "expected_bytes": 0,
+        "progress": 0,
+        "cache_path": None,
+    }
+    try:
+        if not _is_valid_repo_id(repo_id):
+            return _empty
+
+        from huggingface_hub import constants as hf_constants
+
+        cache_dir = Path(hf_constants.HF_HUB_CACHE)
+        target = f"datasets--{repo_id.replace('/', '--')}".lower()
+        completed_bytes = 0
+        in_progress_bytes = 0
+        cache_path: Optional[str] = None
+
+        if cache_dir.is_dir():
+            for entry in cache_dir.iterdir():
+                if entry.name.lower() != target:
+                    continue
+                cache_path = _resolve_hf_cache_realpath(entry)
+                blobs_dir = entry / "blobs"
+                if not blobs_dir.is_dir():
+                    break
+                for f in blobs_dir.iterdir():
+                    if not f.is_file():
+                        continue
+                    if f.name.endswith(".incomplete"):
+                        in_progress_bytes += f.stat().st_size
+                    else:
+                        completed_bytes += f.stat().st_size
+                break
+
+        downloaded_bytes = completed_bytes + in_progress_bytes
+        if downloaded_bytes == 0:
+            return {**_empty, "cache_path": cache_path}
+
+        expected_bytes = _get_dataset_size_cached(repo_id)
+        if expected_bytes <= 0:
+            return {
+                "downloaded_bytes": downloaded_bytes,
+                "expected_bytes": 0,
+                "progress": 0,
+                "cache_path": cache_path,
+            }
+
+        # Same 95% completion threshold as the model endpoint -- HF blob
+        # dedup makes completed_bytes drift slightly under expected_bytes,
+        # and inter-file gaps would otherwise look like "done".
+        if completed_bytes >= expected_bytes * 0.95:
+            progress = 1.0
+        else:
+            progress = min(downloaded_bytes / expected_bytes, 0.99)
+        return {
+            "downloaded_bytes": downloaded_bytes,
+            "expected_bytes": expected_bytes,
+            "progress": round(progress, 3),
+            "cache_path": cache_path,
+        }
+    except Exception as e:
+        logger.warning(f"Error checking dataset download progress for {repo_id}: {e}")
+        return _empty
 
 
 @router.post("/check-format", response_model = CheckFormatResponse)

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1088,6 +1088,25 @@ async def get_gguf_download_progress(
         return {"downloaded_bytes": 0, "expected_bytes": expected_bytes, "progress": 0}
 
 
+def _resolve_hf_cache_realpath(repo_dir: Path) -> Optional[str]:
+    """Pick the most useful on-disk path for a HF cache repo.
+
+    Prefers the most-recent snapshot dir (what `from_pretrained` actually
+    points at). Falls back to the cache repo root. Returns the resolved
+    realpath so symlinks under snapshots/ are followed back to blobs/.
+    """
+    try:
+        snapshots_dir = repo_dir / "snapshots"
+        if snapshots_dir.is_dir():
+            snaps = [s for s in snapshots_dir.iterdir() if s.is_dir()]
+            if snaps:
+                latest = max(snaps, key = lambda s: s.stat().st_mtime)
+                return str(latest.resolve())
+        return str(repo_dir.resolve())
+    except Exception:
+        return None
+
+
 @router.get("/download-progress")
 async def get_download_progress(
     repo_id: str = Query(..., description = "HuggingFace repo ID"),
@@ -1098,8 +1117,16 @@ async def get_download_progress(
     Checks the local HF cache for completed blobs and in-progress
     (.incomplete) downloads. Uses the HF API to determine the expected
     total size on the first call, then caches it for subsequent polls.
+    Also returns ``cache_path``: the realpath of the snapshot directory
+    (or the cache repo root if no snapshot exists yet) so the UI can
+    show users where the weights actually live on disk.
     """
-    _empty = {"downloaded_bytes": 0, "expected_bytes": 0, "progress": 0}
+    _empty = {
+        "downloaded_bytes": 0,
+        "expected_bytes": 0,
+        "progress": 0,
+        "cache_path": None,
+    }
     try:
         if not _is_valid_repo_id(repo_id):
             return _empty
@@ -1110,10 +1137,12 @@ async def get_download_progress(
         target = f"models--{repo_id.replace('/', '--')}".lower()
         completed_bytes = 0
         in_progress_bytes = 0
+        cache_path: Optional[str] = None
 
         for entry in cache_dir.iterdir():
             if entry.name.lower() != target:
                 continue
+            cache_path = _resolve_hf_cache_realpath(entry)
             blobs_dir = entry / "blobs"
             if not blobs_dir.is_dir():
                 break
@@ -1128,7 +1157,7 @@ async def get_download_progress(
 
         downloaded_bytes = completed_bytes + in_progress_bytes
         if downloaded_bytes == 0:
-            return _empty
+            return {**_empty, "cache_path": cache_path}
 
         # Get expected size from HF API (cached per repo_id)
         expected_bytes = _get_repo_size_cached(repo_id)
@@ -1138,6 +1167,7 @@ async def get_download_progress(
                 "downloaded_bytes": downloaded_bytes,
                 "expected_bytes": 0,
                 "progress": 0,
+                "cache_path": cache_path,
             }
 
         # Use 95% threshold for completion (blob deduplication can make
@@ -1153,6 +1183,7 @@ async def get_download_progress(
             "downloaded_bytes": downloaded_bytes,
             "expected_bytes": expected_bytes,
             "progress": round(progress, 3),
+            "cache_path": cache_path,
         }
     except Exception as e:
         logger.warning(f"Error checking download progress for {repo_id}: {e}")

--- a/studio/frontend/src/components/ui/progress.tsx
+++ b/studio/frontend/src/components/ui/progress.tsx
@@ -10,9 +10,12 @@ import { cn } from "@/lib/utils";
 
 function Progress({
   className,
+  indicatorClassName,
   value,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string;
+}) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -24,7 +27,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary size-full flex-1 transition-all"
+        className={cn("bg-primary size-full flex-1 transition-all", indicatorClassName)}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -117,11 +117,31 @@ export async function getGgufDownloadProgress(
   return parseJsonOrThrow(response);
 }
 
+export interface DownloadProgressResponse {
+  downloaded_bytes: number;
+  expected_bytes: number;
+  progress: number;
+  /**
+   * Resolved on-disk path of the snapshot dir (or cache repo root if no
+   * snapshot exists yet). Null when nothing has been written to the
+   * cache for this repo.
+   */
+  cache_path: string | null;
+}
+
 export async function getDownloadProgress(
   repoId: string,
-): Promise<{ downloaded_bytes: number; expected_bytes: number; progress: number }> {
+): Promise<DownloadProgressResponse> {
   const params = new URLSearchParams({ repo_id: repoId });
   const response = await authFetch(`/api/models/download-progress?${params}`);
+  return parseJsonOrThrow(response);
+}
+
+export async function getDatasetDownloadProgress(
+  repoId: string,
+): Promise<DownloadProgressResponse> {
+  const params = new URLSearchParams({ repo_id: repoId });
+  const response = await authFetch(`/api/datasets/download-progress?${params}`);
   return parseJsonOrThrow(response);
 }
 

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -42,6 +42,12 @@ function formatBytes(n: number): string {
   return `${(n / 1024 ** 3).toFixed(2)} GB`;
 }
 
+function formatCachePath(path: string): string {
+  return path
+    .replace(/^\/(?:home|Users)\/[^/]+/, "~")
+    .replace(/^[A-Za-z]:[/\\]Users[/\\][^/\\]+/, "~");
+}
+
 type DownloadState = {
   downloadedBytes: number;
   totalBytes: number;
@@ -146,25 +152,54 @@ type DownloadRowProps = {
 
 function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
   if (state.downloadedBytes <= 0 && !state.cachePath) return null;
+  const isComplete = state.totalBytes > 0 && state.percent >= 100;
+  const statusLabel = isComplete
+    ? "Ready"
+    : state.totalBytes > 0
+      ? "Downloading"
+      : state.downloadedBytes === 0
+        ? "Preparing"
+        : null;
   const sizeLabel =
     state.totalBytes > 0
-      ? `${formatBytes(state.downloadedBytes)} / ${formatBytes(state.totalBytes)} · ${state.percent}%`
+      ? `${formatBytes(state.downloadedBytes)} / ${formatBytes(state.totalBytes)}`
       : state.downloadedBytes > 0
         ? `${formatBytes(state.downloadedBytes)} downloaded`
-        : "preparing...";
+        : null;
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-        <span>{label}</span>
-        <span className="tabular-nums">{sizeLabel}</span>
+    <div className="flex flex-col gap-1.5 rounded-md border border-border/50 bg-muted/20 px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-foreground/90">{label}</span>
+          {statusLabel ? (
+            <span
+              className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${isComplete ? "bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200/80 dark:bg-emerald-500/15 dark:text-emerald-300 dark:ring-emerald-500/30" : "bg-muted text-muted-foreground"}`}
+            >
+              {statusLabel}
+            </span>
+          ) : null}
+        </div>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {state.totalBytes > 0 ? `${state.percent}%` : ""}
+        </span>
       </div>
-      {state.totalBytes > 0 ? <Progress value={state.percent} /> : null}
+      {sizeLabel ? (
+        <div className="text-[11px] tabular-nums text-muted-foreground">
+          {sizeLabel}
+        </div>
+      ) : null}
+      {state.totalBytes > 0 ? (
+        <Progress
+          value={state.percent}
+          indicatorClassName="bg-[linear-gradient(90deg,oklch(0.66_0.142_166.6)_0%,oklch(0.705_0.132_166.6)_55%,oklch(0.75_0.122_166.6)_100%)]"
+        />
+      ) : null}
       {state.cachePath ? (
         <div
-          className="truncate text-[10px] text-muted-foreground/70"
+          className="truncate rounded bg-muted/50 px-2 py-1 text-[10px] text-muted-foreground/70"
           title={state.cachePath}
         >
-          {state.cachePath}
+          {formatCachePath(state.cachePath)}
         </div>
       ) : null}
     </div>
@@ -272,7 +307,7 @@ export function TrainingStartOverlay({
           {datasetDownload.downloadedBytes > 0 || datasetDownload.cachePath ? (
             <AnimatedSpan className="mt-3">
               <DownloadRow
-                label="Downloading dataset..."
+                label="Dataset"
                 state={datasetDownload}
               />
             </AnimatedSpan>
@@ -280,7 +315,7 @@ export function TrainingStartOverlay({
           {modelDownload.downloadedBytes > 0 || modelDownload.cachePath ? (
             <AnimatedSpan className="mt-3">
               <DownloadRow
-                label="Downloading model weights..."
+                label="Model weights"
                 state={modelDownload}
               />
             </AnimatedSpan>

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -18,7 +18,11 @@ import {
   Terminal,
   TypingAnimation,
 } from "@/components/ui/terminal";
-import { getDownloadProgress } from "@/features/chat/api/chat-api";
+import {
+  getDatasetDownloadProgress,
+  getDownloadProgress,
+  type DownloadProgressResponse,
+} from "@/features/chat/api/chat-api";
 import {
   useTrainingActions,
   useTrainingConfigStore,
@@ -42,15 +46,30 @@ type DownloadState = {
   downloadedBytes: number;
   totalBytes: number;
   percent: number;
+  cachePath: string | null;
 };
 
 const EMPTY_DOWNLOAD_STATE: DownloadState = {
   downloadedBytes: 0,
   totalBytes: 0,
   percent: 0,
+  cachePath: null,
 };
 
-function useModelDownloadProgress(modelName: string | null): DownloadState {
+type Fetcher = (repoId: string) => Promise<DownloadProgressResponse>;
+
+/**
+ * Polls a HF repo's download progress on a 1.5s tick. Used for both
+ * model weights (`/api/models/download-progress`) and dataset blobs
+ * (`/api/datasets/download-progress`) by swapping the fetcher.
+ *
+ * Stops polling once `progress >= 1.0` -- the bar freezes at the final
+ * value rather than disappearing, mirroring the existing chat flow.
+ */
+function useHfDownloadProgress(
+  repoId: string | null,
+  fetcher: Fetcher,
+): DownloadState {
   const phase = useTrainingRuntimeStore((s) => s.phase);
   const isStarting = useTrainingRuntimeStore((s) => s.isStarting);
   const [state, setState] = useState<DownloadState>(EMPTY_DOWNLOAD_STATE);
@@ -64,7 +83,7 @@ function useModelDownloadProgress(modelName: string | null): DownloadState {
     phase === "loading_dataset";
 
   useEffect(() => {
-    if (!modelName || !HF_REPO_REGEX.test(modelName) || !shouldPoll) {
+    if (!repoId || !HF_REPO_REGEX.test(repoId) || !shouldPoll) {
       return;
     }
 
@@ -75,7 +94,7 @@ function useModelDownloadProgress(modelName: string | null): DownloadState {
     const poll = async () => {
       if (cancelled || finished) return;
       try {
-        const prog = await getDownloadProgress(modelName);
+        const prog = await fetcher(repoId);
         if (cancelled) return;
         const downloaded = prog.downloaded_bytes ?? 0;
         const total = prog.expected_bytes ?? 0;
@@ -86,6 +105,7 @@ function useModelDownloadProgress(modelName: string | null): DownloadState {
           downloadedBytes: downloaded,
           totalBytes: total,
           percent: pct,
+          cachePath: prog.cache_path ?? null,
         });
         if (ratio >= 1.0) {
           finished = true;
@@ -106,9 +126,49 @@ function useModelDownloadProgress(modelName: string | null): DownloadState {
       cancelled = true;
       if (interval) clearInterval(interval);
     };
-  }, [modelName, shouldPoll]);
+  }, [repoId, shouldPoll, fetcher]);
 
   return state;
+}
+
+function useModelDownloadProgress(modelName: string | null): DownloadState {
+  return useHfDownloadProgress(modelName, getDownloadProgress);
+}
+
+function useDatasetDownloadProgress(datasetName: string | null): DownloadState {
+  return useHfDownloadProgress(datasetName, getDatasetDownloadProgress);
+}
+
+type DownloadRowProps = {
+  label: string;
+  state: DownloadState;
+};
+
+function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
+  if (state.downloadedBytes <= 0 && !state.cachePath) return null;
+  const sizeLabel =
+    state.totalBytes > 0
+      ? `${formatBytes(state.downloadedBytes)} / ${formatBytes(state.totalBytes)} · ${state.percent}%`
+      : state.downloadedBytes > 0
+        ? `${formatBytes(state.downloadedBytes)} downloaded`
+        : "preparing...";
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span>{label}</span>
+        <span className="tabular-nums">{sizeLabel}</span>
+      </div>
+      {state.totalBytes > 0 ? <Progress value={state.percent} /> : null}
+      {state.cachePath ? (
+        <div
+          className="truncate text-[10px] text-muted-foreground/70"
+          title={state.cachePath}
+        >
+          {state.cachePath}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 type TrainingStartOverlayProps = {
@@ -123,7 +183,13 @@ export function TrainingStartOverlay({
   const { stopTrainingRun, dismissTrainingRun } = useTrainingActions();
   const isStarting = useTrainingRuntimeStore((s) => s.isStarting);
   const selectedModel = useTrainingConfigStore((s) => s.selectedModel);
-  const download = useModelDownloadProgress(selectedModel);
+  const datasetSource = useTrainingConfigStore((s) => s.datasetSource);
+  const dataset = useTrainingConfigStore((s) => s.dataset);
+  // Only HF datasets have a download phase to track. Uploaded files are
+  // already on disk by the time the overlay shows up.
+  const hfDatasetName = datasetSource === "huggingface" ? dataset : null;
+  const modelDownload = useModelDownloadProgress(selectedModel);
+  const datasetDownload = useDatasetDownloadProgress(hfDatasetName);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelRequested, setCancelRequested] = useState(false);
 
@@ -203,21 +269,20 @@ export function TrainingStartOverlay({
           <AnimatedSpan className="mt-2 text-muted-foreground">
             {`> ${message || "starting training..."} | waiting for first step... (${currentStep})`}
           </AnimatedSpan>
-          {download.downloadedBytes > 0 ? (
+          {datasetDownload.downloadedBytes > 0 || datasetDownload.cachePath ? (
             <AnimatedSpan className="mt-3">
-              <div className="flex flex-col gap-1.5">
-                <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                  <span>Downloading model weights...</span>
-                  <span className="tabular-nums">
-                    {download.totalBytes > 0
-                      ? `${formatBytes(download.downloadedBytes)} / ${formatBytes(download.totalBytes)} · ${download.percent}%`
-                      : `${formatBytes(download.downloadedBytes)} downloaded`}
-                  </span>
-                </div>
-                {download.totalBytes > 0 ? (
-                  <Progress value={download.percent} />
-                ) : null}
-              </div>
+              <DownloadRow
+                label="Downloading dataset..."
+                state={datasetDownload}
+              />
+            </AnimatedSpan>
+          ) : null}
+          {modelDownload.downloadedBytes > 0 || modelDownload.cachePath ? (
+            <AnimatedSpan className="mt-3">
+              <DownloadRow
+                label="Downloading model weights..."
+                state={modelDownload}
+              />
             </AnimatedSpan>
           ) : null}
           </Terminal>

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -12,15 +12,104 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 import {
   AnimatedSpan,
   Terminal,
   TypingAnimation,
 } from "@/components/ui/terminal";
-import { useTrainingActions, useTrainingRuntimeStore } from "@/features/training";
+import { getDownloadProgress } from "@/features/chat/api/chat-api";
+import {
+  useTrainingActions,
+  useTrainingConfigStore,
+  useTrainingRuntimeStore,
+} from "@/features/training";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useState, type ReactElement } from "react";
+
+const HF_REPO_REGEX = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+function formatBytes(n: number): string {
+  if (n <= 0) return "0 B";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)} MB`;
+  return `${(n / 1024 ** 3).toFixed(2)} GB`;
+}
+
+type DownloadState = {
+  downloadedBytes: number;
+  totalBytes: number;
+  percent: number;
+};
+
+const EMPTY_DOWNLOAD_STATE: DownloadState = {
+  downloadedBytes: 0,
+  totalBytes: 0,
+  percent: 0,
+};
+
+function useModelDownloadProgress(modelName: string | null): DownloadState {
+  const phase = useTrainingRuntimeStore((s) => s.phase);
+  const isStarting = useTrainingRuntimeStore((s) => s.isStarting);
+  const [state, setState] = useState<DownloadState>(EMPTY_DOWNLOAD_STATE);
+
+  const shouldPoll =
+    isStarting ||
+    phase === "configuring" ||
+    phase === "downloading_model" ||
+    phase === "downloading_dataset" ||
+    phase === "loading_model" ||
+    phase === "loading_dataset";
+
+  useEffect(() => {
+    if (!modelName || !HF_REPO_REGEX.test(modelName) || !shouldPoll) {
+      return;
+    }
+
+    let cancelled = false;
+    let finished = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    const poll = async () => {
+      if (cancelled || finished) return;
+      try {
+        const prog = await getDownloadProgress(modelName);
+        if (cancelled) return;
+        const downloaded = prog.downloaded_bytes ?? 0;
+        const total = prog.expected_bytes ?? 0;
+        const ratio = prog.progress ?? 0;
+        const pct =
+          total > 0 ? Math.min(100, Math.round(ratio * 100)) : 0;
+        setState({
+          downloadedBytes: downloaded,
+          totalBytes: total,
+          percent: pct,
+        });
+        if (ratio >= 1.0) {
+          finished = true;
+          if (interval) {
+            clearInterval(interval);
+            interval = null;
+          }
+        }
+      } catch {
+        // Silently swallow; bar freezes at last value (matches chat flow).
+      }
+    };
+
+    void poll();
+    interval = setInterval(poll, 1500);
+
+    return () => {
+      cancelled = true;
+      if (interval) clearInterval(interval);
+    };
+  }, [modelName, shouldPoll]);
+
+  return state;
+}
 
 type TrainingStartOverlayProps = {
   message: string
@@ -33,6 +122,8 @@ export function TrainingStartOverlay({
 }: TrainingStartOverlayProps): ReactElement {
   const { stopTrainingRun, dismissTrainingRun } = useTrainingActions();
   const isStarting = useTrainingRuntimeStore((s) => s.isStarting);
+  const selectedModel = useTrainingConfigStore((s) => s.selectedModel);
+  const download = useModelDownloadProgress(selectedModel);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelRequested, setCancelRequested] = useState(false);
 
@@ -112,6 +203,23 @@ export function TrainingStartOverlay({
           <AnimatedSpan className="mt-2 text-muted-foreground">
             {`> ${message || "starting training..."} | waiting for first step... (${currentStep})`}
           </AnimatedSpan>
+          {download.downloadedBytes > 0 ? (
+            <AnimatedSpan className="mt-3">
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                  <span>Downloading model weights...</span>
+                  <span className="tabular-nums">
+                    {download.totalBytes > 0
+                      ? `${formatBytes(download.downloadedBytes)} / ${formatBytes(download.totalBytes)} · ${download.percent}%`
+                      : `${formatBytes(download.downloadedBytes)} downloaded`}
+                  </span>
+                </div>
+                {download.totalBytes > 0 ? (
+                  <Progress value={download.percent} />
+                ) : null}
+              </div>
+            </AnimatedSpan>
+          ) : null}
           </Terminal>
         </div>
       </div>


### PR DESCRIPTION
## Summary

The training start overlay used to show a static "Loading model..." line while model weights were being pulled from Hugging Face. On slow connections this looked like Studio had frozen, with no indication that anything was happening.

This adds a small progress block inside `TrainingStartOverlay` that polls the existing `GET /api/models/download-progress` endpoint and shows bytes downloaded, total bytes, and percent complete with a `Progress` bar.

Single file change. No backend, worker, SSE, or runtime store edits.

## Before / After

Before:

```
> unsloth training starts...
==((====))==
   \\   /|
O^O/ \_/ \
\        /
 "-____-"
> Preparing model and dataset...
> We are getting everything ready for your run...
> Loading model... | waiting for first step... (0)
```

After (mid download):

```
> unsloth training starts...
==((====))==
   \\   /|
O^O/ \_/ \
\        /
 "-____-"
> Preparing model and dataset...
> We are getting everything ready for your run...
> Loading model... | waiting for first step... (0)
  Downloading model weights...           1.2 GB / 4.5 GB - 27%
  [=========>                                            ]
```

## Implementation

All changes are in `studio/frontend/src/features/studio/training-start-overlay.tsx`:

- New `useModelDownloadProgress(modelName)` hook, kept local to this file since there is only one consumer.
- Polls `getDownloadProgress(modelName)` every 1500 ms while the overlay is mounted and the runtime is in a starting or preparing phase (`configuring`, `downloading_model`, `downloading_dataset`, `loading_model`, `loading_dataset`).
- Gated on the HF repo regex `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`, the same regex the backend already uses in `_VALID_REPO_ID`. Local paths and empty form state never hit the endpoint.
- Polling stops once `progress >= 1.0` so the bar can stay at 100 until the overlay hides on the first training step.
- Network errors are silently swallowed, matching the chat side flow in `use-chat-model-runtime.ts`. The bar simply freezes at the last value rather than disappearing.
- Cleanup runs on unmount and on `modelName` change so a new run with a different model starts a fresh poll.
- New `formatBytes` helper for B / KB / MB / GB output.
- `selectedModel` is read directly from `useTrainingConfigStore` inside the overlay. `live-training-view.tsx` is unchanged and there is no prop drilling.

## Reused, not added

- `getDownloadProgress` from `studio/frontend/src/features/chat/api/chat-api.ts`
- `Progress` from `studio/frontend/src/components/ui/progress.tsx`
- `useTrainingConfigStore` and `useTrainingRuntimeStore` from `@/features/training`
- `GET /api/models/download-progress` in `studio/backend/routes/models.py` (auth gated, scans the HF blob cache for completed and `.incomplete` files, returns `{downloaded_bytes, expected_bytes, progress}`)

No new endpoints, no new dependencies, no backend restart required. Studio serves `studio/frontend/dist/` as static files, so a fresh `bun run build` is picked up on the next page load.

## Edge cases handled

| Case | Behavior |
| --- | --- |
| Model already cached | Bar is hidden entirely (`downloadedBytes === 0` from the endpoint), overlay transitions straight to training. No flicker. |
| Fresh download | Bar appears within ~1.5 s, climbs from 0 to 100 percent. |
| Local path (`/models/foo`) | Regex rejects it, no polling, no bar. Existing behavior unchanged. |
| Empty model name | Regex rejects, no polling. |
| Network error from polling endpoint | `try/catch` swallows, bar freezes at last value. |
| HF API cannot determine size (private model with no token, etc.) | Endpoint returns `expected_bytes: 0`, UI falls back to "X.X GB downloaded" with no percent and no bar. |
| User cancels mid download | Overlay unmounts, React cleanup clears the interval. |
| User starts a second run with a different model | `modelName` dependency changes, cleanup fires, fresh poll starts. |
| Sharded model (multiple safetensors files) | Endpoint sums all blobs, so the total is accurate and the bar advances smoothly. |

## What is explicitly not changed

- No backend Python code
- No worker subprocess code
- No pump thread or SSE generator changes
- No new endpoints
- No new dependencies
- No backend restart
- `live-training-view.tsx` is unchanged
- The runtime store schema is unchanged
- All existing training functionality is untouched

## Test plan

- [x] `cd studio/frontend && bun run build` runs `tsc -b && vite build` cleanly with zero TypeScript errors
- [ ] Cached model: start a training run with a model already in `~/.cache/huggingface/hub/`. Confirm the overlay transitions straight to training with no progress block flash
- [ ] Fresh download: clear `~/.cache/huggingface/hub/models--unsloth--<small-model>` and start a training run with that model. Confirm the bar appears within ~1.5 s and advances smoothly to 100 percent. Confirm `GET /api/models/download-progress?repo_id=...` fires every ~1.5 s in the Network tab
- [ ] Local path: start a training run with a model loaded from a local directory. Confirm no `download-progress` requests are made and no bar appears
- [ ] Cancel mid download: click the X on the overlay during a download. Confirm the polling stops in the Network tab
- [ ] Backend stability: confirm `logs/studio_backend.log` shows no new errors after the change