### PR TITLE
Studio: Fix export subprocess crash by restoring transformers activation helper

### DIFF
--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -409,6 +409,30 @@ def _deactivate_5x() -> None:
     logger.info("Reverted to transformers %s", transformers.__version__)
 
 
+def activate_transformers_for_subprocess(model_name: str) -> None:
+    """Activate the correct transformers version for subprocess workers.
+
+    Call this BEFORE any ML imports in worker subprocesses (training,
+    inference, export). For models that require transformers 5.x, this
+    prepends ``.venv_t5`` to ``sys.path`` and propagates that path via
+    ``PYTHONPATH`` so child processes (e.g. GGUF converter) inherit it.
+    """
+    resolved = _resolve_base_model(model_name)
+    if needs_transformers_5(resolved):
+        if not _ensure_venv_t5_exists():
+            raise RuntimeError(
+                f"Cannot activate transformers 5.x: .venv_t5 missing at {_VENV_T5_DIR}"
+            )
+        if _VENV_T5_DIR not in sys.path:
+            sys.path.insert(0, _VENV_T5_DIR)
+        logger.info("Activated transformers 5.x from %s", _VENV_T5_DIR)
+        # Propagate to child subprocesses (e.g. GGUF converter)
+        _pp = os.environ.get("PYTHONPATH", "")
+        os.environ["PYTHONPATH"] = _VENV_T5_DIR + (os.pathsep + _pp if _pp else "")
+    else:
+        logger.info("Using default transformers (4.57.x) for %s", model_name)
+
+
 def ensure_transformers_version(model_name: str) -> None:
     """Ensure the correct ``transformers`` version is active for *model_name*.
 


### PR DESCRIPTION
### Issue: 
Exporting unsloth/qwen2.5-vl-3b-instruct-unsloth-bnb-4bit checkpoint failed with `Failed to activate transformers version: cannot import name 'activate_transformers_for_subprocess' ...`

Fixes GGUF/export subprocess startup failure caused by a missing `activate_transformers_for_subprocess` symbol.
Restores a backward-compatible helper in `backend/utils/transformers_version.py` so `core/export/worker.py` can activate the correct transformers environment before ML imports.

###  Root Cause
`core/export/worker.py` imported `activate_transformers_for_subprocess`, but the function had been removed from `utils/transformers_version.py` in this branch, causing import-time export failure.

## Test plan
- [x] Start Studio and load a checkpoint in Export.
- [x] Run GGUF export for a known checkpoint that previously failed.
- [x] Confirm export proceeds past subprocess initialization without import errors.
