### PR TITLE
fix(studio): default chart view to full training history

### DIFF
--- a/studio/frontend/src/features/studio/sections/charts/chart-preferences-store.ts
+++ b/studio/frontend/src/features/studio/sections/charts/chart-preferences-store.ts
@@ -3,12 +3,7 @@
 
 import { create } from "zustand";
 import type { OutlierMode, ScaleMode } from "./types";
-import { DEFAULT_VISIBLE_POINTS, clamp } from "./utils";
-
-const DEFAULT_WINDOW_SIZE = Math.max(
-  24,
-  Math.floor(DEFAULT_VISIBLE_POINTS / 2),
-);
+import { clamp } from "./utils";
 
 type ChartPreferencesState = {
   availableSteps: number;
@@ -39,7 +34,7 @@ type ChartPreferencesState = {
 };
 
 const defaultPreferences = {
-  windowSize: DEFAULT_WINDOW_SIZE as number | null,
+  windowSize: null as number | null,
   smoothing: 0.6,
   showRaw: true,
   showSmoothed: true,

--- a/studio/frontend/src/features/studio/sections/charts/chart-preferences-store.ts
+++ b/studio/frontend/src/features/studio/sections/charts/chart-preferences-store.ts
@@ -34,7 +34,7 @@ type ChartPreferencesState = {
 };
 
 const defaultPreferences = {
-  windowSize: null as number | null,
+  windowSize: null as number | null, // null = show full training history
   smoothing: 0.6,
   showRaw: true,
   showSmoothed: true,


### PR DESCRIPTION
## Summary
- Default the chart view window to show the full training run (`null`) instead of the last ~80 steps (`DEFAULT_WINDOW_SIZE`)
- Removes the now-unused `DEFAULT_WINDOW_SIZE` constant and `DEFAULT_VISIBLE_POINTS` import

Users can still manually set a window via the Chart Settings slider to zoom into recent steps.

Fixes #5003