### PR TITLE
studio: fix route transition DOM duplication via AnimatePresence mode="wait"

### DIFF
--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -40,11 +40,12 @@ function RootLayout() {
   return (
     <AppProvider>
       {!hideNavbar && <Navbar />}
-      <AnimatePresence initial={false}>
+      <AnimatePresence initial={false} mode="wait">
         <motion.div
           key={pathname}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
           transition={{ duration: 0.15 }}
           className="flex-1"
         >


### PR DESCRIPTION
 ## Summary
  Rapid navigation between Studio / Export / Recipes / Chat caused pages to stack — the Export page rendered 2x and the Recipes page 3x.
  The root AnimatePresence wrapper had no `mode` prop, so outgoing and incoming routes coexisted in the DOM simultaneously.

  ## Changes
  - Add `mode="wait"` so the outgoing route fully unmounts before the new one mounts
  - Add `exit={{ opacity: 0 }}` to the motion.div for a clean fade-out transition

  ## Files
  - `studio/frontend/src/app/routes/__root.tsx` — 2 insertions, 1 deletion

  ## Test plan
  - [x] Navigate Studio → Export → Recipes → Chat → Studio in a loop — no content duplication
  - [x] No JavaScript errors in console during transitions