### PR TITLE
fix: prevent offline freeze by fixing stats retry and forwarding local_files_only

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1351,9 +1351,9 @@ def has_internet(host = "8.8.8.8", port = 53, timeout = 3):
     if os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1":
         return False
 
-    OFFLINE_TRUE = {"1", "true", "TRUE", "yes", "YES", "on", "ON"}
+    OFFLINE_TRUE = {"1", "true", "yes", "on"}
 
-    if os.environ.get("HF_HUB_OFFLINE", "").strip() in OFFLINE_TRUE:
+    if os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in OFFLINE_TRUE:
         return False
     try:
         socket.setdefaulttimeout(timeout)

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1350,7 +1350,10 @@ import socket
 def has_internet(host = "8.8.8.8", port = 53, timeout = 3):
     if os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1":
         return False
-    if os.environ.get("HF_HUB_OFFLINE", "0") == "1":
+
+    OFFLINE_TRUE = {"1", "true", "TRUE", "yes", "YES", "on", "ON"}
+
+    if os.environ.get("HF_HUB_OFFLINE", "").strip() in OFFLINE_TRUE:
         return False
     try:
         socket.setdefaulttimeout(timeout)

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1350,6 +1350,8 @@ import socket
 def has_internet(host = "8.8.8.8", port = 53, timeout = 3):
     if os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1":
         return False
+    if os.environ.get("HF_HUB_OFFLINE", "0") == "1":
+        return False
     try:
         socket.setdefaulttimeout(timeout)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -1468,8 +1470,7 @@ def _get_statistics(statistics = None, force_download = True):
                     "```"
                 )
             except Exception:
-                # Try no time limit check
-                stats_check()
+                pass  # Don't retry without a time limit — would freeze offline
 
 
 def get_statistics(local_files_only = False):

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1470,7 +1470,8 @@ def _get_statistics(statistics = None, force_download = True):
                     "```"
                 )
             except Exception:
-                pass  # Don't retry without a time limit — would freeze offline
+                logger.debug("Unsloth: stats_check failed with an exception.")
+                # Don't retry without a time limit — would freeze offline
 
 
 def get_statistics(local_files_only = False):

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -439,12 +439,15 @@ class FastLanguageModel(FastLlamaModel):
         peft_error = None
         model_config = None
         peft_config = None
+        local_files_only = kwargs.get("local_files_only", False)
+
         try:
             model_config = AutoConfig.from_pretrained(
                 model_name,
                 token = token,
                 revision = revision,
                 trust_remote_code = trust_remote_code,
+                local_files_only = local_files_only,
             )
             is_model = True
         except ImportError:
@@ -470,6 +473,7 @@ class FastLanguageModel(FastLlamaModel):
                 token = token,
                 revision = revision,
                 trust_remote_code = trust_remote_code,
+                local_files_only = local_files_only,
             )
             is_peft = True
         except ImportError:

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -570,6 +570,7 @@ class FastLanguageModel(FastLlamaModel):
                 model_name,
                 token = token,
                 trust_remote_code = trust_remote_code,
+                local_files_only = local_files_only,
             )
 
         if not was_disabled:
@@ -1053,12 +1054,15 @@ class FastModel(FastBaseModel):
         peft_error = None
         model_config = None
         peft_config = None
+        local_files_only = kwargs.get("local_files_only", False)
+
         try:
             model_config = AutoConfig.from_pretrained(
                 model_name,
                 token = token,
                 revision = revision,
                 trust_remote_code = trust_remote_code,
+                local_files_only = local_files_only,
             )
             is_model = True
         except ImportError:
@@ -1084,6 +1088,7 @@ class FastModel(FastBaseModel):
                 token = token,
                 revision = revision,
                 trust_remote_code = trust_remote_code,
+                local_files_only = local_files_only,
             )
             is_peft = True
         except ImportError:
@@ -1334,6 +1339,7 @@ class FastModel(FastBaseModel):
                 model_name,
                 token = token,
                 trust_remote_code = trust_remote_code,
+                local_files_only = local_files_only,
             )
 
         if not was_disabled:


### PR DESCRIPTION
## Summary
Fixes the offline freeze reported in #2393.

## Root cause
Three issues combine to cause the freeze:

1. `_get_statistics()` in `_utils.py` had a bare `except Exception` that retried `stats_check()` without any time limit. If the time-limited attempt failed for any non-TimeoutError reason (e.g. a DNS error on Kaggle offline mode), the retry would hang indefinitely.

2. `has_internet()` respected `TRANSFORMERS_OFFLINE` but not `HF_HUB_OFFLINE`, meaning explicitly offline HF environments were still treated as online.

3. `AutoConfig.from_pretrained` and `PeftConfig.from_pretrained` in `loader.py` did not receive `local_files_only` from `**kwargs`.

## Changes
- `unsloth/models/_utils.py`: `has_internet()` now checks `HF_HUB_OFFLINE`
- `unsloth/models/_utils.py`: bare `except Exception` retry replaced with `pass`
- `unsloth/models/loader.py`: `local_files_only` forwarded to both config calls

## How to reproduce

The freeze occurs when `has_internet()` returns `True` (DNS reachable) but `snapshot_download` then hangs on the HuggingFace connection — the exact scenario on Kaggle's offline mode. The test below mocks both conditions to confirm the double-call without requiring a real offline environment.

Run this **before** the fix:

```python
import pathlib, tempfile, unittest.mock as mock

counter_file = pathlib.Path(tempfile.mktemp(suffix=".txt"))
counter_file.write_text("0")

def fake_snapshot_download(*args, **kwargs):
    count = int(counter_file.read_text()) + 1
    counter_file.write_text(str(count))
    print(f"  → snapshot_download called (attempt #{count})")
    raise ConnectionError("Simulated DNS failure")

with mock.patch("unsloth.models._utils.has_internet", return_value=True), \
     mock.patch("huggingface_hub.snapshot_download", side_effect=fake_snapshot_download):
    from unsloth.models._utils import _get_statistics
    try:
        _get_statistics("kaggle")
    except Exception:
        pass

total = int(counter_file.read_text())
counter_file.unlink()
print(f"\nTotal calls: {total}")
print("❌ BUG" if total > 1 else "✅ FIXED")
```

**Before fix:**
<img width="1599" height="408" alt="Screenshot_2026-04-14_18-17-58" src="https://github.com/user-attachments/assets/e7f54334-4a4a-49bd-a029-7cedc8c8a0de" />

**After fix:**
<img width="1591" height="312" alt="Screenshot_2026-04-14_18-24-09" src="https://github.com/user-attachments/assets/cc6ca137-435c-4555-a850-ea3f0c7e9a4a" />

Note: `execute_with_time_limit` runs the first attempt in a subprocess, so a simple in-process call counter undercounts — this test uses a temp file as a shared counter visible across process boundaries.