### PR TITLE
Respect classification head skip list on pre-quantized 4-bit checkpoints (#5027)

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2405,6 +2405,29 @@ class FastLlamaModel:
                 bnb_4bit_compute_dtype = dtype,
                 llm_int8_skip_modules = llm_int8_skip_modules,
             )
+            # For pre-quantized checkpoints (e.g. unsloth/Qwen3-4B-bnb-4bit),
+            # transformers uses the quantization_config baked into the
+            # checkpoint's config.json and ignores the runtime BitsAndBytesConfig
+            # we pass via kwargs. Merge our skip list into that bundled config
+            # so task heads like `score` (for *ForSequenceClassification) stay
+            # in the compute dtype. See unslothai/unsloth#5027.
+            _ckpt_qcfg = getattr(model_config, "quantization_config", None)
+            if _ckpt_qcfg is not None:
+                if isinstance(_ckpt_qcfg, dict):
+                    _ckpt_skip = list(_ckpt_qcfg.get("llm_int8_skip_modules") or [])
+                    for _m in llm_int8_skip_modules:
+                        if _m not in _ckpt_skip:
+                            _ckpt_skip.append(_m)
+                    _ckpt_qcfg["llm_int8_skip_modules"] = _ckpt_skip
+                else:
+                    _ckpt_skip = list(getattr(_ckpt_qcfg, "llm_int8_skip_modules", None) or [])
+                    for _m in llm_int8_skip_modules:
+                        if _m not in _ckpt_skip:
+                            _ckpt_skip.append(_m)
+                    try:
+                        _ckpt_qcfg.llm_int8_skip_modules = _ckpt_skip
+                    except Exception:
+                        pass
 
         # https://huggingface.co/togethercomputer/LLaMA-2-7B-32K/discussions/12
         # RoPE Scaling's max_position_embeddings must be updated
@@ -2441,6 +2464,15 @@ class FastLlamaModel:
                 attn_implementation = preferred_attn_impl,
                 **kwargs,
             )
+            # Defensive: make sure the task head ended up in a floating dtype.
+            # The primary protection is SKIP_QUANTIZATION_MODULES plus the skip
+            # list merge above; this guards against a downstream path accidentally
+            # leaving the head in an integer storage. See unslothai/unsloth#5027.
+            for _head_name in ("score", "classifier", "qa_outputs"):
+                _head = getattr(model, _head_name, None)
+                if _head is not None and hasattr(_head, "weight") and \
+                        not _head.weight.is_floating_point():
+                    _head.to(dtype)
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(
                 model_name,

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2420,7 +2420,9 @@ class FastLlamaModel:
                             _ckpt_skip.append(_m)
                     _ckpt_qcfg["llm_int8_skip_modules"] = _ckpt_skip
                 else:
-                    _ckpt_skip = list(getattr(_ckpt_qcfg, "llm_int8_skip_modules", None) or [])
+                    _ckpt_skip = list(
+                        getattr(_ckpt_qcfg, "llm_int8_skip_modules", None) or []
+                    )
                     for _m in llm_int8_skip_modules:
                         if _m not in _ckpt_skip:
                             _ckpt_skip.append(_m)
@@ -2470,8 +2472,11 @@ class FastLlamaModel:
             # leaving the head in an integer storage. See unslothai/unsloth#5027.
             for _head_name in ("score", "classifier", "qa_outputs"):
                 _head = getattr(model, _head_name, None)
-                if _head is not None and hasattr(_head, "weight") and \
-                        not _head.weight.is_floating_point():
+                if (
+                    _head is not None
+                    and hasattr(_head, "weight")
+                    and not _head.weight.is_floating_point()
+                ):
                     _head.to(dtype)
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
## Summary

Fixes [#5027](https://github.com/unslothai/unsloth/issues/5027): `FastLanguageModel.from_pretrained(..., num_labels=N)` crashes with `NotImplementedError: "normal_kernel_cuda" not implemented for 'Byte'` on pre-quantized bnb 4-bit checkpoints (for example `unsloth/Qwen3-4B-bnb-4bit`) when running on `transformers>=5.0`.

Two pieces are needed to close this out. Companion PR on `unsloth-zoo` adds the three task-head names to `SKIP_QUANTIZATION_MODULES`: [unslothai/unsloth-zoo#594](https://github.com/unslothai/unsloth-zoo/pull/594).

## Why the skip-list change alone is not sufficient

For pre-quantized checkpoints, transformers reads `llm_int8_skip_modules` from the `quantization_config` baked into the checkpoint's `config.json` and ignores the runtime `BitsAndBytesConfig` that Unsloth sets via `kwargs["quantization_config"]`.

`unsloth/Qwen3-4B-bnb-4bit/config.json` ships with:

```json
"llm_int8_skip_modules": ["lm_head", "multi_modal_projector", "merger", "modality_projection"]
```

Confirmed by tracing `replace_with_bnb_linear` on `transformers==5.5.0`:

```
[TRACE] replace_with_bnb_linear modules_to_not_convert=['modality_projection', 'lm_head', 'merger', 'multi_modal_projector']
[TRACE] after replace: score -> Linear4bit, weight dtype torch.uint8
```

So `score` gets converted to `bnb.nn.Linear4bit` with uint8 storage, then `self.initialize_weights()` in `_finalize_model_loading` calls `torch.nn.init.normal_(module.weight, ...)` on a uint8 tensor and crashes.

## Changes

`unsloth/models/llama.py`, inside the `load_in_4bit` branch of `FastLlamaModel.from_pretrained`:

1. After building `bnb_config`, merge our `llm_int8_skip_modules` into `model_config.quantization_config.llm_int8_skip_modules` (handles both the `dict` form loaded from `config.json` and the `BitsAndBytesConfig` instance form). This is the load-bearing fix on transformers 5.x.
2. After `AutoModelForSequenceClassification.from_pretrained(...)` returns, defensively cast `score`, `classifier`, and `qa_outputs` to `dtype` if they somehow ended up non-floating. Belt and suspenders in case any future transformers path re-introduces the problem.

## Test plan

Verified on both `transformers==4.57.6` and `transformers==5.5.0`:

- [x] Repro: `unsloth/Qwen3-4B-bnb-4bit` with `num_labels=3` loads without `NotImplementedError`, `model.score` is `nn.Linear` in `bfloat16`
- [x] `unsloth/Qwen3-4B` (non-bnb repo, `load_in_4bit=True`) with `num_labels=3` loads
- [x] `unsloth/Llama-3.2-1B-Instruct` with `num_labels=3` loads
- [x] 3 SFT steps with `num_labels=3`: losses finite, `score.weight.grad` finite and non-trivial, `score.weight` updates between steps
- [x] Causal LM regression: `unsloth/Llama-3.2-1B-Instruct` LoRA + TRL `SFTTrainer` 3-step run unchanged, backbone retains `Linear4bit`, `lm_head` stays `nn.Linear` in `bfloat16`
- [x] `notebooks/nb/bert_classification.ipynb` trimmed to 3 steps on ModernBERT classifier head: loss decreases (1.88 -> 1.49 -> 1.36)
- [x] Skip-list collision check: only the top-level `score` / `classifier` / `qa_outputs` heads match the new tokens, no accidental hits inside the backbone for Qwen3 or Llama
- [x] Causality check: reverting only the skip-list merge on `transformers==5.5.0` brings the exact `NotImplementedError` back, reapplying makes it pass