### PR TITLE
Fix bitsandbytes ROCm install by using pip instead of uv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,12 @@ _install_bnb_rocm() {
     esac
     if [ -n "$_bnb_whl_url" ]; then
         substep "installing bitsandbytes for AMD ROCm (pre-release, PR #1887)..."
-        if run_install_cmd "$_label (pre-release)" uv pip install --python "$_venv_py" \
+        # uv destroys bitsandbytes, use pip instead
+        # Ensure pip is installed, then use it for this install.
+        if ! "$_venv_py" -m pip --version >/dev/null 2>&1; then
+            uv pip install --python "$_venv_py" pip >/dev/null 2>&1 || true
+        fi
+        if run_install_cmd "$_label (pre-release)" "$_venv_py" -m pip install \
             --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
             return 0
         fi

--- a/install.sh
+++ b/install.sh
@@ -124,10 +124,10 @@ _install_bnb_rocm() {
     if [ -n "$_bnb_whl_url" ]; then
         substep "installing bitsandbytes for AMD ROCm (pre-release, PR #1887)..."
         if run_install_cmd "$_label (pre-release)" "$_venv_py" -m pip install \
-            --isolated --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
+            --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
             return 0
         fi
-        substep "[WARN] bnb pre-release unreachable; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
+        substep "[WARN] bnb pre-release install failed; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
     fi
     run_install_cmd "$_label (pypi fallback)" "$_venv_py" -m pip install \
         --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"

--- a/install.sh
+++ b/install.sh
@@ -112,10 +112,14 @@ _install_bnb_rocm() {
             _bnb_whl_url=""
             ;;
     esac
-    # uv destroys bitsandbytes on ROCm, use pip instead.
-    # Ensure pip is installed first.
+    # uv rejects the continuous-release_main bitsandbytes wheel because the
+    # filename version (1.33.7rc0) does not match the embedded metadata version
+    # (0.50.0.dev0). pip accepts the mismatch, so bootstrap pip and use it.
     if ! "$_venv_py" -m pip --version >/dev/null 2>&1; then
-        uv pip install --python "$_venv_py" pip >/dev/null 2>&1 || true
+        if ! run_maybe_quiet "$_venv_py" -m ensurepip --upgrade; then
+            run_maybe_quiet uv pip install --python "$_venv_py" pip || \
+                substep "[WARN] could not bootstrap pip; bitsandbytes install will likely fail" "$C_WARN"
+        fi
     fi
     if [ -n "$_bnb_whl_url" ]; then
         substep "installing bitsandbytes for AMD ROCm (pre-release, PR #1887)..."

--- a/install.sh
+++ b/install.sh
@@ -112,20 +112,20 @@ _install_bnb_rocm() {
             _bnb_whl_url=""
             ;;
     esac
+    # uv destroys bitsandbytes on ROCm, use pip instead.
+    # Ensure pip is installed first.
+    if ! "$_venv_py" -m pip --version >/dev/null 2>&1; then
+        uv pip install --python "$_venv_py" pip >/dev/null 2>&1 || true
+    fi
     if [ -n "$_bnb_whl_url" ]; then
         substep "installing bitsandbytes for AMD ROCm (pre-release, PR #1887)..."
-        # uv destroys bitsandbytes, use pip instead
-        # Ensure pip is installed, then use it for this install.
-        if ! "$_venv_py" -m pip --version >/dev/null 2>&1; then
-            uv pip install --python "$_venv_py" pip >/dev/null 2>&1 || true
-        fi
         if run_install_cmd "$_label (pre-release)" "$_venv_py" -m pip install \
             --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
             return 0
         fi
         substep "[WARN] bnb pre-release unreachable; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
     fi
-    run_install_cmd "$_label (pypi fallback)" uv pip install --python "$_venv_py" \
+    run_install_cmd "$_label (pypi fallback)" "$_venv_py" -m pip install \
         --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -130,7 +130,7 @@ _install_bnb_rocm() {
         substep "[WARN] bnb pre-release unreachable; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
     fi
     run_install_cmd "$_label (pypi fallback)" "$_venv_py" -m pip install \
-        --isolated --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
+        --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
 }
 
 if [ "$_next_is_package" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -124,13 +124,13 @@ _install_bnb_rocm() {
     if [ -n "$_bnb_whl_url" ]; then
         substep "installing bitsandbytes for AMD ROCm (pre-release, PR #1887)..."
         if run_install_cmd "$_label (pre-release)" "$_venv_py" -m pip install \
-            --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
+            --isolated --force-reinstall --no-cache-dir --no-deps "$_bnb_whl_url"; then
             return 0
         fi
         substep "[WARN] bnb pre-release unreachable; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
     fi
     run_install_cmd "$_label (pypi fallback)" "$_venv_py" -m pip install \
-        --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
+        --isolated --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
 }
 
 if [ "$_next_is_package" = true ]; then


### PR DESCRIPTION
Fixes install issue with bitsandbytes on ROCm: 

<img width="960" height="288" alt="Screenshot 2026-04-10 at 3 37 34 PM" src="https://github.com/user-attachments/assets/72cdcda8-aa7d-4537-bd7d-2d0be9d43219" />
