### PR TITLE
Studio: Polish training start overlay download progress UI

### DIFF
--- a/studio/frontend/src/components/ui/progress.tsx
+++ b/studio/frontend/src/components/ui/progress.tsx
@@ -10,9 +10,12 @@ import { cn } from "@/lib/utils";
 
 function Progress({
   className,
+  indicatorClassName,
   value,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string;
+}) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -24,7 +27,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary size-full flex-1 transition-all"
+        className={cn("bg-primary size-full flex-1 transition-all", indicatorClassName)}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -42,6 +42,10 @@ function formatBytes(n: number): string {
   return `${(n / 1024 ** 3).toFixed(2)} GB`;
 }
 
+function formatCachePath(path: string): string {
+  return path.replace(/^\/home\/[^/]+/, "~");
+}
+
 type DownloadState = {
   downloadedBytes: number;
   totalBytes: number;
@@ -146,25 +150,48 @@ type DownloadRowProps = {
 
 function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
   if (state.downloadedBytes <= 0 && !state.cachePath) return null;
+  const isComplete = state.totalBytes > 0 && state.percent >= 100;
+  const statusLabel = isComplete
+    ? "Ready"
+    : state.downloadedBytes > 0
+      ? "Downloading"
+      : "Preparing";
   const sizeLabel =
     state.totalBytes > 0
-      ? `${formatBytes(state.downloadedBytes)} / ${formatBytes(state.totalBytes)} · ${state.percent}%`
+      ? `${formatBytes(state.downloadedBytes)} / ${formatBytes(state.totalBytes)}`
       : state.downloadedBytes > 0
         ? `${formatBytes(state.downloadedBytes)} downloaded`
         : "preparing...";
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-        <span>{label}</span>
-        <span className="tabular-nums">{sizeLabel}</span>
+    <div className="flex flex-col gap-1.5 rounded-md border border-border/50 bg-muted/20 px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-foreground/90">{label}</span>
+          <span
+            className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${isComplete ? "bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200/80 dark:bg-emerald-500/15 dark:text-emerald-300 dark:ring-emerald-500/30" : "bg-muted text-muted-foreground"}`}
+          >
+            {statusLabel}
+          </span>
+        </div>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {state.totalBytes > 0 ? `${state.percent}%` : ""}
+        </span>
       </div>
-      {state.totalBytes > 0 ? <Progress value={state.percent} /> : null}
+      <div className="text-[11px] tabular-nums text-muted-foreground">
+        {sizeLabel}
+      </div>
+      {state.totalBytes > 0 ? (
+        <Progress
+          value={state.percent}
+          indicatorClassName="bg-[linear-gradient(90deg,oklch(0.66_0.142_166.6)_0%,oklch(0.705_0.132_166.6)_55%,oklch(0.75_0.122_166.6)_100%)]"
+        />
+      ) : null}
       {state.cachePath ? (
         <div
-          className="truncate text-[10px] text-muted-foreground/70"
+          className="truncate rounded bg-muted/50 px-2 py-1 text-[10px] text-muted-foreground/70"
           title={state.cachePath}
         >
-          {state.cachePath}
+          {formatCachePath(state.cachePath)}
         </div>
       ) : null}
     </div>
@@ -272,7 +299,7 @@ export function TrainingStartOverlay({
           {datasetDownload.downloadedBytes > 0 || datasetDownload.cachePath ? (
             <AnimatedSpan className="mt-3">
               <DownloadRow
-                label="Downloading dataset..."
+                label="Dataset"
                 state={datasetDownload}
               />
             </AnimatedSpan>
@@ -280,7 +307,7 @@ export function TrainingStartOverlay({
           {modelDownload.downloadedBytes > 0 || modelDownload.cachePath ? (
             <AnimatedSpan className="mt-3">
               <DownloadRow
-                label="Downloading model weights..."
+                label="Model weights"
                 state={modelDownload}
               />
             </AnimatedSpan>

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -43,7 +43,7 @@ function formatBytes(n: number): string {
 }
 
 function formatCachePath(path: string): string {
-  return path.replace(/^\/home\/[^/]+/, "~");
+  return path.replace(/^\/(?:home|Users)\/[^/]+/, "~");
 }
 
 type DownloadState = {
@@ -161,7 +161,7 @@ function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
       ? `${formatBytes(state.downloadedBytes)} / ${formatBytes(state.totalBytes)}`
       : state.downloadedBytes > 0
         ? `${formatBytes(state.downloadedBytes)} downloaded`
-        : "preparing...";
+        : null;
   return (
     <div className="flex flex-col gap-1.5 rounded-md border border-border/50 bg-muted/20 px-3 py-2">
       <div className="flex items-center justify-between gap-3">
@@ -177,9 +177,11 @@ function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
           {state.totalBytes > 0 ? `${state.percent}%` : ""}
         </span>
       </div>
-      <div className="text-[11px] tabular-nums text-muted-foreground">
-        {sizeLabel}
-      </div>
+      {sizeLabel ? (
+        <div className="text-[11px] tabular-nums text-muted-foreground">
+          {sizeLabel}
+        </div>
+      ) : null}
       {state.totalBytes > 0 ? (
         <Progress
           value={state.percent}

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -43,7 +43,9 @@ function formatBytes(n: number): string {
 }
 
 function formatCachePath(path: string): string {
-  return path.replace(/^\/(?:home|Users)\/[^/]+/, "~");
+  return path
+    .replace(/^\/(?:home|Users)\/[^/]+/, "~")
+    .replace(/^[A-Za-z]:[/\\]Users[/\\][^/\\]+/, "~");
 }
 
 type DownloadState = {
@@ -153,9 +155,11 @@ function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
   const isComplete = state.totalBytes > 0 && state.percent >= 100;
   const statusLabel = isComplete
     ? "Ready"
-    : state.downloadedBytes > 0
+    : state.totalBytes > 0
       ? "Downloading"
-      : "Preparing";
+      : state.downloadedBytes === 0
+        ? "Preparing"
+        : null;
   const sizeLabel =
     state.totalBytes > 0
       ? `${formatBytes(state.downloadedBytes)} / ${formatBytes(state.totalBytes)}`
@@ -167,11 +171,13 @@ function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <span className="text-xs text-foreground/90">{label}</span>
-          <span
-            className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${isComplete ? "bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200/80 dark:bg-emerald-500/15 dark:text-emerald-300 dark:ring-emerald-500/30" : "bg-muted text-muted-foreground"}`}
-          >
-            {statusLabel}
-          </span>
+          {statusLabel ? (
+            <span
+              className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${isComplete ? "bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200/80 dark:bg-emerald-500/15 dark:text-emerald-300 dark:ring-emerald-500/30" : "bg-muted text-muted-foreground"}`}
+            >
+              {statusLabel}
+            </span>
+          ) : null}
         </div>
         <span className="text-xs tabular-nums text-muted-foreground">
           {state.totalBytes > 0 ? `${state.percent}%` : ""}


### PR DESCRIPTION
The previous styling made progress state and completion status harder to scan quickly, especially in light mode. This improves readability while staying aligned with existing Unsloth UI color language.

- refines the training start overlay download rows for clearer visual hierarchy
- updates progress fill to use a subtle Unsloth light-green gradient reveal as progress increases
- improves completed-state readability by increasing contrast of the `Ready` badge
- keeps behavior unchanged (polling, progress math, and download status logic remain the same)

Before:
<img width="1349" height="628" alt="image" src="https://github.com/user-attachments/assets/3c679d21-1fb0-4ed8-bf06-4e5d8ba3de93" />

After:
<img width="1362" height="775" alt="image" src="https://github.com/user-attachments/assets/d42ba80e-fe90-4352-9e44-3693557d1044" />
