### PR TITLE
Fix bf16 GGUF deleted by cleanup when exported alongside quantized types

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1349,8 +1349,9 @@ def save_to_gguf(
                         )
         print("Unsloth: Model files cleanup...")
         if quants_created:
-            all_saved_locations.remove(base_gguf)
-            Path(base_gguf).unlink(missing_ok = True)
+            if first_conversion not in frozenset(quantization_method):
+                all_saved_locations.remove(base_gguf)
+                Path(base_gguf).unlink(missing_ok = True)
 
             # flip the list to get [text_model, mmproj] order. for text models stays the same.
             all_saved_locations.reverse()

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1349,12 +1349,18 @@ def save_to_gguf(
                         )
         print("Unsloth: Model files cleanup...")
         if quants_created:
+            all_saved_locations.remove(base_gguf)
             if first_conversion not in frozenset(quantization_method):
-                all_saved_locations.remove(base_gguf)
                 Path(base_gguf).unlink(missing_ok = True)
 
             # flip the list to get [text_model, mmproj] order. for text models stays the same.
             all_saved_locations.reverse()
+
+            if first_conversion in frozenset(quantization_method):
+                if is_vlm:
+                    all_saved_locations.insert(-1, base_gguf)
+                else:
+                    all_saved_locations.append(base_gguf)
     else:
         print("Unsloth: GPT-OSS model - skipping additional quantizations")
 


### PR DESCRIPTION
## Summary
- Fixes the cleanup step in `save_to_gguf` that unconditionally deleted the base GGUF (bf16/f16/f32) after deriving quantized variants, even when the user explicitly requested that format
- Skips deletion when `first_conversion` is in the user's `quantization_method` list

## Test plan
- [x] `quantization_method=["q4_k_m", "q6_k", "q8_0", "bf16"]` → BF16.gguf should be present in output
- [x] `quantization_method=["q4_k_m", "q6_k"]` → bf16 intermediate deleted as before (no regression)
- [x] `quantization_method=["bf16"]` → works as before

Fixes #4932