### PR TITLE
feat: Apple Silicon (MPS) device support

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -220,10 +220,17 @@ elif DEVICE_TYPE == "xpu":
     # torch.xpu.is_bf16_supported() does not have including_emulation
     # set SUPPORTS_BFLOAT16 as torch.xpu.is_bf16_supported()
     SUPPORTS_BFLOAT16 = torch.xpu.is_bf16_supported()
+elif DEVICE_TYPE == "mps":
+    # Apple Silicon (M1+) natively supports bfloat16
+    SUPPORTS_BFLOAT16 = True
 
 # For Gradio HF Spaces?
 # if "SPACE_AUTHOR_NAME" not in os.environ and "SPACE_REPO_NAME" not in os.environ:
-import triton
+if DEVICE_TYPE == "mps":
+    # Triton is not available on MPS; skip triton and bitsandbytes CUDA-specific setup
+    triton = None
+else:
+    import triton
 
 if DEVICE_TYPE == "cuda":
     libcuda_dirs = lambda: None
@@ -329,6 +336,10 @@ elif DEVICE_TYPE == "xpu":
     import bitsandbytes as bnb
 
     # TODO: check triton for intel installed properly.
+    pass
+elif DEVICE_TYPE == "mps":
+    # Apple Silicon MPS: Triton and bitsandbytes CUDA kernels are not available.
+    # 16-bit and full finetuning are supported; 4-bit QLoRA requires future bnb MPS support.
     pass
 
 from .models import *

--- a/unsloth/device_type.py
+++ b/unsloth/device_type.py
@@ -41,6 +41,8 @@ def get_device_type():
         return "cuda"
     elif hasattr(torch, "xpu") and torch.xpu.is_available():
         return "xpu"
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
     # Check torch.accelerator
     if hasattr(torch, "accelerator"):
         if not torch.accelerator.is_available():
@@ -54,13 +56,16 @@ def get_device_type():
                 f"But `torch.accelerator.current_accelerator()` works with it being = `{accelerator}`\n"
                 f"Please reinstall torch - it's most likely broken :("
             )
+        if accelerator == "mps":
+            return "mps"
     raise NotImplementedError(
-        "Unsloth currently only works on NVIDIA, AMD and Intel GPUs."
+        "Unsloth currently only works on NVIDIA, AMD, Intel, and Apple Silicon GPUs."
     )
 
 
 DEVICE_TYPE: str = get_device_type()
 # HIP fails for autocast and other torch functions. Use CUDA instead
+# MPS uses its own device type for torch operations
 DEVICE_TYPE_TORCH = DEVICE_TYPE
 if DEVICE_TYPE_TORCH == "hip":
     DEVICE_TYPE_TORCH = "cuda"
@@ -72,6 +77,8 @@ def get_device_count():
         return torch.cuda.device_count()
     elif DEVICE_TYPE == "xpu":
         return torch.xpu.device_count()
+    elif DEVICE_TYPE == "mps":
+        return 1  # MPS only supports a single device
     else:
         return 1
 

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -39,6 +39,7 @@ if DEVICE_TYPE == "mps":
     next_power_of_2 = lambda n: 1 << (n - 1).bit_length()
 else:
     import triton
+
     next_power_of_2 = triton.next_power_of_2
 
 MAX_FUSED_SIZE: int = 65536
@@ -277,8 +278,12 @@ else:
         cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemv_4bit_inference_fp16
         cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemv_4bit_inference_bf16
     else:
-        cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
-        cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
+        cgemm_4bit_inference_naive_fp16 = (
+            bnb.functional.lib.cgemm_4bit_inference_naive_fp16
+        )
+        cgemm_4bit_inference_naive_bf16 = (
+            bnb.functional.lib.cgemm_4bit_inference_naive_bf16
+        )
 
 
 if DEVICE_TYPE == "mps":

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -45,7 +45,12 @@ else:
 MAX_FUSED_SIZE: int = 65536
 import functools
 
-from .fp8 import weight_dequant, fp8_linear
+if DEVICE_TYPE != "mps":
+    from .fp8 import weight_dequant, fp8_linear
+else:
+    # fp8 requires Triton which is not available on MPS
+    weight_dequant = None
+    fp8_linear = None
 
 if DEVICE_TYPE == "xpu" and Version(torch.__version__) < Version("2.6.0"):
     raise RuntimeError(
@@ -53,9 +58,9 @@ if DEVICE_TYPE == "xpu" and Version(torch.__version__) < Version("2.6.0"):
     )
 
 if DEVICE_TYPE == "mps":
-    # MPS does not support autocast custom_fwd/bwd; use CPU fallback
-    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "cpu")
-    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cpu")
+    # MPS supports autocast since PyTorch 2.3+
+    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "mps")
+    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "mps")
 elif Version(torch.__version__) < Version("2.4.0"):
     torch_amp_custom_fwd = torch.cuda.amp.custom_fwd
     torch_amp_custom_bwd = torch.cuda.amp.custom_bwd

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 import importlib
-import triton
 import ctypes
 
-MAX_FUSED_SIZE: int = 65536
-next_power_of_2 = triton.next_power_of_2
 import functools
 from typing import Optional
 
@@ -29,8 +26,6 @@ from ..device_type import (
     DEVICE_COUNT,
     ALLOW_PREQUANTIZED_MODELS,
 )
-from .fp8 import weight_dequant, fp8_linear
-import functools
 
 # torch.cuda.amp.custom_fwd is deprecated >= 2.4
 import torch
@@ -38,12 +33,29 @@ import torch
 torch_Tensor = torch.Tensor
 from unsloth_zoo.utils import Version
 
+# Triton is not available on MPS (Apple Silicon); conditionally import
+if DEVICE_TYPE == "mps":
+    triton = None
+    next_power_of_2 = lambda n: 1 << (n - 1).bit_length()
+else:
+    import triton
+    next_power_of_2 = triton.next_power_of_2
+
+MAX_FUSED_SIZE: int = 65536
+import functools
+
+from .fp8 import weight_dequant, fp8_linear
+
 if DEVICE_TYPE == "xpu" and Version(torch.__version__) < Version("2.6.0"):
     raise RuntimeError(
         "Intel xpu currently supports unsloth with torch.version >= 2.6.0"
     )
 
-if Version(torch.__version__) < Version("2.4.0"):
+if DEVICE_TYPE == "mps":
+    # MPS does not support autocast custom_fwd/bwd; use CPU fallback
+    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "cpu")
+    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cpu")
+elif Version(torch.__version__) < Version("2.4.0"):
     torch_amp_custom_fwd = torch.cuda.amp.custom_fwd
     torch_amp_custom_bwd = torch.cuda.amp.custom_bwd
 else:
@@ -56,28 +68,36 @@ if DEVICE_TYPE == "xpu":
 
 
 # tl.math.tanh now is libdevice.tanh
-import triton
-import triton.language as tl
+if DEVICE_TYPE != "mps":
+    import triton
+    import triton.language as tl
 
-if Version(triton.__version__) >= Version("3.0.0"):
-    if DEVICE_TYPE == "xpu":
-        triton_tanh = tl.extra.intel.libdevice.tanh
+    if Version(triton.__version__) >= Version("3.0.0"):
+        if DEVICE_TYPE == "xpu":
+            triton_tanh = tl.extra.intel.libdevice.tanh
+        else:
+            from triton.language.extra import libdevice
+
+            triton_tanh = libdevice.tanh
+        triton_cast = tl.cast
     else:
-        from triton.language.extra import libdevice
+        triton_tanh = tl.math.tanh
 
-        triton_tanh = libdevice.tanh
-    triton_cast = tl.cast
+        # No casting in old Triton versions
+        @triton.jit
+        def triton_cast(x, dtype):
+            return x.to(dtype)
 else:
-    triton_tanh = tl.math.tanh
-
-    # No casting in old Triton versions
-    @triton.jit
-    def triton_cast(x, dtype):
-        return x.to(dtype)
+    # MPS: Triton kernels not available; provide stubs
+    tl = None
+    triton_tanh = None
+    triton_cast = None
 
 
 @functools.lru_cache(1)
 def is_cdna():
+    if DEVICE_TYPE == "mps":
+        return False
     return is_hip() and triton.runtime.driver.active.get_current_target().arch in (
         "gfx940",
         "gfx941",
@@ -89,6 +109,8 @@ def is_cdna():
 @functools.lru_cache(1)
 def is_rdna():
     """Detect ROCm-supported RDNA consumer/workstation GPUs (RDNA2, RDNA3, RDNA3.5, RDNA4)."""
+    if DEVICE_TYPE == "mps":
+        return False
     return is_hip() and triton.runtime.driver.active.get_current_target().arch in (
         # RDNA2 (Navi 21-24)
         "gfx1030",
@@ -136,16 +158,29 @@ def calculate_settings(
 
 
 HAS_CUDA_STREAM = False
-import bitsandbytes as bnb
+HAS_MPS_DEVICE = DEVICE_TYPE == "mps"
 
-# https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1330/files
-HAS_CUDA_STREAM = Version(bnb.__version__) > Version("0.43.3")
-get_ptr = bnb.functional.get_ptr
+if HAS_MPS_DEVICE:
+    # bitsandbytes CUDA kernels are not available on MPS; provide stubs
+    bnb = None
+    get_ptr = None
+else:
+    import bitsandbytes as bnb
+
+    # https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1330/files
+    HAS_CUDA_STREAM = Version(bnb.__version__) > Version("0.43.3")
+    get_ptr = bnb.functional.get_ptr
 
 if DEVICE_TYPE == "xpu":
     HAS_XPU_STREAM = True
 
-if DEVICE_COUNT > 1:
+if DEVICE_TYPE == "mps":
+    # MPS only has a single device, no multi-GPU context needed
+    from contextlib import nullcontext
+
+    def torch_gpu_device(device):
+        return nullcontext()
+elif DEVICE_COUNT > 1:
     if DEVICE_TYPE in ("cuda", "hip"):
         torch_gpu_device = torch.cuda.device
     elif DEVICE_TYPE == "xpu":
@@ -157,28 +192,40 @@ else:
         return nullcontext()
 
 
-# INTEL GPU Specific Logic
-if DEVICE_TYPE == "xpu":
-    _gpu_getCurrentRawStream = torch._C._xpu_getCurrentRawStream
-# NVIDIA GPU Default Logic
-else:
-    _gpu_getCurrentRawStream = torch._C._cuda_getCurrentRawStream
-
 c_void_p = ctypes.c_void_p
 
+if DEVICE_TYPE == "mps":
+    # MPS does not have raw CUDA/XPU streams
+    _gpu_getCurrentRawStream = None
 
-def _get_tensor_stream(tensor: torch_Tensor) -> c_void_p:
-    return c_void_p(_gpu_getCurrentRawStream(tensor.device.index))
+    def _get_tensor_stream(tensor: torch_Tensor) -> c_void_p:
+        return c_void_p(0)
+else:
+    # INTEL GPU Specific Logic
+    if DEVICE_TYPE == "xpu":
+        _gpu_getCurrentRawStream = torch._C._xpu_getCurrentRawStream
+    # NVIDIA GPU Default Logic
+    else:
+        _gpu_getCurrentRawStream = torch._C._cuda_getCurrentRawStream
+
+    def _get_tensor_stream(tensor: torch_Tensor) -> c_void_p:
+        return c_void_p(_gpu_getCurrentRawStream(tensor.device.index))
 
 
 # Get array of CUDA streams and other buffers
 global CUDA_STREAMS
 global XPU_STREAMS
+global MPS_STREAMS
 global WEIGHT_BUFFERS
 global ABSMAX_BUFFERS
 
+if DEVICE_TYPE == "mps":
+    # MPS has no explicit stream management; provide minimal stubs
+    MPS_STREAMS = (ctypes.c_void_p(0),)
+    WEIGHT_BUFFERS = [None]
+    ABSMAX_BUFFERS = [None]
 # INTEL GPU Specific Logic
-if DEVICE_TYPE == "xpu":
+elif DEVICE_TYPE == "xpu":
     _XPU_STREAMS = {
         (index := torch.xpu.device(i).idx): ctypes.c_void_p(
             torch._C._xpu_getCurrentRawStream(index)
@@ -211,23 +258,36 @@ else:
 # Bitsandbytes operations
 ctypes_c_int = ctypes.c_int
 ctypes_c_int32 = ctypes.c_int32
-cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
-cdequantize_blockwise_fp16_nf4 = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
-cdequantize_blockwise_bf16_nf4 = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
 
-if DEVICE_TYPE == "xpu":
-    # https://github.com/bitsandbytes-foundation/bitsandbytes/blob/c3b8de268fdb55a88f92feada23fc811a1e6877a/bitsandbytes/backends/xpu/ops.py#L115
-    # for xpu, inference gemv using above link
-    cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemv_4bit_inference_fp16
-    cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemv_4bit_inference_bf16
+if HAS_MPS_DEVICE:
+    # Stubs for bitsandbytes operations not available on MPS
+    cdequantize_blockwise_fp32 = None
+    cdequantize_blockwise_fp16_nf4 = None
+    cdequantize_blockwise_bf16_nf4 = None
+    cgemm_4bit_inference_naive_fp16 = None
+    cgemm_4bit_inference_naive_bf16 = None
 else:
-    cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
-    cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
+    cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
+    cdequantize_blockwise_fp16_nf4 = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
+    cdequantize_blockwise_bf16_nf4 = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
+
+    if DEVICE_TYPE == "xpu":
+        # https://github.com/bitsandbytes-foundation/bitsandbytes/blob/c3b8de268fdb55a88f92feada23fc811a1e6877a/bitsandbytes/backends/xpu/ops.py#L115
+        # for xpu, inference gemv using above link
+        cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemv_4bit_inference_fp16
+        cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemv_4bit_inference_bf16
+    else:
+        cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
+        cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
 
 
-torch_device_stream = (
-    torch.xpu.current_stream if DEVICE_TYPE == "xpu" else torch.cuda.current_stream
-)
+if DEVICE_TYPE == "mps":
+    # MPS does not have stream objects like CUDA/XPU
+    torch_device_stream = None
+elif DEVICE_TYPE == "xpu":
+    torch_device_stream = torch.xpu.current_stream
+else:
+    torch_device_stream = torch.cuda.current_stream
 
 torch_mm = torch.mm
 torch_mv = torch.mv

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -874,6 +874,10 @@ elif DEVICE_TYPE == "xpu":
     else:
         torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")
         torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "xpu")
+elif DEVICE_TYPE == "mps":
+    # MPS does not support autocast custom_fwd/bwd; use CPU fallback for amp decorators
+    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "cpu")
+    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cpu")
 # =============================================
 
 # =============================================
@@ -1022,6 +1026,12 @@ elif DEVICE_TYPE == "hip":
             HAS_FLASH_ATTENTION = False
 elif DEVICE_TYPE == "xpu":
     SUPPORTS_BFLOAT16 = True
+elif DEVICE_TYPE == "mps":
+    # Apple Silicon (M1+) natively supports bfloat16
+    SUPPORTS_BFLOAT16 = True
+    # Flash Attention and xformers are not available on MPS; SDPA is used instead
+    HAS_FLASH_ATTENTION = False
+    HAS_FLASH_ATTENTION_SOFTCAPPING = False
 
 # =============================================
 # Get Xformers
@@ -1190,7 +1200,10 @@ from torch._inductor.runtime.hints import DeviceProperties
 
 @functools.lru_cache(None)
 def is_big_gpu(index) -> bool:
-    if DEVICE_TYPE == "xpu":
+    if DEVICE_TYPE == "mps":
+        # MPS does not expose SM counts; assume Apple Silicon is capable enough
+        return True
+    elif DEVICE_TYPE == "xpu":
         prop = DeviceProperties.create(
             torch.device("xpu", index) if type(index) is int else index
         )
@@ -1499,11 +1512,15 @@ def get_statistics(local_files_only = False):
         disabled = True
     _get_statistics(None)
     _get_statistics("repeat", force_download = False)
-    total_memory = (
-        torch.xpu.get_device_properties(0).total_memory
-        if DEVICE_TYPE == "xpu"
-        else torch.cuda.get_device_properties(0).total_memory
-    )
+    if DEVICE_TYPE == "xpu":
+        total_memory = torch.xpu.get_device_properties(0).total_memory
+    elif DEVICE_TYPE == "mps":
+        # MPS shares unified memory; report recommended allocator limit
+        total_memory = torch.mps.driver_allocated_memory() or (
+            int(os.popen("sysctl -n hw.memsize").read().strip())
+        )
+    else:
+        total_memory = torch.cuda.get_device_properties(0).total_memory
     vram = total_memory / 1024 / 1024 / 1024
     if vram <= 8:
         vram = 8

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1027,8 +1027,13 @@ elif DEVICE_TYPE == "hip":
 elif DEVICE_TYPE == "xpu":
     SUPPORTS_BFLOAT16 = True
 elif DEVICE_TYPE == "mps":
-    # Apple Silicon (M1+) natively supports bfloat16
-    SUPPORTS_BFLOAT16 = True
+    # Check MPS bfloat16 support at runtime (requires PyTorch 2.3+ and macOS 14+)
+    try:
+        _test = torch.zeros(1, dtype=torch.bfloat16, device="mps")
+        del _test
+        SUPPORTS_BFLOAT16 = True
+    except Exception:
+        SUPPORTS_BFLOAT16 = False
     # Flash Attention and xformers are not available on MPS; SDPA is used instead
     HAS_FLASH_ATTENTION = False
     HAS_FLASH_ATTENTION_SOFTCAPPING = False

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -875,9 +875,9 @@ elif DEVICE_TYPE == "xpu":
         torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")
         torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "xpu")
 elif DEVICE_TYPE == "mps":
-    # MPS does not support autocast custom_fwd/bwd; use CPU fallback for amp decorators
-    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "cpu")
-    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cpu")
+    # MPS supports autocast since PyTorch 2.3+
+    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "mps")
+    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "mps")
 # =============================================
 
 # =============================================
@@ -1515,10 +1515,11 @@ def get_statistics(local_files_only = False):
     if DEVICE_TYPE == "xpu":
         total_memory = torch.xpu.get_device_properties(0).total_memory
     elif DEVICE_TYPE == "mps":
-        # MPS shares unified memory; report recommended allocator limit
-        total_memory = torch.mps.driver_allocated_memory() or (
-            int(os.popen("sysctl -n hw.memsize").read().strip())
-        )
+        # MPS shares unified memory; use recommended max working set size
+        if hasattr(torch.mps, "recommended_max_working_set_size"):
+            total_memory = torch.mps.recommended_max_working_set_size()
+        else:
+            total_memory = int(os.popen("sysctl -n hw.memsize").read().strip()) * 3 // 4
     else:
         total_memory = torch.cuda.get_device_properties(0).total_memory
     vram = total_memory / 1024 / 1024 / 1024

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1029,7 +1029,7 @@ elif DEVICE_TYPE == "xpu":
 elif DEVICE_TYPE == "mps":
     # Check MPS bfloat16 support at runtime (requires PyTorch 2.3+ and macOS 14+)
     try:
-        _test = torch.zeros(1, dtype=torch.bfloat16, device="mps")
+        _test = torch.zeros(1, dtype = torch.bfloat16, device = "mps")
         del _test
         SUPPORTS_BFLOAT16 = True
     except Exception:


### PR DESCRIPTION
Adds MPS (Metal Performance Shaders) support for Apple Silicon Macs.

`device_type.py` now detects MPS via `torch.backends.mps`. The rest of the changes make the import chain survive on a machine with no CUDA/Triton/bitsandbytes — Triton kernels get `None` stubs, bitsandbytes is skipped, and AMP decorators target the `mps` device type. Memory reporting uses `recommended_max_working_set_size()` and bfloat16 support is probed at runtime rather than hardcoded.

16-bit finetuning should work on MPS. 4-bit QLoRA still needs bitsandbytes to ship MPS support upstream.

Closes #4