### PR TITLE
fix(studio): remove 300s cap on load_checkpoint (inherits 3600s default)

### DIFF
--- a/studio/backend/core/export/orchestrator.py
+++ b/studio/backend/core/export/orchestrator.py
@@ -241,7 +241,7 @@ class ExportOrchestrator:
         self._spawn_subprocess(sub_config)
 
         try:
-            resp = self._wait_response("loaded", timeout = 300)
+            resp = self._wait_response("loaded", timeout = 900)
         except RuntimeError as exc:
             self._shutdown_subprocess(timeout = 5)
             self.current_checkpoint = None

--- a/studio/backend/core/export/orchestrator.py
+++ b/studio/backend/core/export/orchestrator.py
@@ -241,7 +241,7 @@ class ExportOrchestrator:
         self._spawn_subprocess(sub_config)
 
         try:
-            resp = self._wait_response("loaded", timeout = 900)
+            resp = self._wait_response("loaded")
         except RuntimeError as exc:
             self._shutdown_subprocess(timeout = 5)
             self.current_checkpoint = None


### PR DESCRIPTION
Related to #4845.

`ExportOrchestrator.load_checkpoint` used to pass `timeout = 300` to `_wait_response("loaded")`, capping checkpoint load at 5 minutes. For models that need to pull weights from HF during load, or for larger checkpoints, this easily timed out on slow or cold-cache machines and surfaced as a generic "GGUF export failed" error even before the actual export work began.

This removes the 300s override. `_wait_response` already has a 3600s default (1 hour), matching what `_run_export` uses for the same reason -- the comment there explicitly notes that GGUF conversion for 30B+ models takes 20-30 minutes. Bringing `load_checkpoint` to the same default is consistent with the rest of the file.

No UI change, no API change, no new tests. Single-line diff.