### PR TITLE
fix: use direct registry API for PATH writes instead of SetEnvironmentVariable

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -116,6 +116,47 @@ function Install-UnslothStudio {
         $env:Path = $unique -join ";"
     }
 
+    # ── Helper: safely add a directory to the persistent User PATH ──
+    # Uses direct registry access to preserve REG_EXPAND_SZ type
+    # (avoids .NET SetEnvironmentVariable bug that converts to REG_SZ).
+    function Add-ToUserPath {
+        param(
+            [Parameter(Mandatory = $true)][string]$Directory
+        )
+        try {
+            $regKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+            if (-not $regKey) {
+                Write-Host "[WARN] Could not open HKCU\Environment registry key" -ForegroundColor Yellow
+                return $false
+            }
+            try {
+                $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+                $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
+                $normalDir = $Directory.TrimEnd('\').ToLowerInvariant()
+                foreach ($entry in $entries) {
+                    if ($entry.TrimEnd('\').ToLowerInvariant() -eq $normalDir) {
+                        return $false  # already present
+                    }
+                }
+                if (-not $rawPath) {
+                    Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
+                }
+                $newPath = if ($rawPath) { "$Directory;$rawPath" } else { $Directory }
+                $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+                # Broadcast WM_SETTINGCHANGE so other processes pick up the change
+                $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+                [Environment]::SetEnvironmentVariable($d, '1', 'User')
+                [Environment]::SetEnvironmentVariable($d, $null, 'User')
+                return $true
+            } finally {
+                $regKey.Close()
+            }
+        } catch {
+            Write-Host "[WARN] Could not update User PATH: $($_.Exception.Message)" -ForegroundColor Yellow
+            return $false
+        }
+    }
+
     function step {
         param(
             [Parameter(Mandatory = $true)][string]$Label,
@@ -947,13 +988,7 @@ shell.Run cmd, 0, False
 
     # ── Add venv Scripts dir to User PATH so `unsloth studio` works from any terminal ──
     $ScriptsDir = Join-Path $VenvDir "Scripts"
-    $UserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
-    if (-not $UserPath -or $UserPath -notlike "*$ScriptsDir*") {
-        if ($UserPath) {
-            [System.Environment]::SetEnvironmentVariable("Path", "$ScriptsDir;$UserPath", "User")
-        } else {
-            [System.Environment]::SetEnvironmentVariable("Path", "$ScriptsDir", "User")
-        }
+    if (Add-ToUserPath -Directory $ScriptsDir) {
         Refresh-SessionPath
         step "path" "added unsloth to PATH"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -227,11 +227,17 @@ function Install-UnslothStudio {
                     return $false
                 }
                 $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
-                # Broadcast WM_SETTINGCHANGE so other processes pick up the change
+                # Broadcast WM_SETTINGCHANGE so other processes pick up the change.
+                # Use [NullString]::Value (not $null) for the delete call so the
+                # sentinel crosses into .NET as a real null reference -- on
+                # PowerShell 7.5+ / .NET 9, a bare $null here can be coerced to
+                # an empty string, which sets the dummy variable to "" instead
+                # of deleting it and leaves UnslothPathRefresh_XXXXXXXX in
+                # HKCU\Environment permanently.
                 try {
                     $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
                     [Environment]::SetEnvironmentVariable($d, '1', 'User')
-                    [Environment]::SetEnvironmentVariable($d, $null, 'User')
+                    [Environment]::SetEnvironmentVariable($d, [NullString]::Value, 'User')
                 } catch { }
                 return $true
             } finally {
@@ -1126,11 +1132,18 @@ shell.Run cmd, 0, False
             Write-Host "       Launch unsloth studio directly via '$UnslothExe' until the next successful install." -ForegroundColor Yellow
         }
     }
-    # Only advertise the new launcher when it was actually (re)created and
-    # the shim directory was newly added to PATH. If the shim already
-    # existed on disk AND was already on PATH, both conditions are false
-    # and we stay quiet.
-    $pathAdded = Add-ToUserPath -Directory $ShimDir -Position 'Prepend'
+    # Only add the shim directory to PATH when the launcher actually exists
+    # in it. Otherwise a total shim-creation failure on a fresh install (e.g.
+    # antivirus blocks unsloth.exe, disk full, restrictive FS permissions)
+    # would prepend an empty directory to User PATH and leave the user with
+    # an install that reports success but cannot resolve `unsloth` in a new
+    # shell. Also gate the "added to PATH" step message on both a successful
+    # shim (re)create AND a fresh PATH insertion, so idempotent re-runs stay
+    # quiet.
+    $pathAdded = $false
+    if (Test-Path $ShimExe) {
+        $pathAdded = Add-ToUserPath -Directory $ShimDir -Position 'Prepend'
+    }
     if ($shimUpdated -and $pathAdded) {
         step "path" "added unsloth launcher to PATH"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -142,6 +142,22 @@ function Install-UnslothStudio {
                         return $false  # already present
                     }
                 }
+                # One-time backup of the pristine User PATH before our first
+                # mutation. Stored under HKCU\Software\Unsloth so a wiped/clobbered
+                # PATH can be recovered. Idempotent: existing backup is preserved.
+                if ($rawPath) {
+                    try {
+                        $backupKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Software\Unsloth')
+                        try {
+                            $existingBackup = $backupKey.GetValue('PathBackup', $null)
+                            if (-not $existingBackup) {
+                                $backupKey.SetValue('PathBackup', $rawPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+                            }
+                        } finally {
+                            $backupKey.Close()
+                        }
+                    } catch { }
+                }
                 if (-not $rawPath) {
                     Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
                 }

--- a/install.ps1
+++ b/install.ps1
@@ -1095,16 +1095,43 @@ shell.Run cmd, 0, False
     $ShimDir = Join-Path $StudioHome "bin"
     New-Item -ItemType Directory -Force -Path $ShimDir | Out-Null
     $ShimExe = Join-Path $ShimDir "unsloth.exe"
-    if (Test-Path $ShimExe) { Remove-Item $ShimExe -Force }
+    # Wrap the whole remove/link/copy sequence in a try/catch so a locked
+    # launcher does not crash the installer. The common case is a re-run
+    # while the user still has `unsloth studio` open: the existing shim is
+    # held open by the running process, Remove-Item refuses (and under the
+    # script's $ErrorActionPreference this would otherwise be fatal). When
+    # that happens the existing shim is perfectly usable, so we log and
+    # keep going instead of aborting the install.
+    $shimUpdated = $false
     try {
-        New-Item -ItemType HardLink -Path $ShimExe -Target $UnslothExe -ErrorAction Stop | Out-Null
+        if (Test-Path $ShimExe) { Remove-Item $ShimExe -Force -ErrorAction Stop }
+        try {
+            New-Item -ItemType HardLink -Path $ShimExe -Target $UnslothExe -ErrorAction Stop | Out-Null
+        } catch {
+            # Hardlink unavailable (cross-volume, non-NTFS, permissions). Copy
+            # is self-contained; future pip upgrades inside the venv will not
+            # update the copy until the user re-runs the installer.
+            Copy-Item -Path $UnslothExe -Destination $ShimExe -Force -ErrorAction Stop
+        }
+        $shimUpdated = $true
     } catch {
-        # Hardlink unavailable (cross-volume, non-NTFS, permissions). Copy is
-        # self-contained; future pip upgrades inside the venv will not update
-        # the copy until the user re-runs the installer.
-        Copy-Item -Path $UnslothExe -Destination $ShimExe -Force
+        if (Test-Path $ShimExe) {
+            Write-Host "[WARN] Could not refresh unsloth launcher at $ShimExe." -ForegroundColor Yellow
+            Write-Host "       This usually means a running 'unsloth studio' process still holds the file open." -ForegroundColor Yellow
+            Write-Host "       Close Studio and re-run the installer to pick up the latest launcher." -ForegroundColor Yellow
+            Write-Host "       Continuing with the existing launcher." -ForegroundColor Yellow
+        } else {
+            Write-Host "[WARN] Could not create unsloth launcher at $ShimExe" -ForegroundColor Yellow
+            Write-Host "       $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Host "       Launch unsloth studio directly via '$UnslothExe' until the next successful install." -ForegroundColor Yellow
+        }
     }
-    if (Add-ToUserPath -Directory $ShimDir -Position 'Prepend') {
+    # Only advertise the new launcher when it was actually (re)created and
+    # the shim directory was newly added to PATH. If the shim already
+    # existed on disk AND was already on PATH, both conditions are false
+    # and we stay quiet.
+    $pathAdded = Add-ToUserPath -Directory $ShimDir -Position 'Prepend'
+    if ($shimUpdated -and $pathAdded) {
         step "path" "added unsloth launcher to PATH"
     }
     # Sync the current session unconditionally so re-runs in stale terminals

--- a/install.ps1
+++ b/install.ps1
@@ -124,11 +124,7 @@ function Install-UnslothStudio {
             [Parameter(Mandatory = $true)][string]$Directory
         )
         try {
-            $regKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
-            if (-not $regKey) {
-                Write-Host "[WARN] Could not open HKCU\Environment registry key" -ForegroundColor Yellow
-                return $false
-            }
+            $regKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
             try {
                 $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
                 $entries = if ($rawPath) { $rawPath -split ';' } else { @() }

--- a/install.ps1
+++ b/install.ps1
@@ -1033,6 +1033,11 @@ shell.Run cmd, 0, False
     New-StudioShortcuts -UnslothExePath $UnslothExe
 
     # ── Add venv Scripts dir to User PATH so `unsloth studio` works from any terminal ──
+    # Use the default Append position here: this venv dir holds python.exe and
+    # pip.exe alongside unsloth.exe, so prepending would silently hijack the
+    # user's system python / pip in every future shell. Desktop shortcuts and
+    # the launch-studio wrapper call unsloth.exe by absolute path, so studio
+    # itself does not rely on this entry winning resolution races.
     $ScriptsDir = Join-Path $VenvDir "Scripts"
     if (Add-ToUserPath -Directory $ScriptsDir) {
         Refresh-SessionPath

--- a/install.ps1
+++ b/install.ps1
@@ -1079,18 +1079,31 @@ shell.Run cmd, 0, False
     # Append makes the installer's newly-built unsloth.exe lose to any older
     # unsloth.exe the user already had earlier on PATH. Both are bad.
     #
-    # Instead we create a small directory that contains only a wrapper batch
-    # file pointing at the venv's unsloth.exe by absolute path, and Prepend
-    # just that directory. Result:
-    #   - `unsloth` in any terminal resolves to the studio install
-    #   - `python` / `pip` stay untouched (only unsloth.cmd sits in the shim dir)
-    #   - the wrapper always calls the venv's unsloth.exe by absolute path so
-    #     future pip-upgrades of unsloth inside the venv propagate automatically
+    # Instead we create a small directory that contains only the unsloth
+    # launcher (hardlinked or copied from the venv's Scripts\unsloth.exe),
+    # and Prepend just that directory. Benefits over a .cmd wrapper:
+    #   - no batch %...% expansion of user arguments (e.g. prompts with `%`)
+    #   - works in Git Bash / MSYS2 / POSIX-style shells on Windows that do
+    #     not resolve .cmd by bare name
+    #   - no source encoding concerns on non-ASCII profile paths
+    #   - programmatic callers (subprocess.run, child_process.execFile) hit
+    #     the native executable directly instead of shelling into cmd.exe
+    # We try a hardlink first so pip upgrades inside the venv propagate
+    # automatically (same inode). If the filesystem or volume rejects the
+    # hardlink we fall back to a plain copy, which the next install run
+    # will refresh.
     $ShimDir = Join-Path $StudioHome "bin"
     New-Item -ItemType Directory -Force -Path $ShimDir | Out-Null
-    $ShimCmd = Join-Path $ShimDir "unsloth.cmd"
-    $ShimBody = "@echo off`r`n`"$UnslothExe`" %*`r`nexit /b %ERRORLEVEL%`r`n"
-    Set-Content -Path $ShimCmd -Value $ShimBody -Encoding ASCII -NoNewline
+    $ShimExe = Join-Path $ShimDir "unsloth.exe"
+    if (Test-Path $ShimExe) { Remove-Item $ShimExe -Force }
+    try {
+        New-Item -ItemType HardLink -Path $ShimExe -Target $UnslothExe -ErrorAction Stop | Out-Null
+    } catch {
+        # Hardlink unavailable (cross-volume, non-NTFS, permissions). Copy is
+        # self-contained; future pip upgrades inside the venv will not update
+        # the copy until the user re-runs the installer.
+        Copy-Item -Path $UnslothExe -Destination $ShimExe -Force
+    }
     if (Add-ToUserPath -Directory $ShimDir -Position 'Prepend') {
         step "path" "added unsloth launcher to PATH"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -100,13 +100,23 @@ function Install-UnslothStudio {
     Write-Host ""
 
     # ── Helper: refresh PATH from registry (deduplicating entries) ──
-    # Process entries first so an activated venv keeps precedence, then
-    # machine/user. Dedup by both raw and expanded form so %VAR% and
-    # already-expanded copies of the same dir don't both survive.
+    # Merge order:
+    #   1. Activated venv Scripts dir (only if $env:VIRTUAL_ENV is set) so an
+    #      explicitly-activated venv keeps precedence.
+    #   2. Machine, then User PATH freshly read from registry so a tool we
+    #      just installed wins over any stale shim still in $env:Path.
+    #   3. Current $env:Path as fallback so process-only entries that nothing
+    #      else covers are not lost.
+    # Dedup compares both raw and expanded forms so %VAR% references don't
+    # survive twice (once as %VAR%\foo and once as the expanded literal).
     function Refresh-SessionPath {
         $machine = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
         $user    = [System.Environment]::GetEnvironmentVariable("Path", "User")
-        $merged  = "$env:Path;$machine;$user"
+        $venvScripts = if ($env:VIRTUAL_ENV) { Join-Path $env:VIRTUAL_ENV "Scripts" } else { $null }
+        $sources = @()
+        if ($venvScripts) { $sources += $venvScripts }
+        $sources += @($machine, $user, $env:Path)
+        $merged = ($sources | Where-Object { $_ }) -join ";"
         $seen    = @{}
         $unique  = New-Object System.Collections.Generic.List[string]
         foreach ($p in $merged -split ";") {

--- a/install.ps1
+++ b/install.ps1
@@ -134,9 +134,19 @@ function Install-UnslothStudio {
     # ── Helper: safely add a directory to the persistent User PATH ──
     # Uses direct registry access to preserve REG_EXPAND_SZ type
     # (avoids .NET SetEnvironmentVariable bug that converts to REG_SZ).
+    #
+    # Position: 'Append' (default) adds $Directory to the END of the persisted
+    # User PATH so existing user tools (e.g. system python, pip) keep taking
+    # precedence in new shells. This matches rustup/cargo/nvm/pyenv/uv behavior
+    # and avoids silently hijacking resolution of common executables. Pass
+    # 'Prepend' only when a caller truly needs the new entry to win over
+    # existing ones at registry scope. In-session precedence should be handled
+    # by an inline $env:Path = "$Dir;$env:Path" prepend instead.
     function Add-ToUserPath {
         param(
-            [Parameter(Mandatory = $true)][string]$Directory
+            [Parameter(Mandatory = $true)][string]$Directory,
+            [ValidateSet('Append','Prepend')]
+            [string]$Position = 'Append'
         )
         try {
             $regKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
@@ -171,7 +181,11 @@ function Install-UnslothStudio {
                 if (-not $rawPath) {
                     Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
                 }
-                $newPath = if ($rawPath) { "$Directory;$rawPath" } else { $Directory }
+                $newPath = if ($rawPath) {
+                    if ($Position -eq 'Prepend') { "$Directory;$rawPath" } else { "$rawPath;$Directory" }
+                } else {
+                    $Directory
+                }
                 $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
                 # Broadcast WM_SETTINGCHANGE so other processes pick up the change
                 try {

--- a/install.ps1
+++ b/install.ps1
@@ -142,9 +142,11 @@ function Install-UnslothStudio {
                 $newPath = if ($rawPath) { "$Directory;$rawPath" } else { $Directory }
                 $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
                 # Broadcast WM_SETTINGCHANGE so other processes pick up the change
-                $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
-                [Environment]::SetEnvironmentVariable($d, '1', 'User')
-                [Environment]::SetEnvironmentVariable($d, $null, 'User')
+                try {
+                    $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+                    [Environment]::SetEnvironmentVariable($d, '1', 'User')
+                    [Environment]::SetEnvironmentVariable($d, $null, 'User')
+                } catch { }
                 return $true
             } finally {
                 $regKey.Close()

--- a/install.ps1
+++ b/install.ps1
@@ -105,12 +105,12 @@ function Install-UnslothStudio {
         $user    = [System.Environment]::GetEnvironmentVariable("Path", "User")
         $merged  = "$machine;$user;$env:Path"
         $seen    = @{}
-        $unique  = @()
+        $unique  = New-Object System.Collections.Generic.List[string]
         foreach ($p in $merged -split ";") {
             $key = $p.TrimEnd("\").ToLowerInvariant()
             if ($key -and -not $seen.ContainsKey($key)) {
                 $seen[$key] = $true
-                $unique += $p
+                $unique.Add($p)
             }
         }
         $env:Path = $unique -join ";"
@@ -134,7 +134,9 @@ function Install-UnslothStudio {
                 $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
                 $normalDir = $Directory.TrimEnd('\').ToLowerInvariant()
                 foreach ($entry in $entries) {
-                    if ($entry.TrimEnd('\').ToLowerInvariant() -eq $normalDir) {
+                    $rawNorm = $entry.TrimEnd('\').ToLowerInvariant()
+                    $expNorm = [Environment]::ExpandEnvironmentVariables($entry).TrimEnd('\').ToLowerInvariant()
+                    if ($rawNorm -eq $normalDir -or $expNorm -eq $normalDir) {
                         return $false  # already present
                     }
                 }

--- a/install.ps1
+++ b/install.ps1
@@ -100,16 +100,21 @@ function Install-UnslothStudio {
     Write-Host ""
 
     # ── Helper: refresh PATH from registry (deduplicating entries) ──
+    # Process entries first so an activated venv keeps precedence, then
+    # machine/user. Dedup by both raw and expanded form so %VAR% and
+    # already-expanded copies of the same dir don't both survive.
     function Refresh-SessionPath {
         $machine = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
         $user    = [System.Environment]::GetEnvironmentVariable("Path", "User")
-        $merged  = "$machine;$user;$env:Path"
+        $merged  = "$env:Path;$machine;$user"
         $seen    = @{}
         $unique  = New-Object System.Collections.Generic.List[string]
         foreach ($p in $merged -split ";") {
-            $key = $p.TrimEnd("\").ToLowerInvariant()
-            if ($key -and -not $seen.ContainsKey($key)) {
-                $seen[$key] = $true
+            $rawKey = $p.Trim().Trim('"').TrimEnd("\").ToLowerInvariant()
+            $expKey = [Environment]::ExpandEnvironmentVariables($p).Trim().Trim('"').TrimEnd("\").ToLowerInvariant()
+            if ($rawKey -and -not $seen.ContainsKey($rawKey) -and -not $seen.ContainsKey($expKey)) {
+                $seen[$rawKey] = $true
+                if ($expKey -and $expKey -ne $rawKey) { $seen[$expKey] = $true }
                 $unique.Add($p)
             }
         }
@@ -128,10 +133,11 @@ function Install-UnslothStudio {
             try {
                 $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
                 $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
-                $normalDir = $Directory.TrimEnd('\').ToLowerInvariant()
+                $normalDir = $Directory.Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
                 foreach ($entry in $entries) {
-                    $rawNorm = $entry.TrimEnd('\').ToLowerInvariant()
-                    $expNorm = [Environment]::ExpandEnvironmentVariables($entry).TrimEnd('\').ToLowerInvariant()
+                    $stripped = $entry.Trim().Trim('"')
+                    $rawNorm = $stripped.TrimEnd('\').ToLowerInvariant()
+                    $expNorm = [Environment]::ExpandEnvironmentVariables($stripped).TrimEnd('\').ToLowerInvariant()
                     if ($rawNorm -eq $normalDir -or $expNorm -eq $normalDir) {
                         return $false  # already present
                     }

--- a/install.ps1
+++ b/install.ps1
@@ -152,15 +152,44 @@ function Install-UnslothStudio {
             $regKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
             try {
                 $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
-                $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
+                # Explicit string[] cast: a single-entry split otherwise collapses
+                # to a scalar string, which then gets char-indexed and breaks the
+                # partition loop below.
+                [string[]]$entries = if ($rawPath) { $rawPath -split ';' } else { @() }
+                # Normalize both the raw and expanded forms of the new directory
+                # so dedup catches mirror-image cases: PATH holding %USERPROFILE%\foo
+                # vs Directory passed as C:\Users\me\foo, and vice versa.
                 $normalDir = $Directory.Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
-                foreach ($entry in $entries) {
-                    $stripped = $entry.Trim().Trim('"')
+                $expNormalDir = [Environment]::ExpandEnvironmentVariables($Directory).Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
+                # Partition existing entries into "kept" (not our dir) and "dropped"
+                # (matches our dir). Track match indices so we can distinguish
+                # "already at position 0" from "present but at a late position".
+                $kept = New-Object System.Collections.Generic.List[string]
+                $matchIndices = New-Object System.Collections.Generic.List[int]
+                for ($i = 0; $i -lt $entries.Count; $i++) {
+                    $stripped = $entries[$i].Trim().Trim('"')
                     $rawNorm = $stripped.TrimEnd('\').ToLowerInvariant()
                     $expNorm = [Environment]::ExpandEnvironmentVariables($stripped).TrimEnd('\').ToLowerInvariant()
-                    if ($rawNorm -eq $normalDir -or $expNorm -eq $normalDir) {
-                        return $false  # already present
+                    $isMatch = ($rawNorm -and ($rawNorm -eq $normalDir -or $rawNorm -eq $expNormalDir)) -or
+                               ($expNorm -and ($expNorm -eq $normalDir -or $expNorm -eq $expNormalDir))
+                    if ($isMatch) {
+                        $matchIndices.Add($i)
+                        continue
                     }
+                    $kept.Add($entries[$i])
+                }
+                $alreadyPresent = $matchIndices.Count -gt 0
+                # Append semantics: if the entry is already anywhere in PATH we
+                # leave it untouched (idempotent, never reorder user-curated order).
+                if ($alreadyPresent -and $Position -eq 'Append') {
+                    return $false
+                }
+                # Prepend semantics: if the entry is already at position 0 with
+                # exactly one copy, preserve the user's existing casing/form and
+                # no-op. Only rebuild when a reorder or dedup is actually needed.
+                if ($alreadyPresent -and $Position -eq 'Prepend' -and
+                    $matchIndices.Count -eq 1 -and $matchIndices[0] -eq 0) {
+                    return $false
                 }
                 # One-time backup of the pristine User PATH before our first
                 # mutation. Stored under HKCU\Software\Unsloth so a wiped/clobbered
@@ -179,12 +208,23 @@ function Install-UnslothStudio {
                     } catch { }
                 }
                 if (-not $rawPath) {
-                    Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
+                    Write-Host "[WARN] User PATH is empty - initializing with $Directory" -ForegroundColor Yellow
                 }
                 $newPath = if ($rawPath) {
-                    if ($Position -eq 'Prepend') { "$Directory;$rawPath" } else { "$rawPath;$Directory" }
+                    if ($Position -eq 'Prepend') {
+                        (@($Directory) + $kept) -join ';'
+                    } else {
+                        ($kept + @($Directory)) -join ';'
+                    }
                 } else {
                     $Directory
+                }
+                # Prepend idempotency: if the new directory was already at
+                # position 0 (and no duplicates existed elsewhere) the composed
+                # string matches rawPath byte-for-byte. Skip the registry write
+                # so we do not broadcast an unnecessary WM_SETTINGCHANGE.
+                if ($newPath -ceq $rawPath) {
+                    return $false
                 }
                 $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
                 # Broadcast WM_SETTINGCHANGE so other processes pick up the change
@@ -1032,17 +1072,33 @@ shell.Run cmd, 0, False
 
     New-StudioShortcuts -UnslothExePath $UnslothExe
 
-    # ── Add venv Scripts dir to User PATH so `unsloth studio` works from any terminal ──
-    # Use the default Append position here: this venv dir holds python.exe and
-    # pip.exe alongside unsloth.exe, so prepending would silently hijack the
-    # user's system python / pip in every future shell. Desktop shortcuts and
-    # the launch-studio wrapper call unsloth.exe by absolute path, so studio
-    # itself does not rely on this entry winning resolution races.
-    $ScriptsDir = Join-Path $VenvDir "Scripts"
-    if (Add-ToUserPath -Directory $ScriptsDir) {
-        Refresh-SessionPath
-        step "path" "added unsloth to PATH"
+    # ── Expose the `unsloth` command via a single-purpose shim directory ──
+    # The venv's Scripts dir holds python.exe and pip.exe alongside unsloth.exe,
+    # so adding that dir to PATH (at either position) has unwanted side effects:
+    # Prepend hijacks the user's system python / pip in every future shell;
+    # Append makes the installer's newly-built unsloth.exe lose to any older
+    # unsloth.exe the user already had earlier on PATH. Both are bad.
+    #
+    # Instead we create a small directory that contains only a wrapper batch
+    # file pointing at the venv's unsloth.exe by absolute path, and Prepend
+    # just that directory. Result:
+    #   - `unsloth` in any terminal resolves to the studio install
+    #   - `python` / `pip` stay untouched (only unsloth.cmd sits in the shim dir)
+    #   - the wrapper always calls the venv's unsloth.exe by absolute path so
+    #     future pip-upgrades of unsloth inside the venv propagate automatically
+    $ShimDir = Join-Path $StudioHome "bin"
+    New-Item -ItemType Directory -Force -Path $ShimDir | Out-Null
+    $ShimCmd = Join-Path $ShimDir "unsloth.cmd"
+    $ShimBody = "@echo off`r`n`"$UnslothExe`" %*`r`nexit /b %ERRORLEVEL%`r`n"
+    Set-Content -Path $ShimCmd -Value $ShimBody -Encoding ASCII -NoNewline
+    if (Add-ToUserPath -Directory $ShimDir -Position 'Prepend') {
+        step "path" "added unsloth launcher to PATH"
     }
+    # Sync the current session unconditionally so re-runs in stale terminals
+    # see the shim, and so PATH entries that the studio/setup.ps1 subprocess
+    # persisted (cmake, nvcc, Python Scripts) are visible in this parent
+    # process before it returns control to the user's shell.
+    Refresh-SessionPath
 
     # Launch studio automatically in interactive terminals;
     # in non-interactive environments (CI, Docker) just print instructions.

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -73,10 +73,20 @@ function Refresh-Environment {
     }
     $machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
     $userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
-    # Process entries first so an activated venv keeps precedence, then
-    # machine/user. Dedup by both raw and expanded form so %VAR% and
-    # already-expanded copies of the same dir don't both survive.
-    $merged = "$env:Path;$machinePath;$userPath"
+    # Merge order:
+    #   1. Activated venv Scripts dir (only if $env:VIRTUAL_ENV is set) so an
+    #      explicitly-activated venv keeps precedence.
+    #   2. Machine, then User PATH freshly read from registry so a tool we
+    #      just installed wins over any stale shim still in $env:Path.
+    #   3. Current $env:Path as fallback so process-only entries that nothing
+    #      else covers are not lost.
+    # Dedup compares both raw and expanded forms so %VAR% references don't
+    # survive twice (once as %VAR%\foo and once as the expanded literal).
+    $venvScripts = if ($env:VIRTUAL_ENV) { Join-Path $env:VIRTUAL_ENV 'Scripts' } else { $null }
+    $sources = @()
+    if ($venvScripts) { $sources += $venvScripts }
+    $sources += @($machinePath, $userPath, $env:Path)
+    $merged = ($sources | Where-Object { $_ }) -join ';'
     $seen = @{}
     $unique = New-Object System.Collections.Generic.List[string]
     foreach ($p in $merged -split ";") {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -73,13 +73,18 @@ function Refresh-Environment {
     }
     $machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
     $userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
-    $merged = "$machinePath;$userPath;$env:Path"
+    # Process entries first so an activated venv keeps precedence, then
+    # machine/user. Dedup by both raw and expanded form so %VAR% and
+    # already-expanded copies of the same dir don't both survive.
+    $merged = "$env:Path;$machinePath;$userPath"
     $seen = @{}
     $unique = New-Object System.Collections.Generic.List[string]
     foreach ($p in $merged -split ";") {
-        $key = $p.TrimEnd("\").ToLowerInvariant()
-        if ($key -and -not $seen.ContainsKey($key)) {
-            $seen[$key] = $true
+        $rawKey = $p.Trim().Trim('"').TrimEnd("\").ToLowerInvariant()
+        $expKey = [Environment]::ExpandEnvironmentVariables($p).Trim().Trim('"').TrimEnd("\").ToLowerInvariant()
+        if ($rawKey -and -not $seen.ContainsKey($rawKey) -and -not $seen.ContainsKey($expKey)) {
+            $seen[$rawKey] = $true
+            if ($expKey -and $expKey -ne $rawKey) { $seen[$expKey] = $true }
             $unique.Add($p)
         }
     }
@@ -98,10 +103,11 @@ function Add-ToUserPath {
         try {
             $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
             $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
-            $normalDir = $Directory.TrimEnd('\').ToLowerInvariant()
+            $normalDir = $Directory.Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
             foreach ($entry in $entries) {
-                $rawNorm = $entry.TrimEnd('\').ToLowerInvariant()
-                $expNorm = [Environment]::ExpandEnvironmentVariables($entry).TrimEnd('\').ToLowerInvariant()
+                $stripped = $entry.Trim().Trim('"')
+                $rawNorm = $stripped.TrimEnd('\').ToLowerInvariant()
+                $expNorm = [Environment]::ExpandEnvironmentVariables($stripped).TrimEnd('\').ToLowerInvariant()
                 if ($rawNorm -eq $normalDir -or $expNorm -eq $normalDir) {
                     return $false  # already present
                 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -94,11 +94,7 @@ function Add-ToUserPath {
         [Parameter(Mandatory = $true)][string]$Directory
     )
     try {
-        $regKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
-        if (-not $regKey) {
-            Write-Host "[WARN] Could not open HKCU\Environment registry key" -ForegroundColor Yellow
-            return $false
-        }
+        $regKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
         try {
             $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
             $entries = if ($rawPath) { $rawPath -split ';' } else { @() }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1225,14 +1225,22 @@ if ($HasPython) {
     $PythonOk = $true
 }
 
-# Ensure Python Scripts dir is on PATH (so 'unsloth' command works in new terminals)
-$ScriptsDir = python -c "import sysconfig; print(sysconfig.get_path('scripts', 'nt_user') if __import__('os').path.exists(sysconfig.get_path('scripts', 'nt_user')) else sysconfig.get_path('scripts'))"
+# Ensure the user-scheme Python Scripts dir is on PATH so any pip-installed
+# console scripts (including `unsloth` if installed via `pip install --user`)
+# are discoverable in new terminals. Stick strictly to the 'nt_user' scheme:
+# we do NOT fall back to sysconfig.get_path('scripts') because that returns
+# the venv's Scripts dir when this setup.ps1 is invoked inside an activated
+# venv, which would re-introduce the python / pip hijack that the dedicated
+# shim directory (install.ps1) was designed to avoid.
+$ScriptsDir = python -c "import os, sysconfig; p = sysconfig.get_path('scripts', 'nt_user'); print(p if os.path.exists(p) else '')"
 if ($LASTEXITCODE -eq 0 -and $ScriptsDir -and (Test-Path $ScriptsDir)) {
-    # Prepend so the freshly installed `unsloth` console script wins over any
-    # older pip-installed copy already earlier on the user PATH. This dir holds
-    # entry points only (python.exe lives one level up), so prepending does not
-    # hijack the user's python interpreter.
-    if (Add-ToUserPath -Directory $ScriptsDir -Position 'Prepend') {
+    # Use Append semantics here: this dir holds ALL user-installed pip
+    # console scripts (pip, pytest, huggingface-cli, etc.), and reordering
+    # it to the front of PATH would silently change resolution precedence
+    # for every one of those tools. Install.ps1 already guarantees the new
+    # `unsloth` wins via a dedicated shim dir at PATH position 0, so we
+    # only need to make sure this directory is present, not at the front.
+    if (Add-ToUserPath -Directory $ScriptsDir) {
         # Also add to current process so it's available immediately
         $ProcessPathEntries = $env:PATH.Split(';')
         if (-not ($ProcessPathEntries | Where-Object { $_.TrimEnd('\') -eq $ScriptsDir })) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -752,8 +752,11 @@ if (-not $HasCmake) {
         foreach ($d in $cmakeDefaults) {
             if (Test-Path (Join-Path $d "cmake.exe")) {
                 $env:Path = "$d;$env:Path"
-                # Persist to user PATH so Refresh-Environment does not drop it later
-                Add-ToUserPath -Directory $d | Out-Null
+                # Persist to user PATH so Refresh-Environment does not drop it later.
+                # Prepend so the newly-selected cmake wins over any older cmake
+                # entry already in the user PATH (this dir has only cmake.exe, no
+                # python.exe, so prepending does not hijack the user's interpreter).
+                Add-ToUserPath -Directory $d -Position 'Prepend' | Out-Null
                 $HasCmake = $null -ne (Get-Command cmake -ErrorAction SilentlyContinue)
                 if ($HasCmake) {
                     Write-Host "   Found cmake at $d (added to PATH)" -ForegroundColor Gray
@@ -1019,8 +1022,12 @@ $nvccBinDir = Split-Path $NvccPath -Parent
 if ($env:PATH -notlike "*$nvccBinDir*") {
     [Environment]::SetEnvironmentVariable('PATH', "$nvccBinDir;$env:PATH", 'Process')
 }
-# Persist nvcc bin dir to User PATH so it works in new terminals
-if (Add-ToUserPath -Directory $nvccBinDir) {
+# Persist nvcc bin dir to User PATH so it works in new terminals.
+# Prepend so the toolkit we just selected (driver-compatible) wins over any
+# older CUDA bin dir already on the user PATH. Critical for llama.cpp builds:
+# a later Refresh-Environment could otherwise reorder the selected nvcc behind
+# a stale one. No hijack risk since this dir has only CUDA tools, no python.
+if (Add-ToUserPath -Directory $nvccBinDir -Position 'Prepend') {
     substep "Persisted CUDA bin dir to user PATH"
 }
 
@@ -1181,7 +1188,11 @@ if ($HasPython) {
 # Ensure Python Scripts dir is on PATH (so 'unsloth' command works in new terminals)
 $ScriptsDir = python -c "import sysconfig; print(sysconfig.get_path('scripts', 'nt_user') if __import__('os').path.exists(sysconfig.get_path('scripts', 'nt_user')) else sysconfig.get_path('scripts'))"
 if ($LASTEXITCODE -eq 0 -and $ScriptsDir -and (Test-Path $ScriptsDir)) {
-    if (Add-ToUserPath -Directory $ScriptsDir) {
+    # Prepend so the freshly installed `unsloth` console script wins over any
+    # older pip-installed copy already earlier on the user PATH. This dir holds
+    # entry points only (python.exe lives one level up), so prepending does not
+    # hijack the user's python interpreter.
+    if (Add-ToUserPath -Directory $ScriptsDir -Position 'Prepend') {
         # Also add to current process so it's available immediately
         $ProcessPathEntries = $env:PATH.Split(';')
         if (-not ($ProcessPathEntries | Where-Object { $_.TrimEnd('\') -eq $ScriptsDir })) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -122,15 +122,44 @@ function Add-ToUserPath {
         $regKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
         try {
             $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
-            $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
+            # Explicit string[] cast: a single-entry split otherwise collapses
+            # to a scalar string, which then gets char-indexed and breaks the
+            # partition loop below.
+            [string[]]$entries = if ($rawPath) { $rawPath -split ';' } else { @() }
+            # Normalize both the raw and expanded forms of the new directory
+            # so dedup catches mirror-image cases: PATH holding %USERPROFILE%\foo
+            # vs Directory passed as C:\Users\me\foo, and vice versa.
             $normalDir = $Directory.Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
-            foreach ($entry in $entries) {
-                $stripped = $entry.Trim().Trim('"')
+            $expNormalDir = [Environment]::ExpandEnvironmentVariables($Directory).Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
+            # Partition existing entries into "kept" (not our dir) and "dropped"
+            # (matches our dir). Track match indices so we can distinguish
+            # "already at position 0" from "present but at a late position".
+            $kept = New-Object System.Collections.Generic.List[string]
+            $matchIndices = New-Object System.Collections.Generic.List[int]
+            for ($i = 0; $i -lt $entries.Count; $i++) {
+                $stripped = $entries[$i].Trim().Trim('"')
                 $rawNorm = $stripped.TrimEnd('\').ToLowerInvariant()
                 $expNorm = [Environment]::ExpandEnvironmentVariables($stripped).TrimEnd('\').ToLowerInvariant()
-                if ($rawNorm -eq $normalDir -or $expNorm -eq $normalDir) {
-                    return $false  # already present
+                $isMatch = ($rawNorm -and ($rawNorm -eq $normalDir -or $rawNorm -eq $expNormalDir)) -or
+                           ($expNorm -and ($expNorm -eq $normalDir -or $expNorm -eq $expNormalDir))
+                if ($isMatch) {
+                    $matchIndices.Add($i)
+                    continue
                 }
+                $kept.Add($entries[$i])
+            }
+            $alreadyPresent = $matchIndices.Count -gt 0
+            # Append semantics: if the entry is already anywhere in PATH we
+            # leave it untouched (idempotent, never reorder user-curated order).
+            if ($alreadyPresent -and $Position -eq 'Append') {
+                return $false
+            }
+            # Prepend semantics: if the entry is already at position 0 with
+            # exactly one copy, preserve the user's existing casing/form and
+            # no-op. Only rebuild when a reorder or dedup is actually needed.
+            if ($alreadyPresent -and $Position -eq 'Prepend' -and
+                $matchIndices.Count -eq 1 -and $matchIndices[0] -eq 0) {
+                return $false
             }
             # One-time backup of the pristine User PATH before our first
             # mutation. Stored under HKCU\Software\Unsloth so a wiped/clobbered
@@ -151,12 +180,23 @@ function Add-ToUserPath {
                 } catch { }
             }
             if (-not $rawPath) {
-                Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
+                Write-Host "[WARN] User PATH is empty - initializing with $Directory" -ForegroundColor Yellow
             }
             $newPath = if ($rawPath) {
-                if ($Position -eq 'Prepend') { "$Directory;$rawPath" } else { "$rawPath;$Directory" }
+                if ($Position -eq 'Prepend') {
+                    (@($Directory) + $kept) -join ';'
+                } else {
+                    ($kept + @($Directory)) -join ';'
+                }
             } else {
                 $Directory
+            }
+            # Prepend idempotency: if the new directory was already at
+            # position 0 (and no duplicates existed elsewhere) the composed
+            # string matches rawPath byte-for-byte. Skip the registry write
+            # so we do not broadcast an unnecessary WM_SETTINGCHANGE.
+            if ($newPath -ceq $rawPath) {
+                return $false
             }
             $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
             # Broadcast WM_SETTINGCHANGE so other processes pick up the change

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -199,11 +199,17 @@ function Add-ToUserPath {
                 return $false
             }
             $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
-            # Broadcast WM_SETTINGCHANGE so other processes pick up the change
+            # Broadcast WM_SETTINGCHANGE so other processes pick up the change.
+            # Use [NullString]::Value (not $null) for the delete call so the
+            # sentinel crosses into .NET as a real null reference -- on
+            # PowerShell 7.5+ / .NET 9, a bare $null here can be coerced to
+            # an empty string, which sets the dummy variable to "" instead
+            # of deleting it and leaves UnslothPathRefresh_XXXXXXXX in
+            # HKCU\Environment permanently.
             try {
                 $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
                 [Environment]::SetEnvironmentVariable($d, '1', 'User')
-                [Environment]::SetEnvironmentVariable($d, $null, 'User')
+                [Environment]::SetEnvironmentVariable($d, [NullString]::Value, 'User')
             } catch { }
             return $true
         } finally {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -112,9 +112,11 @@ function Add-ToUserPath {
             $newPath = if ($rawPath) { "$Directory;$rawPath" } else { $Directory }
             $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
             # Broadcast WM_SETTINGCHANGE so other processes pick up the change
-            $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
-            [Environment]::SetEnvironmentVariable($d, '1', 'User')
-            [Environment]::SetEnvironmentVariable($d, $null, 'User')
+            try {
+                $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+                [Environment]::SetEnvironmentVariable($d, '1', 'User')
+                [Environment]::SetEnvironmentVariable($d, $null, 'User')
+            } catch { }
             return $true
         } finally {
             $regKey.Close()

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -112,6 +112,24 @@ function Add-ToUserPath {
                     return $false  # already present
                 }
             }
+            # One-time backup of the pristine User PATH before our first
+            # mutation. Stored under HKCU\Software\Unsloth so a wiped/clobbered
+            # PATH can be recovered. Idempotent: existing backup is preserved.
+            # The script-top backup at line ~547 covers the studio entry point;
+            # this in-helper backup also covers callers that bypass that block.
+            if ($rawPath) {
+                try {
+                    $backupKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Software\Unsloth')
+                    try {
+                        $existingBackup = $backupKey.GetValue('PathBackup', $null)
+                        if (-not $existingBackup) {
+                            $backupKey.SetValue('PathBackup', $rawPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+                        }
+                    } finally {
+                        $backupKey.Close()
+                    }
+                } catch { }
+            }
             if (-not $rawPath) {
                 Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
             }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -73,7 +73,58 @@ function Refresh-Environment {
     }
     $machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
     $userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
-    $env:Path = "$machinePath;$userPath"
+    $merged = "$machinePath;$userPath;$env:Path"
+    $seen = @{}
+    $unique = @()
+    foreach ($p in $merged -split ";") {
+        $key = $p.TrimEnd("\").ToLowerInvariant()
+        if ($key -and -not $seen.ContainsKey($key)) {
+            $seen[$key] = $true
+            $unique += $p
+        }
+    }
+    $env:Path = $unique -join ";"
+}
+
+# ── Helper: safely add a directory to the persistent User PATH ──
+# Uses direct registry access to preserve REG_EXPAND_SZ type
+# (avoids .NET SetEnvironmentVariable bug that converts to REG_SZ).
+function Add-ToUserPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Directory
+    )
+    try {
+        $regKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+        if (-not $regKey) {
+            Write-Host "[WARN] Could not open HKCU\Environment registry key" -ForegroundColor Yellow
+            return $false
+        }
+        try {
+            $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
+            $normalDir = $Directory.TrimEnd('\').ToLowerInvariant()
+            foreach ($entry in $entries) {
+                if ($entry.TrimEnd('\').ToLowerInvariant() -eq $normalDir) {
+                    return $false  # already present
+                }
+            }
+            if (-not $rawPath) {
+                Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
+            }
+            $newPath = if ($rawPath) { "$Directory;$rawPath" } else { $Directory }
+            $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+            # Broadcast WM_SETTINGCHANGE so other processes pick up the change
+            $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            [Environment]::SetEnvironmentVariable($d, '1', 'User')
+            [Environment]::SetEnvironmentVariable($d, $null, 'User')
+            return $true
+        } finally {
+            $regKey.Close()
+        }
+    } catch {
+        Write-Host "[WARN] Could not update User PATH: $($_.Exception.Message)" -ForegroundColor Yellow
+        return $false
+    }
 }
 
 # PowerShell 5.1 compatibility helper: avoid relying on New-TemporaryFile.
@@ -493,6 +544,21 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
     Write-Host "  $Rule" -ForegroundColor DarkGray
 }
 
+# Back up User PATH before any modifications for recovery
+try {
+    $regKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+    if ($regKey) {
+        $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $existingBackup = $regKey.GetValue('UNSLOTH_PATH_BACKUP', $null)
+        if ($rawPath -and -not $existingBackup) {
+            $regKey.SetValue('UNSLOTH_PATH_BACKUP', $rawPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+        }
+        $regKey.Close()
+    }
+} catch {
+    Write-Host "[DEBUG] Could not back up User PATH: $($_.Exception.Message)" -ForegroundColor DarkGray
+}
+
 # ==========================================================================
 #  PHASE 1: System-level prerequisites (winget installs, env vars)
 #  All heavy system tool installs happen here BEFORE touching Python.
@@ -627,10 +693,7 @@ if (-not $HasCmake) {
             if (Test-Path (Join-Path $d "cmake.exe")) {
                 $env:Path = "$d;$env:Path"
                 # Persist to user PATH so Refresh-Environment does not drop it later
-                $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-                if (-not $userPath -or $userPath -notlike "*$d*") {
-                    [Environment]::SetEnvironmentVariable('Path', "$d;$userPath", 'User')
-                }
+                Add-ToUserPath -Directory $d | Out-Null
                 $HasCmake = $null -ne (Get-Command cmake -ErrorAction SilentlyContinue)
                 if ($HasCmake) {
                     Write-Host "   Found cmake at $d (added to PATH)" -ForegroundColor Gray
@@ -897,13 +960,7 @@ if ($env:PATH -notlike "*$nvccBinDir*") {
     [Environment]::SetEnvironmentVariable('PATH', "$nvccBinDir;$env:PATH", 'Process')
 }
 # Persist nvcc bin dir to User PATH so it works in new terminals
-$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-if (-not $userPath -or $userPath -notlike "*$nvccBinDir*") {
-    if ($userPath) {
-        [Environment]::SetEnvironmentVariable('Path', "$nvccBinDir;$userPath", 'User')
-    } else {
-        [Environment]::SetEnvironmentVariable('Path', "$nvccBinDir", 'User')
-    }
+if (Add-ToUserPath -Directory $nvccBinDir) {
     substep "Persisted CUDA bin dir to user PATH"
 }
 
@@ -1064,12 +1121,7 @@ if ($HasPython) {
 # Ensure Python Scripts dir is on PATH (so 'unsloth' command works in new terminals)
 $ScriptsDir = python -c "import sysconfig; print(sysconfig.get_path('scripts', 'nt_user') if __import__('os').path.exists(sysconfig.get_path('scripts', 'nt_user')) else sysconfig.get_path('scripts'))"
 if ($LASTEXITCODE -eq 0 -and $ScriptsDir -and (Test-Path $ScriptsDir)) {
-    $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-    $UserPathEntries = if ($UserPath) { $UserPath.Split(';') } else { @() }
-    if (-not ($UserPathEntries | Where-Object { $_.TrimEnd('\') -eq $ScriptsDir })) {
-        $newUserPath = if ($UserPath) { "$ScriptsDir;$UserPath" } else { $ScriptsDir }
-        [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
-
+    if (Add-ToUserPath -Directory $ScriptsDir) {
         # Also add to current process so it's available immediately
         $ProcessPathEntries = $env:PATH.Split(';')
         if (-not ($ProcessPathEntries | Where-Object { $_.TrimEnd('\') -eq $ScriptsDir })) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -75,12 +75,12 @@ function Refresh-Environment {
     $userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
     $merged = "$machinePath;$userPath;$env:Path"
     $seen = @{}
-    $unique = @()
+    $unique = New-Object System.Collections.Generic.List[string]
     foreach ($p in $merged -split ";") {
         $key = $p.TrimEnd("\").ToLowerInvariant()
         if ($key -and -not $seen.ContainsKey($key)) {
             $seen[$key] = $true
-            $unique += $p
+            $unique.Add($p)
         }
     }
     $env:Path = $unique -join ";"
@@ -104,7 +104,9 @@ function Add-ToUserPath {
             $entries = if ($rawPath) { $rawPath -split ';' } else { @() }
             $normalDir = $Directory.TrimEnd('\').ToLowerInvariant()
             foreach ($entry in $entries) {
-                if ($entry.TrimEnd('\').ToLowerInvariant() -eq $normalDir) {
+                $rawNorm = $entry.TrimEnd('\').ToLowerInvariant()
+                $expNorm = [Environment]::ExpandEnvironmentVariables($entry).TrimEnd('\').ToLowerInvariant()
+                if ($rawNorm -eq $normalDir -or $expNorm -eq $normalDir) {
                     return $false  # already present
                 }
             }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -552,11 +552,14 @@ try {
         $envKey.Close()
         if ($rawPath) {
             $backupKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Software\Unsloth')
-            $existingBackup = $backupKey.GetValue('PathBackup', $null)
-            if (-not $existingBackup) {
-                $backupKey.SetValue('PathBackup', $rawPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+            try {
+                $existingBackup = $backupKey.GetValue('PathBackup', $null)
+                if (-not $existingBackup) {
+                    $backupKey.SetValue('PathBackup', $rawPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+                }
+            } finally {
+                $backupKey.Close()
             }
-            $backupKey.Close()
         }
     }
 } catch {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -542,16 +542,22 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
     Write-Host "  $Rule" -ForegroundColor DarkGray
 }
 
-# Back up User PATH before any modifications for recovery
+# Back up User PATH before any modifications for recovery.
+# Stored under HKCU\Software\Unsloth (not HKCU\Environment) to avoid
+# polluting the process environment block with a multi-KB variable.
 try {
-    $regKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
-    if ($regKey) {
-        $rawPath = $regKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
-        $existingBackup = $regKey.GetValue('UNSLOTH_PATH_BACKUP', $null)
-        if ($rawPath -and -not $existingBackup) {
-            $regKey.SetValue('UNSLOTH_PATH_BACKUP', $rawPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+    $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)
+    if ($envKey) {
+        $rawPath = $envKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $envKey.Close()
+        if ($rawPath) {
+            $backupKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Software\Unsloth')
+            $existingBackup = $backupKey.GetValue('PathBackup', $null)
+            if (-not $existingBackup) {
+                $backupKey.SetValue('PathBackup', $rawPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+            }
+            $backupKey.Close()
         }
-        $regKey.Close()
     }
 } catch {
     Write-Host "[DEBUG] Could not back up User PATH: $($_.Exception.Message)" -ForegroundColor DarkGray

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -104,9 +104,19 @@ function Refresh-Environment {
 # ── Helper: safely add a directory to the persistent User PATH ──
 # Uses direct registry access to preserve REG_EXPAND_SZ type
 # (avoids .NET SetEnvironmentVariable bug that converts to REG_SZ).
+#
+# Position: 'Append' (default) adds $Directory to the END of the persisted
+# User PATH so existing user tools (e.g. system python, pip) keep taking
+# precedence in new shells. This matches rustup/cargo/nvm/pyenv/uv behavior
+# and avoids silently hijacking resolution of common executables. Pass
+# 'Prepend' only when a caller truly needs the new entry to win over
+# existing ones at registry scope. In-session precedence should be handled
+# by an inline $env:Path = "$Dir;$env:Path" prepend instead.
 function Add-ToUserPath {
     param(
-        [Parameter(Mandatory = $true)][string]$Directory
+        [Parameter(Mandatory = $true)][string]$Directory,
+        [ValidateSet('Append','Prepend')]
+        [string]$Position = 'Append'
     )
     try {
         $regKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
@@ -143,7 +153,11 @@ function Add-ToUserPath {
             if (-not $rawPath) {
                 Write-Host "[WARN] User PATH is empty — initializing with $Directory" -ForegroundColor Yellow
             }
-            $newPath = if ($rawPath) { "$Directory;$rawPath" } else { $Directory }
+            $newPath = if ($rawPath) {
+                if ($Position -eq 'Prepend') { "$Directory;$rawPath" } else { "$rawPath;$Directory" }
+            } else {
+                $Directory
+            }
             $regKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
             # Broadcast WM_SETTINGCHANGE so other processes pick up the change
             try {
@@ -584,8 +598,11 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
 try {
     $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)
     if ($envKey) {
-        $rawPath = $envKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
-        $envKey.Close()
+        try {
+            $rawPath = $envKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        } finally {
+            $envKey.Close()
+        }
         if ($rawPath) {
             $backupKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Software\Unsloth')
             try {


### PR DESCRIPTION
Fixes https://github.com/unslothai/unsloth/issues/4955

  ## Problem

  All PATH persistence in `install.ps1` and `studio/setup.ps1` used
  `[System.Environment]::SetEnvironmentVariable("Path", ..., "User")` which has
  two known issues:

  1. It silently converts the registry value type from `REG_EXPAND_SZ` to `REG_SZ`,
     which permanently expands any `%VARIABLE%` references in the user's PATH
     (see dotnet/runtime#1442, open since 2019)

  2. The null-guard pattern used at all call sites hits the `else` branch when
     `GetEnvironmentVariable` returns empty, setting PATH to just the new directory:

     ```powershell
     $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
     if ($userPath) {
         [Environment]::SetEnvironmentVariable('Path', "$newDir;$userPath", 'User')
     } else {
         [Environment]::SetEnvironmentVariable('Path', "$newDir", 'User')  # <-- this
     }

     If GetEnvironmentVariable returns null or empty for any reason (registry type
     mismatch, concurrent write, transient issue), the else branch fires and replaces
     the entire user PATH with a single directory.

  This affected 6 call sites across both scripts (CMake, CUDA nvcc, Python Scripts,
  venv Scripts).

  ## Fix

  Added Add-ToUserPath helper function to both scripts. Uses direct registry API
  (Microsoft.Win32.Registry) instead of SetEnvironmentVariable:

  - Reads raw value with DoNotExpandEnvironmentNames to preserve %USERPROFILE% etc
  - Writes back as ExpandString (REG_EXPAND_SZ) to keep the correct registry type
  - Case-insensitive deduplication with trailing backslash normalization
  - Broadcasts WM_SETTINGCHANGE via dummy variable (same approach as the uv installer)

  This is the same pattern used by rustup, uv/cargo-dist, Chocolatey, and Scoop.

  Other guards

  - Refresh-Environment in setup.ps1 was overwriting $env:Path with only
  machine + user registry values, dropping any process-only entries (like an
  activated venv). Changed to a merge-with-dedup approach that preserves them
  - Added a one-time backup of the user PATH to HKCU\Environment\UNSLOTH_PATH_BACKUP
  before any modifications, so users can recover if needed. Only saves on first run
  to avoid overwriting the original backup
