### PR TITLE
fix: register unions (str | None) in huggingface_hub strict dataclass validation

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -909,8 +909,8 @@ def fix_huggingface_hub():
             and types.UnionType not in _validators
         ):
             _validators[types.UnionType] = _validate_union
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Unsloth: Failed to patch huggingface_hub dataclass validators: {e}")
 
 
 def fix_triton_compiled_kernel_missing_attrs():

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -911,7 +911,8 @@ def fix_huggingface_hub():
             _validators[types.UnionType] = _validate_union
     except Exception:
         pass
-    
+
+
 def fix_triton_compiled_kernel_missing_attrs():
     """
     Triton 3.6.0+ removed direct `num_ctas` and `cluster_dims` attributes from

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -910,7 +910,7 @@ def fix_huggingface_hub():
         ):
             _validators[types.UnionType] = _validate_union
     except Exception as e:
-        logger.debug(
+        logger.info(
             f"Unsloth: Failed to patch huggingface_hub dataclass validators: {e}"
         )
 

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -886,13 +886,32 @@ def fix_diffusers_warnings():
 def fix_huggingface_hub():
     # huggingface_hub.is_offline_mode got removed, so add it back
     import huggingface_hub
+    import types
 
     if not hasattr(huggingface_hub, "is_offline_mode"):
         huggingface_hub.is_offline_mode = (
             lambda: huggingface_hub.constants.HF_HUB_OFFLINE
         )
 
+    # Python 3.10+ PEP 604 unions (`str | None`) use ``types.UnionType``, but older
+    # huggingface_hub only registered ``typing.Union`` in ``_BASIC_TYPE_VALIDATORS``.
+    # That breaks @strict dataclasses with `x | y` annotations (e.g. import_name).
+    # Upstream: _BASIC_TYPE_VALIDATORS[types.UnionType] = _validate_union
+    try:
+        from huggingface_hub import dataclasses as _hf_dataclasses
 
+        _validators = getattr(_hf_dataclasses, "_BASIC_TYPE_VALIDATORS", None)
+        _validate_union = getattr(_hf_dataclasses, "_validate_union", None)
+        if (
+            _validators is not None
+            and _validate_union is not None
+            and hasattr(types, "UnionType")
+            and types.UnionType not in _validators
+        ):
+            _validators[types.UnionType] = _validate_union
+    except Exception:
+        pass
+    
 def fix_triton_compiled_kernel_missing_attrs():
     """
     Triton 3.6.0+ removed direct `num_ctas` and `cluster_dims` attributes from

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -910,7 +910,9 @@ def fix_huggingface_hub():
         ):
             _validators[types.UnionType] = _validate_union
     except Exception as e:
-        logger.debug(f"Unsloth: Failed to patch huggingface_hub dataclass validators: {e}")
+        logger.debug(
+            f"Unsloth: Failed to patch huggingface_hub dataclass validators: {e}"
+        )
 
 
 def fix_triton_compiled_kernel_missing_attrs():


### PR DESCRIPTION
Fixes [Bug] Failed to import ML libraries: Validation error for field 'import_name' #4967
Extends fix_huggingface_hub() in unsloth/import_fixes.py so that huggingface_hub’s @strict dataclass type validator understands PEP 604 union syntax (e.g. str | None), not only typing.Union