### PR TITLE
Bug fix detecting radeon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -984,7 +984,7 @@ _find_no_torch_runtime() {
 # amd-smi list for GPU data rows (excludes header-only output).
 _has_amd_rocm_gpu() {
     if command -v rocminfo >/dev/null 2>&1 && \
-       rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx[1-9]/{found=1} END{exit !found}'; then
+       rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx[0-9]/ && !/Name:[[:space:]]*gfx000/{found=1} END{exit !found}'; then
         return 0
     elif command -v amd-smi >/dev/null 2>&1 && \
          amd-smi list 2>/dev/null | awk '/^GPU[[:space:]]*[:\[][[:space:]]*[0-9]/{ found=1 } END{ exit !found }'; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -926,11 +926,16 @@ else
                 if command -v rocminfo &>/dev/null; then
                     _gfx_list=$(rocminfo 2>/dev/null | grep -oE 'gfx[0-9]{2,4}[a-z]?' | sort -u || true)
                     _valid_gfx=""
+                    # Pre-compute once: is any specific gfx11xx target present?
+                    _has_specific_gfx11=$(echo "$_gfx_list" | grep -E 'gfx11[0-9][0-9a-z]?' || true)
                     for _gfx in $_gfx_list; do
                         if [[ "$_gfx" =~ ^gfx[0-9]{2,4}[a-z]?$ ]]; then
-                            # Filter out gfx11 (RDNA1) if we have RDNA2/RDNA3
-                            if [ "$_gfx" = "gfx11" ] && echo "$_gfx_list" | grep -qE 'gfx9[0-9a-z]|gfx11[1-9][0-9a-z]?'; then
-                                continue  # Skip gfx11 if newer RDNA GPUs detected
+                            # Filter out generic gfx11 family target when a specific gfx11xx
+                            # architecture is also present (rocminfo on ROCm 6.1+ emits both
+                            # e.g. gfx1100 and gfx11-generic; passing bare gfx11 to
+                            # GPU_TARGETS breaks the HIP/llama.cpp build)
+                            if [ "$_gfx" = "gfx11" ] && [ -n "$_has_specific_gfx11" ]; then
+                                continue
                             fi
                             _valid_gfx="${_valid_gfx}${_valid_gfx:+;}$_gfx"
                         fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -928,6 +928,10 @@ else
                     _valid_gfx=""
                     for _gfx in $_gfx_list; do
                         if [[ "$_gfx" =~ ^gfx[0-9]{2,4}[a-z]?$ ]]; then
+                            # Filter out gfx11 (RDNA1) if we have RDNA2/RDNA3
+                            if [ "$_gfx" = "gfx11" ] && echo "$_gfx_list" | grep -qE 'gfx9[0-9a-z]|gfx11[1-9][0-9a-z]?'; then
+                                continue  # Skip gfx11 if newer RDNA GPUs detected
+                            fi
                             _valid_gfx="${_valid_gfx}${_valid_gfx:+;}$_gfx"
                         fi
                     done

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -926,15 +926,20 @@ else
                 if command -v rocminfo &>/dev/null; then
                     _gfx_list=$(rocminfo 2>/dev/null | grep -oE 'gfx[0-9]{2,4}[a-z]?' | sort -u || true)
                     _valid_gfx=""
-                    # Pre-compute once: is any specific gfx11xx target present?
-                    _has_specific_gfx11=$(echo "$_gfx_list" | grep -E 'gfx11[0-9][0-9a-z]?' || true)
                     for _gfx in $_gfx_list; do
                         if [[ "$_gfx" =~ ^gfx[0-9]{2,4}[a-z]?$ ]]; then
-                            # Filter out generic gfx11 family target when a specific gfx11xx
-                            # architecture is also present (rocminfo on ROCm 6.1+ emits both
-                            # e.g. gfx1100 and gfx11-generic; passing bare gfx11 to
-                            # GPU_TARGETS breaks the HIP/llama.cpp build)
-                            if [ "$_gfx" = "gfx11" ] && [ -n "$_has_specific_gfx11" ]; then
+                            # Drop bare family-level targets (gfx10, gfx11, gfx12, ...)
+                            # when a specific sibling is present in the same list.
+                            # rocminfo on ROCm 6.1+ emits both the specific GPU and
+                            # the LLVM generic family line (e.g. gfx1100 alongside
+                            # gfx11-generic), and the outer grep above captures the
+                            # bare family prefix from the generic line. Passing that
+                            # bare prefix to -DGPU_TARGETS breaks the HIP/llama.cpp
+                            # build because clang only accepts specific gfxNNN ids.
+                            # No real AMD GPU has a 2-digit gfx id, so this filter
+                            # can only ever drop family prefixes, never real targets.
+                            if [[ "$_gfx" =~ ^gfx[0-9]{2}$ ]] \
+                               && echo "$_gfx_list" | grep -qE "^${_gfx}[0-9][0-9a-z]?$"; then
                                 continue
                             fi
                             _valid_gfx="${_valid_gfx}${_valid_gfx:+;}$_gfx"


### PR DESCRIPTION
This PR Merges in fix for correctly detecting gfx* architctures for AMD MI/Radeon
The previous pattern /gfx[1-9]/ accidentally excluded all GPUs whose gfx ID starts with 0 

Detects all valid architectures
gfx110X-all
gfx110X-dgpu
gfx1150
gfx1151
gfx1152
gfx90a
gfx908
gfx120X-all
gfx90X-dcgpu
gfx94X-dcgpu
gfx950-dcgpu

<img width="2729" height="1534" alt="Screenshot from 2026-04-09 16-37-54" src="https://github.com/user-attachments/assets/e9e5d93c-9f24-4664-bf92-2ae3e1f47b84" />

<img width="2880" height="1800" alt="Screenshot from 2026-04-09 17-48-29" src="https://github.com/user-attachments/assets/f501e122-92d5-4fa0-931f-b6e309be4187" />

<img width="2703" height="1653" alt="Screenshot from 2026-04-09 17-56-40" src="https://github.com/user-attachments/assets/b0624f10-eda2-4a5d-8876-8113038709d3" />


