### PR TITLE
studio: fix api-keys access + refresh

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -353,7 +353,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
 
     @app.get("/{full_path:path}")
     async def serve_frontend(full_path: str):
-        if full_path.startswith("api"):
+        if full_path == "api" or full_path.startswith("api/"):
             return {"error": "API endpoint not found"}
 
         file_path = (build_path / full_path).resolve()

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -353,7 +353,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
 
     @app.get("/{full_path:path}")
     async def serve_frontend(full_path: str):
-        if full_path == "api" or full_path.startswith("api/"):
+        if full_path in {"api", "v1"} or full_path.startswith(("api/", "v1/")):
             return {"error": "API endpoint not found"}
 
         file_path = (build_path / full_path).resolve()

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -13,7 +13,14 @@ import { AnimatePresence, motion } from "motion/react";
 import { Suspense } from "react";
 import { AppProvider } from "../provider";
 
-const CHAT_ONLY_ALLOWED = new Set(["/", "/chat", "/login", "/signup", "/change-password"]);
+const CHAT_ONLY_ALLOWED = new Set([
+  "/",
+  "/chat",
+  "/login",
+  "/signup",
+  "/change-password",
+  "/api-keys",
+]);
 
 function isChatOnlyAllowed(pathname: string): boolean {
   if (CHAT_ONLY_ALLOWED.has(pathname)) return true;


### PR DESCRIPTION
This fixes two issues around the API Keys page on mac chat only setups.

The page was visible from the navbar but still blocked by the chat only route allowlist. That made access not possible on mac.

A hard refresh on that page also failed because the backend fallback treated any path starting with api as an API route. That matched the page path by accident.

This change allows the API Keys page in chat only mode and narrows the backend check so only real API paths are handled that way.
Tested by opening the page and refreshing it. Also ran frontend typecheck and a backend compile check.