### PR TITLE
Fix grad-accum accepts_loss_kwargs detection for vision wrappers

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2084,17 +2084,22 @@ def patch_gradient_accumulation_fix(Trainer):
         exec(function, globals())
         Trainer.training_step = _unsloth_training_step
 
-    # accepts_loss_kwargs detection is now handled by `apply_accepts_loss_kwargs_fix`
-    # on the model instance (see llama.py / vision.py), not by rewriting
-    # Trainer.__init__ source. See issue #4982.
-
-    # Backport transformers 5.6.0.dev0 fix: clamp accelerator GA to 1 post-init
-    # so the 5.0-5.5 GradientAccumulationPlugin doesn't double-scale on top of
-    # training_step's /GA. No-op on 4.x and 5.6+.
+    # Wrap Trainer.__init__: (1) pre-init, shadow accepts_loss_kwargs on whatever
+    # model was passed in (covers PEFT wrapping done after FastModel.from_pretrained);
+    # (2) post-init, clamp accelerator GA to 1 for the transformers 5.0-5.5
+    # GradientAccumulationPlugin regression. No-op on 4.x and 5.6+. See #4982.
     if not getattr(Trainer, "_unsloth_init_wrapped_for_accelerate_gas", False):
         _original_trainer_init = Trainer.__init__
 
         def _unsloth_trainer_init(self, *args, **kwargs):
+            model = kwargs.get("model")
+            if model is None and len(args) > 0:
+                model = args[0]
+            if model is not None:
+                try:
+                    apply_accepts_loss_kwargs_fix(model)
+                except Exception:
+                    pass
             _original_trainer_init(self, *args, **kwargs)
             try:
                 accelerator = getattr(self, "accelerator", None)
@@ -2117,9 +2122,21 @@ def patch_gradient_accumulation_fix(Trainer):
         Trainer._unsloth_init_wrapped_for_accelerate_gas = True
 
 
+def _unsloth_compile_cache_leaves():
+    # Accepts `UNSLOTH_COMPILE_LOCATION` overrides (the env var unsloth_zoo honors).
+    leaves = {"unsloth_compiled_cache", "unsloth_cache", "unsloth_compiled"}
+    loc = os.environ.get("UNSLOTH_COMPILE_LOCATION", "") or ""
+    loc = loc.rstrip("/\\")
+    if loc:
+        leaves.add(os.path.basename(loc) or loc)
+    return leaves
+
+
 def _forward_is_unsloth_compiled(model):
-    # True iff forward was installed from unsloth_compiled_cache/.
+    # True iff forward was installed from the Unsloth compile cache directory.
     # __module__ stays as the transformers module, so check co_filename.
+    leaves = _unsloth_compile_cache_leaves()
+
     def check(m):
         if m is None:
             return False
@@ -2128,7 +2145,9 @@ def _forward_is_unsloth_compiled(model):
             return False
         code = getattr(fwd, "__code__", None)
         fn = getattr(code, "co_filename", "") if code is not None else ""
-        return "unsloth_compiled" in fn or "unsloth_cache" in fn
+        fn = fn.replace("\\", "/")
+        parts = set(fn.split("/"))
+        return any(leaf in parts for leaf in leaves)
 
     if check(model):
         return True

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2122,7 +2122,10 @@ def patch_gradient_accumulation_fix(Trainer):
             _original_trainer_init(self, *args, **kwargs)
             try:
                 accelerator = getattr(self, "accelerator", None)
-                if accelerator is not None and getattr(accelerator, "gradient_accumulation_steps", 1) > 1:
+                if (
+                    accelerator is not None
+                    and getattr(accelerator, "gradient_accumulation_steps", 1) > 1
+                ):
                     accelerator.gradient_accumulation_steps = 1
                     gs = getattr(accelerator, "gradient_state", None)
                     if gs is not None and hasattr(gs, "plugin_kwargs"):
@@ -2148,6 +2151,7 @@ def _forward_is_unsloth_compiled(model):
     signal. Walks one level through PEFT and HF wrappers to catch the case where
     the outer object is a peft / accelerate wrapper.
     """
+
     def check(m):
         if m is None:
             return False
@@ -2194,7 +2198,9 @@ def _find_concrete_accepts_loss_kwargs(model):
         seen.add(id(m))
         for klass in type(m).__mro__:
             if "accepts_loss_kwargs" in klass.__dict__:
-                return klass.__dict__["accepts_loss_kwargs"], f"{klass.__name__}.accepts_loss_kwargs"
+                return klass.__dict__[
+                    "accepts_loss_kwargs"
+                ], f"{klass.__name__}.accepts_loss_kwargs"
         nxt = getattr(m, "base_model", None)
         if nxt is None or nxt is m:
             nxt = getattr(m, "model", None)

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -45,6 +45,7 @@ __all__ = [
     # "accelerate_old_send_to_device",
     # "accelerate_new_send_to_device",
     "patch_gradient_accumulation_fix",
+    "apply_accepts_loss_kwargs_fix",
     "patch_compiling_bitsandbytes",
     "patch_regional_compilation",
     "patch_layernorm",
@@ -2085,45 +2086,188 @@ def patch_gradient_accumulation_fix(Trainer):
 
     # Prevent double scaling gradient accumulation
     # https://github.com/huggingface/transformers/pull/37208
-    # Patch model_accepts_loss_kwargs detection in Trainer.__init__
-    if Trainer.__init__.__name__ != "_unsloth___init__":
+    # https://github.com/unslothai/unsloth/issues/4982
+    #
+    # The `self.model_accepts_loss_kwargs` flag gates the loss normalization branch
+    # in `Trainer.training_step` and decides whether `num_items_in_batch` gets passed
+    # to the model's forward. Getting it wrong silently over-scales gradients by
+    # `gradient_accumulation_steps` (reproducible as loss ~GA times too large).
+    #
+    # Previous approaches rewrote the source of `Trainer.__init__` via `str.replace`,
+    # which silently no-ops whenever transformers reformats the condition. For
+    # example on transformers 4.48 through 4.52 the parameter is named `model`
+    # (not `unwrapped_model`) and both known patch variants match nothing.
+    #
+    # The new approach moves the fix to the loader side: `apply_accepts_loss_kwargs_fix`
+    # (called from `unsloth/models/llama.py` and `unsloth/models/vision.py` after
+    # the model is loaded) sets the correct value at the instance level directly
+    # on the model. HF Trainer's `hasattr(unwrapped_model, "accepts_loss_kwargs")`
+    # check then picks up the instance attribute and bypasses signature inference
+    # entirely. This is version agnostic and never silently no-ops.
+    #
+    # What remains here is a transformers 5.0 through 5.5 accelerator clamp.
+    # Those versions construct the Accelerator with
+    # `GradientAccumulationPlugin(num_steps=gradient_accumulation_steps)`, which
+    # makes `accelerator.backward` divide loss by GA internally. Combined with
+    # HF's own `loss = loss / current_gradient_accumulation_steps` in
+    # `training_step`, that produces a 1/GA gradient scale mismatch vs. the
+    # full-batch case. This was fixed upstream in transformers 5.6.0.dev0 via
+    # `grad_acc_kwargs["num_steps"] = 1`. We backport the same fix by wrapping
+    # `Trainer.__init__` and clamping `accelerator.gradient_accumulation_steps`
+    # to 1 post-init. On 4.x (already 1) and 5.6+ (HF pins to 1) this is a no-op.
+    if not getattr(Trainer, "_unsloth_init_wrapped_for_accelerate_gas", False):
+        _original_trainer_init = Trainer.__init__
+
+        def _unsloth_trainer_init(self, *args, **kwargs):
+            _original_trainer_init(self, *args, **kwargs)
+            try:
+                accelerator = getattr(self, "accelerator", None)
+                if accelerator is not None and getattr(accelerator, "gradient_accumulation_steps", 1) > 1:
+                    accelerator.gradient_accumulation_steps = 1
+                    gs = getattr(accelerator, "gradient_state", None)
+                    if gs is not None and hasattr(gs, "plugin_kwargs"):
+                        try:
+                            gs.plugin_kwargs["num_steps"] = 1
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+
+        _unsloth_trainer_init.__wrapped__ = _original_trainer_init
+        Trainer.__init__ = _unsloth_trainer_init
+        Trainer._unsloth_init_wrapped_for_accelerate_gas = True
+
+
+def _forward_is_unsloth_compiled(model):
+    """Return True iff this model's forward came from Unsloth's compile cache.
+
+    Unsloth's compiler installs a rewritten `forward` on the class whose
+    `__code__.co_filename` points into `unsloth_compiled_cache/...`. The method's
+    `__module__` still reflects the original transformers module (the function
+    object is assigned onto the existing class), so `co_filename` is the reliable
+    signal. Walks one level through PEFT and HF wrappers to catch the case where
+    the outer object is a peft / accelerate wrapper.
+    """
+    def check(m):
+        if m is None:
+            return False
+        fwd = getattr(type(m), "forward", None)
+        if fwd is None:
+            return False
+        code = getattr(fwd, "__code__", None)
+        fn = getattr(code, "co_filename", "") if code is not None else ""
+        return "unsloth_compiled" in fn or "unsloth_cache" in fn
+
+    if check(model):
+        return True
+    seen = set()
+    m = model
+    for _ in range(4):
+        if m is None or id(m) in seen:
+            break
+        seen.add(id(m))
+        nxt = getattr(m, "base_model", None)
+        if nxt is None or nxt is m:
+            nxt = getattr(m, "model", None)
+        if nxt is None or nxt is m:
+            break
+        if check(nxt):
+            return True
+        m = nxt
+    return False
+
+
+def _find_concrete_accepts_loss_kwargs(model):
+    """Walk the model / .base_model / .model chain looking for the first class
+    that declares `accepts_loss_kwargs` on its own class dict. Returns
+    (value, reason) or (None, reason) if nothing concrete is found.
+
+    Using `type(m).__dict__` (not `hasattr`) avoids picking up attributes we
+    shadow onto the instance ourselves, and avoids descending into PEFT's
+    `__getattr__` forwarding which would return False positives.
+    """
+    seen = set()
+    m = model
+    for _ in range(6):
+        if m is None or id(m) in seen:
+            break
+        seen.add(id(m))
+        for klass in type(m).__mro__:
+            if "accepts_loss_kwargs" in klass.__dict__:
+                return klass.__dict__["accepts_loss_kwargs"], f"{klass.__name__}.accepts_loss_kwargs"
+        nxt = getattr(m, "base_model", None)
+        if nxt is None or nxt is m:
+            nxt = getattr(m, "model", None)
+        if nxt is None or nxt is m:
+            break
+        m = nxt
+    return None, "no explicit accepts_loss_kwargs on any wrapper level"
+
+
+def _shadow_accepts_loss_kwargs(model, value):
+    """Set `accepts_loss_kwargs = value` at the instance level on model and every
+    reachable wrapper (PEFT `base_model`, HF `model`) so HF Trainer's
+    `hasattr(unwrapped_model, "accepts_loss_kwargs")` resolves correctly
+    regardless of which level accelerator / peft unwrap returns."""
+    seen = set()
+    m = model
+    for _ in range(8):
+        if m is None or id(m) in seen:
+            break
+        seen.add(id(m))
         try:
-            init_function = inspect.getsource(Trainer.__init__)
+            setattr(m, "accepts_loss_kwargs", value)
         except Exception:
-            init_function = ""
-        if init_function is not None:
-            init_function = textwrap.dedent(init_function)
+            pass
+        nxt = getattr(m, "base_model", None)
+        if nxt is None or nxt is m:
+            nxt = getattr(m, "model", None)
+        if nxt is None or nxt is m:
+            break
+        m = nxt
 
-            # Import all variables that need importing
-            import transformers.trainer
 
-            items_in_trainer = dir(transformers.trainer)
-            good_items = []
-            for item in items_in_trainer:
-                if item in init_function:
-                    good_items.append(item)
-            exec(
-                "from transformers.trainer import ("
-                + ", ".join(x for x in good_items)
-                + ")",
-                globals(),
-            )
+def apply_accepts_loss_kwargs_fix(model):
+    """Fix HF Trainer's `model_accepts_loss_kwargs` detection for this model.
 
-            init_function = init_function.replace(
-                "def __init__", "def _unsloth___init__", 1
-            )
+    Decides the correct value for `accepts_loss_kwargs` and shadows it at the
+    instance level on the model and its wrapper chain so HF Trainer's
+    `hasattr(unwrapped_model, "accepts_loss_kwargs")` check in `Trainer.__init__`
+    resolves to that value. This replaces the older approach of rewriting
+    `Trainer.__init__` source code, which silently no-op'd on some transformers
+    versions (4.48 through 4.52 name the parameter `model` instead of
+    `unwrapped_model`, for example).
 
-            # Respect an inner wrapped model's explicit accepts_loss_kwargs flag before inferring from forward(**kwargs).
-            # https://github.com/unslothai/unsloth/issues/4982 Gemma4ForConditionalGeneration had issues with grad_acc
-            init_function = init_function.replace(
-                "self.model_accepts_loss_kwargs = unwrapped_model.accepts_loss_kwargs\n    else:",
-                "self.model_accepts_loss_kwargs = unwrapped_model.accepts_loss_kwargs\n"
-                '    elif hasattr(getattr(unwrapped_model, "model", None), "accepts_loss_kwargs"):\n'
-                "        self.model_accepts_loss_kwargs = unwrapped_model.model.accepts_loss_kwargs\n"
-                "    else:",
-            )
-            exec(init_function, globals())
-            Trainer.__init__ = _unsloth___init__
+    Priority:
+      1. If Unsloth's compile pipeline replaced this model's forward
+         (`co_filename` points into `unsloth_compiled_cache/`), set True. The
+         compiled forward calls `unsloth_fixed_cross_entropy` which accepts
+         `num_items_in_batch` and scales the loss accordingly, so Trainer must
+         not divide again.
+      2. Else walk the wrapper chain looking for a class that declares
+         `accepts_loss_kwargs` on its own class dict. Vision conditional
+         generation wrappers like `Gemma3nForConditionalGeneration` have no
+         outer attribute but their inner `.model` (`Gemma3nModel`) declares
+         `accepts_loss_kwargs = False`. This catches those cases and produces
+         the correct False value so HF's training_step divides by GA and the
+         reported loss is not inflated by `gradient_accumulation_steps`.
+      3. Else leave HF's default (signature inspection on forward) untouched.
+         Text language models like Llama / Mistral / Qwen3 fall here, and their
+         forward has `**kwargs` so HF correctly infers True.
+
+    Safe to call more than once on the same model. See
+    https://github.com/unslothai/unsloth/issues/4982 for the original symptom
+    and PRs #4998 and #5030 for earlier attempts.
+    """
+    if _forward_is_unsloth_compiled(model):
+        _shadow_accepts_loss_kwargs(model, True)
+        return "True (Unsloth compiled forward)"
+
+    value, reason = _find_concrete_accepts_loss_kwargs(model)
+    if value is None:
+        return f"default (signature inspection, {reason})"
+    _shadow_accepts_loss_kwargs(model, value)
+    return f"{value} ({reason})"
 
 
 def patch_tokenizer(model, tokenizer):

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2084,37 +2084,13 @@ def patch_gradient_accumulation_fix(Trainer):
         exec(function, globals())
         Trainer.training_step = _unsloth_training_step
 
-    # Prevent double scaling gradient accumulation
-    # https://github.com/huggingface/transformers/pull/37208
-    # https://github.com/unslothai/unsloth/issues/4982
-    #
-    # The `self.model_accepts_loss_kwargs` flag gates the loss normalization branch
-    # in `Trainer.training_step` and decides whether `num_items_in_batch` gets passed
-    # to the model's forward. Getting it wrong silently over-scales gradients by
-    # `gradient_accumulation_steps` (reproducible as loss ~GA times too large).
-    #
-    # Previous approaches rewrote the source of `Trainer.__init__` via `str.replace`,
-    # which silently no-ops whenever transformers reformats the condition. For
-    # example on transformers 4.48 through 4.52 the parameter is named `model`
-    # (not `unwrapped_model`) and both known patch variants match nothing.
-    #
-    # The new approach moves the fix to the loader side: `apply_accepts_loss_kwargs_fix`
-    # (called from `unsloth/models/llama.py` and `unsloth/models/vision.py` after
-    # the model is loaded) sets the correct value at the instance level directly
-    # on the model. HF Trainer's `hasattr(unwrapped_model, "accepts_loss_kwargs")`
-    # check then picks up the instance attribute and bypasses signature inference
-    # entirely. This is version agnostic and never silently no-ops.
-    #
-    # What remains here is a transformers 5.0 through 5.5 accelerator clamp.
-    # Those versions construct the Accelerator with
-    # `GradientAccumulationPlugin(num_steps=gradient_accumulation_steps)`, which
-    # makes `accelerator.backward` divide loss by GA internally. Combined with
-    # HF's own `loss = loss / current_gradient_accumulation_steps` in
-    # `training_step`, that produces a 1/GA gradient scale mismatch vs. the
-    # full-batch case. This was fixed upstream in transformers 5.6.0.dev0 via
-    # `grad_acc_kwargs["num_steps"] = 1`. We backport the same fix by wrapping
-    # `Trainer.__init__` and clamping `accelerator.gradient_accumulation_steps`
-    # to 1 post-init. On 4.x (already 1) and 5.6+ (HF pins to 1) this is a no-op.
+    # accepts_loss_kwargs detection is now handled by `apply_accepts_loss_kwargs_fix`
+    # on the model instance (see llama.py / vision.py), not by rewriting
+    # Trainer.__init__ source. See issue #4982.
+
+    # Backport transformers 5.6.0.dev0 fix: clamp accelerator GA to 1 post-init
+    # so the 5.0-5.5 GradientAccumulationPlugin doesn't double-scale on top of
+    # training_step's /GA. No-op on 4.x and 5.6+.
     if not getattr(Trainer, "_unsloth_init_wrapped_for_accelerate_gas", False):
         _original_trainer_init = Trainer.__init__
 
@@ -2142,16 +2118,8 @@ def patch_gradient_accumulation_fix(Trainer):
 
 
 def _forward_is_unsloth_compiled(model):
-    """Return True iff this model's forward came from Unsloth's compile cache.
-
-    Unsloth's compiler installs a rewritten `forward` on the class whose
-    `__code__.co_filename` points into `unsloth_compiled_cache/...`. The method's
-    `__module__` still reflects the original transformers module (the function
-    object is assigned onto the existing class), so `co_filename` is the reliable
-    signal. Walks one level through PEFT and HF wrappers to catch the case where
-    the outer object is a peft / accelerate wrapper.
-    """
-
+    # True iff forward was installed from unsloth_compiled_cache/.
+    # __module__ stays as the transformers module, so check co_filename.
     def check(m):
         if m is None:
             return False
@@ -2182,14 +2150,8 @@ def _forward_is_unsloth_compiled(model):
 
 
 def _find_concrete_accepts_loss_kwargs(model):
-    """Walk the model / .base_model / .model chain looking for the first class
-    that declares `accepts_loss_kwargs` on its own class dict. Returns
-    (value, reason) or (None, reason) if nothing concrete is found.
-
-    Using `type(m).__dict__` (not `hasattr`) avoids picking up attributes we
-    shadow onto the instance ourselves, and avoids descending into PEFT's
-    `__getattr__` forwarding which would return False positives.
-    """
+    # Walk wrapper chain for first class that declares accepts_loss_kwargs in its
+    # own __mro__ dict. Avoids PEFT __getattr__ forwarding and our own shadow.
     seen = set()
     m = model
     for _ in range(6):
@@ -2211,10 +2173,8 @@ def _find_concrete_accepts_loss_kwargs(model):
 
 
 def _shadow_accepts_loss_kwargs(model, value):
-    """Set `accepts_loss_kwargs = value` at the instance level on model and every
-    reachable wrapper (PEFT `base_model`, HF `model`) so HF Trainer's
-    `hasattr(unwrapped_model, "accepts_loss_kwargs")` resolves correctly
-    regardless of which level accelerator / peft unwrap returns."""
+    # Set the attribute at every wrapper level so HF's hasattr check resolves
+    # regardless of where accelerator / peft unwrap lands.
     seen = set()
     m = model
     for _ in range(8):
@@ -2234,37 +2194,10 @@ def _shadow_accepts_loss_kwargs(model, value):
 
 
 def apply_accepts_loss_kwargs_fix(model):
-    """Fix HF Trainer's `model_accepts_loss_kwargs` detection for this model.
-
-    Decides the correct value for `accepts_loss_kwargs` and shadows it at the
-    instance level on the model and its wrapper chain so HF Trainer's
-    `hasattr(unwrapped_model, "accepts_loss_kwargs")` check in `Trainer.__init__`
-    resolves to that value. This replaces the older approach of rewriting
-    `Trainer.__init__` source code, which silently no-op'd on some transformers
-    versions (4.48 through 4.52 name the parameter `model` instead of
-    `unwrapped_model`, for example).
-
-    Priority:
-      1. If Unsloth's compile pipeline replaced this model's forward
-         (`co_filename` points into `unsloth_compiled_cache/`), set True. The
-         compiled forward calls `unsloth_fixed_cross_entropy` which accepts
-         `num_items_in_batch` and scales the loss accordingly, so Trainer must
-         not divide again.
-      2. Else walk the wrapper chain looking for a class that declares
-         `accepts_loss_kwargs` on its own class dict. Vision conditional
-         generation wrappers like `Gemma3nForConditionalGeneration` have no
-         outer attribute but their inner `.model` (`Gemma3nModel`) declares
-         `accepts_loss_kwargs = False`. This catches those cases and produces
-         the correct False value so HF's training_step divides by GA and the
-         reported loss is not inflated by `gradient_accumulation_steps`.
-      3. Else leave HF's default (signature inspection on forward) untouched.
-         Text language models like Llama / Mistral / Qwen3 fall here, and their
-         forward has `**kwargs` so HF correctly infers True.
-
-    Safe to call more than once on the same model. See
-    https://github.com/unslothai/unsloth/issues/4982 for the original symptom
-    and PRs #4998 and #5030 for earlier attempts.
-    """
+    # Shadow the correct accepts_loss_kwargs on the model so HF Trainer picks it
+    # up via hasattr(unwrapped_model, ...). Replaces the old Trainer.__init__
+    # source rewrite. Priority: compiled forward -> True; else first class attr
+    # in wrapper chain; else leave HF default. Issue #4982.
     if _forward_is_unsloth_compiled(model):
         _shadow_accepts_loss_kwargs(model, True)
         return "True (Unsloth compiled forward)"

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2658,7 +2658,12 @@ class FastLlamaModel:
         patch_saving_functions(model)
         Trainer._inner_training_loop = _fast_inner_training_loop
 
-        # Fix gradient accumulation
+        # Fix gradient accumulation. `apply_accepts_loss_kwargs_fix` sets the
+        # correct `accepts_loss_kwargs` value at the instance level on this
+        # model so HF Trainer's `hasattr(unwrapped_model, "accepts_loss_kwargs")`
+        # check resolves without needing to rewrite `Trainer.__init__` source.
+        # See `_utils.apply_accepts_loss_kwargs_fix` and issue #4982.
+        apply_accepts_loss_kwargs_fix(model)
         patch_gradient_accumulation_fix(Trainer)
 
         # Save tokenizer for inference purposes

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2658,11 +2658,7 @@ class FastLlamaModel:
         patch_saving_functions(model)
         Trainer._inner_training_loop = _fast_inner_training_loop
 
-        # Fix gradient accumulation. `apply_accepts_loss_kwargs_fix` sets the
-        # correct `accepts_loss_kwargs` value at the instance level on this
-        # model so HF Trainer's `hasattr(unwrapped_model, "accepts_loss_kwargs")`
-        # check resolves without needing to rewrite `Trainer.__init__` source.
-        # See `_utils.apply_accepts_loss_kwargs_fix` and issue #4982.
+        # Fix gradient accumulation. See issue #4982.
         apply_accepts_loss_kwargs_fix(model)
         patch_gradient_accumulation_fix(Trainer)
 

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1123,9 +1123,18 @@ class FastBaseModel:
                     )
         patch_saving_functions(tokenizer, vision = True)
 
-        # Fix gradient accumulation
+        # Fix gradient accumulation. `apply_accepts_loss_kwargs_fix` sets the
+        # correct `accepts_loss_kwargs` value at the instance level on this
+        # model so HF Trainer's `hasattr(unwrapped_model, "accepts_loss_kwargs")`
+        # check resolves without needing to rewrite `Trainer.__init__` source.
+        # This handles vision conditional generation wrappers whose outer class
+        # has no `accepts_loss_kwargs` but whose inner `.model` declares False
+        # (Gemma3n, earlier Gemma3, PaliGemma, Qwen-VL family, etc.), and also
+        # handles Unsloth-compiled forwards by setting True. See
+        # `_utils.apply_accepts_loss_kwargs_fix` and issue #4982.
         from transformers.trainer import Trainer
 
+        apply_accepts_loss_kwargs_fix(model)
         patch_gradient_accumulation_fix(Trainer)
 
         # Save tokenizer for inference purposes

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1123,15 +1123,7 @@ class FastBaseModel:
                     )
         patch_saving_functions(tokenizer, vision = True)
 
-        # Fix gradient accumulation. `apply_accepts_loss_kwargs_fix` sets the
-        # correct `accepts_loss_kwargs` value at the instance level on this
-        # model so HF Trainer's `hasattr(unwrapped_model, "accepts_loss_kwargs")`
-        # check resolves without needing to rewrite `Trainer.__init__` source.
-        # This handles vision conditional generation wrappers whose outer class
-        # has no `accepts_loss_kwargs` but whose inner `.model` declares False
-        # (Gemma3n, earlier Gemma3, PaliGemma, Qwen-VL family, etc.), and also
-        # handles Unsloth-compiled forwards by setting True. See
-        # `_utils.apply_accepts_loss_kwargs_fix` and issue #4982.
+        # Fix gradient accumulation. See issue #4982.
         from transformers.trainer import Trainer
 
         apply_accepts_loss_kwargs_fix(model)


### PR DESCRIPTION
## Summary

Replaces the `Trainer.__init__` source-string rewrite for `accepts_loss_kwargs` detection with an instance-level shadow applied on the loaded model. This is version agnostic, never silently no-ops, and unifies the coverage of #4998 (stock forward fallback via inner `.model`) and #5030 (Unsloth-compiled forward via signature inspection).

Also backports the transformers 5.6.0.dev0 `GradientAccumulationPlugin(num_steps=1)` pin to 5.0-5.5 by clamping `accelerator.gradient_accumulation_steps = 1` post-init. No-op on transformers 4.x and 5.6+.

Closes #4982. Supersedes #5030.

## Why the previous approach was fragile

`patch_gradient_accumulation_fix` has been rewriting `Trainer.__init__` source via `str.replace` / `re.sub`. I checked every transformers release from 4.47.0 through 5.5.4 and every TRL release from 0.22.2 through 1.1.0:

- transformers 4.48 through 4.52 name the parameter `model` (not `unwrapped_model`), so both known patch variants silently no-op on those versions.
- PR #4998 catches Gemma3nForConditionalGeneration full-finetune via its inner `.model.accepts_loss_kwargs = False` fallback, but misses it under PEFT because `peft_model.model` returns `LoraModel` (which has no attribute), not the inner `Gemma3nModel`.
- PR #5030 (the revert) is correct only when Unsloth's compile pipeline installed the fused-CE forward, and reintroduces #4982 under `trust_remote_code=True`, `UNSLOTH_COMPILE_DISABLE=1`, or a compile-cache write failure (reproduces on Colab's ephemeral filesystem).

## What this PR does

Adds a single helper `apply_accepts_loss_kwargs_fix(model)` in `unsloth/models/_utils.py` and calls it unconditionally from both loaders (`unsloth/models/llama.py` and `unsloth/models/vision.py`) after the model is loaded. The helper:

1. Checks `type(model).forward.__code__.co_filename` against `unsloth_compiled_cache/`. If the compiled forward is in use, shadows `accepts_loss_kwargs = True` on every wrapper level. Unsloth's compiled forward calls `unsloth_fixed_cross_entropy` which accepts `num_items_in_batch`, so Trainer must not divide again.
2. Otherwise walks `.base_model` / `.model` looking for the first class that declares `accepts_loss_kwargs` on its own class dict (uses `type(m).__dict__` to avoid PEFT's `__getattr__` forwarding returning false positives), and shadows that value. This catches Gemma3nForConditionalGeneration, PaliGemma, Qwen-VL family, and every other vision wrapper where only the inner `.model` carries the flag.
3. Otherwise leaves HF's default signature inspection untouched. Text LMs (Llama, Mistral, Qwen3, etc.) fall here and HF correctly infers True from `**kwargs` in `forward`.

The removed source-string `__init__` rewrite is no longer needed. The `training_step` rewrite and the `compute_loss` fix are unchanged.

## Scenario matrix (Gemma3nForConditionalGeneration full-FT)

| Scenario | Expected | Stock HF | #4998 | #5030 | This PR |
|---|---|---|---|---|---|
| Stock forward (trust_remote_code or compile skipped) | False | True, bug | False, correct | True, bug | False, correct |
| Unsloth-compiled forward | True | True, correct | False (still works via dual-mode CE) | True, correct | True, correct |

## Verification

End-to-end on transformers 4.57.6 + TRL 0.25.1 + accelerate 1.13.0 + H100, `unsloth/gemma-3-270m-it` + LoRA:

```
model type: Gemma3ForCausalLM
instance 'accepts_loss_kwargs' = True
type.forward co_filename: unsloth_compiled_cache/unsloth_compiled_module_gemma3.py

=== Trainer state AFTER init ===
trainer.model_accepts_loss_kwargs = True
trainer.accelerator.gradient_accumulation_steps = 1

=== Walk chain ===
  PeftModelForCausalLM: instance_attr=False   (forwards via __getattr__)
  base_model->LoraModel: instance_attr=False  (forwards via __getattr__)
  base_model->Gemma3ForCausalLM: instance_attr=True, val=True
  model->Gemma3TextModel: instance_attr=True, val=True

=== Training step ===
{'loss': 4.9626, 'grad_norm': 14915175424.0, 'learning_rate': 0.0, 'epoch': 0.25}
```

Source inspection coverage:

- transformers 4.47.0 through 5.5.4: new helper works on all (no source rewrite dependency).
- TRL 0.22.2 through 1.1.0: SFTTrainer inherits from `Trainer` / `BaseTrainer(Trainer)` / `_BaseTrainer(Trainer)` and never overrides `model_accepts_loss_kwargs`. All RL / preference trainers (GRPO, DPO, KTO, CPO, ORPO, RLOO, BCO, SDFT, async-GRPO) explicitly set `self.model_accepts_loss_kwargs = False` post super-init, so this fix is a no-op for them (no regression surface).

## Test plan

- [x] Import check: `from unsloth.models._utils import apply_accepts_loss_kwargs_fix`
- [x] End-to-end SFT step on Gemma-3 270m + LoRA matches pre-PR loss and grad-norm
- [x] Scenario matrix (mock Gemma3n, Gemma3, Llama, compiled) produces correct values
- [ ] Run against Gemma-3n-E2B + LoRA with `trust_remote_code=True` on Colab to confirm #4982 no longer reproduces
- [ ] Run against Gemma-3-4B vision + LoRA to confirm no regression on the compiled path