### PR TITLE
Studio: refresh Downloaded GGUF list and recurse into variant subdirs

### DIFF
--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1185,7 +1185,10 @@ def list_local_gguf_variants(
             size = 0
         quant = _extract_quant_label(f.name)
         quant_totals[quant] = quant_totals.get(quant, 0) + size
-        rel_name = str(f.relative_to(p))
+        # Always use posix-style separators so the filename matches what
+        # ``list_gguf_variants`` (the remote HF API path) returns on every
+        # platform; otherwise Windows would emit ``BF16\foo.gguf`` here.
+        rel_name = f.relative_to(p).as_posix()
         if quant not in quant_first_file:
             quant_first_file[quant] = rel_name
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -917,9 +917,7 @@ def _iter_gguf_files(directory: Path, recursive: bool = False):
             yield f
 
 
-def detect_mmproj_file(
-    path: str, search_root: Optional[str] = None
-) -> Optional[str]:
+def detect_mmproj_file(path: str, search_root: Optional[str] = None) -> Optional[str]:
     """
     Find the mmproj (vision projection) GGUF file for a given model.
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1171,7 +1171,11 @@ def list_local_gguf_variants(
     quant_first_file: dict[str, str] = {}
     has_vision = False
 
-    for f in sorted(p.glob("*.gguf")):
+    # Use rglob so that variant-specific subdirectories (e.g. ``BF16/...gguf``
+    # used by some HF GGUF repos for the largest quants) are picked up.
+    # Filenames in the result preserve the relative subpath so that
+    # ``_find_local_gguf_by_variant`` can locate the file again.
+    for f in sorted(p.rglob("*.gguf")):
         if _is_mmproj(f.name):
             has_vision = True
             continue
@@ -1181,8 +1185,9 @@ def list_local_gguf_variants(
             size = 0
         quant = _extract_quant_label(f.name)
         quant_totals[quant] = quant_totals.get(quant, 0) + size
+        rel_name = str(f.relative_to(p))
         if quant not in quant_first_file:
-            quant_first_file[quant] = f.name
+            quant_first_file[quant] = rel_name
 
     variants = [
         GgufVariantInfo(
@@ -1208,9 +1213,11 @@ def _find_local_gguf_by_variant(directory: str, variant: str) -> Optional[str]:
     if p is None:
         return None
 
+    # Recurse into subdirectories so variants stored under a quant-named
+    # subdir (e.g. ``BF16/foo-BF16-00001-of-00002.gguf``) are found.
     matches = sorted(
         f
-        for f in p.glob("*.gguf")
+        for f in p.rglob("*.gguf")
         if not _is_mmproj(f.name) and _extract_quant_label(f.name) == variant
     )
     if matches:

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1188,7 +1188,7 @@ def list_local_gguf_variants(
     # used by some HF GGUF repos for the largest quants) are picked up.
     # Filenames in the result preserve the relative subpath so that
     # ``_find_local_gguf_by_variant`` can locate the file again.
-    for f in sorted(_iter_gguf_files(p, recursive=True)):
+    for f in sorted(_iter_gguf_files(p, recursive = True)):
         if _is_mmproj(f.name):
             has_vision = True
             continue
@@ -1233,7 +1233,7 @@ def _find_local_gguf_by_variant(directory: str, variant: str) -> Optional[str]:
     # subdir (e.g. ``BF16/foo-BF16-00001-of-00002.gguf``) are found.
     matches = sorted(
         f
-        for f in _iter_gguf_files(p, recursive=True)
+        for f in _iter_gguf_files(p, recursive = True)
         if not _is_mmproj(f.name) and _extract_quant_label(f.name) == variant
     )
     if matches:

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -917,24 +917,74 @@ def _iter_gguf_files(directory: Path, recursive: bool = False):
             yield f
 
 
-def detect_mmproj_file(path: str) -> Optional[str]:
+def detect_mmproj_file(
+    path: str, search_root: Optional[str] = None
+) -> Optional[str]:
     """
-    Find the mmproj (vision projection) GGUF file in a directory.
+    Find the mmproj (vision projection) GGUF file for a given model.
 
     Args:
-        path: Directory to search — or a .gguf file (uses its parent dir).
+        path: Directory to search — or a .gguf file (uses its parent dir
+            as the starting point).
+        search_root: Optional outer directory that should also be scanned
+            (and any directory between it and ``path``). This handles
+            local layouts where the model weights live in a quant-named
+            subdir (``snapshot/BF16/foo.gguf``) but the mmproj sits at
+            the snapshot root (``snapshot/mmproj-BF16.gguf``). When
+            ``None``, only the immediate parent dir is scanned, matching
+            the historical behavior.
 
     Returns:
         Full path to the mmproj .gguf file, or None if not found.
     """
     p = Path(path)
-    search_dir = p.parent if p.is_file() else p
-    if not search_dir.is_dir():
+    start_dir = p.parent if p.is_file() else p
+    if not start_dir.is_dir():
         return None
 
-    for f in _iter_gguf_files(search_dir):
-        if _is_mmproj(f.name):
-            return str(f.resolve())
+    # Build the list of dirs to scan: immediate dir first, then walk up
+    # to (and including) ``search_root`` if it is an ancestor. We walk
+    # incrementally rather than recursing into ``search_root`` so we
+    # don't accidentally pick up an mmproj from a sibling subdir
+    # belonging to a different model variant.
+    seen: set[Path] = set()
+    scan_order: list[Path] = []
+
+    def _add(d: Path) -> None:
+        try:
+            resolved = d.resolve()
+        except OSError:
+            return
+        if resolved in seen or not resolved.is_dir():
+            return
+        seen.add(resolved)
+        scan_order.append(resolved)
+
+    _add(start_dir)
+    if search_root is not None:
+        try:
+            root_resolved = Path(search_root).resolve()
+            start_resolved = start_dir.resolve()
+            # Only walk if start_dir is inside (or equal to) search_root.
+            if root_resolved == start_resolved or (
+                start_resolved.is_relative_to(root_resolved)
+                if hasattr(start_resolved, "is_relative_to")
+                else str(start_resolved).startswith(str(root_resolved) + "/")
+            ):
+                cur = start_resolved
+                # Walk up from start_dir to (and including) root_resolved.
+                while cur != root_resolved and cur.parent != cur:
+                    cur = cur.parent
+                    _add(cur)
+                    if cur == root_resolved:
+                        break
+        except OSError:
+            pass
+
+    for d in scan_order:
+        for f in _iter_gguf_files(d):
+            if _is_mmproj(f.name):
+                return str(f.resolve())
     return None
 
 
@@ -1198,12 +1248,14 @@ def list_local_gguf_variants(
             size = 0
         quant = _extract_quant_label(f.name)
         quant_totals[quant] = quant_totals.get(quant, 0) + size
-        # Always use posix-style separators so the filename matches what
-        # ``list_gguf_variants`` (the remote HF API path) returns on every
-        # platform; otherwise Windows would emit ``BF16\foo.gguf`` here.
-        rel_name = f.relative_to(p).as_posix()
+        # Only compute the (potentially expensive) relative path when this
+        # is the first file we've seen for this quant -- after that we'd
+        # discard the result anyway. Use posix-style separators so the
+        # filename matches what ``list_gguf_variants`` (the remote HF
+        # API path) returns on every platform; otherwise Windows would
+        # emit ``BF16\foo.gguf`` here.
         if quant not in quant_first_file:
-            quant_first_file[quant] = rel_name
+            quant_first_file[quant] = f.relative_to(p).as_posix()
 
     variants = [
         GgufVariantInfo(
@@ -1943,8 +1995,16 @@ class ModelConfig:
                     except Exception as e:
                         logger.debug(f"Could not read export metadata: {e}")
 
-                # If vision (or mmproj happens to exist), find the mmproj file
-                mmproj_file = detect_mmproj_file(gguf_file)
+                # If vision (or mmproj happens to exist), find the mmproj
+                # file. The recursive variant scan in
+                # ``_find_local_gguf_by_variant`` may have returned a
+                # weight file inside a quant-named subdir (e.g.
+                # ``.../BF16/foo.gguf``) while ``mmproj-*.gguf`` lives
+                # at the snapshot root. Pass ``search_root=path`` so
+                # ``detect_mmproj_file`` walks up to the snapshot root
+                # instead of seeing only the weight file's immediate
+                # parent.
+                mmproj_file = detect_mmproj_file(gguf_file, search_root = path)
                 if mmproj_file:
                     gguf_is_vision = True
                     logger.info(f"Detected mmproj for vision: {mmproj_file}")

--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -569,7 +569,11 @@ export function HubModelPicker({
     refreshLocalModelsList();
     refreshScanFolders();
 
-    if (alreadyCached) return;
+    // Always refetch cached GGUF/model lists. The module-level caches give
+    // an instant render with stale data (no spinner flash), but newly
+    // downloaded repos won't appear unless we re-hit the backend on every
+    // mount.  Initial state already has cachedReady=alreadyCached, so the
+    // background refresh is invisible when we already had data.
     let done = 0;
     const check = () => {
       if (++done >= 2) setCachedReady(true);
@@ -588,7 +592,7 @@ export function HubModelPicker({
       })
       .catch(() => {})
       .finally(check);
-  }, [alreadyCached, refreshLocalModelsList, refreshScanFolders]);
+  }, [refreshLocalModelsList, refreshScanFolders]);
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;


### PR DESCRIPTION
## Summary

Two small fixes for the model picker's "Downloaded" section in Studio.

### 1. Frontend stale cache hides newly downloaded GGUF repos

`HubModelPicker`'s mount effect short-circuits the cached list refetch whenever the module-level cache already has entries:

```ts
// pickers.tsx (before)
if (alreadyCached) return;
listCachedGguf().then(...)
listCachedModels().then(...)
```

`_cachedGgufCache` and `_cachedModelsCache` are module-level, so once they are populated, every subsequent mount of the picker (closing and reopening the popover) skips the network call entirely. After downloading a new repo in the same session, reopening the picker keeps showing the stale list, and the new repo only appears after a full page reload.

This PR drops the early return so the cached lists are always refreshed on mount. The instant render still uses the module cache (so there is no spinner flash when we already had data), the background refresh updates state when it returns.

Repro before the fix:

1. Open the model picker, download `unsloth/gemma-4-26B-A4B-it-GGUF` BF16.
2. Close and reopen the picker.
3. The repo does not show under "Downloaded" until the page is hard-refreshed, even though `GET /api/models/cached-gguf` already lists it.

### 2. Backend non-recursive scan misses variants in subdirectories

`list_local_gguf_variants` and `_find_local_gguf_by_variant` use a non-recursive `Path.glob("*.gguf")`. Some HF GGUF repos place the largest quants under a variant-named subdirectory, e.g. `unsloth/gemma-4-26B-A4B-it-GGUF` ships BF16 as:

```
snapshots/<rev>/BF16/gemma-4-26B-A4B-it-BF16-00001-of-00002.gguf
snapshots/<rev>/BF16/gemma-4-26B-A4B-it-BF16-00002-of-00002.gguf
snapshots/<rev>/mmproj-BF16.gguf
```

The top-level glob never walks into `BF16/`, so for any local GGUF directory in this layout (LM Studio mirror, custom scan folder, snapshot path passed directly) `list_local_gguf_variants` returns `[]` and `_find_local_gguf_by_variant("BF16")` returns `None`. The remote `gguf-variants` path is unaffected because it already uses `snap.rglob("*.gguf")` for cache-bytes accounting.

Both helpers now use `rglob`. The variant filename is stored as a path relative to the scan root (e.g. `BF16/gemma-4-26B-A4B-it-BF16-00001-of-00002.gguf`) so the locator can still find the file.

The flat-layout case (variants directly in the snapshot root, e.g. `unsloth/gemma-4-E2B-it-GGUF`) is unchanged.

## Files changed

| File | Change |
|---|---|
| `studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx` | Drop `if (alreadyCached) return;` short-circuit in the mount effect; remove `alreadyCached` from the dep list. |
| `studio/backend/utils/models/model_config.py` | `list_local_gguf_variants`: `glob` -> `rglob`, store filename as relative path. `_find_local_gguf_by_variant`: `glob` -> `rglob`. |

## Test plan

- [x] Open model picker, download a fresh GGUF repo, close and reopen picker. Verify the repo appears under "Downloaded" without a page reload.
- [x] `list_local_gguf_variants` on `models--unsloth--gemma-4-26B-A4B-it-GGUF/snapshots/<rev>/` returns the BF16 variant with `has_vision=True`.
- [x] `list_local_gguf_variants` on `models--unsloth--gemma-4-E2B-it-GGUF/snapshots/<rev>/` still returns the UD-Q4_K_XL variant (flat layout regression check).
- [x] `_find_local_gguf_by_variant(<bf16 snapshot dir>, "BF16")` returns the resolved blob path of the first shard.
- [x] Frontend builds clean (`bun run build`).