### PR TITLE
Gate trl disable_gradient_checkpointing warning on UNSLOTH_ENABLE_LOGGING

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -2018,11 +2018,12 @@ def patch_trl_disable_gradient_checkpointing():
         except (AttributeError, TypeError):
             pass
 
-    logger.warning_once(
-        "Unsloth: Patched trl.models.utils.disable_gradient_checkpointing with "
-        "a no-op to preserve Unsloth gradient checkpointing across TRL "
-        "generation passes."
-    )
+    if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
+        logger.warning_once(
+            "Unsloth: Patched trl.models.utils.disable_gradient_checkpointing with "
+            "a no-op to preserve Unsloth gradient checkpointing across TRL "
+            "generation passes."
+        )
     return
 
 


### PR DESCRIPTION
## Summary

`patch_trl_disable_gradient_checkpointing` emits a `warning_once` line on every Unsloth import:

```
Unsloth: Patched trl.models.utils.disable_gradient_checkpointing with a no-op to preserve Unsloth gradient checkpointing across TRL generation passes.
```

This is a routine integration patch, not something the user needs to act on. It clutters Colab and notebook output. Gate it on `UNSLOTH_ENABLE_LOGGING=1` so it only shows when the user opted into verbose logging, matching the pattern used elsewhere in the codebase.

## Test plan

- [x] `python -c "import unsloth"` no longer prints the warning by default
- [x] `UNSLOTH_ENABLE_LOGGING=1 python -c "import unsloth"` still prints it