### PR TITLE
studio: skip training status/metrics polling when idle

### DIFF
--- a/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
@@ -14,6 +14,7 @@ import type { TrainingRuntimeStore } from "../types/runtime";
 
 const STATUS_POLL_INTERVAL_MS = 3000;
 const METRICS_POLL_INTERVAL_MS = 5000;
+const IDLE_POLL_INTERVAL_MS = 30000;
 const STREAM_RECONNECT_DELAY_MS = 1500;
 
 function shouldUseLiveSync(state: TrainingRuntimeStore): boolean {
@@ -164,24 +165,36 @@ export function useTrainingRuntimeLifecycle(): void {
 
     void hydrate();
 
-    const statusTimer = setInterval(() => {
+    const isIdle = () => {
       const s = runtimeStore.getState();
-      if (s.phase === "idle" && s.hasHydrated && !s.isTrainingRunning) return;
+      return s.phase === "idle" && s.hasHydrated && !s.isTrainingRunning;
+    };
+
+    const statusTimer = setInterval(() => {
+      if (isIdle()) return;
       void pollStatus();
     }, STATUS_POLL_INTERVAL_MS);
 
     const metricsTimer = setInterval(() => {
+      if (isIdle()) return;
       const s = runtimeStore.getState();
-      if (s.phase === "idle" && s.hasHydrated && !s.isTrainingRunning) return;
       if (shouldUseLiveSync(s) || s.currentStep > 0) {
         void pollMetrics();
       }
     }, METRICS_POLL_INTERVAL_MS);
 
+    // Low-frequency background poll to recover from failed hydration or detect
+    // out-of-band state changes (e.g. training started from another client).
+    const idleTimer = setInterval(() => {
+      if (!isIdle()) return;
+      void pollStatus();
+    }, IDLE_POLL_INTERVAL_MS);
+
     return () => {
       disposed = true;
       clearInterval(statusTimer);
       clearInterval(metricsTimer);
+      clearInterval(idleTimer);
       stopStream();
     };
   }, []);

--- a/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
@@ -165,12 +165,15 @@ export function useTrainingRuntimeLifecycle(): void {
     void hydrate();
 
     const statusTimer = setInterval(() => {
+      const s = runtimeStore.getState();
+      if (s.phase === "idle" && s.hasHydrated && !s.isTrainingRunning) return;
       void pollStatus();
     }, STATUS_POLL_INTERVAL_MS);
 
     const metricsTimer = setInterval(() => {
-      const state = runtimeStore.getState();
-      if (shouldUseLiveSync(state) || state.currentStep > 0) {
+      const s = runtimeStore.getState();
+      if (s.phase === "idle" && s.hasHydrated && !s.isTrainingRunning) return;
+      if (shouldUseLiveSync(s) || s.currentStep > 0) {
         void pollMetrics();
       }
     }, METRICS_POLL_INTERVAL_MS);

--- a/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
@@ -167,11 +167,12 @@ export function useTrainingRuntimeLifecycle(): void {
 
     const isIdle = () => {
       const s = runtimeStore.getState();
-      return s.phase === "idle" && s.hasHydrated && !s.isTrainingRunning;
+      return s.phase === "idle" && !s.isTrainingRunning;
     };
 
     const statusTimer = setInterval(() => {
-      if (isIdle()) return;
+      const s = runtimeStore.getState();
+      if (isIdle() && s.hasHydrated) return;
       void pollStatus();
     }, STATUS_POLL_INTERVAL_MS);
 

--- a/studio/frontend/src/features/training/stores/training-runtime-store.ts
+++ b/studio/frontend/src/features/training/stores/training-runtime-store.ts
@@ -125,6 +125,7 @@ export const useTrainingRuntimeStore = create<TrainingRuntimeStore>()((set) => (
   resetRuntime: () =>
     set((state) => ({
       ...initialState,
+      hasHydrated: state.hasHydrated,
       lossHistory: [],
       lrHistory: [],
       gradNormHistory: [],


### PR DESCRIPTION
 ## Summary
  The training lifecycle hook polled `/api/train/status` (every 3s) and `/api/train/metrics` (every 5s) unconditionally, even when no
  training was running. This generated unnecessary network traffic and `ERR_CONNECTION_REFUSED` console spam after server restarts.

  ## Changes
  - Add early return in both setInterval callbacks when `phase === "idle" && hasHydrated && !isTrainingRunning`
  - No behavior change when training is actually running

  ## Files
  - `studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts` — 5 insertions, 2 deletions

  ## Test plan
  - [x] Open Studio Configure page, wait 30s — no `/api/train/status` requests in backend logs
  - [x] Start training — polling resumes normally