### PR TITLE
Pin kernels==0.12.1 to fix training import failure

### DIFF
--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -13,4 +13,4 @@ torch-c-dlpack-ext
 sentence_transformers==5.2.0
 transformers==4.57.6
 pytorch_tokenizers
-kernels
+kernels==0.12.1


### PR DESCRIPTION
## Summary

Pin `kernels==0.12.1` in `studio/backend/requirements/extras-no-deps.txt` to prevent automatic upgrade to `kernels==0.13.0`, which breaks all training with `Failed to import ML libraries`.

## The error

When starting training, users see:

```
Training error: Failed to import ML libraries: Validation error for field 'import_name':
    TypeError: Unsupported type for field 'import_name': str | None
```

Full traceback bottoms out in `kernels/deps.py` at module import time:

```
File ".../kernels/deps.py", line 62, in <module>
    _DEPENDENCY_DATA = DependencyData.from_dict(json.load(f))
File ".../kernels/deps.py", line 19, in from_dict
    return PythonPackage(pkg=data["pkg"], import_name=data.get("import"))
File ".../huggingface_hub/dataclasses.py", line 332, in type_validator
    raise TypeError(f"Unsupported type for field '{name}': {expected_type}")
huggingface_hub.errors.StrictDataclassFieldValidationError: Validation error for field 'import_name':
    TypeError: Unsupported type for field 'import_name': str | None
```

## Root cause

`kernels==0.13.0` rewrote `deps.py` to use `huggingface_hub`-strict dataclasses and declared:

```python
class PythonPackage:
    pkg: str
    import_name: str | None = None   # PEP 604 union
```

`huggingface_hub`'s `type_validator` (see `huggingface_hub/dataclasses.py`) dispatches on `get_origin(expected_type)` via `_BASIC_TYPE_VALIDATORS`, but that table only maps `typing.Union` — not `types.UnionType`, which is what `get_origin(str | None)` returns. So the validator falls through to the ``Unsupported type`` branch and raises at module import time.

Because `kernels` is transitively imported via `transformers.integrations.hub_kernels` → `transformers.modeling_utils` → `transformers.processing_utils` → `unsloth_zoo.temporary_patches.utils` → `unsloth_zoo` → `unsloth`, the failure happens before any training code runs, surfacing as ``Failed to import ML libraries``.

`kernels==0.12.x` uses plain dicts in `deps.py` and is not affected.

## Fix

Pin `kernels==0.12.1` in `studio/backend/requirements/extras-no-deps.txt` so `--no-deps` installs cannot pick up `0.13.0`.

## Test plan

- [ ] Fresh `./install.sh --local` pulls `kernels==0.12.1`
- [ ] `from unsloth import FastLanguageModel` succeeds
- [ ] Kicking off a training run from Studio no longer errors with ``Failed to import ML libraries``


## Solves
https://github.com/unslothai/unsloth/issues/4997