### PR TITLE
Studio: add Anthropic-compatible /v1/messages endpoint

### DIFF
--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -224,6 +224,12 @@ class AnthropicStreamEmitter:
         events = []
         # Close the tool_use block
         events.append(self._close_block())
+        # Emit custom tool_result event (non-standard, ignored by SDKs)
+        events.append(build_anthropic_sse_event("tool_result", {
+            "type": "tool_result",
+            "tool_use_id": event.get("tool_call_id", ""),
+            "content": event.get("result", ""),
+        }))
         # Open a new text block for the model's next response
         self.block_index += 1
         events.extend(self._open_text_block())

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""
+Anthropic Messages API ↔ OpenAI format translation utilities.
+
+Pure functions and a stateful stream emitter — no FastAPI, no I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional, Union
+
+
+def anthropic_messages_to_openai(
+    messages: list[dict],
+    system: Optional[Union[str, list]] = None,
+) -> list[dict]:
+    """Convert Anthropic messages + system to OpenAI-format message dicts."""
+    result: list[dict] = []
+
+    # System prompt
+    if system:
+        if isinstance(system, str):
+            result.append({"role": "system", "content": system})
+        elif isinstance(system, list):
+            parts = []
+            for block in system:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block["text"])
+                elif isinstance(block, str):
+                    parts.append(block)
+            if parts:
+                result.append({"role": "system", "content": "\n".join(parts)})
+
+    for msg in messages:
+        role = msg["role"] if isinstance(msg, dict) else msg.role
+        content = msg["content"] if isinstance(msg, dict) else msg.content
+
+        if isinstance(content, str):
+            result.append({"role": role, "content": content})
+            continue
+
+        # Content is a list of blocks
+        text_parts: list[str] = []
+        tool_calls: list[dict] = []
+        tool_results: list[dict] = []
+
+        for block in content:
+            b = block if isinstance(block, dict) else block.model_dump()
+            btype = b.get("type", "")
+
+            if btype == "text":
+                text_parts.append(b["text"])
+            elif btype == "tool_use":
+                tool_calls.append({
+                    "id": b["id"],
+                    "type": "function",
+                    "function": {
+                        "name": b["name"],
+                        "arguments": json.dumps(b["input"]),
+                    },
+                })
+            elif btype == "tool_result":
+                tc = b.get("content", "")
+                if isinstance(tc, list):
+                    tc = " ".join(
+                        p["text"] for p in tc
+                        if isinstance(p, dict) and p.get("type") == "text"
+                    )
+                tool_results.append({
+                    "role": "tool",
+                    "tool_call_id": b["tool_use_id"],
+                    "content": str(tc),
+                })
+
+        if role == "assistant":
+            msg_dict: dict[str, Any] = {"role": "assistant"}
+            if text_parts:
+                msg_dict["content"] = "\n".join(text_parts)
+            if tool_calls:
+                msg_dict["tool_calls"] = tool_calls
+            result.append(msg_dict)
+        elif role == "user":
+            if text_parts:
+                result.append({"role": "user", "content": "\n".join(text_parts)})
+            for tr in tool_results:
+                result.append(tr)
+
+    return result
+
+
+def anthropic_tools_to_openai(tools: list) -> list[dict]:
+    """Convert Anthropic tool definitions to OpenAI function-tool format."""
+    result = []
+    for t in tools:
+        td = t if isinstance(t, dict) else t.model_dump()
+        result.append({
+            "type": "function",
+            "function": {
+                "name": td["name"],
+                "description": td.get("description", ""),
+                "parameters": td.get("input_schema", {}),
+            },
+        })
+    return result
+
+
+def build_anthropic_sse_event(event_type: str, data: dict) -> str:
+    """Format a single Anthropic SSE event."""
+    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+
+class AnthropicStreamEmitter:
+    """Converts generator events from generate_chat_completion_with_tools()
+    into Anthropic Messages SSE strings."""
+
+    def __init__(self) -> None:
+        self.block_index: int = 0
+        self._text_block_open: bool = False
+        self._prev_text: str = ""
+        self._usage: dict = {}
+
+    def start(self, message_id: str, model: str) -> list[str]:
+        """Emit message_start and open the first text content block."""
+        events = []
+        events.append(build_anthropic_sse_event("message_start", {
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": model,
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
+        }))
+        events.extend(self._open_text_block())
+        return events
+
+    def feed(self, event: dict) -> list[str]:
+        """Process one generator event, return SSE strings."""
+        etype = event.get("type", "")
+        if etype == "content":
+            return self._handle_content(event)
+        elif etype == "tool_start":
+            return self._handle_tool_start(event)
+        elif etype == "tool_end":
+            return self._handle_tool_end(event)
+        elif etype == "metadata":
+            self._usage = event.get("usage", {})
+            return []
+        # status events — no Anthropic equivalent
+        return []
+
+    def finish(self, stop_reason: str = "end_turn") -> list[str]:
+        """Close any open block and emit message_delta + message_stop."""
+        events = []
+        if self._text_block_open:
+            events.append(self._close_block())
+        events.append(build_anthropic_sse_event("message_delta", {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {
+                "output_tokens": self._usage.get("completion_tokens", 0),
+            },
+        }))
+        events.append(build_anthropic_sse_event("message_stop", {
+            "type": "message_stop",
+        }))
+        return events
+
+    def _handle_content(self, event: dict) -> list[str]:
+        cumulative = event.get("text", "")
+        new_text = cumulative[len(self._prev_text):]
+        self._prev_text = cumulative
+        if not new_text:
+            return []
+        if not self._text_block_open:
+            events = self._open_text_block()
+        else:
+            events = []
+        events.append(build_anthropic_sse_event("content_block_delta", {
+            "type": "content_block_delta",
+            "index": self.block_index,
+            "delta": {"type": "text_delta", "text": new_text},
+        }))
+        return events
+
+    def _handle_tool_start(self, event: dict) -> list[str]:
+        events = []
+        # Close current text block if open
+        if self._text_block_open:
+            events.append(self._close_block())
+        # Open a tool_use block
+        self.block_index += 1
+        events.append(build_anthropic_sse_event("content_block_start", {
+            "type": "content_block_start",
+            "index": self.block_index,
+            "content_block": {
+                "type": "tool_use",
+                "id": event.get("tool_call_id", ""),
+                "name": event.get("tool_name", ""),
+                "input": {},
+            },
+        }))
+        # Emit the arguments as input_json_delta
+        args = event.get("arguments", {})
+        if args:
+            events.append(build_anthropic_sse_event("content_block_delta", {
+                "type": "content_block_delta",
+                "index": self.block_index,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": json.dumps(args),
+                },
+            }))
+        return events
+
+    def _handle_tool_end(self, event: dict) -> list[str]:
+        events = []
+        # Close the tool_use block
+        events.append(self._close_block())
+        # Open a new text block for the model's next response
+        self.block_index += 1
+        events.extend(self._open_text_block())
+        # Reset text tracking for the next synthesis turn
+        self._prev_text = ""
+        return events
+
+    def _open_text_block(self) -> list[str]:
+        self._text_block_open = True
+        return [build_anthropic_sse_event("content_block_start", {
+            "type": "content_block_start",
+            "index": self.block_index,
+            "content_block": {"type": "text", "text": ""},
+        })]
+
+    def _close_block(self) -> str:
+        self._text_block_open = False
+        return build_anthropic_sse_event("content_block_stop", {
+            "type": "content_block_stop",
+            "index": self.block_index,
+        })

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -301,3 +301,188 @@ class AnthropicStreamEmitter:
                 "index": self.block_index,
             },
         )
+
+
+class AnthropicPassthroughEmitter:
+    """Converts llama-server's OpenAI-format streaming chunks into Anthropic SSE.
+
+    Used for the client-side tool-use pass-through path: the client (e.g. Claude
+    Code) sends its own tool definitions in the ``tools`` field and expects to
+    execute them itself. We forward them to llama-server and translate the
+    streaming response back to Anthropic format without executing anything.
+    """
+
+    def __init__(self) -> None:
+        self.block_index: int = -1
+        self._current_block_type: Optional[str] = None  # "text" | "tool_use" | None
+        self._tool_call_states: dict = {}  # delta index -> {block_index, id, name}
+        self._usage: dict = {}
+        self._stop_reason: str = "end_turn"
+
+    def start(self, message_id: str, model: str) -> list[str]:
+        return [
+            build_anthropic_sse_event(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": message_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": model,
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                    },
+                },
+            )
+        ]
+
+    def feed_chunk(self, chunk: dict) -> list[str]:
+        """Process one OpenAI streaming chat.completion.chunk."""
+        events: list[str] = []
+
+        # usage-only chunks carry token totals
+        usage = chunk.get("usage")
+        if usage:
+            self._usage = usage
+
+        choices = chunk.get("choices") or []
+        if not choices:
+            return events
+
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+        finish_reason = choice.get("finish_reason")
+
+        # ── Text content ──
+        content = delta.get("content")
+        if content:
+            if self._current_block_type != "text":
+                if self._current_block_type is not None:
+                    events.append(self._close_current_block())
+                events.extend(self._open_text_block())
+            events.append(
+                build_anthropic_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": self.block_index,
+                        "delta": {"type": "text_delta", "text": content},
+                    },
+                )
+            )
+
+        # ── Tool calls (streaming deltas) ──
+        tool_calls = delta.get("tool_calls") or []
+        for tc in tool_calls:
+            tc_idx = tc.get("index", 0)
+            fn = tc.get("function") or {}
+            if tc_idx not in self._tool_call_states:
+                # New tool call — close prior block, open tool_use block
+                if self._current_block_type is not None:
+                    events.append(self._close_current_block())
+                tc_id = tc.get("id", "")
+                tc_name = fn.get("name", "")
+                self.block_index += 1
+                self._current_block_type = "tool_use"
+                self._tool_call_states[tc_idx] = {
+                    "block_index": self.block_index,
+                    "id": tc_id,
+                    "name": tc_name,
+                }
+                events.append(
+                    build_anthropic_sse_event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": self.block_index,
+                            "content_block": {
+                                "type": "tool_use",
+                                "id": tc_id,
+                                "name": tc_name,
+                                "input": {},
+                            },
+                        },
+                    )
+                )
+
+            args_delta = fn.get("arguments", "")
+            if args_delta:
+                events.append(
+                    build_anthropic_sse_event(
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": self._tool_call_states[tc_idx]["block_index"],
+                            "delta": {
+                                "type": "input_json_delta",
+                                "partial_json": args_delta,
+                            },
+                        },
+                    )
+                )
+
+        # ── Finish reason ──
+        if finish_reason:
+            if finish_reason == "tool_calls":
+                self._stop_reason = "tool_use"
+            elif finish_reason == "length":
+                self._stop_reason = "max_tokens"
+            else:
+                self._stop_reason = "end_turn"
+
+        return events
+
+    def finish(self) -> list[str]:
+        events: list[str] = []
+        if self._current_block_type is not None:
+            events.append(self._close_current_block())
+        events.append(
+            build_anthropic_sse_event(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {
+                        "stop_reason": self._stop_reason,
+                        "stop_sequence": None,
+                    },
+                    "usage": {
+                        "output_tokens": self._usage.get("completion_tokens", 0),
+                    },
+                },
+            )
+        )
+        events.append(
+            build_anthropic_sse_event(
+                "message_stop",
+                {"type": "message_stop"},
+            )
+        )
+        return events
+
+    def _open_text_block(self) -> list[str]:
+        self.block_index += 1
+        self._current_block_type = "text"
+        return [
+            build_anthropic_sse_event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": self.block_index,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            )
+        ]
+
+    def _close_current_block(self) -> str:
+        idx = self.block_index
+        self._current_block_type = None
+        return build_anthropic_sse_event(
+            "content_block_stop",
+            {
+                "type": "content_block_stop",
+                "index": idx,
+            },
+        )

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -54,26 +54,31 @@ def anthropic_messages_to_openai(
             if btype == "text":
                 text_parts.append(b["text"])
             elif btype == "tool_use":
-                tool_calls.append({
-                    "id": b["id"],
-                    "type": "function",
-                    "function": {
-                        "name": b["name"],
-                        "arguments": json.dumps(b["input"]),
-                    },
-                })
+                tool_calls.append(
+                    {
+                        "id": b["id"],
+                        "type": "function",
+                        "function": {
+                            "name": b["name"],
+                            "arguments": json.dumps(b["input"]),
+                        },
+                    }
+                )
             elif btype == "tool_result":
                 tc = b.get("content", "")
                 if isinstance(tc, list):
                     tc = " ".join(
-                        p["text"] for p in tc
+                        p["text"]
+                        for p in tc
                         if isinstance(p, dict) and p.get("type") == "text"
                     )
-                tool_results.append({
-                    "role": "tool",
-                    "tool_call_id": b["tool_use_id"],
-                    "content": str(tc),
-                })
+                tool_results.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": b["tool_use_id"],
+                        "content": str(tc),
+                    }
+                )
 
         if role == "assistant":
             msg_dict: dict[str, Any] = {"role": "assistant"}
@@ -96,14 +101,16 @@ def anthropic_tools_to_openai(tools: list) -> list[dict]:
     result = []
     for t in tools:
         td = t if isinstance(t, dict) else t.model_dump()
-        result.append({
-            "type": "function",
-            "function": {
-                "name": td["name"],
-                "description": td.get("description", ""),
-                "parameters": td.get("input_schema", {}),
-            },
-        })
+        result.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": td["name"],
+                    "description": td.get("description", ""),
+                    "parameters": td.get("input_schema", {}),
+                },
+            }
+        )
     return result
 
 
@@ -125,19 +132,24 @@ class AnthropicStreamEmitter:
     def start(self, message_id: str, model: str) -> list[str]:
         """Emit message_start and open the first text content block."""
         events = []
-        events.append(build_anthropic_sse_event("message_start", {
-            "type": "message_start",
-            "message": {
-                "id": message_id,
-                "type": "message",
-                "role": "assistant",
-                "content": [],
-                "model": model,
-                "stop_reason": None,
-                "stop_sequence": None,
-                "usage": {"input_tokens": 0, "output_tokens": 0},
-            },
-        }))
+        events.append(
+            build_anthropic_sse_event(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": message_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": model,
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                    },
+                },
+            )
+        )
         events.extend(self._open_text_block())
         return events
 
@@ -161,21 +173,31 @@ class AnthropicStreamEmitter:
         events = []
         if self._text_block_open:
             events.append(self._close_block())
-        events.append(build_anthropic_sse_event("message_delta", {
-            "type": "message_delta",
-            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
-            "usage": {
-                "output_tokens": self._usage.get("completion_tokens", 0),
-            },
-        }))
-        events.append(build_anthropic_sse_event("message_stop", {
-            "type": "message_stop",
-        }))
+        events.append(
+            build_anthropic_sse_event(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                    "usage": {
+                        "output_tokens": self._usage.get("completion_tokens", 0),
+                    },
+                },
+            )
+        )
+        events.append(
+            build_anthropic_sse_event(
+                "message_stop",
+                {
+                    "type": "message_stop",
+                },
+            )
+        )
         return events
 
     def _handle_content(self, event: dict) -> list[str]:
         cumulative = event.get("text", "")
-        new_text = cumulative[len(self._prev_text):]
+        new_text = cumulative[len(self._prev_text) :]
         self._prev_text = cumulative
         if not new_text:
             return []
@@ -183,11 +205,16 @@ class AnthropicStreamEmitter:
             events = self._open_text_block()
         else:
             events = []
-        events.append(build_anthropic_sse_event("content_block_delta", {
-            "type": "content_block_delta",
-            "index": self.block_index,
-            "delta": {"type": "text_delta", "text": new_text},
-        }))
+        events.append(
+            build_anthropic_sse_event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": self.block_index,
+                    "delta": {"type": "text_delta", "text": new_text},
+                },
+            )
+        )
         return events
 
     def _handle_tool_start(self, event: dict) -> list[str]:
@@ -197,27 +224,37 @@ class AnthropicStreamEmitter:
             events.append(self._close_block())
         # Open a tool_use block
         self.block_index += 1
-        events.append(build_anthropic_sse_event("content_block_start", {
-            "type": "content_block_start",
-            "index": self.block_index,
-            "content_block": {
-                "type": "tool_use",
-                "id": event.get("tool_call_id", ""),
-                "name": event.get("tool_name", ""),
-                "input": {},
-            },
-        }))
+        events.append(
+            build_anthropic_sse_event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": self.block_index,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": event.get("tool_call_id", ""),
+                        "name": event.get("tool_name", ""),
+                        "input": {},
+                    },
+                },
+            )
+        )
         # Emit the arguments as input_json_delta
         args = event.get("arguments", {})
         if args:
-            events.append(build_anthropic_sse_event("content_block_delta", {
-                "type": "content_block_delta",
-                "index": self.block_index,
-                "delta": {
-                    "type": "input_json_delta",
-                    "partial_json": json.dumps(args),
-                },
-            }))
+            events.append(
+                build_anthropic_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": self.block_index,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": json.dumps(args),
+                        },
+                    },
+                )
+            )
         return events
 
     def _handle_tool_end(self, event: dict) -> list[str]:
@@ -225,11 +262,16 @@ class AnthropicStreamEmitter:
         # Close the tool_use block
         events.append(self._close_block())
         # Emit custom tool_result event (non-standard, ignored by SDKs)
-        events.append(build_anthropic_sse_event("tool_result", {
-            "type": "tool_result",
-            "tool_use_id": event.get("tool_call_id", ""),
-            "content": event.get("result", ""),
-        }))
+        events.append(
+            build_anthropic_sse_event(
+                "tool_result",
+                {
+                    "type": "tool_result",
+                    "tool_use_id": event.get("tool_call_id", ""),
+                    "content": event.get("result", ""),
+                },
+            )
+        )
         # Open a new text block for the model's next response
         self.block_index += 1
         events.extend(self._open_text_block())
@@ -239,15 +281,23 @@ class AnthropicStreamEmitter:
 
     def _open_text_block(self) -> list[str]:
         self._text_block_open = True
-        return [build_anthropic_sse_event("content_block_start", {
-            "type": "content_block_start",
-            "index": self.block_index,
-            "content_block": {"type": "text", "text": ""},
-        })]
+        return [
+            build_anthropic_sse_event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": self.block_index,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            )
+        ]
 
     def _close_block(self) -> str:
         self._text_block_open = False
-        return build_anthropic_sse_event("content_block_stop", {
-            "type": "content_block_stop",
-            "index": self.block_index,
-        })
+        return build_anthropic_sse_event(
+            "content_block_stop",
+            {
+                "type": "content_block_stop",
+                "index": self.block_index,
+            },
+        )

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -633,6 +633,15 @@ class AnthropicMessagesRequest(BaseModel):
     stop_sequences: Optional[list[str]] = None
     metadata: Optional[dict] = None
     # [x-unsloth] extensions — mirror the OpenAI endpoint convenience fields
+    min_p: Optional[float] = Field(
+        None, ge = 0.0, le = 1.0, description = "[x-unsloth] Min-p sampling threshold"
+    )
+    repetition_penalty: Optional[float] = Field(
+        None, ge = 1.0, le = 2.0, description = "[x-unsloth] Repetition penalty"
+    )
+    presence_penalty: Optional[float] = Field(
+        None, ge = 0.0, le = 2.0, description = "[x-unsloth] Presence penalty"
+    )
     enable_tools: Optional[bool] = None
     enabled_tools: Optional[list[str]] = None
     session_id: Optional[str] = None

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -621,7 +621,7 @@ class AnthropicTool(BaseModel):
 
 class AnthropicMessagesRequest(BaseModel):
     model: str = "default"
-    max_tokens: int
+    max_tokens: Optional[int] = None
     messages: list[AnthropicMessage]
     system: Optional[Union[str, list]] = None
     tools: Optional[list[AnthropicTool]] = None
@@ -632,6 +632,10 @@ class AnthropicMessagesRequest(BaseModel):
     top_k: Optional[int] = None
     stop_sequences: Optional[list[str]] = None
     metadata: Optional[dict] = None
+    # [x-unsloth] extensions — mirror the OpenAI endpoint convenience fields
+    enable_tools: Optional[bool] = None
+    enabled_tools: Optional[list[str]] = None
+    session_id: Optional[str] = None
     model_config = {"extra": "allow"}
 
 

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -560,3 +560,110 @@ class ResponsesResponse(BaseModel):
     tool_choice: Optional[Any] = None
     tools: list = Field(default_factory = list)
     truncation: Optional[Any] = None
+
+
+# =====================================================================
+# Anthropic Messages API Models  (/v1/messages)
+# =====================================================================
+
+
+# ── Request models ─────────────────────────────────────────────
+
+
+class AnthropicTextBlock(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class AnthropicImageSource(BaseModel):
+    type: Literal["base64", "url"]
+    media_type: Optional[str] = None
+    data: Optional[str] = None
+    url: Optional[str] = None
+
+
+class AnthropicImageBlock(BaseModel):
+    type: Literal["image"]
+    source: AnthropicImageSource
+
+
+class AnthropicToolUseBlock(BaseModel):
+    type: Literal["tool_use"]
+    id: str
+    name: str
+    input: dict
+
+
+class AnthropicToolResultBlock(BaseModel):
+    type: Literal["tool_result"]
+    tool_use_id: str
+    content: Union[str, list] = ""
+
+
+AnthropicContentBlock = Union[
+    AnthropicTextBlock,
+    AnthropicImageBlock,
+    AnthropicToolUseBlock,
+    AnthropicToolResultBlock,
+]
+
+
+class AnthropicMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    content: Union[str, list[AnthropicContentBlock]]
+
+
+class AnthropicTool(BaseModel):
+    name: str
+    description: Optional[str] = None
+    input_schema: dict
+
+
+class AnthropicMessagesRequest(BaseModel):
+    model: str = "default"
+    max_tokens: int
+    messages: list[AnthropicMessage]
+    system: Optional[Union[str, list]] = None
+    tools: Optional[list[AnthropicTool]] = None
+    tool_choice: Optional[Any] = None
+    stream: bool = False
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    stop_sequences: Optional[list[str]] = None
+    metadata: Optional[dict] = None
+    model_config = {"extra": "allow"}
+
+
+# ── Response models ────────────────────────────────────────────
+
+
+class AnthropicUsage(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+class AnthropicResponseTextBlock(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+class AnthropicResponseToolUseBlock(BaseModel):
+    type: Literal["tool_use"] = "tool_use"
+    id: str
+    name: str
+    input: dict
+
+
+AnthropicResponseBlock = Union[AnthropicResponseTextBlock, AnthropicResponseToolUseBlock]
+
+
+class AnthropicMessagesResponse(BaseModel):
+    id: str = Field(default_factory = lambda: f"msg_{uuid.uuid4().hex[:24]}")
+    type: Literal["message"] = "message"
+    role: Literal["assistant"] = "assistant"
+    content: list[AnthropicResponseBlock] = Field(default_factory = list)
+    model: str = "default"
+    stop_reason: Optional[str] = None
+    stop_sequence: Optional[str] = None
+    usage: AnthropicUsage = Field(default_factory = AnthropicUsage)

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -659,7 +659,9 @@ class AnthropicResponseToolUseBlock(BaseModel):
     input: dict
 
 
-AnthropicResponseBlock = Union[AnthropicResponseTextBlock, AnthropicResponseToolUseBlock]
+AnthropicResponseBlock = Union[
+    AnthropicResponseTextBlock, AnthropicResponseToolUseBlock
+]
 
 
 class AnthropicMessagesResponse(BaseModel):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2672,21 +2672,36 @@ async def _anthropic_passthrough_stream(
                     json = body,
                     timeout = 600,
                 ) as resp:
-                    async for raw_line in resp.aiter_lines():
-                        if await request.is_disconnected():
-                            cancel_event.set()
-                            return
-                        if not raw_line or not raw_line.startswith("data: "):
-                            continue
-                        data_str = raw_line[6:]
-                        if data_str.strip() == "[DONE]":
-                            break
+                    # Explicitly manage the aiter_lines() iterator so it is
+                    # closed in this task before the surrounding `async with`
+                    # blocks unwind the response / client. Without this, the
+                    # inner httpcore byte-stream gets finalized by the GC in
+                    # a different asyncio task on Python 3.13 + httpcore 1.x,
+                    # raising "Attempted to exit cancel scope in a different
+                    # task" and "async generator ignored GeneratorExit".
+                    lines_iter = resp.aiter_lines()
+                    try:
+                        async for raw_line in lines_iter:
+                            if await request.is_disconnected():
+                                cancel_event.set()
+                                return
+                            if not raw_line or not raw_line.startswith("data: "):
+                                continue
+                            data_str = raw_line[6:]
+                            if data_str.strip() == "[DONE]":
+                                break
+                            try:
+                                chunk = json.loads(data_str)
+                            except json.JSONDecodeError:
+                                continue
+                            for line in emitter.feed_chunk(chunk):
+                                yield line
+                    finally:
                         try:
-                            chunk = json.loads(data_str)
-                        except json.JSONDecodeError:
-                            continue
-                        for line in emitter.feed_chunk(chunk):
-                            yield line
+                            await lines_iter.aclose()
+                        except RuntimeError:
+                            # Python 3.13 + httpcore 1.0.x asyncgen cleanup
+                            pass
         except Exception as e:
             logger.error("anthropic_messages passthrough stream error: %s", e)
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2564,9 +2564,20 @@ async def _anthropic_plain_stream(
 
 
 async def _anthropic_tool_non_streaming(run_gen, message_id, model_name):
-    """Non-streaming response for the tool-calling path."""
-    text_parts = []
-    tool_blocks = []
+    """Non-streaming response for the tool-calling path.
+
+    Builds ``content_blocks`` in generation order (text → tool_use → text →
+    tool_use → ...), mirroring the streaming emitter's behavior. Deltas
+    within a single synthesis turn are merged into the trailing text block;
+    tool_use blocks interrupt the text sequence and open a new text block on
+    the next content event.
+
+    ``prev_text`` is reset on ``tool_end`` because
+    ``generate_chat_completion_with_tools`` yields cumulative content *per
+    turn* — the first content event of turn N+1 must diff against an empty
+    baseline, not against turn N's final length.
+    """
+    content_blocks: list = []
     usage = {}
     prev_text = ""
 
@@ -2578,24 +2589,24 @@ async def _anthropic_tool_non_streaming(run_gen, message_id, model_name):
             new = clean[len(prev_text) :]
             prev_text = clean
             if new:
-                text_parts.append(new)
+                if content_blocks and isinstance(
+                    content_blocks[-1], AnthropicResponseTextBlock
+                ):
+                    content_blocks[-1].text += new
+                else:
+                    content_blocks.append(AnthropicResponseTextBlock(text = new))
         elif etype == "tool_start":
-            tool_blocks.append(
+            content_blocks.append(
                 AnthropicResponseToolUseBlock(
                     id = event["tool_call_id"],
                     name = event["tool_name"],
                     input = event.get("arguments", {}),
                 )
             )
+        elif etype == "tool_end":
+            prev_text = ""
         elif etype == "metadata":
             usage = event.get("usage", {})
-
-    content_blocks = []
-    for tb in tool_blocks:
-        content_blocks.append(tb)
-    full_text = "".join(text_parts).strip()
-    if full_text:
-        content_blocks.append(AnthropicResponseTextBlock(text = full_text))
 
     resp = AnthropicMessagesResponse(
         id = message_id,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -96,6 +96,16 @@ from models.inference import (
     ResponsesOutputMessage,
     ResponsesUsage,
     ResponsesResponse,
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+    AnthropicResponseTextBlock,
+    AnthropicResponseToolUseBlock,
+    AnthropicUsage,
+)
+from core.inference.anthropic_compat import (
+    anthropic_messages_to_openai,
+    anthropic_tools_to_openai,
+    AnthropicStreamEmitter,
 )
 from auth.authentication import get_current_subject
 
@@ -2201,3 +2211,320 @@ async def openai_responses(
     if payload.stream:
         return await _responses_stream(payload, messages, request)
     return await _responses_non_streaming(payload, messages, request)
+
+
+# =====================================================================
+# Anthropic-Compatible Messages API  (/messages → /v1/messages)
+# =====================================================================
+
+
+@router.post("/messages")
+async def anthropic_messages(
+    payload: AnthropicMessagesRequest,
+    request: Request,
+    current_subject: str = Depends(get_current_subject),
+):
+    """
+    Anthropic-compatible Messages API endpoint.
+
+    Translates Anthropic message format to internal OpenAI format, runs
+    through the existing agentic tool loop when tools are provided, and
+    returns responses in Anthropic Messages API format (streaming SSE or
+    non-streaming JSON).
+    """
+    llama_backend = get_llama_cpp_backend()
+    if not llama_backend.is_loaded:
+        raise HTTPException(
+            status_code = 503,
+            detail = "No GGUF model loaded. Load a GGUF model first.",
+        )
+
+    model_name = getattr(llama_backend, "model_identifier", None) or payload.model
+    message_id = f"msg_{uuid.uuid4().hex[:24]}"
+
+    # ── Translate Anthropic → OpenAI ──────────────────────────
+    openai_messages = anthropic_messages_to_openai(
+        [m.model_dump() for m in payload.messages],
+        payload.system,
+    )
+
+    temperature = payload.temperature if payload.temperature is not None else 0.6
+    top_p = payload.top_p if payload.top_p is not None else 0.95
+    top_k = payload.top_k if payload.top_k is not None else 20
+
+    cancel_event = threading.Event()
+
+    # ── Tool-calling path ─────────────────────────────────────
+    use_tools = (
+        payload.tools
+        and len(payload.tools) > 0
+        and llama_backend.supports_tools
+    )
+
+    if use_tools:
+        from core.inference.tools import ALL_TOOLS
+
+        openai_tools = anthropic_tools_to_openai(payload.tools)
+
+        # Build tool-use system prompt nudge (same logic as /chat/completions)
+        _tool_names = {t["function"]["name"] for t in openai_tools}
+        _has_web = "web_search" in _tool_names
+        _has_code = "python" in _tool_names or "terminal" in _tool_names
+
+        _date_line = f"The current date is {_date.today().isoformat()}."
+        _model_size_b = _extract_model_size_b(model_name)
+        _is_small_model = _model_size_b is not None and _model_size_b < 9
+
+        if _is_small_model:
+            _web_tips = "Do not repeat the same search query."
+        else:
+            _web_tips = (
+                "When you search and find a relevant URL in the results, "
+                "fetch its full content by calling web_search with the url parameter. "
+                "Do not repeat the same search query. If a search returns "
+                "no useful results, try rephrasing or fetching a result URL directly."
+            )
+        _code_tips = (
+            "Use code execution for math, calculations, data processing, "
+            "or to parse and analyze information from tool results."
+        )
+
+        if _has_web and _has_code:
+            _nudge = (
+                _date_line + " "
+                "You have access to tools. When appropriate, prefer using "
+                "tools rather than answering from memory. "
+                + _web_tips + " " + _code_tips
+            )
+        elif _has_code:
+            _nudge = (
+                _date_line + " "
+                "You have access to tools. When appropriate, prefer using "
+                "code execution rather than answering from memory. " + _code_tips
+            )
+        elif _has_web:
+            _nudge = (
+                _date_line + " "
+                "You have access to tools. When appropriate, prefer using "
+                "web search for up-to-date or uncertain factual "
+                "information rather than answering from memory. " + _web_tips
+            )
+        else:
+            _nudge = ""
+
+        if _nudge:
+            _nudge += _TOOL_ACTION_NUDGE
+            # Inject into system prompt
+            if openai_messages and openai_messages[0].get("role") == "system":
+                openai_messages[0]["content"] = (
+                    openai_messages[0]["content"].rstrip() + "\n\n" + _nudge
+                )
+            else:
+                openai_messages.insert(0, {"role": "system", "content": _nudge})
+
+        # Strip stale tool-call XML from conversation
+        for _msg in openai_messages:
+            if _msg.get("role") == "assistant" and isinstance(_msg.get("content"), str):
+                _msg["content"] = _TOOL_XML_RE.sub("", _msg["content"]).strip()
+
+        def _run_tool_gen():
+            return llama_backend.generate_chat_completion_with_tools(
+                messages = openai_messages,
+                tools = openai_tools,
+                temperature = temperature,
+                top_p = top_p,
+                top_k = top_k,
+                max_tokens = payload.max_tokens,
+                cancel_event = cancel_event,
+                max_tool_iterations = 25,
+                auto_heal_tool_calls = True,
+                tool_call_timeout = 300,
+            )
+
+        if payload.stream:
+            return await _anthropic_tool_stream(
+                request, cancel_event, _run_tool_gen, message_id, model_name,
+            )
+        return await _anthropic_tool_non_streaming(
+            _run_tool_gen, message_id, model_name,
+        )
+
+    # ── No-tool path ──────────────────────────────────────────
+    def _run_plain_gen():
+        return llama_backend.generate_chat_completion(
+            messages = openai_messages,
+            temperature = temperature,
+            top_p = top_p,
+            top_k = top_k,
+            max_tokens = payload.max_tokens,
+            cancel_event = cancel_event,
+        )
+
+    if payload.stream:
+        return await _anthropic_plain_stream(
+            request, cancel_event, _run_plain_gen, message_id, model_name,
+        )
+    return await _anthropic_plain_non_streaming(
+        _run_plain_gen, message_id, model_name,
+    )
+
+
+async def _anthropic_tool_stream(
+    request, cancel_event, run_gen, message_id, model_name,
+):
+    """Streaming response for the tool-calling path."""
+    _sentinel = object()
+
+    async def _stream():
+        emitter = AnthropicStreamEmitter()
+        for line in emitter.start(message_id, model_name):
+            yield line
+
+        gen = run_gen()
+        try:
+            while True:
+                if await request.is_disconnected():
+                    cancel_event.set()
+                    return
+                event = await asyncio.to_thread(next, gen, _sentinel)
+                if event is _sentinel:
+                    break
+                for line in emitter.feed(event):
+                    yield line
+        except Exception as e:
+            logger.error("anthropic_messages stream error: %s", e)
+
+        for line in emitter.finish("end_turn"):
+            yield line
+
+    return StreamingResponse(
+        _stream(),
+        media_type = "text/event-stream",
+        headers = {
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _anthropic_plain_stream(
+    request, cancel_event, run_gen, message_id, model_name,
+):
+    """Streaming response for the no-tool path."""
+    _sentinel = object()
+
+    async def _stream():
+        emitter = AnthropicStreamEmitter()
+        for line in emitter.start(message_id, model_name):
+            yield line
+
+        gen = run_gen()
+        try:
+            while True:
+                if await request.is_disconnected():
+                    cancel_event.set()
+                    return
+                cumulative = await asyncio.to_thread(next, gen, _sentinel)
+                if cumulative is _sentinel:
+                    break
+                if isinstance(cumulative, dict):
+                    if cumulative.get("type") == "metadata":
+                        for line in emitter.feed(cumulative):
+                            yield line
+                    continue
+                # Plain generator yields cumulative text strings
+                for line in emitter.feed({"type": "content", "text": cumulative}):
+                    yield line
+        except Exception as e:
+            logger.error("anthropic_messages stream error: %s", e)
+
+        for line in emitter.finish("end_turn"):
+            yield line
+
+    return StreamingResponse(
+        _stream(),
+        media_type = "text/event-stream",
+        headers = {
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _anthropic_tool_non_streaming(run_gen, message_id, model_name):
+    """Non-streaming response for the tool-calling path."""
+    text_parts = []
+    tool_blocks = []
+    usage = {}
+    prev_text = ""
+
+    for event in run_gen():
+        etype = event.get("type", "")
+        if etype == "content":
+            new = event["text"][len(prev_text):]
+            prev_text = event["text"]
+            if new:
+                text_parts.append(new)
+        elif etype == "tool_start":
+            tool_blocks.append(AnthropicResponseToolUseBlock(
+                id = event["tool_call_id"],
+                name = event["tool_name"],
+                input = event.get("arguments", {}),
+            ))
+        elif etype == "metadata":
+            usage = event.get("usage", {})
+
+    content_blocks = []
+    for tb in tool_blocks:
+        content_blocks.append(tb)
+    full_text = "".join(text_parts)
+    if full_text:
+        content_blocks.append(AnthropicResponseTextBlock(text = full_text))
+
+    resp = AnthropicMessagesResponse(
+        id = message_id,
+        model = model_name,
+        content = content_blocks,
+        stop_reason = "end_turn",
+        usage = AnthropicUsage(
+            input_tokens = usage.get("prompt_tokens", 0),
+            output_tokens = usage.get("completion_tokens", 0),
+        ),
+    )
+    return JSONResponse(content = resp.model_dump())
+
+
+async def _anthropic_plain_non_streaming(run_gen, message_id, model_name):
+    """Non-streaming response for the no-tool path."""
+    text_parts = []
+    usage = {}
+    prev_text = ""
+
+    for cumulative in run_gen():
+        if isinstance(cumulative, dict):
+            if cumulative.get("type") == "metadata":
+                usage = cumulative.get("usage", {})
+            continue
+        new = cumulative[len(prev_text):]
+        prev_text = cumulative
+        if new:
+            text_parts.append(new)
+
+    full_text = "".join(text_parts)
+    content_blocks = []
+    if full_text:
+        content_blocks.append(AnthropicResponseTextBlock(text = full_text))
+
+    resp = AnthropicMessagesResponse(
+        id = message_id,
+        model = model_name,
+        content = content_blocks,
+        stop_reason = "end_turn",
+        usage = AnthropicUsage(
+            input_tokens = usage.get("prompt_tokens", 0),
+            output_tokens = usage.get("completion_tokens", 0),
+        ),
+    )
+    return JSONResponse(content = resp.model_dump())

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2259,8 +2259,7 @@ async def anthropic_messages(
     # 1. Anthropic-style: send full tool definitions in payload.tools
     # 2. Unsloth shorthand: enable_tools=true + optional enabled_tools list
     use_tools = llama_backend.supports_tools and (
-        (payload.tools and len(payload.tools) > 0)
-        or payload.enable_tools
+        (payload.tools and len(payload.tools) > 0) or payload.enable_tools
     )
 
     if use_tools:
@@ -2270,8 +2269,7 @@ async def anthropic_messages(
             openai_tools = anthropic_tools_to_openai(payload.tools)
         elif payload.enabled_tools is not None:
             openai_tools = [
-                t for t in ALL_TOOLS
-                if t["function"]["name"] in payload.enabled_tools
+                t for t in ALL_TOOLS if t["function"]["name"] in payload.enabled_tools
             ]
         else:
             openai_tools = ALL_TOOLS
@@ -2304,7 +2302,9 @@ async def anthropic_messages(
                 _date_line + " "
                 "You have access to tools. When appropriate, prefer using "
                 "tools rather than answering from memory. "
-                + _web_tips + " " + _code_tips
+                + _web_tips
+                + " "
+                + _code_tips
             )
         elif _has_code:
             _nudge = (
@@ -2354,10 +2354,16 @@ async def anthropic_messages(
 
         if payload.stream:
             return await _anthropic_tool_stream(
-                request, cancel_event, _run_tool_gen, message_id, model_name,
+                request,
+                cancel_event,
+                _run_tool_gen,
+                message_id,
+                model_name,
             )
         return await _anthropic_tool_non_streaming(
-            _run_tool_gen, message_id, model_name,
+            _run_tool_gen,
+            message_id,
+            model_name,
         )
 
     # ── No-tool path ──────────────────────────────────────────
@@ -2373,15 +2379,25 @@ async def anthropic_messages(
 
     if payload.stream:
         return await _anthropic_plain_stream(
-            request, cancel_event, _run_plain_gen, message_id, model_name,
+            request,
+            cancel_event,
+            _run_plain_gen,
+            message_id,
+            model_name,
         )
     return await _anthropic_plain_non_streaming(
-        _run_plain_gen, message_id, model_name,
+        _run_plain_gen,
+        message_id,
+        model_name,
     )
 
 
 async def _anthropic_tool_stream(
-    request, cancel_event, run_gen, message_id, model_name,
+    request,
+    cancel_event,
+    run_gen,
+    message_id,
+    model_name,
 ):
     """Streaming response for the tool-calling path."""
     _sentinel = object()
@@ -2424,7 +2440,11 @@ async def _anthropic_tool_stream(
 
 
 async def _anthropic_plain_stream(
-    request, cancel_event, run_gen, message_id, model_name,
+    request,
+    cancel_event,
+    run_gen,
+    message_id,
+    model_name,
 ):
     """Streaming response for the no-tool path."""
     _sentinel = object()
@@ -2480,16 +2500,18 @@ async def _anthropic_tool_non_streaming(run_gen, message_id, model_name):
         if etype == "content":
             # Strip leaked tool-call XML
             clean = _TOOL_XML_RE.sub("", event["text"])
-            new = clean[len(prev_text):]
+            new = clean[len(prev_text) :]
             prev_text = clean
             if new:
                 text_parts.append(new)
         elif etype == "tool_start":
-            tool_blocks.append(AnthropicResponseToolUseBlock(
-                id = event["tool_call_id"],
-                name = event["tool_name"],
-                input = event.get("arguments", {}),
-            ))
+            tool_blocks.append(
+                AnthropicResponseToolUseBlock(
+                    id = event["tool_call_id"],
+                    name = event["tool_name"],
+                    input = event.get("arguments", {}),
+                )
+            )
         elif etype == "metadata":
             usage = event.get("usage", {})
 
@@ -2524,7 +2546,7 @@ async def _anthropic_plain_non_streaming(run_gen, message_id, model_name):
             if cumulative.get("type") == "metadata":
                 usage = cumulative.get("usage", {})
             continue
-        new = cumulative[len(prev_text):]
+        new = cumulative[len(prev_text) :]
         prev_text = cumulative
         if new:
             text_parts.append(new)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2400,6 +2400,10 @@ async def _anthropic_tool_stream(
                 event = await asyncio.to_thread(next, gen, _sentinel)
                 if event is _sentinel:
                     break
+                # Strip leaked tool-call XML from content events
+                if event.get("type") == "content":
+                    event = dict(event)
+                    event["text"] = _TOOL_XML_RE.sub("", event["text"])
                 for line in emitter.feed(event):
                     yield line
         except Exception as e:
@@ -2474,8 +2478,10 @@ async def _anthropic_tool_non_streaming(run_gen, message_id, model_name):
     for event in run_gen():
         etype = event.get("type", "")
         if etype == "content":
-            new = event["text"][len(prev_text):]
-            prev_text = event["text"]
+            # Strip leaked tool-call XML
+            clean = _TOOL_XML_RE.sub("", event["text"])
+            new = clean[len(prev_text):]
+            prev_text = clean
             if new:
                 text_parts.append(new)
         elif etype == "tool_start":
@@ -2490,7 +2496,7 @@ async def _anthropic_tool_non_streaming(run_gen, message_id, model_name):
     content_blocks = []
     for tb in tool_blocks:
         content_blocks.append(tb)
-    full_text = "".join(text_parts)
+    full_text = "".join(text_parts).strip()
     if full_text:
         content_blocks.append(AnthropicResponseTextBlock(text = full_text))
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -106,6 +106,7 @@ from core.inference.anthropic_compat import (
     anthropic_messages_to_openai,
     anthropic_tools_to_openai,
     AnthropicStreamEmitter,
+    AnthropicPassthroughEmitter,
 )
 from auth.authentication import get_current_subject
 
@@ -2254,20 +2255,53 @@ async def anthropic_messages(
 
     cancel_event = threading.Event()
 
-    # ── Tool-calling path ─────────────────────────────────────
-    # Two ways to enable tools:
-    # 1. Anthropic-style: send full tool definitions in payload.tools
-    # 2. Unsloth shorthand: enable_tools=true + optional enabled_tools list
-    use_tools = llama_backend.supports_tools and (
-        (payload.tools and len(payload.tools) > 0) or payload.enable_tools
+    # ── Tool routing ──────────────────────────────────────────
+    # Three paths:
+    # 1. enable_tools=true → server-side execution of built-in tools (Unsloth shorthand)
+    # 2. tools=[...] only  → client-side pass-through (standard Anthropic behavior)
+    # 3. neither           → plain chat
+    server_tools = payload.enable_tools and llama_backend.supports_tools
+    client_tools = (
+        not server_tools
+        and payload.tools
+        and len(payload.tools) > 0
+        and llama_backend.supports_tools
     )
 
-    if use_tools:
+    # ── Client-side pass-through path ─────────────────────────
+    if client_tools:
+        openai_tools = anthropic_tools_to_openai(payload.tools)
+
+        if payload.stream:
+            return await _anthropic_passthrough_stream(
+                request,
+                cancel_event,
+                llama_backend,
+                openai_messages,
+                openai_tools,
+                temperature,
+                top_p,
+                top_k,
+                payload.max_tokens,
+                message_id,
+                model_name,
+            )
+        return await _anthropic_passthrough_non_streaming(
+            llama_backend,
+            openai_messages,
+            openai_tools,
+            temperature,
+            top_p,
+            top_k,
+            payload.max_tokens,
+            message_id,
+            model_name,
+        )
+
+    if server_tools:
         from core.inference.tools import ALL_TOOLS
 
-        if payload.tools and len(payload.tools) > 0:
-            openai_tools = anthropic_tools_to_openai(payload.tools)
-        elif payload.enabled_tools is not None:
+        if payload.enabled_tools is not None:
             openai_tools = [
                 t for t in ALL_TOOLS if t["function"]["name"] in payload.enabled_tools
             ]
@@ -2567,3 +2601,184 @@ async def _anthropic_plain_non_streaming(run_gen, message_id, model_name):
         ),
     )
     return JSONResponse(content = resp.model_dump())
+
+
+# =====================================================================
+# Client-side tool pass-through (Anthropic-native tools field)
+# =====================================================================
+
+
+def _build_passthrough_payload(
+    openai_messages,
+    openai_tools,
+    temperature,
+    top_p,
+    top_k,
+    max_tokens,
+    stream,
+):
+    body = {
+        "messages": openai_messages,
+        "tools": openai_tools,
+        "tool_choice": "auto",
+        "temperature": temperature,
+        "top_p": top_p,
+        "top_k": top_k,
+        "stream": stream,
+    }
+    if stream:
+        body["stream_options"] = {"include_usage": True}
+    if max_tokens is not None:
+        body["max_tokens"] = max_tokens
+    return body
+
+
+async def _anthropic_passthrough_stream(
+    request,
+    cancel_event,
+    llama_backend,
+    openai_messages,
+    openai_tools,
+    temperature,
+    top_p,
+    top_k,
+    max_tokens,
+    message_id,
+    model_name,
+):
+    """Streaming client-side pass-through: forward tools to llama-server and
+    translate its streaming response to Anthropic SSE without executing anything."""
+    target_url = f"{llama_backend.base_url}/v1/chat/completions"
+    body = _build_passthrough_payload(
+        openai_messages,
+        openai_tools,
+        temperature,
+        top_p,
+        top_k,
+        max_tokens,
+        True,
+    )
+
+    async def _stream():
+        emitter = AnthropicPassthroughEmitter()
+        for line in emitter.start(message_id, model_name):
+            yield line
+
+        try:
+            async with httpx.AsyncClient() as client:
+                async with client.stream(
+                    "POST",
+                    target_url,
+                    json = body,
+                    timeout = 600,
+                ) as resp:
+                    async for raw_line in resp.aiter_lines():
+                        if await request.is_disconnected():
+                            cancel_event.set()
+                            return
+                        if not raw_line or not raw_line.startswith("data: "):
+                            continue
+                        data_str = raw_line[6:]
+                        if data_str.strip() == "[DONE]":
+                            break
+                        try:
+                            chunk = json.loads(data_str)
+                        except json.JSONDecodeError:
+                            continue
+                        for line in emitter.feed_chunk(chunk):
+                            yield line
+        except Exception as e:
+            logger.error("anthropic_messages passthrough stream error: %s", e)
+
+        for line in emitter.finish():
+            yield line
+
+    return StreamingResponse(
+        _stream(),
+        media_type = "text/event-stream",
+        headers = {
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _anthropic_passthrough_non_streaming(
+    llama_backend,
+    openai_messages,
+    openai_tools,
+    temperature,
+    top_p,
+    top_k,
+    max_tokens,
+    message_id,
+    model_name,
+):
+    """Non-streaming client-side pass-through."""
+    target_url = f"{llama_backend.base_url}/v1/chat/completions"
+    body = _build_passthrough_payload(
+        openai_messages,
+        openai_tools,
+        temperature,
+        top_p,
+        top_k,
+        max_tokens,
+        False,
+    )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(target_url, json = body, timeout = 600)
+
+    if resp.status_code != 200:
+        raise HTTPException(
+            status_code = resp.status_code,
+            detail = f"llama-server error: {resp.text[:500]}",
+        )
+
+    data = resp.json()
+    choice = (data.get("choices") or [{}])[0]
+    message = choice.get("message") or {}
+    finish_reason = choice.get("finish_reason")
+
+    content_blocks = []
+    text = message.get("content") or ""
+    if text:
+        text = _TOOL_XML_RE.sub("", text).strip()
+        if text:
+            content_blocks.append(AnthropicResponseTextBlock(text = text))
+
+    tool_calls = message.get("tool_calls") or []
+    for tc in tool_calls:
+        fn = tc.get("function") or {}
+        try:
+            args = json.loads(fn.get("arguments", "{}"))
+        except json.JSONDecodeError:
+            args = {}
+        content_blocks.append(
+            AnthropicResponseToolUseBlock(
+                id = tc.get("id", ""),
+                name = fn.get("name", ""),
+                input = args,
+            )
+        )
+
+    if tool_calls:
+        stop_reason = "tool_use"
+    elif finish_reason == "length":
+        stop_reason = "max_tokens"
+    else:
+        stop_reason = "end_turn"
+
+    usage = data.get("usage") or {}
+    resp_obj = AnthropicMessagesResponse(
+        id = message_id,
+        model = model_name,
+        content = content_blocks,
+        stop_reason = stop_reason,
+        usage = AnthropicUsage(
+            input_tokens = usage.get("prompt_tokens", 0),
+            output_tokens = usage.get("completion_tokens", 0),
+        ),
+    )
+    return JSONResponse(content = resp_obj.model_dump())

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2252,6 +2252,13 @@ async def anthropic_messages(
     temperature = payload.temperature if payload.temperature is not None else 0.6
     top_p = payload.top_p if payload.top_p is not None else 0.95
     top_k = payload.top_k if payload.top_k is not None else 20
+    min_p = payload.min_p if payload.min_p is not None else 0.01
+    repetition_penalty = (
+        payload.repetition_penalty if payload.repetition_penalty is not None else 1.0
+    )
+    presence_penalty = (
+        payload.presence_penalty if payload.presence_penalty is not None else 0.0
+    )
     stop = payload.stop_sequences or None
 
     # tool_choice is declared on AnthropicMessagesRequest for Anthropic SDK
@@ -2304,6 +2311,9 @@ async def anthropic_messages(
                 message_id,
                 model_name,
                 stop = stop,
+                min_p = min_p,
+                repetition_penalty = repetition_penalty,
+                presence_penalty = presence_penalty,
             )
         return await _anthropic_passthrough_non_streaming(
             llama_backend,
@@ -2316,6 +2326,9 @@ async def anthropic_messages(
             message_id,
             model_name,
             stop = stop,
+            min_p = min_p,
+            repetition_penalty = repetition_penalty,
+            presence_penalty = presence_penalty,
         )
 
     if server_tools:
@@ -2398,6 +2411,9 @@ async def anthropic_messages(
                 temperature = temperature,
                 top_p = top_p,
                 top_k = top_k,
+                min_p = min_p,
+                repetition_penalty = repetition_penalty,
+                presence_penalty = presence_penalty,
                 max_tokens = payload.max_tokens,
                 stop = stop,
                 cancel_event = cancel_event,
@@ -2428,6 +2444,9 @@ async def anthropic_messages(
             temperature = temperature,
             top_p = top_p,
             top_k = top_k,
+            min_p = min_p,
+            repetition_penalty = repetition_penalty,
+            presence_penalty = presence_penalty,
             max_tokens = payload.max_tokens,
             stop = stop,
             cancel_event = cancel_event,
@@ -2639,6 +2658,9 @@ def _build_passthrough_payload(
     max_tokens,
     stream,
     stop = None,
+    min_p = None,
+    repetition_penalty = None,
+    presence_penalty = None,
 ):
     body = {
         "messages": openai_messages,
@@ -2655,6 +2677,13 @@ def _build_passthrough_payload(
         body["max_tokens"] = max_tokens
     if stop:
         body["stop"] = stop
+    if min_p is not None:
+        body["min_p"] = min_p
+    if repetition_penalty is not None:
+        # llama-server's field is "repeat_penalty", not "repetition_penalty"
+        body["repeat_penalty"] = repetition_penalty
+    if presence_penalty is not None:
+        body["presence_penalty"] = presence_penalty
     return body
 
 
@@ -2671,6 +2700,9 @@ async def _anthropic_passthrough_stream(
     message_id,
     model_name,
     stop = None,
+    min_p = None,
+    repetition_penalty = None,
+    presence_penalty = None,
 ):
     """Streaming client-side pass-through: forward tools to llama-server and
     translate its streaming response to Anthropic SSE without executing anything."""
@@ -2684,6 +2716,9 @@ async def _anthropic_passthrough_stream(
         max_tokens,
         True,
         stop = stop,
+        min_p = min_p,
+        repetition_penalty = repetition_penalty,
+        presence_penalty = presence_penalty,
     )
 
     async def _stream():
@@ -2757,6 +2792,9 @@ async def _anthropic_passthrough_non_streaming(
     message_id,
     model_name,
     stop = None,
+    min_p = None,
+    repetition_penalty = None,
+    presence_penalty = None,
 ):
     """Non-streaming client-side pass-through."""
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
@@ -2769,6 +2807,9 @@ async def _anthropic_passthrough_non_streaming(
         max_tokens,
         False,
         stop = stop,
+        min_p = min_p,
+        repetition_penalty = repetition_penalty,
+        presence_penalty = presence_penalty,
     )
 
     async with httpx.AsyncClient() as client:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2252,6 +2252,24 @@ async def anthropic_messages(
     temperature = payload.temperature if payload.temperature is not None else 0.6
     top_p = payload.top_p if payload.top_p is not None else 0.95
     top_k = payload.top_k if payload.top_k is not None else 20
+    stop = payload.stop_sequences or None
+
+    # tool_choice is declared on AnthropicMessagesRequest for Anthropic SDK
+    # compatibility (the SDK often sets it by default), but it is not
+    # currently honored by Unsloth's backend. Warn once per request so the
+    # silent drop is visible to operators instead of looking like a model
+    # quality issue to clients.
+    if payload.tool_choice is not None:
+        logger.warning(
+            "anthropic_messages.tool_choice_ignored",
+            tool_choice = payload.tool_choice,
+            note = (
+                "tool_choice is accepted for Anthropic SDK compatibility but not "
+                "honored by Unsloth. Use enable_tools / enabled_tools (server-side "
+                "built-in tools) or restrict the `tools` array (client-side) to "
+                "control which tools the model sees."
+            ),
+        )
 
     cancel_event = threading.Event()
 
@@ -2285,6 +2303,7 @@ async def anthropic_messages(
                 payload.max_tokens,
                 message_id,
                 model_name,
+                stop = stop,
             )
         return await _anthropic_passthrough_non_streaming(
             llama_backend,
@@ -2296,6 +2315,7 @@ async def anthropic_messages(
             payload.max_tokens,
             message_id,
             model_name,
+            stop = stop,
         )
 
     if server_tools:
@@ -2379,6 +2399,7 @@ async def anthropic_messages(
                 top_p = top_p,
                 top_k = top_k,
                 max_tokens = payload.max_tokens,
+                stop = stop,
                 cancel_event = cancel_event,
                 max_tool_iterations = 25,
                 auto_heal_tool_calls = True,
@@ -2408,6 +2429,7 @@ async def anthropic_messages(
             top_p = top_p,
             top_k = top_k,
             max_tokens = payload.max_tokens,
+            stop = stop,
             cancel_event = cancel_event,
         )
 
@@ -2616,6 +2638,7 @@ def _build_passthrough_payload(
     top_k,
     max_tokens,
     stream,
+    stop = None,
 ):
     body = {
         "messages": openai_messages,
@@ -2630,6 +2653,8 @@ def _build_passthrough_payload(
         body["stream_options"] = {"include_usage": True}
     if max_tokens is not None:
         body["max_tokens"] = max_tokens
+    if stop:
+        body["stop"] = stop
     return body
 
 
@@ -2645,6 +2670,7 @@ async def _anthropic_passthrough_stream(
     max_tokens,
     message_id,
     model_name,
+    stop = None,
 ):
     """Streaming client-side pass-through: forward tools to llama-server and
     translate its streaming response to Anthropic SSE without executing anything."""
@@ -2657,6 +2683,7 @@ async def _anthropic_passthrough_stream(
         top_k,
         max_tokens,
         True,
+        stop = stop,
     )
 
     async def _stream():
@@ -2729,6 +2756,7 @@ async def _anthropic_passthrough_non_streaming(
     max_tokens,
     message_id,
     model_name,
+    stop = None,
 ):
     """Non-streaming client-side pass-through."""
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
@@ -2740,6 +2768,7 @@ async def _anthropic_passthrough_non_streaming(
         top_k,
         max_tokens,
         False,
+        stop = stop,
     )
 
     async with httpx.AsyncClient() as client:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2255,16 +2255,26 @@ async def anthropic_messages(
     cancel_event = threading.Event()
 
     # ── Tool-calling path ─────────────────────────────────────
-    use_tools = (
-        payload.tools
-        and len(payload.tools) > 0
-        and llama_backend.supports_tools
+    # Two ways to enable tools:
+    # 1. Anthropic-style: send full tool definitions in payload.tools
+    # 2. Unsloth shorthand: enable_tools=true + optional enabled_tools list
+    use_tools = llama_backend.supports_tools and (
+        (payload.tools and len(payload.tools) > 0)
+        or payload.enable_tools
     )
 
     if use_tools:
         from core.inference.tools import ALL_TOOLS
 
-        openai_tools = anthropic_tools_to_openai(payload.tools)
+        if payload.tools and len(payload.tools) > 0:
+            openai_tools = anthropic_tools_to_openai(payload.tools)
+        elif payload.enabled_tools is not None:
+            openai_tools = [
+                t for t in ALL_TOOLS
+                if t["function"]["name"] in payload.enabled_tools
+            ]
+        else:
+            openai_tools = ALL_TOOLS
 
         # Build tool-use system prompt nudge (same logic as /chat/completions)
         _tool_names = {t["function"]["name"] for t in openai_tools}
@@ -2339,6 +2349,7 @@ async def anthropic_messages(
                 max_tool_iterations = 25,
                 auto_heal_tool_calls = True,
                 tool_call_timeout = 300,
+                session_id = payload.session_id,
             )
 
         if payload.stream:

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -9,7 +9,7 @@ Responsibilities:
    (and similar flat imports) resolve in test modules — mirrors how the
    app itself is launched.
 2. Provide a hybrid ``studio_server`` session fixture for end-to-end tests
-   (see ``test_studio_run.py``). The fixture supports two invocation modes:
+   (see ``test_studio_api.py``). The fixture supports two invocation modes:
 
    a. **External server.** If ``UNSLOTH_E2E_BASE_URL`` is set, tests point
       at an already-running Studio instance. ``UNSLOTH_E2E_API_KEY`` must
@@ -24,7 +24,7 @@ Responsibilities:
    The model / variant for mode (b) come from ``--unsloth-model`` /
    ``--unsloth-gguf-variant`` pytest options, then ``UNSLOTH_E2E_MODEL`` /
    ``UNSLOTH_E2E_VARIANT`` env vars, then the defaults in
-   ``test_studio_run.py``.
+   ``test_studio_api.py``.
 """
 
 import os
@@ -54,7 +54,7 @@ def pytest_addoption(parser):
         help = (
             "GGUF model id used when starting a server for e2e tests. "
             "Ignored if UNSLOTH_E2E_BASE_URL is set. Overrides "
-            "UNSLOTH_E2E_MODEL env var. Defaults to test_studio_run.py's "
+            "UNSLOTH_E2E_MODEL env var. Defaults to test_studio_api.py's "
             "DEFAULT_MODEL."
         ),
     )
@@ -65,7 +65,7 @@ def pytest_addoption(parser):
         help = (
             "GGUF variant used when starting a server for e2e tests. "
             "Ignored if UNSLOTH_E2E_BASE_URL is set. Overrides "
-            "UNSLOTH_E2E_VARIANT env var. Defaults to test_studio_run.py's "
+            "UNSLOTH_E2E_VARIANT env var. Defaults to test_studio_api.py's "
             "DEFAULT_VARIANT."
         ),
     )
@@ -83,7 +83,7 @@ def studio_server(request):
     1. If ``UNSLOTH_E2E_BASE_URL`` is set → point at that server,
        require ``UNSLOTH_E2E_API_KEY`` alongside (skip if missing).
     2. Otherwise → start a fresh ``unsloth studio run`` subprocess via
-       the existing ``_start_server`` helper in ``test_studio_run.py``
+       the existing ``_start_server`` helper in ``test_studio_api.py``
        and tear it down on session teardown.
 
     Session-scoped so the expensive GGUF load happens at most once per
@@ -103,10 +103,10 @@ def studio_server(request):
         yield external_url, api_key
         return
 
-    # Lazy import: pytest has already loaded test_studio_run into
+    # Lazy import: pytest has already loaded test_studio_api into
     # sys.modules by the time any test requests this fixture, so this
     # is a cache hit, not a re-execution.
-    import test_studio_run as _e2e
+    import test_studio_api as _e2e
 
     model = (
         request.config.getoption("--unsloth-model")

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -3,14 +3,136 @@
 
 """
 Shared pytest configuration for the backend test suite.
-Ensures that the backend root is on sys.path so that
-`import utils.utils` (and similar flat imports) resolve correctly.
+
+Responsibilities:
+1. Put the backend root on sys.path so `from models.inference import ...`
+   (and similar flat imports) resolve in test modules — mirrors how the
+   app itself is launched.
+2. Provide a hybrid ``studio_server`` session fixture for end-to-end tests
+   (see ``test_studio_run.py``). The fixture supports two invocation modes:
+
+   a. **External server.** If ``UNSLOTH_E2E_BASE_URL`` is set, tests point
+      at an already-running Studio instance. ``UNSLOTH_E2E_API_KEY`` must
+      also be set. This is the fast-iteration mode: start the server once
+      with ``unsloth studio run ...``, then run pytest against it many
+      times with no per-run GGUF load cost.
+
+   b. **Fixture-managed server.** Otherwise, the fixture launches a fresh
+      server via ``_start_server`` and tears it down at session end. This
+      is the one-shot mode for CI or a clean-slate verification run.
+
+   The model / variant for mode (b) come from ``--unsloth-model`` /
+   ``--unsloth-gguf-variant`` pytest options, then ``UNSLOTH_E2E_MODEL`` /
+   ``UNSLOTH_E2E_VARIANT`` env vars, then the defaults in
+   ``test_studio_run.py``.
 """
 
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 # Add backend root to sys.path (mirrors how the app itself is launched)
 _backend_root = Path(__file__).resolve().parent.parent
 if str(_backend_root) not in sys.path:
     sys.path.insert(0, str(_backend_root))
+
+
+# ── Pytest CLI options ───────────────────────────────────────────────
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup(
+        "unsloth-e2e",
+        "Unsloth Studio end-to-end test options",
+    )
+    group.addoption(
+        "--unsloth-model",
+        action = "store",
+        default = None,
+        help = (
+            "GGUF model id used when starting a server for e2e tests. "
+            "Ignored if UNSLOTH_E2E_BASE_URL is set. Overrides "
+            "UNSLOTH_E2E_MODEL env var. Defaults to test_studio_run.py's "
+            "DEFAULT_MODEL."
+        ),
+    )
+    group.addoption(
+        "--unsloth-gguf-variant",
+        action = "store",
+        default = None,
+        help = (
+            "GGUF variant used when starting a server for e2e tests. "
+            "Ignored if UNSLOTH_E2E_BASE_URL is set. Overrides "
+            "UNSLOTH_E2E_VARIANT env var. Defaults to test_studio_run.py's "
+            "DEFAULT_VARIANT."
+        ),
+    )
+
+
+# ── E2E server fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture(scope = "session")
+def studio_server(request):
+    """Yield ``(base_url, api_key)`` for e2e tests.
+
+    Resolution order:
+
+    1. If ``UNSLOTH_E2E_BASE_URL`` is set → point at that server,
+       require ``UNSLOTH_E2E_API_KEY`` alongside (skip if missing).
+    2. Otherwise → start a fresh ``unsloth studio run`` subprocess via
+       the existing ``_start_server`` helper in ``test_studio_run.py``
+       and tear it down on session teardown.
+
+    Session-scoped so the expensive GGUF load happens at most once per
+    pytest invocation. Lazily instantiated — tests that don't request
+    the fixture (e.g. the unit tests in ``test_anthropic_messages.py``
+    or ``test_help_output``) do not trigger server startup.
+    """
+    external_url = os.environ.get("UNSLOTH_E2E_BASE_URL")
+    if external_url:
+        api_key = os.environ.get("UNSLOTH_E2E_API_KEY")
+        if not api_key:
+            pytest.skip(
+                "UNSLOTH_E2E_BASE_URL is set but UNSLOTH_E2E_API_KEY is "
+                "missing — tests that require auth cannot run against an "
+                "external server without it.",
+            )
+        yield external_url, api_key
+        return
+
+    # Lazy import: pytest has already loaded test_studio_run into
+    # sys.modules by the time any test requests this fixture, so this
+    # is a cache hit, not a re-execution.
+    import test_studio_run as _e2e
+
+    model = (
+        request.config.getoption("--unsloth-model")
+        or os.environ.get("UNSLOTH_E2E_MODEL")
+        or _e2e.DEFAULT_MODEL
+    )
+    variant = (
+        request.config.getoption("--unsloth-gguf-variant")
+        or os.environ.get("UNSLOTH_E2E_VARIANT")
+        or _e2e.DEFAULT_VARIANT
+    )
+
+    proc, api_key = _e2e._start_server(model, variant)
+    try:
+        yield f"http://{_e2e.HOST}:{_e2e.PORT}", api_key
+    finally:
+        _e2e._kill_server(proc)
+
+
+@pytest.fixture
+def base_url(studio_server):
+    """Base URL for the e2e Studio server (from ``studio_server``)."""
+    return studio_server[0]
+
+
+@pytest.fixture
+def api_key(studio_server):
+    """API key for the e2e Studio server (from ``studio_server``)."""
+    return studio_server[1]

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -328,11 +328,15 @@ class TestAnthropicStreamEmitter:
         e.start("msg_1", "m")
         e.feed({"type": "tool_start", "tool_name": "t", "tool_call_id": "tc_1", "arguments": {}})
         events = e.feed({"type": "tool_end", "tool_name": "t", "tool_call_id": "tc_1", "result": "done"})
-        # content_block_stop (tool) + content_block_start (new text)
-        assert len(events) == 2
+        # content_block_stop (tool) + tool_result + content_block_start (new text)
+        assert len(events) == 3
         assert "content_block_stop" in events[0]
-        assert "content_block_start" in events[1]
-        assert '"type": "text"' in events[1]
+        assert "tool_result" in events[1]
+        parsed = json.loads(events[1].split("data: ")[1])
+        assert parsed["content"] == "done"
+        assert parsed["tool_use_id"] == "tc_1"
+        assert "content_block_start" in events[2]
+        assert '"type": "text"' in events[2]
 
     def test_finish_emits_stop_events(self):
         e = AnthropicStreamEmitter()

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -30,6 +30,7 @@ from core.inference.anthropic_compat import (
     anthropic_tools_to_openai,
     build_anthropic_sse_event,
     AnthropicStreamEmitter,
+    AnthropicPassthroughEmitter,
 )
 
 
@@ -486,3 +487,193 @@ class TestAnthropicStreamEmitter:
         events = e.feed({"type": "content", "text": "After tool"})
         parsed = json.loads(events[0].split("data: ")[1])
         assert parsed["delta"]["text"] == "After tool"
+
+
+# =====================================================================
+# Pass-through emitter tests (client-side tool execution path)
+# =====================================================================
+
+
+class TestAnthropicPassthroughEmitter:
+
+    def _parse(self, event_str):
+        return json.loads(event_str.split("data: ")[1])
+
+    def test_start_emits_message_start_only(self):
+        e = AnthropicPassthroughEmitter()
+        events = e.start("msg_1", "test-model")
+        assert len(events) == 1
+        assert "message_start" in events[0]
+        parsed = self._parse(events[0])
+        assert parsed["message"]["id"] == "msg_1"
+        assert parsed["message"]["model"] == "test-model"
+
+    def test_text_chunk_opens_text_block_and_emits_delta(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        chunk = {"choices": [{"delta": {"content": "Hello"}}]}
+        events = e.feed_chunk(chunk)
+        # content_block_start + content_block_delta
+        assert len(events) == 2
+        assert "content_block_start" in events[0]
+        assert '"type": "text"' in events[0]
+        delta = self._parse(events[1])
+        assert delta["delta"]["type"] == "text_delta"
+        assert delta["delta"]["text"] == "Hello"
+
+    def test_sequential_text_chunks_single_block(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        events1 = e.feed_chunk({"choices": [{"delta": {"content": "Hello"}}]})
+        events2 = e.feed_chunk({"choices": [{"delta": {"content": " world"}}]})
+        # First chunk opens the block, second only emits delta
+        assert len(events1) == 2
+        assert len(events2) == 1
+        assert self._parse(events2[0])["delta"]["text"] == " world"
+
+    def test_tool_call_opens_tool_use_block(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        chunk = {
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "Bash", "arguments": ""},
+                    }]
+                }
+            }]
+        }
+        events = e.feed_chunk(chunk)
+        assert len(events) == 1
+        parsed = self._parse(events[0])
+        assert parsed["type"] == "content_block_start"
+        assert parsed["content_block"]["type"] == "tool_use"
+        assert parsed["content_block"]["id"] == "call_1"
+        assert parsed["content_block"]["name"] == "Bash"
+
+    def test_tool_call_arguments_streamed_as_input_json_delta(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        # Open the tool call
+        e.feed_chunk({"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "id": "c1", "type": "function",
+             "function": {"name": "Bash", "arguments": ""}}
+        ]}}]})
+        # Stream argument fragments
+        events1 = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "function": {"arguments": "{\"cmd"}}
+        ]}}]})
+        events2 = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "function": {"arguments": "\": \"ls\"}"}}
+        ]}}]})
+        parsed1 = self._parse(events1[0])
+        parsed2 = self._parse(events2[0])
+        assert parsed1["delta"]["type"] == "input_json_delta"
+        assert parsed1["delta"]["partial_json"] == "{\"cmd"
+        assert parsed2["delta"]["partial_json"] == "\": \"ls\"}"
+
+    def test_text_then_tool_closes_text_block(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        e.feed_chunk({"choices": [{"delta": {"content": "Let me check."}}]})
+        events = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "id": "c1", "type": "function",
+             "function": {"name": "Bash", "arguments": ""}}
+        ]}}]})
+        # Should close text block and open tool_use block
+        assert "content_block_stop" in events[0]
+        assert "content_block_start" in events[1]
+        assert '"type": "tool_use"' in events[1]
+
+    def test_finish_reason_tool_calls_sets_tool_use_stop(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        e.feed_chunk({"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "id": "c1", "type": "function",
+             "function": {"name": "Bash", "arguments": "{}"}}
+        ]}}]})
+        e.feed_chunk({"choices": [{"delta": {}, "finish_reason": "tool_calls"}]})
+        events = e.finish()
+        delta_event = [ev for ev in events if "message_delta" in ev][0]
+        parsed = self._parse(delta_event)
+        assert parsed["delta"]["stop_reason"] == "tool_use"
+
+    def test_finish_reason_stop_sets_end_turn(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        e.feed_chunk({"choices": [{"delta": {"content": "Hi"}}]})
+        e.feed_chunk({"choices": [{"delta": {}, "finish_reason": "stop"}]})
+        events = e.finish()
+        delta_event = [ev for ev in events if "message_delta" in ev][0]
+        parsed = self._parse(delta_event)
+        assert parsed["delta"]["stop_reason"] == "end_turn"
+
+    def test_finish_reason_length_sets_max_tokens(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        e.feed_chunk({"choices": [{"delta": {"content": "Hi"}}]})
+        e.feed_chunk({"choices": [{"delta": {}, "finish_reason": "length"}]})
+        events = e.finish()
+        delta_event = [ev for ev in events if "message_delta" in ev][0]
+        parsed = self._parse(delta_event)
+        assert parsed["delta"]["stop_reason"] == "max_tokens"
+
+    def test_finish_closes_current_block(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        e.feed_chunk({"choices": [{"delta": {"content": "Hi"}}]})
+        events = e.finish()
+        assert "content_block_stop" in events[0]
+        assert "message_delta" in events[1]
+        assert "message_stop" in events[2]
+
+    def test_usage_chunk_captured(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        e.feed_chunk({"choices": [{"delta": {"content": "Hi"}}]})
+        e.feed_chunk({
+            "choices": [],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        })
+        events = e.finish()
+        delta_event = [ev for ev in events if "message_delta" in ev][0]
+        parsed = self._parse(delta_event)
+        assert parsed["usage"]["output_tokens"] == 5
+
+    def test_empty_chunk_returns_no_events(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        events = e.feed_chunk({"choices": []})
+        assert events == []
+
+    def test_no_blocks_at_all_still_produces_valid_finish(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        events = e.finish()
+        # No content_block_stop because no block was opened
+        assert not any("content_block_stop" in ev for ev in events)
+        assert any("message_delta" in ev for ev in events)
+        assert any("message_stop" in ev for ev in events)
+
+    def test_multiple_tool_calls_distinct_blocks(self):
+        e = AnthropicPassthroughEmitter()
+        e.start("msg_1", "m")
+        # First tool call
+        e.feed_chunk({"choices": [{"delta": {"tool_calls": [
+            {"index": 0, "id": "c1", "type": "function",
+             "function": {"name": "Bash", "arguments": "{}"}}
+        ]}}]})
+        # Second tool call (different index)
+        events = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
+            {"index": 1, "id": "c2", "type": "function",
+             "function": {"name": "Read", "arguments": "{}"}}
+        ]}}]})
+        # Should close block 0, open block 1
+        assert "content_block_stop" in events[0]
+        assert "content_block_start" in events[1]
+        parsed = self._parse(events[1])
+        assert parsed["content_block"]["name"] == "Read"
+        assert parsed["content_block"]["id"] == "c2"

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -495,7 +495,6 @@ class TestAnthropicStreamEmitter:
 
 
 class TestAnthropicPassthroughEmitter:
-
     def _parse(self, event_str):
         return json.loads(event_str.split("data: ")[1])
 
@@ -535,16 +534,20 @@ class TestAnthropicPassthroughEmitter:
         e = AnthropicPassthroughEmitter()
         e.start("msg_1", "m")
         chunk = {
-            "choices": [{
-                "delta": {
-                    "tool_calls": [{
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "Bash", "arguments": ""},
-                    }]
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "Bash", "arguments": ""},
+                            }
+                        ]
+                    }
                 }
-            }]
+            ]
         }
         events = e.feed_chunk(chunk)
         assert len(events) == 1
@@ -558,31 +561,79 @@ class TestAnthropicPassthroughEmitter:
         e = AnthropicPassthroughEmitter()
         e.start("msg_1", "m")
         # Open the tool call
-        e.feed_chunk({"choices": [{"delta": {"tool_calls": [
-            {"index": 0, "id": "c1", "type": "function",
-             "function": {"name": "Bash", "arguments": ""}}
-        ]}}]})
+        e.feed_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "c1",
+                                    "type": "function",
+                                    "function": {"name": "Bash", "arguments": ""},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
         # Stream argument fragments
-        events1 = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
-            {"index": 0, "function": {"arguments": "{\"cmd"}}
-        ]}}]})
-        events2 = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
-            {"index": 0, "function": {"arguments": "\": \"ls\"}"}}
-        ]}}]})
+        events1 = e.feed_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "function": {"arguments": '{"cmd'}}
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
+        events2 = e.feed_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "function": {"arguments": '": "ls"}'}}
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
         parsed1 = self._parse(events1[0])
         parsed2 = self._parse(events2[0])
         assert parsed1["delta"]["type"] == "input_json_delta"
-        assert parsed1["delta"]["partial_json"] == "{\"cmd"
-        assert parsed2["delta"]["partial_json"] == "\": \"ls\"}"
+        assert parsed1["delta"]["partial_json"] == '{"cmd'
+        assert parsed2["delta"]["partial_json"] == '": "ls"}'
 
     def test_text_then_tool_closes_text_block(self):
         e = AnthropicPassthroughEmitter()
         e.start("msg_1", "m")
         e.feed_chunk({"choices": [{"delta": {"content": "Let me check."}}]})
-        events = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
-            {"index": 0, "id": "c1", "type": "function",
-             "function": {"name": "Bash", "arguments": ""}}
-        ]}}]})
+        events = e.feed_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "c1",
+                                    "type": "function",
+                                    "function": {"name": "Bash", "arguments": ""},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
         # Should close text block and open tool_use block
         assert "content_block_stop" in events[0]
         assert "content_block_start" in events[1]
@@ -591,10 +642,24 @@ class TestAnthropicPassthroughEmitter:
     def test_finish_reason_tool_calls_sets_tool_use_stop(self):
         e = AnthropicPassthroughEmitter()
         e.start("msg_1", "m")
-        e.feed_chunk({"choices": [{"delta": {"tool_calls": [
-            {"index": 0, "id": "c1", "type": "function",
-             "function": {"name": "Bash", "arguments": "{}"}}
-        ]}}]})
+        e.feed_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "c1",
+                                    "type": "function",
+                                    "function": {"name": "Bash", "arguments": "{}"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
         e.feed_chunk({"choices": [{"delta": {}, "finish_reason": "tool_calls"}]})
         events = e.finish()
         delta_event = [ev for ev in events if "message_delta" in ev][0]
@@ -634,10 +699,12 @@ class TestAnthropicPassthroughEmitter:
         e = AnthropicPassthroughEmitter()
         e.start("msg_1", "m")
         e.feed_chunk({"choices": [{"delta": {"content": "Hi"}}]})
-        e.feed_chunk({
-            "choices": [],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
-        })
+        e.feed_chunk(
+            {
+                "choices": [],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+            }
+        )
         events = e.finish()
         delta_event = [ev for ev in events if "message_delta" in ev][0]
         parsed = self._parse(delta_event)
@@ -662,15 +729,43 @@ class TestAnthropicPassthroughEmitter:
         e = AnthropicPassthroughEmitter()
         e.start("msg_1", "m")
         # First tool call
-        e.feed_chunk({"choices": [{"delta": {"tool_calls": [
-            {"index": 0, "id": "c1", "type": "function",
-             "function": {"name": "Bash", "arguments": "{}"}}
-        ]}}]})
+        e.feed_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "c1",
+                                    "type": "function",
+                                    "function": {"name": "Bash", "arguments": "{}"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
         # Second tool call (different index)
-        events = e.feed_chunk({"choices": [{"delta": {"tool_calls": [
-            {"index": 1, "id": "c2", "type": "function",
-             "function": {"name": "Read", "arguments": "{}"}}
-        ]}}]})
+        events = e.feed_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 1,
+                                    "id": "c2",
+                                    "type": "function",
+                                    "function": {"name": "Read", "arguments": "{}"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
         # Should close block 0, open block 1
         assert "content_block_stop" in events[0]
         assert "content_block_start" in events[1]

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""
+Tests for the Anthropic Messages API schemas and translation layer.
+No running server or GPU required.
+"""
+
+import sys
+import os
+import json
+
+_backend = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, _backend)
+
+from models.inference import (
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+    AnthropicMessage,
+    AnthropicTextBlock,
+    AnthropicToolUseBlock,
+    AnthropicToolResultBlock,
+    AnthropicTool,
+    AnthropicUsage,
+    AnthropicResponseTextBlock,
+    AnthropicResponseToolUseBlock,
+)
+from core.inference.anthropic_compat import (
+    anthropic_messages_to_openai,
+    anthropic_tools_to_openai,
+    build_anthropic_sse_event,
+    AnthropicStreamEmitter,
+)
+
+
+# =====================================================================
+# Pydantic model tests
+# =====================================================================
+
+
+class TestAnthropicModels:
+
+    def test_minimal_request(self):
+        req = AnthropicMessagesRequest(
+            max_tokens = 100,
+            messages = [{"role": "user", "content": "Hi"}],
+        )
+        assert req.max_tokens == 100
+        assert req.model == "default"
+        assert req.stream is False
+
+    def test_system_as_string(self):
+        req = AnthropicMessagesRequest(
+            max_tokens = 50,
+            messages = [{"role": "user", "content": "Hi"}],
+            system = "You are helpful.",
+        )
+        assert req.system == "You are helpful."
+
+    def test_tools_field_parses(self):
+        req = AnthropicMessagesRequest(
+            max_tokens = 100,
+            messages = [{"role": "user", "content": "Hi"}],
+            tools = [{"name": "web_search", "input_schema": {"type": "object"}}],
+        )
+        assert len(req.tools) == 1
+        assert req.tools[0].name == "web_search"
+
+    def test_extra_fields_accepted(self):
+        req = AnthropicMessagesRequest(
+            max_tokens = 100,
+            messages = [{"role": "user", "content": "Hi"}],
+            some_future_field = "hello",
+        )
+        assert req.max_tokens == 100
+
+    def test_stream_defaults_false(self):
+        req = AnthropicMessagesRequest(
+            max_tokens = 100,
+            messages = [{"role": "user", "content": "Hi"}],
+        )
+        assert req.stream is False
+
+    def test_response_model_defaults(self):
+        resp = AnthropicMessagesResponse()
+        assert resp.type == "message"
+        assert resp.role == "assistant"
+        assert resp.id.startswith("msg_")
+        assert resp.content == []
+        assert resp.usage.input_tokens == 0
+
+
+# =====================================================================
+# Message translation tests
+# =====================================================================
+
+
+class TestAnthropicMessagesToOpenAI:
+
+    def test_simple_user_message(self):
+        msgs = [{"role": "user", "content": "Hello"}]
+        result = anthropic_messages_to_openai(msgs)
+        assert result == [{"role": "user", "content": "Hello"}]
+
+    def test_system_string_prepended(self):
+        msgs = [{"role": "user", "content": "Hello"}]
+        result = anthropic_messages_to_openai(msgs, system = "Be brief.")
+        assert result[0] == {"role": "system", "content": "Be brief."}
+        assert result[1] == {"role": "user", "content": "Hello"}
+
+    def test_system_as_block_list(self):
+        system = [{"type": "text", "text": "Be brief."}, {"type": "text", "text": "Be accurate."}]
+        msgs = [{"role": "user", "content": "Hello"}]
+        result = anthropic_messages_to_openai(msgs, system = system)
+        assert result[0]["role"] == "system"
+        assert "Be brief." in result[0]["content"]
+        assert "Be accurate." in result[0]["content"]
+
+    def test_multi_turn_conversation(self):
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        assert len(result) == 3
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[2]["role"] == "user"
+
+    def test_assistant_tool_use_maps_to_tool_calls(self):
+        msgs = [{
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me search."},
+                {"type": "tool_use", "id": "tu_1", "name": "web_search", "input": {"query": "test"}},
+            ],
+        }]
+        result = anthropic_messages_to_openai(msgs)
+        assert len(result) == 1
+        m = result[0]
+        assert m["role"] == "assistant"
+        assert m["content"] == "Let me search."
+        assert len(m["tool_calls"]) == 1
+        tc = m["tool_calls"][0]
+        assert tc["id"] == "tu_1"
+        assert tc["function"]["name"] == "web_search"
+        assert json.loads(tc["function"]["arguments"]) == {"query": "test"}
+
+    def test_tool_result_maps_to_tool_role(self):
+        msgs = [{
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tu_1", "content": "Result text"},
+            ],
+        }]
+        result = anthropic_messages_to_openai(msgs)
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        assert result[0]["tool_call_id"] == "tu_1"
+        assert result[0]["content"] == "Result text"
+
+    def test_mixed_text_and_tool_use_blocks(self):
+        msgs = [{
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Thinking..."},
+                {"type": "tool_use", "id": "tu_1", "name": "python", "input": {"code": "1+1"}},
+                {"type": "tool_use", "id": "tu_2", "name": "terminal", "input": {"command": "ls"}},
+            ],
+        }]
+        result = anthropic_messages_to_openai(msgs)
+        assert len(result) == 1
+        m = result[0]
+        assert m["content"] == "Thinking..."
+        assert len(m["tool_calls"]) == 2
+
+    def test_tool_result_with_list_content(self):
+        msgs = [{
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tu_1", "content": [
+                    {"type": "text", "text": "Line 1"},
+                    {"type": "text", "text": "Line 2"},
+                ]},
+            ],
+        }]
+        result = anthropic_messages_to_openai(msgs)
+        assert result[0]["content"] == "Line 1 Line 2"
+
+
+# =====================================================================
+# Tool translation tests
+# =====================================================================
+
+
+class TestAnthropicToolsToOpenAI:
+
+    def test_single_tool(self):
+        tools = [{"name": "web_search", "description": "Search", "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}}}]
+        result = anthropic_tools_to_openai(tools)
+        assert len(result) == 1
+        assert result[0]["type"] == "function"
+        assert result[0]["function"]["name"] == "web_search"
+        assert result[0]["function"]["parameters"]["type"] == "object"
+
+    def test_multiple_tools(self):
+        tools = [
+            {"name": "a", "description": "Tool A", "input_schema": {}},
+            {"name": "b", "description": "Tool B", "input_schema": {}},
+        ]
+        result = anthropic_tools_to_openai(tools)
+        assert len(result) == 2
+        assert result[0]["function"]["name"] == "a"
+        assert result[1]["function"]["name"] == "b"
+
+    def test_empty_list(self):
+        assert anthropic_tools_to_openai([]) == []
+
+    def test_pydantic_model_input(self):
+        tool = AnthropicTool(name = "test", description = "desc", input_schema = {"type": "object"})
+        result = anthropic_tools_to_openai([tool])
+        assert result[0]["function"]["name"] == "test"
+
+
+# =====================================================================
+# SSE event helper tests
+# =====================================================================
+
+
+class TestBuildAnthropicSSEEvent:
+
+    def test_basic_event(self):
+        result = build_anthropic_sse_event("message_start", {"type": "message_start"})
+        assert result.startswith("event: message_start\n")
+        assert "data: " in result
+        assert result.endswith("\n\n")
+
+    def test_data_is_valid_json(self):
+        result = build_anthropic_sse_event("test", {"key": "value"})
+        data_line = result.split("\n")[1]
+        payload = json.loads(data_line.removeprefix("data: "))
+        assert payload == {"key": "value"}
+
+
+# =====================================================================
+# Stream emitter tests
+# =====================================================================
+
+
+class TestAnthropicStreamEmitter:
+
+    def test_start_emits_message_start_and_content_block_start(self):
+        e = AnthropicStreamEmitter()
+        events = e.start("msg_123", "test-model")
+        assert len(events) == 2
+        assert "message_start" in events[0]
+        assert "content_block_start" in events[1]
+        assert '"type": "text"' in events[1]
+
+    def test_content_delta_emits_text_delta(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        events = e.feed({"type": "content", "text": "Hello"})
+        assert len(events) == 1
+        parsed = json.loads(events[0].split("data: ")[1])
+        assert parsed["delta"]["type"] == "text_delta"
+        assert parsed["delta"]["text"] == "Hello"
+
+    def test_cumulative_content_diffs_correctly(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        e.feed({"type": "content", "text": "Hel"})
+        events = e.feed({"type": "content", "text": "Hello"})
+        parsed = json.loads(events[0].split("data: ")[1])
+        assert parsed["delta"]["text"] == "lo"
+
+    def test_empty_content_diff_no_event(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        e.feed({"type": "content", "text": "Hi"})
+        events = e.feed({"type": "content", "text": "Hi"})
+        assert events == []
+
+    def test_tool_start_closes_text_opens_tool_block(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        e.feed({"type": "content", "text": "Thinking"})
+        events = e.feed({
+            "type": "tool_start",
+            "tool_name": "web_search",
+            "tool_call_id": "tc_1",
+            "arguments": {"query": "test"},
+        })
+        # content_block_stop + content_block_start(tool_use) + content_block_delta(input_json)
+        assert len(events) == 3
+        assert "content_block_stop" in events[0]
+        assert "tool_use" in events[1]
+        assert "input_json_delta" in events[2]
+
+    def test_tool_end_closes_tool_opens_new_text_block(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        e.feed({"type": "tool_start", "tool_name": "t", "tool_call_id": "tc_1", "arguments": {}})
+        events = e.feed({"type": "tool_end", "tool_name": "t", "tool_call_id": "tc_1", "result": "done"})
+        # content_block_stop (tool) + content_block_start (new text)
+        assert len(events) == 2
+        assert "content_block_stop" in events[0]
+        assert "content_block_start" in events[1]
+        assert '"type": "text"' in events[1]
+
+    def test_finish_emits_stop_events(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        events = e.finish("end_turn")
+        # content_block_stop + message_delta + message_stop
+        assert len(events) == 3
+        assert "content_block_stop" in events[0]
+        assert "message_delta" in events[1]
+        assert "end_turn" in events[1]
+        assert "message_stop" in events[2]
+
+    def test_metadata_captured_in_finish_usage(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        e.feed({"type": "metadata", "usage": {"prompt_tokens": 10, "completion_tokens": 20}})
+        events = e.finish("end_turn")
+        delta_event = [ev for ev in events if "message_delta" in ev][0]
+        parsed = json.loads(delta_event.split("data: ")[1])
+        assert parsed["usage"]["output_tokens"] == 20
+
+    def test_status_events_ignored(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        events = e.feed({"type": "status", "text": "Searching..."})
+        assert events == []
+
+    def test_no_tool_calls_simple_text_flow(self):
+        e = AnthropicStreamEmitter()
+        start_events = e.start("msg_1", "m")
+        content_events = e.feed({"type": "content", "text": "Hello world"})
+        meta_events = e.feed({"type": "metadata", "usage": {"prompt_tokens": 5, "completion_tokens": 2}})
+        end_events = e.finish("end_turn")
+
+        assert len(start_events) == 2
+        assert len(content_events) == 1
+        assert meta_events == []
+        assert len(end_events) == 3
+
+    def test_block_index_increments(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        assert e.block_index == 0
+        e.feed({"type": "tool_start", "tool_name": "t", "tool_call_id": "tc_1", "arguments": {}})
+        assert e.block_index == 1
+        e.feed({"type": "tool_end", "tool_name": "t", "tool_call_id": "tc_1", "result": "ok"})
+        assert e.block_index == 2
+
+    def test_text_after_tool_resets_prev_text(self):
+        e = AnthropicStreamEmitter()
+        e.start("msg_1", "m")
+        e.feed({"type": "content", "text": "Before tool"})
+        e.feed({"type": "tool_start", "tool_name": "t", "tool_call_id": "tc_1", "arguments": {}})
+        e.feed({"type": "tool_end", "tool_name": "t", "tool_call_id": "tc_1", "result": "ok"})
+        # After tool_end, prev_text should be reset
+        events = e.feed({"type": "content", "text": "After tool"})
+        parsed = json.loads(events[0].split("data: ")[1])
+        assert parsed["delta"]["text"] == "After tool"

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -42,12 +42,18 @@ class TestAnthropicModels:
 
     def test_minimal_request(self):
         req = AnthropicMessagesRequest(
+            messages = [{"role": "user", "content": "Hi"}],
+        )
+        assert req.max_tokens is None
+        assert req.model == "default"
+        assert req.stream is False
+
+    def test_max_tokens_optional(self):
+        req = AnthropicMessagesRequest(
             max_tokens = 100,
             messages = [{"role": "user", "content": "Hi"}],
         )
         assert req.max_tokens == 100
-        assert req.model == "default"
-        assert req.stream is False
 
     def test_system_as_string(self):
         req = AnthropicMessagesRequest(
@@ -80,6 +86,25 @@ class TestAnthropicModels:
             messages = [{"role": "user", "content": "Hi"}],
         )
         assert req.stream is False
+
+    def test_enable_tools_shorthand(self):
+        req = AnthropicMessagesRequest(
+            messages = [{"role": "user", "content": "Hi"}],
+            enable_tools = True,
+            enabled_tools = ["web_search", "python"],
+            session_id = "my-session",
+        )
+        assert req.enable_tools is True
+        assert req.enabled_tools == ["web_search", "python"]
+        assert req.session_id == "my-session"
+
+    def test_extension_fields_default_none(self):
+        req = AnthropicMessagesRequest(
+            messages = [{"role": "user", "content": "Hi"}],
+        )
+        assert req.enable_tools is None
+        assert req.enabled_tools is None
+        assert req.session_id is None
 
     def test_response_model_defaults(self):
         resp = AnthropicMessagesResponse()

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -39,7 +39,6 @@ from core.inference.anthropic_compat import (
 
 
 class TestAnthropicModels:
-
     def test_minimal_request(self):
         req = AnthropicMessagesRequest(
             messages = [{"role": "user", "content": "Hi"}],
@@ -121,7 +120,6 @@ class TestAnthropicModels:
 
 
 class TestAnthropicMessagesToOpenAI:
-
     def test_simple_user_message(self):
         msgs = [{"role": "user", "content": "Hello"}]
         result = anthropic_messages_to_openai(msgs)
@@ -134,7 +132,10 @@ class TestAnthropicMessagesToOpenAI:
         assert result[1] == {"role": "user", "content": "Hello"}
 
     def test_system_as_block_list(self):
-        system = [{"type": "text", "text": "Be brief."}, {"type": "text", "text": "Be accurate."}]
+        system = [
+            {"type": "text", "text": "Be brief."},
+            {"type": "text", "text": "Be accurate."},
+        ]
         msgs = [{"role": "user", "content": "Hello"}]
         result = anthropic_messages_to_openai(msgs, system = system)
         assert result[0]["role"] == "system"
@@ -154,13 +155,20 @@ class TestAnthropicMessagesToOpenAI:
         assert result[2]["role"] == "user"
 
     def test_assistant_tool_use_maps_to_tool_calls(self):
-        msgs = [{
-            "role": "assistant",
-            "content": [
-                {"type": "text", "text": "Let me search."},
-                {"type": "tool_use", "id": "tu_1", "name": "web_search", "input": {"query": "test"}},
-            ],
-        }]
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Let me search."},
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "web_search",
+                        "input": {"query": "test"},
+                    },
+                ],
+            }
+        ]
         result = anthropic_messages_to_openai(msgs)
         assert len(result) == 1
         m = result[0]
@@ -173,12 +181,18 @@ class TestAnthropicMessagesToOpenAI:
         assert json.loads(tc["function"]["arguments"]) == {"query": "test"}
 
     def test_tool_result_maps_to_tool_role(self):
-        msgs = [{
-            "role": "user",
-            "content": [
-                {"type": "tool_result", "tool_use_id": "tu_1", "content": "Result text"},
-            ],
-        }]
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tu_1",
+                        "content": "Result text",
+                    },
+                ],
+            }
+        ]
         result = anthropic_messages_to_openai(msgs)
         assert len(result) == 1
         assert result[0]["role"] == "tool"
@@ -186,14 +200,26 @@ class TestAnthropicMessagesToOpenAI:
         assert result[0]["content"] == "Result text"
 
     def test_mixed_text_and_tool_use_blocks(self):
-        msgs = [{
-            "role": "assistant",
-            "content": [
-                {"type": "text", "text": "Thinking..."},
-                {"type": "tool_use", "id": "tu_1", "name": "python", "input": {"code": "1+1"}},
-                {"type": "tool_use", "id": "tu_2", "name": "terminal", "input": {"command": "ls"}},
-            ],
-        }]
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Thinking..."},
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "python",
+                        "input": {"code": "1+1"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tu_2",
+                        "name": "terminal",
+                        "input": {"command": "ls"},
+                    },
+                ],
+            }
+        ]
         result = anthropic_messages_to_openai(msgs)
         assert len(result) == 1
         m = result[0]
@@ -201,15 +227,21 @@ class TestAnthropicMessagesToOpenAI:
         assert len(m["tool_calls"]) == 2
 
     def test_tool_result_with_list_content(self):
-        msgs = [{
-            "role": "user",
-            "content": [
-                {"type": "tool_result", "tool_use_id": "tu_1", "content": [
-                    {"type": "text", "text": "Line 1"},
-                    {"type": "text", "text": "Line 2"},
-                ]},
-            ],
-        }]
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tu_1",
+                        "content": [
+                            {"type": "text", "text": "Line 1"},
+                            {"type": "text", "text": "Line 2"},
+                        ],
+                    },
+                ],
+            }
+        ]
         result = anthropic_messages_to_openai(msgs)
         assert result[0]["content"] == "Line 1 Line 2"
 
@@ -220,9 +252,17 @@ class TestAnthropicMessagesToOpenAI:
 
 
 class TestAnthropicToolsToOpenAI:
-
     def test_single_tool(self):
-        tools = [{"name": "web_search", "description": "Search", "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}}}]
+        tools = [
+            {
+                "name": "web_search",
+                "description": "Search",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+            }
+        ]
         result = anthropic_tools_to_openai(tools)
         assert len(result) == 1
         assert result[0]["type"] == "function"
@@ -243,7 +283,9 @@ class TestAnthropicToolsToOpenAI:
         assert anthropic_tools_to_openai([]) == []
 
     def test_pydantic_model_input(self):
-        tool = AnthropicTool(name = "test", description = "desc", input_schema = {"type": "object"})
+        tool = AnthropicTool(
+            name = "test", description = "desc", input_schema = {"type": "object"}
+        )
         result = anthropic_tools_to_openai([tool])
         assert result[0]["function"]["name"] == "test"
 
@@ -254,7 +296,6 @@ class TestAnthropicToolsToOpenAI:
 
 
 class TestBuildAnthropicSSEEvent:
-
     def test_basic_event(self):
         result = build_anthropic_sse_event("message_start", {"type": "message_start"})
         assert result.startswith("event: message_start\n")
@@ -274,7 +315,6 @@ class TestBuildAnthropicSSEEvent:
 
 
 class TestAnthropicStreamEmitter:
-
     def test_start_emits_message_start_and_content_block_start(self):
         e = AnthropicStreamEmitter()
         events = e.start("msg_123", "test-model")
@@ -311,12 +351,14 @@ class TestAnthropicStreamEmitter:
         e = AnthropicStreamEmitter()
         e.start("msg_1", "m")
         e.feed({"type": "content", "text": "Thinking"})
-        events = e.feed({
-            "type": "tool_start",
-            "tool_name": "web_search",
-            "tool_call_id": "tc_1",
-            "arguments": {"query": "test"},
-        })
+        events = e.feed(
+            {
+                "type": "tool_start",
+                "tool_name": "web_search",
+                "tool_call_id": "tc_1",
+                "arguments": {"query": "test"},
+            }
+        )
         # content_block_stop + content_block_start(tool_use) + content_block_delta(input_json)
         assert len(events) == 3
         assert "content_block_stop" in events[0]
@@ -326,8 +368,22 @@ class TestAnthropicStreamEmitter:
     def test_tool_end_closes_tool_opens_new_text_block(self):
         e = AnthropicStreamEmitter()
         e.start("msg_1", "m")
-        e.feed({"type": "tool_start", "tool_name": "t", "tool_call_id": "tc_1", "arguments": {}})
-        events = e.feed({"type": "tool_end", "tool_name": "t", "tool_call_id": "tc_1", "result": "done"})
+        e.feed(
+            {
+                "type": "tool_start",
+                "tool_name": "t",
+                "tool_call_id": "tc_1",
+                "arguments": {},
+            }
+        )
+        events = e.feed(
+            {
+                "type": "tool_end",
+                "tool_name": "t",
+                "tool_call_id": "tc_1",
+                "result": "done",
+            }
+        )
         # content_block_stop (tool) + tool_result + content_block_start (new text)
         assert len(events) == 3
         assert "content_block_stop" in events[0]
@@ -352,7 +408,12 @@ class TestAnthropicStreamEmitter:
     def test_metadata_captured_in_finish_usage(self):
         e = AnthropicStreamEmitter()
         e.start("msg_1", "m")
-        e.feed({"type": "metadata", "usage": {"prompt_tokens": 10, "completion_tokens": 20}})
+        e.feed(
+            {
+                "type": "metadata",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 20},
+            }
+        )
         events = e.finish("end_turn")
         delta_event = [ev for ev in events if "message_delta" in ev][0]
         parsed = json.loads(delta_event.split("data: ")[1])
@@ -368,7 +429,9 @@ class TestAnthropicStreamEmitter:
         e = AnthropicStreamEmitter()
         start_events = e.start("msg_1", "m")
         content_events = e.feed({"type": "content", "text": "Hello world"})
-        meta_events = e.feed({"type": "metadata", "usage": {"prompt_tokens": 5, "completion_tokens": 2}})
+        meta_events = e.feed(
+            {"type": "metadata", "usage": {"prompt_tokens": 5, "completion_tokens": 2}}
+        )
         end_events = e.finish("end_turn")
 
         assert len(start_events) == 2
@@ -380,17 +443,45 @@ class TestAnthropicStreamEmitter:
         e = AnthropicStreamEmitter()
         e.start("msg_1", "m")
         assert e.block_index == 0
-        e.feed({"type": "tool_start", "tool_name": "t", "tool_call_id": "tc_1", "arguments": {}})
+        e.feed(
+            {
+                "type": "tool_start",
+                "tool_name": "t",
+                "tool_call_id": "tc_1",
+                "arguments": {},
+            }
+        )
         assert e.block_index == 1
-        e.feed({"type": "tool_end", "tool_name": "t", "tool_call_id": "tc_1", "result": "ok"})
+        e.feed(
+            {
+                "type": "tool_end",
+                "tool_name": "t",
+                "tool_call_id": "tc_1",
+                "result": "ok",
+            }
+        )
         assert e.block_index == 2
 
     def test_text_after_tool_resets_prev_text(self):
         e = AnthropicStreamEmitter()
         e.start("msg_1", "m")
         e.feed({"type": "content", "text": "Before tool"})
-        e.feed({"type": "tool_start", "tool_name": "t", "tool_call_id": "tc_1", "arguments": {}})
-        e.feed({"type": "tool_end", "tool_name": "t", "tool_call_id": "tc_1", "result": "ok"})
+        e.feed(
+            {
+                "type": "tool_start",
+                "tool_name": "t",
+                "tool_call_id": "tc_1",
+                "arguments": {},
+            }
+        )
+        e.feed(
+            {
+                "type": "tool_end",
+                "tool_name": "t",
+                "tool_call_id": "tc_1",
+                "result": "ok",
+            }
+        )
         # After tool_end, prev_text should be reset
         events = e.feed({"type": "content", "text": "After tool"})
         parsed = json.loads(events[0].split("data: ")[1])

--- a/studio/backend/tests/test_studio_api.py
+++ b/studio/backend/tests/test_studio_api.py
@@ -2,10 +2,11 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """
-End-to-end tests for ``unsloth studio run`` and API key authentication.
+End-to-end tests for Unsloth Studio's HTTP API surface.
 
-Exercises the usage examples shown on the API Keys page plus the Anthropic
-Messages API:
+Covers the OpenAI-compatible and Anthropic-compatible endpoints exposed
+by the server that ``unsloth studio run`` boots, plus API key
+authentication and the CLI's ``--help`` output:
 
     1. curl -- basic chat completions (non-streaming)
     2. curl -- streaming chat completions
@@ -16,24 +17,25 @@ Messages API:
     7. Anthropic Python SDK -- non-streaming
     8. Anthropic Messages API -- streaming with tools
 
-The test also validates the ``--help`` output and the server banner.
+Training, export, fine-tuning, and chat-UI concerns are out of scope —
+see the unit suites elsewhere under ``studio/backend/tests/`` for those.
 
 Usage:
 
     # Script mode — launches its own server via ``unsloth studio run``.
-    python tests/test_studio_run.py
-    python tests/test_studio_run.py --model unsloth/... --gguf-variant ...
+    python tests/test_studio_api.py
+    python tests/test_studio_api.py --model unsloth/... --gguf-variant ...
 
     # Pytest mode, external server — start a Studio server yourself,
     # then point pytest at it. Fastest iteration loop.
     unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --gguf-variant UD-Q4_K_XL &
     export UNSLOTH_E2E_BASE_URL=http://127.0.0.1:8080
     export UNSLOTH_E2E_API_KEY=sk-unsloth-...   # from the server banner
-    pytest tests/test_studio_run.py -v
+    pytest tests/test_studio_api.py -v
 
     # Pytest mode, fixture-managed server — pytest launches and tears
     # down the server itself. One-shot verification, CI-friendly.
-    pytest tests/test_studio_run.py -v \\
+    pytest tests/test_studio_api.py -v \\
         --unsloth-model unsloth/Qwen3-1.7B-GGUF \\
         --unsloth-gguf-variant UD-Q4_K_XL
 
@@ -68,7 +70,7 @@ STARTUP_TIMEOUT = 120  # seconds to wait for banner
 LOG_FILE = (
     Path(__file__).resolve().parent.parent.parent.parent
     / "temp"
-    / "test_studio_run.log"
+    / "test_studio_api.log"
 )
 
 

--- a/studio/backend/tests/test_studio_run.py
+++ b/studio/backend/tests/test_studio_run.py
@@ -4,8 +4,8 @@
 """
 End-to-end tests for ``unsloth studio run`` and API key authentication.
 
-Starts a Studio server via the ``run`` subcommand, then exercises the
-usage examples shown on the API Keys page plus the Anthropic Messages API:
+Exercises the usage examples shown on the API Keys page plus the Anthropic
+Messages API:
 
     1. curl -- basic chat completions (non-streaming)
     2. curl -- streaming chat completions
@@ -19,8 +19,26 @@ usage examples shown on the API Keys page plus the Anthropic Messages API:
 The test also validates the ``--help`` output and the server banner.
 
 Usage:
-    python test_studio_run.py                        # default model
-    python test_studio_run.py --model unsloth/...    # custom model
+
+    # Script mode — launches its own server via ``unsloth studio run``.
+    python tests/test_studio_run.py
+    python tests/test_studio_run.py --model unsloth/... --gguf-variant ...
+
+    # Pytest mode, external server — start a Studio server yourself,
+    # then point pytest at it. Fastest iteration loop.
+    unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --gguf-variant UD-Q4_K_XL &
+    export UNSLOTH_E2E_BASE_URL=http://127.0.0.1:8080
+    export UNSLOTH_E2E_API_KEY=sk-unsloth-...   # from the server banner
+    pytest tests/test_studio_run.py -v
+
+    # Pytest mode, fixture-managed server — pytest launches and tears
+    # down the server itself. One-shot verification, CI-friendly.
+    pytest tests/test_studio_run.py -v \\
+        --unsloth-model unsloth/Qwen3-1.7B-GGUF \\
+        --unsloth-gguf-variant UD-Q4_K_XL
+
+The ``base_url`` / ``api_key`` parameters on the test functions resolve
+via the ``studio_server`` session fixture in ``conftest.py``.
 
 Requires a GPU and ~2 GB of disk for the GGUF download.
 """

--- a/studio/backend/tests/test_studio_run.py
+++ b/studio/backend/tests/test_studio_run.py
@@ -417,7 +417,10 @@ def test_anthropic_with_tools(base_url: str, api_key: str):
                     "input_schema": {
                         "type": "object",
                         "properties": {
-                            "code": {"type": "string", "description": "The Python code to run"},
+                            "code": {
+                                "type": "string",
+                                "description": "The Python code to run",
+                            },
                         },
                         "required": ["code"],
                     },
@@ -436,7 +439,9 @@ def test_anthropic_with_tools(base_url: str, api_key: str):
     assert "message_stop" in event_types, "Missing message_stop"
 
     full = _collect_anthropic_text(events)
-    print(f"  PASS  anthropic with tools: {len(events)} events, {len(full)} chars content")
+    print(
+        f"  PASS  anthropic with tools: {len(events)} events, {len(full)} chars content"
+    )
 
 
 # ── Server lifecycle ─────────────────────────────────────────────────

--- a/studio/backend/tests/test_studio_run.py
+++ b/studio/backend/tests/test_studio_run.py
@@ -5,12 +5,16 @@
 End-to-end tests for ``unsloth studio run`` and API key authentication.
 
 Starts a Studio server via the ``run`` subcommand, then exercises the
-four usage examples shown on the API Keys page:
+usage examples shown on the API Keys page plus the Anthropic Messages API:
 
     1. curl -- basic chat completions (non-streaming)
     2. curl -- streaming chat completions
     3. Python OpenAI SDK -- streaming completions
     4. curl -- with tools (web_search + python)
+    5. Anthropic Messages API -- basic non-streaming
+    6. Anthropic Messages API -- streaming SSE
+    7. Anthropic Python SDK -- non-streaming
+    8. Anthropic Messages API -- streaming with tools
 
 The test also validates the ``--help`` output and the server banner.
 
@@ -271,6 +275,170 @@ def test_no_key_rejected(base_url: str):
     print(f"  PASS  no API key rejected ({status})")
 
 
+# ── Anthropic SSE helper ─────────────────────────────────────────────
+
+
+def _stream_anthropic_http(
+    url: str,
+    *,
+    body: dict,
+    headers: dict,
+    timeout: int = 60,
+) -> tuple[int, list[tuple[str, dict]]]:
+    """POST a streaming request and collect Anthropic SSE events.
+
+    Returns (status, [(event_type, data_dict), ...]).
+    """
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data = data, headers = headers, method = "POST")
+    req.add_header("Content-Type", "application/json")
+    events: list[tuple[str, dict]] = []
+    try:
+        with urllib.request.urlopen(req, timeout = timeout) as resp:
+            status = resp.status
+            current_event = None
+            for raw_line in resp:
+                line = raw_line.decode().strip()
+                if line.startswith("event: "):
+                    current_event = line[7:]
+                elif line.startswith("data: ") and current_event:
+                    try:
+                        events.append((current_event, json.loads(line[6:])))
+                    except json.JSONDecodeError:
+                        pass
+                    current_event = None
+            return status, events
+    except urllib.error.HTTPError as exc:
+        return exc.code, []
+
+
+def _collect_anthropic_text(events: list[tuple[str, dict]]) -> str:
+    """Extract text content from Anthropic SSE events."""
+    parts = []
+    for etype, data in events:
+        if etype == "content_block_delta":
+            delta = data.get("delta", {})
+            if delta.get("type") == "text_delta":
+                parts.append(delta.get("text", ""))
+    return "".join(parts)
+
+
+# ── Anthropic /v1/messages test functions ────────────────────────────
+
+
+def test_anthropic_basic(base_url: str, api_key: str):
+    """Anthropic Messages API: non-streaming."""
+    status, text = _http(
+        "POST",
+        f"{base_url}/v1/messages",
+        body = {
+            "model": "default",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Say just the word hello"}],
+        },
+        headers = {"Authorization": f"Bearer {api_key}"},
+    )
+    assert status == 200, f"Expected 200, got {status}: {text[:300]}"
+    data = json.loads(text)
+    assert data.get("type") == "message", f"Expected type 'message': {text[:300]}"
+    assert data.get("role") == "assistant"
+    content = data.get("content", [])
+    assert len(content) > 0, "Empty content array"
+    text_block = content[-1]
+    assert text_block.get("type") == "text", f"Expected text block: {text_block}"
+    assert len(text_block.get("text", "")) > 0, "Empty text in response"
+    print(f"  PASS  anthropic basic: {text_block['text'][:80]!r}")
+
+
+def test_anthropic_streaming(base_url: str, api_key: str):
+    """Anthropic Messages API: streaming SSE."""
+    status, events = _stream_anthropic_http(
+        f"{base_url}/v1/messages",
+        body = {
+            "model": "default",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Count from 1 to 3"}],
+            "stream": True,
+        },
+        headers = {"Authorization": f"Bearer {api_key}"},
+    )
+    assert status == 200, f"Expected 200, got {status}"
+    assert len(events) > 0, "No SSE events received"
+
+    event_types = [e[0] for e in events]
+    assert "message_start" in event_types, "Missing message_start event"
+    assert "message_stop" in event_types, "Missing message_stop event"
+
+    full = _collect_anthropic_text(events)
+    assert len(full) > 0, "Streamed text content is empty"
+    print(f"  PASS  anthropic streaming: {len(events)} events, {len(full)} chars")
+
+
+def test_anthropic_sdk(base_url: str, api_key: str):
+    """Anthropic Python SDK: non-streaming."""
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        print("  SKIP  anthropic SDK not installed")
+        return
+
+    client = Anthropic(base_url = f"{base_url}/v1", api_key = api_key)
+    message = client.messages.create(
+        model = "default",
+        max_tokens = 100,
+        messages = [
+            {"role": "user", "content": "What is 2+2? Answer with just the number."}
+        ],
+    )
+    assert message.role == "assistant"
+    assert len(message.content) > 0, "Empty content"
+    text = message.content[0].text
+    assert len(text) > 0, "Empty text"
+    print(f"  PASS  Anthropic SDK: {text.strip()[:80]!r}")
+
+
+def test_anthropic_with_tools(base_url: str, api_key: str):
+    """Anthropic Messages API: streaming with tools."""
+    status, events = _stream_anthropic_http(
+        f"{base_url}/v1/messages",
+        body = {
+            "model": "default",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is 123 * 456? Use code to compute it.",
+                }
+            ],
+            "tools": [
+                {
+                    "name": "python",
+                    "description": "Execute Python code in a sandbox and return stdout/stderr.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "code": {"type": "string", "description": "The Python code to run"},
+                        },
+                        "required": ["code"],
+                    },
+                }
+            ],
+            "stream": True,
+        },
+        headers = {"Authorization": f"Bearer {api_key}"},
+        timeout = 120,
+    )
+    assert status == 200, f"Expected 200, got {status}"
+    assert len(events) > 0, "No SSE events received for tools request"
+
+    event_types = [e[0] for e in events]
+    assert "message_start" in event_types, "Missing message_start"
+    assert "message_stop" in event_types, "Missing message_stop"
+
+    full = _collect_anthropic_text(events)
+    print(f"  PASS  anthropic with tools: {len(events)} events, {len(full)} chars content")
+
+
 # ── Server lifecycle ─────────────────────────────────────────────────
 
 
@@ -385,10 +553,10 @@ def main():
             print(f"  ERROR {fn.__name__}: {type(exc).__name__}: {exc}")
 
     # ── 1. Test --help (no server needed) ────────────────────────────
-    print("\n[1/7] Testing --help output")
+    print("\n[1/11] Testing --help output")
     run_test(test_help_output)
 
-    # ── 2-7. Start server and run API tests ──────────────────────────
+    # ── 2-11. Start server and run API tests ─────────────────────────
     print(
         f"\nStarting server: {args.model} (variant={args.gguf_variant}) on port {PORT}..."
     )
@@ -398,27 +566,39 @@ def main():
         base_url = f"http://{HOST}:{PORT}"
         print(f"Server ready.  API Key: {api_key[:20]}...\n")
 
-        print("[2/7] Testing curl basic (non-streaming)")
+        print("[2/11] Testing curl basic (non-streaming)")
         run_test(test_curl_basic, base_url, api_key)
 
-        print("[3/7] Testing curl streaming")
+        print("[3/11] Testing curl streaming")
         run_test(test_curl_streaming, base_url, api_key)
 
-        print("[4/7] Testing OpenAI Python SDK (streaming)")
+        print("[4/11] Testing OpenAI Python SDK (streaming)")
         run_test(test_openai_sdk, base_url, api_key)
 
-        print("[5/7] Testing curl with tools")
+        print("[5/11] Testing curl with tools")
         run_test(test_curl_with_tools, base_url, api_key)
 
-        print("[6/7] Testing invalid API key rejection")
+        print("[6/11] Testing invalid API key rejection")
         run_test(test_invalid_key_rejected, base_url)
 
-        print("[7/7] Testing no API key rejection")
+        print("[7/11] Testing no API key rejection")
         run_test(test_no_key_rejected, base_url)
+
+        print("[8/11] Testing Anthropic basic (non-streaming)")
+        run_test(test_anthropic_basic, base_url, api_key)
+
+        print("[9/11] Testing Anthropic streaming")
+        run_test(test_anthropic_streaming, base_url, api_key)
+
+        print("[10/11] Testing Anthropic Python SDK")
+        run_test(test_anthropic_sdk, base_url, api_key)
+
+        print("[11/11] Testing Anthropic with tools")
+        run_test(test_anthropic_with_tools, base_url, api_key)
 
     except RuntimeError as exc:
         print(f"\nFATAL: Server failed to start: {exc}")
-        failed += 7  # count remaining tests as failed
+        failed += 11  # count remaining tests as failed
     finally:
         if proc:
             print("\nStopping server...")


### PR DESCRIPTION
## Summary

Adds a `/v1/messages` endpoint that speaks the **Anthropic Messages API format**, so Anthropic SDK clients (and any Anthropic-compatible tool like Claude Code, etc.) can connect to Unsloth Studio alongside the existing OpenAI-compatible endpoints.

- Translates Anthropic ↔ internal OpenAI format and **reuses the existing server-side agentic tool loop** (`generate_chat_completion_with_tools`) — no duplicated tool execution logic
- Supports **streaming SSE** (`message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`) and **non-streaming JSON**
- Emits a custom `tool_result` SSE event so clients can see server-side tool execution output (Anthropic SDKs ignore unknown event types)
- Supports both **Anthropic-native tool definitions** (`name`, `description`, `input_schema`) and the **Unsloth shorthand** (`enable_tools`, `enabled_tools`, `session_id`) from the OpenAI endpoint
- Strips leaked `<tool_call>` / `<function=...>` XML from content, same as the OpenAI endpoint
- No auth or tool-execution changes — uses the existing `Depends(get_current_subject)` and `ALL_TOOLS`

## How it works

### Backend changes

| File | Change |
|------|--------|
| `studio/backend/models/inference.py` | Anthropic request/response Pydantic models (`AnthropicMessagesRequest`, `AnthropicMessage`, `AnthropicTool`, `AnthropicContentBlock`, `AnthropicMessagesResponse`, etc.) |
| `studio/backend/core/inference/anthropic_compat.py` | **New file.** Pure translation functions (`anthropic_messages_to_openai`, `anthropic_tools_to_openai`) + `AnthropicStreamEmitter` class that converts the 5 generator event types into Anthropic SSE |
| `studio/backend/routes/inference.py` | `POST /messages` handler with 4 helpers for streaming/non-streaming × tool/no-tool paths. Reuses `generate_chat_completion_with_tools()` and the existing system-prompt nudge + XML stripping logic |

### Request format

Accepts the Anthropic Messages API format plus Unsloth extension fields:

```
{
  model?: str = "default"
  max_tokens?: int
  messages: [{role: "user"|"assistant", content: str | ContentBlock[]}]
  system?: str | TextBlock[]
  tools?: [{name, description, input_schema}]        // Anthropic-native
  tool_choice?: any
  stream?: bool = false
  temperature?, top_p?, top_k?, stop_sequences?
  // Unsloth shorthand (mirrors /chat/completions)
  enable_tools?: bool
  enabled_tools?: [str]
  session_id?: str
}
```

### Tool loop flow

1. Translate Anthropic messages → OpenAI-format list[dict]
2. If tools requested (either Anthropic-native or shorthand), translate + pass into `generate_chat_completion_with_tools()`
3. Generator yields 5 event types (`status`, `tool_start`, `tool_end`, `content`, `metadata`)
4. `AnthropicStreamEmitter` converts them to Anthropic SSE events:
   - `content` → `content_block_delta` (text_delta) with cumulative diff
   - `tool_start` → close text block + open `tool_use` block + `input_json_delta`
   - `tool_end` → close tool block + custom `tool_result` event + open new text block
   - `metadata` → captured for final `message_delta`
5. Non-streaming path exhausts the generator and assembles an `AnthropicMessagesResponse`

## Testing

### Offline unit tests (no GPU / server required)

`studio/backend/tests/test_anthropic_messages.py` — 30+ tests covering:

- `TestAnthropicModels` — Pydantic validation (required/optional fields, extension fields, extra="allow")
- `TestAnthropicMessagesToOpenAI` — message translation (string content, block content, system as string/list, multi-turn, assistant `tool_use`, user `tool_result`, mixed blocks)
- `TestAnthropicToolsToOpenAI` — tool format translation
- `TestBuildAnthropicSSEEvent` — SSE event framing
- `TestAnthropicStreamEmitter` — all state transitions (content diffs, cumulative, empty, tool_start → tool_end flow, block indexing, prev_text reset, metadata capture, status ignored, finish)

Run:
```bash
cd studio/backend && python -m pytest tests/test_anthropic_messages.py -v
```

### End-to-end tests (requires GPU + GGUF model)

`studio/backend/tests/test_studio_api.py` — extended with 4 new e2e tests that hit `/v1/messages` against a running Studio server:

- `test_anthropic_basic` — non-streaming, verifies message/content/text block shape
- `test_anthropic_streaming` — SSE stream, verifies `message_start`/`message_stop` events and text content
- `test_anthropic_sdk` — Anthropic Python SDK (`from anthropic import Anthropic`)
- `test_anthropic_with_tools` — streaming with Anthropic-native `tools` field

The file was renamed from `test_studio_run.py` to `test_studio_api.py` to reflect its actual scope (HTTP API surface testing — OpenAI-compatible and Anthropic-compatible endpoints plus API-key auth — not training, export, or chat UI). A session-scoped `studio_server` fixture in `conftest.py` provides `base_url` / `api_key` to the test functions, enabling three invocation modes:

**Script mode** — launches its own server via `unsloth studio run` (backward-compatible with the pre-rename workflow):
```bash
cd studio/backend && python tests/test_studio_api.py
# or with a specific model
python tests/test_studio_api.py --model unsloth/Qwen3-1.7B-GGUF --gguf-variant UD-Q4_K_XL
```

**Pytest mode, external server** — start a Studio server once, iterate tests against it. Fastest feedback loop, no per-run GGUF load cost:
```bash
unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --gguf-variant UD-Q4_K_XL &
export UNSLOTH_E2E_BASE_URL=http://127.0.0.1:8080
export UNSLOTH_E2E_API_KEY=sk-unsloth-...   # from the server banner
cd studio/backend && pytest tests/test_studio_api.py -v
# or just the Anthropic tests
cd studio/backend && pytest tests/test_studio_api.py -k anthropic -v
```

**Pytest mode, fixture-managed server** — pytest drives `_start_server` / `_kill_server` itself. CI-friendly, single command:
```bash
cd studio/backend && pytest tests/test_studio_api.py -v \
    --unsloth-model unsloth/Qwen3-1.7B-GGUF \
    --unsloth-gguf-variant UD-Q4_K_XL
```

## Manual curl examples

**Basic chat, streaming, no tools:**
```bash
curl http://localhost:8080/v1/messages \
  -H "Authorization: Bearer sk-unsloth-..." \
  -H "Content-Type: application/json" \
  -d '{"messages":[{"role":"user","content":"Hello"}], "stream":true}'
```

**With tools (shorthand), streaming — math:**
```bash
curl http://localhost:8080/v1/messages \
  -H "Authorization: Bearer sk-unsloth-..." \
  -H "Content-Type: application/json" \
  -d '{
    "messages":[{"role":"user","content":"What is 123 * 456? Use code to compute it."}],
    "stream": true,
    "enable_tools": true,
    "enabled_tools": ["python"],
    "session_id": "my-session"
  }'
```

**With tools (shorthand), streaming — Fibonacci:**
```bash
curl http://localhost:8080/v1/messages \
  -H "Authorization: Bearer sk-unsloth-..." \
  -H "Content-Type: application/json" \
  -d '{
    "messages":[{"role":"user","content":"Write and run a Python script that prints the first 10 Fibonacci numbers"}],
    "stream": true,
    "enable_tools": true,
    "enabled_tools": ["python"],
    "session_id": "my-session"
  }'
```

## Test plan

- [x] Offline unit tests pass
- [x] `curl /v1/messages` non-streaming returns valid Anthropic JSON
- [x] `curl /v1/messages` streaming emits correct SSE event sequence
- [x] `enable_tools` + `enabled_tools` shorthand works (matches OpenAI endpoint behavior)
- [x] Anthropic-native `tools` field works (auto-converted to OpenAI format)
- [x] `session_id` propagates to the sandbox (Python/terminal tools)
- [x] Leaked tool-call XML is stripped from content
- [x] Custom `tool_result` event is emitted on tool completion
- [x] Test against Anthropic Python SDK (`anthropic.Anthropic(base_url=..., api_key=...)`)
- [x] Tested with Claude Code
- [x] Tested with opencode

