### PR TITLE
fix(rocm): tighten gfx regex to ignore generic ISA lines

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2576,8 +2576,11 @@ def detect_host() -> HostInfo:
     has_rocm = False
     if is_linux:
         for _cmd, _check in (
-            # rocminfo: look for "gfxNNNN" with nonzero first digit (gfx000 is CPU agent)
-            (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9]", out.lower()))),
+            # rocminfo: look for a real gfx GPU id (3-4 chars, nonzero first digit).
+            # gfx000 is the CPU agent; ROCm 6.1+ also emits generic ISA lines like
+            # "gfx11-generic" or "gfx9-4-generic" which only have 1-2 digits before
+            # the dash and must not be treated as a real GPU.
+            (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower()))),
             (["amd-smi", "list"], _amd_smi_has_gpu),
         ):
             _exe = shutil.which(_cmd[0])

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2580,7 +2580,10 @@ def detect_host() -> HostInfo:
             # gfx000 is the CPU agent; ROCm 6.1+ also emits generic ISA lines like
             # "gfx11-generic" or "gfx9-4-generic" which only have 1-2 digits before
             # the dash and must not be treated as a real GPU.
-            (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower()))),
+            (
+                ["rocminfo"],
+                lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower())),
+            ),
             (["amd-smi", "list"], _amd_smi_has_gpu),
         ):
             _exe = shutil.which(_cmd[0])

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -183,8 +183,11 @@ def _has_rocm_gpu() -> bool:
     import re
 
     for cmd, check_fn in (
-        # rocminfo: look for "Name: gfxNNNN" with nonzero first digit (gfx000 is the CPU agent)
-        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9]", out.lower()))),
+        # rocminfo: look for a real gfx GPU id (3-4 chars, nonzero first digit).
+        # gfx000 is the CPU agent; ROCm 6.1+ also emits generic ISA lines like
+        # "gfx11-generic" or "gfx9-4-generic" which only have 1-2 digits before
+        # the dash and must not be treated as a real GPU.
+        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower()))),
         # amd-smi list: require "GPU: <number>" data rows, not just a header
         (
             ["amd-smi", "list"],

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -187,7 +187,10 @@ def _has_rocm_gpu() -> bool:
         # gfx000 is the CPU agent; ROCm 6.1+ also emits generic ISA lines like
         # "gfx11-generic" or "gfx9-4-generic" which only have 1-2 digits before
         # the dash and must not be treated as a real GPU.
-        (["rocminfo"], lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower()))),
+        (
+            ["rocminfo"],
+            lambda out: bool(re.search(r"gfx[1-9][0-9a-z]{2,3}", out.lower())),
+        ),
         # amd-smi list: require "GPU: <number>" data rows, not just a header
         (
             ["amd-smi", "list"],


### PR DESCRIPTION
## Summary

ROCm 6.1+ `rocminfo` emits generic ISA entries like `amdgcn-amd-amdhsa--gfx11-generic` and `amdgcn-amd-amdhsa--gfx9-4-generic` alongside the real GPU `Name:` line. The current `gfx[1-9]` regex used inside `_has_rocm_gpu` matches both, so a host that only exposes a generic ISA entry (no real GPU) would still be reported as ROCm-capable. This also lined up with the build-time symptom reported in #5022 where a bare family prefix could leak into `-DGPU_TARGETS`.

This PR tightens the regex to `gfx[1-9][0-9a-z]{2,3}` so only real gfx ids match, and applies the same pattern to both Python detection paths so they agree.

## Coverage

Verified against the canonical [LLVM AMDGPU backend target list](https://llvm.org/docs/AMDGPUUsage.html) and the [ROCm GPU hardware specs](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html):

Real targets that match (47 ids checked, all pass):
- GFX6: `gfx600`, `gfx601`, `gfx602`
- GFX7: `gfx700` to `gfx705`
- GFX8: `gfx801`, `gfx802`, `gfx803`, `gfx805`, `gfx810`
- GFX9: `gfx900`, `gfx902`, `gfx904`, `gfx906`, `gfx908`, `gfx909`, `gfx90a`, `gfx90c`
- GFX9-4: `gfx940`, `gfx941`, `gfx942`, `gfx950`
- GFX10.1: `gfx1010` to `gfx1013`
- GFX10.3: `gfx1030` to `gfx1036`
- GFX11: `gfx1100` to `gfx1103`
- GFX11.5: `gfx1150` to `gfx1153`
- GFX12: `gfx1200`, `gfx1201`

Generic ISA names that no longer match (6 documented variants, all rejected):
- `gfx9-generic`, `gfx9-4-generic`, `gfx10-1-generic`, `gfx10-3-generic`, `gfx11-generic`, `gfx12-generic`

The `[0-9a-z]` (rather than `[0-9]`) inside the quantifier is required to keep matching letter-suffixed targets such as `gfx90a` (MI210, MI250, MI250X) and `gfx90c` (Ryzen 4000G iGPU). Restricting to digits would silently drop those.

## Relationship to #5022

This PR is a minimal, regex-only version of #5022. It picks up the same intent (ignore generic ISA lines) and credits the original author via `Co-authored-by`, but skips the unrelated whitespace and keyword-argument formatting changes that touched ~100 other files. It also avoids the malformed tuple in `studio/install_llama_prebuilt.py` that was present in that PR. Closes #5022 if merged.

## Test plan

- [x] `python -m py_compile studio/install_llama_prebuilt.py studio/install_python_stack.py`
- [x] Regex matches all 47 real `gfxNNN[a-z]?` and `gfxNNNN` targets from GFX6 through GFX12
- [x] Regex rejects all 6 documented generic ISA name variants
- [x] Regex rejects the `gfx000` CPU agent line
- [x] On a realistic mixed `rocminfo` block (real GPU plus generic ISA), still returns True
- [x] On a generic-only block (no real GPU), now correctly returns False