### PR TITLE
tighten rocminfo regex to ignore generic ISA lines

### DIFF
--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -30,8 +30,8 @@ def _get_secret_for_subject(subject: str) -> str:
     secret = get_jwt_secret(subject)
     if secret is None:
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Invalid or expired token",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
         )
     return secret
 
@@ -40,7 +40,7 @@ def _decode_subject_without_verification(token: str) -> Optional[str]:
     try:
         payload = jwt.decode(
             token,
-            options = {"verify_signature": False, "verify_exp": False},
+            options={"verify_signature": False, "verify_exp": False},
         )
     except jwt.InvalidTokenError:
         return None
@@ -60,13 +60,13 @@ def create_access_token(
     """
     to_encode = {"sub": subject}
     expire = datetime.now(timezone.utc) + (
-        expires_delta or timedelta(minutes = ACCESS_TOKEN_EXPIRE_MINUTES)
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode.update({"exp": expire})
     return jwt.encode(
         to_encode,
         _get_secret_for_subject(subject),
-        algorithm = ALGORITHM,
+        algorithm=ALGORITHM,
     )
 
 
@@ -77,7 +77,7 @@ def create_refresh_token(subject: str) -> str:
     Refresh tokens are opaque (not JWTs) and expire after REFRESH_TOKEN_EXPIRE_DAYS.
     """
     token = secrets.token_urlsafe(48)
-    expires_at = datetime.now(timezone.utc) + timedelta(days = REFRESH_TOKEN_EXPIRE_DAYS)
+    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     save_refresh_token(token, subject, expires_at.isoformat())
     return token
 
@@ -92,7 +92,7 @@ def refresh_access_token(refresh_token: str) -> Tuple[Optional[str], Optional[st
     username = verify_refresh_token(refresh_token)
     if username is None:
         return None, None
-    return create_access_token(subject = username), username
+    return create_access_token(subject=username), username
 
 
 def reload_secret() -> None:
@@ -110,7 +110,7 @@ async def get_current_subject(
     """Validate JWT and require the password-change flow to be completed."""
     return await _get_current_subject(
         credentials,
-        allow_password_change = False,
+        allow_password_change=False,
     )
 
 
@@ -120,7 +120,7 @@ async def get_current_subject_allow_password_change(
     """Validate JWT but allow access to the password-change endpoint."""
     return await _get_current_subject(
         credentials,
-        allow_password_change = True,
+        allow_password_change=True,
     )
 
 
@@ -145,8 +145,8 @@ async def _get_current_subject(
         username = validate_api_key(token)
         if username is None:
             raise HTTPException(
-                status_code = status.HTTP_401_UNAUTHORIZED,
-                detail = "Invalid or expired API key",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired API key",
             )
         return username
 
@@ -154,33 +154,33 @@ async def _get_current_subject(
     subject = _decode_subject_without_verification(token)
     if subject is None:
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Invalid token payload",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
         )
 
     record = get_user_and_secret(subject)
     if record is None:
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Invalid or expired token",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
         )
 
     _salt, _pwd_hash, jwt_secret, must_change_password = record
     try:
-        payload = jwt.decode(token, jwt_secret, algorithms = [ALGORITHM])
+        payload = jwt.decode(token, jwt_secret, algorithms=[ALGORITHM])
         if payload.get("sub") != subject:
             raise HTTPException(
-                status_code = status.HTTP_401_UNAUTHORIZED,
-                detail = "Invalid token payload",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token payload",
             )
         if must_change_password and not allow_password_change:
             raise HTTPException(
-                status_code = status.HTTP_403_FORBIDDEN,
-                detail = "Password change required",
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Password change required",
             )
         return subject
     except jwt.InvalidTokenError:
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Invalid or expired token",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
         )

--- a/studio/backend/core/data_recipe/jobs/manager.py
+++ b/studio/backend/core/data_recipe/jobs/manager.py
@@ -52,7 +52,7 @@ class Subscription:
         if event_id is None:
             self._next_id += 1
             event_id = self._next_id
-        body = json.dumps(event, separators = (",", ":"), ensure_ascii = False)
+        body = json.dumps(event, separators=(",", ":"), ensure_ascii=False)
         event_type = event.get("type") or "message"
         return (
             f"id: {event_id}\n" f"event: {event_type}\n" f"data: {body}\n\n"
@@ -66,7 +66,7 @@ class JobManager:
         self._job: Job | None = None
         self._proc: mp.Process | None = None
         self._mp_q: Any | None = None
-        self._events: deque[dict] = deque(maxlen = 5000)
+        self._events: deque[dict] = deque(maxlen=5000)
         self._subs: list[queue.Queue] = []
         self._pump_thread: threading.Thread | None = None
         self._seq: int = 0
@@ -90,7 +90,7 @@ class JobManager:
                 raise RuntimeError("job already running")
 
             job_id = uuid.uuid4().hex
-            self._job = Job(job_id = job_id, status = "pending", started_at = time.time())
+            self._job = Job(job_id=job_id, status="pending", started_at=time.time())
             self._job.progress_columns_total = llm_column_count
             self._events.clear()
             self._seq = 0
@@ -99,15 +99,15 @@ class JobManager:
             run_payload["_job_id"] = job_id
             mp_q = _CTX.Queue()
             proc = _CTX.Process(
-                target = run_job_process,
-                kwargs = {"event_queue": mp_q, "recipe": recipe, "run": run_payload},
-                daemon = True,
+                target=run_job_process,
+                kwargs={"event_queue": mp_q, "recipe": recipe, "run": run_payload},
+                daemon=True,
             )
             proc.start()
 
             self._mp_q = mp_q
             self._proc = proc
-            self._pump_thread = threading.Thread(target = self._pump_loop, daemon = True)
+            self._pump_thread = threading.Thread(target=self._pump_loop, daemon=True)
             self._pump_thread.start()
 
             self._emit(
@@ -242,7 +242,7 @@ class JobManager:
                 return {"error": f"dataset path missing: {parquet_dir}"}
 
             return self._load_dataset_page(
-                parquet_dir = parquet_dir, limit = limit, offset = offset
+                parquet_dir=parquet_dir, limit=limit, offset=offset
             )
         except Exception as exc:
             return {"error": f"dataset load failed: {exc}"}
@@ -255,16 +255,16 @@ class JobManager:
         offset: int,
     ) -> dict[str, Any]:
         dataset_page = JobManager._load_dataset_page_with_duckdb(
-            parquet_dir = parquet_dir,
-            limit = limit,
-            offset = offset,
+            parquet_dir=parquet_dir,
+            limit=limit,
+            offset=offset,
         )
         if dataset_page is not None:
             return dataset_page
         return JobManager._load_dataset_page_with_data_designer(
-            parquet_dir = parquet_dir,
-            limit = limit,
-            offset = offset,
+            parquet_dir=parquet_dir,
+            limit=limit,
+            offset=offset,
         )
 
     @staticmethod
@@ -304,9 +304,9 @@ class JobManager:
 
         for helper_col in ("filename", "__row_num__"):
             if helper_col in dataframe.columns:
-                dataframe = dataframe.drop(columns = [helper_col])
+                dataframe = dataframe.drop(columns=[helper_col])
 
-        rows = dataframe.to_dict(orient = "records")
+        rows = dataframe.to_dict(orient="records")
         return {"dataset": to_preview_jsonable(rows), "total": total}
 
     @staticmethod
@@ -320,7 +320,7 @@ class JobManager:
 
         dataframe = read_parquet_dataset(parquet_dir)
         total = int(len(dataframe.index))
-        rows = dataframe.iloc[offset : offset + limit].to_dict(orient = "records")
+        rows = dataframe.iloc[offset : offset + limit].to_dict(orient="records")
         return {"dataset": to_preview_jsonable(rows), "total": total}
 
     def subscribe(
@@ -330,13 +330,13 @@ class JobManager:
         with self._lock:
             if self._job is None or self._job.job_id != job_id:
                 return None
-            q: queue.Queue = queue.Queue(maxsize = 2000)
+            q: queue.Queue = queue.Queue(maxsize=2000)
             self._subs.append(q)
             if after_seq is None:
                 replay = list(self._events)
             else:
                 replay = [e for e in self._events if int(e.get("seq") or 0) > after_seq]
-            return Subscription(replay = replay, _q = q)
+            return Subscription(replay=replay, _q=q)
 
     def unsubscribe(self, sub: Subscription) -> None:
         """Drop SSE subscriber (client disconnected)."""
@@ -368,7 +368,7 @@ class JobManager:
     def _read_queue_with_timeout(q: Any, *, timeout_sec: float) -> dict | None:
         """Try read 1 event from mp queue. Timeout = pump stays responsive."""
         try:
-            return coerce_event(q.get(timeout = timeout_sec))
+            return coerce_event(q.get(timeout=timeout_sec))
         except queue.Empty:
             return None
         except (EOFError, OSError, ValueError):
@@ -394,7 +394,7 @@ class JobManager:
                 return
             job, proc, mp_q = snap
 
-            event = self._read_queue_with_timeout(mp_q, timeout_sec = 0.25)
+            event = self._read_queue_with_timeout(mp_q, timeout_sec=0.25)
             if event is not None:
                 self._handle_event(job, event)
                 continue

--- a/studio/backend/core/data_recipe/jobs/types.py
+++ b/studio/backend/core/data_recipe/jobs/types.py
@@ -54,9 +54,9 @@ class Job:
     status: JobStatus = "created"
     stage: str | None = None
     current_column: str | None = None
-    progress: Progress = field(default_factory = Progress)
-    column_progress: Progress = field(default_factory = Progress)
-    batch: BatchProgress = field(default_factory = BatchProgress)
+    progress: Progress = field(default_factory=Progress)
+    column_progress: Progress = field(default_factory=Progress)
+    batch: BatchProgress = field(default_factory=BatchProgress)
     rows: int | None = None
     cols: int | None = None
     error: str | None = None
@@ -68,10 +68,10 @@ class Job:
     execution_type: str | None = None
     dataset: list[dict[str, Any]] | None = None
     processor_artifacts: dict[str, Any] | None = None
-    model_usage: dict[str, ModelUsage] = field(default_factory = dict)
+    model_usage: dict[str, ModelUsage] = field(default_factory=dict)
     progress_columns_total: int | None = None
-    completed_columns: list[str] = field(default_factory = list)
+    completed_columns: list[str] = field(default_factory=list)
     _current_usage_model: str | None = None
     _in_usage_summary: bool = False
-    _seen_generation_columns: list[str] = field(default_factory = list)
-    _column_done: dict[str, int] = field(default_factory = dict)
+    _seen_generation_columns: list[str] = field(default_factory=list)
+    _column_done: dict[str, int] = field(default_factory=dict)

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -51,7 +51,7 @@ def _apply_wsl_sudo_patch():
     try:
         import unsloth_zoo.llama_cpp as llama_cpp_module
 
-        def _wsl_do_we_need_sudo(system_type = "debian"):
+        def _wsl_do_we_need_sudo(system_type="debian"):
             logger.info(
                 "WSL detected — skipping sudo check "
                 "(build deps pre-installed by setup.sh)"
@@ -141,7 +141,7 @@ class ExportBackend:
         """
         from utils.models.checkpoints import scan_checkpoints
 
-        return scan_checkpoints(outputs_dir = outputs_dir)
+        return scan_checkpoints(outputs_dir=outputs_dir)
 
     def load_checkpoint(
         self,
@@ -185,12 +185,12 @@ class ExportBackend:
 
                 logger.info("Loading as CSM audio model...")
                 model, tokenizer = FastModel.from_pretrained(
-                    model_name = checkpoint_path,
-                    max_seq_length = max_seq_length,
-                    dtype = None,
-                    auto_model = CsmForConditionalGeneration,
-                    load_in_4bit = False,
-                    trust_remote_code = trust_remote_code,
+                    model_name=checkpoint_path,
+                    max_seq_length=max_seq_length,
+                    dtype=None,
+                    auto_model=CsmForConditionalGeneration,
+                    load_in_4bit=False,
+                    trust_remote_code=trust_remote_code,
                 )
 
             elif self._audio_type == "whisper":
@@ -199,21 +199,21 @@ class ExportBackend:
 
                 logger.info("Loading as Whisper audio model...")
                 model, tokenizer = FastModel.from_pretrained(
-                    model_name = checkpoint_path,
-                    dtype = None,
-                    load_in_4bit = False,
-                    auto_model = WhisperForConditionalGeneration,
-                    trust_remote_code = trust_remote_code,
+                    model_name=checkpoint_path,
+                    dtype=None,
+                    load_in_4bit=False,
+                    auto_model=WhisperForConditionalGeneration,
+                    trust_remote_code=trust_remote_code,
                 )
 
             elif self._audio_type == "snac":
                 logger.info("Loading as SNAC (Orpheus) audio model...")
                 model, tokenizer = FastLanguageModel.from_pretrained(
-                    model_name = checkpoint_path,
-                    max_seq_length = max_seq_length,
-                    dtype = None,
-                    load_in_4bit = load_in_4bit,
-                    trust_remote_code = trust_remote_code,
+                    model_name=checkpoint_path,
+                    max_seq_length=max_seq_length,
+                    dtype=None,
+                    load_in_4bit=load_in_4bit,
+                    trust_remote_code=trust_remote_code,
                 )
 
             elif self._audio_type == "bicodec":
@@ -221,11 +221,11 @@ class ExportBackend:
 
                 logger.info("Loading as BiCodec (Spark-TTS) audio model...")
                 model, tokenizer = FastModel.from_pretrained(
-                    model_name = checkpoint_path,
-                    max_seq_length = max_seq_length,
-                    dtype = torch.float32,
-                    load_in_4bit = False,
-                    trust_remote_code = trust_remote_code,
+                    model_name=checkpoint_path,
+                    max_seq_length=max_seq_length,
+                    dtype=torch.float32,
+                    load_in_4bit=False,
+                    trust_remote_code=trust_remote_code,
                 )
 
             elif self._audio_type == "dac":
@@ -233,31 +233,31 @@ class ExportBackend:
 
                 logger.info("Loading as DAC (OuteTTS) audio model...")
                 model, tokenizer = FastModel.from_pretrained(
-                    model_name = checkpoint_path,
-                    max_seq_length = max_seq_length,
-                    load_in_4bit = False,
-                    trust_remote_code = trust_remote_code,
+                    model_name=checkpoint_path,
+                    max_seq_length=max_seq_length,
+                    load_in_4bit=False,
+                    trust_remote_code=trust_remote_code,
                 )
 
             elif self.is_vision:
                 logger.info("Loading as vision model...")
                 model, processor = FastVisionModel.from_pretrained(
-                    model_name = checkpoint_path,
-                    max_seq_length = max_seq_length,
-                    dtype = None,
-                    load_in_4bit = load_in_4bit,
-                    trust_remote_code = trust_remote_code,
+                    model_name=checkpoint_path,
+                    max_seq_length=max_seq_length,
+                    dtype=None,
+                    load_in_4bit=load_in_4bit,
+                    trust_remote_code=trust_remote_code,
                 )
                 tokenizer = processor  # For vision models, processor acts as tokenizer
 
             else:
                 logger.info("Loading as text model...")
                 model, tokenizer = FastLanguageModel.from_pretrained(
-                    model_name = checkpoint_path,
-                    max_seq_length = max_seq_length,
-                    dtype = None,
-                    load_in_4bit = load_in_4bit,
-                    trust_remote_code = trust_remote_code,
+                    model_name=checkpoint_path,
+                    max_seq_length=max_seq_length,
+                    dtype=None,
+                    load_in_4bit=load_in_4bit,
+                    trust_remote_code=trust_remote_code,
                 )
 
             # Check if PEFT model
@@ -297,7 +297,7 @@ class ExportBackend:
             metadata = {"base_model": base_model}
             metadata_path = os.path.join(save_directory, "export_metadata.json")
             with open(metadata_path, "w") as f:
-                json.dump(metadata, f, indent = 2)
+                json.dump(metadata, f, indent=2)
             logger.info(f"Wrote export metadata to {metadata_path}")
         except Exception as e:
             logger.warning(f"Could not write export metadata: {e}")
@@ -355,7 +355,7 @@ class ExportBackend:
                 ensure_dir(Path(save_directory))
 
                 self.current_model.save_pretrained_merged(
-                    save_directory, self.current_tokenizer, save_method = save_method
+                    save_directory, self.current_tokenizer, save_method=save_method
                 )
 
                 # Write export metadata so the Chat page can identify the base model
@@ -381,9 +381,9 @@ class ExportBackend:
                 self.current_model.push_to_hub_merged(
                     repo_id,
                     self.current_tokenizer,
-                    save_method = hub_save_method,
-                    token = hf_token,
-                    private = private,
+                    save_method=hub_save_method,
+                    token=hf_token,
+                    private=private,
                 )
                 logger.info(f"Model pushed successfully to {repo_id}")
 
@@ -458,32 +458,32 @@ class ExportBackend:
                 )
 
                 # Create repo
-                hf_api = HfApi(token = hf_token)
+                hf_api = HfApi(token=hf_token)
                 repo_id = PushToHubMixin._create_repo(
                     PushToHubMixin,
-                    repo_id = repo_id,
-                    private = private,
-                    token = hf_token,
+                    repo_id=repo_id,
+                    private=private,
+                    token=hf_token,
                 )
                 username = repo_id.split("/")[0]
 
                 # Create and push model card
                 content = MODEL_CARD.format(
-                    username = username,
-                    base_model = base_model,
-                    model_type = self.current_model.config.model_type,
-                    method = "",
-                    extra = "unsloth",
+                    username=username,
+                    base_model=base_model,
+                    model_type=self.current_model.config.model_type,
+                    method="",
+                    extra="unsloth",
                 )
                 card = ModelCard(content)
                 card.push_to_hub(
-                    repo_id, token = hf_token, commit_message = "Unsloth Model Card"
+                    repo_id, token=hf_token, commit_message="Unsloth Model Card"
                 )
 
                 # Upload model files
                 if save_directory:
                     hf_api.upload_folder(
-                        folder_path = save_directory, repo_id = repo_id, repo_type = "model"
+                        folder_path=save_directory, repo_id=repo_id, repo_type="model"
                     )
                     logger.info(f"Model pushed successfully to {repo_id}")
                 else:
@@ -557,7 +557,7 @@ class ExportBackend:
                 self.current_model.save_pretrained_gguf(
                     model_save_path,
                     self.current_tokenizer,
-                    quantization_method = quant_method,
+                    quantization_method=quant_method,
                 )
 
                 # Relocate GGUF artifacts into the export directory.
@@ -584,7 +584,7 @@ class ExportBackend:
                         shutil.move(str(src), dest)
                         logger.info(f"Relocated GGUF: {src.name} → {abs_save_dir}/")
                     # Clean up the subdirectory (intermediate HF files, etc.)
-                    shutil.rmtree(str(sub), ignore_errors = True)
+                    shutil.rmtree(str(sub), ignore_errors=True)
                     logger.info(f"Cleaned up subdirectory: {sub.name}")
 
                 # For non-PEFT models, save_pretrained_gguf redirects to the
@@ -605,7 +605,7 @@ class ExportBackend:
                                 str(modelfile), os.path.join(abs_save_dir, "Modelfile")
                             )
                             logger.info(f"Relocated Modelfile → {abs_save_dir}/")
-                        shutil.rmtree(str(gguf_dir), ignore_errors = True)
+                        shutil.rmtree(str(gguf_dir), ignore_errors=True)
                         logger.info(f"Cleaned up intermediate GGUF dir: {gguf_dir}")
 
                 # Write export metadata so the Chat page can identify the base model
@@ -635,8 +635,8 @@ class ExportBackend:
                 self.current_model.push_to_hub_gguf(
                     repo_id,
                     self.current_tokenizer,
-                    quantization_method = quant_method,
-                    token = hf_token,
+                    quantization_method=quant_method,
+                    token=hf_token,
                 )
                 logger.info(f"GGUF model pushed successfully to {repo_id}")
 
@@ -699,9 +699,9 @@ class ExportBackend:
 
                 logger.info(f"Pushing LoRA adapter to Hub: {repo_id}")
 
-                self.current_model.push_to_hub(repo_id, token = hf_token, private = private)
+                self.current_model.push_to_hub(repo_id, token=hf_token, private=private)
                 self.current_tokenizer.push_to_hub(
-                    repo_id, token = hf_token, private = private
+                    repo_id, token=hf_token, private=private
                 )
                 logger.info(f"Adapter pushed successfully to {repo_id}")
 

--- a/studio/backend/core/export/worker.py
+++ b/studio/backend/core/export/worker.py
@@ -96,8 +96,8 @@ def _setup_log_capture(resp_queue: Any) -> None:
     # Replace Python's sys.stdout/sys.stderr with line-buffered writers
     # bound to the (now-redirected) fds 1 and 2.
     try:
-        sys.stdout = os.fdopen(1, "w", buffering = 1, encoding = "utf-8", errors = "replace")
-        sys.stderr = os.fdopen(2, "w", buffering = 1, encoding = "utf-8", errors = "replace")
+        sys.stdout = os.fdopen(1, "w", buffering=1, encoding="utf-8", errors="replace")
+        sys.stderr = os.fdopen(2, "w", buffering=1, encoding="utf-8", errors="replace")
     except Exception:
         pass
 
@@ -128,7 +128,7 @@ def _setup_log_capture(resp_queue: Any) -> None:
                         break
                 if nl < 0:
                     break
-                line = bytes(buf[:nl]).decode("utf-8", errors = "replace")
+                line = bytes(buf[:nl]).decode("utf-8", errors="replace")
                 del buf[: nl + 1]
                 if not line:
                     continue
@@ -156,7 +156,7 @@ def _setup_log_capture(resp_queue: Any) -> None:
                     {
                         "type": "log",
                         "stream": stream_name,
-                        "line": bytes(buf).decode("utf-8", errors = "replace"),
+                        "line": bytes(buf).decode("utf-8", errors="replace"),
                         "ts": time.time(),
                     }
                 )
@@ -164,16 +164,16 @@ def _setup_log_capture(resp_queue: Any) -> None:
                 pass
 
     t_out = threading.Thread(
-        target = _reader,
-        args = (r_out, "stdout", saved_out_fd),
-        daemon = True,
-        name = "export-log-stdout",
+        target=_reader,
+        args=(r_out, "stdout", saved_out_fd),
+        daemon=True,
+        name="export-log-stdout",
     )
     t_err = threading.Thread(
-        target = _reader,
-        args = (r_err, "stderr", saved_err_fd),
-        daemon = True,
-        name = "export-log-stderr",
+        target=_reader,
+        args=(r_err, "stderr", saved_err_fd),
+        daemon=True,
+        name="export-log-stderr",
     )
     t_out.start()
     t_err.start()
@@ -230,10 +230,10 @@ def _handle_load(backend, cmd: dict, resp_queue: Any) -> None:
         )
 
         success, message = backend.load_checkpoint(
-            checkpoint_path = checkpoint_path,
-            max_seq_length = max_seq_length,
-            load_in_4bit = load_in_4bit,
-            trust_remote_code = trust_remote_code,
+            checkpoint_path=checkpoint_path,
+            max_seq_length=max_seq_length,
+            load_in_4bit=load_in_4bit,
+            trust_remote_code=trust_remote_code,
         )
 
         _send_response(
@@ -256,7 +256,7 @@ def _handle_load(backend, cmd: dict, resp_queue: Any) -> None:
                 "type": "loaded",
                 "success": False,
                 "message": str(exc),
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -278,37 +278,37 @@ def _handle_export(backend, cmd: dict, resp_queue: Any) -> None:
     try:
         if export_type == "merged":
             success, message, output_path = backend.export_merged_model(
-                save_directory = cmd.get("save_directory", ""),
-                format_type = cmd.get("format_type", "16-bit (FP16)"),
-                push_to_hub = cmd.get("push_to_hub", False),
-                repo_id = cmd.get("repo_id"),
-                hf_token = cmd.get("hf_token"),
-                private = cmd.get("private", False),
+                save_directory=cmd.get("save_directory", ""),
+                format_type=cmd.get("format_type", "16-bit (FP16)"),
+                push_to_hub=cmd.get("push_to_hub", False),
+                repo_id=cmd.get("repo_id"),
+                hf_token=cmd.get("hf_token"),
+                private=cmd.get("private", False),
             )
         elif export_type == "base":
             success, message, output_path = backend.export_base_model(
-                save_directory = cmd.get("save_directory", ""),
-                push_to_hub = cmd.get("push_to_hub", False),
-                repo_id = cmd.get("repo_id"),
-                hf_token = cmd.get("hf_token"),
-                private = cmd.get("private", False),
-                base_model_id = cmd.get("base_model_id"),
+                save_directory=cmd.get("save_directory", ""),
+                push_to_hub=cmd.get("push_to_hub", False),
+                repo_id=cmd.get("repo_id"),
+                hf_token=cmd.get("hf_token"),
+                private=cmd.get("private", False),
+                base_model_id=cmd.get("base_model_id"),
             )
         elif export_type == "gguf":
             success, message, output_path = backend.export_gguf(
-                save_directory = cmd.get("save_directory", ""),
-                quantization_method = cmd.get("quantization_method", "Q4_K_M"),
-                push_to_hub = cmd.get("push_to_hub", False),
-                repo_id = cmd.get("repo_id"),
-                hf_token = cmd.get("hf_token"),
+                save_directory=cmd.get("save_directory", ""),
+                quantization_method=cmd.get("quantization_method", "Q4_K_M"),
+                push_to_hub=cmd.get("push_to_hub", False),
+                repo_id=cmd.get("repo_id"),
+                hf_token=cmd.get("hf_token"),
             )
         elif export_type == "lora":
             success, message, output_path = backend.export_lora_adapter(
-                save_directory = cmd.get("save_directory", ""),
-                push_to_hub = cmd.get("push_to_hub", False),
-                repo_id = cmd.get("repo_id"),
-                hf_token = cmd.get("hf_token"),
-                private = cmd.get("private", False),
+                save_directory=cmd.get("save_directory", ""),
+                push_to_hub=cmd.get("push_to_hub", False),
+                repo_id=cmd.get("repo_id"),
+                hf_token=cmd.get("hf_token"),
+                private=cmd.get("private", False),
             )
         else:
             success, message = False, f"Unknown export type: {export_type}"
@@ -332,7 +332,7 @@ def _handle_export(backend, cmd: dict, resp_queue: Any) -> None:
                 "success": False,
                 "message": str(exc),
                 "output_path": None,
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -405,8 +405,8 @@ def run_export_process(
         warnings.filterwarnings("ignore")
 
     LogConfig.setup_logging(
-        service_name = "unsloth-studio-export-worker",
-        env = os.getenv("ENVIRONMENT_TYPE", "production"),
+        service_name="unsloth-studio-export-worker",
+        env=os.getenv("ENVIRONMENT_TYPE", "production"),
     )
 
     checkpoint_path = config["checkpoint_path"]
@@ -420,7 +420,7 @@ def run_export_process(
             {
                 "type": "error",
                 "error": f"Failed to activate transformers version: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -468,7 +468,7 @@ def run_export_process(
             {
                 "type": "error",
                 "error": f"Failed to import ML libraries: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -486,7 +486,7 @@ def run_export_process(
             {
                 "type": "error",
                 "error": f"Failed to initialize export backend: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -497,7 +497,7 @@ def run_export_process(
 
     while True:
         try:
-            cmd = cmd_queue.get(timeout = 1.0)
+            cmd = cmd_queue.get(timeout=1.0)
         except _queue.Empty:
             continue
         except (EOFError, OSError):
@@ -562,14 +562,14 @@ def run_export_process(
 
         except Exception as exc:
             logger.error(
-                "Error handling command '%s': %s", cmd_type, exc, exc_info = True
+                "Error handling command '%s': %s", cmd_type, exc, exc_info=True
             )
             _send_response(
                 resp_queue,
                 {
                     "type": "error",
                     "error": f"Command '{cmd_type}' failed: {exc}",
-                    "stack": traceback.format_exc(limit = 20),
+                    "stack": traceback.format_exc(limit=20),
                     "ts": time.time(),
                 },
             )

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -54,7 +54,7 @@ class _MarkdownRenderer(HTMLParser):
     """HTMLParser subclass that emits Markdown tokens into a list."""
 
     def __init__(self):
-        super().__init__(convert_charrefs = False)
+        super().__init__(convert_charrefs=False)
         self._out: list[str] = []
         self._skip_depth: int = 0
 
@@ -103,7 +103,7 @@ class _MarkdownRenderer(HTMLParser):
     def _prefix_blockquote(self, content: str) -> str:
         """Prefix every line of *content* with ``> ``."""
         # Strip trailing whitespace first, then collapse blank lines
-        content = re.sub(r"[ \t]+$", "", content, flags = re.MULTILINE)
+        content = re.sub(r"[ \t]+$", "", content, flags=re.MULTILINE)
         content = re.sub(r"\n{3,}", "\n\n", content).strip()
         if not content:
             return ""

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -255,7 +255,7 @@ class LlamaCppBackend:
         # Read VmRSS from /proc/<pid>/status. Kilobytes on Linux.
         bytes_loaded = 0
         try:
-            with open(f"/proc/{pid}/status", "r", encoding = "utf-8") as f:
+            with open(f"/proc/{pid}/status", "r", encoding="utf-8") as f:
                 for line in f:
                     if line.startswith("VmRSS:"):
                         kb = int(line.split()[1])
@@ -437,9 +437,9 @@ class LlamaCppBackend:
                     "--query-gpu=index,memory.free",
                     "--format=csv,noheader,nounits",
                 ],
-                capture_output = True,
-                text = True,
-                timeout = 10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if result.returncode != 0:
                 return []
@@ -489,7 +489,7 @@ class LlamaCppBackend:
         model_size_mib = model_size_bytes / (1024 * 1024)
 
         # Sort GPUs by free memory descending
-        ranked = sorted(gpus, key = lambda g: g[1], reverse = True)
+        ranked = sorted(gpus, key=lambda g: g[1], reverse=True)
 
         # Try fitting on 1 GPU (90% of free memory threshold)
         if ranked[0][1] * 0.90 >= model_size_mib:
@@ -507,8 +507,8 @@ class LlamaCppBackend:
         # Model is too large even for all GPUs, let --fit handle it
         logger.debug(
             "Model does not fit in available GPU memory, falling back to --fit",
-            model_size_mib = round(model_size_mib, 2),
-            ranked_gpus = ranked,
+            model_size_mib=round(model_size_mib, 2),
+            ranked_gpus=ranked,
         )
         return None, True
 
@@ -635,8 +635,8 @@ class LlamaCppBackend:
         if not self._can_estimate_kv():
             logger.debug(
                 "Skipping context fit because KV cache metadata is unavailable",
-                requested_ctx = requested_ctx,
-                available_mib = available_mib,
+                requested_ctx=requested_ctx,
+                available_mib=available_mib,
             )
             return requested_ctx
 
@@ -653,9 +653,9 @@ class LlamaCppBackend:
         if model_footprint >= budget_bytes:
             logger.debug(
                 "Model footprint exceeds GPU budget before KV cache",
-                requested_ctx = requested_ctx,
-                available_mib = available_mib,
-                model_size_gb = round(model_footprint / (1024**3), 2),
+                requested_ctx=requested_ctx,
+                available_mib=available_mib,
+                model_size_gb=round(model_footprint / (1024**3), 2),
             )
             return requested_ctx
 
@@ -697,7 +697,7 @@ class LlamaCppBackend:
         try:
             from huggingface_hub import get_paths_info, list_repo_files
 
-            files = list_repo_files(hf_repo, token = hf_token)
+            files = list_repo_files(hf_repo, token=hf_token)
             gguf_files = [
                 f for f in files if f.endswith(".gguf") and "mmproj" not in f.lower()
             ]
@@ -705,7 +705,7 @@ class LlamaCppBackend:
                 return None
 
             # Get sizes for all GGUF files
-            path_infos = list(get_paths_info(hf_repo, gguf_files, token = hf_token))
+            path_infos = list(get_paths_info(hf_repo, gguf_files, token=hf_token))
             size_map = {p.path: (p.size or 0) for p in path_infos}
 
             # Group files by variant: shards share a prefix before -NNNNN-of-NNNNN
@@ -723,7 +723,7 @@ class LlamaCppBackend:
                 variant_sizes.append((first, total, shard_files))
 
             # Sort by total size ascending and pick the smallest that fits
-            variant_sizes.sort(key = lambda x: x[1])
+            variant_sizes.sort(key=lambda x: x[1])
             for first_file, total_size, _ in variant_sizes:
                 if total_size > 0 and total_size <= free_bytes:
                     return first_file, total_size
@@ -966,7 +966,7 @@ class LlamaCppBackend:
             try:
                 from huggingface_hub import list_repo_files
 
-                files = list_repo_files(hf_repo, token = hf_token)
+                files = list_repo_files(hf_repo, token=hf_token)
                 variant_lower = hf_variant.lower()
                 boundary = re.compile(
                     r"(?<![a-zA-Z0-9])" + re.escape(variant_lower) + r"(?![a-zA-Z0-9])"
@@ -1006,7 +1006,7 @@ class LlamaCppBackend:
 
             from huggingface_hub import get_paths_info, try_to_load_from_cache
 
-            path_infos = list(get_paths_info(hf_repo, all_gguf_files, token = hf_token))
+            path_infos = list(get_paths_info(hf_repo, all_gguf_files, token=hf_token))
             total_bytes = sum((p.size or 0) for p in path_infos)
 
             # Subtract bytes already present in the HF cache so we only
@@ -1038,7 +1038,7 @@ class LlamaCppBackend:
                     "HF_HUB_CACHE",
                     str(Path.home() / ".cache" / "huggingface" / "hub"),
                 )
-                Path(cache_dir).mkdir(parents = True, exist_ok = True)
+                Path(cache_dir).mkdir(parents=True, exist_ok=True)
                 free_bytes = shutil.disk_usage(cache_dir).free
 
                 total_gb = total_download_bytes / (1024**3)
@@ -1095,18 +1095,18 @@ class LlamaCppBackend:
                 raise RuntimeError("Cancelled")
             dl_start = time.monotonic()
             local_path = hf_hub_download(
-                repo_id = hf_repo,
-                filename = gguf_filename,
-                token = hf_token,
+                repo_id=hf_repo,
+                filename=gguf_filename,
+                token=hf_token,
             )
             for shard in gguf_extra_shards:
                 if self._cancel_event.is_set():
                     raise RuntimeError("Cancelled")
                 logger.info(f"Resolving GGUF shard: {shard}")
                 hf_hub_download(
-                    repo_id = hf_repo,
-                    filename = shard,
-                    token = hf_token,
+                    repo_id=hf_repo,
+                    filename=shard,
+                    token=hf_token,
                 )
         except RuntimeError as e:
             if "Cancelled" in str(e):
@@ -1140,7 +1140,7 @@ class LlamaCppBackend:
         try:
             from huggingface_hub import hf_hub_download, list_repo_files
 
-            files = list_repo_files(hf_repo, token = hf_token)
+            files = list_repo_files(hf_repo, token=hf_token)
             mmproj_files = sorted(
                 f for f in files if f.endswith(".gguf") and "mmproj" in f.lower()
             )
@@ -1158,9 +1158,9 @@ class LlamaCppBackend:
 
             logger.info(f"Downloading mmproj: {hf_repo}/{target}")
             local_path = hf_hub_download(
-                repo_id = hf_repo,
-                filename = target,
-                token = hf_token,
+                repo_id=hf_repo,
+                filename=target,
+                token=hf_token,
             )
             return local_path
         except Exception as e:
@@ -1220,15 +1220,15 @@ class LlamaCppBackend:
         # ── Phase 2: download (NO lock held, so cancel can proceed) ──
         if hf_repo:
             model_path = self._download_gguf(
-                hf_repo = hf_repo,
-                hf_variant = hf_variant,
-                hf_token = hf_token,
+                hf_repo=hf_repo,
+                hf_variant=hf_variant,
+                hf_token=hf_token,
             )
             # Auto-download mmproj for vision models
             if is_vision and not mmproj_path:
                 mmproj_path = self._download_mmproj(
-                    hf_repo = hf_repo,
-                    hf_token = hf_token,
+                    hf_repo=hf_repo,
+                    hf_token=hf_token,
                 )
         elif gguf_path:
             if not Path(gguf_path).is_file():
@@ -1302,7 +1302,7 @@ class LlamaCppBackend:
                     # bounds), independent of the currently requested context.
                     native_ctx_for_cap = self._context_length or effective_ctx
                     if native_ctx_for_cap > 0:
-                        ranked_for_cap = sorted(gpus, key = lambda g: g[1], reverse = True)
+                        ranked_for_cap = sorted(gpus, key=lambda g: g[1], reverse=True)
                         best_cap = 0
                         for n_gpus in range(1, len(ranked_for_cap) + 1):
                             subset = ranked_for_cap[:n_gpus]
@@ -1343,7 +1343,7 @@ class LlamaCppBackend:
                         # No silent shrink: effective_ctx stays == n_ctx.
                     else:
                         # Auto context: prefer fewer GPUs, cap context to fit.
-                        ranked = sorted(gpus, key = lambda g: g[1], reverse = True)
+                        ranked = sorted(gpus, key=lambda g: g[1], reverse=True)
                         for n_gpus in range(1, len(ranked) + 1):
                             subset = ranked[:n_gpus]
                             pool_mib = sum(free for _, free in subset)
@@ -1374,7 +1374,7 @@ class LlamaCppBackend:
                     # keep the ceiling at the native context (already the default).
                     logger.debug(
                         "Falling back to file-size-only GPU selection",
-                        model_size_gb = round(model_size / (1024**3), 2),
+                        model_size_gb=round(model_size / (1024**3), 2),
                     )
                     gpu_indices, use_fit = self._select_gpus(model_size, gpus)
                     if use_fit and not explicit_ctx:
@@ -1501,10 +1501,10 @@ class LlamaCppBackend:
                 import tempfile
 
                 self._chat_template_file = tempfile.NamedTemporaryFile(
-                    mode = "w",
-                    suffix = ".jinja",
-                    delete = False,
-                    prefix = "unsloth_chat_template_",
+                    mode="w",
+                    suffix=".jinja",
+                    delete=False,
+                    prefix="unsloth_chat_template_",
                 )
                 self._chat_template_file.write(chat_template_override)
                 self._chat_template_file.close()
@@ -1654,15 +1654,15 @@ class LlamaCppBackend:
             self._stdout_lines = []
             self._process = subprocess.Popen(
                 cmd,
-                stdout = subprocess.PIPE,
-                stderr = subprocess.STDOUT,
-                text = True,
-                env = env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
             )
 
             # Start background thread to drain stdout and prevent pipe deadlock
             self._stdout_thread = threading.Thread(
-                target = self._drain_stdout, daemon = True, name = "llama-stdout"
+                target=self._drain_stdout, daemon=True, name="llama-stdout"
             )
             self._stdout_thread.start()
 
@@ -1701,7 +1701,7 @@ class LlamaCppBackend:
             )
 
             # Wait for llama-server to become healthy
-            if not self._wait_for_health(timeout = 600.0):
+            if not self._wait_for_health(timeout=600.0):
                 self._kill_process()
                 raise RuntimeError(
                     "llama-server failed to start. "
@@ -1777,17 +1777,17 @@ class LlamaCppBackend:
             return
         try:
             self._process.terminate()
-            self._process.wait(timeout = 5)
+            self._process.wait(timeout=5)
         except subprocess.TimeoutExpired:
             logger.warning("llama-server did not exit on SIGTERM, sending SIGKILL")
             self._process.kill()
-            self._process.wait(timeout = 5)
+            self._process.wait(timeout=5)
         except Exception as e:
             logger.warning(f"Error killing llama-server process: {e}")
         finally:
             self._process = None
             if self._stdout_thread is not None:
-                self._stdout_thread.join(timeout = 2)
+                self._stdout_thread.join(timeout=2)
                 self._stdout_thread = None
 
     @staticmethod
@@ -1904,9 +1904,9 @@ class LlamaCppBackend:
                     return
                 result = subprocess.run(
                     ["pgrep", "-a", "-f", "llama-server"],
-                    capture_output = True,
-                    text = True,
-                    timeout = 5,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
                 )
                 if result.returncode != 0:
                     return
@@ -1926,13 +1926,13 @@ class LlamaCppBackend:
                     # unavailable.
                     proc_exe = Path(f"/proc/{pid}/exe")
                     try:
-                        binary = proc_exe.resolve(strict = True)
+                        binary = proc_exe.resolve(strict=True)
                     except (OSError, ValueError):
                         cmdline = parts[1]
                         token = cmdline.split()[0] if cmdline.strip() else ""
                         if not token:
                             continue
-                        binary = Path(token).resolve(strict = False)
+                        binary = Path(token).resolve(strict=False)
 
                     owned = binary in exact_binaries or any(
                         binary.is_relative_to(root) for root in resolved_roots
@@ -1948,7 +1948,7 @@ class LlamaCppBackend:
                     except PermissionError:
                         pass
         except Exception:
-            logger.warning("Error during orphan server cleanup", exc_info = True)
+            logger.warning("Error during orphan server cleanup", exc_info=True)
 
     def _cleanup(self):
         """atexit handler to ensure llama-server is terminated."""
@@ -1968,7 +1968,7 @@ class LlamaCppBackend:
             if self._process.poll() is not None:
                 # Give the drain thread a moment to collect final output
                 if self._stdout_thread is not None:
-                    self._stdout_thread.join(timeout = 2)
+                    self._stdout_thread.join(timeout=2)
                 output = "\n".join(self._stdout_lines[-50:])
                 logger.error(
                     f"llama-server exited with code {self._process.returncode}. "
@@ -1977,7 +1977,7 @@ class LlamaCppBackend:
                 return False
 
             try:
-                resp = httpx.get(url, timeout = 2.0)
+                resp = httpx.get(url, timeout=2.0)
                 if resp.status_code == 200:
                     return True
             except (httpx.ConnectError, httpx.TimeoutException):
@@ -2217,7 +2217,7 @@ class LlamaCppBackend:
 
         def _cancel_watcher():
             while not _cancel_closed.is_set():
-                if cancel_event.wait(timeout = 0.3):
+                if cancel_event.wait(timeout=0.3):
                     # Cancel requested. Keep polling until the response object
                     # exists so we can close it, or until the main thread
                     # finishes on its own (_cancel_closed is set in finally).
@@ -2232,13 +2232,13 @@ class LlamaCppBackend:
                                     f"Error closing response in cancel watcher: {e}"
                                 )
                         # Response not created yet -- wait briefly and retry
-                        _cancel_closed.wait(timeout = 0.1)
+                        _cancel_closed.wait(timeout=0.1)
                     return
 
         watcher = None
         if cancel_event is not None:
             watcher = threading.Thread(
-                target = _cancel_watcher, daemon = True, name = "prefill-cancel"
+                target=_cancel_watcher, daemon=True, name="prefill-cancel"
             )
             watcher.start()
 
@@ -2248,17 +2248,17 @@ class LlamaCppBackend:
             # prefill and streaming is handled by the watcher thread
             # which closes the response, unblocking any httpx read.
             prefill_timeout = httpx.Timeout(
-                connect = 30,
-                read = 120.0,
-                write = 10,
-                pool = 10,
+                connect=30,
+                read=120.0,
+                write=10,
+                pool=10,
             )
             with client.stream(
                 "POST",
                 url,
-                json = payload,
-                timeout = prefill_timeout,
-                headers = headers,
+                json=payload,
+                timeout=prefill_timeout,
+                headers=headers,
             ) as response:
                 _response_ref[0] = response
                 if cancel_event is not None and cancel_event.is_set():
@@ -2331,17 +2331,17 @@ class LlamaCppBackend:
             # _stream_with_retry uses a 120 s read timeout so prefill
             # can finish.  Cancel during streaming is handled by the
             # watcher thread (closes the response on cancel_event).
-            stream_timeout = httpx.Timeout(connect = 10, read = 0.5, write = 10, pool = 10)
+            stream_timeout = httpx.Timeout(connect=10, read=0.5, write=10, pool=10)
             _auth_headers = (
                 {"Authorization": f"Bearer {self._api_key}"} if self._api_key else None
             )
-            with httpx.Client(timeout = stream_timeout) as client:
+            with httpx.Client(timeout=stream_timeout) as client:
                 with self._stream_with_retry(
                     client,
                     url,
                     payload,
                     cancel_event,
-                    headers = _auth_headers,
+                    headers=_auth_headers,
                 ) as response:
                     if response.status_code != 200:
                         error_body = response.read().decode()
@@ -2564,18 +2564,18 @@ class LlamaCppBackend:
                 _last_emitted = ""
 
                 stream_timeout = httpx.Timeout(
-                    connect = 10,
-                    read = 0.5,
-                    write = 10,
-                    pool = 10,
+                    connect=10,
+                    read=0.5,
+                    write=10,
+                    pool=10,
                 )
-                with httpx.Client(timeout = stream_timeout) as client:
+                with httpx.Client(timeout=stream_timeout) as client:
                     with self._stream_with_retry(
                         client,
                         url,
                         payload,
                         cancel_event,
-                        headers = _auth_headers,
+                        headers=_auth_headers,
                     ) as response:
                         if response.status_code != 200:
                             error_body = response.read().decode()
@@ -2605,7 +2605,7 @@ class LlamaCppBackend:
                                                 "type": "content",
                                                 "text": _strip_tool_markup(
                                                     cumulative_display,
-                                                    final = True,
+                                                    final=True,
                                                 ),
                                             }
                                         else:
@@ -2789,7 +2789,7 @@ class LlamaCppBackend:
                                 "type": "content",
                                 "text": _strip_tool_markup(
                                     cumulative_display,
-                                    final = True,
+                                    final=True,
                                 ),
                             }
                         elif reasoning_accum and not has_content_tokens:
@@ -2909,7 +2909,7 @@ class LlamaCppBackend:
                     tool_calls = _safety_tc
                     content_text = _strip_tool_markup(
                         content_accum,
-                        final = True,
+                        final=True,
                     )
                     logger.info(
                         f"Safety net: parsed {len(tool_calls)} tool call(s) "
@@ -2943,7 +2943,7 @@ class LlamaCppBackend:
                     if tool_calls and not has_structured_tc:
                         content_text = _strip_tool_markup(
                             content_text,
-                            final = True,
+                            final=True,
                         )
                     if tool_calls:
                         logger.info(
@@ -2958,7 +2958,7 @@ class LlamaCppBackend:
                         if content_accum:
                             # Strip leaked tool-call XML before yielding
                             content_accum = _strip_tool_markup(
-                                content_accum, final = True
+                                content_accum, final=True
                             )
                         if content_accum:
                             yield {"type": "content", "text": content_accum}
@@ -3086,9 +3086,9 @@ class LlamaCppBackend:
                         result = execute_tool(
                             tool_name,
                             arguments,
-                            cancel_event = cancel_event,
-                            timeout = _effective_timeout,
-                            session_id = session_id,
+                            cancel_event=cancel_event,
+                            timeout=_effective_timeout,
+                            session_id=session_id,
                         )
 
                     yield {
@@ -3197,17 +3197,17 @@ class LlamaCppBackend:
         _stream_done = False
 
         try:
-            stream_timeout = httpx.Timeout(connect = 10, read = 0.5, write = 10, pool = 10)
+            stream_timeout = httpx.Timeout(connect=10, read=0.5, write=10, pool=10)
             _auth_headers = (
                 {"Authorization": f"Bearer {self._api_key}"} if self._api_key else None
             )
-            with httpx.Client(timeout = stream_timeout) as client:
+            with httpx.Client(timeout=stream_timeout) as client:
                 with self._stream_with_retry(
                     client,
                     url,
                     stream_payload,
                     cancel_event,
-                    headers = _auth_headers,
+                    headers=_auth_headers,
                 ) as response:
                     if response.status_code != 200:
                         error_body = response.read().decode()
@@ -3233,7 +3233,7 @@ class LlamaCppBackend:
                                         yield {
                                             "type": "content",
                                             "text": _strip_tool_markup(
-                                                cumulative, final = True
+                                                cumulative, final=True
                                             ),
                                         }
                                     else:
@@ -3336,18 +3336,18 @@ class LlamaCppBackend:
             _auth_headers = (
                 {"Authorization": f"Bearer {self._api_key}"} if self._api_key else None
             )
-            with httpx.Client(timeout = 10, headers = _auth_headers) as client:
+            with httpx.Client(timeout=10, headers=_auth_headers) as client:
 
                 def _detok(tid: int) -> str:
                     r = client.post(
-                        f"{self.base_url}/detokenize", json = {"tokens": [tid]}
+                        f"{self.base_url}/detokenize", json={"tokens": [tid]}
                     )
                     return r.json().get("content", "") if r.status_code == 200 else ""
 
                 def _tok(text: str) -> list[int]:
                     r = client.post(
                         f"{self.base_url}/tokenize",
-                        json = {"content": text, "add_special": False},
+                        json={"content": text, "add_special": False},
                     )
                     return r.json().get("tokens", []) if r.status_code == 200 else []
 
@@ -3410,12 +3410,12 @@ class LlamaCppBackend:
             import os
 
             repo_path = snapshot_download(
-                "unsloth/Spark-TTS-0.5B", local_dir = "Spark-TTS-0.5B"
+                "unsloth/Spark-TTS-0.5B", local_dir="Spark-TTS-0.5B"
             )
             model_repo_path = os.path.abspath(repo_path)
 
         LlamaCppBackend._codec_mgr.load_codec(
-            audio_type, device, model_repo_path = model_repo_path
+            audio_type, device, model_repo_path=model_repo_path
         )
         logger.info(f"Loaded audio codec for GGUF TTS: {audio_type}")
 
@@ -3440,7 +3440,7 @@ class LlamaCppBackend:
         tpl, stop, need_ids = self._TTS_PROMPTS[audio_type]
 
         payload: dict = {
-            "prompt": tpl.format(text = text),
+            "prompt": tpl.format(text=text),
             "stream": False,
             "n_predict": max_new_tokens,
             "temperature": temperature,
@@ -3458,9 +3458,9 @@ class LlamaCppBackend:
             {"Authorization": f"Bearer {self._api_key}"} if self._api_key else None
         )
         with httpx.Client(
-            timeout = httpx.Timeout(300, connect = 10), headers = _auth_headers
+            timeout=httpx.Timeout(300, connect=10), headers=_auth_headers
         ) as client:
-            resp = client.post(f"{self.base_url}/completion", json = payload)
+            resp = client.post(f"{self.base_url}/completion", json=payload)
             if resp.status_code != 200:
                 raise RuntimeError(
                     f"llama-server returned {resp.status_code}: {resp.text}"
@@ -3477,5 +3477,5 @@ class LlamaCppBackend:
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
         return LlamaCppBackend._codec_mgr.decode(
-            audio_type, device, token_ids = token_ids, text = data.get("content", "")
+            audio_type, device, token_ids=token_ids, text=data.get("content", "")
         )

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -84,9 +84,9 @@ def _build_model_config(config: dict):
     gguf_variant = config.get("gguf_variant")
 
     mc = ModelConfig.from_identifier(
-        model_id = model_name,
-        hf_token = hf_token,
-        gguf_variant = gguf_variant,
+        model_id=model_name,
+        hf_token=hf_token,
+        gguf_variant=gguf_variant,
     )
     if not mc:
         raise ValueError(f"Invalid model identifier: {model_name}")
@@ -239,7 +239,7 @@ def _start_heartbeat(
                 },
             )
 
-    t = threading.Thread(target = _beat, daemon = True)
+    t = threading.Thread(target=_beat, daemon=True)
     t.start()
     return stop
 
@@ -318,18 +318,18 @@ def _handle_load(backend, config: dict, resp_queue: Any) -> None:
 
         heartbeat_stop = _start_heartbeat(
             resp_queue,
-            interval = 30.0,
-            xet_disabled = xet_disabled,
-            model_names = watch_repos,
+            interval=30.0,
+            xet_disabled=xet_disabled,
+            model_names=watch_repos,
         )
         try:
             success = backend.load_model(
-                config = mc,
-                max_seq_length = config.get("max_seq_length", 2048),
-                load_in_4bit = load_in_4bit,
-                hf_token = hf_token,
-                trust_remote_code = trust_remote_code,
-                gpu_ids = config.get("resolved_gpu_ids"),
+                config=mc,
+                max_seq_length=config.get("max_seq_length", 2048),
+                load_in_4bit=load_in_4bit,
+                hf_token=hf_token,
+                trust_remote_code=trust_remote_code,
+                gpu_ids=config.get("resolved_gpu_ids"),
             )
         finally:
             heartbeat_stop.set()
@@ -373,7 +373,7 @@ def _handle_load(backend, config: dict, resp_queue: Any) -> None:
                 "type": "loaded",
                 "success": False,
                 "error": str(exc),
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -420,7 +420,7 @@ def _handle_generate(
         use_adapter = cmd.get("use_adapter")
         if use_adapter is not None:
             generator = backend.generate_with_adapter_control(
-                use_adapter = use_adapter,
+                use_adapter=use_adapter,
                 **gen_kwargs,
             )
         else:
@@ -455,14 +455,14 @@ def _handle_generate(
         logger.info("Finished text generation for request_id=%s", request_id)
 
     except Exception as exc:
-        logger.error("Generation error: %s", exc, exc_info = True)
+        logger.error("Generation error: %s", exc, exc_info=True)
         _send_response(
             resp_queue,
             {
                 "type": "gen_error",
                 "request_id": request_id,
                 "error": str(exc),
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -478,14 +478,14 @@ def _handle_generate_audio(
     try:
         logger.info("Starting audio generation for request_id=%s", request_id)
         wav_bytes, sample_rate = backend.generate_audio_response(
-            text = cmd["text"],
-            temperature = cmd.get("temperature", 0.6),
-            top_p = cmd.get("top_p", 0.95),
-            top_k = cmd.get("top_k", 50),
-            min_p = cmd.get("min_p", 0.0),
-            max_new_tokens = cmd.get("max_new_tokens", 2048),
-            repetition_penalty = cmd.get("repetition_penalty", 1.0),
-            use_adapter = cmd.get("use_adapter"),
+            text=cmd["text"],
+            temperature=cmd.get("temperature", 0.6),
+            top_p=cmd.get("top_p", 0.95),
+            top_k=cmd.get("top_k", 50),
+            min_p=cmd.get("min_p", 0.0),
+            max_new_tokens=cmd.get("max_new_tokens", 2048),
+            repetition_penalty=cmd.get("repetition_penalty", 1.0),
+            use_adapter=cmd.get("use_adapter"),
         )
 
         # Send WAV bytes as base64 (bytes can't go through mp.Queue directly)
@@ -502,14 +502,14 @@ def _handle_generate_audio(
         logger.info("Finished audio generation for request_id=%s", request_id)
 
     except Exception as exc:
-        logger.error("Audio generation error: %s", exc, exc_info = True)
+        logger.error("Audio generation error: %s", exc, exc_info=True)
         _send_response(
             resp_queue,
             {
                 "type": "audio_error",
                 "request_id": request_id,
                 "error": str(exc),
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -528,27 +528,27 @@ def _handle_generate_audio_input(
         import numpy as np
 
         # Decode audio array from list (numpy arrays can't go through mp.Queue)
-        audio_array = np.array(cmd["audio_data"], dtype = np.float32)
+        audio_array = np.array(cmd["audio_data"], dtype=np.float32)
 
         audio_type = cmd.get("audio_type")
 
         if audio_type == "whisper":
             generator = backend.generate_whisper_response(
-                audio_array = audio_array,
-                cancel_event = cancel_event,
+                audio_array=audio_array,
+                cancel_event=cancel_event,
             )
         else:
             generator = backend.generate_audio_input_response(
-                messages = cmd.get("messages", []),
-                system_prompt = cmd.get("system_prompt", ""),
-                audio_array = audio_array,
-                temperature = cmd.get("temperature", 0.7),
-                top_p = cmd.get("top_p", 0.9),
-                top_k = cmd.get("top_k", 40),
-                min_p = cmd.get("min_p", 0.0),
-                max_new_tokens = cmd.get("max_new_tokens", 512),
-                repetition_penalty = cmd.get("repetition_penalty", 1.0),
-                cancel_event = cancel_event,
+                messages=cmd.get("messages", []),
+                system_prompt=cmd.get("system_prompt", ""),
+                audio_array=audio_array,
+                temperature=cmd.get("temperature", 0.7),
+                top_p=cmd.get("top_p", 0.9),
+                top_k=cmd.get("top_k", 40),
+                min_p=cmd.get("min_p", 0.0),
+                max_new_tokens=cmd.get("max_new_tokens", 512),
+                repetition_penalty=cmd.get("repetition_penalty", 1.0),
+                cancel_event=cancel_event,
             )
 
         logger.info("Starting audio input generation for request_id=%s", request_id)
@@ -581,14 +581,14 @@ def _handle_generate_audio_input(
         logger.info("Finished audio input generation for request_id=%s", request_id)
 
     except Exception as exc:
-        logger.error("Audio input generation error: %s", exc, exc_info = True)
+        logger.error("Audio input generation error: %s", exc, exc_info=True)
         _send_response(
             resp_queue,
             {
                 "type": "gen_error",
                 "request_id": request_id,
                 "error": str(exc),
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -655,8 +655,8 @@ def run_inference_process(
         warnings.filterwarnings("ignore")
 
     LogConfig.setup_logging(
-        service_name = "unsloth-studio-inference-worker",
-        env = os.getenv("ENVIRONMENT_TYPE", "production"),
+        service_name="unsloth-studio-inference-worker",
+        env=os.getenv("ENVIRONMENT_TYPE", "production"),
     )
 
     apply_gpu_ids(config.get("resolved_gpu_ids"))
@@ -672,7 +672,7 @@ def run_inference_process(
             {
                 "type": "error",
                 "error": f"Failed to activate transformers version: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -718,7 +718,7 @@ def run_inference_process(
             {
                 "type": "error",
                 "error": f"Failed to import ML libraries: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -745,7 +745,7 @@ def run_inference_process(
             {
                 "type": "error",
                 "error": f"Failed to initialize inference backend: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             },
         )
@@ -758,7 +758,7 @@ def run_inference_process(
 
     while True:
         try:
-            cmd = cmd_queue.get(timeout = 1.0)
+            cmd = cmd_queue.get(timeout=1.0)
         except _queue.Empty:
             continue
         except (EOFError, OSError):
@@ -859,14 +859,14 @@ def run_inference_process(
 
         except Exception as exc:
             logger.error(
-                "Error handling command '%s': %s", cmd_type, exc, exc_info = True
+                "Error handling command '%s': %s", cmd_type, exc, exc_info=True
             )
             _send_response(
                 resp_queue,
                 {
                     "type": "error",
                     "error": f"Command '{cmd_type}' failed: {exc}",
-                    "stack": traceback.format_exc(limit = 20),
+                    "stack": traceback.format_exc(limit=20),
                     "ts": time.time(),
                 },
             )

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -191,7 +191,7 @@ class UnslothTrainer:
 
         # --- Detect VLM ---
         vision = (
-            is_vision_model(model_name, hf_token = hf_token)
+            is_vision_model(model_name, hf_token=hf_token)
             if not self.is_audio
             else False
         )
@@ -213,16 +213,16 @@ class UnslothTrainer:
 
             self.tokenizer = AutoProcessor.from_pretrained(
                 model_name,
-                trust_remote_code = trust_remote_code,
-                token = hf_token,
+                trust_remote_code=trust_remote_code,
+                token=hf_token,
             )
         else:
             from transformers import AutoTokenizer
 
             self.tokenizer = AutoTokenizer.from_pretrained(
                 model_name,
-                trust_remote_code = trust_remote_code,
-                token = hf_token,
+                trust_remote_code=trust_remote_code,
+                token=hf_token,
             )
 
         logger.info("Pre-loaded tokenizer for %s", model_name)
@@ -252,7 +252,7 @@ class UnslothTrainer:
         trainer_ref = self
 
         class _ProgressCallback(TrainerCallback):
-            def on_log(self, args, state, control, logs = None, **kwargs):
+            def on_log(self, args, state, control, logs=None, **kwargs):
                 if not logs:
                     return
                 loss_value = logs.get("loss", logs.get("train_loss", None))
@@ -276,20 +276,20 @@ class UnslothTrainer:
                 num_tokens = getattr(state, "num_input_tokens_seen", None)
 
                 trainer_ref._update_progress(
-                    step = current_step,
-                    epoch = round(state.epoch, 2) if state.epoch else 0,
-                    loss = loss_value,
-                    learning_rate = logs.get("learning_rate", None),
-                    elapsed_seconds = elapsed_seconds,
-                    eta_seconds = eta_seconds,
-                    grad_norm = grad_norm,
-                    num_tokens = num_tokens,
-                    eval_loss = logs.get("eval_loss", None),
-                    status_message = "",
+                    step=current_step,
+                    epoch=round(state.epoch, 2) if state.epoch else 0,
+                    loss=loss_value,
+                    learning_rate=logs.get("learning_rate", None),
+                    elapsed_seconds=elapsed_seconds,
+                    eta_seconds=eta_seconds,
+                    grad_norm=grad_norm,
+                    num_tokens=num_tokens,
+                    eval_loss=logs.get("eval_loss", None),
+                    status_message="",
                 )
 
             def on_epoch_end(self, args, state, control, **kwargs):
-                trainer_ref._update_progress(epoch = state.epoch, step = state.global_step)
+                trainer_ref._update_progress(epoch=state.epoch, step=state.global_step)
 
             def on_step_end(self, args, state, control, **kwargs):
                 if trainer_ref.should_stop:
@@ -311,7 +311,7 @@ class UnslothTrainer:
         )
         return steps_per_epoch * num_epochs
 
-    def _build_audio_training_args(self, training_args, output_dir, *, extra_args = None):
+    def _build_audio_training_args(self, training_args, output_dir, *, extra_args=None):
         """Build training args dict for audio branches.
 
         Constructs the common config (batch size, lr, warmup, fp16/bf16, etc.)
@@ -368,7 +368,7 @@ class UnslothTrainer:
 
         return config
 
-    def _finalize_training(self, output_dir, label = ""):
+    def _finalize_training(self, output_dir, label=""):
         """Save model after training and update progress. Used by all training branches."""
         if self.should_stop and self.save_on_stop:
             self.trainer.save_model()
@@ -377,14 +377,14 @@ class UnslothTrainer:
             msg = f"{label} training stopped" if label else "Training stopped"
             logger.info(f"\n{msg}. Model saved to {output_dir}\n")
             self._update_progress(
-                is_training = False,
-                status_message = f"Training stopped. Model saved to {output_dir}",
+                is_training=False,
+                status_message=f"Training stopped. Model saved to {output_dir}",
             )
         elif self.should_stop:
             msg = f"{label} training cancelled" if label else "Training cancelled"
             logger.info(f"\n{msg}.\n")
             self._update_progress(
-                is_training = False, status_message = "Training cancelled."
+                is_training=False, status_message="Training cancelled."
             )
         else:
             self.trainer.save_model()
@@ -393,9 +393,9 @@ class UnslothTrainer:
             msg = f"{label} training completed" if label else "Training completed"
             logger.info(f"\n{msg}! Model saved to {output_dir}\n")
             self._update_progress(
-                is_training = False,
-                is_completed = True,
-                status_message = f"Training completed! Model saved to {output_dir}",
+                is_training=False,
+                is_completed=True,
+                status_message=f"Training completed! Model saved to {output_dir}",
             )
 
     def _cleanup_audio_artifacts(self):
@@ -544,7 +544,7 @@ class UnslothTrainer:
             _preserve = (
                 ["Unsloth*Trainer.py"] if sys.platform in ("win32", "darwin") else None
             )
-            clear_unsloth_compiled_cache(preserve_patterns = _preserve)
+            clear_unsloth_compiled_cache(preserve_patterns=_preserve)
             # Detect audio model type dynamically (config.json + tokenizer)
             self._audio_type = detect_audio_type(model_name, hf_token)
             # audio_vlm is detected as an audio_type now, handle it separately
@@ -563,7 +563,7 @@ class UnslothTrainer:
 
             # VLM: vision model with image dataset (mutually exclusive with audio paths)
             vision = (
-                is_vision_model(model_name, hf_token = hf_token)
+                is_vision_model(model_name, hf_token=hf_token)
                 if not self.is_audio
                 else False
             )
@@ -581,12 +581,12 @@ class UnslothTrainer:
 
             # Reset training state for new run
             self._update_progress(
-                is_training = True,
-                is_completed = False,
-                error = None,
-                step = 0,
-                loss = 0.0,
-                epoch = 0,
+                is_training=True,
+                is_completed=False,
+                error=None,
+                step=0,
+                loss=0.0,
+                epoch=0,
             )
 
             # Update UI immediately with loading message
@@ -597,7 +597,7 @@ class UnslothTrainer:
                 "audio" if self.is_audio else ("vision" if self.is_vlm else "text")
             )
             self._update_progress(
-                status_message = f"Loading {model_type_label} model... {model_display}"
+                status_message=f"Loading {model_type_label} model... {model_display}"
             )
 
             logger.info(f"\nLoading {model_type_label} model: {model_name}")
@@ -612,7 +612,7 @@ class UnslothTrainer:
                 try:
                     from huggingface_hub import model_info as hf_model_info
 
-                    info = hf_model_info(model_name, token = hf_token or None)
+                    info = hf_model_info(model_name, token=hf_token or None)
                     # model_info succeeds even for gated repos (metadata is public),
                     # but info.gated tells us if files require acceptance/token.
                     if info.gated and not hf_token:
@@ -623,7 +623,7 @@ class UnslothTrainer:
                         logger.error(
                             f"Model '{model_name}' is gated (gated={info.gated}) and no HF token provided"
                         )
-                        self._update_progress(error = friendly, is_training = False)
+                        self._update_progress(error=friendly, is_training=False)
                         return False
                 except Exception as gate_err:
                     from huggingface_hub.utils import (
@@ -637,7 +637,7 @@ class UnslothTrainer:
                             f"Please add a Hugging Face token with access and try again."
                         )
                         logger.error(f"Gated model check failed: {gate_err}")
-                        self._update_progress(error = friendly, is_training = False)
+                        self._update_progress(error=friendly, is_training=False)
                         return False
 
             device_map = get_device_map(gpu_ids)
@@ -652,15 +652,15 @@ class UnslothTrainer:
                 from transformers import CsmForConditionalGeneration
 
                 self.model, self.tokenizer = FastModel.from_pretrained(
-                    model_name = model_name,
-                    max_seq_length = max_seq_length,
-                    dtype = None,
-                    auto_model = CsmForConditionalGeneration,
-                    load_in_4bit = False,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    model_name=model_name,
+                    max_seq_length=max_seq_length,
+                    dtype=None,
+                    auto_model=CsmForConditionalGeneration,
+                    load_in_4bit=False,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 logger.info("Loaded CSM audio model")
 
@@ -670,16 +670,16 @@ class UnslothTrainer:
                 from transformers import WhisperForConditionalGeneration
 
                 self.model, self.tokenizer = FastModel.from_pretrained(
-                    model_name = model_name,
-                    dtype = None,
-                    load_in_4bit = False,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    auto_model = WhisperForConditionalGeneration,
-                    whisper_language = "English",
-                    whisper_task = "transcribe",
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    model_name=model_name,
+                    dtype=None,
+                    load_in_4bit=False,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    auto_model=WhisperForConditionalGeneration,
+                    whisper_language="English",
+                    whisper_task="transcribe",
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 # Configure generation settings (notebook lines 100-105)
                 self.model.generation_config.language = "<|en|>"
@@ -691,14 +691,14 @@ class UnslothTrainer:
             elif self._audio_type == "snac":
                 # Orpheus: language model with audio codec tokens
                 self.model, self.tokenizer = FastLanguageModel.from_pretrained(
-                    model_name = model_name,
-                    max_seq_length = max_seq_length,
-                    dtype = None,
-                    load_in_4bit = load_in_4bit,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    model_name=model_name,
+                    max_seq_length=max_seq_length,
+                    dtype=None,
+                    load_in_4bit=load_in_4bit,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 logger.info(
                     f"Loaded {self._audio_type} audio model (FastLanguageModel)"
@@ -724,21 +724,21 @@ class UnslothTrainer:
                     local_dir = model_name.split("/")[-1]
                     llm_path = f"{local_dir}/LLM"
 
-                repo_path = snapshot_download(hf_repo, local_dir = local_dir)
+                repo_path = snapshot_download(hf_repo, local_dir=local_dir)
                 self._spark_tts_repo_dir = os.path.abspath(
                     repo_path
                 )  # Absolute path for sys.path
                 llm_path = os.path.join(self._spark_tts_repo_dir, "LLM")
 
                 self.model, self.tokenizer = FastModel.from_pretrained(
-                    model_name = llm_path,
-                    max_seq_length = max_seq_length,
-                    dtype = torch.float32,  # Spark-TTS requires float32
-                    load_in_4bit = False,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    model_name=llm_path,
+                    max_seq_length=max_seq_length,
+                    dtype=torch.float32,  # Spark-TTS requires float32
+                    load_in_4bit=False,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 logger.info("Loaded Spark-TTS (bicodec) model")
 
@@ -748,12 +748,12 @@ class UnslothTrainer:
 
                 self.model, self.tokenizer = FastModel.from_pretrained(
                     model_name,
-                    max_seq_length = max_seq_length,
-                    load_in_4bit = False,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    max_seq_length=max_seq_length,
+                    load_in_4bit=False,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 logger.info("Loaded OuteTTS (dac) model (FastModel)")
 
@@ -763,28 +763,28 @@ class UnslothTrainer:
                 from unsloth import FastModel
 
                 self.model, self.tokenizer = FastModel.from_pretrained(
-                    model_name = model_name,
-                    max_seq_length = max_seq_length,
-                    dtype = None,
-                    load_in_4bit = load_in_4bit,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    model_name=model_name,
+                    max_seq_length=max_seq_length,
+                    dtype=None,
+                    load_in_4bit=load_in_4bit,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 logger.info("Loaded audio VLM model (FastModel)")
 
             elif self.is_vlm:
                 # Load vision model - returns (model, tokenizer)
                 self.model, self.tokenizer = FastVisionModel.from_pretrained(
-                    model_name = model_name,
-                    max_seq_length = max_seq_length,
-                    dtype = None,  # Auto-detect
-                    load_in_4bit = load_in_4bit,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    model_name=model_name,
+                    max_seq_length=max_seq_length,
+                    dtype=None,  # Auto-detect
+                    load_in_4bit=load_in_4bit,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 logger.info("Loaded vision model")
 
@@ -810,14 +810,14 @@ class UnslothTrainer:
             else:
                 # Load text model - returns (model, tokenizer)
                 self.model, self.tokenizer = FastLanguageModel.from_pretrained(
-                    model_name = model_name,
-                    max_seq_length = max_seq_length,
-                    dtype = None,  # Auto-detect
-                    load_in_4bit = load_in_4bit,
-                    device_map = device_map,
-                    full_finetuning = full_finetuning,
-                    token = hf_token,
-                    trust_remote_code = trust_remote_code,
+                    model_name=model_name,
+                    max_seq_length=max_seq_length,
+                    dtype=None,  # Auto-detect
+                    load_in_4bit=load_in_4bit,
+                    device_map=device_map,
+                    full_finetuning=full_finetuning,
+                    token=hf_token,
+                    trust_remote_code=trust_remote_code,
                 )
                 logger.info("Loaded text model")
 
@@ -831,7 +831,7 @@ class UnslothTrainer:
                 # This ensures all model parameters are trainable; otherwise, they might be frozen.
                 self.model.for_training()
 
-            self._update_progress(status_message = "Model loaded successfully")
+            self._update_progress(status_message="Model loaded successfully")
             logger.info("Model loaded successfully")
             return True
 
@@ -847,15 +847,15 @@ class UnslothTrainer:
                 self._source_code_retried = True
                 logger.info(f"\n'could not get source code' — retrying once...\n")
                 return self.load_model(
-                    model_name = model_name,
-                    max_seq_length = max_seq_length,
-                    load_in_4bit = load_in_4bit,
-                    hf_token = hf_token,
-                    is_dataset_image = is_dataset_image,
-                    is_dataset_audio = is_dataset_audio,
-                    trust_remote_code = trust_remote_code,
-                    full_finetuning = full_finetuning,
-                    gpu_ids = gpu_ids,
+                    model_name=model_name,
+                    max_seq_length=max_seq_length,
+                    load_in_4bit=load_in_4bit,
+                    hf_token=hf_token,
+                    is_dataset_image=is_dataset_image,
+                    is_dataset_audio=is_dataset_audio,
+                    trust_remote_code=trust_remote_code,
+                    full_finetuning=full_finetuning,
+                    gpu_ids=gpu_ids,
                 )
             error_msg = str(e)
             error_lower = error_msg.lower()
@@ -875,7 +875,7 @@ class UnslothTrainer:
                     f"Please add a Hugging Face token with access and try again."
                 )
             logger.error(f"Error loading model: {e}")
-            self._update_progress(error = error_msg, is_training = False)
+            self._update_progress(error=error_msg, is_training=False)
             return False
         except Exception as e:
             error_msg = str(e)
@@ -897,7 +897,7 @@ class UnslothTrainer:
                     f"Please add a Hugging Face token with access and try again."
                 )
             logger.error(f"Error loading model: {e}")
-            self._update_progress(error = error_msg, is_training = False)
+            self._update_progress(error=error_msg, is_training=False)
             return False
         finally:
             self._source_code_retried = False
@@ -929,7 +929,7 @@ class UnslothTrainer:
             # Full finetuning mode - skip PEFT entirely
             if not use_lora:
                 self._update_progress(
-                    status_message = "Full finetuning mode - no LoRA adapters"
+                    status_message="Full finetuning mode - no LoRA adapters"
                 )
                 logger.info("Full finetuning mode - training all parameters\n")
                 return True
@@ -984,14 +984,14 @@ class UnslothTrainer:
             if self.model is None:
                 error_msg = "Model is None - model was not loaded properly"
                 logger.error(error_msg)
-                self._update_progress(error = error_msg)
+                self._update_progress(error=error_msg)
                 return False
 
             # Check if model has the expected attributes
             if not hasattr(self.model, "config"):
                 error_msg = "Model does not have config attribute - model may not be loaded correctly"
                 logger.error(error_msg)
-                self._update_progress(error = error_msg)
+                self._update_progress(error=error_msg)
                 return False
 
             logger.info(
@@ -1021,25 +1021,25 @@ class UnslothTrainer:
                 logger.info()
 
                 peft_kwargs = dict(
-                    r = lora_r,
-                    target_modules = target_modules,
-                    lora_alpha = lora_alpha,
-                    lora_dropout = lora_dropout,
-                    bias = "none",
-                    use_gradient_checkpointing = use_gradient_checkpointing,
-                    random_state = 3407,
-                    use_rslora = use_rslora,
-                    loftq_config = {"loftq_bits": 4, "loftq_iter": 1}
+                    r=lora_r,
+                    target_modules=target_modules,
+                    lora_alpha=lora_alpha,
+                    lora_dropout=lora_dropout,
+                    bias="none",
+                    use_gradient_checkpointing=use_gradient_checkpointing,
+                    random_state=3407,
+                    use_rslora=use_rslora,
+                    loftq_config={"loftq_bits": 4, "loftq_iter": 1}
                     if use_loftq
                     else None,
                 )
                 # Audio VLM models support VLM-style layer selection
                 if self.is_audio_vlm:
                     peft_kwargs.update(
-                        finetune_vision_layers = finetune_vision_layers,
-                        finetune_language_layers = finetune_language_layers,
-                        finetune_attention_modules = finetune_attention_modules,
-                        finetune_mlp_modules = finetune_mlp_modules,
+                        finetune_vision_layers=finetune_vision_layers,
+                        finetune_language_layers=finetune_language_layers,
+                        finetune_attention_modules=finetune_attention_modules,
+                        finetune_mlp_modules=finetune_mlp_modules,
                     )
 
                 self.model = FastModel.get_peft_model(self.model, **peft_kwargs)
@@ -1053,18 +1053,18 @@ class UnslothTrainer:
 
                 self.model = FastModel.get_peft_model(
                     self.model,
-                    r = lora_r,
-                    target_modules = target_modules,
-                    lora_alpha = lora_alpha,
-                    lora_dropout = lora_dropout,
-                    bias = "none",
-                    use_gradient_checkpointing = use_gradient_checkpointing,
-                    random_state = 3407,
-                    use_rslora = use_rslora,
-                    loftq_config = {"loftq_bits": 4, "loftq_iter": 1}
+                    r=lora_r,
+                    target_modules=target_modules,
+                    lora_alpha=lora_alpha,
+                    lora_dropout=lora_dropout,
+                    bias="none",
+                    use_gradient_checkpointing=use_gradient_checkpointing,
+                    random_state=3407,
+                    use_rslora=use_rslora,
+                    loftq_config={"loftq_bits": 4, "loftq_iter": 1}
                     if use_loftq
                     else None,
-                    task_type = None,
+                    task_type=None,
                 )
 
             elif self._audio_type == "snac":
@@ -1074,15 +1074,15 @@ class UnslothTrainer:
 
                 self.model = FastLanguageModel.get_peft_model(
                     self.model,
-                    r = lora_r,
-                    target_modules = target_modules,
-                    lora_alpha = lora_alpha,
-                    lora_dropout = lora_dropout,
-                    bias = "none",
-                    use_gradient_checkpointing = use_gradient_checkpointing,
-                    random_state = 3407,
-                    use_rslora = use_rslora,
-                    loftq_config = {"loftq_bits": 4, "loftq_iter": 1}
+                    r=lora_r,
+                    target_modules=target_modules,
+                    lora_alpha=lora_alpha,
+                    lora_dropout=lora_dropout,
+                    bias="none",
+                    use_gradient_checkpointing=use_gradient_checkpointing,
+                    random_state=3407,
+                    use_rslora=use_rslora,
+                    loftq_config={"loftq_bits": 4, "loftq_iter": 1}
                     if use_loftq
                     else None,
                 )
@@ -1099,19 +1099,19 @@ class UnslothTrainer:
 
                 self.model = FastVisionModel.get_peft_model(
                     self.model,
-                    finetune_vision_layers = finetune_vision_layers,
-                    finetune_language_layers = finetune_language_layers,
-                    finetune_attention_modules = finetune_attention_modules,
-                    finetune_mlp_modules = finetune_mlp_modules,
-                    r = lora_r,
-                    target_modules = target_modules,
-                    lora_alpha = lora_alpha,
-                    lora_dropout = lora_dropout,
-                    bias = "none",
-                    use_gradient_checkpointing = use_gradient_checkpointing,
-                    random_state = 3407,
-                    use_rslora = use_rslora,
-                    loftq_config = {"loftq_bits": 4, "loftq_iter": 1}
+                    finetune_vision_layers=finetune_vision_layers,
+                    finetune_language_layers=finetune_language_layers,
+                    finetune_attention_modules=finetune_attention_modules,
+                    finetune_mlp_modules=finetune_mlp_modules,
+                    r=lora_r,
+                    target_modules=target_modules,
+                    lora_alpha=lora_alpha,
+                    lora_dropout=lora_dropout,
+                    bias="none",
+                    use_gradient_checkpointing=use_gradient_checkpointing,
+                    random_state=3407,
+                    use_rslora=use_rslora,
+                    loftq_config={"loftq_bits": 4, "loftq_iter": 1}
                     if use_loftq
                     else None,
                 )
@@ -1122,15 +1122,15 @@ class UnslothTrainer:
 
                 self.model = FastLanguageModel.get_peft_model(
                     self.model,
-                    r = lora_r,
-                    target_modules = target_modules,
-                    lora_alpha = lora_alpha,
-                    lora_dropout = lora_dropout,
-                    bias = "none",
-                    use_gradient_checkpointing = use_gradient_checkpointing,
-                    random_state = 3407,
-                    use_rslora = use_rslora,
-                    loftq_config = {"loftq_bits": 4, "loftq_iter": 1}
+                    r=lora_r,
+                    target_modules=target_modules,
+                    lora_alpha=lora_alpha,
+                    lora_dropout=lora_dropout,
+                    bias="none",
+                    use_gradient_checkpointing=use_gradient_checkpointing,
+                    random_state=3407,
+                    use_rslora=use_rslora,
+                    loftq_config={"loftq_bits": 4, "loftq_iter": 1}
                     if use_loftq
                     else None,
                 )
@@ -1140,7 +1140,7 @@ class UnslothTrainer:
                 logger.info("Stopped during LoRA configuration\n")
                 return False
 
-            self._update_progress(status_message = "LoRA adapters configured")
+            self._update_progress(status_message="LoRA adapters configured")
             logger.info("LoRA adapters configured successfully\n")
             return True
 
@@ -1158,7 +1158,7 @@ class UnslothTrainer:
             logger.error(f"Full traceback:\n{full_traceback}")
             logger.info(f"\n[ERROR] Error preparing model: {error_details}")
             logger.info(f"[ERROR] Full traceback:\n{full_traceback}")
-            self._update_progress(error = error_details)
+            self._update_progress(error=error_details)
             return False
 
     def _apply_csm_forward_fix(self):
@@ -1198,17 +1198,17 @@ class UnslothTrainer:
 
         def _fixed_csm_forward(
             self,
-            input_ids = None,
-            input_values = None,
-            attention_mask = None,
-            input_values_cutoffs = None,
-            position_ids = None,
-            past_key_values = None,
-            inputs_embeds = None,
-            labels = None,
-            use_cache = None,
-            cache_position = None,
-            logits_to_keep = 0,
+            input_ids=None,
+            input_values=None,
+            attention_mask=None,
+            input_values_cutoffs=None,
+            position_ids=None,
+            past_key_values=None,
+            inputs_embeds=None,
+            labels=None,
+            use_cache=None,
+            cache_position=None,
+            logits_to_keep=0,
             **kwargs,
         ):
             # Strip non-standard kwargs injected by Unsloth/PEFT (causal_mask,
@@ -1234,15 +1234,15 @@ class UnslothTrainer:
                 input_ids = None
 
             backbone_outputs = self.backbone_model(
-                input_ids = input_ids,
-                attention_mask = attention_mask,
-                position_ids = position_ids,
-                past_key_values = past_key_values,
-                inputs_embeds = inputs_embeds,
-                use_cache = use_cache,
-                cache_position = cache_position,
-                output_attentions = output_attentions,
-                output_hidden_states = output_hidden_states,
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
                 **clean_kwargs,
             )
 
@@ -1261,21 +1261,21 @@ class UnslothTrainer:
             if labels is not None:
                 backbone_labels = labels[:, :, 0]
                 backbone_loss = self.loss_function(
-                    logits = backbone_logits,
-                    labels = backbone_labels,
-                    vocab_size = self.config.vocab_size,
+                    logits=backbone_logits,
+                    labels=backbone_labels,
+                    vocab_size=self.config.vocab_size,
                     **clean_kwargs,
                 )
 
-                train_mask = ~(labels[:, :, 1:] == -100).all(dim = -1)
+                train_mask = ~(labels[:, :, 1:] == -100).all(dim=-1)
                 depth_decoder_input_ids = labels[train_mask][
                     ..., : self.config.num_codebooks - 1
                 ]
                 depth_decoder_input_ids = nn.functional.pad(
-                    depth_decoder_input_ids, (1, 0), value = 0
+                    depth_decoder_input_ids, (1, 0), value=0
                 )
 
-                train_idxs = train_mask.nonzero(as_tuple = True)
+                train_idxs = train_mask.nonzero(as_tuple=True)
                 backbone_last_hidden_states = backbone_hidden_states[
                     train_idxs[0], train_idxs[1] - 1, :
                 ]
@@ -1290,13 +1290,13 @@ class UnslothTrainer:
                     ] * (self.config.num_codebooks - 1)
 
                 depth_decoder_outputs = self.depth_decoder(
-                    input_ids = depth_decoder_input_ids,
-                    backbone_last_hidden_state = backbone_last_hidden_states,
-                    use_cache = False,
-                    return_dict = True,
-                    labels = depth_decoder_labels,
-                    output_attentions = output_attentions,
-                    output_hidden_states = output_hidden_states,
+                    input_ids=depth_decoder_input_ids,
+                    backbone_last_hidden_state=backbone_last_hidden_states,
+                    use_cache=False,
+                    return_dict=True,
+                    labels=depth_decoder_labels,
+                    output_attentions=output_attentions,
+                    output_hidden_states=output_hidden_states,
                     **dd_kwargs,
                 )
 
@@ -1313,27 +1313,27 @@ class UnslothTrainer:
                     loss = backbone_loss + depth_decoder_loss
 
             return CsmOutputWithPast(
-                loss = loss,
-                backbone_loss = backbone_loss,
-                depth_decoder_loss = depth_decoder_loss,
-                logits = backbone_logits,
-                past_key_values = backbone_outputs.past_key_values,
-                hidden_states = backbone_outputs.hidden_states,
-                attentions = backbone_outputs.attentions,
-                depth_decoder_logits = (
+                loss=loss,
+                backbone_loss=backbone_loss,
+                depth_decoder_loss=depth_decoder_loss,
+                logits=backbone_logits,
+                past_key_values=backbone_outputs.past_key_values,
+                hidden_states=backbone_outputs.hidden_states,
+                attentions=backbone_outputs.attentions,
+                depth_decoder_logits=(
                     depth_decoder_outputs.logits if depth_decoder_outputs else None
                 ),
-                depth_decoder_past_key_values = (
+                depth_decoder_past_key_values=(
                     depth_decoder_outputs.past_key_values
                     if depth_decoder_outputs
                     else None
                 ),
-                depth_decoder_hidden_states = (
+                depth_decoder_hidden_states=(
                     depth_decoder_outputs.hidden_states
                     if depth_decoder_outputs
                     else None
                 ),
-                depth_decoder_attentions = (
+                depth_decoder_attentions=(
                     depth_decoder_outputs.attentions if depth_decoder_outputs else None
                 ),
             )
@@ -1345,7 +1345,7 @@ class UnslothTrainer:
         CsmForConditionalGeneration.forward = _fixed_csm_forward
         logger.info("Applied CSM forward fix (class + instance level)\n")
 
-    def _preprocess_csm_dataset(self, dataset, custom_format_mapping = None):
+    def _preprocess_csm_dataset(self, dataset, custom_format_mapping=None):
         """Preprocess dataset for CSM TTS training (exact notebook copy)."""
         from transformers import AutoProcessor
         from datasets import Audio
@@ -1353,7 +1353,7 @@ class UnslothTrainer:
 
         processor = AutoProcessor.from_pretrained(
             self.model_name,
-            trust_remote_code = getattr(self, "trust_remote_code", False),
+            trust_remote_code=getattr(self, "trust_remote_code", False),
         )
 
         # Strip pad_to_multiple_of from tokenizer init_kwargs — fine-tuned models
@@ -1386,7 +1386,7 @@ class UnslothTrainer:
             f"CSM preprocessing: audio_col='{audio_col}', text_col='{text_col}', speaker_key='{speaker_key}'\n"
         )
 
-        dataset = dataset.cast_column(audio_col, Audio(sampling_rate = 24000))
+        dataset = dataset.cast_column(audio_col, Audio(sampling_rate=24000))
 
         required_keys = [
             "input_ids",
@@ -1396,7 +1396,7 @@ class UnslothTrainer:
             "input_values_cutoffs",
         ]
 
-        self._update_progress(status_message = "Preprocessing CSM dataset...")
+        self._update_progress(status_message="Preprocessing CSM dataset...")
         processed_examples = []
         skipped = 0
         for idx in range(len(dataset)):
@@ -1419,20 +1419,20 @@ class UnslothTrainer:
                 # CsmProcessor._merge_kwargs leaks it to EncodecFeatureExtractor which rejects it.
                 model_inputs = processor.apply_chat_template(
                     conversation,
-                    tokenize = True,
-                    return_dict = True,
-                    output_labels = True,
-                    text_kwargs = {
+                    tokenize=True,
+                    return_dict=True,
+                    output_labels=True,
+                    text_kwargs={
                         "padding": "max_length",
                         "max_length": 256,
                         "padding_side": "right",
                     },
-                    audio_kwargs = {
+                    audio_kwargs={
                         "sampling_rate": 24_000,
                         "max_length": 240001,
                         "padding": "max_length",
                     },
-                    common_kwargs = {"return_tensors": "pt"},
+                    common_kwargs={"return_tensors": "pt"},
                 )
 
                 out = {}
@@ -1454,7 +1454,7 @@ class UnslothTrainer:
 
             if (idx + 1) % 100 == 0:
                 self._update_progress(
-                    status_message = f"Preprocessing CSM... {idx + 1}/{len(dataset)}"
+                    status_message=f"Preprocessing CSM... {idx + 1}/{len(dataset)}"
                 )
 
         if not processed_examples:
@@ -1469,7 +1469,7 @@ class UnslothTrainer:
         )
         return result_dataset
 
-    def _format_audio_vlm_dataset(self, dataset, custom_format_mapping = None):
+    def _format_audio_vlm_dataset(self, dataset, custom_format_mapping=None):
         """Format dataset as audio chat messages for multimodal models (e.g. Gemma 3N).
 
         Expects columns: audio (Audio), text (str).
@@ -1489,7 +1489,7 @@ class UnslothTrainer:
         self._audio_vlm_audio_col = audio_col
 
         # Cast audio to 16kHz (standard for speech models)
-        dataset = dataset.cast_column(audio_col, Audio(sampling_rate = 16000))
+        dataset = dataset.cast_column(audio_col, Audio(sampling_rate=16000))
 
         def format_messages(samples):
             formatted = {"messages": []}
@@ -1518,17 +1518,17 @@ class UnslothTrainer:
                 formatted["messages"].append(message)
             return formatted
 
-        self._update_progress(status_message = "Formatting audio VLM dataset...")
+        self._update_progress(status_message="Formatting audio VLM dataset...")
         dataset = dataset.map(
             format_messages,
-            batched = True,
-            batch_size = 4,
-            num_proc = dataset_map_num_proc(4),
+            batched=True,
+            batch_size=4,
+            num_proc=dataset_map_num_proc(4),
         )
         logger.info(f"Audio VLM dataset formatted: {len(dataset)} examples\n")
         return dataset
 
-    def _preprocess_snac_dataset(self, dataset, custom_format_mapping = None):
+    def _preprocess_snac_dataset(self, dataset, custom_format_mapping=None):
         """Preprocess dataset for Orpheus TTS training with SNAC codec.
 
         Mirrors Orpheus_(3B)-TTS.ipynb: encode audio with SNAC (24kHz, 3 hierarchical
@@ -1567,7 +1567,7 @@ class UnslothTrainer:
         # Cast audio column so datasets 4.x AudioDecoder objects are decoded to dicts
         from datasets import Audio
 
-        dataset = dataset.cast_column(audio_col, Audio(sampling_rate = SNAC_SAMPLE_RATE))
+        dataset = dataset.cast_column(audio_col, Audio(sampling_rate=SNAC_SAMPLE_RATE))
 
         # Get dataset sample rate from first example (after cast, always SNAC_SAMPLE_RATE)
         first_audio = dataset[0][audio_col]
@@ -1578,7 +1578,7 @@ class UnslothTrainer:
         )
 
         # Load SNAC codec model
-        self._update_progress(status_message = "Loading SNAC codec model...")
+        self._update_progress(status_message="Loading SNAC codec model...")
         logger.info("Loading SNAC codec model...\n")
         from snac import SNAC
 
@@ -1587,12 +1587,12 @@ class UnslothTrainer:
 
         # Resample transform (created once)
         resample_transform = (
-            T.Resample(orig_freq = ds_sample_rate, new_freq = SNAC_SAMPLE_RATE)
+            T.Resample(orig_freq=ds_sample_rate, new_freq=SNAC_SAMPLE_RATE)
             if ds_sample_rate != SNAC_SAMPLE_RATE
             else None
         )
 
-        self._update_progress(status_message = "Encoding audio with SNAC...")
+        self._update_progress(status_message="Encoding audio with SNAC...")
         logger.info(
             f"SNAC preprocessing: audio_col='{audio_col}', text_col='{text_col}', "
             f"has_source={has_source}, ds_sample_rate={ds_sample_rate}\n"
@@ -1621,7 +1621,7 @@ class UnslothTrainer:
                 waveform = (
                     torch.from_numpy(audio_data["array"])
                     .unsqueeze(0)
-                    .to(dtype = torch.float32)
+                    .to(dtype=torch.float32)
                 )
                 if resample_transform is not None:
                     waveform = resample_transform(waveform)
@@ -1668,7 +1668,7 @@ class UnslothTrainer:
                     if has_source and example.get(speaker_col)
                     else text
                 )
-                text_ids = tokenizer.encode(text_prompt, add_special_tokens = True)
+                text_ids = tokenizer.encode(text_prompt, add_special_tokens=True)
                 text_ids.append(END_OF_TEXT)
 
                 # --- Build full input_ids (notebook lines 225-234) ---
@@ -1706,7 +1706,7 @@ class UnslothTrainer:
             # Progress update every 100 examples
             if (idx + 1) % 100 == 0:
                 self._update_progress(
-                    status_message = f"Encoding audio... {idx + 1}/{len(dataset)}"
+                    status_message=f"Encoding audio... {idx + 1}/{len(dataset)}"
                 )
 
         # Free SNAC model from GPU
@@ -1731,7 +1731,7 @@ class UnslothTrainer:
         )
         return result_dataset
 
-    def _preprocess_bicodec_dataset(self, dataset, custom_format_mapping = None):
+    def _preprocess_bicodec_dataset(self, dataset, custom_format_mapping=None):
         """Preprocess dataset for Spark-TTS training with BiCodec tokenizer.
 
         Mirrors Spark_TTS_(0_5B).ipynb: encode audio with BiCodec (semantic + global tokens),
@@ -1753,7 +1753,7 @@ class UnslothTrainer:
         )
         sparktts_pkg = os.path.join(spark_code_dir, "sparktts")
         if not os.path.isdir(sparktts_pkg):
-            self._update_progress(status_message = "Cloning Spark-TTS code repo...")
+            self._update_progress(status_message="Cloning Spark-TTS code repo...")
             logger.info(f"Cloning SparkAudio/Spark-TTS to {spark_code_dir}...\n")
             subprocess.run(
                 [
@@ -1764,7 +1764,7 @@ class UnslothTrainer:
                     "https://github.com/SparkAudio/Spark-TTS",
                     spark_code_dir,
                 ],
-                check = True,
+                check=True,
             )
 
         if spark_code_dir not in sys.path:
@@ -1791,13 +1791,13 @@ class UnslothTrainer:
         dataset = dataset.cast_column(audio_col, Audio())
 
         # Load BiCodec tokenizer
-        self._update_progress(status_message = "Loading BiCodec tokenizer...")
+        self._update_progress(status_message="Loading BiCodec tokenizer...")
         logger.info("Loading BiCodec tokenizer...\n")
         audio_tokenizer = BiCodecTokenizer(self._spark_tts_repo_dir, device)
 
         target_sr = audio_tokenizer.config["sample_rate"]
 
-        self._update_progress(status_message = "Encoding audio with BiCodec...")
+        self._update_progress(status_message="Encoding audio with BiCodec...")
         logger.info(
             f"BiCodec preprocessing: audio_col='{audio_col}', text_col='{text_col}', "
             f"has_source={has_source}, target_sr={target_sr}\n"
@@ -1811,9 +1811,9 @@ class UnslothTrainer:
 
             processed = audio_tokenizer.processor(
                 wav_np,
-                sampling_rate = 16000,
-                return_tensors = "pt",
-                padding = True,
+                sampling_rate=16000,
+                return_tensors="pt",
+                padding=True,
             )
             input_values = processed.input_values.to(
                 audio_tokenizer.feature_extractor.device
@@ -1854,7 +1854,7 @@ class UnslothTrainer:
 
                 # Resample if needed
                 if sampling_rate != target_sr:
-                    resampler = T.Resample(orig_freq = sampling_rate, new_freq = target_sr)
+                    resampler = T.Resample(orig_freq=sampling_rate, new_freq=target_sr)
                     audio_tensor_temp = torch.from_numpy(audio_array).float()
                     audio_array = resampler(audio_tensor_temp).numpy()
 
@@ -1933,7 +1933,7 @@ class UnslothTrainer:
             # Progress update every 100 examples
             if (idx + 1) % 100 == 0:
                 self._update_progress(
-                    status_message = f"Encoding audio with BiCodec... {idx + 1}/{len(dataset)}"
+                    status_message=f"Encoding audio with BiCodec... {idx + 1}/{len(dataset)}"
                 )
 
         # Free BiCodec model from GPU
@@ -1963,7 +1963,7 @@ class UnslothTrainer:
         logger.info(f"Sample text length: {len(sample)} chars\n")
         return result_dataset
 
-    def _preprocess_dac_dataset(self, dataset, custom_format_mapping = None):
+    def _preprocess_dac_dataset(self, dataset, custom_format_mapping=None):
         """Preprocess dataset for OuteTTS training with DAC codec.
 
         Mirrors Oute_TTS_(1B).ipynb DataCreationV3: uses Whisper for word timings,
@@ -1988,7 +1988,7 @@ class UnslothTrainer:
         outetts_code_dir = os.path.join(base_dir, "inference", "OuteTTS")
         outetts_pkg = os.path.join(outetts_code_dir, "outetts")
         if not os.path.isdir(outetts_pkg):
-            self._update_progress(status_message = "Cloning OuteTTS code repo...")
+            self._update_progress(status_message="Cloning OuteTTS code repo...")
             logger.info(f"Cloning edwko/OuteTTS to {outetts_code_dir}...\n")
             subprocess.run(
                 [
@@ -1999,7 +1999,7 @@ class UnslothTrainer:
                     "https://github.com/edwko/OuteTTS",
                     outetts_code_dir,
                 ],
-                check = True,
+                check=True,
             )
             for fpath in [
                 os.path.join(outetts_pkg, "models", "gguf_model.py"),
@@ -2030,31 +2030,31 @@ class UnslothTrainer:
         # Cast audio to 24kHz (notebook: dataset.cast_column("audio", Audio(sampling_rate=24000)))
         from datasets import Audio
 
-        dataset = dataset.cast_column(audio_col, Audio(sampling_rate = 24000))
+        dataset = dataset.cast_column(audio_col, Audio(sampling_rate=24000))
         logger.info("Cast audio column to 24kHz\n")
 
         # Load Whisper for word timings
         self._update_progress(
-            status_message = "Loading Whisper model for word timings..."
+            status_message="Loading Whisper model for word timings..."
         )
         logger.info("Loading Whisper model for word timings...\n")
         import whisper
 
-        whisper_model = whisper.load_model("turbo", device = device)
+        whisper_model = whisper.load_model("turbo", device=device)
 
         # Load OuteTTS AudioProcessor + PromptProcessor
-        self._update_progress(status_message = "Loading OuteTTS AudioProcessor...")
+        self._update_progress(status_message="Loading OuteTTS AudioProcessor...")
         logger.info("Loading OuteTTS AudioProcessor...\n")
         model_tokenizer_path = "OuteAI/Llama-OuteTTS-1.0-1B"
         dummy_config = OuteTTSModelConfig(
-            tokenizer_path = model_tokenizer_path,
-            device = device,
-            audio_codec_path = None,
+            tokenizer_path=model_tokenizer_path,
+            device=device,
+            audio_codec_path=None,
         )
-        audio_processor = AudioProcessor(config = dummy_config)
+        audio_processor = AudioProcessor(config=dummy_config)
         prompt_processor = PromptProcessor(model_tokenizer_path)
 
-        self._update_progress(status_message = "Preprocessing audio with OuteTTS...")
+        self._update_progress(status_message="Preprocessing audio with OuteTTS...")
         logger.info(
             f"DAC preprocessing: audio_col='{audio_col}', text_col='{text_col}'\n"
         )
@@ -2078,30 +2078,30 @@ class UnslothTrainer:
                     skipped += 1
                     continue
 
-                audio_array = np.array(audio_data["array"], dtype = np.float32)
+                audio_array = np.array(audio_data["array"], dtype=np.float32)
                 sampling_rate = audio_data.get("sampling_rate", 24000)
 
                 # Convert to WAV bytes (Whisper needs a file path)
                 buf = io.BytesIO()
-                sf.write(buf, audio_array, sampling_rate, format = "WAV", subtype = "FLOAT")
+                sf.write(buf, audio_array, sampling_rate, format="WAV", subtype="FLOAT")
                 buf.seek(0)
                 audio_bytes = buf.getvalue()
 
                 # 1. Get word timings from Whisper
                 with tempfile.NamedTemporaryFile(
-                    suffix = ".wav",
-                    delete = False,
-                    dir = str(ensure_dir(tmp_root())),
+                    suffix=".wav",
+                    delete=False,
+                    dir=str(ensure_dir(tmp_root())),
                 ) as tmp:
                     tmp.write(audio_bytes)
                     tmp.flush()
                     tmp_path = tmp.name
                 try:
                     whisper_result = whisper_model.transcribe(
-                        tmp_path, word_timestamps = True
+                        tmp_path, word_timestamps=True
                     )
                 finally:
-                    Path(tmp_path).unlink(missing_ok = True)
+                    Path(tmp_path).unlink(missing_ok=True)
 
                 normalized_transcript = text_normalizations(text)
                 words_with_timings = []
@@ -2145,7 +2145,7 @@ class UnslothTrainer:
 
             if (idx + 1) % 100 == 0:
                 self._update_progress(
-                    status_message = f"Preprocessing audio with OuteTTS... {idx + 1}/{len(dataset)}"
+                    status_message=f"Preprocessing audio with OuteTTS... {idx + 1}/{len(dataset)}"
                 )
 
         # Free Whisper from GPU (notebook: data_processor.whisper_model.to('cpu'))
@@ -2175,7 +2175,7 @@ class UnslothTrainer:
         return result_dataset
 
     def _preprocess_whisper_dataset(
-        self, dataset, eval_split = None, custom_format_mapping = None
+        self, dataset, eval_split=None, custom_format_mapping=None
     ):
         """Preprocess dataset for Whisper speech-to-text training.
 
@@ -2197,23 +2197,23 @@ class UnslothTrainer:
 
         # Cast audio to 16kHz (Whisper's expected sample rate)
         dataset = dataset.cast_column(
-            audio_col, Audio(sampling_rate = WHISPER_SAMPLE_RATE)
+            audio_col, Audio(sampling_rate=WHISPER_SAMPLE_RATE)
         )
 
         # Train/eval split (notebook does dataset.train_test_split)
         eval_dataset_raw = None
         if eval_split:
-            splits = dataset.train_test_split(test_size = 0.06, seed = 42)
+            splits = dataset.train_test_split(test_size=0.06, seed=42)
             dataset = splits["train"]
             eval_dataset_raw = splits["test"]
 
-        self._update_progress(status_message = "Processing audio for Whisper...")
+        self._update_progress(status_message="Processing audio for Whisper...")
         logger.info(
             f"Whisper preprocessing: audio_col='{audio_col}', text_col='{text_col}', "
             f"samples={len(dataset)}\n"
         )
 
-        def process_split(ds, split_name = "train"):
+        def process_split(ds, split_name="train"):
             processed = []
             skipped = 0
             for idx in range(len(ds)):
@@ -2235,7 +2235,7 @@ class UnslothTrainer:
 
                     # Extract audio features (notebook line 112-115)
                     features = self.tokenizer.feature_extractor(
-                        audio_data["array"], sampling_rate = audio_data["sampling_rate"]
+                        audio_data["array"], sampling_rate=audio_data["sampling_rate"]
                     )
                     # Tokenize text (notebook line 116)
                     tokenized_text = self.tokenizer.tokenizer(text)
@@ -2255,7 +2255,7 @@ class UnslothTrainer:
 
                 if (idx + 1) % 100 == 0:
                     self._update_progress(
-                        status_message = f"Processing {split_name} audio... {idx + 1}/{len(ds)}"
+                        status_message=f"Processing {split_name} audio... {idx + 1}/{len(ds)}"
                     )
 
             logger.info(
@@ -2361,7 +2361,7 @@ class UnslothTrainer:
 
                 if all_files:
                     loader = self._loader_for_files(all_files)
-                    dataset = load_dataset(loader, data_files = all_files, split = "train")
+                    dataset = load_dataset(loader, data_files=all_files, split="train")
 
                     # Check if stopped during dataset loading
                     if self.should_stop:
@@ -2369,7 +2369,7 @@ class UnslothTrainer:
                         return None
 
                     self._update_progress(
-                        status_message = f"Loaded {len(dataset)} samples from local files"
+                        status_message=f"Loaded {len(dataset)} samples from local files"
                     )
                     logger.info(f"Loaded {len(dataset)} samples from local files\n")
                     logger.info(f"[DEBUG] Dataset cache_files: {dataset.cache_files}\n")
@@ -2380,7 +2380,7 @@ class UnslothTrainer:
                     if eval_all_files:
                         eval_loader = self._loader_for_files(eval_all_files)
                         eval_dataset = load_dataset(
-                            eval_loader, data_files = eval_all_files, split = "train"
+                            eval_loader, data_files=eval_all_files, split="train"
                         )
                         has_separate_eval_source = True
                         logger.info(
@@ -2408,18 +2408,18 @@ class UnslothTrainer:
                         f"(start={dataset_slice_start}, end={dataset_slice_end}), "
                         f"streaming {rows_to_stream} rows\n"
                     )
-                    stream = load_dataset(**load_kwargs, streaming = True)
+                    stream = load_dataset(**load_kwargs, streaming=True)
                     dataset = Dataset.from_list(list(stream.take(rows_to_stream)))
                     logger.info(
                         f"[dataset-slice] Downloaded {len(dataset)} rows "
                         f"(requested {rows_to_stream})\n"
                     )
                     self._update_progress(
-                        status_message = f"Streamed {len(dataset)} rows from HuggingFace"
+                        status_message=f"Streamed {len(dataset)} rows from HuggingFace"
                     )
                 else:
                     self._update_progress(
-                        status_message = f"Downloading dataset: {dataset_source}..."
+                        status_message=f"Downloading dataset: {dataset_source}..."
                     )
                     dataset = load_dataset(**load_kwargs)
 
@@ -2430,7 +2430,7 @@ class UnslothTrainer:
 
                 n_rows = len(dataset) if hasattr(dataset, "__len__") else 0
                 self._update_progress(
-                    status_message = f"Downloaded {dataset_source} ({n_rows:,} rows)"
+                    status_message=f"Downloaded {dataset_source} ({n_rows:,} rows)"
                 )
                 logger.info(
                     f"Loaded dataset from Hugging Face: {dataset_source} ({n_rows:,} rows)\n"
@@ -2458,8 +2458,8 @@ class UnslothTrainer:
                     else:
                         # Auto-detect eval split from HF (returns a separate dataset, or None)
                         eval_dataset = self._auto_detect_eval_split_from_hf(
-                            dataset_source = dataset_source,
-                            subset = subset,
+                            dataset_source=dataset_source,
+                            subset=subset,
                         )
                         if eval_dataset is not None:
                             has_separate_eval_source = True
@@ -2488,7 +2488,7 @@ class UnslothTrainer:
                     f"Sliced dataset to rows [{start}, {end}]: {len(dataset)} of {total_rows} rows\n"
                 )
                 self._update_progress(
-                    status_message = f"Sliced dataset to {len(dataset)} rows (indices {start}-{end})"
+                    status_message=f"Sliced dataset to {len(dataset)} rows (indices {start}-{end})"
                 )
 
             # Check if stopped before applying template
@@ -2504,8 +2504,8 @@ class UnslothTrainer:
             elif self._audio_type == "whisper":
                 train_data, eval_data = self._preprocess_whisper_dataset(
                     dataset,
-                    eval_split = eval_split,
-                    custom_format_mapping = custom_format_mapping,
+                    eval_split=eval_split,
+                    custom_format_mapping=custom_format_mapping,
                 )
                 return (train_data, eval_data)
 
@@ -2536,13 +2536,13 @@ class UnslothTrainer:
 
             dataset_info = format_and_template_dataset(
                 dataset,
-                model_name = self.model_name,
-                tokenizer = self.tokenizer,
-                is_vlm = self.is_vlm,
-                format_type = format_type,
-                dataset_name = dataset_source,
-                custom_format_mapping = custom_format_mapping,
-                progress_callback = self._update_progress,
+                model_name=self.model_name,
+                tokenizer=self.tokenizer,
+                is_vlm=self.is_vlm,
+                format_type=format_type,
+                dataset_name=dataset_source,
+                custom_format_mapping=custom_format_mapping,
+                progress_callback=self._update_progress,
             )
 
             # Check if stopped during formatting
@@ -2555,14 +2555,14 @@ class UnslothTrainer:
                 errors = dataset_info.get("errors", [])
                 error_msg = "; ".join(errors) if errors else "Dataset formatting failed"
                 logger.error(f"Dataset conversion failed: {error_msg}")
-                self._update_progress(error = error_msg)
+                self._update_progress(error=error_msg)
                 return None
 
             detected = dataset_info.get("detected_format", "unknown")
             final_ds = dataset_info.get("dataset")
             final_n = len(final_ds) if hasattr(final_ds, "__len__") else "?"
             self._update_progress(
-                status_message = f"Dataset ready ({final_n:,} samples, {detected} format)"
+                status_message=f"Dataset ready ({final_n:,} samples, {detected} format)"
             )
             logger.info(
                 f"Dataset formatted successfully ({final_n} samples, {detected})\n"
@@ -2574,12 +2574,12 @@ class UnslothTrainer:
                 logger.info(f"Formatting eval dataset ({len(eval_dataset)} rows)...\n")
                 eval_info = format_and_template_dataset(
                     eval_dataset,
-                    model_name = self.model_name,
-                    tokenizer = self.tokenizer,
-                    is_vlm = self.is_vlm,
-                    format_type = format_type,
-                    dataset_name = dataset_source,
-                    custom_format_mapping = custom_format_mapping,
+                    model_name=self.model_name,
+                    tokenizer=self.tokenizer,
+                    is_vlm=self.is_vlm,
+                    format_type=format_type,
+                    dataset_name=dataset_source,
+                    custom_format_mapping=custom_format_mapping,
                 )
                 eval_dataset = eval_info["dataset"]
                 logger.info(f"Eval dataset formatted successfully\n")
@@ -2595,7 +2595,7 @@ class UnslothTrainer:
 
         except Exception as e:
             logger.error(f"Error loading dataset: {e}")
-            self._update_progress(error = str(e))
+            self._update_progress(error=str(e))
             return None
 
     def _auto_detect_eval_split_from_hf(
@@ -2653,7 +2653,7 @@ class UnslothTrainer:
         eval_size = min(eval_size, n // 2)
 
         logger.info(f"Auto-splitting: {eval_size} rows for eval from {n} total\n")
-        split_result = dataset.train_test_split(test_size = eval_size, seed = 3407)
+        split_result = dataset.train_test_split(test_size=eval_size, seed=3407)
         logger.info(
             f"Split complete: {len(split_result['train'])} train, {len(split_result['test'])} eval\n"
         )
@@ -2691,7 +2691,7 @@ class UnslothTrainer:
             return False
 
         if self.model is None or self.tokenizer is None:
-            self._update_progress(error = "Model not loaded")
+            self._update_progress(error="Model not loaded")
             return False
 
         # Pre-import heavy transformers modules on the main thread.
@@ -2713,9 +2713,9 @@ class UnslothTrainer:
 
         # Start training in separate thread
         self.training_thread = threading.Thread(
-            target = self._train_worker,
-            args = (dataset,),
-            kwargs = {
+            target=self._train_worker,
+            args=(dataset,),
+            kwargs={
                 "output_dir": output_dir,
                 "num_epochs": num_epochs,
                 "learning_rate": learning_rate,
@@ -2772,7 +2772,7 @@ class UnslothTrainer:
             # Set training start time
             self.training_start_time = time.time()
 
-            self._update_progress(is_training = True, error = None)
+            self._update_progress(is_training=True, error=None)
 
             # Setup logging
             if training_args.get("enable_wandb", False) and training_args.get(
@@ -2782,7 +2782,7 @@ class UnslothTrainer:
                 import wandb
 
                 wandb.init(
-                    project = training_args.get("wandb_project", "unsloth-training")
+                    project=training_args.get("wandb_project", "unsloth-training")
                 )
 
             # Create output directory
@@ -2800,14 +2800,14 @@ class UnslothTrainer:
                 config = self._build_audio_training_args(
                     training_args,
                     output_dir,
-                    extra_args = {
+                    extra_args={
                         "remove_unused_columns": False,
                     },
                 )
                 self.trainer = HFTrainer(
-                    model = self.model,
-                    train_dataset = dataset,
-                    args = TrainingArguments(**config),
+                    model=self.model,
+                    train_dataset=dataset,
+                    args=TrainingArguments(**config),
                 )
                 self.trainer.add_callback(self._create_progress_callback())
 
@@ -2820,7 +2820,7 @@ class UnslothTrainer:
                     training_args.get("max_steps", 0),
                 )
                 self._update_progress(
-                    total_steps = total, status_message = "Starting CSM training..."
+                    total_steps=total, status_message="Starting CSM training..."
                 )
                 logger.info(f"CSM training config: {config}\n")
                 self.trainer.train()
@@ -2839,13 +2839,13 @@ class UnslothTrainer:
 
                 config = self._build_audio_training_args(training_args, output_dir)
                 self.trainer = HFTrainer(
-                    model = self.model,
-                    train_dataset = dataset,
-                    args = TrainingArguments(**config),
-                    data_collator = DataCollatorForSeq2Seq(
-                        tokenizer = self.tokenizer,
-                        padding = True,
-                        pad_to_multiple_of = 8,
+                    model=self.model,
+                    train_dataset=dataset,
+                    args=TrainingArguments(**config),
+                    data_collator=DataCollatorForSeq2Seq(
+                        tokenizer=self.tokenizer,
+                        padding=True,
+                        pad_to_multiple_of=8,
                     ),
                 )
                 self.trainer.add_callback(self._create_progress_callback())
@@ -2859,7 +2859,7 @@ class UnslothTrainer:
                     training_args.get("max_steps", 0),
                 )
                 self._update_progress(
-                    total_steps = total, status_message = "Starting SNAC training..."
+                    total_steps=total, status_message="Starting SNAC training..."
                 )
                 logger.info(f"SNAC training config: {config}\n")
                 self.trainer.train()
@@ -2878,14 +2878,14 @@ class UnslothTrainer:
                     extra["eval_steps"] = training_args.get("eval_steps", 5)
 
                 config = self._build_audio_training_args(
-                    training_args, output_dir, extra_args = extra
+                    training_args, output_dir, extra_args=extra
                 )
 
                 trainer_kwargs = {
                     "model": self.model,
                     "train_dataset": dataset,
                     "data_collator": DataCollatorSpeechSeq2SeqWithPadding(
-                        processor = self.tokenizer
+                        processor=self.tokenizer
                     ),
                     "processing_class": self.tokenizer.feature_extractor,
                     "args": Seq2SeqTrainingArguments(**config),
@@ -2905,7 +2905,7 @@ class UnslothTrainer:
                     training_args.get("max_steps", 0),
                 )
                 self._update_progress(
-                    total_steps = total, status_message = "Starting Whisper training..."
+                    total_steps=total, status_message="Starting Whisper training..."
                 )
                 logger.info(f"Whisper training config: {config}\n")
                 self.trainer.train()
@@ -2943,7 +2943,7 @@ class UnslothTrainer:
                         "snapshot_download('unsloth/DeepSeek-OCR', local_dir='deepseek_ocr')"
                     )
                     logger.error(error_msg)
-                    self._update_progress(error = error_msg, is_training = False)
+                    self._update_progress(error=error_msg, is_training=False)
                     return
 
                 try:
@@ -2952,12 +2952,12 @@ class UnslothTrainer:
                     logger.info("Configuring DeepSeek OCR data collator...\n")
                     FastVisionModel.for_training(self.model)
                     data_collator = DeepSeekOCRDataCollator(
-                        tokenizer = self.tokenizer,
-                        model = self.model,
-                        image_size = 640,
-                        base_size = 1024,
-                        crop_mode = True,
-                        train_on_responses_only = training_args.get(
+                        tokenizer=self.tokenizer,
+                        model=self.model,
+                        image_size=640,
+                        base_size=1024,
+                        crop_mode=True,
+                        train_on_responses_only=training_args.get(
                             "train_on_completions", False
                         ),
                     )
@@ -2966,7 +2966,7 @@ class UnslothTrainer:
                 except Exception as e:
                     logger.error(f"Failed to configure DeepSeek OCR collator: {e}")
                     error_msg = f"Error configuring DeepSeek OCR: {str(e)}"
-                    self._update_progress(error = error_msg, is_training = False)
+                    self._update_progress(error=error_msg, is_training=False)
                     return
 
             elif self.is_audio_vlm:
@@ -2983,14 +2983,14 @@ class UnslothTrainer:
                     for example in examples:
                         text = processor.apply_chat_template(
                             example["messages"],
-                            tokenize = False,
-                            add_generation_prompt = False,
+                            tokenize=False,
+                            add_generation_prompt=False,
                         ).strip()
                         texts.append(text)
                         audios.append(example[audio_col_name]["array"])
 
                     batch = processor(
-                        text = texts, audio = audios, return_tensors = "pt", padding = True
+                        text=texts, audio=audios, return_tensors="pt", padding=True
                     )
 
                     # Labels = input_ids with special tokens masked
@@ -3310,9 +3310,9 @@ class UnslothTrainer:
 
                     self.trainer = train_on_responses_only(
                         self.trainer,
-                        instruction_part = instruction_part,
-                        response_part = response_part,
-                        num_proc = config_args["dataset_num_proc"],
+                        instruction_part=instruction_part,
+                        response_part=response_part,
+                        num_proc=config_args["dataset_num_proc"],
                     )
                     logger.info("Train on responses only configured successfully\n")
 
@@ -3343,7 +3343,7 @@ class UnslothTrainer:
                             f"or disabling 'Train on completions'."
                         )
                         logger.error(error_msg)
-                        self._update_progress(error = error_msg, is_training = False)
+                        self._update_progress(error=error_msg, is_training=False)
                         return
 
                     if dropped > 0:
@@ -3398,10 +3398,10 @@ class UnslothTrainer:
                 training_args.get("num_epochs", 3),
                 training_args.get("max_steps", 0),
             )
-            self._update_progress(total_steps = total_steps)
+            self._update_progress(total_steps=total_steps)
 
             # ========== START TRAINING ==========
-            self._update_progress(status_message = "Starting training...")
+            self._update_progress(status_message="Starting training...")
             logger.info("Starting training...\n")
             self.trainer.train()
 
@@ -3413,7 +3413,7 @@ class UnslothTrainer:
 
             logger.error(f"Training error: {e}")
             logger.error(f"Full traceback:\n{traceback.format_exc()}")
-            self._update_progress(is_training = False, error = str(e))
+            self._update_progress(is_training=False, error=str(e))
 
         finally:
             self.is_training = False
@@ -3445,7 +3445,7 @@ class UnslothTrainer:
             )
 
             with open(config_path, "w") as f:
-                json.dump(config, f, indent = 2)
+                json.dump(config, f, indent=2)
 
         except Exception as e:
             logger.warning(f"Failed to patch adapter_config.json: {e}")
@@ -3460,7 +3460,7 @@ class UnslothTrainer:
             if save
             else "Cancelling training..."
         )
-        self._update_progress(status_message = stop_msg)
+        self._update_progress(status_message=stop_msg)
 
         # If trainer exists, try to stop it gracefully
         if self.trainer:
@@ -3523,7 +3523,7 @@ def _ensure_deepseek_ocr_installed():
         local_dir = os.path.join(parent_dir, "deepseek_ocr")
 
         snapshot_download(
-            "unsloth/DeepSeek-OCR", local_dir = local_dir, local_dir_use_symlinks = False
+            "unsloth/DeepSeek-OCR", local_dir=local_dir, local_dir_use_symlinks=False
         )
 
         # Add to sys.path if not already there

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -85,16 +85,16 @@ def _install_package_wheel_first(
     except ImportError:
         pass
 
-    env = probe_torch_wheel_env(timeout = 30)
+    env = probe_torch_wheel_env(timeout=30)
     if wheel_url_builder is not None:
         wheel_url = wheel_url_builder(env)
     else:
         wheel_url = direct_wheel_url(
-            filename_prefix = filename_prefix,
-            package_version = pypi_version,
-            release_tag = release_tag,
-            release_base_url = release_base_url,
-            env = env,
+            filename_prefix=filename_prefix,
+            package_version=pypi_version,
+            release_tag=release_tag,
+            release_base_url=release_base_url,
+            env=env,
         )
 
     if wheel_url is None:
@@ -103,9 +103,9 @@ def _install_package_wheel_first(
         _send_status(event_queue, f"Installing prebuilt {display_name} wheel...")
         for installer, result in install_wheel(
             wheel_url,
-            python_executable = sys.executable,
-            use_uv = bool(shutil.which("uv")),
-            run = _sp.run,
+            python_executable=sys.executable,
+            use_uv=bool(shutil.which("uv")),
+            run=_sp.run,
         ):
             if result.returncode == 0:
                 logger.info("Installed prebuilt %s wheel successfully", display_name)
@@ -251,14 +251,14 @@ def _ensure_causal_conv1d_fast_path(event_queue: Any, model_name: str) -> None:
         return
 
     _install_package_wheel_first(
-        event_queue = event_queue,
-        import_name = "causal_conv1d",
-        display_name = "causal-conv1d",
-        pypi_name = "causal-conv1d",
-        pypi_version = _CAUSAL_CONV1D_PACKAGE_VERSION,
-        filename_prefix = "causal_conv1d",
-        release_tag = _CAUSAL_CONV1D_RELEASE_TAG,
-        release_base_url = "https://github.com/Dao-AILab/causal-conv1d/releases/download",
+        event_queue=event_queue,
+        import_name="causal_conv1d",
+        display_name="causal-conv1d",
+        pypi_name="causal-conv1d",
+        pypi_version=_CAUSAL_CONV1D_PACKAGE_VERSION,
+        filename_prefix="causal_conv1d",
+        release_tag=_CAUSAL_CONV1D_RELEASE_TAG,
+        release_base_url="https://github.com/Dao-AILab/causal-conv1d/releases/download",
     )
 
 
@@ -279,14 +279,14 @@ def _ensure_mamba_ssm(event_queue: Any, model_name: str) -> None:
 
     logger.info("SSM model detected; setting up mamba-ssm after causal-conv1d")
     _install_package_wheel_first(
-        event_queue = event_queue,
-        import_name = "mamba_ssm",
-        display_name = "mamba-ssm",
-        pypi_name = "mamba-ssm",
-        pypi_version = _MAMBA_SSM_PACKAGE_VERSION,
-        filename_prefix = "mamba_ssm",
-        release_tag = _MAMBA_SSM_RELEASE_TAG,
-        release_base_url = "https://github.com/state-spaces/mamba/releases/download",
+        event_queue=event_queue,
+        import_name="mamba_ssm",
+        display_name="mamba-ssm",
+        pypi_name="mamba-ssm",
+        pypi_version=_MAMBA_SSM_PACKAGE_VERSION,
+        filename_prefix="mamba_ssm",
+        release_tag=_MAMBA_SSM_RELEASE_TAG,
+        release_base_url="https://github.com/state-spaces/mamba/releases/download",
     )
 
 
@@ -303,13 +303,13 @@ def _ensure_flash_attn_for_long_context(event_queue: Any, max_seq_length: int) -
         return
 
     installed = _install_package_wheel_first(
-        event_queue = event_queue,
-        import_name = "flash_attn",
-        display_name = "flash-attn",
-        pypi_name = "flash-attn",
-        wheel_url_builder = flash_attn_wheel_url,
-        pypi_spec = "flash-attn",
-        pypi_status_message = "Installing flash-attn from PyPI for long-context training...",
+        event_queue=event_queue,
+        import_name="flash_attn",
+        display_name="flash-attn",
+        pypi_name="flash-attn",
+        wheel_url_builder=flash_attn_wheel_url,
+        pypi_spec="flash-attn",
+        pypi_status_message="Installing flash-attn from PyPI for long-context training...",
     )
     if not installed:
         _send_status(event_queue, "Continuing without flash-attn")
@@ -352,8 +352,8 @@ def run_training_process(
         warnings.filterwarnings("ignore")
 
     LogConfig.setup_logging(
-        service_name = "unsloth-studio-training-worker",
-        env = os.getenv("ENVIRONMENT_TYPE", "production"),
+        service_name="unsloth-studio-training-worker",
+        env=os.getenv("ENVIRONMENT_TYPE", "production"),
     )
 
     apply_gpu_ids(config.get("resolved_gpu_ids"))
@@ -368,7 +368,7 @@ def run_training_process(
             {
                 "type": "error",
                 "error": f"Failed to activate transformers version: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -410,7 +410,7 @@ def run_training_process(
                     f"causal-conv1d / mamba-ssm failed to install "
                     f"with error: {exc}"
                 ),
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -427,7 +427,7 @@ def run_training_process(
         import multiprocessing as _mp
 
         try:
-            _mp.set_start_method("fork", force = True)
+            _mp.set_start_method("fork", force=True)
         except RuntimeError:
             pass  # Already set
 
@@ -468,7 +468,7 @@ def run_training_process(
             {
                 "type": "error",
                 "error": f"Failed to import ML libraries: {exc}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -486,7 +486,7 @@ def run_training_process(
                 {
                     "type": "error",
                     "error": str(exc),
-                    "stack": traceback.format_exc(limit = 20),
+                    "stack": traceback.format_exc(limit=20),
                     "ts": time.time(),
                 }
             )
@@ -529,7 +529,7 @@ def run_training_process(
     def _poll_stop():
         while True:
             try:
-                msg = stop_queue.get(timeout = 1.0)
+                msg = stop_queue.get(timeout=1.0)
                 if msg and msg.get("type") == "stop":
                     save = msg.get("save", True)
                     trainer.should_stop = True
@@ -541,7 +541,7 @@ def run_training_process(
             except (EOFError, OSError):
                 return
 
-    stop_thread = threading.Thread(target = _poll_stop, daemon = True)
+    stop_thread = threading.Thread(target=_poll_stop, daemon=True)
     stop_thread.start()
 
     # ── 4. Execute the training pipeline ──
@@ -555,12 +555,12 @@ def run_training_process(
         # ── 4a. Lightweight detection + tokenizer (no VRAM) ──
         _send_status(event_queue, "Detecting model type...")
         trainer.pre_detect_and_load_tokenizer(
-            model_name = model_name,
-            max_seq_length = config["max_seq_length"],
-            hf_token = hf_token,
-            is_dataset_image = config.get("is_dataset_image", False),
-            is_dataset_audio = config.get("is_dataset_audio", False),
-            trust_remote_code = config.get("trust_remote_code", False),
+            model_name=model_name,
+            max_seq_length=config["max_seq_length"],
+            hf_token=hf_token,
+            is_dataset_image=config.get("is_dataset_image", False),
+            is_dataset_audio=config.get("is_dataset_audio", False),
+            trust_remote_code=config.get("trust_remote_code", False),
         )
         if trainer.should_stop:
             event_queue.put({"type": "complete", "output_dir": None, "ts": time.time()})
@@ -570,17 +570,17 @@ def run_training_process(
         _send_status(event_queue, "Loading and formatting dataset...")
         hf_dataset = config.get("hf_dataset", "")
         dataset_result = trainer.load_and_format_dataset(
-            dataset_source = hf_dataset if hf_dataset and hf_dataset.strip() else None,
-            format_type = config.get("format_type", ""),
-            local_datasets = config.get("local_datasets") or None,
-            local_eval_datasets = config.get("local_eval_datasets") or None,
-            custom_format_mapping = config.get("custom_format_mapping"),
-            subset = config.get("subset"),
-            train_split = config.get("train_split", "train"),
-            eval_split = config.get("eval_split"),
-            eval_steps = config.get("eval_steps", 0.00),
-            dataset_slice_start = config.get("dataset_slice_start"),
-            dataset_slice_end = config.get("dataset_slice_end"),
+            dataset_source=hf_dataset if hf_dataset and hf_dataset.strip() else None,
+            format_type=config.get("format_type", ""),
+            local_datasets=config.get("local_datasets") or None,
+            local_eval_datasets=config.get("local_eval_datasets") or None,
+            custom_format_mapping=config.get("custom_format_mapping"),
+            subset=config.get("subset"),
+            train_split=config.get("train_split", "train"),
+            eval_split=config.get("eval_split"),
+            eval_steps=config.get("eval_steps", 0.00),
+            dataset_slice_start=config.get("dataset_slice_start"),
+            dataset_slice_end=config.get("dataset_slice_end"),
         )
 
         if isinstance(dataset_result, tuple):
@@ -662,7 +662,7 @@ def run_training_process(
                         pass
                 _tqdm_stop.wait(3)
 
-        _tqdm_thread = _th.Thread(target = _monitor_tqdm, daemon = True)
+        _tqdm_thread = _th.Thread(target=_monitor_tqdm, daemon=True)
         _tqdm_thread.start()
 
         training_type = config.get("training_type", "LoRA/QLoRA")
@@ -671,15 +671,15 @@ def run_training_process(
         # ── 4c. Load training model (uses VRAM — dataset already formatted) ──
         _send_status(event_queue, "Loading model...")
         success = trainer.load_model(
-            model_name = model_name,
-            max_seq_length = config["max_seq_length"],
-            load_in_4bit = config["load_in_4bit"],
-            full_finetuning = not use_lora,
-            hf_token = hf_token,
-            is_dataset_image = config.get("is_dataset_image", False),
-            is_dataset_audio = config.get("is_dataset_audio", False),
-            trust_remote_code = config.get("trust_remote_code", False),
-            gpu_ids = config.get("resolved_gpu_ids"),
+            model_name=model_name,
+            max_seq_length=config["max_seq_length"],
+            load_in_4bit=config["load_in_4bit"],
+            full_finetuning=not use_lora,
+            hf_token=hf_token,
+            is_dataset_image=config.get("is_dataset_image", False),
+            is_dataset_audio=config.get("is_dataset_audio", False),
+            trust_remote_code=config.get("trust_remote_code", False),
+            gpu_ids=config.get("resolved_gpu_ids"),
         )
         if not success or trainer.should_stop:
             if trainer.should_stop:
@@ -702,26 +702,26 @@ def run_training_process(
         if use_lora:
             _send_status(event_queue, "Configuring LoRA adapters...")
             success = trainer.prepare_model_for_training(
-                use_lora = True,
-                finetune_vision_layers = config.get("finetune_vision_layers", True),
-                finetune_language_layers = config.get("finetune_language_layers", True),
-                finetune_attention_modules = config.get(
+                use_lora=True,
+                finetune_vision_layers=config.get("finetune_vision_layers", True),
+                finetune_language_layers=config.get("finetune_language_layers", True),
+                finetune_attention_modules=config.get(
                     "finetune_attention_modules", True
                 ),
-                finetune_mlp_modules = config.get("finetune_mlp_modules", True),
-                target_modules = config.get("target_modules"),
-                lora_r = config.get("lora_r", 16),
-                lora_alpha = config.get("lora_alpha", 16),
-                lora_dropout = config.get("lora_dropout", 0.0),
-                use_gradient_checkpointing = config.get(
+                finetune_mlp_modules=config.get("finetune_mlp_modules", True),
+                target_modules=config.get("target_modules"),
+                lora_r=config.get("lora_r", 16),
+                lora_alpha=config.get("lora_alpha", 16),
+                lora_dropout=config.get("lora_dropout", 0.0),
+                use_gradient_checkpointing=config.get(
                     "gradient_checkpointing", "unsloth"
                 ),
-                use_rslora = config.get("use_rslora", False),
-                use_loftq = config.get("use_loftq", False),
+                use_rslora=config.get("use_rslora", False),
+                use_loftq=config.get("use_loftq", False),
             )
         else:
             _send_status(event_queue, "Preparing model for full finetuning...")
-            success = trainer.prepare_model_for_training(use_lora = False)
+            success = trainer.prepare_model_for_training(use_lora=False)
 
         if not success or trainer.should_stop:
             if trainer.should_stop:
@@ -780,29 +780,29 @@ def run_training_process(
 
         trainer._train_worker(
             dataset,
-            output_dir = output_dir,
-            num_epochs = config.get("num_epochs", 3),
-            learning_rate = lr_value,
-            batch_size = config.get("batch_size", 2),
-            gradient_accumulation_steps = config.get("gradient_accumulation_steps", 4),
-            warmup_steps = config.get("warmup_steps"),
-            warmup_ratio = config.get("warmup_ratio"),
-            max_steps = max_steps if max_steps and max_steps > 0 else 0,
-            save_steps = save_steps if save_steps and save_steps > 0 else 0,
-            weight_decay = config.get("weight_decay", 0.001),
-            random_seed = config.get("random_seed", 3407),
-            packing = config.get("packing", False),
-            train_on_completions = config.get("train_on_completions", False),
-            enable_wandb = config.get("enable_wandb", False),
-            wandb_project = config.get("wandb_project", "unsloth-training"),
-            wandb_token = config.get("wandb_token"),
-            enable_tensorboard = config.get("enable_tensorboard", False),
-            tensorboard_dir = tensorboard_dir,
-            eval_dataset = eval_dataset,
-            eval_steps = eval_steps,
-            max_seq_length = config.get("max_seq_length", 2048),
-            optim = config.get("optim", "adamw_8bit"),
-            lr_scheduler_type = config.get("lr_scheduler_type", "linear"),
+            output_dir=output_dir,
+            num_epochs=config.get("num_epochs", 3),
+            learning_rate=lr_value,
+            batch_size=config.get("batch_size", 2),
+            gradient_accumulation_steps=config.get("gradient_accumulation_steps", 4),
+            warmup_steps=config.get("warmup_steps"),
+            warmup_ratio=config.get("warmup_ratio"),
+            max_steps=max_steps if max_steps and max_steps > 0 else 0,
+            save_steps=save_steps if save_steps and save_steps > 0 else 0,
+            weight_decay=config.get("weight_decay", 0.001),
+            random_seed=config.get("random_seed", 3407),
+            packing=config.get("packing", False),
+            train_on_completions=config.get("train_on_completions", False),
+            enable_wandb=config.get("enable_wandb", False),
+            wandb_project=config.get("wandb_project", "unsloth-training"),
+            wandb_token=config.get("wandb_token"),
+            enable_tensorboard=config.get("enable_tensorboard", False),
+            tensorboard_dir=tensorboard_dir,
+            eval_dataset=eval_dataset,
+            eval_steps=eval_steps,
+            max_seq_length=config.get("max_seq_length", 2048),
+            optim=config.get("optim", "adamw_8bit"),
+            lr_scheduler_type=config.get("lr_scheduler_type", "linear"),
         )
 
         _tqdm_stop.set()
@@ -833,7 +833,7 @@ def run_training_process(
             {
                 "type": "error",
                 "error": str(exc),
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -887,7 +887,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
                 "type": "error",
                 "error": f"Failed to import embedding libraries: {e}. "
                 "Ensure 'sentence_transformers' and 'unsloth' are installed.",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -901,7 +901,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
         nonlocal _should_stop, _save_on_stop
         while True:
             try:
-                msg = stop_queue.get(timeout = 1.0)
+                msg = stop_queue.get(timeout=1.0)
                 if msg and msg.get("type") == "stop":
                     _save_on_stop = msg.get("save", True)
                     _should_stop = True
@@ -915,7 +915,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
             except (EOFError, OSError):
                 return
 
-    stop_thread = threading.Thread(target = _poll_stop, daemon = True)
+    stop_thread = threading.Thread(target=_poll_stop, daemon=True)
     stop_thread.start()
 
     # ── 2. Load model ──
@@ -928,17 +928,17 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
         use_lora = training_type == "LoRA/QLoRA"
 
         model = FastSentenceTransformer.from_pretrained(
-            model_name = model_name,
-            max_seq_length = max_seq_length,
-            full_finetuning = not use_lora,
-            token = hf_token,
+            model_name=model_name,
+            max_seq_length=max_seq_length,
+            full_finetuning=not use_lora,
+            token=hf_token,
         )
     except Exception as e:
         event_queue.put(
             {
                 "type": "error",
                 "error": f"Failed to load embedding model '{model_name}': {e}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -959,26 +959,26 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
 
             model = FastSentenceTransformer.get_peft_model(
                 model,
-                r = config.get("lora_r", 32),
-                target_modules = config.get("target_modules")
+                r=config.get("lora_r", 32),
+                target_modules=config.get("target_modules")
                 or ["q_proj", "k_proj", "v_proj", "o_proj"],
-                lora_alpha = config.get("lora_alpha", 64),
-                lora_dropout = config.get("lora_dropout", 0.0),
-                bias = "none",
-                use_gradient_checkpointing = gradient_checkpointing,
-                random_state = config.get("random_seed", 3407),
-                use_rslora = config.get("use_rslora", False),
-                loftq_config = {"loftq_bits": 4, "loftq_iter": 1}
+                lora_alpha=config.get("lora_alpha", 64),
+                lora_dropout=config.get("lora_dropout", 0.0),
+                bias="none",
+                use_gradient_checkpointing=gradient_checkpointing,
+                random_state=config.get("random_seed", 3407),
+                use_rslora=config.get("use_rslora", False),
+                loftq_config={"loftq_bits": 4, "loftq_iter": 1}
                 if config.get("use_loftq")
                 else None,
-                task_type = "FEATURE_EXTRACTION",
+                task_type="FEATURE_EXTRACTION",
             )
         except Exception as e:
             event_queue.put(
                 {
                     "type": "error",
                     "error": f"Failed to configure LoRA for embedding model: {e}",
-                    "stack": traceback.format_exc(limit = 20),
+                    "stack": traceback.format_exc(limit=20),
                     "ts": time.time(),
                 }
             )
@@ -1002,8 +1002,8 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
             dataset = load_dataset(
                 hf_dataset.strip(),
                 subset,
-                split = train_split,
-                token = hf_token,
+                split=train_split,
+                token=hf_token,
             )
         elif local_datasets:
             # Load from local file(s) — mirrors the non-embedding pipeline's
@@ -1053,7 +1053,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
                     raise ValueError(
                         f"Unsupported local dataset format: {all_files[0]}"
                     )
-                dataset = load_dataset(loader, data_files = all_files, split = "train")
+                dataset = load_dataset(loader, data_files=all_files, split="train")
         else:
             event_queue.put(
                 {
@@ -1079,7 +1079,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
             {
                 "type": "error",
                 "error": f"Failed to load dataset: {e}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -1171,7 +1171,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
     class _EmbeddingProgressCallback(TrainerCallback):
         """Sends training progress events to the parent process via event_queue."""
 
-        def on_log(self, args, state, control, logs = None, **kwargs):
+        def on_log(self, args, state, control, logs=None, **kwargs):
             if not logs:
                 return
             loss_value = logs.get("loss", logs.get("train_loss", None))
@@ -1212,11 +1212,11 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
     _send_status(event_queue, "Starting embedding training...")
     try:
         trainer = SentenceTransformerTrainer(
-            model = model,
-            train_dataset = dataset,
-            loss = loss,
-            args = args,
-            callbacks = [_EmbeddingProgressCallback()],
+            model=model,
+            train_dataset=dataset,
+            loss=loss,
+            args=args,
+            callbacks=[_EmbeddingProgressCallback()],
         )
 
         trainer.train()
@@ -1225,7 +1225,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
             {
                 "type": "error",
                 "error": f"Embedding training failed: {e}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )
@@ -1254,7 +1254,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
             {
                 "type": "error",
                 "error": f"Training completed but failed to save: {e}",
-                "stack": traceback.format_exc(limit = 20),
+                "stack": traceback.format_exc(limit=20),
                 "ts": time.time(),
             }
         )

--- a/studio/backend/loggers/config.py
+++ b/studio/backend/loggers/config.py
@@ -45,9 +45,9 @@ class LogConfig:
         log_level = getattr(logging, log_level_name, logging.INFO)
 
         structlog.configure(
-            processors = [
+            processors=[
                 # Reorder processors to control field order
-                structlog.processors.TimeStamper(fmt = "iso"),  # timestamp first
+                structlog.processors.TimeStamper(fmt="iso"),  # timestamp first
                 structlog.processors.add_log_level,  # level second
                 structlog.contextvars.merge_contextvars,
                 # Custom processor to flatten the extra field
@@ -63,14 +63,14 @@ class LogConfig:
                     },
                 },
                 (
-                    structlog.processors.JSONRenderer(sort_keys = False)  # Preserve order
+                    structlog.processors.JSONRenderer(sort_keys=False)  # Preserve order
                     if env == "production"
                     else structlog.dev.ConsoleRenderer()
                 ),
             ],
-            wrapper_class = structlog.make_filtering_bound_logger(log_level),
-            logger_factory = structlog.PrintLoggerFactory(file = sys.stdout),
-            cache_logger_on_first_use = True,
+            wrapper_class=structlog.make_filtering_bound_logger(log_level),
+            logger_factory=structlog.PrintLoggerFactory(file=sys.stdout),
+            cache_logger_on_first_use=True,
         )
 
         return structlog.get_logger(service_name)

--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -52,10 +52,10 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             if not is_excluded:
                 logger.info(
                     "request_completed",
-                    method = request.method,
-                    path = request.url.path,
-                    status_code = response.status_code,
-                    process_time_ms = round(process_time, 2),
+                    method=request.method,
+                    path=request.url.path,
+                    status_code=response.status_code,
+                    process_time_ms=round(process_time, 2),
                 )
 
             return response
@@ -63,10 +63,10 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         except Exception as e:
             logger.error(
                 "request_failed",
-                path = request.url.path,
-                method = request.method,
-                error = str(e),
-                exc_info = True,
+                path=request.url.path,
+                method=request.method,
+                error=str(e),
+                exc_info=True,
             )
             raise
 

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -88,7 +88,7 @@ async def lifespan(app: FastAPI):
     # Version switching now uses .venv_t5/ (pre-installed by setup.sh).
     overlay_dir = Path(__file__).resolve().parent.parent.parent / ".venv_overlay"
     if overlay_dir.is_dir():
-        shutil.rmtree(overlay_dir, ignore_errors = True)
+        shutil.rmtree(overlay_dir, ignore_errors=True)
 
     # Detect hardware first — sets DEVICE global used everywhere
     detect_hardware()
@@ -116,7 +116,7 @@ async def lifespan(app: FastAPI):
         except Exception:
             pass  # non-critical
 
-    threading.Thread(target = _precache, daemon = True).start()
+    threading.Thread(target=_precache, daemon=True).start()
 
     if storage.ensure_default_admin():
         bootstrap_pw = storage.get_bootstrap_password()
@@ -139,10 +139,10 @@ async def lifespan(app: FastAPI):
 
 # Create FastAPI app
 app = FastAPI(
-    title = "Unsloth UI Backend",
-    version = "1.0.0",
-    description = "Backend API for Unsloth UI - Training and Model Management",
-    lifespan = lifespan,
+    title="Unsloth UI Backend",
+    version="1.0.0",
+    description="Backend API for Unsloth UI - Training and Model Management",
+    lifespan=lifespan,
 )
 
 # Initialize structured logging
@@ -150,8 +150,8 @@ from loggers.config import LogConfig
 from loggers.handlers import LoggingMiddleware
 
 logger = LogConfig.setup_logging(
-    service_name = "unsloth-studio-backend",
-    env = os.getenv("ENVIRONMENT_TYPE", "production"),
+    service_name="unsloth-studio-backend",
+    env=os.getenv("ENVIRONMENT_TYPE", "production"),
 )
 
 app.add_middleware(LoggingMiddleware)
@@ -159,29 +159,29 @@ app.add_middleware(LoggingMiddleware)
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins = ["*"],  # In production, specify allowed origins
-    allow_credentials = True,
-    allow_methods = ["*"],
-    allow_headers = ["*"],
+    allow_origins=["*"],  # In production, specify allowed origins
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # ============ Register API Routes ============
 
 # Register routers
-app.include_router(auth_router, prefix = "/api/auth", tags = ["auth"])
-app.include_router(training_router, prefix = "/api/train", tags = ["training"])
-app.include_router(models_router, prefix = "/api/models", tags = ["models"])
-app.include_router(inference_router, prefix = "/api/inference", tags = ["inference"])
+app.include_router(auth_router, prefix="/api/auth", tags=["auth"])
+app.include_router(training_router, prefix="/api/train", tags=["training"])
+app.include_router(models_router, prefix="/api/models", tags=["models"])
+app.include_router(inference_router, prefix="/api/inference", tags=["inference"])
 
 # OpenAI-compatible endpoints: mount the same inference router at /v1
 # so external tools (Open WebUI, SillyTavern, etc.) can use the
 # standard /v1/chat/completions path.
-app.include_router(inference_router, prefix = "/v1", tags = ["openai-compat"])
-app.include_router(datasets_router, prefix = "/api/datasets", tags = ["datasets"])
-app.include_router(data_recipe_router, prefix = "/api/data-recipe", tags = ["data-recipe"])
-app.include_router(export_router, prefix = "/api/export", tags = ["export"])
+app.include_router(inference_router, prefix="/v1", tags=["openai-compat"])
+app.include_router(datasets_router, prefix="/api/datasets", tags=["datasets"])
+app.include_router(data_recipe_router, prefix="/api/data-recipe", tags=["data-recipe"])
+app.include_router(export_router, prefix="/api/export", tags=["export"])
 app.include_router(
-    training_history_router, prefix = "/api/train", tags = ["training-history"]
+    training_history_router, prefix="/api/train", tags=["training-history"]
 )
 
 
@@ -338,7 +338,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
     # Mount assets
     assets_dir = build_path / "assets"
     if assets_dir.exists():
-        app.mount("/assets", StaticFiles(directory = assets_dir), name = "assets")
+        app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
 
     @app.get("/")
     async def serve_root():
@@ -346,9 +346,9 @@ def setup_frontend(app: FastAPI, build_path: Path):
         content = _strip_crossorigin(content)
         content = _inject_bootstrap(content, app)
         return Response(
-            content = content,
-            media_type = "text/html",
-            headers = {"Cache-Control": "no-cache, no-store, must-revalidate"},
+            content=content,
+            media_type="text/html",
+            headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
         )
 
     @app.get("/{full_path:path}")
@@ -360,7 +360,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
 
         # Block path traversal — ensure resolved path stays inside build_path
         if not file_path.is_relative_to(build_path.resolve()):
-            return Response(status_code = 403)
+            return Response(status_code=403)
 
         if file_path.is_file():
             return FileResponse(file_path)
@@ -370,9 +370,9 @@ def setup_frontend(app: FastAPI, build_path: Path):
         content = _strip_crossorigin(content)
         content = _inject_bootstrap(content, app)
         return Response(
-            content = content,
-            media_type = "text/html",
-            headers = {"Cache-Control": "no-cache, no-store, must-revalidate"},
+            content=content,
+            media_type="text/html",
+            headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
         )
 
     return True

--- a/studio/backend/models/models.py
+++ b/studio/backend/models/models.py
@@ -15,99 +15,99 @@ class CheckpointInfo(BaseModel):
     """Information about a discovered checkpoint directory."""
 
     display_name: str = Field(
-        ..., description = "User-friendly checkpoint name (folder name)"
+        ..., description="User-friendly checkpoint name (folder name)"
     )
-    path: str = Field(..., description = "Full path to the checkpoint directory")
-    loss: Optional[float] = Field(None, description = "Training loss at this checkpoint")
+    path: str = Field(..., description="Full path to the checkpoint directory")
+    loss: Optional[float] = Field(None, description="Training loss at this checkpoint")
 
 
 class ModelCheckpoints(BaseModel):
     """A training run and its associated checkpoints."""
 
-    name: str = Field(..., description = "Training run folder name")
+    name: str = Field(..., description="Training run folder name")
     checkpoints: List[CheckpointInfo] = Field(
-        default_factory = list,
-        description = "List of checkpoints for this training run (final + intermediate)",
+        default_factory=list,
+        description="List of checkpoints for this training run (final + intermediate)",
     )
     base_model: Optional[str] = Field(
         None,
-        description = "Base model name from adapter_config.json or config.json",
+        description="Base model name from adapter_config.json or config.json",
     )
     peft_type: Optional[str] = Field(
         None,
-        description = "PEFT type (e.g. LORA) if adapter training, None for full fine-tune",
+        description="PEFT type (e.g. LORA) if adapter training, None for full fine-tune",
     )
     lora_rank: Optional[int] = Field(
         None,
-        description = "LoRA rank (r) if applicable",
+        description="LoRA rank (r) if applicable",
     )
     is_quantized: bool = Field(
         False,
-        description = "Whether the model uses BNB quantization (e.g. bnb-4bit)",
+        description="Whether the model uses BNB quantization (e.g. bnb-4bit)",
     )
 
 
 class CheckpointListResponse(BaseModel):
     """Response for listing available checkpoints in an outputs directory."""
 
-    outputs_dir: str = Field(..., description = "Directory that was scanned")
+    outputs_dir: str = Field(..., description="Directory that was scanned")
     models: List[ModelCheckpoints] = Field(
-        default_factory = list,
-        description = "List of training runs with their checkpoints",
+        default_factory=list,
+        description="List of training runs with their checkpoints",
     )
 
 
 class ModelDetails(BaseModel):
     """Detailed model configuration and metadata - can be used for both list and detail views"""
 
-    id: str = Field(..., description = "Model identifier")
+    id: str = Field(..., description="Model identifier")
     model_name: Optional[str] = Field(
-        None, description = "Model identifier (alias for id, for backward compatibility)"
+        None, description="Model identifier (alias for id, for backward compatibility)"
     )
-    name: Optional[str] = Field(None, description = "Display name for the model")
+    name: Optional[str] = Field(None, description="Display name for the model")
     config: Optional[Dict[str, Any]] = Field(
-        None, description = "Model configuration dictionary"
+        None, description="Model configuration dictionary"
     )
-    is_vision: bool = Field(False, description = "Whether model is a vision model")
+    is_vision: bool = Field(False, description="Whether model is a vision model")
     is_embedding: bool = Field(
-        False, description = "Whether model is an embedding/sentence-transformer model"
+        False, description="Whether model is an embedding/sentence-transformer model"
     )
-    is_lora: bool = Field(False, description = "Whether model is a LoRA adapter")
+    is_lora: bool = Field(False, description="Whether model is a LoRA adapter")
     is_gguf: bool = Field(
-        False, description = "Whether model is a GGUF model (llama.cpp format)"
+        False, description="Whether model is a GGUF model (llama.cpp format)"
     )
-    is_audio: bool = Field(False, description = "Whether model is a TTS audio model")
+    is_audio: bool = Field(False, description="Whether model is a TTS audio model")
     audio_type: Optional[str] = Field(
-        None, description = "Audio codec type: snac, csm, bicodec, dac"
+        None, description="Audio codec type: snac, csm, bicodec, dac"
     )
     has_audio_input: bool = Field(
-        False, description = "Whether model accepts audio input (ASR)"
+        False, description="Whether model accepts audio input (ASR)"
     )
     model_type: Optional[ModelType] = Field(
-        None, description = "Collapsed model modality: text, vision, audio, or embeddings"
+        None, description="Collapsed model modality: text, vision, audio, or embeddings"
     )
     base_model: Optional[str] = Field(
-        None, description = "Base model if this is a LoRA adapter"
+        None, description="Base model if this is a LoRA adapter"
     )
     max_position_embeddings: Optional[int] = Field(
-        None, description = "Maximum context length supported by the model"
+        None, description="Maximum context length supported by the model"
     )
     model_size_bytes: Optional[int] = Field(
-        None, description = "Total size of model weight files in bytes"
+        None, description="Total size of model weight files in bytes"
     )
 
 
 class LoRAInfo(BaseModel):
     """LoRA adapter or exported model information"""
 
-    display_name: str = Field(..., description = "Display name for the LoRA")
+    display_name: str = Field(..., description="Display name for the LoRA")
     adapter_path: str = Field(
-        ..., description = "Path to the LoRA adapter or exported model"
+        ..., description="Path to the LoRA adapter or exported model"
     )
-    base_model: Optional[str] = Field(None, description = "Base model identifier")
-    source: Optional[str] = Field(None, description = "'training' or 'exported'")
+    base_model: Optional[str] = Field(None, description="Base model identifier")
+    source: Optional[str] = Field(None, description="'training' or 'exported'")
     export_type: Optional[str] = Field(
-        None, description = "'lora', 'merged', or 'gguf' (for exports)"
+        None, description="'lora', 'merged', or 'gguf' (for exports)"
     )
 
 
@@ -115,19 +115,19 @@ class LoRAScanResponse(BaseModel):
     """Response schema for scanning trained LoRA adapters"""
 
     loras: List[LoRAInfo] = Field(
-        default_factory = list, description = "List of found LoRA adapters"
+        default_factory=list, description="List of found LoRA adapters"
     )
-    outputs_dir: str = Field(..., description = "Directory that was scanned")
+    outputs_dir: str = Field(..., description="Directory that was scanned")
 
 
 class ModelListResponse(BaseModel):
     """Response schema for listing models"""
 
     models: List[ModelDetails] = Field(
-        default_factory = list, description = "List of models"
+        default_factory=list, description="List of models"
     )
     default_models: List[str] = Field(
-        default_factory = list, description = "List of default model IDs"
+        default_factory=list, description="List of default model IDs"
     )
 
 
@@ -135,47 +135,47 @@ class GgufVariantDetail(BaseModel):
     """A single GGUF quantization variant in a HuggingFace repo."""
 
     filename: str = Field(
-        ..., description = "GGUF filename (e.g., 'gemma-3-4b-it-Q4_K_M.gguf')"
+        ..., description="GGUF filename (e.g., 'gemma-3-4b-it-Q4_K_M.gguf')"
     )
-    quant: str = Field(..., description = "Quantization label (e.g., 'Q4_K_M')")
-    size_bytes: int = Field(0, description = "File size in bytes")
+    quant: str = Field(..., description="Quantization label (e.g., 'Q4_K_M')")
+    size_bytes: int = Field(0, description="File size in bytes")
     downloaded: bool = Field(
-        False, description = "Whether this variant is already in the local HF cache"
+        False, description="Whether this variant is already in the local HF cache"
     )
 
 
 class GgufVariantsResponse(BaseModel):
     """Response for listing GGUF quantization variants in a HuggingFace repo."""
 
-    repo_id: str = Field(..., description = "HuggingFace repo ID")
+    repo_id: str = Field(..., description="HuggingFace repo ID")
     variants: List[GgufVariantDetail] = Field(
-        default_factory = list, description = "Available GGUF variants"
+        default_factory=list, description="Available GGUF variants"
     )
     has_vision: bool = Field(
-        False, description = "Whether the model has vision support (mmproj files)"
+        False, description="Whether the model has vision support (mmproj files)"
     )
     default_variant: Optional[str] = Field(
-        None, description = "Recommended default quantization variant"
+        None, description="Recommended default quantization variant"
     )
 
 
 class LocalModelInfo(BaseModel):
     """Discovered local model candidate."""
 
-    id: str = Field(..., description = "Identifier to use for loading/training")
-    display_name: str = Field(..., description = "Display label")
-    path: str = Field(..., description = "Local path where model data was discovered")
+    id: str = Field(..., description="Identifier to use for loading/training")
+    display_name: str = Field(..., description="Display label")
+    path: str = Field(..., description="Local path where model data was discovered")
     source: Literal["models_dir", "hf_cache", "lmstudio", "custom"] = Field(
         ...,
-        description = "Discovery source",
+        description="Discovery source",
     )
     model_id: Optional[str] = Field(
         None,
-        description = "HF repo id for cached models, e.g. org/model",
+        description="HF repo id for cached models, e.g. org/model",
     )
     updated_at: Optional[float] = Field(
         None,
-        description = "Unix timestamp of latest observed update",
+        description="Unix timestamp of latest observed update",
     )
 
 
@@ -183,19 +183,19 @@ class LocalModelListResponse(BaseModel):
     """Response schema for listing local/cached models."""
 
     models_dir: str = Field(
-        ..., description = "Directory scanned for custom local models"
+        ..., description="Directory scanned for custom local models"
     )
     hf_cache_dir: Optional[str] = Field(
         None,
-        description = "HF cache root that was scanned",
+        description="HF cache root that was scanned",
     )
     lmstudio_dirs: List[str] = Field(
-        default_factory = list,
-        description = "LM Studio model directories that were scanned",
+        default_factory=list,
+        description="LM Studio model directories that were scanned",
     )
     models: List[LocalModelInfo] = Field(
-        default_factory = list,
-        description = "Discovered local/cached models",
+        default_factory=list,
+        description="Discovered local/cached models",
     )
 
 
@@ -203,13 +203,13 @@ class AddScanFolderRequest(BaseModel):
     """Request body for adding a custom scan folder."""
 
     path: str = Field(
-        ..., description = "Absolute or relative directory path to scan for models"
+        ..., description="Absolute or relative directory path to scan for models"
     )
 
 
 class ScanFolderInfo(BaseModel):
     """A registered custom model scan folder."""
 
-    id: int = Field(..., description = "Database row ID")
-    path: str = Field(..., description = "Normalized absolute path")
-    created_at: str = Field(..., description = "ISO 8601 creation timestamp")
+    id: int = Field(..., description="Database row ID")
+    path: str = Field(..., description="Normalized absolute path")
+    created_at: str = Field(..., description="ISO 8601 creation timestamp")

--- a/studio/backend/plugins/data-designer-unstructured-seed/src/data_designer_unstructured_seed/impl.py
+++ b/studio/backend/plugins/data-designer-unstructured-seed/src/data_designer_unstructured_seed/impl.py
@@ -34,8 +34,8 @@ class UnstructuredSeedReader(SeedReader[UnstructuredSeedSource]):
             file_entries.append((path_obj, orig_name))
 
         path, _ = materialize_multi_file_unstructured_seed(
-            file_entries = file_entries,
-            chunk_size = self.source.chunk_size,
-            chunk_overlap = self.source.chunk_overlap,
+            file_entries=file_entries,
+            chunk_size=self.source.chunk_size,
+            chunk_overlap=self.source.chunk_overlap,
         )
         return str(path)

--- a/studio/backend/requirements/single-env/patch_metadata.py
+++ b/studio/backend/requirements/single-env/patch_metadata.py
@@ -49,13 +49,13 @@ def metadata_path(dist_name: str) -> Path | None:
 
 
 def patch_file(path: Path) -> bool:
-    original = path.read_text(encoding = "utf-8")
+    original = path.read_text(encoding="utf-8")
     updated = original
     for pattern, repl in PATCHES:
         updated = pattern.sub(repl, updated)
     if updated == original:
         return False
-    path.write_text(updated, encoding = "utf-8")
+    path.write_text(updated, encoding="utf-8")
     return True
 
 

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -32,7 +32,7 @@ from auth.authentication import (
 router = APIRouter()
 
 
-@router.get("/status", response_model = AuthStatusResponse)
+@router.get("/status", response_model=AuthStatusResponse)
 async def auth_status() -> AuthStatusResponse:
     """
     Check whether auth has already been initialized.
@@ -41,9 +41,9 @@ async def auth_status() -> AuthStatusResponse:
     - initialized = True  -> frontend should show login or force the first password change.
     """
     return AuthStatusResponse(
-        initialized = storage.is_initialized(),
-        default_username = storage.DEFAULT_ADMIN_USERNAME,
-        requires_password_change = storage.requires_password_change(
+        initialized=storage.is_initialized(),
+        default_username=storage.DEFAULT_ADMIN_USERNAME,
+        requires_password_change=storage.requires_password_change(
             storage.DEFAULT_ADMIN_USERNAME
         )
         if storage.is_initialized()
@@ -51,7 +51,7 @@ async def auth_status() -> AuthStatusResponse:
     )
 
 
-@router.post("/login", response_model = Token)
+@router.post("/login", response_model=Token)
 async def login(payload: AuthLoginRequest) -> Token:
     """
     Login with username/password and receive access + refresh tokens.
@@ -59,28 +59,28 @@ async def login(payload: AuthLoginRequest) -> Token:
     record = storage.get_user_and_secret(payload.username)
     if record is None:
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Incorrect password. Run 'unsloth studio reset-password' in your terminal to reset it.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect password. Run 'unsloth studio reset-password' in your terminal to reset it.",
         )
 
     salt, pwd_hash, _jwt_secret, must_change_password = record
     if not hashing.verify_password(payload.password, salt, pwd_hash):
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Incorrect password. Run 'unsloth studio reset-password' in your terminal to reset it.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect password. Run 'unsloth studio reset-password' in your terminal to reset it.",
         )
 
-    access_token = create_access_token(subject = payload.username)
-    refresh_token = create_refresh_token(subject = payload.username)
+    access_token = create_access_token(subject=payload.username)
+    refresh_token = create_refresh_token(subject=payload.username)
     return Token(
-        access_token = access_token,
-        refresh_token = refresh_token,
-        token_type = "bearer",
-        must_change_password = must_change_password,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        must_change_password=must_change_password,
     )
 
 
-@router.post("/refresh", response_model = Token)
+@router.post("/refresh", response_model=Token)
 async def refresh(payload: RefreshTokenRequest) -> Token:
     """
     Exchange a valid refresh token for a new access token.
@@ -90,19 +90,19 @@ async def refresh(payload: RefreshTokenRequest) -> Token:
     new_access_token, username = refresh_access_token(payload.refresh_token)
     if new_access_token is None or username is None:
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Invalid or expired refresh token",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
         )
 
     return Token(
-        access_token = new_access_token,
-        refresh_token = payload.refresh_token,
-        token_type = "bearer",
-        must_change_password = storage.requires_password_change(username),
+        access_token=new_access_token,
+        refresh_token=payload.refresh_token,
+        token_type="bearer",
+        must_change_password=storage.requires_password_change(username),
     )
 
 
-@router.post("/change-password", response_model = Token)
+@router.post("/change-password", response_model=Token)
 async def change_password(
     payload: ChangePasswordRequest,
     current_subject: str = Depends(get_current_subject_allow_password_change),
@@ -111,31 +111,31 @@ async def change_password(
     record = storage.get_user_and_secret(current_subject)
     if record is None:
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "User session is invalid",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User session is invalid",
         )
 
     salt, pwd_hash, _jwt_secret, _must_change_password = record
     if not hashing.verify_password(payload.current_password, salt, pwd_hash):
         raise HTTPException(
-            status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Current password is incorrect",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Current password is incorrect",
         )
     if payload.current_password == payload.new_password:
         raise HTTPException(
-            status_code = status.HTTP_400_BAD_REQUEST,
-            detail = "New password must be different from the current password",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New password must be different from the current password",
         )
 
     storage.update_password(current_subject, payload.new_password)
     storage.revoke_user_refresh_tokens(current_subject)
-    access_token = create_access_token(subject = current_subject)
-    refresh_token = create_refresh_token(subject = current_subject)
+    access_token = create_access_token(subject=current_subject)
+    refresh_token = create_refresh_token(subject=current_subject)
     return Token(
-        access_token = access_token,
-        refresh_token = refresh_token,
-        token_type = "bearer",
-        must_change_password = False,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        must_change_password=False,
     )
 
 
@@ -146,17 +146,17 @@ async def change_password(
 
 def _row_to_api_key_response(row: dict) -> ApiKeyResponse:
     return ApiKeyResponse(
-        id = row["id"],
-        name = row["name"],
-        key_prefix = row["key_prefix"],
-        created_at = row["created_at"],
-        last_used_at = row.get("last_used_at"),
-        expires_at = row.get("expires_at"),
-        is_active = bool(row["is_active"]),
+        id=row["id"],
+        name=row["name"],
+        key_prefix=row["key_prefix"],
+        created_at=row["created_at"],
+        last_used_at=row.get("last_used_at"),
+        expires_at=row.get("expires_at"),
+        is_active=bool(row["is_active"]),
     )
 
 
-@router.post("/api-keys", response_model = CreateApiKeyResponse)
+@router.post("/api-keys", response_model=CreateApiKeyResponse)
 async def create_api_key(
     payload: CreateApiKeyRequest,
     current_subject: str = Depends(get_current_subject),
@@ -165,28 +165,28 @@ async def create_api_key(
     expires_at = None
     if payload.expires_in_days is not None:
         expires_at = (
-            datetime.now(timezone.utc) + timedelta(days = payload.expires_in_days)
+            datetime.now(timezone.utc) + timedelta(days=payload.expires_in_days)
         ).isoformat()
 
     raw_key, row = storage.create_api_key(
-        username = current_subject,
-        name = payload.name,
-        expires_at = expires_at,
+        username=current_subject,
+        name=payload.name,
+        expires_at=expires_at,
     )
     return CreateApiKeyResponse(
-        key = raw_key,
-        api_key = _row_to_api_key_response(row),
+        key=raw_key,
+        api_key=_row_to_api_key_response(row),
     )
 
 
-@router.get("/api-keys", response_model = ApiKeyListResponse)
+@router.get("/api-keys", response_model=ApiKeyListResponse)
 async def list_api_keys(
     current_subject: str = Depends(get_current_subject),
 ) -> ApiKeyListResponse:
     """List all API keys for the authenticated user (raw keys are never exposed)."""
     rows = storage.list_api_keys(current_subject)
     return ApiKeyListResponse(
-        api_keys = [_row_to_api_key_response(r) for r in rows],
+        api_keys=[_row_to_api_key_response(r) for r in rows],
     )
 
 
@@ -198,7 +198,7 @@ async def revoke_api_key(
     """Revoke (soft-delete) an API key."""
     if not storage.revoke_api_key(current_subject, key_id):
         raise HTTPException(
-            status_code = status.HTTP_404_NOT_FOUND,
-            detail = "API key not found",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="API key not found",
         )
     return {"detail": "API key revoked"}

--- a/studio/backend/routes/data_recipe/jobs.py
+++ b/studio/backend/routes/data_recipe/jobs.py
@@ -152,8 +152,8 @@ def _inject_local_providers(recipe: dict[str, Any], request: Request) -> None:
         # the JWT secret rotates and this token becomes invalid mid-run.
         # Acceptable for v1 - recipes typically finish well within one session.
         token = create_access_token(
-            subject = "unsloth",
-            expires_delta = timedelta(hours = 24),
+            subject="unsloth",
+            expires_delta=timedelta(hours=24),
         )
 
     # Defensively strip any stale "external"-only fields the frontend may
@@ -188,7 +188,7 @@ def _normalize_run_name(value: Any) -> str | None:
         return None
     if not isinstance(value, str):
         raise HTTPException(
-            status_code = 400, detail = "invalid run_name: must be a string"
+            status_code=400, detail="invalid run_name: must be a string"
         )
     trimmed = value.strip()
     if not trimmed:
@@ -196,11 +196,11 @@ def _normalize_run_name(value: Any) -> str | None:
     return trimmed[:120]
 
 
-@router.post("/jobs", response_class = JSONResponse, response_model = JobCreateResponse)
+@router.post("/jobs", response_class=JSONResponse, response_model=JobCreateResponse)
 def create_job(payload: RecipePayload, request: Request):
     recipe = payload.recipe
     if not recipe.get("columns"):
-        raise HTTPException(status_code = 400, detail = "Recipe must include columns.")
+        raise HTTPException(status_code=400, detail="Recipe must include columns.")
 
     run: dict[str, Any] = payload.run or {}
     run.pop("artifact_path", None)
@@ -208,8 +208,8 @@ def create_job(payload: RecipePayload, request: Request):
     execution_type = str(run.get("execution_type") or "full").strip().lower()
     if execution_type not in {"preview", "full"}:
         raise HTTPException(
-            status_code = 400,
-            detail = "invalid execution_type: must be 'preview' or 'full'",
+            status_code=400,
+            detail="invalid execution_type: must be 'preview' or 'full'",
         )
     run["execution_type"] = execution_type
     run["run_name"] = _normalize_run_name(run.get("run_name"))
@@ -221,21 +221,21 @@ def create_job(payload: RecipePayload, request: Request):
             RunConfig.model_validate(run_config_raw)
         except (ImportError, ValidationError, TypeError, ValueError) as exc:
             raise HTTPException(
-                status_code = 400, detail = f"invalid run_config: {exc}"
+                status_code=400, detail=f"invalid run_config: {exc}"
             ) from exc
 
     try:
         _inject_local_providers(recipe, request)
     except ValueError as exc:
-        raise HTTPException(status_code = 400, detail = str(exc)) from exc
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     mgr = get_job_manager()
     try:
-        job_id = mgr.start(recipe = recipe, run = run)
+        job_id = mgr.start(recipe=recipe, run=run)
     except RuntimeError as exc:
-        raise HTTPException(status_code = 409, detail = str(exc)) from exc
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code = 400, detail = str(exc)) from exc
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return {"job_id": job_id}
 
@@ -245,7 +245,7 @@ def job_status(job_id: str):
     mgr = get_job_manager()
     state = mgr.get_status(job_id)
     if state is None:
-        raise HTTPException(status_code = 404, detail = "job not found")
+        raise HTTPException(status_code=404, detail="job not found")
     return state
 
 
@@ -254,7 +254,7 @@ def current_job():
     mgr = get_job_manager()
     state = mgr.get_current_status()
     if state is None:
-        raise HTTPException(status_code = 404, detail = "no job")
+        raise HTTPException(status_code=404, detail="no job")
     return state
 
 
@@ -263,7 +263,7 @@ def cancel_job(job_id: str):
     mgr = get_job_manager()
     ok = mgr.cancel(job_id)
     if not ok:
-        raise HTTPException(status_code = 404, detail = "job not found")
+        raise HTTPException(status_code=404, detail="job not found")
     return mgr.get_status(job_id)
 
 
@@ -272,22 +272,22 @@ def job_analysis(job_id: str):
     mgr = get_job_manager()
     analysis = mgr.get_analysis(job_id)
     if analysis is None:
-        raise HTTPException(status_code = 404, detail = "analysis not ready")
+        raise HTTPException(status_code=404, detail="analysis not ready")
     return analysis
 
 
 @router.get("/jobs/{job_id}/dataset")
 def job_dataset(
     job_id: str,
-    limit: int = Query(default = 20, ge = 1, le = 500),
-    offset: int = Query(default = 0, ge = 0),
+    limit: int = Query(default=20, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
 ):
     mgr = get_job_manager()
-    result = mgr.get_dataset(job_id, limit = limit, offset = offset)
+    result = mgr.get_dataset(job_id, limit=limit, offset=offset)
     if result is None:
-        raise HTTPException(status_code = 404, detail = "dataset not ready")
+        raise HTTPException(status_code=404, detail="dataset not ready")
     if "error" in result:
-        raise HTTPException(status_code = 422, detail = result["error"])
+        raise HTTPException(status_code=422, detail=result["error"])
     return {
         "dataset": result["dataset"],
         "total": result["total"],
@@ -298,8 +298,8 @@ def job_dataset(
 
 @router.post(
     "/jobs/{job_id}/publish",
-    response_class = JSONResponse,
-    response_model = PublishDatasetResponse,
+    response_class=JSONResponse,
+    response_model=PublishDatasetResponse,
 )
 def publish_job_dataset(job_id: str, payload: PublishDatasetRequest):
     repo_id = payload.repo_id.strip()
@@ -312,9 +312,9 @@ def publish_job_dataset(job_id: str, payload: PublishDatasetRequest):
     )
 
     if not repo_id:
-        raise HTTPException(status_code = 400, detail = "repo_id is required")
+        raise HTTPException(status_code=400, detail="repo_id is required")
     if not description:
-        raise HTTPException(status_code = 400, detail = "description is required")
+        raise HTTPException(status_code=400, detail="description is required")
 
     mgr = get_job_manager()
     status = mgr.get_status(job_id)
@@ -324,8 +324,8 @@ def publish_job_dataset(job_id: str, payload: PublishDatasetRequest):
             or status.get("execution_type") != "full"
         ):
             raise HTTPException(
-                status_code = 409,
-                detail = "Only completed full runs can be published.",
+                status_code=409,
+                detail="Only completed full runs can be published.",
             )
         status_artifact = status.get("artifact_path")
         if isinstance(status_artifact, str) and status_artifact.strip():
@@ -333,22 +333,22 @@ def publish_job_dataset(job_id: str, payload: PublishDatasetRequest):
 
     if not artifact_path:
         raise HTTPException(
-            status_code = 400,
-            detail = "This execution does not have publishable dataset artifacts.",
+            status_code=400,
+            detail="This execution does not have publishable dataset artifacts.",
         )
 
     try:
         url = publish_recipe_dataset(
-            artifact_path = artifact_path,
-            repo_id = repo_id,
-            description = description,
-            hf_token = hf_token or None,
-            private = payload.private,
+            artifact_path=artifact_path,
+            repo_id=repo_id,
+            description=description,
+            hf_token=hf_token or None,
+            private=payload.private,
         )
     except RecipeDatasetPublishError as exc:
-        raise HTTPException(status_code = 400, detail = str(exc)) from exc
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(status_code = 500, detail = str(exc)) from exc
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     return {
         "success": True,
@@ -375,9 +375,9 @@ async def job_events(request: Request, job_id: str):
         except (TypeError, ValueError):
             pass
 
-    sub = mgr.subscribe(job_id, after_seq = after_seq)
+    sub = mgr.subscribe(job_id, after_seq=after_seq)
     if sub is None:
-        raise HTTPException(status_code = 404, detail = "job not found")
+        raise HTTPException(status_code=404, detail="job not found")
 
     async def gen():
         try:
@@ -387,11 +387,11 @@ async def job_events(request: Request, job_id: str):
             while True:
                 if await request.is_disconnected():
                     break
-                event = await sub.next_event(timeout_sec = 1.0)
+                event = await sub.next_event(timeout_sec=1.0)
                 if event is None:
                     continue
                 yield sub.format_sse(event)
         finally:
             mgr.unsubscribe(sub)
 
-    return StreamingResponse(gen(), media_type = "text/event-stream")
+    return StreamingResponse(gen(), media_type="text/event-stream")

--- a/studio/backend/routes/data_recipe/mcp.py
+++ b/studio/backend/routes/data_recipe/mcp.py
@@ -19,16 +19,16 @@ from models.data_recipe import (
 router = APIRouter()
 
 
-@router.post("/mcp/tools", response_model = McpToolsListResponse)
+@router.post("/mcp/tools", response_model=McpToolsListResponse)
 def list_mcp_tools(payload: McpToolsListRequest) -> McpToolsListResponse:
     try:
         from data_designer.engine.mcp import io as mcp_io
     except ImportError as exc:
         return McpToolsListResponse(
-            providers = [
+            providers=[
                 McpToolsProviderResult(
-                    name = "",
-                    error = f"MCP dependencies unavailable: {exc}",
+                    name="",
+                    error=f"MCP dependencies unavailable: {exc}",
                 )
             ]
         )
@@ -42,15 +42,15 @@ def list_mcp_tools(payload: McpToolsListRequest) -> McpToolsListResponse:
         if len(built) != 1:
             providers.append(
                 McpToolsProviderResult(
-                    name = provider_name,
-                    error = "Unsupported MCP provider config.",
+                    name=provider_name,
+                    error="Unsupported MCP provider config.",
                 )
             )
             continue
 
         provider = built[0]
         try:
-            tools = mcp_io.list_tools(provider, timeout_sec = payload.timeout_sec)
+            tools = mcp_io.list_tools(provider, timeout_sec=payload.timeout_sec)
             tool_names = sorted(
                 {tool.name for tool in tools if getattr(tool, "name", "")}
             )
@@ -58,15 +58,15 @@ def list_mcp_tools(payload: McpToolsListRequest) -> McpToolsListResponse:
                 tool_to_providers[tool_name].append(provider.name)
             providers.append(
                 McpToolsProviderResult(
-                    name = provider.name,
-                    tools = tool_names,
+                    name=provider.name,
+                    tools=tool_names,
                 )
             )
         except Exception as exc:
             providers.append(
                 McpToolsProviderResult(
-                    name = provider.name or provider_name,
-                    error = str(exc).strip() or "Failed to load tools.",
+                    name=provider.name or provider_name,
+                    error=str(exc).strip() or "Failed to load tools.",
                 )
             )
 
@@ -77,6 +77,6 @@ def list_mcp_tools(payload: McpToolsListRequest) -> McpToolsListResponse:
     }
 
     return McpToolsListResponse(
-        providers = providers,
-        duplicate_tools = duplicate_tools,
+        providers=providers,
+        duplicate_tools=duplicate_tools,
     )

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -33,7 +33,7 @@ def _get_dataset_size_cached(repo_id: str) -> int:
     try:
         from huggingface_hub import dataset_info as hf_dataset_info
 
-        info = hf_dataset_info(repo_id, token = None, files_metadata = True)
+        info = hf_dataset_info(repo_id, token=None, files_metadata=True)
         total = sum(s.size for s in info.siblings if getattr(s, "size", None))
         _dataset_size_cache[repo_id] = total
         return total
@@ -53,7 +53,7 @@ def _resolve_hf_cache_realpath(repo_dir: Path) -> Optional[str]:
         if snapshots_dir.is_dir():
             snaps = [s for s in snapshots_dir.iterdir() if s.is_dir()]
             if snaps:
-                latest = max(snaps, key = lambda s: s.stat().st_mtime)
+                latest = max(snaps, key=lambda s: s.stat().st_mtime)
                 return str(latest.resolve())
         return str(repo_dir.resolve())
     except Exception:
@@ -100,7 +100,7 @@ def _serialize_preview_value(value):
 
         if isinstance(value, PILImage):
             buffer = io.BytesIO()
-            value.convert("RGB").save(buffer, format = "JPEG", quality = 85)
+            value.convert("RGB").save(buffer, format="JPEG", quality=85)
             return {
                 "type": "image",
                 "mime": "image/jpeg",
@@ -144,7 +144,7 @@ DATASET_UPLOAD_DIR = dataset_uploads_root()
 
 def _safe_read_metadata(path: Path) -> dict | None:
     try:
-        payload = json.loads(path.read_text(encoding = "utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
         return None
     if not isinstance(payload, dict):
@@ -245,16 +245,16 @@ def _build_local_dataset_items() -> list[LocalDatasetItem]:
 
         items.append(
             LocalDatasetItem(
-                id = entry.name,
-                label = entry.name,
-                path = str(parquet_dir.resolve()),
-                rows = rows,
-                updated_at = updated_at,
-                metadata = metadata_summary,
+                id=entry.name,
+                label=entry.name,
+                path=str(parquet_dir.resolve()),
+                rows=rows,
+                updated_at=updated_at,
+                metadata=metadata_summary,
             )
         )
 
-    items.sort(key = lambda item: item.updated_at or 0, reverse = True)
+    items.sort(key=lambda item: item.updated_at or 0, reverse=True)
     return items
 
 
@@ -273,8 +273,8 @@ def _load_local_preview_slice(
         if parquet_files:
             dataset = load_dataset(
                 "parquet",
-                data_files = [str(path) for path in parquet_files],
-                split = train_split,
+                data_files=[str(path) for path in parquet_files],
+                split=train_split,
             )
             total_rows = len(dataset)
             preview_slice = dataset.select(range(min(preview_size, total_rows)))
@@ -285,22 +285,22 @@ def _load_local_preview_slice(
                 candidate_files.extend(sorted(dataset_path.glob(f"*{ext}")))
             if not candidate_files:
                 raise HTTPException(
-                    status_code = 400,
-                    detail = "Unsupported local dataset directory (expected parquet/json/jsonl/csv files)",
+                    status_code=400,
+                    detail="Unsupported local dataset directory (expected parquet/json/jsonl/csv files)",
                 )
             dataset_path = candidate_files[0]
 
     if dataset_path.suffix in [".json", ".jsonl"]:
-        dataset = load_dataset("json", data_files = str(dataset_path), split = train_split)
+        dataset = load_dataset("json", data_files=str(dataset_path), split=train_split)
     elif dataset_path.suffix == ".csv":
-        dataset = load_dataset("csv", data_files = str(dataset_path), split = train_split)
+        dataset = load_dataset("csv", data_files=str(dataset_path), split=train_split)
     elif dataset_path.suffix == ".parquet":
         dataset = load_dataset(
-            "parquet", data_files = str(dataset_path), split = train_split
+            "parquet", data_files=str(dataset_path), split=train_split
         )
     else:
         raise HTTPException(
-            status_code = 400, detail = f"Unsupported file format: {dataset_path.suffix}"
+            status_code=400, detail=f"Unsupported file format: {dataset_path.suffix}"
         )
 
     total_rows = len(dataset)
@@ -315,7 +315,7 @@ def _sanitize_filename(filename: str) -> str:
     return name
 
 
-@router.post("/upload", response_model = UploadDatasetResponse)
+@router.post("/upload", response_model=UploadDatasetResponse)
 async def upload_dataset(
     file: UploadFile,
     current_subject: str = Depends(get_current_subject),
@@ -325,8 +325,8 @@ async def upload_dataset(
     if ext not in LOCAL_UPLOAD_EXTS:
         allowed = ", ".join(sorted(LOCAL_UPLOAD_EXTS))
         raise HTTPException(
-            status_code = 400,
-            detail = f"Unsupported file type: {ext}. Allowed: {allowed}",
+            status_code=400,
+            detail=f"Unsupported file type: {ext}. Allowed: {allowed}",
         )
 
     ensure_dir(DATASET_UPLOAD_DIR)
@@ -340,23 +340,23 @@ async def upload_dataset(
             f.write(chunk)
 
     if stored_path.stat().st_size == 0:
-        stored_path.unlink(missing_ok = True)
-        raise HTTPException(status_code = 400, detail = "Empty upload payload")
+        stored_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=400, detail="Empty upload payload")
 
-    return UploadDatasetResponse(filename = filename, stored_path = str(stored_path))
+    return UploadDatasetResponse(filename=filename, stored_path=str(stored_path))
 
 
-@router.get("/local", response_model = LocalDatasetsResponse)
+@router.get("/local", response_model=LocalDatasetsResponse)
 def list_local_datasets(
     current_subject: str = Depends(get_current_subject),
 ) -> LocalDatasetsResponse:
-    return LocalDatasetsResponse(datasets = _build_local_dataset_items())
+    return LocalDatasetsResponse(datasets=_build_local_dataset_items())
 
 
 @router.get("/download-progress")
 async def get_dataset_download_progress(
     repo_id: str = Query(
-        ..., description = "HuggingFace dataset repo ID, e.g. 'unsloth/LaTeX_OCR'"
+        ..., description="HuggingFace dataset repo ID, e.g. 'unsloth/LaTeX_OCR'"
     ),
     current_subject: str = Depends(get_current_subject),
 ):
@@ -436,7 +436,7 @@ async def get_dataset_download_progress(
         return _empty
 
 
-@router.post("/check-format", response_model = CheckFormatResponse)
+@router.post("/check-format", response_model=CheckFormatResponse)
 def check_format(
     request: CheckFormatRequest,
     current_subject: str = Depends(get_current_subject),
@@ -470,9 +470,9 @@ def check_format(
             # ── Local file ──────────────────────────────────────────
             train_split = request.train_split or "train"
             preview_slice, total_rows = _load_local_preview_slice(
-                dataset_path = dataset_path,
-                train_split = train_split,
-                preview_size = PREVIEW_SIZE,
+                dataset_path=dataset_path,
+                train_split=train_split,
+                preview_size=PREVIEW_SIZE,
             )
         else:
             # ── HuggingFace dataset ─────────────────────────────────
@@ -485,8 +485,8 @@ def check_format(
                 api = HfApi()
                 repo_files = api.list_repo_files(
                     request.dataset_name,
-                    repo_type = "dataset",
-                    token = request.hf_token or None,
+                    repo_type="dataset",
+                    token=request.hf_token or None,
                 )
                 data_files = [
                     f for f in repo_files if any(f.endswith(ext) for ext in DATA_EXTS)
@@ -547,15 +547,15 @@ def check_format(
                 rows = list(islice(streamed_ds, PREVIEW_SIZE))
                 if not rows:
                     raise HTTPException(
-                        status_code = 400,
-                        detail = "Dataset appears to be empty or could not be streamed",
+                        status_code=400,
+                        detail="Dataset appears to be empty or could not be streamed",
                     )
 
                 preview_slice = Dataset.from_list(rows)
             total_rows = None
 
         # Run lightweight format check on the preview slice
-        result = check_dataset_format(preview_slice, is_vlm = request.is_vlm)
+        result = check_dataset_format(preview_slice, is_vlm=request.is_vlm)
 
         logger.info(
             f"Format check result: requires_mapping={result['requires_manual_mapping']}, format={result['detected_format']}, is_image={result.get('is_image', False)}"
@@ -572,8 +572,8 @@ def check_format(
                 try:
                     format_result = format_dataset(
                         preview_slice,
-                        format_type = "auto",
-                        num_proc = None,  # Only 10 preview rows -- no need for multiprocessing
+                        format_type="auto",
+                        num_proc=None,  # Only 10 preview rows -- no need for multiprocessing
                     )
                     processed = format_result["dataset"]
                     preview_samples = _serialize_preview_rows(processed)
@@ -604,32 +604,32 @@ def check_format(
                 pass
 
         return CheckFormatResponse(
-            requires_manual_mapping = result["requires_manual_mapping"],
-            detected_format = result["detected_format"],
-            columns = result["columns"],
-            is_image = result.get("is_image", False),
-            is_audio = result.get("is_audio", False),
-            multimodal_columns = result.get("multimodal_columns"),
-            suggested_mapping = result.get("suggested_mapping"),
-            detected_image_column = result.get("detected_image_column"),
-            detected_audio_column = result.get("detected_audio_column"),
-            detected_text_column = result.get("detected_text_column"),
-            detected_speaker_column = result.get("detected_speaker_column"),
-            preview_samples = preview_samples,
-            total_rows = total_rows,
-            warning = warning,
+            requires_manual_mapping=result["requires_manual_mapping"],
+            detected_format=result["detected_format"],
+            columns=result["columns"],
+            is_image=result.get("is_image", False),
+            is_audio=result.get("is_audio", False),
+            multimodal_columns=result.get("multimodal_columns"),
+            suggested_mapping=result.get("suggested_mapping"),
+            detected_image_column=result.get("detected_image_column"),
+            detected_audio_column=result.get("detected_audio_column"),
+            detected_text_column=result.get("detected_text_column"),
+            detected_speaker_column=result.get("detected_speaker_column"),
+            preview_samples=preview_samples,
+            total_rows=total_rows,
+            warning=warning,
         )
 
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error checking dataset format: {e}", exc_info = True)
+        logger.error(f"Error checking dataset format: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500, detail = f"Failed to check dataset format: {str(e)}"
+            status_code=500, detail=f"Failed to check dataset format: {str(e)}"
         )
 
 
-@router.post("/ai-assist-mapping", response_model = AiAssistMappingResponse)
+@router.post("/ai-assist-mapping", response_model=AiAssistMappingResponse)
 def ai_assist_mapping(
     request: AiAssistMappingRequest,
     current_subject: str = Depends(get_current_subject),
@@ -654,32 +654,32 @@ def ai_assist_mapping(
         ]
 
         result = llm_conversion_advisor(
-            column_names = request.columns,
-            samples = truncated,
-            dataset_name = request.dataset_name,
-            hf_token = request.hf_token,
-            model_name = request.model_name,
-            model_type = request.model_type,
+            column_names=request.columns,
+            samples=truncated,
+            dataset_name=request.dataset_name,
+            hf_token=request.hf_token,
+            model_name=request.model_name,
+            model_type=request.model_type,
         )
 
         if result and result.get("success"):
             return AiAssistMappingResponse(
-                success = True,
-                suggested_mapping = result.get("suggested_mapping"),
-                system_prompt = result.get("system_prompt"),
-                user_template = result.get("user_template"),
-                assistant_template = result.get("assistant_template"),
-                label_mapping = result.get("label_mapping"),
-                dataset_type = result.get("dataset_type"),
-                is_conversational = result.get("is_conversational"),
-                user_notification = result.get("user_notification"),
+                success=True,
+                suggested_mapping=result.get("suggested_mapping"),
+                system_prompt=result.get("system_prompt"),
+                user_template=result.get("user_template"),
+                assistant_template=result.get("assistant_template"),
+                label_mapping=result.get("label_mapping"),
+                dataset_type=result.get("dataset_type"),
+                is_conversational=result.get("is_conversational"),
+                user_notification=result.get("user_notification"),
             )
 
         return AiAssistMappingResponse(
-            success = False,
-            warning = "AI could not determine column roles. Please assign them manually.",
+            success=False,
+            warning="AI could not determine column roles. Please assign them manually.",
         )
 
     except Exception as e:
-        logger.error(f"AI assist mapping failed: {e}", exc_info = True)
-        raise HTTPException(status_code = 500, detail = f"AI assist failed: {str(e)}")
+        logger.error(f"AI assist mapping failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"AI assist failed: {str(e)}")

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -49,7 +49,7 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 
-@router.post("/load-checkpoint", response_model = ExportOperationResponse)
+@router.post("/load-checkpoint", response_model=ExportOperationResponse)
 async def load_checkpoint(
     request: LoadCheckpointRequest,
     current_subject: str = Depends(get_current_subject),
@@ -108,27 +108,27 @@ async def load_checkpoint(
         # free to serve the live log SSE stream concurrently.
         success, message = await asyncio.to_thread(
             backend.load_checkpoint,
-            checkpoint_path = request.checkpoint_path,
-            max_seq_length = request.max_seq_length,
-            load_in_4bit = request.load_in_4bit,
-            trust_remote_code = request.trust_remote_code,
+            checkpoint_path=request.checkpoint_path,
+            max_seq_length=request.max_seq_length,
+            load_in_4bit=request.load_in_4bit,
+            trust_remote_code=request.trust_remote_code,
         )
 
         if not success:
-            raise HTTPException(status_code = 400, detail = message)
+            raise HTTPException(status_code=400, detail=message)
 
-        return ExportOperationResponse(success = True, message = message)
+        return ExportOperationResponse(success=True, message=message)
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error loading checkpoint: {e}", exc_info = True)
+        logger.error(f"Error loading checkpoint: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to load checkpoint: {str(e)}",
+            status_code=500,
+            detail=f"Failed to load checkpoint: {str(e)}",
         )
 
 
-@router.post("/cleanup", response_model = ExportOperationResponse)
+@router.post("/cleanup", response_model=ExportOperationResponse)
 async def cleanup_export_memory(
     current_subject: str = Depends(get_current_subject),
 ):
@@ -143,25 +143,25 @@ async def cleanup_export_memory(
 
         if not success:
             raise HTTPException(
-                status_code = 500,
-                detail = "Memory cleanup failed. See server logs for details.",
+                status_code=500,
+                detail="Memory cleanup failed. See server logs for details.",
             )
 
         return ExportOperationResponse(
-            success = True,
-            message = "Memory cleanup completed successfully",
+            success=True,
+            message="Memory cleanup completed successfully",
         )
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error during export memory cleanup: {e}", exc_info = True)
+        logger.error(f"Error during export memory cleanup: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to cleanup export memory: {str(e)}",
+            status_code=500,
+            detail=f"Failed to cleanup export memory: {str(e)}",
         )
 
 
-@router.get("/status", response_model = ExportStatusResponse)
+@router.get("/status", response_model=ExportStatusResponse)
 async def get_export_status(
     current_subject: str = Depends(get_current_subject),
 ):
@@ -171,15 +171,15 @@ async def get_export_status(
     try:
         backend = get_export_backend()
         return ExportStatusResponse(
-            current_checkpoint = backend.current_checkpoint,
-            is_vision = bool(getattr(backend, "is_vision", False)),
-            is_peft = bool(getattr(backend, "is_peft", False)),
+            current_checkpoint=backend.current_checkpoint,
+            is_vision=bool(getattr(backend, "is_vision", False)),
+            is_peft=bool(getattr(backend, "is_peft", False)),
         )
     except Exception as e:
-        logger.error(f"Error getting export status: {e}", exc_info = True)
+        logger.error(f"Error getting export status: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to get export status: {str(e)}",
+            status_code=500,
+            detail=f"Failed to get export status: {str(e)}",
         )
 
 
@@ -194,7 +194,7 @@ def _export_details(output_path: Optional[str]) -> Optional[Dict[str, Any]]:
     return {"output_path": output_path}
 
 
-@router.post("/export/merged", response_model = ExportOperationResponse)
+@router.post("/export/merged", response_model=ExportOperationResponse)
 async def export_merged_model(
     request: ExportMergedModelRequest,
     current_subject: str = Depends(get_current_subject),
@@ -208,33 +208,33 @@ async def export_merged_model(
         backend = get_export_backend()
         success, message, output_path = await asyncio.to_thread(
             backend.export_merged_model,
-            save_directory = request.save_directory,
-            format_type = request.format_type,
-            push_to_hub = request.push_to_hub,
-            repo_id = request.repo_id,
-            hf_token = request.hf_token,
-            private = request.private,
+            save_directory=request.save_directory,
+            format_type=request.format_type,
+            push_to_hub=request.push_to_hub,
+            repo_id=request.repo_id,
+            hf_token=request.hf_token,
+            private=request.private,
         )
 
         if not success:
-            raise HTTPException(status_code = 400, detail = message)
+            raise HTTPException(status_code=400, detail=message)
 
         return ExportOperationResponse(
-            success = True,
-            message = message,
-            details = _export_details(output_path),
+            success=True,
+            message=message,
+            details=_export_details(output_path),
         )
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error exporting merged model: {e}", exc_info = True)
+        logger.error(f"Error exporting merged model: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to export merged model: {str(e)}",
+            status_code=500,
+            detail=f"Failed to export merged model: {str(e)}",
         )
 
 
-@router.post("/export/base", response_model = ExportOperationResponse)
+@router.post("/export/base", response_model=ExportOperationResponse)
 async def export_base_model(
     request: ExportBaseModelRequest,
     current_subject: str = Depends(get_current_subject),
@@ -248,33 +248,33 @@ async def export_base_model(
         backend = get_export_backend()
         success, message, output_path = await asyncio.to_thread(
             backend.export_base_model,
-            save_directory = request.save_directory,
-            push_to_hub = request.push_to_hub,
-            repo_id = request.repo_id,
-            hf_token = request.hf_token,
-            private = request.private,
-            base_model_id = request.base_model_id,
+            save_directory=request.save_directory,
+            push_to_hub=request.push_to_hub,
+            repo_id=request.repo_id,
+            hf_token=request.hf_token,
+            private=request.private,
+            base_model_id=request.base_model_id,
         )
 
         if not success:
-            raise HTTPException(status_code = 400, detail = message)
+            raise HTTPException(status_code=400, detail=message)
 
         return ExportOperationResponse(
-            success = True,
-            message = message,
-            details = _export_details(output_path),
+            success=True,
+            message=message,
+            details=_export_details(output_path),
         )
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error exporting base model: {e}", exc_info = True)
+        logger.error(f"Error exporting base model: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to export base model: {str(e)}",
+            status_code=500,
+            detail=f"Failed to export base model: {str(e)}",
         )
 
 
-@router.post("/export/gguf", response_model = ExportOperationResponse)
+@router.post("/export/gguf", response_model=ExportOperationResponse)
 async def export_gguf(
     request: ExportGGUFRequest,
     current_subject: str = Depends(get_current_subject),
@@ -288,32 +288,32 @@ async def export_gguf(
         backend = get_export_backend()
         success, message, output_path = await asyncio.to_thread(
             backend.export_gguf,
-            save_directory = request.save_directory,
-            quantization_method = request.quantization_method,
-            push_to_hub = request.push_to_hub,
-            repo_id = request.repo_id,
-            hf_token = request.hf_token,
+            save_directory=request.save_directory,
+            quantization_method=request.quantization_method,
+            push_to_hub=request.push_to_hub,
+            repo_id=request.repo_id,
+            hf_token=request.hf_token,
         )
 
         if not success:
-            raise HTTPException(status_code = 400, detail = message)
+            raise HTTPException(status_code=400, detail=message)
 
         return ExportOperationResponse(
-            success = True,
-            message = message,
-            details = _export_details(output_path),
+            success=True,
+            message=message,
+            details=_export_details(output_path),
         )
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error exporting GGUF model: {e}", exc_info = True)
+        logger.error(f"Error exporting GGUF model: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to export GGUF model: {str(e)}",
+            status_code=500,
+            detail=f"Failed to export GGUF model: {str(e)}",
         )
 
 
-@router.post("/export/lora", response_model = ExportOperationResponse)
+@router.post("/export/lora", response_model=ExportOperationResponse)
 async def export_lora_adapter(
     request: ExportLoRAAdapterRequest,
     current_subject: str = Depends(get_current_subject),
@@ -327,28 +327,28 @@ async def export_lora_adapter(
         backend = get_export_backend()
         success, message, output_path = await asyncio.to_thread(
             backend.export_lora_adapter,
-            save_directory = request.save_directory,
-            push_to_hub = request.push_to_hub,
-            repo_id = request.repo_id,
-            hf_token = request.hf_token,
-            private = request.private,
+            save_directory=request.save_directory,
+            push_to_hub=request.push_to_hub,
+            repo_id=request.repo_id,
+            hf_token=request.hf_token,
+            private=request.private,
         )
 
         if not success:
-            raise HTTPException(status_code = 400, detail = message)
+            raise HTTPException(status_code=400, detail=message)
 
         return ExportOperationResponse(
-            success = True,
-            message = message,
-            details = _export_details(output_path),
+            success=True,
+            message=message,
+            details=_export_details(output_path),
         )
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error exporting LoRA adapter: {e}", exc_info = True)
+        logger.error(f"Error exporting LoRA adapter: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to export LoRA adapter: {str(e)}",
+            status_code=500,
+            detail=f"Failed to export LoRA adapter: {str(e)}",
         )
 
 
@@ -387,7 +387,7 @@ async def stream_export_logs(
     request: Request,
     since: Optional[int] = Query(
         None,
-        description = "Return log entries with seq strictly greater than this cursor.",
+        description="Return log entries with seq strictly greater than this cursor.",
     ),
     current_subject: str = Depends(get_current_subject),
 ):
@@ -451,8 +451,8 @@ async def stream_export_logs(
                         )
                         yield _format_sse(
                             payload,
-                            event = "log",
-                            event_id = int(entry.get("seq", 0)),
+                            event="log",
+                            event_id=int(entry.get("seq", 0)),
                         )
                     cursor = new_cursor
                     last_yield = time.monotonic()
@@ -460,7 +460,7 @@ async def stream_export_logs(
                 else:
                     now = time.monotonic()
                     if now - last_yield > 10.0:
-                        yield _format_sse("{}", event = "heartbeat")
+                        yield _format_sse("{}", event="heartbeat")
                         last_yield = now
                     if not backend.is_export_active():
                         # Give the reader thread a moment to drain any
@@ -471,8 +471,8 @@ async def stream_export_logs(
                         elif now - idle_since > 1.0:
                             yield _format_sse(
                                 "{}",
-                                event = "complete",
-                                event_id = cursor,
+                                event="complete",
+                                event_id=cursor,
                             )
                             return
                     else:
@@ -484,19 +484,19 @@ async def stream_export_logs(
             # the generator cleanly so StreamingResponse finalizes.
             return
         except Exception as exc:
-            logger.error("Export log stream failed: %s", exc, exc_info = True)
+            logger.error("Export log stream failed: %s", exc, exc_info=True)
             try:
                 yield _format_sse(
                     json.dumps({"error": str(exc)}),
-                    event = "error",
+                    event="error",
                 )
             except Exception:
                 pass
 
     return StreamingResponse(
         event_generator(),
-        media_type = "text/event-stream",
-        headers = {
+        media_type="text/event-stream",
+        headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -74,8 +74,8 @@ def _validate_local_dataset_paths(
     if missing:
         missing_detail = "; ".join(missing[:3])
         raise HTTPException(
-            status_code = 400,
-            detail = f"{label} not found: {missing_detail}",
+            status_code=400,
+            detail=f"{label} not found: {missing_detail}",
         )
     return validated
 
@@ -128,13 +128,13 @@ async def start_training(
         if backend.is_training_active():
             existing_job_id: Optional[str] = getattr(backend, "current_job_id", "")
             return TrainingJobResponse(
-                job_id = existing_job_id or "",
-                status = "error",
-                message = (
+                job_id=existing_job_id or "",
+                status="error",
+                message=(
                     "Training is already in progress. "
                     "Stop current training before starting a new one."
                 ),
-                error = "Training already active",
+                error="Training already active",
             )
 
         # Generate job ID — passed into start_training() which sets it on the
@@ -260,36 +260,36 @@ async def start_training(
             logger.warning("Could not shut down export subprocess: %s", e)
 
         # start_training now spawns a subprocess (non-blocking)
-        success = backend.start_training(job_id = job_id, **training_kwargs)
+        success = backend.start_training(job_id=job_id, **training_kwargs)
 
         if not success:
             progress_error = backend.trainer.training_progress.error
             return TrainingJobResponse(
-                job_id = backend.current_job_id or "",
-                status = "error",
-                message = progress_error or "Failed to start training subprocess",
-                error = progress_error or "subprocess_start_failed",
+                job_id=backend.current_job_id or "",
+                status="error",
+                message=progress_error or "Failed to start training subprocess",
+                error=progress_error or "subprocess_start_failed",
             )
 
         return TrainingJobResponse(
-            job_id = job_id,
-            status = "queued",
-            message = "Training job queued and starting in subprocess",
-            error = None,
+            job_id=job_id,
+            status="queued",
+            message="Training job queued and starting in subprocess",
+            error=None,
         )
 
     except ValueError as e:
         logger.warning("Rejected training GPU selection: %s", e)
-        raise HTTPException(status_code = 400, detail = str(e))
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Error starting training: {e}", exc_info = True)
+        logger.error(f"Error starting training: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to start training: {str(e)}",
+            status_code=500,
+            detail=f"Failed to start training: {str(e)}",
         )
 
 
-@router.post("/stop", response_model = TrainingStopResponse)
+@router.post("/stop", response_model=TrainingStopResponse)
 async def stop_training(
     body: TrainingStopRequest = TrainingStopRequest(),
     current_subject: str = Depends(get_current_subject),
@@ -307,21 +307,21 @@ async def stop_training(
 
         if not is_active:
             return TrainingStopResponse(
-                status = "idle", message = "No training job is currently running"
+                status="idle", message="No training job is currently running"
             )
 
         # Call backend stop method
-        backend.stop_training(save = body.save)
+        backend.stop_training(save=body.save)
 
         return TrainingStopResponse(
-            status = "stopped",
-            message = "Stop requested. Training will stop at the next safe step.",
+            status="stopped",
+            message="Stop requested. Training will stop at the next safe step.",
         )
 
     except Exception as e:
-        logger.error(f"Error stopping training: {e}", exc_info = True)
+        logger.error(f"Error stopping training: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500, detail = f"Failed to stop training: {str(e)}"
+            status_code=500, detail=f"Failed to stop training: {str(e)}"
         )
 
 
@@ -348,21 +348,21 @@ async def reset_training(
                     "Rejected reset while training active: is_active=%s", is_active
                 )
                 raise HTTPException(
-                    status_code = 409,
-                    detail = "Training is still running. Stop training and wait for it to finish before resetting.",
+                    status_code=409,
+                    detail="Training is still running. Stop training and wait for it to finish before resetting.",
                 )
 
         logger.info("Reset training state: clearing runtime + metric history")
         backend._should_stop = False  # Clear stop flag so status returns to idle
         backend.trainer._update_progress(
-            is_training = False,
-            is_completed = False,
-            error = None,
-            status_message = "Ready to train",
-            step = 0,
-            loss = None,
-            epoch = 0,
-            total_steps = 0,
+            is_training=False,
+            is_completed=False,
+            error=None,
+            status_message="Ready to train",
+            step=0,
+            loss=None,
+            epoch=0,
+            total_steps=0,
         )
         backend.loss_history = []
         backend.lr_history = []
@@ -373,10 +373,10 @@ async def reset_training(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error resetting training: {e}", exc_info = True)
+        logger.error(f"Error resetting training: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500,
-            detail = f"Failed to reset training: {str(e)}",
+            status_code=500,
+            detail=f"Failed to reset training: {str(e)}",
         )
 
 
@@ -452,24 +452,24 @@ async def get_training_status(
             }
 
         return TrainingStatus(
-            job_id = job_id,
-            phase = phase,
-            is_training_running = is_active,
-            eval_enabled = backend.eval_enabled,
-            message = status_message,
-            error = error_message,
-            details = details,
-            metric_history = metric_history,
+            job_id=job_id,
+            phase=phase,
+            is_training_running=is_active,
+            eval_enabled=backend.eval_enabled,
+            message=status_message,
+            error=error_message,
+            details=details,
+            metric_history=metric_history,
         )
 
     except Exception as e:
-        logger.error(f"Error getting training status: {e}", exc_info = True)
+        logger.error(f"Error getting training status: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500, detail = f"Failed to get training status: {str(e)}"
+            status_code=500, detail=f"Failed to get training status: {str(e)}"
         )
 
 
-@router.get("/metrics", response_model = TrainingMetricsResponse)
+@router.get("/metrics", response_model=TrainingMetricsResponse)
 async def get_training_metrics(
     current_subject: str = Depends(get_current_subject),
 ):
@@ -492,20 +492,20 @@ async def get_training_metrics(
         current_step = step_history[-1] if step_history else None
 
         return TrainingMetricsResponse(
-            loss_history = loss_history,
-            lr_history = lr_history,
-            step_history = step_history,
-            grad_norm_history = grad_norm_history,
-            grad_norm_step_history = grad_norm_step_history,
-            current_loss = current_loss,
-            current_lr = current_lr,
-            current_step = current_step,
+            loss_history=loss_history,
+            lr_history=lr_history,
+            step_history=step_history,
+            grad_norm_history=grad_norm_history,
+            grad_norm_step_history=grad_norm_step_history,
+            current_loss=current_loss,
+            current_lr=current_lr,
+            current_step=current_step,
         )
 
     except Exception as e:
-        logger.error(f"Error getting training metrics: {e}", exc_info = True)
+        logger.error(f"Error getting training metrics: {e}", exc_info=True)
         raise HTTPException(
-            status_code = 500, detail = f"Failed to get training metrics: {str(e)}"
+            status_code=500, detail=f"Failed to get training metrics: {str(e)}"
         )
 
 
@@ -571,18 +571,18 @@ async def stream_training_progress(
                 eval_loss = getattr(progress, "eval_loss", None)
 
             return TrainingProgress(
-                job_id = job_id,
-                step = step,
-                total_steps = total,
-                loss = loss,
-                learning_rate = learning_rate,
-                progress_percent = progress_percent,
-                epoch = epoch,
-                elapsed_seconds = elapsed_seconds,
-                eta_seconds = eta_seconds,
-                grad_norm = grad_norm,
-                num_tokens = num_tokens,
-                eval_loss = eval_loss,
+                job_id=job_id,
+                step=step,
+                total_steps=total,
+                loss=loss,
+                learning_rate=learning_rate,
+                progress_percent=progress_percent,
+                epoch=epoch,
+                elapsed_seconds=elapsed_seconds,
+                eta_seconds=eta_seconds,
+                grad_norm=grad_norm,
+                num_tokens=num_tokens,
+                eval_loss=eval_loss,
             )
 
         def format_sse(
@@ -641,11 +641,11 @@ async def stream_training_progress(
                         lr_val,
                         total_replay,
                         epoch_replay,
-                        progress = tp_replay,
-                        grad_norm_override = grad_norm_by_step.get(step_val),
+                        progress=tp_replay,
+                        grad_norm_override=grad_norm_by_step.get(step_val),
                     )
                     yield format_sse(
-                        payload.model_dump_json(), event = "progress", event_id = step_val
+                        payload.model_dump_json(), event="progress", event_id=step_val
                     )
                     replayed += 1
             if replayed:
@@ -659,15 +659,15 @@ async def stream_training_progress(
             initial_epoch = getattr(tp, "epoch", None) if tp else None
 
             initial_progress = build_progress(
-                step = 0,
-                loss = None,
-                learning_rate = None,
-                total_steps = initial_total_steps,
-                epoch = initial_epoch,
-                progress = tp,
+                step=0,
+                loss=None,
+                learning_rate=None,
+                total_steps=initial_total_steps,
+                epoch=initial_epoch,
+                progress=tp,
             )
             yield format_sse(
-                initial_progress.model_dump_json(), event = "progress", event_id = 0
+                initial_progress.model_dump_json(), event="progress", event_id=0
             )
 
             # If not active, send final state and exit
@@ -688,18 +688,18 @@ async def stream_training_progress(
                         final_lr,
                         final_total_steps,
                         final_epoch,
-                        progress = tp,
+                        progress=tp,
                     )
                     yield format_sse(
-                        payload.model_dump_json(), event = "complete", event_id = final_step
+                        payload.model_dump_json(), event="complete", event_id=final_step
                     )
                 else:
                     yield format_sse(
                         build_progress(
-                            -1, None, None, 0, progress = tp
+                            -1, None, None, 0, progress=tp
                         ).model_dump_json(),
-                        event = "complete",
-                        event_id = 0,
+                        event="complete",
+                        event_id=0,
                     )
                 return
 
@@ -738,12 +738,12 @@ async def stream_training_progress(
                             current_lr,
                             current_total_steps,
                             current_epoch,
-                            progress = tp_inner,
+                            progress=tp_inner,
                         )
                         yield format_sse(
                             progress_payload.model_dump_json(),
-                            event = "progress",
-                            event_id = current_step,
+                            event="progress",
+                            event_id=current_step,
                         )
                         last_step = current_step
                         no_update_count = 0
@@ -757,12 +757,12 @@ async def stream_training_progress(
                                 current_lr,
                                 current_total_steps,
                                 current_epoch,
-                                progress = tp_inner,
+                                progress=tp_inner,
                             )
                             yield format_sse(
                                 heartbeat_payload.model_dump_json(),
-                                event = "heartbeat",
-                                event_id = current_step,
+                                event="heartbeat",
+                                event_id=current_step,
                             )
                 else:
                     # No steps yet, but training is active (model loading, etc.)
@@ -783,12 +783,12 @@ async def stream_training_progress(
                             None,
                             None,
                             prep_total,
-                            progress = tp_prep,
+                            progress=tp_prep,
                         )
                         yield format_sse(
                             preparing_payload.model_dump_json(),
-                            event = "heartbeat",
-                            event_id = 0,
+                            event="heartbeat",
+                            event_id=0,
                         )
 
                 # Timeout check
@@ -798,27 +798,27 @@ async def stream_training_progress(
                         getattr(backend, "trainer", None), "training_progress", None
                     )
                     timeout_payload = build_progress(
-                        last_step, None, None, 0, progress = tp_timeout
+                        last_step, None, None, 0, progress=tp_timeout
                     )
                     yield format_sse(
                         timeout_payload.model_dump_json(),
-                        event = "error",
-                        event_id = last_step if last_step >= 0 else 0,
+                        event="error",
+                        event_id=last_step if last_step >= 0 else 0,
                     )
                     break
 
                 await asyncio.sleep(1)  # Poll every second
 
             except Exception as e:
-                logger.error(f"Error in progress stream: {e}", exc_info = True)
+                logger.error(f"Error in progress stream: {e}", exc_info=True)
                 tp_error = getattr(
                     getattr(backend, "trainer", None), "training_progress", None
                 )
-                error_payload = build_progress(0, None, None, 0, progress = tp_error)
+                error_payload = build_progress(0, None, None, 0, progress=tp_error)
                 yield format_sse(
                     error_payload.model_dump_json(),
-                    event = "error",
-                    event_id = last_step if last_step >= 0 else 0,
+                    event="error",
+                    event_id=last_step if last_step >= 0 else 0,
                 )
                 break
 
@@ -837,18 +837,18 @@ async def stream_training_progress(
             final_lr,
             final_total_steps,
             final_epoch,
-            progress = final_tp,
+            progress=final_tp,
         )
         yield format_sse(
             final_payload.model_dump_json(),
-            event = "complete",
-            event_id = final_step if final_step >= 0 else 0,
+            event="complete",
+            event_id=final_step if final_step >= 0 else 0,
         )
 
     return StreamingResponse(
         event_generator(),
-        media_type = "text/event-stream",
-        headers = {
+        media_type="text/event-stream",
+        headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",

--- a/studio/backend/routes/training_history.py
+++ b/studio/backend/routes/training_history.py
@@ -25,21 +25,21 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.get("/runs", response_model = TrainingRunListResponse)
+@router.get("/runs", response_model=TrainingRunListResponse)
 async def list_training_runs(
-    limit: int = Query(50, ge = 1, le = 200),
-    offset: int = Query(0, ge = 0),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
     current_subject: str = Depends(get_current_subject),
 ):
     """List training runs, newest first."""
-    result = list_runs(limit = limit, offset = offset)
+    result = list_runs(limit=limit, offset=offset)
     return TrainingRunListResponse(
-        runs = [TrainingRunSummary(**r) for r in result["runs"]],
-        total = result["total"],
+        runs=[TrainingRunSummary(**r) for r in result["runs"]],
+        total=result["total"],
     )
 
 
-@router.get("/runs/{run_id}", response_model = TrainingRunDetailResponse)
+@router.get("/runs/{run_id}", response_model=TrainingRunDetailResponse)
 async def get_training_run_detail(
     run_id: str,
     current_subject: str = Depends(get_current_subject),
@@ -47,7 +47,7 @@ async def get_training_run_detail(
     """Get a single training run with full config and metrics."""
     run = get_run(run_id)
     if run is None:
-        raise HTTPException(status_code = 404, detail = f"Run {run_id} not found")
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
 
     try:
         config = json.loads(run.get("config_json", "{}"))
@@ -58,13 +58,13 @@ async def get_training_run_detail(
     metrics_data = get_run_metrics(run_id)
 
     return TrainingRunDetailResponse(
-        run = TrainingRunSummary(**{k: v for k, v in run.items() if k != "config_json"}),
-        config = config,
-        metrics = TrainingRunMetrics(**metrics_data),
+        run=TrainingRunSummary(**{k: v for k, v in run.items() if k != "config_json"}),
+        config=config,
+        metrics=TrainingRunMetrics(**metrics_data),
     )
 
 
-@router.delete("/runs/{run_id}", response_model = TrainingRunDeleteResponse)
+@router.delete("/runs/{run_id}", response_model=TrainingRunDeleteResponse)
 async def delete_training_run(
     run_id: str,
     current_subject: str = Depends(get_current_subject),
@@ -72,14 +72,14 @@ async def delete_training_run(
     """Delete a training run and its metrics (CASCADE)."""
     run = get_run(run_id)
     if run is None:
-        raise HTTPException(status_code = 404, detail = f"Run {run_id} not found")
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
     if run["status"] == "running":
         raise HTTPException(
-            status_code = 409, detail = "Cannot delete a running training run"
+            status_code=409, detail="Cannot delete a running training run"
         )
     logger.info("Deleting training run %s", run_id)
     delete_run(run_id)
     return TrainingRunDeleteResponse(
-        status = "deleted",
-        message = f"Run {run_id} deleted",
+        status="deleted",
+        message=f"Run {run_id} deleted",
     )

--- a/studio/backend/tests/test_cache_case_resolution.py
+++ b/studio/backend/tests/test_cache_case_resolution.py
@@ -14,8 +14,8 @@ if "structlog" not in sys.modules:
             return lambda *args, **kwargs: None
 
     sys.modules["structlog"] = types.SimpleNamespace(
-        BoundLogger = _DummyLogger,
-        get_logger = lambda *args, **kwargs: _DummyLogger(),
+        BoundLogger=_DummyLogger,
+        get_logger=lambda *args, **kwargs: _DummyLogger(),
     )
 
 from utils.paths.path_utils import (
@@ -28,7 +28,7 @@ import utils.paths.path_utils as path_utils
 
 def _mk_cache_repo(cache_root: Path, repo_id: str) -> Path:
     repo_dir = cache_root / f"models--{repo_id.replace('/', '--')}"
-    repo_dir.mkdir(parents = True, exist_ok = True)
+    repo_dir.mkdir(parents=True, exist_ok=True)
     return repo_dir
 
 

--- a/studio/backend/tests/test_gpu_selection_sandbox.py
+++ b/studio/backend/tests/test_gpu_selection_sandbox.py
@@ -25,25 +25,25 @@ if str(_backend_root) not in sys.path:
 
 
 def _make_fake_config(
-    vocab_size = 32000,
-    hidden_size = 4096,
-    intermediate_size = 11008,
-    num_hidden_layers = 32,
-    num_attention_heads = 32,
-    num_key_value_heads = 8,
-    tie_word_embeddings = False,
+    vocab_size=32000,
+    hidden_size=4096,
+    intermediate_size=11008,
+    num_hidden_layers=32,
+    num_attention_heads=32,
+    num_key_value_heads=8,
+    tie_word_embeddings=False,
 ):
     """Create a fake HF config-like object for estimation tests."""
     from types import SimpleNamespace
 
     return SimpleNamespace(
-        vocab_size = vocab_size,
-        hidden_size = hidden_size,
-        intermediate_size = intermediate_size,
-        num_hidden_layers = num_hidden_layers,
-        num_attention_heads = num_attention_heads,
-        num_key_value_heads = num_key_value_heads,
-        tie_word_embeddings = tie_word_embeddings,
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        tie_word_embeddings=tie_word_embeddings,
     )
 
 
@@ -54,13 +54,13 @@ class TestEstimateFP16ModelSizeFromConfig(unittest.TestCase):
         from utils.hardware.hardware import _estimate_fp16_model_size_bytes_from_config
 
         config = _make_fake_config(
-            vocab_size = 128256,
-            hidden_size = 4096,
-            intermediate_size = 14336,
-            num_hidden_layers = 32,
-            num_attention_heads = 32,
-            num_key_value_heads = 8,
-            tie_word_embeddings = False,
+            vocab_size=128256,
+            hidden_size=4096,
+            intermediate_size=14336,
+            num_hidden_layers=32,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            tie_word_embeddings=False,
         )
         size = _estimate_fp16_model_size_bytes_from_config(config)
         self.assertIsNotNone(size)
@@ -73,12 +73,12 @@ class TestEstimateFP16ModelSizeFromConfig(unittest.TestCase):
         from utils.hardware.hardware import _estimate_fp16_model_size_bytes_from_config
 
         config = _make_fake_config(
-            vocab_size = 32000,
-            hidden_size = 2048,
-            intermediate_size = 5504,
-            num_hidden_layers = 22,
-            num_attention_heads = 32,
-            num_key_value_heads = 4,
+            vocab_size=32000,
+            hidden_size=2048,
+            intermediate_size=5504,
+            num_hidden_layers=22,
+            num_attention_heads=32,
+            num_key_value_heads=4,
         )
         size = _estimate_fp16_model_size_bytes_from_config(config)
         self.assertIsNotNone(size)
@@ -91,7 +91,7 @@ class TestEstimateFP16ModelSizeFromConfig(unittest.TestCase):
         from utils.hardware.hardware import _estimate_fp16_model_size_bytes_from_config
         from types import SimpleNamespace
 
-        config = SimpleNamespace(vocab_size = 32000)  # Missing most fields
+        config = SimpleNamespace(vocab_size=32000)  # Missing most fields
         size = _estimate_fp16_model_size_bytes_from_config(config)
         self.assertIsNone(size)
 
@@ -100,15 +100,15 @@ class TestEstimateFP16ModelSizeFromConfig(unittest.TestCase):
         from types import SimpleNamespace
 
         config = SimpleNamespace(
-            vocab_size = 152064,
-            hidden_size = 3584,
-            intermediate_size = 18944,
-            num_hidden_layers = 28,
-            num_attention_heads = 28,
-            num_key_value_heads = 4,
-            tie_word_embeddings = False,
-            num_local_experts = 64,
-            moe_intermediate_size = 2560,
+            vocab_size=152064,
+            hidden_size=3584,
+            intermediate_size=18944,
+            num_hidden_layers=28,
+            num_attention_heads=28,
+            num_key_value_heads=4,
+            tie_word_embeddings=False,
+            num_local_experts=64,
+            moe_intermediate_size=2560,
         )
         size = _estimate_fp16_model_size_bytes_from_config(config)
         self.assertIsNotNone(size)
@@ -125,15 +125,15 @@ class TestEstimateRequiredModelMemory(unittest.TestCase):
 
         with patch(
             "utils.hardware.hardware.estimate_fp16_model_size_bytes",
-            return_value = (10 * (1024**3), "config"),  # 10GB model
+            return_value=(10 * (1024**3), "config"),  # 10GB model
         ):
             required, meta = estimate_required_model_memory_gb(
                 "test/model",
-                training_type = None,  # inference
-                load_in_4bit = False,
+                training_type=None,  # inference
+                load_in_4bit=False,
             )
             self.assertIsNotNone(required)
-            self.assertAlmostEqual(required, 13.0, places = 0)
+            self.assertAlmostEqual(required, 13.0, places=0)
             self.assertEqual(meta["mode"], "inference")
 
     def test_inference_4bit_uses_reduced_estimate(self):
@@ -141,54 +141,54 @@ class TestEstimateRequiredModelMemory(unittest.TestCase):
 
         with patch(
             "utils.hardware.hardware.estimate_fp16_model_size_bytes",
-            return_value = (30 * (1024**3), "config"),  # 30GB fp16 model
+            return_value=(30 * (1024**3), "config"),  # 30GB fp16 model
         ):
             required, meta = estimate_required_model_memory_gb(
                 "test/model",
-                training_type = None,  # inference
-                load_in_4bit = True,
+                training_type=None,  # inference
+                load_in_4bit=True,
             )
             self.assertIsNotNone(required)
             # 4bit base = 30/3.2 = 9.375GB, required = 9.375 + max(9.375*0.3, 2) = 12.19GB
-            self.assertAlmostEqual(required, 12.2, places = 0)
+            self.assertAlmostEqual(required, 12.2, places=0)
 
     def test_4bit_training_reduces_base(self):
         from utils.hardware.hardware import estimate_required_model_memory_gb
 
         with patch(
             "utils.hardware.hardware.estimate_fp16_model_size_bytes",
-            return_value = (30 * (1024**3), "config"),  # 30GB fp16 model
+            return_value=(30 * (1024**3), "config"),  # 30GB fp16 model
         ):
             required, meta = estimate_required_model_memory_gb(
                 "test/model",
-                training_type = "LoRA/QLoRA",
-                load_in_4bit = True,
+                training_type="LoRA/QLoRA",
+                load_in_4bit=True,
             )
             self.assertIsNotNone(required)
             # fallback: base=30/3.2=9.375, lora=30*0.04=1.2, act=30*0.15=4.5, cuda=1.4
-            self.assertAlmostEqual(required, 16.5, places = 0)
+            self.assertAlmostEqual(required, 16.5, places=0)
 
     def test_full_finetune_uses_3_5x(self):
         from utils.hardware.hardware import estimate_required_model_memory_gb
 
         with patch(
             "utils.hardware.hardware.estimate_fp16_model_size_bytes",
-            return_value = (10 * (1024**3), "config"),  # 10GB model
+            return_value=(10 * (1024**3), "config"),  # 10GB model
         ):
             required, meta = estimate_required_model_memory_gb(
                 "test/model",
-                training_type = "Full Finetuning",
+                training_type="Full Finetuning",
             )
             self.assertIsNotNone(required)
             # fallback: 10 * 3.5 + 1.4 cuda overhead = 36.4
-            self.assertAlmostEqual(required, 36.4, places = 0)
+            self.assertAlmostEqual(required, 36.4, places=0)
 
     def test_returns_none_when_unavailable(self):
         from utils.hardware.hardware import estimate_required_model_memory_gb
 
         with patch(
             "utils.hardware.hardware.estimate_fp16_model_size_bytes",
-            return_value = (None, "unavailable"),
+            return_value=(None, "unavailable"),
         ):
             required, meta = estimate_required_model_memory_gb("test/model")
             self.assertIsNone(required)
@@ -216,11 +216,11 @@ class TestAutoSelectGpuIds(unittest.TestCase):
         import utils.hardware.hardware as hw
 
         with (
-            patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA),
+            patch.object(hw, "get_device", return_value=hw.DeviceType.CUDA),
             patch.object(
                 hw,
                 "estimate_required_model_memory_gb",
-                return_value = (
+                return_value=(
                     10.0,
                     {
                         "mode": "inference",
@@ -233,17 +233,17 @@ class TestAutoSelectGpuIds(unittest.TestCase):
             patch.object(
                 hw,
                 "_get_parent_visible_gpu_spec",
-                return_value = {
+                return_value={
                     "raw": "0,1,2,3",
                     "numeric_ids": [0, 1, 2, 3],
                     "supports_explicit_gpu_ids": True,
                 },
             ),
-            patch.object(hw, "get_parent_visible_gpu_ids", return_value = [0, 1, 2, 3]),
+            patch.object(hw, "get_parent_visible_gpu_ids", return_value=[0, 1, 2, 3]),
             patch.object(
                 hw,
                 "get_visible_gpu_utilization",
-                return_value = self._make_utilization(
+                return_value=self._make_utilization(
                     [
                         (0, 80.0, 75.0),
                         (1, 80.0, 78.0),
@@ -263,11 +263,11 @@ class TestAutoSelectGpuIds(unittest.TestCase):
         import utils.hardware.hardware as hw
 
         with (
-            patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA),
+            patch.object(hw, "get_device", return_value=hw.DeviceType.CUDA),
             patch.object(
                 hw,
                 "estimate_required_model_memory_gb",
-                return_value = (
+                return_value=(
                     50.0,
                     {
                         "mode": "inference",
@@ -280,17 +280,17 @@ class TestAutoSelectGpuIds(unittest.TestCase):
             patch.object(
                 hw,
                 "_get_parent_visible_gpu_spec",
-                return_value = {
+                return_value={
                     "raw": "0,1",
                     "numeric_ids": [0, 1],
                     "supports_explicit_gpu_ids": True,
                 },
             ),
-            patch.object(hw, "get_parent_visible_gpu_ids", return_value = [0, 1]),
+            patch.object(hw, "get_parent_visible_gpu_ids", return_value=[0, 1]),
             patch.object(
                 hw,
                 "get_visible_gpu_utilization",
-                return_value = self._make_utilization(
+                return_value=self._make_utilization(
                     [
                         (0, 40.0, 30.0),  # 30GB free
                         (1, 40.0, 35.0),  # 35GB free
@@ -306,7 +306,7 @@ class TestAutoSelectGpuIds(unittest.TestCase):
         from utils.hardware.hardware import auto_select_gpu_ids
         import utils.hardware.hardware as hw
 
-        with patch.object(hw, "get_device", return_value = hw.DeviceType.CPU):
+        with patch.object(hw, "get_device", return_value=hw.DeviceType.CPU):
             selected, meta = auto_select_gpu_ids("test/model")
             self.assertIsNone(selected)
             self.assertEqual(meta["selection_mode"], "non_cuda")
@@ -320,35 +320,35 @@ class TestGetDeviceMap(unittest.TestCase):
         import utils.hardware.hardware as hw
 
         with (
-            patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA),
+            patch.object(hw, "get_device", return_value=hw.DeviceType.CUDA),
             patch.object(
                 hw,
                 "_get_parent_visible_gpu_spec",
-                return_value = {
+                return_value={
                     "raw": "0",
                     "numeric_ids": [0],
                     "supports_explicit_gpu_ids": True,
                 },
             ),
-            patch.object(hw, "get_visible_gpu_count", return_value = 1),
+            patch.object(hw, "get_visible_gpu_count", return_value=1),
         ):
-            dm = get_device_map(gpu_ids = [0])
+            dm = get_device_map(gpu_ids=[0])
             self.assertEqual(dm, "sequential")
 
     def test_multi_gpu_returns_balanced(self):
         from utils.hardware.hardware import get_device_map
         import utils.hardware.hardware as hw
 
-        with patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA):
-            dm = get_device_map(gpu_ids = [0, 1])
+        with patch.object(hw, "get_device", return_value=hw.DeviceType.CUDA):
+            dm = get_device_map(gpu_ids=[0, 1])
             self.assertEqual(dm, "balanced")
 
     def test_cpu_returns_sequential(self):
         from utils.hardware.hardware import get_device_map
         import utils.hardware.hardware as hw
 
-        with patch.object(hw, "get_device", return_value = hw.DeviceType.CPU):
-            dm = get_device_map(gpu_ids = None)
+        with patch.object(hw, "get_device", return_value=hw.DeviceType.CPU):
+            dm = get_device_map(gpu_ids=None)
             self.assertEqual(dm, "sequential")
 
 
@@ -359,8 +359,8 @@ class TestResolveRequestedGpuIds(unittest.TestCase):
         from utils.hardware.hardware import resolve_requested_gpu_ids
 
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "2,3"}, clear = False),
-            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "2,3"}, clear=False),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value=8),
         ):
             result = resolve_requested_gpu_ids(None)
             self.assertEqual(result, [2, 3])
@@ -369,8 +369,8 @@ class TestResolveRequestedGpuIds(unittest.TestCase):
         from utils.hardware.hardware import resolve_requested_gpu_ids
 
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "2,3"}, clear = False),
-            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "2,3"}, clear=False),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value=8),
         ):
             result = resolve_requested_gpu_ids([])
             self.assertEqual(result, [2, 3])
@@ -379,8 +379,8 @@ class TestResolveRequestedGpuIds(unittest.TestCase):
         from utils.hardware.hardware import resolve_requested_gpu_ids
 
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1,2"}, clear = False),
-            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1,2"}, clear=False),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value=8),
         ):
             with self.assertRaises(ValueError):
                 resolve_requested_gpu_ids([1, 1])
@@ -389,8 +389,8 @@ class TestResolveRequestedGpuIds(unittest.TestCase):
         from utils.hardware.hardware import resolve_requested_gpu_ids
 
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}, clear = False),
-            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 4),
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}, clear=False),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value=4),
         ):
             with self.assertRaises(ValueError):
                 resolve_requested_gpu_ids([5])
@@ -400,9 +400,9 @@ class TestResolveRequestedGpuIds(unittest.TestCase):
 
         with (
             patch.dict(
-                os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-abc,GPU-def"}, clear = False
+                os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-abc,GPU-def"}, clear=False
             ),
-            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value=8),
         ):
             with self.assertRaises(ValueError):
                 resolve_requested_gpu_ids([0])
@@ -414,7 +414,7 @@ class TestApplyGpuIds(unittest.TestCase):
     def test_apply_list(self):
         from utils.hardware.hardware import apply_gpu_ids
 
-        with patch.dict(os.environ, {}, clear = False):
+        with patch.dict(os.environ, {}, clear=False):
             apply_gpu_ids([3, 5])
             self.assertEqual(os.environ.get("CUDA_VISIBLE_DEVICES"), "3,5")
 
@@ -453,11 +453,11 @@ class TestMultiGpuOverheadAccounting(unittest.TestCase):
 
         # Model requires 79GB, GPU has 80GB free
         with (
-            patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA),
+            patch.object(hw, "get_device", return_value=hw.DeviceType.CUDA),
             patch.object(
                 hw,
                 "estimate_required_model_memory_gb",
-                return_value = (
+                return_value=(
                     79.0,
                     {
                         "mode": "inference",
@@ -470,17 +470,17 @@ class TestMultiGpuOverheadAccounting(unittest.TestCase):
             patch.object(
                 hw,
                 "_get_parent_visible_gpu_spec",
-                return_value = {
+                return_value={
                     "raw": "0,1",
                     "numeric_ids": [0, 1],
                     "supports_explicit_gpu_ids": True,
                 },
             ),
-            patch.object(hw, "get_parent_visible_gpu_ids", return_value = [0, 1]),
+            patch.object(hw, "get_parent_visible_gpu_ids", return_value=[0, 1]),
             patch.object(
                 hw,
                 "get_visible_gpu_utilization",
-                return_value = self._make_utilization(
+                return_value=self._make_utilization(
                     [
                         (0, 80.0, 80.0),
                         (1, 80.0, 80.0),
@@ -500,11 +500,11 @@ class TestMultiGpuOverheadAccounting(unittest.TestCase):
         # Model requires 110GB. First GPU has 80GB, second has 40GB.
         # With overhead: 80 + 40*0.85 = 114GB -- just enough
         with (
-            patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA),
+            patch.object(hw, "get_device", return_value=hw.DeviceType.CUDA),
             patch.object(
                 hw,
                 "estimate_required_model_memory_gb",
-                return_value = (
+                return_value=(
                     110.0,
                     {
                         "mode": "inference",
@@ -517,17 +517,17 @@ class TestMultiGpuOverheadAccounting(unittest.TestCase):
             patch.object(
                 hw,
                 "_get_parent_visible_gpu_spec",
-                return_value = {
+                return_value={
                     "raw": "0,1",
                     "numeric_ids": [0, 1],
                     "supports_explicit_gpu_ids": True,
                 },
             ),
-            patch.object(hw, "get_parent_visible_gpu_ids", return_value = [0, 1]),
+            patch.object(hw, "get_parent_visible_gpu_ids", return_value=[0, 1]),
             patch.object(
                 hw,
                 "get_visible_gpu_utilization",
-                return_value = self._make_utilization(
+                return_value=self._make_utilization(
                     [
                         (0, 80.0, 80.0),
                         (1, 80.0, 40.0),

--- a/studio/backend/tests/test_kv_cache_estimation.py
+++ b/studio/backend/tests/test_kv_cache_estimation.py
@@ -116,7 +116,7 @@ def _backend_from_gguf(arch: str, fields: dict) -> LlamaCppBackend:
     import tempfile, os
 
     data = _make_gguf_bytes(arch, kv)
-    fd, path = tempfile.mkstemp(suffix = ".gguf")
+    fd, path = tempfile.mkstemp(suffix=".gguf")
     try:
         os.write(fd, data)
         os.close(fd)
@@ -221,7 +221,7 @@ class TestGGUFParserReset:
         import tempfile, os
 
         data = _make_gguf_bytes("arch2", kv)
-        fd, path = tempfile.mkstemp(suffix = ".gguf")
+        fd, path = tempfile.mkstemp(suffix=".gguf")
         os.write(fd, data)
         os.close(fd)
         try:
@@ -335,7 +335,7 @@ class TestMLAEstimation:
 
     def test_mla_fallback_when_no_key_length(self):
         """If key_length is missing, fallback to kv_lora_rank + key_length_mla."""
-        b = self._mla_backend(_kv_key_length = None)
+        b = self._mla_backend(_kv_key_length=None)
         # _key_length_mla=192 in default, so rope_dim=192
         result = b._estimate_kv_cache_bytes(1000, "f16")
         expected = 61 * 1000 * 1 * (512 + 192) * 2  # 704
@@ -343,14 +343,14 @@ class TestMLAEstimation:
 
     def test_mla_fallback_no_key_length_mla(self):
         """If both key_length and key_length_mla are missing, fallback to +64."""
-        b = self._mla_backend(_kv_key_length = None, _key_length_mla = None)
+        b = self._mla_backend(_kv_key_length=None, _key_length_mla=None)
         result = b._estimate_kv_cache_bytes(1000, "f16")
         expected = 61 * 1000 * 1 * (512 + 64) * 2  # 576
         assert result == expected
 
     def test_mla_defaults_n_kv_to_1_when_heads_absent(self):
         """MLA should use n_kv=1 even if n_kv_heads is None (not n_heads)."""
-        b = self._mla_backend(_n_kv_heads = None)  # n_heads=128 still set
+        b = self._mla_backend(_n_kv_heads=None)  # n_heads=128 still set
         result = b._estimate_kv_cache_bytes(1000, "f16")
         # Should use n_kv_mla=1, NOT n_heads=128
         expected = 61 * 1000 * 1 * 576 * 2
@@ -399,11 +399,11 @@ class TestHybridMambaEstimation:
 
     def test_qwen35_35b_a3b(self):
         b = self._hybrid_backend(
-            _n_layers = 40,
-            _n_kv_heads = 2,
-            _n_heads = 16,
-            _embedding_length = 2048,
-            _ssm_inner_size = 4096,
+            _n_layers=40,
+            _n_kv_heads=2,
+            _n_heads=16,
+            _embedding_length=2048,
+            _ssm_inner_size=4096,
         )
         # n_attn = 40 // 4 = 10
         expected = 10 * 262144 * 2 * (256 + 256) * 2
@@ -411,14 +411,14 @@ class TestHybridMambaEstimation:
 
     def test_hybrid_without_explicit_dims(self):
         """Fallback to head_dim when key_length/value_length are missing."""
-        b = self._hybrid_backend(_kv_key_length = None, _kv_value_length = None)
+        b = self._hybrid_backend(_kv_key_length=None, _kv_value_length=None)
         head_dim = 5120 // 24  # 213
         expected = 16 * 4096 * 4 * 2 * head_dim * 2
         assert b._estimate_kv_cache_bytes(4096, "f16") == expected
 
     def test_fai_zero_safety(self):
         """full_attention_interval=0 should not cause ZeroDivisionError."""
-        b = self._hybrid_backend(_full_attention_interval = 0)
+        b = self._hybrid_backend(_full_attention_interval=0)
         result = b._estimate_kv_cache_bytes(4096, "f16")
         # fai=0 -> n_attn = n_layers (all layers)
         expected = 64 * 4096 * 4 * (256 + 256) * 2
@@ -460,13 +460,13 @@ class TestSlidingWindowEstimation:
 
     def test_gpt_oss(self):
         b = self._swa_backend(
-            _n_layers = 24,
-            _n_kv_heads = 8,
-            _n_heads = 64,
-            _embedding_length = 2880,
-            _kv_key_length = 64,
-            _kv_value_length = 64,
-            _sliding_window = 128,
+            _n_layers=24,
+            _n_kv_heads=8,
+            _n_heads=64,
+            _embedding_length=2880,
+            _kv_key_length=64,
+            _kv_value_length=64,
+            _sliding_window=128,
         )
         # 1/4 heuristic: 24 // 4 = 6 global, 18 SWA
         n_global = max(1, 24 // 4)  # 6
@@ -477,7 +477,7 @@ class TestSlidingWindowEstimation:
 
     def test_ctx_smaller_than_window(self):
         """When context < sliding_window, SWA layers use full context anyway."""
-        b = self._swa_backend(_sliding_window = 8192)
+        b = self._swa_backend(_sliding_window=8192)
         n_global = max(1, 62 // 4)  # 15
         n_swa = 62 - n_global  # 47
         kv_per = 16 * (128 + 128) * 2
@@ -488,7 +488,7 @@ class TestSlidingWindowEstimation:
 
     def test_odd_layer_count(self):
         """Odd layer count: n_global = max(1, n//4), n_swa = n - n_global."""
-        b = self._swa_backend(_n_layers = 63)
+        b = self._swa_backend(_n_layers=63)
         n_global = max(1, 63 // 4)  # 15
         n_swa = 63 - n_global  # 48
         kv_per = 16 * (128 + 128) * 2
@@ -526,7 +526,7 @@ class TestStandardGQAEstimation:
 
     def test_asymmetric_kv_dims(self):
         """key_length != value_length (some architectures have this)."""
-        b = self._gqa_backend(_kv_key_length = 192, _kv_value_length = 64)
+        b = self._gqa_backend(_kv_key_length=192, _kv_value_length=64)
         expected = 28 * 4096 * 8 * (192 + 64) * 2
         assert b._estimate_kv_cache_bytes(4096, "f16") == expected
 
@@ -571,7 +571,7 @@ class TestLegacyEstimation:
 
     def test_legacy_with_only_n_heads(self):
         """n_kv_heads is None, falls back to n_heads."""
-        b = self._legacy_backend(_n_kv_heads = None)
+        b = self._legacy_backend(_n_kv_heads=None)
         head_dim = 4096 // 32
         expected = int(2 * 32 * head_dim * 32 * 4096 * 2)
         assert b._estimate_kv_cache_bytes(4096, "f16") == expected

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -95,12 +95,12 @@ FALLBACK_CTX = 4096
 
 
 def _make_backend(
-    native_ctx = 131072,
-    n_layers = 80,
-    n_kv_heads = 8,
-    n_heads = 64,
-    kv_key_length = 128,
-    kv_value_length = 128,
+    native_ctx=131072,
+    n_layers=80,
+    n_kv_heads=8,
+    n_heads=64,
+    kv_key_length=128,
+    kv_value_length=128,
 ):
     """Create a LlamaCppBackend instance with GGUF metadata fields set and
     the helpers used by the decision block stubbed out."""
@@ -124,20 +124,20 @@ def _drive(
     n_ctx,
     model_gib,
     gpus,
-    native_ctx = 131072,
-    kv_per_token_bytes = 325_000,
-    can_estimate_kv = True,
+    native_ctx=131072,
+    kv_per_token_bytes=325_000,
+    can_estimate_kv=True,
 ):
     """Drive the post-metadata portion of load_model with stubbed inputs.
 
     Mirrors the decision block at llama_cpp.py:1137-1296 so we can assert
     the command that would be built, without subprocesses or GPU probes.
     """
-    inst = _make_backend(native_ctx = native_ctx)
+    inst = _make_backend(native_ctx=native_ctx)
     model_size = int(model_gib * GIB)
     cache_type_kv = None
 
-    def fake_estimate(n_ctx_, _type = None):
+    def fake_estimate(n_ctx_, _type=None):
         return 0 if n_ctx_ <= 0 else n_ctx_ * kv_per_token_bytes
 
     inst._estimate_kv_cache_bytes = fake_estimate
@@ -162,7 +162,7 @@ def _drive(
     if gpus and inst._can_estimate_kv() and effective_ctx > 0:
         native_ctx_for_cap = context_length or effective_ctx
         if native_ctx_for_cap > 0:
-            ranked_for_cap = sorted(gpus, key = lambda g: g[1], reverse = True)
+            ranked_for_cap = sorted(gpus, key=lambda g: g[1], reverse=True)
             best_cap = 0
             for n_gpus in range(1, len(ranked_for_cap) + 1):
                 subset = ranked_for_cap[:n_gpus]
@@ -186,7 +186,7 @@ def _drive(
             )
             gpu_indices, use_fit = inst._select_gpus(requested_total, gpus)
         else:
-            ranked = sorted(gpus, key = lambda g: g[1], reverse = True)
+            ranked = sorted(gpus, key=lambda g: g[1], reverse=True)
             matched = False
             for n_gpus in range(1, len(ranked) + 1):
                 subset = ranked[:n_gpus]
@@ -233,10 +233,10 @@ class TestAutoModeWeightsExceedVRAM:
 
     def test_minimax_like_single_gpu(self):
         plan = _drive(
-            n_ctx = 0,
-            model_gib = 131,
-            gpus = [(0, 97_000)],
-            native_ctx = 196608,
+            n_ctx=0,
+            model_gib=131,
+            gpus=[(0, 97_000)],
+            native_ctx=196608,
         )
         assert plan["c_arg"] == FALLBACK_CTX
         assert plan["use_fit"] is True
@@ -247,10 +247,10 @@ class TestAutoModeWeightsExceedVRAM:
 
     def test_multi_gpu_all_subsets_fail(self):
         plan = _drive(
-            n_ctx = 0,
-            model_gib = 400,
-            gpus = [(0, 80_000), (1, 80_000), (2, 80_000), (3, 80_000)],
-            native_ctx = 131072,
+            n_ctx=0,
+            model_gib=400,
+            gpus=[(0, 80_000), (1, 80_000), (2, 80_000), (3, 80_000)],
+            native_ctx=131072,
         )
         assert plan["c_arg"] == FALLBACK_CTX
         assert plan["use_fit"] is True
@@ -259,11 +259,11 @@ class TestAutoModeWeightsExceedVRAM:
     def test_no_kv_metadata_auto(self):
         """File-size-only fallback path also defaults to 4096."""
         plan = _drive(
-            n_ctx = 0,
-            model_gib = 131,
-            gpus = [(0, 97_000)],
-            native_ctx = 196608,
-            can_estimate_kv = False,
+            n_ctx=0,
+            model_gib=131,
+            gpus=[(0, 97_000)],
+            native_ctx=196608,
+            can_estimate_kv=False,
         )
         assert plan["c_arg"] == FALLBACK_CTX
         assert plan["use_fit"] is True
@@ -282,10 +282,10 @@ class TestExplicitCtxRespectsUser:
         # Budget = 21.6 GB, KV at 131k >> 13.6 GB remaining, so
         # _select_gpus flips use_fit=True.
         plan = _drive(
-            n_ctx = 131072,
-            model_gib = 8,
-            gpus = [(0, 24_000)],
-            native_ctx = 131072,
+            n_ctx=131072,
+            model_gib=8,
+            gpus=[(0, 24_000)],
+            native_ctx=131072,
         )
         assert plan["c_arg"] == 131072
         assert plan["use_fit"] is True
@@ -293,10 +293,10 @@ class TestExplicitCtxRespectsUser:
 
     def test_explicit_that_fits_uses_ngl(self):
         plan = _drive(
-            n_ctx = 8192,
-            model_gib = 8,
-            gpus = [(0, 24_000)],
-            native_ctx = 131072,
+            n_ctx=8192,
+            model_gib=8,
+            gpus=[(0, 24_000)],
+            native_ctx=131072,
         )
         assert plan["c_arg"] == 8192
         assert plan["use_fit"] is False
@@ -305,20 +305,20 @@ class TestExplicitCtxRespectsUser:
     def test_explicit_on_weights_exceed_vram(self):
         # User drags the slider to 32k on a too-big model: honored.
         plan = _drive(
-            n_ctx = 32768,
-            model_gib = 131,
-            gpus = [(0, 97_000)],
-            native_ctx = 196608,
+            n_ctx=32768,
+            model_gib=131,
+            gpus=[(0, 97_000)],
+            native_ctx=196608,
         )
         assert plan["c_arg"] == 32768
         assert plan["use_fit"] is True
 
     def test_explicit_at_fallback_on_too_big(self):
         plan = _drive(
-            n_ctx = FALLBACK_CTX,
-            model_gib = 131,
-            gpus = [(0, 97_000)],
-            native_ctx = 196608,
+            n_ctx=FALLBACK_CTX,
+            model_gib=131,
+            gpus=[(0, 97_000)],
+            native_ctx=196608,
         )
         assert plan["c_arg"] == FALLBACK_CTX
         assert plan["use_fit"] is True
@@ -326,9 +326,9 @@ class TestExplicitCtxRespectsUser:
     def test_explicit_below_floor_honored(self):
         # 2048 is below --fit-ctx default; still honored since user set it.
         plan = _drive(
-            n_ctx = 2048,
-            model_gib = 8,
-            gpus = [(0, 24_000)],
+            n_ctx=2048,
+            model_gib=8,
+            gpus=[(0, 24_000)],
         )
         assert plan["c_arg"] == 2048
 
@@ -341,11 +341,11 @@ class TestExplicitCtxRespectsUser:
 class TestFittableAutoPickRegressions:
     def test_small_model_one_gpu(self):
         plan = _drive(
-            n_ctx = 0,
-            model_gib = 8,
-            gpus = [(0, 24_000)],
-            native_ctx = 131072,
-            kv_per_token_bytes = 8192,
+            n_ctx=0,
+            model_gib=8,
+            gpus=[(0, 24_000)],
+            native_ctx=131072,
+            kv_per_token_bytes=8192,
         )
         assert plan["use_fit"] is False
         assert plan["gpu_indices"] == [0]
@@ -353,22 +353,22 @@ class TestFittableAutoPickRegressions:
 
     def test_medium_model_needs_multi_gpu(self):
         plan = _drive(
-            n_ctx = 0,
-            model_gib = 60,
-            gpus = [(0, 40_000), (1, 40_000)],
-            native_ctx = 131072,
-            kv_per_token_bytes = 8192,
+            n_ctx=0,
+            model_gib=60,
+            gpus=[(0, 40_000), (1, 40_000)],
+            native_ctx=131072,
+            kv_per_token_bytes=8192,
         )
         assert plan["use_fit"] is False
         assert plan["gpu_indices"] == [0, 1]
 
     def test_no_kv_metadata_fittable_auto(self):
         plan = _drive(
-            n_ctx = 0,
-            model_gib = 8,
-            gpus = [(0, 24_000)],
-            native_ctx = 131072,
-            can_estimate_kv = False,
+            n_ctx=0,
+            model_gib=8,
+            gpus=[(0, 24_000)],
+            native_ctx=131072,
+            can_estimate_kv=False,
         )
         assert plan["use_fit"] is False
         assert plan["gpu_indices"] == [0]
@@ -384,6 +384,6 @@ def test_identical_decision_across_platforms(platform_tag):
     """The decision function takes ``[(gpu_idx, free_mib), ...]`` regardless
     of how upstream (nvidia-smi / nvidia-smi.exe / Metal / rocm-smi) produced
     it. Identical inputs must yield identical plans."""
-    plan_a = _drive(n_ctx = 0, model_gib = 8, gpus = [(0, 24_000)])
-    plan_b = _drive(n_ctx = 0, model_gib = 8, gpus = [(0, 24_000)])
+    plan_a = _drive(n_ctx=0, model_gib=8, gpus=[(0, 24_000)])
+    plan_b = _drive(n_ctx=0, model_gib=8, gpus=[(0, 24_000)])
     assert plan_a == plan_b, platform_tag

--- a/studio/backend/tests/test_llama_cpp_load_progress.py
+++ b/studio/backend/tests/test_llama_cpp_load_progress.py
@@ -131,7 +131,7 @@ class TestLoadProgressEmptyStates:
 
     def test_returns_none_when_process_has_no_pid(self):
         inst = _make_instance()
-        inst._process = _FakeProc(pid = None)  # type: ignore[arg-type]
+        inst._process = _FakeProc(pid=None)  # type: ignore[arg-type]
         assert inst.load_progress() is None
 
 
@@ -142,7 +142,7 @@ class TestLoadProgressSingleShard:
         _write_sparse_file(gguf, 40 * 1024**3)  # 40 GB
 
         inst = _make_instance()
-        inst._process = _FakeProc(pid = os.getpid())  # use our own pid
+        inst._process = _FakeProc(pid=os.getpid())  # use our own pid
         inst._gguf_path = str(gguf)
         inst._healthy = False
 
@@ -154,7 +154,7 @@ class TestLoadProgressSingleShard:
                 return io.StringIO(f"Name:\ttest\nVmRSS:\t{10 * 1024 ** 2}\tkB\n")
             return open(path, *args, **kwargs)  # fall through
 
-        with patch("builtins.open", side_effect = fake_open):
+        with patch("builtins.open", side_effect=fake_open):
             out = inst.load_progress()
 
         assert out is not None
@@ -168,7 +168,7 @@ class TestLoadProgressSingleShard:
         _write_sparse_file(gguf, 8 * 1024**3)
 
         inst = _make_instance()
-        inst._process = _FakeProc(pid = os.getpid())
+        inst._process = _FakeProc(pid=os.getpid())
         inst._gguf_path = str(gguf)
         inst._healthy = True
 
@@ -179,7 +179,7 @@ class TestLoadProgressSingleShard:
                 return io.StringIO(f"VmRSS:\t{8 * 1024 ** 2}\tkB\n")
             return open(path, *args, **kwargs)
 
-        with patch("builtins.open", side_effect = fake_open):
+        with patch("builtins.open", side_effect=fake_open):
             out = inst.load_progress()
 
         assert out is not None
@@ -197,13 +197,13 @@ class TestLoadProgressMultiShard:
         for i in range(1, 5):
             _write_sparse_file(
                 tmp_path / f"model-{i:05d}-of-00004.gguf",
-                size_bytes = 20 * 1024**3,
+                size_bytes=20 * 1024**3,
             )
         # Drop an unrelated .gguf in the same folder -- must not be counted.
         _write_sparse_file(tmp_path / "mmproj-BF16.gguf", 2 * 1024**3)
 
         inst = _make_instance()
-        inst._process = _FakeProc(pid = os.getpid())
+        inst._process = _FakeProc(pid=os.getpid())
         inst._gguf_path = str(tmp_path / "model-00001-of-00004.gguf")
         inst._healthy = False
 
@@ -214,7 +214,7 @@ class TestLoadProgressMultiShard:
                 return io.StringIO("VmRSS:\t0\tkB\n")
             return open(path, *args, **kwargs)
 
-        with patch("builtins.open", side_effect = fake_open):
+        with patch("builtins.open", side_effect=fake_open):
             out = inst.load_progress()
 
         assert out is not None
@@ -226,7 +226,7 @@ class TestLoadProgressDegradation:
 
     def test_missing_gguf_path_still_reports_rss(self, tmp_path):
         inst = _make_instance()
-        inst._process = _FakeProc(pid = os.getpid())
+        inst._process = _FakeProc(pid=os.getpid())
         inst._gguf_path = None
         inst._healthy = False
 
@@ -237,7 +237,7 @@ class TestLoadProgressDegradation:
                 return io.StringIO("VmRSS:\t1024\tkB\n")
             return open(path, *args, **kwargs)
 
-        with patch("builtins.open", side_effect = fake_open):
+        with patch("builtins.open", side_effect=fake_open):
             out = inst.load_progress()
 
         assert out is not None
@@ -249,7 +249,7 @@ class TestLoadProgressDegradation:
     def test_unreadable_proc_returns_none(self, tmp_path):
         inst = _make_instance()
         # Pid that doesn't exist -> /proc read fails.
-        inst._process = _FakeProc(pid = 999_999_999)
+        inst._process = _FakeProc(pid=999_999_999)
         inst._gguf_path = str(tmp_path / "model.gguf")  # doesn't need to exist
         inst._healthy = False
 

--- a/studio/backend/tests/test_llama_cpp_max_context_threshold.py
+++ b/studio/backend/tests/test_llama_cpp_max_context_threshold.py
@@ -88,7 +88,7 @@ from core.inference.llama_cpp import LlamaCppBackend
 GIB = 1024**3
 
 
-def _make_backend(native_ctx = 131072):
+def _make_backend(native_ctx=131072):
     inst = LlamaCppBackend.__new__(LlamaCppBackend)
     inst._context_length = native_ctx
     inst._n_layers = 80
@@ -105,16 +105,16 @@ def _make_backend(native_ctx = 131072):
     return inst
 
 
-def _compute_max_available_ctx(native_ctx, model_gib, gpus, kv_per_token_bytes = 325_000):
+def _compute_max_available_ctx(native_ctx, model_gib, gpus, kv_per_token_bytes=325_000):
     """Run the ceiling-probe block from load_model and return the final
     ``max_available_ctx`` value the backend would assign to
     ``_max_context_length``.
     """
-    inst = _make_backend(native_ctx = native_ctx)
+    inst = _make_backend(native_ctx=native_ctx)
     model_size = int(model_gib * GIB)
 
     inst._estimate_kv_cache_bytes = (
-        lambda n, _t = None: 0 if n <= 0 else n * kv_per_token_bytes
+        lambda n, _t=None: 0 if n <= 0 else n * kv_per_token_bytes
     )
     inst._can_estimate_kv = lambda: True
 
@@ -125,7 +125,7 @@ def _compute_max_available_ctx(native_ctx, model_gib, gpus, kv_per_token_bytes =
     cache_type_kv = None
     native_ctx_for_cap = context_length
 
-    ranked_for_cap = sorted(gpus, key = lambda g: g[1], reverse = True)
+    ranked_for_cap = sorted(gpus, key=lambda g: g[1], reverse=True)
     best_cap = 0
     for n_gpus in range(1, len(ranked_for_cap) + 1):
         subset = ranked_for_cap[:n_gpus]
@@ -161,18 +161,18 @@ class TestMaxContextLengthForWeightsExceedVRAM:
     def test_minimax_like(self):
         """131 GB weights, single 97 GB GPU, native ctx 196608."""
         got = _compute_max_available_ctx(
-            native_ctx = 196608,
-            model_gib = 131,
-            gpus = [(0, 97_000)],
+            native_ctx=196608,
+            model_gib=131,
+            gpus=[(0, 97_000)],
         )
         assert got == 4096
 
     def test_multi_gpu_all_subsets_fail(self):
         """400 GB weights across a 4x80 GB pool (320 GB total, still too small)."""
         got = _compute_max_available_ctx(
-            native_ctx = 131072,
-            model_gib = 400,
-            gpus = [(0, 80_000), (1, 80_000), (2, 80_000), (3, 80_000)],
+            native_ctx=131072,
+            model_gib=400,
+            gpus=[(0, 80_000), (1, 80_000), (2, 80_000), (3, 80_000)],
         )
         assert got == 4096
 
@@ -180,9 +180,9 @@ class TestMaxContextLengthForWeightsExceedVRAM:
         """If the model's native ctx is itself smaller than 4096, do not
         advertise a larger value than the model supports."""
         got = _compute_max_available_ctx(
-            native_ctx = 2048,
-            model_gib = 200,
-            gpus = [(0, 80_000)],
+            native_ctx=2048,
+            model_gib=200,
+            gpus=[(0, 80_000)],
         )
         assert got == 2048
 
@@ -198,10 +198,10 @@ class TestMaxContextLengthForFittableModels:
     def test_small_model_fits_easily(self):
         """8 GB model on 24 GB GPU: should auto-pick a large ctx."""
         got = _compute_max_available_ctx(
-            native_ctx = 131072,
-            model_gib = 8,
-            gpus = [(0, 24_000)],
-            kv_per_token_bytes = 8192,
+            native_ctx=131072,
+            model_gib=8,
+            gpus=[(0, 24_000)],
+            kv_per_token_bytes=8192,
         )
         assert got > 4096
         assert got <= 131072
@@ -209,20 +209,20 @@ class TestMaxContextLengthForFittableModels:
     def test_medium_model_multi_gpu(self):
         """60 GB model split across 2 GPUs: picks a fitting ctx."""
         got = _compute_max_available_ctx(
-            native_ctx = 131072,
-            model_gib = 60,
-            gpus = [(0, 40_000), (1, 40_000)],
-            kv_per_token_bytes = 8192,
+            native_ctx=131072,
+            model_gib=60,
+            gpus=[(0, 40_000), (1, 40_000)],
+            kv_per_token_bytes=8192,
         )
         assert got > 4096
 
     def test_tiny_model_on_huge_gpu_near_native(self):
         """2 GB model, 80 GB GPU, negligible KV: should approach native."""
         got = _compute_max_available_ctx(
-            native_ctx = 131072,
-            model_gib = 2,
-            gpus = [(0, 80_000)],
-            kv_per_token_bytes = 64,
+            native_ctx=131072,
+            model_gib=2,
+            gpus=[(0, 80_000)],
+            kv_per_token_bytes=64,
         )
         assert got >= 131072 - 256  # rounded to 256 boundary
 
@@ -234,11 +234,11 @@ class TestMaxContextLengthForFittableModels:
 
 class TestMaxContextLengthProperty:
     def test_falls_back_to_native_when_unset(self):
-        inst = _make_backend(native_ctx = 131072)
+        inst = _make_backend(native_ctx=131072)
         inst._max_context_length = None
         assert inst.max_context_length == 131072
 
     def test_returns_stored_value_when_set(self):
-        inst = _make_backend(native_ctx = 131072)
+        inst = _make_backend(native_ctx=131072)
         inst._max_context_length = 4096
         assert inst.max_context_length == 4096

--- a/studio/backend/tests/test_llama_cpp_no_context_shift.py
+++ b/studio/backend/tests/test_llama_cpp_no_context_shift.py
@@ -132,6 +132,6 @@ def test_flag_sits_inside_the_base_cmd_list():
 def _iter_lines_with_offset(text: str):
     """Yield (offset, line) pairs over ``text`` without losing offsets."""
     offset = 0
-    for line in text.splitlines(keepends = True):
+    for line in text.splitlines(keepends=True):
         yield offset, line
         offset += len(line)

--- a/studio/backend/tests/test_responses_api.py
+++ b/studio/backend/tests/test_responses_api.py
@@ -45,12 +45,12 @@ def _normalise_responses_input(payload: ResponsesRequest) -> list:
 
     # System / developer instructions
     if payload.instructions:
-        messages.append(ChatMessage(role = "system", content = payload.instructions))
+        messages.append(ChatMessage(role="system", content=payload.instructions))
 
     # Simple string input
     if isinstance(payload.input, str):
         if payload.input:
-            messages.append(ChatMessage(role = "user", content = payload.input))
+            messages.append(ChatMessage(role="user", content=payload.input))
         return messages
 
     # List of ResponsesInputMessage
@@ -58,21 +58,21 @@ def _normalise_responses_input(payload: ResponsesRequest) -> list:
         role = "system" if msg.role == "developer" else msg.role
 
         if isinstance(msg.content, str):
-            messages.append(ChatMessage(role = role, content = msg.content))
+            messages.append(ChatMessage(role=role, content=msg.content))
         else:
             # Convert Responses content parts -> Chat content parts
             parts = []
             for part in msg.content:
                 if isinstance(part, ResponsesInputTextPart):
-                    parts.append(TextContentPart(type = "text", text = part.text))
+                    parts.append(TextContentPart(type="text", text=part.text))
                 elif isinstance(part, ResponsesInputImagePart):
                     parts.append(
                         ImageContentPart(
-                            type = "image_url",
-                            image_url = ImageUrl(url = part.image_url, detail = part.detail),
+                            type="image_url",
+                            image_url=ImageUrl(url=part.image_url, detail=part.detail),
                         )
                     )
-            messages.append(ChatMessage(role = role, content = parts if parts else ""))
+            messages.append(ChatMessage(role=role, content=parts if parts else ""))
 
     return messages
 
@@ -86,14 +86,14 @@ class TestResponsesRequest:
     """Validate ResponsesRequest accepts the shapes the OpenAI SDK sends."""
 
     def test_minimal_string_input(self):
-        req = ResponsesRequest(input = "Hello")
+        req = ResponsesRequest(input="Hello")
         assert req.input == "Hello"
         assert req.stream is False
         assert req.model == "default"
 
     def test_message_list_input(self):
         req = ResponsesRequest(
-            input = [
+            input=[
                 {"role": "user", "content": "Hi"},
                 {"role": "assistant", "content": "Hello!"},
             ],
@@ -104,7 +104,7 @@ class TestResponsesRequest:
 
     def test_multimodal_input(self):
         req = ResponsesRequest(
-            input = [
+            input=[
                 {
                     "role": "user",
                     "content": [
@@ -124,39 +124,39 @@ class TestResponsesRequest:
 
     def test_instructions_field(self):
         req = ResponsesRequest(
-            input = "test",
-            instructions = "You are a helpful assistant.",
+            input="test",
+            instructions="You are a helpful assistant.",
         )
         assert req.instructions == "You are a helpful assistant."
 
     def test_extra_fields_accepted(self):
         """OpenAI SDK may send fields we don't model -- extra='allow' should pass."""
         req = ResponsesRequest(
-            input = "test",
-            tools = [{"type": "web_search_preview"}],
-            store = True,
-            metadata = {"key": "value"},
-            previous_response_id = "resp_abc123",
+            input="test",
+            tools=[{"type": "web_search_preview"}],
+            store=True,
+            metadata={"key": "value"},
+            previous_response_id="resp_abc123",
         )
         assert req.tools == [{"type": "web_search_preview"}]
         assert req.store is True
 
     def test_stream_flag(self):
-        req = ResponsesRequest(input = "test", stream = True)
+        req = ResponsesRequest(input="test", stream=True)
         assert req.stream is True
 
     def test_temperature_and_top_p(self):
-        req = ResponsesRequest(input = "test", temperature = 0.8, top_p = 0.9)
+        req = ResponsesRequest(input="test", temperature=0.8, top_p=0.9)
         assert req.temperature == 0.8
         assert req.top_p == 0.9
 
     def test_max_output_tokens(self):
-        req = ResponsesRequest(input = "test", max_output_tokens = 512)
+        req = ResponsesRequest(input="test", max_output_tokens=512)
         assert req.max_output_tokens == 512
 
     def test_developer_role(self):
         req = ResponsesRequest(
-            input = [{"role": "developer", "content": "System instructions"}],
+            input=[{"role": "developer", "content": "System instructions"}],
         )
         assert req.input[0].role == "developer"
 
@@ -171,13 +171,13 @@ class TestResponsesResponse:
 
     def test_basic_response(self):
         resp = ResponsesResponse(
-            model = "test-model",
-            output = [
+            model="test-model",
+            output=[
                 ResponsesOutputMessage(
-                    content = [ResponsesOutputTextContent(text = "Hello!")]
+                    content=[ResponsesOutputTextContent(text="Hello!")]
                 ),
             ],
-            usage = ResponsesUsage(input_tokens = 10, output_tokens = 5, total_tokens = 15),
+            usage=ResponsesUsage(input_tokens=10, output_tokens=5, total_tokens=15),
         )
         d = resp.model_dump()
         assert d["object"] == "response"
@@ -201,18 +201,18 @@ class TestResponsesResponse:
         assert msg.id.startswith("msg_")
 
     def test_annotations_default_empty(self):
-        part = ResponsesOutputTextContent(text = "hi")
+        part = ResponsesOutputTextContent(text="hi")
         assert part.annotations == []
 
     def test_response_json_roundtrip(self):
         resp = ResponsesResponse(
-            model = "gpt-4",
-            output = [
+            model="gpt-4",
+            output=[
                 ResponsesOutputMessage(
-                    content = [ResponsesOutputTextContent(text = "ok")],
+                    content=[ResponsesOutputTextContent(text="ok")],
                 ),
             ],
-            usage = ResponsesUsage(input_tokens = 1, output_tokens = 1, total_tokens = 2),
+            usage=ResponsesUsage(input_tokens=1, output_tokens=1, total_tokens=2),
         )
         j = json.loads(resp.model_dump_json())
         assert j["object"] == "response"
@@ -229,7 +229,7 @@ class TestNormaliseResponsesInput:
     """Test _normalise_responses_input converts Responses input to ChatMessages."""
 
     def test_string_input(self):
-        payload = ResponsesRequest(input = "Hello world")
+        payload = ResponsesRequest(input="Hello world")
         msgs = _normalise_responses_input(payload)
         assert len(msgs) == 1
         assert msgs[0].role == "user"
@@ -237,8 +237,8 @@ class TestNormaliseResponsesInput:
 
     def test_instructions_become_system_message(self):
         payload = ResponsesRequest(
-            input = "Hi",
-            instructions = "Be concise.",
+            input="Hi",
+            instructions="Be concise.",
         )
         msgs = _normalise_responses_input(payload)
         assert len(msgs) == 2
@@ -249,7 +249,7 @@ class TestNormaliseResponsesInput:
 
     def test_message_list(self):
         payload = ResponsesRequest(
-            input = [
+            input=[
                 {"role": "user", "content": "First"},
                 {"role": "assistant", "content": "Response"},
                 {"role": "user", "content": "Second"},
@@ -263,7 +263,7 @@ class TestNormaliseResponsesInput:
 
     def test_developer_role_maps_to_system(self):
         payload = ResponsesRequest(
-            input = [{"role": "developer", "content": "Instructions"}],
+            input=[{"role": "developer", "content": "Instructions"}],
         )
         msgs = _normalise_responses_input(payload)
         assert msgs[0].role == "system"
@@ -271,7 +271,7 @@ class TestNormaliseResponsesInput:
 
     def test_multimodal_parts(self):
         payload = ResponsesRequest(
-            input = [
+            input=[
                 {
                     "role": "user",
                     "content": [
@@ -295,25 +295,25 @@ class TestNormaliseResponsesInput:
         assert content[1].image_url.url == "data:image/png;base64,abc"
 
     def test_empty_string_input(self):
-        payload = ResponsesRequest(input = "")
+        payload = ResponsesRequest(input="")
         msgs = _normalise_responses_input(payload)
         assert len(msgs) == 0
 
     def test_empty_list_input(self):
-        payload = ResponsesRequest(input = [])
+        payload = ResponsesRequest(input=[])
         msgs = _normalise_responses_input(payload)
         assert len(msgs) == 0
 
     def test_instructions_only(self):
-        payload = ResponsesRequest(input = "", instructions = "System msg")
+        payload = ResponsesRequest(input="", instructions="System msg")
         msgs = _normalise_responses_input(payload)
         assert len(msgs) == 1
         assert msgs[0].role == "system"
 
     def test_instructions_plus_message_list(self):
         payload = ResponsesRequest(
-            input = [{"role": "user", "content": "Hello"}],
-            instructions = "Be brief.",
+            input=[{"role": "user", "content": "Hello"}],
+            instructions="Be brief.",
         )
         msgs = _normalise_responses_input(payload)
         assert len(msgs) == 2

--- a/studio/backend/tests/test_studio_api.py
+++ b/studio/backend/tests/test_studio_api.py
@@ -87,14 +87,14 @@ def _http(
 ) -> tuple[int, str]:
     """Minimal stdlib HTTP helper.  Returns (status_code, body_text)."""
     data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(url, data = data, headers = headers or {}, method = method)
+    req = urllib.request.Request(url, data=data, headers=headers or {}, method=method)
     if body:
         req.add_header("Content-Type", "application/json")
     try:
-        with urllib.request.urlopen(req, timeout = timeout) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status, resp.read().decode()
     except urllib.error.HTTPError as exc:
-        return exc.code, exc.read().decode(errors = "replace")
+        return exc.code, exc.read().decode(errors="replace")
 
 
 def _stream_http(
@@ -106,11 +106,11 @@ def _stream_http(
 ) -> tuple[int, list[dict]]:
     """POST a streaming request and collect SSE chunks."""
     data = json.dumps(body).encode()
-    req = urllib.request.Request(url, data = data, headers = headers, method = "POST")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     req.add_header("Content-Type", "application/json")
     chunks: list[dict] = []
     try:
-        with urllib.request.urlopen(req, timeout = timeout) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             status = resp.status
             for raw_line in resp:
                 line = raw_line.decode().strip()
@@ -131,9 +131,9 @@ def test_help_output():
     """``unsloth studio run --help`` should show all documented options."""
     result = subprocess.run(
         ["unsloth", "studio", "run", "--help"],
-        capture_output = True,
-        text = True,
-        timeout = 15,
+        capture_output=True,
+        text=True,
+        timeout=15,
     )
     out = result.stdout
     assert result.returncode == 0, f"--help exited with {result.returncode}"
@@ -158,11 +158,11 @@ def test_curl_basic(base_url: str, api_key: str):
     status, text = _http(
         "POST",
         f"{base_url}/v1/chat/completions",
-        body = {
+        body={
             "messages": [{"role": "user", "content": "Say just the word hello"}],
             "stream": False,
         },
-        headers = {"Authorization": f"Bearer {api_key}"},
+        headers={"Authorization": f"Bearer {api_key}"},
     )
     assert status == 200, f"Expected 200, got {status}: {text[:300]}"
     data = json.loads(text)
@@ -190,11 +190,11 @@ def test_curl_streaming(base_url: str, api_key: str):
     """Example 2: streaming chat completion via HTTP SSE."""
     status, chunks = _stream_http(
         f"{base_url}/v1/chat/completions",
-        body = {
+        body={
             "messages": [{"role": "user", "content": "Count from 1 to 3"}],
             "stream": True,
         },
-        headers = {"Authorization": f"Bearer {api_key}"},
+        headers={"Authorization": f"Bearer {api_key}"},
     )
     assert status == 200, f"Expected 200, got {status}"
     assert len(chunks) > 0, "No SSE chunks received"
@@ -211,13 +211,13 @@ def test_openai_sdk(base_url: str, api_key: str):
         print("  SKIP  openai SDK not installed")
         return
 
-    client = OpenAI(base_url = f"{base_url}/v1", api_key = api_key)
+    client = OpenAI(base_url=f"{base_url}/v1", api_key=api_key)
     response = client.chat.completions.create(
-        model = "current",
-        messages = [
+        model="current",
+        messages=[
             {"role": "user", "content": "What is 2+2? Answer with just the number."}
         ],
-        stream = True,
+        stream=True,
     )
     content_parts = []
     for chunk in response:
@@ -241,7 +241,7 @@ def test_curl_with_tools(base_url: str, api_key: str):
     """
     status, chunks = _stream_http(
         f"{base_url}/v1/chat/completions",
-        body = {
+        body={
             "messages": [
                 {
                     "role": "user",
@@ -253,8 +253,8 @@ def test_curl_with_tools(base_url: str, api_key: str):
             "enabled_tools": ["python"],
             "session_id": "test-session",
         },
-        headers = {"Authorization": f"Bearer {api_key}"},
-        timeout = 120,
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=120,
     )
     assert status == 200, f"Expected 200, got {status}"
     assert len(chunks) > 0, "No SSE chunks received for tools request"
@@ -271,11 +271,11 @@ def test_invalid_key_rejected(base_url: str):
     status, _text = _http(
         "POST",
         f"{base_url}/v1/chat/completions",
-        body = {
+        body={
             "messages": [{"role": "user", "content": "Hello"}],
             "stream": False,
         },
-        headers = {"Authorization": "Bearer sk-unsloth-boguskey123"},
+        headers={"Authorization": "Bearer sk-unsloth-boguskey123"},
     )
     assert status == 401, f"Expected 401 for invalid key, got {status}"
     print("  PASS  invalid API key rejected (401)")
@@ -286,7 +286,7 @@ def test_no_key_rejected(base_url: str):
     status, _text = _http(
         "POST",
         f"{base_url}/v1/chat/completions",
-        body = {
+        body={
             "messages": [{"role": "user", "content": "Hello"}],
             "stream": False,
         },
@@ -310,11 +310,11 @@ def _stream_anthropic_http(
     Returns (status, [(event_type, data_dict), ...]).
     """
     data = json.dumps(body).encode()
-    req = urllib.request.Request(url, data = data, headers = headers, method = "POST")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     req.add_header("Content-Type", "application/json")
     events: list[tuple[str, dict]] = []
     try:
-        with urllib.request.urlopen(req, timeout = timeout) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             status = resp.status
             current_event = None
             for raw_line in resp:
@@ -351,12 +351,12 @@ def test_anthropic_basic(base_url: str, api_key: str):
     status, text = _http(
         "POST",
         f"{base_url}/v1/messages",
-        body = {
+        body={
             "model": "default",
             "max_tokens": 100,
             "messages": [{"role": "user", "content": "Say just the word hello"}],
         },
-        headers = {"Authorization": f"Bearer {api_key}"},
+        headers={"Authorization": f"Bearer {api_key}"},
     )
     assert status == 200, f"Expected 200, got {status}: {text[:300]}"
     data = json.loads(text)
@@ -374,13 +374,13 @@ def test_anthropic_streaming(base_url: str, api_key: str):
     """Anthropic Messages API: streaming SSE."""
     status, events = _stream_anthropic_http(
         f"{base_url}/v1/messages",
-        body = {
+        body={
             "model": "default",
             "max_tokens": 100,
             "messages": [{"role": "user", "content": "Count from 1 to 3"}],
             "stream": True,
         },
-        headers = {"Authorization": f"Bearer {api_key}"},
+        headers={"Authorization": f"Bearer {api_key}"},
     )
     assert status == 200, f"Expected 200, got {status}"
     assert len(events) > 0, "No SSE events received"
@@ -402,11 +402,11 @@ def test_anthropic_sdk(base_url: str, api_key: str):
         print("  SKIP  anthropic SDK not installed")
         return
 
-    client = Anthropic(base_url = f"{base_url}/v1", api_key = api_key)
+    client = Anthropic(base_url=f"{base_url}/v1", api_key=api_key)
     message = client.messages.create(
-        model = "default",
-        max_tokens = 100,
-        messages = [
+        model="default",
+        max_tokens=100,
+        messages=[
             {"role": "user", "content": "What is 2+2? Answer with just the number."}
         ],
     )
@@ -421,7 +421,7 @@ def test_anthropic_with_tools(base_url: str, api_key: str):
     """Anthropic Messages API: streaming with tools."""
     status, events = _stream_anthropic_http(
         f"{base_url}/v1/messages",
-        body = {
+        body={
             "model": "default",
             "max_tokens": 1024,
             "messages": [
@@ -448,8 +448,8 @@ def test_anthropic_with_tools(base_url: str, api_key: str):
             ],
             "stream": True,
         },
-        headers = {"Authorization": f"Bearer {api_key}"},
-        timeout = 120,
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=120,
     )
     assert status == 200, f"Expected 200, got {status}"
     assert len(events) > 0, "No SSE events received for tools request"
@@ -488,13 +488,13 @@ def _start_server(model: str, variant: str | None) -> tuple[subprocess.Popen, st
     if variant:
         cmd.extend(["--gguf-variant", variant])
 
-    LOG_FILE.parent.mkdir(parents = True, exist_ok = True)
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     log_fh = open(LOG_FILE, "w")
     proc = subprocess.Popen(
         cmd,
-        stdout = log_fh,
-        stderr = subprocess.STDOUT,
-        preexec_fn = os.setsid,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        preexec_fn=os.setsid,
     )
 
     # Wait for the banner containing the API key
@@ -533,13 +533,13 @@ def _kill_server(proc: subprocess.Popen):
     except (ProcessLookupError, PermissionError):
         pass
     try:
-        proc.wait(timeout = 10)
+        proc.wait(timeout=10)
     except subprocess.TimeoutExpired:
         try:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             pass
-        proc.wait(timeout = 5)
+        proc.wait(timeout=5)
 
 
 # ── Main ─────────────────────────────────────────────────────────────
@@ -547,17 +547,17 @@ def _kill_server(proc: subprocess.Popen):
 
 def main():
     parser = argparse.ArgumentParser(
-        description = "End-to-end tests for unsloth studio run"
+        description="End-to-end tests for unsloth studio run"
     )
     parser.add_argument(
         "--model",
-        default = DEFAULT_MODEL,
-        help = f"Model to test with (default: {DEFAULT_MODEL})",
+        default=DEFAULT_MODEL,
+        help=f"Model to test with (default: {DEFAULT_MODEL})",
     )
     parser.add_argument(
         "--gguf-variant",
-        default = DEFAULT_VARIANT,
-        help = f"GGUF variant (default: {DEFAULT_VARIANT})",
+        default=DEFAULT_VARIANT,
+        help=f"GGUF variant (default: {DEFAULT_VARIANT})",
     )
     args = parser.parse_args()
 

--- a/studio/backend/tests/test_trained_model_scan.py
+++ b/studio/backend/tests/test_trained_model_scan.py
@@ -72,9 +72,9 @@ def test_get_base_model_from_lora_rejects_full_finetune_dirs(tmp_path: Path):
     assert get_base_model_from_lora(str(tmp_path)) is None
 
 
-@patch("utils.models.model_config.is_audio_input_type", return_value = False)
-@patch("utils.models.model_config.detect_audio_type", return_value = None)
-@patch("utils.models.model_config.is_vision_model", return_value = False)
+@patch("utils.models.model_config.is_audio_input_type", return_value=False)
+@patch("utils.models.model_config.detect_audio_type", return_value=None)
+@patch("utils.models.model_config.is_vision_model", return_value=False)
 def test_model_config_full_finetune_local_path_is_not_lora(
     _mock_vision,
     _mock_audio_type,

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -14,7 +14,7 @@ from core.training import worker
 def _missing_flash_attn_import():
     real_import = builtins.__import__
 
-    def fake_import(name, globals = None, locals = None, fromlist = (), level = 0):
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "flash_attn":
             raise ImportError
         return real_import(name, globals, locals, fromlist, level)
@@ -23,7 +23,7 @@ def _missing_flash_attn_import():
 
 
 def test_should_try_runtime_flash_attn_install_threshold_and_skip(monkeypatch):
-    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
+    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising=False)
     assert worker._should_try_runtime_flash_attn_install(32767) is False
     assert worker._should_try_runtime_flash_attn_install(
         32768
@@ -36,7 +36,7 @@ def test_should_try_runtime_flash_attn_install_threshold_and_skip(monkeypatch):
 def test_runtime_flash_attn_prefers_prebuilt_wheel(monkeypatch):
     statuses: list[str] = []
 
-    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
+    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising=False)
     monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
     monkeypatch.setattr(
         worker,
@@ -55,7 +55,7 @@ def test_runtime_flash_attn_prefers_prebuilt_wheel(monkeypatch):
         lambda *args, **kwargs: [("pip", subprocess.CompletedProcess(["pip"], 0, ""))],
     )
 
-    worker._ensure_flash_attn_for_long_context(event_queue = [], max_seq_length = 32768)
+    worker._ensure_flash_attn_for_long_context(event_queue=[], max_seq_length=32768)
 
     assert statuses == ["Installing prebuilt flash-attn wheel..."]
 
@@ -64,12 +64,12 @@ def test_runtime_flash_attn_falls_back_to_pypi(monkeypatch):
     calls: list[list[str]] = []
     statuses: list[str] = []
 
-    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising = False)
+    monkeypatch.delenv(worker._FLASH_ATTN_SKIP_ENV, raising=False)
     monkeypatch.setattr(builtins, "__import__", _missing_flash_attn_import())
     monkeypatch.setattr(
         worker,
         "probe_torch_wheel_env",
-        lambda timeout = 30: {
+        lambda timeout=30: {
             "python_tag": "cp313",
             "torch_mm": "2.10",
             "cuda_major": "13",
@@ -91,13 +91,13 @@ def test_runtime_flash_attn_falls_back_to_pypi(monkeypatch):
     )
     monkeypatch.setattr(worker, "install_wheel", mock.Mock())
 
-    def fake_run(cmd, stdout = None, stderr = None, text = None):
+    def fake_run(cmd, stdout=None, stderr=None, text=None):
         calls.append(list(cmd))
         return subprocess.CompletedProcess(cmd, 0, "")
 
     monkeypatch.setattr(worker._sp, "run", fake_run)
 
-    worker._ensure_flash_attn_for_long_context(event_queue = [], max_seq_length = 32768)
+    worker._ensure_flash_attn_for_long_context(event_queue=[], max_seq_length=32768)
 
     assert statuses == ["Installing flash-attn from PyPI for long-context training..."]
     assert calls == [[sys.executable, "-m", "pip", "install", "flash-attn"]]
@@ -107,48 +107,48 @@ def test_runtime_flash_attn_skip_env_avoids_all_install_work(monkeypatch):
     monkeypatch.setenv(worker._FLASH_ATTN_SKIP_ENV, "1")
     monkeypatch.setattr(worker._sp, "run", mock.Mock())
 
-    worker._ensure_flash_attn_for_long_context(event_queue = [], max_seq_length = 32768)
+    worker._ensure_flash_attn_for_long_context(event_queue=[], max_seq_length=32768)
 
     worker._sp.run.assert_not_called()
 
 
 def test_causal_conv1d_fast_path_preserves_wheel_first_install_args(monkeypatch):
-    install_mock = mock.Mock(return_value = True)
+    install_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(worker, "_install_package_wheel_first", install_mock)
 
     worker._ensure_causal_conv1d_fast_path(
-        event_queue = [],
-        model_name = "tiiuae/Falcon-H1-0.5B-Instruct",
+        event_queue=[],
+        model_name="tiiuae/Falcon-H1-0.5B-Instruct",
     )
 
     install_mock.assert_called_once_with(
-        event_queue = [],
-        import_name = "causal_conv1d",
-        display_name = "causal-conv1d",
-        pypi_name = "causal-conv1d",
-        pypi_version = worker._CAUSAL_CONV1D_PACKAGE_VERSION,
-        filename_prefix = "causal_conv1d",
-        release_tag = worker._CAUSAL_CONV1D_RELEASE_TAG,
-        release_base_url = "https://github.com/Dao-AILab/causal-conv1d/releases/download",
+        event_queue=[],
+        import_name="causal_conv1d",
+        display_name="causal-conv1d",
+        pypi_name="causal-conv1d",
+        pypi_version=worker._CAUSAL_CONV1D_PACKAGE_VERSION,
+        filename_prefix="causal_conv1d",
+        release_tag=worker._CAUSAL_CONV1D_RELEASE_TAG,
+        release_base_url="https://github.com/Dao-AILab/causal-conv1d/releases/download",
     )
 
 
 def test_mamba_ssm_path_preserves_wheel_first_install_args(monkeypatch):
-    install_mock = mock.Mock(return_value = True)
+    install_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(worker, "_install_package_wheel_first", install_mock)
 
     worker._ensure_mamba_ssm(
-        event_queue = [],
-        model_name = "tiiuae/Falcon-H1-0.5B-Instruct",
+        event_queue=[],
+        model_name="tiiuae/Falcon-H1-0.5B-Instruct",
     )
 
     install_mock.assert_called_once_with(
-        event_queue = [],
-        import_name = "mamba_ssm",
-        display_name = "mamba-ssm",
-        pypi_name = "mamba-ssm",
-        pypi_version = worker._MAMBA_SSM_PACKAGE_VERSION,
-        filename_prefix = "mamba_ssm",
-        release_tag = worker._MAMBA_SSM_RELEASE_TAG,
-        release_base_url = "https://github.com/state-spaces/mamba/releases/download",
+        event_queue=[],
+        import_name="mamba_ssm",
+        display_name="mamba-ssm",
+        pypi_name="mamba-ssm",
+        pypi_version=worker._MAMBA_SSM_PACKAGE_VERSION,
+        filename_prefix="mamba_ssm",
+        release_tag=worker._MAMBA_SSM_RELEASE_TAG,
+        release_base_url="https://github.com/state-spaces/mamba/releases/download",
     )

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -177,7 +177,7 @@ class TestNeedsTransformers5:
         # Patch network call to avoid real fetch
         with patch(
             "utils.transformers_version._check_tokenizer_config_needs_v5",
-            return_value = False,
+            return_value=False,
         ):
             assert needs_transformers_5("meta-llama/Llama-3-8B") is False
 
@@ -286,14 +286,14 @@ class TestGetTransformersTier:
     def test_qwen35_returns_530(self):
         with patch(
             "utils.transformers_version._check_config_needs_550",
-            return_value = False,
+            return_value=False,
         ):
             assert get_transformers_tier("Qwen/Qwen3.5-9B") == "530"
 
     def test_ministral_returns_530(self):
         with patch(
             "utils.transformers_version._check_config_needs_550",
-            return_value = False,
+            return_value=False,
         ):
             assert (
                 get_transformers_tier("mistralai/Ministral-3-8B-Instruct-2512") == "530"
@@ -303,11 +303,11 @@ class TestGetTransformersTier:
         with (
             patch(
                 "utils.transformers_version._check_config_needs_550",
-                return_value = False,
+                return_value=False,
             ),
             patch(
                 "utils.transformers_version._check_tokenizer_config_needs_v5",
-                return_value = False,
+                return_value=False,
             ),
         ):
             assert get_transformers_tier("meta-llama/Llama-3-8B") == "default"
@@ -322,17 +322,17 @@ class TestGetTransformersTier:
         assert needs_transformers_5("google/gemma-4-E2B-it") is True
         with patch(
             "utils.transformers_version._check_config_needs_550",
-            return_value = False,
+            return_value=False,
         ):
             assert needs_transformers_5("Qwen/Qwen3.5-9B") is True
         with (
             patch(
                 "utils.transformers_version._check_config_needs_550",
-                return_value = False,
+                return_value=False,
             ),
             patch(
                 "utils.transformers_version._check_tokenizer_config_needs_v5",
-                return_value = False,
+                return_value=False,
             ),
         ):
             assert needs_transformers_5("meta-llama/Llama-3-8B") is False

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -91,8 +91,8 @@ def clear_unsloth_compiled_cache(preserve_patterns: Optional[List[str]] = None) 
 
                 elif item.is_dir():
                     # Always clear __pycache__ and other subdirectories
-                    shutil.rmtree(item, ignore_errors = True)
+                    shutil.rmtree(item, ignore_errors=True)
         else:
             # Legacy behavior: nuke the entire directory
             logger.info(f"Removing unsloth compiled cache: {cache_dir}")
-            shutil.rmtree(cache_dir, ignore_errors = True)
+            shutil.rmtree(cache_dir, ignore_errors=True)

--- a/studio/backend/utils/datasets/dataset_utils.py
+++ b/studio/backend/utils/datasets/dataset_utils.py
@@ -249,9 +249,9 @@ def _apply_user_mapping(dataset, mapping: dict, batch_size: int = 1000):
 
     return dataset.map(
         _convert,
-        batched = True,
-        batch_size = batch_size,
-        remove_columns = dataset.column_names,
+        batched=True,
+        batch_size=batch_size,
+        remove_columns=dataset.column_names,
     )
 
 
@@ -264,7 +264,7 @@ def _extract_column_value(val, col: str, label_mapping: dict) -> str:
             inner = val["text"]
             str_val = inner[0] if isinstance(inner, list) and inner else str(inner)
         else:
-            str_val = json.dumps(val, ensure_ascii = False)
+            str_val = json.dumps(val, ensure_ascii=False)
     elif isinstance(val, list):
         str_val = val[0] if len(val) == 1 else ", ".join(str(v) for v in val)
     else:
@@ -344,9 +344,9 @@ def _apply_template_mapping(
 
     return dataset.map(
         _convert,
-        batched = True,
-        batch_size = batch_size,
-        remove_columns = dataset.column_names,
+        batched=True,
+        batch_size=batch_size,
+        remove_columns=dataset.column_names,
     )
 
 
@@ -391,33 +391,33 @@ def _apply_user_mapping_alpaca(dataset, mapping: dict, batch_size: int = 1000):
 
     return dataset.map(
         _convert,
-        batched = True,
-        batch_size = batch_size,
-        remove_columns = dataset.column_names,
+        batched=True,
+        batch_size=batch_size,
+        remove_columns=dataset.column_names,
     )
 
 
 def format_dataset(
     dataset,
-    format_type = "auto",
-    tokenizer = None,
-    aliases_for_system = [
+    format_type="auto",
+    tokenizer=None,
+    aliases_for_system=[
         "system",
     ],
-    aliases_for_user = [
+    aliases_for_user=[
         "user",
         "human",
         "input",
     ],
-    aliases_for_assistant = [
+    aliases_for_assistant=[
         "gpt",
         "assistant",
         "output",
     ],
-    batch_size = 1000,
-    num_proc = None,
-    auto_detect_custom = True,
-    custom_format_mapping = None,
+    batch_size=1000,
+    num_proc=None,
+    auto_detect_custom=True,
+    custom_format_mapping=None,
 ):
     """
     Formats dataset and returns metadata.
@@ -600,7 +600,7 @@ def format_dataset(
 
                     try:
                         dataset = dataset.map(
-                            _apply_auto_mapping, batched = True, batch_size = batch_size
+                            _apply_auto_mapping, batched=True, batch_size=batch_size
                         )
                         return {
                             "dataset": dataset,
@@ -812,35 +812,35 @@ def format_and_template_dataset(
     dataset,
     model_name,
     tokenizer,
-    is_vlm = False,
-    format_type = "auto",
+    is_vlm=False,
+    format_type="auto",
     # VLM-specific parameters
-    vlm_instruction = None,  # Now optional - will auto-generate
-    vlm_text_column = None,
-    vlm_image_column = None,
-    dataset_name = None,
-    custom_prompt_template = None,
-    add_eos_token = False,
-    remove_bos_prefix = False,
-    custom_format_mapping = None,
-    auto_detect_custom = True,
-    auto_detect_mapping = True,
-    aliases_for_system = [
+    vlm_instruction=None,  # Now optional - will auto-generate
+    vlm_text_column=None,
+    vlm_image_column=None,
+    dataset_name=None,
+    custom_prompt_template=None,
+    add_eos_token=False,
+    remove_bos_prefix=False,
+    custom_format_mapping=None,
+    auto_detect_custom=True,
+    auto_detect_mapping=True,
+    aliases_for_system=[
         "system",
     ],
-    aliases_for_user = [
+    aliases_for_user=[
         "user",
         "human",
         "input",
     ],
-    aliases_for_assistant = [
+    aliases_for_assistant=[
         "gpt",
         "assistant",
         "output",
     ],
-    batch_size = 1000,
-    num_proc = None,
-    progress_callback = None,
+    batch_size=1000,
+    num_proc=None,
+    progress_callback=None,
 ):
     """
     Convenience function that combines format_dataset and apply_chat_template_to_dataset.
@@ -882,11 +882,11 @@ def format_and_template_dataset(
                 try:
                     dataset = convert_to_vlm_format(
                         dataset,
-                        instruction = vlm_instruction,
-                        text_column = user_vlm_text_column,
-                        image_column = user_vlm_image_column,
-                        dataset_name = dataset_name,
-                        progress_callback = progress_callback,
+                        instruction=vlm_instruction,
+                        text_column=user_vlm_text_column,
+                        image_column=user_vlm_image_column,
+                        dataset_name=dataset_name,
+                        progress_callback=progress_callback,
                     )
                     warnings.append(
                         f"Applied user VLM mapping: image='{user_vlm_image_column}', text='{user_vlm_text_column}'"
@@ -964,10 +964,10 @@ def format_and_template_dataset(
             try:
                 dataset = convert_sharegpt_with_images_to_vlm_format(
                     dataset,
-                    image_column = vlm_structure["image_column"],
-                    messages_column = vlm_structure["messages_column"],
-                    dataset_name = dataset_name,
-                    progress_callback = progress_callback,
+                    image_column=vlm_structure["image_column"],
+                    messages_column=vlm_structure["messages_column"],
+                    dataset_name=dataset_name,
+                    progress_callback=progress_callback,
                 )
                 warnings.append(
                     "Converted from ShareGPT+image format to standard VLM format"
@@ -1008,9 +1008,9 @@ def format_and_template_dataset(
 
                     friendly = llm_generate_dataset_warning(
                         issues,
-                        dataset_name = dataset_name,
-                        modality = "vision",
-                        column_names = columns,
+                        dataset_name=dataset_name,
+                        modality="vision",
+                        column_names=columns,
                     )
                 except Exception:
                     pass
@@ -1032,11 +1032,11 @@ def format_and_template_dataset(
             try:
                 dataset = convert_to_vlm_format(
                     dataset,
-                    instruction = vlm_instruction,
-                    text_column = vlm_text_column,
-                    image_column = vlm_image_column,
-                    dataset_name = dataset_name,
-                    progress_callback = progress_callback,
+                    instruction=vlm_instruction,
+                    text_column=vlm_text_column,
+                    image_column=vlm_image_column,
+                    dataset_name=dataset_name,
+                    progress_callback=progress_callback,
                 )
 
                 if vlm_instruction:
@@ -1091,25 +1091,25 @@ def format_and_template_dataset(
         # Step 1: Format the dataset
         n_rows = len(dataset) if hasattr(dataset, "__len__") else None
         if progress_callback and n_rows:
-            progress_callback(status_message = f"Formatting dataset ({n_rows:,} rows)...")
+            progress_callback(status_message=f"Formatting dataset ({n_rows:,} rows)...")
         dataset_info = format_dataset(
             dataset,
-            format_type = format_type,
-            tokenizer = tokenizer,
-            auto_detect_custom = auto_detect_custom,
-            custom_format_mapping = custom_format_mapping,
-            aliases_for_system = aliases_for_system,
-            aliases_for_user = aliases_for_user,
-            aliases_for_assistant = aliases_for_assistant,
-            batch_size = batch_size,
-            num_proc = num_proc,
+            format_type=format_type,
+            tokenizer=tokenizer,
+            auto_detect_custom=auto_detect_custom,
+            custom_format_mapping=custom_format_mapping,
+            aliases_for_system=aliases_for_system,
+            aliases_for_user=aliases_for_user,
+            aliases_for_assistant=aliases_for_assistant,
+            batch_size=batch_size,
+            num_proc=num_proc,
         )
 
         # Step 2: Apply chat template
         detected = dataset_info.get("detected_format", "unknown")
         if progress_callback and n_rows:
             progress_callback(
-                status_message = f"Applying chat template to {detected} ({n_rows:,} rows)..."
+                status_message=f"Applying chat template to {detected} ({n_rows:,} rows)..."
             )
         # Gemma emits a leading <bos> that must be stripped for text-only chatml/sharegpt.
         is_alpaca = format_type == "alpaca" or (
@@ -1119,17 +1119,17 @@ def format_and_template_dataset(
         if is_gemma and not dataset_info["is_image"] and not is_alpaca:
             remove_bos_prefix = True
         template_result = apply_chat_template_to_dataset(
-            dataset_info = dataset_info,
-            tokenizer = tokenizer,
-            model_name = model_name,
-            custom_prompt_template = custom_prompt_template,
-            add_eos_token = add_eos_token,
-            remove_bos_prefix = remove_bos_prefix,
-            custom_format_mapping = custom_format_mapping,
-            auto_detect_mapping = auto_detect_mapping,
-            batch_size = batch_size,
-            num_proc = num_proc,
-            progress_callback = progress_callback,
+            dataset_info=dataset_info,
+            tokenizer=tokenizer,
+            model_name=model_name,
+            custom_prompt_template=custom_prompt_template,
+            add_eos_token=add_eos_token,
+            remove_bos_prefix=remove_bos_prefix,
+            custom_format_mapping=custom_format_mapping,
+            auto_detect_mapping=auto_detect_mapping,
+            batch_size=batch_size,
+            num_proc=num_proc,
+            progress_callback=progress_callback,
         )
 
         # Step 3: Generate summary

--- a/studio/backend/utils/datasets/vlm_processing.py
+++ b/studio/backend/utils/datasets/vlm_processing.py
@@ -14,9 +14,9 @@ from itertools import islice
 
 def generate_smart_vlm_instruction(
     dataset,
-    text_column = "text",
-    image_column = "image",
-    dataset_name = None,
+    text_column="text",
+    image_column="image",
+    dataset_name=None,
 ):
     """
     Generate smart, context-aware instruction for VLM datasets using heuristics.
@@ -201,15 +201,15 @@ def generate_smart_vlm_instruction(
             sample_rows.append(row)
 
         llm_result = llm_generate_vlm_instruction(
-            column_names = list(column_names),
-            samples = sample_rows,
-            dataset_name = dataset_name,
+            column_names=list(column_names),
+            samples=sample_rows,
+            dataset_name=dataset_name,
         )
         if llm_result and llm_result.get("instruction"):
             print(
                 f"\n[DEBUG] LLM-assisted VLM instruction generated: "
                 f"'{llm_result['instruction']}' (confidence={llm_result.get('confidence', 'N/A')})\n",
-                flush = True,
+                flush=True,
             )
             return {
                 "instruction": llm_result["instruction"],

--- a/studio/backend/utils/hardware/amd.py
+++ b/studio/backend/utils/hardware/amd.py
@@ -25,9 +25,9 @@ def _run_amd_smi(*args: str, timeout: int = 5) -> Optional[Any]:
     try:
         result = subprocess.run(
             ["amd-smi", *args, "--json"],
-            capture_output = True,
-            text = True,
-            timeout = timeout,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
         )
     except (OSError, subprocess.TimeoutExpired) as e:
         logger.warning("amd-smi query failed: %s", e)

--- a/studio/backend/utils/hardware/vram_estimation.py
+++ b/studio/backend/utils/hardware/vram_estimation.py
@@ -75,7 +75,7 @@ class TrainingVramConfig:
     batch_size: int = 4
     max_seq_length: int = 2048
     lora_rank: int = 16
-    target_modules: list = field(default_factory = lambda: list(DEFAULT_TARGET_MODULES))
+    target_modules: list = field(default_factory=lambda: list(DEFAULT_TARGET_MODULES))
     gradient_checkpointing: str = "unsloth"
     optimizer: str = "adamw_8bit"
     load_in_4bit: bool = True
@@ -197,22 +197,22 @@ def extract_arch_config(hf_config) -> Optional[ModelArchConfig]:
     v_head_dim = getattr(text_config, "v_head_dim", None)
 
     return ModelArchConfig(
-        hidden_size = hidden_size,
-        num_hidden_layers = num_layers,
-        num_attention_heads = num_heads,
-        num_key_value_heads = num_kv_heads,
-        intermediate_size = intermediate_size,
-        vocab_size = vocab_size,
-        tie_word_embeddings = getattr(text_config, "tie_word_embeddings", True),
-        num_experts = num_experts,
-        moe_intermediate_size = moe_intermediate,
-        n_shared_experts = n_shared_experts,
-        num_dense_layers = num_dense_layers,
-        q_lora_rank = q_lora_rank,
-        kv_lora_rank = kv_lora_rank,
-        qk_nope_head_dim = qk_nope_head_dim,
-        qk_rope_head_dim = qk_rope_head_dim,
-        v_head_dim = v_head_dim,
+        hidden_size=hidden_size,
+        num_hidden_layers=num_layers,
+        num_attention_heads=num_heads,
+        num_key_value_heads=num_kv_heads,
+        intermediate_size=intermediate_size,
+        vocab_size=vocab_size,
+        tie_word_embeddings=getattr(text_config, "tie_word_embeddings", True),
+        num_experts=num_experts,
+        moe_intermediate_size=moe_intermediate,
+        n_shared_experts=n_shared_experts,
+        num_dense_layers=num_dense_layers,
+        q_lora_rank=q_lora_rank,
+        kv_lora_rank=kv_lora_rank,
+        qk_nope_head_dim=qk_nope_head_dim,
+        qk_rope_head_dim=qk_rope_head_dim,
+        v_head_dim=v_head_dim,
     )
 
 
@@ -483,7 +483,7 @@ def estimate_training_vram(
         config.batch_size,
         config.max_seq_length,
         config.gradient_checkpointing,
-        is_lora = is_lora,
+        is_lora=is_lora,
     )
     activation_bytes = max(
         activations_computed,
@@ -491,11 +491,11 @@ def estimate_training_vram(
     )
 
     return VramBreakdown(
-        model_weights = model_weights,
-        lora_adapters = lora_adapter_bytes,
-        optimizer_states = optimizer_bytes,
-        gradients = gradient_bytes,
-        activations = activation_bytes,
-        cuda_overhead = CUDA_OVERHEAD_BYTES,
-        activations_computed = activations_computed,
+        model_weights=model_weights,
+        lora_adapters=lora_adapter_bytes,
+        optimizer_states=optimizer_bytes,
+        gradients=gradient_bytes,
+        activations=activation_bytes,
+        cuda_overhead=CUDA_OVERHEAD_BYTES,
+        activations_computed=activations_computed,
     )

--- a/studio/backend/utils/models/checkpoints.py
+++ b/studio/backend/utils/models/checkpoints.py
@@ -136,7 +136,7 @@ def scan_checkpoints(
             )
 
         # Sort by modification time (newest first)
-        models.sort(key = lambda x: Path(x[1][0][1]).stat().st_mtime, reverse = True)
+        models.sort(key=lambda x: Path(x[1][0][1]).stat().st_mtime, reverse=True)
 
         logger.info(f"Found {len(models)} training runs in {outputs_dir}")
         return models

--- a/studio/backend/utils/paths/storage_roots.py
+++ b/studio/backend/utils/paths/storage_roots.py
@@ -79,7 +79,7 @@ def tensorboard_root() -> Path:
 
 
 def ensure_dir(path: Path) -> Path:
-    path.mkdir(parents = True, exist_ok = True)
+    path.mkdir(parents=True, exist_ok=True)
     return path
 
 
@@ -158,7 +158,7 @@ def _setup_cache_env() -> None:
     for key, value in defaults.items():
         if key not in os.environ:
             os.environ[key] = value
-            Path(value).mkdir(parents = True, exist_ok = True)
+            Path(value).mkdir(parents=True, exist_ok=True)
 
 
 def ensure_studio_directories() -> None:
@@ -202,31 +202,31 @@ def resolve_under_root(
     if path.is_absolute():
         return path
 
-    cleaned = _clean_relative_path(str(path), strip_prefixes = strip_prefixes)
+    cleaned = _clean_relative_path(str(path), strip_prefixes=strip_prefixes)
     return root / cleaned
 
 
 def resolve_output_dir(path_value: str | None = None) -> Path:
     return resolve_under_root(
         path_value,
-        root = outputs_root(),
-        strip_prefixes = ("outputs",),
+        root=outputs_root(),
+        strip_prefixes=("outputs",),
     )
 
 
 def resolve_export_dir(path_value: str | None = None) -> Path:
     return resolve_under_root(
         path_value,
-        root = exports_root(),
-        strip_prefixes = ("exports",),
+        root=exports_root(),
+        strip_prefixes=("exports",),
     )
 
 
 def resolve_tensorboard_dir(path_value: str | None = None) -> Path:
     return resolve_under_root(
         path_value,
-        root = tensorboard_root(),
-        strip_prefixes = ("runs", "tensorboard"),
+        root=tensorboard_root(),
+        strip_prefixes=("runs", "tensorboard"),
     )
 
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -238,8 +238,8 @@ def _check_tokenizer_config_needs_v5(model_name: str) -> bool:
 
     url = f"https://huggingface.co/{model_name}/raw/main/tokenizer_config.json"
     try:
-        req = urllib.request.Request(url, headers = {"User-Agent": "unsloth-studio"})
-        with urllib.request.urlopen(req, timeout = 10) as resp:
+        req = urllib.request.Request(url, headers={"User-Agent": "unsloth-studio"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read().decode())
         tokenizer_class = data.get("tokenizer_class", "")
         result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
@@ -304,8 +304,8 @@ def _check_config_needs_550(model_name: str) -> bool:
 
     url = f"https://huggingface.co/{model_name}/raw/main/config.json"
     try:
-        req = urllib.request.Request(url, headers = {"User-Agent": "unsloth-studio"})
-        with urllib.request.urlopen(req, timeout = 10) as resp:
+        req = urllib.request.Request(url, headers={"User-Agent": "unsloth-studio"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
             cfg = json.loads(resp.read().decode())
         result = _check_cfg(cfg)
         if result:
@@ -452,7 +452,7 @@ def _venv_dir_is_valid(venv_dir: str, packages: tuple[str, ...]) -> bool:
             metadata = di / "METADATA"
             if not metadata.is_file():
                 continue
-            for line in metadata.read_text(errors = "replace").splitlines():
+            for line in metadata.read_text(errors="replace").splitlines():
                 if line.startswith("Version:"):
                     installed_ver = line.split(":", 1)[1].strip()
                     if installed_ver != pkg_version:
@@ -495,9 +495,9 @@ def _install_to_dir(pkg: str, target_dir: str) -> bool:
                 "--upgrade",
                 pkg,
             ],
-            stdout = subprocess.PIPE,
-            stderr = subprocess.STDOUT,
-            text = True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
         )
         if result.returncode == 0:
             return True
@@ -516,9 +516,9 @@ def _install_to_dir(pkg: str, target_dir: str) -> bool:
             "--upgrade",
             pkg,
         ],
-        stdout = subprocess.PIPE,
-        stderr = subprocess.STDOUT,
-        text = True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
     )
     if result.returncode != 0:
         logger.error("install failed:\n%s", result.stdout)
@@ -534,8 +534,8 @@ def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bo
     logger.warning(
         "%s not found or incomplete at %s -- installing at runtime", label, venv_dir
     )
-    shutil.rmtree(venv_dir, ignore_errors = True)
-    os.makedirs(venv_dir, exist_ok = True)
+    shutil.rmtree(venv_dir, ignore_errors=True)
+    os.makedirs(venv_dir, exist_ok=True)
     for pkg in packages:
         if not _install_to_dir(pkg, venv_dir):
             return False

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -48,7 +48,7 @@ def without_hf_auth():
 
     for token_loc in token_locations:
         if token_loc.exists():
-            temp = tempfile.NamedTemporaryFile(delete = False)
+            temp = tempfile.NamedTemporaryFile(delete=False)
             temp.close()
             shutil.move(str(token_loc), temp.name)
             token_files.append((token_loc, temp.name))
@@ -59,7 +59,7 @@ def without_hf_auth():
         # Restore tokens
         for original, temp in token_files:
             try:
-                original.parent.mkdir(parents = True, exist_ok = True)
+                original.parent.mkdir(parents=True, exist_ok=True)
                 shutil.move(temp, str(original))
             except Exception as e:
                 logger.error(f"Failed to restore token {original}: {e}")

--- a/studio/backend/utils/wheel_utils.py
+++ b/studio/backend/utils/wheel_utils.py
@@ -55,10 +55,10 @@ def probe_torch_wheel_env(*, timeout: int | None = None) -> dict[str, str] | Non
                     "}))"
                 ),
             ],
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE,
-            text = True,
-            timeout = timeout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired:
         return None
@@ -113,11 +113,11 @@ def flash_attn_wheel_url(env: dict[str, str] | None) -> str | None:
     if package_version is None:
         return None
     return direct_wheel_url(
-        filename_prefix = "flash_attn",
-        package_version = package_version,
-        release_tag = f"v{package_version}",
-        release_base_url = FLASH_ATTN_RELEASE_BASE_URL,
-        env = env,
+        filename_prefix="flash_attn",
+        package_version=package_version,
+        release_tag=f"v{package_version}",
+        release_base_url=FLASH_ATTN_RELEASE_BASE_URL,
+        env=env,
     )
 
 
@@ -139,9 +139,9 @@ def install_wheel(
         uv_cmd.extend(["--python", python_executable, "--no-deps", wheel_url])
         result = run(
             uv_cmd,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.STDOUT,
-            text = True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
         )
         attempts.append(("uv", result))
         if result.returncode == 0:
@@ -150,9 +150,9 @@ def install_wheel(
     pip_cmd = [python_executable, "-m", "pip", "install", "--no-deps", wheel_url]
     result = run(
         pip_cmd,
-        stdout = subprocess.PIPE,
-        stderr = subprocess.STDOUT,
-        text = True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
     )
     attempts.append(("pip", result))
     return attempts
@@ -160,8 +160,8 @@ def install_wheel(
 
 def url_exists(url: str) -> bool:
     try:
-        request = urllib.request.Request(url, method = "HEAD")
-        with urllib.request.urlopen(request, timeout = 10):
+        request = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(request, timeout=10):
             return True
     except urllib.error.HTTPError as exc:
         _logger.debug("url_exists(%s): HTTP %s", url, exc.code)

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2576,8 +2576,13 @@ def detect_host() -> HostInfo:
     has_rocm = False
     if is_linux:
         for _cmd, _check in (
-            # rocminfo: look for "gfxNNNN" with nonzero first digit (gfx000 is CPU agent)
-            (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9]", out.lower()))),
+            # rocminfo: look for a real gfx GPU ID (3-4 digits, nonzero first).
+            # gfx000 is the CPU agent; generic ISA lines like "gfx11-generic"
+            # only have 2 digits and are not actual GPU targets.
+            (
+                ["rocminfo"],
+                lambda out: bool(re.search(r"gfx[1-9][0-9]{2,3}", out.lower())),
+            ),
             (["amd-smi", "list"], _amd_smi_has_gpu),
         ):
             _exe = shutil.which(_cmd[0])

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2576,10 +2576,10 @@ def detect_host() -> HostInfo:
     has_rocm = False
     if is_linux:
         for _cmd, _check in (
-            # rocminfo: look for a real gfx GPU ID (3-4 digits, nonzero first).
+            # rocminfo: look for a real gfx GPU ID (3-4 chars, nonzero first digit).
             # gfx000 is the CPU agent; generic ISA lines like "gfx11-generic"
             # only have 2 digits and are not actual GPU targets.
-            (
+            (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower()))),
                 ["rocminfo"],
                 lambda out: bool(re.search(r"gfx[1-9][0-9]{2,3}", out.lower())),
             ),

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -181,10 +181,10 @@ def _has_rocm_gpu() -> bool:
     import re
 
     for cmd, check_fn in (
-        # rocminfo: look for a real gfx GPU ID (3-4 digits, nonzero first).
+        # rocminfo: look for a real gfx GPU ID (3-4 chars, nonzero first digit).
         # gfx000 is the CPU agent; generic ISA lines like "gfx11-generic"
         # only have 2 digits and are not actual GPU targets.
-        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9]{2,3}", out.lower()))),
+        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower()))),
         # amd-smi list: require "GPU: <number>" data rows, not just a header
         (
             ["amd-smi", "list"],

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -181,8 +181,10 @@ def _has_rocm_gpu() -> bool:
     import re
 
     for cmd, check_fn in (
-        # rocminfo: look for "Name: gfxNNNN" with nonzero first digit (gfx000 is the CPU agent)
-        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9]", out.lower()))),
+        # rocminfo: look for a real gfx GPU ID (3-4 digits, nonzero first).
+        # gfx000 is the CPU agent; generic ISA lines like "gfx11-generic"
+        # only have 2 digits and are not actual GPU targets.
+        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9]{2,3}", out.lower()))),
         # amd-smi list: require "GPU: <number>" data rows, not just a header
         (
             ["amd-smi", "list"],

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -184,7 +184,10 @@ def _has_rocm_gpu() -> bool:
         # rocminfo: look for a real gfx GPU ID (3-4 chars, nonzero first digit).
         # gfx000 is the CPU agent; generic ISA lines like "gfx11-generic"
         # only have 2 digits and are not actual GPU targets.
-        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower()))),
+        (
+            ["rocminfo"],
+            lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower())),
+        ),
         # amd-smi list: require "GPU: <number>" data rows, not just a header
         (
             ["amd-smi", "list"],

--- a/tests/python/test_flash_attn_install_python_stack.py
+++ b/tests/python/test_flash_attn_install_python_stack.py
@@ -76,7 +76,7 @@ class TestEnsureFlashAttn:
             mock.patch.object(
                 ips,
                 "probe_torch_wheel_env",
-                return_value = {
+                return_value={
                     "python_tag": "cp313",
                     "torch_mm": "2.10",
                     "cuda_major": "12",
@@ -84,9 +84,9 @@ class TestEnsureFlashAttn:
                     "platform_tag": "linux_x86_64",
                 },
             ),
-            mock.patch.object(ips, "url_exists", return_value = True),
-            mock.patch.object(ips, "install_wheel", side_effect = fake_install_wheel),
-            mock.patch("subprocess.run", return_value = self._import_check()),
+            mock.patch.object(ips, "url_exists", return_value=True),
+            mock.patch.object(ips, "install_wheel", side_effect=fake_install_wheel),
+            mock.patch("subprocess.run", return_value=self._import_check()),
         ):
             ips._ensure_flash_attn()
 
@@ -115,7 +115,7 @@ class TestEnsureFlashAttn:
             mock.patch.object(
                 ips,
                 "probe_torch_wheel_env",
-                return_value = {
+                return_value={
                     "python_tag": "cp313",
                     "torch_mm": "2.10",
                     "cuda_major": "12",
@@ -123,9 +123,9 @@ class TestEnsureFlashAttn:
                     "platform_tag": "linux_x86_64",
                 },
             ),
-            mock.patch.object(ips, "url_exists", return_value = True),
-            mock.patch.object(ips, "install_wheel", side_effect = fake_install_wheel),
-            mock.patch("subprocess.run", return_value = self._import_check()),
+            mock.patch.object(ips, "url_exists", return_value=True),
+            mock.patch.object(ips, "install_wheel", side_effect=fake_install_wheel),
+            mock.patch("subprocess.run", return_value=self._import_check()),
         ):
             ips._ensure_flash_attn()
 
@@ -137,7 +137,7 @@ class TestEnsureFlashAttn:
         step_messages: list[tuple[str, str]] = []
         printed_failures: list[str] = []
 
-        def fake_step(label: str, value: str, color_fn = None):
+        def fake_step(label: str, value: str, color_fn=None):
             step_messages.append((label, value))
 
         with (
@@ -149,7 +149,7 @@ class TestEnsureFlashAttn:
             mock.patch.object(
                 ips,
                 "probe_torch_wheel_env",
-                return_value = {
+                return_value={
                     "python_tag": "cp313",
                     "torch_mm": "2.10",
                     "cuda_major": "12",
@@ -157,11 +157,11 @@ class TestEnsureFlashAttn:
                     "platform_tag": "linux_x86_64",
                 },
             ),
-            mock.patch.object(ips, "url_exists", return_value = True),
+            mock.patch.object(ips, "url_exists", return_value=True),
             mock.patch.object(
                 ips,
                 "install_wheel",
-                return_value = [
+                return_value=[
                     ("uv", subprocess.CompletedProcess(["uv"], 1, "uv wheel failed")),
                     (
                         "pip",
@@ -172,10 +172,10 @@ class TestEnsureFlashAttn:
             mock.patch.object(
                 ips,
                 "_print_optional_install_failure",
-                side_effect = lambda label, result: printed_failures.append(label),
+                side_effect=lambda label, result: printed_failures.append(label),
             ),
-            mock.patch.object(ips, "_step", side_effect = fake_step),
-            mock.patch("subprocess.run", return_value = self._import_check()),
+            mock.patch.object(ips, "_step", side_effect=fake_step),
+            mock.patch("subprocess.run", return_value=self._import_check()),
         ):
             ips._ensure_flash_attn()
 
@@ -188,7 +188,7 @@ class TestEnsureFlashAttn:
     def test_wheel_missing_skips_install_at_setup_time(self):
         step_messages: list[tuple[str, str]] = []
 
-        def fake_step(label: str, value: str, color_fn = None):
+        def fake_step(label: str, value: str, color_fn=None):
             step_messages.append((label, value))
 
         with (
@@ -198,7 +198,7 @@ class TestEnsureFlashAttn:
             mock.patch.object(
                 ips,
                 "probe_torch_wheel_env",
-                return_value = {
+                return_value={
                     "python_tag": "cp313",
                     "torch_mm": "2.10",
                     "cuda_major": "13",
@@ -206,10 +206,10 @@ class TestEnsureFlashAttn:
                     "platform_tag": "linux_x86_64",
                 },
             ),
-            mock.patch.object(ips, "url_exists", return_value = False),
+            mock.patch.object(ips, "url_exists", return_value=False),
             mock.patch.object(ips, "install_wheel") as mock_install_wheel,
-            mock.patch.object(ips, "_step", side_effect = fake_step),
-            mock.patch("subprocess.run", return_value = self._import_check()),
+            mock.patch.object(ips, "_step", side_effect=fake_step),
+            mock.patch("subprocess.run", return_value=self._import_check()),
         ):
             ips._ensure_flash_attn()
 
@@ -227,7 +227,7 @@ class TestEnsureFlashAttn:
             mock.patch.dict(os.environ, {"UNSLOTH_STUDIO_SKIP_FLASHATTN_INSTALL": "1"}),
             mock.patch.object(ips, "probe_torch_wheel_env") as mock_probe,
             mock.patch.object(ips, "install_wheel") as mock_install_wheel,
-            mock.patch("subprocess.run", return_value = self._import_check()),
+            mock.patch("subprocess.run", return_value=self._import_check()),
         ):
             ips._ensure_flash_attn()
 
@@ -253,30 +253,30 @@ class TestInstallPythonStackFlashAttnIntegration:
             mock.patch.object(ips, "USE_UV", True),
             mock.patch.object(ips, "UV_NEEDS_SYSTEM", False),
             mock.patch.object(ips, "VERBOSE", False),
-            mock.patch.object(ips, "_bootstrap_uv", return_value = True),
-            mock.patch.object(ips, "_ensure_flash_attn", side_effect = count_flash_attn),
-            mock.patch("subprocess.run", side_effect = fake_run),
-            mock.patch.object(ips, "_has_usable_nvidia_gpu", return_value = False),
-            mock.patch.object(ips, "_has_rocm_gpu", return_value = False),
+            mock.patch.object(ips, "_bootstrap_uv", return_value=True),
+            mock.patch.object(ips, "_ensure_flash_attn", side_effect=count_flash_attn),
+            mock.patch("subprocess.run", side_effect=fake_run),
+            mock.patch.object(ips, "_has_usable_nvidia_gpu", return_value=False),
+            mock.patch.object(ips, "_has_rocm_gpu", return_value=False),
             mock.patch.object(
                 ips, "LOCAL_DD_UNSTRUCTURED_PLUGIN", Path("/fake/plugin")
             ),
-            mock.patch("pathlib.Path.is_dir", return_value = True),
-            mock.patch("pathlib.Path.is_file", return_value = True),
-            mock.patch.dict(os.environ, {"SKIP_STUDIO_BASE": "1"}, clear = False),
+            mock.patch("pathlib.Path.is_dir", return_value=True),
+            mock.patch("pathlib.Path.is_file", return_value=True),
+            mock.patch.dict(os.environ, {"SKIP_STUDIO_BASE": "1"}, clear=False),
         ):
             ips.install_python_stack()
 
         return flash_attn_calls
 
     def test_linux_torch_install_calls_flash_attn_step(self):
-        assert self._run_install(no_torch = False, is_macos = False, is_windows = False) == 1
+        assert self._run_install(no_torch=False, is_macos=False, is_windows=False) == 1
 
     def test_no_torch_install_skips_flash_attn_step(self):
-        assert self._run_install(no_torch = True, is_macos = False, is_windows = False) == 0
+        assert self._run_install(no_torch=True, is_macos=False, is_windows=False) == 0
 
     def test_macos_install_skips_flash_attn_step(self):
-        assert self._run_install(no_torch = False, is_macos = True, is_windows = False) == 0
+        assert self._run_install(no_torch=False, is_macos=True, is_windows=False) == 0
 
     def test_windows_install_skips_flash_attn_step(self):
-        assert self._run_install(no_torch = False, is_macos = False, is_windows = True) == 0
+        assert self._run_install(no_torch=False, is_macos=False, is_windows=True) == 0

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -29,7 +29,7 @@ class TestBuildUvCmdTorchBackend:
         """Without UV_TORCH_BACKEND env var, no --torch-backend flag."""
         env = os.environ.copy()
         env.pop("UV_TORCH_BACKEND", None)
-        with mock.patch.dict(os.environ, env, clear = True):
+        with mock.patch.dict(os.environ, env, clear=True):
             cmd = self._call(("somepackage",))
         assert not any(
             a.startswith("--torch-backend") for a in cmd

--- a/tests/python/test_no_torch_filtering.py
+++ b/tests/python/test_no_torch_filtering.py
@@ -43,7 +43,7 @@ class TestFilterRequirements:
 
     def _write_req(self, tmp_path: Path, content: str) -> Path:
         req = tmp_path / "requirements.txt"
-        req.write_text(textwrap.dedent(content), encoding = "utf-8")
+        req.write_text(textwrap.dedent(content), encoding="utf-8")
         return req
 
     def test_filters_no_torch_packages(self, tmp_path):
@@ -58,7 +58,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         # Only numpy should remain (non-blank lines)
         non_blank = [l.strip() for l in lines if l.strip()]
         assert non_blank == ["numpy"], f"Expected only numpy, got: {non_blank}"
@@ -66,7 +66,7 @@ class TestFilterRequirements:
     def test_empty_file(self, tmp_path):
         req = self._write_req(tmp_path, "")
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        content = Path(result).read_text(encoding = "utf-8")
+        content = Path(result).read_text(encoding="utf-8")
         assert content.strip() == ""
 
     def test_comments_preserved(self, tmp_path):
@@ -78,7 +78,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         # Comment starts with "#", not "torch-stoi", so it's preserved
         assert len(non_blank) == 2
@@ -94,7 +94,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         assert non_blank == [], f"Expected empty, got: {non_blank}"
 
@@ -108,7 +108,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         assert non_blank == ["numpy"]
 
@@ -123,7 +123,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         assert non_blank == ["numpy"]
 
@@ -138,7 +138,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        content = Path(result).read_text(encoding = "utf-8")
+        content = Path(result).read_text(encoding="utf-8")
         # Blank lines should be preserved (not stripped)
         assert "\n\n" in content or content.count("\n") >= 3
 
@@ -159,7 +159,7 @@ class TestFilterRequirements:
         result = ips._filter_requirements(
             Path(intermediate), ips.NO_TORCH_SKIP_PACKAGES
         )
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         assert non_blank == [
             "numpy"
@@ -175,7 +175,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         assert non_blank == [
             "numpy"
@@ -191,7 +191,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         assert non_blank == [
             "numpy"
@@ -207,7 +207,7 @@ class TestFilterRequirements:
         """,
         )
         result = ips._filter_requirements(req, ips.NO_TORCH_SKIP_PACKAGES)
-        lines = Path(result).read_text(encoding = "utf-8").splitlines()
+        lines = Path(result).read_text(encoding="utf-8").splitlines()
         non_blank = [l.strip() for l in lines if l.strip()]
         # The git+ URL doesn't start with any skip package, so it is preserved
         assert len(non_blank) == 2, f"git+ URL should be preserved, got: {non_blank}"
@@ -219,7 +219,7 @@ class TestFilterRequirements:
 class TestRealRequirementsFiltering:
     """Filter the ACTUAL extras.txt and extras-no-deps.txt with NO_TORCH_SKIP_PACKAGES."""
 
-    @pytest.fixture(autouse = True)
+    @pytest.fixture(autouse=True)
     def _check_req_files(self):
         if not EXTRAS_TXT.is_file():
             pytest.skip("extras.txt not found in repo")
@@ -228,7 +228,7 @@ class TestRealRequirementsFiltering:
 
     def _non_blank_non_comment(self, path: Path) -> list[str]:
         """Return non-blank, non-comment lines from a requirements file."""
-        lines = path.read_text(encoding = "utf-8").splitlines()
+        lines = path.read_text(encoding="utf-8").splitlines()
         return [l.strip() for l in lines if l.strip() and not l.strip().startswith("#")]
 
     def test_extras_txt_torch_packages_removed(self):
@@ -282,11 +282,11 @@ class TestRealRequirementsFiltering:
     def test_extras_txt_most_packages_preserved(self):
         """Ensure a representative set of non-torch packages survive filtering."""
         result = ips._filter_requirements(EXTRAS_TXT, ips.NO_TORCH_SKIP_PACKAGES)
-        filtered_text = Path(result).read_text(encoding = "utf-8").lower()
+        filtered_text = Path(result).read_text(encoding="utf-8").lower()
 
         must_survive = ["scikit-learn", "loguru", "tiktoken", "einops", "tabulate"]
         for pkg in must_survive:
-            if pkg in EXTRAS_TXT.read_text(encoding = "utf-8").lower():
+            if pkg in EXTRAS_TXT.read_text(encoding="utf-8").lower():
                 assert pkg in filtered_text, f"{pkg} should survive NO_TORCH filtering"
 
     def test_extras_no_deps_txt_trl_preserved(self):
@@ -294,7 +294,7 @@ class TestRealRequirementsFiltering:
         result = ips._filter_requirements(
             EXTRAS_NO_DEPS_TXT, ips.NO_TORCH_SKIP_PACKAGES
         )
-        filtered_text = Path(result).read_text(encoding = "utf-8").lower()
+        filtered_text = Path(result).read_text(encoding="utf-8").lower()
         assert "trl" in filtered_text, "trl should survive NO_TORCH filtering"
 
 
@@ -330,7 +330,7 @@ class TestNoTorchConstant:
     def test_not_set(self):
         env = os.environ.copy()
         env.pop("UNSLOTH_NO_TORCH", None)
-        with mock.patch.dict(os.environ, env, clear = True):
+        with mock.patch.dict(os.environ, env, clear=True):
             assert self._reimport_no_torch() is False
 
     def test_infer_no_torch_on_intel_mac(self):
@@ -338,7 +338,7 @@ class TestNoTorchConstant:
         env = os.environ.copy()
         env.pop("UNSLOTH_NO_TORCH", None)
         with (
-            mock.patch.dict(os.environ, env, clear = True),
+            mock.patch.dict(os.environ, env, clear=True),
             mock.patch.object(ips, "IS_MAC_INTEL", True),
         ):
             assert ips._infer_no_torch() is True
@@ -356,7 +356,7 @@ class TestNoTorchConstant:
         env = os.environ.copy()
         env.pop("UNSLOTH_NO_TORCH", None)
         with (
-            mock.patch.dict(os.environ, env, clear = True),
+            mock.patch.dict(os.environ, env, clear=True),
             mock.patch.object(ips, "IS_MAC_INTEL", False),
         ):
             assert ips._infer_no_torch() is False
@@ -383,7 +383,7 @@ class TestInstallPythonStackSubprocessMock:
     then verify which requirements files are used/skipped under
     different NO_TORCH / IS_MACOS / IS_WINDOWS configurations."""
 
-    @pytest.fixture(autouse = True)
+    @pytest.fixture(autouse=True)
     def _check_req_files(self):
         """Skip if requirements files are missing."""
         for f in [EXTRAS_TXT, EXTRAS_NO_DEPS_TXT, OVERRIDES_TXT]:
@@ -419,18 +419,18 @@ class TestInstallPythonStackSubprocessMock:
             mock.patch.object(ips, "USE_UV", True),
             mock.patch.object(ips, "UV_NEEDS_SYSTEM", False),
             mock.patch.object(ips, "VERBOSE", False),
-            mock.patch.object(ips, "_ensure_flash_attn", return_value = None),
-            mock.patch.object(ips, "_has_usable_nvidia_gpu", return_value = False),
-            mock.patch.object(ips, "_has_rocm_gpu", return_value = False),
-            mock.patch("subprocess.run", side_effect = mock_run),
-            mock.patch.object(ips, "_bootstrap_uv", return_value = True),
+            mock.patch.object(ips, "_ensure_flash_attn", return_value=None),
+            mock.patch.object(ips, "_has_usable_nvidia_gpu", return_value=False),
+            mock.patch.object(ips, "_has_rocm_gpu", return_value=False),
+            mock.patch("subprocess.run", side_effect=mock_run),
+            mock.patch.object(ips, "_bootstrap_uv", return_value=True),
             mock.patch.object(
                 ips, "LOCAL_DD_UNSTRUCTURED_PLUGIN", Path("/fake/plugin")
             ),
-            mock.patch("pathlib.Path.is_dir", return_value = True),
-            mock.patch("pathlib.Path.is_file", return_value = True),
+            mock.patch("pathlib.Path.is_dir", return_value=True),
+            mock.patch("pathlib.Path.is_file", return_value=True),
         ):
-            with mock.patch.dict(os.environ, env, clear = False):
+            with mock.patch.dict(os.environ, env, clear=False):
                 ips.install_python_stack()
 
         return [" ".join(str(c) for c in cmd) for cmd in captured_cmds]
@@ -443,21 +443,21 @@ class TestInstallPythonStackSubprocessMock:
 
     def test_no_torch_macos_skips_overrides(self):
         """With NO_TORCH=True, overrides.txt pip_install must NOT be called."""
-        cmds = self._capture_install(no_torch = True, is_macos = True, is_windows = False)
+        cmds = self._capture_install(no_torch=True, is_macos=True, is_windows=False)
         assert not self._cmds_contain_file(
             cmds, "overrides.txt"
         ), "overrides.txt should be skipped when NO_TORCH=True"
 
     def test_no_torch_macos_skips_triton(self):
         """With IS_MACOS=True, triton-kernels.txt must NOT be called."""
-        cmds = self._capture_install(no_torch = True, is_macos = True, is_windows = False)
+        cmds = self._capture_install(no_torch=True, is_macos=True, is_windows=False)
         assert not self._cmds_contain_file(
             cmds, "triton-kernels.txt"
         ), "triton-kernels.txt should be skipped on macOS"
 
     def test_no_torch_macos_extras_called(self):
         """With NO_TORCH=True, extras.txt is still called (but filtered)."""
-        cmds = self._capture_install(no_torch = True, is_macos = True, is_windows = False)
+        cmds = self._capture_install(no_torch=True, is_macos=True, is_windows=False)
         has_extras = self._cmds_contain_file(cmds, "extras.txt") or any(
             "-r" in cmd and "tmp" in cmd.lower() for cmd in cmds
         )
@@ -465,7 +465,7 @@ class TestInstallPythonStackSubprocessMock:
 
     def test_no_torch_macos_extras_no_deps_called(self):
         """With NO_TORCH=True, extras-no-deps.txt is still called (but filtered)."""
-        cmds = self._capture_install(no_torch = True, is_macos = True, is_windows = False)
+        cmds = self._capture_install(no_torch=True, is_macos=True, is_windows=False)
         has_extras_nd = self._cmds_contain_file(cmds, "extras-no-deps.txt") or any(
             "-r" in cmd and "tmp" in cmd.lower() for cmd in cmds
         )
@@ -477,14 +477,14 @@ class TestInstallPythonStackSubprocessMock:
 
     def test_windows_no_torch_skips_overrides(self):
         """Windows+NO_TORCH: overrides.txt must be skipped."""
-        cmds = self._capture_install(no_torch = True, is_macos = False, is_windows = True)
+        cmds = self._capture_install(no_torch=True, is_macos=False, is_windows=True)
         assert not self._cmds_contain_file(
             cmds, "overrides.txt"
         ), "overrides.txt should be skipped with NO_TORCH=True on Windows"
 
     def test_windows_no_torch_skips_triton(self):
         """Windows: triton-kernels.txt must be skipped (IS_WINDOWS guard)."""
-        cmds = self._capture_install(no_torch = True, is_macos = False, is_windows = True)
+        cmds = self._capture_install(no_torch=True, is_macos=False, is_windows=True)
         assert not self._cmds_contain_file(
             cmds, "triton-kernels.txt"
         ), "triton-kernels.txt should be skipped on Windows"
@@ -493,28 +493,28 @@ class TestInstallPythonStackSubprocessMock:
 
     def test_normal_linux_includes_overrides(self):
         """Normal Linux: overrides.txt IS called."""
-        cmds = self._capture_install(no_torch = False, is_macos = False, is_windows = False)
+        cmds = self._capture_install(no_torch=False, is_macos=False, is_windows=False)
         assert self._cmds_contain_file(
             cmds, "overrides.txt"
         ), "overrides.txt should be called on normal Linux"
 
     def test_normal_linux_includes_triton(self):
         """Normal Linux: triton-kernels.txt IS called."""
-        cmds = self._capture_install(no_torch = False, is_macos = False, is_windows = False)
+        cmds = self._capture_install(no_torch=False, is_macos=False, is_windows=False)
         assert self._cmds_contain_file(
             cmds, "triton-kernels.txt"
         ), "triton-kernels.txt should be called on normal Linux"
 
     def test_normal_linux_includes_extras(self):
         """Normal Linux: extras.txt IS called (no filtering)."""
-        cmds = self._capture_install(no_torch = False, is_macos = False, is_windows = False)
+        cmds = self._capture_install(no_torch=False, is_macos=False, is_windows=False)
         assert self._cmds_contain_file(
             cmds, "extras.txt"
         ), "extras.txt should be called on normal Linux"
 
     def test_normal_linux_includes_extras_no_deps(self):
         """Normal Linux: extras-no-deps.txt IS called (no filtering)."""
-        cmds = self._capture_install(no_torch = False, is_macos = False, is_windows = False)
+        cmds = self._capture_install(no_torch=False, is_macos=False, is_windows=False)
         assert self._cmds_contain_file(
             cmds, "extras-no-deps.txt"
         ), "extras-no-deps.txt should be called on normal Linux"
@@ -523,7 +523,7 @@ class TestInstallPythonStackSubprocessMock:
 
     def test_windows_only_skips_triton(self):
         """Windows (without NO_TORCH): triton still skipped."""
-        cmds = self._capture_install(no_torch = False, is_macos = False, is_windows = True)
+        cmds = self._capture_install(no_torch=False, is_macos=False, is_windows=True)
         assert not self._cmds_contain_file(
             cmds, "triton-kernels.txt"
         ), "triton-kernels.txt should be skipped on Windows even without NO_TORCH"
@@ -535,7 +535,7 @@ class TestInstallPythonStackSubprocessMock:
         so the command uses a temp file, not overrides.txt directly. We check for
         --reinstall (uv translation of --force-reinstall) which is unique to overrides.
         """
-        cmds = self._capture_install(no_torch = False, is_macos = False, is_windows = True)
+        cmds = self._capture_install(no_torch=False, is_macos=False, is_windows=True)
         assert any(
             "--reinstall" in cmd for cmd in cmds
         ), "overrides step (--reinstall) should be called on Windows when NO_TORCH=False"
@@ -545,7 +545,7 @@ class TestInstallPythonStackSubprocessMock:
     def test_update_path_intel_macos_still_skips_overrides(self):
         """Update path (no SKIP_STUDIO_BASE): overrides still skipped on Intel Mac."""
         cmds = self._capture_install(
-            no_torch = True, is_macos = True, is_windows = False, skip_base = False
+            no_torch=True, is_macos=True, is_windows=False, skip_base=False
         )
         assert not self._cmds_contain_file(
             cmds, "overrides.txt"
@@ -554,7 +554,7 @@ class TestInstallPythonStackSubprocessMock:
     def test_update_path_intel_macos_still_skips_triton(self):
         """Update path (no SKIP_STUDIO_BASE): triton still skipped on macOS."""
         cmds = self._capture_install(
-            no_torch = True, is_macos = True, is_windows = False, skip_base = False
+            no_torch=True, is_macos=True, is_windows=False, skip_base=False
         )
         assert not self._cmds_contain_file(
             cmds, "triton-kernels.txt"
@@ -569,14 +569,14 @@ class TestOverridesSkip:
 
     def test_no_torch_guard_exists_in_source(self):
         """The install_python_stack source must contain a NO_TORCH guard around overrides."""
-        source = Path(ips.__file__).read_text(encoding = "utf-8")
+        source = Path(ips.__file__).read_text(encoding="utf-8")
         assert (
             "if NO_TORCH:" in source
         ), "NO_TORCH guard not found in install_python_stack.py"
 
     def test_overrides_skipped_when_no_torch(self):
         """With NO_TORCH=True on the module, pip_install should NOT be called for overrides."""
-        source = Path(ips.__file__).read_text(encoding = "utf-8")
+        source = Path(ips.__file__).read_text(encoding="utf-8")
         overrides_match = re.search(r"if NO_TORCH:.*?overrides", source, re.DOTALL)
         assert (
             overrides_match is not None
@@ -589,13 +589,13 @@ class TestOverridesSkip:
 class TestInstallShNoTorchFlag:
     """Verify install.sh has the --no-torch flag and SKIP_TORCH variable."""
 
-    @pytest.fixture(autouse = True)
+    @pytest.fixture(autouse=True)
     def _check_install_sh(self):
         install_sh = Path(__file__).resolve().parents[2] / "install.sh"
         if not install_sh.is_file():
             pytest.skip("install.sh not found")
         self.install_sh = install_sh
-        self.source = install_sh.read_text(encoding = "utf-8")
+        self.source = install_sh.read_text(encoding="utf-8")
 
     def test_no_torch_flag_in_case_statement(self):
         """--no-torch must appear in the flag parser case statement."""
@@ -669,8 +669,8 @@ class TestInstallShNoTorchFlag:
         """)
         result = subprocess.run(
             ["bash", "-c", script, "_", "--no-torch"],
-            capture_output = True,
-            text = True,
+            capture_output=True,
+            text=True,
         )
         assert (
             result.stdout.strip() == "true"
@@ -699,8 +699,8 @@ class TestInstallShNoTorchFlag:
         """)
         result = subprocess.run(
             ["bash", "-c", script, "_", "--local", "--no-torch"],
-            capture_output = True,
-            text = True,
+            capture_output=True,
+            text=True,
         )
         assert (
             result.stdout.strip() == "true true"
@@ -722,8 +722,8 @@ class TestInstallShNoTorchFlag:
         """)
         result = subprocess.run(
             ["bash", "-c", script],
-            capture_output = True,
-            text = True,
+            capture_output=True,
+            text=True,
         )
         assert "HINT_PRINTED" in result.stdout, "CPU hint should print"
 
@@ -731,8 +731,8 @@ class TestInstallShNoTorchFlag:
         script2 = script.replace("SKIP_TORCH=false", "SKIP_TORCH=true")
         result2 = subprocess.run(
             ["bash", "-c", script2],
-            capture_output = True,
-            text = True,
+            capture_output=True,
+            text=True,
         )
         assert (
             "HINT_PRINTED" not in result2.stdout
@@ -747,7 +747,7 @@ class TestTritonMacosSkip:
 
     def test_triton_guard_in_source(self):
         """Source must skip triton on both Windows and macOS."""
-        source = Path(ips.__file__).read_text(encoding = "utf-8")
+        source = Path(ips.__file__).read_text(encoding="utf-8")
         assert (
             "not IS_MACOS" in source
         ), "IS_MACOS guard for triton not found in install_python_stack.py"

--- a/tests/python/test_studio_import_no_torch.py
+++ b/tests/python/test_studio_import_no_torch.py
@@ -42,7 +42,7 @@ def _create_venv(venv_dir: Path, python_version: str) -> Path | None:
     """Create a uv venv at the given Python version. Returns python path or None."""
     result = subprocess.run(
         ["uv", "venv", str(venv_dir), "--python", python_version],
-        capture_output = True,
+        capture_output=True,
     )
     if result.returncode != 0:
         return None
@@ -52,7 +52,7 @@ def _create_venv(venv_dir: Path, python_version: str) -> Path | None:
     return venv_python if venv_python.exists() else None
 
 
-@pytest.fixture(params = ["3.12", "3.13"], scope = "module")
+@pytest.fixture(params=["3.12", "3.13"], scope="module")
 def no_torch_venv(request, tmp_path_factory):
     """Create a temporary venv at the requested Python version with no torch.
 
@@ -70,7 +70,7 @@ def no_torch_venv(request, tmp_path_factory):
     # Verify torch is NOT importable
     check = subprocess.run(
         [str(venv_python), "-c", "import torch"],
-        capture_output = True,
+        capture_output=True,
     )
     assert (
         check.returncode != 0
@@ -87,13 +87,13 @@ class TestDataCollatorsAST:
 
     def test_ast_parse(self):
         """data_collators.py must be valid Python syntax."""
-        source = DATA_COLLATORS.read_text(encoding = "utf-8")
-        tree = ast.parse(source, filename = str(DATA_COLLATORS))
+        source = DATA_COLLATORS.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(DATA_COLLATORS))
         assert tree is not None
 
     def test_no_top_level_torch_import(self):
         """No top-level 'import torch' or 'from torch' statements."""
-        source = DATA_COLLATORS.read_text(encoding = "utf-8")
+        source = DATA_COLLATORS.read_text(encoding="utf-8")
         tree = ast.parse(source)
         for node in ast.iter_child_nodes(tree):
             if isinstance(node, ast.Import):
@@ -113,13 +113,13 @@ class TestChatTemplatesAST:
 
     def test_ast_parse(self):
         """chat_templates.py must be valid Python syntax."""
-        source = CHAT_TEMPLATES.read_text(encoding = "utf-8")
-        tree = ast.parse(source, filename = str(CHAT_TEMPLATES))
+        source = CHAT_TEMPLATES.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(CHAT_TEMPLATES))
         assert tree is not None
 
     def test_no_top_level_torch_import(self):
         """No top-level 'import torch' or 'from torch' at module level."""
-        source = CHAT_TEMPLATES.read_text(encoding = "utf-8")
+        source = CHAT_TEMPLATES.read_text(encoding="utf-8")
         tree = ast.parse(source)
         for node in ast.iter_child_nodes(tree):
             if isinstance(node, ast.Import):
@@ -135,7 +135,7 @@ class TestChatTemplatesAST:
 
     def test_torch_imports_only_inside_functions(self):
         """All 'from torch' imports must be inside function/method bodies."""
-        source = CHAT_TEMPLATES.read_text(encoding = "utf-8")
+        source = CHAT_TEMPLATES.read_text(encoding="utf-8")
         tree = ast.parse(source)
         torch_imports = []
         for node in ast.walk(tree):
@@ -174,8 +174,8 @@ class TestDataCollatorsNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -196,8 +196,8 @@ class TestDataCollatorsNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -220,8 +220,8 @@ class TestDataCollatorsNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -243,8 +243,8 @@ class TestDataCollatorsNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -293,8 +293,8 @@ class TestChatTemplatesNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -332,8 +332,8 @@ class TestChatTemplatesNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -349,13 +349,13 @@ class TestFormatConversionAST:
 
     def test_ast_parse(self):
         """format_conversion.py must be valid Python syntax."""
-        source = FORMAT_CONVERSION.read_text(encoding = "utf-8")
-        tree = ast.parse(source, filename = str(FORMAT_CONVERSION))
+        source = FORMAT_CONVERSION.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(FORMAT_CONVERSION))
         assert tree is not None
 
     def test_no_bare_torch_import_in_functions(self):
         """All 'from torch' imports in function bodies must be inside try/except."""
-        source = FORMAT_CONVERSION.read_text(encoding = "utf-8")
+        source = FORMAT_CONVERSION.read_text(encoding="utf-8")
         tree = ast.parse(source)
 
         for node in ast.walk(tree):
@@ -437,8 +437,8 @@ class TestFormatConversionNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -492,8 +492,8 @@ class TestFormatConversionNoTorchVenv:
         """)
         result = subprocess.run(
             [no_torch_venv, "-c", code],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert (
             result.returncode == 0
@@ -510,10 +510,10 @@ class TestNegativeControls:
     def test_import_torch_prepended_fails(self, no_torch_venv):
         """Prepending 'import torch' to data_collators.py causes ModuleNotFoundError."""
         with tempfile.NamedTemporaryFile(
-            mode = "w", suffix = ".py", delete = False, encoding = "utf-8"
+            mode="w", suffix=".py", delete=False, encoding="utf-8"
         ) as f:
             f.write("import torch\n")
-            f.write(DATA_COLLATORS.read_text(encoding = "utf-8"))
+            f.write(DATA_COLLATORS.read_text(encoding="utf-8"))
             temp_file = f.name
 
         try:
@@ -526,8 +526,8 @@ class TestNegativeControls:
             """)
             result = subprocess.run(
                 [no_torch_venv, "-c", code],
-                capture_output = True,
-                timeout = 30,
+                capture_output=True,
+                timeout=30,
             )
             assert (
                 result.returncode != 0
@@ -553,8 +553,8 @@ class TestNegativeControls:
                 "torchao==0.14.0",
                 "--dry-run",
             ],
-            capture_output = True,
-            timeout = 60,
+            capture_output=True,
+            timeout=60,
         )
         if result.returncode != 0:
             # torchao install/resolution failed as expected
@@ -563,7 +563,7 @@ class TestNegativeControls:
             # pip dry-run may not catch dependency issues; verify torch is missing
             check = subprocess.run(
                 [no_torch_venv, "-c", "import torch"],
-                capture_output = True,
+                capture_output=True,
             )
             assert (
                 check.returncode != 0
@@ -573,8 +573,8 @@ class TestNegativeControls:
         """Direct 'import torch' fails in the no-torch venv."""
         result = subprocess.run(
             [no_torch_venv, "-c", "import torch; print('torch loaded')"],
-            capture_output = True,
-            timeout = 30,
+            capture_output=True,
+            timeout=30,
         )
         assert result.returncode != 0, "import torch should fail in no-torch venv"
         assert (

--- a/tests/python/test_tokenizers_and_torch_constraint.py
+++ b/tests/python/test_tokenizers_and_torch_constraint.py
@@ -24,7 +24,7 @@ _NO_TORCH_RT = (
 
 
 def _read(path: pathlib.Path) -> str:
-    return path.read_text(encoding = "utf-8")
+    return path.read_text(encoding="utf-8")
 
 
 def _lines(path: pathlib.Path) -> list[str]:
@@ -157,7 +157,7 @@ class TestTorchConstraintShell:
         """Create a mock python that prints a controlled minor version."""
         venv = tmp_path / "venv"
         bin_dir = venv / "bin"
-        bin_dir.mkdir(parents = True, exist_ok = True)
+        bin_dir.mkdir(parents=True, exist_ok=True)
         mock_py = bin_dir / "python"
         mock_py.write_text(
             textwrap.dedent(f"""\
@@ -184,19 +184,19 @@ class TestTorchConstraintShell:
     ) -> str:
         venv = self._make_mock_python(tmp_path, py_minor)
         script = self._SNIPPET_TEMPLATE.format(
-            skip_torch = skip_torch,
-            os = os_val,
-            arch = arch,
-            venv_dir = str(venv),
+            skip_torch=skip_torch,
+            os=os_val,
+            arch=arch,
+            venv_dir=str(venv),
         )
         script_file = tmp_path / "test_snippet.sh"
         script_file.write_text(script)
         script_file.chmod(0o755)
         result = subprocess.run(
             ["bash", str(script_file)],
-            capture_output = True,
-            text = True,
-            timeout = 10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0, f"Script failed: {result.stderr}"
         return result.stdout.strip()
@@ -204,37 +204,37 @@ class TestTorchConstraintShell:
     # -- arm64 macOS tightening cases --
 
     def test_arm64_macos_py313_tightened(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 13, os_val = "macos", arch = "arm64")
+        out = self._run(tmp_path, py_minor=13, os_val="macos", arch="arm64")
         assert out == "torch>=2.6,<2.11.0"
 
     def test_arm64_macos_py314_tightened(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 14, os_val = "macos", arch = "arm64")
+        out = self._run(tmp_path, py_minor=14, os_val="macos", arch="arm64")
         assert out == "torch>=2.6,<2.11.0"
 
     # -- arm64 macOS default (older python) --
 
     def test_arm64_macos_py312_default(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 12, os_val = "macos", arch = "arm64")
+        out = self._run(tmp_path, py_minor=12, os_val="macos", arch="arm64")
         assert out == "torch>=2.4,<2.11.0"
 
     def test_arm64_macos_py311_default(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 11, os_val = "macos", arch = "arm64")
+        out = self._run(tmp_path, py_minor=11, os_val="macos", arch="arm64")
         assert out == "torch>=2.4,<2.11.0"
 
     # -- Linux (unaffected) --
 
     def test_linux_x86_py313_default(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 13, os_val = "linux", arch = "x86_64")
+        out = self._run(tmp_path, py_minor=13, os_val="linux", arch="x86_64")
         assert out == "torch>=2.4,<2.11.0"
 
     def test_linux_aarch64_py313_default(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 13, os_val = "linux", arch = "aarch64")
+        out = self._run(tmp_path, py_minor=13, os_val="linux", arch="aarch64")
         assert out == "torch>=2.4,<2.11.0"
 
     # -- Intel Mac (arch mismatch) --
 
     def test_intel_mac_x86_py313_default(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 13, os_val = "macos", arch = "x86_64")
+        out = self._run(tmp_path, py_minor=13, os_val="macos", arch="x86_64")
         assert out == "torch>=2.4,<2.11.0"
 
     # -- SKIP_TORCH bypass --
@@ -242,37 +242,37 @@ class TestTorchConstraintShell:
     def test_skip_torch_arm64_macos_py313_default(self, tmp_path):
         out = self._run(
             tmp_path,
-            py_minor = 13,
-            os_val = "macos",
-            arch = "arm64",
-            skip_torch = "true",
+            py_minor=13,
+            os_val="macos",
+            arch="arm64",
+            skip_torch="true",
         )
         assert out == "torch>=2.4,<2.11.0"
 
     # -- WSL --
 
     def test_wsl_py313_default(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 13, os_val = "wsl", arch = "x86_64")
+        out = self._run(tmp_path, py_minor=13, os_val="wsl", arch="x86_64")
         assert out == "torch>=2.4,<2.11.0"
 
     # -- Edge cases --
 
     def test_py_minor_0_fallback_default(self, tmp_path):
         """If python query fails (returns 0), should stay at default."""
-        out = self._run(tmp_path, py_minor = 0, os_val = "macos", arch = "arm64")
+        out = self._run(tmp_path, py_minor=0, os_val="macos", arch="arm64")
         assert out == "torch>=2.4,<2.11.0"
 
     def test_boundary_py_minor_12_not_tightened(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 12, os_val = "macos", arch = "arm64")
+        out = self._run(tmp_path, py_minor=12, os_val="macos", arch="arm64")
         assert out == "torch>=2.4,<2.11.0"
 
     def test_boundary_py_minor_13_tightened(self, tmp_path):
-        out = self._run(tmp_path, py_minor = 13, os_val = "macos", arch = "arm64")
+        out = self._run(tmp_path, py_minor=13, os_val="macos", arch="arm64")
         assert out == "torch>=2.6,<2.11.0"
 
     def test_mock_uv_receives_correct_constraint(self, tmp_path):
         """Verify a mock uv would receive the correct constraint string."""
-        venv = self._make_mock_python(tmp_path, minor = 13)
+        venv = self._make_mock_python(tmp_path, minor=13)
 
         # Create a mock uv that logs its arguments
         mock_uv = tmp_path / "mock_uv"
@@ -310,9 +310,9 @@ class TestTorchConstraintShell:
 
         result = subprocess.run(
             ["bash", str(script_file)],
-            capture_output = True,
-            text = True,
-            timeout = 10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0, f"Script failed: {result.stderr}"
         logged = log_file.read_text()
@@ -320,7 +320,7 @@ class TestTorchConstraintShell:
 
     def test_mock_uv_receives_default_constraint(self, tmp_path):
         """On py3.12 arm64 macOS, uv should receive the default constraint."""
-        venv = self._make_mock_python(tmp_path, minor = 12)
+        venv = self._make_mock_python(tmp_path, minor=12)
         mock_uv = tmp_path / "mock_uv"
         log_file = tmp_path / "uv_log.txt"
         mock_uv.write_text(
@@ -355,9 +355,9 @@ class TestTorchConstraintShell:
 
         result = subprocess.run(
             ["bash", str(script_file)],
-            capture_output = True,
-            text = True,
-            timeout = 10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0, f"Script failed: {result.stderr}"
         logged = log_file.read_text()
@@ -377,9 +377,9 @@ class TestE2ETokenizersFix:
         venv = tmp_path / name
         result = subprocess.run(
             ["uv", "venv", str(venv), "--python", py],
-            capture_output = True,
-            text = True,
-            timeout = 120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
         if result.returncode != 0:
             pytest.skip(f"uv venv creation failed for {py}: {result.stderr}")
@@ -389,16 +389,16 @@ class TestE2ETokenizersFix:
     def _pip_install(venv: pathlib.Path, *args: str) -> subprocess.CompletedProcess:
         py = str(venv / "bin" / "python")
         cmd = ["uv", "pip", "install", "--python", py, *args]
-        return subprocess.run(cmd, capture_output = True, text = True, timeout = 300)
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=300)
 
     @staticmethod
     def _run_python(venv: pathlib.Path, code: str) -> subprocess.CompletedProcess:
         py = str(venv / "bin" / "python")
         return subprocess.run(
             [py, "-c", code],
-            capture_output = True,
-            text = True,
-            timeout = 60,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
 
     @pytest.mark.parametrize("py_version", ["3.12", "3.13"])
@@ -445,7 +445,7 @@ class TestE2ETokenizersFix:
                 for line in _read(_NO_TORCH_RT).splitlines()
                 if line.strip() != "tokenizers"
             ),
-            encoding = "utf-8",
+            encoding="utf-8",
         )
         r = self._pip_install(venv, "--no-deps", "-r", str(req_no_tokenizers))
         assert r.returncode == 0, f"Install failed: {r.stderr}"
@@ -505,9 +505,9 @@ class TestE2EFullNoTorchSandbox:
         venv = tmp_path / name
         result = subprocess.run(
             ["uv", "venv", str(venv), "--python", "3.12"],
-            capture_output = True,
-            text = True,
-            timeout = 120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
         if result.returncode != 0:
             pytest.skip(f"uv venv creation failed: {result.stderr}")
@@ -517,16 +517,16 @@ class TestE2EFullNoTorchSandbox:
     def _pip_install(venv: pathlib.Path, *args: str) -> subprocess.CompletedProcess:
         py = str(venv / "bin" / "python")
         cmd = ["uv", "pip", "install", "--python", py, *args]
-        return subprocess.run(cmd, capture_output = True, text = True, timeout = 600)
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=600)
 
     @staticmethod
     def _run_python(venv: pathlib.Path, code: str) -> subprocess.CompletedProcess:
         py = str(venv / "bin" / "python")
         return subprocess.run(
             [py, "-c", code],
-            capture_output = True,
-            text = True,
-            timeout = 60,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
 
     def test_autoconfig_succeeds(self, tmp_path):

--- a/tests/saving/gpt-oss-merge/train_and_merge.py
+++ b/tests/saving/gpt-oss-merge/train_and_merge.py
@@ -29,7 +29,7 @@ def formatting_prompts_func(examples):
     convos = examples["messages"]
     texts = [
         tokenizer.apply_chat_template(
-            convo, tokenize = False, add_generation_prompt = False
+            convo, tokenize=False, add_generation_prompt=False
         )
         for convo in convos
     ]
@@ -40,17 +40,17 @@ def formatting_prompts_func(examples):
 print("Loading 4-bit Mxfp4 gpt-oss model for training...")
 max_seq_length = 1024
 model, tokenizer = FastLanguageModel.from_pretrained(
-    "unsloth/gpt-oss-20b", max_seq_length = max_seq_length, load_in_4bit = True
+    "unsloth/gpt-oss-20b", max_seq_length=max_seq_length, load_in_4bit=True
 )
 
-dataset = load_dataset("HuggingFaceH4/Multilingual-Thinking", split = "train[:50]").map(
-    formatting_prompts_func, batched = True
+dataset = load_dataset("HuggingFaceH4/Multilingual-Thinking", split="train[:50]").map(
+    formatting_prompts_func, batched=True
 )
 
 model = FastLanguageModel.get_peft_model(
     model,
-    r = 8,
-    target_modules = [
+    r=8,
+    target_modules=[
         "q_proj",
         "k_proj",
         "v_proj",
@@ -59,22 +59,22 @@ model = FastLanguageModel.get_peft_model(
         "up_proj",
         "down_proj",
     ],
-    lora_alpha = 16,
-    use_gradient_checkpointing = "unsloth",
-    random_state = 3407,
+    lora_alpha=16,
+    use_gradient_checkpointing="unsloth",
+    random_state=3407,
 )
 
 trainer = SFTTrainer(
-    model = model,
-    tokenizer = tokenizer,
-    train_dataset = dataset,
-    args = SFTConfig(
-        per_device_train_batch_size = 1,
-        gradient_accumulation_steps = 4,
-        max_steps = 10,
-        learning_rate = 2e-4,
-        output_dir = "outputs",
-        report_to = "none",
+    model=model,
+    tokenizer=tokenizer,
+    train_dataset=dataset,
+    args=SFTConfig(
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=4,
+        max_steps=10,
+        learning_rate=2e-4,
+        output_dir="outputs",
+        report_to="none",
     ),
 )
 
@@ -85,7 +85,7 @@ print("Fine-tuning complete.")
 # --- Merge and Save ---
 print("\n💾 Merging and saving the 16-bit model to './gpt-oss-finetuned-merged'...")
 model.save_pretrained_merged(
-    save_directory = "./gpt-oss-finetuned-merged", tokenizer = tokenizer
+    save_directory="./gpt-oss-finetuned-merged", tokenizer=tokenizer
 )
 print("✅ Model merged and saved.")
 

--- a/tests/saving/language_models/test_merged_model_perplexity_llama-3.1-8b.py
+++ b/tests/saving/language_models/test_merged_model_perplexity_llama-3.1-8b.py
@@ -35,14 +35,14 @@ def formatting_prompts_func(examples):
     convos = examples["messages"]
     texts = [
         tokenizer.apply_chat_template(
-            convo, tokenize = False, add_generation_prompt = False
+            convo, tokenize=False, add_generation_prompt=False
         )
         for convo in convos
     ]
     return {"text": texts}
 
 
-def load_and_compute_8bit_ppl(result_queue, load_in_4bit = False, load_in_8bit = False):
+def load_and_compute_8bit_ppl(result_queue, load_in_4bit=False, load_in_8bit=False):
     """Load model and compute perplexity in subprocess"""
     from unsloth import FastLanguageModel
     from unsloth.chat_templates import get_chat_template
@@ -50,20 +50,20 @@ def load_and_compute_8bit_ppl(result_queue, load_in_4bit = False, load_in_8bit =
 
     # Load model
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_llama_text_model",
-        max_seq_length = 2048,
-        load_in_4bit = load_in_4bit,
-        load_in_8bit = load_in_8bit,
+        model_name="./unsloth_out/merged_llama_text_model",
+        max_seq_length=2048,
+        load_in_4bit=load_in_4bit,
+        load_in_8bit=load_in_8bit,
     )
     # Set up tokenizer
     merged_tokenizer = get_chat_template(
         merged_tokenizer,
-        chat_template = "llama-3.1",
+        chat_template="llama-3.1",
     )
 
     # Load dataset fresh in subprocess
     dataset_ppl = load_dataset(
-        "allenai/openassistant-guanaco-reformatted", split = "eval"
+        "allenai/openassistant-guanaco-reformatted", split="eval"
     )
 
     # Format the dataset
@@ -71,13 +71,13 @@ def load_and_compute_8bit_ppl(result_queue, load_in_4bit = False, load_in_8bit =
         convos = examples["messages"]
         texts = [
             merged_tokenizer.apply_chat_template(
-                convo, tokenize = False, add_generation_prompt = False
+                convo, tokenize=False, add_generation_prompt=False
             )
             for convo in convos
         ]
         return {"text": texts}
 
-    dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched = True)
+    dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched=True)
 
     # Compute perplexity using the passed dataset
     ppl_value = ppl_model(merged_model, merged_tokenizer, dataset_ppl)
@@ -103,7 +103,7 @@ def load_and_compute_8bit_ppl(result_queue, load_in_4bit = False, load_in_8bit =
 
 # Main execution code should be wrapped in this guard
 if __name__ == "__main__":
-    mp.set_start_method("spawn", force = True)
+    mp.set_start_method("spawn", force=True)
 
     if torch.cuda.is_bf16_supported():
         compute_dtype = torch.bfloat16
@@ -113,31 +113,31 @@ if __name__ == "__main__":
         attn_implementation = "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "unsloth/Llama-3.1-8B-Instruct",
-        max_seq_length = 2048,
-        dtype = compute_dtype,
-        load_in_4bit = True,
-        load_in_8bit = False,
-        full_finetuning = False,
-        attn_implementation = attn_implementation,
+        model_name="unsloth/Llama-3.1-8B-Instruct",
+        max_seq_length=2048,
+        dtype=compute_dtype,
+        load_in_4bit=True,
+        load_in_8bit=False,
+        full_finetuning=False,
+        attn_implementation=attn_implementation,
     )
 
     tokenizer = get_chat_template(
         tokenizer,
-        chat_template = "llama-3.1",
+        chat_template="llama-3.1",
     )
 
     from unsloth.chat_templates import standardize_sharegpt
 
     dataset_train = load_dataset(
-        "allenai/openassistant-guanaco-reformatted", split = "train"
+        "allenai/openassistant-guanaco-reformatted", split="train"
     )
     dataset_ppl = load_dataset(
-        "allenai/openassistant-guanaco-reformatted", split = "eval"
+        "allenai/openassistant-guanaco-reformatted", split="eval"
     )
 
-    dataset_train = dataset_train.map(formatting_prompts_func, batched = True)
-    dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched = True)
+    dataset_train = dataset_train.map(formatting_prompts_func, batched=True)
+    dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched=True)
 
     print("\n dataset sample [0]")
     print(dataset_train[0])
@@ -146,8 +146,8 @@ if __name__ == "__main__":
 
     model = FastLanguageModel.get_peft_model(
         model,
-        r = 16,
-        target_modules = [
+        r=16,
+        target_modules=[
             "k_proj",
             "q_proj",
             "v_proj",
@@ -156,40 +156,40 @@ if __name__ == "__main__":
             "down_proj",
             "up_proj",
         ],
-        lora_alpha = 16,
-        lora_dropout = 0,
-        bias = "none",
-        use_gradient_checkpointing = "unsloth",
-        random_state = 3407,
-        use_rslora = False,
-        loftq_config = None,
+        lora_alpha=16,
+        lora_dropout=0,
+        bias="none",
+        use_gradient_checkpointing="unsloth",
+        random_state=3407,
+        use_rslora=False,
+        loftq_config=None,
     )
 
     from unsloth import is_bfloat16_supported
 
     trainer = SFTTrainer(
-        model = model,
-        tokenizer = tokenizer,
-        train_dataset = dataset_train,
-        dataset_text_field = "text",
-        max_seq_length = 2048,
-        data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer),
-        dataset_num_proc = 2,
-        packing = False,
-        args = TrainingArguments(
-            per_device_train_batch_size = 2,
-            gradient_accumulation_steps = 4,
-            warmup_ratio = 0.1,
-            max_steps = 200,
-            learning_rate = 2e-4,
-            fp16 = not is_bfloat16_supported(),
-            bf16 = is_bfloat16_supported(),
-            logging_steps = 50,
-            optim = "adamw_8bit",
-            lr_scheduler_type = "linear",
-            seed = 3407,
-            output_dir = "outputs",
-            report_to = "none",
+        model=model,
+        tokenizer=tokenizer,
+        train_dataset=dataset_train,
+        dataset_text_field="text",
+        max_seq_length=2048,
+        data_collator=DataCollatorForSeq2Seq(tokenizer=tokenizer),
+        dataset_num_proc=2,
+        packing=False,
+        args=TrainingArguments(
+            per_device_train_batch_size=2,
+            gradient_accumulation_steps=4,
+            warmup_ratio=0.1,
+            max_steps=200,
+            learning_rate=2e-4,
+            fp16=not is_bfloat16_supported(),
+            bf16=is_bfloat16_supported(),
+            logging_steps=50,
+            optim="adamw_8bit",
+            lr_scheduler_type="linear",
+            seed=3407,
+            output_dir="outputs",
+            report_to="none",
         ),
     )
 
@@ -197,8 +197,8 @@ if __name__ == "__main__":
 
     trainer = train_on_responses_only(
         trainer,
-        instruction_part = "<|start_header_id|>user<|end_header_id|>\n\n",
-        response_part = "<|start_header_id|>assistant<|end_header_id|>\n\n",
+        instruction_part="<|start_header_id|>user<|end_header_id|>\n\n",
+        response_part="<|start_header_id|>assistant<|end_header_id|>\n\n",
     )
 
     tokenizer.decode(trainer.train_dataset[0]["input_ids"])
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     # saving and merging the model to local disk
     print("merge and save to local disk")
     model.save_pretrained_merged(
-        save_directory = "./unsloth_out/merged_llama_text_model", tokenizer = tokenizer
+        save_directory="./unsloth_out/merged_llama_text_model", tokenizer=tokenizer
     )
 
     # print("cleaning")
@@ -223,10 +223,10 @@ if __name__ == "__main__":
     # load model from local disk and test
     print("Loading merged model in 4 bit for perplexity test")
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_llama_text_model",
-        max_seq_length = 2048,
-        load_in_4bit = True,
-        load_in_8bit = False,
+        model_name="./unsloth_out/merged_llama_text_model",
+        max_seq_length=2048,
+        load_in_4bit=True,
+        load_in_8bit=False,
     )
 
     add_to_comparison(
@@ -235,7 +235,7 @@ if __name__ == "__main__":
 
     print("Computing 8-bit model perplexity in subprocess...")
     result_queue = mp.Queue()
-    p = mp.Process(target = load_and_compute_8bit_ppl, args = (result_queue, False, True))
+    p = mp.Process(target=load_and_compute_8bit_ppl, args=(result_queue, False, True))
     p.start()
     p.join()
 
@@ -244,10 +244,10 @@ if __name__ == "__main__":
 
     print("Loading merged model in 16 bit for perplexity test")
     merged_model, merged_tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "./unsloth_out/merged_llama_text_model",
-        max_seq_length = 2048,
-        load_in_4bit = False,
-        load_in_8bit = False,
+        model_name="./unsloth_out/merged_llama_text_model",
+        max_seq_length=2048,
+        load_in_4bit=False,
+        load_in_8bit=False,
     )
 
     add_to_comparison(

--- a/tests/saving/language_models/test_push_to_hub_merged_sharded_index_file.py
+++ b/tests/saving/language_models/test_push_to_hub_merged_sharded_index_file.py
@@ -37,7 +37,7 @@ def formatting_prompts_func(examples):
     convos = examples["messages"]
     texts = [
         tokenizer.apply_chat_template(
-            convo, tokenize = False, add_generation_prompt = False
+            convo, tokenize=False, add_generation_prompt=False
         )
         for convo in convos
     ]
@@ -52,34 +52,34 @@ else:
     attn_implementation = "sdpa"
 
 model, tokenizer = FastLanguageModel.from_pretrained(
-    model_name = "unsloth/Llama-3.1-8B-Instruct",
-    max_seq_length = 2048,
-    dtype = compute_dtype,
-    load_in_4bit = True,
-    load_in_8bit = False,
-    full_finetuning = False,
-    attn_implementation = attn_implementation,
+    model_name="unsloth/Llama-3.1-8B-Instruct",
+    max_seq_length=2048,
+    dtype=compute_dtype,
+    load_in_4bit=True,
+    load_in_8bit=False,
+    full_finetuning=False,
+    attn_implementation=attn_implementation,
 )
 
 tokenizer = get_chat_template(
     tokenizer,
-    chat_template = "llama-3.1",
+    chat_template="llama-3.1",
 )
 
 from unsloth.chat_templates import standardize_sharegpt
 
-dataset_train = load_dataset("allenai/openassistant-guanaco-reformatted", split = "train")
-dataset_ppl = load_dataset("allenai/openassistant-guanaco-reformatted", split = "eval")
+dataset_train = load_dataset("allenai/openassistant-guanaco-reformatted", split="train")
+dataset_ppl = load_dataset("allenai/openassistant-guanaco-reformatted", split="eval")
 
-dataset_train = dataset_train.map(formatting_prompts_func, batched = True)
-dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched = True)
+dataset_train = dataset_train.map(formatting_prompts_func, batched=True)
+dataset_ppl = dataset_ppl.map(formatting_prompts_func, batched=True)
 
 add_to_comparison("Base model 4 bits", ppl_model(model, tokenizer, dataset_ppl))
 
 model = FastLanguageModel.get_peft_model(
     model,
-    r = 16,
-    target_modules = [
+    r=16,
+    target_modules=[
         "k_proj",
         "q_proj",
         "v_proj",
@@ -88,40 +88,40 @@ model = FastLanguageModel.get_peft_model(
         "down_proj",
         "up_proj",
     ],
-    lora_alpha = 16,
-    lora_dropout = 0,
-    bias = "none",
-    use_gradient_checkpointing = "unsloth",
-    random_state = 3407,
-    use_rslora = False,
-    loftq_config = None,
+    lora_alpha=16,
+    lora_dropout=0,
+    bias="none",
+    use_gradient_checkpointing="unsloth",
+    random_state=3407,
+    use_rslora=False,
+    loftq_config=None,
 )
 
 from unsloth import is_bfloat16_supported
 
 trainer = SFTTrainer(
-    model = model,
-    tokenizer = tokenizer,
-    train_dataset = dataset_train,
-    dataset_text_field = "text",
-    max_seq_length = 2048,
-    data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer),
-    dataset_num_proc = 2,
-    packing = False,
-    args = TrainingArguments(
-        per_device_train_batch_size = 2,
-        gradient_accumulation_steps = 4,
-        warmup_ratio = 0.1,
-        max_steps = 30,
-        learning_rate = 2e-4,
-        fp16 = not is_bfloat16_supported(),
-        bf16 = is_bfloat16_supported(),
-        logging_steps = 50,
-        optim = "adamw_8bit",
-        lr_scheduler_type = "linear",
-        seed = 3407,
-        output_dir = "outputs",
-        report_to = "none",
+    model=model,
+    tokenizer=tokenizer,
+    train_dataset=dataset_train,
+    dataset_text_field="text",
+    max_seq_length=2048,
+    data_collator=DataCollatorForSeq2Seq(tokenizer=tokenizer),
+    dataset_num_proc=2,
+    packing=False,
+    args=TrainingArguments(
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=4,
+        warmup_ratio=0.1,
+        max_steps=30,
+        learning_rate=2e-4,
+        fp16=not is_bfloat16_supported(),
+        bf16=is_bfloat16_supported(),
+        logging_steps=50,
+        optim="adamw_8bit",
+        lr_scheduler_type="linear",
+        seed=3407,
+        output_dir="outputs",
+        report_to="none",
     ),
 )
 
@@ -129,8 +129,8 @@ from unsloth.chat_templates import train_on_responses_only
 
 trainer = train_on_responses_only(
     trainer,
-    instruction_part = "<|start_header_id|>user<|end_header_id|>\n\n",
-    response_part = "<|start_header_id|>assistant<|end_header_id|>\n\n",
+    instruction_part="<|start_header_id|>user<|end_header_id|>\n\n",
+    response_part="<|start_header_id|>assistant<|end_header_id|>\n\n",
 )
 
 # run training
@@ -161,7 +161,7 @@ try:
     print("\n" + "=" * 80)
     print("=== UPLOADING MODEL TO HUB ===".center(80))
     print("=" * 80 + "\n")
-    model.push_to_hub_merged(repo_name, tokenizer = tokenizer, token = hf_token)
+    model.push_to_hub_merged(repo_name, tokenizer=tokenizer, token=hf_token)
     success["upload"] = True
     print("✅ Model uploaded successfully!")
 except Exception as e:
@@ -173,8 +173,8 @@ try:
     print("\n" + "=" * 80)
     print("=== VERIFYING REPO CONTENTS ===".center(80))
     print("=" * 80 + "\n")
-    fs = HfFileSystem(token = hf_token)
-    file_list = fs.ls(repo_name, detail = True)
+    fs = HfFileSystem(token=hf_token)
+    file_list = fs.ls(repo_name, detail=True)
     safetensors_found = any(
         file["name"].endswith("model.safetensors.index.json") for file in file_list
     )

--- a/tests/saving/non_peft/test_mistral_non_peft.py
+++ b/tests/saving/non_peft/test_mistral_non_peft.py
@@ -16,12 +16,12 @@ print("🔍 PHASE 1: Loading Base Model")
 print(f"{'='*80}")
 
 model, tokenizer = FastLanguageModel.from_pretrained(
-    model_name = "unsloth/mistral-7b-v0.3",
-    max_seq_length = 2048,
-    dtype = None,
-    load_in_4bit = True,
-    load_in_8bit = False,
-    full_finetuning = False,
+    model_name="unsloth/mistral-7b-v0.3",
+    max_seq_length=2048,
+    dtype=None,
+    load_in_4bit=True,
+    load_in_8bit=False,
+    full_finetuning=False,
 )
 
 
@@ -34,7 +34,7 @@ print(f"\n{'='*80}")
 print("🔍 PHASE 2: Attempting save_pretrained_merged (Should Warn)")
 print(f"{'='*80}")
 
-with warnings.catch_warnings(record = True) as w:
+with warnings.catch_warnings(record=True) as w:
     warnings.simplefilter("always")
     model.save_pretrained_merged("test_output", tokenizer)
 

--- a/tests/saving/test_save_shell_injection.py
+++ b/tests/saving/test_save_shell_injection.py
@@ -8,7 +8,7 @@ SAVE_PY = Path(__file__).resolve().parents[2] / "unsloth" / "save.py"
 
 
 def _function_calls(source: str, function_name: str) -> list[ast.Call]:
-    tree = ast.parse(source, filename = str(SAVE_PY))
+    tree = ast.parse(source, filename=str(SAVE_PY))
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name == function_name:
             return [child for child in ast.walk(node) if isinstance(child, ast.Call)]
@@ -65,7 +65,7 @@ def _assert_safe_ggml_calls(calls: list[ast.Call]) -> None:
 
 
 def test_ggml_conversion_paths_do_not_use_shell() -> None:
-    source = SAVE_PY.read_text(encoding = "utf-8")
+    source = SAVE_PY.read_text(encoding="utf-8")
     for function_name in (
         "unsloth_convert_lora_to_ggml_and_push_to_hub",
         "unsloth_convert_lora_to_ggml_and_save_locally",

--- a/tests/saving/text_to_speech_models/test_csm.py
+++ b/tests/saving/text_to_speech_models/test_csm.py
@@ -26,11 +26,11 @@ print(f"{'='*80}")
 
 
 model, tokenizer = FastModel.from_pretrained(
-    model_name = "unsloth/csm-1b",
-    max_seq_length = 2048,  # Choose any for long context!
-    dtype = None,  # Leave as None for auto-detection
-    auto_model = CsmForConditionalGeneration,
-    load_in_4bit = False,  # Select True for 4bit - reduces memory usage
+    model_name="unsloth/csm-1b",
+    max_seq_length=2048,  # Choose any for long context!
+    dtype=None,  # Leave as None for auto-detection
+    auto_model=CsmForConditionalGeneration,
+    load_in_4bit=False,  # Select True for 4bit - reduces memory usage
 )
 
 
@@ -39,8 +39,8 @@ base_model_class = model.__class__.__name__
 
 model = FastModel.get_peft_model(
     model,
-    r = 32,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
-    target_modules = [
+    r=32,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
+    target_modules=[
         "q_proj",
         "k_proj",
         "v_proj",
@@ -49,14 +49,14 @@ model = FastModel.get_peft_model(
         "up_proj",
         "down_proj",
     ],
-    lora_alpha = 32,
-    lora_dropout = 0,  # Supports any, but = 0 is optimized
-    bias = "none",  # Supports any, but = "none" is optimized
+    lora_alpha=32,
+    lora_dropout=0,  # Supports any, but = 0 is optimized
+    bias="none",  # Supports any, but = "none" is optimized
     # [NEW] "unsloth" uses 30% less VRAM, fits 2x larger batch sizes!
-    use_gradient_checkpointing = "unsloth",  # True or "unsloth" for very long context
-    random_state = 3407,
-    use_rslora = False,  # We support rank stabilized LoRA
-    loftq_config = None,  # And LoftQ
+    use_gradient_checkpointing="unsloth",  # True or "unsloth" for very long context
+    random_state=3407,
+    use_rslora=False,  # We support rank stabilized LoRA
+    loftq_config=None,  # And LoftQ
 )
 
 print("✅ Model and LoRA adapters loaded successfully!")
@@ -110,11 +110,11 @@ print(f"{'='*80}")
 
 
 model, processor = FastModel.from_pretrained(
-    model_name = "./csm",
-    max_seq_length = 2048,  # Choose any for long context!
-    dtype = None,  # Leave as None for auto-detection
-    auto_model = CsmForConditionalGeneration,
-    load_in_4bit = False,  # Select True for 4bit - reduces memory usage
+    model_name="./csm",
+    max_seq_length=2048,  # Choose any for long context!
+    dtype=None,  # Leave as None for auto-detection
+    auto_model=CsmForConditionalGeneration,
+    load_in_4bit=False,  # Select True for 4bit - reduces memory usage
 )
 
 from transformers import AutoProcessor
@@ -138,19 +138,19 @@ try:
         "We just finished fine tuning a text to speech model... and it's pretty good!"
     )
     speaker_id = 0
-    inputs = processor(f"[{speaker_id}]{text}", add_special_tokens = True).to("cuda")
+    inputs = processor(f"[{speaker_id}]{text}", add_special_tokens=True).to("cuda")
     audio_values = model.generate(
         **inputs,
-        max_new_tokens = 125,  # 125 tokens is 10 seconds of audio, for longer speech increase this
+        max_new_tokens=125,  # 125 tokens is 10 seconds of audio, for longer speech increase this
         # play with these parameters to get the best results
-        depth_decoder_temperature = 0.6,
-        depth_decoder_top_k = 0,
-        depth_decoder_top_p = 0.9,
-        temperature = 0.8,
-        top_k = 50,
-        top_p = 1.0,
+        depth_decoder_temperature=0.6,
+        depth_decoder_top_k=0,
+        depth_decoder_top_p=0.9,
+        temperature=0.8,
+        top_k=50,
+        top_p=1.0,
         #########################################################
-        output_audio = True,
+        output_audio=True,
     )
     audio = audio_values[0].to(torch.float32).cpu().numpy()
     sf.write("example_without_context.wav", audio, 24000)

--- a/tests/saving/text_to_speech_models/test_orpheus.py
+++ b/tests/saving/text_to_speech_models/test_orpheus.py
@@ -30,10 +30,10 @@ print(f"{'='*80}")
 
 
 model, tokenizer = FastLanguageModel.from_pretrained(
-    model_name = "unsloth/orpheus-3b-0.1-ft",
-    max_seq_length = 2048,  # Choose any for long context!
-    dtype = None,  # Select None for auto detection
-    load_in_4bit = False,  # Select True for 4bit which reduces memory usage
+    model_name="unsloth/orpheus-3b-0.1-ft",
+    max_seq_length=2048,  # Choose any for long context!
+    dtype=None,  # Select None for auto detection
+    load_in_4bit=False,  # Select True for 4bit which reduces memory usage
     # token = "hf_...", # use one if using gated models like meta-llama/Llama-2-7b-hf
 )
 
@@ -42,8 +42,8 @@ base_model_class = model.__class__.__name__
 
 model = FastLanguageModel.get_peft_model(
     model,
-    r = 64,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
-    target_modules = [
+    r=64,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
+    target_modules=[
         "q_proj",
         "k_proj",
         "v_proj",
@@ -52,14 +52,14 @@ model = FastLanguageModel.get_peft_model(
         "up_proj",
         "down_proj",
     ],
-    lora_alpha = 64,
-    lora_dropout = 0,  # Supports any, but = 0 is optimized
-    bias = "none",  # Supports any, but = "none" is optimized
+    lora_alpha=64,
+    lora_dropout=0,  # Supports any, but = 0 is optimized
+    bias="none",  # Supports any, but = "none" is optimized
     # [NEW] "unsloth" uses 30% less VRAM, fits 2x larger batch sizes!
-    use_gradient_checkpointing = "unsloth",  # True or "unsloth" for very long context
-    random_state = 3407,
-    use_rslora = False,  # We support rank stabilized LoRA
-    loftq_config = None,  # And LoftQ
+    use_gradient_checkpointing="unsloth",  # True or "unsloth" for very long context
+    random_state=3407,
+    use_rslora=False,  # We support rank stabilized LoRA
+    loftq_config=None,  # And LoftQ
 )
 print("✅ Model and LoRA adapters loaded successfully!")
 
@@ -112,10 +112,10 @@ print(f"{'='*80}")
 
 
 model, tokenizer = FastLanguageModel.from_pretrained(
-    model_name = "unsloth/orpheus-3b-0.1-ft",
-    max_seq_length = 2048,  # Choose any for long context!
-    dtype = None,  # Select None for auto detection
-    load_in_4bit = False,  # Select True for 4bit which reduces memory usage
+    model_name="unsloth/orpheus-3b-0.1-ft",
+    max_seq_length=2048,  # Choose any for long context!
+    dtype=None,  # Select None for auto detection
+    load_in_4bit=False,  # Select True for 4bit which reduces memory usage
     # token = "hf_...", # use one if using gated models like meta-llama/Llama-2-7b-hf
 )
 
@@ -148,18 +148,18 @@ prompts_ = [(f"{chosen_voice}: " + p) if chosen_voice else p for p in prompts]
 all_input_ids = []
 
 for prompt in prompts_:
-    input_ids = tokenizer(prompt, return_tensors = "pt").input_ids
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
     all_input_ids.append(input_ids)
 
-start_token = torch.tensor([[128259]], dtype = torch.int64)  # Start of human
+start_token = torch.tensor([[128259]], dtype=torch.int64)  # Start of human
 end_tokens = torch.tensor(
-    [[128009, 128260]], dtype = torch.int64
+    [[128009, 128260]], dtype=torch.int64
 )  # End of text, End of human
 
 all_modified_input_ids = []
 for input_ids in all_input_ids:
     modified_input_ids = torch.cat(
-        [start_token, input_ids, end_tokens], dim = 1
+        [start_token, input_ids, end_tokens], dim=1
     )  # SOH SOT Text EOT EOH
     all_modified_input_ids.append(modified_input_ids)
 
@@ -171,39 +171,39 @@ max_length = max(
 for modified_input_ids in all_modified_input_ids:
     padding = max_length - modified_input_ids.shape[1]
     padded_tensor = torch.cat(
-        [torch.full((1, padding), 128263, dtype = torch.int64), modified_input_ids], dim = 1
+        [torch.full((1, padding), 128263, dtype=torch.int64), modified_input_ids], dim=1
     )
     attention_mask = torch.cat(
         [
-            torch.zeros((1, padding), dtype = torch.int64),
-            torch.ones((1, modified_input_ids.shape[1]), dtype = torch.int64),
+            torch.zeros((1, padding), dtype=torch.int64),
+            torch.ones((1, modified_input_ids.shape[1]), dtype=torch.int64),
         ],
-        dim = 1,
+        dim=1,
     )
     all_padded_tensors.append(padded_tensor)
     all_attention_masks.append(attention_mask)
 
-all_padded_tensors = torch.cat(all_padded_tensors, dim = 0)
-all_attention_masks = torch.cat(all_attention_masks, dim = 0)
+all_padded_tensors = torch.cat(all_padded_tensors, dim=0)
+all_attention_masks = torch.cat(all_attention_masks, dim=0)
 
 input_ids = all_padded_tensors.to("cuda")
 attention_mask = all_attention_masks.to("cuda")
 generated_ids = model.generate(
-    input_ids = input_ids,
-    attention_mask = attention_mask,
-    max_new_tokens = 1200,
-    do_sample = True,
-    temperature = 0.6,
-    top_p = 0.95,
-    repetition_penalty = 1.1,
-    num_return_sequences = 1,
-    eos_token_id = 128258,
-    use_cache = True,
+    input_ids=input_ids,
+    attention_mask=attention_mask,
+    max_new_tokens=1200,
+    do_sample=True,
+    temperature=0.6,
+    top_p=0.95,
+    repetition_penalty=1.1,
+    num_return_sequences=1,
+    eos_token_id=128258,
+    use_cache=True,
 )
 token_to_find = 128257
 token_to_remove = 128258
 
-token_indices = (generated_ids == token_to_find).nonzero(as_tuple = True)
+token_indices = (generated_ids == token_to_find).nonzero(as_tuple=True)
 
 if len(token_indices[1]) > 0:
     last_occurrence_idx = token_indices[1][-1].item()

--- a/tests/saving/text_to_speech_models/test_whisper.py
+++ b/tests/saving/text_to_speech_models/test_whisper.py
@@ -28,12 +28,12 @@ print(f"{'='*80}")
 
 
 model, tokenizer = FastModel.from_pretrained(
-    model_name = "unsloth/whisper-large-v3",
-    dtype = None,  # Leave as None for auto detection
-    load_in_4bit = False,  # Set to True to do 4bit quantization which reduces memory
-    auto_model = WhisperForConditionalGeneration,
-    whisper_language = "English",
-    whisper_task = "transcribe",
+    model_name="unsloth/whisper-large-v3",
+    dtype=None,  # Leave as None for auto detection
+    load_in_4bit=False,  # Set to True to do 4bit quantization which reduces memory
+    auto_model=WhisperForConditionalGeneration,
+    whisper_language="English",
+    whisper_task="transcribe",
     # token = "hf_...", # use one if using gated models like meta-llama/Llama-2-7b-hf
 )
 
@@ -46,17 +46,17 @@ model.generation_config.forced_decoder_ids = None
 
 model = FastModel.get_peft_model(
     model,
-    r = 64,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
-    target_modules = ["q_proj", "v_proj"],
-    lora_alpha = 64,
-    lora_dropout = 0,  # Supports any, but = 0 is optimized
-    bias = "none",  # Supports any, but = "none" is optimized
+    r=64,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
+    target_modules=["q_proj", "v_proj"],
+    lora_alpha=64,
+    lora_dropout=0,  # Supports any, but = 0 is optimized
+    bias="none",  # Supports any, but = "none" is optimized
     # [NEW] "unsloth" uses 30% less VRAM, fits 2x larger batch sizes!
-    use_gradient_checkpointing = "unsloth",  # True or "unsloth" for very long context
-    random_state = 3407,
-    use_rslora = False,  # We support rank stabilized LoRA
-    loftq_config = None,  # And LoftQ
-    task_type = None,  # ** MUST set this for Whisper **
+    use_gradient_checkpointing="unsloth",  # True or "unsloth" for very long context
+    random_state=3407,
+    use_rslora=False,  # We support rank stabilized LoRA
+    loftq_config=None,  # And LoftQ
+    task_type=None,  # ** MUST set this for Whisper **
 )
 
 print("✅ Model and LoRA adapters loaded successfully!")
@@ -110,12 +110,12 @@ print(f"{'='*80}")
 
 
 model, tokenizer = FastModel.from_pretrained(
-    model_name = "./whisper",
-    dtype = None,  # Leave as None for auto detection
-    load_in_4bit = False,  # Set to True to do 4bit quantization which reduces memory
-    auto_model = WhisperForConditionalGeneration,
-    whisper_language = "English",
-    whisper_task = "transcribe",
+    model_name="./whisper",
+    dtype=None,  # Leave as None for auto detection
+    load_in_4bit=False,  # Set to True to do 4bit quantization which reduces memory
+    auto_model=WhisperForConditionalGeneration,
+    whisper_language="English",
+    whisper_task="transcribe",
     # token = "hf_...", # use one if using gated models like meta-llama/Llama-2-7b-hf
 )
 
@@ -135,7 +135,7 @@ try:
     headers = {
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
     }
-    response = requests.get(audio_url, headers = headers)
+    response = requests.get(audio_url, headers=headers)
     response.raise_for_status()
     with open(audio_file, "wb") as f:
         f.write(response.content)
@@ -156,12 +156,12 @@ model.eval()
 # Create pipeline without specifying the device
 whisper = pipeline(
     "automatic-speech-recognition",
-    model = model,
-    tokenizer = tokenizer.tokenizer,
-    feature_extractor = tokenizer.feature_extractor,
-    processor = tokenizer,
-    return_language = True,
-    torch_dtype = torch.float16,  # Remove the device parameter
+    model=model,
+    tokenizer=tokenizer.tokenizer,
+    feature_extractor=tokenizer.feature_extractor,
+    processor=tokenizer,
+    return_language=True,
+    torch_dtype=torch.float16,  # Remove the device parameter
 )
 # Example usage
 audio_file = "Speech_12dB_s16.flac"

--- a/tests/saving/vision_models/test_index_file_sharded_model.py
+++ b/tests/saving/vision_models/test_index_file_sharded_model.py
@@ -21,7 +21,7 @@ from tests.utils.cleanup_utils import safe_remove_directory
 ## Dataset Preparation"""
 
 print("\n📊 Loading and preparing dataset...")
-dataset = load_dataset("lbourdois/OCR-liboaccn-OPUS-MIT-5M-clean", "en", split = "train")
+dataset = load_dataset("lbourdois/OCR-liboaccn-OPUS-MIT-5M-clean", "en", split="train")
 # To select the first 2000 examples
 train_dataset = dataset.select(range(2000))
 
@@ -81,11 +81,11 @@ print("🤖 Loading base vision model...")
 try:
     model, tokenizer = FastVisionModel.from_pretrained(
         # model_name = "unsloth/Qwen2-VL-7B-Instruct",
-        model_name = "unsloth/Qwen2-VL-7B-Instruct",
-        max_seq_length = 2048,  # Choose any for long context!
-        load_in_4bit = True,  # 4 bit quantization to reduce memory
-        load_in_8bit = False,  # [NEW!] A bit more accurate, uses 2x memory
-        full_finetuning = False,  # [NEW!] We have full finetuning now!
+        model_name="unsloth/Qwen2-VL-7B-Instruct",
+        max_seq_length=2048,  # Choose any for long context!
+        load_in_4bit=True,  # 4 bit quantization to reduce memory
+        load_in_8bit=False,  # [NEW!] A bit more accurate, uses 2x memory
+        full_finetuning=False,  # [NEW!] We have full finetuning now!
     )
 except Exception as e:
     print(f"❌ Failed to load base model: {e}")
@@ -96,18 +96,18 @@ print("\n🔧 Setting up LoRA configuration...")
 try:
     model = FastVisionModel.get_peft_model(
         model,
-        finetune_vision_layers = True,  # Turn off for just text!
-        finetune_language_layers = True,  # Should leave on!
-        finetune_attention_modules = True,  # Attention good for GRPO
-        finetune_mlp_modules = True,  # SHould leave on always!
-        r = 16,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
-        lora_alpha = 32,
-        lora_dropout = 0,  # Supports any, but = 0 is optimized
-        bias = "none",  # Supports any, but = "none" is optimized
-        use_gradient_checkpointing = "unsloth",  # True or "unsloth" for very long context
-        random_state = 3407,
-        use_rslora = False,  # We support rank stabilized LoRA
-        loftq_config = None,  # And LoftQ
+        finetune_vision_layers=True,  # Turn off for just text!
+        finetune_language_layers=True,  # Should leave on!
+        finetune_attention_modules=True,  # Attention good for GRPO
+        finetune_mlp_modules=True,  # SHould leave on always!
+        r=16,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
+        lora_alpha=32,
+        lora_dropout=0,  # Supports any, but = 0 is optimized
+        bias="none",  # Supports any, but = "none" is optimized
+        use_gradient_checkpointing="unsloth",  # True or "unsloth" for very long context
+        random_state=3407,
+        use_rslora=False,  # We support rank stabilized LoRA
+        loftq_config=None,  # And LoftQ
     )
     print("✅ LoRA configuration applied successfully!")
     print(f"   🎯 LoRA rank (r): 16")
@@ -128,40 +128,40 @@ FastVisionModel.for_training(model)  # Enable for training!
 
 try:
     trainer = SFTTrainer(
-        model = model,
-        tokenizer = tokenizer,
-        data_collator = UnslothVisionDataCollator(model, tokenizer),
-        train_dataset = train_dataset,
-        args = SFTConfig(
+        model=model,
+        tokenizer=tokenizer,
+        data_collator=UnslothVisionDataCollator(model, tokenizer),
+        train_dataset=train_dataset,
+        args=SFTConfig(
             # per_device_train_batch_size = 4,
             # gradient_accumulation_steps = 8,
-            per_device_train_batch_size = 2,
-            gradient_accumulation_steps = 4,
-            gradient_checkpointing = True,
-            gradient_checkpointing_kwargs = {
+            per_device_train_batch_size=2,
+            gradient_accumulation_steps=4,
+            gradient_checkpointing=True,
+            gradient_checkpointing_kwargs={
                 "use_reentrant": False
             },  # use reentrant checkpointing
-            max_grad_norm = 0.3,  # max gradient norm based on QLoRA paper
-            warmup_ratio = 0.03,
+            max_grad_norm=0.3,  # max gradient norm based on QLoRA paper
+            warmup_ratio=0.03,
             # num_train_epochs = 2, # Set this instead of max_steps for full training runs
-            max_steps = 10,
-            learning_rate = 2e-4,
-            fp16 = not is_bf16_supported(),
-            bf16 = is_bf16_supported(),
-            logging_steps = 5,
-            save_strategy = "epoch",
-            optim = "adamw_torch_fused",
-            weight_decay = 0.01,
-            lr_scheduler_type = "linear",
-            seed = 3407,
-            output_dir = "checkpoints",
-            report_to = "none",  # For Weights and Biases
+            max_steps=10,
+            learning_rate=2e-4,
+            fp16=not is_bf16_supported(),
+            bf16=is_bf16_supported(),
+            logging_steps=5,
+            save_strategy="epoch",
+            optim="adamw_torch_fused",
+            weight_decay=0.01,
+            lr_scheduler_type="linear",
+            seed=3407,
+            output_dir="checkpoints",
+            report_to="none",  # For Weights and Biases
             # You MUST put the below items for vision finetuning:
-            remove_unused_columns = False,
-            dataset_text_field = "",
-            dataset_kwargs = {"skip_prepare_dataset": True},
-            dataset_num_proc = 4,
-            max_seq_length = 2048,
+            remove_unused_columns=False,
+            dataset_text_field="",
+            dataset_kwargs={"skip_prepare_dataset": True},
+            dataset_num_proc=4,
+            max_seq_length=2048,
         ),
     )
     print("✅ Trainer setup completed!")
@@ -221,7 +221,7 @@ try:
     print("=== UPLOADING MODEL TO HUB ===".center(80))
     print("=" * 80 + "\n")
     print(f"🚀 Uploading to repository: {repo_name}")
-    model.push_to_hub_merged(repo_name, tokenizer = tokenizer, token = hf_token)
+    model.push_to_hub_merged(repo_name, tokenizer=tokenizer, token=hf_token)
     success["upload"] = True
     print("✅ Model uploaded successfully!")
 except Exception as e:
@@ -233,8 +233,8 @@ try:
     print("\n" + "=" * 80)
     print("=== VERIFYING REPO CONTENTS ===".center(80))
     print("=" * 80 + "\n")
-    fs = HfFileSystem(token = hf_token)
-    file_list = fs.ls(repo_name, detail = True)
+    fs = HfFileSystem(token=hf_token)
+    file_list = fs.ls(repo_name, detail=True)
     safetensors_found = any(
         file["name"].endswith("model.safetensors.index.json") for file in file_list
     )

--- a/tests/saving/vision_models/test_save_merge_vision_model_ocr_benchmark.py
+++ b/tests/saving/vision_models/test_save_merge_vision_model_ocr_benchmark.py
@@ -22,7 +22,7 @@ from tests.utils.ocr_eval import OCRModelEvaluator
 ## Dataset Preparation
 from datasets import load_dataset
 
-dataset = load_dataset("lbourdois/OCR-liboaccn-OPUS-MIT-5M-clean", "en", split = "train")
+dataset = load_dataset("lbourdois/OCR-liboaccn-OPUS-MIT-5M-clean", "en", split="train")
 # To select the first 2000 examples
 train_dataset = dataset.select(range(2000))
 
@@ -81,39 +81,39 @@ model_comparison_results = {}
 # Load Base Model
 
 model, tokenizer = FastVisionModel.from_pretrained(
-    model_name = "unsloth/Qwen2-VL-7B-Instruct",
-    max_seq_length = 2048,  # Choose any for long context!
-    load_in_4bit = True,  # 4 bit quantization to reduce memory
-    load_in_8bit = False,  # [NEW!] A bit more accurate, uses 2x memory
-    full_finetuning = False,  # [NEW!] We have full finetuning now!
+    model_name="unsloth/Qwen2-VL-7B-Instruct",
+    max_seq_length=2048,  # Choose any for long context!
+    load_in_4bit=True,  # 4 bit quantization to reduce memory
+    load_in_8bit=False,  # [NEW!] A bit more accurate, uses 2x memory
+    full_finetuning=False,  # [NEW!] We have full finetuning now!
 )
 
 # benchmark base model performance
 model_name = "Unsloth Base model"
 FastVisionModel.for_inference(model)
 avg_wer, avg_cer = ocr_evaluator.evaluate_model(
-    model, tokenizer, eval_dataset, output_dir = "unsloth_base_model_results"
+    model, tokenizer, eval_dataset, output_dir="unsloth_base_model_results"
 )
 ocr_evaluator.add_to_comparison(model_name, avg_wer, avg_cer)
 
 ## Lora Finetuning
 model = FastVisionModel.get_peft_model(
     model,
-    finetune_vision_layers = True,  # Turn off for just text!
-    finetune_language_layers = True,  # Should leave on!
-    finetune_attention_modules = True,  # Attention good for GRPO
-    finetune_mlp_modules = True,  # SHould leave on always!
-    r = 16,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
+    finetune_vision_layers=True,  # Turn off for just text!
+    finetune_language_layers=True,  # Should leave on!
+    finetune_attention_modules=True,  # Attention good for GRPO
+    finetune_mlp_modules=True,  # SHould leave on always!
+    r=16,  # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
     # target_modules = ["q_proj", "k_proj", "v_proj", "o_proj",
     # "gate_proj", "up_proj", "down_proj",],
-    lora_alpha = 32,
-    lora_dropout = 0,  # Supports any, but = 0 is optimized
-    bias = "none",  # Supports any, but = "none" is optimized
+    lora_alpha=32,
+    lora_dropout=0,  # Supports any, but = 0 is optimized
+    bias="none",  # Supports any, but = "none" is optimized
     # [NEW] "unsloth" uses 30% less VRAM, fits 2x larger batch sizes!
-    use_gradient_checkpointing = "unsloth",  # True or "unsloth" for very long context
-    random_state = 3407,
-    use_rslora = False,  # We support rank stabilized LoRA
-    loftq_config = None,  # And LoftQ
+    use_gradient_checkpointing="unsloth",  # True or "unsloth" for very long context
+    random_state=3407,
+    use_rslora=False,  # We support rank stabilized LoRA
+    loftq_config=None,  # And LoftQ
 )
 
 from unsloth import is_bf16_supported
@@ -124,40 +124,40 @@ model.config.use_cache = False
 
 
 trainer = SFTTrainer(
-    model = model,
-    tokenizer = tokenizer,
-    data_collator = UnslothVisionDataCollator(model, tokenizer),
-    train_dataset = train_dataset,
-    args = SFTConfig(
+    model=model,
+    tokenizer=tokenizer,
+    data_collator=UnslothVisionDataCollator(model, tokenizer),
+    train_dataset=train_dataset,
+    args=SFTConfig(
         # per_device_train_batch_size = 4,
         # gradient_accumulation_steps = 8,
-        per_device_train_batch_size = 2,
-        gradient_accumulation_steps = 4,
-        gradient_checkpointing = True,
-        gradient_checkpointing_kwargs = {
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=4,
+        gradient_checkpointing=True,
+        gradient_checkpointing_kwargs={
             "use_reentrant": False
         },  # use reentrant checkpointing
-        max_grad_norm = 0.3,  # max gradient norm based on QLoRA paper
-        warmup_ratio = 0.03,
+        max_grad_norm=0.3,  # max gradient norm based on QLoRA paper
+        warmup_ratio=0.03,
         # num_train_epochs = 2, # Set this instead of max_steps for full training runs
-        max_steps = 60,
-        learning_rate = 2e-4,
-        fp16 = not is_bf16_supported(),
-        bf16 = is_bf16_supported(),
-        logging_steps = 5,
-        save_strategy = "epoch",
-        optim = "adamw_torch_fused",
-        weight_decay = 0.01,
-        lr_scheduler_type = "linear",
-        seed = 3407,
-        output_dir = "unsloth-qwen2-7vl-french-ocr-checkpoints",
-        report_to = "none",  # For Weights and Biases
+        max_steps=60,
+        learning_rate=2e-4,
+        fp16=not is_bf16_supported(),
+        bf16=is_bf16_supported(),
+        logging_steps=5,
+        save_strategy="epoch",
+        optim="adamw_torch_fused",
+        weight_decay=0.01,
+        lr_scheduler_type="linear",
+        seed=3407,
+        output_dir="unsloth-qwen2-7vl-french-ocr-checkpoints",
+        report_to="none",  # For Weights and Biases
         # You MUST put the below items for vision finetuning:
-        remove_unused_columns = False,
-        dataset_text_field = "",
-        dataset_kwargs = {"skip_prepare_dataset": True},
-        dataset_num_proc = 4,
-        max_seq_length = 2048,
+        remove_unused_columns=False,
+        dataset_text_field="",
+        dataset_kwargs={"skip_prepare_dataset": True},
+        dataset_num_proc=4,
+        max_seq_length=2048,
     ),
 )
 
@@ -173,7 +173,7 @@ tokenizer.save_pretrained("unsloth-qwen2-7vl-french-ocr-adapter")
 model_name = "Unsloth lora adapter model"
 FastVisionModel.for_inference(model)
 avg_wer, avg_cer = ocr_evaluator.evaluate_model(
-    model, tokenizer, eval_dataset, output_dir = "unsloth_lora_model_results"
+    model, tokenizer, eval_dataset, output_dir="unsloth_lora_model_results"
 )
 ocr_evaluator.add_to_comparison(model_name, avg_wer, avg_cer)
 
@@ -195,7 +195,7 @@ print((base.__class__.__name__))
 
 # merge default 16 bits
 model.save_pretrained_merged(
-    save_directory = "qwen2-ocr-merged-finetune-merge-16bit", tokenizer = tokenizer
+    save_directory="qwen2-ocr-merged-finetune-merge-16bit", tokenizer=tokenizer
 )
 
 
@@ -204,7 +204,7 @@ model.save_pretrained_merged(
 ### 16 bits merged model
 
 model, tokenizer = FastVisionModel.from_pretrained(
-    "./qwen2-ocr-merged-finetune-merge-16bit", load_in_4bit = False, load_in_8bit = False
+    "./qwen2-ocr-merged-finetune-merge-16bit", load_in_4bit=False, load_in_8bit=False
 )
 
 # benchmark 4bit loaded, 16bits merged model performance
@@ -215,13 +215,13 @@ avg_wer, avg_cer = ocr_evaluator.evaluate_model(
     model,
     tokenizer,
     eval_dataset,
-    output_dir = "unsloth_16bits_merged_model_load_16bits_results",
+    output_dir="unsloth_16bits_merged_model_load_16bits_results",
 )
 ocr_evaluator.add_to_comparison(model_name, avg_wer, avg_cer)
 
 # load 16bits-merged model in 4 bits
 model, tokenizer = FastVisionModel.from_pretrained(
-    "./qwen2-ocr-merged-finetune-merge-16bit", load_in_4bit = True, load_in_8bit = False
+    "./qwen2-ocr-merged-finetune-merge-16bit", load_in_4bit=True, load_in_8bit=False
 )
 
 # benchmark 4bit loaded, 16bits merged model performance
@@ -232,13 +232,13 @@ avg_wer, avg_cer = ocr_evaluator.evaluate_model(
     model,
     tokenizer,
     eval_dataset,
-    output_dir = "unsloth_16bits_merged_model_load_4bits_results",
+    output_dir="unsloth_16bits_merged_model_load_4bits_results",
 )
 ocr_evaluator.add_to_comparison(model_name, avg_wer, avg_cer)
 
 # load model in 8 bits
 model, tokenizer = FastVisionModel.from_pretrained(
-    "./qwen2-ocr-merged-finetune-merge-16bit", load_in_4bit = False, load_in_8bit = True
+    "./qwen2-ocr-merged-finetune-merge-16bit", load_in_4bit=False, load_in_8bit=True
 )
 
 # benchmark 4bit loaded, 16bits merged model performance
@@ -247,7 +247,7 @@ avg_wer, avg_cer = ocr_evaluator.evaluate_model(
     model,
     tokenizer,
     eval_dataset,
-    output_dir = "unsloth_16bits_merged_model_load_8bits_results",
+    output_dir="unsloth_16bits_merged_model_load_8bits_results",
 )
 ocr_evaluator.add_to_comparison(model_name, avg_wer, avg_cer)
 

--- a/tests/studio/install/smoke_test_llama_prebuilt.py
+++ b/tests/studio/install/smoke_test_llama_prebuilt.py
@@ -31,38 +31,38 @@ installer = load_installer_module()
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description = (
+        description=(
             "Run a real end-to-end prebuilt llama.cpp install into an isolated temporary "
             "directory on the current machine."
         )
     )
     parser.add_argument(
         "--llama-tag",
-        default = "latest",
-        help = "llama.cpp tag to resolve. Defaults to the latest usable published Unsloth release.",
+        default="latest",
+        help="llama.cpp tag to resolve. Defaults to the latest usable published Unsloth release.",
     )
     parser.add_argument(
         "--published-repo",
-        default = installer.DEFAULT_PUBLISHED_REPO,
-        help = "Published bundle repository used for Linux CUDA selection.",
+        default=installer.DEFAULT_PUBLISHED_REPO,
+        help="Published bundle repository used for Linux CUDA selection.",
     )
     parser.add_argument(
         "--published-release-tag",
-        default = installer.DEFAULT_PUBLISHED_TAG or "",
-        help = "Optional published GitHub release tag to pin.",
+        default=installer.DEFAULT_PUBLISHED_TAG or "",
+        help="Optional published GitHub release tag to pin.",
     )
     parser.add_argument(
         "--work-dir",
-        default = "",
-        help = (
+        default="",
+        help=(
             "Optional directory under which the smoke install temp dir will be created. "
             "If omitted, defaults to ./.tmp/llama-prebuilt-smoke under the current directory."
         ),
     )
     parser.add_argument(
         "--keep-temp",
-        action = "store_true",
-        help = "Keep the temporary smoke install directory after success.",
+        action="store_true",
+        help="Keep the temporary smoke install directory after success.",
     )
     return parser.parse_args()
 
@@ -74,9 +74,9 @@ def smoke_root_base(work_dir: str) -> Path:
 
 
 def make_smoke_root(base_dir: Path) -> Path:
-    base_dir.mkdir(parents = True, exist_ok = True)
+    base_dir.mkdir(parents=True, exist_ok=True)
     timestamp = time.strftime("%Y%m%d%H%M%S", time.gmtime())
-    return Path(tempfile.mkdtemp(prefix = f"run-{timestamp}-", dir = base_dir))
+    return Path(tempfile.mkdtemp(prefix=f"run-{timestamp}-", dir=base_dir))
 
 
 def main() -> int:
@@ -106,10 +106,10 @@ def main() -> int:
         print(f"[smoke] selected_source={choice.source_label}")
         print(f"[smoke] install_dir={install_dir}")
         installer.install_prebuilt(
-            install_dir = install_dir,
-            llama_tag = args.llama_tag,
-            published_repo = args.published_repo,
-            published_release_tag = args.published_release_tag,
+            install_dir=install_dir,
+            llama_tag=args.llama_tag,
+            published_repo=args.published_repo,
+            published_release_tag=args.published_release_tag,
         )
         print(f"[smoke] PASS install_dir={install_dir}")
         print(
@@ -135,7 +135,7 @@ def main() -> int:
         if args.keep_temp:
             print(f"[smoke] keeping_temp_root={smoke_root}")
         elif smoke_root.exists():
-            shutil.rmtree(smoke_root, ignore_errors = True)
+            shutil.rmtree(smoke_root, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -43,22 +43,22 @@ def approved_checksums_for(
     upstream_tag: str, *, source_archive: Path, bundle_archive: Path, bundle_name: str
 ) -> ApprovedReleaseChecksums:
     return ApprovedReleaseChecksums(
-        repo = "local",
-        release_tag = upstream_tag,
-        upstream_tag = upstream_tag,
-        source_commit = None,
-        artifacts = {
+        repo="local",
+        release_tag=upstream_tag,
+        upstream_tag=upstream_tag,
+        source_commit=None,
+        artifacts={
             source_archive_logical_name(upstream_tag): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name(upstream_tag),
-                sha256 = sha256_file(source_archive),
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name(upstream_tag),
+                sha256=sha256_file(source_archive),
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             bundle_name: ApprovedArtifactHash(
-                asset_name = bundle_name,
-                sha256 = sha256_file(bundle_archive),
-                repo = "local",
-                kind = "local-test-bundle",
+                asset_name=bundle_name,
+                sha256=sha256_file(bundle_archive),
+                repo="local",
+                kind="local-test-bundle",
             ),
         },
     )
@@ -122,7 +122,7 @@ def test_extract_archive_rejects_absolute_tar_symlink_target(tmp_path: Path):
         entry.linkname = "/tmp/libllama.so.0"
         archive.addfile(entry)
 
-    with pytest.raises(PrebuiltFallback, match = "archive link used an absolute target"):
+    with pytest.raises(PrebuiltFallback, match="archive link used an absolute target"):
         extract_archive(archive_path, tmp_path / "extract")
 
 
@@ -135,7 +135,7 @@ def test_extract_archive_rejects_escaping_tar_symlink_target(tmp_path: Path):
         entry.linkname = "../outside/libllama.so.0"
         archive.addfile(entry)
 
-    with pytest.raises(PrebuiltFallback, match = "archive link escaped destination"):
+    with pytest.raises(PrebuiltFallback, match="archive link escaped destination"):
         extract_archive(archive_path, tmp_path / "extract")
 
 
@@ -148,7 +148,7 @@ def test_extract_archive_rejects_unresolved_tar_symlink_target(tmp_path: Path):
         entry.linkname = "libllama.so.0"
         archive.addfile(entry)
 
-    with pytest.raises(PrebuiltFallback, match = "unresolved link entries"):
+    with pytest.raises(PrebuiltFallback, match="unresolved link entries"):
         extract_archive(archive_path, tmp_path / "extract")
 
 
@@ -161,7 +161,7 @@ def test_extract_archive_rejects_zip_symlink_entry(tmp_path: Path):
         info.external_attr = 0o120777 << 16
         archive.writestr(info, "libllama.so.0")
 
-    with pytest.raises(PrebuiltFallback, match = "zip archive contained a symlink entry"):
+    with pytest.raises(PrebuiltFallback, match="zip archive contained a symlink entry"):
         extract_archive(archive_path, tmp_path / "extract")
 
 
@@ -199,7 +199,7 @@ def test_hydrate_source_tree_extracts_upstream_archive_contents(
     work_dir = tmp_path / "work"
     work_dir.mkdir()
     hydrate_source_tree(
-        upstream_tag, install_dir, work_dir, expected_sha256 = sha256_file(archive_path)
+        upstream_tag, install_dir, work_dir, expected_sha256=sha256_file(archive_path)
     )
 
     assert (install_dir / "CMakeLists.txt").exists()
@@ -232,8 +232,8 @@ def test_validate_prebuilt_choice_creates_repo_shaped_linux_install(
             b"__all__ = []\n",
         )
     with tarfile.open(bundle_archive, "w:gz") as archive:
-        add_bytes_to_tar(archive, "llama-server", b"#!/bin/sh\nexit 0\n", mode = 0o755)
-        add_bytes_to_tar(archive, "llama-quantize", b"#!/bin/sh\nexit 0\n", mode = 0o755)
+        add_bytes_to_tar(archive, "llama-server", b"#!/bin/sh\nexit 0\n", mode=0o755)
+        add_bytes_to_tar(archive, "llama-quantize", b"#!/bin/sh\nexit 0\n", mode=0o755)
         add_bytes_to_tar(archive, "libllama.so.0.0.1", b"libllama")
         add_symlink_to_tar(archive, "libllama.so.0", "libllama.so.0.0.1")
         add_symlink_to_tar(archive, "libllama.so", "libllama.so.0")
@@ -282,31 +282,31 @@ def test_validate_prebuilt_choice_creates_repo_shaped_linux_install(
     )
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "local",
-        tag = upstream_tag,
-        name = bundle_name,
-        url = "file://bundle",
-        source_label = "local",
-        is_ready_bundle = True,
-        install_kind = "linux-cuda",
-        bundle_profile = "cuda13-newer",
-        runtime_line = "cuda13",
-        expected_sha256 = sha256_file(bundle_archive),
+        repo="local",
+        tag=upstream_tag,
+        name=bundle_name,
+        url="file://bundle",
+        source_label="local",
+        is_ready_bundle=True,
+        install_kind="linux-cuda",
+        bundle_profile="cuda13-newer",
+        runtime_line="cuda13",
+        expected_sha256=sha256_file(bundle_archive),
     )
 
     install_dir = tmp_path / "install"
@@ -320,17 +320,17 @@ def test_validate_prebuilt_choice_creates_repo_shaped_linux_install(
         install_dir,
         work_dir,
         probe_path,
-        requested_tag = upstream_tag,
-        llama_tag = upstream_tag,
-        release_tag = upstream_tag,
-        approved_checksums = approved_checksums_for(
+        requested_tag=upstream_tag,
+        llama_tag=upstream_tag,
+        release_tag=upstream_tag,
+        approved_checksums=approved_checksums_for(
             upstream_tag,
-            source_archive = source_archive,
-            bundle_archive = bundle_archive,
-            bundle_name = bundle_name,
+            source_archive=source_archive,
+            bundle_archive=bundle_archive,
+            bundle_name=bundle_name,
         ),
-        prebuilt_fallback_used = False,
-        quantized_path = quantized_path,
+        prebuilt_fallback_used=False,
+        quantized_path=quantized_path,
     )
 
     assert (install_dir / "gguf-py" / "gguf" / "__init__.py").exists()
@@ -403,29 +403,29 @@ def test_validate_prebuilt_choice_creates_repo_shaped_windows_install(
     )
 
     host = HostInfo(
-        system = "Windows",
-        machine = "AMD64",
-        is_windows = True,
-        is_linux = False,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Windows",
+        machine="AMD64",
+        is_windows=True,
+        is_linux=False,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "local",
-        tag = upstream_tag,
-        name = bundle_name,
-        url = "file://bundle.zip",
-        source_label = "local",
-        is_ready_bundle = True,
-        install_kind = "windows-cpu",
-        expected_sha256 = sha256_file(bundle_archive),
+        repo="local",
+        tag=upstream_tag,
+        name=bundle_name,
+        url="file://bundle.zip",
+        source_label="local",
+        is_ready_bundle=True,
+        install_kind="windows-cpu",
+        expected_sha256=sha256_file(bundle_archive),
     )
 
     install_dir = tmp_path / "install"
@@ -439,17 +439,17 @@ def test_validate_prebuilt_choice_creates_repo_shaped_windows_install(
         install_dir,
         work_dir,
         probe_path,
-        requested_tag = upstream_tag,
-        llama_tag = upstream_tag,
-        release_tag = upstream_tag,
-        approved_checksums = approved_checksums_for(
+        requested_tag=upstream_tag,
+        llama_tag=upstream_tag,
+        release_tag=upstream_tag,
+        approved_checksums=approved_checksums_for(
             upstream_tag,
-            source_archive = source_archive,
-            bundle_archive = bundle_archive,
-            bundle_name = bundle_name,
+            source_archive=source_archive,
+            bundle_archive=bundle_archive,
+            bundle_name=bundle_name,
         ),
-        prebuilt_fallback_used = False,
-        quantized_path = quantized_path,
+        prebuilt_fallback_used=False,
+        quantized_path=quantized_path,
     )
 
     assert (install_dir / "gguf-py" / "gguf" / "__init__.py").exists()
@@ -475,19 +475,19 @@ def test_activate_install_tree_restores_existing_install_after_activation_failur
     (staging_dir / "new.txt").write_text("new install\n")
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
 
     monkeypatch.setattr(
@@ -500,7 +500,7 @@ def test_activate_install_tree_restores_existing_install_after_activation_failur
 
     with pytest.raises(
         PrebuiltFallback,
-        match = "activation failed; restored previous install",
+        match="activation failed; restored previous install",
     ):
         activate_install_tree(staging_dir, install_dir, host)
 
@@ -528,19 +528,19 @@ def test_activate_install_tree_cleans_all_paths_when_rollback_restore_fails(
     (staging_dir / "new.txt").write_text("new install\n")
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
 
     monkeypatch.setattr(
@@ -564,7 +564,7 @@ def test_activate_install_tree_cleans_all_paths_when_rollback_restore_fails(
 
     with pytest.raises(
         PrebuiltFallback,
-        match = "activation and rollback failed; cleaned install state for fresh source build",
+        match="activation and rollback failed; cleaned install state for fresh source build",
     ):
         activate_install_tree(staging_dir, install_dir, host)
 
@@ -588,24 +588,24 @@ def test_binary_env_linux_includes_binary_parent_in_ld_library_path(
 ):
     install_dir = tmp_path / "llama.cpp"
     bin_dir = install_dir / "build" / "bin"
-    bin_dir.mkdir(parents = True)
+    bin_dir.mkdir(parents=True)
     binary_path = bin_dir / "llama-server"
     binary_path.write_bytes(b"fake")
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "linux_runtime_dirs", lambda _bp: [])
@@ -623,61 +623,61 @@ def test_install_prebuilt_falls_back_to_older_release_plan(
 ):
     install_dir = tmp_path / "llama.cpp"
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
 
     first_choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "old-release",
-        name = "app-b9002-linux-x64.tar.gz",
-        url = "https://example.com/app-b9002-linux-x64.tar.gz",
-        source_label = "published",
-        install_kind = "linux-cpu",
+        repo="unslothai/llama.cpp",
+        tag="old-release",
+        name="app-b9002-linux-x64.tar.gz",
+        url="https://example.com/app-b9002-linux-x64.tar.gz",
+        source_label="published",
+        install_kind="linux-cpu",
     )
     second_choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "older-release",
-        name = "app-b9001-linux-x64.tar.gz",
-        url = "https://example.com/app-b9001-linux-x64.tar.gz",
-        source_label = "published",
-        install_kind = "linux-cpu",
+        repo="unslothai/llama.cpp",
+        tag="older-release",
+        name="app-b9001-linux-x64.tar.gz",
+        url="https://example.com/app-b9001-linux-x64.tar.gz",
+        source_label="published",
+        install_kind="linux-cpu",
     )
     first_plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9002",
-        release_tag = "release-2",
-        attempts = [first_choice],
-        approved_checksums = ApprovedReleaseChecksums(
-            repo = "unslothai/llama.cpp",
-            release_tag = "release-2",
-            upstream_tag = "b9002",
-            source_commit = None,
-            artifacts = {},
+        requested_tag="latest",
+        llama_tag="b9002",
+        release_tag="release-2",
+        attempts=[first_choice],
+        approved_checksums=ApprovedReleaseChecksums(
+            repo="unslothai/llama.cpp",
+            release_tag="release-2",
+            upstream_tag="b9002",
+            source_commit=None,
+            artifacts={},
         ),
     )
     second_plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [second_choice],
-        approved_checksums = ApprovedReleaseChecksums(
-            repo = "unslothai/llama.cpp",
-            release_tag = "release-1",
-            upstream_tag = "b9001",
-            source_commit = None,
-            artifacts = {},
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[second_choice],
+        approved_checksums=ApprovedReleaseChecksums(
+            repo="unslothai/llama.cpp",
+            release_tag="release-1",
+            upstream_tag="b9001",
+            source_commit=None,
+            artifacts={},
         ),
     )
 
@@ -709,8 +709,8 @@ def test_install_prebuilt_falls_back_to_older_release_plan(
         llama_tag,
         release_tag,
         approved_checksums,
-        initial_fallback_used = False,
-        existing_install_dir = None,
+        initial_fallback_used=False,
+        existing_install_dir=None,
     ):
         call_log.append((llama_tag, initial_fallback_used))
         if llama_tag == "b9002":
@@ -749,27 +749,27 @@ def test_install_prebuilt_falls_back_to_older_release_plan(
 
 def write_linux_install_shape(install_dir: Path) -> None:
     runtime_dir = install_dir / "build" / "bin"
-    runtime_dir.mkdir(parents = True, exist_ok = True)
-    (install_dir / "llama-server").write_text("#!/bin/sh\n", encoding = "utf-8")
-    (install_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding = "utf-8")
-    (runtime_dir / "llama-server").write_text("#!/bin/sh\n", encoding = "utf-8")
-    (runtime_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding = "utf-8")
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (install_dir / "llama-server").write_text("#!/bin/sh\n", encoding="utf-8")
+    (install_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding="utf-8")
+    (runtime_dir / "llama-server").write_text("#!/bin/sh\n", encoding="utf-8")
+    (runtime_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding="utf-8")
     (runtime_dir / "libllama.so.0").write_bytes(b"DLL")
     (runtime_dir / "libggml.so.0").write_bytes(b"DLL")
     (runtime_dir / "libggml-base.so.0").write_bytes(b"DLL")
     (runtime_dir / "libggml-cpu-x64.so.0").write_bytes(b"DLL")
     (runtime_dir / "libmtmd.so.0").write_bytes(b"DLL")
     (install_dir / "convert_hf_to_gguf.py").write_text(
-        "#!/usr/bin/env python3\n", encoding = "utf-8"
+        "#!/usr/bin/env python3\n", encoding="utf-8"
     )
-    (install_dir / "gguf-py" / "gguf").mkdir(parents = True, exist_ok = True)
+    (install_dir / "gguf-py" / "gguf").mkdir(parents=True, exist_ok=True)
 
 
 def write_windows_install_shape(
     install_dir: Path, *, include_llama_dll: bool = True, include_cuda_dll: bool = False
 ) -> None:
     runtime_dir = install_dir / "build" / "bin" / "Release"
-    runtime_dir.mkdir(parents = True, exist_ok = True)
+    runtime_dir.mkdir(parents=True, exist_ok=True)
     (runtime_dir / "llama-server.exe").write_bytes(b"MZ")
     (runtime_dir / "llama-quantize.exe").write_bytes(b"MZ")
     if include_llama_dll:
@@ -777,9 +777,9 @@ def write_windows_install_shape(
     if include_cuda_dll:
         (runtime_dir / "ggml-cuda.dll").write_bytes(b"DLL")
     (install_dir / "convert_hf_to_gguf.py").write_text(
-        "#!/usr/bin/env python3\n", encoding = "utf-8"
+        "#!/usr/bin/env python3\n", encoding="utf-8"
     )
-    (install_dir / "gguf-py" / "gguf").mkdir(parents = True, exist_ok = True)
+    (install_dir / "gguf-py" / "gguf").mkdir(parents=True, exist_ok=True)
 
 
 def write_macos_install_shape(
@@ -790,11 +790,11 @@ def write_macos_install_shape(
     include_libmtmd: bool = True,
 ) -> None:
     runtime_dir = install_dir / "build" / "bin"
-    runtime_dir.mkdir(parents = True, exist_ok = True)
-    (install_dir / "llama-server").write_text("#!/bin/sh\n", encoding = "utf-8")
-    (install_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding = "utf-8")
-    (runtime_dir / "llama-server").write_text("#!/bin/sh\n", encoding = "utf-8")
-    (runtime_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding = "utf-8")
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (install_dir / "llama-server").write_text("#!/bin/sh\n", encoding="utf-8")
+    (install_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding="utf-8")
+    (runtime_dir / "llama-server").write_text("#!/bin/sh\n", encoding="utf-8")
+    (runtime_dir / "llama-quantize").write_text("#!/bin/sh\n", encoding="utf-8")
     if include_libllama:
         (runtime_dir / "libllama.0.dylib").write_bytes(b"DLL")
     if include_libggml:
@@ -802,9 +802,9 @@ def write_macos_install_shape(
     if include_libmtmd:
         (runtime_dir / "libmtmd.0.dylib").write_bytes(b"DLL")
     (install_dir / "convert_hf_to_gguf.py").write_text(
-        "#!/usr/bin/env python3\n", encoding = "utf-8"
+        "#!/usr/bin/env python3\n", encoding="utf-8"
     )
-    (install_dir / "gguf-py" / "gguf").mkdir(parents = True, exist_ok = True)
+    (install_dir / "gguf-py" / "gguf").mkdir(parents=True, exist_ok=True)
 
 
 def test_existing_install_matches_plan_with_fingerprint_linux(tmp_path: Path):
@@ -813,65 +813,65 @@ def test_existing_install_matches_plan_with_fingerprint_linux(tmp_path: Path):
     write_linux_install_shape(install_dir)
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
 
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is True
@@ -884,59 +884,59 @@ def test_existing_install_matches_plan_false_without_fingerprint(tmp_path: Path)
     (install_dir / "UNSLOTH_PREBUILT_INFO.json").write_text(
         json.dumps({"tag": "b9001", "asset": "llama-b9001-bin-ubuntu-x64.tar.gz"})
         + "\n",
-        encoding = "utf-8",
+        encoding="utf-8",
     )
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/x.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/x.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is False
@@ -947,59 +947,59 @@ def test_existing_install_matches_plan_false_with_malformed_metadata(tmp_path: P
     install_dir.mkdir()
     write_linux_install_shape(install_dir)
     (install_dir / "UNSLOTH_PREBUILT_INFO.json").write_text(
-        "{not-json\n", encoding = "utf-8"
+        "{not-json\n", encoding="utf-8"
     )
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/x.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/x.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is False
@@ -1008,67 +1008,67 @@ def test_existing_install_matches_plan_false_with_malformed_metadata(tmp_path: P
 def test_existing_install_matches_plan_windows_cpu_requires_llama_dll(tmp_path: Path):
     install_dir = tmp_path / "llama.cpp"
     install_dir.mkdir()
-    write_windows_install_shape(install_dir, include_llama_dll = True)
+    write_windows_install_shape(install_dir, include_llama_dll=True)
 
     host = HostInfo(
-        system = "Windows",
-        machine = "AMD64",
-        is_windows = True,
-        is_linux = False,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Windows",
+        machine="AMD64",
+        is_windows=True,
+        is_linux=False,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-win-cpu-x64.zip",
-        url = "https://example.com/x.zip",
-        source_label = "published",
-        install_kind = "windows-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-win-cpu-x64.zip",
+        url="https://example.com/x.zip",
+        source_label="published",
+        install_kind="windows-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "unslothai/llama.cpp",
-                kind = "prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="unslothai/llama.cpp",
+                kind="prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is True
@@ -1080,69 +1080,69 @@ def test_existing_install_matches_plan_windows_cuda_requires_cuda_dll(tmp_path: 
     install_dir = tmp_path / "llama.cpp"
     install_dir.mkdir()
     write_windows_install_shape(
-        install_dir, include_llama_dll = True, include_cuda_dll = True
+        install_dir, include_llama_dll=True, include_cuda_dll=True
     )
 
     host = HostInfo(
-        system = "Windows",
-        machine = "AMD64",
-        is_windows = True,
-        is_linux = False,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = (12, 4),
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = True,
+        system="Windows",
+        machine="AMD64",
+        is_windows=True,
+        is_linux=False,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=(12, 4),
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=True,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-win-cuda-12.4-x64.zip",
-        url = "https://example.com/x.zip",
-        source_label = "published",
-        install_kind = "windows-cuda",
-        runtime_line = "cuda12",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-win-cuda-12.4-x64.zip",
+        url="https://example.com/x.zip",
+        source_label="published",
+        install_kind="windows-cuda",
+        runtime_line="cuda12",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "unslothai/llama.cpp",
-                kind = "prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="unslothai/llama.cpp",
+                kind="prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is True
@@ -1156,64 +1156,64 @@ def test_existing_install_matches_plan_macos_requires_dylibs(tmp_path: Path):
     write_macos_install_shape(install_dir)
 
     host = HostInfo(
-        system = "Darwin",
-        machine = "arm64",
-        is_windows = False,
-        is_linux = False,
-        is_macos = True,
-        is_x86_64 = False,
-        is_arm64 = True,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Darwin",
+        machine="arm64",
+        is_windows=False,
+        is_linux=False,
+        is_macos=True,
+        is_x86_64=False,
+        is_arm64=True,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-macos-arm64.tar.gz",
-        url = "https://example.com/x.tar.gz",
-        source_label = "published",
-        install_kind = "macos-arm64",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-macos-arm64.tar.gz",
+        url="https://example.com/x.tar.gz",
+        source_label="published",
+        install_kind="macos-arm64",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "unslothai/llama.cpp",
-                kind = "prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="unslothai/llama.cpp",
+                kind="prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is True
@@ -1229,65 +1229,65 @@ def test_install_prebuilt_skips_download_when_existing_install_matches(
     write_linux_install_shape(install_dir)
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
 
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "detect_host", lambda: host)
@@ -1321,65 +1321,65 @@ def test_install_prebuilt_does_not_skip_unhealthy_existing_install(
     (install_dir / "llama-quantize").unlink()
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[choice],
+        approved_checksums=checksums,
     )
 
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "detect_host", lambda: host)
@@ -1400,7 +1400,7 @@ def test_install_prebuilt_does_not_skip_unhealthy_existing_install(
     )
 
     with pytest.raises(
-        AssertionError, match = "unhealthy install must continue into normal install flow"
+        AssertionError, match="unhealthy install must continue into normal install flow"
     ):
         install_prebuilt(install_dir, "latest", "unslothai/llama.cpp", "")
 
@@ -1413,101 +1413,101 @@ def test_install_prebuilt_skips_when_older_release_fallback_matches_existing_ins
     write_linux_install_shape(install_dir)
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     latest_choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-2",
-        name = "llama-b9002-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9002-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "c" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-2",
+        name="llama-b9002-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9002-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="c" * 64,
     )
     fallback_choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     latest_checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-2",
-        upstream_tag = "b9002",
-        source_commit = "beadfeed",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-2",
+        upstream_tag="b9002",
+        source_commit="beadfeed",
+        artifacts={
             source_archive_logical_name("b9002"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9002"),
-                sha256 = "d" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9002"),
+                sha256="d" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             latest_choice.name: ApprovedArtifactHash(
-                asset_name = latest_choice.name,
-                sha256 = latest_choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=latest_choice.name,
+                sha256=latest_choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     fallback_checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             fallback_choice.name: ApprovedArtifactHash(
-                asset_name = fallback_choice.name,
-                sha256 = fallback_choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=fallback_choice.name,
+                sha256=fallback_choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     latest_plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9002",
-        release_tag = "release-2",
-        attempts = [latest_choice],
-        approved_checksums = latest_checksums,
+        requested_tag="latest",
+        llama_tag="b9002",
+        release_tag="release-2",
+        attempts=[latest_choice],
+        approved_checksums=latest_checksums,
     )
     fallback_plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [fallback_choice],
-        approved_checksums = fallback_checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[fallback_choice],
+        approved_checksums=fallback_checksums,
     )
 
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = fallback_choice,
-        approved_checksums = fallback_checksums,
-        prebuilt_fallback_used = True,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=fallback_choice,
+        approved_checksums=fallback_checksums,
+        prebuilt_fallback_used=True,
     )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "detect_host", lambda: host)
@@ -1538,8 +1538,8 @@ def test_install_prebuilt_skips_when_older_release_fallback_matches_existing_ins
         llama_tag,
         release_tag,
         approved_checksums,
-        initial_fallback_used = False,
-        existing_install_dir = None,
+        initial_fallback_used=False,
+        existing_install_dir=None,
     ):
         call_log.append(llama_tag)
         raise PrebuiltFallback("validation failed for latest release")
@@ -1570,89 +1570,89 @@ def test_install_prebuilt_skips_same_release_fallback_attempt_when_installed(
     write_linux_install_shape(install_dir)
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     first_choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64-bad.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64-bad.tar.gz",
-        source_label = "published",
-        install_kind = "linux-cpu",
-        expected_sha256 = "c" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64-bad.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64-bad.tar.gz",
+        source_label="published",
+        install_kind="linux-cpu",
+        expected_sha256="c" * 64,
     )
     fallback_choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64-good.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64-good.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64-good.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64-good.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             first_choice.name: ApprovedArtifactHash(
-                asset_name = first_choice.name,
-                sha256 = first_choice.expected_sha256,
-                repo = "unslothai/llama.cpp",
-                kind = "prebuilt",
+                asset_name=first_choice.name,
+                sha256=first_choice.expected_sha256,
+                repo="unslothai/llama.cpp",
+                kind="prebuilt",
             ),
             fallback_choice.name: ApprovedArtifactHash(
-                asset_name = fallback_choice.name,
-                sha256 = fallback_choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=fallback_choice.name,
+                sha256=fallback_choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [first_choice, fallback_choice],
-        approved_checksums = checksums,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[first_choice, fallback_choice],
+        approved_checksums=checksums,
     )
 
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = fallback_choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = True,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=fallback_choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=True,
     )
     assert (
         existing_install_matches_choice(
             install_dir,
             host,
-            llama_tag = "b9001",
-            release_tag = "release-1",
-            choice = fallback_choice,
-            approved_checksums = checksums,
+            llama_tag="b9001",
+            release_tag="release-1",
+            choice=fallback_choice,
+            approved_checksums=checksums,
         )
         is True
     )
@@ -1716,63 +1716,63 @@ def test_install_prebuilt_same_tag_upstream_failure_uses_older_unsloth_release_p
 ):
     install_dir = tmp_path / "llama.cpp"
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
 
     same_tag_upstream_choice = AssetChoice(
-        repo = "ggml-org/llama.cpp",
-        tag = "b9002",
-        name = "llama-b9002-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9002-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="ggml-org/llama.cpp",
+        tag="b9002",
+        name="llama-b9002-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9002-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     older_release_choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "b" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="b" * 64,
     )
     latest_plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9002",
-        release_tag = "release-2",
-        attempts = [same_tag_upstream_choice],
-        approved_checksums = ApprovedReleaseChecksums(
-            repo = "unslothai/llama.cpp",
-            release_tag = "release-2",
-            upstream_tag = "b9002",
-            source_commit = None,
-            artifacts = {},
+        requested_tag="latest",
+        llama_tag="b9002",
+        release_tag="release-2",
+        attempts=[same_tag_upstream_choice],
+        approved_checksums=ApprovedReleaseChecksums(
+            repo="unslothai/llama.cpp",
+            release_tag="release-2",
+            upstream_tag="b9002",
+            source_commit=None,
+            artifacts={},
         ),
     )
     older_plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        attempts = [older_release_choice],
-        approved_checksums = ApprovedReleaseChecksums(
-            repo = "unslothai/llama.cpp",
-            release_tag = "release-1",
-            upstream_tag = "b9001",
-            source_commit = None,
-            artifacts = {},
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        attempts=[older_release_choice],
+        approved_checksums=ApprovedReleaseChecksums(
+            repo="unslothai/llama.cpp",
+            release_tag="release-1",
+            upstream_tag="b9001",
+            source_commit=None,
+            artifacts={},
         ),
     )
 
@@ -1811,8 +1811,8 @@ def test_install_prebuilt_same_tag_upstream_failure_uses_older_unsloth_release_p
         llama_tag,
         release_tag,
         approved_checksums,
-        initial_fallback_used = False,
-        existing_install_dir = None,
+        initial_fallback_used=False,
+        existing_install_dir=None,
     ):
         attempted.append((llama_tag, release_tag, attempts[0].source_label))
         if llama_tag == "b9002":
@@ -1877,57 +1877,57 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete(
     write_linux_install_shape(install_dir)
 
     host = HostInfo(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
-        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
-        source_label = "upstream",
-        install_kind = "linux-cpu",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-ubuntu-x64.tar.gz",
+        url="https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label="upstream",
+        install_kind="linux-cpu",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     # Full install should match
@@ -1935,10 +1935,10 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete(
         existing_install_matches_choice(
             install_dir,
             host,
-            llama_tag = "b9001",
-            release_tag = "release-1",
-            choice = choice,
-            approved_checksums = checksums,
+            llama_tag="b9001",
+            release_tag="release-1",
+            choice=choice,
+            approved_checksums=checksums,
         )
         is True
     )
@@ -1950,10 +1950,10 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete(
         existing_install_matches_choice(
             install_dir,
             host,
-            llama_tag = "b9001",
-            release_tag = "release-1",
-            choice = choice,
-            approved_checksums = checksums,
+            llama_tag="b9001",
+            release_tag="release-1",
+            choice=choice,
+            approved_checksums=checksums,
         )
         is False
     )
@@ -1968,57 +1968,57 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete_maco
     write_macos_install_shape(install_dir)
 
     host = HostInfo(
-        system = "Darwin",
-        machine = "arm64",
-        is_windows = False,
-        is_linux = False,
-        is_macos = True,
-        is_x86_64 = False,
-        is_arm64 = True,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
+        system="Darwin",
+        machine="arm64",
+        is_windows=False,
+        is_linux=False,
+        is_macos=True,
+        is_x86_64=False,
+        is_arm64=True,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
     )
     choice = AssetChoice(
-        repo = "unslothai/llama.cpp",
-        tag = "release-1",
-        name = "llama-b9001-bin-macos-arm64.tar.gz",
-        url = "https://example.com/llama-b9001-bin-macos-arm64.tar.gz",
-        source_label = "upstream",
-        install_kind = "macos-arm64",
-        expected_sha256 = "a" * 64,
+        repo="unslothai/llama.cpp",
+        tag="release-1",
+        name="llama-b9001-bin-macos-arm64.tar.gz",
+        url="https://example.com/llama-b9001-bin-macos-arm64.tar.gz",
+        source_label="upstream",
+        install_kind="macos-arm64",
+        expected_sha256="a" * 64,
     )
     checksums = ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "release-1",
-        upstream_tag = "b9001",
-        source_commit = "deadbeef",
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="release-1",
+        upstream_tag="b9001",
+        source_commit="deadbeef",
+        artifacts={
             source_archive_logical_name("b9001"): ApprovedArtifactHash(
-                asset_name = source_archive_logical_name("b9001"),
-                sha256 = "b" * 64,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-source",
+                asset_name=source_archive_logical_name("b9001"),
+                sha256="b" * 64,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-source",
             ),
             choice.name: ApprovedArtifactHash(
-                asset_name = choice.name,
-                sha256 = choice.expected_sha256,
-                repo = "ggml-org/llama.cpp",
-                kind = "upstream-prebuilt",
+                asset_name=choice.name,
+                sha256=choice.expected_sha256,
+                repo="ggml-org/llama.cpp",
+                kind="upstream-prebuilt",
             ),
         },
     )
     write_prebuilt_metadata(
         install_dir,
-        requested_tag = "latest",
-        llama_tag = "b9001",
-        release_tag = "release-1",
-        choice = choice,
-        approved_checksums = checksums,
-        prebuilt_fallback_used = False,
+        requested_tag="latest",
+        llama_tag="b9001",
+        release_tag="release-1",
+        choice=choice,
+        approved_checksums=checksums,
+        prebuilt_fallback_used=False,
     )
 
     # Full install should match
@@ -2026,10 +2026,10 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete_maco
         existing_install_matches_choice(
             install_dir,
             host,
-            llama_tag = "b9001",
-            release_tag = "release-1",
-            choice = choice,
-            approved_checksums = checksums,
+            llama_tag="b9001",
+            release_tag="release-1",
+            choice=choice,
+            approved_checksums=checksums,
         )
         is True
     )
@@ -2040,10 +2040,10 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete_maco
         existing_install_matches_choice(
             install_dir,
             host,
-            llama_tag = "b9001",
-            release_tag = "release-1",
-            choice = choice,
-            approved_checksums = checksums,
+            llama_tag="b9001",
+            release_tag="release-1",
+            choice=choice,
+            approved_checksums=checksums,
         )
         is False
     )

--- a/tests/studio/install/test_llama_pr_force_and_source.py
+++ b/tests/studio/install/test_llama_pr_force_and_source.py
@@ -28,7 +28,7 @@ SETUP_PS1 = PACKAGE_ROOT / "studio" / "setup.ps1"
 BASH = "/bin/bash"
 PWSH = "/usr/bin/pwsh"
 PWSH_AVAILABLE = os.path.isfile(PWSH) and os.access(PWSH, os.X_OK)
-requires_pwsh = pytest.mark.skipif(not PWSH_AVAILABLE, reason = "pwsh not available")
+requires_pwsh = pytest.mark.skipif(not PWSH_AVAILABLE, reason="pwsh not available")
 
 
 # ---------------------------------------------------------------------------
@@ -43,10 +43,10 @@ def run_bash(
         run_env.update(env)
     return subprocess.run(
         [BASH, "-c", script],
-        capture_output = True,
-        text = True,
-        timeout = timeout,
-        env = run_env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=run_env,
     )
 
 
@@ -60,10 +60,10 @@ def run_pwsh(
         run_env.update(env)
     return subprocess.run(
         [PWSH, "-NoProfile", "-Command", script],
-        capture_output = True,
-        text = True,
-        timeout = timeout,
-        env = run_env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=run_env,
     )
 
 
@@ -86,7 +86,7 @@ RUN_QUIET_STUB = textwrap.dedent("""\
 def make_mock_git(tmp_path: Path, *, fail_on: str = "") -> tuple[Path, Path]:
     """Create a mock git binary that logs calls. Returns (mock_bin, log_file)."""
     mock_bin = tmp_path / "mock_bin"
-    mock_bin.mkdir(exist_ok = True)
+    mock_bin.mkdir(exist_ok=True)
     log_file = tmp_path / "git_calls.log"
 
     if fail_on:
@@ -158,14 +158,14 @@ class TestBashPrForcePromotion:
     """PR_FORCE promotes to _LLAMA_PR when user hasn't set one."""
 
     def test_baked_in_pr_force_promotes(self):
-        script = _bash_resolution_fragment(default_pr_force = "12345")
+        script = _bash_resolution_fragment(default_pr_force="12345")
         r = run_bash(script)
         assert r.returncode == 0
         assert "LLAMA_PR=12345" in r.stdout
         assert "baked-in PR_FORCE=12345" in r.stdout
 
     def test_env_pr_force_promotes(self):
-        script = _bash_resolution_fragment(llama_pr_force = "999")
+        script = _bash_resolution_fragment(llama_pr_force="999")
         r = run_bash(script)
         assert r.returncode == 0
         assert "LLAMA_PR=999" in r.stdout
@@ -173,8 +173,8 @@ class TestBashPrForcePromotion:
     def test_user_pr_overrides_pr_force(self):
         """UNSLOTH_LLAMA_PR takes priority over PR_FORCE."""
         script = _bash_resolution_fragment(
-            llama_pr = "100",
-            llama_pr_force = "200",
+            llama_pr="100",
+            llama_pr_force="200",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -183,8 +183,8 @@ class TestBashPrForcePromotion:
 
     def test_user_pr_overrides_baked_in(self):
         script = _bash_resolution_fragment(
-            llama_pr = "100",
-            default_pr_force = "200",
+            llama_pr="100",
+            default_pr_force="200",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -192,34 +192,34 @@ class TestBashPrForcePromotion:
         assert "baked-in PR_FORCE" not in r.stdout
 
     def test_pr_force_zero_ignored(self):
-        script = _bash_resolution_fragment(llama_pr_force = "0")
+        script = _bash_resolution_fragment(llama_pr_force="0")
         r = run_bash(script)
         assert r.returncode == 0
         assert "LLAMA_PR=" in r.stdout
         assert "baked-in PR_FORCE" not in r.stdout
 
     def test_pr_force_empty_ignored(self):
-        script = _bash_resolution_fragment(default_pr_force = "")
+        script = _bash_resolution_fragment(default_pr_force="")
         r = run_bash(script)
         assert r.returncode == 0
         assert "LLAMA_PR=" in r.stdout
         assert "baked-in PR_FORCE" not in r.stdout
 
     def test_pr_force_alpha_ignored(self):
-        script = _bash_resolution_fragment(llama_pr_force = "abc")
+        script = _bash_resolution_fragment(llama_pr_force="abc")
         r = run_bash(script)
         assert r.returncode == 0
         assert "LLAMA_PR=" in r.stdout
         assert "baked-in PR_FORCE" not in r.stdout
 
     def test_pr_force_negative_ignored(self):
-        script = _bash_resolution_fragment(llama_pr_force = "-5")
+        script = _bash_resolution_fragment(llama_pr_force="-5")
         r = run_bash(script)
         assert r.returncode == 0
         assert "LLAMA_PR=" in r.stdout
 
     def test_pr_force_decimal_ignored(self):
-        script = _bash_resolution_fragment(llama_pr_force = "12.34")
+        script = _bash_resolution_fragment(llama_pr_force="12.34")
         r = run_bash(script)
         assert r.returncode == 0
         assert "LLAMA_PR=" in r.stdout
@@ -241,7 +241,7 @@ class TestBashFixedMainlineSource:
 
     def test_env_source_override_is_ignored(self):
         script = _bash_resolution_fragment(
-            llama_source = "https://github.com/unslothai/llama.cpp.git",
+            llama_source="https://github.com/unslothai/llama.cpp.git",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -251,7 +251,7 @@ class TestBashFixedMainlineSource:
 
     def test_baked_in_source_stays_mainline(self):
         script = _bash_resolution_fragment(
-            default_source = "https://github.com/ggml-org/llama.cpp",
+            default_source="https://github.com/ggml-org/llama.cpp",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -301,8 +301,8 @@ class TestBashCloneUrlParameterized:
         script = self._clone_script(
             mock_bin,
             build_tmp,
-            llama_pr = "123",
-            llama_source = "https://github.com/unslothai/llama.cpp",
+            llama_pr="123",
+            llama_source="https://github.com/unslothai/llama.cpp",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -316,7 +316,7 @@ class TestBashCloneUrlParameterized:
         script = self._clone_script(
             mock_bin,
             build_tmp,
-            llama_source = "https://github.com/unslothai/llama.cpp",
+            llama_source="https://github.com/unslothai/llama.cpp",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -340,7 +340,7 @@ class TestBashCloneUrlParameterized:
         script = self._clone_script(
             mock_bin,
             build_tmp,
-            resolved_tag = "latest",
+            resolved_tag="latest",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -355,7 +355,7 @@ class TestBashCloneUrlParameterized:
         script = self._clone_script(
             mock_bin,
             build_tmp,
-            resolved_tag = "",
+            resolved_tag="",
         )
         r = run_bash(script)
         assert r.returncode == 0
@@ -370,7 +370,7 @@ class TestBashCloneUrlParameterized:
 class TestSourcePatternsSh:
     """Verify setup.sh keeps the temporary mainline-only llama.cpp policy."""
 
-    @pytest.fixture(autouse = True)
+    @pytest.fixture(autouse=True)
     def _load_source(self):
         self.content = SETUP_SH.read_text()
 
@@ -443,7 +443,7 @@ class TestSourcePatternsSh:
 class TestSourcePatternsPs1:
     """Verify setup.ps1 keeps the temporary mainline-only llama.cpp policy."""
 
-    @pytest.fixture(autouse = True)
+    @pytest.fixture(autouse=True)
     def _load_source(self):
         self.content = SETUP_PS1.read_text()
 
@@ -568,22 +568,22 @@ class TestPwshPrForcePromotion:
         run_env["UNSLOTH_LLAMA_PR_FORCE"] = ""
         if env:
             run_env.update(env)
-        return run_pwsh(script, env = run_env)
+        return run_pwsh(script, env=run_env)
 
     def test_baked_in_pr_force_promotes(self):
-        r = self._run(default_pr_force = "12345")
+        r = self._run(default_pr_force="12345")
         assert r.returncode == 0
         assert "LLAMA_PR=12345" in r.stdout
         assert "baked-in PR_FORCE=12345" in r.stdout
 
     def test_env_pr_force_promotes(self):
-        r = self._run(env = {"UNSLOTH_LLAMA_PR_FORCE": "999"})
+        r = self._run(env={"UNSLOTH_LLAMA_PR_FORCE": "999"})
         assert r.returncode == 0
         assert "LLAMA_PR=999" in r.stdout
 
     def test_user_pr_overrides_pr_force(self):
         r = self._run(
-            env = {
+            env={
                 "UNSLOTH_LLAMA_PR": "100",
                 "UNSLOTH_LLAMA_PR_FORCE": "200",
             }
@@ -593,19 +593,19 @@ class TestPwshPrForcePromotion:
         assert "baked-in PR_FORCE" not in r.stdout
 
     def test_pr_force_zero_ignored(self):
-        r = self._run(env = {"UNSLOTH_LLAMA_PR_FORCE": "0"})
+        r = self._run(env={"UNSLOTH_LLAMA_PR_FORCE": "0"})
         assert r.returncode == 0
         assert "LLAMA_PR=" in r.stdout
         assert "baked-in PR_FORCE" not in r.stdout
 
     def test_pr_force_alpha_ignored(self):
-        r = self._run(env = {"UNSLOTH_LLAMA_PR_FORCE": "abc"})
+        r = self._run(env={"UNSLOTH_LLAMA_PR_FORCE": "abc"})
         assert r.returncode == 0
         assert "baked-in PR_FORCE" not in r.stdout
 
     def test_env_source_override_is_ignored(self):
         r = self._run(
-            env = {
+            env={
                 "UNSLOTH_LLAMA_SOURCE": "https://github.com/unslothai/llama.cpp",
             }
         )
@@ -622,7 +622,7 @@ class TestPwshPrForcePromotion:
 
     def test_trailing_git_override_is_ignored(self):
         r = self._run(
-            env = {
+            env={
                 "UNSLOTH_LLAMA_SOURCE": "https://github.com/unslothai/llama.cpp.git",
             }
         )
@@ -630,6 +630,6 @@ class TestPwshPrForcePromotion:
         assert "LLAMA_SOURCE=https://github.com/ggml-org/llama.cpp" in r.stdout
 
     def test_baked_in_source_stays_mainline(self):
-        r = self._run(default_source = "https://github.com/ggml-org/llama.cpp")
+        r = self._run(default_source="https://github.com/ggml-org/llama.cpp")
         assert r.returncode == 0
         assert "LLAMA_SOURCE=https://github.com/ggml-org/llama.cpp" in r.stdout

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -59,20 +59,20 @@ _ROCM_TORCH_INDEX = stack_mod._ROCM_TORCH_INDEX
 def nvidia_host(**overrides) -> HostInfo:
     """NVIDIA Linux x86_64 host."""
     defaults = dict(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = "/usr/bin/nvidia-smi",
-        driver_cuda_version = (12, 6),
-        compute_caps = ["89"],
-        visible_cuda_devices = None,
-        has_physical_nvidia = True,
-        has_usable_nvidia = True,
-        has_rocm = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi="/usr/bin/nvidia-smi",
+        driver_cuda_version=(12, 6),
+        compute_caps=["89"],
+        visible_cuda_devices=None,
+        has_physical_nvidia=True,
+        has_usable_nvidia=True,
+        has_rocm=False,
     )
     defaults.update(overrides)
     return HostInfo(**defaults)
@@ -81,20 +81,20 @@ def nvidia_host(**overrides) -> HostInfo:
 def rocm_host(**overrides) -> HostInfo:
     """AMD ROCm Linux x86_64 host (no NVIDIA)."""
     defaults = dict(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
-        has_rocm = True,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
+        has_rocm=True,
     )
     defaults.update(overrides)
     return HostInfo(**defaults)
@@ -103,20 +103,20 @@ def rocm_host(**overrides) -> HostInfo:
 def cpu_host(**overrides) -> HostInfo:
     """CPU-only Linux x86_64 host."""
     defaults = dict(
-        system = "Linux",
-        machine = "x86_64",
-        is_windows = False,
-        is_linux = True,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
-        has_rocm = False,
+        system="Linux",
+        machine="x86_64",
+        is_windows=False,
+        is_linux=True,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
+        has_rocm=False,
     )
     defaults.update(overrides)
     return HostInfo(**defaults)
@@ -125,20 +125,20 @@ def cpu_host(**overrides) -> HostInfo:
 def macos_host(**overrides) -> HostInfo:
     """macOS arm64 host."""
     defaults = dict(
-        system = "Darwin",
-        machine = "arm64",
-        is_windows = False,
-        is_linux = False,
-        is_macos = True,
-        is_x86_64 = False,
-        is_arm64 = True,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
-        has_rocm = False,
+        system="Darwin",
+        machine="arm64",
+        is_windows=False,
+        is_linux=False,
+        is_macos=True,
+        is_x86_64=False,
+        is_arm64=True,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
+        has_rocm=False,
     )
     defaults.update(overrides)
     return HostInfo(**defaults)
@@ -147,20 +147,20 @@ def macos_host(**overrides) -> HostInfo:
 def windows_host(**overrides) -> HostInfo:
     """Windows x86_64 host."""
     defaults = dict(
-        system = "Windows",
-        machine = "amd64",
-        is_windows = True,
-        is_linux = False,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
-        has_rocm = False,
+        system="Windows",
+        machine="amd64",
+        is_windows=True,
+        is_linux=False,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
+        has_rocm=False,
     )
     defaults.update(overrides)
     return HostInfo(**defaults)
@@ -169,20 +169,20 @@ def windows_host(**overrides) -> HostInfo:
 def windows_rocm_host(**overrides) -> HostInfo:
     """Windows x86_64 host with ROCm."""
     defaults = dict(
-        system = "Windows",
-        machine = "amd64",
-        is_windows = True,
-        is_linux = False,
-        is_macos = False,
-        is_x86_64 = True,
-        is_arm64 = False,
-        nvidia_smi = None,
-        driver_cuda_version = None,
-        compute_caps = [],
-        visible_cuda_devices = None,
-        has_physical_nvidia = False,
-        has_usable_nvidia = False,
-        has_rocm = True,
+        system="Windows",
+        machine="amd64",
+        is_windows=True,
+        is_linux=False,
+        is_macos=False,
+        is_x86_64=True,
+        is_arm64=False,
+        nvidia_smi=None,
+        driver_cuda_version=None,
+        compute_caps=[],
+        visible_cuda_devices=None,
+        has_physical_nvidia=False,
+        has_usable_nvidia=False,
+        has_rocm=True,
     )
     defaults.update(overrides)
     return HostInfo(**defaults)
@@ -211,7 +211,7 @@ UPSTREAM_ASSETS = {
 class TestResolveUpstreamAssetChoice:
     """Verify that the asset selection logic picks the right binary for each platform."""
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_nvidia_linux_gets_cpu_asset(self, mock_assets):
         """NVIDIA host should NOT hit the ROCm path -- gets CPU asset (CUDA handled elsewhere)."""
         host = nvidia_host()
@@ -220,7 +220,7 @@ class TestResolveUpstreamAssetChoice:
         assert "ubuntu-x64" in choice.name
         assert "rocm" not in choice.name
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_rocm_linux_gets_rocm_prebuilt(self, mock_assets):
         """AMD ROCm Linux host should get the ROCm prebuilt."""
         host = rocm_host()
@@ -228,7 +228,7 @@ class TestResolveUpstreamAssetChoice:
         assert choice.install_kind == "linux-rocm"
         assert "rocm" in choice.name
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_cpu_linux_gets_cpu_asset(self, mock_assets):
         """CPU-only Linux host should get CPU asset."""
         host = cpu_host()
@@ -236,7 +236,7 @@ class TestResolveUpstreamAssetChoice:
         assert choice.install_kind == "linux-cpu"
         assert "ubuntu-x64" in choice.name
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_macos_arm64_gets_macos_asset(self, mock_assets):
         """macOS arm64 host should get macOS asset."""
         host = macos_host()
@@ -244,7 +244,7 @@ class TestResolveUpstreamAssetChoice:
         assert choice.install_kind == "macos-arm64"
         assert "macos-arm64" in choice.name
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_windows_cpu_gets_cpu_asset(self, mock_assets):
         """Windows CPU-only host should get Windows CPU asset."""
         host = windows_host()
@@ -252,7 +252,7 @@ class TestResolveUpstreamAssetChoice:
         assert choice.install_kind == "windows-cpu"
         assert "win-cpu" in choice.name
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_windows_rocm_gets_hip_asset(self, mock_assets):
         """Windows ROCm host should get Windows HIP asset."""
         host = windows_rocm_host()
@@ -260,10 +260,10 @@ class TestResolveUpstreamAssetChoice:
         assert choice.install_kind == "windows-hip"
         assert "hip" in choice.name
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_mixed_nvidia_rocm_prefers_nvidia(self, mock_assets):
         """Host with both NVIDIA and ROCm should use NVIDIA (CPU path here, CUDA elsewhere)."""
-        host = nvidia_host(has_rocm = True)
+        host = nvidia_host(has_rocm=True)
         choice = resolve_upstream_asset_choice(host, LLAMA_TAG)
         # NVIDIA hosts go through the normal path (CUDA handled by resolve_linux_cuda_choice)
         assert choice.install_kind == "linux-cpu"
@@ -278,7 +278,7 @@ class TestResolveUpstreamAssetChoice:
         }
         mock_assets.return_value = assets_without_rocm
         host = rocm_host()
-        with pytest.raises(PrebuiltFallback, match = "ROCm detected"):
+        with pytest.raises(PrebuiltFallback, match="ROCm detected"):
             resolve_upstream_asset_choice(host, LLAMA_TAG)
 
     @patch.object(prebuilt_mod, "github_release_assets")
@@ -290,17 +290,17 @@ class TestResolveUpstreamAssetChoice:
         choice = resolve_upstream_asset_choice(host, LLAMA_TAG)
         assert choice.install_kind == "windows-cpu"
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_macos_rocm_impossible_has_rocm_false(self, mock_assets):
         """macOS host should never have has_rocm=True in practice; verify it gets macOS asset."""
-        host = macos_host(has_rocm = True)
+        host = macos_host(has_rocm=True)
         choice = resolve_upstream_asset_choice(host, LLAMA_TAG)
         assert choice.install_kind == "macos-arm64"
 
-    @patch.object(prebuilt_mod, "github_release_assets", return_value = UPSTREAM_ASSETS)
+    @patch.object(prebuilt_mod, "github_release_assets", return_value=UPSTREAM_ASSETS)
     def test_linux_aarch64_rocm_gets_prebuilt_fallback(self, mock_assets):
         """Linux aarch64 with ROCm -- no x86_64 match, should raise PrebuiltFallback."""
-        host = rocm_host(machine = "aarch64", is_x86_64 = False, is_arm64 = True)
+        host = rocm_host(machine="aarch64", is_x86_64=False, is_arm64=True)
         with pytest.raises(PrebuiltFallback):
             resolve_upstream_asset_choice(host, LLAMA_TAG)
 
@@ -315,7 +315,7 @@ class TestRuntimePatterns:
 
     def test_linux_cpu_patterns(self):
         choice = AssetChoice(
-            repo = "", tag = "", name = "", url = "", source_label = "", install_kind = "linux-cpu"
+            repo="", tag="", name="", url="", source_label="", install_kind="linux-cpu"
         )
         patterns = runtime_patterns_for_choice(choice)
         assert "llama-server" in patterns
@@ -323,14 +323,14 @@ class TestRuntimePatterns:
 
     def test_linux_cuda_patterns(self):
         choice = AssetChoice(
-            repo = "", tag = "", name = "", url = "", source_label = "", install_kind = "linux-cuda"
+            repo="", tag="", name="", url="", source_label="", install_kind="linux-cuda"
         )
         patterns = runtime_patterns_for_choice(choice)
         assert "libggml-cuda.so*" in patterns
 
     def test_linux_rocm_patterns(self):
         choice = AssetChoice(
-            repo = "", tag = "", name = "", url = "", source_label = "", install_kind = "linux-rocm"
+            repo="", tag="", name="", url="", source_label="", install_kind="linux-rocm"
         )
         patterns = runtime_patterns_for_choice(choice)
         assert "libggml-hip.so*" in patterns
@@ -338,12 +338,12 @@ class TestRuntimePatterns:
 
     def test_windows_hip_patterns(self):
         choice = AssetChoice(
-            repo = "",
-            tag = "",
-            name = "",
-            url = "",
-            source_label = "",
-            install_kind = "windows-hip",
+            repo="",
+            tag="",
+            name="",
+            url="",
+            source_label="",
+            install_kind="windows-hip",
         )
         patterns = runtime_patterns_for_choice(choice)
         assert "*.exe" in patterns
@@ -351,12 +351,12 @@ class TestRuntimePatterns:
 
     def test_macos_patterns(self):
         choice = AssetChoice(
-            repo = "",
-            tag = "",
-            name = "",
-            url = "",
-            source_label = "",
-            install_kind = "macos-arm64",
+            repo="",
+            tag="",
+            name="",
+            url="",
+            source_label="",
+            install_kind="macos-arm64",
         )
         patterns = runtime_patterns_for_choice(choice)
         assert "lib*.dylib" in patterns
@@ -372,19 +372,19 @@ class TestHostInfoRocm:
 
     def test_has_rocm_default_false(self):
         host = HostInfo(
-            system = "Linux",
-            machine = "x86_64",
-            is_windows = False,
-            is_linux = True,
-            is_macos = False,
-            is_x86_64 = True,
-            is_arm64 = False,
-            nvidia_smi = None,
-            driver_cuda_version = None,
-            compute_caps = [],
-            visible_cuda_devices = None,
-            has_physical_nvidia = False,
-            has_usable_nvidia = False,
+            system="Linux",
+            machine="x86_64",
+            is_windows=False,
+            is_linux=True,
+            is_macos=False,
+            is_x86_64=True,
+            is_arm64=False,
+            nvidia_smi=None,
+            driver_cuda_version=None,
+            compute_caps=[],
+            visible_cuda_devices=None,
+            has_physical_nvidia=False,
+            has_usable_nvidia=False,
         )
         assert host.has_rocm is False
 
@@ -424,7 +424,7 @@ class TestDetectRocmVersion:
     def test_no_rocm_returns_none(self, tmp_path):
         """No ROCm installed should return None."""
         with patch.dict(os.environ, {"ROCM_PATH": str(tmp_path / "nonexistent")}):
-            with patch("shutil.which", return_value = None):
+            with patch("shutil.which", return_value=None):
                 result = _detect_rocm_version()
                 assert result is None
 
@@ -452,8 +452,8 @@ class TestDetectRocmVersion:
             mock_result = MagicMock()
             mock_result.returncode = 0
             mock_result.stdout = b"6.3.21234.2\n"
-            with patch("shutil.which", return_value = "/usr/bin/hipconfig"):
-                with patch("subprocess.run", return_value = mock_result):
+            with patch("shutil.which", return_value="/usr/bin/hipconfig"):
+                with patch("subprocess.run", return_value=mock_result):
                     result = _detect_rocm_version()
                     assert result == (6, 3)
 
@@ -463,7 +463,7 @@ class TestDetectRocmVersion:
         info_dir.mkdir()
         (info_dir / "version").write_text("")
         with patch.dict(os.environ, {"ROCM_PATH": str(tmp_path)}):
-            with patch("shutil.which", return_value = None):
+            with patch("shutil.which", return_value=None):
                 result = _detect_rocm_version()
                 assert result is None
 
@@ -495,18 +495,18 @@ class TestDetectRocmVersion:
             mock_result = MagicMock()
             mock_result.returncode = 0
             mock_result.stdout = b"6.3.21234.2\nSome extra info\n"
-            with patch("shutil.which", return_value = "/usr/bin/hipconfig"):
-                with patch("subprocess.run", return_value = mock_result):
+            with patch("shutil.which", return_value="/usr/bin/hipconfig"):
+                with patch("subprocess.run", return_value=mock_result):
                     result = _detect_rocm_version()
                     assert result == (6, 3)
 
     def test_hipconfig_timeout(self, tmp_path):
         """hipconfig that times out should return None."""
         with patch.dict(os.environ, {"ROCM_PATH": str(tmp_path / "nonexistent")}):
-            with patch("shutil.which", return_value = "/usr/bin/hipconfig"):
+            with patch("shutil.which", return_value="/usr/bin/hipconfig"):
                 with patch(
                     "subprocess.run",
-                    side_effect = subprocess.TimeoutExpired("hipconfig", 5),
+                    side_effect=subprocess.TimeoutExpired("hipconfig", 5),
                 ):
                     result = _detect_rocm_version()
                     assert result is None
@@ -521,18 +521,18 @@ class TestEnsureRocmTorch:
     """Verify ROCm torch reinstall logic."""
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
     def test_no_rocm_skips(self, mock_nvidia, mock_pip):
         """No ROCm toolchain should skip entirely."""
-        with patch("os.path.isdir", return_value = False):
-            with patch("shutil.which", return_value = None):
+        with patch("os.path.isdir", return_value=False):
+            with patch("shutil.which", return_value=None):
                 _ensure_rocm_torch()
         mock_pip.assert_not_called()
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = (7, 1))
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=(7, 1))
     def test_torch_already_has_cuda_skips(
         self, mock_ver, mock_gpu, mock_nvidia, mock_pip
     ):
@@ -540,15 +540,15 @@ class TestEnsureRocmTorch:
         mock_probe = MagicMock()
         mock_probe.returncode = 0
         mock_probe.stdout = b"12.6\n"  # CUDA version string
-        with patch("os.path.isdir", return_value = True):
-            with patch("subprocess.run", return_value = mock_probe):
+        with patch("os.path.isdir", return_value=True):
+            with patch("subprocess.run", return_value=mock_probe):
                 _ensure_rocm_torch()
         mock_pip.assert_not_called()
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = (7, 1))
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=(7, 1))
     def test_torch_already_has_hip_skips(
         self, mock_ver, mock_gpu, mock_nvidia, mock_pip
     ):
@@ -556,15 +556,15 @@ class TestEnsureRocmTorch:
         mock_probe = MagicMock()
         mock_probe.returncode = 0
         mock_probe.stdout = b"7.1.12345\n"  # HIP version string
-        with patch("os.path.isdir", return_value = True):
-            with patch("subprocess.run", return_value = mock_probe):
+        with patch("os.path.isdir", return_value=True):
+            with patch("subprocess.run", return_value=mock_probe):
                 _ensure_rocm_torch()
         mock_pip.assert_not_called()
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = (7, 1))
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=(7, 1))
     def test_cpu_torch_gets_rocm_reinstall(
         self, mock_ver, mock_gpu, mock_nvidia, mock_pip
     ):
@@ -572,8 +572,8 @@ class TestEnsureRocmTorch:
         mock_probe = MagicMock()
         mock_probe.returncode = 0
         mock_probe.stdout = b"\n"  # empty = no GPU backend
-        with patch("os.path.isdir", return_value = True):
-            with patch("subprocess.run", return_value = mock_probe):
+        with patch("os.path.isdir", return_value=True):
+            with patch("subprocess.run", return_value=mock_probe):
                 _ensure_rocm_torch()
         # Should call pip_install twice: once for torch, once for bitsandbytes
         assert mock_pip.call_count == 2
@@ -583,9 +583,9 @@ class TestEnsureRocmTorch:
         assert "bitsandbytes" in str(bnb_call)
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = (6, 3))
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=(6, 3))
     def test_rocm_63_selects_correct_tag(
         self, mock_ver, mock_gpu, mock_nvidia, mock_pip
     ):
@@ -593,66 +593,66 @@ class TestEnsureRocmTorch:
         mock_probe = MagicMock()
         mock_probe.returncode = 0
         mock_probe.stdout = b"\n"
-        with patch("os.path.isdir", return_value = True):
-            with patch("subprocess.run", return_value = mock_probe):
+        with patch("os.path.isdir", return_value=True):
+            with patch("subprocess.run", return_value=mock_probe):
                 _ensure_rocm_torch()
         torch_call = mock_pip.call_args_list[0]
         assert "rocm6.3" in str(torch_call)
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = (5, 0))
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=(5, 0))
     def test_old_rocm_skips(self, mock_ver, mock_gpu, mock_nvidia, mock_pip):
         """ROCm version too old (below 6.0) should skip."""
         mock_probe = MagicMock()
         mock_probe.returncode = 0
         mock_probe.stdout = b"\n"
-        with patch("os.path.isdir", return_value = True):
-            with patch("subprocess.run", return_value = mock_probe):
+        with patch("os.path.isdir", return_value=True):
+            with patch("subprocess.run", return_value=mock_probe):
                 _ensure_rocm_torch()
         mock_pip.assert_not_called()
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = None)
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=None)
     def test_version_unreadable_prints_warning(
         self, mock_ver, mock_gpu, mock_nvidia, mock_pip, capsys
     ):
         """ROCm detected but version unreadable should print warning and skip."""
-        with patch("os.path.isdir", return_value = True):
+        with patch("os.path.isdir", return_value=True):
             _ensure_rocm_torch()
         mock_pip.assert_not_called()
         captured = capsys.readouterr()
         assert "unreadable" in captured.out
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = (7, 2))
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=(7, 2))
     def test_rocm_72_selects_71_tag(self, mock_ver, mock_gpu, mock_nvidia, mock_pip):
         """ROCm 7.2 should select rocm7.1 tag (capped, not in mapping)."""
         mock_probe = MagicMock()
         mock_probe.returncode = 0
         mock_probe.stdout = b"\n"
-        with patch("os.path.isdir", return_value = True):
-            with patch("subprocess.run", return_value = mock_probe):
+        with patch("os.path.isdir", return_value=True):
+            with patch("subprocess.run", return_value=mock_probe):
                 _ensure_rocm_torch()
         torch_call = mock_pip.call_args_list[0]
         assert "rocm7.1" in str(torch_call)
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
-    @patch.object(stack_mod, "_detect_rocm_version", return_value = (7, 1))
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=True)
+    @patch.object(stack_mod, "_detect_rocm_version", return_value=(7, 1))
     def test_probe_timeout_triggers_reinstall(
         self, mock_ver, mock_gpu, mock_nvidia, mock_pip
     ):
         """Probe subprocess timeout should not crash; should proceed to reinstall."""
-        with patch("os.path.isdir", return_value = True):
+        with patch("os.path.isdir", return_value=True):
             with patch(
-                "subprocess.run", side_effect = subprocess.TimeoutExpired("python", 30)
+                "subprocess.run", side_effect=subprocess.TimeoutExpired("python", 30)
             ):
                 _ensure_rocm_torch()
         # If probe times out, the function should treat torch as unusable and reinstall
@@ -660,11 +660,11 @@ class TestEnsureRocmTorch:
         assert "rocm7.1" in str(mock_pip.call_args_list[0])
 
     @patch.object(stack_mod, "pip_install")
-    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
-    @patch.object(stack_mod, "_has_rocm_gpu", return_value = False)
+    @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value=False)
+    @patch.object(stack_mod, "_has_rocm_gpu", return_value=False)
     def test_no_gpu_with_rocm_tools_skips(self, mock_gpu, mock_nvidia, mock_pip):
         """ROCm tools present but no actual AMD GPU should skip entirely."""
-        with patch("os.path.isdir", return_value = True):
+        with patch("os.path.isdir", return_value=True):
             _ensure_rocm_torch()
         mock_pip.assert_not_called()
 
@@ -680,7 +680,7 @@ class TestRocmTorchIndex:
     def test_mapping_is_sorted_descending(self):
         """Keys should be in descending order for the next() iteration to work."""
         keys = list(_ROCM_TORCH_INDEX.keys())
-        assert keys == sorted(keys, reverse = True)
+        assert keys == sorted(keys, reverse=True)
 
     def test_rocm_72_not_in_mapping(self):
         """ROCm 7.2 should NOT be in the active mapping (torch 2.11.0 exceeds bound)."""
@@ -707,7 +707,7 @@ class TestRocmTorchIndex:
         tag = next(
             (
                 t
-                for (maj, mn), t in sorted(_ROCM_TORCH_INDEX.items(), reverse = True)
+                for (maj, mn), t in sorted(_ROCM_TORCH_INDEX.items(), reverse=True)
                 if ver >= (maj, mn)
             ),
             None,
@@ -719,7 +719,7 @@ class TestRocmTorchIndex:
         tag = next(
             (
                 t
-                for (maj, mn), t in sorted(_ROCM_TORCH_INDEX.items(), reverse = True)
+                for (maj, mn), t in sorted(_ROCM_TORCH_INDEX.items(), reverse=True)
                 if ver >= (maj, mn)
             ),
             None,
@@ -972,9 +972,9 @@ class TestLiveRegression:
                 f"eval \"$(sed -n '/^get_torch_index_url()/,/^}}/p' '{sh_path}')\"; "
                 "get_torch_index_url",
             ],
-            capture_output = True,
-            text = True,
-            timeout = 30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             pytest.skip("Could not extract get_torch_index_url for live test")
@@ -1015,7 +1015,7 @@ class TestWorkerRocmMambaSsm:
         # Mock all the imports worker.py needs
         sys.modules["structlog"] = MagicMock()
         sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        sys.modules["loggers"].get_logger = MagicMock(return_value=MagicMock())
         sys.modules["utils"] = MagicMock()
         sys.modules["utils.hardware"] = MagicMock()
 
@@ -1032,11 +1032,11 @@ class TestWorkerRocmMambaSsm:
             "cxx11abi": "TRUE",
         }
         result = worker_mod._direct_wheel_url(
-            filename_prefix = "causal_conv1d",
-            package_version = "1.6.1",
-            release_tag = "v1.6.1.post4",
-            release_base_url = "https://github.com/Dao-AILab/causal-conv1d/releases/download",
-            env = env_rocm,
+            filename_prefix="causal_conv1d",
+            package_version="1.6.1",
+            release_tag="v1.6.1.post4",
+            release_base_url="https://github.com/Dao-AILab/causal-conv1d/releases/download",
+            env=env_rocm,
         )
         assert result is None
 
@@ -1091,7 +1091,7 @@ class TestAmdGpuMonitoring:
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
         sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        sys.modules["loggers"].get_logger = MagicMock(return_value=MagicMock())
 
         try:
             _amd_spec.loader.exec_module(amd_mod)
@@ -1129,7 +1129,7 @@ class TestAmdGpuMonitoring:
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
         sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        sys.modules["loggers"].get_logger = MagicMock(return_value=MagicMock())
 
         try:
             _amd_spec.loader.exec_module(amd_mod)
@@ -1150,7 +1150,7 @@ class TestAmdGpuMonitoring:
         mock_result.returncode = 0
         mock_result.stdout = mock_json
 
-        with patch.object(subprocess, "run", return_value = mock_result):
+        with patch.object(subprocess, "run", return_value=mock_result):
             result = amd_mod.get_primary_gpu_utilization()
         assert result["available"] is True
         assert result["gpu_utilization_pct"] == 50.0
@@ -1164,14 +1164,14 @@ class TestAmdGpuMonitoring:
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
         sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        sys.modules["loggers"].get_logger = MagicMock(return_value=MagicMock())
 
         try:
             _amd_spec.loader.exec_module(amd_mod)
         except Exception:
             pytest.skip("Could not load amd module")
 
-        with patch.object(subprocess, "run", side_effect = OSError("amd-smi not found")):
+        with patch.object(subprocess, "run", side_effect=OSError("amd-smi not found")):
             result = amd_mod.get_primary_gpu_utilization()
         assert result["available"] is False
 
@@ -1183,7 +1183,7 @@ class TestAmdGpuMonitoring:
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
         sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        sys.modules["loggers"].get_logger = MagicMock(return_value=MagicMock())
 
         try:
             _amd_spec.loader.exec_module(amd_mod)
@@ -1193,7 +1193,7 @@ class TestAmdGpuMonitoring:
         with patch.object(
             subprocess,
             "run",
-            side_effect = subprocess.TimeoutExpired("amd-smi", 5),
+            side_effect=subprocess.TimeoutExpired("amd-smi", 5),
         ):
             result = amd_mod.get_primary_gpu_utilization()
         assert result["available"] is False

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -85,19 +85,19 @@ def make_host(**overrides):
     system = overrides.pop("system", "Linux")
     machine = overrides.pop("machine", "x86_64")
     defaults = dict(
-        system = system,
-        machine = machine,
-        is_linux = system == "Linux",
-        is_windows = system == "Windows",
-        is_macos = system == "Darwin",
-        is_x86_64 = machine.lower() in {"x86_64", "amd64"},
-        is_arm64 = machine.lower() in {"arm64", "aarch64"},
-        nvidia_smi = "/usr/bin/nvidia-smi",
-        driver_cuda_version = (12, 8),
-        compute_caps = ["86"],
-        visible_cuda_devices = None,
-        has_physical_nvidia = True,
-        has_usable_nvidia = True,
+        system=system,
+        machine=machine,
+        is_linux=system == "Linux",
+        is_windows=system == "Windows",
+        is_macos=system == "Darwin",
+        is_x86_64=machine.lower() in {"x86_64", "amd64"},
+        is_arm64=machine.lower() in {"arm64", "aarch64"},
+        nvidia_smi="/usr/bin/nvidia-smi",
+        driver_cuda_version=(12, 8),
+        compute_caps=["86"],
+        visible_cuda_devices=None,
+        has_physical_nvidia=True,
+        has_usable_nvidia=True,
     )
     defaults.update(overrides)
     return HostInfo(**defaults)
@@ -105,15 +105,15 @@ def make_host(**overrides):
 
 def make_artifact(asset_name, **overrides):
     defaults = dict(
-        asset_name = asset_name,
-        install_kind = "linux-cuda",
-        runtime_line = "cuda12",
-        coverage_class = "targeted",
-        supported_sms = ["75", "80", "86", "89", "90"],
-        min_sm = 75,
-        max_sm = 90,
-        bundle_profile = "cuda12-newer",
-        rank = 100,
+        asset_name=asset_name,
+        install_kind="linux-cuda",
+        runtime_line="cuda12",
+        coverage_class="targeted",
+        supported_sms=["75", "80", "86", "89", "90"],
+        min_sm=75,
+        max_sm=90,
+        bundle_profile="cuda12-newer",
+        rank=100,
     )
     defaults.update(overrides)
     return PublishedLlamaArtifact(**defaults)
@@ -121,20 +121,20 @@ def make_artifact(asset_name, **overrides):
 
 def make_release(artifacts, **overrides):
     defaults = dict(
-        repo = "unslothai/llama.cpp",
-        release_tag = "v1.0",
-        upstream_tag = "b8508",
-        source_repo = None,
-        source_repo_url = None,
-        source_ref_kind = None,
-        requested_source_ref = None,
-        resolved_source_ref = None,
-        source_commit = None,
-        source_commit_short = None,
-        assets = {a.asset_name: f"https://example.com/{a.asset_name}" for a in artifacts},
-        manifest_asset_name = "llama-prebuilt-manifest.json",
-        artifacts = artifacts,
-        selection_log = [],
+        repo="unslothai/llama.cpp",
+        release_tag="v1.0",
+        upstream_tag="b8508",
+        source_repo=None,
+        source_repo_url=None,
+        source_ref_kind=None,
+        requested_source_ref=None,
+        resolved_source_ref=None,
+        source_commit=None,
+        source_commit_short=None,
+        assets={a.asset_name: f"https://example.com/{a.asset_name}" for a in artifacts},
+        manifest_asset_name="llama-prebuilt-manifest.json",
+        artifacts=artifacts,
+        selection_log=[],
     )
     defaults.update(overrides)
     return PublishedReleaseBundle(**defaults)
@@ -142,22 +142,22 @@ def make_release(artifacts, **overrides):
 
 def make_checksums(asset_names):
     return ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = "v1.0",
-        upstream_tag = "b8508",
-        source_repo = None,
-        source_repo_url = None,
-        source_ref_kind = None,
-        requested_source_ref = None,
-        resolved_source_ref = None,
-        source_commit = None,
-        source_commit_short = None,
-        artifacts = {
+        repo="unslothai/llama.cpp",
+        release_tag="v1.0",
+        upstream_tag="b8508",
+        source_repo=None,
+        source_repo_url=None,
+        source_ref_kind=None,
+        requested_source_ref=None,
+        resolved_source_ref=None,
+        source_commit=None,
+        source_commit_short=None,
+        artifacts={
             name: ApprovedArtifactHash(
-                asset_name = name,
-                sha256 = "a" * 64,
-                repo = "unslothai/llama.cpp",
-                kind = "prebuilt",
+                asset_name=name,
+                sha256="a" * 64,
+                repo="unslothai/llama.cpp",
+                kind="prebuilt",
             )
             for name in asset_names
         },
@@ -167,30 +167,30 @@ def make_checksums(asset_names):
 def make_checksums_with_source(
     asset_names,
     *,
-    release_tag = "v1.0",
-    upstream_tag = "b8508",
-    source_repo = None,
-    source_repo_url = None,
-    source_ref_kind = None,
-    requested_source_ref = None,
-    resolved_source_ref = None,
-    source_commit = None,
+    release_tag="v1.0",
+    upstream_tag="b8508",
+    source_repo=None,
+    source_repo_url=None,
+    source_ref_kind=None,
+    requested_source_ref=None,
+    resolved_source_ref=None,
+    source_commit=None,
 ):
     artifacts = {
         **{
             name: ApprovedArtifactHash(
-                asset_name = name,
-                sha256 = "a" * 64,
-                repo = "unslothai/llama.cpp",
-                kind = "prebuilt",
+                asset_name=name,
+                sha256="a" * 64,
+                repo="unslothai/llama.cpp",
+                kind="prebuilt",
             )
             for name in asset_names
         },
         source_archive_logical_name(upstream_tag): ApprovedArtifactHash(
-            asset_name = source_archive_logical_name(upstream_tag),
-            sha256 = "b" * 64,
-            repo = "ggml-org/llama.cpp",
-            kind = "upstream-source",
+            asset_name=source_archive_logical_name(upstream_tag),
+            sha256="b" * 64,
+            repo="ggml-org/llama.cpp",
+            kind="upstream-source",
         ),
     }
     normalized_source_commit = (
@@ -199,26 +199,26 @@ def make_checksums_with_source(
     if normalized_source_commit:
         artifacts[exact_source_archive_logical_name(normalized_source_commit)] = (
             ApprovedArtifactHash(
-                asset_name = exact_source_archive_logical_name(normalized_source_commit),
-                sha256 = "c" * 64,
-                repo = source_repo or "example/custom-llama.cpp",
-                kind = "exact-source",
+                asset_name=exact_source_archive_logical_name(normalized_source_commit),
+                sha256="c" * 64,
+                repo=source_repo or "example/custom-llama.cpp",
+                kind="exact-source",
             )
         )
     return ApprovedReleaseChecksums(
-        repo = "unslothai/llama.cpp",
-        release_tag = release_tag,
-        upstream_tag = upstream_tag,
-        source_repo = source_repo,
-        source_repo_url = source_repo_url,
-        source_ref_kind = source_ref_kind,
-        requested_source_ref = requested_source_ref,
-        resolved_source_ref = resolved_source_ref,
-        source_commit = normalized_source_commit,
-        source_commit_short = normalized_source_commit[:7]
+        repo="unslothai/llama.cpp",
+        release_tag=release_tag,
+        upstream_tag=upstream_tag,
+        source_repo=source_repo,
+        source_repo_url=source_repo_url,
+        source_ref_kind=source_ref_kind,
+        requested_source_ref=requested_source_ref,
+        resolved_source_ref=resolved_source_ref,
+        source_commit=normalized_source_commit,
+        source_commit_short=normalized_source_commit[:7]
         if normalized_source_commit
         else None,
-        artifacts = artifacts,
+        artifacts=artifacts,
     )
 
 
@@ -382,19 +382,19 @@ class TestSelectVisibleGpuRows:
 
 class TestCompatibleLinuxRuntimeLines:
     def test_no_driver(self):
-        host = make_host(driver_cuda_version = None)
+        host = make_host(driver_cuda_version=None)
         assert compatible_linux_runtime_lines(host) == []
 
     def test_driver_11_8(self):
-        host = make_host(driver_cuda_version = (11, 8))
+        host = make_host(driver_cuda_version=(11, 8))
         assert compatible_linux_runtime_lines(host) == []
 
     def test_driver_12_4(self):
-        host = make_host(driver_cuda_version = (12, 4))
+        host = make_host(driver_cuda_version=(12, 4))
         assert compatible_linux_runtime_lines(host) == ["cuda12"]
 
     def test_driver_13_0(self):
-        host = make_host(driver_cuda_version = (13, 0))
+        host = make_host(driver_cuda_version=(13, 0))
         assert compatible_linux_runtime_lines(host) == ["cuda13", "cuda12"]
 
 
@@ -405,33 +405,33 @@ class TestCompatibleLinuxRuntimeLines:
 
 class TestPickWindowsCudaRuntime:
     def test_no_driver(self):
-        host = make_host(driver_cuda_version = None)
+        host = make_host(driver_cuda_version=None)
         assert pick_windows_cuda_runtime(host) is None
 
     def test_below_threshold(self):
-        host = make_host(driver_cuda_version = (12, 3))
+        host = make_host(driver_cuda_version=(12, 3))
         assert pick_windows_cuda_runtime(host) is None
 
     def test_driver_12_4(self):
-        host = make_host(driver_cuda_version = (12, 4))
+        host = make_host(driver_cuda_version=(12, 4))
         assert pick_windows_cuda_runtime(host) == "12.4"
 
     def test_driver_13_1(self):
-        host = make_host(driver_cuda_version = (13, 1))
+        host = make_host(driver_cuda_version=(13, 1))
         assert pick_windows_cuda_runtime(host) == "13.1"
 
 
 class TestCompatibleWindowsRuntimeLines:
     def test_no_driver(self):
-        host = make_host(driver_cuda_version = None)
+        host = make_host(driver_cuda_version=None)
         assert compatible_windows_runtime_lines(host) == []
 
     def test_driver_12_4(self):
-        host = make_host(driver_cuda_version = (12, 4))
+        host = make_host(driver_cuda_version=(12, 4))
         assert compatible_windows_runtime_lines(host) == ["cuda12"]
 
     def test_driver_13_1(self):
-        host = make_host(driver_cuda_version = (13, 1))
+        host = make_host(driver_cuda_version=(13, 1))
         assert compatible_windows_runtime_lines(host) == ["cuda13", "cuda12"]
 
 
@@ -465,11 +465,11 @@ class TestRuntimeLineFromCudaVersion:
 class TestApplyApprovedHashes:
     def _choice(self, name):
         return AssetChoice(
-            repo = "test",
-            tag = "v1",
-            name = name,
-            url = f"https://x/{name}",
-            source_label = "test",
+            repo="test",
+            tag="v1",
+            name=name,
+            url=f"https://x/{name}",
+            source_label="test",
         )
 
     def test_both_approved(self):
@@ -488,22 +488,22 @@ class TestApplyApprovedHashes:
 
     def test_upstream_asset_can_match_compatibility_tag_name(self):
         choice = AssetChoice(
-            repo = UPSTREAM_REPO,
-            tag = "main",
-            name = "llama-main-bin-macos-arm64.tar.gz",
-            url = "https://x/llama-main-bin-macos-arm64.tar.gz",
-            source_label = "upstream",
+            repo=UPSTREAM_REPO,
+            tag="main",
+            name="llama-main-bin-macos-arm64.tar.gz",
+            url="https://x/llama-main-bin-macos-arm64.tar.gz",
+            source_label="upstream",
         )
         checksums = ApprovedReleaseChecksums(
-            repo = "unslothai/llama.cpp",
-            release_tag = "r1",
-            upstream_tag = "b9000",
-            artifacts = {
+            repo="unslothai/llama.cpp",
+            release_tag="r1",
+            upstream_tag="b9000",
+            artifacts={
                 "llama-b9000-bin-macos-arm64.tar.gz": ApprovedArtifactHash(
-                    asset_name = "llama-b9000-bin-macos-arm64.tar.gz",
-                    sha256 = "a" * 64,
-                    repo = UPSTREAM_REPO,
-                    kind = "macos-arm64-upstream",
+                    asset_name="llama-b9000-bin-macos-arm64.tar.gz",
+                    sha256="a" * 64,
+                    repo=UPSTREAM_REPO,
+                    kind="macos-arm64-upstream",
                 )
             },
         )
@@ -513,22 +513,22 @@ class TestApplyApprovedHashes:
 
     def test_windows_cuda_legacy_choice_can_match_current_upstream_name(self):
         choice = AssetChoice(
-            repo = UPSTREAM_REPO,
-            tag = "b9000",
-            name = "llama-b9000-bin-win-cuda-13.1-x64.zip",
-            url = "https://x/llama-b9000-bin-win-cuda-13.1-x64.zip",
-            source_label = "upstream",
+            repo=UPSTREAM_REPO,
+            tag="b9000",
+            name="llama-b9000-bin-win-cuda-13.1-x64.zip",
+            url="https://x/llama-b9000-bin-win-cuda-13.1-x64.zip",
+            source_label="upstream",
         )
         checksums = ApprovedReleaseChecksums(
-            repo = "unslothai/llama.cpp",
-            release_tag = "r1",
-            upstream_tag = "b9000",
-            artifacts = {
+            repo="unslothai/llama.cpp",
+            release_tag="r1",
+            upstream_tag="b9000",
+            artifacts={
                 "cudart-llama-bin-win-cuda-13.1-x64.zip": ApprovedArtifactHash(
-                    asset_name = "cudart-llama-bin-win-cuda-13.1-x64.zip",
-                    sha256 = "b" * 64,
-                    repo = UPSTREAM_REPO,
-                    kind = "windows-cuda-upstream",
+                    asset_name="cudart-llama-bin-win-cuda-13.1-x64.zip",
+                    sha256="b" * 64,
+                    repo=UPSTREAM_REPO,
+                    kind="windows-cuda-upstream",
                 )
             },
         )
@@ -538,22 +538,22 @@ class TestApplyApprovedHashes:
 
     def test_windows_cuda_current_choice_can_match_legacy_compatibility_name(self):
         choice = AssetChoice(
-            repo = UPSTREAM_REPO,
-            tag = "main",
-            name = "cudart-llama-bin-win-cuda-13.1-x64.zip",
-            url = "https://x/cudart-llama-bin-win-cuda-13.1-x64.zip",
-            source_label = "upstream",
+            repo=UPSTREAM_REPO,
+            tag="main",
+            name="cudart-llama-bin-win-cuda-13.1-x64.zip",
+            url="https://x/cudart-llama-bin-win-cuda-13.1-x64.zip",
+            source_label="upstream",
         )
         checksums = ApprovedReleaseChecksums(
-            repo = "unslothai/llama.cpp",
-            release_tag = "r1",
-            upstream_tag = "b9000",
-            artifacts = {
+            repo="unslothai/llama.cpp",
+            release_tag="r1",
+            upstream_tag="b9000",
+            artifacts={
                 "llama-b9000-bin-win-cuda-13.1-x64.zip": ApprovedArtifactHash(
-                    asset_name = "llama-b9000-bin-win-cuda-13.1-x64.zip",
-                    sha256 = "c" * 64,
-                    repo = UPSTREAM_REPO,
-                    kind = "windows-cuda-upstream",
+                    asset_name="llama-b9000-bin-win-cuda-13.1-x64.zip",
+                    sha256="c" * 64,
+                    repo=UPSTREAM_REPO,
+                    kind="windows-cuda-upstream",
                 )
             },
         )
@@ -564,12 +564,12 @@ class TestApplyApprovedHashes:
     def test_none_approved(self):
         c1 = self._choice("missing.tar.gz")
         checksums = make_checksums(["other.tar.gz"])
-        with pytest.raises(PrebuiltFallback, match = "approved checksum"):
+        with pytest.raises(PrebuiltFallback, match="approved checksum"):
             apply_approved_hashes([c1], checksums)
 
     def test_empty_input(self):
         checksums = make_checksums(["a.tar.gz"])
-        with pytest.raises(PrebuiltFallback, match = "approved checksum"):
+        with pytest.raises(PrebuiltFallback, match="approved checksum"):
             apply_approved_hashes([], checksums)
 
 
@@ -580,20 +580,20 @@ class TestApplyApprovedHashes:
 
 class TestPublishedReleaseResolution:
     def test_latest_skips_invalid_release_and_uses_next_valid(self, monkeypatch):
-        invalid = make_release([], release_tag = "v2.0", upstream_tag = "b9000")
-        valid = make_release([], release_tag = "v1.0", upstream_tag = "b8999")
+        invalid = make_release([], release_tag="v2.0", upstream_tag="b9000")
+        valid = make_release([], release_tag="v1.0", upstream_tag="b8999")
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_published_release_bundles",
-            lambda repo, published_release_tag = "": iter([invalid, valid]),
+            lambda repo, published_release_tag="": iter([invalid, valid]),
         )
 
         def fake_load(repo, release_tag):
             if release_tag == "v2.0":
                 raise PrebuiltFallback("checksum asset missing")
             return make_checksums_with_source(
-                [], release_tag = "v1.0", upstream_tag = "b8999"
+                [], release_tag="v1.0", upstream_tag="b8999"
             )
 
         monkeypatch.setattr(
@@ -608,19 +608,19 @@ class TestPublishedReleaseResolution:
         assert resolved.checksums.release_tag == "v1.0"
 
     def test_concrete_tag_matches_manifest_upstream_tag(self, monkeypatch):
-        release = make_release([], release_tag = "release-b8508", upstream_tag = "b8508")
+        release = make_release([], release_tag="release-b8508", upstream_tag="b8508")
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_published_release_bundles",
-            lambda repo, published_release_tag = "": iter([release]),
+            lambda repo, published_release_tag="": iter([release]),
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
             lambda repo, release_tag: make_checksums_with_source(
                 [],
-                release_tag = release_tag,
-                upstream_tag = "b8508",
+                release_tag=release_tag,
+                upstream_tag="b8508",
             ),
         )
 
@@ -629,19 +629,19 @@ class TestPublishedReleaseResolution:
         )
 
     def test_concrete_tag_without_matching_release_raises(self, monkeypatch):
-        release = make_release([], release_tag = "release-b9000", upstream_tag = "b9000")
+        release = make_release([], release_tag="release-b9000", upstream_tag="b9000")
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_published_release_bundles",
-            lambda repo, published_release_tag = "": iter([release]),
+            lambda repo, published_release_tag="": iter([release]),
         )
 
-        with pytest.raises(PrebuiltFallback, match = "matched upstream tag b8508"):
+        with pytest.raises(PrebuiltFallback, match="matched upstream tag b8508"):
             resolve_requested_install_tag("b8508", "", "unslothai/llama.cpp")
 
     def test_pinned_release_must_match_requested_upstream_tag(self, monkeypatch):
         bundle = make_release(
-            [], release_tag = "llama-prebuilt-latest", upstream_tag = "b9000"
+            [], release_tag="llama-prebuilt-latest", upstream_tag="b9000"
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
@@ -653,12 +653,12 @@ class TestPublishedReleaseResolution:
             "load_approved_release_checksums",
             lambda repo, release_tag: make_checksums_with_source(
                 [],
-                release_tag = release_tag,
-                upstream_tag = "b9000",
+                release_tag=release_tag,
+                upstream_tag="b9000",
             ),
         )
 
-        with pytest.raises(PrebuiltFallback, match = "but requested b8508"):
+        with pytest.raises(PrebuiltFallback, match="but requested b8508"):
             resolve_requested_install_tag(
                 "b8508",
                 "llama-prebuilt-latest",
@@ -668,25 +668,25 @@ class TestPublishedReleaseResolution:
     def test_request_matches_requested_source_ref(self, monkeypatch):
         release = make_release(
             [],
-            release_tag = "release-main",
-            upstream_tag = "b9000",
-            requested_source_ref = "main",
-            resolved_source_ref = "refs/heads/main",
+            release_tag="release-main",
+            upstream_tag="b9000",
+            requested_source_ref="main",
+            resolved_source_ref="refs/heads/main",
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_published_release_bundles",
-            lambda repo, published_release_tag = "": iter([release]),
+            lambda repo, published_release_tag="": iter([release]),
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
             lambda repo, release_tag: make_checksums_with_source(
                 [],
-                release_tag = release_tag,
-                upstream_tag = "b9000",
-                requested_source_ref = "main",
-                resolved_source_ref = "refs/heads/main",
+                release_tag=release_tag,
+                upstream_tag="b9000",
+                requested_source_ref="main",
+                resolved_source_ref="refs/heads/main",
             ),
         )
 
@@ -697,23 +697,23 @@ class TestPublishedReleaseResolution:
         commit = "a" * 40
         release = make_release(
             [],
-            release_tag = "release-commit",
-            upstream_tag = "b9000",
-            source_commit = commit,
+            release_tag="release-commit",
+            upstream_tag="b9000",
+            source_commit=commit,
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_published_release_bundles",
-            lambda repo, published_release_tag = "": iter([release]),
+            lambda repo, published_release_tag="": iter([release]),
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
             lambda repo, release_tag: make_checksums_with_source(
                 [],
-                release_tag = release_tag,
-                upstream_tag = "b9000",
-                source_commit = commit,
+                release_tag=release_tag,
+                upstream_tag="b9000",
+                source_commit=commit,
             ),
         )
 
@@ -725,9 +725,9 @@ class TestSourceBuildPlanResolution:
     def test_matches_request_by_non_tag_provenance(self):
         bundle = make_release(
             [],
-            requested_source_ref = "main",
-            resolved_source_ref = "refs/heads/main",
-            source_commit = "a" * 40,
+            requested_source_ref="main",
+            resolved_source_ref="refs/heads/main",
+            source_commit="a" * 40,
         )
         assert published_release_matches_request(bundle, "main") is True
         assert published_release_matches_request(bundle, "refs/heads/main") is True
@@ -737,8 +737,8 @@ class TestSourceBuildPlanResolution:
     def test_matches_pull_ref_aliases(self):
         bundle = make_release(
             [],
-            requested_source_ref = "refs/pull/123/head",
-            resolved_source_ref = "pull/123/head",
+            requested_source_ref="refs/pull/123/head",
+            resolved_source_ref="pull/123/head",
         )
         assert published_release_matches_request(bundle, "refs/pull/123/head") is True
         assert published_release_matches_request(bundle, "pull/123/head") is True
@@ -746,33 +746,33 @@ class TestSourceBuildPlanResolution:
     def test_prefers_exact_source_commit_when_available(self, monkeypatch):
         commit = "a" * 40
         resolved = INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-            bundle = make_release(
+            bundle=make_release(
                 [],
-                release_tag = "release-main",
-                upstream_tag = "b9000",
-                source_repo = "example/custom-llama.cpp",
-                source_repo_url = "https://github.com/example/custom-llama.cpp",
-                source_ref_kind = "branch",
-                requested_source_ref = "main",
-                resolved_source_ref = "refs/heads/main",
-                source_commit = commit,
+                release_tag="release-main",
+                upstream_tag="b9000",
+                source_repo="example/custom-llama.cpp",
+                source_repo_url="https://github.com/example/custom-llama.cpp",
+                source_ref_kind="branch",
+                requested_source_ref="main",
+                resolved_source_ref="refs/heads/main",
+                source_commit=commit,
             ),
-            checksums = make_checksums_with_source(
+            checksums=make_checksums_with_source(
                 [],
-                release_tag = "release-main",
-                upstream_tag = "b9000",
-                source_repo = "example/custom-llama.cpp",
-                source_repo_url = "https://github.com/example/custom-llama.cpp",
-                source_ref_kind = "branch",
-                requested_source_ref = "main",
-                resolved_source_ref = "refs/heads/main",
-                source_commit = commit,
+                release_tag="release-main",
+                upstream_tag="b9000",
+                source_repo="example/custom-llama.cpp",
+                source_repo_url="https://github.com/example/custom-llama.cpp",
+                source_ref_kind="branch",
+                requested_source_ref="main",
+                resolved_source_ref="refs/heads/main",
+                source_commit=commit,
             ),
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "resolve_published_release",
-            lambda requested_tag, published_repo, published_release_tag = "": resolved,
+            lambda requested_tag, published_repo, published_release_tag="": resolved,
         )
 
         plan = resolve_source_build_plan("main", "unslothai/llama.cpp")
@@ -783,32 +783,32 @@ class TestSourceBuildPlanResolution:
 
     def test_uses_branch_provenance_without_exact_source_hash(self, monkeypatch):
         resolved = INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-            bundle = make_release(
+            bundle=make_release(
                 [],
-                release_tag = "release-main",
-                upstream_tag = "b9000",
-                source_repo = "example/custom-llama.cpp",
-                source_repo_url = "https://github.com/example/custom-llama.cpp",
-                source_ref_kind = "branch",
-                requested_source_ref = "main",
-                resolved_source_ref = "main",
+                release_tag="release-main",
+                upstream_tag="b9000",
+                source_repo="example/custom-llama.cpp",
+                source_repo_url="https://github.com/example/custom-llama.cpp",
+                source_ref_kind="branch",
+                requested_source_ref="main",
+                resolved_source_ref="main",
             ),
-            checksums = make_checksums_with_source(
+            checksums=make_checksums_with_source(
                 [],
-                release_tag = "release-main",
-                upstream_tag = "b9000",
-                source_repo = "example/custom-llama.cpp",
-                source_repo_url = "https://github.com/example/custom-llama.cpp",
-                source_ref_kind = "branch",
-                requested_source_ref = "main",
-                resolved_source_ref = "main",
-                source_commit = None,
+                release_tag="release-main",
+                upstream_tag="b9000",
+                source_repo="example/custom-llama.cpp",
+                source_repo_url="https://github.com/example/custom-llama.cpp",
+                source_ref_kind="branch",
+                requested_source_ref="main",
+                resolved_source_ref="main",
+                source_commit=None,
             ),
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "resolve_published_release",
-            lambda requested_tag, published_repo, published_release_tag = "": resolved,
+            lambda requested_tag, published_repo, published_release_tag="": resolved,
         )
 
         plan = resolve_source_build_plan("main", "unslothai/llama.cpp")
@@ -823,7 +823,7 @@ class TestSourceBuildPlanResolution:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "resolve_published_release",
-            lambda requested_tag, published_repo, published_release_tag = "": (
+            lambda requested_tag, published_repo, published_release_tag="": (
                 _ for _ in ()
             ).throw(PrebuiltFallback("missing")),
         )
@@ -836,7 +836,7 @@ class TestSourceBuildPlanResolution:
 
 class TestParseApprovedReleaseChecksums:
     def test_rejects_wrong_component(self):
-        with pytest.raises(RuntimeError, match = "did not describe llama.cpp"):
+        with pytest.raises(RuntimeError, match="did not describe llama.cpp"):
             parse_approved_release_checksums(
                 "repo/test",
                 "r1",
@@ -850,7 +850,7 @@ class TestParseApprovedReleaseChecksums:
             )
 
     def test_rejects_mismatched_release_tag(self):
-        with pytest.raises(RuntimeError, match = "did not match pinned release tag"):
+        with pytest.raises(RuntimeError, match="did not match pinned release tag"):
             parse_approved_release_checksums(
                 "repo/test",
                 "r1",
@@ -864,7 +864,7 @@ class TestParseApprovedReleaseChecksums:
             )
 
     def test_rejects_bad_sha256(self):
-        with pytest.raises(RuntimeError, match = "valid sha256"):
+        with pytest.raises(RuntimeError, match="valid sha256"):
             parse_approved_release_checksums(
                 "repo/test",
                 "r1",
@@ -882,7 +882,7 @@ class TestParseApprovedReleaseChecksums:
             )
 
     def test_rejects_unsupported_schema_version(self):
-        with pytest.raises(RuntimeError, match = "schema_version=2 is unsupported"):
+        with pytest.raises(RuntimeError, match="schema_version=2 is unsupported"):
             parse_approved_release_checksums(
                 "repo/test",
                 "r1",
@@ -898,16 +898,16 @@ class TestParseApprovedReleaseChecksums:
 
 class TestValidatedChecksumsForBundle:
     def test_rejects_manifest_checksum_mismatch(self, monkeypatch):
-        bundle = make_release([], release_tag = "r1", upstream_tag = "b8508")
+        bundle = make_release([], release_tag="r1", upstream_tag="b8508")
         bundle.manifest_sha256 = "a" * 64
         checksums = make_checksums_with_source(
-            [], release_tag = "r1", upstream_tag = "b8508"
+            [], release_tag="r1", upstream_tag="b8508"
         )
         checksums.artifacts[bundle.manifest_asset_name] = ApprovedArtifactHash(
-            asset_name = bundle.manifest_asset_name,
-            sha256 = "b" * 64,
-            repo = "unslothai/llama.cpp",
-            kind = "published-manifest",
+            asset_name=bundle.manifest_asset_name,
+            sha256="b" * 64,
+            repo="unslothai/llama.cpp",
+            kind="published-manifest",
         )
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
@@ -915,7 +915,7 @@ class TestValidatedChecksumsForBundle:
             lambda repo, release_tag: checksums,
         )
 
-        with pytest.raises(PrebuiltFallback, match = "manifest checksum"):
+        with pytest.raises(PrebuiltFallback, match="manifest checksum"):
             validated_checksums_for_bundle("unslothai/llama.cpp", bundle)
 
 
@@ -929,22 +929,22 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_no_runtime_lines_detected(self, monkeypatch):
         mock_linux_runtime(monkeypatch, [])
-        host = make_host(driver_cuda_version = (12, 8))
+        host = make_host(driver_cuda_version=(12, 8))
         art = make_artifact("bundle-cuda12.tar.gz")
         release = make_release([art])
         assert linux_cuda_choice_from_release(host, release) is None
 
     def test_detected_lines_incompatible_with_driver(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda13"])
-        host = make_host(driver_cuda_version = (12, 4))
-        art = make_artifact("bundle-cuda13.tar.gz", runtime_line = "cuda13")
+        host = make_host(driver_cuda_version=(12, 4))
+        art = make_artifact("bundle-cuda13.tar.gz", runtime_line="cuda13")
         release = make_release([art])
         assert linux_cuda_choice_from_release(host, release) is None
 
     def test_driver_13_only_cuda12_detected(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(driver_cuda_version = (13, 0))
-        art = make_artifact("bundle-cuda12.tar.gz", runtime_line = "cuda12")
+        host = make_host(driver_cuda_version=(13, 0))
+        art = make_artifact("bundle-cuda12.tar.gz", runtime_line="cuda12")
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
         assert result is not None
@@ -952,23 +952,23 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_preferred_runtime_line_reorders(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda13", "cuda12"])
-        host = make_host(driver_cuda_version = (13, 0))
-        art12 = make_artifact("bundle-cuda12.tar.gz", runtime_line = "cuda12")
-        art13 = make_artifact("bundle-cuda13.tar.gz", runtime_line = "cuda13")
+        host = make_host(driver_cuda_version=(13, 0))
+        art12 = make_artifact("bundle-cuda12.tar.gz", runtime_line="cuda12")
+        art13 = make_artifact("bundle-cuda13.tar.gz", runtime_line="cuda13")
         release = make_release([art12, art13])
         result = linux_cuda_choice_from_release(
-            host, release, preferred_runtime_line = "cuda12"
+            host, release, preferred_runtime_line="cuda12"
         )
         assert result is not None
         assert result.primary.runtime_line == "cuda12"
 
     def test_preferred_runtime_line_unavailable(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(driver_cuda_version = (12, 8))
-        art = make_artifact("bundle-cuda12.tar.gz", runtime_line = "cuda12")
+        host = make_host(driver_cuda_version=(12, 8))
+        art = make_artifact("bundle-cuda12.tar.gz", runtime_line="cuda12")
         release = make_release([art])
         result = linux_cuda_choice_from_release(
-            host, release, preferred_runtime_line = "cuda13"
+            host, release, preferred_runtime_line="cuda13"
         )
         assert result is not None
         assert result.primary.runtime_line == "cuda12"
@@ -979,9 +979,9 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_exact_sm_match(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
+        host = make_host(compute_caps=["86"])
         art = make_artifact(
-            "bundle.tar.gz", supported_sms = ["75", "86", "89"], min_sm = 75, max_sm = 89
+            "bundle.tar.gz", supported_sms=["75", "86", "89"], min_sm=75, max_sm=89
         )
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
@@ -990,9 +990,9 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_sm_not_in_supported_sms(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
+        host = make_host(compute_caps=["86"])
         art = make_artifact(
-            "bundle.tar.gz", supported_sms = ["75", "80", "89"], min_sm = 75, max_sm = 89
+            "bundle.tar.gz", supported_sms=["75", "80", "89"], min_sm=75, max_sm=89
         )
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
@@ -1000,9 +1000,9 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_sm_outside_min_range(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["50"])
+        host = make_host(compute_caps=["50"])
         art = make_artifact(
-            "bundle.tar.gz", supported_sms = ["50", "75", "86"], min_sm = 75, max_sm = 90
+            "bundle.tar.gz", supported_sms=["50", "75", "86"], min_sm=75, max_sm=90
         )
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
@@ -1010,9 +1010,9 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_sm_outside_max_range(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["100"])
+        host = make_host(compute_caps=["100"])
         art = make_artifact(
-            "bundle.tar.gz", supported_sms = ["100", "75", "86"], min_sm = 75, max_sm = 90
+            "bundle.tar.gz", supported_sms=["100", "75", "86"], min_sm=75, max_sm=90
         )
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
@@ -1020,16 +1020,16 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_very_old_sm(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["50"])
-        art = make_artifact("bundle.tar.gz", min_sm = 75, max_sm = 90)
+        host = make_host(compute_caps=["50"])
+        art = make_artifact("bundle.tar.gz", min_sm=75, max_sm=90)
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
 
     def test_very_new_sm(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["100"])
-        art = make_artifact("bundle.tar.gz", min_sm = 75, max_sm = 90)
+        host = make_host(compute_caps=["100"])
+        art = make_artifact("bundle.tar.gz", min_sm=75, max_sm=90)
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
@@ -1038,9 +1038,9 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_unknown_caps_only_portable(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = [])
-        targeted = make_artifact("targeted.tar.gz", coverage_class = "targeted")
-        portable = make_artifact("portable.tar.gz", coverage_class = "portable")
+        host = make_host(compute_caps=[])
+        targeted = make_artifact("targeted.tar.gz", coverage_class="targeted")
+        portable = make_artifact("portable.tar.gz", coverage_class="portable")
         release = make_release([targeted, portable])
         result = linux_cuda_choice_from_release(host, release)
         assert result is not None
@@ -1048,8 +1048,8 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_unknown_caps_no_portable(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = [])
-        targeted = make_artifact("targeted.tar.gz", coverage_class = "targeted")
+        host = make_host(compute_caps=[])
+        targeted = make_artifact("targeted.tar.gz", coverage_class="targeted")
         release = make_release([targeted])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
@@ -1058,12 +1058,12 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_multi_gpu_all_covered(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["75", "89"])
+        host = make_host(compute_caps=["75", "89"])
         art = make_artifact(
             "bundle.tar.gz",
-            supported_sms = ["75", "80", "86", "89", "90"],
-            min_sm = 75,
-            max_sm = 90,
+            supported_sms=["75", "80", "86", "89", "90"],
+            min_sm=75,
+            max_sm=90,
         )
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
@@ -1071,9 +1071,9 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_multi_gpu_not_all_covered(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["50", "89"])
+        host = make_host(compute_caps=["50", "89"])
         art = make_artifact(
-            "bundle.tar.gz", supported_sms = ["75", "89"], min_sm = 75, max_sm = 89
+            "bundle.tar.gz", supported_sms=["75", "89"], min_sm=75, max_sm=89
         )
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
@@ -1083,20 +1083,20 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_narrowest_sm_range_wins(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
+        host = make_host(compute_caps=["86"])
         wide = make_artifact(
             "wide.tar.gz",
-            supported_sms = ["75", "86", "90"],
-            min_sm = 75,
-            max_sm = 90,
-            rank = 100,
+            supported_sms=["75", "86", "90"],
+            min_sm=75,
+            max_sm=90,
+            rank=100,
         )
         narrow = make_artifact(
             "narrow.tar.gz",
-            supported_sms = ["80", "86", "89"],
-            min_sm = 80,
-            max_sm = 89,
-            rank = 100,
+            supported_sms=["80", "86", "89"],
+            min_sm=80,
+            max_sm=89,
+            rank=100,
         )
         release = make_release([wide, narrow])
         result = linux_cuda_choice_from_release(host, release)
@@ -1105,20 +1105,20 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_range_tie_lower_rank_wins(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
+        host = make_host(compute_caps=["86"])
         high = make_artifact(
             "high.tar.gz",
-            supported_sms = ["75", "86", "90"],
-            min_sm = 75,
-            max_sm = 90,
-            rank = 200,
+            supported_sms=["75", "86", "90"],
+            min_sm=75,
+            max_sm=90,
+            rank=200,
         )
         low = make_artifact(
             "low.tar.gz",
-            supported_sms = ["75", "86", "90"],
-            min_sm = 75,
-            max_sm = 90,
-            rank = 50,
+            supported_sms=["75", "86", "90"],
+            min_sm=75,
+            max_sm=90,
+            rank=50,
         )
         release = make_release([high, low])
         result = linux_cuda_choice_from_release(host, release)
@@ -1127,9 +1127,9 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_targeted_preferred_portable_fallback(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
-        targeted = make_artifact("targeted.tar.gz", coverage_class = "targeted", rank = 100)
-        portable = make_artifact("portable.tar.gz", coverage_class = "portable", rank = 100)
+        host = make_host(compute_caps=["86"])
+        targeted = make_artifact("targeted.tar.gz", coverage_class="targeted", rank=100)
+        portable = make_artifact("portable.tar.gz", coverage_class="portable", rank=100)
         release = make_release([targeted, portable])
         result = linux_cuda_choice_from_release(host, release)
         assert result is not None
@@ -1141,47 +1141,47 @@ class TestLinuxCudaChoiceFromRelease:
 
     def test_asset_missing_from_release_assets(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
+        host = make_host(compute_caps=["86"])
         art = make_artifact("bundle.tar.gz")
-        release = make_release([art], assets = {})
+        release = make_release([art], assets={})
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
 
     def test_artifact_empty_supported_sms(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
-        art = make_artifact("bundle.tar.gz", supported_sms = [])
+        host = make_host(compute_caps=["86"])
+        art = make_artifact("bundle.tar.gz", supported_sms=[])
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
 
     def test_artifact_missing_min_sm(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
-        art = make_artifact("bundle.tar.gz", min_sm = None, max_sm = 90)
+        host = make_host(compute_caps=["86"])
+        art = make_artifact("bundle.tar.gz", min_sm=None, max_sm=90)
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
 
     def test_artifact_missing_max_sm(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
-        art = make_artifact("bundle.tar.gz", min_sm = 75, max_sm = None)
+        host = make_host(compute_caps=["86"])
+        art = make_artifact("bundle.tar.gz", min_sm=75, max_sm=None)
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
 
     def test_no_linux_cuda_artifacts(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
-        art = make_artifact("bundle.tar.gz", install_kind = "windows-cuda")
+        host = make_host(compute_caps=["86"])
+        art = make_artifact("bundle.tar.gz", install_kind="windows-cuda")
         release = make_release([art])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
 
     def test_empty_artifacts_list(self, monkeypatch):
         mock_linux_runtime(monkeypatch, ["cuda12"])
-        host = make_host(compute_caps = ["86"])
+        host = make_host(compute_caps=["86"])
         release = make_release([])
         result = linux_cuda_choice_from_release(host, release)
         assert result is None
@@ -1196,7 +1196,7 @@ class TestResolveInstallAttempts:
     def test_windows_cuda_prefers_published_asset_from_selected_release(
         self, monkeypatch
     ):
-        host = make_host(system = "Windows", machine = "AMD64")
+        host = make_host(system="Windows", machine="AMD64")
         host.driver_cuda_version = (12, 4)
         mock_windows_runtime(monkeypatch, ["cuda12"])
         asset_name = "llama-b9000-bin-win-cuda-12.4-x64.zip"
@@ -1204,33 +1204,33 @@ class TestResolveInstallAttempts:
             [
                 make_artifact(
                     asset_name,
-                    install_kind = "windows-cuda",
-                    runtime_line = "cuda12",
-                    coverage_class = None,
-                    supported_sms = [],
-                    min_sm = None,
-                    max_sm = None,
-                    bundle_profile = None,
+                    install_kind="windows-cuda",
+                    runtime_line="cuda12",
+                    coverage_class=None,
+                    supported_sms=[],
+                    min_sm=None,
+                    max_sm=None,
+                    bundle_profile=None,
                 )
             ],
-            release_tag = "llama-prebuilt-latest",
-            upstream_tag = "b9000",
-            assets = {asset_name: f"https://published.example/{asset_name}"},
+            release_tag="llama-prebuilt-latest",
+            upstream_tag="b9000",
+            assets={asset_name: f"https://published.example/{asset_name}"},
         )
         checksums = make_checksums_with_source(
             [asset_name],
-            release_tag = release.release_tag,
-            upstream_tag = "b9000",
+            release_tag=release.release_tag,
+            upstream_tag="b9000",
         )
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 [
                     INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                        bundle = release,
-                        checksums = checksums,
+                        bundle=release,
+                        checksums=checksums,
                     )
                 ]
             ),
@@ -1260,26 +1260,26 @@ class TestResolveInstallAttempts:
         assert approved.release_tag == "llama-prebuilt-latest"
 
     def test_windows_cuda_uses_selected_release_upstream_tag(self, monkeypatch):
-        host = make_host(system = "Windows", machine = "AMD64")
+        host = make_host(system="Windows", machine="AMD64")
         host.driver_cuda_version = (12, 4)
         mock_windows_runtime(monkeypatch, ["cuda12"])
         release = make_release(
-            [], release_tag = "llama-prebuilt-latest", upstream_tag = "b9000"
+            [], release_tag="llama-prebuilt-latest", upstream_tag="b9000"
         )
         checksums = make_checksums_with_source(
             ["llama-b9000-bin-win-cuda-12.4-x64.zip"],
-            release_tag = release.release_tag,
-            upstream_tag = "b9000",
+            release_tag=release.release_tag,
+            upstream_tag="b9000",
         )
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 [
                     INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                        bundle = release,
-                        checksums = checksums,
+                        bundle=release,
+                        checksums=checksums,
                     )
                 ]
             ),
@@ -1296,13 +1296,13 @@ class TestResolveInstallAttempts:
             "resolve_windows_cuda_choices",
             lambda host, tag, assets: [
                 AssetChoice(
-                    repo = UPSTREAM_REPO,
-                    tag = tag,
-                    name = f"llama-{tag}-bin-win-cuda-12.4-x64.zip",
-                    url = assets[f"llama-{tag}-bin-win-cuda-12.4-x64.zip"],
-                    source_label = "upstream",
-                    install_kind = "windows-cuda",
-                    runtime_line = "cuda12",
+                    repo=UPSTREAM_REPO,
+                    tag=tag,
+                    name=f"llama-{tag}-bin-win-cuda-12.4-x64.zip",
+                    url=assets[f"llama-{tag}-bin-win-cuda-12.4-x64.zip"],
+                    source_label="upstream",
+                    install_kind="windows-cuda",
+                    runtime_line="cuda12",
                 )
             ],
         )
@@ -1322,27 +1322,27 @@ class TestResolveInstallAttempts:
 
     def test_linux_cpu_uses_same_tag_upstream_asset(self, monkeypatch):
         host = make_host(
-            has_usable_nvidia = False,
-            has_physical_nvidia = False,
-            nvidia_smi = None,
+            has_usable_nvidia=False,
+            has_physical_nvidia=False,
+            nvidia_smi=None,
         )
         release = make_release(
-            [], release_tag = "llama-prebuilt-latest", upstream_tag = "b9000"
+            [], release_tag="llama-prebuilt-latest", upstream_tag="b9000"
         )
         checksums = make_checksums_with_source(
             ["llama-b9000-bin-ubuntu-x64.tar.gz"],
-            release_tag = release.release_tag,
-            upstream_tag = "b9000",
+            release_tag=release.release_tag,
+            upstream_tag="b9000",
         )
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 [
                     INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                        bundle = release,
-                        checksums = checksums,
+                        bundle=release,
+                        checksums=checksums,
                     )
                 ]
             ),
@@ -1368,24 +1368,24 @@ class TestResolveInstallAttempts:
         assert attempts[0].expected_sha256 == "a" * 64
 
     def test_linux_cuda_does_not_fall_back_to_upstream_cpu(self, monkeypatch):
-        host = make_host(system = "Linux", machine = "x86_64", compute_caps = ["86"])
+        host = make_host(system="Linux", machine="x86_64", compute_caps=["86"])
         release = make_release(
-            [], release_tag = "llama-prebuilt-latest", upstream_tag = "b9000"
+            [], release_tag="llama-prebuilt-latest", upstream_tag="b9000"
         )
         checksums = make_checksums_with_source(
             [],
-            release_tag = release.release_tag,
-            upstream_tag = "b9000",
+            release_tag=release.release_tag,
+            upstream_tag="b9000",
         )
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 [
                     INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                        bundle = release,
-                        checksums = checksums,
+                        bundle=release,
+                        checksums=checksums,
                     )
                 ]
             ),
@@ -1393,50 +1393,50 @@ class TestResolveInstallAttempts:
         mock_linux_runtime(monkeypatch, ["cuda12"])
 
         with pytest.raises(
-            PrebuiltFallback, match = "no compatible published Linux CUDA bundle"
+            PrebuiltFallback, match="no compatible published Linux CUDA bundle"
         ):
             resolve_install_attempts("latest", host, "unslothai/llama.cpp", "")
 
     def test_windows_cpu_prefers_published_asset(self, monkeypatch):
         host = make_host(
-            system = "Windows",
-            machine = "AMD64",
-            has_usable_nvidia = False,
-            has_physical_nvidia = False,
-            nvidia_smi = None,
+            system="Windows",
+            machine="AMD64",
+            has_usable_nvidia=False,
+            has_physical_nvidia=False,
+            nvidia_smi=None,
         )
         asset_name = "llama-b9000-bin-win-cpu-x64.zip"
         release = make_release(
             [
                 make_artifact(
                     asset_name,
-                    install_kind = "windows-cpu",
-                    runtime_line = None,
-                    coverage_class = None,
-                    supported_sms = [],
-                    min_sm = None,
-                    max_sm = None,
-                    bundle_profile = None,
+                    install_kind="windows-cpu",
+                    runtime_line=None,
+                    coverage_class=None,
+                    supported_sms=[],
+                    min_sm=None,
+                    max_sm=None,
+                    bundle_profile=None,
                 )
             ],
-            release_tag = "llama-prebuilt-latest",
-            upstream_tag = "b9000",
-            assets = {asset_name: f"https://published.example/{asset_name}"},
+            release_tag="llama-prebuilt-latest",
+            upstream_tag="b9000",
+            assets={asset_name: f"https://published.example/{asset_name}"},
         )
         checksums = make_checksums_with_source(
             [asset_name],
-            release_tag = release.release_tag,
-            upstream_tag = "b9000",
+            release_tag=release.release_tag,
+            upstream_tag="b9000",
         )
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 [
                     INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                        bundle = release,
-                        checksums = checksums,
+                        bundle=release,
+                        checksums=checksums,
                     )
                 ]
             ),
@@ -1462,46 +1462,46 @@ class TestResolveInstallAttempts:
 
     def test_macos_prefers_published_asset(self, monkeypatch):
         host = make_host(
-            system = "Darwin",
-            machine = "arm64",
-            nvidia_smi = None,
-            driver_cuda_version = None,
-            compute_caps = [],
-            has_physical_nvidia = False,
-            has_usable_nvidia = False,
+            system="Darwin",
+            machine="arm64",
+            nvidia_smi=None,
+            driver_cuda_version=None,
+            compute_caps=[],
+            has_physical_nvidia=False,
+            has_usable_nvidia=False,
         )
         asset_name = "llama-b9000-bin-macos-arm64.tar.gz"
         release = make_release(
             [
                 make_artifact(
                     asset_name,
-                    install_kind = "macos-arm64",
-                    runtime_line = None,
-                    coverage_class = None,
-                    supported_sms = [],
-                    min_sm = None,
-                    max_sm = None,
-                    bundle_profile = None,
+                    install_kind="macos-arm64",
+                    runtime_line=None,
+                    coverage_class=None,
+                    supported_sms=[],
+                    min_sm=None,
+                    max_sm=None,
+                    bundle_profile=None,
                 )
             ],
-            release_tag = "llama-prebuilt-latest",
-            upstream_tag = "b9000",
-            assets = {asset_name: f"https://published.example/{asset_name}"},
+            release_tag="llama-prebuilt-latest",
+            upstream_tag="b9000",
+            assets={asset_name: f"https://published.example/{asset_name}"},
         )
         checksums = make_checksums_with_source(
             [asset_name],
-            release_tag = release.release_tag,
-            upstream_tag = "b9000",
+            release_tag=release.release_tag,
+            upstream_tag="b9000",
         )
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 [
                     INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                        bundle = release,
-                        checksums = checksums,
+                        bundle=release,
+                        checksums=checksums,
                     )
                 ]
             ),
@@ -1527,44 +1527,44 @@ class TestResolveInstallAttempts:
 
     def test_windows_cpu_missing_checksum_rejects_install(self, monkeypatch):
         host = make_host(
-            system = "Windows",
-            machine = "AMD64",
-            has_usable_nvidia = False,
-            has_physical_nvidia = False,
-            nvidia_smi = None,
+            system="Windows",
+            machine="AMD64",
+            has_usable_nvidia=False,
+            has_physical_nvidia=False,
+            nvidia_smi=None,
         )
         published_name = "llama-b9000-bin-win-cpu-x64.zip"
         release = make_release(
             [
                 make_artifact(
                     published_name,
-                    install_kind = "windows-cpu",
-                    runtime_line = None,
-                    coverage_class = None,
-                    supported_sms = [],
-                    min_sm = None,
-                    max_sm = None,
-                    bundle_profile = None,
+                    install_kind="windows-cpu",
+                    runtime_line=None,
+                    coverage_class=None,
+                    supported_sms=[],
+                    min_sm=None,
+                    max_sm=None,
+                    bundle_profile=None,
                 )
             ],
-            release_tag = "llama-prebuilt-latest",
-            upstream_tag = "b9000",
-            assets = {published_name: f"https://published.example/{published_name}"},
+            release_tag="llama-prebuilt-latest",
+            upstream_tag="b9000",
+            assets={published_name: f"https://published.example/{published_name}"},
         )
         checksums = make_checksums_with_source(
             [],
-            release_tag = release.release_tag,
-            upstream_tag = "b9000",
+            release_tag=release.release_tag,
+            upstream_tag="b9000",
         )
 
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 [
                     INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                        bundle = release,
-                        checksums = checksums,
+                        bundle=release,
+                        checksums=checksums,
                     )
                 ]
             ),
@@ -1579,7 +1579,7 @@ class TestResolveInstallAttempts:
 
         with pytest.raises(
             PrebuiltFallback,
-            match = "approved checksum asset did not contain the selected prebuilt archive",
+            match="approved checksum asset did not contain the selected prebuilt archive",
         ):
             resolve_install_attempts(
                 "latest",
@@ -1594,33 +1594,33 @@ class TestResolveInstallReleasePlans:
         self, monkeypatch
     ):
         host = make_host(
-            has_usable_nvidia = False,
-            has_physical_nvidia = False,
-            nvidia_smi = None,
+            has_usable_nvidia=False,
+            has_physical_nvidia=False,
+            nvidia_smi=None,
         )
         releases = [
             INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                bundle = make_release([], release_tag = "r3", upstream_tag = "b9003"),
-                checksums = make_checksums_with_source(
+                bundle=make_release([], release_tag="r3", upstream_tag="b9003"),
+                checksums=make_checksums_with_source(
                     ["llama-b9003-bin-ubuntu-x64.tar.gz"],
-                    release_tag = "r3",
-                    upstream_tag = "b9003",
+                    release_tag="r3",
+                    upstream_tag="b9003",
                 ),
             ),
             INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                bundle = make_release([], release_tag = "r2", upstream_tag = "b9002"),
-                checksums = make_checksums_with_source(
+                bundle=make_release([], release_tag="r2", upstream_tag="b9002"),
+                checksums=make_checksums_with_source(
                     ["llama-b9002-bin-ubuntu-x64.tar.gz"],
-                    release_tag = "r2",
-                    upstream_tag = "b9002",
+                    release_tag="r2",
+                    upstream_tag="b9002",
                 ),
             ),
             INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                bundle = make_release([], release_tag = "r1", upstream_tag = "b9001"),
-                checksums = make_checksums_with_source(
+                bundle=make_release([], release_tag="r1", upstream_tag="b9001"),
+                checksums=make_checksums_with_source(
                     ["llama-b9001-bin-ubuntu-x64.tar.gz"],
-                    release_tag = "r1",
-                    upstream_tag = "b9001",
+                    release_tag="r1",
+                    upstream_tag="b9001",
                 ),
             ),
         ]
@@ -1628,7 +1628,7 @@ class TestResolveInstallReleasePlans:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 releases
             ),
         )
@@ -1645,7 +1645,7 @@ class TestResolveInstallReleasePlans:
             host,
             "unslothai/llama.cpp",
             "",
-            max_release_fallbacks = 2,
+            max_release_fallbacks=2,
         )
 
         assert requested_tag == "latest"
@@ -1656,25 +1656,25 @@ class TestResolveInstallReleasePlans:
         self, monkeypatch
     ):
         host = make_host(
-            has_usable_nvidia = False,
-            has_physical_nvidia = False,
-            nvidia_smi = None,
+            has_usable_nvidia=False,
+            has_physical_nvidia=False,
+            nvidia_smi=None,
         )
         releases = [
             INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                bundle = make_release([], release_tag = "r2", upstream_tag = "b9002"),
-                checksums = make_checksums_with_source(
+                bundle=make_release([], release_tag="r2", upstream_tag="b9002"),
+                checksums=make_checksums_with_source(
                     [],
-                    release_tag = "r2",
-                    upstream_tag = "b9002",
+                    release_tag="r2",
+                    upstream_tag="b9002",
                 ),
             ),
             INSTALL_LLAMA_PREBUILT.ResolvedPublishedRelease(
-                bundle = make_release([], release_tag = "r1", upstream_tag = "b9001"),
-                checksums = make_checksums_with_source(
+                bundle=make_release([], release_tag="r1", upstream_tag="b9001"),
+                checksums=make_checksums_with_source(
                     ["llama-b9001-bin-ubuntu-x64.tar.gz"],
-                    release_tag = "r1",
-                    upstream_tag = "b9001",
+                    release_tag="r1",
+                    upstream_tag="b9001",
                 ),
             ),
         ]
@@ -1682,7 +1682,7 @@ class TestResolveInstallReleasePlans:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "iter_resolved_published_releases",
-            lambda requested_tag, published_repo, published_release_tag = "": iter(
+            lambda requested_tag, published_repo, published_release_tag="": iter(
                 releases
             ),
         )
@@ -1703,7 +1703,7 @@ class TestResolveInstallReleasePlans:
             host,
             "unslothai/llama.cpp",
             "",
-            max_release_fallbacks = 2,
+            max_release_fallbacks=2,
         )
 
         assert len(plans) == 1
@@ -1713,7 +1713,7 @@ class TestResolveInstallReleasePlans:
     def test_malformed_release_fallback_env_uses_default(self, monkeypatch):
         monkeypatch.setenv("UNSLOTH_LLAMA_MAX_PREBUILT_RELEASE_FALLBACKS", "not-an-int")
         assert (
-            env_int("UNSLOTH_LLAMA_MAX_PREBUILT_RELEASE_FALLBACKS", 3, minimum = 1) == 3
+            env_int("UNSLOTH_LLAMA_MAX_PREBUILT_RELEASE_FALLBACKS", 3, minimum=1) == 3
         )
 
     def test_import_with_malformed_release_fallback_env_does_not_crash(
@@ -1754,7 +1754,7 @@ class TestWindowsCudaAttempts:
 
     def test_driver_12_4_no_dlls_fallback(self, monkeypatch):
         mock_windows_runtime(monkeypatch, [])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (12, 4))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(12, 4))
         assets = self._upstream("12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert len(result) == 1
@@ -1762,7 +1762,7 @@ class TestWindowsCudaAttempts:
 
     def test_driver_13_1_both_dlls(self, monkeypatch):
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 1))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(13, 1))
         assets = self._upstream("13.1", "12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert len(result) == 2
@@ -1771,7 +1771,7 @@ class TestWindowsCudaAttempts:
 
     def test_preferred_reorders(self, monkeypatch):
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 1))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(13, 1))
         assets = self._upstream("13.1", "12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, "cuda12")
         assert len(result) == 2
@@ -1779,7 +1779,7 @@ class TestWindowsCudaAttempts:
 
     def test_preferred_unavailable(self, monkeypatch):
         mock_windows_runtime(monkeypatch, ["cuda12"])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (12, 4))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(12, 4))
         assets = self._upstream("12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, "cuda13")
         assert len(result) == 1
@@ -1787,7 +1787,7 @@ class TestWindowsCudaAttempts:
 
     def test_detected_incompatible_with_driver(self, monkeypatch):
         mock_windows_runtime(monkeypatch, ["cuda13"])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (12, 4))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(12, 4))
         assets = self._upstream("12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert len(result) == 1
@@ -1795,28 +1795,28 @@ class TestWindowsCudaAttempts:
 
     def test_driver_too_old(self, monkeypatch):
         mock_windows_runtime(monkeypatch, [])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (11, 8))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(11, 8))
         assets = self._upstream("12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert result == []
 
     def test_asset_missing_from_upstream(self, monkeypatch):
         mock_windows_runtime(monkeypatch, ["cuda12"])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (12, 4))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(12, 4))
         result = windows_cuda_attempts(host, self.TAG, {}, None)
         assert result == []
 
     def test_both_assets_present(self, monkeypatch):
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 1))
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(13, 1))
         assets = self._upstream("13.1", "12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert len(result) == 2
 
     def test_current_upstream_names_are_supported(self, monkeypatch):
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
-        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 1))
-        assets = self._upstream("13.1", "12.4", current_names = True)
+        host = make_host(system="Windows", machine="AMD64", driver_cuda_version=(13, 1))
+        assets = self._upstream("13.1", "12.4", current_names=True)
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert len(result) == 2
         assert result[0].name == "cudart-llama-bin-win-cuda-13.1-x64.zip"
@@ -1842,7 +1842,7 @@ class TestResolveUpstreamAssetChoice:
         name = f"llama-{self.TAG}-bin-ubuntu-x64.tar.gz"
         self._mock_github_assets(monkeypatch, {name: f"https://x/{name}"})
         host = make_host(
-            has_usable_nvidia = False, nvidia_smi = None, has_physical_nvidia = False
+            has_usable_nvidia=False, nvidia_smi=None, has_physical_nvidia=False
         )
         result = resolve_upstream_asset_choice(host, self.TAG)
         assert result.install_kind == "linux-cpu"
@@ -1851,20 +1851,20 @@ class TestResolveUpstreamAssetChoice:
     def test_linux_cpu_missing(self, monkeypatch):
         self._mock_github_assets(monkeypatch, {})
         host = make_host(
-            has_usable_nvidia = False, nvidia_smi = None, has_physical_nvidia = False
+            has_usable_nvidia=False, nvidia_smi=None, has_physical_nvidia=False
         )
-        with pytest.raises(PrebuiltFallback, match = "Linux CPU"):
+        with pytest.raises(PrebuiltFallback, match="Linux CPU"):
             resolve_upstream_asset_choice(host, self.TAG)
 
     def test_windows_x86_64_cpu(self, monkeypatch):
         name = f"llama-{self.TAG}-bin-win-cpu-x64.zip"
         self._mock_github_assets(monkeypatch, {name: f"https://x/{name}"})
         host = make_host(
-            system = "Windows",
-            machine = "AMD64",
-            has_usable_nvidia = False,
-            nvidia_smi = None,
-            has_physical_nvidia = False,
+            system="Windows",
+            machine="AMD64",
+            has_usable_nvidia=False,
+            nvidia_smi=None,
+            has_physical_nvidia=False,
         )
         result = resolve_upstream_asset_choice(host, self.TAG)
         assert result.install_kind == "windows-cpu"
@@ -1873,26 +1873,26 @@ class TestResolveUpstreamAssetChoice:
     def test_windows_cpu_missing(self, monkeypatch):
         self._mock_github_assets(monkeypatch, {})
         host = make_host(
-            system = "Windows",
-            machine = "AMD64",
-            has_usable_nvidia = False,
-            nvidia_smi = None,
-            has_physical_nvidia = False,
+            system="Windows",
+            machine="AMD64",
+            has_usable_nvidia=False,
+            nvidia_smi=None,
+            has_physical_nvidia=False,
         )
-        with pytest.raises(PrebuiltFallback, match = "Windows CPU"):
+        with pytest.raises(PrebuiltFallback, match="Windows CPU"):
             resolve_upstream_asset_choice(host, self.TAG)
 
     def test_macos_arm64(self, monkeypatch):
         name = f"llama-{self.TAG}-bin-macos-arm64.tar.gz"
         self._mock_github_assets(monkeypatch, {name: f"https://x/{name}"})
         host = make_host(
-            system = "Darwin",
-            machine = "arm64",
-            nvidia_smi = None,
-            driver_cuda_version = None,
-            compute_caps = [],
-            has_physical_nvidia = False,
-            has_usable_nvidia = False,
+            system="Darwin",
+            machine="arm64",
+            nvidia_smi=None,
+            driver_cuda_version=None,
+            compute_caps=[],
+            has_physical_nvidia=False,
+            has_usable_nvidia=False,
         )
         result = resolve_upstream_asset_choice(host, self.TAG)
         assert result.install_kind == "macos-arm64"
@@ -1901,28 +1901,28 @@ class TestResolveUpstreamAssetChoice:
     def test_macos_arm64_missing(self, monkeypatch):
         self._mock_github_assets(monkeypatch, {})
         host = make_host(
-            system = "Darwin",
-            machine = "arm64",
-            nvidia_smi = None,
-            driver_cuda_version = None,
-            compute_caps = [],
-            has_physical_nvidia = False,
-            has_usable_nvidia = False,
+            system="Darwin",
+            machine="arm64",
+            nvidia_smi=None,
+            driver_cuda_version=None,
+            compute_caps=[],
+            has_physical_nvidia=False,
+            has_usable_nvidia=False,
         )
-        with pytest.raises(PrebuiltFallback, match = "macOS arm64"):
+        with pytest.raises(PrebuiltFallback, match="macOS arm64"):
             resolve_upstream_asset_choice(host, self.TAG)
 
     def test_macos_x86_64(self, monkeypatch):
         name = f"llama-{self.TAG}-bin-macos-x64.tar.gz"
         self._mock_github_assets(monkeypatch, {name: f"https://x/{name}"})
         host = make_host(
-            system = "Darwin",
-            machine = "x86_64",
-            nvidia_smi = None,
-            driver_cuda_version = None,
-            compute_caps = [],
-            has_physical_nvidia = False,
-            has_usable_nvidia = False,
+            system="Darwin",
+            machine="x86_64",
+            nvidia_smi=None,
+            driver_cuda_version=None,
+            compute_caps=[],
+            has_physical_nvidia=False,
+            has_usable_nvidia=False,
         )
         result = resolve_upstream_asset_choice(host, self.TAG)
         assert result.install_kind == "macos-x64"
@@ -1931,16 +1931,16 @@ class TestResolveUpstreamAssetChoice:
     def test_linux_aarch64(self, monkeypatch):
         self._mock_github_assets(monkeypatch, {})
         host = make_host(
-            system = "Linux",
-            machine = "aarch64",
-            nvidia_smi = None,
-            driver_cuda_version = None,
-            compute_caps = [],
-            has_physical_nvidia = False,
-            has_usable_nvidia = False,
+            system="Linux",
+            machine="aarch64",
+            nvidia_smi=None,
+            driver_cuda_version=None,
+            compute_caps=[],
+            has_physical_nvidia=False,
+            has_usable_nvidia=False,
         )
         with pytest.raises(
-            PrebuiltFallback, match = "no prebuilt policy exists for Linux aarch64"
+            PrebuiltFallback, match="no prebuilt policy exists for Linux aarch64"
         ):
             resolve_upstream_asset_choice(host, self.TAG)
 
@@ -1953,21 +1953,21 @@ class TestResolveUpstreamAssetChoice:
             "resolve_windows_cuda_choices",
             lambda host, tag, assets: [
                 AssetChoice(
-                    repo = UPSTREAM_REPO,
-                    tag = tag,
-                    name = cuda_name,
-                    url = f"https://x/{cuda_name}",
-                    source_label = "upstream",
-                    install_kind = "windows-cuda",
-                    runtime_line = "cuda12",
+                    repo=UPSTREAM_REPO,
+                    tag=tag,
+                    name=cuda_name,
+                    url=f"https://x/{cuda_name}",
+                    source_label="upstream",
+                    install_kind="windows-cuda",
+                    runtime_line="cuda12",
                 )
             ],
         )
         host = make_host(
-            system = "Windows",
-            machine = "AMD64",
-            driver_cuda_version = (12, 4),
-            has_usable_nvidia = True,
+            system="Windows",
+            machine="AMD64",
+            driver_cuda_version=(12, 4),
+            has_usable_nvidia=True,
         )
         result = resolve_upstream_asset_choice(host, self.TAG)
         assert result.install_kind == "windows-cuda"

--- a/tests/test_get_model_name.py
+++ b/tests/test_get_model_name.py
@@ -11,7 +11,7 @@ def _no_remote_mapper():
 
 class TestGetModelName(unittest.TestCase):
     def _assert_mapping(self, model_name, load_in_4bit, expected, should_change):
-        mapped = get_model_name(model_name, load_in_4bit = load_in_4bit)
+        mapped = get_model_name(model_name, load_in_4bit=load_in_4bit)
         self.assertEqual(mapped.lower(), expected.lower())
         if should_change:
             self.assertNotEqual(mapped.lower(), model_name.lower())
@@ -96,11 +96,11 @@ class TestGetModelName(unittest.TestCase):
         for case in cases:
             if isinstance(case, str):
                 model_name = case
-                with self.subTest(model_name = model_name, load_in_4bit = True):
+                with self.subTest(model_name=model_name, load_in_4bit=True):
                     self._assert_mapping(model_name, True, model_name, False)
             else:
                 model_name, load_in_4bit, expected, should_change = case
-                with self.subTest(model_name = model_name, load_in_4bit = load_in_4bit):
+                with self.subTest(model_name=model_name, load_in_4bit=load_in_4bit):
                     self._assert_mapping(
                         model_name, load_in_4bit, expected, should_change
                     )
@@ -116,7 +116,7 @@ class TestGetModelName(unittest.TestCase):
             ("unsloth/kimi-k2-instruct", "unsloth/kimi-k2-instruct-bf16"),
         ]
         for src, expected in contracts:
-            with self.subTest(src = src):
+            with self.subTest(src=src):
                 self.assertEqual(FLOAT_TO_INT_MAPPER[src], expected)
         self.assertEqual(
             MAP_TO_UNSLOTH_16bit["qwen/qwen3-8b-fp8"], "unsloth/Qwen3-8B-FP8"

--- a/tests/test_loader_glob_skip.py
+++ b/tests/test_loader_glob_skip.py
@@ -15,7 +15,7 @@ class TestGlobSkippedWhenNotBothConfigs(unittest.TestCase):
     """Verify HfFileSystem.glob is not called when is_model or is_peft is False."""
 
     def _run_both_exist_block(
-        self, is_model, is_peft, supports_llama32, model_name, is_local_dir = False
+        self, is_model, is_peft, supports_llama32, model_name, is_local_dir=False
     ):
         """Simulate the both_exist detection block from loader.py.
 
@@ -26,7 +26,7 @@ class TestGlobSkippedWhenNotBothConfigs(unittest.TestCase):
 
         both_exist = (is_model and is_peft) and not supports_llama32
         glob_mock = MagicMock(
-            return_value = [
+            return_value=[
                 f"{model_name}/config.json",
                 f"{model_name}/adapter_config.json",
             ]
@@ -52,40 +52,40 @@ class TestGlobSkippedWhenNotBothConfigs(unittest.TestCase):
 
     def test_glob_skipped_when_is_model_false(self):
         both_exist, glob_called = self._run_both_exist_block(
-            is_model = False,
-            is_peft = True,
-            supports_llama32 = True,
-            model_name = "org/some-adapter",
+            is_model=False,
+            is_peft=True,
+            supports_llama32=True,
+            model_name="org/some-adapter",
         )
         self.assertFalse(glob_called, "glob should not be called when is_model=False")
         self.assertFalse(both_exist)
 
     def test_glob_skipped_when_is_peft_false(self):
         both_exist, glob_called = self._run_both_exist_block(
-            is_model = True,
-            is_peft = False,
-            supports_llama32 = True,
-            model_name = "org/some-model",
+            is_model=True,
+            is_peft=False,
+            supports_llama32=True,
+            model_name="org/some-model",
         )
         self.assertFalse(glob_called, "glob should not be called when is_peft=False")
         self.assertFalse(both_exist)
 
     def test_glob_skipped_when_both_false(self):
         both_exist, glob_called = self._run_both_exist_block(
-            is_model = False,
-            is_peft = False,
-            supports_llama32 = True,
-            model_name = "org/bad-repo",
+            is_model=False,
+            is_peft=False,
+            supports_llama32=True,
+            model_name="org/bad-repo",
         )
         self.assertFalse(glob_called, "glob should not be called when both are False")
         self.assertFalse(both_exist)
 
     def test_glob_skipped_when_supports_llama32_false(self):
         both_exist, glob_called = self._run_both_exist_block(
-            is_model = True,
-            is_peft = True,
-            supports_llama32 = False,
-            model_name = "org/some-model",
+            is_model=True,
+            is_peft=True,
+            supports_llama32=False,
+            model_name="org/some-model",
         )
         self.assertFalse(
             glob_called, "glob should not be called when SUPPORTS_LLAMA32=False"
@@ -97,10 +97,10 @@ class TestGlobSkippedWhenNotBothConfigs(unittest.TestCase):
 
     def test_glob_called_when_both_true_and_supports_llama32(self):
         both_exist, glob_called = self._run_both_exist_block(
-            is_model = True,
-            is_peft = True,
-            supports_llama32 = True,
-            model_name = "org/mixed-repo",
+            is_model=True,
+            is_peft=True,
+            supports_llama32=True,
+            model_name="org/mixed-repo",
         )
         self.assertTrue(
             glob_called, "glob should be called when is_model and is_peft are both True"
@@ -109,11 +109,11 @@ class TestGlobSkippedWhenNotBothConfigs(unittest.TestCase):
 
     def test_local_dir_skips_glob(self):
         both_exist, glob_called = self._run_both_exist_block(
-            is_model = True,
-            is_peft = True,
-            supports_llama32 = True,
-            model_name = "/local/path/to/model",
-            is_local_dir = True,
+            is_model=True,
+            is_peft=True,
+            supports_llama32=True,
+            model_name="/local/path/to/model",
+            is_local_dir=True,
         )
         self.assertFalse(glob_called, "glob should not be called for local directories")
         self.assertTrue(both_exist)

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -63,7 +63,7 @@ def test_raw_text_loader():
             self.eos_token = "</s>"
             self.eos_token_id = 2  # Mock EOS token ID
 
-        def __call__(self, text, return_tensors = None, add_special_tokens = False):
+        def __call__(self, text, return_tensors=None, add_special_tokens=False):
             words = text.split()
             token_ids = list(range(len(words)))
 
@@ -85,27 +85,27 @@ def test_raw_text_loader():
                 return {"input_ids": [MockTensor(token_ids)]}
             return {"input_ids": token_ids}
 
-        def decode(self, token_ids, skip_special_tokens = False):
+        def decode(self, token_ids, skip_special_tokens=False):
             return " ".join([f"word_{i}" for i in token_ids])
 
     # Create test file
     test_content = "This is a test file for raw text training. " * 10
-    with tempfile.NamedTemporaryFile(mode = "w", suffix = ".txt", delete = False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
         f.write(test_content)
         test_file = f.name
 
     try:
         # Test loader
         tokenizer = MockTokenizer()
-        loader = RawTextDataLoader(tokenizer, chunk_size = 5, stride = 2)
+        loader = RawTextDataLoader(tokenizer, chunk_size=5, stride=2)
 
         # Test loading with text output (legacy mode)
-        text_dataset = loader.load_from_file(test_file, return_tokenized = False)
+        text_dataset = loader.load_from_file(test_file, return_tokenized=False)
         assert len(text_dataset) > 0, "Should create at least one chunk"
         assert "text" in text_dataset.column_names, "Dataset should have 'text' column"
 
         # Test loading with tokenized output (new efficient mode)
-        tokenized_dataset = loader.load_from_file(test_file, return_tokenized = True)
+        tokenized_dataset = loader.load_from_file(test_file, return_tokenized=True)
         assert len(tokenized_dataset) > 0, "Should create at least one tokenized chunk"
         assert (
             "input_ids" in tokenized_dataset.column_names
@@ -134,13 +134,13 @@ def test_raw_text_loader():
 
         # Test constructor validation
         try:
-            bad_loader = RawTextDataLoader(tokenizer, chunk_size = 0, stride = 2)
+            bad_loader = RawTextDataLoader(tokenizer, chunk_size=0, stride=2)
             assert False, "Should raise ValueError for chunk_size=0"
         except ValueError as e:
             assert "chunk_size must be positive" in str(e)
 
         try:
-            bad_loader = RawTextDataLoader(tokenizer, chunk_size = 5, stride = 10)
+            bad_loader = RawTextDataLoader(tokenizer, chunk_size=5, stride=10)
             assert False, "Should raise ValueError for stride >= chunk_size"
         except ValueError as e:
             assert "stride" in str(e) and "chunk_size" in str(e)

--- a/tests/utils/aime_eval.py
+++ b/tests/utils/aime_eval.py
@@ -24,7 +24,7 @@ def download_and_combine_aime_datasets(data_dir: str = "./data/aime") -> str:
         "test2025-II": "https://raw.githubusercontent.com/GAIR-NLP/AIME-Preview/main/eval/data/aime/test2025-II.jsonl",
     }
 
-    os.makedirs(data_dir, exist_ok = True)
+    os.makedirs(data_dir, exist_ok=True)
     combined_filepath = os.path.join(data_dir, "aime.jsonl")
 
     # Check if combined file already exists
@@ -67,9 +67,9 @@ def download_and_combine_aime_datasets(data_dir: str = "./data/aime") -> str:
 
     # Write combined dataset
     if all_problems:
-        with open(combined_filepath, "w", encoding = "utf-8") as f:
+        with open(combined_filepath, "w", encoding="utf-8") as f:
             for problem in all_problems:
-                f.write(json.dumps(problem, ensure_ascii = False) + "\n")
+                f.write(json.dumps(problem, ensure_ascii=False) + "\n")
 
         print(f"✅ Combined {len(all_problems)} problems from {len(datasets)} datasets")
         print(f"   Saved to: {combined_filepath}")
@@ -92,7 +92,7 @@ def load_aime_dataset(data_dir: str = "./data/aime") -> List[Dict[str, Any]]:
     filepath = download_and_combine_aime_datasets(data_dir)
 
     examples = []
-    with open(filepath, "r", encoding = "utf-8") as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         for line_num, line in enumerate(f):
             line = line.strip()
             if line:
@@ -188,20 +188,20 @@ def get_num_tokens(text, tokenizer_instance):
     """Count tokens in text"""
     if not text:
         return 0
-    encoding = tokenizer_instance(text, return_tensors = "pt")
+    encoding = tokenizer_instance(text, return_tensors="pt")
     return len(encoding["input_ids"][0])
 
 
 def evaluate_model_aime(
     model,
     tokenizer,
-    model_type = "base",
-    lora_request = None,
-    temperature = 0.3,
-    n_sampling = 8,
-    max_tokens = 32768,
-    top_p = 0.95,
-    seed = 0,
+    model_type="base",
+    lora_request=None,
+    temperature=0.3,
+    n_sampling=8,
+    max_tokens=32768,
+    top_p=0.95,
+    seed=0,
 ):
     """Evaluate model on combined AIME dataset with official configuration"""
 
@@ -237,11 +237,11 @@ def evaluate_model_aime(
 
     # Setup sampling parameters (AIME configuration)
     sampling_params = SamplingParams(
-        temperature = temperature,
-        top_p = top_p,
-        max_tokens = max_tokens,
-        n = n_sampling,  # Multiple samples per question
-        seed = seed,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+        n=n_sampling,  # Multiple samples per question
+        seed=seed,
     )
 
     print(f"\n🔧 Configuration:")
@@ -272,13 +272,13 @@ def evaluate_model_aime(
 
         # Main evaluation loop
         with tqdm(
-            total = len(eval_dataset), desc = "Processing AIME problems", unit = "problem"
+            total=len(eval_dataset), desc="Processing AIME problems", unit="problem"
         ) as pbar:
             for task_id, item in enumerate(eval_dataset):
                 try:
                     # Prepare prompt
                     prompt_text = tokenizer.apply_chat_template(
-                        item["prompt"], add_generation_prompt = True, tokenize = False
+                        item["prompt"], add_generation_prompt=True, tokenize=False
                     )
 
                     input_tokens.append(get_num_tokens(prompt_text, tokenizer))
@@ -286,9 +286,9 @@ def evaluate_model_aime(
                     # Generate multiple responses
                     outputs = model.fast_generate(
                         [prompt_text],
-                        sampling_params = sampling_params,
-                        lora_request = lora_request,
-                        use_tqdm = False,
+                        sampling_params=sampling_params,
+                        lora_request=lora_request,
+                        use_tqdm=False,
                     )[0].outputs
 
                     # Process all generated responses
@@ -413,8 +413,8 @@ def evaluate_model_aime(
 
     # Save results
     filename = f"aime_eval_combined_{model_type}_t{temperature}_n{n_sampling}.json"
-    with open(filename, "w", encoding = "utf-8") as f:
-        json.dump({"results": results, "records": records}, f, indent = 4)
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump({"results": results, "records": records}, f, indent=4)
 
     # Print comprehensive summary
     print(f"\n{'='*70}")
@@ -517,27 +517,27 @@ def compare_aime_results(all_results):
     if all_results and "source_accuracies" in all_results[0]:
         datasets = list(all_results[0]["source_accuracies"].keys())
 
-        print(f"{'Model':<15}", end = "")
+        print(f"{'Model':<15}", end="")
         for dataset in datasets:
-            print(f"{dataset:<15}", end = "")
+            print(f"{dataset:<15}", end="")
         print()
         print("-" * (15 + 15 * len(datasets)))
 
         for result in all_results:
-            print(f"{result['model_type']:<15}", end = "")
+            print(f"{result['model_type']:<15}", end="")
             for dataset in datasets:
                 accuracy = result["source_accuracies"].get(dataset, 0)
-                print(f"{accuracy:<15.1f}", end = "")
+                print(f"{accuracy:<15.1f}", end="")
             print()
 
     # Save comparison
     comparison_data = {
         "summary": all_results,
-        "best_model": max(all_results, key = lambda x: x["accuracy"]),
+        "best_model": max(all_results, key=lambda x: x["accuracy"]),
     }
 
     with open("aime_model_comparison.json", "w") as f:
-        json.dump(comparison_data, f, indent = 4)
+        json.dump(comparison_data, f, indent=4)
 
     print(
         f"\nBest performing model: {comparison_data['best_model']['model_type']} "

--- a/tests/utils/cleanup_utils.py
+++ b/tests/utils/cleanup_utils.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 
 
-def clear_memory(variables_to_clear = None, verbose = False, clear_all_caches = True):
+def clear_memory(variables_to_clear=None, verbose=False, clear_all_caches=True):
     """
     Comprehensive memory clearing for persistent memory leaks.
 
@@ -104,7 +104,7 @@ def clear_memory(variables_to_clear = None, verbose = False, clear_all_caches = 
             logger.setLevel(level)
 
 
-def clear_all_lru_caches(verbose = True):
+def clear_all_lru_caches(verbose=True):
     """Clear all LRU caches in loaded modules."""
     cleared_caches = []
 
@@ -210,7 +210,7 @@ def monitor_cache_sizes():
         except:
             pass
 
-    return sorted(cache_info, key = lambda x: x["size"], reverse = True)
+    return sorted(cache_info, key=lambda x: x["size"], reverse=True)
 
 
 def safe_remove_directory(path):

--- a/tests/utils/data_utils.py
+++ b/tests/utils/data_utils.py
@@ -32,10 +32,10 @@ def create_dataset(tokenizer, num_examples: int = None, messages: list[dict] = N
     dataset = create_instruction_dataset(messages)
 
     def _apply_chat_template(example):
-        chat = tokenizer.apply_chat_template(example["messages"], tokenize = False)
+        chat = tokenizer.apply_chat_template(example["messages"], tokenize=False)
         return {"text": chat}
 
-    dataset = dataset.map(_apply_chat_template, remove_columns = "messages")
+    dataset = dataset.map(_apply_chat_template, remove_columns="messages")
     if num_examples is not None:
         if len(dataset) < num_examples:
             num_repeats = num_examples // len(dataset) + 1
@@ -139,11 +139,11 @@ def get_peft_weights(model):
 
 def describe_peft_weights(model):
     for name, param in get_peft_weights(model).items():
-        yield name, describe_param(param, as_str = True)
+        yield name, describe_param(param, as_str=True)
 
 
 def check_responses(responses: list[str], answer: str, prompt: str = None) -> bool:
-    for i, response in enumerate(responses, start = 1):
+    for i, response in enumerate(responses, start=1):
         if answer in response:
             print(f"\u2713 response {i} contains answer")
         else:

--- a/tests/utils/hf_utils.py
+++ b/tests/utils/hf_utils.py
@@ -79,27 +79,27 @@ def generate_responses(
     skip_special_tokens: bool = True,
     dtype: torch.dtype = None,
 ):
-    inputs = [tokenizer(prompt, return_tensors = "pt") for _ in range(num_generations)]
+    inputs = [tokenizer(prompt, return_tensors="pt") for _ in range(num_generations)]
     keys = inputs[0].keys()
     batched_inputs = {
-        key: torch.cat([input[key] for input in inputs], dim = 0).to(model.device)
+        key: torch.cat([input[key] for input in inputs], dim=0).to(model.device)
         for key in keys
     }
 
     if dtype is not None:
-        inference_context = torch.autocast(device_type = "cuda", dtype = dtype)
+        inference_context = torch.autocast(device_type="cuda", dtype=dtype)
     else:
         inference_context = nullcontext()
 
     with inference_context:
         outputs = model.generate(
             **batched_inputs,
-            max_new_tokens = max_new_tokens,
-            do_sample = do_sample,
-            temperature = temperature,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
         )
 
-    responses = tokenizer.batch_decode(outputs, skip_special_tokens = skip_special_tokens)
+    responses = tokenizer.batch_decode(outputs, skip_special_tokens=skip_special_tokens)
     return responses
 
 
@@ -117,11 +117,11 @@ def sample_responses(
         model,
         tokenizer,
         prompt,
-        temperature = temperature,
-        num_generations = num_generations,
-        max_new_tokens = max_new_tokens,
-        skip_special_tokens = skip_special_tokens,
-        dtype = dtype,
+        temperature=temperature,
+        num_generations=num_generations,
+        max_new_tokens=max_new_tokens,
+        skip_special_tokens=skip_special_tokens,
+        dtype=dtype,
     )
     return responses
 
@@ -136,32 +136,32 @@ def setup_tokenizer(model_name, fixup_funcs: list[Callable] = []):
 def setup_model(
     model_name,
     quantize: bool = True,
-    dtype = torch.bfloat16,
-    peft_config = None,
+    dtype=torch.bfloat16,
+    peft_config=None,
     autocast_adapter: bool = True,
 ):
     if quantize:
         bnb_config = BitsAndBytesConfig(
-            load_in_4bit = True,
-            bnb_4bit_use_double_quant = True,
-            bnb_4bit_quant_type = "nf4",
-            bnb_4bit_compute_dtype = dtype,
+            load_in_4bit=True,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=dtype,
         )
     else:
         bnb_config = None
 
     model = AutoModelForCausalLM.from_pretrained(
         model_name,
-        device_map = "cuda:0",
-        attn_implementation = "sdpa",
-        quantization_config = bnb_config,
-        torch_dtype = dtype,
+        device_map="cuda:0",
+        attn_implementation="sdpa",
+        quantization_config=bnb_config,
+        torch_dtype=dtype,
     )
     model = prepare_model_for_kbit_training(model) if quantize else model
 
     if peft_config is not None:
         model = get_peft_model(
-            model, peft_config, autocast_adapter_dtype = autocast_adapter
+            model, peft_config, autocast_adapter_dtype=autocast_adapter
         )
 
     return model
@@ -169,19 +169,19 @@ def setup_model(
 
 def get_peft_config(
     lora_rank,
-    lora_alpha = None,
-    lora_dropout = 0.0,
-    bias = "none",
-    target_modules = "all-linear",
+    lora_alpha=None,
+    lora_dropout=0.0,
+    bias="none",
+    target_modules="all-linear",
 ):
     lora_alpha = lora_alpha or 2 * lora_rank
     peft_config = LoraConfig(
-        lora_alpha = lora_alpha,
-        lora_dropout = lora_dropout,
-        r = lora_rank,
-        bias = bias,
-        target_modules = target_modules,
-        task_type = "CAUSAL_LM",
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        r=lora_rank,
+        bias=bias,
+        target_modules=target_modules,
+        task_type="CAUSAL_LM",
     )
     return peft_config
 
@@ -191,18 +191,18 @@ def setup_trainer(
     tokenizer,
     dataset,
     train_args,
-    peft_config = None,
-    formatting_func = None,
-    collator = None,
+    peft_config=None,
+    formatting_func=None,
+    collator=None,
 ):
     return SFTTrainer(
-        model = model,
-        peft_config = peft_config,
-        train_dataset = dataset,
-        processing_class = tokenizer,
-        formatting_func = formatting_func,
-        data_collator = collator,
-        args = train_args,
+        model=model,
+        peft_config=peft_config,
+        train_dataset=dataset,
+        processing_class=tokenizer,
+        formatting_func=formatting_func,
+        data_collator=collator,
+        args=train_args,
     )
 
 
@@ -212,17 +212,17 @@ def setup_lora(
     dataset,
     peft_config,
     train_args,
-    formatting_func = None,
-    collator = None,
+    formatting_func=None,
+    collator=None,
 ):
     return LoraConfig(
-        model = model,
-        peft_config = peft_config,
-        train_dataset = dataset,
-        processing_class = tokenizer,
-        formatting_func = formatting_func,
-        data_collator = collator,
-        args = train_args,
+        model=model,
+        peft_config=peft_config,
+        train_dataset=dataset,
+        processing_class=tokenizer,
+        formatting_func=formatting_func,
+        data_collator=collator,
+        args=train_args,
     )
 
 
@@ -236,7 +236,7 @@ def convert_weights_back_to_dtype(model, dtype):
             param.data = param.data.to(dtype)
 
 
-def fix_llama3_tokenizer(tokenizer, padding_side = "right"):
+def fix_llama3_tokenizer(tokenizer, padding_side="right"):
     tokenizer.padding_side = padding_side
     added_vocab = tokenizer.get_added_vocab()
     pad_token = [w for w in added_vocab if "pad" in w]
@@ -276,12 +276,12 @@ def _convert_lora_to_linear(module: LoraLayer, adapter_name: str = "default"):
     w_dq = w_dq.to(original_dtype)
 
     new_module = torch.nn.Linear(
-        w_dq.shape[1], w_dq.shape[0], bias = module.base_layer.bias is not None
+        w_dq.shape[1], w_dq.shape[0], bias=module.base_layer.bias is not None
     )
-    new_module.weight.data = torch.nn.Parameter(w_dq, requires_grad = False)
+    new_module.weight.data = torch.nn.Parameter(w_dq, requires_grad=False)
     if module.lora_bias[adapter_name]:
         bias_data = module.base_layer.bias.data + module.lora_B[adapter_name].bias
-        new_module.bias.data = torch.nn.Parameter(bias_data, requires_grad = False)
+        new_module.bias.data = torch.nn.Parameter(bias_data, requires_grad=False)
     return new_module
 
 

--- a/tests/utils/test_attention_masks.py
+++ b/tests/utils/test_attention_masks.py
@@ -24,11 +24,11 @@ from unsloth.utils import packing as packing_utils
 
 
 def _make_seq_info(lengths):
-    lengths = torch.tensor(lengths, dtype = torch.int32)
+    lengths = torch.tensor(lengths, dtype=torch.int32)
     cu = torch.cat(
         [
-            torch.zeros(1, dtype = torch.int32),
-            torch.cumsum(lengths, dim = 0, dtype = torch.int32),
+            torch.zeros(1, dtype=torch.int32),
+            torch.cumsum(lengths, dim=0, dtype=torch.int32),
         ]
     )
     max_len = int(lengths.max().item())
@@ -39,15 +39,15 @@ def test_sdpa_packed_attention_mask_sliding_window():
     seq_info = _make_seq_info([5, 3])
     mask = packing_utils.build_sdpa_packed_attention_mask(
         seq_info,
-        dtype = torch.float32,
-        device = torch.device("cpu"),
-        sliding_window = 3,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        sliding_window=3,
     )
 
     assert mask.shape == (1, 1, 8, 8)
 
     block_first = mask[0, 0, :5, :5]
-    upper = torch.triu(torch.ones_like(block_first), diagonal = 1).bool()
+    upper = torch.triu(torch.ones_like(block_first), diagonal=1).bool()
     assert torch.all(block_first[upper] == float("-inf"))
     assert block_first[3, 0].item() == float("-inf")
     assert block_first[4, 1].item() == float("-inf")
@@ -57,7 +57,7 @@ def test_sdpa_packed_attention_mask_sliding_window():
 
 def test_xformers_block_mask_sliding_window(monkeypatch):
     class _FakeMask:
-        def __init__(self, lengths, window = None):
+        def __init__(self, lengths, window=None):
             self.lengths = lengths
             self.window = window
 
@@ -66,14 +66,14 @@ def test_xformers_block_mask_sliding_window(monkeypatch):
             return cls(tuple(lengths))
 
         def make_local_attention(self, window_size):
-            return _FakeMask(self.lengths, window = window_size)
+            return _FakeMask(self.lengths, window=window_size)
 
-    monkeypatch.setattr(packing_utils, "_XFormersBlockMask", _FakeMask, raising = False)
+    monkeypatch.setattr(packing_utils, "_XFormersBlockMask", _FakeMask, raising=False)
 
     seq_info = _make_seq_info([4, 4])
     mask = packing_utils.build_xformers_block_causal_mask(
         seq_info,
-        sliding_window = 2,
+        sliding_window=2,
     )
 
     assert isinstance(mask, _FakeMask)
@@ -87,13 +87,13 @@ def test_run_attention_sdpa_passes_sliding_window(monkeypatch):
     original_builder = attention_dispatch.build_sdpa_packed_attention_mask
     captured = {}
 
-    def _capture_builder(seq_info_arg, *, dtype, device, sliding_window = None):
+    def _capture_builder(seq_info_arg, *, dtype, device, sliding_window=None):
         captured["window"] = sliding_window
         return original_builder(
             seq_info_arg,
-            dtype = dtype,
-            device = device,
-            sliding_window = sliding_window,
+            dtype=dtype,
+            device=device,
+            sliding_window=sliding_window,
         )
 
     monkeypatch.setattr(
@@ -109,22 +109,22 @@ def test_run_attention_sdpa_passes_sliding_window(monkeypatch):
     monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
 
     config = attention_dispatch.AttentionConfig(
-        backend = attention_dispatch.SDPA,
-        n_kv_heads = 1,
-        n_groups = 1,
+        backend=attention_dispatch.SDPA,
+        n_kv_heads=1,
+        n_groups=1,
     )
 
     context = attention_dispatch.AttentionContext(
-        bsz = 1,
-        q_len = 5,
-        kv_seq_len = 5,
-        n_heads = 1,
-        head_dim = 1,
-        requires_grad = False,
-        seq_info = seq_info,
-        attention_mask = None,
-        causal_mask = None,
-        sliding_window = sliding_window,
+        bsz=1,
+        q_len=5,
+        kv_seq_len=5,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+        sliding_window=sliding_window,
     )
 
     Q = torch.zeros(1, 1, 5, 1)
@@ -132,11 +132,11 @@ def test_run_attention_sdpa_passes_sliding_window(monkeypatch):
     V = torch.zeros_like(Q)
 
     attention_dispatch.run_attention(
-        config = config,
-        context = context,
-        Q = Q,
-        K = K,
-        V = V,
+        config=config,
+        context=context,
+        Q=Q,
+        K=K,
+        V=V,
     )
 
     assert captured["window"] == sliding_window
@@ -154,12 +154,12 @@ def test_run_attention_xformers_passes_sliding_window(monkeypatch):
 
     captured = {}
 
-    def _fake_builder(seq_info_arg, *, sliding_window = None, base_mask = None):
+    def _fake_builder(seq_info_arg, *, sliding_window=None, base_mask=None):
         captured["window"] = sliding_window
         captured["base"] = base_mask
         return _FakeBias()
 
-    def _fake_attention(Q, K, V, attn_bias = None, **_):
+    def _fake_attention(Q, K, V, attn_bias=None, **_):
         captured["bias"] = attn_bias
         return torch.zeros_like(Q)
 
@@ -167,29 +167,29 @@ def test_run_attention_xformers_passes_sliding_window(monkeypatch):
         attention_dispatch, "build_xformers_block_causal_mask", _fake_builder
     )
     monkeypatch.setattr(
-        attention_dispatch, "xformers_attention", _fake_attention, raising = False
+        attention_dispatch, "xformers_attention", _fake_attention, raising=False
     )
     monkeypatch.setattr(
-        attention_dispatch, "XFORMERS_BLOCK_DIAG_CLS", _FakeBias, raising = False
+        attention_dispatch, "XFORMERS_BLOCK_DIAG_CLS", _FakeBias, raising=False
     )
 
     config = attention_dispatch.AttentionConfig(
-        backend = attention_dispatch.XFORMERS,
-        n_kv_heads = 1,
-        n_groups = 1,
+        backend=attention_dispatch.XFORMERS,
+        n_kv_heads=1,
+        n_groups=1,
     )
 
     context = attention_dispatch.AttentionContext(
-        bsz = 1,
-        q_len = 4,
-        kv_seq_len = 4,
-        n_heads = 1,
-        head_dim = 1,
-        requires_grad = False,
-        seq_info = seq_info,
-        attention_mask = None,
-        causal_mask = None,
-        sliding_window = sliding_window,
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+        sliding_window=sliding_window,
     )
 
     Q = torch.zeros(1, 1, 4, 1)
@@ -197,11 +197,11 @@ def test_run_attention_xformers_passes_sliding_window(monkeypatch):
     V = torch.zeros_like(Q)
 
     attention_dispatch.run_attention(
-        config = config,
-        context = context,
-        Q = Q,
-        K = K,
-        V = V,
+        config=config,
+        context=context,
+        Q=Q,
+        K=K,
+        V=V,
     )
 
     assert captured["window"] == sliding_window
@@ -228,10 +228,10 @@ def test_run_attention_flash_varlen_receives_window_and_softcap(monkeypatch):
     monkeypatch.setattr(attention_dispatch, "HAS_FLASH_ATTENTION", True)
 
     config = attention_dispatch.AttentionConfig(
-        backend = attention_dispatch.FLASH_VARLEN,
-        n_kv_heads = 1,
-        n_groups = 1,
-        flash_varlen_kwargs = {
+        backend=attention_dispatch.FLASH_VARLEN,
+        n_kv_heads=1,
+        n_groups=1,
+        flash_varlen_kwargs={
             "dropout_p": 0.0,
             "softmax_scale": 1.0,
             "causal": True,
@@ -241,16 +241,16 @@ def test_run_attention_flash_varlen_receives_window_and_softcap(monkeypatch):
     )
 
     context = attention_dispatch.AttentionContext(
-        bsz = 1,
-        q_len = 4,
-        kv_seq_len = 4,
-        n_heads = 1,
-        head_dim = 2,
-        requires_grad = False,
-        seq_info = seq_info,
-        attention_mask = None,
-        causal_mask = None,
-        sliding_window = sliding_window,
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=2,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+        sliding_window=sliding_window,
     )
 
     Q = torch.zeros(1, 1, 4, 2)
@@ -258,11 +258,11 @@ def test_run_attention_flash_varlen_receives_window_and_softcap(monkeypatch):
     V = torch.zeros_like(Q)
 
     attention_dispatch.run_attention(
-        config = config,
-        context = context,
-        Q = Q,
-        K = K,
-        V = V,
+        config=config,
+        context=context,
+        Q=Q,
+        K=K,
+        V=V,
     )
 
     assert captured["kwargs"]["softcap"] == softcap

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -44,10 +44,10 @@ def _build_packed_training_setup(tmp_path, device):
 
     try:
         model, tokenizer = FastLanguageModel.from_pretrained(
-            model_name = "hf-internal-testing/tiny-random-LlamaForCausalLM",
-            max_seq_length = 64,
-            load_in_4bit = False,
-            dtype = dtype,
+            model_name="hf-internal-testing/tiny-random-LlamaForCausalLM",
+            max_seq_length=64,
+            load_in_4bit=False,
+            dtype=dtype,
         )
     except OSError as exc:  # pragma: no cover - offline CI
         pytest.skip(f"Requires access to tiny llama checkpoint: {exc}")
@@ -66,25 +66,25 @@ def _build_packed_training_setup(tmp_path, device):
     )
 
     training_args = SFTConfig(
-        per_device_train_batch_size = 1,
-        per_device_eval_batch_size = 1,
-        gradient_accumulation_steps = 1,
-        dataset_text_field = "text",
-        max_length = 64,
-        logging_steps = 1,
-        max_steps = 1,
-        fp16 = device.type == "cuda" and not torch.cuda.is_bf16_supported(),
-        bf16 = device.type == "cuda" and torch.cuda.is_bf16_supported(),
-        dataset_num_proc = 1,
-        output_dir = str(tmp_path),
-        packing = True,
+        per_device_train_batch_size=1,
+        per_device_eval_batch_size=1,
+        gradient_accumulation_steps=1,
+        dataset_text_field="text",
+        max_length=64,
+        logging_steps=1,
+        max_steps=1,
+        fp16=device.type == "cuda" and not torch.cuda.is_bf16_supported(),
+        bf16=device.type == "cuda" and torch.cuda.is_bf16_supported(),
+        dataset_num_proc=1,
+        output_dir=str(tmp_path),
+        packing=True,
     )
 
     trainer = SFTTrainer(
-        model = model,
-        processing_class = tokenizer,
-        train_dataset = dataset,
-        args = training_args,
+        model=model,
+        processing_class=tokenizer,
+        train_dataset=dataset,
+        args=training_args,
     )
 
     enable_sample_packing(model, trainer)
@@ -119,10 +119,10 @@ def _trim_batch_to_total_tokens(data, total_tokens):
 
 
 def test_mask_packed_sequence_boundaries_marks_single_row():
-    shift_labels = torch.arange(6, dtype = torch.long).view(1, 6)
+    shift_labels = torch.arange(6, dtype=torch.long).view(1, 6)
     changed = mask_packed_sequence_boundaries(
         shift_labels,
-        torch.tensor([2, 1, 3], dtype = torch.int32),
+        torch.tensor([2, 1, 3], dtype=torch.int32),
     )
     assert changed is True
     flat = shift_labels.view(-1)
@@ -133,8 +133,8 @@ def test_mask_packed_sequence_boundaries_marks_single_row():
 
 
 def test_mask_packed_sequence_boundaries_across_multiple_rows():
-    shift_labels = torch.arange(10, dtype = torch.long).view(2, 5)
-    lengths = torch.tensor([3, 2, 4, 1], dtype = torch.int32)
+    shift_labels = torch.arange(10, dtype=torch.long).view(2, 5)
+    lengths = torch.tensor([3, 2, 4, 1], dtype=torch.int32)
     changed = mask_packed_sequence_boundaries(shift_labels, lengths)
     assert changed is True
     flat = shift_labels.view(-1)
@@ -153,7 +153,7 @@ def test_configure_sample_packing():
 
 
 def test_configure_padding_free():
-    config = SimpleNamespace(remove_unused_columns = True)
+    config = SimpleNamespace(remove_unused_columns=True)
     configure_padding_free(config)
 
     assert config.padding_free is True
@@ -171,13 +171,13 @@ class _DummyModel(torch.nn.Module):
         super().__init__()
         self.max_seq_length = 16
         self.child = _DummyChild()
-        self.config = SimpleNamespace(_attn_implementation = "sdpa")
-        self.generation_config = SimpleNamespace(attn_implementation = "sdpa")
+        self.config = SimpleNamespace(_attn_implementation="sdpa")
+        self.generation_config = SimpleNamespace(attn_implementation="sdpa")
 
 
 class _DummyTrainer:
     def __init__(self):
-        self.args = SimpleNamespace(remove_unused_columns = True)
+        self.args = SimpleNamespace(remove_unused_columns=True)
         collator_args = {
             "pad_token_id": 0,
             "completion_only_loss": False,
@@ -212,7 +212,7 @@ class _PaddingFreeCollator:
     def torch_call(self, examples):
         self.calls += 1
         return {
-            "input_ids": torch.tensor([[0]], dtype = torch.long),
+            "input_ids": torch.tensor([[0]], dtype=torch.long),
             "examples_seen": self.calls,
         }
 
@@ -249,11 +249,11 @@ def test_enable_sample_packing():
     assert "packed_seq_lengths" in batch
     assert torch.equal(
         batch["packed_seq_lengths"],
-        torch.tensor([2, 1, 3], dtype = torch.int32),
+        torch.tensor([2, 1, 3], dtype=torch.int32),
     )
 
     assert batch["input_ids"].shape == (1, 6)
-    expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype = torch.long)
+    expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype=torch.long)
     assert torch.equal(batch["position_ids"].view(-1)[:6], expected_positions)
 
 
@@ -281,10 +281,10 @@ def test_enable_sample_packing_trl_collator(tmp_path):
     assert batch["input_ids"].shape == (1, 6)
     assert torch.equal(
         batch["packed_seq_lengths"],
-        torch.tensor([2, 1, 3], dtype = torch.int32),
+        torch.tensor([2, 1, 3], dtype=torch.int32),
     )
 
-    expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype = torch.long)
+    expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype=torch.long)
     assert torch.equal(batch["position_ids"].view(-1)[:6], expected_positions)
 
     if hasattr(trainer, "accelerator"):
@@ -294,8 +294,8 @@ def test_enable_sample_packing_trl_collator(tmp_path):
 def test_enable_padding_free_metadata():
     model = _DummyModel()
     trainer = SimpleNamespace(
-        args = SimpleNamespace(remove_unused_columns = True),
-        data_collator = _PaddingFreeCollator(),
+        args=SimpleNamespace(remove_unused_columns=True),
+        data_collator=_PaddingFreeCollator(),
     )
 
     enable_padding_free_metadata(model, trainer)
@@ -314,7 +314,7 @@ def test_enable_padding_free_metadata():
     batch = collator.torch_call(examples)
     assert torch.equal(
         batch["packed_seq_lengths"],
-        torch.tensor([3, 2], dtype = torch.int32),
+        torch.tensor([3, 2], dtype=torch.int32),
     )
     assert trainer.args.remove_unused_columns is False
 
@@ -335,7 +335,7 @@ def test_packing_sdpa(tmp_path):
     flat_positions = batch["position_ids"].reshape(-1)[:packed_tokens]
     expected_positions = torch.cat(
         [
-            torch.arange(length, dtype = torch.long)
+            torch.arange(length, dtype=torch.long)
             for length in batch["packed_seq_lengths"].tolist()
         ]
     )
@@ -352,18 +352,18 @@ def test_packing_sdpa(tmp_path):
     mask_calls = []
     captured_loss_labels = {}
 
-    def _capture_mask(seq_info, dtype, device, *, sliding_window = None):
+    def _capture_mask(seq_info, dtype, device, *, sliding_window=None):
         mask_calls.append(tuple(seq_info[0].tolist()))
         return original_mask(
             seq_info,
-            dtype = dtype,
-            device = device,
-            sliding_window = sliding_window,
+            dtype=dtype,
+            device=device,
+            sliding_window=sliding_window,
         )
 
     def _capture_loss(*, logits, labels, **loss_kwargs):
         captured_loss_labels["labels"] = labels.detach().to("cpu")
-        return torch.zeros((), device = logits.device, dtype = logits.dtype)
+        return torch.zeros((), device=logits.device, dtype=logits.dtype)
 
     with ExitStack() as stack:
         stack.enter_context(
@@ -376,14 +376,14 @@ def test_packing_sdpa(tmp_path):
             patch.object(
                 attention_dispatch_utils,
                 "build_sdpa_packed_attention_mask",
-                side_effect = _capture_mask,
+                side_effect=_capture_mask,
             )
         )
         stack.enter_context(
             patch.object(
                 llama_mod,
                 "fast_cross_entropy_loss",
-                side_effect = _capture_loss,
+                side_effect=_capture_loss,
             )
         )
         with torch.no_grad():
@@ -395,7 +395,7 @@ def test_packing_sdpa(tmp_path):
     flat_loss_labels = captured_loss_labels["labels"].reshape(-1)
     boundaries = (
         torch.cumsum(
-            batch["packed_seq_lengths"].to(device = "cpu", dtype = torch.long), dim = 0
+            batch["packed_seq_lengths"].to(device="cpu", dtype=torch.long), dim=0
         )
         - 1
     )

--- a/unsloth-cli.py
+++ b/unsloth-cli.py
@@ -48,18 +48,18 @@ def run(args):
     # Load model and tokenizer
     device_map, distributed = prepare_device_map()
     model, tokenizer = FastLanguageModel.from_pretrained(
-        model_name = args.model_name,
-        max_seq_length = args.max_seq_length,
-        dtype = args.dtype,
-        load_in_4bit = args.load_in_4bit,
-        device_map = device_map,
+        model_name=args.model_name,
+        max_seq_length=args.max_seq_length,
+        dtype=args.dtype,
+        load_in_4bit=args.load_in_4bit,
+        device_map=device_map,
     )
 
     # Configure PEFT model
     model = FastLanguageModel.get_peft_model(
         model,
-        r = args.r,
-        target_modules = [
+        r=args.r,
+        target_modules=[
             "q_proj",
             "k_proj",
             "v_proj",
@@ -68,13 +68,13 @@ def run(args):
             "up_proj",
             "down_proj",
         ],
-        lora_alpha = args.lora_alpha,
-        lora_dropout = args.lora_dropout,
-        bias = args.bias,
-        use_gradient_checkpointing = args.use_gradient_checkpointing,
-        random_state = args.random_state,
-        use_rslora = args.use_rslora,
-        loftq_config = args.loftq_config,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        bias=args.bias,
+        use_gradient_checkpointing=args.use_gradient_checkpointing,
+        random_state=args.random_state,
+        use_rslora=args.use_rslora,
+        loftq_config=args.loftq_config,
     )
 
     alpaca_prompt = """Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
@@ -119,13 +119,13 @@ def run(args):
             if use_modelscope:
                 from modelscope import MsDataset
 
-                dataset = MsDataset.load(args.dataset, split = "train")
+                dataset = MsDataset.load(args.dataset, split="train")
             else:
                 # Existing HuggingFace dataset logic
-                dataset = load_dataset(args.dataset, split = "train")
+                dataset = load_dataset(args.dataset, split="train")
 
             # Apply formatting for structured datasets
-            dataset = dataset.map(formatting_prompts_func, batched = True)
+            dataset = dataset.map(formatting_prompts_func, batched=True)
         return dataset
 
     # Load dataset using smart loader
@@ -134,33 +134,33 @@ def run(args):
 
     # Configure training arguments
     training_args = SFTConfig(
-        per_device_train_batch_size = args.per_device_train_batch_size,
-        per_device_eval_batch_size = args.per_device_eval_batch_size,
-        gradient_accumulation_steps = args.gradient_accumulation_steps,
-        warmup_steps = args.warmup_steps,
-        max_steps = args.max_steps,
-        learning_rate = args.learning_rate,
-        fp16 = not is_bfloat16_supported(),
-        bf16 = is_bfloat16_supported(),
-        logging_steps = args.logging_steps,
-        optim = args.optim,
-        weight_decay = args.weight_decay,
-        lr_scheduler_type = args.lr_scheduler_type,
-        seed = args.seed,
-        output_dir = args.output_dir,
-        report_to = args.report_to,
-        max_length = args.max_seq_length,
-        dataset_num_proc = 2,
-        ddp_find_unused_parameters = False if distributed else None,
-        packing = args.packing,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        per_device_eval_batch_size=args.per_device_eval_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        warmup_steps=args.warmup_steps,
+        max_steps=args.max_steps,
+        learning_rate=args.learning_rate,
+        fp16=not is_bfloat16_supported(),
+        bf16=is_bfloat16_supported(),
+        logging_steps=args.logging_steps,
+        optim=args.optim,
+        weight_decay=args.weight_decay,
+        lr_scheduler_type=args.lr_scheduler_type,
+        seed=args.seed,
+        output_dir=args.output_dir,
+        report_to=args.report_to,
+        max_length=args.max_seq_length,
+        dataset_num_proc=2,
+        ddp_find_unused_parameters=False if distributed else None,
+        packing=args.packing,
     )
 
     # Initialize trainer
     trainer = SFTTrainer(
-        model = model,
-        processing_class = tokenizer,
-        train_dataset = dataset,
-        args = training_args,
+        model=model,
+        processing_class=tokenizer,
+        train_dataset=dataset,
+        args=training_args,
     )
 
     trainer.train()
@@ -177,26 +177,26 @@ def run(args):
                     model.save_pretrained_gguf(
                         args.save_path,
                         tokenizer,
-                        quantization_method = quantization_method,
+                        quantization_method=quantization_method,
                     )
                     if args.push_model:
                         model.push_to_hub_gguf(
-                            hub_path = args.hub_path,
-                            hub_token = args.hub_token,
-                            quantization_method = quantization_method,
+                            hub_path=args.hub_path,
+                            hub_token=args.hub_token,
+                            quantization_method=quantization_method,
                         )
             else:
                 print(f"Saving model with quantization method: {args.quantization}")
                 model.save_pretrained_gguf(
                     args.save_path,
                     tokenizer,
-                    quantization_method = args.quantization,
+                    quantization_method=args.quantization,
                 )
                 if args.push_model:
                     model.push_to_hub_gguf(
-                        hub_path = args.hub_path,
-                        hub_token = args.hub_token,
-                        quantization_method = args.quantization,
+                        hub_path=args.hub_path,
+                        hub_token=args.hub_token,
+                        quantization_method=args.quantization,
                     )
         else:
             model.save_pretrained_merged(args.save_path, tokenizer, args.save_method)
@@ -208,38 +208,38 @@ def run(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description = "🦥 Fine-tune your llm faster using unsloth!"
+        description="🦥 Fine-tune your llm faster using unsloth!"
     )
 
     model_group = parser.add_argument_group("🤖 Model Options")
     model_group.add_argument(
         "--model_name",
-        type = str,
-        default = "unsloth/llama-3-8b",
-        help = "Model name to load",
+        type=str,
+        default="unsloth/llama-3-8b",
+        help="Model name to load",
     )
     model_group.add_argument(
         "--max_seq_length",
-        type = int,
-        default = 2048,
-        help = "Maximum sequence length, default is 2048. We auto support RoPE Scaling internally!",
+        type=int,
+        default=2048,
+        help="Maximum sequence length, default is 2048. We auto support RoPE Scaling internally!",
     )
     model_group.add_argument(
         "--dtype",
-        type = str,
-        default = None,
-        help = "Data type for model (None for auto detection)",
+        type=str,
+        default=None,
+        help="Data type for model (None for auto detection)",
     )
     model_group.add_argument(
         "--load_in_4bit",
-        action = "store_true",
-        help = "Use 4bit quantization to reduce memory usage",
+        action="store_true",
+        help="Use 4bit quantization to reduce memory usage",
     )
     model_group.add_argument(
         "--dataset",
-        type = str,
-        default = "yahma/alpaca-cleaned",
-        help = "Huggingface dataset to use for training",
+        type=str,
+        default="yahma/alpaca-cleaned",
+        help="Huggingface dataset to use for training",
     )
 
     lora_group = parser.add_argument_group(
@@ -248,125 +248,125 @@ if __name__ == "__main__":
     )
     lora_group.add_argument(
         "--r",
-        type = int,
-        default = 16,
-        help = "Rank for Lora model, default is 16.  (common values: 8, 16, 32, 64, 128)",
+        type=int,
+        default=16,
+        help="Rank for Lora model, default is 16.  (common values: 8, 16, 32, 64, 128)",
     )
     lora_group.add_argument(
         "--lora_alpha",
-        type = int,
-        default = 16,
-        help = "LoRA alpha parameter, default is 16. (common values: 8, 16, 32, 64, 128)",
+        type=int,
+        default=16,
+        help="LoRA alpha parameter, default is 16. (common values: 8, 16, 32, 64, 128)",
     )
     lora_group.add_argument(
         "--lora_dropout",
-        type = float,
-        default = 0.0,
-        help = "LoRA dropout rate, default is 0.0 which is optimized.",
+        type=float,
+        default=0.0,
+        help="LoRA dropout rate, default is 0.0 which is optimized.",
     )
     lora_group.add_argument(
         "--bias",
-        type = str,
-        default = "none",
-        help = "Bias setting for LoRA",
+        type=str,
+        default="none",
+        help="Bias setting for LoRA",
     )
     lora_group.add_argument(
         "--use_gradient_checkpointing",
-        type = str,
-        default = "unsloth",
-        help = "Use gradient checkpointing",
+        type=str,
+        default="unsloth",
+        help="Use gradient checkpointing",
     )
     lora_group.add_argument(
         "--random_state",
-        type = int,
-        default = 3407,
-        help = "Random state for reproducibility, default is 3407.",
+        type=int,
+        default=3407,
+        help="Random state for reproducibility, default is 3407.",
     )
     lora_group.add_argument(
         "--use_rslora",
-        action = "store_true",
-        help = "Use rank stabilized LoRA",
+        action="store_true",
+        help="Use rank stabilized LoRA",
     )
     lora_group.add_argument(
         "--loftq_config",
-        type = str,
-        default = None,
-        help = "Configuration for LoftQ",
+        type=str,
+        default=None,
+        help="Configuration for LoftQ",
     )
 
     training_group = parser.add_argument_group("🎓 Training Options")
     training_group.add_argument(
         "--per_device_train_batch_size",
-        type = int,
-        default = 2,
-        help = "Batch size per device during training, default is 2.",
+        type=int,
+        default=2,
+        help="Batch size per device during training, default is 2.",
     )
     training_group.add_argument(
         "--per_device_eval_batch_size",
-        type = int,
-        default = 4,
-        help = "Batch size per device during evaluation, default is 4.",
+        type=int,
+        default=4,
+        help="Batch size per device during evaluation, default is 4.",
     )
     training_group.add_argument(
         "--gradient_accumulation_steps",
-        type = int,
-        default = 4,
-        help = "Number of gradient accumulation steps, default is 4.",
+        type=int,
+        default=4,
+        help="Number of gradient accumulation steps, default is 4.",
     )
     training_group.add_argument(
         "--warmup_steps",
-        type = int,
-        default = 5,
-        help = "Number of warmup steps, default is 5.",
+        type=int,
+        default=5,
+        help="Number of warmup steps, default is 5.",
     )
     training_group.add_argument(
         "--max_steps",
-        type = int,
-        default = 400,
-        help = "Maximum number of training steps.",
+        type=int,
+        default=400,
+        help="Maximum number of training steps.",
     )
     training_group.add_argument(
         "--learning_rate",
-        type = float,
-        default = 2e-4,
-        help = "Learning rate, default is 2e-4.",
+        type=float,
+        default=2e-4,
+        help="Learning rate, default is 2e-4.",
     )
     training_group.add_argument(
         "--optim",
-        type = str,
-        default = "adamw_8bit",
-        help = "Optimizer type.",
+        type=str,
+        default="adamw_8bit",
+        help="Optimizer type.",
     )
     training_group.add_argument(
         "--weight_decay",
-        type = float,
-        default = 0.01,
-        help = "Weight decay, default is 0.01.",
+        type=float,
+        default=0.01,
+        help="Weight decay, default is 0.01.",
     )
     training_group.add_argument(
         "--lr_scheduler_type",
-        type = str,
-        default = "linear",
-        help = "Learning rate scheduler type, default is 'linear'.",
+        type=str,
+        default="linear",
+        help="Learning rate scheduler type, default is 'linear'.",
     )
     training_group.add_argument(
         "--seed",
-        type = int,
-        default = 3407,
-        help = "Seed for reproducibility, default is 3407.",
+        type=int,
+        default=3407,
+        help="Seed for reproducibility, default is 3407.",
     )
     training_group.add_argument(
         "--packing",
-        action = "store_true",
-        help = "Enable padding-free sample packing via TRL's bin packer.",
+        action="store_true",
+        help="Enable padding-free sample packing via TRL's bin packer.",
     )
 
     report_group = parser.add_argument_group("📊 Report Options")
     report_group.add_argument(
         "--report_to",
-        type = str,
-        default = "tensorboard",
-        choices = [
+        type=str,
+        default="tensorboard",
+        choices=[
             "azure_ml",
             "clearml",
             "codecarbon",
@@ -381,7 +381,7 @@ if __name__ == "__main__":
             "all",
             "none",
         ],
-        help = (
+        help=(
             "The list of integrations to report the results and logs to. Supported platforms are:\n\t\t "
             "'azure_ml', 'clearml', 'codecarbon', 'comet_ml', 'dagshub', 'dvclive', 'flyte', "
             "'mlflow', 'neptune', 'tensorboard', and 'wandb'. Use 'all' to report to all integrations "
@@ -390,47 +390,47 @@ if __name__ == "__main__":
     )
     report_group.add_argument(
         "--logging_steps",
-        type = int,
-        default = 1,
-        help = "Logging steps, default is 1",
+        type=int,
+        default=1,
+        help="Logging steps, default is 1",
     )
 
     save_group = parser.add_argument_group("💾 Save Model Options")
     save_group.add_argument(
         "--output_dir",
-        type = str,
-        default = "outputs",
-        help = "Output directory",
+        type=str,
+        default="outputs",
+        help="Output directory",
     )
     save_group.add_argument(
         "--save_model",
-        action = "store_true",
-        help = "Save the model after training",
+        action="store_true",
+        help="Save the model after training",
     )
     save_group.add_argument(
         "--save_method",
-        type = str,
-        default = "merged_16bit",
-        choices = ["merged_16bit", "merged_4bit", "lora"],
-        help = "Save method for the model, default is 'merged_16bit'",
+        type=str,
+        default="merged_16bit",
+        choices=["merged_16bit", "merged_4bit", "lora"],
+        help="Save method for the model, default is 'merged_16bit'",
     )
     save_group.add_argument(
         "--save_gguf",
-        action = "store_true",
-        help = "Convert the model to GGUF after training",
+        action="store_true",
+        help="Convert the model to GGUF after training",
     )
     save_group.add_argument(
         "--save_path",
-        type = str,
-        default = "model",
-        help = "Path to save the model",
+        type=str,
+        default="model",
+        help="Path to save the model",
     )
     save_group.add_argument(
         "--quantization",
-        type = str,
-        default = "q8_0",
-        nargs = "+",
-        help = (
+        type=str,
+        default="q8_0",
+        nargs="+",
+        help=(
             "Quantization method for saving the model. common values ('f16', 'q4_k_m', 'q8_0'), "
             "Check our wiki for all quantization methods https://github.com/unslothai/unsloth/wiki#saving-to-gguf"
         ),
@@ -439,34 +439,34 @@ if __name__ == "__main__":
     push_group = parser.add_argument_group("🚀 Push Model Options")
     push_group.add_argument(
         "--push_model",
-        action = "store_true",
-        help = "Push the model to Hugging Face hub after training",
+        action="store_true",
+        help="Push the model to Hugging Face hub after training",
     )
     push_group.add_argument(
         "--push_gguf",
-        action = "store_true",
-        help = "Push the model as GGUF to Hugging Face hub after training",
+        action="store_true",
+        help="Push the model as GGUF to Hugging Face hub after training",
     )
     push_group.add_argument(
         "--hub_path",
-        type = str,
-        default = "hf/model",
-        help = "Path on Hugging Face hub to push the model",
+        type=str,
+        default="hf/model",
+        help="Path on Hugging Face hub to push the model",
     )
     push_group.add_argument(
         "--hub_token",
-        type = str,
-        help = "Token for pushing the model to Hugging Face hub",
+        type=str,
+        help="Token for pushing the model to Hugging Face hub",
     )
 
     parser.add_argument(
-        "--raw_text_file", type = str, help = "Path to raw text file for training"
+        "--raw_text_file", type=str, help="Path to raw text file for training"
     )
     parser.add_argument(
-        "--chunk_size", type = int, default = 2048, help = "Size of text chunks for training"
+        "--chunk_size", type=int, default=2048, help="Size of text chunks for training"
     )
     parser.add_argument(
-        "--stride", type = int, default = 512, help = "Overlap between chunks"
+        "--stride", type=int, default=512, help="Overlap between chunks"
     )
 
     args = parser.parse_args()

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -66,7 +66,7 @@ if already_imported:
         f"to ensure all optimizations are applied. Your code may run slower or encounter "
         f"memory issues without these optimizations.\n\n"
         f"Please restructure your imports with 'import unsloth' at the top of your file.",
-        stacklevel = 2,
+        stacklevel=2,
     )
 del already_imported, critical_modules
 
@@ -203,7 +203,7 @@ if DEVICE_TYPE == "cuda":
     old_is_bf16_supported = torch.cuda.is_bf16_supported
     if "including_emulation" in str(inspect.signature(old_is_bf16_supported)):
 
-        def is_bf16_supported(including_emulation = False):
+        def is_bf16_supported(including_emulation=False):
             return old_is_bf16_supported(including_emulation)
 
         torch.cuda.is_bf16_supported = is_bf16_supported

--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -45,7 +45,7 @@ def _load_vllm_utils():
     return load_vllm, patch_vllm, delete_vllm
 
 
-def terminate_tree(proc: subprocess.Popen, timeout = 15):
+def terminate_tree(proc: subprocess.Popen, timeout=15):
     if proc is None or proc.poll() is not None:
         return
 
@@ -53,10 +53,10 @@ def terminate_tree(proc: subprocess.Popen, timeout = 15):
         import psutil
 
         parent = psutil.Process(proc.pid)
-        for child in parent.children(recursive = True):
+        for child in parent.children(recursive=True):
             child.terminate()
         parent.terminate()
-        parent.wait(timeout = timeout / 2)
+        parent.wait(timeout=timeout / 2)
         return
     except:
         pass
@@ -65,17 +65,17 @@ def terminate_tree(proc: subprocess.Popen, timeout = 15):
         try:
             subprocess.run(
                 ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
-                capture_output = True,
-                timeout = 5,
+                capture_output=True,
+                timeout=5,
             )
-            proc.wait(timeout = 1)
+            proc.wait(timeout=1)
             return
         except:
             pass
 
     proc.kill()
     try:
-        proc.wait(timeout = 5)
+        proc.wait(timeout=5)
     except:
         pass
 
@@ -86,16 +86,16 @@ class PipeCapture:
     def __init__(
         self,
         pipe,
-        keep_lines = 2000,
-        echo = False,
-        name = "",
-        text = True,
-        encoding = "utf-8",
-        errors = "replace",
-        ready_regex = None,
+        keep_lines=2000,
+        echo=False,
+        name="",
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        ready_regex=None,
     ):
         self.pipe = pipe
-        self.buf = deque(maxlen = keep_lines)
+        self.buf = deque(maxlen=keep_lines)
         self.lock = threading.Lock()
         self.echo = echo
         self.name = name
@@ -112,7 +112,7 @@ class PipeCapture:
                 ready_regex = re.compile(ready_regex)
             self.ready_regex = ready_regex
 
-        self.t = threading.Thread(target = self._reader, daemon = True)
+        self.t = threading.Thread(target=self._reader, daemon=True)
         self.t.start()
 
     def _reader(self):
@@ -141,16 +141,16 @@ class PipeCapture:
                 pass
             self.closed_event.set()
 
-    def wait_for_ready(self, timeout = None):
+    def wait_for_ready(self, timeout=None):
         return self.ready_event.wait(timeout)
 
     def has_closed(self):
         return self.closed_event.is_set()
 
-    def wait_until_closed(self, timeout = None):
+    def wait_until_closed(self, timeout=None):
         return self.closed_event.wait(timeout)
 
-    def tail(self, n = 200):
+    def tail(self, n=200):
         with self.lock:
             return "\n".join(list(self.buf)[-n:])
 
@@ -158,13 +158,13 @@ class PipeCapture:
 class SyntheticDataKit:
     def __init__(
         self,
-        model_name = "unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
-        max_seq_length = 2048,
-        gpu_memory_utilization = 0.98,
-        float8_kv_cache = False,
-        conservativeness = 1.0,
-        token = None,
-        timeout = 1200,  # maybe this is not enough for large models if we need to download
+        model_name="unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
+        max_seq_length=2048,
+        gpu_memory_utilization=0.98,
+        float8_kv_cache=False,
+        conservativeness=1.0,
+        token=None,
+        timeout=1200,  # maybe this is not enough for large models if we need to download
         **kwargs,
     ):
         assert type(model_name) is str
@@ -181,27 +181,27 @@ class SyntheticDataKit:
 
         self.config = AutoConfig.from_pretrained(
             model_name,
-            token = token,
+            token=token,
         )
         self.tokenizer = AutoTokenizer.from_pretrained(
             model_name,
-            token = token,
+            token=token,
         )
         load_vllm, patch_vllm, delete_vllm = _load_vllm_utils()
         self._delete_vllm = delete_vllm
-        patch_vllm(debug = False)
+        patch_vllm(debug=False)
         engine_args = load_vllm(
-            model_name = model_name,
-            config = self.config,
-            gpu_memory_utilization = gpu_memory_utilization,
-            max_seq_length = max_seq_length,
-            disable_log_stats = True,
-            float8_kv_cache = float8_kv_cache,
-            conservativeness = conservativeness,
-            return_args = True,
-            enable_lora = False,
-            use_bitsandbytes = False,
-            compilation_config = 3,
+            model_name=model_name,
+            config=self.config,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_seq_length=max_seq_length,
+            disable_log_stats=True,
+            float8_kv_cache=float8_kv_cache,
+            conservativeness=conservativeness,
+            return_args=True,
+            enable_lora=False,
+            use_bitsandbytes=False,
+            compilation_config=3,
             **kwargs,
         )
         if "dtype" in engine_args:
@@ -259,31 +259,31 @@ class SyntheticDataKit:
         logger.info(subprocess_commands)
         vllm_process = subprocess.Popen(
             subprocess_commands,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE,
-            start_new_session = True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
         )
         ready_re = re.compile(r"Starting vLLM API server(?:\s+\d+)?\s+on\b")
         self.vllm_process = vllm_process
         self.stdout_capture = PipeCapture(
             vllm_process.stdout,
-            keep_lines = 1000,
-            echo = True,
-            name = "vLLM STDOUT",
-            ready_regex = ready_re,
-            text = False,
+            keep_lines=1000,
+            echo=True,
+            name="vLLM STDOUT",
+            ready_regex=ready_re,
+            text=False,
         )
         self.stderr_capture = PipeCapture(
             vllm_process.stderr,
-            keep_lines = 2000,
-            echo = False,
-            name = "vLLM STDERR",
-            ready_regex = None,
-            text = False,
+            keep_lines=2000,
+            echo=False,
+            name="vLLM STDERR",
+            ready_regex=None,
+            text=False,
         )
         # we don't print stderr to console but self.stderr_capture.tail(200) will print the last 200 lines
 
-        ready = self.stdout_capture.wait_for_ready(timeout = timeout)
+        ready = self.stdout_capture.wait_for_ready(timeout=timeout)
         if not ready:
             if self.stdout_capture.has_closed() or self.vllm_process.poll() is not None:
                 print("Stdout stream ended before readiness message detected.")
@@ -312,21 +312,21 @@ class SyntheticDataKit:
 
     @staticmethod
     def from_pretrained(
-        model_name = "unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
-        max_seq_length = 2048,
-        gpu_memory_utilization = 0.9,
-        float8_kv_cache = False,
-        conservativeness = 1.0,
-        token = None,
+        model_name="unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
+        max_seq_length=2048,
+        gpu_memory_utilization=0.9,
+        float8_kv_cache=False,
+        conservativeness=1.0,
+        token=None,
         **kwargs,
     ):
         return SyntheticDataKit(
-            model_name = model_name,
-            max_seq_length = max_seq_length,
-            gpu_memory_utilization = gpu_memory_utilization,
-            float8_kv_cache = float8_kv_cache,
-            conservativeness = conservativeness,
-            token = token,
+            model_name=model_name,
+            max_seq_length=max_seq_length,
+            gpu_memory_utilization=gpu_memory_utilization,
+            float8_kv_cache=float8_kv_cache,
+            conservativeness=conservativeness,
+            token=token,
             **kwargs,
         )
 
@@ -347,7 +347,7 @@ class SyntheticDataKit:
         print("Attempting to terminate the VLLM server gracefully...")
         try:
             vllm_process.terminate()
-            vllm_process.wait(timeout = 10)
+            vllm_process.wait(timeout=10)
             print("Server terminated gracefully.")
         except subprocess.TimeoutExpired:
             print(
@@ -372,7 +372,7 @@ class SyntheticDataKit:
 
         # Delete vLLM module as well
         if hasattr(self, "_delete_vllm"):
-            self._delete_vllm(llm = None)
+            self._delete_vllm(llm=None)
 
     def __enter__(self):
         return self
@@ -383,7 +383,7 @@ class SyntheticDataKit:
     def __del__(self):
         self.cleanup()
 
-    def chunk_data(self, filename = None):
+    def chunk_data(self, filename=None):
         # Chunks data by max tokens and generation length
         assert filename is not None
         assert os.path.exists(filename)
@@ -395,7 +395,7 @@ class SyntheticDataKit:
         if not hasattr(self, "overlap") or not hasattr(self, "max_generation_tokens"):
             raise RuntimeError("Please use prepare_qa_generation first!")
 
-        with open(filename, "r", encoding = "utf-8") as f:
+        with open(filename, "r", encoding="utf-8") as f:
             text = f.read()
 
         max_tokens = (
@@ -403,7 +403,7 @@ class SyntheticDataKit:
         )  # -128 to reduce errors
         if max_tokens <= 5:
             raise RuntimeError("Generation length is way too long!")
-        input_ids = self.tokenizer(text, add_special_tokens = False).input_ids
+        input_ids = self.tokenizer(text, add_special_tokens=False).input_ids
 
         # Get left and right boundaries
         length = len(input_ids)
@@ -424,21 +424,21 @@ class SyntheticDataKit:
             chunked_text = self.tokenizer.decode(input_ids[left:right])
             new_filename = f"{filename}_{i}{extension}"
             all_filenames.append(new_filename)
-            with open(new_filename, "w", encoding = "utf-8") as f:
+            with open(new_filename, "w", encoding="utf-8") as f:
                 f.write(chunked_text)
         return all_filenames
 
     def prepare_qa_generation(
         self,
-        output_folder = "data",
-        max_generation_tokens = 512,
-        temperature = 0.7,
-        top_p = 0.95,
-        overlap = 64,
-        default_num_pairs = 25,
-        cleanup_threshold = 1.0,
-        cleanup_batch_size = 4,
-        cleanup_temperature = 0.3,
+        output_folder="data",
+        max_generation_tokens=512,
+        temperature=0.7,
+        top_p=0.95,
+        overlap=64,
+        default_num_pairs=25,
+        cleanup_threshold=1.0,
+        cleanup_batch_size=4,
+        cleanup_temperature=0.3,
     ):
         assert hasattr(self, "model_name")
         assert hasattr(self, "max_seq_length")
@@ -447,7 +447,7 @@ class SyntheticDataKit:
         locations = "pdf,html,youtube,docx,ppt,txt,output,generated,cleaned,final"
         locations = locations.split(",")
         for path in locations:
-            os.makedirs(os.path.join(output_folder, path), exist_ok = True)
+            os.makedirs(os.path.join(output_folder, path), exist_ok=True)
 
         self.max_generation_tokens = max_generation_tokens
 
@@ -467,7 +467,7 @@ class SyntheticDataKit:
             .replace("{cleanup_temperature}", str(cleanup_temperature))
         )
 
-        with open("synthetic_data_kit_config.yaml", "w", encoding = "utf-8") as f:
+        with open("synthetic_data_kit_config.yaml", "w", encoding="utf-8") as f:
             f.write(config)
 
         self.overlap = overlap

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -35,12 +35,12 @@ UNSLOTH_ENABLE_LOGGING = os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") in (
 logger = logging.getLogger(__name__)
 if UNSLOTH_ENABLE_LOGGING:
     logging.basicConfig(
-        level = logging.INFO, format = "[%(name)s|%(levelname)s]%(message)s"
+        level=logging.INFO, format="[%(name)s|%(levelname)s]%(message)s"
     )
     logger.setLevel(logging.INFO)
 else:
     logging.basicConfig(
-        level = logging.WARNING, format = "[%(name)s|%(levelname)s]%(message)s"
+        level=logging.WARNING, format="[%(name)s|%(levelname)s]%(message)s"
     )
     logger.setLevel(logging.WARNING)
 
@@ -164,74 +164,74 @@ if not UNSLOTH_ENABLE_LOGGING:
     sys.stderr.add_filter("Skipping import of cpp extensions")
     # SyntaxWarning: invalid escape sequence '\.'
     warnings.filterwarnings(
-        "ignore", message = "invalid escape sequence", category = SyntaxWarning
+        "ignore", message="invalid escape sequence", category=SyntaxWarning
     )
     # PYTORCH_CUDA_ALLOC_CONF is deprecated warning from torch
-    warnings.filterwarnings("ignore", message = "PYTORCH_CUDA_ALLOC_CONF is deprecated")
+    warnings.filterwarnings("ignore", message="PYTORCH_CUDA_ALLOC_CONF is deprecated")
     # TF32 precision deprecation warning from torch
     warnings.filterwarnings(
-        "ignore", message = "Please use the new API settings to control TF32"
+        "ignore", message="Please use the new API settings to control TF32"
     )
     # Deprecation warnings from torchao
-    warnings.filterwarnings("ignore", message = "`int4_weight_only` is deprecated")
-    warnings.filterwarnings("ignore", message = "`int8_weight_only` is deprecated")
+    warnings.filterwarnings("ignore", message="`int4_weight_only` is deprecated")
+    warnings.filterwarnings("ignore", message="`int8_weight_only` is deprecated")
 
     # TorchAO deprecated import paths (https://github.com/pytorch/ao/issues/2752)
     warnings.filterwarnings(
         "ignore",
-        message = r"Importing.*from torchao\.dtypes.*is deprecated",
-        category = DeprecationWarning,
+        message=r"Importing.*from torchao\.dtypes.*is deprecated",
+        category=DeprecationWarning,
     )
     warnings.filterwarnings(
         "ignore",
-        message = r"Importing BlockSparseLayout from torchao\.dtypes is deprecated",
-        category = DeprecationWarning,
+        message=r"Importing BlockSparseLayout from torchao\.dtypes is deprecated",
+        category=DeprecationWarning,
     )
 
     # SWIG builtin type warnings (from bitsandbytes/triton SWIG bindings)
     warnings.filterwarnings(
         "ignore",
-        message = r"builtin type Swig.*has no __module__ attribute",
-        category = DeprecationWarning,
+        message=r"builtin type Swig.*has no __module__ attribute",
+        category=DeprecationWarning,
     )
 
     # Triton autotuner deprecation (https://github.com/triton-lang/triton/pull/4496)
     warnings.filterwarnings(
         "ignore",
-        message = r"warmup, rep, and use_cuda_graph parameters are deprecated",
-        category = DeprecationWarning,
+        message=r"warmup, rep, and use_cuda_graph parameters are deprecated",
+        category=DeprecationWarning,
     )
 
     # Python 3.12+ multiprocessing fork warning in multi-threaded processes
     warnings.filterwarnings(
         "ignore",
-        message = r".*multi-threaded.*use of fork\(\) may lead to deadlocks",
-        category = DeprecationWarning,
+        message=r".*multi-threaded.*use of fork\(\) may lead to deadlocks",
+        category=DeprecationWarning,
     )
 
     # Resource warnings from internal socket/file operations
     warnings.filterwarnings(
-        "ignore", message = r"unclosed.*socket", category = ResourceWarning
+        "ignore", message=r"unclosed.*socket", category=ResourceWarning
     )
     warnings.filterwarnings(
-        "ignore", message = r"unclosed file.*dev/null", category = ResourceWarning
+        "ignore", message=r"unclosed file.*dev/null", category=ResourceWarning
     )
 
     # torch 2.9+ pin_memory/is_pinned device arg deprecation
     warnings.filterwarnings(
         "ignore",
-        message = r"The `device` argument is deprecated",
-        category = DeprecationWarning,
+        message=r"The `device` argument is deprecated",
+        category=DeprecationWarning,
     )
     warnings.filterwarnings(
         "ignore",
-        message = r".*pin_memory.*device.*deprecated",
-        category = DeprecationWarning,
+        message=r".*pin_memory.*device.*deprecated",
+        category=DeprecationWarning,
     )
     warnings.filterwarnings(
         "ignore",
-        message = r".*is_pinned.*device.*deprecated",
-        category = DeprecationWarning,
+        message=r".*is_pinned.*device.*deprecated",
+        category=DeprecationWarning,
     )
 
     # vllm "Level is deprecated" stderr noise
@@ -240,11 +240,11 @@ if not UNSLOTH_ENABLE_LOGGING:
     # PydanticSerializationUnexpectedValue warning
     warnings.filterwarnings(
         "ignore",
-        message = r".*PydanticSerializationUnexpectedValue",
+        message=r".*PydanticSerializationUnexpectedValue",
     )
     warnings.filterwarnings(
         "ignore",
-        message = r"Expected.*but got.*with value.*is not.*subclass",
+        message=r"Expected.*but got.*with value.*is not.*subclass",
     )
 
     # Triton "df: No such file or directory" stderr noise
@@ -254,9 +254,9 @@ if not UNSLOTH_ENABLE_LOGGING:
     # Apex ROCm fused RoPE backend selection warning when Aiter is enabled.
     warnings.filterwarnings(
         "ignore",
-        message = r"^Aiter backend is selected for fused RoPE\.?",
-        category = UserWarning,
-        module = r"^apex\.transformer\.functional\.fused_rope$",
+        message=r"^Aiter backend is selected for fused RoPE\.?",
+        category=UserWarning,
+        module=r"^apex\.transformer\.functional\.fused_rope$",
     )
 
 
@@ -322,7 +322,7 @@ def fix_xformers_performance_issue():
         cutlass = Path(xformers_location) / "ops" / "fmha" / "cutlass.py"
         try:
             if cutlass.exists():
-                with open(cutlass, "r+", encoding = "utf-8") as f:
+                with open(cutlass, "r+", encoding="utf-8") as f:
                     text = f.read()
                     # See https://github.com/facebookresearch/xformers/issues/1176#issuecomment-2545829591
                     if "num_splits_key=-1," in text:
@@ -414,7 +414,7 @@ def fix_vllm_aimv2_issue():
         ovis_config = Path(vllm_location) / "transformers_utils" / "configs" / "ovis.py"
         try:
             if ovis_config.exists():
-                with open(ovis_config, "r+", encoding = "utf-8") as f:
+                with open(ovis_config, "r+", encoding="utf-8") as f:
                     text = f.read()
                     # See https://github.com/vllm-project/vllm-ascend/issues/2046
                     if 'AutoConfig.register("aimv2", AIMv2Config)' in text:
@@ -786,7 +786,7 @@ def fix_openenv_no_vllm():
         return
 
     try:
-        with open(openenv, "r+", encoding = "utf-8") as f:
+        with open(openenv, "r+", encoding="utf-8") as f:
             text = f.read()
             bad = (
                 "if is_vllm_available():\n"
@@ -865,7 +865,7 @@ def fix_executorch():
         """
         what = textwrap.dedent(what)
 
-        with open(executorch, "r+", encoding = "utf-8") as f:
+        with open(executorch, "r+", encoding="utf-8") as f:
             text = f.read()
             bad = "from enum import Enum\n"
             if bad in text and what not in text:
@@ -970,16 +970,16 @@ def patch_trunc_normal_precision_issue():
 
     def _call_original(target, mean, std, a, b, generator):
         if generator is None:
-            return original_trunc_normal(target, mean = mean, std = std, a = a, b = b)
+            return original_trunc_normal(target, mean=mean, std=std, a=a, b=b)
         try:
             return original_trunc_normal(
-                target, mean = mean, std = std, a = a, b = b, generator = generator
+                target, mean=mean, std=std, a=a, b=b, generator=generator
             )
         except TypeError as exc:
             # Older torch versions may not accept a generator keyword argument.
             msg = str(exc).lower()
             if "unexpected keyword argument" in msg and "generator" in msg:
-                return original_trunc_normal(target, mean = mean, std = std, a = a, b = b)
+                return original_trunc_normal(target, mean=mean, std=std, a=a, b=b)
             raise
 
     try:
@@ -994,7 +994,7 @@ def patch_trunc_normal_precision_issue():
         std: float = 1.0,
         a: float = -2.0,
         b: float = 2.0,
-        generator = None,
+        generator=None,
     ):
         if DTensor is not None and isinstance(tensor, DTensor):
             local_tensor = getattr(tensor, "_local_tensor", None)
@@ -1003,14 +1003,14 @@ def patch_trunc_normal_precision_issue():
             if local_tensor.dtype in low_precision_dtypes:
                 local_fp32 = local_tensor.float()
                 _call_original(local_fp32, mean, std, a, b, generator)
-                local_tensor.copy_(local_fp32.to(dtype = local_tensor.dtype))
+                local_tensor.copy_(local_fp32.to(dtype=local_tensor.dtype))
                 return tensor
             return _call_original(tensor, mean, std, a, b, generator)
 
         if tensor.dtype in low_precision_dtypes:
             tensor_fp32 = tensor.float()
             _call_original(tensor_fp32, mean, std, a, b, generator)
-            tensor.copy_(tensor_fp32.to(dtype = tensor.dtype))
+            tensor.copy_(tensor_fp32.to(dtype=tensor.dtype))
             return tensor
 
         return _call_original(tensor, mean, std, a, b, generator)
@@ -1627,13 +1627,13 @@ class _CausalConv1dImportBlockerFinder(importlib.abc.MetaPathFinder):
     def __init__(self):
         setattr(self, _CAUSAL_CONV1D_BLOCKER_SENTINEL, True)
 
-    def find_spec(self, fullname, path = None, target = None):
+    def find_spec(self, fullname, path=None, target=None):
         if not CAUSAL_CONV1D_BROKEN or not _is_causal_conv1d_name(fullname):
             return None
         return importlib.machinery.ModuleSpec(
-            name = fullname,
-            loader = _CausalConv1dImportBlockerLoader(fullname),
-            is_package = fullname == _CAUSAL_CONV1D_PREFIX,
+            name=fullname,
+            loader=_CausalConv1dImportBlockerLoader(fullname),
+            is_package=fullname == _CAUSAL_CONV1D_PREFIX,
         )
 
 
@@ -1656,13 +1656,13 @@ class _VllmImportBlockerFinder(importlib.abc.MetaPathFinder):
     def __init__(self):
         setattr(self, _VLLM_BLOCKER_SENTINEL, True)
 
-    def find_spec(self, fullname, path = None, target = None):
+    def find_spec(self, fullname, path=None, target=None):
         if not VLLM_BROKEN or not _is_vllm_name(fullname):
             return None
         return importlib.machinery.ModuleSpec(
-            name = fullname,
-            loader = _VllmImportBlockerLoader(fullname),
-            is_package = fullname == _VLLM_PREFIX,
+            name=fullname,
+            loader=_VllmImportBlockerLoader(fullname),
+            is_package=fullname == _VLLM_PREFIX,
         )
 
 
@@ -1671,7 +1671,7 @@ def _patch_find_spec_for_causal_conv1d():
     if getattr(current_find_spec, "_unsloth_causal_conv1d_find_spec_patch", False):
         return
 
-    def _blocked_find_spec(name, package = None):
+    def _blocked_find_spec(name, package=None):
         resolved_name = _resolve_module_name(name, package)
         if CAUSAL_CONV1D_BROKEN and isinstance(resolved_name, str):
             if _is_causal_conv1d_name(resolved_name):
@@ -1688,7 +1688,7 @@ def _patch_find_spec_for_vllm():
     if getattr(current_find_spec, "_unsloth_vllm_find_spec_patch", False):
         return
 
-    def _blocked_find_spec(name, package = None):
+    def _blocked_find_spec(name, package=None):
         resolved_name = _resolve_module_name(name, package)
         if VLLM_BROKEN and isinstance(resolved_name, str):
             if _is_vllm_name(resolved_name):
@@ -1728,7 +1728,7 @@ def _clear_vllm_modules():
             sys.modules.pop(module_name, None)
 
 
-def disable_broken_vllm(error = None):
+def disable_broken_vllm(error=None):
     """Disable vLLM dynamically when its shared library is ABI-broken."""
     global VLLM_BROKEN
     if VLLM_BROKEN:

--- a/unsloth/kernels/fast_lora.py
+++ b/unsloth/kernels/fast_lora.py
@@ -86,7 +86,7 @@ class LoRA_MLP(torch.autograd.Function):
         downS,
         _forward_function,
         _backward_function,
-        inplace = True,
+        inplace=True,
     ):
         dtype = X.dtype
 
@@ -169,39 +169,39 @@ class LoRA_MLP(torch.autograd.Function):
         # d_downB = (downA.t() @ h.t()) @ dY
         # d_downA *= downS
         # d_downB *= downS
-        d_downA.addmm_(h.t(), dY @ downB.t(), alpha = downS, beta = 0)
-        d_downB.addmm_(downA.t() @ h.t(), dY, alpha = downS, beta = 0)
+        d_downA.addmm_(h.t(), dY @ downB.t(), alpha=downS, beta=0)
+        d_downB.addmm_(downA.t() @ h.t(), dY, alpha=downS, beta=0)
 
         # Up projection LoRA weights
         # d_upA   = X.t() @ (df @ upB.t())
         # d_upB   = (upA.t() @ X.t()) @ df
         # d_upA  *= upS
         # d_upB  *= upS
-        d_upA.addmm_(X.t(), df @ upB.t(), alpha = upS, beta = 0)
-        d_upB.addmm_(upA.t() @ X.t(), df, alpha = upS, beta = 0)
+        d_upA.addmm_(X.t(), df @ upB.t(), alpha=upS, beta=0)
+        d_upB.addmm_(upA.t() @ X.t(), df, alpha=upS, beta=0)
 
         # Gate projection LoRA weights
         # d_gateA = X.t() @ (de @ gateB.t())
         # d_gateB = (gateA.t() @ X.t()) @ de
         # d_gateA *= gateS
         # d_gateB *= gateS
-        d_gateA.addmm_(X.t(), de @ gateB.t(), alpha = gateS, beta = 0)
-        d_gateB.addmm_(gateA.t() @ X.t(), de, alpha = gateS, beta = 0)
+        d_gateA.addmm_(X.t(), de @ gateB.t(), alpha=gateS, beta=0)
+        d_gateB.addmm_(gateA.t() @ X.t(), de, alpha=gateS, beta=0)
 
         # dX  = matmul_lora(df, upW.t(), upW_quant, upB, upA, upS)
         # dX += matmul_lora(de, gateW.t(), gateW_quant, gateB, gateA, gateS)
         upW = fast_dequantize(upW.t(), upW_quant)
-        dX = torch.matmul(df, upW.t(), out = X if ctx.inplace else None)
+        dX = torch.matmul(df, upW.t(), out=X if ctx.inplace else None)
         del upW
         # dX += df @ upB.to(dtype).t() @ (upS * upA.to(dtype).t())
-        dX.addmm_(df @ upB.t(), upA.t(), alpha = upS)
+        dX.addmm_(df @ upB.t(), upA.t(), alpha=upS)
 
         gateW = fast_dequantize(gateW.t(), gateW_quant)
         # dX += de @ gateW.t()
         dX.addmm_(de, gateW.t())
         del gateW
         # dX += de @ gateB.to(dtype).t() @ (gateS * gateA.to(dtype).t())
-        dX.addmm_(de @ gateB.t(), gateA.t(), alpha = gateS)
+        dX.addmm_(de @ gateB.t(), gateA.t(), alpha=gateS)
 
         # gateW, gateW_quant, gateA, gateB, gateS,
         #  upW,    upW_quant,   upA,   upB,   upS,
@@ -232,7 +232,7 @@ class LoRA_MLP(torch.autograd.Function):
 from .swiglu import swiglu_fg_kernel, swiglu_DWf_DW_dfg_kernel
 
 
-def apply_lora_mlp_swiglu(self, X, inplace = True):
+def apply_lora_mlp_swiglu(self, X, inplace=True):
     X = _maybe_fake_quantize_activations(X, self.gate_proj)
     gateW, gateW_quant, gateA, gateB, gateS = get_lora_parameters(self.gate_proj)
     upW, upW_quant, upA, upB, upS = get_lora_parameters(self.up_proj)
@@ -264,7 +264,7 @@ def apply_lora_mlp_swiglu(self, X, inplace = True):
 from .geglu import geglu_exact_forward_kernel, geglu_exact_backward_kernel
 
 
-def apply_lora_mlp_geglu_exact(self, X, inplace = True):
+def apply_lora_mlp_geglu_exact(self, X, inplace=True):
     X = _maybe_fake_quantize_activations(X, self.gate_proj)
     gateW, gateW_quant, gateA, gateB, gateS = get_lora_parameters(self.gate_proj)
     upW, upW_quant, upA, upB, upS = get_lora_parameters(self.up_proj)
@@ -375,7 +375,7 @@ class LoRA_QKV(torch.autograd.Function):
         VA,
         VB,
         VS,
-        inplace = True,
+        inplace=True,
     ):
         dtype = X.dtype
 
@@ -465,32 +465,32 @@ class LoRA_QKV(torch.autograd.Function):
         # d_QB = (QA.t() @ X.t()) @ dQ
         # d_QA *= QS
         # d_QB *= QS
-        d_QA.addmm_(X.t(), dQ @ QB.t(), alpha = QS, beta = 0)
-        d_QB.addmm_(QA.t() @ X.t(), dQ, alpha = QS, beta = 0)
+        d_QA.addmm_(X.t(), dQ @ QB.t(), alpha=QS, beta=0)
+        d_QB.addmm_(QA.t() @ X.t(), dQ, alpha=QS, beta=0)
 
         # K Projection
         # d_KA = X.t() @ (dK @ KB.t())
         # d_KB = (KA.t() @ X.t()) @ dK
         # d_KA *= KS
         # d_KB *= KS
-        d_KA.addmm_(X.t(), dK @ KB.t(), alpha = KS, beta = 0)
-        d_KB.addmm_(KA.t() @ X.t(), dK, alpha = KS, beta = 0)
+        d_KA.addmm_(X.t(), dK @ KB.t(), alpha=KS, beta=0)
+        d_KB.addmm_(KA.t() @ X.t(), dK, alpha=KS, beta=0)
 
         # V Projection
         # d_VA = X.t() @ (dV @ VB.t())
         # d_VB = (VA.t() @ X.t()) @ dV
         # d_VA *= VS
         # d_VB *= VS
-        d_VA.addmm_(X.t(), dV @ VB.t(), alpha = VS, beta = 0)
-        d_VB.addmm_(VA.t() @ X.t(), dV, alpha = VS, beta = 0)
+        d_VA.addmm_(X.t(), dV @ VB.t(), alpha=VS, beta=0)
+        d_VB.addmm_(VA.t() @ X.t(), dV, alpha=VS, beta=0)
 
         # Combine derivatives to find dX
         # dQ
         QW = fast_dequantize(QW.t(), QW_quant)
-        dX = torch.matmul(dQ, QW.t(), out = X if ctx.inplace else None)
+        dX = torch.matmul(dQ, QW.t(), out=X if ctx.inplace else None)
         del QW
         # dX += (dQ @ QB.to(dtype).t() @ (QS * QA.to(dtype).t()))
-        dX.addmm_(dQ @ QB.t(), QA.t(), alpha = QS)
+        dX.addmm_(dQ @ QB.t(), QA.t(), alpha=QS)
 
         # dK
         KW = fast_dequantize(KW.t(), KW_quant)
@@ -498,7 +498,7 @@ class LoRA_QKV(torch.autograd.Function):
         dX.addmm_(dK, KW.t())
         del KW
         # dX += dK @ KB.to(dtype).t() @ (KS * KA.to(dtype).t())
-        dX.addmm_(dK @ KB.t(), KA.t(), alpha = KS)
+        dX.addmm_(dK @ KB.t(), KA.t(), alpha=KS)
 
         # dV
         VW = fast_dequantize(VW.t(), VW_quant)
@@ -506,7 +506,7 @@ class LoRA_QKV(torch.autograd.Function):
         dX.addmm_(dV, VW.t())
         del VW
         # dX += dV @ VB.to(dtype).t() @ (VS * VA.to(dtype).t())
-        dX.addmm_(dV @ VB.t(), VA.t(), alpha = VS)
+        dX.addmm_(dV @ VB.t(), VA.t(), alpha=VS)
 
         # QW, QW_quant, QA, QB, QS,
         # KW, KW_quant, KA, KB, KS,
@@ -532,7 +532,7 @@ class LoRA_QKV(torch.autograd.Function):
         )
 
 
-def apply_lora_qkv(self, X, inplace = True):
+def apply_lora_qkv(self, X, inplace=True):
     X = _maybe_fake_quantize_activations(X, self.q_proj)
     QW, QW_quant, QA, QB, QS = get_lora_parameters(self.q_proj)
     KW, KW_quant, KA, KB, KS = get_lora_parameters(self.k_proj)
@@ -624,15 +624,15 @@ class LoRA_W(torch.autograd.Function):
         # d_B = (A.t() @ X.t()) @ dY
         # d_A *= S
         # d_B *= S
-        d_A.addmm_(X.t(), dY @ B.t(), alpha = S, beta = 0)
-        d_B.addmm_(A.t() @ X.t(), dY, alpha = S, beta = 0)
+        d_A.addmm_(X.t(), dY @ B.t(), alpha=S, beta=0)
+        d_B.addmm_(A.t() @ X.t(), dY, alpha=S, beta=0)
 
         # Get derivative for dX
         W = fast_dequantize(W.t(), W_quant)
         dX = dY @ W.t()
         del W
         # dX += dY @ B.to(dtype).t() @ (S * A.to(dtype).t())
-        dX.addmm_(dY @ B.t(), A.t(), alpha = S)
+        dX.addmm_(dY @ B.t(), A.t(), alpha=S)
 
         # W, W_quant, A, B, S
         return dX.view(batch, seq_len, hd), None, None, d_A.t(), d_B.t(), None
@@ -662,7 +662,7 @@ def fast_lora_forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         result = self.base_layer(x, *args, **kwargs)
     elif adapter_names is not None:
         result = self._mixed_batch_forward(
-            x, *args, adapter_names = adapter_names, **kwargs
+            x, *args, adapter_names=adapter_names, **kwargs
         )
     elif self.merged:
         result = self.base_layer(x, *args, **kwargs)
@@ -718,11 +718,11 @@ def fast_lora_forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
 
                 result = result + self.lora_magnitude_vector[active_adapter](
                     x,
-                    lora_A = lora_A,
-                    lora_B = lora_B,
-                    scaling = scaling,
-                    base_layer = self.get_base_layer(),
-                    base_result = base_result,
+                    lora_A=lora_A,
+                    lora_B=lora_B,
+                    scaling=scaling,
+                    base_layer=self.get_base_layer(),
+                    base_result=base_result,
                 )
             if requires_conversion:
                 result = result.to(expected_dtype)

--- a/unsloth/kernels/geglu.py
+++ b/unsloth/kernels/geglu.py
@@ -49,22 +49,22 @@ def _exact_forward_kernel(
 
     # f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
     # h = f * up
-    e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
-    g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)  # .to(tl.float32)
 
     f_row = 0.5 * e_row * (tl.math.erf(tl.math.rsqrt(2.0) * e_row) + 1.0)
     f_row = f_row.to(g_row.dtype)  # Exact copy from HF
     h_row = f_row * g_row
 
     # Store h
-    tl.store(h + offsets, h_row, mask = mask)
+    tl.store(h + offsets, h_row, mask=mask)
 
 
 def geglu_exact_forward_kernel(gate, up):
     batch, seq_len, hd = gate.shape
     n_elements = gate.numel()
     device = gate.device
-    out = torch.empty((batch, seq_len, hd), dtype = gate.dtype, device = device)
+    out = torch.empty((batch, seq_len, hd), dtype=gate.dtype, device=device)
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     with torch_gpu_device(device):
         _exact_forward_kernel[grid](
@@ -72,8 +72,8 @@ def geglu_exact_forward_kernel(gate, up):
             up,
             out,
             n_elements,
-            BLOCK_SIZE = BLOCK_SIZE,
-            LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
         )
     return out
 
@@ -107,9 +107,9 @@ def _exact_backward_kernel(
         offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
 
-    DW_row = tl.load(DW + offsets, mask = mask, other = 0)  # .to(tl.float32)
-    e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
-    g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
+    DW_row = tl.load(DW + offsets, mask=mask, other=0)  # .to(tl.float32)
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)  # .to(tl.float32)
 
     # Break e_row away for re-use
     # f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
@@ -132,9 +132,9 @@ def _exact_backward_kernel(
     de_row = de_row.to(DW_row.dtype)
 
     # Store derivatives in buffers
-    tl.store(DW + offsets, h_row, mask = mask)  # h  = f * g
-    tl.store(e + offsets, df_row, mask = mask)  # df = DW * f
-    tl.store(g + offsets, de_row, mask = mask)  # de
+    tl.store(DW + offsets, h_row, mask=mask)  # h  = f * g
+    tl.store(e + offsets, df_row, mask=mask)  # df = DW * f
+    tl.store(g + offsets, de_row, mask=mask)  # de
 
 
 def geglu_exact_backward_kernel(DW, e, g):
@@ -147,8 +147,8 @@ def geglu_exact_backward_kernel(DW, e, g):
             e,
             g,
             n_elements,
-            BLOCK_SIZE = BLOCK_SIZE,
-            LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
         )
     return DW, e, g
 
@@ -177,8 +177,8 @@ def _approx_forward_kernel(
     # h = f * up
     s = 0.7978845608028654  # math.sqrt(2 / math.pi)
 
-    e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
-    g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)  # .to(tl.float32)
 
     f_row = (
         0.5 * e_row * (triton_tanh(s * e_row * (1.0 + 0.044715 * e_row * e_row)) + 1.0)
@@ -187,14 +187,14 @@ def _approx_forward_kernel(
     h_row = f_row * g_row
 
     # Store h
-    tl.store(h + offsets, h_row, mask = mask)
+    tl.store(h + offsets, h_row, mask=mask)
 
 
 def geglu_approx_forward_kernel(gate, up):
     batch, seq_len, hd = gate.shape
     n_elements = gate.numel()
     device = gate.device
-    out = torch.empty((batch, seq_len, hd), dtype = gate.dtype, device = device)
+    out = torch.empty((batch, seq_len, hd), dtype=gate.dtype, device=device)
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     with torch_gpu_device(device):
         _approx_forward_kernel[grid](
@@ -202,8 +202,8 @@ def geglu_approx_forward_kernel(gate, up):
             up,
             out,
             n_elements,
-            BLOCK_SIZE = BLOCK_SIZE,
-            LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
         )
     return out
 
@@ -241,9 +241,9 @@ def _approx_backward_kernel(
         offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
 
-    DW_row = tl.load(DW + offsets, mask = mask, other = 0)  # .to(tl.float32)
-    e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
-    g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
+    DW_row = tl.load(DW + offsets, mask=mask, other=0)  # .to(tl.float32)
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)  # .to(tl.float32)
 
     # See https://www.desmos.com/calculator/nqprfoni6x
     s = 0.7978845608028654  # math.sqrt(2 / math.pi)
@@ -269,9 +269,9 @@ def _approx_backward_kernel(
     de_row = de_row.to(DW_row.dtype)
 
     # Store derivatives in buffers
-    tl.store(DW + offsets, h_row, mask = mask)  # h  = f * g
-    tl.store(e + offsets, df_row, mask = mask)  # df = DW * f
-    tl.store(g + offsets, de_row, mask = mask)  # de
+    tl.store(DW + offsets, h_row, mask=mask)  # h  = f * g
+    tl.store(e + offsets, df_row, mask=mask)  # df = DW * f
+    tl.store(g + offsets, de_row, mask=mask)  # de
 
 
 def geglu_approx_backward_kernel(DW, e, g):
@@ -284,7 +284,7 @@ def geglu_approx_backward_kernel(DW, e, g):
             e,
             g,
             n_elements,
-            BLOCK_SIZE = BLOCK_SIZE,
-            LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
         )
     return DW, e, g

--- a/unsloth/kernels/moe/benchmark/benchmark_fused_moe.py
+++ b/unsloth/kernels/moe/benchmark/benchmark_fused_moe.py
@@ -56,7 +56,7 @@ def run_benchmark_forward(
     hidden_size = config.hidden_size
 
     X = torch.randn(
-        bs, seqlen, hidden_size, dtype = dtype, device = device, requires_grad = True
+        bs, seqlen, hidden_size, dtype=dtype, device=device, requires_grad=True
     )
 
     # Forward
@@ -89,7 +89,7 @@ def run_benchmark_backward(
     config: AutoConfig,
     seqlen: int,
     dtype: torch.dtype,
-    bs = 1,
+    bs=1,
 ):
     torch.manual_seed(
         SEED
@@ -98,7 +98,7 @@ def run_benchmark_backward(
     hidden_size = config.hidden_size
 
     X = torch.randn(
-        bs, seqlen, hidden_size, dtype = dtype, device = device, requires_grad = True
+        bs, seqlen, hidden_size, dtype=dtype, device=device, requires_grad=True
     )
     X_test = X.detach().clone().requires_grad_(True)
 
@@ -114,14 +114,14 @@ def run_benchmark_backward(
 
     # Bench
     grad_output = torch.randn_like(output)
-    bench_backward_ref = lambda: output.backward(grad_output, retain_graph = True)  # noqa: E731
-    bench_backward_fused = lambda: test_output.backward(grad_output, retain_graph = True)  # noqa: E731
+    bench_backward_ref = lambda: output.backward(grad_output, retain_graph=True)  # noqa: E731
+    bench_backward_fused = lambda: test_output.backward(grad_output, retain_graph=True)  # noqa: E731
 
     ref_backward_time = do_bench(
-        bench_backward_ref, grad_to_none = [X, *ref_model.parameters()]
+        bench_backward_ref, grad_to_none=[X, *ref_model.parameters()]
     )
     fused_backward_time = do_bench(
-        bench_backward_fused, grad_to_none = [X_test, *tt_model.parameters()]
+        bench_backward_fused, grad_to_none=[X_test, *tt_model.parameters()]
     )
     print(
         f"Backward: ref {ref_backward_time:.4f}, fused {fused_backward_time:.4f}, speedup {ref_backward_time / fused_backward_time:.1f}x"
@@ -138,10 +138,10 @@ def setup_model(
     kernel_config_fwd,
     kernel_config_bwd_dW,
     kernel_config_bwd_dX,
-    dX_only = False,
-    dW_only = False,
-    overlap_router_shared = False,
-    device = "cuda",
+    dX_only=False,
+    dW_only=False,
+    overlap_router_shared=False,
+    device="cuda",
 ):
     if isinstance(config, Qwen3MoeConfig):
         ref_model = Qwen3MoeSparseMoeBlock(config).to(device, dtype)
@@ -149,29 +149,29 @@ def setup_model(
         # Triton kernel grouped gemm version of MoE Block -- this is what we're testing
         tt_model = Qwen3MoeFusedGroupedGEMMBlock.from_hf(
             ref_model,
-            permute_x = permute_x,
-            permute_y = permute_y,
-            autotune = autotune,
-            kernel_config_fwd = kernel_config_fwd,
-            kernel_config_bwd_dW = kernel_config_bwd_dW,
-            kernel_config_bwd_dX = kernel_config_bwd_dX,
-            dX_only = dX_only,
-            dW_only = dW_only,
+            permute_x=permute_x,
+            permute_y=permute_y,
+            autotune=autotune,
+            kernel_config_fwd=kernel_config_fwd,
+            kernel_config_bwd_dW=kernel_config_bwd_dW,
+            kernel_config_bwd_dX=kernel_config_bwd_dX,
+            dX_only=dX_only,
+            dW_only=dW_only,
         ).to(device, dtype)
 
     elif isinstance(config, Llama4TextConfig):
         ref_model = Llama4TextMoe(config).to(device, dtype)
         tt_model = Llama4TritonTextMoe(
             config,
-            overlap_router_shared = overlap_router_shared,
-            permute_x = permute_x,
-            permute_y = permute_y,
-            autotune = autotune,
-            kernel_config_fwd = kernel_config_fwd,
-            kernel_config_bwd_dW = kernel_config_bwd_dW,
-            kernel_config_bwd_dX = kernel_config_bwd_dX,
-            dX_only = dX_only,
-            dW_only = dW_only,
+            overlap_router_shared=overlap_router_shared,
+            permute_x=permute_x,
+            permute_y=permute_y,
+            autotune=autotune,
+            kernel_config_fwd=kernel_config_fwd,
+            kernel_config_bwd_dW=kernel_config_bwd_dW,
+            kernel_config_bwd_dX=kernel_config_bwd_dX,
+            dX_only=dX_only,
+            dW_only=dW_only,
         ).to(device, dtype)
 
     else:
@@ -205,31 +205,31 @@ def run_benchmark(
 
     ref_model, tt_model = setup_model(
         model_config,
-        dtype = dtype,
-        permute_x = permute_x,
-        permute_y = permute_y,
-        autotune = autotune,
-        kernel_config_fwd = kernel_config_fwd,
-        kernel_config_bwd_dW = kernel_config_bwd_dW,
-        kernel_config_bwd_dX = kernel_config_bwd_dX,
-        dX_only = dX_only,
-        dW_only = dW_only,
-        overlap_router_shared = overlap_router_shared,
+        dtype=dtype,
+        permute_x=permute_x,
+        permute_y=permute_y,
+        autotune=autotune,
+        kernel_config_fwd=kernel_config_fwd,
+        kernel_config_bwd_dW=kernel_config_bwd_dW,
+        kernel_config_bwd_dX=kernel_config_bwd_dX,
+        dX_only=dX_only,
+        dW_only=dW_only,
+        overlap_router_shared=overlap_router_shared,
     )
 
     if mode == "forward":
         ref_time, fused_time = run_benchmark_forward(
             ref_model,
             tt_model,
-            config = model_config,
-            seqlen = seqlen,
-            dtype = dtype,
-            autotune = autotune,
-            kernel_config_fwd = kernel_config_fwd,
+            config=model_config,
+            seqlen=seqlen,
+            dtype=dtype,
+            autotune=autotune,
+            kernel_config_fwd=kernel_config_fwd,
         )
     else:
         ref_time, fused_time = run_benchmark_backward(
-            ref_model, tt_model, config = model_config, seqlen = seqlen, dtype = dtype
+            ref_model, tt_model, config=model_config, seqlen=seqlen, dtype=dtype
         )
 
     if autotune:
@@ -251,60 +251,60 @@ def run_benchmark(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--results_dir", type = str, default = "benchmark_results")
-    parser.add_argument("--model", type = str, choices = ["llama4", "qwen3"], required = True)
-    parser.add_argument("--seqlen", type = int, default = 1024)
+    parser.add_argument("--results_dir", type=str, default="benchmark_results")
+    parser.add_argument("--model", type=str, choices=["llama4", "qwen3"], required=True)
+    parser.add_argument("--seqlen", type=int, default=1024)
     parser.add_argument(
-        "--dtype", type = str, choices = ["bfloat16", "float16"], default = "bfloat16"
+        "--dtype", type=str, choices=["bfloat16", "float16"], default="bfloat16"
     )
-    parser.add_argument("--permute_x", action = "store_true")
-    parser.add_argument("--permute_y", action = "store_true")
-    parser.add_argument("--autotune", action = "store_true")
-    parser.add_argument("--overlap_router_shared", action = "store_true")
+    parser.add_argument("--permute_x", action="store_true")
+    parser.add_argument("--permute_y", action="store_true")
+    parser.add_argument("--autotune", action="store_true")
+    parser.add_argument("--overlap_router_shared", action="store_true")
     parser.add_argument(
         "--BLOCK_SIZE_M",
-        nargs = 2,
-        type = int,
-        default = [DEFAULT_M_BLOCK_SIZES[0], DEFAULT_M_BLOCK_SIZES[-1]],
+        nargs=2,
+        type=int,
+        default=[DEFAULT_M_BLOCK_SIZES[0], DEFAULT_M_BLOCK_SIZES[-1]],
     )
     parser.add_argument(
         "--BLOCK_SIZE_N",
-        nargs = 2,
-        type = int,
-        default = [DEFAULT_N_BLOCK_SIZES[0], DEFAULT_N_BLOCK_SIZES[-1]],
+        nargs=2,
+        type=int,
+        default=[DEFAULT_N_BLOCK_SIZES[0], DEFAULT_N_BLOCK_SIZES[-1]],
     )
     parser.add_argument(
         "--BLOCK_SIZE_K",
-        nargs = 2,
-        type = int,
-        default = [DEFAULT_K_BLOCK_SIZES[0], DEFAULT_K_BLOCK_SIZES[-1]],
+        nargs=2,
+        type=int,
+        default=[DEFAULT_K_BLOCK_SIZES[0], DEFAULT_K_BLOCK_SIZES[-1]],
     )
     parser.add_argument(
         "--num_warps",
-        nargs = 2,
-        type = int,
-        default = [DEFAULT_NUM_WARPS[0], DEFAULT_NUM_WARPS[-1]],
+        nargs=2,
+        type=int,
+        default=[DEFAULT_NUM_WARPS[0], DEFAULT_NUM_WARPS[-1]],
     )
     parser.add_argument(
         "--num_stages",
-        nargs = 2,
-        type = int,
-        default = [DEFAULT_NUM_STAGES[0], DEFAULT_NUM_STAGES[-1]],
+        nargs=2,
+        type=int,
+        default=[DEFAULT_NUM_STAGES[0], DEFAULT_NUM_STAGES[-1]],
     )
     parser.add_argument(
-        "--use_tma_load_w", action = "store_true"
+        "--use_tma_load_w", action="store_true"
     )  # No need to specify, will automatically parametrize these for each kernel config
     parser.add_argument(
-        "--use_tma_load_x", action = "store_true"
+        "--use_tma_load_x", action="store_true"
     )  # No need to specify, will automatically parametrize these for each kernel config
     parser.add_argument(
-        "--use_tma_load_dy", action = "store_true"
+        "--use_tma_load_dy", action="store_true"
     )  # No need to specify, will automatically parametrize these for each kernel config
     parser.add_argument(
         "--mode",
-        type = str,
-        choices = ["forward", "backward", "dW", "dX"],
-        default = "forward",
+        type=str,
+        choices=["forward", "backward", "dW", "dX"],
+        default="forward",
     )
     args = parser.parse_args()
     args.dtype = getattr(torch, args.dtype)
@@ -324,13 +324,13 @@ if __name__ == "__main__":
         ref_time, fused_time = run_benchmark(
             args.mode,
             model_config,
-            seqlen = args.seqlen,
-            dtype = args.dtype,
-            permute_x = args.permute_x,
-            permute_y = args.permute_y,
-            autotune = args.autotune,
-            overlap_router_shared = args.overlap_router_shared,
-            results_dir = args.results_dir,
+            seqlen=args.seqlen,
+            dtype=args.dtype,
+            permute_x=args.permute_x,
+            permute_y=args.permute_y,
+            autotune=args.autotune,
+            overlap_router_shared=args.overlap_router_shared,
+            results_dir=args.results_dir,
         )
         end_time = time.time()
         print(f"Total time: {end_time - start_time:.4f} seconds")
@@ -343,13 +343,13 @@ if __name__ == "__main__":
         kernel_configs = create_kernel_configs(args, args.permute_x, args.permute_y)
         print(f"Running {len(kernel_configs)} kernel configs")
         default_kernel_config_fwd = KernelConfigForward(
-            permute_x = args.permute_x, permute_y = args.permute_y
+            permute_x=args.permute_x, permute_y=args.permute_y
         )
         default_kernel_config_bwd_dW = KernelConfigBackward_dW(
-            permute_x = args.permute_x, permute_y = args.permute_y
+            permute_x=args.permute_x, permute_y=args.permute_y
         )
         default_kernel_config_bwd_dX = KernelConfigBackward_dX(
-            permute_x = args.permute_x, permute_y = args.permute_y
+            permute_x=args.permute_x, permute_y=args.permute_y
         )
         results = []
         for kernel_config in kernel_configs:
@@ -374,21 +374,21 @@ if __name__ == "__main__":
             ref_time, fused_time = run_benchmark(
                 args.mode,
                 model_config,
-                seqlen = args.seqlen,
-                dtype = args.dtype,
-                permute_x = kernel_config.permute_x,
-                permute_y = kernel_config.permute_y,
-                autotune = False,
-                kernel_config_fwd = kernel_config_fwd,
-                kernel_config_bwd_dW = kernel_config_bwd_dW,
-                kernel_config_bwd_dX = kernel_config_bwd_dX,
+                seqlen=args.seqlen,
+                dtype=args.dtype,
+                permute_x=kernel_config.permute_x,
+                permute_y=kernel_config.permute_y,
+                autotune=False,
+                kernel_config_fwd=kernel_config_fwd,
+                kernel_config_bwd_dW=kernel_config_bwd_dW,
+                kernel_config_bwd_dX=kernel_config_bwd_dX,
             )
             results.append(
                 KernelResult(
-                    torch_time = ref_time,
-                    triton_time = fused_time,
-                    speedup = ref_time / fused_time,
-                    kernel_config = kernel_config,
+                    torch_time=ref_time,
+                    triton_time=fused_time,
+                    speedup=ref_time / fused_time,
+                    kernel_config=kernel_config,
                 )
             )
         df = post_process_results(

--- a/unsloth/kernels/moe/grouped_gemm/kernels/autotuning.py
+++ b/unsloth/kernels/moe/grouped_gemm/kernels/autotuning.py
@@ -66,15 +66,15 @@ _TRITON_HAS_TMA = False  # _triton_supports_tma()
 
 
 def get_forward_configs(
-    BLOCK_M = DEFAULT_M_BLOCK_SIZES,
-    BLOCK_N = DEFAULT_N_BLOCK_SIZES,
-    BLOCK_K = DEFAULT_K_BLOCK_SIZES,
-    TMA_LOAD_X = None,  # Auto-detect if not specified
-    TMA_LOAD_W = None,  # Auto-detect if not specified
-    TMA_STORE = False,  # NOTE: TMA_STORE is disabled for now
-    num_warps = DEFAULT_NUM_WARPS,
-    num_stages = DEFAULT_NUM_STAGES,
-    num_ctas = DEFAULT_NUM_CTAS,
+    BLOCK_M=DEFAULT_M_BLOCK_SIZES,
+    BLOCK_N=DEFAULT_N_BLOCK_SIZES,
+    BLOCK_K=DEFAULT_K_BLOCK_SIZES,
+    TMA_LOAD_X=None,  # Auto-detect if not specified
+    TMA_LOAD_W=None,  # Auto-detect if not specified
+    TMA_STORE=False,  # NOTE: TMA_STORE is disabled for now
+    num_warps=DEFAULT_NUM_WARPS,
+    num_stages=DEFAULT_NUM_STAGES,
+    num_ctas=DEFAULT_NUM_CTAS,
 ):
     # Auto-detect TMA support
     if TMA_LOAD_X is None:
@@ -130,16 +130,16 @@ def get_forward_configs(
         kernel_configs.append(
             triton.Config(
                 dict(
-                    BLOCK_SIZE_M = block_m,
-                    BLOCK_SIZE_N = block_n,
-                    BLOCK_SIZE_K = block_k,
-                    USE_TMA_LOAD_X = tma_load_x,
-                    USE_TMA_LOAD_W = tma_load_w,
-                    USE_TMA_STORE = tma_store,
+                    BLOCK_SIZE_M=block_m,
+                    BLOCK_SIZE_N=block_n,
+                    BLOCK_SIZE_K=block_k,
+                    USE_TMA_LOAD_X=tma_load_x,
+                    USE_TMA_LOAD_W=tma_load_w,
+                    USE_TMA_STORE=tma_store,
                 ),
-                num_warps = w,
-                num_stages = s,
-                num_ctas = num_ctas,
+                num_warps=w,
+                num_stages=s,
+                num_ctas=num_ctas,
             )
         )
 
@@ -147,15 +147,15 @@ def get_forward_configs(
 
 
 def get_dX_kernel_configs(
-    BLOCK_M = DEFAULT_M_BLOCK_SIZES,
-    BLOCK_N = DEFAULT_N_BLOCK_SIZES,
-    BLOCK_K = DEFAULT_K_BLOCK_SIZES,
-    TMA_LOAD_dY = None,  # Auto-detect if not specified
-    TMA_LOAD_W = None,  # Auto-detect if not specified
-    TMA_STORE = False,  # NOTE: TMA_STORE is disabled for now
-    num_warps = DEFAULT_NUM_WARPS,
-    num_stages = DEFAULT_NUM_STAGES,
-    num_ctas = DEFAULT_NUM_CTAS,
+    BLOCK_M=DEFAULT_M_BLOCK_SIZES,
+    BLOCK_N=DEFAULT_N_BLOCK_SIZES,
+    BLOCK_K=DEFAULT_K_BLOCK_SIZES,
+    TMA_LOAD_dY=None,  # Auto-detect if not specified
+    TMA_LOAD_W=None,  # Auto-detect if not specified
+    TMA_STORE=False,  # NOTE: TMA_STORE is disabled for now
+    num_warps=DEFAULT_NUM_WARPS,
+    num_stages=DEFAULT_NUM_STAGES,
+    num_ctas=DEFAULT_NUM_CTAS,
 ):
     # Auto-detect TMA support
     if TMA_LOAD_dY is None:
@@ -210,16 +210,16 @@ def get_dX_kernel_configs(
         kernel_configs.append(
             triton.Config(
                 dict(
-                    BLOCK_SIZE_M = block_m,
-                    BLOCK_SIZE_N = block_n,
-                    BLOCK_SIZE_K = block_k,
-                    USE_TMA_LOAD_dY = tma_load_dy,
-                    USE_TMA_LOAD_W = tma_load_w,
-                    USE_TMA_STORE = tma_store,
+                    BLOCK_SIZE_M=block_m,
+                    BLOCK_SIZE_N=block_n,
+                    BLOCK_SIZE_K=block_k,
+                    USE_TMA_LOAD_dY=tma_load_dy,
+                    USE_TMA_LOAD_W=tma_load_w,
+                    USE_TMA_STORE=tma_store,
                 ),
-                num_warps = w,
-                num_stages = s,
-                num_ctas = num_ctas,
+                num_warps=w,
+                num_stages=s,
+                num_ctas=num_ctas,
             )
         )
 
@@ -227,15 +227,15 @@ def get_dX_kernel_configs(
 
 
 def get_dW_kernel_configs(
-    BLOCK_M = DEFAULT_M_BLOCK_SIZES,
-    BLOCK_N = DEFAULT_N_BLOCK_SIZES,
-    BLOCK_K = DEFAULT_K_BLOCK_SIZES,
-    num_warps = DEFAULT_NUM_WARPS,
-    num_stages = DEFAULT_NUM_STAGES,
-    num_ctas = DEFAULT_NUM_CTAS,
-    TMA_LOAD_dY = None,  # Auto-detect if not specified
-    TMA_LOAD_X = None,  # Auto-detect if not specified
-    TMA_STORE = False,
+    BLOCK_M=DEFAULT_M_BLOCK_SIZES,
+    BLOCK_N=DEFAULT_N_BLOCK_SIZES,
+    BLOCK_K=DEFAULT_K_BLOCK_SIZES,
+    num_warps=DEFAULT_NUM_WARPS,
+    num_stages=DEFAULT_NUM_STAGES,
+    num_ctas=DEFAULT_NUM_CTAS,
+    TMA_LOAD_dY=None,  # Auto-detect if not specified
+    TMA_LOAD_X=None,  # Auto-detect if not specified
+    TMA_STORE=False,
 ):
     # Auto-detect TMA support
     if TMA_LOAD_dY is None:
@@ -290,16 +290,16 @@ def get_dW_kernel_configs(
         kernel_configs.append(
             triton.Config(
                 dict(
-                    BLOCK_SIZE_M = block_m,
-                    BLOCK_SIZE_N = block_n,
-                    BLOCK_SIZE_K = block_k,
-                    USE_TMA_LOAD_dY = tma_load_dy,
-                    USE_TMA_LOAD_X = tma_load_x,
-                    USE_TMA_STORE = tma_store,
+                    BLOCK_SIZE_M=block_m,
+                    BLOCK_SIZE_N=block_n,
+                    BLOCK_SIZE_K=block_k,
+                    USE_TMA_LOAD_dY=tma_load_dy,
+                    USE_TMA_LOAD_X=tma_load_x,
+                    USE_TMA_STORE=tma_store,
                 ),
-                num_warps = w,
-                num_stages = s,
-                num_ctas = num_ctas,
+                num_warps=w,
+                num_stages=s,
+                num_ctas=num_ctas,
             )
         )
 

--- a/unsloth/kernels/moe/grouped_gemm/kernels/backward.py
+++ b/unsloth/kernels/moe/grouped_gemm/kernels/backward.py
@@ -84,18 +84,18 @@ def _grouped_gemm_dX_kernel(
     if USE_TMA_LOAD_dY:
         dY_desc = tl.make_tensor_descriptor(
             dY_ptr,
-            shape = [TOTAL_TOKENS, N],
-            strides = [N, 1],
-            block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_N],
+            shape=[TOTAL_TOKENS, N],
+            strides=[N, 1],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
         )
 
     if USE_TMA_LOAD_W:
         expert_stride = N * K
         w_desc = tl.make_tensor_descriptor(
             w_ptr,
-            shape = [NUM_EXPERTS, N, K],
-            strides = [expert_stride, K, 1],
-            block_shape = [1, BLOCK_SIZE_N, BLOCK_SIZE_K],
+            shape=[NUM_EXPERTS, N, K],
+            strides=[expert_stride, K, 1],
+            block_shape=[1, BLOCK_SIZE_N, BLOCK_SIZE_K],
         )
 
     m_end = 0
@@ -104,7 +104,7 @@ def _grouped_gemm_dX_kernel(
     n_block_range = tl.arange(0, BLOCK_SIZE_N)
     k_block_range = tl.arange(0, BLOCK_SIZE_K)
 
-    for expert_idx in range(NUM_EXPERTS, flatten = FLATTEN):
+    for expert_idx in range(NUM_EXPERTS, flatten=FLATTEN):
         m_start = m_end
         m_size = tl.load(m_sizes_ptr + expert_idx).to(tl.int32)
         m_end = m_start + m_size
@@ -125,9 +125,9 @@ def _grouped_gemm_dX_kernel(
                 )
                 dX_desc = tl.make_tensor_descriptor(
                     dX_ptr,
-                    shape = [m_end, K],
-                    strides = [K, 1],
-                    block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_K],
+                    shape=[m_end, K],
+                    strides=[K, 1],
+                    block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
                 )
 
             # Lower bound and upper bound are defined relative to the total tiles processed so far
@@ -152,7 +152,7 @@ def _grouped_gemm_dX_kernel(
                     )
                     expert_token_idx = tl.load(
                         gather_indices_ptr + indices_to_gather,
-                        mask = indices_to_gather < TOTAL_TOKENS,
+                        mask=indices_to_gather < TOTAL_TOKENS,
                     )
                     expert_token_offsets = expert_token_idx[:, None]
 
@@ -210,13 +210,13 @@ def _grouped_gemm_dX_kernel(
                 # col_mask = offs_bk[None, :] < K
                 store_mask = row_mask  # & col_mask
 
-                accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_K), dtype = tl.float32)
+                accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_K), dtype=tl.float32)
 
                 # GEMM main loop
                 for n_offset in range(0, N, BLOCK_SIZE_N):
                     # dY block [M, N]
                     if not USE_TMA_LOAD_dY:
-                        dY = tl.load(dY_ptrs, mask = row_mask)
+                        dY = tl.load(dY_ptrs, mask=row_mask)
                     else:
                         dY = dY_desc.load(
                             [m_start + tile_m_idx * BLOCK_SIZE_M, n_offset]
@@ -254,7 +254,7 @@ def _grouped_gemm_dX_kernel(
                     tl.store(
                         dX_ptr + store_idx + offs_bk[None, :],
                         dX,
-                        mask = store_mask,
+                        mask=store_mask,
                     )
 
                 # Move to the next tile within this expert group
@@ -265,10 +265,10 @@ def _grouped_gemm_dX_kernel(
 
 
 _autotuned_grouped_gemm_dX_kernel = triton.autotune(
-    configs = get_dX_kernel_configs(),
-    prune_configs_by = {"early_config_prune": prune_dX_configs},
+    configs=get_dX_kernel_configs(),
+    prune_configs_by={"early_config_prune": prune_dX_configs},
     # NOTE: NUM_TOKENS removed from key to avoid recompilation for every sequence length
-    key = ["NUM_EXPERTS", "N", "K", "PERMUTE_X", "PERMUTE_Y"],
+    key=["NUM_EXPERTS", "N", "K", "PERMUTE_X", "PERMUTE_Y"],
 )(_grouped_gemm_dX_kernel)
 
 """
@@ -326,17 +326,17 @@ def _grouped_gemm_dW_kernel(
     if USE_TMA_LOAD_dY and not TMA_LOAD_BOTH:
         dY_desc = tl.make_tensor_descriptor(
             dY_ptr,
-            shape = [TOTAL_TOKENS, N],
-            strides = [N, 1],
-            block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_N],
+            shape=[TOTAL_TOKENS, N],
+            strides=[N, 1],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
         )
 
     if USE_TMA_LOAD_X and not TMA_LOAD_BOTH:
         x_desc = tl.make_tensor_descriptor(
             x_ptr,
-            shape = [TOTAL_TOKENS, K],
-            strides = [K, 1],
-            block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_K],
+            shape=[TOTAL_TOKENS, K],
+            strides=[K, 1],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
         )
     # Output tiles per expert, since each expert weight matrix is [N, K]
     num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N)
@@ -353,9 +353,9 @@ def _grouped_gemm_dW_kernel(
         tl.static_assert(K % BLOCK_SIZE_K == 0, "K must be divisible by BLOCK_SIZE_K")
         dW_desc = tl.make_tensor_descriptor(
             dW_ptr,
-            shape = [NUM_EXPERTS, N, K],
-            strides = [N * K, K, 1],
-            block_shape = [1, BLOCK_SIZE_N, BLOCK_SIZE_K],
+            shape=[NUM_EXPERTS, N, K],
+            strides=[N * K, K, 1],
+            block_shape=[1, BLOCK_SIZE_N, BLOCK_SIZE_K],
         )
 
     for tile_idx in range(
@@ -379,7 +379,7 @@ def _grouped_gemm_dW_kernel(
         m_end = 0
         for expert_idx in range(NUM_EXPERTS):
             # We need to instantiate a fresh accumulator for each expert
-            accumulator = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_K), dtype = acc_dtype)
+            accumulator = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_K), dtype=acc_dtype)
 
             m_start = m_end
             # Need to figure out why this cast is needed, otherwise compiler complains about mismatching types
@@ -394,16 +394,16 @@ def _grouped_gemm_dW_kernel(
                 if TMA_LOAD_BOTH:
                     dY_desc = tl.make_tensor_descriptor(
                         dY_ptr,
-                        shape = [m_end, N],
-                        strides = [N, 1],
-                        block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_N],
+                        shape=[m_end, N],
+                        strides=[N, 1],
+                        block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
                     )
 
                     x_desc = tl.make_tensor_descriptor(
                         x_ptr,
-                        shape = [m_end, K],
-                        strides = [K, 1],
-                        block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_K],
+                        shape=[m_end, K],
+                        strides=[K, 1],
+                        block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
                     )
 
                 for tile_m_idx in range(0, m_size, BLOCK_SIZE_M):
@@ -427,7 +427,7 @@ def _grouped_gemm_dW_kernel(
                             # indices_to_gather = m_start + gather_offsets
                             expert_token_idx = tl.load(
                                 gather_indices_ptr + indices_to_gather,
-                                mask = indices_to_gather < TOTAL_TOKENS,
+                                mask=indices_to_gather < TOTAL_TOKENS,
                             )
                             expert_token_offsets = expert_token_idx[:, None]
 
@@ -463,7 +463,7 @@ def _grouped_gemm_dW_kernel(
                                 x_ptr
                                 + x_row_load_idx
                                 + (k_offset + block_range_k)[None, :],
-                                mask = mk_mask,
+                                mask=mk_mask,
                             )
 
                         if USE_TMA_LOAD_dY:
@@ -473,7 +473,7 @@ def _grouped_gemm_dW_kernel(
                                 dY_ptr
                                 + dY_row_load_idx
                                 + (n_offset + block_range_n)[None, :],
-                                mask = mn_mask,
+                                mask=mn_mask,
                             )
 
                         accumulator += tl.dot(
@@ -493,13 +493,13 @@ def _grouped_gemm_dW_kernel(
                         + store_row_offs[:, None] * K
                         + (k_offset + block_range_k)[None, :],
                         y,
-                        mask = nk_mask,
+                        mask=nk_mask,
                     )
 
 
 _autotuned_grouped_gemm_dW_kernel = triton.autotune(
-    configs = get_dW_kernel_configs(),
-    prune_configs_by = {"early_config_prune": prune_kernel_configs_backward_dW},
+    configs=get_dW_kernel_configs(),
+    prune_configs_by={"early_config_prune": prune_kernel_configs_backward_dW},
     # NOTE: NUM_TOKENS removed from key to avoid recompilation for every sequence length
-    key = ["NUM_EXPERTS", "N", "K", "PERMUTE_X", "PERMUTE_Y"],
+    key=["NUM_EXPERTS", "N", "K", "PERMUTE_X", "PERMUTE_Y"],
 )(_grouped_gemm_dW_kernel)

--- a/unsloth/kernels/moe/grouped_gemm/kernels/forward.py
+++ b/unsloth/kernels/moe/grouped_gemm/kernels/forward.py
@@ -68,25 +68,25 @@ def _grouped_gemm_forward_kernel(
     if USE_TMA_LOAD_X:
         x_desc = tl.make_tensor_descriptor(
             x_ptr,
-            shape = [TOTAL_TOKENS, K],
-            strides = [K, 1],
-            block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_K],
+            shape=[TOTAL_TOKENS, K],
+            strides=[K, 1],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
         )
 
     if USE_TMA_LOAD_W:
         expert_stride = N * K
         w_desc = tl.make_tensor_descriptor(
             w_ptr,
-            shape = [NUM_EXPERTS, N, K],
-            strides = [expert_stride, K, 1],
-            block_shape = [1, BLOCK_SIZE_N, BLOCK_SIZE_K],
+            shape=[NUM_EXPERTS, N, K],
+            strides=[expert_stride, K, 1],
+            block_shape=[1, BLOCK_SIZE_N, BLOCK_SIZE_K],
         )
 
     m_end = 0
     processed_tiles = 0
     m_block_range = tl.arange(0, BLOCK_SIZE_M)
 
-    for expert_idx in tl.range(NUM_EXPERTS, flatten = FLATTEN):
+    for expert_idx in tl.range(NUM_EXPERTS, flatten=FLATTEN):
         m_start = m_end
         m_size = tl.load(m_sizes_ptr + expert_idx).to(tl.int32)
         m_end = m_start + m_size
@@ -102,9 +102,9 @@ def _grouped_gemm_forward_kernel(
             if USE_TMA_STORE:
                 y_desc = tl.make_tensor_descriptor(
                     y_ptr,  # + m_start * N,
-                    shape = [m_end, N],
-                    strides = [N, 1],
-                    block_shape = [BLOCK_SIZE_M, BLOCK_SIZE_N],
+                    shape=[m_end, N],
+                    strides=[N, 1],
+                    block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
                 )
 
             # Process tiles for this expert
@@ -127,7 +127,7 @@ def _grouped_gemm_forward_kernel(
                     )
                     expert_token_idx = tl.load(
                         gather_indices_ptr + indices_to_gather,
-                        mask = indices_to_gather < TOTAL_TOKENS,
+                        mask=indices_to_gather < TOTAL_TOKENS,
                     )
                     expert_token_offsets = expert_token_idx[:, None]
 
@@ -178,7 +178,7 @@ def _grouped_gemm_forward_kernel(
                 if SHOULD_FUSE_MUL:
                     topk_load_idx = expert_token_offsets
 
-                accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype = acc_dtype)
+                accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
                 offs_k = tl.arange(0, BLOCK_SIZE_K)
 
@@ -194,19 +194,19 @@ def _grouped_gemm_forward_kernel(
 
                 for k_offset in range(0, K, BLOCK_SIZE_K):
                     if not USE_TMA_LOAD_X:
-                        x = tl.load(x_ptrs, mask = row_mask)
+                        x = tl.load(x_ptrs, mask=row_mask)
                     else:
                         x = x_desc.load([m_start + off_am, k_offset])
 
                     if FUSE_MUL_PRE:
                         # Check for correct broadcasting
                         topk_weights = tl.load(
-                            topk_weights_ptr + topk_load_idx, mask = row_mask
+                            topk_weights_ptr + topk_load_idx, mask=row_mask
                         )
                         x *= topk_weights.to(x.dtype)
 
                     if not USE_TMA_LOAD_W:
-                        w = tl.load(w_ptrs, mask = offs_bn[:, None] < N)
+                        w = tl.load(w_ptrs, mask=offs_bn[:, None] < N)
                     else:
                         w = w_desc.load(
                             [expert_idx, tile_n_idx * BLOCK_SIZE_N, k_offset]
@@ -229,7 +229,7 @@ def _grouped_gemm_forward_kernel(
                 if FUSE_MUL_POST:
                     # Check for correct broadcasting
                     topk_weights = tl.load(
-                        topk_weights_ptr + topk_load_idx, mask = row_mask
+                        topk_weights_ptr + topk_load_idx, mask=row_mask
                     )
                     y *= topk_weights.to(output_dtype)
 
@@ -244,7 +244,7 @@ def _grouped_gemm_forward_kernel(
                     tl.store(
                         y_ptr + store_idx + offs_bn[None, :],
                         y,
-                        mask = store_mask,
+                        mask=store_mask,
                     )
                 tidx += NUM_SMS
 
@@ -252,11 +252,11 @@ def _grouped_gemm_forward_kernel(
 
 
 _autotuned_grouped_gemm_forward_kernel = triton.autotune(
-    configs = get_forward_configs(),
-    prune_configs_by = {"early_config_prune": prune_kernel_configs_fwd},
+    configs=get_forward_configs(),
+    prune_configs_by={"early_config_prune": prune_kernel_configs_fwd},
     # NOTE: NUM_TOKENS removed from key to avoid recompilation for every sequence length
     # The kernel handles variable token counts via m_sizes and tile-based processing
-    key = [
+    key=[
         "NUM_EXPERTS",
         "N",
         "K",

--- a/unsloth/kernels/moe/grouped_gemm/reference/moe_block.py
+++ b/unsloth/kernels/moe/grouped_gemm/reference/moe_block.py
@@ -80,14 +80,14 @@ class Qwen3MoeFusedGroupedGEMMBlock(Qwen3MoeGroupedGEMMBlock):
             gate,
             gate_up_proj,
             down_proj,
-            permute_x = permute_x,
-            permute_y = permute_y,
-            autotune = autotune,
-            kernel_config_fwd = kernel_config_fwd,
-            kernel_config_bwd_dW = kernel_config_bwd_dW,
-            kernel_config_bwd_dX = kernel_config_bwd_dX,
-            dW_only = dW_only,
-            dX_only = dX_only,
+            permute_x=permute_x,
+            permute_y=permute_y,
+            autotune=autotune,
+            kernel_config_fwd=kernel_config_fwd,
+            kernel_config_bwd_dW=kernel_config_bwd_dW,
+            kernel_config_bwd_dX=kernel_config_bwd_dX,
+            dW_only=dW_only,
+            dX_only=dX_only,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -112,37 +112,37 @@ class Qwen3MoeFusedGroupedGEMMBlock(Qwen3MoeGroupedGEMMBlock):
             hidden_states = permute(hidden_states, gather_indices, self.top_k)
         # Start expert computation
         hidden_states = grouped_gemm(
-            X = hidden_states,
-            W = self.gate_up_proj,
-            m_sizes = token_counts_by_expert,
-            gather_indices = gather_indices,
-            topk = self.top_k,
-            permute_x = self.permute_x,
-            permute_y = False,  # output of first grouped gemm should never be permuted
-            autotune = self.autotune,
-            kernel_config_fwd = self.kernel_config_fwd,
-            kernel_config_bwd_dW = self.kernel_config_bwd_dW,
-            kernel_config_bwd_dX = self.kernel_config_bwd_dX,
-            is_first_gemm = True,
-            dW_only = self.dW_only,
-            dX_only = self.dX_only,
+            X=hidden_states,
+            W=self.gate_up_proj,
+            m_sizes=token_counts_by_expert,
+            gather_indices=gather_indices,
+            topk=self.top_k,
+            permute_x=self.permute_x,
+            permute_y=False,  # output of first grouped gemm should never be permuted
+            autotune=self.autotune,
+            kernel_config_fwd=self.kernel_config_fwd,
+            kernel_config_bwd_dW=self.kernel_config_bwd_dW,
+            kernel_config_bwd_dX=self.kernel_config_bwd_dX,
+            is_first_gemm=True,
+            dW_only=self.dW_only,
+            dX_only=self.dX_only,
         )
         hidden_states = self.act_and_mul(hidden_states)
         hidden_states = grouped_gemm(
-            X = hidden_states,
-            W = self.down_proj,
-            m_sizes = token_counts_by_expert,
-            gather_indices = gather_indices,
-            topk = self.top_k,
-            permute_x = False,
-            permute_y = self.permute_y,
-            autotune = self.autotune,
-            kernel_config_fwd = self.kernel_config_fwd,
-            kernel_config_bwd_dW = self.kernel_config_bwd_dW,
-            kernel_config_bwd_dX = self.kernel_config_bwd_dX,
-            is_first_gemm = False,
-            dW_only = self.dW_only,
-            dX_only = self.dX_only,
+            X=hidden_states,
+            W=self.down_proj,
+            m_sizes=token_counts_by_expert,
+            gather_indices=gather_indices,
+            topk=self.top_k,
+            permute_x=False,
+            permute_y=self.permute_y,
+            autotune=self.autotune,
+            kernel_config_fwd=self.kernel_config_fwd,
+            kernel_config_bwd_dW=self.kernel_config_bwd_dW,
+            kernel_config_bwd_dX=self.kernel_config_bwd_dX,
+            is_first_gemm=False,
+            dW_only=self.dW_only,
+            dX_only=self.dX_only,
         )
 
         # Post-processing
@@ -155,7 +155,7 @@ class Qwen3MoeFusedGroupedGEMMBlock(Qwen3MoeGroupedGEMMBlock):
             hidden_states.view(num_tokens, self.top_k, hidden_dim)
             * routing_weights[..., None]
         )
-        hidden_states = hidden_states.sum(dim = 1)
+        hidden_states = hidden_states.sum(dim=1)
 
         hidden_states = hidden_states.view(batch_size, sequence_length, hidden_dim)
         return hidden_states, router_logits

--- a/unsloth/kernels/moe/tests/common.py
+++ b/unsloth/kernels/moe/tests/common.py
@@ -18,7 +18,7 @@ from grouped_gemm.kernels.tuning import (
 )
 
 
-def print_delimiter(char = "-", length = 80):
+def print_delimiter(char="-", length=80):
     print(char * length)
 
 
@@ -29,28 +29,28 @@ def delimiter_context():
     print_delimiter()
 
 
-def make_inputs(M, N, K, E, topk, dtype, requires_grad = False):
+def make_inputs(M, N, K, E, topk, dtype, requires_grad=False):
     X1 = (
-        torch.randn((M, K), device = "cuda", dtype = dtype, requires_grad = requires_grad)
+        torch.randn((M, K), device="cuda", dtype=dtype, requires_grad=requires_grad)
         / 10
     )
     X2 = (
         torch.randn(
-            (M * topk, N), device = "cuda", dtype = dtype, requires_grad = requires_grad
+            (M * topk, N), device="cuda", dtype=dtype, requires_grad=requires_grad
         )
         / 10
     )
     W1 = (
         torch.randn(
-            (E, 2 * N, K), device = "cuda", dtype = dtype, requires_grad = requires_grad
+            (E, 2 * N, K), device="cuda", dtype=dtype, requires_grad=requires_grad
         )
         / 10
     )
     W2 = (
-        torch.randn((E, K, N), device = "cuda", dtype = dtype, requires_grad = requires_grad)
+        torch.randn((E, K, N), device="cuda", dtype=dtype, requires_grad=requires_grad)
         / 10
     )
-    score = torch.randn((M, E), device = "cuda", dtype = dtype, requires_grad = requires_grad)
+    score = torch.randn((M, E), device="cuda", dtype=dtype, requires_grad=requires_grad)
     if requires_grad:
         X1.retain_grad()
         X2.retain_grad()
@@ -60,7 +60,7 @@ def make_inputs(M, N, K, E, topk, dtype, requires_grad = False):
     return X1, X2, W1, W2, score
 
 
-@dataclass(kw_only = True)
+@dataclass(kw_only=True)
 class DataConfig:
     seq_len: int
     dtype: torch.dtype
@@ -68,7 +68,7 @@ class DataConfig:
     bs: int = 1
 
 
-@dataclass(kw_only = True)
+@dataclass(kw_only=True)
 class ModelConfig:
     hidden_size: int
     intermediate_size: int
@@ -77,13 +77,13 @@ class ModelConfig:
     use_sigmoid: bool
     renormalize: bool
     pre_mul: bool = False
-    post_mul: bool = field(init = False)
+    post_mul: bool = field(init=False)
 
     def __post_init__(self):
         self.post_mul = not self.pre_mul
 
 
-@dataclass(kw_only = True)
+@dataclass(kw_only=True)
 class GroupedGEMMTestConfig:
     name: str = "test"
     data_config: DataConfig
@@ -105,7 +105,7 @@ def assert_equal(ref, tri):
         assert ref == tri, f"ref not equal to tri {ref} != {tri}"
 
 
-def assert_close(ref, tri, maxtol = None, rmstol = None, description = "--", verbose = True):
+def assert_close(ref, tri, maxtol=None, rmstol=None, description="--", verbose=True):
     if tri.dtype.itemsize == 1:
         ref_as_type = ref.to(tri.dtype)
         if ref.dtype == tri.dtype:
@@ -182,11 +182,11 @@ def assert_indx_equal(ref, tri):
 
 
 def get_kernel_test_configs(
-    BLOCK_SIZE_M = 32,
-    BLOCK_SIZE_N = 32,
-    BLOCK_SIZE_K = 32,
-    num_warps = 4,
-    num_stages = 2,
+    BLOCK_SIZE_M=32,
+    BLOCK_SIZE_N=32,
+    BLOCK_SIZE_K=32,
+    num_warps=4,
+    num_stages=2,
 ) -> list[KernelConfig]:
     configs_fwd = []
     configs_bwd_dX = []
@@ -199,44 +199,44 @@ def get_kernel_test_configs(
                     for use_tma_store in [True, False]:
                         configs_fwd.append(
                             KernelConfigForward(
-                                BLOCK_SIZE_M = BLOCK_SIZE_M,
-                                BLOCK_SIZE_N = BLOCK_SIZE_N,
-                                BLOCK_SIZE_K = BLOCK_SIZE_K,
-                                num_warps = num_warps,
-                                num_stages = num_stages,
-                                use_tma_load_w = use_tma_load_w,
-                                use_tma_load_x = use_tma_load_x,
-                                use_tma_store = use_tma_store,
-                                permute_x = permute_x,
-                                permute_y = permute_y,
+                                BLOCK_SIZE_M=BLOCK_SIZE_M,
+                                BLOCK_SIZE_N=BLOCK_SIZE_N,
+                                BLOCK_SIZE_K=BLOCK_SIZE_K,
+                                num_warps=num_warps,
+                                num_stages=num_stages,
+                                use_tma_load_w=use_tma_load_w,
+                                use_tma_load_x=use_tma_load_x,
+                                use_tma_store=use_tma_store,
+                                permute_x=permute_x,
+                                permute_y=permute_y,
                             )
                         )
                         configs_bwd_dX.append(
                             KernelConfigBackward_dX(
-                                BLOCK_SIZE_M = BLOCK_SIZE_M,
-                                BLOCK_SIZE_N = BLOCK_SIZE_N,
-                                BLOCK_SIZE_K = BLOCK_SIZE_K,
-                                num_warps = num_warps,
-                                num_stages = num_stages,
-                                use_tma_load_dy = use_tma_load_x,
-                                use_tma_load_w = use_tma_load_w,
-                                permute_x = permute_x,
-                                permute_y = permute_y,
-                                use_tma_store = use_tma_store,
+                                BLOCK_SIZE_M=BLOCK_SIZE_M,
+                                BLOCK_SIZE_N=BLOCK_SIZE_N,
+                                BLOCK_SIZE_K=BLOCK_SIZE_K,
+                                num_warps=num_warps,
+                                num_stages=num_stages,
+                                use_tma_load_dy=use_tma_load_x,
+                                use_tma_load_w=use_tma_load_w,
+                                permute_x=permute_x,
+                                permute_y=permute_y,
+                                use_tma_store=use_tma_store,
                             )
                         )
                         configs_bwd_dW.append(
                             KernelConfigBackward_dW(
-                                BLOCK_SIZE_M = BLOCK_SIZE_M,
-                                BLOCK_SIZE_N = BLOCK_SIZE_N,
-                                BLOCK_SIZE_K = BLOCK_SIZE_K,
-                                num_warps = num_warps,
-                                num_stages = num_stages,
-                                use_tma_load_dy = use_tma_load_w,
-                                use_tma_load_x = use_tma_load_x,
-                                permute_x = permute_x,
-                                permute_y = permute_y,
-                                use_tma_store = use_tma_store,
+                                BLOCK_SIZE_M=BLOCK_SIZE_M,
+                                BLOCK_SIZE_N=BLOCK_SIZE_N,
+                                BLOCK_SIZE_K=BLOCK_SIZE_K,
+                                num_warps=num_warps,
+                                num_stages=num_stages,
+                                use_tma_load_dy=use_tma_load_w,
+                                use_tma_load_x=use_tma_load_x,
+                                permute_x=permute_x,
+                                permute_y=permute_y,
+                                use_tma_store=use_tma_store,
                             )
                         )
     configs_fwd = prune_kernel_configs_fwd(configs_fwd)
@@ -289,39 +289,39 @@ TEST_MODEL_SIZES = [
 
 SMALL_MODEL_CONFIGS = [
     ModelConfig(
-        topk = topk,
-        num_experts = num_experts,
-        hidden_size = model_size[0],
-        intermediate_size = model_size[1],
-        use_sigmoid = False,
-        renormalize = False,
+        topk=topk,
+        num_experts=num_experts,
+        hidden_size=model_size[0],
+        intermediate_size=model_size[1],
+        use_sigmoid=False,
+        renormalize=False,
     )
     for topk, num_experts, model_size in itertools.product(
         TOPK, NUM_EXPERTS, TEST_MODEL_SIZES
     )
 ]
 LLAMA_MODEL_CONFIG = ModelConfig(
-    topk = 1,
-    num_experts = 16,
-    hidden_size = 5120,
-    intermediate_size = 8192,
-    use_sigmoid = True,
-    renormalize = False,
+    topk=1,
+    num_experts=16,
+    hidden_size=5120,
+    intermediate_size=8192,
+    use_sigmoid=True,
+    renormalize=False,
 )
 QWEN_MODEL_CONFIG = ModelConfig(
-    topk = 8,
-    num_experts = 128,
-    hidden_size = 2048,
-    intermediate_size = 768,
-    use_sigmoid = False,
-    renormalize = False,
+    topk=8,
+    num_experts=128,
+    hidden_size=2048,
+    intermediate_size=768,
+    use_sigmoid=False,
+    renormalize=False,
 )
 
 SEQLENS = [128, 1024]
 DTYPE = [torch.bfloat16]
 
 DATA_CONFIGS = [
-    DataConfig(seq_len = seq_len, dtype = dtype)
+    DataConfig(seq_len=seq_len, dtype=dtype)
     for seq_len, dtype in itertools.product(SEQLENS, DTYPE)
 ]
 KERNEL_CONFIGS_FWD, KERNEL_CONFIGS_BWD_dX, KERNEL_CONFIGS_BWD_dW = (
@@ -331,6 +331,6 @@ KERNEL_CONFIGS_FWD, KERNEL_CONFIGS_BWD_dX, KERNEL_CONFIGS_BWD_dW = (
 if __name__ == "__main__":
     print(
         KERNEL_CONFIGS_BWD_dX[0].to_string(
-            include_tuning_params = False, include_tma = False
+            include_tuning_params=False, include_tma=False
         )
     )

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -178,7 +178,7 @@ def resolve_hip_gpu_stats_name(gpu_stats):
 
     if arch_name:
         arch_name = arch_name.strip()
-        match = re.search(r"(gfx[0-9a-z]+)", arch_name, flags = re.I)
+        match = re.search(r"(gfx[0-9a-z]+)", arch_name, flags=re.I)
         if match:
             return f"AMD {match.group(1).lower()} GPU. "
     return "AMD GPU. "
@@ -214,7 +214,7 @@ def apply_unsloth_gradient_checkpointing(
             unpatch_unsloth_smart_gradient_checkpointing()
             return True
         else:
-            patch_unsloth_smart_gradient_checkpointing(dtype = dtype)
+            patch_unsloth_smart_gradient_checkpointing(dtype=dtype)
             return "unsloth"
     elif use_gradient_checkpointing in (True, False):
         # User explicitly set True or False - unpatch any previous "unsloth" patching
@@ -302,7 +302,7 @@ def _run_temporary_patches(phase):
         try:
             sig = inspect.signature(temporary_patch)
             if "phase" in sig.parameters:
-                temporary_patch(phase = phase)
+                temporary_patch(phase=phase)
             else:
                 temporary_patch()
         except (ValueError, TypeError):
@@ -313,24 +313,24 @@ _run_temporary_patches("init")
 
 # =============================================
 # Disable some warnings which can get annoying
-warnings.filterwarnings(action = "ignore", category = UserWarning, module = "torch")
-warnings.filterwarnings(action = "ignore", category = FutureWarning, module = "torch")
-warnings.filterwarnings(action = "ignore", category = UserWarning, module = "huggingface_hub")
+warnings.filterwarnings(action="ignore", category=UserWarning, module="torch")
+warnings.filterwarnings(action="ignore", category=FutureWarning, module="torch")
+warnings.filterwarnings(action="ignore", category=UserWarning, module="huggingface_hub")
 warnings.filterwarnings(
-    action = "ignore", category = FutureWarning, module = "huggingface_hub"
+    action="ignore", category=FutureWarning, module="huggingface_hub"
 )
-warnings.filterwarnings(action = "ignore", category = UserWarning, module = "trl")
-warnings.filterwarnings(action = "ignore", category = FutureWarning, module = "trl")
-warnings.filterwarnings(action = "ignore", category = FutureWarning, module = "xformers")
-warnings.filterwarnings(action = "ignore", category = RuntimeWarning, module = "subprocess")
-warnings.filterwarnings(action = "ignore", category = UserWarning, module = "transformers")
-warnings.filterwarnings(action = "ignore", category = FutureWarning, module = "accelerate")
+warnings.filterwarnings(action="ignore", category=UserWarning, module="trl")
+warnings.filterwarnings(action="ignore", category=FutureWarning, module="trl")
+warnings.filterwarnings(action="ignore", category=FutureWarning, module="xformers")
+warnings.filterwarnings(action="ignore", category=RuntimeWarning, module="subprocess")
+warnings.filterwarnings(action="ignore", category=UserWarning, module="transformers")
+warnings.filterwarnings(action="ignore", category=FutureWarning, module="accelerate")
 warnings.filterwarnings(
-    action = "ignore", category = RuntimeWarning, module = "multiprocessing"
+    action="ignore", category=RuntimeWarning, module="multiprocessing"
 )
-warnings.filterwarnings(action = "ignore", category = RuntimeWarning, module = "multiprocess")
-warnings.filterwarnings(action = "ignore", category = UserWarning, module = "triton")
-warnings.filterwarnings(action = "ignore", category = UserWarning, module = "bitsandbytes")
+warnings.filterwarnings(action="ignore", category=RuntimeWarning, module="multiprocess")
+warnings.filterwarnings(action="ignore", category=UserWarning, module="triton")
+warnings.filterwarnings(action="ignore", category=UserWarning, module="bitsandbytes")
 
 # Stop "Special tokens have been added in the vocabulary, ..."
 logging.getLogger("transformers.tokenization_utils_base").setLevel(logging.CRITICAL + 1)
@@ -361,7 +361,7 @@ class ReplaceWarningMessage:
     _installed = False
 
     @classmethod
-    def add_rule(cls, match_text, replacement, category = None):
+    def add_rule(cls, match_text, replacement, category=None):
         cls._rules.append((match_text, replacement, category))
         if not cls._installed:
             cls._install()
@@ -372,7 +372,7 @@ class ReplaceWarningMessage:
         cls._installed = True
 
         def _patched_showwarning(
-            message, category, filename, lineno, file = None, line = None
+            message, category, filename, lineno, file=None, line=None
         ):
             msg_str = str(message)
             for match_text, replacement, match_category in cls._rules:
@@ -567,10 +567,10 @@ except:
 # You passed `quantization_config` or equivalent parameters
 try:
     warnings.filterwarnings(
-        action = "ignore",
-        message = r".*quantization_config.*",
-        category = UserWarning,
-        append = True,
+        action="ignore",
+        message=r".*quantization_config.*",
+        category=UserWarning,
+        append=True,
     )
 except:
     pass
@@ -579,10 +579,10 @@ except:
 # Will be fixed in torch 2.8.1 https://github.com/pytorch/pytorch/issues/158463
 try:
     warnings.filterwarnings(
-        action = "ignore",
-        message = r".*Logical operators 'and' and 'or'.*",
-        category = UserWarning,
-        append = True,
+        action="ignore",
+        message=r".*Logical operators 'and' and 'or'.*",
+        category=UserWarning,
+        append=True,
     )
 except:
     pass
@@ -692,12 +692,12 @@ except:
 
 # Replace PEFT target_parameters warning with Unsloth branded message for MoE models
 ReplaceWarningMessage.add_rule(
-    match_text = "target_parameters",
-    replacement = (
+    match_text="target_parameters",
+    replacement=(
         "Unsloth: PEFT set target_parameters but found no matching parameters.\n"
         "This is expected for MoE models - Unsloth handles MoE expert LoRA targeting separately."
     ),
-    category = RuntimeWarning,
+    category=RuntimeWarning,
 )
 
 # Patch get_model_param_count to record correct 4bit / 8bit
@@ -717,7 +717,7 @@ def extract_quant_model_param_count(model):
     return count
 
 
-def get_model_param_count(model, trainable_only = False):
+def get_model_param_count(model, trainable_only=False):
     """
     Calculate model's total param count. If trainable_only is True then count only those requiring grads
     """
@@ -866,14 +866,14 @@ if DEVICE_TYPE in ("cuda", "hip"):
         torch_amp_custom_fwd = torch.cuda.amp.custom_fwd
         torch_amp_custom_bwd = torch.cuda.amp.custom_bwd
     else:
-        torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "cuda")
-        torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "cuda")
+        torch_amp_custom_fwd = torch.amp.custom_fwd(device_type="cuda")
+        torch_amp_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
 elif DEVICE_TYPE == "xpu":
     if Version(torch_version) < Version("2.6.0"):
         raise RuntimeError("torch.xpu currently only supports torch.version >= 2.6.0")
     else:
-        torch_amp_custom_fwd = torch.amp.custom_fwd(device_type = "xpu")
-        torch_amp_custom_bwd = torch.amp.custom_bwd(device_type = "xpu")
+        torch_amp_custom_fwd = torch.amp.custom_fwd(device_type="xpu")
+        torch_amp_custom_bwd = torch.amp.custom_bwd(device_type="xpu")
 # =============================================
 
 # =============================================
@@ -1211,9 +1211,9 @@ import torch._inductor.utils
 
 torch._inductor.utils.is_big_gpu = is_big_gpu
 patch_torch_compile(
-    debug = UNSLOTH_COMPILE_DEBUG,
-    O3 = UNSLOTH_COMPILE_MAXIMUM,
-    ignore_errors = UNSLOTH_COMPILE_IGNORE_ERRORS,
+    debug=UNSLOTH_COMPILE_DEBUG,
+    O3=UNSLOTH_COMPILE_MAXIMUM,
+    ignore_errors=UNSLOTH_COMPILE_IGNORE_ERRORS,
 )
 
 torch_compile_options = {
@@ -1260,9 +1260,9 @@ def patch_regional_compilation():
                     [
                         torch.compile(
                             x,
-                            dynamic = True,
-                            options = torch_compile_options,
-                            fullgraph = False,
+                            dynamic=True,
+                            options=torch_compile_options,
+                            fullgraph=False,
                         )
                         for x in args[0]
                     ]
@@ -1285,14 +1285,14 @@ def prepare_model_for_kbit_training(
     use_reentrant: Optional[bool] = True,
 ) -> Any:
     return prepare_model_for_training(
-        model = model,
-        use_gradient_checkpointing = use_gradient_checkpointing,
-        use_reentrant = use_reentrant,
-        full_finetuning = False,
-        train_layernorms = False,
-        train_embedding = False,
-        train_lm_head = False,
-        float32_mixed_precision = True,
+        model=model,
+        use_gradient_checkpointing=use_gradient_checkpointing,
+        use_reentrant=use_reentrant,
+        full_finetuning=False,
+        train_layernorms=False,
+        train_embedding=False,
+        train_lm_head=False,
+        float32_mixed_precision=True,
     )
 
 
@@ -1310,7 +1310,7 @@ if Version(peft_version) < Version("0.12.0"):
         text = "if weight is not None:\n"
         start = source.find(text) + len(text)
         end = source.find("self.to(weight.device)", start)
-        spaces = re.findall(r"^([ ]{1,})break", source, flags = re.MULTILINE)[0]
+        spaces = re.findall(r"^([ ]{1,})break", source, flags=re.MULTILINE)[0]
         source = source.replace(source[start:end], spaces)
         spaces = len(re.match(r"[\s]{1,}", source).group(0))
         lines = source.split("\n")
@@ -1347,7 +1347,7 @@ import socket
 
 
 @functools.lru_cache(1)
-def has_internet(host = "8.8.8.8", port = 53, timeout = 3):
+def has_internet(host="8.8.8.8", port=53, timeout=3):
     if os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1":
         return False
     try:
@@ -1365,12 +1365,12 @@ def has_internet(host = "8.8.8.8", port = 53, timeout = 3):
 import psutil
 
 
-def _get_statistics(statistics = None, force_download = True):
+def _get_statistics(statistics=None, force_download=True):
     # We log some basic stats about which environment is being used.
     # We simply download a README.md file from HF - all data is made public.
     # This is simply so we can check if some envs are broken or not.
     # You can disable this by commenting the below out
-    n_cpus = psutil.cpu_count(logical = False)
+    n_cpus = psutil.cpu_count(logical=False)
     keynames = "\n" + "\n".join(os.environ.keys())
     # Check modelscope for down detection
     global USE_MODELSCOPE
@@ -1444,12 +1444,12 @@ def _get_statistics(statistics = None, force_download = True):
         if has_internet():
 
             def stats_check():
-                with tempfile.TemporaryDirectory(ignore_cleanup_errors = True) as f:
+                with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as f:
                     snapshot_download(
                         f"unslothai/{statistics}",
-                        force_download = True,
-                        cache_dir = f,
-                        local_dir = f,
+                        force_download=True,
+                        cache_dir=f,
+                        local_dir=f,
                     )
 
             time_limited_stats_check = execute_with_time_limit(120)(stats_check)
@@ -1472,7 +1472,7 @@ def _get_statistics(statistics = None, force_download = True):
                 stats_check()
 
 
-def get_statistics(local_files_only = False):
+def get_statistics(local_files_only=False):
     # We log some basic stats about which environment is being used.
     # This is also to check if HuggingFace is down or not!
     # We simply download a README.md file from HF - all data is made public.
@@ -1498,7 +1498,7 @@ def get_statistics(local_files_only = False):
         disable_progress_bars()
         disabled = True
     _get_statistics(None)
-    _get_statistics("repeat", force_download = False)
+    _get_statistics("repeat", force_download=False)
     total_memory = (
         torch.xpu.get_device_properties(0).total_memory
         if DEVICE_TYPE == "xpu"
@@ -1539,7 +1539,7 @@ BitsAndBytesConfig__init__ = re.sub(
     r"if[\s]{1,}kwargs\:[\s]{1,}.+?\n",
     "",
     BitsAndBytesConfig__init__,
-    flags = re.MULTILINE,
+    flags=re.MULTILINE,
 )
 BitsAndBytesConfig__init__ = BitsAndBytesConfig__init__.split("\n")
 length_spaces = len(re.match(r"[\s]{1,}", BitsAndBytesConfig__init__[0]).group(0))
@@ -1619,12 +1619,12 @@ def offload_to_disk(
     torch.save(
         W,
         filename,
-        pickle_module = pickle,
-        pickle_protocol = pickle.HIGHEST_PROTOCOL,
+        pickle_module=pickle,
+        pickle_protocol=pickle.HIGHEST_PROTOCOL,
     )
     # We must use weights_only = False due to pickling
     offloaded_W = torch.load(
-        filename, map_location = "cpu", mmap = True, weights_only = False
+        filename, map_location="cpu", mmap=True, weights_only=False
     )
     offloaded_W._offloaded_file_location = filename
     return offloaded_W
@@ -1649,7 +1649,7 @@ def offload_output_embeddings(
         model.get_output_embeddings(), model, "output_embeddings", temporary_location
     )
 
-    new_output_embeddings = torch.nn.Linear(1, 1, bias = None)
+    new_output_embeddings = torch.nn.Linear(1, 1, bias=None)
     del new_output_embeddings.weight
     new_output_embeddings.weight = offloaded_W
     new_output_embeddings.in_features = offloaded_W.shape[1]
@@ -1673,10 +1673,10 @@ def is_vLLM_available():
 
 # Patches models to add RoPE Scaling
 def patch_linear_scaling(
-    model_name = "gemma2",
-    rope_module = None,
-    scaled_rope_module = None,
-    attention_module = None,
+    model_name="gemma2",
+    rope_module=None,
+    scaled_rope_module=None,
+    attention_module=None,
 ):
     assert rope_module is not None and scaled_rope_module is not None
     assert attention_module is not None
@@ -1727,13 +1727,13 @@ def patch_linear_scaling(
     pass
     """
     fix_rope_function = fix_rope_function.format(
-        rope_function = rope_module.__name__,
-        scaled_rope_function = scaled_rope_module.__name__,
+        rope_function=rope_module.__name__,
+        scaled_rope_function=scaled_rope_module.__name__,
     )
     rotary_emb = re.findall(
         r"self\.rotary\_emb \= .+?\)",
         function,
-        flags = re.DOTALL | re.MULTILINE,
+        flags=re.DOTALL | re.MULTILINE,
     )
     if len(rotary_emb) == 0:
         return None, exec_code + "\n\n" + function
@@ -1746,12 +1746,12 @@ def patch_linear_scaling(
 
 # Patches for Llama-3 LlamaExtendedRotaryEmbedding
 def patch_llama_rope_scaling(
-    model_name = "llama",
-    rope_module = None,
-    scaled_rope_module = None,
-    extended_rope_module = None,
-    attention_module = None,
-    longrope_module = None,
+    model_name="llama",
+    rope_module=None,
+    scaled_rope_module=None,
+    extended_rope_module=None,
+    attention_module=None,
+    longrope_module=None,
 ):
     assert (
         rope_module is not None
@@ -1825,17 +1825,17 @@ def patch_llama_rope_scaling(
     """
 
     fix_rope_function = fix_rope_function.format(
-        rope_function = rope_module.__name__,
-        scaled_rope_function = scaled_rope_module.__name__,
-        extended_rope_function = extended_rope_module.__name__,
-        longrope_rope_function = (
+        rope_function=rope_module.__name__,
+        scaled_rope_function=scaled_rope_module.__name__,
+        extended_rope_function=extended_rope_module.__name__,
+        longrope_rope_function=(
             longrope_module if longrope_module is not None else rope_module
         ).__name__,
     )
     rotary_emb = re.findall(
         r"self\.rotary\_emb \= .+?\)",
         function,
-        flags = re.DOTALL | re.MULTILINE,
+        flags=re.DOTALL | re.MULTILINE,
     )
     if len(rotary_emb) == 0:
         return None, function
@@ -1845,15 +1845,15 @@ def patch_llama_rope_scaling(
     return init_name, function
 
 
-def create_boolean_mask(n = 4096, sliding_window = 2048):
+def create_boolean_mask(n=4096, sliding_window=2048):
     # Creates a boolean mask for attention
-    mask = torch.ones(n, n, dtype = torch.bool)
+    mask = torch.ones(n, n, dtype=torch.bool)
     if sliding_window == 0:
-        return torch.triu(mask, diagonal = 1, out = mask)
-    torch.triu(mask, diagonal = 0, out = mask)
-    torch.triu(mask.T, diagonal = -sliding_window, out = mask.T)
+        return torch.triu(mask, diagonal=1, out=mask)
+    torch.triu(mask, diagonal=0, out=mask)
+    torch.triu(mask.T, diagonal=-sliding_window, out=mask.T)
     mask = mask.T
-    torch.logical_not(mask, out = mask)
+    torch.logical_not(mask, out=mask)
     return mask
 
 
@@ -1864,37 +1864,37 @@ def test_mask_creation():
         for s in range(1, 23):
             correct_mask = (
                 AttentionMaskConverter(
-                    is_causal = True,
-                    sliding_window = s,
+                    is_causal=True,
+                    sliding_window=s,
                 )
                 .to_causal_4d(
                     1,
                     n,
                     n,
-                    dtype = torch.float16,
+                    dtype=torch.float16,
                 )
                 .squeeze(0)
                 .squeeze(0)
             )
             correct_mask = correct_mask == correct_mask.min()
-            our_mask = create_boolean_mask(n = n, sliding_window = s)
+            our_mask = create_boolean_mask(n=n, sliding_window=s)
             assert torch.all(correct_mask == our_mask)
         correct_mask = (
             AttentionMaskConverter(
-                is_causal = True,
-                sliding_window = None,
+                is_causal=True,
+                sliding_window=None,
             )
             .to_causal_4d(
                 1,
                 n,
                 n,
-                dtype = torch.float16,
+                dtype=torch.float16,
             )
             .squeeze(0)
             .squeeze(0)
         )
         correct_mask = correct_mask == correct_mask.min()
-        our_mask = create_boolean_mask(n = n, sliding_window = 0)
+        our_mask = create_boolean_mask(n=n, sliding_window=0)
         assert torch.all(correct_mask == our_mask)
 
 
@@ -2138,34 +2138,34 @@ def unsloth_compile_transformers(
     dtype,
     model_name,
     model_types,
-    token = None,
-    revision = None,
-    trust_remote_code = False,
-    sdpa_dynamic_mask = True,
-    sdpa_bool_masks = True,
-    sdpa_gqa_replace = True,
-    sdpa_dynamic_compile = True,
-    compile_attention = True,
-    disable_causal_masks = True,
-    compile_torch_modules = True,
-    compile_custom_modules = True,
-    compile_function_calls = True,
-    fuse_lm_head = True,
-    gradient_checkpointing = True,
-    manual_replacements = True,
-    fast_lora_forwards = True,
-    fast_residual_stream = True,
-    accurate_accumulation = True,
-    epilogue_fusion = True,
-    max_autotune = False,
-    shape_padding = True,
-    cudagraphs = False,
-    debug = False,
-    fullgraph = True,
-    import_from_cache = False,
-    disable = False,
-    return_logits = False,
-    unsloth_force_compile = False,
+    token=None,
+    revision=None,
+    trust_remote_code=False,
+    sdpa_dynamic_mask=True,
+    sdpa_bool_masks=True,
+    sdpa_gqa_replace=True,
+    sdpa_dynamic_compile=True,
+    compile_attention=True,
+    disable_causal_masks=True,
+    compile_torch_modules=True,
+    compile_custom_modules=True,
+    compile_function_calls=True,
+    fuse_lm_head=True,
+    gradient_checkpointing=True,
+    manual_replacements=True,
+    fast_lora_forwards=True,
+    fast_residual_stream=True,
+    accurate_accumulation=True,
+    epilogue_fusion=True,
+    max_autotune=False,
+    shape_padding=True,
+    cudagraphs=False,
+    debug=False,
+    fullgraph=True,
+    import_from_cache=False,
+    disable=False,
+    return_logits=False,
+    unsloth_force_compile=False,
 ):
     if Version(torch_version) < Version("2.4.0"):
         print(
@@ -2195,31 +2195,31 @@ def unsloth_compile_transformers(
     for model_type in model_types:
         _unsloth_compile_transformers(
             model_type,
-            sdpa_dynamic_mask = sdpa_dynamic_mask,
-            sdpa_bool_masks = sdpa_bool_masks,
-            sdpa_gqa_replace = sdpa_gqa_replace,
-            sdpa_dynamic_compile = sdpa_dynamic_compile,
-            compile_attention = compile_attention,
-            disable_causal_masks = disable_causal_masks,
-            compile_torch_modules = compile_torch_modules,
-            compile_custom_modules = compile_custom_modules,
-            compile_function_calls = compile_function_calls,
-            fuse_lm_head = fuse_lm_head,
-            gradient_checkpointing = gradient_checkpointing,
-            manual_replacements = manual_replacements,
-            fast_lora_forwards = fast_lora_forwards,
-            fast_residual_stream = fast_residual_stream,
-            accurate_accumulation = accurate_accumulation,
-            epilogue_fusion = epilogue_fusion,
-            max_autotune = max_autotune,
-            shape_padding = shape_padding,
-            cudagraphs = cudagraphs,
-            debug = debug,
-            fullgraph = fullgraph,
-            import_from_cache = import_from_cache,
-            disable = disable,
-            return_logits = return_logits,
-            supports_sdpa = supports_sdpa,
+            sdpa_dynamic_mask=sdpa_dynamic_mask,
+            sdpa_bool_masks=sdpa_bool_masks,
+            sdpa_gqa_replace=sdpa_gqa_replace,
+            sdpa_dynamic_compile=sdpa_dynamic_compile,
+            compile_attention=compile_attention,
+            disable_causal_masks=disable_causal_masks,
+            compile_torch_modules=compile_torch_modules,
+            compile_custom_modules=compile_custom_modules,
+            compile_function_calls=compile_function_calls,
+            fuse_lm_head=fuse_lm_head,
+            gradient_checkpointing=gradient_checkpointing,
+            manual_replacements=manual_replacements,
+            fast_lora_forwards=fast_lora_forwards,
+            fast_residual_stream=fast_residual_stream,
+            accurate_accumulation=accurate_accumulation,
+            epilogue_fusion=epilogue_fusion,
+            max_autotune=max_autotune,
+            shape_padding=shape_padding,
+            cudagraphs=cudagraphs,
+            debug=debug,
+            fullgraph=fullgraph,
+            import_from_cache=import_from_cache,
+            disable=disable,
+            return_logits=return_logits,
+            supports_sdpa=supports_sdpa,
         )
     # Redo patches which override compiler
     _run_temporary_patches("post_compile")
@@ -2324,7 +2324,7 @@ def validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, m
                 "Unsloth: init_lora_weights = `loftq` is set, but `loftq_config` is None.\n"
                 "We shall use `loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)`."
             )
-            loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)
+            loftq_config = LoftQConfig(loftq_bits=4, loftq_iter=1)
 
         if hasattr(model.config, "quantization_config"):
             raise ValueError(
@@ -2400,9 +2400,9 @@ class TorchAOConfig:
     base_config_and_filter_fns: List[
         Tuple["AOBaseConfig", Optional[Callable[[torch.nn.Module, str], bool]]]
     ] = field(
-        default_factory = lambda: [
+        default_factory=lambda: [
             (
-                Int4WeightOnlyConfig(group_size = 128),
+                Int4WeightOnlyConfig(group_size=128),
                 lambda m, _: isinstance(m, torch.nn.Linear)
                 and getattr(m, "in_features", 0) >= 128,
             ),
@@ -2474,7 +2474,7 @@ def _convert_torchao_model(model):
 
     module_to_fqn_dict = {}
     for base_config, filter_fn in model._torchao_config.base_config_and_filter_fns:
-        quantize_(model, QATConfig(base_config, step = "convert"), filter_fn = filter_fn)
+        quantize_(model, QATConfig(base_config, step="convert"), filter_fn=filter_fn)
 
         # Default filter function used for quantize_
         if filter_fn is None:
@@ -2497,7 +2497,7 @@ def _convert_torchao_model(model):
         kwargs["modules_to_not_convert"] = []
 
     quant_config = ModuleFqnToConfig(module_to_fqn_dict)
-    quantization_config = TorchAoConfig(quant_type = quant_config, **kwargs)
+    quantization_config = TorchAoConfig(quant_type=quant_config, **kwargs)
     model.config.quantization_config = quantization_config
 
 
@@ -2547,8 +2547,8 @@ def _prepare_model_for_qat(
                 and m.in_features >= group_size
             )
             torchao_config = TorchAOConfig(
-                qat_scheme = qat_scheme,
-                base_config_and_filter_fns = [(base_config, filter_fn)],
+                qat_scheme=qat_scheme,
+                base_config_and_filter_fns=[(base_config, filter_fn)],
             )
         elif qat_scheme == "fp8-fp8":
             try:
@@ -2558,10 +2558,10 @@ def _prepare_model_for_qat(
             except ImportError:
                 raise ImportError(TORCHAO_MSG)
             base_config = Float8DynamicActivationFloat8WeightConfig(
-                granularity = PerRow()
+                granularity=PerRow()
             )
             torchao_config = TorchAOConfig(
-                qat_scheme = qat_scheme, base_config_and_filter_fns = [(base_config, None)]
+                qat_scheme=qat_scheme, base_config_and_filter_fns=[(base_config, None)]
             )
         elif qat_scheme == "int8-int4":
             try:
@@ -2572,22 +2572,22 @@ def _prepare_model_for_qat(
             except ImportError:
                 raise ImportError(TORCHAO_MSG)
             torchao_config = TorchAOConfig(
-                qat_scheme = qat_scheme,
-                base_config_and_filter_fns = [
+                qat_scheme=qat_scheme,
+                base_config_and_filter_fns=[
                     (
                         IntxWeightOnlyConfig(
-                            weight_dtype = torch.int8, granularity = PerAxis(0)
+                            weight_dtype=torch.int8, granularity=PerAxis(0)
                         ),
                         lambda m, fqn: isinstance(m, torch.nn.Embedding),
                     ),
                     (
                         Int8DynamicActivationIntxWeightConfig(
-                            weight_dtype = torch.int4, weight_granularity = PerGroup(32)
+                            weight_dtype=torch.int4, weight_granularity=PerGroup(32)
                         ),
                         None,
                     ),
                 ],
-                prequantization_transform = _untie_input_output_embeddings,
+                prequantization_transform=_untie_input_output_embeddings,
             )
         elif qat_scheme == "int4":
             try:
@@ -2595,14 +2595,14 @@ def _prepare_model_for_qat(
             except ImportError:
                 raise ImportError(TORCHAO_MSG)
             group_size = 128
-            base_config = Int4WeightOnlyConfig(group_size = group_size)
+            base_config = Int4WeightOnlyConfig(group_size=group_size)
             filter_fn = (
                 lambda m, _: isinstance(m, torch.nn.Linear)
                 and m.in_features >= group_size
             )
             torchao_config = TorchAOConfig(
-                qat_scheme = qat_scheme,
-                base_config_and_filter_fns = [(base_config, filter_fn)],
+                qat_scheme=qat_scheme,
+                base_config_and_filter_fns=[(base_config, filter_fn)],
             )
         elif qat_scheme == "int8":
             try:
@@ -2612,13 +2612,13 @@ def _prepare_model_for_qat(
                 raise ImportError(TORCHAO_MSG)
 
             base_config = IntxWeightOnlyConfig(
-                weight_dtype = torch.int8,
-                granularity = PerAxis(0),
+                weight_dtype=torch.int8,
+                granularity=PerAxis(0),
             )
             filter_fn = lambda m, _: isinstance(m, torch.nn.Linear)
             torchao_config = TorchAOConfig(
-                qat_scheme = qat_scheme,
-                base_config_and_filter_fns = [(base_config, filter_fn)],
+                qat_scheme=qat_scheme,
+                base_config_and_filter_fns=[(base_config, filter_fn)],
             )
         else:
             raise ValueError(f"Unexpected QAT scheme {qat_scheme}")
@@ -2636,7 +2636,7 @@ def _prepare_model_for_qat(
     if torchao_config.prequantization_transform is not None:
         torchao_config.prequantization_transform(model)
     for base_config, filter_fn in torchao_config.base_config_and_filter_fns:
-        quantize_(model, QATConfig(base_config, step = "prepare"), filter_fn = filter_fn)
+        quantize_(model, QATConfig(base_config, step="prepare"), filter_fn=filter_fn)
 
     return model
 
@@ -2730,7 +2730,7 @@ def hf_login(token: Optional[str] = None) -> Optional[str]:
     try:
         from huggingface_hub import login
 
-        login(token = token)
+        login(token=token)
         return token
     except Exception as e:
         logger.info(f"Failed to login to huggingface using token with error: {e}")
@@ -2773,7 +2773,7 @@ def is_moe_model(model) -> bool:
     return num_experts is not None and num_experts > 0
 
 
-def get_moe_target_parameters(model, target_modules = None) -> Optional[List[str]]:
+def get_moe_target_parameters(model, target_modules=None) -> Optional[List[str]]:
     """
     Get the target_parameters for MoE expert layers if applicable.
 
@@ -2954,7 +2954,7 @@ if (
             expanded.update(_get_pattern_aliases(pattern))
         return expanded
 
-    def patched_should_convert_module(full_name, patterns = None):
+    def patched_should_convert_module(full_name, patterns=None):
         if patterns is None:
             return _original_should_convert_module(full_name, patterns)
 

--- a/unsloth/models/gemma2.py
+++ b/unsloth/models/gemma2.py
@@ -125,8 +125,8 @@ def Gemma2Attention_fast_forward(
         Q, K = fast_rope_embedding(Q, K, cos, sin)
 
     if past_key_value is not None:
-        K = torch.cat([past_key_value[0], K], dim = 2)
-        V = torch.cat([past_key_value[1], V], dim = 2)
+        K = torch.cat([past_key_value[0], K], dim=2)
+        V = torch.cat([past_key_value[1], V], dim=2)
     past_key_value = (K, V) if use_cache else None
 
     # Only enable if the attention_mask is True
@@ -160,16 +160,16 @@ def Gemma2Attention_fast_forward(
         use_varlen = seq_info is not None and past_key_value is None
 
         attention_config = AttentionConfig(
-            backend = select_attention_backend(use_varlen),
-            n_kv_heads = n_kv_heads,
-            n_groups = n_groups,
-            flash_dense_kwargs = {
+            backend=select_attention_backend(use_varlen),
+            n_kv_heads=n_kv_heads,
+            n_groups=n_groups,
+            flash_dense_kwargs={
                 "causal": True,
                 "softcap": self.config.attn_logit_softcapping,
                 "softmax_scale": self._flash_attention_softmax_scale,
                 "window_size": window,
             },
-            flash_varlen_kwargs = {
+            flash_varlen_kwargs={
                 "dropout_p": 0.0,
                 "softmax_scale": self._flash_attention_softmax_scale,
                 "causal": True,
@@ -179,19 +179,19 @@ def Gemma2Attention_fast_forward(
         )
 
         context = AttentionContext(
-            bsz = bsz,
-            q_len = q_len,
-            kv_seq_len = kv_seq_len,
-            n_heads = n_heads,
-            head_dim = head_dim,
-            requires_grad = hidden_states.requires_grad,
-            seq_info = seq_info,
-            attention_mask = attention_mask,
-            causal_mask = causal_mask,
-            sliding_window = sliding_window,
+            bsz=bsz,
+            q_len=q_len,
+            kv_seq_len=kv_seq_len,
+            n_heads=n_heads,
+            head_dim=head_dim,
+            requires_grad=hidden_states.requires_grad,
+            seq_info=seq_info,
+            attention_mask=attention_mask,
+            causal_mask=causal_mask,
+            sliding_window=sliding_window,
         )
 
-        A = run_attention(config = attention_config, context = context, Q = Q, K = K, V = V)
+        A = run_attention(config=attention_config, context=context, Q=Q, K=K, V=V)
         A = A.reshape(bsz, q_len, n_heads * head_dim)
     else:
         fx = (
@@ -223,8 +223,8 @@ def Gemma2DecoderLayer_fast_forward(
     ):  # past_key_value is not None:
         out_weight = torch.empty(
             self.input_layernorm.weight.shape,
-            dtype = torch.float32,
-            device = f"{DEVICE_TYPE_TORCH}:0",
+            dtype=torch.float32,
+            device=f"{DEVICE_TYPE_TORCH}:0",
         )
 
         # Self Attention
@@ -233,15 +233,15 @@ def Gemma2DecoderLayer_fast_forward(
             self.input_layernorm, hidden_states, out_weight
         )
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            _flag_for_generation = self._flag_for_generation,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            _flag_for_generation=self._flag_for_generation,
             **kwargs,
         )
         hidden_states = fast_rms_layernorm_inference_gemma(
@@ -262,32 +262,32 @@ def Gemma2DecoderLayer_fast_forward(
     else:
         residual = hidden_states
         hidden_states = fast_rms_layernorm(
-            self.input_layernorm, hidden_states, gemma = True
+            self.input_layernorm, hidden_states, gemma=True
         )
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
             **kwargs,
         )
         hidden_states = fast_rms_layernorm(
-            self.post_attention_layernorm, hidden_states, gemma = True
+            self.post_attention_layernorm, hidden_states, gemma=True
         )
         hidden_states = residual + hidden_states
 
         # Fully Connected
         residual = hidden_states
         hidden_states = fast_rms_layernorm(
-            self.pre_feedforward_layernorm, hidden_states, gemma = True
+            self.pre_feedforward_layernorm, hidden_states, gemma=True
         )
         hidden_states = self.mlp(hidden_states)
         hidden_states = fast_rms_layernorm(
-            self.post_feedforward_layernorm, hidden_states, gemma = True
+            self.post_feedforward_layernorm, hidden_states, gemma=True
         )
         hidden_states = residual + hidden_states
 
@@ -312,9 +312,9 @@ def Gemma2Attention_fast_forward_inference(
     hidden_states: torch.Tensor,
     past_key_value: Optional[Tuple[torch.Tensor]],
     position_ids,
-    do_prefill = False,
-    attention_mask = None,
-    use_sliding_window = False,
+    do_prefill=False,
+    attention_mask=None,
+    use_sliding_window=False,
     **kwargs,
 ):
     Xn = hidden_states
@@ -339,24 +339,24 @@ def Gemma2Attention_fast_forward_inference(
     if do_prefill:
         self.paged_attention = torch.empty(
             (KV_CACHE_INCREMENT + seq_len + 1, 2, bsz, n_kv_heads, head_dim),
-            dtype = dtype,
-            device = device,
+            dtype=dtype,
+            device=device,
         )
         self.paged_attention_K = self.paged_attention[:, 0]
         self.paged_attention_V = self.paged_attention[:, 1]
         self.paged_attention_K[:seq_len] = K1.permute(2, 0, 1, 3)
         self.paged_attention_V[:seq_len] = V1.permute(2, 0, 1, 3)
         self.temp_QA = torch.empty(
-            (2, bsz, 1, attention_size), dtype = dtype, device = device
+            (2, bsz, 1, attention_size), dtype=dtype, device=device
         )
         self.temp_KV = torch.empty(
-            (2, bsz, 1, n_kv_heads * head_dim), dtype = dtype, device = device
+            (2, bsz, 1, n_kv_heads * head_dim), dtype=dtype, device=device
         )
-        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
+        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype=dtype, device=device)
         # Only for Gemma2
-        self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
+        self.temp_O = torch.empty((bsz, 1, hidden_size), dtype=dtype, device=device)
         self.attention = torch.empty(
-            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
+            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype=dtype, device=device
         )
 
         # See https://github.com/google/gemma_pytorch/commit/03e657582d17cb5a8617ebf333c1c16f3694670e
@@ -384,9 +384,9 @@ def Gemma2Attention_fast_forward_inference(
             (bsz, n_heads, 1, self.attention.shape[-1] + KV_CACHE_INCREMENT)
         )
 
-    Qn = fast_linear_forward(self.q_proj, Xn, out = self.temp_QA[0])
-    Kn = fast_linear_forward(self.k_proj, Xn, out = self.temp_KV[0])
-    Vn = fast_linear_forward(self.v_proj, Xn, out = self.temp_KV[1])
+    Qn = fast_linear_forward(self.q_proj, Xn, out=self.temp_QA[0])
+    Kn = fast_linear_forward(self.k_proj, Xn, out=self.temp_KV[0])
+    Vn = fast_linear_forward(self.v_proj, Xn, out=self.temp_KV[1])
     Qn = Qn.view(bsz, 1, n_heads, head_dim).transpose(1, 2)
     Kn = Kn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
     Vn = Vn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
@@ -455,7 +455,7 @@ def Gemma2Attention_fast_forward_inference(
         self.scalar
     )  # See https://github.com/ggerganov/llama.cpp/issues/7805#issuecomment-2153349963
     # It seems like doing (Q * scalar) @ K is better than (Q @ K) * scalar to stop overflows
-    A = torch_matmul(Qn, Knn.transpose(2, 3), out = self.attention[:, :, :, :cached_len])
+    A = torch_matmul(Qn, Knn.transpose(2, 3), out=self.attention[:, :, :, :cached_len])
 
     # Softcapping must happen BEFORE the mask is applied.
     # Reference: google-deepmind/gemma _modules.py and transformers gemma2 eager_attention_forward
@@ -469,11 +469,11 @@ def Gemma2Attention_fast_forward_inference(
             attention_mask = attention_mask[:, :, :, -A.shape[-1] :]
         A += attention_mask
 
-    A[:] = torch_nn_functional_softmax(A, dim = -1, dtype = torch.float32)  # .to(A.dtype)
-    A = torch_matmul(A, Vnn, out = Qn)
+    A[:] = torch_nn_functional_softmax(A, dim=-1, dtype=torch.float32)  # .to(A.dtype)
+    A = torch_matmul(A, Vnn, out=Qn)
     A = A.transpose(1, 2)
     A = A.reshape(bsz, 1, attention_size)
-    A = fast_linear_forward(self.o_proj, A, out = self.temp_O)
+    A = fast_linear_forward(self.o_proj, A, out=self.temp_O)
     return A, (Kn, Vn)
 
 
@@ -484,14 +484,14 @@ def Gemma2Model_fast_forward_inference(
     input_ids,
     past_key_values,
     position_ids,
-    attention_mask = None,
+    attention_mask=None,
     **kwargs,
 ):
     out_weights = tuple(
         torch.empty_like(
             self.model.layers[0].input_layernorm.weight,
-            dtype = torch.float32,
-            device = torch.device(x),
+            dtype=torch.float32,
+            device=torch.device(x),
         )
         for x in range(DEVICE_COUNT)
     )
@@ -501,7 +501,7 @@ def Gemma2Model_fast_forward_inference(
     # 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
     # 2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
     hidden_states *= torch.tensor(
-        math_sqrt(self.config.hidden_size), dtype = hidden_states.dtype
+        math_sqrt(self.config.hidden_size), dtype=hidden_states.dtype
     )
 
     bsz, q_len, hd = hidden_states.shape
@@ -516,7 +516,7 @@ def Gemma2Model_fast_forward_inference(
                 (bsz, q_len),
                 hidden_states,
                 seq_len,
-                sliding_window = self.config.sliding_window,
+                sliding_window=self.config.sliding_window,
             )
             GA = _prepare_4d_causal_attention_mask_for_sdpa(
                 attention_mask,
@@ -544,12 +544,12 @@ def Gemma2Model_fast_forward_inference(
         )
         hidden_states, present_key_value = Gemma2Attention_fast_forward_inference(
             decoder_layer.self_attn,
-            hidden_states = hidden_states,
-            past_key_value = past_key_values[idx],
-            position_ids = position_ids,
-            attention_mask = SWA if use_sliding_window else GA,
-            do_prefill = not hasattr(decoder_layer.self_attn, "paged_attention"),
-            use_sliding_window = use_sliding_window,
+            hidden_states=hidden_states,
+            past_key_value=past_key_values[idx],
+            position_ids=position_ids,
+            attention_mask=SWA if use_sliding_window else GA,
+            do_prefill=not hasattr(decoder_layer.self_attn, "paged_attention"),
+            use_sliding_window=use_sliding_window,
         )
         hidden_states = fast_rms_layernorm_inference_gemma(
             decoder_layer.post_attention_layernorm,
@@ -578,10 +578,10 @@ def Gemma2Model_fast_forward_inference(
     )
 
     return BaseModelOutputWithPast(
-        last_hidden_state = hidden_states,
-        past_key_values = next_decoder_cache,
-        hidden_states = [],
-        attentions = [],
+        last_hidden_state=hidden_states,
+        past_key_values=next_decoder_cache,
+        hidden_states=[],
+        attentions=[],
     )
 
 
@@ -589,10 +589,10 @@ class FastGemma2Model(FastLlamaModel):
     @staticmethod
     def pre_patch():
         init_name, function = patch_linear_scaling(
-            model_name = "gemma2",
-            rope_module = GemmaFixedRotaryEmbedding,
-            scaled_rope_module = GemmaFixedLinearScalingRotaryEmbedding,
-            attention_module = Gemma2Attention,
+            model_name="gemma2",
+            rope_module=GemmaFixedRotaryEmbedding,
+            scaled_rope_module=GemmaFixedLinearScalingRotaryEmbedding,
+            attention_module=Gemma2Attention,
         )
         if init_name is not None:
             exec(function, globals())
@@ -621,10 +621,10 @@ class FastGemma2Model(FastLlamaModel):
         return
 
     @staticmethod
-    def post_patch(model, tokenizer, correct_dtype = None):
+    def post_patch(model, tokenizer, correct_dtype=None):
         # Gemma does not downcast RoPE
         model, tokenizer = patch_model_and_tokenizer(
-            model, tokenizer, downcast_rope = False, correct_dtype = correct_dtype
+            model, tokenizer, downcast_rope=False, correct_dtype=correct_dtype
         )
 
         # Add 1 to weight

--- a/unsloth/models/glm4_moe.py
+++ b/unsloth/models/glm4_moe.py
@@ -163,40 +163,40 @@ def Glm4MoeLiteMoE_fast_forward(self, hidden_states):
         # First grouped GEMM: gate_up_proj with permute_x
         # Input: [num_tokens, hidden_dim] -> Output: [total_tokens, 2*intermediate_dim]
         intermediate = grouped_gemm(
-            X = hidden_states,
-            W = self.experts.gate_up_proj,
-            m_sizes = token_counts_by_expert.int(),
-            topk = self.top_k,
-            gather_indices = gather_indices,
-            permute_x = True,
-            permute_y = False,
-            autotune = True,
-            is_first_gemm = True,
+            X=hidden_states,
+            W=self.experts.gate_up_proj,
+            m_sizes=token_counts_by_expert.int(),
+            topk=self.top_k,
+            gather_indices=gather_indices,
+            permute_x=True,
+            permute_y=False,
+            autotune=True,
+            is_first_gemm=True,
         )
 
         # Activation: SiLU(gate) * up
-        gate, up = intermediate.chunk(2, dim = -1)
+        gate, up = intermediate.chunk(2, dim=-1)
         intermediate = torch_nn_functional_silu(gate) * up
 
         # Second grouped GEMM: down_proj with permute_y
         # Input: [total_tokens, intermediate_dim] -> Output: [total_tokens, hidden_dim]
         expert_output = grouped_gemm(
-            X = intermediate,
-            W = self.experts.down_proj,
-            m_sizes = token_counts_by_expert.int(),
-            topk = self.top_k,
-            gather_indices = gather_indices,
-            permute_x = False,
-            permute_y = True,
-            autotune = True,
-            is_first_gemm = False,
+            X=intermediate,
+            W=self.experts.down_proj,
+            m_sizes=token_counts_by_expert.int(),
+            topk=self.top_k,
+            gather_indices=gather_indices,
+            permute_x=False,
+            permute_y=True,
+            autotune=True,
+            is_first_gemm=False,
         )
 
         # Merge topk weights: [num_tokens, top_k, hidden_dim] -> [num_tokens, hidden_dim]
         hidden_states = (
             expert_output.view(num_tokens, self.top_k, hidden_dim)
             * topk_weights.unsqueeze(-1)
-        ).sum(dim = 1)
+        ).sum(dim=1)
     else:
         # Fallback to naive implementation
         hidden_states = self.experts(hidden_states, topk_indices, topk_weights)
@@ -234,10 +234,10 @@ def Glm4MoeLiteNaiveMoe_fast_forward(
         final_hidden_states = torch.zeros_like(hidden_states)
         with torch.no_grad():
             expert_mask = torch.nn.functional.one_hot(
-                top_k_index, num_classes = self.num_experts
+                top_k_index, num_classes=self.num_experts
             )
             expert_mask = expert_mask.permute(2, 1, 0)
-            expert_hit = torch.greater(expert_mask.sum(dim = (-1, -2)), 0).nonzero()
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
 
         for expert_idx in expert_hit:
             expert_idx = expert_idx[0]
@@ -247,7 +247,7 @@ def Glm4MoeLiteNaiveMoe_fast_forward(
             current_state = hidden_states[token_idx]
             gate, up = torch.nn.functional.linear(
                 current_state, self.gate_up_proj[expert_idx]
-            ).chunk(2, dim = -1)
+            ).chunk(2, dim=-1)
             current_hidden_states = self.act_fn(gate) * up
             current_hidden_states = torch.nn.functional.linear(
                 current_hidden_states, self.down_proj[expert_idx]
@@ -273,38 +273,38 @@ def Glm4MoeLiteNaiveMoe_fast_forward(
 
     # First grouped GEMM: gate_up_proj
     intermediate = grouped_gemm(
-        X = hidden_states,
-        W = self.gate_up_proj,
-        m_sizes = token_counts_by_expert.int(),
-        topk = top_k,
-        gather_indices = gather_indices,
-        permute_x = True,
-        permute_y = False,
-        autotune = True,
-        is_first_gemm = True,
+        X=hidden_states,
+        W=self.gate_up_proj,
+        m_sizes=token_counts_by_expert.int(),
+        topk=top_k,
+        gather_indices=gather_indices,
+        permute_x=True,
+        permute_y=False,
+        autotune=True,
+        is_first_gemm=True,
     )
 
     # Activation: SiLU(gate) * up
-    gate, up = intermediate.chunk(2, dim = -1)
+    gate, up = intermediate.chunk(2, dim=-1)
     intermediate = self.act_fn(gate) * up
 
     # Second grouped GEMM: down_proj
     expert_output = grouped_gemm(
-        X = intermediate,
-        W = self.down_proj,
-        m_sizes = token_counts_by_expert.int(),
-        topk = top_k,
-        gather_indices = gather_indices,
-        permute_x = False,
-        permute_y = True,
-        autotune = True,
-        is_first_gemm = False,
+        X=intermediate,
+        W=self.down_proj,
+        m_sizes=token_counts_by_expert.int(),
+        topk=top_k,
+        gather_indices=gather_indices,
+        permute_x=False,
+        permute_y=True,
+        autotune=True,
+        is_first_gemm=False,
     )
 
     # Merge topk weights
     final_hidden_states = (
         expert_output.view(num_tokens, top_k, hidden_dim) * top_k_weights.unsqueeze(-1)
-    ).sum(dim = 1)
+    ).sum(dim=1)
 
     return final_hidden_states
 
@@ -314,7 +314,7 @@ def Glm4MoeLiteDecoderLayer_fast_forward(
     hidden_states: torch.Tensor,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
-    past_key_values = None,
+    past_key_values=None,
     use_cache: bool = False,
     cache_position: Optional[torch.LongTensor] = None,
     position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
@@ -333,13 +333,13 @@ def Glm4MoeLiteDecoderLayer_fast_forward(
             self.input_layernorm, hidden_states
         )
         hidden_states, _ = self.self_attn(
-            hidden_states = hidden_states,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_values = past_key_values,
-            use_cache = use_cache,
-            cache_position = cache_position,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -356,13 +356,13 @@ def Glm4MoeLiteDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.input_layernorm, hidden_states)
         hidden_states, _ = self.self_attn(
-            hidden_states = hidden_states,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_values = past_key_values,
-            use_cache = use_cache,
-            cache_position = cache_position,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -418,33 +418,33 @@ class FastGLM47Model(FastLlamaModel):
 
     @staticmethod
     def from_pretrained(
-        model_name = "unsloth/GLM-4.7-Flash",
-        max_seq_length = 4096,
-        dtype = None,
-        load_in_4bit = True,
-        token = None,
-        device_map = "sequential",
-        rope_scaling = None,
-        fix_tokenizer = True,
-        model_patcher = None,
-        tokenizer_name = None,
-        trust_remote_code = False,
+        model_name="unsloth/GLM-4.7-Flash",
+        max_seq_length=4096,
+        dtype=None,
+        load_in_4bit=True,
+        token=None,
+        device_map="sequential",
+        rope_scaling=None,
+        fix_tokenizer=True,
+        model_patcher=None,
+        tokenizer_name=None,
+        trust_remote_code=False,
         **kwargs,
     ):
         # Pop kwargs that are used by loader but not passed to model
         kwargs.pop("unsloth_force_compile", None)
 
         return FastLlamaModel.from_pretrained(
-            model_name = model_name,
-            max_seq_length = max_seq_length,
-            dtype = dtype,
-            load_in_4bit = load_in_4bit,
-            token = token,
-            device_map = device_map,
-            rope_scaling = rope_scaling,
-            fix_tokenizer = fix_tokenizer,
-            model_patcher = FastGLM47Model,
-            tokenizer_name = tokenizer_name,
-            trust_remote_code = trust_remote_code,
+            model_name=model_name,
+            max_seq_length=max_seq_length,
+            dtype=dtype,
+            load_in_4bit=load_in_4bit,
+            token=token,
+            device_map=device_map,
+            rope_scaling=rope_scaling,
+            fix_tokenizer=fix_tokenizer,
+            model_patcher=FastGLM47Model,
+            tokenizer_name=tokenizer_name,
+            trust_remote_code=trust_remote_code,
             **kwargs,
         )

--- a/unsloth/models/granite.py
+++ b/unsloth/models/granite.py
@@ -120,8 +120,8 @@ def GraniteAttention_fast_forward(
         Q, K = fast_rope_embedding(Q, K, cos, sin)
 
     if past_key_value is not None:
-        K = torch.cat([past_key_value[0], K], dim = 2)
-        V = torch.cat([past_key_value[1], V], dim = 2)
+        K = torch.cat([past_key_value[0], K], dim=2)
+        V = torch.cat([past_key_value[1], V], dim=2)
     past_key_value = (K, V) if use_cache else None
 
     # Attention module
@@ -136,21 +136,21 @@ def GraniteAttention_fast_forward(
     window = (kv_seq_len, kv_seq_len)
     softmax_scale = getattr(self, "scaling", None)
     attention_config = AttentionConfig(
-        backend = backend,
-        n_kv_heads = n_kv_heads,
-        n_groups = n_groups,
-        flash_dense_kwargs = {
+        backend=backend,
+        n_kv_heads=n_kv_heads,
+        n_groups=n_groups,
+        flash_dense_kwargs={
             "causal": True,
             "softmax_scale": softmax_scale,
             "dropout_p": dropout_p,
             "window_size": window,
         },
-        flash_varlen_kwargs = {
+        flash_varlen_kwargs={
             "dropout_p": 0.0,
             "softmax_scale": softmax_scale,
             "causal": True,
         },
-        sdpa_kwargs = {
+        sdpa_kwargs={
             k: v
             for k, v in {
                 "attn_mask": attention_mask,
@@ -159,25 +159,25 @@ def GraniteAttention_fast_forward(
             }.items()
             if v is not None
         },
-        xformers_kwargs = {
+        xformers_kwargs={
             "scale": softmax_scale,
             "p": dropout_p,
         },
     )
 
     context = AttentionContext(
-        bsz = bsz,
-        q_len = q_len,
-        kv_seq_len = kv_seq_len,
-        n_heads = n_heads,
-        head_dim = head_dim,
-        requires_grad = hidden_states.requires_grad,
-        seq_info = seq_info,
-        attention_mask = attention_mask,
-        causal_mask = causal_mask,
+        bsz=bsz,
+        q_len=q_len,
+        kv_seq_len=kv_seq_len,
+        n_heads=n_heads,
+        head_dim=head_dim,
+        requires_grad=hidden_states.requires_grad,
+        seq_info=seq_info,
+        attention_mask=attention_mask,
+        causal_mask=causal_mask,
     )
 
-    A = run_attention(config = attention_config, context = context, Q = Q, K = K, V = V)
+    A = run_attention(config=attention_config, context=context, Q=Q, K=K, V=V)
 
     attn_output = A.reshape(bsz, q_len, n_heads * head_dim)
     attn_output = self.apply_o(self, attn_output)
@@ -213,19 +213,19 @@ def GraniteDecoderLayer_fast_forward(
             self.input_layernorm, hidden_states
         )
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
-            _flag_for_generation = self._flag_for_generation,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
+            _flag_for_generation=self._flag_for_generation,
             **kwargs,
         )
-        hidden_states = torch.add(residual, hidden_states, alpha = residual_multiplier)
+        hidden_states = torch.add(residual, hidden_states, alpha=residual_multiplier)
 
         # Fully Connected
         residual = hidden_states
@@ -233,29 +233,29 @@ def GraniteDecoderLayer_fast_forward(
             self.post_attention_layernorm, hidden_states
         )
         hidden_states = fast_swiglu_inference(self.mlp, hidden_states)
-        hidden_states = torch.add(residual, hidden_states, alpha = residual_multiplier)
+        hidden_states = torch.add(residual, hidden_states, alpha=residual_multiplier)
     else:
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
-        hidden_states = torch.add(residual, hidden_states, alpha = residual_multiplier)
+        hidden_states = torch.add(residual, hidden_states, alpha=residual_multiplier)
 
         # Fully Connected
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.post_attention_layernorm, hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = torch.add(residual, hidden_states, alpha = residual_multiplier)
+        hidden_states = torch.add(residual, hidden_states, alpha=residual_multiplier)
 
     outputs = (hidden_states,)
     if output_attentions:
@@ -278,9 +278,9 @@ def GraniteAttention_fast_forward_inference(
     hidden_states: torch.Tensor,
     past_key_value: Optional[Tuple[torch.Tensor]],
     position_ids,
-    do_prefill = False,
-    attention_mask = None,
-    use_sliding_window = False,
+    do_prefill=False,
+    attention_mask=None,
+    use_sliding_window=False,
     position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
 ):
     assert (
@@ -309,23 +309,23 @@ def GraniteAttention_fast_forward_inference(
     if do_prefill:
         self.paged_attention = torch.empty(
             (KV_CACHE_INCREMENT + seq_len + 1, 2, bsz, n_kv_heads, head_dim),
-            dtype = dtype,
-            device = device,
+            dtype=dtype,
+            device=device,
         )
         self.paged_attention_K = self.paged_attention[:, 0]
         self.paged_attention_V = self.paged_attention[:, 1]
         self.paged_attention_K[:seq_len] = K1.permute(2, 0, 1, 3)
         self.paged_attention_V[:seq_len] = V1.permute(2, 0, 1, 3)
         self.temp_QA = torch.empty(
-            (2, bsz, 1, attention_size), dtype = dtype, device = device
+            (2, bsz, 1, attention_size), dtype=dtype, device=device
         )
         self.temp_KV = torch.empty(
-            (2, bsz, 1, n_kv_heads * head_dim), dtype = dtype, device = device
+            (2, bsz, 1, n_kv_heads * head_dim), dtype=dtype, device=device
         )
-        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
-        self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
+        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype=dtype, device=device)
+        self.temp_O = torch.empty((bsz, 1, hidden_size), dtype=dtype, device=device)
         self.attention = torch.empty(
-            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
+            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype=dtype, device=device
         )
 
         self.half_head_dim = head_dim // 2
@@ -345,9 +345,9 @@ def GraniteAttention_fast_forward_inference(
             (bsz, n_heads, 1, self.attention.shape[-1] + KV_CACHE_INCREMENT)
         )
 
-    Qn = fast_linear_forward(self.q_proj, Xn, out = self.temp_QA[0])
-    Kn = fast_linear_forward(self.k_proj, Xn, out = self.temp_KV[0])
-    Vn = fast_linear_forward(self.v_proj, Xn, out = self.temp_KV[1])
+    Qn = fast_linear_forward(self.q_proj, Xn, out=self.temp_QA[0])
+    Kn = fast_linear_forward(self.k_proj, Xn, out=self.temp_KV[0])
+    Vn = fast_linear_forward(self.v_proj, Xn, out=self.temp_KV[1])
     Qn = Qn.view(bsz, 1, n_heads, head_dim).transpose(1, 2)
     Kn = Kn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
     Vn = Vn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
@@ -401,10 +401,10 @@ def GraniteAttention_fast_forward_inference(
     if bsz == 1:
         Qn *= self.scaling
         A = torch_matmul(
-            Qn, Kn.transpose(2, 3), out = self.attention[:, :, :, :cached_len]
+            Qn, Kn.transpose(2, 3), out=self.attention[:, :, :, :cached_len]
         )
-        A[:] = torch_nn_functional_softmax(A, dim = -1, dtype = torch.float32)
-        A = torch_matmul(A, Vn, out = Qn)
+        A[:] = torch_nn_functional_softmax(A, dim=-1, dtype=torch.float32)
+        A = torch_matmul(A, Vn, out=Qn)
     else:
         if (
             attention_mask is not None
@@ -417,21 +417,21 @@ def GraniteAttention_fast_forward_inference(
                 Qn,
                 Kn,
                 Vn,
-                attn_mask = attention_mask,
-                scale = self.scaling,
-                enable_gqa = True,
+                attn_mask=attention_mask,
+                scale=self.scaling,
+                enable_gqa=True,
             )
         else:
             A = scaled_dot_product_attention(
                 Qn,
                 Kn,
                 Vn,
-                attn_mask = attention_mask,
-                scale = self.scaling,
+                attn_mask=attention_mask,
+                scale=self.scaling,
             )
     A = A.transpose(1, 2)
     A = A.reshape(bsz, 1, attention_size)
-    A = fast_linear_forward(self.o_proj, A, out = self.temp_O)
+    A = fast_linear_forward(self.o_proj, A, out=self.temp_O)
     return A, (Kn, Vn)
 
 
@@ -442,7 +442,7 @@ def GraniteModel_fast_forward_inference(
     input_ids,
     past_key_values,
     position_ids,
-    attention_mask = None,
+    attention_mask=None,
 ):
     input_ids = input_ids[:, : self.max_seq_length]
     hidden_states = self.model.embed_tokens(input_ids)
@@ -486,37 +486,37 @@ def GraniteModel_fast_forward_inference(
         )
         hidden_states, present_key_value = GraniteAttention_fast_forward_inference(
             decoder_layer.self_attn,
-            hidden_states = hidden_states,
-            past_key_value = past_key_values[idx],
-            position_ids = position_ids,
-            attention_mask = attention_mask,
-            do_prefill = not hasattr(decoder_layer.self_attn, "paged_attention"),
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            past_key_value=past_key_values[idx],
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            do_prefill=not hasattr(decoder_layer.self_attn, "paged_attention"),
+            position_embeddings=position_embeddings,
         )
 
-        hidden_states = torch.add(residual, hidden_states, alpha = residual_multiplier)
+        hidden_states = torch.add(residual, hidden_states, alpha=residual_multiplier)
 
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference(
             decoder_layer.post_attention_layernorm, hidden_states
         )
         hidden_states = fast_swiglu_inference(decoder_layer.mlp, hidden_states)
-        hidden_states = torch.add(residual, hidden_states, alpha = residual_multiplier)
+        hidden_states = torch.add(residual, hidden_states, alpha=residual_multiplier)
 
         next_decoder_cache.append(present_key_value)
     hidden_states = fast_rms_layernorm_inference(self.model.norm, hidden_states)
 
     return BaseModelOutputWithPast(
-        last_hidden_state = hidden_states,
-        past_key_values = next_decoder_cache,
-        hidden_states = [],
-        attentions = [],
+        last_hidden_state=hidden_states,
+        past_key_values=next_decoder_cache,
+        hidden_states=[],
+        attentions=[],
     )
 
 
 class GraniteRotaryEmbedding(LlamaRotaryEmbedding):
     def __init__(self, config):
-        super().__init__(config = config)
+        super().__init__(config=config)
 
 
 def patched_init(original_init):
@@ -537,10 +537,10 @@ class FastGraniteModel(FastLlamaModel):
     @staticmethod
     def pre_patch():
         init_name, function = patch_linear_scaling(
-            model_name = "granite",
-            rope_module = GraniteRotaryEmbedding,
-            scaled_rope_module = LlamaLinearScalingRotaryEmbedding,
-            attention_module = GraniteAttention,
+            model_name="granite",
+            rope_module=GraniteRotaryEmbedding,
+            scaled_rope_module=LlamaLinearScalingRotaryEmbedding,
+            attention_module=GraniteAttention,
         )
         if init_name is not None:
             exec(function, globals())
@@ -566,7 +566,7 @@ class FastGraniteModel(FastLlamaModel):
         return
 
     @staticmethod
-    def post_patch(model, tokenizer, correct_dtype = None):
+    def post_patch(model, tokenizer, correct_dtype=None):
         # Torch.compile fails on embedding matrix??
         # Workaround randomnly fixes it for torch versions < 2.2
         model.model.embed_tokens = torch.nn.Embedding.from_pretrained(
@@ -575,7 +575,7 @@ class FastGraniteModel(FastLlamaModel):
         model.config.update({"unsloth_version": __version__})
 
         # We also do this for the lm_head
-        lm_head = torch.nn.Linear(1, 1, bias = None)
+        lm_head = torch.nn.Linear(1, 1, bias=None)
         del lm_head.weight
         lm_head.weight = model.lm_head.weight
         lm_head.in_features = lm_head.weight.shape[1]
@@ -587,7 +587,7 @@ class FastGraniteModel(FastLlamaModel):
             model.model.embed_tokens.weight.data_ptr()
             != model.lm_head.weight.data_ptr()
         ):
-            lm_head = torch.nn.Linear(1, 1, bias = None)
+            lm_head = torch.nn.Linear(1, 1, bias=None)
             del lm_head.weight
             lm_head.weight = model.model.embed_tokens.weight
             lm_head.in_features = lm_head.weight.shape[1]

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -196,13 +196,13 @@ def _offload_frozen_module_for_training(
         new_dtype = torch.float32
 
     module.modules_to_save.default.to(
-        device = device_type, dtype = new_dtype, non_blocking = True
+        device=device_type, dtype=new_dtype, non_blocking=True
     )
     module.modules_to_save.default.requires_grad_(True)
 
     # [TODO] Move old module to CPU - should be disk!
     if offload_device is not None:
-        module.original_module.to(device = offload_device, non_blocking = True)
+        module.original_module.to(device=offload_device, non_blocking=True)
     module.original_module.requires_grad_(False)
 
 
@@ -210,8 +210,8 @@ def _offload_frozen_module_for_training(
 def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
-    attention_mask = None,
-    inputs_embeds = None,
+    attention_mask=None,
+    inputs_embeds=None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -278,8 +278,8 @@ def _fast_prepare_inputs_for_generation(
                 kwargs["cache_position"] = torch.arange(
                     past_len,
                     past_len + seq_length,
-                    device = device,
-                    dtype = torch.long,
+                    device=device,
+                    dtype=torch.long,
                 )
             else:
                 if (
@@ -385,9 +385,9 @@ def LlamaAttention_fast_forward_inference(
     hidden_states: torch.Tensor,
     past_key_value: Optional[Tuple[torch.Tensor]],
     position_ids,
-    do_prefill = False,
-    attention_mask = None,
-    rotary_seq_len = None,
+    do_prefill=False,
+    attention_mask=None,
+    rotary_seq_len=None,
 ):
     """
     https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L406
@@ -439,29 +439,29 @@ def LlamaAttention_fast_forward_inference(
     if do_prefill:
         self.paged_attention = torch.empty(
             (KV_CACHE_INCREMENT + seq_len + 1, 2, bsz, n_kv_heads, head_dim),
-            dtype = dtype,
-            device = device,
+            dtype=dtype,
+            device=device,
         )
         self.paged_attention_K = self.paged_attention[:, 0]
         self.paged_attention_V = self.paged_attention[:, 1]
         self.paged_attention_K[:seq_len] = K1.permute(2, 0, 1, 3)
         self.paged_attention_V[:seq_len] = V1.permute(2, 0, 1, 3)
         self.temp_QA = torch.empty(
-            (2, bsz, 1, attention_size), dtype = dtype, device = device
+            (2, bsz, 1, attention_size), dtype=dtype, device=device
         )
         self.temp_KV = torch.empty(
-            (2, bsz, 1, n_kv_heads * head_dim), dtype = dtype, device = device
+            (2, bsz, 1, n_kv_heads * head_dim), dtype=dtype, device=device
         )
-        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
+        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype=dtype, device=device)
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype=dtype, device=device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 
         self.attention = torch.empty(
-            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
+            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype=dtype, device=device
         )
         self.scalar = 1.0 / math_sqrt(self.head_dim)
         self.half_head_dim = head_dim // 2
@@ -481,9 +481,9 @@ def LlamaAttention_fast_forward_inference(
             (bsz, n_heads, 1, self.attention.shape[-1] + KV_CACHE_INCREMENT)
         )
 
-    Qn = fast_linear_forward(self.q_proj, Xn, out = self.temp_QA[0])
-    Kn = fast_linear_forward(self.k_proj, Xn, out = self.temp_KV[0])
-    Vn = fast_linear_forward(self.v_proj, Xn, out = self.temp_KV[1])
+    Qn = fast_linear_forward(self.q_proj, Xn, out=self.temp_QA[0])
+    Kn = fast_linear_forward(self.k_proj, Xn, out=self.temp_KV[0])
+    Vn = fast_linear_forward(self.v_proj, Xn, out=self.temp_KV[1])
     Qn = Qn.view(bsz, 1, n_heads, head_dim).transpose(1, 2)
     Kn = Kn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
     Vn = Vn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
@@ -507,8 +507,8 @@ def LlamaAttention_fast_forward_inference(
     self.rotary_emb.extend_rope_embedding(Vn, rotary_seq_len + 1)  # +1 slack
     cos, sin = self.rotary_emb.get_cached(rotary_seq_len, Qn.device.index or 0)
 
-    cos = cos[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
-    sin = sin[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
+    cos = cos[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
+    sin = sin[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
 
     h = self.half_head_dim
 
@@ -572,12 +572,12 @@ def LlamaAttention_fast_forward_inference(
         Qn *= self.scalar  # See https://github.com/ggerganov/llama.cpp/issues/7805#issuecomment-2153349963
         # It seems like doing (Q * scalar) @ K is better than (Q @ K) * scalar to stop overflows
         A = torch_matmul(
-            Qn, Knn.transpose(2, 3), out = self.attention[:, :, :, :cached_len]
+            Qn, Knn.transpose(2, 3), out=self.attention[:, :, :, :cached_len]
         )
         A[:] = torch_nn_functional_softmax(
-            A, dim = -1, dtype = torch.float32
+            A, dim=-1, dtype=torch.float32
         )  # .to(A.dtype)
-        A = torch_matmul(A, Vnn, out = Qn)
+        A = torch_matmul(A, Vnn, out=Qn)
     # --- attention_mask fixup for SDPA if user passes 2D padding mask
     else:
         if attention_mask is not None and attention_mask.dim() == 2:
@@ -596,17 +596,17 @@ def LlamaAttention_fast_forward_inference(
                 Qn,
                 Knn,
                 Vnn,
-                attn_mask = attention_mask,
-                is_causal = is_causal,
-                enable_gqa = True,
+                attn_mask=attention_mask,
+                is_causal=is_causal,
+                enable_gqa=True,
             )
         else:
             A = scaled_dot_product_attention(
-                Qn, Knn, Vnn, attn_mask = attention_mask, is_causal = is_causal
+                Qn, Knn, Vnn, attn_mask=attention_mask, is_causal=is_causal
             )
     A = A.transpose(1, 2)
     A = A.reshape(bsz, 1, attention_size)
-    A = fast_linear_forward(self.o_proj, A, out = self.temp_O)
+    A = fast_linear_forward(self.o_proj, A, out=self.temp_O)
     return A, (Kn, Vn)
 
 
@@ -614,7 +614,7 @@ torch_nn_functional_silu = torch.nn.functional.silu
 
 
 def fast_swiglu_inference(
-    self, X, temp_gate = None, temp_up = None, gate_multiplier = None, down_multiplier = None
+    self, X, temp_gate=None, temp_up=None, gate_multiplier=None, down_multiplier=None
 ):
     # gate = self.gate_proj(X)
     # up   = self.up_proj(X)
@@ -622,18 +622,18 @@ def fast_swiglu_inference(
     # mlp_size = self.config.intermediate_size
     # temp = torch.empty((2, bsz, 1, mlp_size), dtype = X.dtype, device = "cuda:0")
 
-    gate = fast_linear_forward(self.gate_proj, X, out = temp_gate)
+    gate = fast_linear_forward(self.gate_proj, X, out=temp_gate)
 
     if gate_multiplier is not None:
         gate *= gate_multiplier
 
-    up = fast_linear_forward(self.up_proj, X, out = temp_up)
+    up = fast_linear_forward(self.up_proj, X, out=temp_up)
 
-    gate = torch_nn_functional_silu(gate, inplace = True)
+    gate = torch_nn_functional_silu(gate, inplace=True)
     gate *= up
 
     # X = self.down_proj(gate)
-    down = fast_linear_forward(self.down_proj, gate, out = up[:, :, :hd])
+    down = fast_linear_forward(self.down_proj, gate, out=up[:, :, :hd])
 
     if down_multiplier is not None:
         down *= down_multiplier
@@ -645,14 +645,14 @@ torch_square = torch.square
 torch_mean = torch.mean
 
 
-def fast_rms_layernorm_inference(self, X, XX = None, XX2 = None, variance = None):
+def fast_rms_layernorm_inference(self, X, XX=None, XX2=None, variance=None):
     old_dtype = X.dtype
     if XX is None:
         XX = X.to(torch.float32)
-        variance = XX.square().mean(-1, keepdim = True)
+        variance = XX.square().mean(-1, keepdim=True)
     else:
         XX.copy_(X)
-        torch_mean(torch_square(XX, out = XX2), -1, keepdim = True, out = variance)
+        torch_mean(torch_square(XX, out=XX2), -1, keepdim=True, out=variance)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -665,9 +665,9 @@ def fast_rms_layernorm_inference(self, X, XX = None, XX2 = None, variance = None
     return X
 
 
-def fast_rms_layernorm_inference_gemma(self, X, out_weight = None):
+def fast_rms_layernorm_inference_gemma(self, X, out_weight=None):
     XX = X.to(torch.float32)
-    variance = XX.square().mean(-1, keepdim = True)
+    variance = XX.square().mean(-1, keepdim=True)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -682,15 +682,15 @@ def fast_rms_layernorm_inference_gemma(self, X, out_weight = None):
 
 
 # Normal layernorm with mean removal
-@torch.compile(fullgraph = False, dynamic = True, options = torch_compile_options)
+@torch.compile(fullgraph=False, dynamic=True, options=torch_compile_options)
 def fast_layernorm_compiled(layernorm, X):
     old_dtype = X.dtype
     X = X.float()
-    mean = X.mean(-1, keepdim = True)
+    mean = X.mean(-1, keepdim=True)
     Xbar = X - mean
     X = (
         Xbar
-        * torch.rsqrt(Xbar.square().mean(-1, keepdim = True) + layernorm.variance_epsilon)
+        * torch.rsqrt(Xbar.square().mean(-1, keepdim=True) + layernorm.variance_epsilon)
         * layernorm.weight.float()
     )
     return X.to(old_dtype)
@@ -742,10 +742,10 @@ def LlamaAttention_fast_forward(
         cos, sin = position_embeddings
     else:
         rotary_emb = self.rotary_emb
-        rotary_emb.extend_rope_embedding(V, seq_len = kv_seq_len)
+        rotary_emb.extend_rope_embedding(V, seq_len=kv_seq_len)
         cos, sin = rotary_emb.get_cached(kv_seq_len, Q.device.index)
-        cos = cos.to(device = Q.device, dtype = Q.dtype)
-        sin = sin.to(device = Q.device, dtype = Q.dtype)
+        cos = cos.to(device=Q.device, dtype=Q.dtype)
+        sin = sin.to(device=Q.device, dtype=Q.dtype)
 
     rope_position_ids = position_ids
     if rope_position_ids is None and seq_info is not None:
@@ -759,8 +759,8 @@ def LlamaAttention_fast_forward(
     Q, K = fast_rope_embedding(Q, K, cos, sin, rope_position_ids)
 
     if past_key_value is not None:
-        K = torch.cat([past_key_value[0], K], dim = 2)
-        V = torch.cat([past_key_value[1], V], dim = 2)
+        K = torch.cat([past_key_value[0], K], dim=2)
+        V = torch.cat([past_key_value[1], V], dim=2)
     past_key_value = (K, V) if use_cache else None
 
     # Attention module
@@ -771,25 +771,25 @@ def LlamaAttention_fast_forward(
 
     # should dropout be hardcoded to 0.0?
     config = AttentionConfig(
-        backend = backend,
-        n_kv_heads = n_kv_heads,
-        n_groups = n_groups,
-        flash_dense_kwargs = {"causal": True},
-        flash_varlen_kwargs = {"dropout_p": 0.0, "causal": True},
+        backend=backend,
+        n_kv_heads=n_kv_heads,
+        n_groups=n_groups,
+        flash_dense_kwargs={"causal": True},
+        flash_varlen_kwargs={"dropout_p": 0.0, "causal": True},
     )
     context = AttentionContext(
-        bsz = bsz,
-        q_len = q_len,
-        kv_seq_len = kv_seq_len,
-        n_heads = n_heads,
-        head_dim = head_dim,
-        requires_grad = hidden_states.requires_grad,
-        seq_info = seq_info,
-        attention_mask = attention_mask,
-        causal_mask = causal_mask,
+        bsz=bsz,
+        q_len=q_len,
+        kv_seq_len=kv_seq_len,
+        n_heads=n_heads,
+        head_dim=head_dim,
+        requires_grad=hidden_states.requires_grad,
+        seq_info=seq_info,
+        attention_mask=attention_mask,
+        causal_mask=causal_mask,
     )
 
-    A = run_attention(config = config, context = context, Q = Q, K = K, V = V)
+    A = run_attention(config=config, context=context, Q=Q, K=K, V=V)
     attn_output = A.reshape(bsz, q_len, n_heads * head_dim)
     attn_output = self.apply_o(self, attn_output)
     attn_weights = None
@@ -800,7 +800,7 @@ def LlamaAttention_fast_forward(
 def LlamaDecoderLayer_fast_forward(
     self,
     hidden_states: torch.Tensor,
-    causal_mask = None,
+    causal_mask=None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
     past_key_value: Optional[Tuple[torch.Tensor]] = None,
@@ -830,15 +830,15 @@ def LlamaDecoderLayer_fast_forward(
             self.input_layernorm, hidden_states
         )
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states += residual
@@ -854,15 +854,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -973,8 +973,8 @@ def LlamaModel_fast_forward(
         position_ids = torch.arange(
             past_key_values_length,
             seq_length + past_key_values_length,
-            dtype = torch.int32,
-            device = f"{DEVICE_TYPE_TORCH}:0",
+            dtype=torch.int32,
+            device=f"{DEVICE_TYPE_TORCH}:0",
         )
         position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
     elif position_ids is not None:
@@ -1007,7 +1007,7 @@ def LlamaModel_fast_forward(
         # Ie 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
         # &  2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
         normalizer = torch.tensor(
-            math_sqrt(self.config.hidden_size), dtype = inputs_embeds.dtype
+            math_sqrt(self.config.hidden_size), dtype=inputs_embeds.dtype
         )
 
         if train_embed_tokens:
@@ -1065,7 +1065,7 @@ def LlamaModel_fast_forward(
             (batch_size, seq_length),
             inputs_embeds,
             past_key_values_length,
-            sliding_window = getattr(self.config, "sliding_window", None),
+            sliding_window=getattr(self.config, "sliding_window", None),
         )
         # Must NOT convert to bool - weirdly this causes stuff to error out!
         # if attention_mask is not None:
@@ -1120,14 +1120,14 @@ def LlamaModel_fast_forward(
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window = self.config.sliding_window,
+                sliding_window=self.config.sliding_window,
             )
             dynamic_GA_mask = _prepare_4d_causal_attention_mask_for_sdpa(
                 attention_mask,
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window = None,
+                sliding_window=None,
             )
             use_static_mask = False
 
@@ -1147,15 +1147,15 @@ def LlamaModel_fast_forward(
 
                 self.SWA_mask = (
                     AttentionMaskConverter(
-                        is_causal = True,
-                        sliding_window = self.config.sliding_window,
+                        is_causal=True,
+                        sliding_window=self.config.sliding_window,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype = inputs_embeds.dtype,
-                        device = DEVICE_TYPE_TORCH,
+                        dtype=inputs_embeds.dtype,
+                        device=DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1163,14 +1163,14 @@ def LlamaModel_fast_forward(
 
                 self.GA_mask = (
                     AttentionMaskConverter(
-                        is_causal = True,
+                        is_causal=True,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype = inputs_embeds.dtype,
-                        device = DEVICE_TYPE_TORCH,
+                        dtype=inputs_embeds.dtype,
+                        device=DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1224,8 +1224,8 @@ def LlamaModel_fast_forward(
                         *inputs,
                         past_key_value,
                         output_attentions,
-                        padding_mask = padding_mask,
-                        position_embeddings = position_embeddings,
+                        padding_mask=padding_mask,
+                        position_embeddings=position_embeddings,
                         **kwargs,
                     )
 
@@ -1237,22 +1237,22 @@ def LlamaModel_fast_forward(
                 mask,
                 attention_mask,
                 position_ids,
-                use_reentrant = True,
-                preserve_rng_state = False,
+                use_reentrant=True,
+                preserve_rng_state=False,
             )
             hidden_states = layer_outputs[0]
 
         else:
             layer_outputs = decoder_layer(
                 hidden_states,
-                causal_mask = mask,
-                attention_mask = attention_mask,
-                position_ids = position_ids,
-                past_key_value = past_key_value,
-                output_attentions = output_attentions,
-                use_cache = use_cache,
-                padding_mask = padding_mask,
-                position_embeddings = position_embeddings,
+                causal_mask=mask,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                padding_mask=padding_mask,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
             hidden_states = layer_outputs[0]
@@ -1278,10 +1278,10 @@ def LlamaModel_fast_forward(
         hidden_states = self.norm(hidden_states)
     elif IS_FALCON_H1:
         hidden_states = fast_rms_layernorm(
-            self.final_layernorm, hidden_states, gemma = IS_GEMMA
+            self.final_layernorm, hidden_states, gemma=IS_GEMMA
         )
     else:
-        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma = IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma=IS_GEMMA)
 
     if output_hidden_states:
         all_hidden_states += (hidden_states,)
@@ -1294,17 +1294,17 @@ def LlamaModel_fast_forward(
             if v is not None
         )
     return BaseModelOutputWithPast(
-        last_hidden_state = hidden_states,
-        past_key_values = next_cache,
-        hidden_states = all_hidden_states,
-        attentions = all_self_attns,
+        last_hidden_state=hidden_states,
+        past_key_values=next_cache,
+        hidden_states=all_hidden_states,
+        attentions=all_self_attns,
     )
 
 
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L825
 def _LlamaModel_fast_forward_inference(
-    attention_fast_forward_inference = LlamaAttention_fast_forward_inference,
-    mlp_fast_forward_inference = fast_swiglu_inference,
+    attention_fast_forward_inference=LlamaAttention_fast_forward_inference,
+    mlp_fast_forward_inference=fast_swiglu_inference,
 ):
     # This makes the attention and MLP customisable.
     # Now for models like qwen3 or cohere which use custom attention operations, we can use this function
@@ -1313,7 +1313,7 @@ def _LlamaModel_fast_forward_inference(
         input_ids,
         past_key_values,
         position_ids,
-        attention_mask = None,
+        attention_mask=None,
         **kwargs,
     ):
         input_ids = input_ids[:, : self.max_seq_length]
@@ -1327,17 +1327,17 @@ def _LlamaModel_fast_forward_inference(
         assert q_len == 1
         # Get saved buffers to reduce memory movement
         residual = torch.empty(
-            (bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         _XX = torch.empty(
-            (2, bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
+            (2, bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         XX, XX2 = _XX[0], _XX[1]
         variance = torch.empty(
-            (bsz, q_len, 1), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, 1), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_mlp = torch.empty(
-            (2, bsz, 1, mlp_size), dtype = X.dtype, device = f"{DEVICE_TYPE_TORCH}:0"
+            (2, bsz, 1, mlp_size), dtype=X.dtype, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_gates, temp_ups = (
             tuple(temp_mlp[0].to(torch.device(x)) for x in range(DEVICE_COUNT)),
@@ -1352,7 +1352,7 @@ def _LlamaModel_fast_forward_inference(
                 (bsz, q_len),
                 X,
                 seq_len,
-                sliding_window = getattr(self.config, "sliding_window", None),
+                sliding_window=getattr(self.config, "sliding_window", None),
             )
             # Pre-convert to bool once for all layers (avoids per-layer .eq(0))
             if attention_mask is not None and attention_mask.dtype != torch.bool:
@@ -1374,18 +1374,18 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.input_layernorm,
                 X,
-                XX = XX,
-                XX2 = XX2,
-                variance = variance,
+                XX=XX,
+                XX2=XX2,
+                variance=variance,
             )
             X, present_key_value = attention_fast_forward_inference(
                 decoder_layer.self_attn,
-                hidden_states = X,
-                past_key_value = past_key_values[idx],
-                position_ids = position_ids,
-                attention_mask = attention_mask,
-                do_prefill = not hasattr(decoder_layer.self_attn, "paged_attention"),
-                rotary_seq_len = rotary_seq_len,
+                hidden_states=X,
+                past_key_value=past_key_values[idx],
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                do_prefill=not hasattr(decoder_layer.self_attn, "paged_attention"),
+                rotary_seq_len=rotary_seq_len,
             )
             X += residual
 
@@ -1393,15 +1393,15 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.post_attention_layernorm,
                 X,
-                XX = XX,
-                XX2 = XX2,
-                variance = variance,
+                XX=XX,
+                XX2=XX2,
+                variance=variance,
             )
             X = mlp_fast_forward_inference(
                 decoder_layer.mlp,
                 X,
-                temp_gate = temp_gates[device_index],
-                temp_up = temp_ups[device_index],
+                temp_gate=temp_gates[device_index],
+                temp_up=temp_ups[device_index],
             )
             X += residual
 
@@ -1409,16 +1409,16 @@ def _LlamaModel_fast_forward_inference(
         X = fast_rms_layernorm_inference(
             self.model.norm,
             X,
-            XX = XX,
-            XX2 = XX2,
-            variance = variance,
+            XX=XX,
+            XX2=XX2,
+            variance=variance,
         )
 
         return BaseModelOutputWithPast(
-            last_hidden_state = X,
-            past_key_values = next_decoder_cache,
-            hidden_states = [],
-            attentions = [],
+            last_hidden_state=X,
+            past_key_values=next_decoder_cache,
+            hidden_states=[],
+            attentions=[],
         )
 
     return LlamaModel_fast_forward_inference_custom
@@ -1452,8 +1452,8 @@ def CausalLM_fast_forward(fast_forward_inference):
                 self,
                 input_ids,
                 past_key_values,
-                position_ids = position_ids,
-                attention_mask = attention_mask,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
                 **kwargs,
             )
         else:
@@ -1477,16 +1477,16 @@ def CausalLM_fast_forward(fast_forward_inference):
             # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
             self.model._has_no_labels = labels is None
             outputs = self.model(
-                input_ids = input_ids,
-                causal_mask = causal_mask,
-                attention_mask = attention_mask,
-                position_ids = position_ids,
-                past_key_values = past_key_values,
-                inputs_embeds = inputs_embeds,
-                use_cache = use_cache,
-                output_attentions = output_attentions,
-                output_hidden_states = output_hidden_states,
-                return_dict = return_dict,
+                input_ids=input_ids,
+                causal_mask=causal_mask,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
                 **kwargs,
             )
         hidden_states = outputs[0]
@@ -1510,11 +1510,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if num_logits_to_keep != 0:
                 hidden_states = hidden_states[:, -num_logits_to_keep:, :]
             return CausalLMOutputWithPast(
-                loss = None,
-                logits = hidden_states,
-                past_key_values = outputs.past_key_values,
-                hidden_states = outputs.hidden_states,
-                attentions = outputs.attentions,
+                loss=None,
+                logits=hidden_states,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
             )
 
         if bsz == 1 and q_len == 1:
@@ -1547,28 +1547,28 @@ def CausalLM_fast_forward(fast_forward_inference):
                 #     logit_softcapping  = logit_softcapping,
                 # )
                 loss = unsloth_fused_ce_loss(
-                    trainer = None,
-                    hidden_states = hidden_states,
-                    lm_head_weight = lm_head,
-                    lm_head_bias = None,
-                    labels = labels,
-                    mask = None,
-                    n_items = n_items,
-                    scaling = getattr(self, "accelerator_scaler", None),
-                    target_gb = None,
-                    torch_compile = True,
-                    logit_softcapping = logit_softcapping,
+                    trainer=None,
+                    hidden_states=hidden_states,
+                    lm_head_weight=lm_head,
+                    lm_head_bias=None,
+                    labels=labels,
+                    mask=None,
+                    n_items=n_items,
+                    scaling=getattr(self, "accelerator_scaler", None),
+                    target_gb=None,
+                    torch_compile=True,
+                    logit_softcapping=logit_softcapping,
                 )
                 if not return_dict:
                     output = (logits,) + outputs[1:]
                     return (loss,) + output if loss is not None else output
 
                 output = CausalLMOutputWithPast(
-                    loss = loss,
-                    logits = EMPTY_LOGITS,
-                    past_key_values = outputs.past_key_values,
-                    hidden_states = outputs.hidden_states,
-                    attentions = outputs.attentions,
+                    loss=loss,
+                    logits=EMPTY_LOGITS,
+                    past_key_values=outputs.past_key_values,
+                    hidden_states=outputs.hidden_states,
+                    attentions=outputs.attentions,
                 )
                 return output
             pass
@@ -1605,11 +1605,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if n_items is None:
                 n_items = kwargs.get("n_items", None)
             loss = fast_cross_entropy_loss(
-                logits = shift_logits,
-                labels = shift_labels,
-                logit_softcapping = logit_softcapping,
-                logit_scaling = logit_scaling,
-                n_items = n_items,
+                logits=shift_logits,
+                labels=shift_labels,
+                logit_softcapping=logit_softcapping,
+                logit_scaling=logit_scaling,
+                n_items=n_items,
             )
         else:
             if logit_scaling != 0:
@@ -1631,11 +1631,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             output = (logits,) + outputs[1:]
             return (loss,) + output if loss is not None else output
         return CausalLMOutputWithPast(
-            loss = loss,
-            logits = logits,
-            past_key_values = outputs.past_key_values,
-            hidden_states = outputs.hidden_states,
-            attentions = outputs.attentions,
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
     return _CausalLM_fast_forward
@@ -1644,48 +1644,48 @@ def CausalLM_fast_forward(fast_forward_inference):
 @torch._disable_dynamo
 def PeftModel_fast_forward(
     self,
-    input_ids = None,
-    causal_mask = None,
-    attention_mask = None,
-    inputs_embeds = None,
-    labels = None,
-    output_attentions = None,
-    output_hidden_states = None,
-    return_dict = None,
-    task_ids = None,
-    num_logits_to_keep = 0,
-    logits_to_keep = 0,
+    input_ids=None,
+    causal_mask=None,
+    attention_mask=None,
+    inputs_embeds=None,
+    labels=None,
+    output_attentions=None,
+    output_hidden_states=None,
+    return_dict=None,
+    task_ids=None,
+    num_logits_to_keep=0,
+    logits_to_keep=0,
     **kwargs,
 ):
     is_classification = "Classification" in str(type(self.base_model.model))
     if is_classification:
         return self.base_model(
-            input_ids = input_ids,
-            attention_mask = attention_mask,
-            inputs_embeds = inputs_embeds,
-            labels = labels,
-            output_attentions = output_attentions,
-            output_hidden_states = output_hidden_states,
-            return_dict = return_dict,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
             **kwargs,
         )
     else:
         return self.base_model(
-            input_ids = input_ids,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            inputs_embeds = inputs_embeds,
-            labels = labels,
-            output_attentions = output_attentions,
-            output_hidden_states = output_hidden_states,
-            return_dict = return_dict,
-            num_logits_to_keep = num_logits_to_keep,
-            logits_to_keep = logits_to_keep,
+            input_ids=input_ids,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            num_logits_to_keep=num_logits_to_keep,
+            logits_to_keep=logits_to_keep,
             **kwargs,
         )
 
 
-def _get_rope_theta(config, default = 10000.0):
+def _get_rope_theta(config, default=10000.0):
     """Get rope_theta from config, handling both transformers 4.x and 5.x."""
     try:
         return config.rope_theta
@@ -1708,16 +1708,16 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default = base)
+            base = _get_rope_theta(config, default=base)
             partial_rotary_factor = (
                 config.partial_rotary_factor
                 if hasattr(config, "partial_rotary_factor")
@@ -1741,27 +1741,27 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         inv_freq = 1.0 / (
             self.base
             ** (
-                torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float()
+                torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float()
                 / self.dim
             )
         )
         inv_freq = self._apply_inv_freq_scaling(inv_freq)
-        self.register_buffer("inv_freq", inv_freq, persistent = False)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
 
         # Build here to make `torch.jit.trace` work.
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                seq_len = self.current_rope_size,
-                device = torch.device(device_idx),
-                dtype = torch.get_default_dtype(),
+                seq_len=self.current_rope_size,
+                device=torch.device(device_idx),
+                dtype=torch.get_default_dtype(),
             )
 
         # dummy so that patch_utils doesn't fail for now
         self.cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
 
     def _apply_inv_freq_scaling(self, inv_freq):
@@ -1777,23 +1777,23 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
         t = torch.arange(
-            self.current_rope_size, device = self.inv_freq.device, dtype = torch.int64
+            self.current_rope_size, device=self.inv_freq.device, dtype=torch.int64
         ).float()
         t = self._apply_time_scaling(t)
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
-        emb = torch.cat((freqs, freqs), dim = -1)
-        cos = emb.cos().to(dtype = dtype, device = device, non_blocking = True)
-        sin = emb.sin().to(dtype = dtype, device = device, non_blocking = True)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos().to(dtype=dtype, device=device, non_blocking=True)
+        sin = emb.sin().to(dtype=dtype, device=device, non_blocking=True)
         self.multi_gpu_cos_cached[device.index] = cos
         self.multi_gpu_sin_cached[device.index] = sin
         return cos, sin
 
-    def forward(self, x, position_ids = None, seq_len = None):
+    def forward(self, x, position_ids=None, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
 
         device_index = x.device.index
         return (
@@ -1801,7 +1801,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             self.multi_gpu_sin_cached[device_index][:seq_len],
         )
 
-    def get_cached(self, seq_len = None, device_index = None):
+    def get_cached(self, seq_len=None, device_index=None):
         if device_index is None:
             device_index = get_current_device()
         return self.multi_gpu_cos_cached[device_index], self.multi_gpu_sin_cached[
@@ -1815,7 +1815,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
+                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
             )
 
 
@@ -1827,20 +1827,20 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        scaling_factor = 1.0,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        scaling_factor=1.0,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         self.scaling_factor = scaling_factor
         super().__init__(
-            dim = dim,
-            max_position_embeddings = max_position_embeddings,
-            base = base,
-            device = device,
-            config = config,
+            dim=dim,
+            max_position_embeddings=max_position_embeddings,
+            base=base,
+            device=device,
+            config=config,
         )
 
     def _apply_time_scaling(self, t):
@@ -1853,18 +1853,18 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
 class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__(
-            dim = dim,
-            max_position_embeddings = max_position_embeddings,
-            base = base,
-            device = device,
-            config = config,
+            dim=dim,
+            max_position_embeddings=max_position_embeddings,
+            base=base,
+            device=device,
+            config=config,
         )
 
     # From https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/api/model.py#L41
@@ -1890,21 +1890,21 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
                     high_freq_factor - low_freq_factor
                 )
                 new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-        return torch.tensor(new_freqs, dtype = freqs.dtype, device = freqs.device)
+        return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
 class LongRopeRotaryEmbedding(torch.nn.Module):
     # For Phi 3.5 128K https://huggingface.co/microsoft/Phi-3.5-mini-instruct/blob/main/modeling_phi3.py
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 131072,
-        original_max_position_embeddings = 4096,
-        base = 10000,
-        short_factor = None,
-        long_factor = None,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=131072,
+        original_max_position_embeddings=4096,
+        base=10000,
+        short_factor=None,
+        long_factor=None,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         assert short_factor is not None
@@ -1913,7 +1913,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default = base)
+            base = _get_rope_theta(config, default=base)
             partial_rotary_factor = (
                 config.partial_rotary_factor
                 if hasattr(config, "partial_rotary_factor")
@@ -1939,11 +1939,11 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         # Long RoPE similar to RoPE except short sequences have 1 cos / sin
         # and long sequences have another cos / sin
         inv_freq_shape = (
-            torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float()
+            torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float()
             / self.dim
         )
-        short_factor = torch.tensor(short_factor, device = "cpu", dtype = torch.float32)
-        long_factor = torch.tensor(long_factor, device = "cpu", dtype = torch.float32)
+        short_factor = torch.tensor(short_factor, device="cpu", dtype=torch.float32)
+        long_factor = torch.tensor(long_factor, device="cpu", dtype=torch.float32)
         short_inv_freq = 1.0 / (short_factor * self.base**inv_freq_shape)
         long_inv_freq = 1.0 / (long_factor * self.base**inv_freq_shape)
 
@@ -1958,43 +1958,43 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.scaling_factor = scaling_factor
 
         # Short and long inv_freq
-        self.register_buffer("short_inv_freq", short_inv_freq, persistent = False)
-        self.register_buffer("long_inv_freq", long_inv_freq, persistent = False)
+        self.register_buffer("short_inv_freq", short_inv_freq, persistent=False)
+        self.register_buffer("long_inv_freq", long_inv_freq, persistent=False)
 
         # Build here to make `torch.jit.trace` work.
         # Initialize short sequences cache for all devices
         dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
         t = torch.arange(
             original_max_position_embeddings,
-            device = self.short_inv_freq.device,
-            dtype = torch.int64,
+            device=self.short_inv_freq.device,
+            dtype=torch.int64,
         ).float()
         freqs = torch.outer(t, self.short_inv_freq)
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
 
         for device_idx in range(DEVICE_COUNT):
             device_obj = torch.device(device_idx)
             cos_cached = (emb.cos() * self.scaling_factor).to(
-                dtype = dtype, device = device_obj, non_blocking = True
+                dtype=dtype, device=device_obj, non_blocking=True
             )
             sin_cached = (emb.sin() * self.scaling_factor).to(
-                dtype = dtype, device = device_obj, non_blocking = True
+                dtype=dtype, device=device_obj, non_blocking=True
             )
             self.multi_gpu_short_cos_cached[device_idx] = cos_cached
             self.multi_gpu_short_sin_cached[device_idx] = sin_cached
 
         # dummy so that patch_utils doesn't fail for now
         self.short_cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.short_sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.long_cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.long_sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
@@ -2003,25 +2003,25 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = seq_len
 
         t = torch.arange(
-            self.current_rope_size, device = self.long_inv_freq.device, dtype = torch.int64
+            self.current_rope_size, device=self.long_inv_freq.device, dtype=torch.int64
         ).float()
         # Long sequences
         freqs = torch.outer(t, self.long_inv_freq)
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
         cos_cached = (emb.cos() * self.scaling_factor).to(
-            dtype = dtype, device = device, non_blocking = True
+            dtype=dtype, device=device, non_blocking=True
         )
         sin_cached = (emb.sin() * self.scaling_factor).to(
-            dtype = dtype, device = device, non_blocking = True
+            dtype=dtype, device=device, non_blocking=True
         )
         self.multi_gpu_long_cos_cached[device.index] = cos_cached
         self.multi_gpu_long_sin_cached[device.index] = sin_cached
         return cos_cached, sin_cached
 
-    def forward(self, x, position_ids = None, seq_len = None):
+    def forward(self, x, position_ids=None, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
 
         device_index = x.device.index
 
@@ -2036,7 +2036,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
                 self.multi_gpu_long_sin_cached[device_index][:seq_len],
             )
 
-    def get_cached(self, seq_len = None, device_index = None):
+    def get_cached(self, seq_len=None, device_index=None):
         if device_index is None:
             device_index = get_current_device()
         if seq_len is not None and seq_len < self.original_max_position_embeddings:
@@ -2054,7 +2054,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
+                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
             )
 
 
@@ -2128,7 +2128,7 @@ def unsloth_fast_generate(
     # Mixed precision autocast
     with (
         _get_inference_mode_context_manager(self),
-        torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = dtype),
+        torch.autocast(device_type=DEVICE_TYPE_TORCH, dtype=dtype),
     ):
         output = self._old_generate(*args, **kwargs)
 
@@ -2152,12 +2152,12 @@ class FastLlamaModel:
     @staticmethod
     def pre_patch():
         init_name, function = patch_llama_rope_scaling(
-            model_name = "llama",
-            rope_module = LlamaRotaryEmbedding,
-            scaled_rope_module = LlamaLinearScalingRotaryEmbedding,
-            extended_rope_module = LlamaExtendedRotaryEmbedding,
-            attention_module = LlamaAttention,
-            longrope_module = LongRopeRotaryEmbedding,
+            model_name="llama",
+            rope_module=LlamaRotaryEmbedding,
+            scaled_rope_module=LlamaLinearScalingRotaryEmbedding,
+            extended_rope_module=LlamaExtendedRotaryEmbedding,
+            attention_module=LlamaAttention,
+            longrope_module=LongRopeRotaryEmbedding,
         )
         if init_name is not None:
             exec(function, globals())
@@ -2190,28 +2190,28 @@ class FastLlamaModel:
 
     @staticmethod
     def from_pretrained(
-        model_name = "unsloth/llama-3-8b-bnb-4bit",
-        max_seq_length = None,
-        dtype = None,
-        load_in_4bit = True,
-        token = None,
-        device_map = "sequential",
-        rope_scaling = None,
-        fix_tokenizer = True,
-        model_patcher = None,
-        tokenizer_name = None,
-        trust_remote_code = False,
-        revision = None,
-        fast_inference = False,  # uses vLLM
-        gpu_memory_utilization = 0.5,
-        float8_kv_cache = False,
-        random_state = 3407,
-        max_lora_rank = 16,
-        disable_log_stats = False,
-        unsloth_vllm_standby = False,
-        num_labels = None,
-        qat_scheme = None,
-        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
+        model_name="unsloth/llama-3-8b-bnb-4bit",
+        max_seq_length=None,
+        dtype=None,
+        load_in_4bit=True,
+        token=None,
+        device_map="sequential",
+        rope_scaling=None,
+        fix_tokenizer=True,
+        model_patcher=None,
+        tokenizer_name=None,
+        trust_remote_code=False,
+        revision=None,
+        fast_inference=False,  # uses vLLM
+        gpu_memory_utilization=0.5,
+        float8_kv_cache=False,
+        random_state=3407,
+        max_lora_rank=16,
+        disable_log_stats=False,
+        unsloth_vllm_standby=False,
+        num_labels=None,
+        qat_scheme=None,
+        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
         **kwargs,
     ):
         os.environ["UNSLOTH_USE_NEW_MODEL"] = "0"
@@ -2334,8 +2334,8 @@ class FastLlamaModel:
         # RoPE Scaling
         model_config = AutoConfig.from_pretrained(
             model_name,
-            token = token,
-            attn_implementation = "sdpa",
+            token=token,
+            attn_implementation="sdpa",
         )
         model_config.model_name = model_name
         model_max_seq_length = model_config.max_position_embeddings
@@ -2352,7 +2352,7 @@ class FastLlamaModel:
 
         has_rope_scaling = False
         try:
-            with open(inspect.getfile(model_function), "r", encoding = "utf-8") as file:
+            with open(inspect.getfile(model_function), "r", encoding="utf-8") as file:
                 has_rope_scaling = "self.config.rope_scaling" in file.read()
         except:
             pass
@@ -2399,11 +2399,11 @@ class FastLlamaModel:
                 # we cannot quantize out_proj layer due to mamba kernels: https://github.com/tiiuae/Falcon-H1/issues/13#issuecomment-2918671274
                 llm_int8_skip_modules.append("out_proj")
             bnb_config = BitsAndBytesConfig(
-                load_in_4bit = True,
-                bnb_4bit_use_double_quant = True,
-                bnb_4bit_quant_type = "nf4",
-                bnb_4bit_compute_dtype = dtype,
-                llm_int8_skip_modules = llm_int8_skip_modules,
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=dtype,
+                llm_int8_skip_modules=llm_int8_skip_modules,
             )
 
         # https://huggingface.co/togethercomputer/LLaMA-2-7B-32K/discussions/12
@@ -2432,25 +2432,25 @@ class FastLlamaModel:
                     setattr(model_config, _cfg_key, _cfg_val)
             model = AutoModelForSequenceClassification.from_pretrained(
                 model_name,
-                config = model_config,
-                device_map = device_map,
+                config=model_config,
+                device_map=device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token = token,
-                trust_remote_code = trust_remote_code,
-                attn_implementation = preferred_attn_impl,
+                token=token,
+                trust_remote_code=trust_remote_code,
+                attn_implementation=preferred_attn_impl,
                 **kwargs,
             )
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(
                 model_name,
-                device_map = device_map,
+                device_map=device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token = token,
-                max_position_embeddings = max_position_embeddings,
-                trust_remote_code = trust_remote_code,
-                attn_implementation = preferred_attn_impl,
+                token=token,
+                max_position_embeddings=max_position_embeddings,
+                trust_remote_code=trust_remote_code,
+                attn_implementation=preferred_attn_impl,
                 **kwargs,
             )
             model.fast_generate = make_fast_generate_wrapper(model.generate)
@@ -2472,18 +2472,18 @@ class FastLlamaModel:
 
             allowed_args = inspect.getfullargspec(load_vllm).args
             load_vllm_kwargs = dict(
-                model_name = model_name,
-                config = model_config,
-                gpu_memory_utilization = gpu_memory_utilization,
-                max_seq_length = max_seq_length,
-                dtype = dtype,
-                float8_kv_cache = float8_kv_cache,
-                enable_lora = True,
-                max_lora_rank = max_lora_rank,
-                disable_log_stats = disable_log_stats,
-                use_bitsandbytes = load_in_4bit,
-                unsloth_vllm_standby = unsloth_vllm_standby,
-                fp8_mode = fp8_mode,
+                model_name=model_name,
+                config=model_config,
+                gpu_memory_utilization=gpu_memory_utilization,
+                max_seq_length=max_seq_length,
+                dtype=dtype,
+                float8_kv_cache=float8_kv_cache,
+                enable_lora=True,
+                max_lora_rank=max_lora_rank,
+                disable_log_stats=disable_log_stats,
+                use_bitsandbytes=load_in_4bit,
+                unsloth_vllm_standby=unsloth_vllm_standby,
+                fp8_mode=fp8_mode,
             )
             for allowed_arg in allowed_args:
                 if allowed_arg not in load_vllm_kwargs and allowed_arg in kwargs:
@@ -2496,8 +2496,8 @@ class FastLlamaModel:
             # Convert to HF format
             _, quant_state_dict = get_vllm_state_dict(
                 llm,
-                config = model_config,
-                load_in_fp8 = load_in_fp8,
+                config=model_config,
+                load_in_fp8=load_in_fp8,
             )
             model = convert_vllm_to_huggingface(
                 quant_state_dict, model_config, dtype, bnb_config
@@ -2514,17 +2514,17 @@ class FastLlamaModel:
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name
         tokenizer = load_correct_tokenizer(
-            tokenizer_name = tokenizer_name,
-            model_max_length = max_position_embeddings,
-            padding_side = "right",
-            token = token,
-            trust_remote_code = trust_remote_code,
-            fix_tokenizer = fix_tokenizer,
+            tokenizer_name=tokenizer_name,
+            model_max_length=max_position_embeddings,
+            padding_side="right",
+            token=token,
+            trust_remote_code=trust_remote_code,
+            fix_tokenizer=fix_tokenizer,
         )
 
         model, tokenizer = patch_tokenizer(model, tokenizer)
         model, tokenizer = model_patcher.post_patch(
-            model, tokenizer, correct_dtype = dtype
+            model, tokenizer, correct_dtype=dtype
         )
 
         # Patch up QKV / O and MLP
@@ -2602,7 +2602,7 @@ class FastLlamaModel:
 
         front_spaces = re.match(r"[\t\s]{1,}", inner_training_loop).group(0)
         inner_training_loop = re.sub(
-            r"^" + front_spaces, "", inner_training_loop, flags = re.MULTILINE
+            r"^" + front_spaces, "", inner_training_loop, flags=re.MULTILINE
         )
         inner_training_loop = inner_training_loop.replace(
             "train_dataloader = tpu_spmd_dataloader(train_dataloader)",
@@ -2634,12 +2634,12 @@ class FastLlamaModel:
         # We check the tokenizer first for errors
         if fix_tokenizer:
             tokenizer = check_tokenizer(
-                model = model,
-                tokenizer = tokenizer,
-                model_name = model_name,
-                model_max_length = max_position_embeddings,
-                padding_side = "right",
-                token = token,
+                model=model,
+                tokenizer=tokenizer,
+                model_name=model_name,
+                model_max_length=max_position_embeddings,
+                padding_side="right",
+                token=token,
             )
         patch_saving_functions(tokenizer)
 
@@ -2731,17 +2731,17 @@ class FastLlamaModel:
         return model, tokenizer
 
     @staticmethod
-    def post_patch(model, tokenizer, correct_dtype = None):
+    def post_patch(model, tokenizer, correct_dtype=None):
         model, tokenizer = patch_model_and_tokenizer(
-            model, tokenizer, downcast_rope = True, correct_dtype = correct_dtype
+            model, tokenizer, downcast_rope=True, correct_dtype=correct_dtype
         )
         return model, tokenizer
 
     @staticmethod
     def get_peft_model(
         model,
-        r = 16,
-        target_modules = [
+        r=16,
+        target_modules=[
             "q_proj",
             "k_proj",
             "v_proj",
@@ -2750,22 +2750,22 @@ class FastLlamaModel:
             "up_proj",
             "down_proj",
         ],
-        lora_alpha = 16,
-        lora_dropout = 0.0,
-        bias = "none",
-        layers_to_transform = None,
-        layers_pattern = None,
-        use_gradient_checkpointing = "unsloth",
-        random_state = 3407,
-        max_seq_length = 2048,  # not used anymore
-        use_rslora = False,
-        modules_to_save = None,
-        init_lora_weights = True,
-        loftq_config = {},
-        temporary_location = "_unsloth_temporary_saved_buffers",
-        qat_scheme = None,
-        target_parameters = None,  # For MoE expert layers (nn.Parameter)
-        ensure_weight_tying = False,
+        lora_alpha=16,
+        lora_dropout=0.0,
+        bias="none",
+        layers_to_transform=None,
+        layers_pattern=None,
+        use_gradient_checkpointing="unsloth",
+        random_state=3407,
+        max_seq_length=2048,  # not used anymore
+        use_rslora=False,
+        modules_to_save=None,
+        init_lora_weights=True,
+        loftq_config={},
+        temporary_location="_unsloth_temporary_saved_buffers",
+        qat_scheme=None,
+        target_parameters=None,  # For MoE expert layers (nn.Parameter)
+        ensure_weight_tying=False,
         **kwargs,
     ):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
@@ -2779,24 +2779,24 @@ class FastLlamaModel:
                 if peft_arg not in kwargs:
                     kwargs[peft_arg] = flag
             return FastBaseModel.get_peft_model(
-                model = model,
-                r = r,
-                target_modules = target_modules,
-                lora_alpha = lora_alpha,
-                lora_dropout = lora_dropout,
-                bias = bias,
-                layers_to_transform = layers_to_transform,
-                layers_pattern = layers_pattern,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                random_state = random_state,
-                max_seq_length = max_seq_length,
-                use_rslora = use_rslora,
-                modules_to_save = modules_to_save,
-                init_lora_weights = init_lora_weights,
-                loftq_config = loftq_config,
-                temporary_location = temporary_location,
-                target_parameters = target_parameters,
-                ensure_weight_tying = ensure_weight_tying,
+                model=model,
+                r=r,
+                target_modules=target_modules,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                bias=bias,
+                layers_to_transform=layers_to_transform,
+                layers_pattern=layers_pattern,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                random_state=random_state,
+                max_seq_length=max_seq_length,
+                use_rslora=use_rslora,
+                modules_to_save=modules_to_save,
+                init_lora_weights=init_lora_weights,
+                loftq_config=loftq_config,
+                temporary_location=temporary_location,
+                target_parameters=target_parameters,
+                ensure_weight_tying=ensure_weight_tying,
                 **kwargs,
             )
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
@@ -2942,7 +2942,7 @@ class FastLlamaModel:
                     "Unsloth: init_lora_weights = `loftq` is set, but `loftq_config` is None.\n"
                     "We shall use `loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)`."
                 )
-                loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)
+                loftq_config = LoftQConfig(loftq_bits=4, loftq_iter=1)
 
             if hasattr(model.config, "quantization_config"):
                 raise ValueError(
@@ -3085,19 +3085,19 @@ class FastLlamaModel:
             target_parameters = get_moe_target_parameters(model, target_modules)
 
         arguments = dict(
-            r = r,
-            lora_alpha = lora_alpha,
-            target_modules = final_modules,
-            lora_dropout = lora_dropout,
-            bias = bias,
-            task_type = TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
-            layers_to_transform = layers_to_transform,
-            init_lora_weights = init_lora_weights,
-            loftq_config = loftq_config,
-            use_rslora = use_rslora,
-            modules_to_save = modules_to_save,
-            target_parameters = target_parameters,
-            ensure_weight_tying = ensure_weight_tying,
+            r=r,
+            lora_alpha=lora_alpha,
+            target_modules=final_modules,
+            lora_dropout=lora_dropout,
+            bias=bias,
+            task_type=TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
+            layers_to_transform=layers_to_transform,
+            init_lora_weights=init_lora_weights,
+            loftq_config=loftq_config,
+            use_rslora=use_rslora,
+            modules_to_save=modules_to_save,
+            target_parameters=target_parameters,
+            ensure_weight_tying=ensure_weight_tying,
             **kwargs,
         )
         if not SUPPORTS_LOFTQ:
@@ -3201,7 +3201,7 @@ class FastLlamaModel:
             assert hasattr(model.get_input_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
             )
 
         if train_lm_head:
@@ -3209,7 +3209,7 @@ class FastLlamaModel:
             assert hasattr(model.get_output_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
             )
 
         # Patch tokenizer to pad to the right
@@ -3245,12 +3245,12 @@ class FastLlamaModel:
     @staticmethod
     def patch_peft_model(
         model,
-        use_gradient_checkpointing = "unsloth",
+        use_gradient_checkpointing="unsloth",
     ):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
             return FastBaseModel.patch_peft_model(
-                model = model,
-                use_gradient_checkpointing = use_gradient_checkpointing,
+                model=model,
+                use_gradient_checkpointing=use_gradient_checkpointing,
             )
         if not isinstance(model, PeftModelForCausalLM) and not isinstance(
             model, PeftModelForSequenceClassification
@@ -3287,8 +3287,8 @@ class FastLlamaModel:
 
         model = prepare_model_for_kbit_training(
             model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
-            use_reentrant = True,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            use_reentrant=True,
         )
 
         # Fix up config for transformers uploading PEFT
@@ -3341,7 +3341,7 @@ class FastLlamaModel:
 
         # We also do not inplace edit QKV for Cohere!
         _apply_lora_mlp = (
-            functools.partial(apply_lora_mlp, inplace = False)
+            functools.partial(apply_lora_mlp, inplace=False)
             if model_type == "cohere"
             else apply_lora_mlp
         )
@@ -3524,7 +3524,7 @@ class FastLlamaModel:
         return model
 
     @staticmethod
-    def for_training(model, use_gradient_checkpointing = True):
+    def for_training(model, use_gradient_checkpointing=True):
         if not hasattr(model, "parameters"):
             raise TypeError(
                 "Unsloth: I think you're passing a tokenizer, not the model to for_training!"
@@ -3573,4 +3573,4 @@ class FastLlamaModel:
 
 from .rl import PatchFastRL
 
-PatchFastRL(FastLanguageModel = FastLlamaModel)
+PatchFastRL(FastLanguageModel=FastLlamaModel)

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -171,7 +171,7 @@ def _fix_rope_inv_freq(model):
                 module.base
                 ** (
                     torch.arange(
-                        0, module.dim, 2, dtype = torch.int64, device = "cpu"
+                        0, module.dim, 2, dtype=torch.int64, device="cpu"
                     ).float()
                     / module.dim
                 )
@@ -181,9 +181,9 @@ def _fix_rope_inv_freq(model):
             for device_idx in range(len(module.multi_gpu_cos_cached)):
                 if module.multi_gpu_cos_cached[device_idx] is not None:
                     module._set_cos_sin_cache(
-                        seq_len = module.current_rope_size,
-                        device = torch.device(device_idx),
-                        dtype = torch.get_default_dtype(),
+                        seq_len=module.current_rope_size,
+                        device=torch.device(device_idx),
+                        dtype=torch.get_default_dtype(),
                     )
 
         # LongRopeRotaryEmbedding (Phi-3.5 style with short_inv_freq + long_inv_freq)
@@ -201,65 +201,65 @@ def _fix_rope_inv_freq(model):
                 if short_factor is not None and long_factor is not None:
                     inv_freq_shape = (
                         torch.arange(
-                            0, module.dim, 2, dtype = torch.int64, device = "cpu"
+                            0, module.dim, 2, dtype=torch.int64, device="cpu"
                         ).float()
                         / module.dim
                     )
-                    sf = torch.tensor(short_factor, device = "cpu", dtype = torch.float32)
-                    lf = torch.tensor(long_factor, device = "cpu", dtype = torch.float32)
+                    sf = torch.tensor(short_factor, device="cpu", dtype=torch.float32)
+                    lf = torch.tensor(long_factor, device="cpu", dtype=torch.float32)
                     module.short_inv_freq = 1.0 / (sf * module.base**inv_freq_shape)
                     module.long_inv_freq = 1.0 / (lf * module.base**inv_freq_shape)
 
                     dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
                     t = torch.arange(
                         module.original_max_position_embeddings,
-                        device = module.short_inv_freq.device,
-                        dtype = torch.int64,
+                        device=module.short_inv_freq.device,
+                        dtype=torch.int64,
                     ).float()
                     freqs = torch.outer(t, module.short_inv_freq)
-                    emb = torch.cat((freqs, freqs), dim = -1)
+                    emb = torch.cat((freqs, freqs), dim=-1)
                     for device_idx in range(len(module.multi_gpu_short_cos_cached)):
                         if module.multi_gpu_short_cos_cached[device_idx] is not None:
                             device_obj = torch.device(device_idx)
                             module.multi_gpu_short_cos_cached[device_idx] = (
                                 emb.cos() * module.scaling_factor
-                            ).to(dtype = dtype, device = device_obj, non_blocking = True)
+                            ).to(dtype=dtype, device=device_obj, non_blocking=True)
                             module.multi_gpu_short_sin_cached[device_idx] = (
                                 emb.sin() * module.scaling_factor
-                            ).to(dtype = dtype, device = device_obj, non_blocking = True)
+                            ).to(dtype=dtype, device=device_obj, non_blocking=True)
     return model
 
 
 class FastLanguageModel(FastLlamaModel):
     @staticmethod
     def from_pretrained(
-        model_name = "unsloth/Llama-3.2-1B-Instruct",
-        max_seq_length = 2048,
-        dtype = None,
-        load_in_4bit = True,  # 4bit QLoRA
-        load_in_8bit = False,  # 8bit  LoRA
-        load_in_16bit = False,  # 16bit LoRA
-        full_finetuning = False,
-        token = None,
-        device_map = "sequential",
-        rope_scaling = None,
-        fix_tokenizer = True,
-        trust_remote_code = False,
-        use_gradient_checkpointing = "unsloth",
-        resize_model_vocab = None,
-        revision = None,
-        use_exact_model_name = False,
-        offload_embedding = False,
-        float32_mixed_precision = None,  # Forces float32 mixed precision
-        fast_inference = False,  # uses vLLM
-        gpu_memory_utilization = 0.5,
-        float8_kv_cache = False,
-        random_state = 3407,
-        max_lora_rank = 64,
-        disable_log_stats = True,
-        qat_scheme = None,
-        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
-        unsloth_tiled_mlp = False,
+        model_name="unsloth/Llama-3.2-1B-Instruct",
+        max_seq_length=2048,
+        dtype=None,
+        load_in_4bit=True,  # 4bit QLoRA
+        load_in_8bit=False,  # 8bit  LoRA
+        load_in_16bit=False,  # 16bit LoRA
+        full_finetuning=False,
+        token=None,
+        device_map="sequential",
+        rope_scaling=None,
+        fix_tokenizer=True,
+        trust_remote_code=False,
+        use_gradient_checkpointing="unsloth",
+        resize_model_vocab=None,
+        revision=None,
+        use_exact_model_name=False,
+        offload_embedding=False,
+        float32_mixed_precision=None,  # Forces float32 mixed precision
+        fast_inference=False,  # uses vLLM
+        gpu_memory_utilization=0.5,
+        float8_kv_cache=False,
+        random_state=3407,
+        max_lora_rank=64,
+        disable_log_stats=True,
+        qat_scheme=None,
+        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
+        unsloth_tiled_mlp=False,
         *args,
         **kwargs,
     ):
@@ -310,36 +310,36 @@ class FastLanguageModel(FastLlamaModel):
 
         if load_in_8bit or full_finetuning or qat_scheme is not None:
             return FastModel.from_pretrained(
-                model_name = model_name,
-                max_seq_length = max_seq_length,
-                dtype = dtype,
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = load_in_8bit,
-                load_in_16bit = load_in_16bit,
-                full_finetuning = full_finetuning,
-                token = token,
-                device_map = device_map,
-                rope_scaling = rope_scaling,  # [TODO] No effect
-                fix_tokenizer = fix_tokenizer,  # [TODO] No effect
-                trust_remote_code = trust_remote_code,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                resize_model_vocab = resize_model_vocab,  # [TODO] No effect
-                revision = revision,
-                return_logits = False,  # Return logits
-                fullgraph = True,  # No graph breaks
-                use_exact_model_name = use_exact_model_name,
-                offload_embedding = offload_embedding,
-                float32_mixed_precision = float32_mixed_precision,
+                model_name=model_name,
+                max_seq_length=max_seq_length,
+                dtype=dtype,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=load_in_8bit,
+                load_in_16bit=load_in_16bit,
+                full_finetuning=full_finetuning,
+                token=token,
+                device_map=device_map,
+                rope_scaling=rope_scaling,  # [TODO] No effect
+                fix_tokenizer=fix_tokenizer,  # [TODO] No effect
+                trust_remote_code=trust_remote_code,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                resize_model_vocab=resize_model_vocab,  # [TODO] No effect
+                revision=revision,
+                return_logits=False,  # Return logits
+                fullgraph=True,  # No graph breaks
+                use_exact_model_name=use_exact_model_name,
+                offload_embedding=offload_embedding,
+                float32_mixed_precision=float32_mixed_precision,
                 # Pass vLLM/inference parameters
-                fast_inference = fast_inference,
-                gpu_memory_utilization = gpu_memory_utilization,
-                float8_kv_cache = float8_kv_cache,
-                random_state = random_state,
-                max_lora_rank = max_lora_rank,
-                disable_log_stats = disable_log_stats,
-                qat_scheme = qat_scheme,
-                load_in_fp8 = load_in_fp8,
-                unsloth_tiled_mlp = unsloth_tiled_mlp,
+                fast_inference=fast_inference,
+                gpu_memory_utilization=gpu_memory_utilization,
+                float8_kv_cache=float8_kv_cache,
+                random_state=random_state,
+                max_lora_rank=max_lora_rank,
+                disable_log_stats=disable_log_stats,
+                qat_scheme=qat_scheme,
+                load_in_fp8=load_in_fp8,
+                unsloth_tiled_mlp=unsloth_tiled_mlp,
                 *args,
                 **kwargs,
             )
@@ -384,10 +384,10 @@ class FastLanguageModel(FastLlamaModel):
         if not use_exact_model_name:
             new_model_name = get_model_name(
                 model_name,
-                load_in_4bit = load_in_4bit,
-                load_in_fp8 = load_in_fp8,
-                token = token,
-                trust_remote_code = trust_remote_code,
+                load_in_4bit=load_in_4bit,
+                load_in_fp8=load_in_fp8,
+                token=token,
+                trust_remote_code=trust_remote_code,
             )
             if new_model_name is None and load_in_fp8 != False:
                 fp8_mode = _get_fp8_mode_and_check_settings(
@@ -442,9 +442,9 @@ class FastLanguageModel(FastLlamaModel):
         try:
             model_config = AutoConfig.from_pretrained(
                 model_name,
-                token = token,
-                revision = revision,
-                trust_remote_code = trust_remote_code,
+                token=token,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
             )
             is_model = True
         except ImportError:
@@ -467,9 +467,9 @@ class FastLanguageModel(FastLlamaModel):
         try:
             peft_config = PeftConfig.from_pretrained(
                 model_name,
-                token = token,
-                revision = revision,
-                trust_remote_code = trust_remote_code,
+                token=token,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
             )
             is_peft = True
         except ImportError:
@@ -496,7 +496,7 @@ class FastLanguageModel(FastLlamaModel):
             )
         model_types = get_transformers_model_type(
             peft_config if peft_config is not None else model_config,
-            trust_remote_code = trust_remote_code,
+            trust_remote_code=trust_remote_code,
         )
         if len(model_types) == 1:
             model_type = model_types[0]
@@ -544,10 +544,10 @@ class FastLanguageModel(FastLlamaModel):
             if not use_exact_model_name:
                 model_name = get_model_name(
                     model_name,
-                    load_in_4bit = load_in_4bit,
-                    load_in_fp8 = load_in_fp8,
-                    token = token,
-                    trust_remote_code = trust_remote_code,
+                    load_in_4bit=load_in_4bit,
+                    load_in_fp8=load_in_fp8,
+                    token=token,
+                    trust_remote_code=trust_remote_code,
                 )
             # Check if pre-quantized models are allowed
             # AMD Instinct GPUs need blocksize = 128 on bitsandbytes < 0.49.2 (our pre-quants use blocksize = 64)
@@ -564,8 +564,8 @@ class FastLanguageModel(FastLlamaModel):
 
             model_config = AutoConfig.from_pretrained(
                 model_name,
-                token = token,
-                trust_remote_code = trust_remote_code,
+                token=token,
+                trust_remote_code=trust_remote_code,
             )
 
         if not was_disabled:
@@ -655,36 +655,36 @@ class FastLanguageModel(FastLlamaModel):
         #     dispatch_model = FastGraniteModel
         else:
             return FastModel.from_pretrained(
-                model_name = old_model_name,
-                max_seq_length = max_seq_length,
-                dtype = dtype,
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = load_in_8bit,
-                load_in_16bit = load_in_16bit,
-                full_finetuning = full_finetuning,
-                token = token,
-                device_map = device_map,
-                rope_scaling = rope_scaling,  # [TODO] No effect
-                fix_tokenizer = fix_tokenizer,  # [TODO] No effect
-                trust_remote_code = trust_remote_code,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                resize_model_vocab = resize_model_vocab,  # [TODO] No effect
-                revision = revision,
-                return_logits = False,  # Return logits
-                fullgraph = True,  # No graph breaks
-                use_exact_model_name = use_exact_model_name,
-                offload_embedding = offload_embedding,
-                float32_mixed_precision = float32_mixed_precision,
+                model_name=old_model_name,
+                max_seq_length=max_seq_length,
+                dtype=dtype,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=load_in_8bit,
+                load_in_16bit=load_in_16bit,
+                full_finetuning=full_finetuning,
+                token=token,
+                device_map=device_map,
+                rope_scaling=rope_scaling,  # [TODO] No effect
+                fix_tokenizer=fix_tokenizer,  # [TODO] No effect
+                trust_remote_code=trust_remote_code,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                resize_model_vocab=resize_model_vocab,  # [TODO] No effect
+                revision=revision,
+                return_logits=False,  # Return logits
+                fullgraph=True,  # No graph breaks
+                use_exact_model_name=use_exact_model_name,
+                offload_embedding=offload_embedding,
+                float32_mixed_precision=float32_mixed_precision,
                 # Pass vLLM/inference parameters
-                fast_inference = fast_inference,
-                gpu_memory_utilization = gpu_memory_utilization,
-                float8_kv_cache = float8_kv_cache,
-                random_state = random_state,
-                max_lora_rank = max_lora_rank,
-                disable_log_stats = disable_log_stats,
-                qat_scheme = qat_scheme,
-                load_in_fp8 = load_in_fp8,
-                unsloth_tiled_mlp = unsloth_tiled_mlp,
+                fast_inference=fast_inference,
+                gpu_memory_utilization=gpu_memory_utilization,
+                float8_kv_cache=float8_kv_cache,
+                random_state=random_state,
+                max_lora_rank=max_lora_rank,
+                disable_log_stats=disable_log_stats,
+                qat_scheme=qat_scheme,
+                load_in_fp8=load_in_fp8,
+                unsloth_tiled_mlp=unsloth_tiled_mlp,
                 *args,
                 **kwargs,
             )
@@ -714,25 +714,25 @@ class FastLanguageModel(FastLlamaModel):
             load_in_8bit_kwargs = False
 
         model, tokenizer = dispatch_model.from_pretrained(
-            model_name = model_name,
-            max_seq_length = max_seq_length,
-            dtype = _get_dtype(dtype),
-            load_in_4bit = load_in_4bit_kwargs,
-            token = token,
-            device_map = device_map,
-            rope_scaling = rope_scaling,
-            fix_tokenizer = fix_tokenizer,
-            model_patcher = dispatch_model,
-            tokenizer_name = tokenizer_name,
-            trust_remote_code = trust_remote_code,
-            revision = revision if not is_peft else None,
-            fast_inference = fast_inference,
-            gpu_memory_utilization = gpu_memory_utilization,
-            float8_kv_cache = float8_kv_cache,
-            random_state = random_state,
-            max_lora_rank = max_lora_rank,
-            disable_log_stats = disable_log_stats,
-            load_in_fp8 = load_in_fp8,
+            model_name=model_name,
+            max_seq_length=max_seq_length,
+            dtype=_get_dtype(dtype),
+            load_in_4bit=load_in_4bit_kwargs,
+            token=token,
+            device_map=device_map,
+            rope_scaling=rope_scaling,
+            fix_tokenizer=fix_tokenizer,
+            model_patcher=dispatch_model,
+            tokenizer_name=tokenizer_name,
+            trust_remote_code=trust_remote_code,
+            revision=revision if not is_peft else None,
+            fast_inference=fast_inference,
+            gpu_memory_utilization=gpu_memory_utilization,
+            float8_kv_cache=float8_kv_cache,
+            random_state=random_state,
+            max_lora_rank=max_lora_rank,
+            disable_log_stats=disable_log_stats,
+            load_in_fp8=load_in_fp8,
             *args,
             **kwargs,
         )
@@ -789,10 +789,10 @@ class FastLanguageModel(FastLlamaModel):
             model = PeftModel.from_pretrained(
                 model,
                 old_model_name,
-                token = token,
-                revision = revision,
-                is_trainable = True,
-                trust_remote_code = trust_remote_code,
+                token=token,
+                revision=revision,
+                is_trainable=True,
+                trust_remote_code=trust_remote_code,
             )
             # Patch it as well!
             model = dispatch_model.patch_peft_model(model, use_gradient_checkpointing)
@@ -803,7 +803,7 @@ class FastLanguageModel(FastLlamaModel):
             "UNSLOTH_TILED_MLP", "arctic" if unsloth_tiled_mlp else "0"
         )
         if patch_tiled_mlp_choice != "0" or unsloth_tiled_mlp:
-            patch_tiled_mlp(model, patch_options_str = patch_tiled_mlp_choice)
+            patch_tiled_mlp(model, patch_options_str=patch_tiled_mlp_choice)
 
         model = _fix_rope_inv_freq(model)
         return model, tokenizer
@@ -834,41 +834,41 @@ class FastModel(FastBaseModel):
 
     @staticmethod
     def from_pretrained(
-        model_name = "unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit",
-        max_seq_length = 2048,
-        dtype = None,
-        load_in_4bit = True,  # 4bit QLoRA
-        load_in_8bit = False,  # 8bit  LoRA
-        load_in_16bit = False,  # 16bit LoRA
-        full_finetuning = False,
-        token = None,
-        device_map = "sequential",
-        rope_scaling = None,  # [TODO] No effect
-        fix_tokenizer = True,  # [TODO] No effect
-        trust_remote_code = False,
-        use_gradient_checkpointing = "unsloth",
-        resize_model_vocab = None,  # [TODO] No effect
-        revision = None,
-        return_logits = False,  # Return logits
-        fullgraph = True,  # No graph breaks
-        use_exact_model_name = False,
-        auto_model = None,
-        whisper_language = None,
-        whisper_task = None,
-        unsloth_force_compile = False,
-        offload_embedding = False,
-        float32_mixed_precision = None,  # Forces float32 mixed precision
+        model_name="unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit",
+        max_seq_length=2048,
+        dtype=None,
+        load_in_4bit=True,  # 4bit QLoRA
+        load_in_8bit=False,  # 8bit  LoRA
+        load_in_16bit=False,  # 16bit LoRA
+        full_finetuning=False,
+        token=None,
+        device_map="sequential",
+        rope_scaling=None,  # [TODO] No effect
+        fix_tokenizer=True,  # [TODO] No effect
+        trust_remote_code=False,
+        use_gradient_checkpointing="unsloth",
+        resize_model_vocab=None,  # [TODO] No effect
+        revision=None,
+        return_logits=False,  # Return logits
+        fullgraph=True,  # No graph breaks
+        use_exact_model_name=False,
+        auto_model=None,
+        whisper_language=None,
+        whisper_task=None,
+        unsloth_force_compile=False,
+        offload_embedding=False,
+        float32_mixed_precision=None,  # Forces float32 mixed precision
         # Add the missing vLLM/inference parameters
-        fast_inference = False,  # uses vLLM
-        gpu_memory_utilization = 0.5,
-        float8_kv_cache = False,
-        random_state = 3407,
-        max_lora_rank = 64,
-        disable_log_stats = True,
-        qat_scheme = None,
-        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
-        unsloth_tiled_mlp = False,
-        target_parameters = None,  # For MoE expert parameters
+        fast_inference=False,  # uses vLLM
+        gpu_memory_utilization=0.5,
+        float8_kv_cache=False,
+        random_state=3407,
+        max_lora_rank=64,
+        disable_log_stats=True,
+        qat_scheme=None,
+        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
+        unsloth_tiled_mlp=False,
+        target_parameters=None,  # For MoE expert parameters
         *args,
         **kwargs,
     ):
@@ -996,7 +996,7 @@ class FastModel(FastBaseModel):
         fp8_mode = None
         if not use_exact_model_name:
             new_model_name = get_model_name(
-                model_name, load_in_4bit = load_in_4bit, load_in_fp8 = load_in_fp8
+                model_name, load_in_4bit=load_in_4bit, load_in_fp8=load_in_fp8
             )
             if new_model_name is None and load_in_fp8 != False:
                 fp8_mode = _get_fp8_mode_and_check_settings(
@@ -1052,9 +1052,9 @@ class FastModel(FastBaseModel):
         try:
             model_config = AutoConfig.from_pretrained(
                 model_name,
-                token = token,
-                revision = revision,
-                trust_remote_code = trust_remote_code,
+                token=token,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
             )
             is_model = True
         except ImportError:
@@ -1077,9 +1077,9 @@ class FastModel(FastBaseModel):
         try:
             peft_config = PeftConfig.from_pretrained(
                 model_name,
-                token = token,
-                revision = revision,
-                trust_remote_code = trust_remote_code,
+                token=token,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
             )
             is_peft = True
         except ImportError:
@@ -1104,7 +1104,7 @@ class FastModel(FastBaseModel):
             )
         model_types = get_transformers_model_type(
             peft_config if peft_config is not None else model_config,
-            trust_remote_code = trust_remote_code,
+            trust_remote_code=trust_remote_code,
         )
         model_types_all = ",".join(model_types) + ","
 
@@ -1328,8 +1328,8 @@ class FastModel(FastBaseModel):
 
             model_config = AutoConfig.from_pretrained(
                 model_name,
-                token = token,
-                trust_remote_code = trust_remote_code,
+                token=token,
+                trust_remote_code=trust_remote_code,
             )
 
         if not was_disabled:
@@ -1364,38 +1364,38 @@ class FastModel(FastBaseModel):
             use_gradient_checkpointing, max_seq_length, dtype
         )
         with redirector:
-            patch_loss_functions(torch_compile = False)
+            patch_loss_functions(torch_compile=False)
             model_types, supports_sdpa = unsloth_compile_transformers(
-                dtype = dtype,
-                model_name = model_name,
-                model_types = model_types,
-                token = token,
-                sdpa_dynamic_mask = True,
-                sdpa_bool_masks = True,
-                sdpa_gqa_replace = True,
-                sdpa_dynamic_compile = True,
-                compile_attention = True,
-                disable_causal_masks = True,
-                compile_torch_modules = True,
-                compile_custom_modules = True,
-                compile_function_calls = True,
-                fuse_lm_head = True,
-                gradient_checkpointing = True,
-                manual_replacements = True,
-                fast_lora_forwards = True,
-                fast_residual_stream = False,
-                accurate_accumulation = True,
-                epilogue_fusion = True,
-                max_autotune = False,
-                shape_padding = True,
-                cudagraphs = False,
-                debug = False,
-                fullgraph = fullgraph,
-                import_from_cache = False,
-                disable = False,
-                return_logits = return_logits,
-                trust_remote_code = trust_remote_code,
-                unsloth_force_compile = unsloth_force_compile,
+                dtype=dtype,
+                model_name=model_name,
+                model_types=model_types,
+                token=token,
+                sdpa_dynamic_mask=True,
+                sdpa_bool_masks=True,
+                sdpa_gqa_replace=True,
+                sdpa_dynamic_compile=True,
+                compile_attention=True,
+                disable_causal_masks=True,
+                compile_torch_modules=True,
+                compile_custom_modules=True,
+                compile_function_calls=True,
+                fuse_lm_head=True,
+                gradient_checkpointing=True,
+                manual_replacements=True,
+                fast_lora_forwards=True,
+                fast_residual_stream=False,
+                accurate_accumulation=True,
+                epilogue_fusion=True,
+                max_autotune=False,
+                shape_padding=True,
+                cudagraphs=False,
+                debug=False,
+                fullgraph=fullgraph,
+                import_from_cache=False,
+                disable=False,
+                return_logits=return_logits,
+                trust_remote_code=trust_remote_code,
+                unsloth_force_compile=unsloth_force_compile,
             )
         # Fix SDPA issues
         for model_type in DISABLE_SDPA_MODEL_NAMES:
@@ -1448,35 +1448,35 @@ class FastModel(FastBaseModel):
             load_in_8bit_kwargs = False
 
         model, tokenizer = FastBaseModel.from_pretrained(
-            model_name = model_name,
-            max_seq_length = max_seq_length,
-            dtype = _get_dtype(dtype),
-            load_in_4bit = load_in_4bit_kwargs,
-            load_in_8bit = load_in_8bit_kwargs,
-            load_in_16bit = load_in_16bit,
-            full_finetuning = full_finetuning,
-            token = token,
-            device_map = device_map,
-            trust_remote_code = trust_remote_code,
-            revision = revision if not is_peft else None,
-            model_types = model_types,
-            tokenizer_name = tokenizer_name,
-            auto_model = auto_model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
-            supports_sdpa = supports_sdpa,
-            whisper_language = whisper_language,
-            whisper_task = whisper_task,
-            auto_config = model_config,
-            offload_embedding = offload_embedding,
-            float32_mixed_precision = float32_mixed_precision,
+            model_name=model_name,
+            max_seq_length=max_seq_length,
+            dtype=_get_dtype(dtype),
+            load_in_4bit=load_in_4bit_kwargs,
+            load_in_8bit=load_in_8bit_kwargs,
+            load_in_16bit=load_in_16bit,
+            full_finetuning=full_finetuning,
+            token=token,
+            device_map=device_map,
+            trust_remote_code=trust_remote_code,
+            revision=revision if not is_peft else None,
+            model_types=model_types,
+            tokenizer_name=tokenizer_name,
+            auto_model=auto_model,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            supports_sdpa=supports_sdpa,
+            whisper_language=whisper_language,
+            whisper_task=whisper_task,
+            auto_config=model_config,
+            offload_embedding=offload_embedding,
+            float32_mixed_precision=float32_mixed_precision,
             # Pass vLLM/inference parameters
-            fast_inference = fast_inference,
-            gpu_memory_utilization = gpu_memory_utilization,
-            float8_kv_cache = float8_kv_cache,
-            random_state = random_state,
-            max_lora_rank = max_lora_rank,
-            disable_log_stats = disable_log_stats,
-            load_in_fp8 = load_in_fp8,
+            fast_inference=fast_inference,
+            gpu_memory_utilization=gpu_memory_utilization,
+            float8_kv_cache=float8_kv_cache,
+            random_state=random_state,
+            max_lora_rank=max_lora_rank,
+            disable_log_stats=disable_log_stats,
+            load_in_fp8=load_in_fp8,
             *args,
             **kwargs,
         )
@@ -1555,7 +1555,7 @@ class FastModel(FastBaseModel):
                     target,
                     target_name,
                     parent,
-                    current_key = None,
+                    current_key=None,
                     **kwargs,
                 ):
                     if isinstance(target, _clippable_linear_cls):
@@ -1566,7 +1566,7 @@ class FastModel(FastBaseModel):
                             target.linear,
                             "linear",
                             target,
-                            current_key = current_key,
+                            current_key=current_key,
                             **kwargs,
                         )
                     return _original_car(
@@ -1576,7 +1576,7 @@ class FastModel(FastBaseModel):
                         target,
                         target_name,
                         parent,
-                        current_key = current_key,
+                        current_key=current_key,
                         **kwargs,
                     )
 
@@ -1586,10 +1586,10 @@ class FastModel(FastBaseModel):
                 model = PeftModel.from_pretrained(
                     model,
                     old_model_name,
-                    token = token,
-                    revision = revision,
-                    is_trainable = True,
-                    trust_remote_code = trust_remote_code,
+                    token=token,
+                    revision=revision,
+                    is_trainable=True,
+                    trust_remote_code=trust_remote_code,
                 )
             finally:
                 # Always restore original PEFT method, even if loading fails
@@ -1598,7 +1598,7 @@ class FastModel(FastBaseModel):
 
             # Patch it as well!
             model = FastBaseModel.post_patch_model(
-                model, use_gradient_checkpointing, trust_remote_code = trust_remote_code
+                model, use_gradient_checkpointing, trust_remote_code=trust_remote_code
             )
 
         # Apply QAT if specified
@@ -1612,7 +1612,7 @@ class FastModel(FastBaseModel):
             "UNSLOTH_TILED_MLP", "arctic" if unsloth_tiled_mlp else "0"
         )
         if patch_tiled_mlp_choice != "0" or unsloth_tiled_mlp:
-            patch_tiled_mlp(model, patch_options_str = patch_tiled_mlp_choice)
+            patch_tiled_mlp(model, patch_options_str=patch_tiled_mlp_choice)
 
         model = _fix_rope_inv_freq(model)
         return model, tokenizer

--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -101,13 +101,13 @@ def prepare_device_map():
 
 def __get_model_name(
     model_name,
-    load_in_4bit = True,
-    INT_TO_FLOAT_MAPPER = None,
-    FLOAT_TO_INT_MAPPER = None,
-    MAP_TO_UNSLOTH_16bit = None,
-    load_in_fp8 = False,
-    FLOAT_TO_FP8_BLOCK_MAPPER = None,
-    FLOAT_TO_FP8_ROW_MAPPER = None,
+    load_in_4bit=True,
+    INT_TO_FLOAT_MAPPER=None,
+    FLOAT_TO_INT_MAPPER=None,
+    MAP_TO_UNSLOTH_16bit=None,
+    load_in_fp8=False,
+    FLOAT_TO_FP8_BLOCK_MAPPER=None,
+    FLOAT_TO_FP8_ROW_MAPPER=None,
 ):
     model_name = str(model_name)
     lower_model_name = model_name.lower()
@@ -179,7 +179,7 @@ def _get_new_mapper():
         import requests
 
         new_mapper = "https://raw.githubusercontent.com/unslothai/unsloth/main/unsloth/models/mapper.py"
-        with requests.get(new_mapper, timeout = 3) as new_mapper:
+        with requests.get(new_mapper, timeout=3) as new_mapper:
             new_mapper = new_mapper.text
         new_mapper = new_mapper[new_mapper.find("__INT_TO_FLOAT_MAPPER") :]
         new_mapper = (
@@ -207,32 +207,32 @@ def _resolve_with_mappers(
     map_to_unsloth_16bit,
 ):
     return __get_model_name(
-        model_name = model_name,
-        load_in_4bit = load_in_4bit,
-        INT_TO_FLOAT_MAPPER = int_to_float,
-        FLOAT_TO_INT_MAPPER = float_to_int,
-        MAP_TO_UNSLOTH_16bit = map_to_unsloth_16bit,
-        load_in_fp8 = load_in_fp8,
-        FLOAT_TO_FP8_BLOCK_MAPPER = FLOAT_TO_FP8_BLOCK_MAPPER,
-        FLOAT_TO_FP8_ROW_MAPPER = FLOAT_TO_FP8_ROW_MAPPER,
+        model_name=model_name,
+        load_in_4bit=load_in_4bit,
+        INT_TO_FLOAT_MAPPER=int_to_float,
+        FLOAT_TO_INT_MAPPER=float_to_int,
+        MAP_TO_UNSLOTH_16bit=map_to_unsloth_16bit,
+        load_in_fp8=load_in_fp8,
+        FLOAT_TO_FP8_BLOCK_MAPPER=FLOAT_TO_FP8_BLOCK_MAPPER,
+        FLOAT_TO_FP8_ROW_MAPPER=FLOAT_TO_FP8_ROW_MAPPER,
     )
 
 
 def get_model_name(
     model_name,
-    load_in_4bit = True,
-    load_in_fp8 = False,
-    token = None,
-    trust_remote_code = False,
+    load_in_4bit=True,
+    load_in_fp8=False,
+    token=None,
+    trust_remote_code=False,
 ):
     assert load_in_fp8 in (True, False, "block")
     new_model_name = _resolve_with_mappers(
-        model_name = model_name,
-        load_in_4bit = load_in_4bit,
-        load_in_fp8 = load_in_fp8,
-        int_to_float = INT_TO_FLOAT_MAPPER,
-        float_to_int = FLOAT_TO_INT_MAPPER,
-        map_to_unsloth_16bit = MAP_TO_UNSLOTH_16bit,
+        model_name=model_name,
+        load_in_4bit=load_in_4bit,
+        load_in_fp8=load_in_fp8,
+        int_to_float=INT_TO_FLOAT_MAPPER,
+        float_to_int=FLOAT_TO_INT_MAPPER,
+        map_to_unsloth_16bit=MAP_TO_UNSLOTH_16bit,
     )
     # In the rare case, we convert bad model names to other names
     # For eg too large dynamic quants or MoEs
@@ -253,12 +253,12 @@ def get_model_name(
             _get_new_mapper()
         )
         upgraded_model_name = _resolve_with_mappers(
-            model_name = model_name,
-            load_in_4bit = load_in_4bit,
-            load_in_fp8 = load_in_fp8,
-            int_to_float = NEW_INT_TO_FLOAT_MAPPER,
-            float_to_int = NEW_FLOAT_TO_INT_MAPPER,
-            map_to_unsloth_16bit = NEW_MAP_TO_UNSLOTH_16bit,
+            model_name=model_name,
+            load_in_4bit=load_in_4bit,
+            load_in_fp8=load_in_fp8,
+            int_to_float=NEW_INT_TO_FLOAT_MAPPER,
+            float_to_int=NEW_FLOAT_TO_INT_MAPPER,
+            map_to_unsloth_16bit=NEW_MAP_TO_UNSLOTH_16bit,
         )
         if upgraded_model_name is not None:
             raise NotImplementedError(
@@ -315,12 +315,12 @@ def _offline_quantize_to_fp8(model_name: str, fp8_mode: str) -> str:
         auto_processor = AutoProcessor if is_vlm else AutoTokenizer
         model = auto_model.from_pretrained(
             model_name,
-            torch_dtype = "auto",
-            device_map = "auto",
-            quantization_config = qconfig,
+            torch_dtype="auto",
+            device_map="auto",
+            quantization_config=qconfig,
         )
         tokenizer = auto_processor.from_pretrained(model_name)
-        model.save_pretrained(new_model_name, safe_serialization = False)
+        model.save_pretrained(new_model_name, safe_serialization=False)
         del model
         for _ in range(2):
             torch.cuda.empty_cache()
@@ -336,8 +336,8 @@ def _tag_model_with_fp8_torchao_config(model: torch.nn.Module, fp8_mode: str):
     try:
         base_config = _get_torchao_fp8_config(fp8_mode)
         model.torchao_config = TorchAOConfig(
-            qat_scheme = None,
-            base_config_and_filter_fns = [(base_config, None)],
+            qat_scheme=None,
+            base_config_and_filter_fns=[(base_config, None)],
         )
     except:
         pass

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -159,7 +159,7 @@ def PatchRL(FastLanguageModel):
 
             @_cm
             def unwrap_model_for_generation(
-                model, accelerator, gather_deepspeed3_params = True
+                model, accelerator, gather_deepspeed3_params=True
             ):
                 unwrapped_model = accelerator.unwrap_model(model)
                 is_gc = getattr(unwrapped_model, "is_gradient_checkpointing", False)
@@ -284,8 +284,8 @@ def PatchRL(FastLanguageModel):
                     loss, outputs = self.compute_loss(
                         model,
                         inputs,
-                        return_outputs = True,
-                        num_items_in_batch = num_items_in_batch,
+                        return_outputs=True,
+                        num_items_in_batch=num_items_in_batch,
                     )
                 loss = loss.mean().detach()
 
@@ -300,9 +300,9 @@ def PatchRL(FastLanguageModel):
                 with self.compute_loss_context_manager():
                     tokenized_output = self.processing_class(
                         inputs["prompt"],
-                        padding = True,
-                        truncation = True,
-                        return_tensors = "pt",
+                        padding=True,
+                        truncation=True,
+                        return_tensors="pt",
                     ).to(model.device)
                     outputs = model(**tokenized_output)
                 if isinstance(outputs, dict):
@@ -539,7 +539,7 @@ def _wrap_grpo_generate_and_score(trainer_cls):
     trainer_cls._generate_and_score_completions = wrapped
 
 
-def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
+def _patch_trl_rl_trainers(trainer_file="grpo_trainer"):
     # Patch for vLLM and Unsloth PEFT
     import trl
     import trl.trainer
@@ -1358,33 +1358,33 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
     sanitize_logprob_code = inspect.getsource(sanitize_logprob)
     # Get final source code
     RLTrainer_source = RLTrainer_replacement.format(
-        RLTrainer_name = RLTrainer_name,
-        __RLTrainer_doc__ = __RLTrainer_doc__,
-        RLTrainer_arguments = RLTrainer_arguments,
-        RLTrainer_extra_args = RLTrainer_extra_args,
-        RLTrainer_call_args = RLTrainer_call_args,
-        RLTrainer_kwargs = ",**kwargs"[1 if RLTrainer_call_args.endswith(",") else 0 :],
-        RLConfig_name = RLConfig_name,
-        __RLConfig_doc__ = __RLConfig_doc__,
-        RLConfig_arguments = RLConfig_arguments,
-        RLConfig_extra_args = RLConfig_extra_args,
-        RLConfig_call_args = RLConfig_call_args,
-        RLConfig_kwargs = ",**kwargs"[1 if RLConfig_call_args.endswith(",") else 0 :],
-        RLConfig_post = RLConfig_post,
-        RLTrainer_extras = RLTrainer_extras,
-        RLTrainer_post = RLTrainer_post,
-        RL_pre = RL_pre,
-        max_seq_length_pre = max_seq_length_pre,
-        max_seq_length_call = max_seq_length_call,
-        max_seq_length_post = max_seq_length_post,
-        selective_log_softmax_code = selective_log_softmax_code,
-        grpo_selective_log_softmax_code = grpo_selective_log_softmax_code,
-        calculate_pad_tokens_in_prompt_code = calculate_pad_tokens_in_prompt_code,
-        create_completion_attention_mask_code = create_completion_attention_mask_code,
-        autotune_batch_and_chunks_code = autotune_batch_and_chunks_code,
-        left_pack_padding_code = left_pack_padding_code,
-        align_logprobs_with_mask_code = align_logprobs_with_mask_code,
-        sanitize_logprob_code = sanitize_logprob_code,
+        RLTrainer_name=RLTrainer_name,
+        __RLTrainer_doc__=__RLTrainer_doc__,
+        RLTrainer_arguments=RLTrainer_arguments,
+        RLTrainer_extra_args=RLTrainer_extra_args,
+        RLTrainer_call_args=RLTrainer_call_args,
+        RLTrainer_kwargs=",**kwargs"[1 if RLTrainer_call_args.endswith(",") else 0 :],
+        RLConfig_name=RLConfig_name,
+        __RLConfig_doc__=__RLConfig_doc__,
+        RLConfig_arguments=RLConfig_arguments,
+        RLConfig_extra_args=RLConfig_extra_args,
+        RLConfig_call_args=RLConfig_call_args,
+        RLConfig_kwargs=",**kwargs"[1 if RLConfig_call_args.endswith(",") else 0 :],
+        RLConfig_post=RLConfig_post,
+        RLTrainer_extras=RLTrainer_extras,
+        RLTrainer_post=RLTrainer_post,
+        RL_pre=RL_pre,
+        max_seq_length_pre=max_seq_length_pre,
+        max_seq_length_call=max_seq_length_call,
+        max_seq_length_post=max_seq_length_post,
+        selective_log_softmax_code=selective_log_softmax_code,
+        grpo_selective_log_softmax_code=grpo_selective_log_softmax_code,
+        calculate_pad_tokens_in_prompt_code=calculate_pad_tokens_in_prompt_code,
+        create_completion_attention_mask_code=create_completion_attention_mask_code,
+        autotune_batch_and_chunks_code=autotune_batch_and_chunks_code,
+        left_pack_padding_code=left_pack_padding_code,
+        align_logprobs_with_mask_code=align_logprobs_with_mask_code,
+        sanitize_logprob_code=sanitize_logprob_code,
     )
 
     if RLTrainer_name == "GRPOTrainer":
@@ -1421,7 +1421,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         pattern = r"torch_compile_options\s*=\s*\{[^}]*\}"
 
         RLTrainer_source = re.sub(
-            pattern, new_options, RLTrainer_source, flags = re.DOTALL
+            pattern, new_options, RLTrainer_source, flags=re.DOTALL
         )
 
         if trl_version >= Version("0.27.0"):
@@ -1434,7 +1434,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
             replacement_comment = "\n        # PEFT initialization logic removed via script for trl >= 0.27.0\n"
 
             RLTrainer_source = re.sub(
-                peft_pattern, replacement_comment, RLTrainer_source, flags = re.DOTALL
+                peft_pattern, replacement_comment, RLTrainer_source, flags=re.DOTALL
             )
 
         elif trl_version >= Version("0.26.0"):
@@ -1448,7 +1448,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
                 peft_block_pattern,
                 "\n        # TRL PEFT 0.26.0 initialization logic removed on unsloth side.\n",
                 RLTrainer_source,
-                flags = re.DOTALL,
+                flags=re.DOTALL,
             )
 
     # Remove TRL's unconditional bfloat16 cast of trainable params (added in
@@ -1516,7 +1516,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         _prep_pattern = r"([ \t]*)train_dataset = self\._prepare_dataset\("
         _prep_replacement = r"\1self._unsloth_model_ref = model\n\1train_dataset = self._prepare_dataset("
         RLTrainer_source = re.sub(
-            _prep_pattern, _prep_replacement, RLTrainer_source, count = 1
+            _prep_pattern, _prep_replacement, RLTrainer_source, count=1
         )
 
     # Silence TRL's noisy batch_size=1 + padding-free warning (handles both
@@ -1564,7 +1564,7 @@ def _patch_trl_rl_trainers(trainer_file = "grpo_trainer"):
         RLTrainer_source,
         _model_location,
         imports,
-        overwrite = False,
+        overwrite=False,
     )
     patched_trainer = getattr(created_module, f"Unsloth{RLTrainer_name}")
     if trainer_file == "grpo_trainer":
@@ -1680,7 +1680,7 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
                 commented_lines.append(line)
         return "\n".join(commented_lines)
 
-    init = re.sub(add_adapter_block_pattern, comment_out_block, init, flags = re.DOTALL)
+    init = re.sub(add_adapter_block_pattern, comment_out_block, init, flags=re.DOTALL)
 
     # Set use_vllm if not set
     if "args.use_vllm" in init and "model" in init and "args" in init:
@@ -1688,7 +1688,7 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
         replacer = re.findall(
             r"def __init__\(.*?\).*?\:\n",
             init,
-            flags = re.MULTILINE | re.DOTALL,
+            flags=re.MULTILINE | re.DOTALL,
         )
         if len(replacer) != 0:
             replacer = replacer[0]
@@ -1723,24 +1723,24 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
     vllm_part = re.findall(
         r"(\n[\s]{8}" r"if (self|args)\.use_vllm\:.*?" r"\n[\s]{8}" "else:\n)",
         init,
-        flags = re.MULTILINE | re.DOTALL,
+        flags=re.MULTILINE | re.DOTALL,
     )
 
     if len(vllm_part) == 1:
         vllm_part, args = vllm_part[0][0], vllm_part[0][1]
         # Strip all comments
         new_vllm_part = re.sub(
-            r"^\s*\#[^\n]*\n?", "", vllm_part, flags = re.MULTILINE
+            r"^\s*\#[^\n]*\n?", "", vllm_part, flags=re.MULTILINE
         )  # to also remove whole comment line instead of just starting at #
         new_vllm_part = re.sub(
-            r"\s*\#.*$", "", new_vllm_part, flags = re.MULTILINE
+            r"\s*\#.*$", "", new_vllm_part, flags=re.MULTILINE
         )  # remove comments that occur after code
 
         # Get SamplingParams
         sampling_params = re.findall(
             r"\n[\s]{4,}(self\.[^\s]{1,}[\s]{0,}\=[\s]{0,}" r"SamplingParams\(.+?\))",
             new_vllm_part,
-            flags = re.MULTILINE | re.DOTALL,
+            flags=re.MULTILINE | re.DOTALL,
         )
 
         if len(sampling_params) == 1:
@@ -1797,7 +1797,7 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
                 vllm_llm_init_pattern,
                 vllm_llm_replacement,
                 new_vllm_part,
-                flags = re.DOTALL,  # Ensure . matches newlines [[5]]
+                flags=re.DOTALL,  # Ensure . matches newlines [[5]]
             )
 
         init = init.replace(vllm_part, new_vllm_part)
@@ -1986,7 +1986,7 @@ def patch_trl_disable_gradient_checkpointing():
         return
 
     @contextmanager
-    def _noop_disable_gradient_checkpointing(model, gradient_checkpointing_kwargs = None):
+    def _noop_disable_gradient_checkpointing(model, gradient_checkpointing_kwargs=None):
         yield
 
     _noop_disable_gradient_checkpointing._unsloth_noop_patched = True
@@ -2057,7 +2057,7 @@ def patch_trl_vllm_generation():
     return
 
 
-def PatchFastRL(algorithm = None, FastLanguageModel = None):
+def PatchFastRL(algorithm=None, FastLanguageModel=None):
     if FastLanguageModel is not None:
         PatchRL(FastLanguageModel)
     # Install the disable_gradient_checkpointing noop BEFORE

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -42,10 +42,10 @@ import shutil
 def _save_pretrained_torchao(
     self,
     save_directory,
-    tokenizer = None,
-    torchao_config = None,
-    push_to_hub = False,
-    token = None,
+    tokenizer=None,
+    torchao_config=None,
+    push_to_hub=False,
+    token=None,
 ):
     self.save_pretrained(save_directory)
 
@@ -97,24 +97,24 @@ def _save_pretrained_torchao(
         unsloth_save_pretrained_torchao(
             inner_model,
             transformer_dir,
-            tokenizer = tokenizer,
-            torchao_config = torchao_config,
-            push_to_hub = push_to_hub,
-            token = token,
+            tokenizer=tokenizer,
+            torchao_config=torchao_config,
+            push_to_hub=push_to_hub,
+            token=token,
         )
 
     # avoid `0_Transformer-torchao`, it was either this or fix modules.json
     torchao_dir = transformer_dir + "-torchao"
     if os.path.exists(torchao_dir):
         if not os.path.exists(transformer_dir):
-            os.makedirs(transformer_dir, exist_ok = True)
+            os.makedirs(transformer_dir, exist_ok=True)
 
         # move contents
         for item in os.listdir(torchao_dir):
             s = os.path.join(torchao_dir, item)
             d = os.path.join(transformer_dir, item)
             if os.path.isdir(s):
-                shutil.copytree(s, d, dirs_exist_ok = True)
+                shutil.copytree(s, d, dirs_exist_ok=True)
             else:
                 shutil.copy2(s, d)
 
@@ -140,14 +140,14 @@ def _save_pretrained_torchao(
 def _save_pretrained_gguf(
     self,
     save_directory,
-    tokenizer = None,
-    quantization_method = "fast_quantized",
-    first_conversion = None,
-    push_to_hub = False,
-    token = None,
-    max_shard_size = "5GB",
-    temporary_location = "_unsloth_temporary_saved_buffers",
-    maximum_memory_usage = 0.85,
+    tokenizer=None,
+    quantization_method="fast_quantized",
+    first_conversion=None,
+    push_to_hub=False,
+    token=None,
+    max_shard_size="5GB",
+    temporary_location="_unsloth_temporary_saved_buffers",
+    maximum_memory_usage=0.85,
     **kwargs,
 ):
     """
@@ -201,15 +201,15 @@ def _save_pretrained_gguf(
     with patch_unsloth_gguf_save():
         result = unsloth_save_pretrained_gguf(
             inner_model,
-            save_directory = transformer_dir,
-            tokenizer = tokenizer,
-            quantization_method = quantization_method,
-            first_conversion = first_conversion,
-            push_to_hub = False,  # Force local first to move files
-            token = token,
-            max_shard_size = max_shard_size,
-            temporary_location = temporary_location,
-            maximum_memory_usage = maximum_memory_usage,
+            save_directory=transformer_dir,
+            tokenizer=tokenizer,
+            quantization_method=quantization_method,
+            first_conversion=first_conversion,
+            push_to_hub=False,  # Force local first to move files
+            token=token,
+            max_shard_size=max_shard_size,
+            temporary_location=temporary_location,
+            maximum_memory_usage=maximum_memory_usage,
         )
 
     # 6. Move GGUF files from the subdirectory (0_Transformer) to the root save_directory
@@ -255,7 +255,7 @@ def _save_pretrained_gguf(
         # Add GGUF details to README
         readme_path = os.path.join(save_directory, "README.md")
         if os.path.exists(readme_path):
-            with open(readme_path, "a", encoding = "utf-8") as f:
+            with open(readme_path, "a", encoding="utf-8") as f:
                 f.write("\n## GGUF Quantization\n")
                 f.write(
                     f"This model contains GGUF quantized versions in: {', '.join([os.path.basename(f) for f in new_gguf_locations])}\n"
@@ -268,18 +268,18 @@ def _save_pretrained_gguf(
         if token is None:
             token = get_token()
 
-        api = HfApi(token = token)
+        api = HfApi(token=token)
         repo_id = save_directory  # Assuming save_directory is the repo name if pushing
 
         print(f"Unsloth: Uploading to {repo_id}...")
         try:
             api.create_repo(
-                repo_id = repo_id, exist_ok = True, private = kwargs.get("private", False)
+                repo_id=repo_id, exist_ok=True, private=kwargs.get("private", False)
             )
             api.upload_folder(
-                folder_path = save_directory,
-                repo_id = repo_id,
-                commit_message = "Upload GGUF and SentenceTransformer model",
+                folder_path=save_directory,
+                repo_id=repo_id,
+                commit_message="Upload GGUF and SentenceTransformer model",
             )
             print(f"Unsloth: Uploaded to https://huggingface.co/{repo_id}")
         except Exception as e:
@@ -291,19 +291,19 @@ def _save_pretrained_gguf(
 def _push_to_hub_gguf(
     self,
     repo_id,
-    tokenizer = None,
-    quantization_method = "fast_quantized",
-    first_conversion = None,
-    token = None,
-    private = None,
-    commit_message = "Upload GGUF SentenceTransformer model trained with Unsloth",
-    commit_description = "Upload GGUF model trained with Unsloth 2x faster",
-    max_shard_size = "5GB",
-    temporary_location = "_unsloth_temporary_saved_buffers",
-    maximum_memory_usage = 0.85,
-    create_pr = False,
-    revision = None,
-    tags = None,
+    tokenizer=None,
+    quantization_method="fast_quantized",
+    first_conversion=None,
+    token=None,
+    private=None,
+    commit_message="Upload GGUF SentenceTransformer model trained with Unsloth",
+    commit_description="Upload GGUF model trained with Unsloth 2x faster",
+    max_shard_size="5GB",
+    temporary_location="_unsloth_temporary_saved_buffers",
+    maximum_memory_usage=0.85,
+    create_pr=False,
+    revision=None,
+    tags=None,
     **kwargs,
 ):
     """
@@ -360,7 +360,7 @@ def _push_to_hub_gguf(
             "No HF token provided. Please provide a token or login with `huggingface-cli login`"
         )
 
-    api = HfApi(token = token)
+    api = HfApi(token=token)
 
     # Determine full repo_id
     if "/" not in repo_id:
@@ -374,30 +374,30 @@ def _push_to_hub_gguf(
     # Create repo
     try:
         api.create_repo(
-            repo_id = full_repo_id,
-            private = private,
-            exist_ok = True,
-            repo_type = "model",
+            repo_id=full_repo_id,
+            private=private,
+            exist_ok=True,
+            repo_type="model",
         )
     except Exception as e:
         print(f"Unsloth Warning: Could not create repo: {e}")
 
     # Save to temporary directory first
-    with tempfile.TemporaryDirectory(prefix = "unsloth_st_gguf_") as temp_dir:
+    with tempfile.TemporaryDirectory(prefix="unsloth_st_gguf_") as temp_dir:
         print(f"Unsloth: Converting SentenceTransformer to GGUF format...")
 
         # Call save_pretrained_gguf to do the local conversion
         result = _save_pretrained_gguf(
             self,
-            save_directory = temp_dir,
-            tokenizer = tokenizer,
-            quantization_method = quantization_method,
-            first_conversion = first_conversion,
-            push_to_hub = False,  # We handle upload ourselves
-            token = token,
-            max_shard_size = max_shard_size,
-            temporary_location = temporary_location,
-            maximum_memory_usage = maximum_memory_usage,
+            save_directory=temp_dir,
+            tokenizer=tokenizer,
+            quantization_method=quantization_method,
+            first_conversion=first_conversion,
+            push_to_hub=False,  # We handle upload ourselves
+            token=token,
+            max_shard_size=max_shard_size,
+            temporary_location=temporary_location,
+            maximum_memory_usage=maximum_memory_usage,
         )
 
         gguf_files = result.get("gguf_files", [])
@@ -413,27 +413,27 @@ def _push_to_hub_gguf(
                 filename = os.path.basename(file_location)
                 print(f"  Uploading {filename}...")
                 api.upload_file(
-                    path_or_fileobj = file_location,
-                    path_in_repo = filename,
-                    repo_id = full_repo_id,
-                    repo_type = "model",
-                    commit_message = commit_message,
-                    commit_description = commit_description,
-                    create_pr = create_pr,
-                    revision = revision,
+                    path_or_fileobj=file_location,
+                    path_in_repo=filename,
+                    repo_id=full_repo_id,
+                    repo_type="model",
+                    commit_message=commit_message,
+                    commit_description=commit_description,
+                    create_pr=create_pr,
+                    revision=revision,
                 )
 
         # Upload Modelfile if exists
         if modelfile_location and os.path.exists(modelfile_location):
             print("  Uploading Ollama Modelfile...")
             api.upload_file(
-                path_or_fileobj = modelfile_location,
-                path_in_repo = "Modelfile",
-                repo_id = full_repo_id,
-                repo_type = "model",
-                commit_message = f"{commit_message} - Ollama Modelfile",
-                create_pr = create_pr,
-                revision = revision,
+                path_or_fileobj=modelfile_location,
+                path_in_repo="Modelfile",
+                repo_id=full_repo_id,
+                repo_type="model",
+                commit_message=f"{commit_message} - Ollama Modelfile",
+                create_pr=create_pr,
+                revision=revision,
             )
 
         # Upload config.json if exists
@@ -441,13 +441,13 @@ def _push_to_hub_gguf(
         if os.path.exists(config_path):
             print("  Uploading config.json...")
             api.upload_file(
-                path_or_fileobj = config_path,
-                path_in_repo = "config.json",
-                repo_id = full_repo_id,
-                repo_type = "model",
-                commit_message = f"{commit_message} - config",
-                create_pr = create_pr,
-                revision = revision,
+                path_or_fileobj=config_path,
+                path_in_repo="config.json",
+                repo_id=full_repo_id,
+                repo_type="model",
+                commit_message=f"{commit_message} - config",
+                create_pr=create_pr,
+                revision=revision,
             )
 
         # Create and upload README
@@ -486,17 +486,17 @@ This sentence-transformers model was finetuned and converted to GGUF format usin
         )
 
         readme_path = os.path.join(temp_dir, "README.md")
-        with open(readme_path, "w", encoding = "utf-8") as f:
+        with open(readme_path, "w", encoding="utf-8") as f:
             f.write(readme_content)
 
         api.upload_file(
-            path_or_fileobj = readme_path,
-            path_in_repo = "README.md",
-            repo_id = full_repo_id,
-            repo_type = "model",
-            commit_message = "Add README",
-            create_pr = create_pr,
-            revision = revision,
+            path_or_fileobj=readme_path,
+            path_in_repo="README.md",
+            repo_id=full_repo_id,
+            repo_type="model",
+            commit_message="Add README",
+            create_pr=create_pr,
+            revision=revision,
         )
 
     # Add tags
@@ -509,7 +509,7 @@ This sentence-transformers model was finetuned and converted to GGUF format usin
         else:
             all_tags.append(tags)
     try:
-        api.add_tags(repo_id = full_repo_id, tags = all_tags, repo_type = "model")
+        api.add_tags(repo_id=full_repo_id, tags=all_tags, repo_type="model")
     except:
         pass
 
@@ -532,7 +532,7 @@ class FastSentenceTransformer(FastModel):
                 modules_json_path = os.path.join(model_name, "modules.json")
             else:
                 modules_json_path = hf_hub_download(
-                    model_name, "modules.json", token = token
+                    model_name, "modules.json", token=token
                 )
 
             with open(modules_json_path, "r") as f:
@@ -554,7 +554,7 @@ class FastSentenceTransformer(FastModel):
                             pooling_config_path = hf_hub_download(
                                 model_name,
                                 os.path.join(pooling_path, "config.json"),
-                                token = token,
+                                token=token,
                             )
                         break
 
@@ -596,7 +596,7 @@ class FastSentenceTransformer(FastModel):
         modeling_mpnet.MPNetModel.supports_gradient_checkpointing = True
 
         # add _set_gradient_checkpointing method
-        def _set_gradient_checkpointing(self, module = None, value = True):
+        def _set_gradient_checkpointing(self, module=None, value=True):
             if module is None:
                 module = self.encoder
             if isinstance(module, modeling_mpnet.MPNetEncoder):
@@ -633,7 +633,7 @@ class FastSentenceTransformer(FastModel):
                     def create_custom_forward(module):
                         # bog standard checkpoint
                         def custom_forward(*inputs):
-                            return module(*inputs, output_attentions = output_attentions)
+                            return module(*inputs, output_attentions=output_attentions)
 
                         return custom_forward
 
@@ -643,7 +643,7 @@ class FastSentenceTransformer(FastModel):
                         attention_mask,
                         head_mask[i] if head_mask is not None else None,
                         position_bias,
-                        use_reentrant = True,  # fix for torch 2.9
+                        use_reentrant=True,  # fix for torch 2.9
                     )
                 else:
                     # original code from here on
@@ -652,7 +652,7 @@ class FastSentenceTransformer(FastModel):
                         attention_mask,
                         head_mask[i] if head_mask is not None else None,
                         position_bias,
-                        output_attentions = output_attentions,
+                        output_attentions=output_attentions,
                         **kwargs,
                     )
 
@@ -671,9 +671,9 @@ class FastSentenceTransformer(FastModel):
                     if v is not None
                 )
             return BaseModelOutput(
-                last_hidden_state = hidden_states,
-                hidden_states = all_hidden_states,
-                attentions = all_attentions,
+                last_hidden_state=hidden_states,
+                hidden_states=all_hidden_states,
+                attentions=all_attentions,
             )
 
         # assign the patched forward
@@ -691,7 +691,7 @@ class FastSentenceTransformer(FastModel):
         modeling_mpnet.MPNetModel.supports_gradient_checkpointing = True
 
         # add _set_gradient_checkpointing method
-        def _set_gradient_checkpointing(self, module = None, value = True):
+        def _set_gradient_checkpointing(self, module=None, value=True):
             if module is None:
                 module = self.encoder
             if isinstance(module, modeling_mpnet.MPNetEncoder):
@@ -727,7 +727,7 @@ class FastSentenceTransformer(FastModel):
                     def create_custom_forward(module):
                         # checkpoint
                         def custom_forward(*inputs):
-                            return module(*inputs, output_attentions = output_attentions)
+                            return module(*inputs, output_attentions=output_attentions)
 
                         return custom_forward
 
@@ -736,7 +736,7 @@ class FastSentenceTransformer(FastModel):
                         hidden_states,
                         attention_mask,
                         position_bias,
-                        use_reentrant = True,  # required for torch >= 2.9
+                        use_reentrant=True,  # required for torch >= 2.9
                     )
                 else:
                     # original code from here on
@@ -763,9 +763,9 @@ class FastSentenceTransformer(FastModel):
                     if v is not None
                 )
             return BaseModelOutput(
-                last_hidden_state = hidden_states,
-                hidden_states = all_hidden_states,
-                attentions = all_attentions,
+                last_hidden_state=hidden_states,
+                hidden_states=all_hidden_states,
+                attentions=all_attentions,
             )
 
         modeling_mpnet.MPNetEncoder.forward = forward
@@ -838,7 +838,7 @@ class FastSentenceTransformer(FastModel):
             else:
                 if attention_mask is None:
                     attention_mask = torch.ones(
-                        input_shape, device = device
+                        input_shape, device=device
                     )  # (bs, seq_length)
 
                 if (
@@ -847,7 +847,7 @@ class FastSentenceTransformer(FastModel):
                     and not output_attentions
                 ):
                     attention_mask = _prepare_4d_attention_mask_for_sdpa(
-                        attention_mask, embeddings.dtype, tgt_len = input_shape[1]
+                        attention_mask, embeddings.dtype, tgt_len=input_shape[1]
                     )
             # patch here, change kwargs to positional args:
             return self.transformer(
@@ -862,7 +862,7 @@ class FastSentenceTransformer(FastModel):
         modeling_distilbert.DistilBertModel.forward = forward
 
     @staticmethod
-    def _has_add_pooling_layer(config, auto_model_class = None):
+    def _has_add_pooling_layer(config, auto_model_class=None):
         """
         Checks if the model class supports the `add_pooling_layer` argument
         """
@@ -907,9 +907,9 @@ class FastSentenceTransformer(FastModel):
             embeddings = self.embeddings(input_ids, inputs_embeds, position_ids)
 
             attention_mask = create_bidirectional_mask(
-                config = self.config,
-                input_embeds = embeddings,
-                attention_mask = attention_mask,
+                config=self.config,
+                input_embeds=embeddings,
+                attention_mask=attention_mask,
             )
 
             # patch here: unsloth gradient checkpointing hook needs positional arguments
@@ -922,21 +922,21 @@ class FastSentenceTransformer(FastModel):
         modeling_distilbert.DistilBertModel.forward = forward
 
     @staticmethod
-    def _add_unsloth_tags(repo_id, token, tags = None):
+    def _add_unsloth_tags(repo_id, token, tags=None):
         """
         Add Unsloth and sentence-transformers tags to the Hugging Face Hub repository.
         """
         from huggingface_hub import HfApi
 
-        api = HfApi(token = token)
+        api = HfApi(token=token)
         if tags is None:
             tags = []
         tags.extend(["unsloth", "sentence-transformers"])
         try:
             api.add_tags(
-                repo_id = repo_id,
-                tags = tags,
-                repo_type = "model",
+                repo_id=repo_id,
+                tags=tags,
+                repo_type="model",
             )
         except:
             pass
@@ -950,7 +950,7 @@ class FastSentenceTransformer(FastModel):
         if not os.path.exists(readme_path):
             return
 
-        with open(readme_path, "r", encoding = "utf-8") as f:
+        with open(readme_path, "r", encoding="utf-8") as f:
             content = f.read()
 
         # add unsloth tag to frontmatter
@@ -961,7 +961,7 @@ class FastSentenceTransformer(FastModel):
             pattern = r"(^tags:\s*\n)"
             if re.search(pattern, content, re.MULTILINE):
                 content = re.sub(
-                    pattern, r"\1- unsloth\n", content, count = 1, flags = re.MULTILINE
+                    pattern, r"\1- unsloth\n", content, count=1, flags=re.MULTILINE
                 )
 
         # add branding badge and text
@@ -977,11 +977,11 @@ class FastSentenceTransformer(FastModel):
         else:
             content += branding
 
-        with open(readme_path, "w", encoding = "utf-8") as f:
+        with open(readme_path, "w", encoding="utf-8") as f:
             f.write(content)
 
     @staticmethod
-    def _module_path(model_name, token = None):
+    def _module_path(model_name, token=None):
         """
         Returns the path to the modules.json file or None
         """
@@ -991,7 +991,7 @@ class FastSentenceTransformer(FastModel):
                 return path if os.path.exists(path) else None
             else:
                 try:
-                    return hf_hub_download(model_name, "modules.json", token = token)
+                    return hf_hub_download(model_name, "modules.json", token=token)
                 except:
                     return None
         except:
@@ -1021,9 +1021,9 @@ class FastSentenceTransformer(FastModel):
             # Initialize Transformer
             transformer_module = Transformer(
                 model_name,
-                max_seq_length = max_seq_length,
-                model_args = {"trust_remote_code": trust_remote_code},
-                config_args = {"trust_remote_code": trust_remote_code},
+                max_seq_length=max_seq_length,
+                model_args={"trust_remote_code": trust_remote_code},
+                config_args={"trust_remote_code": trust_remote_code},
             )
         finally:
             # Restore original functionality immediately
@@ -1069,7 +1069,7 @@ class FastSentenceTransformer(FastModel):
         tokenizer,
         max_seq_length,
         pooling_mode,
-        trust_remote_code = False,
+        trust_remote_code=False,
     ) -> tuple[OrderedDict, bool]:
         """
         Load modules from modules.json if available, otherwise fallback to hard-coded modules.
@@ -1084,7 +1084,7 @@ class FastSentenceTransformer(FastModel):
         modules_json_path = FastSentenceTransformer._module_path(model_name, token)
 
         if modules_json_path:
-            with open(modules_json_path, encoding = "utf8") as f:
+            with open(modules_json_path, encoding="utf8") as f:
                 modules_config = json.load(f)
 
             for module_config in modules_config:
@@ -1112,7 +1112,7 @@ class FastSentenceTransformer(FastModel):
                     else:
                         try:
                             load_path = load_dir_path(
-                                model_name, module_path, token = token
+                                model_name, module_path, token=token
                             )
                         except Exception as e:
                             print(
@@ -1147,7 +1147,7 @@ class FastSentenceTransformer(FastModel):
             pooling_mode = FastSentenceTransformer._read_pooling_mode(model_name, token)
 
         modules["1"] = Pooling(
-            word_embedding_dimension = hidden_size, pooling_mode = pooling_mode
+            word_embedding_dimension=hidden_size, pooling_mode=pooling_mode
         )
         modules["2"] = Normalize()
 
@@ -1168,9 +1168,9 @@ class FastSentenceTransformer(FastModel):
     @staticmethod
     def _estimate_compile_threshold(
         model,
-        batch_size = None,
-        grad_accum = None,
-        max_seq_length = None,
+        batch_size=None,
+        grad_accum=None,
+        max_seq_length=None,
     ):
         """
         Estimate the minimum training steps needed for torch.compile to be beneficial.
@@ -1288,14 +1288,14 @@ class FastSentenceTransformer(FastModel):
         return int(max(20, final_threshold))
 
     @staticmethod
-    def _apply_torch_compile(model, mode = "default"):
+    def _apply_torch_compile(model, mode="default"):
         """
         Apply torch.compile to a SentenceTransformer model.
         Includes workaround for accelerate's unwrap_model bug.
         """
         if hasattr(model, "__getitem__"):
             inner_model = model[0].auto_model
-            compiled = torch.compile(inner_model, mode = mode)
+            compiled = torch.compile(inner_model, mode=mode)
             model[0].auto_model = compiled
             # Fix for accelerate unwrap_model bug:
             # When SentenceTransformer contains a compiled inner model,
@@ -1304,35 +1304,35 @@ class FastSentenceTransformer(FastModel):
             # This workaround sets _orig_mod to satisfy accelerate.
             model.__dict__["_orig_mod"] = model
         else:
-            model = torch.compile(model, mode = mode)
+            model = torch.compile(model, mode=mode)
         return model
 
     @staticmethod
     def from_pretrained(
         model_name,
-        max_seq_length = None,
-        dtype = None,
-        load_in_4bit = False,  # Changed default: 4-bit is slow for encoders
-        load_in_8bit = False,
-        load_in_16bit = True,  # Changed default: 16-bit is optimal for encoders
-        full_finetuning = False,
-        token = None,
-        device_map = "sequential",
-        rope_scaling = None,
-        fix_tokenizer = True,
-        trust_remote_code = False,
-        use_gradient_checkpointing = False,  # Changed default: conflicts with torch.compile
-        resize_model_vocab = None,
-        revision = None,
-        use_exact_model_name = False,
-        offload_embedding = False,
-        random_state = 3407,
-        max_lora_rank = 64,
-        disable_log_stats = True,
-        qat_scheme = None,
-        unsloth_tiled_mlp = False,
-        pooling_mode = "mean",
-        for_inference = False,
+        max_seq_length=None,
+        dtype=None,
+        load_in_4bit=False,  # Changed default: 4-bit is slow for encoders
+        load_in_8bit=False,
+        load_in_16bit=True,  # Changed default: 16-bit is optimal for encoders
+        full_finetuning=False,
+        token=None,
+        device_map="sequential",
+        rope_scaling=None,
+        fix_tokenizer=True,
+        trust_remote_code=False,
+        use_gradient_checkpointing=False,  # Changed default: conflicts with torch.compile
+        resize_model_vocab=None,
+        revision=None,
+        use_exact_model_name=False,
+        offload_embedding=False,
+        random_state=3407,
+        max_lora_rank=64,
+        disable_log_stats=True,
+        qat_scheme=None,
+        unsloth_tiled_mlp=False,
+        pooling_mode="mean",
+        for_inference=False,
         **kwargs,
     ):
         try:
@@ -1406,7 +1406,7 @@ class FastSentenceTransformer(FastModel):
         config = None
         try:
             config = AutoConfig.from_pretrained(
-                model_name, token = token, trust_remote_code = trust_remote_code
+                model_name, token=token, trust_remote_code=trust_remote_code
             )
             model_type = getattr(config, "model_type", "")
         except:
@@ -1489,10 +1489,10 @@ class FastSentenceTransformer(FastModel):
                 from transformers import BitsAndBytesConfig
 
                 bnb_config = BitsAndBytesConfig(
-                    load_in_4bit = True,
-                    bnb_4bit_compute_dtype = dtype,
-                    bnb_4bit_quant_type = "nf4",
-                    bnb_4bit_use_double_quant = True,
+                    load_in_4bit=True,
+                    bnb_4bit_compute_dtype=dtype,
+                    bnb_4bit_quant_type="nf4",
+                    bnb_4bit_use_double_quant=True,
                 )
                 model_kwargs["quantization_config"] = bnb_config
                 # When using quantization, device must be handled by accelerate
@@ -1517,11 +1517,11 @@ class FastSentenceTransformer(FastModel):
             # Load via native SentenceTransformer (bypasses Unsloth patching)
             st_model = SentenceTransformer(
                 model_name,
-                device = st_device,
-                trust_remote_code = trust_remote_code,
-                token = token,
-                revision = revision,
-                model_kwargs = model_kwargs,
+                device=st_device,
+                trust_remote_code=trust_remote_code,
+                token=token,
+                revision=revision,
+                model_kwargs=model_kwargs,
             )
 
             # Store metadata for get_peft_model
@@ -1567,13 +1567,13 @@ class FastSentenceTransformer(FastModel):
                 hub_token = push_kwargs.get("token", None) or get_token()
                 if hub_token is None:
                     raise ValueError("No HF token provided")
-                api = HfApi(token = hub_token)
+                api = HfApi(token=hub_token)
                 try:
                     api.create_repo(
-                        repo_id = repo_id,
-                        private = push_kwargs.get("private"),
-                        exist_ok = True,
-                        repo_type = "model",
+                        repo_id=repo_id,
+                        private=push_kwargs.get("private"),
+                        exist_ok=True,
+                        repo_type="model",
                     )
                 except:
                     pass
@@ -1581,9 +1581,9 @@ class FastSentenceTransformer(FastModel):
                 with tempfile.TemporaryDirectory() as temp_dir:
                     self.save_pretrained_merged(temp_dir, **push_kwargs)
                     api.upload_folder(
-                        folder_path = temp_dir,
-                        repo_id = repo_id,
-                        commit_message = push_kwargs.get(
+                        folder_path=temp_dir,
+                        repo_id=repo_id,
+                        commit_message=push_kwargs.get(
                             "commit_message", "Upload model"
                         ),
                     )
@@ -1651,30 +1651,30 @@ class FastSentenceTransformer(FastModel):
 
         try:
             model, tokenizer = FastModel.from_pretrained(
-                model_name = model_name,
-                max_seq_length = max_seq_length,
-                dtype = dtype,
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = load_in_8bit,
-                load_in_16bit = load_in_16bit,
-                full_finetuning = full_finetuning,
-                token = token,
-                device_map = device_map,
-                rope_scaling = rope_scaling,
-                fix_tokenizer = fix_tokenizer,
-                trust_remote_code = trust_remote_code,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                resize_model_vocab = resize_model_vocab,
-                revision = revision,
-                return_logits = False,
-                use_exact_model_name = use_exact_model_name,
-                offload_embedding = offload_embedding,
-                random_state = random_state,
-                max_lora_rank = max_lora_rank,
-                disable_log_stats = disable_log_stats,
-                qat_scheme = qat_scheme,
-                load_in_fp8 = load_in_fp8,
-                unsloth_tiled_mlp = unsloth_tiled_mlp,
+                model_name=model_name,
+                max_seq_length=max_seq_length,
+                dtype=dtype,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=load_in_8bit,
+                load_in_16bit=load_in_16bit,
+                full_finetuning=full_finetuning,
+                token=token,
+                device_map=device_map,
+                rope_scaling=rope_scaling,
+                fix_tokenizer=fix_tokenizer,
+                trust_remote_code=trust_remote_code,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                resize_model_vocab=resize_model_vocab,
+                revision=revision,
+                return_logits=False,
+                use_exact_model_name=use_exact_model_name,
+                offload_embedding=offload_embedding,
+                random_state=random_state,
+                max_lora_rank=max_lora_rank,
+                disable_log_stats=disable_log_stats,
+                qat_scheme=qat_scheme,
+                load_in_fp8=load_in_fp8,
+                unsloth_tiled_mlp=unsloth_tiled_mlp,
                 **kwargs,
             )
         finally:
@@ -1690,7 +1690,7 @@ class FastSentenceTransformer(FastModel):
             tokenizer,
             max_seq_length,
             pooling_mode,
-            trust_remote_code = trust_remote_code,
+            trust_remote_code=trust_remote_code,
         )
 
         st_device = device_map
@@ -1699,7 +1699,7 @@ class FastSentenceTransformer(FastModel):
         ):
             st_device = None
 
-        st_model = SentenceTransformer(modules = modules, device = st_device)
+        st_model = SentenceTransformer(modules=modules, device=st_device)
         st_model.no_modules = no_modules
 
         def _save_pretrained_merged(self, save_directory, **kwargs):
@@ -1744,7 +1744,7 @@ class FastSentenceTransformer(FastModel):
                     tokenizer.save_pretrained(save_directory)
             else:
                 self[0].auto_model.save_pretrained_merged(
-                    save_directory, tokenizer = tokenizer, **kwargs
+                    save_directory, tokenizer=tokenizer, **kwargs
                 )
 
             # add Unsloth branding to the generated README
@@ -1778,13 +1778,13 @@ class FastSentenceTransformer(FastModel):
 
             from huggingface_hub import HfApi
 
-            api = HfApi(token = token)
+            api = HfApi(token=token)
             try:
                 api.create_repo(
-                    repo_id = repo_id,
-                    private = private,
-                    exist_ok = True,
-                    repo_type = "model",
+                    repo_id=repo_id,
+                    private=private,
+                    exist_ok=True,
+                    repo_type="model",
                 )
             except:
                 pass
@@ -1795,9 +1795,9 @@ class FastSentenceTransformer(FastModel):
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.save_pretrained_merged(temp_dir, **kwargs)
                 api.upload_folder(
-                    folder_path = temp_dir,
-                    repo_id = repo_id,
-                    commit_message = commit_message,
+                    folder_path=temp_dir,
+                    repo_id=repo_id,
+                    commit_message=commit_message,
                 )
             print(
                 f"Unsloth: Successfully pushed merged model to https://huggingface.co/{repo_id}"
@@ -1809,25 +1809,25 @@ class FastSentenceTransformer(FastModel):
     @staticmethod
     def get_peft_model(
         model,
-        r = 16,
-        target_modules = [
+        r=16,
+        target_modules=[
             "query",
             "key",
             "value",
             "dense",
         ],
-        lora_alpha = 16,
-        lora_dropout = 0.0,
-        bias = "none",
-        layers_to_transform = None,
-        layers_pattern = None,
-        use_gradient_checkpointing = False,  # Changed default: conflicts with torch.compile
-        random_state = 3407,
-        max_seq_length = 2048,
-        use_rslora = False,
-        modules_to_save = None,
-        init_lora_weights = True,
-        loftq_config = {},
+        lora_alpha=16,
+        lora_dropout=0.0,
+        bias="none",
+        layers_to_transform=None,
+        layers_pattern=None,
+        use_gradient_checkpointing=False,  # Changed default: conflicts with torch.compile
+        random_state=3407,
+        max_seq_length=2048,
+        use_rslora=False,
+        modules_to_save=None,
+        init_lora_weights=True,
+        loftq_config={},
         **kwargs,
     ):
         from sentence_transformers import SentenceTransformer
@@ -1882,7 +1882,7 @@ class FastSentenceTransformer(FastModel):
                     try:
                         inner_model = prepare_model_for_kbit_training(
                             inner_model,
-                            use_gradient_checkpointing = _gc_for_kbit,
+                            use_gradient_checkpointing=_gc_for_kbit,
                         )
                         print("Unsloth: Prepared quantized model for k-bit training")
                         gc_enabled = bool(_gc_for_kbit)
@@ -1894,7 +1894,7 @@ class FastSentenceTransformer(FastModel):
                             )
                             inner_model = prepare_model_for_kbit_training(
                                 inner_model,
-                                use_gradient_checkpointing = False,
+                                use_gradient_checkpointing=False,
                             )
                             print(
                                 "Unsloth: Prepared quantized model for k-bit training (without gradient checkpointing)"
@@ -1917,12 +1917,12 @@ class FastSentenceTransformer(FastModel):
 
                 # Create LoRA config
                 lora_config = LoraConfig(
-                    r = r,
-                    lora_alpha = lora_alpha,
-                    target_modules = target_modules,
-                    lora_dropout = lora_dropout,
-                    bias = bias,
-                    task_type = kwargs.get("task_type", "FEATURE_EXTRACTION"),
+                    r=r,
+                    lora_alpha=lora_alpha,
+                    target_modules=target_modules,
+                    lora_dropout=lora_dropout,
+                    bias=bias,
+                    task_type=kwargs.get("task_type", "FEATURE_EXTRACTION"),
                 )
 
                 # Apply PEFT directly (not through FastModel)
@@ -1973,21 +1973,21 @@ class FastSentenceTransformer(FastModel):
             inner_model = transformer_module.auto_model
 
             peft_model = FastModel.get_peft_model(
-                model = inner_model,
-                r = r,
-                target_modules = target_modules,
-                lora_alpha = lora_alpha,
-                lora_dropout = lora_dropout,
-                bias = bias,
-                layers_to_transform = layers_to_transform,
-                layers_pattern = layers_pattern,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                random_state = random_state,
-                max_seq_length = max_seq_length,
-                use_rslora = use_rslora,
-                modules_to_save = modules_to_save,
-                init_lora_weights = init_lora_weights,
-                loftq_config = loftq_config,
+                model=inner_model,
+                r=r,
+                target_modules=target_modules,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                bias=bias,
+                layers_to_transform=layers_to_transform,
+                layers_pattern=layers_pattern,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                random_state=random_state,
+                max_seq_length=max_seq_length,
+                use_rslora=use_rslora,
+                modules_to_save=modules_to_save,
+                init_lora_weights=init_lora_weights,
+                loftq_config=loftq_config,
                 **kwargs,
             )
 
@@ -1996,21 +1996,21 @@ class FastSentenceTransformer(FastModel):
             return model
         else:
             return FastModel.get_peft_model(
-                model = model,
-                r = r,
-                target_modules = target_modules,
-                lora_alpha = lora_alpha,
-                lora_dropout = lora_dropout,
-                bias = bias,
-                layers_to_transform = layers_to_transform,
-                layers_pattern = layers_pattern,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                random_state = random_state,
-                max_seq_length = max_seq_length,
-                use_rslora = use_rslora,
-                modules_to_save = modules_to_save,
-                init_lora_weights = init_lora_weights,
-                loftq_config = loftq_config,
+                model=model,
+                r=r,
+                target_modules=target_modules,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                bias=bias,
+                layers_to_transform=layers_to_transform,
+                layers_pattern=layers_pattern,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                random_state=random_state,
+                max_seq_length=max_seq_length,
+                use_rslora=use_rslora,
+                modules_to_save=modules_to_save,
+                init_lora_weights=init_lora_weights,
+                loftq_config=loftq_config,
                 **kwargs,
             )
 
@@ -2068,9 +2068,9 @@ def _patch_sentence_transformer_trainer():
 
             threshold = FastSentenceTransformer._estimate_compile_threshold(
                 model,
-                batch_size = batch_size,
-                grad_accum = grad_accum,
-                max_seq_length = max_seq_length,
+                batch_size=batch_size,
+                grad_accum=grad_accum,
+                max_seq_length=max_seq_length,
             )
             model._compile_threshold = threshold
 
@@ -2078,7 +2078,7 @@ def _patch_sentence_transformer_trainer():
                 print(
                     f"Unsloth: Auto-compiling model ({max_steps} steps >= {threshold} threshold)"
                 )
-                FastSentenceTransformer._apply_torch_compile(model, mode = compile_mode)
+                FastSentenceTransformer._apply_torch_compile(model, mode=compile_mode)
                 model._compile_pending = False
             elif max_steps > 0:
                 print(

--- a/unsloth/optimizers/q_galore_adamw.py
+++ b/unsloth/optimizers/q_galore_adamw.py
@@ -98,7 +98,7 @@ class QGaLoreAdamW8bit(Optimizer2State):
             min_8bit_size,
             percentile_clipping,
             block_wise,
-            is_paged = is_paged,
+            is_paged=is_paged,
         )
 
     # ------------------------------------------------------------------
@@ -106,7 +106,7 @@ class QGaLoreAdamW8bit(Optimizer2State):
     # ------------------------------------------------------------------
 
     @torch.no_grad()
-    def step(self, closure = None):
+    def step(self, closure=None):
         """Perform a single optimization step.
 
         For each parameter that has a ``rank`` key in its param group, the
@@ -155,16 +155,16 @@ class QGaLoreAdamW8bit(Optimizer2State):
                 if "rank" in group:
                     if "projector" not in state:
                         state["projector"] = GaLoreProjector(
-                            rank = group["rank"],
-                            update_proj_gap = group.get("update_proj_gap", 200),
-                            scale = group.get("scale", 0.25),
-                            proj_type = group.get("proj_type", "std"),
-                            quant = group.get("quant", False),
-                            group_size = group.get("quant_group_size", -1),
-                            n_bit = group.get("quant_n_bit", 4),
-                            cos_threshold = group.get("cos_threshold", 0.4),
-                            gamma_proj = group.get("gamma_proj", 2.0),
-                            queue_size = group.get("queue_size", 5),
+                            rank=group["rank"],
+                            update_proj_gap=group.get("update_proj_gap", 200),
+                            scale=group.get("scale", 0.25),
+                            proj_type=group.get("proj_type", "std"),
+                            quant=group.get("quant", False),
+                            group_size=group.get("quant_group_size", -1),
+                            n_bit=group.get("quant_n_bit", 4),
+                            cos_threshold=group.get("cos_threshold", 0.4),
+                            gamma_proj=group.get("gamma_proj", 2.0),
+                            queue_size=group.get("queue_size", 5),
                         )
 
                     # Temporarily disable weight decay for GaLore params
@@ -179,7 +179,7 @@ class QGaLoreAdamW8bit(Optimizer2State):
                     # the 8-bit update writes the pure weight delta.
                     p._saved_data = p.data.clone()
                     p.data = torch.zeros_like(
-                        grad, dtype = p.data.dtype, device = p.data.device
+                        grad, dtype=p.data.dtype, device=p.data.device
                     )
                     p.grad = grad
 
@@ -199,7 +199,7 @@ class QGaLoreAdamW8bit(Optimizer2State):
                     if "_wd_saved" in group:
                         p.data.add_(
                             p.data,
-                            alpha = -group["lr"] * group["_wd_saved"],
+                            alpha=-group["lr"] * group["_wd_saved"],
                         )
                         group["weight_decay"] = group["_wd_saved"]
                         del group["_wd_saved"]
@@ -212,7 +212,7 @@ class QGaLoreAdamW8bit(Optimizer2State):
                     stochastic = group.get("stochastic_round", True)
                     gsize = group.get("weight_group_size", 128)
                     quant_fn = _quantize_stochastic if stochastic else _quantize
-                    q, scales, zeros, shape = quant_fn(float_data, q_group_size = gsize)
+                    q, scales, zeros, shape = quant_fn(float_data, q_group_size=gsize)
                     p._q_data = q.to(p.data.device)
                     p._q_scales = scales
                     p._q_zeros = zeros
@@ -220,7 +220,7 @@ class QGaLoreAdamW8bit(Optimizer2State):
                     # Replace p.data with a scalar placeholder to free float memory.
                     # A forward pre-hook (install_weight_quant_hooks) will
                     # dequantize back to float before the next forward pass.
-                    p.data = torch.empty(1, dtype = p.data.dtype, device = p.data.device)
+                    p.data = torch.empty(1, dtype=p.data.dtype, device=p.data.device)
 
                 state["step"] += 1
 
@@ -277,7 +277,7 @@ class QGaLoreAdamW8bit(Optimizer2State):
 
 def _weight_quant_pre_hook(module, args):
     """Forward pre-hook: dequantize INT8 weights to float before forward."""
-    for p in module.parameters(recurse = False):
+    for p in module.parameters(recurse=False):
         if hasattr(p, "_q_scales") and p._q_scales is not None:
             float_weight = _dequantize(
                 p._q_data,
@@ -296,7 +296,7 @@ def install_weight_quant_hooks(model: torch.nn.Module) -> list:
     handles = []
     for module in model.modules():
         has_quant_param = any(
-            hasattr(p, "_q_scales") for p in module.parameters(recurse = False)
+            hasattr(p, "_q_scales") for p in module.parameters(recurse=False)
         )
         if has_quant_param:
             h = module.register_forward_pre_hook(_weight_quant_pre_hook)

--- a/unsloth/registry/_gemma.py
+++ b/unsloth/registry/_gemma.py
@@ -15,26 +15,26 @@ class GemmaModelInfo(ModelInfo):
 
 # Gemma3 Base Model Meta
 GemmaMeta3Base = ModelMeta(
-    org = "google",
-    base_name = "gemma",
-    instruct_tags = ["pt"],  # pt = base
-    model_version = "3",
-    model_sizes = ["1", "4", "12", "27"],
-    model_info_cls = GemmaModelInfo,
-    is_multimodal = True,
-    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
+    org="google",
+    base_name="gemma",
+    instruct_tags=["pt"],  # pt = base
+    model_version="3",
+    model_sizes=["1", "4", "12", "27"],
+    model_info_cls=GemmaModelInfo,
+    is_multimodal=True,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
 )
 
 # Gemma3 Instruct Model Meta
 GemmaMeta3Instruct = ModelMeta(
-    org = "google",
-    base_name = "gemma",
-    instruct_tags = ["it"],  # it = instruction tuned
-    model_version = "3",
-    model_sizes = ["1", "4", "12", "27"],
-    model_info_cls = GemmaModelInfo,
-    is_multimodal = True,
-    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH, QuantType.GGUF],
+    org="google",
+    base_name="gemma",
+    instruct_tags=["it"],  # it = instruction tuned
+    model_version="3",
+    model_sizes=["1", "4", "12", "27"],
+    model_info_cls=GemmaModelInfo,
+    is_multimodal=True,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH, QuantType.GGUF],
 )
 
 
@@ -42,7 +42,7 @@ def register_gemma_3_base_models(include_original_model: bool = False):
     global _IS_GEMMA_3_BASE_REGISTERED
     if _IS_GEMMA_3_BASE_REGISTERED:
         return
-    _register_models(GemmaMeta3Base, include_original_model = include_original_model)
+    _register_models(GemmaMeta3Base, include_original_model=include_original_model)
     _IS_GEMMA_3_BASE_REGISTERED = True
 
 
@@ -50,13 +50,13 @@ def register_gemma_3_instruct_models(include_original_model: bool = False):
     global _IS_GEMMA_3_INSTRUCT_REGISTERED
     if _IS_GEMMA_3_INSTRUCT_REGISTERED:
         return
-    _register_models(GemmaMeta3Instruct, include_original_model = include_original_model)
+    _register_models(GemmaMeta3Instruct, include_original_model=include_original_model)
     _IS_GEMMA_3_INSTRUCT_REGISTERED = True
 
 
 def register_gemma_models(include_original_model: bool = False):
-    register_gemma_3_base_models(include_original_model = include_original_model)
-    register_gemma_3_instruct_models(include_original_model = include_original_model)
+    register_gemma_3_base_models(include_original_model=include_original_model)
+    register_gemma_3_instruct_models(include_original_model=include_original_model)
 
 
 if __name__ == "__main__":
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     MODEL_REGISTRY.clear()
 
-    register_gemma_models(include_original_model = True)
+    register_gemma_models(include_original_model=True)
 
     for model_id, model_info in MODEL_REGISTRY.items():
         model_info = _check_model_info(model_id)

--- a/unsloth/registry/_llama.py
+++ b/unsloth/registry/_llama.py
@@ -25,50 +25,50 @@ class LlamaVisionModelInfo(ModelInfo):
 
 # Llama 3.1
 LlamaMeta_3_1 = ModelMeta(
-    org = "meta-llama",
-    base_name = "Llama",
-    instruct_tags = [None, "Instruct"],
-    model_version = "3.1",
-    model_sizes = ["8"],
-    model_info_cls = LlamaModelInfo,
-    is_multimodal = False,
-    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
+    org="meta-llama",
+    base_name="Llama",
+    instruct_tags=[None, "Instruct"],
+    model_version="3.1",
+    model_sizes=["8"],
+    model_info_cls=LlamaModelInfo,
+    is_multimodal=False,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
 )
 
 # Llama 3.2 Base Models
 LlamaMeta_3_2_Base = ModelMeta(
-    org = "meta-llama",
-    base_name = "Llama",
-    instruct_tags = [None],
-    model_version = "3.2",
-    model_sizes = ["1", "3"],
-    model_info_cls = LlamaModelInfo,
-    is_multimodal = False,
-    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
+    org="meta-llama",
+    base_name="Llama",
+    instruct_tags=[None],
+    model_version="3.2",
+    model_sizes=["1", "3"],
+    model_info_cls=LlamaModelInfo,
+    is_multimodal=False,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
 )
 
 # Llama 3.2 Instruction Tuned Models
 LlamaMeta_3_2_Instruct = ModelMeta(
-    org = "meta-llama",
-    base_name = "Llama",
-    instruct_tags = ["Instruct"],
-    model_version = "3.2",
-    model_sizes = ["1", "3"],
-    model_info_cls = LlamaModelInfo,
-    is_multimodal = False,
-    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH, QuantType.GGUF],
+    org="meta-llama",
+    base_name="Llama",
+    instruct_tags=["Instruct"],
+    model_version="3.2",
+    model_sizes=["1", "3"],
+    model_info_cls=LlamaModelInfo,
+    is_multimodal=False,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH, QuantType.GGUF],
 )
 
 # Llama 3.2 Vision
 LlamaMeta_3_2_Vision = ModelMeta(
-    org = "meta-llama",
-    base_name = "Llama",
-    instruct_tags = [None, "Instruct"],
-    model_version = "3.2",
-    model_sizes = ["11", "90"],
-    model_info_cls = LlamaVisionModelInfo,
-    is_multimodal = True,
-    quant_types = {
+    org="meta-llama",
+    base_name="Llama",
+    instruct_tags=[None, "Instruct"],
+    model_version="3.2",
+    model_sizes=["11", "90"],
+    model_info_cls=LlamaVisionModelInfo,
+    is_multimodal=True,
+    quant_types={
         "11": [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
         "90": [QuantType.NONE],
     },
@@ -79,7 +79,7 @@ def register_llama_3_1_models(include_original_model: bool = False):
     global _IS_LLAMA_3_1_REGISTERED
     if _IS_LLAMA_3_1_REGISTERED:
         return
-    _register_models(LlamaMeta_3_1, include_original_model = include_original_model)
+    _register_models(LlamaMeta_3_1, include_original_model=include_original_model)
     _IS_LLAMA_3_1_REGISTERED = True
 
 
@@ -87,9 +87,9 @@ def register_llama_3_2_models(include_original_model: bool = False):
     global _IS_LLAMA_3_2_REGISTERED
     if _IS_LLAMA_3_2_REGISTERED:
         return
-    _register_models(LlamaMeta_3_2_Base, include_original_model = include_original_model)
+    _register_models(LlamaMeta_3_2_Base, include_original_model=include_original_model)
     _register_models(
-        LlamaMeta_3_2_Instruct, include_original_model = include_original_model
+        LlamaMeta_3_2_Instruct, include_original_model=include_original_model
     )
     _IS_LLAMA_3_2_REGISTERED = True
 
@@ -99,15 +99,15 @@ def register_llama_3_2_vision_models(include_original_model: bool = False):
     if _IS_LLAMA_3_2_VISION_REGISTERED:
         return
     _register_models(
-        LlamaMeta_3_2_Vision, include_original_model = include_original_model
+        LlamaMeta_3_2_Vision, include_original_model=include_original_model
     )
     _IS_LLAMA_3_2_VISION_REGISTERED = True
 
 
 def register_llama_models(include_original_model: bool = False):
-    register_llama_3_1_models(include_original_model = include_original_model)
-    register_llama_3_2_models(include_original_model = include_original_model)
-    register_llama_3_2_vision_models(include_original_model = include_original_model)
+    register_llama_3_1_models(include_original_model=include_original_model)
+    register_llama_3_2_models(include_original_model=include_original_model)
+    register_llama_3_2_vision_models(include_original_model=include_original_model)
 
 
 if __name__ == "__main__":
@@ -115,7 +115,7 @@ if __name__ == "__main__":
 
     MODEL_REGISTRY.clear()
 
-    register_llama_models(include_original_model = True)
+    register_llama_models(include_original_model=True)
 
     for model_id, model_info in MODEL_REGISTRY.items():
         model_info = _check_model_info(model_id)

--- a/unsloth/registry/_mistral.py
+++ b/unsloth/registry/_mistral.py
@@ -23,14 +23,14 @@ class MistralSmallModelInfo(ModelInfo):
 
 
 MistralSmall_2503_Base_Meta = ModelMeta(
-    org = "mistralai",
-    base_name = "Mistral-Small",
-    instruct_tags = ["Base"],
-    model_version = _MISTRAL_SMALL_03_25_VERSION,
-    model_sizes = ["24"],
-    model_info_cls = MistralSmallModelInfo,
-    is_multimodal = False,
-    quant_types = [QuantType.NONE, QuantType.UNSLOTH, QuantType.BNB],
+    org="mistralai",
+    base_name="Mistral-Small",
+    instruct_tags=["Base"],
+    model_version=_MISTRAL_SMALL_03_25_VERSION,
+    model_sizes=["24"],
+    model_info_cls=MistralSmallModelInfo,
+    is_multimodal=False,
+    quant_types=[QuantType.NONE, QuantType.UNSLOTH, QuantType.BNB],
 )
 
 MistralSmall_2503_Instruct_Meta = copy.deepcopy(MistralSmall_2503_Base_Meta)
@@ -54,23 +54,23 @@ def register_mistral_small_models(include_original_model: bool = False):
     if _IS_MISTRAL_SMALL_REGISTERED:
         return
     _register_models(
-        MistralSmall_2503_Base_Meta, include_original_model = include_original_model
+        MistralSmall_2503_Base_Meta, include_original_model=include_original_model
     )
     _register_models(
-        MistralSmall_2503_Instruct_Meta, include_original_model = include_original_model
+        MistralSmall_2503_Instruct_Meta, include_original_model=include_original_model
     )
     _register_models(
-        MistralSmall_2501_Base_Meta, include_original_model = include_original_model
+        MistralSmall_2501_Base_Meta, include_original_model=include_original_model
     )
     _register_models(
-        MistralSmall_2501_Instruct_Meta, include_original_model = include_original_model
+        MistralSmall_2501_Instruct_Meta, include_original_model=include_original_model
     )
 
     _IS_MISTRAL_SMALL_REGISTERED = True
 
 
 def register_mistral_models(include_original_model: bool = False):
-    register_mistral_small_models(include_original_model = include_original_model)
+    register_mistral_small_models(include_original_model=include_original_model)
 
 
 if __name__ == "__main__":
@@ -78,7 +78,7 @@ if __name__ == "__main__":
 
     MODEL_REGISTRY.clear()
 
-    register_mistral_models(include_original_model = True)
+    register_mistral_models(include_original_model=True)
 
     for model_id, model_info in MODEL_REGISTRY.items():
         model_info = _check_model_info(model_id)

--- a/unsloth/registry/_phi.py
+++ b/unsloth/registry/_phi.py
@@ -15,26 +15,26 @@ class PhiModelInfo(ModelInfo):
 
 # Phi Model Meta
 PhiMeta4 = ModelMeta(
-    org = "microsoft",
-    base_name = "phi",
-    instruct_tags = [None],
-    model_version = "4",
-    model_sizes = ["1"],  # Assuming only one size
-    model_info_cls = PhiModelInfo,
-    is_multimodal = False,
-    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
+    org="microsoft",
+    base_name="phi",
+    instruct_tags=[None],
+    model_version="4",
+    model_sizes=["1"],  # Assuming only one size
+    model_info_cls=PhiModelInfo,
+    is_multimodal=False,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH],
 )
 
 # Phi Instruct Model Meta
 PhiInstructMeta4 = ModelMeta(
-    org = "microsoft",
-    base_name = "phi",
-    instruct_tags = ["mini-instruct"],
-    model_version = "4",
-    model_sizes = ["1"],  # Assuming only one size
-    model_info_cls = PhiModelInfo,
-    is_multimodal = False,
-    quant_types = [QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH, QuantType.GGUF],
+    org="microsoft",
+    base_name="phi",
+    instruct_tags=["mini-instruct"],
+    model_version="4",
+    model_sizes=["1"],  # Assuming only one size
+    model_info_cls=PhiModelInfo,
+    is_multimodal=False,
+    quant_types=[QuantType.NONE, QuantType.BNB, QuantType.UNSLOTH, QuantType.GGUF],
 )
 
 
@@ -42,7 +42,7 @@ def register_phi_4_models(include_original_model: bool = False):
     global _IS_PHI_4_REGISTERED
     if _IS_PHI_4_REGISTERED:
         return
-    _register_models(PhiMeta4, include_original_model = include_original_model)
+    _register_models(PhiMeta4, include_original_model=include_original_model)
     _IS_PHI_4_REGISTERED = True
 
 
@@ -50,13 +50,13 @@ def register_phi_4_instruct_models(include_original_model: bool = False):
     global _IS_PHI_4_INSTRUCT_REGISTERED
     if _IS_PHI_4_INSTRUCT_REGISTERED:
         return
-    _register_models(PhiInstructMeta4, include_original_model = include_original_model)
+    _register_models(PhiInstructMeta4, include_original_model=include_original_model)
     _IS_PHI_4_INSTRUCT_REGISTERED = True
 
 
 def register_phi_models(include_original_model: bool = False):
-    register_phi_4_models(include_original_model = include_original_model)
-    register_phi_4_instruct_models(include_original_model = include_original_model)
+    register_phi_4_models(include_original_model=include_original_model)
+    register_phi_4_instruct_models(include_original_model=include_original_model)
 
 
 if __name__ == "__main__":
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     MODEL_REGISTRY.clear()
 
-    register_phi_models(include_original_model = True)
+    register_phi_models(include_original_model=True)
 
     for model_id, model_info in MODEL_REGISTRY.items():
         model_info = _check_model_info(model_id)

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -154,7 +154,7 @@ def print_quantization_methods():
 
 
 def check_if_sentencepiece_model(
-    model, temporary_location = "_unsloth_sentencepiece_temp"
+    model, temporary_location="_unsloth_sentencepiece_temp"
 ):
     if not hasattr(model, "_saved_temp_tokenizer"):
         return False
@@ -170,7 +170,7 @@ def check_if_sentencepiece_model(
     if os.path.isfile(f"{file_location}/tokenizer.model"):
         sentencepiece_model = True
     if created_folder:
-        shutil.rmtree(file_location, ignore_errors = True)
+        shutil.rmtree(file_location, ignore_errors=True)
     return sentencepiece_model
 
 
@@ -214,7 +214,7 @@ def _merge_lora(layer, name):
         if A is not None:
             # sAB = (A.t().to(torch.float32) @ (s * B.t().to(torch.float32)))
             # W += sAB
-            W.addmm_(A.t().to(torch.float32), B.t().to(torch.float32), alpha = s)
+            W.addmm_(A.t().to(torch.float32), B.t().to(torch.float32), alpha=s)
             # W.addmm_(A.t().to(W.dtype), B.t().to(W.dtype), alpha = s)
             # if not torch.isfinite(W).all():
             maximum_element = torch.max(W.min().abs(), W.max())
@@ -309,7 +309,7 @@ def unsloth_save_model(
         from huggingface_hub import whoami
 
         try:
-            username = whoami(token = token)["name"]
+            username = whoami(token=token)["name"]
         except:
             raise RuntimeError(
                 "Unsloth: Please supply a token!\n"
@@ -375,24 +375,24 @@ def unsloth_save_model(
             token,
             "finetuned",
             "trl",
-            file_location = None,
-            old_username = None,
-            private = private,
-            datasets = datasets,
+            file_location=None,
+            old_username=None,
+            private=private,
+            datasets=datasets,
         )
 
         getattr(model, "original_push_to_hub", model.push_to_hub)(
-            repo_id = save_directory,
-            use_temp_dir = use_temp_dir,
-            commit_message = commit_message,
-            private = private,
-            token = token,
-            max_shard_size = max_shard_size,
-            create_pr = create_pr,
-            safe_serialization = safe_serialization,
-            revision = revision,
-            commit_description = commit_description,
-            tags = tags,
+            repo_id=save_directory,
+            use_temp_dir=use_temp_dir,
+            commit_message=commit_message,
+            private=private,
+            token=token,
+            max_shard_size=max_shard_size,
+            create_pr=create_pr,
+            safe_serialization=safe_serialization,
+            revision=revision,
+            commit_description=commit_description,
+            tags=tags,
         )
         if tokenizer is not None:
             # Set padding side to left for inference
@@ -400,17 +400,17 @@ def unsloth_save_model(
             tokenizer.padding_side = "left"
 
             getattr(tokenizer, "original_push_to_hub", tokenizer.push_to_hub)(
-                repo_id = save_directory,
-                use_temp_dir = use_temp_dir,
-                commit_message = commit_message,
-                private = private,
-                token = token,
-                max_shard_size = max_shard_size,
-                create_pr = create_pr,
-                safe_serialization = safe_serialization,
-                revision = revision,
-                commit_description = commit_description,
-                tags = tags,
+                repo_id=save_directory,
+                use_temp_dir=use_temp_dir,
+                commit_message=commit_message,
+                private=private,
+                token=token,
+                max_shard_size=max_shard_size,
+                create_pr=create_pr,
+                safe_serialization=safe_serialization,
+                revision=revision,
+                commit_description=commit_description,
+                tags=tags,
             )
 
             # Revert back padding side
@@ -485,14 +485,14 @@ def unsloth_save_model(
                 token,
                 "finetuned",
                 "trl",
-                file_location = None,
-                old_username = None,
-                private = private,
-                datasets = datasets,
+                file_location=None,
+                old_username=None,
+                private=private,
+                datasets=datasets,
             )
 
         if tokenizer is not None:
-            print("Unsloth: Saving tokenizer...", end = "")
+            print("Unsloth: Saving tokenizer...", end="")
 
             # Set padding side to left for inference
             old_padding_side = tokenizer.padding_side
@@ -507,9 +507,9 @@ def unsloth_save_model(
         else:
             print()
 
-        print("Unsloth: Saving model...", end = "")
+        print("Unsloth: Saving model...", end="")
         if save_method != "lora":
-            print(" This might take 10 minutes for Llama-7b...", end = "")
+            print(" This might take 10 minutes for Llama-7b...", end="")
 
         # [TODO] Is this correct?
         if save_method == "lora":
@@ -558,10 +558,10 @@ def unsloth_save_model(
     sharded_ram_usage = 5 * 1024 * 1024 * 1024
     if type(max_shard_size) is str:
         gb_found = re.match(
-            r"([0-9]{1,})[\s]{0,}GB", max_shard_size, flags = re.IGNORECASE
+            r"([0-9]{1,})[\s]{0,}GB", max_shard_size, flags=re.IGNORECASE
         )
         mb_found = re.match(
-            r"([0-9]{1,})[\s]{0,}MB", max_shard_size, flags = re.IGNORECASE
+            r"([0-9]{1,})[\s]{0,}MB", max_shard_size, flags=re.IGNORECASE
         )
         if gb_found:
             sharded_ram_usage = int(gb_found.group(1)) * 1024 * 1024 * 1024
@@ -571,7 +571,7 @@ def unsloth_save_model(
         sharded_ram_usage = max_shard_size
 
     # Switch to our fast saving modules if it's a slow PC!
-    n_cpus = psutil.cpu_count(logical = False)
+    n_cpus = psutil.cpu_count(logical=False)
     if n_cpus is None:
         n_cpus = psutil.cpu_count()
     if n_cpus is None:
@@ -673,12 +673,12 @@ def unsloth_save_model(
                 torch.save(
                     W,
                     filename,
-                    pickle_module = pickle,
-                    pickle_protocol = pickle.HIGHEST_PROTOCOL,
+                    pickle_module=pickle,
+                    pickle_protocol=pickle.HIGHEST_PROTOCOL,
                 )
                 # weights_only = True weirdly fails?
                 state_dict[name] = torch.load(
-                    filename, map_location = "cpu", mmap = True, weights_only = False
+                    filename, map_location="cpu", mmap=True, weights_only=False
                 )
         for item in LLAMA_LAYERNORMS:
             try:
@@ -748,10 +748,10 @@ def unsloth_save_model(
             token,
             "finetuned",
             "trl",
-            file_location = None,
-            old_username = username,
-            private = private,
-            datasets = datasets,
+            file_location=None,
+            old_username=username,
+            private=private,
+            datasets=datasets,
         )
 
     # First check if we're pushing to an organization!
@@ -765,7 +765,7 @@ def unsloth_save_model(
         if token is not None:
             from huggingface_hub import whoami
 
-            actual_username = whoami(token = token)["name"]
+            actual_username = whoami(token=token)["name"]
         else:
             actual_username = username
 
@@ -778,7 +778,7 @@ def unsloth_save_model(
 
     # Save tokenizer
     if tokenizer is not None:
-        print("Unsloth: Saving tokenizer...", end = "")
+        print("Unsloth: Saving tokenizer...", end="")
 
         # Set padding side to left for inference
         old_padding_side = tokenizer.padding_side
@@ -822,16 +822,16 @@ def unsloth_save_model(
         # Now manually go through each file and upload them manually!
         filenames = os.listdir(new_save_directory)
 
-        hf_api = HfApi(token = save_pretrained_settings["token"])
+        hf_api = HfApi(token=save_pretrained_settings["token"])
 
         print("Unsloth: Uploading all files... Please wait...")
         hf_api.upload_folder(
-            folder_path = new_save_directory,
-            path_in_repo = ".",
-            repo_id = new_save_directory,
-            repo_type = "model",
-            commit_message = "(Trained with Unsloth)",
-            ignore_patterns = "*.md",
+            folder_path=new_save_directory,
+            path_in_repo=".",
+            repo_id=new_save_directory,
+            repo_type="model",
+            commit_message="(Trained with Unsloth)",
+            ignore_patterns="*.md",
         )
     else:
         internal_model.save_pretrained(**save_pretrained_settings)
@@ -864,7 +864,7 @@ def unsloth_save_model(
     # Remove temporary location
     import shutil
 
-    shutil.rmtree(temporary_location, ignore_errors = True)
+    shutil.rmtree(temporary_location, ignore_errors=True)
 
     for _ in range(3):
         torch.cuda.empty_cache()
@@ -880,7 +880,7 @@ def install_llama_cpp_clone_non_blocking():
         "https://github.com/ggerganov/llama.cpp",
     ]
     run_installer = subprocess.Popen(
-        full_command, stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT
+        full_command, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
     )
     return run_installer
 
@@ -924,30 +924,30 @@ def install_llama_cpp_make_non_blocking():
     # Weirdly GPU conversion for GGUF breaks??
     # run_installer = subprocess.Popen(full_command, env = env, stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT)
     run_installer = subprocess.Popen(
-        full_command, stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT
+        full_command, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
     )
     return run_installer, IS_CMAKE
 
 
-def install_python_non_blocking(packages = []):
+def install_python_non_blocking(packages=[]):
     full_command = ["pip", "install"] + packages
     run_installer = subprocess.Popen(
-        full_command, stdout = subprocess.DEVNULL, stderr = subprocess.STDOUT
+        full_command, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
     )
     return run_installer
 
 
-def try_execute(commands, force_complete = False):
+def try_execute(commands, force_complete=False):
     for command in commands:
         with subprocess.Popen(
             command,
-            shell = True,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.STDOUT,
-            bufsize = 1,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
         ) as sp:
             for line in sp.stdout:
-                line = line.decode("utf-8", errors = "replace")
+                line = line.decode("utf-8", errors="replace")
                 if "undefined reference" in line:
                     raise RuntimeError(
                         f"*** Unsloth: Failed compiling llama.cpp with {line}. Please report this ASAP!"
@@ -962,13 +962,13 @@ def try_execute(commands, force_complete = False):
                     raise RuntimeError(
                         f"*** Unsloth: Failed compiling llama.cpp with {line}. Please report this ASAP!"
                     )
-                print(line, flush = True, end = "")
+                print(line, flush=True, end="")
             if force_complete and sp.returncode is not None and sp.returncode != 0:
                 raise subprocess.CalledProcessError(sp.returncode, sp.args)
     return None
 
 
-def install_llama_cpp_old(version = -10):
+def install_llama_cpp_old(version=-10):
     # Download the 10th latest release since the latest might be broken!
     # FALLBACK mechanism
     releases = subprocess.check_output(
@@ -996,7 +996,7 @@ def install_llama_cpp_old(version = -10):
             time.sleep(1)
         import shutil
 
-        shutil.rmtree("llama.cpp", ignore_errors = True)
+        shutil.rmtree("llama.cpp", ignore_errors=True)
 
     # Clone a specific commit
     # Also don't use the GPU!
@@ -1038,7 +1038,7 @@ def install_llama_cpp_old(version = -10):
         )
 
 
-def install_llama_cpp_blocking(use_cuda = False):
+def install_llama_cpp_blocking(use_cuda=False):
     # https://github.com/ggerganov/llama.cpp/issues/7062
     # Weirdly GPU conversion for GGUF breaks??
     # use_cuda = "LLAMA_CUDA=1" if use_cuda else ""
@@ -1088,7 +1088,7 @@ def save_to_gguf(
     model_dtype: str,
     is_sentencepiece: bool = False,
     model_directory: str = "unsloth_finetuned_model",
-    quantization_method = "fast_quantized",  # Can be a list of options! ["q4_k_m", "q8_0", "q5_k_m"]
+    quantization_method="fast_quantized",  # Can be a list of options! ["q4_k_m", "q8_0", "q5_k_m"]
     first_conversion: str = None,
     is_vlm: bool = False,
     is_gpt_oss: bool = False,
@@ -1220,12 +1220,12 @@ def save_to_gguf(
         if IS_KAGGLE_ENVIRONMENT:
             # Kaggle: no CUDA support due to environment limitations
             quantizer_location, converter_location = install_llama_cpp(
-                gpu_support = False, print_output = print_output
+                gpu_support=False, print_output=print_output
             )
         else:
             quantizer_location, converter_location = install_llama_cpp(
-                gpu_support = False,  # GGUF conversion doesn't need CUDA
-                print_output = print_output,
+                gpu_support=False,  # GGUF conversion doesn't need CUDA
+                print_output=print_output,
             )
 
     # Step 2: Download and patch converter script
@@ -1242,17 +1242,17 @@ def save_to_gguf(
         print(f"This might take 3 minutes...")
 
         initial_files, is_vlm_update = convert_to_gguf(
-            model_name = model_name,
-            input_folder = model_directory,
-            model_dtype = model_dtype,
-            quantization_type = first_conversion,
-            converter_location = converter_path,
-            supported_text_archs = supported_text_archs,
-            supported_vision_archs = supported_vision_archs,
-            is_vlm = is_vlm,
-            is_gpt_oss = is_gpt_oss,
-            max_shard_size = "50GB",
-            print_output = print_output,
+            model_name=model_name,
+            input_folder=model_directory,
+            model_dtype=model_dtype,
+            quantization_type=first_conversion,
+            converter_location=converter_path,
+            supported_text_archs=supported_text_archs,
+            supported_vision_archs=supported_vision_archs,
+            is_vlm=is_vlm,
+            is_gpt_oss=is_gpt_oss,
+            max_shard_size="50GB",
+            print_output=print_output,
         )
     # update is_vlm switch
     is_vlm = is_vlm_update
@@ -1274,7 +1274,7 @@ def save_to_gguf(
 
     # Move initial GGUF files into a dedicated _gguf directory
     gguf_directory = f"{model_directory}_gguf"
-    os.makedirs(gguf_directory, exist_ok = True)
+    os.makedirs(gguf_directory, exist_ok=True)
     moved_files = []
     for fpath in initial_files:
         dst = os.path.join(gguf_directory, os.path.basename(fpath))
@@ -1307,11 +1307,11 @@ def save_to_gguf(
                 try:
                     # Use the quantize_gguf function we created
                     quantized_file = quantize_gguf(
-                        input_gguf = base_gguf,
-                        output_gguf = output_location,
-                        quant_type = quant_method,
-                        quantizer_location = quantizer_location,
-                        print_output = print_output,
+                        input_gguf=base_gguf,
+                        output_gguf=output_location,
+                        quant_type=quant_method,
+                        quantizer_location=quantizer_location,
+                        print_output=print_output,
                     )
                     all_saved_locations.append(quantized_file)
                     quants_created = True
@@ -1350,7 +1350,7 @@ def save_to_gguf(
         print("Unsloth: Model files cleanup...")
         if quants_created:
             all_saved_locations.remove(base_gguf)
-            Path(base_gguf).unlink(missing_ok = True)
+            Path(base_gguf).unlink(missing_ok=True)
 
             # flip the list to get [text_model, mmproj] order. for text models stays the same.
             all_saved_locations.reverse()
@@ -1371,7 +1371,7 @@ def save_to_gguf(
 def unsloth_save_pretrained_merged(
     self,
     save_directory: Union[str, os.PathLike],
-    tokenizer = None,
+    tokenizer=None,
     save_method: str = "merged_16bit",  # ["lora", "merged_16bit", "merged_4bit"]
     push_to_hub: bool = False,
     token: Optional[Union[str, bool]] = None,
@@ -1413,7 +1413,7 @@ def unsloth_save_pretrained_merged(
 def unsloth_push_to_hub_merged(
     self,
     repo_id: str,
-    tokenizer = None,
+    tokenizer=None,
     save_method: str = "merged_16bit",  # ["lora", "merged_16bit", "merged_4bit"]
     use_temp_dir: Optional[bool] = None,
     commit_message: Optional[str] = "Trained with Unsloth",
@@ -1487,7 +1487,7 @@ def _determine_username(save_directory, old_username, token):
         from huggingface_hub import whoami
 
         try:
-            username = whoami(token = token)["name"]
+            username = whoami(token=token)["name"]
             if type(old_username) is str and username != old_username:
                 username = old_username
             save_directory = f"{username}/{save_directory}"
@@ -1503,9 +1503,9 @@ def _determine_username(save_directory, old_username, token):
 def create_huggingface_repo(
     model,
     save_directory,
-    token = None,
-    private = False,
-    datasets = None,
+    token=None,
+    private=False,
+    datasets=None,
 ):
     if token is None:
         token = get_token()
@@ -1515,27 +1515,27 @@ def create_huggingface_repo(
 
     try:
         create_repo(
-            repo_id = save_directory,
-            token = token,
-            repo_type = "model",
-            exist_ok = False,
-            private = private,
+            repo_id=save_directory,
+            token=token,
+            repo_type="model",
+            exist_ok=False,
+            private=private,
         )
 
         # Create model card
         from huggingface_hub import ModelCard
 
         content = MODEL_CARD.format(
-            username = username,
-            base_model = model.config._name_or_path,
-            model_type = model.config.model_type,
-            method = "",
-            extra = "unsloth",
+            username=username,
+            base_model=model.config._name_or_path,
+            model_type=model.config.model_type,
+            method="",
+            extra="unsloth",
         )
         card = ModelCard(content)
         if datasets:
             card.data.datasets = datasets
-        card.push_to_hub(save_directory, token = token)
+        card.push_to_hub(save_directory, token=token)
     except:
         # Repo already exists — update datasets metadata separately
         if datasets:
@@ -1543,13 +1543,13 @@ def create_huggingface_repo(
                 from huggingface_hub import metadata_update
 
                 metadata_update(
-                    save_directory, {"datasets": datasets}, overwrite = True, token = token
+                    save_directory, {"datasets": datasets}, overwrite=True, token=token
                 )
             except Exception as e:
                 logger.warning_once(
                     f"Unsloth: Could not update datasets metadata for {save_directory}: {e}"
                 )
-    hf_api = HfApi(token = token)
+    hf_api = HfApi(token=token)
     return save_directory, hf_api
 
 
@@ -1558,12 +1558,12 @@ def upload_to_huggingface(
     save_directory,
     token,
     method,
-    extra = "",
-    file_location = None,
-    old_username = None,
-    private = None,
-    create_config = True,
-    datasets = None,
+    extra="",
+    file_location=None,
+    old_username=None,
+    private=None,
+    create_config=True,
+    datasets=None,
 ):
     save_directory, username = _determine_username(save_directory, old_username, token)
 
@@ -1571,27 +1571,27 @@ def upload_to_huggingface(
 
     try:
         create_repo(
-            repo_id = save_directory,
-            token = token,
-            repo_type = "model",
-            exist_ok = False,
-            private = private,
+            repo_id=save_directory,
+            token=token,
+            repo_type="model",
+            exist_ok=False,
+            private=private,
         )
 
         # Create model card
         from huggingface_hub import ModelCard
 
         content = MODEL_CARD.format(
-            username = username,
-            base_model = model.config._name_or_path,
-            model_type = model.config.model_type,
-            method = "",
-            extra = extra,
+            username=username,
+            base_model=model.config._name_or_path,
+            model_type=model.config.model_type,
+            method="",
+            extra=extra,
         )
         card = ModelCard(content)
         if datasets:
             card.data.datasets = datasets
-        card.push_to_hub(save_directory, token = token)
+        card.push_to_hub(save_directory, token=token)
     except:
         # Repo already exists — update datasets metadata separately
         if datasets:
@@ -1599,7 +1599,7 @@ def upload_to_huggingface(
                 from huggingface_hub import metadata_update
 
                 metadata_update(
-                    save_directory, {"datasets": datasets}, overwrite = True, token = token
+                    save_directory, {"datasets": datasets}, overwrite=True, token=token
                 )
             except Exception as e:
                 logger.warning_once(
@@ -1608,7 +1608,7 @@ def upload_to_huggingface(
 
     if file_location is not None:
         # Now upload file
-        hf_api = HfApi(token = token)
+        hf_api = HfApi(token=token)
 
         if "/" in file_location:
             uploaded_location = file_location[file_location.rfind("/") + 1 :]
@@ -1618,7 +1618,7 @@ def upload_to_huggingface(
         # find ftevent file from tensorboard and upload it
         import glob
 
-        ftevent_files = glob.glob("*out.tfevents*", recursive = True)
+        ftevent_files = glob.glob("*out.tfevents*", recursive=True)
         if len(ftevent_files) > 0:
             print(
                 "Unsloth: Uploading tensorboard files... Please wait...",
@@ -1626,33 +1626,33 @@ def upload_to_huggingface(
             )
             for ftevent_file in ftevent_files:
                 hf_api.upload_file(
-                    path_or_fileobj = ftevent_file,
-                    path_in_repo = ftevent_file.replace(file_location, ""),
-                    repo_id = save_directory,
-                    repo_type = "model",
-                    commit_message = "(Trained with Unsloth)",
+                    path_or_fileobj=ftevent_file,
+                    path_in_repo=ftevent_file.replace(file_location, ""),
+                    repo_id=save_directory,
+                    repo_type="model",
+                    commit_message="(Trained with Unsloth)",
                 )
 
         hf_api.upload_file(
-            path_or_fileobj = file_location,
-            path_in_repo = uploaded_location,
-            repo_id = save_directory,
-            repo_type = "model",
-            commit_message = "(Trained with Unsloth)",
+            path_or_fileobj=file_location,
+            path_in_repo=uploaded_location,
+            repo_id=save_directory,
+            repo_type="model",
+            commit_message="(Trained with Unsloth)",
         )
 
         # We also upload a config.json file
         if create_config:
             import json
 
-            with open("_temporary_unsloth_config.json", "w", encoding = "utf-8") as file:
-                json.dump({"model_type": model.config.model_type}, file, indent = 4)
+            with open("_temporary_unsloth_config.json", "w", encoding="utf-8") as file:
+                json.dump({"model_type": model.config.model_type}, file, indent=4)
             hf_api.upload_file(
-                path_or_fileobj = "_temporary_unsloth_config.json",
-                path_in_repo = "config.json",
-                repo_id = save_directory,
-                repo_type = "model",
-                commit_message = "(Trained with Unsloth)",
+                path_or_fileobj="_temporary_unsloth_config.json",
+                path_in_repo="config.json",
+                repo_id=save_directory,
+                repo_type="model",
+                commit_message="(Trained with Unsloth)",
             )
             os.remove("_temporary_unsloth_config.json")
     return username
@@ -1734,12 +1734,12 @@ def create_ollama_modelfile(tokenizer, base_model_name, model_location):
 
     if "__EOS_TOKEN__" in modelfile:
         modelfile = modelfile.format(
-            __FILE_LOCATION__ = model_location,
-            __EOS_TOKEN__ = tokenizer.eos_token,
+            __FILE_LOCATION__=model_location,
+            __EOS_TOKEN__=tokenizer.eos_token,
         )
     else:
         modelfile = modelfile.format(
-            __FILE_LOCATION__ = model_location,
+            __FILE_LOCATION__=model_location,
         )
 
     modelfile = modelfile.replace("⚫@✅#🦥", "{").replace("⚡@🦥#⛵", "}").rstrip()
@@ -1751,9 +1751,9 @@ def create_ollama_model(username: str, model_name: str, tag: str, modelfile_path
     try:
         init_check = subprocess.run(
             ["curl", "http://localhost:11434"],
-            capture_output = True,
-            text = True,
-            timeout = 3,
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
         if init_check.returncode == 0:
             print(init_check.stdout.strip())
@@ -1770,15 +1770,15 @@ def create_ollama_model(username: str, model_name: str, tag: str, modelfile_path
             "-f",
             f"{modelfile_path}",
         ],
-        stdout = subprocess.PIPE,
-        stderr = subprocess.STDOUT,
-        text = True,
-        bufsize = 1,
-        universal_newlines = True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True,
     )
 
     for line in iter(process.stdout.readline, ""):
-        print(line, end = "")
+        print(line, end="")
         sys.stdout.flush()
 
     return_code = process.wait()
@@ -1793,9 +1793,9 @@ def push_to_ollama_hub(username: str, model_name: str, tag: str):
     try:
         init_check = subprocess.run(
             ["curl", "http://localhost:11434"],
-            capture_output = True,
-            text = True,
-            timeout = 3,
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
         if init_check.returncode == 0:
             print(init_check.stdout.strip())
@@ -1806,15 +1806,15 @@ def push_to_ollama_hub(username: str, model_name: str, tag: str):
 
     process = subprocess.Popen(
         ["ollama", "push", f"{username}/{model_name}:{tag}"],
-        stdout = subprocess.PIPE,
-        stderr = subprocess.STDOUT,
-        text = True,
-        bufsize = 1,
-        universal_newlines = True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True,
     )
 
     for line in iter(process.stdout.readline, ""):
-        print(line, end = "")
+        print(line, end="")
         sys.stdout.flush()
 
     return_code = process.wait()
@@ -1827,21 +1827,21 @@ def push_to_ollama_hub(username: str, model_name: str, tag: str):
 
 def push_to_ollama(tokenizer, gguf_location, username: str, model_name: str, tag: str):
     model_file = create_ollama_modelfile(
-        tokenizer = tokenizer, gguf_location = gguf_location
+        tokenizer=tokenizer, gguf_location=gguf_location
     )
 
-    with open(f"Modelfile_{model_name}", "w", encoding = "utf-8") as f:
+    with open(f"Modelfile_{model_name}", "w", encoding="utf-8") as f:
         f.write(model_file)
         f.close()
 
     create_ollama_model(
-        username = username,
-        model_name = model_name,
-        tag = tag,
-        modelfile_path = f"Modelfile_{model_name}",
+        username=username,
+        model_name=model_name,
+        tag=tag,
+        modelfile_path=f"Modelfile_{model_name}",
     )
 
-    push_to_ollama_hub(username = username, model_name = model_name, tag = tag)
+    push_to_ollama_hub(username=username, model_name=model_name, tag=tag)
 
     print("Successfully pushed to ollama")
 
@@ -1849,8 +1849,8 @@ def push_to_ollama(tokenizer, gguf_location, username: str, model_name: str, tag
 def unsloth_save_pretrained_gguf(
     self,
     save_directory: Union[str, os.PathLike],
-    tokenizer = None,
-    quantization_method = "fast_quantized",
+    tokenizer=None,
+    quantization_method="fast_quantized",
     first_conversion: str = None,
     push_to_hub: bool = False,
     token: Optional[Union[str, bool]] = None,
@@ -1901,7 +1901,7 @@ def unsloth_save_pretrained_gguf(
         raise ValueError("Unsloth: Saving to GGUF must have a tokenizer.")
 
     try:
-        base_model_name = get_model_name(self.config._name_or_path, load_in_4bit = False)
+        base_model_name = get_model_name(self.config._name_or_path, load_in_4bit=False)
         model_name = base_model_name.split("/")[-1]
     except:
         base_model_name = self.config._name_or_path
@@ -2009,7 +2009,7 @@ def unsloth_save_pretrained_gguf(
             print(
                 "Unsloth: Model is not a PEFT model. Saving directly without LoRA merge..."
             )
-            os.makedirs(save_directory, exist_ok = True)
+            os.makedirs(save_directory, exist_ok=True)
             try:
                 self.save_pretrained(save_directory)
                 if tokenizer is not None:
@@ -2083,15 +2083,15 @@ def unsloth_save_pretrained_gguf(
 
     try:
         all_file_locations, want_full_precision, is_vlm_update = save_to_gguf(
-            model_name = model_name,
-            model_type = model_type,
-            model_dtype = model_dtype,
-            is_sentencepiece = False,
-            model_directory = save_directory,
-            quantization_method = quantization_methods,
-            first_conversion = first_conversion,
-            is_vlm = is_vlm,  # Pass VLM flag
-            is_gpt_oss = is_gpt_oss,  # Pass gpt_oss Flag
+            model_name=model_name,
+            model_type=model_type,
+            model_dtype=model_dtype,
+            is_sentencepiece=False,
+            model_directory=save_directory,
+            quantization_method=quantization_methods,
+            first_conversion=first_conversion,
+            is_vlm=is_vlm,  # Pass VLM flag
+            is_gpt_oss=is_gpt_oss,  # Pass gpt_oss Flag
         )
     except Exception as e:
         if IS_KAGGLE_ENVIRONMENT:
@@ -2120,7 +2120,7 @@ def unsloth_save_pretrained_gguf(
                 )
             if modelfile is not None:
                 modelfile_location = os.path.join(gguf_directory, "Modelfile")
-                with open(modelfile_location, "w", encoding = "utf-8") as file:
+                with open(modelfile_location, "w", encoding="utf-8") as file:
                     file.write(modelfile)
                 ollama_success = True
         except Exception as e:
@@ -2172,8 +2172,8 @@ def unsloth_save_pretrained_gguf(
 def unsloth_push_to_hub_gguf(
     self,
     repo_id: str,
-    tokenizer = None,
-    quantization_method = "fast_quantized",
+    tokenizer=None,
+    quantization_method="fast_quantized",
     first_conversion: str = None,
     use_temp_dir: Optional[bool] = None,
     commit_message: Optional[str] = "Trained with Unsloth",
@@ -2223,7 +2223,7 @@ def unsloth_push_to_hub_gguf(
     if use_temp_dir or use_temp_dir is None:
         import tempfile
 
-        temp_dir = tempfile.mkdtemp(prefix = "unsloth_gguf_")
+        temp_dir = tempfile.mkdtemp(prefix="unsloth_gguf_")
         save_directory = temp_dir
         cleanup_temp = True
     else:
@@ -2236,17 +2236,17 @@ def unsloth_push_to_hub_gguf(
     try:
         # Call save_pretrained_gguf - it returns all the info we need
         result = unsloth_save_pretrained_gguf(
-            self = self,
-            save_directory = save_directory,
-            tokenizer = tokenizer,
-            quantization_method = quantization_method,
-            first_conversion = first_conversion,
-            push_to_hub = False,  # Never push from here
-            token = None,  # Don't need token for local save
-            max_shard_size = max_shard_size,
-            safe_serialization = safe_serialization,
-            temporary_location = temporary_location,
-            maximum_memory_usage = maximum_memory_usage,
+            self=self,
+            save_directory=save_directory,
+            tokenizer=tokenizer,
+            quantization_method=quantization_method,
+            first_conversion=first_conversion,
+            push_to_hub=False,  # Never push from here
+            token=None,  # Don't need token for local save
+            max_shard_size=max_shard_size,
+            safe_serialization=safe_serialization,
+            temporary_location=temporary_location,
+            maximum_memory_usage=maximum_memory_usage,
         )
 
         # Extract results
@@ -2274,7 +2274,7 @@ def unsloth_push_to_hub_gguf(
     try:
         from huggingface_hub import HfApi
 
-        api = HfApi(token = token)
+        api = HfApi(token=token)
 
         # Get full repo id
         if "/" not in repo_id:
@@ -2285,10 +2285,10 @@ def unsloth_push_to_hub_gguf(
 
         # Create repo
         api.create_repo(
-            repo_id = full_repo_id,
-            repo_type = "model",
-            private = private,
-            exist_ok = True,
+            repo_id=full_repo_id,
+            repo_type="model",
+            private=private,
+            exist_ok=True,
         )
 
         # Upload GGUF files
@@ -2311,14 +2311,14 @@ def unsloth_push_to_hub_gguf(
             print(f"Uploading {proper_name}...")
 
             api.upload_file(
-                path_or_fileobj = file_location,
-                path_in_repo = proper_name,
-                repo_id = full_repo_id,
-                repo_type = "model",
-                commit_message = commit_message,
-                commit_description = commit_description,
-                create_pr = create_pr,
-                revision = revision,
+                path_or_fileobj=file_location,
+                path_in_repo=proper_name,
+                repo_id=full_repo_id,
+                repo_type="model",
+                commit_message=commit_message,
+                commit_description=commit_description,
+                create_pr=create_pr,
+                revision=revision,
             )
 
         # Upload config.json if exists
@@ -2326,26 +2326,26 @@ def unsloth_push_to_hub_gguf(
         if os.path.exists(config_path):
             print("Uploading config.json...")
             api.upload_file(
-                path_or_fileobj = config_path,
-                path_in_repo = "config.json",
-                repo_id = full_repo_id,
-                repo_type = "model",
-                commit_message = f"{commit_message} - config",
-                create_pr = create_pr,
-                revision = revision,
+                path_or_fileobj=config_path,
+                path_in_repo="config.json",
+                repo_id=full_repo_id,
+                repo_type="model",
+                commit_message=f"{commit_message} - config",
+                create_pr=create_pr,
+                revision=revision,
             )
 
         # Upload Modelfile if exists
         if modelfile_location and os.path.exists(modelfile_location):
             print("Uploading Ollama Modelfile...")
             api.upload_file(
-                path_or_fileobj = modelfile_location,
-                path_in_repo = "Modelfile",
-                repo_id = full_repo_id,
-                repo_type = "model",
-                commit_message = f"{commit_message} - Ollama Modelfile",
-                create_pr = create_pr,
-                revision = revision,
+                path_or_fileobj=modelfile_location,
+                path_in_repo="Modelfile",
+                repo_id=full_repo_id,
+                repo_type="model",
+                commit_message=f"{commit_message} - Ollama Modelfile",
+                create_pr=create_pr,
+                revision=revision,
             )
 
         # Create and upload README
@@ -2414,13 +2414,13 @@ This model was finetuned and converted to GGUF format using [Unsloth](https://gi
             f.write(readme_content)
 
         api.upload_file(
-            path_or_fileobj = readme_path,
-            path_in_repo = "README.md",
-            repo_id = full_repo_id,
-            repo_type = "model",
-            commit_message = "Add README",
-            create_pr = create_pr,
-            revision = revision,
+            path_or_fileobj=readme_path,
+            path_in_repo="README.md",
+            repo_id=full_repo_id,
+            repo_type="model",
+            commit_message="Add README",
+            create_pr=create_pr,
+            revision=revision,
         )
 
         print(
@@ -2436,9 +2436,9 @@ This model was finetuned and converted to GGUF format using [Unsloth](https://gi
 
         try:
             api.add_tags(
-                repo_id = full_repo_id,
-                tags = tags,
-                repo_type = "model",
+                repo_id=full_repo_id,
+                tags=tags,
+                repo_type="model",
             )
         except:
             pass
@@ -2448,7 +2448,7 @@ This model was finetuned and converted to GGUF format using [Unsloth](https://gi
                 from huggingface_hub import metadata_update
 
                 metadata_update(
-                    full_repo_id, {"datasets": datasets}, overwrite = True, token = token
+                    full_repo_id, {"datasets": datasets}, overwrite=True, token=token
                 )
             except Exception as e:
                 logger.warning_once(
@@ -2477,15 +2477,15 @@ This model was finetuned and converted to GGUF format using [Unsloth](https://gi
 # Corrected function to save LoRA to a custom directory
 def save_lora_to_custom_dir(model, tokenizer, save_directory):
     # Create the custom directory if it doesn't exist
-    os.makedirs(save_directory, exist_ok = True)
+    os.makedirs(save_directory, exist_ok=True)
 
     # Call the unsloth_save_model function with the custom directory
     unsloth_save_model(
         model,
         tokenizer,
-        save_directory = save_directory,
-        save_method = "lora",
-        push_to_hub = False,
+        save_directory=save_directory,
+        save_method="lora",
+        push_to_hub=False,
     )
 
 
@@ -2508,7 +2508,7 @@ def unsloth_convert_lora_to_ggml_and_push_to_hub(
         if IS_KAGGLE_ENVIRONMENT:
             python_install = install_python_non_blocking(["protobuf"])
             python_install.wait()
-            install_llama_cpp_blocking(use_cuda = False)
+            install_llama_cpp_blocking(use_cuda=False)
             makefile = None
         else:
             git_clone = install_llama_cpp_clone_non_blocking()
@@ -2542,15 +2542,15 @@ def unsloth_convert_lora_to_ggml_and_push_to_hub(
                 output_file,
                 "llama",
             ],
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE,
-            bufsize = 1,
-            universal_newlines = True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=1,
+            universal_newlines=True,
         ) as sp:
             for line in sp.stdout:
-                print(line, end = "", flush = True)
+                print(line, end="", flush=True)
             for line in sp.stderr:
-                print(line, end = "", flush = True)
+                print(line, end="", flush=True)
             sp.wait()
             if sp.returncode != 0:
                 raise subprocess.CalledProcessError(sp.returncode, sp.args)
@@ -2590,7 +2590,7 @@ def unsloth_convert_lora_to_ggml_and_save_locally(
         if IS_KAGGLE_ENVIRONMENT:
             python_install = install_python_non_blocking(["protobuf"])
             python_install.wait()
-            install_llama_cpp_blocking(use_cuda = False)
+            install_llama_cpp_blocking(use_cuda=False)
             makefile = None
         else:
             git_clone = install_llama_cpp_clone_non_blocking()
@@ -2624,15 +2624,15 @@ def unsloth_convert_lora_to_ggml_and_save_locally(
                 output_file,
                 "llama",
             ],
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE,
-            bufsize = 1,
-            universal_newlines = True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=1,
+            universal_newlines=True,
         ) as sp:
             for line in sp.stdout:
-                print(line, end = "", flush = True)
+                print(line, end="", flush=True)
             for line in sp.stderr:
-                print(line, end = "", flush = True)
+                print(line, end="", flush=True)
             sp.wait()
             if sp.returncode != 0:
                 raise subprocess.CalledProcessError(sp.returncode, sp.args)
@@ -2662,10 +2662,10 @@ def save_to_gguf_generic(
     model,
     save_directory,
     tokenizer,
-    quantization_method = None,
-    quantization_type = "Q8_0",
-    repo_id = None,
-    token = None,
+    quantization_method=None,
+    quantization_type="Q8_0",
+    repo_id=None,
+    token=None,
 ):
     if token is None and repo_id is not None:
         token = get_token()
@@ -2673,7 +2673,7 @@ def save_to_gguf_generic(
         raise RuntimeError("Unsloth: Please specify a token for uploading!")
 
     if not os.path.exists(os.path.join("llama.cpp", "unsloth_convert_hf_to_gguf.py")):
-        install_llama_cpp(just_clone_repo = True)
+        install_llama_cpp(just_clone_repo=True)
 
     # Use old style quantization_method
     new_quantization_methods = []
@@ -2717,27 +2717,27 @@ def save_to_gguf_generic(
     for quantization_type in new_quantization_methods:
         metadata = _convert_to_gguf(
             save_directory,
-            print_output = True,
-            quantization_type = quantization_type,
+            print_output=True,
+            quantization_type=quantization_type,
         )
         if repo_id is not None:
             prepare_saving(
                 model,
                 repo_id,
-                push_to_hub = True,
-                max_shard_size = "50GB",
-                private = True,
-                token = token,
+                push_to_hub=True,
+                max_shard_size="50GB",
+                private=True,
+                token=token,
             )
 
             from huggingface_hub import HfApi
 
-            api = HfApi(token = token)
+            api = HfApi(token=token)
             api.upload_folder(
-                folder_path = save_directory,
-                repo_id = repo_id,
-                repo_type = "model",
-                allow_patterns = ["*.gguf"],
+                folder_path=save_directory,
+                repo_id=repo_id,
+                repo_type="model",
+                allow_patterns=["*.gguf"],
             )
     return metadata
 
@@ -2794,30 +2794,30 @@ def unsloth_generic_save(
 
         # Honor merged_16bit by casting to the target dtype if needed
         _save_kwargs = dict(
-            safe_serialization = safe_serialization,
-            max_shard_size = max_shard_size,
-            variant = variant,
+            safe_serialization=safe_serialization,
+            max_shard_size=max_shard_size,
+            variant=variant,
         )
         if "16bit" in save_method:
             _target_dtype = (
                 torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
             )
             _save_kwargs["state_dict"] = {
-                k: v.to(dtype = _target_dtype) if v.is_floating_point() else v
+                k: v.to(dtype=_target_dtype) if v.is_floating_point() else v
                 for k, v in model.state_dict().items()
             }
 
         if push_to_hub:
             print(f"Unsloth: Pushing full fine-tuned model to '{save_directory}' ...")
             model.push_to_hub(
-                repo_id = save_directory,
-                token = token,
-                private = private,
-                commit_message = commit_message,
-                create_pr = create_pr,
-                revision = revision,
-                commit_description = commit_description,
-                tags = tags,
+                repo_id=save_directory,
+                token=token,
+                private=private,
+                commit_message=commit_message,
+                create_pr=create_pr,
+                revision=revision,
+                commit_description=commit_description,
+                tags=tags,
                 **_save_kwargs,
             )
             if tokenizer is not None:
@@ -2825,11 +2825,11 @@ def unsloth_generic_save(
                 tokenizer.padding_side = "left"
                 tokenizer.push_to_hub(
                     save_directory,
-                    token = token,
-                    private = private,
-                    commit_message = commit_message,
-                    create_pr = create_pr,
-                    revision = revision,
+                    token=token,
+                    private=private,
+                    commit_message=commit_message,
+                    create_pr=create_pr,
+                    revision=revision,
                 )
                 tokenizer.padding_side = old_padding_side
         else:
@@ -2845,16 +2845,16 @@ def unsloth_generic_save(
     else:
         merge_and_overwrite_lora(
             get_model_name,
-            model = model,
-            tokenizer = tokenizer,
-            save_directory = save_directory,
-            push_to_hub = push_to_hub,
-            private = private,
-            token = token,
-            save_method = save_method,
-            output_dtype = None,
-            low_disk_space_usage = True,
-            use_temp_file = False,
+            model=model,
+            tokenizer=tokenizer,
+            save_directory=save_directory,
+            push_to_hub=push_to_hub,
+            private=private,
+            token=token,
+            save_method=save_method,
+            output_dtype=None,
+            low_disk_space_usage=True,
+            use_temp_file=False,
         )
 
     if push_to_hub and datasets:
@@ -2863,7 +2863,7 @@ def unsloth_generic_save(
 
             save_dir, _ = _determine_username(save_directory, None, token)
             metadata_update(
-                save_dir, {"datasets": datasets}, overwrite = True, token = token
+                save_dir, {"datasets": datasets}, overwrite=True, token=token
             )
         except Exception as e:
             logger.warning_once(
@@ -2876,7 +2876,7 @@ def unsloth_generic_save(
 def unsloth_generic_save_pretrained_merged(
     self,
     save_directory: Union[str, os.PathLike],
-    tokenizer = None,
+    tokenizer=None,
     save_method: str = "merged_16bit",  # ["lora", "merged_16bit", "merged_4bit"]
     push_to_hub: bool = False,
     token: Optional[Union[str, bool]] = None,
@@ -2918,7 +2918,7 @@ def unsloth_generic_save_pretrained_merged(
 def unsloth_generic_push_to_hub_merged(
     self,
     repo_id: str,
-    tokenizer = None,
+    tokenizer=None,
     save_method: str = "merged_16bit",  # ["lora", "merged_16bit", "merged_4bit"]
     use_temp_dir: Optional[bool] = None,
     commit_message: Optional[str] = "Trained with Unsloth",
@@ -2973,12 +2973,12 @@ def _unsloth_save_torchao_with_attached_config(
     # PEFT models also might come here, so parse it
     if isinstance(model, PeftModelForCausalLM):
         _unsloth_save_torchao_with_given_config(
-            model = model,
-            save_directory = save_directory,
-            tokenizer = tokenizer,
-            torchao_config = model.config.quantization_config,
-            push_to_hub = push_to_hub,
-            token = token,
+            model=model,
+            save_directory=save_directory,
+            tokenizer=tokenizer,
+            torchao_config=model.config.quantization_config,
+            push_to_hub=push_to_hub,
+            token=token,
         )
         return
 
@@ -2987,11 +2987,11 @@ def _unsloth_save_torchao_with_attached_config(
 
     if push_to_hub:
         model.push_to_hub(
-            save_directory, safe_serialization = safe_serialization, token = token
+            save_directory, safe_serialization=safe_serialization, token=token
         )
-        tokenizer.push_to_hub(save_directory, token = token)
+        tokenizer.push_to_hub(save_directory, token=token)
     else:
-        model.save_pretrained(save_directory, safe_serialization = safe_serialization)
+        model.save_pretrained(save_directory, safe_serialization=safe_serialization)
         tokenizer.save_pretrained(save_directory)
 
 
@@ -3045,7 +3045,7 @@ def _unsloth_save_torchao_with_given_config(
     if isinstance(torchao_config, TorchAoConfig):
         quantization_config = torchao_config
     else:
-        quantization_config = TorchAoConfig(quant_type = torchao_config)
+        quantization_config = TorchAoConfig(quant_type=torchao_config)
 
     # Determine if this is a VLM
     is_vlm = False
@@ -3069,8 +3069,8 @@ def _unsloth_save_torchao_with_given_config(
     # Reload with quantization applied
     quantized_model = auto_model.from_pretrained(
         save_directory,
-        device_map = "auto",
-        quantization_config = quantization_config,
+        device_map="auto",
+        quantization_config=quantization_config,
         **kwargs,
     )
 
@@ -3082,12 +3082,12 @@ def _unsloth_save_torchao_with_given_config(
 
     if push_to_hub:
         quantized_model.push_to_hub(
-            torchao_save_directory, safe_serialization = safe_serialization, token = token
+            torchao_save_directory, safe_serialization=safe_serialization, token=token
         )
-        tokenizer.push_to_hub(torchao_save_directory, token = token)
+        tokenizer.push_to_hub(torchao_save_directory, token=token)
     else:
         quantized_model.save_pretrained(
-            torchao_save_directory, safe_serialization = safe_serialization
+            torchao_save_directory, safe_serialization=safe_serialization
         )
         tokenizer.save_pretrained(torchao_save_directory)
 
@@ -3102,8 +3102,8 @@ def _unsloth_save_torchao_with_given_config(
 def unsloth_save_pretrained_torchao(
     self,
     save_directory: Union[str, os.PathLike],
-    tokenizer = None,
-    torchao_config = None,
+    tokenizer=None,
+    torchao_config=None,
     push_to_hub: bool = False,
     token: Optional[Union[str, bool]] = None,
 ):
@@ -3143,12 +3143,12 @@ def unsloth_save_pretrained_torchao(
             "attached to the model from training."
         )
         _unsloth_save_torchao_with_given_config(
-            model = self,
-            save_directory = save_directory,
-            tokenizer = tokenizer,
-            torchao_config = torchao_config,
-            push_to_hub = push_to_hub,
-            token = token,
+            model=self,
+            save_directory=save_directory,
+            tokenizer=tokenizer,
+            torchao_config=torchao_config,
+            push_to_hub=push_to_hub,
+            token=token,
         )
     else:
         # QAT path: no config provided, model must have QAT config
@@ -3158,11 +3158,11 @@ def unsloth_save_pretrained_torchao(
             "post-training quantization."
         )
         _unsloth_save_torchao_with_attached_config(
-            model = self,
-            save_directory = save_directory,
-            tokenizer = tokenizer,
-            push_to_hub = push_to_hub,
-            token = token,
+            model=self,
+            save_directory=save_directory,
+            tokenizer=tokenizer,
+            push_to_hub=push_to_hub,
+            token=token,
         )
 
     for _ in range(3):
@@ -3175,7 +3175,7 @@ def not_implemented_save(*args, **kwargs):
     )
 
 
-def patch_saving_functions(model, vision = False):
+def patch_saving_functions(model, vision=False):
     import inspect
     import types
     from typing import Callable, Optional, Union, List

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -172,7 +172,7 @@ def _create_unsloth_optimizer(
     model,
     optimizer_cls,
     optimizer_kwargs,
-    embedding_lr = 5e-5,
+    embedding_lr=5e-5,
 ):
     lr = optimizer_kwargs["lr"]
     weight_decay = optimizer_kwargs.get("weight_decay", 0.0)
@@ -236,7 +236,7 @@ class UnslothTrainer(SFTTrainer):
             )
         return self.optimizer
 
-    def _create_q_galore_optimizer(self, config: "QGaloreConfig", embedding_lr = None):
+    def _create_q_galore_optimizer(self, config: "QGaloreConfig", embedding_lr=None):
         """Build the Q-GaLore optimizer from a QGaloreConfig."""
         from unsloth.optimizers.q_galore_adamw import (
             QGaLoreAdamW8bit,
@@ -249,21 +249,21 @@ class UnslothTrainer(SFTTrainer):
 
         param_groups = make_q_galore_param_groups(
             self.model,
-            lr = lr,
-            weight_decay = weight_decay,
-            rank = config.rank,
-            update_proj_gap = config.update_proj_gap,
-            scale = config.scale,
-            proj_quant = config.proj_quant,
-            proj_quant_group_size = config.proj_quant_group_size,
-            proj_quant_n_bit = config.proj_quant_n_bit,
-            weight_quant = config.weight_quant,
-            stochastic_round = config.stochastic_round,
-            weight_group_size = config.weight_group_size,
-            cos_threshold = config.cos_threshold,
-            gamma_proj = config.gamma_proj,
-            queue_size = config.queue_size,
-            target_modules = config.target_modules,
+            lr=lr,
+            weight_decay=weight_decay,
+            rank=config.rank,
+            update_proj_gap=config.update_proj_gap,
+            scale=config.scale,
+            proj_quant=config.proj_quant,
+            proj_quant_group_size=config.proj_quant_group_size,
+            proj_quant_n_bit=config.proj_quant_n_bit,
+            weight_quant=config.weight_quant,
+            stochastic_round=config.stochastic_round,
+            weight_group_size=config.weight_group_size,
+            cos_threshold=config.cos_threshold,
+            gamma_proj=config.gamma_proj,
+            queue_size=config.queue_size,
+            target_modules=config.target_modules,
         )
 
         # --- Split embedding params with custom LR (Fix #2) ---
@@ -306,10 +306,10 @@ class UnslothTrainer(SFTTrainer):
         # --- Forward optimizer hyperparameters (Fix #3) ---
         self.optimizer = QGaLoreAdamW8bit(
             param_groups,
-            lr = lr,
-            weight_decay = weight_decay,
-            betas = (self.args.adam_beta1, self.args.adam_beta2),
-            eps = self.args.adam_epsilon,
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=(self.args.adam_beta1, self.args.adam_beta2),
+            eps=self.args.adam_epsilon,
         )
 
         # Initialize INT8 weight quantization if enabled
@@ -317,8 +317,8 @@ class UnslothTrainer(SFTTrainer):
             QGaLoreAdamW8bit.init_weight_quantization(
                 self.model,
                 param_groups,
-                group_size = config.weight_group_size,
-                stochastic = config.stochastic_round,
+                group_size=config.weight_group_size,
+                stochastic=config.stochastic_round,
             )
             # Forward pre-hooks dequantize INT8 weights to float before each
             # forward pass, allowing the optimizer to free float weight memory

--- a/unsloth/utils/attention_dispatch.py
+++ b/unsloth/utils/attention_dispatch.py
@@ -178,8 +178,8 @@ def run_attention(
     elif backend == XFORMERS:
         attn_bias = build_xformers_block_causal_mask(
             context.seq_info,
-            sliding_window = sliding_window,
-            base_mask = context.causal_mask,
+            sliding_window=sliding_window,
+            base_mask=context.causal_mask,
         )
 
         Q_t = Q.transpose(1, 2)
@@ -232,7 +232,7 @@ def run_attention(
             Q_mod,
             K_mod,
             V_mod,
-            attn_bias = attn_bias,
+            attn_bias=attn_bias,
             **xformers_kwargs,
         )
 
@@ -248,16 +248,16 @@ def run_attention(
         if context.seq_info is not None and local_mask is None:
             local_mask = build_sdpa_packed_attention_mask(
                 context.seq_info,
-                dtype = Q.dtype,
-                device = Q.device,
-                sliding_window = sliding_window,
+                dtype=Q.dtype,
+                device=Q.device,
+                sliding_window=sliding_window,
             )
         else:
             q_len_local = Q.shape[-2]
             k_len_local = K.shape[-2]
             # ---- SDPA mask normalization for left padding / 2D masks ----
             if local_mask is not None and isinstance(local_mask, torch.Tensor):
-                local_mask = local_mask.to(device = Q.device)
+                local_mask = local_mask.to(device=Q.device)
 
                 if local_mask.dim() == 2:
                     # key padding keep mask: (bsz, k_len), 1/True = real token
@@ -271,9 +271,9 @@ def run_attention(
                         k_len_local - q_len_local
                     )  # works for prefill (0) and decode
                     q_pos = torch.arange(
-                        past_len, past_len + q_len_local, device = Q.device
+                        past_len, past_len + q_len_local, device=Q.device
                     )
-                    k_pos = torch.arange(k_len_local, device = Q.device)
+                    k_pos = torch.arange(k_len_local, device=Q.device)
 
                     causal_keep = (
                         k_pos[None, :] <= q_pos[:, None]
@@ -304,7 +304,7 @@ def run_attention(
                 # Avoid NaNs from fully-masked rows (common with left padding).
                 if local_mask.dtype == torch.bool:
                     no_allowed = ~local_mask.any(
-                        dim = -1, keepdim = True
+                        dim=-1, keepdim=True
                     )  # (bsz,1,q_len,1)
                     local_mask = local_mask | no_allowed
 

--- a/unsloth/utils/hf_hub.py
+++ b/unsloth/utils/hf_hub.py
@@ -38,7 +38,7 @@ def get_model_info(
     if _HFAPI is None:
         _HFAPI = HfApi()
     try:
-        model_info: ModelInfo = _HFAPI.model_info(model_id, expand = properties)
+        model_info: ModelInfo = _HFAPI.model_info(model_id, expand=properties)
     except Exception as e:
         print(f"Error getting model info for {model_id}: {e}")
         model_info = None
@@ -70,11 +70,11 @@ def list_models(
         properties = None
 
     models: list[ModelInfo] = _HFAPI.list_models(
-        author = author,
-        search = search,
-        sort = sort,
-        limit = limit,
-        expand = properties,
-        full = full,
+        author=author,
+        search=search,
+        sort=sort,
+        limit=limit,
+        expand=properties,
+        full=full,
     )
     return models

--- a/unsloth_cli/commands/inference.py
+++ b/unsloth_cli/commands/inference.py
@@ -8,10 +8,10 @@ import typer
 
 
 def inference(
-    model: str = typer.Argument(..., help = "HF model id or local path."),
-    prompt: str = typer.Argument(..., help = "Prompt to send to the model."),
+    model: str = typer.Argument(..., help="HF model id or local path."),
+    prompt: str = typer.Argument(..., help="Prompt to send to the model."),
     hf_token: Optional[str] = typer.Option(
-        None, "--hf-token", envvar = "HF_TOKEN", help = "Hugging Face token if needed."
+        None, "--hf-token", envvar="HF_TOKEN", help="Hugging Face token if needed."
     ),
     temperature: float = typer.Option(0.7, "--temperature"),
     top_p: float = typer.Option(0.9, "--top-p"),
@@ -21,7 +21,7 @@ def inference(
     system_prompt: str = typer.Option(
         "",
         "--system-prompt",
-        help = "Optional system prompt to prepend.",
+        help="Optional system prompt to prepend.",
     ),
     max_seq_length: int = typer.Option(2048, "--max-seq-length"),
     load_in_4bit: bool = typer.Option(True, "--load-in-4bit/--no-load-in-4bit"),
@@ -31,33 +31,33 @@ def inference(
 
     inference_backend = get_inference_backend()
     model_config = ModelConfig.from_ui_selection(
-        dropdown_value = model, search_value = None, hf_token = hf_token, is_lora = False
+        dropdown_value=model, search_value=None, hf_token=hf_token, is_lora=False
     )
     if not model_config:
-        typer.echo("Could not resolve model config", err = True)
-        raise typer.Exit(code = 1)
+        typer.echo("Could not resolve model config", err=True)
+        raise typer.Exit(code=1)
 
     if not inference_backend.load_model(
-        config = model_config,
-        max_seq_length = max_seq_length,
-        load_in_4bit = load_in_4bit,
-        hf_token = hf_token,
+        config=model_config,
+        max_seq_length=max_seq_length,
+        load_in_4bit=load_in_4bit,
+        hf_token=hf_token,
     ):
-        typer.echo("Model load failed", err = True)
-        raise typer.Exit(code = 1)
+        typer.echo("Model load failed", err=True)
+        raise typer.Exit(code=1)
 
     messages = [{"role": "user", "content": prompt}]
     stream = inference_backend.generate_chat_response(
-        messages = messages,
-        system_prompt = system_prompt,
-        temperature = temperature,
-        top_p = top_p,
-        top_k = top_k,
-        max_new_tokens = max_new_tokens,
-        repetition_penalty = repetition_penalty,
+        messages=messages,
+        system_prompt=system_prompt,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        max_new_tokens=max_new_tokens,
+        repetition_penalty=repetition_penalty,
     )
 
-    typer.echo("Assistant:", nl = True)
+    typer.echo("Assistant:", nl=True)
     previous = ""
     for chunk in stream:
         delta = chunk[len(previous) :]

--- a/unsloth_cli/config.py
+++ b/unsloth_cli/config.py
@@ -58,10 +58,10 @@ class LoggingConfig(BaseModel):
 
 class Config(BaseModel):
     model: Optional[str] = None
-    data: DataConfig = Field(default_factory = DataConfig)
-    training: TrainingConfig = Field(default_factory = TrainingConfig)
-    lora: LoraConfig = Field(default_factory = LoraConfig)
-    logging: LoggingConfig = Field(default_factory = LoggingConfig)
+    data: DataConfig = Field(default_factory=DataConfig)
+    training: TrainingConfig = Field(default_factory=TrainingConfig)
+    lora: LoraConfig = Field(default_factory=LoraConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
 
     def apply_overrides(self, **kwargs):
         """Apply CLI overrides by matching arg names to config fields."""
@@ -138,7 +138,7 @@ def load_config(path: Optional[Path]) -> Config:
     if not path.exists():
         raise FileNotFoundError(f"Config file not found: {path}")
 
-    text = path.read_text(encoding = "utf-8")
+    text = path.read_text(encoding="utf-8")
     if path.suffix.lower() in {".yaml", ".yml"}:
         data = yaml.safe_load(text) or {}
     else:

--- a/unsloth_cli/options.py
+++ b/unsloth_cli/options.py
@@ -107,22 +107,22 @@ def add_options_from_config(config_class: type[BaseModel]) -> Callable:
                 default = typer.Option(
                     None,
                     f"{flag_name}/--no-{field_name.replace('_', '-')}",
-                    help = help_text,
+                    help=help_text,
                 )
                 param = inspect.Parameter(
                     field_name,
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default = default,
-                    annotation = Optional[bool],
+                    default=default,
+                    annotation=Optional[bool],
                 )
             else:
                 py_type = _get_python_type(annotation)
-                default = typer.Option(None, flag_name, help = help_text)
+                default = typer.Option(None, flag_name, help=help_text)
                 param = inspect.Parameter(
                     field_name,
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default = default,
-                    annotation = Optional[py_type],
+                    default=default,
+                    annotation=Optional[py_type],
                 )
             new_params.append(param)
 
@@ -131,7 +131,7 @@ def add_options_from_config(config_class: type[BaseModel]) -> Callable:
             if param.name != "config_overrides":
                 new_params.append(param)
 
-        new_sig = sig.replace(parameters = new_params)
+        new_sig = sig.replace(parameters=new_params)
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
rocminfo on ROCm 6.1+ emits generic family ISA entries like "amdgcn-amd-amdhsa--gfx11-generic" alongside the real GPU name (e.g. gfx1100). The old `gfx[1-9]` pattern matched both; the new `gfx[1-9][0-9]{2,3}` requires 3-4 digit IDs, matching only real GPU targets and never bare family prefixes.

This manifests in llama-cpp build error, as additional gpu target is being added like: `-DGPU_TARGETS=gfx1100 -DGPU_TARGETS=gfx11` (instead of just gfx1100)