### PR TITLE
Pin bitsandbytes to continuous-release_main on ROCm (4-bit decode fix)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,17 +94,10 @@ run_install_cmd() {
     return $_rc
 }
 
-# Install bitsandbytes on AMD ROCm hosts. Prefers the continuous-release_main
-# wheel from the bnb GitHub release so we pick up the CDNA/RDNA 4-bit GEMV
-# fix in PR #1887 (merged 2026-03-09, post-0.49.2). The GEMV kernel in
-# bitsandbytes <= 0.49.2 produces NaN at decode-shape (seq_len=1) on every
-# ROCm target -- CDNA (gfx90a/gfx942/gfx950 = MI210/MI300X/MI350) via a
-# broken blocksize=32/64 warp64 kernel, RDNA (gfx1100-1103/gfx1150-1152)
-# via a compile-time warp-size dispatch bug -- so autoregressive generation
-# is broken even though training passes. Falls back to PyPI >=0.49.1 when
-# the pre-release URL is unreachable (offline installs, firewalled hosts,
-# unknown architectures). Drop the pre-release pin once bnb cuts a 0.50+
-# tag on PyPI.
+# Install bitsandbytes on AMD ROCm hosts. Uses the continuous-release_main
+# wheel for the ROCm 4-bit GEMV fix (bnb PR #1887, post-0.49.2); bnb <= 0.49.2
+# NaNs at decode shape on every AMD GPU. Falls back to PyPI >=0.49.1 if the
+# pre-release URL is unreachable. Drop the pin once bnb 0.50+ ships on PyPI.
 _install_bnb_rocm() {
     _label="$1"
     _venv_py="$2"
@@ -120,12 +113,12 @@ _install_bnb_rocm() {
             ;;
     esac
     if [ -n "$_bnb_whl_url" ]; then
-        substep "installing bitsandbytes for AMD ROCm (pre-release main, bnb PR #1887 GEMV fix)..."
+        substep "installing bitsandbytes for AMD ROCm (pre-release, PR #1887)..."
         if run_install_cmd "$_label (pre-release)" uv pip install --python "$_venv_py" \
             --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
             return 0
         fi
-        substep "[WARN] bnb pre-release wheel unreachable; falling back to PyPI >=0.49.1 (4-bit decode will be broken on ROCm -- use 16-bit instead)" "$C_WARN"
+        substep "[WARN] bnb pre-release unreachable; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
     fi
     run_install_cmd "$_label (pypi fallback)" uv pip install --python "$_venv_py" \
         --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,43 @@ run_install_cmd() {
     return $_rc
 }
 
+# Install bitsandbytes on AMD ROCm hosts. Prefers the continuous-release_main
+# wheel from the bnb GitHub release so we pick up the CDNA/RDNA 4-bit GEMV
+# fix in PR #1887 (merged 2026-03-09, post-0.49.2). The GEMV kernel in
+# bitsandbytes <= 0.49.2 produces NaN at decode-shape (seq_len=1) on every
+# ROCm target -- CDNA (gfx90a/gfx942/gfx950 = MI210/MI300X/MI350) via a
+# broken blocksize=32/64 warp64 kernel, RDNA (gfx1100-1103/gfx1150-1152)
+# via a compile-time warp-size dispatch bug -- so autoregressive generation
+# is broken even though training passes. Falls back to PyPI >=0.49.1 when
+# the pre-release URL is unreachable (offline installs, firewalled hosts,
+# unknown architectures). Drop the pre-release pin once bnb cuts a 0.50+
+# tag on PyPI.
+_install_bnb_rocm() {
+    _label="$1"
+    _venv_py="$2"
+    case "$_ARCH" in
+        x86_64|amd64)
+            _bnb_whl_url="https://github.com/bitsandbytes-foundation/bitsandbytes/releases/download/continuous-release_main/bitsandbytes-1.33.7.preview-py3-none-manylinux_2_24_x86_64.whl"
+            ;;
+        aarch64|arm64)
+            _bnb_whl_url="https://github.com/bitsandbytes-foundation/bitsandbytes/releases/download/continuous-release_main/bitsandbytes-1.33.7.preview-py3-none-manylinux_2_24_aarch64.whl"
+            ;;
+        *)
+            _bnb_whl_url=""
+            ;;
+    esac
+    if [ -n "$_bnb_whl_url" ]; then
+        substep "installing bitsandbytes for AMD ROCm (pre-release main, bnb PR #1887 GEMV fix)..."
+        if run_install_cmd "$_label (pre-release)" uv pip install --python "$_venv_py" \
+            --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
+            return 0
+        fi
+        substep "[WARN] bnb pre-release wheel unreachable; falling back to PyPI >=0.49.1 (4-bit decode will be broken on ROCm -- use 16-bit instead)" "$C_WARN"
+    fi
+    run_install_cmd "$_label (pypi fallback)" uv pip install --python "$_venv_py" \
+        --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
+}
+
 if [ "$_next_is_package" = true ]; then
     echo "❌ ERROR: --package requires an argument." >&2
     exit 1
@@ -1296,8 +1333,7 @@ if [ "$_MIGRATED" = true ]; then
     if [ "$SKIP_TORCH" = false ]; then
         case "$TORCH_INDEX_URL" in
             */rocm*)
-                substep "installing bitsandbytes for AMD ROCm..."
-                run_install_cmd "install bitsandbytes (AMD)" uv pip install --python "$_VENV_PY" --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
+                _install_bnb_rocm "install bitsandbytes (AMD)" "$_VENV_PY"
                 # Repair ROCm torch if overwritten during migrated install
                 _has_hip=$("$_VENV_PY" -c "import torch; print(getattr(torch.version,'hip','') or '')" 2>/dev/null || true)
                 if [ -z "$_has_hip" ]; then
@@ -1437,8 +1473,7 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
     if [ "$SKIP_TORCH" = false ]; then
         case "$TORCH_INDEX_URL" in
             */rocm*)
-                substep "installing bitsandbytes for AMD ROCm..."
-                run_install_cmd "install bitsandbytes (AMD)" uv pip install --python "$_VENV_PY" --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
+                _install_bnb_rocm "install bitsandbytes (AMD)" "$_VENV_PY"
                 ;;
         esac
     fi

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -10,7 +10,6 @@ from unsloth.chat_templates import get_chat_template
 from transformers import TextStreamer
 from peft import PeftModel, PeftModelForCausalLM
 
-import functools
 import json
 import sys
 import torch
@@ -35,24 +34,6 @@ from loggers import get_logger
 
 
 logger = get_logger(__name__)
-
-
-@functools.cache
-def _bnb_rocm_4bit_ok() -> bool:
-    """True when installed bitsandbytes has the ROCm 4-bit GEMV fix
-    (bnb PR #1887, shipped in 0.50.0.dev0+). bnb <= 0.49.2 NaNs at
-    decode shape on every AMD GPU, breaking autoregressive inference.
-    Cached because load_model() is called many times per session.
-    """
-    if not _hw_module.IS_ROCM:
-        return True
-    try:
-        import bitsandbytes
-        from packaging.version import Version
-
-        return Version(bitsandbytes.__version__) >= Version("0.50.0.dev0")
-    except Exception:
-        return False
 
 
 class HarmonyTextStreamer:
@@ -552,27 +533,9 @@ class InferenceBackend:
                 self.models[model_name]["processor"] = processor
 
             else:
-                # Text model (or text LoRA adapter).
-                # Safety net for old bnb on ROCm (< 0.50): force 16-bit
-                # and strip any -bnb-4bit suffix so pre-quantized repos
-                # resolve to their FP16 sibling. No-op on new installs
-                # where install.sh pins bnb >= 0.50.
-                _load_path = config.path
-                if not _bnb_rocm_4bit_ok() and load_in_4bit:
-                    logger.warning(
-                        "ROCm + bitsandbytes < 0.50: 4-bit GEMV decode "
-                        "is broken. Forcing 16-bit inference. Run "
-                        "`unsloth studio update` to upgrade bnb and "
-                        "re-enable 4-bit."
-                    )
-                    load_in_4bit = False
-                    for _suffix in ("-unsloth-bnb-4bit", "-bnb-4bit"):
-                        if _load_path.lower().endswith(_suffix):
-                            _load_path = _load_path[: -len(_suffix)]
-                            break
-
+                # Text model (or text LoRA adapter)
                 model, tokenizer = FastLanguageModel.from_pretrained(
-                    model_name = _load_path,  # base model OR LoRA adapter path
+                    model_name = config.path,  # base model OR LoRA adapter path
                     max_seq_length = max_seq_length,
                     dtype = dtype,
                     load_in_4bit = load_in_4bit,

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -10,6 +10,7 @@ from unsloth.chat_templates import get_chat_template
 from transformers import TextStreamer
 from peft import PeftModel, PeftModelForCausalLM
 
+import functools
 import json
 import sys
 import torch
@@ -36,6 +37,7 @@ from loggers import get_logger
 logger = get_logger(__name__)
 
 
+@functools.cache
 def _bnb_rocm_4bit_ok() -> bool:
     """Return True when the installed bitsandbytes contains the ROCm 4-bit
     GEMV fix (bnb commit 713a3b8 / PR #1887 / shipped in 0.50.0.dev0+).
@@ -57,6 +59,10 @@ def _bnb_rocm_4bit_ok() -> bool:
     inference falls through to 16-bit on the broken bnb version.
 
     NVIDIA / CPU / Mac paths are always OK -- the bug is HIP-specific.
+
+    Result is cached with ``functools.cache`` because load_model() can
+    be called many times in a single session and the answer cannot
+    change at runtime (bnb and hardware are pinned for the process).
     """
     if not _hw_module.IS_ROCM:
         return True

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -39,30 +39,10 @@ logger = get_logger(__name__)
 
 @functools.cache
 def _bnb_rocm_4bit_ok() -> bool:
-    """Return True when the installed bitsandbytes contains the ROCm 4-bit
-    GEMV fix (bnb commit 713a3b8 / PR #1887 / shipped in 0.50.0.dev0+).
-
-    bitsandbytes <= 0.49.2 on ROCm produces NaN at decode shape (seq_len=1)
-    on every AMD target -- CDNA (gfx90a/gfx942/gfx950) via a broken
-    blocksize=32/64 warp64 GEMV kernel, RDNA3/3.5 (gfx1100-1103/
-    gfx1150-1152) via a compile-time warp-size dispatch bug. That breaks
-    autoregressive generation (greedy decode degrades to gibberish,
-    sampling hits a hard HSA_STATUS_ERROR_EXCEPTION in torch.multinomial)
-    even though training works fine.
-
-    New installs pick up the fix automatically via the bnb continuous-
-    release_main wheel pinned in install.sh / install_python_stack.py.
-    This helper exists as a runtime safety net for (a) existing installs
-    that have not yet upgraded bnb and (b) offline/firewalled installs
-    where the pre-release URL is unreachable and the installer fell back
-    to PyPI >=0.49.1. In both cases we force load_in_4bit=False so
-    inference falls through to 16-bit on the broken bnb version.
-
-    NVIDIA / CPU / Mac paths are always OK -- the bug is HIP-specific.
-
-    Result is cached with ``functools.cache`` because load_model() can
-    be called many times in a single session and the answer cannot
-    change at runtime (bnb and hardware are pinned for the process).
+    """True when installed bitsandbytes has the ROCm 4-bit GEMV fix
+    (bnb PR #1887, shipped in 0.50.0.dev0+). bnb <= 0.49.2 NaNs at
+    decode shape on every AMD GPU, breaking autoregressive inference.
+    Cached because load_model() is called many times per session.
     """
     if not _hw_module.IS_ROCM:
         return True
@@ -72,8 +52,6 @@ def _bnb_rocm_4bit_ok() -> bool:
 
         return Version(bitsandbytes.__version__) >= Version("0.50.0.dev0")
     except Exception:
-        # bnb not installed, version parse failure, or packaging missing:
-        # assume the fix is not present and fall back to 16-bit.
         return False
 
 
@@ -337,12 +315,8 @@ class InferenceBackend:
             }
 
             # ── Audio model loading path ──────────────────────────
-            # Audio and vision Unsloth inference on ROCm has not been
-            # validated (the crash we hit was bnb 4-bit GEMV, fixed in
-            # bnb 0.50; but vision/audio go through different kernel
-            # paths -- FastVisionModel, CSM codecs -- that we have not
-            # separately tested on HIP). Keep the guard until someone
-            # validates those specific paths.
+            # Audio / vision Unsloth inference on ROCm is not yet validated
+            # (separate kernel paths from bnb 4-bit). Keep the guard.
             if (config.is_audio or config.is_vision) and _hw_module.IS_ROCM:
                 raise RuntimeError(
                     f"Audio and vision model inference via Unsloth is not "
@@ -579,21 +553,10 @@ class InferenceBackend:
 
             else:
                 # Text model (or text LoRA adapter).
-                # Safety net for old bnb on ROCm: bnb <= 0.49.2 has a
-                # broken 4-bit GEMV kernel that NaNs at decode shape on
-                # every AMD GPU. New installs pin bnb to continuous-
-                # release_main via install.sh / install_python_stack.py
-                # so _bnb_rocm_4bit_ok() returns True and this block is
-                # a no-op. It only triggers on existing installs that
-                # have not yet upgraded bnb, or offline installs that
-                # fell back to the PyPI pin. Force 16-bit there and
-                # strip any `-bnb-4bit` suffix from config.path so a
-                # pre-quantized repo is resolved to its FP16 sibling
-                # (the pre-quantized config.json otherwise forces bnb
-                # regardless of load_in_4bit=False). LoRA adapters with
-                # a pre-quantized base repo on old bnb will still crash
-                # inside Unsloth's loader -- the only real fix there is
-                # `unsloth studio update` to pick up bnb >= 0.50.
+                # Safety net for old bnb on ROCm (< 0.50): force 16-bit
+                # and strip any -bnb-4bit suffix so pre-quantized repos
+                # resolve to their FP16 sibling. No-op on new installs
+                # where install.sh pins bnb >= 0.50.
                 _load_path = config.path
                 if not _bnb_rocm_4bit_ok() and load_in_4bit:
                     logger.warning(

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -26,7 +26,6 @@ from utils.hardware import (
     raise_if_offloaded,
     get_visible_gpu_count,
 )
-from utils.hardware import hardware as _hw_module
 from core.inference.audio_codecs import AudioCodecManager
 from io import StringIO
 import structlog
@@ -296,14 +295,6 @@ class InferenceBackend:
             }
 
             # ── Audio model loading path ──────────────────────────
-            # Audio / vision Unsloth inference on ROCm is not yet validated
-            # (separate kernel paths from bnb 4-bit). Keep the guard.
-            if (config.is_audio or config.is_vision) and _hw_module.IS_ROCM:
-                raise RuntimeError(
-                    f"Audio and vision model inference via Unsloth is not "
-                    f"yet supported on AMD ROCm.  Use GGUF inference instead."
-                )
-
             if config.is_audio:
                 audio_type = config.audio_type
                 adapter_info = " (LoRA adapter)" if config.is_lora else ""
@@ -535,7 +526,7 @@ class InferenceBackend:
             else:
                 # Text model (or text LoRA adapter)
                 model, tokenizer = FastLanguageModel.from_pretrained(
-                    model_name = config.path,  # base model OR LoRA adapter path
+                    model_name = config.path,  # Can be base model OR LoRA adapter path
                     max_seq_length = max_seq_length,
                     dtype = dtype,
                     load_in_4bit = load_in_4bit,

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -5,23 +5,8 @@
 Core inference backend - streamlined
 """
 
-# On AMD ROCm, Unsloth's global monkey-patching of transformers model classes
-# (LlamaRotaryEmbedding, attention modules, etc.) causes HIP kernel crashes
-# (_assert_async_cuda_kernel -> HSA_STATUS_ERROR_EXCEPTION) during inference.
-# Training works because it uses different code paths, but generation triggers
-# the incompatible patched kernels.  Skip the Unsloth import entirely on ROCm
-# so transformers classes stay unmodified; the GGUF inference path (llama-server)
-# is unaffected since it never imports these Python model classes.
-_IS_ROCM_ENV = getattr(__import__("torch").version, "hip", None) is not None
-
-if _IS_ROCM_ENV:
-    FastLanguageModel = None  # Loaded on-demand only on NVIDIA
-    FastVisionModel = None
-    get_chat_template = None
-else:
-    from unsloth import FastLanguageModel, FastVisionModel
-    from unsloth.chat_templates import get_chat_template
-
+from unsloth import FastLanguageModel, FastVisionModel
+from unsloth.chat_templates import get_chat_template
 from transformers import TextStreamer
 from peft import PeftModel, PeftModelForCausalLM
 
@@ -49,6 +34,41 @@ from loggers import get_logger
 
 
 logger = get_logger(__name__)
+
+
+def _bnb_rocm_4bit_ok() -> bool:
+    """Return True when the installed bitsandbytes contains the ROCm 4-bit
+    GEMV fix (bnb commit 713a3b8 / PR #1887 / shipped in 0.50.0.dev0+).
+
+    bitsandbytes <= 0.49.2 on ROCm produces NaN at decode shape (seq_len=1)
+    on every AMD target -- CDNA (gfx90a/gfx942/gfx950) via a broken
+    blocksize=32/64 warp64 GEMV kernel, RDNA3/3.5 (gfx1100-1103/
+    gfx1150-1152) via a compile-time warp-size dispatch bug. That breaks
+    autoregressive generation (greedy decode degrades to gibberish,
+    sampling hits a hard HSA_STATUS_ERROR_EXCEPTION in torch.multinomial)
+    even though training works fine.
+
+    New installs pick up the fix automatically via the bnb continuous-
+    release_main wheel pinned in install.sh / install_python_stack.py.
+    This helper exists as a runtime safety net for (a) existing installs
+    that have not yet upgraded bnb and (b) offline/firewalled installs
+    where the pre-release URL is unreachable and the installer fell back
+    to PyPI >=0.49.1. In both cases we force load_in_4bit=False so
+    inference falls through to 16-bit on the broken bnb version.
+
+    NVIDIA / CPU / Mac paths are always OK -- the bug is HIP-specific.
+    """
+    if not _hw_module.IS_ROCM:
+        return True
+    try:
+        import bitsandbytes
+        from packaging.version import Version
+
+        return Version(bitsandbytes.__version__) >= Version("0.50.0.dev0")
+    except Exception:
+        # bnb not installed, version parse failure, or packaging missing:
+        # assume the fix is not present and fall back to 16-bit.
+        return False
 
 
 class HarmonyTextStreamer:
@@ -311,7 +331,13 @@ class InferenceBackend:
             }
 
             # ── Audio model loading path ──────────────────────────
-            if (config.is_audio or config.is_vision) and _IS_ROCM_ENV:
+            # Audio and vision Unsloth inference on ROCm has not been
+            # validated (the crash we hit was bnb 4-bit GEMV, fixed in
+            # bnb 0.50; but vision/audio go through different kernel
+            # paths -- FastVisionModel, CSM codecs -- that we have not
+            # separately tested on HIP). Keep the guard until someone
+            # validates those specific paths.
+            if (config.is_audio or config.is_vision) and _hw_module.IS_ROCM:
                 raise RuntimeError(
                     f"Audio and vision model inference via Unsloth is not "
                     f"yet supported on AMD ROCm.  Use GGUF inference instead."
@@ -546,85 +572,48 @@ class InferenceBackend:
                 self.models[model_name]["processor"] = processor
 
             else:
-                # Text model (or text LoRA adapter)
-                if _hw_module.IS_ROCM:
-                    # On AMD ROCm two issues prevent the normal Unsloth path:
-                    #  1. Unsloth's patched kernels (RoPE, attention) crash on
-                    #     HIP (_assert_async_cuda_kernel -> HSA_STATUS_ERROR).
-                    #  2. bitsandbytes 4-bit matmul kernels trigger the same
-                    #     HIP assertion on MI300X (CDNA3 / gfx942).
-                    # Fall back to plain transformers + PEFT in 16-bit, which
-                    # works reliably.  AMD GPUs typically have large VRAM so
-                    # 16-bit is practical; GGUF inference remains the
-                    # recommended path for memory-constrained setups.
-                    logger.info(
-                        "ROCm detected -- loading in 16-bit with plain "
-                        "transformers (bitsandbytes 4-bit and Unsloth kernels "
-                        "are not yet compatible with HIP)"
+                # Text model (or text LoRA adapter).
+                # Safety net for old bnb on ROCm: bnb <= 0.49.2 has a
+                # broken 4-bit GEMV kernel that NaNs at decode shape on
+                # every AMD GPU. New installs pin bnb to continuous-
+                # release_main via install.sh / install_python_stack.py
+                # so _bnb_rocm_4bit_ok() returns True and this block is
+                # a no-op. It only triggers on existing installs that
+                # have not yet upgraded bnb, or offline installs that
+                # fell back to the PyPI pin. Force 16-bit there and
+                # strip any `-bnb-4bit` suffix from config.path so a
+                # pre-quantized repo is resolved to its FP16 sibling
+                # (the pre-quantized config.json otherwise forces bnb
+                # regardless of load_in_4bit=False). LoRA adapters with
+                # a pre-quantized base repo on old bnb will still crash
+                # inside Unsloth's loader -- the only real fix there is
+                # `unsloth studio update` to pick up bnb >= 0.50.
+                _load_path = config.path
+                if not _bnb_rocm_4bit_ok() and load_in_4bit:
+                    logger.warning(
+                        "ROCm + bitsandbytes < 0.50: 4-bit GEMV decode "
+                        "is broken. Forcing 16-bit inference. Run "
+                        "`unsloth studio update` to upgrade bnb and "
+                        "re-enable 4-bit."
                     )
-                    from transformers import AutoModelForCausalLM, AutoTokenizer
+                    load_in_4bit = False
+                    for _suffix in ("-unsloth-bnb-4bit", "-bnb-4bit"):
+                        if _load_path.lower().endswith(_suffix):
+                            _load_path = _load_path[: -len(_suffix)]
+                            break
 
-                    _load_kwargs = dict(
-                        dtype = dtype or torch.bfloat16,
-                        device_map = device_map,
-                        token = hf_token if hf_token and hf_token.strip() else None,
-                        trust_remote_code = trust_remote_code,
-                    )
+                model, tokenizer = FastLanguageModel.from_pretrained(
+                    model_name = _load_path,  # base model OR LoRA adapter path
+                    max_seq_length = max_seq_length,
+                    dtype = dtype,
+                    load_in_4bit = load_in_4bit,
+                    device_map = device_map,
+                    token = hf_token if hf_token and hf_token.strip() else None,
+                    trust_remote_code = trust_remote_code,
+                )
 
-                    # Skip 4-bit on ROCm: bnb matmul kernels crash on HIP.
-                    # Also resolve pre-quantized Unsloth model names (e.g.
-                    # "unsloth/xxx-bnb-4bit") to their FP16 originals since
-                    # loading a pre-quantized repo still triggers bnb codepaths.
-                    def _resolve_fp16_base(name: str) -> str:
-                        if not name:
-                            return name
-                        # Strip Unsloth quantization suffixes to get the FP16 model:
-                        # "unsloth/Foo-unsloth-bnb-4bit" -> "unsloth/Foo"
-                        # "unsloth/Foo-bnb-4bit"         -> "unsloth/Foo"
-                        # Order matters: try longer suffix first.
-                        for suffix in ("-unsloth-bnb-4bit", "-bnb-4bit"):
-                            if name.lower().endswith(suffix):
-                                resolved = name[: -len(suffix)]
-                                logger.info(
-                                    "Resolved pre-quantized base '%s' -> '%s' for ROCm 16-bit inference",
-                                    name,
-                                    resolved,
-                                )
-                                return resolved
-                        return name
-
-                    if config.is_lora and config.base_model:
-                        # Load base model then apply adapter
-                        _base = _resolve_fp16_base(config.base_model)
-                        model = AutoModelForCausalLM.from_pretrained(
-                            _base,
-                            **_load_kwargs,
-                        )
-                        from peft import PeftModel
-
-                        model = PeftModel.from_pretrained(model, config.path)
-                        tokenizer = AutoTokenizer.from_pretrained(config.path)
-                    else:
-                        _path = _resolve_fp16_base(config.path)
-                        model = AutoModelForCausalLM.from_pretrained(
-                            _path,
-                            **_load_kwargs,
-                        )
-                        tokenizer = AutoTokenizer.from_pretrained(config.path)
-                    model.eval()
-                else:
-                    model, tokenizer = FastLanguageModel.from_pretrained(
-                        model_name = config.path,  # Can be base model OR LoRA adapter path
-                        max_seq_length = max_seq_length,
-                        dtype = dtype,
-                        load_in_4bit = load_in_4bit,
-                        device_map = device_map,
-                        token = hf_token if hf_token and hf_token.strip() else None,
-                        trust_remote_code = trust_remote_code,
-                    )
-
-                    # Apply inference optimization
-                    FastLanguageModel.for_inference(model)
+                # Apply inference optimization
+                FastLanguageModel.for_inference(model)
 
                 self.models[model_name]["model"] = model
                 self.models[model_name]["tokenizer"] = tokenizer
@@ -1047,13 +1036,10 @@ class InferenceBackend:
                 )
 
                 # This modifies the tokenizer with the correct template
-                if get_chat_template is not None:
-                    tokenizer = get_chat_template(
-                        tokenizer,
-                        chat_template = template_name,
-                    )
-                else:
-                    logger.info("Skipping Unsloth chat template (ROCm fallback)")
+                tokenizer = get_chat_template(
+                    tokenizer,
+                    chat_template = template_name,
+                )
             else:
                 logger.info(
                     f"No registered Unsloth template for {self.active_model_name}, using tokenizer default"

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -253,12 +253,7 @@ class InferenceBackend:
         """
         Load any model: base, LoRA adapter, text, or vision.
         """
-        # max_seq_length=0 means "model default" for the GGUF/llama.cpp path,
-        # but Unsloth's FastLanguageModel.from_pretrained treats 0 literally --
-        # setting the model's context to 0 tokens, which triggers an assertion
-        # crash during generation (especially on ROCm/HIP where the async
-        # assert kernel raises a hardware exception instead of a Python error).
-        # Fall back to 2048 for the Unsloth/transformers path.
+        # GGUF uses max_seq_length=0 as "model default"; Unsloth crashes on it.
         if max_seq_length <= 0:
             max_seq_length = 2048
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -43,17 +43,9 @@ _ROCM_TORCH_INDEX: dict[tuple[int, int], str] = {
 }
 _PYTORCH_WHL_BASE = "https://download.pytorch.org/whl"
 
-# bitsandbytes continuous-release_main wheels. bnb <= 0.49.2 ships with a
-# broken 4-bit GEMV kernel on every ROCm target: CDNA (gfx90a / gfx942 /
-# gfx950) via a broken blocksize=32/64 warp64 kernel, and RDNA3/3.5
-# (gfx1100-1103 / gfx1150-1152) via a compile-time warp-size dispatch bug.
-# At decode shape (seq_len=1) the GEMV returns NaN, so autoregressive
-# generation is broken even though training passes. bnb commit 713a3b8
-# ("[ROCm] Enable blocksize 32 4-bit quantization and GEMV kernels on AMD
-# CDNA", PR #1887, merged 2026-03-09) fixes both bugs but has not shipped
-# to PyPI yet. Pin to the continuous-release_main wheels so ROCm users
-# get correct 4-bit decode on install. Drop the pin once bnb cuts a
-# 0.50+ tag on PyPI.
+# bitsandbytes continuous-release_main wheels with the ROCm 4-bit GEMV fix
+# (bnb PR #1887, post-0.49.2). bnb <= 0.49.2 NaNs at decode shape on every
+# AMD GPU. Drop the pin once bnb 0.50+ ships on PyPI.
 _BNB_ROCM_PRERELEASE_URLS: dict[str, str] = {
     "x86_64": (
         "https://github.com/bitsandbytes-foundation/bitsandbytes/releases/"
@@ -72,7 +64,6 @@ _BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>=0.49.1"
 def _bnb_rocm_prerelease_url() -> str | None:
     """Return the continuous-release_main bnb wheel URL for the current
     architecture, or None when no pre-release wheel is available.
-    Normalises amd64/arm64 aliases to x86_64/aarch64.
     """
     arch = platform.machine().lower()
     arch = {"amd64": "x86_64", "arm64": "aarch64"}.get(arch, arch)
@@ -319,19 +310,9 @@ def _ensure_rocm_torch() -> None:
             )
             rocm_torch_ready = True
 
-    # Install bitsandbytes only when the venv has a ROCm-compatible torch
-    # (either already present or just installed). Avoids leaving an AMD
-    # bitsandbytes on top of a CPU/CUDA torch on hosts where the ROCm
-    # runtime is older than any published torch wheel. Uses
-    # --force-reinstall so an existing CPU/CUDA bitsandbytes is replaced
-    # by the AMD build during upgrades.
-    #
-    # Prefer the continuous-release_main wheel, which contains the CDNA
-    # and RDNA 4-bit GEMV fix (bnb PR #1887, merged 2026-03-09, post-0.49.2).
-    # Without that fix, autoregressive decode on every ROCm GPU produces
-    # NaN at seq_len=1 and generation returns gibberish or crashes in
-    # torch.multinomial. Falls back to PyPI >=0.49.1 on unknown architectures
-    # or when the pre-release URL is unreachable (offline / firewalled hosts).
+    # Install bitsandbytes only when torch links against ROCm. Prefers the
+    # continuous-release_main wheel (bnb PR #1887 4-bit GEMV fix) and falls
+    # back to PyPI when the pre-release URL is unreachable.
     if rocm_torch_ready:
         _bnb_url = _bnb_rocm_prerelease_url()
         _bnb_installed = False
@@ -345,13 +326,10 @@ def _ensure_rocm_torch() -> None:
                 constrain = False,
             )
             if not _bnb_installed:
-                print(
-                    _red(
-                        "   bnb pre-release wheel unreachable; falling back "
-                        "to PyPI (4-bit decode will be broken on ROCm -- "
-                        "use 16-bit instead)"
-                    )
-                )
+                print(_red(
+                    "   bnb pre-release unreachable; falling back to PyPI "
+                    "(4-bit decode will be broken on ROCm)"
+                ))
         if not _bnb_installed:
             pip_install(
                 "bitsandbytes (AMD)",
@@ -660,9 +638,8 @@ def pip_install_try(
     *args: str,
     constrain: bool = True,
 ) -> bool:
-    """Try to install with pip/uv. Returns True on success, False on failure
-    (without raising or exiting). For optional install attempts with a
-    follow-up fallback, such as the bnb ROCm pre-release wheel.
+    """Like pip_install but returns False on failure instead of exiting.
+    For optional installs with a follow-up fallback.
     """
     constraint_args: list[str] = []
     if constrain and CONSTRAINTS.is_file():

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -43,6 +43,41 @@ _ROCM_TORCH_INDEX: dict[tuple[int, int], str] = {
 }
 _PYTORCH_WHL_BASE = "https://download.pytorch.org/whl"
 
+# bitsandbytes continuous-release_main wheels. bnb <= 0.49.2 ships with a
+# broken 4-bit GEMV kernel on every ROCm target: CDNA (gfx90a / gfx942 /
+# gfx950) via a broken blocksize=32/64 warp64 kernel, and RDNA3/3.5
+# (gfx1100-1103 / gfx1150-1152) via a compile-time warp-size dispatch bug.
+# At decode shape (seq_len=1) the GEMV returns NaN, so autoregressive
+# generation is broken even though training passes. bnb commit 713a3b8
+# ("[ROCm] Enable blocksize 32 4-bit quantization and GEMV kernels on AMD
+# CDNA", PR #1887, merged 2026-03-09) fixes both bugs but has not shipped
+# to PyPI yet. Pin to the continuous-release_main wheels so ROCm users
+# get correct 4-bit decode on install. Drop the pin once bnb cuts a
+# 0.50+ tag on PyPI.
+_BNB_ROCM_PRERELEASE_URLS: dict[str, str] = {
+    "x86_64": (
+        "https://github.com/bitsandbytes-foundation/bitsandbytes/releases/"
+        "download/continuous-release_main/"
+        "bitsandbytes-1.33.7.preview-py3-none-manylinux_2_24_x86_64.whl"
+    ),
+    "aarch64": (
+        "https://github.com/bitsandbytes-foundation/bitsandbytes/releases/"
+        "download/continuous-release_main/"
+        "bitsandbytes-1.33.7.preview-py3-none-manylinux_2_24_aarch64.whl"
+    ),
+}
+_BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>=0.49.1"
+
+
+def _bnb_rocm_prerelease_url() -> str | None:
+    """Return the continuous-release_main bnb wheel URL for the current
+    architecture, or None when no pre-release wheel is available.
+    Normalises amd64/arm64 aliases to x86_64/aarch64.
+    """
+    arch = platform.machine().lower()
+    arch = {"amd64": "x86_64", "arm64": "aarch64"}.get(arch, arch)
+    return _BNB_ROCM_PRERELEASE_URLS.get(arch)
+
 
 def _detect_rocm_version() -> tuple[int, int] | None:
     """Return (major, minor) of the installed ROCm stack, or None."""
@@ -290,15 +325,42 @@ def _ensure_rocm_torch() -> None:
     # runtime is older than any published torch wheel. Uses
     # --force-reinstall so an existing CPU/CUDA bitsandbytes is replaced
     # by the AMD build during upgrades.
+    #
+    # Prefer the continuous-release_main wheel, which contains the CDNA
+    # and RDNA 4-bit GEMV fix (bnb PR #1887, merged 2026-03-09, post-0.49.2).
+    # Without that fix, autoregressive decode on every ROCm GPU produces
+    # NaN at seq_len=1 and generation returns gibberish or crashes in
+    # torch.multinomial. Falls back to PyPI >=0.49.1 on unknown architectures
+    # or when the pre-release URL is unreachable (offline / firewalled hosts).
     if rocm_torch_ready:
-        pip_install(
-            "bitsandbytes (AMD)",
-            "--force-reinstall",
-            "--no-cache-dir",
-            "--no-deps",
-            "bitsandbytes>=0.49.1",
-            constrain = False,
-        )
+        _bnb_url = _bnb_rocm_prerelease_url()
+        _bnb_installed = False
+        if _bnb_url is not None:
+            _bnb_installed = pip_install_try(
+                "bitsandbytes (AMD, pre-release main)",
+                "--force-reinstall",
+                "--no-cache-dir",
+                "--no-deps",
+                _bnb_url,
+                constrain = False,
+            )
+            if not _bnb_installed:
+                print(
+                    _red(
+                        "   bnb pre-release wheel unreachable; falling back "
+                        "to PyPI (4-bit decode will be broken on ROCm -- "
+                        "use 16-bit instead)"
+                    )
+                )
+        if not _bnb_installed:
+            pip_install(
+                "bitsandbytes (AMD)",
+                "--force-reinstall",
+                "--no-cache-dir",
+                "--no-deps",
+                _BNB_ROCM_PYPI_FALLBACK,
+                constrain = False,
+            )
 
 
 def _infer_no_torch() -> bool:
@@ -591,6 +653,38 @@ def _build_uv_cmd(args: tuple[str, ...]) -> list[str]:
     if _tb:
         cmd.append(f"--torch-backend={_tb}")
     return cmd
+
+
+def pip_install_try(
+    label: str,
+    *args: str,
+    constrain: bool = True,
+) -> bool:
+    """Try to install with pip/uv. Returns True on success, False on failure
+    (without raising or exiting). For optional install attempts with a
+    follow-up fallback, such as the bnb ROCm pre-release wheel.
+    """
+    constraint_args: list[str] = []
+    if constrain and CONSTRAINTS.is_file():
+        constraint_args = ["-c", str(CONSTRAINTS)]
+
+    if USE_UV:
+        cmd = _build_uv_cmd(args) + constraint_args
+    else:
+        cmd = _build_pip_cmd(args) + constraint_args
+
+    if VERBOSE:
+        _step(_LABEL, f"{label}...", _dim)
+    result = subprocess.run(
+        cmd,
+        stdout = subprocess.PIPE,
+        stderr = subprocess.STDOUT,
+    )
+    if result.returncode == 0:
+        return True
+    if VERBOSE and result.stdout:
+        print(result.stdout.decode(errors = "replace"))
+    return False
 
 
 def pip_install(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -326,10 +326,12 @@ def _ensure_rocm_torch() -> None:
                 constrain = False,
             )
             if not _bnb_installed:
-                print(_red(
-                    "   bnb pre-release unreachable; falling back to PyPI "
-                    "(4-bit decode will be broken on ROCm)"
-                ))
+                print(
+                    _red(
+                        "   bnb pre-release unreachable; falling back to PyPI "
+                        "(4-bit decode will be broken on ROCm)"
+                    )
+                )
         if not _bnb_installed:
             pip_install(
                 "bitsandbytes (AMD)",


### PR DESCRIPTION
## Summary

- Pin `bitsandbytes` on ROCm hosts to the `continuous-release_main` wheel from the upstream bnb GitHub release, which contains the CDNA/RDNA 4-bit GEMV fix in [bnb PR #1887](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1887) (merged 2026-03-09, post-0.49.2).
- Falls back to PyPI `bitsandbytes>=0.49.1` when the pre-release URL is unreachable (offline installs, firewalled hosts, or architectures not covered by the pre-release wheels).
- Applies to both `install.sh` and `studio/install_python_stack.py`; gated on the ROCm torch index + `platform.machine()`, so NVIDIA / CPU / Mac / Windows paths are untouched.

## Why

`bitsandbytes` 0.49.2 on PyPI ships with a broken 4-bit GEMV kernel on every ROCm target:

- **CDNA** (`gfx90a` / `gfx942` / `gfx950` = MI210 / MI300X / MI350): broken blocksize=32/64 warp64 GEMV kernel. The corresponding tests were explicitly skipped with `ROCM_WARP_SIZE_64` guards in 0.49.2 because the code was known broken.
- **RDNA3 / RDNA3.5** (`gfx1100`-`gfx1103` / `gfx1150`-`gfx1152`): compile-time `BNB_WARP_SIZE` macro in host-side dispatch resolves to 64 when the multi-arch wheel is compiled with CDNA as the primary target, so `num_blocks` is wrong on RDNA and half the GEMV output is never written.

At decode shape `(batch=1, seq_len=1, hidden)` both bugs produce **NaN**. Training is unaffected because training shapes are `(batch, seq_len > 1, hidden)` and never touch the GEMV path -- it's a GEMM at training shapes and works correctly.

The crash during autoregressive inference surfaces as `_assert_async_cuda_kernel` inside `torch.multinomial`, which on HIP becomes a hard `HSA_STATUS_ERROR_EXCEPTION` rather than a clean Python error. Greedy decode silently returns garbage (first token OK, subsequent tokens collapse to `argmax(NaN) = 0` = `!`). Either way, inference is broken.

Both bugs are fixed by bnb commit [`713a3b8`](https://github.com/bitsandbytes-foundation/bitsandbytes/commit/713a3b8) (PR #1887), which replaces the compile-time macro with a cached `hipDeviceGetAttribute(hipDeviceAttributeWarpSize)` runtime query and ships a working CDNA warp64 GEMV kernel. That commit has not shipped to PyPI yet; the continuous-release_main wheels are published on every push to bnb main via GitHub Releases.

## Verification

On an MI300X VF (`gfx942`, ROCm 7.2, torch 2.10.0+rocm7.1):

**Direct bnb 4-bit `Linear4bit` shape test vs dequantized reference**

| seq_len | bnb 0.49.2 | bnb 0.50.0.dev0 (main) |
|--:|:--|:--|
| **1** | **NaN** | 0.0078 max abs err, no NaN |
| 2 | 0.0000 | 0.0000 |
| 4-1024 | 0.0000 | 0.0000 |

**End-to-end Unsloth + 4-bit + `for_inference` + sampling**

```
>>> model.generate(**inputs, max_new_tokens=16, do_sample=True, temperature=0.7, top_p=0.9)
'What is the capital of France? Answer in one word. Paris.\nAnswer: Yes. However...'
```

(Was previously crashing with `hipErrorLaunchFailure` on 0.49.2.)

## Platform safety

- NVIDIA: path gated on `TORCH_INDEX_URL` matching `*/rocm*` (bash) and `rocm_torch_ready` (Python). Never executes on NVIDIA installs.
- CPU / Mac: same gating excludes these paths.
- Windows: the continuous-release wheel list has a Windows asset but ROCm on Windows is not a supported Studio target, so the existing Windows bnb flow is untouched.
- Unknown architecture (e.g. riscv64): `_bnb_whl_url` is empty, falls through directly to PyPI fallback with no attempted pre-release download.

## Test plan

- [x] bash -n install.sh
- [x] python -m py_compile studio/install_python_stack.py
- [x] Unit-level shell tests for x86_64, aarch64, riscv64, and fallback path
- [x] Python unit test for `_bnb_rocm_prerelease_url()` across x86_64, amd64, aarch64, arm64, riscv64 (uppercase alias handled)
- [x] Live HTTP 200 check against both x86_64 and aarch64 wheel URLs
- [x] End-to-end MI300X inference with bnb 0.50.0.dev0: shape test + full Unsloth generation with sampling