### PR TITLE
fix(gemma4): cast RoPE offset to int before mx.arange()

### DIFF
--- a/unsloth/models/gemma4_text.py
+++ b/unsloth/models/gemma4_text.py
@@ -247,7 +247,7 @@ class ProportionalRoPE(nn.Module):
     def __call__(self, x: mx.array, offset: int = 0) -> mx.array:
         # x shape: (B, n_heads, L, head_dim)
         seq_len = x.shape[-2]
-        positions = mx.arange(int(offset), int(offset) + seq_len, dtype = mx.float32)
+        positions = mx.arange(seq_len, dtype = mx.float32) + offset
 
         # (L, head_dim//2)
         freqs = mx.outer(positions, self._inv_freq)

--- a/unsloth/models/gemma4_text.py
+++ b/unsloth/models/gemma4_text.py
@@ -247,7 +247,7 @@ class ProportionalRoPE(nn.Module):
     def __call__(self, x: mx.array, offset: int = 0) -> mx.array:
         # x shape: (B, n_heads, L, head_dim)
         seq_len = x.shape[-2]
-        positions = mx.arange(offset, offset + seq_len, dtype = mx.float32)
+        positions = mx.arange(int(offset), int(offset) + seq_len, dtype = mx.float32)
 
         # (L, head_dim//2)
         freqs = mx.outer(positions, self._inv_freq)


### PR DESCRIPTION
## Problem
`mx.arange()` receives an `mlx.core.array` for `offset` instead of a 
Python native int, causing a TypeError at inference time with Gemma 4 models.

## Fix
Cast `offset` to `int` before passing to `mx.arange()`.

## Tested on
M3 Max 128GB — unsloth/gemma-4-31b-it-UD-MLX-4bit