### PR TITLE
studio: pin peft to 0.18.1 to fix export subprocess issues

### DIFF
--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -5,6 +5,10 @@ julius
 torchcodec
 snac
 
+# peft 0.19.0 causes export subprocess shutdown issues in Studio;
+# installing with --no-deps to avoid pulling in torch>=0.11.0
+peft==0.18.1
+
 # TRL and related packages
 trl==0.23.1
 git+https://github.com/meta-pytorch/OpenEnv.git

--- a/studio/backend/requirements/overrides.txt
+++ b/studio/backend/requirements/overrides.txt
@@ -1,2 +1,5 @@
 # Torch AO overrides (installed with --force-reinstall --no-cache-dir)
 torchao==0.14.0
+
+# peft 0.19.0 causes export subprocess shutdown issues in Studio
+peft==0.18.1

--- a/studio/backend/requirements/overrides.txt
+++ b/studio/backend/requirements/overrides.txt
@@ -1,5 +1,2 @@
 # Torch AO overrides (installed with --force-reinstall --no-cache-dir)
 torchao==0.14.0
-
-# peft 0.19.0 causes export subprocess shutdown issues in Studio
-peft==0.18.1


### PR DESCRIPTION
## Summary
- `peft` 0.19.0 causes export subprocess shutdown failures in Studio
- Pin `peft==0.18.1` in `studio/backend/requirements/extras-no-deps.txt` (installed with `--no-deps` to avoid pulling in `torch>=0.11.0` which breaks other pinned packages)

## Error with peft 0.19.0
```
{"timestamp": "2026-04-14T16:01:34.645488Z", "level": "info", "event": "Starting memory cleanup..."}
{"timestamp": "2026-04-14T16:01:34.876145Z", "level": "info", "event": "Memory cleanup completed successfully"}
{"timestamp": "2026-04-14T16:01:34.876787Z", "level": "info", "event": "Received command: shutdown"}
{"timestamp": "2026-04-14T16:01:34.876817Z", "level": "info", "event": "Shutdown command received, cleaning up and exiting"}
{"timestamp": "2026-04-14T16:01:34.876837Z", "level": "info", "event": "Starting memory cleanup..."}
{"timestamp": "2026-04-14T16:01:35.222754Z", "level": "info", "event": "Memory cleanup completed successfully"}
{"timestamp": "2026-04-14T16:01:36.929783Z", "level": "info", "event": "Export subprocess shut down"}
{"timestamp": "2026-04-14T16:01:36.930507Z", "level": "info", "event": "request_completed", "method": "POST", "path": "/api/export/cleanup", "status_code": 200, "process_time_ms": 2286.58}
```

## Test plan
- [x] Verify Studio export works correctly with peft 0.18.1
- [x ] Verify no dependency conflicts with pinned torch/torchao versions