### PR TITLE
Studio: hard-stop at n_ctx with a 'Context limit reached' toast

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1419,14 +1419,7 @@ class LlamaCppBackend:
                 str(n_parallel),
                 "--flash-attn",
                 "on",  # Force flash attention for speed
-                # Refuse to rotate the KV cache when it fills up. Without
-                # this flag llama-server silently drops the oldest
-                # non-``n_keep`` tokens to keep generating, which means
-                # the conversation quietly loses earlier turns and the
-                # UI has no way to tell the user. With ``--no-context-shift``
-                # the server returns a clean HTTP error once the request
-                # would exceed ``n_ctx``; the frontend catches it and
-                # points the user at the "Context Length" setting.
+                # Error out at n_ctx instead of silently rotating the KV cache; frontend catches it and points the user at "Context Length".
                 "--no-context-shift",
             ]
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1419,6 +1419,15 @@ class LlamaCppBackend:
                 str(n_parallel),
                 "--flash-attn",
                 "on",  # Force flash attention for speed
+                # Refuse to rotate the KV cache when it fills up. Without
+                # this flag llama-server silently drops the oldest
+                # non-``n_keep`` tokens to keep generating, which means
+                # the conversation quietly loses earlier turns and the
+                # UI has no way to tell the user. With ``--no-context-shift``
+                # the server returns a clean HTTP error once the request
+                # would exceed ``n_ctx``; the frontend catches it and
+                # points the user at the "Context Length" setting.
+                "--no-context-shift",
             ]
 
             if use_fit:

--- a/studio/backend/tests/test_llama_cpp_no_context_shift.py
+++ b/studio/backend/tests/test_llama_cpp_no_context_shift.py
@@ -18,6 +18,7 @@ actual GGUF on disk, which is out of scope for the fast test suite.
 
 from __future__ import annotations
 
+import inspect
 import sys
 import types as _types
 from pathlib import Path
@@ -64,16 +65,27 @@ sys.modules.setdefault("httpx", _httpx_stub)
 from core.inference import llama_cpp as llama_cpp_module
 
 
-def test_no_context_shift_is_in_source():
+def _load_model_source() -> str:
+    """Return the source of ``LlamaCppBackend.load_model``.
+
+    Using ``inspect.getsource`` instead of reading the file directly
+    scopes the assertions to the function that actually launches
+    llama-server, so neither the presence check nor the location check
+    can be fooled by a stray occurrence of ``"--no-context-shift"``
+    elsewhere in the module.
+    """
+    return inspect.getsource(llama_cpp_module.LlamaCppBackend.load_model)
+
+
+def test_no_context_shift_is_in_load_model():
     """The flag is part of the static launch-command template.
 
-    We intentionally check the source rather than mocking up the whole
-    ``load_model`` call chain (GPU probing, GGUF stat, etc.): the flag
-    is written as a literal in one place and any regression would have
-    to delete it, which a text search will catch.
+    We check the source of ``load_model`` rather than mocking the whole
+    call chain (GPU probing, GGUF stat, etc.): the flag is written as
+    a literal in one place and any regression has to delete it, which
+    a text search will catch.
     """
-    source = Path(llama_cpp_module.__file__).read_text()
-    assert '"--no-context-shift"' in source, (
+    assert '"--no-context-shift"' in _load_model_source(), (
         "llama-server must be launched with --no-context-shift so the "
         "UI can surface a clean 'context full' error instead of silently "
         "losing old turns to a KV-cache rotation."
@@ -82,16 +94,31 @@ def test_no_context_shift_is_in_source():
 
 def test_flag_sits_inside_the_base_cmd_list():
     """Pin the flag's location so a future refactor can't accidentally
-    move it into a branch that only fires on some code paths."""
-    source = Path(llama_cpp_module.__file__).read_text()
-    # The base ``cmd = [ ... ]`` list opens with ``binary,\n  "-m",`` and
-    # closes before the first ``if use_fit``. The flag must be inside
-    # that block.
+    move it into a branch that only fires on some code paths.
+
+    We slice from ``cmd = [`` to the first ``]`` at the same indent.
+    Using ``inspect.getsource`` means the function lives in its own
+    string and there are no siblings to worry about, so a plain
+    bracket search would also work -- anchoring on the trailing indent
+    just keeps the slice from wandering into a later expression if the
+    opening literal ever grows an in-line comment trailing it.
+    """
+    source = _load_model_source()
     start = source.find("cmd = [")
     assert start >= 0, "could not find the base cmd = [...] block"
-    end = source.find("            ]", start)
-    assert end > start, "could not find end of cmd = [...] block"
-    block = source[start:end]
+    # Find the first line containing only ``]`` (possibly indented).
+    # Works for any indentation style the formatter picks.
+    rest = source[start:]
+    end_rel = -1
+    for line_start, line in _iter_lines_with_offset(rest):
+        if line_start == 0:
+            # Skip the opening ``cmd = [`` line itself.
+            continue
+        if line.strip() == "]":
+            end_rel = line_start
+            break
+    assert end_rel > 0, "could not find end of cmd = [...] block"
+    block = rest[:end_rel]
     assert '"--no-context-shift"' in block, (
         "--no-context-shift must be in the base cmd list, not in a "
         "conditional branch -- otherwise some code paths would still "
@@ -100,3 +127,11 @@ def test_flag_sits_inside_the_base_cmd_list():
     # Also pin that it is next to -c / --ctx so the grouping makes sense.
     assert '"-c"' in block
     assert '"--flash-attn"' in block
+
+
+def _iter_lines_with_offset(text: str):
+    """Yield (offset, line) pairs over ``text`` without losing offsets."""
+    offset = 0
+    for line in text.splitlines(keepends = True):
+        yield offset, line
+        offset += len(line)

--- a/studio/backend/tests/test_llama_cpp_no_context_shift.py
+++ b/studio/backend/tests/test_llama_cpp_no_context_shift.py
@@ -41,14 +41,23 @@ sys.modules.setdefault("structlog", _structlog_stub)
 
 _httpx_stub = _types.ModuleType("httpx")
 for _exc in (
-    "ConnectError", "TimeoutException", "ReadTimeout", "ReadError",
-    "RemoteProtocolError", "CloseError",
+    "ConnectError",
+    "TimeoutException",
+    "ReadTimeout",
+    "ReadError",
+    "RemoteProtocolError",
+    "CloseError",
 ):
     setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
 _httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
 _httpx_stub.Client = type(
-    "C", (),
-    {"__init__": lambda s, **kw: None, "__enter__": lambda s: s, "__exit__": lambda s, *a: None},
+    "C",
+    (),
+    {
+        "__init__": lambda s, **kw: None,
+        "__enter__": lambda s: s,
+        "__exit__": lambda s, *a: None,
+    },
 )
 sys.modules.setdefault("httpx", _httpx_stub)
 
@@ -78,7 +87,7 @@ def test_flag_sits_inside_the_base_cmd_list():
     # The base ``cmd = [ ... ]`` list opens with ``binary,\n  "-m",`` and
     # closes before the first ``if use_fit``. The flag must be inside
     # that block.
-    start = source.find('cmd = [')
+    start = source.find("cmd = [")
     assert start >= 0, "could not find the base cmd = [...] block"
     end = source.find("            ]", start)
     assert end > start, "could not find end of cmd = [...] block"

--- a/studio/backend/tests/test_llama_cpp_no_context_shift.py
+++ b/studio/backend/tests/test_llama_cpp_no_context_shift.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""``--no-context-shift`` launch-flag contract.
+
+When llama-server runs with its default context-shift behavior, the UI
+has no way to tell the user that the KV cache has been rotated --
+earlier turns silently vanish from the conversation. The Studio
+backend always passes ``--no-context-shift`` so the server returns a
+clean error instead, and the chat adapter can point the user at the
+``Context Length`` input in the settings panel.
+
+This file is a static read of the launch command: we ask
+``LlamaCppBackend`` to assemble its ``cmd`` list and assert the flag
+is always present. Testing via the real subprocess would require an
+actual GGUF on disk, which is out of scope for the fast test suite.
+"""
+
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Same external-dep stubs as the other llama_cpp tests.
+# ---------------------------------------------------------------------------
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+
+_structlog_stub = _types.ModuleType("structlog")
+sys.modules.setdefault("structlog", _structlog_stub)
+
+_httpx_stub = _types.ModuleType("httpx")
+for _exc in (
+    "ConnectError", "TimeoutException", "ReadTimeout", "ReadError",
+    "RemoteProtocolError", "CloseError",
+):
+    setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
+_httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
+_httpx_stub.Client = type(
+    "C", (),
+    {"__init__": lambda s, **kw: None, "__enter__": lambda s: s, "__exit__": lambda s, *a: None},
+)
+sys.modules.setdefault("httpx", _httpx_stub)
+
+from core.inference import llama_cpp as llama_cpp_module
+
+
+def test_no_context_shift_is_in_source():
+    """The flag is part of the static launch-command template.
+
+    We intentionally check the source rather than mocking up the whole
+    ``load_model`` call chain (GPU probing, GGUF stat, etc.): the flag
+    is written as a literal in one place and any regression would have
+    to delete it, which a text search will catch.
+    """
+    source = Path(llama_cpp_module.__file__).read_text()
+    assert '"--no-context-shift"' in source, (
+        "llama-server must be launched with --no-context-shift so the "
+        "UI can surface a clean 'context full' error instead of silently "
+        "losing old turns to a KV-cache rotation."
+    )
+
+
+def test_flag_sits_inside_the_base_cmd_list():
+    """Pin the flag's location so a future refactor can't accidentally
+    move it into a branch that only fires on some code paths."""
+    source = Path(llama_cpp_module.__file__).read_text()
+    # The base ``cmd = [ ... ]`` list opens with ``binary,\n  "-m",`` and
+    # closes before the first ``if use_fit``. The flag must be inside
+    # that block.
+    start = source.find('cmd = [')
+    assert start >= 0, "could not find the base cmd = [...] block"
+    end = source.find("            ]", start)
+    assert end > start, "could not find end of cmd = [...] block"
+    block = source[start:end]
+    assert '"--no-context-shift"' in block, (
+        "--no-context-shift must be in the base cmd list, not in a "
+        "conditional branch -- otherwise some code paths would still "
+        "run with silent context shift enabled."
+    )
+    # Also pin that it is next to -c / --ctx so the grouping makes sense.
+    assert '"-c"' in block
+    assert '"--flash-attn"' in block

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -47,6 +47,25 @@ type RunMessage = RunMessages[number];
 /** Tracks which user messages were sent with an audio file (messageId → filename). */
 export const sentAudioNames = new Map<string, string>();
 
+/**
+ * Match llama-server error messages that indicate the request filled or
+ * would fill the KV cache. The server emits these when it was started
+ * with ``--no-context-shift`` and the prompt + pending completion would
+ * exceed ``n_ctx`` -- the canonical phrase from llama.cpp is
+ * "the request exceeds the available context size", but we also accept
+ * looser variants since the exact wording has drifted across versions.
+ */
+export function isContextLimitError(message: string): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return (
+    m.includes("context size") ||
+    m.includes("context shift") ||
+    m.includes("exceeds the available context") ||
+    (m.includes("n_ctx") && (m.includes("exceed") || m.includes("full")))
+  );
+}
+
 /** Parse "Title: ...\nURL: ...\nSnippet: ..." blocks into source content parts. */
 function parseSourcesFromResult(raw: string): { type: "source"; sourceType: "url"; id: string; url: string; title: string; metadata?: { description: string } }[] {
   if (!raw) return [];
@@ -868,9 +887,24 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       } catch (err) {
         settleFirstTokenErr(err instanceof Error ? err : new Error("Generation failed"));
         if (!abortSignal.aborted) {
-          toast.error("Generation failed", {
-            description: err instanceof Error ? err.message : "Unknown error",
-          });
+          const msg = err instanceof Error ? err.message : String(err);
+          if (isContextLimitError(msg)) {
+            // llama-server was launched with --no-context-shift, so it
+            // returns a hard error instead of silently dropping old
+            // turns from the KV cache. Point the user at the exact
+            // control that raises the ceiling.
+            toast.error("Context limit reached", {
+              description:
+                "The conversation has filled the model's context window. " +
+                "Increase \"Context Length\" in the chat Settings panel (⚙ in the top-right), " +
+                "or start a new chat.",
+              duration: 8000,
+            });
+          } else {
+            toast.error("Generation failed", {
+              description: msg || "Unknown error",
+            });
+          }
         }
         throw err;
       } finally {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -48,20 +48,36 @@ type RunMessage = RunMessages[number];
 export const sentAudioNames = new Map<string, string>();
 
 /**
- * Match llama-server error messages that indicate the request filled or
- * would fill the KV cache. The server emits these when it was started
- * with ``--no-context-shift`` and the prompt + pending completion would
- * exceed ``n_ctx`` -- the canonical phrase from llama.cpp is
- * "the request exceeds the available context size", but we also accept
- * looser variants since the exact wording has drifted across versions.
+ * Match error messages that indicate the request filled or would fill
+ * the KV cache, so the UI can show a dedicated toast pointing at the
+ * ``Context Length`` setting.
+ *
+ * Two wordings reach the client and both must hit:
+ *
+ *   1. The raw llama-server text when ``--no-context-shift`` trips --
+ *      "the request exceeds the available context size (N tokens)".
+ *   2. The rewritten friendly text emitted by
+ *      ``backend/routes/inference.py::_friendly_error`` -- "Message too
+ *      long: X tokens exceeds the Y-token context window. Try
+ *      increasing the Context Length ..." This is the one most users
+ *      see on the streaming GGUF path.
+ *
+ * We match on substrings rather than full regexes because both layers
+ * have drifted across versions (llama.cpp master has tweaked the
+ * phrasing; ``_friendly_error`` has gone through several copy edits).
  */
 export function isContextLimitError(message: string): boolean {
   if (!message) return false;
   const m = message.toLowerCase();
   return (
+    // Raw llama-server wording.
     m.includes("context size") ||
     m.includes("context shift") ||
     m.includes("exceeds the available context") ||
+    // Backend _friendly_error rewrite.
+    m.includes("message too long") ||
+    m.includes("context window") ||
+    // n_ctx mentions that carry an "exceed"/"full" signal.
     (m.includes("n_ctx") && (m.includes("exceed") || m.includes("full")))
   );
 }

--- a/studio/frontend/src/features/chat/components/context-usage-bar.tsx
+++ b/studio/frontend/src/features/chat/components/context-usage-bar.tsx
@@ -104,6 +104,13 @@ export const ContextUsageBar: FC<{
               {formatTokenCountFull(used)} / {formatTokenCountFull(total)}
             </span>
           </div>
+          {percent > 85 && (
+            <div className="mt-1 max-w-64 text-[11px] leading-snug text-muted-foreground/90">
+              Close to the context limit. Generation will stop at 100%.
+              Increase <span className="font-medium">Context Length</span> in
+              the chat Settings panel to keep going.
+            </div>
+          )}
         </div>
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## Summary

Fixes the confusing `5,361 / 4,096` display reported on the chat context-usage bar after a long completion. The real issue isn't just the number -- it's that llama-server has been silently rotating the KV cache underneath the conversation.

### What was happening

llama-server launches with `-c <n_ctx>` but no `--no-context-shift`, so its default behavior kicked in once the KV cache filled:

- Prompt (2,956) + generated completion hit `n_ctx` (4,096).
- llama-server silently dropped the oldest non-`n_keep` tokens to keep generating.
- `usage.total_tokens` is the cumulative tokens processed (prompt + completion) -- that's why it overshoots `n_ctx` in the UI (`5,361 / 4,096`).
- The bar was clamped at 100% via `Math.min(...)`, but the user had no signal that earlier turns were already evicted from the KV cache. Continuity just quietly degrades.

### Fix

1. **Backend** (`studio/backend/core/inference/llama_cpp.py`) -- add `--no-context-shift` to the base launch command. llama-server now returns an HTTP error when the request would exceed `n_ctx`, instead of silently rotating.
2. **Frontend adapter** (`studio/frontend/src/features/chat/api/chat-adapter.ts`) -- add `isContextLimitError()` and match it in the generation `catch` block. When the heuristic fires, show a dedicated toast titled `"Context limit reached"` with a description that names the exact control to raise: `"Increase \"Context Length\" in the chat Settings panel (⚙ in the top-right), or start a new chat."` Longer display time (8s) so the message doesn't disappear before the user reads it.
3. **UI hint** (`studio/frontend/src/features/chat/components/context-usage-bar.tsx`) -- when usage crosses 85% (already the "red" severity threshold), the tooltip now carries the same suggestion. Users see the remediation *before* they hit the hard stop.

### Tests

- `studio/backend/tests/test_llama_cpp_no_context_shift.py` -- pins the `--no-context-shift` flag in the static launch template, and pins it inside the unconditional `cmd = [ ... ]` block so a future refactor can't accidentally hide it behind a branch.
- Existing load-progress suite still runs (33 tests from PR #5017 + matrix + live files).

## Test plan

- [x] `pytest tests/test_llama_cpp_no_context_shift.py` -- 2 passed
- [x] Full llama_cpp test suite still green (35 total)
- [x] `bun run typecheck` clean
- [x] `bun test` on `isContextLimitError` heuristic -- 9 passed (positive: canonical llama.cpp wording, variants, case-insensitive, n_ctx-exceed wording; negative: empty, generic errors, unrelated "context" usages, n_ctx mentions in config dumps)
- [ ] Eyeball: trigger a long completion that overshoots `n_ctx`, confirm (a) the server returns a clean error, (b) the toast names the Context Length setting, (c) the usage bar tooltip shows the hint at 85%+