### PR TITLE
Studio: Polish API key copy button and harden async clipboard fallback

### DIFF
--- a/studio/frontend/src/features/auth/api-keys-page.tsx
+++ b/studio/frontend/src/features/auth/api-keys-page.tsx
@@ -14,7 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { copyToClipboardAsync } from "@/lib/copy-to-clipboard";
 import {
   AlertCircleIcon,
   Copy01Icon,
@@ -96,6 +96,7 @@ function formatDate(iso: string | null): string {
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
+  const [copying, setCopying] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -104,20 +105,37 @@ function CopyButton({ text }: { text: string }) {
     };
   }, []);
 
-  const handleCopy = () => {
-    if (!copyToClipboard(text)) return;
-    setCopied(true);
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    if (copying) return;
+    setCopying(true);
+    try {
+      const ok = await copyToClipboardAsync(text);
+      if (!ok) return;
+      setCopied(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    } finally {
+      setCopying(false);
+    }
   };
 
   return (
-    <Button variant="outline" size="sm" onClick={handleCopy} className="shrink-0">
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      onClick={handleCopy}
+      disabled={copying}
+      className={cn(
+        "shrink-0 rounded-md text-muted-foreground hover:text-foreground",
+        copied && "text-emerald-600 hover:text-emerald-600",
+      )}
+      aria-label={copied ? "Copied API key" : "Copy API key"}
+      title={copied ? "Copied" : "Copy"}
+    >
       <HugeiconsIcon
         icon={copied ? Tick02Icon : Copy01Icon}
-        className={cn("size-3.5 mr-1.5", copied && "text-emerald-600")}
+        className="size-4"
       />
-      {copied ? "Copied" : "Copy"}
     </Button>
   );
 }

--- a/studio/frontend/src/features/auth/api-keys-page.tsx
+++ b/studio/frontend/src/features/auth/api-keys-page.tsx
@@ -96,7 +96,6 @@ function formatDate(iso: string | null): string {
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
-  const [copying, setCopying] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -106,17 +105,10 @@ function CopyButton({ text }: { text: string }) {
   }, []);
 
   const handleCopy = async () => {
-    if (copying) return;
-    setCopying(true);
-    try {
-      const ok = await copyToClipboardAsync(text);
-      if (!ok) return;
-      setCopied(true);
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setCopied(false), 2000);
-    } finally {
-      setCopying(false);
-    }
+    if (!(await copyToClipboardAsync(text))) return;
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -124,7 +116,6 @@ function CopyButton({ text }: { text: string }) {
       variant="ghost"
       size="icon-sm"
       onClick={handleCopy}
-      disabled={copying}
       className={cn(
         "shrink-0 rounded-md text-muted-foreground hover:text-foreground",
         copied && "text-emerald-600 hover:text-emerald-600",

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -35,7 +35,21 @@ export function copyToClipboard(text: string): boolean {
     return false;
   }
 
-  return copyWithExecCommand(text);
+  if (document.queryCommandSupported?.("copy") !== false) {
+    return copyWithExecCommand(text);
+  }
+
+  // Async fallback for environments where execCommand is entirely unsupported
+  // but the Clipboard API is available (rare; kept for original contract parity).
+  if (typeof navigator?.clipboard?.writeText === "function") {
+    navigator.clipboard.writeText(text).then(
+      () => {},
+      () => {},
+    );
+    return true;
+  }
+
+  return false;
 }
 
 export async function copyToClipboardAsync(text: string): Promise<boolean> {
@@ -50,9 +64,13 @@ export async function copyToClipboardAsync(text: string): Promise<boolean> {
       await navigator.clipboard.writeText(text);
       return true;
     } catch {
-      // Fall through to execCommand (older Safari, non-secure context).
+      // After an await rejection the synchronous user-gesture frame is gone,
+      // so execCommand will also fail. Return false rather than attempting it.
+      return false;
     }
   }
 
+  // No Clipboard API (older browser / non-secure context): still in the
+  // original user-gesture frame, so execCommand can work.
   return copyWithExecCommand(text);
 }

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -6,35 +6,39 @@
  * Uses a synchronous textarea + execCommand fallback so the copy runs in the
  * same user gesture as the click (required by Safari's clipboard security).
  */
+function copyWithExecCommand(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  if (document.queryCommandSupported?.("copy") === false) return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.setAttribute("aria-hidden", "true");
+  document.body.appendChild(textarea);
+  textarea.focus({ preventScroll: true });
+  textarea.select();
+
+  try {
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    document.body.removeChild(textarea);
+    return false;
+  }
+}
+
 export function copyToClipboard(text: string): boolean {
   if (typeof text !== "string" || text.length === 0) {
     return false;
   }
 
-  // Synchronous fallback: works in Safari/Mac when clipboard API fails
-  // because it runs entirely within the user gesture (click) stack.
-  if (document.queryCommandSupported?.("copy") !== false) {
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.style.position = "fixed";
-    textarea.style.top = "0";
-    textarea.style.left = "0";
-    textarea.style.opacity = "0";
-    textarea.setAttribute("aria-hidden", "true");
-    document.body.appendChild(textarea);
-    textarea.focus({ preventScroll: true });
-    textarea.select();
-    try {
-      const ok = document.execCommand("copy");
-      document.body.removeChild(textarea);
-      return ok;
-    } catch {
-      document.body.removeChild(textarea);
-      return false;
-    }
-  }
+  if (copyWithExecCommand(text)) return true;
 
-  // Modern API only when fallback not available (e.g. non-browser)
+  // If synchronous copy is unavailable or failed, try modern async clipboard.
   if (typeof navigator?.clipboard?.writeText === "function") {
     navigator.clipboard.writeText(text).then(
       () => {},
@@ -44,4 +48,21 @@ export function copyToClipboard(text: string): boolean {
   }
 
   return false;
+}
+
+export async function copyToClipboardAsync(text: string): Promise<boolean> {
+  if (typeof text !== "string" || text.length === 0) {
+    return false;
+  }
+
+  if (typeof navigator?.clipboard?.writeText === "function") {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back to execCommand below.
+    }
+  }
+
+  return copyWithExecCommand(text);
 }

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -11,9 +11,11 @@ function copyWithExecCommand(text: string): boolean {
 
   const textarea = document.createElement("textarea");
   textarea.value = text;
+  textarea.readOnly = true;
   textarea.style.position = "fixed";
   textarea.style.top = "0";
   textarea.style.left = "0";
+  textarea.style.fontSize = "12pt";
   textarea.style.opacity = "0";
   textarea.setAttribute("aria-hidden", "true");
   document.body.appendChild(textarea);
@@ -35,8 +37,8 @@ export function copyToClipboard(text: string): boolean {
     return false;
   }
 
-  if (document.queryCommandSupported?.("copy") !== false) {
-    return copyWithExecCommand(text);
+  if (typeof document !== "undefined" && document.queryCommandSupported?.("copy") !== false) {
+    if (copyWithExecCommand(text)) return true;
   }
 
   // Async fallback for environments where execCommand is entirely unsupported

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -7,8 +7,7 @@
  * same user gesture as the click (required by Safari's clipboard security).
  */
 function copyWithExecCommand(text: string): boolean {
-  if (typeof document === "undefined") return false;
-  if (document.queryCommandSupported?.("copy") === false) return false;
+  if (typeof document === "undefined" || !document.body) return false;
 
   const textarea = document.createElement("textarea");
   textarea.value = text;
@@ -36,18 +35,7 @@ export function copyToClipboard(text: string): boolean {
     return false;
   }
 
-  if (copyWithExecCommand(text)) return true;
-
-  // If synchronous copy is unavailable or failed, try modern async clipboard.
-  if (typeof navigator?.clipboard?.writeText === "function") {
-    navigator.clipboard.writeText(text).then(
-      () => {},
-      () => {}
-    );
-    return true;
-  }
-
-  return false;
+  return copyWithExecCommand(text);
 }
 
 export async function copyToClipboardAsync(text: string): Promise<boolean> {
@@ -55,12 +43,14 @@ export async function copyToClipboardAsync(text: string): Promise<boolean> {
     return false;
   }
 
+  // Prefer the async Clipboard API: avoids focus disruption in Radix
+  // focus-trapped dialogs where execCommand always fails.
   if (typeof navigator?.clipboard?.writeText === "function") {
     try {
       await navigator.clipboard.writeText(text);
       return true;
     } catch {
-      // Fall back to execCommand below.
+      // Fall through to execCommand (older Safari, non-secure context).
     }
   }
 

--- a/studio/frontend/src/lib/copy-to-clipboard.ts
+++ b/studio/frontend/src/lib/copy-to-clipboard.ts
@@ -64,9 +64,12 @@ export async function copyToClipboardAsync(text: string): Promise<boolean> {
       await navigator.clipboard.writeText(text);
       return true;
     } catch {
-      // After an await rejection the synchronous user-gesture frame is gone,
-      // so execCommand will also fail. Return false rather than attempting it.
-      return false;
+      // Clipboard API rejected (e.g. NotAllowedError, permission policy).
+      // User activation is still valid through promise chains per spec, so
+      // execCommand can succeed for callers outside focus-trapped dialogs.
+      // Inside a Radix modal the focus trap will block textarea.focus() and
+      // execCommand returns false harmlessly.
+      return copyWithExecCommand(text);
     }
   }
 


### PR DESCRIPTION
Follow up from #4960

Clipboard copy in the API key reveal flow was unreliable in some browser/modal conditions, and the previous visual treatment was noisy. This change improves UX and makes copy behavior more robust, especially in Safari/focus-trapped dialog scenarios.


`studio/frontend/src/features/auth/api-keys-page.tsx`
`studio/frontend/src/lib/copy-to-clipboard.ts`

Test:
 Create a new API key, click the copy icon, and paste into another app/field
 Confirm copied state appears briefly only after a successful copy
- [ ]  macOS Safari
- [ ]  macOS Chrome
- [x]  Windows Chrome/Edge/Firefox
