### PR TITLE
fix: preserve bf16 GGUF file when explicitly requested in quantization list

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1348,9 +1348,10 @@ def save_to_gguf(
                             f"Error: {e}"
                         )
         print("Unsloth: Model files cleanup...")
-        if quants_created and first_conversion not in frozenset(quantization_method):
-            all_saved_locations.remove(base_gguf)
-            Path(base_gguf).unlink(missing_ok = True)
+        if quants_created:
+            if first_conversion not in frozenset(quantization_method):
+                all_saved_locations.remove(base_gguf)
+                Path(base_gguf).unlink(missing_ok = True)
 
             # flip the list to get [text_model, mmproj] order. for text models stays the same.
             all_saved_locations.reverse()

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1348,7 +1348,7 @@ def save_to_gguf(
                             f"Error: {e}"
                         )
         print("Unsloth: Model files cleanup...")
-        if quants_created:
+        if quants_created and first_conversion not in frozenset(quantization_method):
             all_saved_locations.remove(base_gguf)
             Path(base_gguf).unlink(missing_ok = True)
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1359,7 +1359,11 @@ def save_to_gguf(
 
             # When the base format is preserved, move it away from list boundaries
             # so example commands (which use [0] for model and [-1] for mmproj) stay correct.
-            if preserved_base and base_gguf in all_saved_locations and len(all_saved_locations) > 2:
+            if (
+                preserved_base
+                and base_gguf in all_saved_locations
+                and len(all_saved_locations) > 2
+            ):
                 all_saved_locations.remove(base_gguf)
                 all_saved_locations.insert(1, base_gguf)
     else:

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1349,12 +1349,19 @@ def save_to_gguf(
                         )
         print("Unsloth: Model files cleanup...")
         if quants_created:
-            if first_conversion not in frozenset(quantization_method):
+            preserved_base = first_conversion in frozenset(quantization_method)
+            if not preserved_base:
                 all_saved_locations.remove(base_gguf)
                 Path(base_gguf).unlink(missing_ok = True)
 
             # flip the list to get [text_model, mmproj] order. for text models stays the same.
             all_saved_locations.reverse()
+
+            # When the base format is preserved, move it away from list boundaries
+            # so example commands (which use [0] for model and [-1] for mmproj) stay correct.
+            if preserved_base and base_gguf in all_saved_locations and len(all_saved_locations) > 2:
+                all_saved_locations.remove(base_gguf)
+                all_saved_locations.insert(1, base_gguf)
     else:
         print("Unsloth: GPT-OSS model - skipping additional quantizations")
 


### PR DESCRIPTION
## What does this PR do?

When users request multiple quantization methods including the base format
(e.g., `["q4_k_m", "bf16"]`), the `bf16` GGUF file serves dual roles: it is
both the intermediate conversion (`first_conversion`) and a user-requested
output.

The cleanup step at `save.py:1351-1353` unconditionally deletes the base GGUF
file after quantization, which loses the explicitly requested `bf16` output.

### Fix

Add a guard to only delete the intermediate base GGUF when the user did **not**
request it as one of their quantization formats:

```python
# Before
if quants_created:

# After  
if quants_created and first_conversion not in frozenset(quantization_method):
```

### Reproduction

```python
model.save_pretrained_gguf(
    "model",
    tokenizer,
    quantization_method=["q4_k_m", "bf16"],  # bf16 is deleted!
)
```

Fixes #4932