### PR TITLE
Chat-template repair: warn-by-default, AST classification, dict support

### DIFF
--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -636,95 +636,350 @@ def load_correct_tokenizer(
     return tokenizer
 
 
-def _find_end_position(template, endfor, endif):
-    where_endfor = template.find(endfor)
-    where_endif = template.find(endif)
-    if where_endfor == where_endif == -1:
+# All four Jinja whitespace-control variants of endfor/endif:
+#   {% endfor %}    {%- endfor %}    {% endfor -%}    {%- endfor -%}
+_RE_ENDFOR = re.compile(r"\{%(-?)\s*endfor\s*(-?)%\}")
+_RE_ENDIF = re.compile(r"\{%(-?)\s*endif\s*(-?)%\}")
+_RE_JINJA_COMMENT = re.compile(r"\{#.*?#\}", flags = re.DOTALL)
+
+
+def _find_end_position(template, endfor = None, endif = None):
+    """Return the last {% endfor %}/{% endif %} in the template (whichever is
+    further right), as a dict with start, end, dash_left, dash_right.
+
+    Unlike the older substring-based version, this accepts any of the four
+    Jinja whitespace-control variants ({% ... %}, {%- ... %}, {% ... -%},
+    {%- ... -%}) and returns the rightmost match so multi-for templates are
+    not locked onto the first loop. The `endfor`/`endif` kwargs are accepted
+    for backward compatibility and ignored.
+    """
+    endfor_matches = list(_RE_ENDFOR.finditer(template))
+    endif_matches = list(_RE_ENDIF.finditer(template))
+    last_endfor = endfor_matches[-1] if endfor_matches else None
+    last_endif = endif_matches[-1] if endif_matches else None
+    candidates = [m for m in (last_endfor, last_endif) if m is not None]
+    if not candidates:
         return None
-    elif where_endfor > where_endif:
-        return endfor
-    else:
-        return endif
+    m = max(candidates, key = lambda x: x.end())
+    return {
+        "start": m.start(),
+        "end": m.end(),
+        "text": m.group(0),
+        "dash_left": bool(m.group(1)),
+        "dash_right": bool(m.group(2)),
+    }
+
+
+def _template_ends_with_toplevel_for(chat_template):
+    """Return True if the last structural node at the template's top level is
+    a For (message-iteration) loop, ignoring trailing pure-whitespace Output
+    nodes. Used to gate the GH#4150 ChatML repair: if the outermost structure
+    is something else (e.g. an outer If that wraps the whole template, as in
+    Qwen3-Guard), we shouldn't inject an {% if add_generation_prompt %}
+    block at the end -- it would land inside or after an unrelated control
+    structure."""
+    try:
+        import jinja2
+        import jinja2.nodes
+        ast = jinja2.Environment().parse(chat_template)
+    except Exception:
+        return False
+    for node in reversed(ast.body):
+        # Skip trailing output nodes that are only whitespace -- they come
+        # from trailing whitespace/newlines in the source, not from real
+        # message-rendering logic.
+        if isinstance(node, jinja2.nodes.Output):
+            only_ws = all(
+                isinstance(child, jinja2.nodes.TemplateData)
+                and child.data.strip() == ""
+                for child in node.nodes
+            )
+            if only_ws:
+                continue
+        return isinstance(node, jinja2.nodes.For)
+    return False
+
+
+def _has_add_generation_prompt_block(chat_template):
+    """Return True if the template contains an {% if add_generation_prompt %}
+    block. Uses Jinja AST so comments and whitespace-control variants cannot
+    fool the check. Falls back to a string scan if Jinja cannot parse.
+    """
+    try:
+        import jinja2
+        import jinja2.nodes
+        ast = jinja2.Environment().parse(chat_template)
+    except Exception:
+        return (
+            "if add_generation_prompt" in chat_template
+            and "%}" in chat_template
+        )
+    for if_node in ast.find_all(jinja2.nodes.If):
+        test = if_node.test
+        # `find_all` only walks descendants, so a bare Name test (the common
+        # `{% if add_generation_prompt %}` form) needs an explicit check here.
+        if isinstance(test, jinja2.nodes.Name) and test.name == "add_generation_prompt":
+            return True
+        for name_node in test.find_all(jinja2.nodes.Name):
+            if name_node.name == "add_generation_prompt":
+                return True
+    return False
+
+
+def _infer_assistant_separator(scrubbed):
+    """Infer the separator that follows 'assistant' in a ChatML template.
+
+    Strategy: prefer an explicit '<|im_start|>assistant<sep>' literal; else
+    the unique `message['role'] + '<sep>'` from role concatenations; else
+    '<|im_sep|>' if present (Phi-4-mini mixes '\\n' for system with
+    '<|im_sep|>' for user/assistant); else '\\n'.
+    """
+    assistant_match = re.search(
+        r"""(['"])<\|im_start\|>assistant([^'"]*)\1""",
+        scrubbed,
+    )
+    role_seps = [
+        m.group(2)
+        for m in re.finditer(
+            r"""message(?:\[['"]role['"]\]|\.role)\s*\+\s*(['"])([^'"]*)\1""",
+            scrubbed,
+        )
+    ]
+    unique_role_seps = list(dict.fromkeys(role_seps))
+    if assistant_match is not None and assistant_match.group(2):
+        return assistant_match.group(2)
+    if len(unique_role_seps) == 1:
+        return unique_role_seps[0]
+    if "<|im_sep|>" in scrubbed:
+        return "<|im_sep|>"
+    return "\\n"
 
 
 def _fix_chat_template(chat_template):
-    endfor = "{% endfor %}"
-    endif = "{% endif %}"
-    chosen_end = _find_end_position(chat_template, endfor, endif)
-    if chosen_end is None:
-        endfor = "{%- endfor %}"
-        endif = "{%- endif %}"
-        chosen_end = _find_end_position(chat_template, endfor, endif)
-    if chosen_end is None:
+    # Fast path: already has an {% if add_generation_prompt %} block, nothing
+    # to do. This catches cases the old string-based check would miss (e.g.
+    # templates that use {%- if add_generation_prompt -%} with both-side dash,
+    # or that sneak the block into a nested If/For).
+    if _has_add_generation_prompt_block(chat_template):
         return chat_template
 
-    where = chat_template.find(chosen_end)
+    end = _find_end_position(chat_template)
+    if end is None:
+        return chat_template
 
-    after_endfor = chat_template[where + len(chosen_end) :]
+    after_endfor = chat_template[end["end"]:]
+    dash_l = "-" if end["dash_left"] else ""
+    dash_r = "-" if end["dash_right"] else ""
+    open_tag = lambda body: "{%" + dash_l + " " + body + " " + dash_r + "%}"
 
-    dash = "-" if chosen_end.startswith("{%-") else ""
-
+    # Case 1 (pre-existing base case): template ends with a single trailing
+    # {{ expr }} that is the generation prefix. Wrap it in an
+    # {% if add_generation_prompt %} ... {% endif %}.
     if (
-        "{%" + dash + " if" not in after_endfor
-        and "{%" + dash + " set " not in after_endfor
+        "{%" + dash_l + " if" not in after_endfor
+        and "{%" + dash_l + " set " not in after_endfor
         and after_endfor.startswith("{{")
         and after_endfor.endswith("}}")
         and after_endfor.count("{{") == 1
         and after_endfor.count("}}") == 1
     ):
-        after_endfor = (
-            "{%" + dash + " if add_generation_prompt %}" + after_endfor + endif
+        wrapped = (
+            open_tag("if add_generation_prompt") + after_endfor + open_tag("endif")
         )
+        return chat_template[: end["end"]] + wrapped
 
-        chat_template = chat_template[: where + len(chosen_end)] + after_endfor
-
-    elif re.sub(r"\{#.*?#\}", "", after_endfor, flags = re.DOTALL).strip() == "":
-        # GH#4150: ChatML templates ending at {% endfor %} without an
-        # add_generation_prompt block. Scrub Jinja `{# ... #}` comments so
-        # tokens inside comments cannot fool the guard below.
-        scrubbed = re.sub(r"\{#.*?#\}", "", chat_template, flags = re.DOTALL)
+    # Case 2 (GH#4150): template ends at {% endfor %} with only whitespace or
+    # Jinja comments left. Inject an {% if add_generation_prompt %} block
+    # with a model-specific assistant-turn separator inferred from the
+    # template body. Require the top-level body to END in a For node so we
+    # don't inject inside a wider wrapper (e.g. Qwen3-Guard wraps the whole
+    # template in an outer If -- there the generation block would be out of
+    # place).
+    if (
+        _RE_JINJA_COMMENT.sub("", after_endfor).strip() == ""
+        and _template_ends_with_toplevel_for(chat_template)
+    ):
+        scrubbed = _RE_JINJA_COMMENT.sub("", chat_template)
         if (
             "<|im_start|>" in scrubbed
             and "<|im_end|>" in scrubbed
             and "add_generation_prompt" not in scrubbed
         ):
-            # Infer the assistant-turn separator. Prefer an explicit
-            # '<|im_start|>assistant<sep>' literal; else the unique
-            # `message['role'] + '<sep>'` from role concatenations; else
-            # '<|im_sep|>' if present (Phi-4-mini uses '\n' for system and
-            # '<|im_sep|>' for user/assistant); else '\n'.
-            assistant_match = re.search(
-                r"""(['"])<\|im_start\|>assistant([^'"]*)\1""",
-                scrubbed,
-            )
-            role_seps = [
-                m.group(2)
-                for m in re.finditer(
-                    r"""message(?:\[['"]role['"]\]|\.role)\s*\+\s*(['"])([^'"]*)\1""",
-                    scrubbed,
-                )
-            ]
-            unique_role_seps = list(dict.fromkeys(role_seps))
-            if assistant_match is not None and assistant_match.group(2):
-                separator = assistant_match.group(2)
-            elif len(unique_role_seps) == 1:
-                separator = unique_role_seps[0]
-            elif "<|im_sep|>" in scrubbed:
-                separator = "<|im_sep|>"
-            else:
-                separator = "\\n"
-            # Emit a double-quoted Jinja literal so a single quote in the
-            # separator cannot break the block. Drop trailing whitespace/
-            # comments after endfor: they would render as stray output
-            # after the generation prefix.
+            separator = _infer_assistant_separator(scrubbed)
             assistant_prefix = "<|im_start|>assistant" + separator
+            # Double-quoted Jinja literal so a single quote in the separator
+            # cannot break the block. Trailing whitespace/comments after
+            # endfor are dropped: they would render as stray output after
+            # the generation prefix.
             generation_block = (
-                "{%" + dash + " if add_generation_prompt %}"
-                '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
-                "{%" + dash + " endif %}"
+                open_tag("if add_generation_prompt")
+                + '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
+                + open_tag("endif")
             )
-            chat_template = chat_template[: where + len(chosen_end)] + generation_block
+            return chat_template[: end["end"]] + generation_block
 
+    return chat_template
+
+
+def _is_strict_chat_template_mode():
+    """Opt-in strict mode restores the pre-warn RuntimeError behavior."""
+    val = os.environ.get("UNSLOTH_STRICT_CHAT_TEMPLATE", "0")
+    return str(val).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _name_is_local_path(name_or_path):
+    """True if name_or_path refers to an existing local directory. Used to
+    tailor the warning message: for local paths the user cannot 'file a bug
+    report to the maintainers of <path>' since that path is their own."""
+    if not name_or_path:
+        return False
+    try:
+        return os.path.isdir(str(name_or_path))
+    except Exception:
+        return False
+
+
+def _format_chat_template_message(name_or_path, repaired):
+    """Build a user-facing warning/error message that points at the right
+    responsible party (user's downstream tool vs. upstream model maintainer)."""
+    local = _name_is_local_path(name_or_path)
+    if local:
+        source_hint = (
+            "This tokenizer was loaded from a local path. The likely cause is a "
+            "downstream tool (LlamaFactory, Axolotl, etc.) that re-serialized "
+            "the tokenizer during save and stripped the generation-prompt "
+            "block. Either re-save with the original template, or set "
+            "`tokenizer.chat_template` manually before loading."
+        )
+    else:
+        source_hint = (
+            "The chat_template shipped with `{name}` appears incomplete. "
+            "Consider filing a bug report with the model maintainers."
+        ).format(name = name_or_path)
+    if repaired:
+        return (
+            "Unsloth: Patched the chat_template on `{name}` to add a "
+            "{{% if add_generation_prompt %}} block. {hint}"
+        ).format(name = name_or_path, hint = source_hint)
+    return (
+        "Unsloth: The tokenizer `{name}` does not have a "
+        "{{% if add_generation_prompt %}} block for generation purposes, and "
+        "automatic repair was not possible. The model will still load, but "
+        "`apply_chat_template(add_generation_prompt=True)` may not produce a "
+        "correct assistant-turn marker. {hint} Set "
+        "UNSLOTH_STRICT_CHAT_TEMPLATE=1 to raise instead of warn."
+    ).format(name = name_or_path, hint = source_hint)
+
+
+def _validate_patched_template(tokenizer, patched_template, is_sharegpt):
+    """Render the just-patched template with and without
+    add_generation_prompt, and confirm the patched output responds to the
+    flag by appending (not replacing) content. Returns True if validation
+    passes."""
+    msgs = (
+        [{"from": "human", "value": "Hi"}]
+        if is_sharegpt
+        else [{"role": "user", "content": "Hi"}]
+    )
+    original = getattr(tokenizer, "chat_template", None)
+    try:
+        tokenizer.chat_template = patched_template
+        try:
+            yes = tokenizer.apply_chat_template(
+                msgs, add_generation_prompt = True, tokenize = False,
+            )
+            no = tokenizer.apply_chat_template(
+                msgs, add_generation_prompt = False, tokenize = False,
+            )
+        except Exception:
+            return False
+    finally:
+        tokenizer.chat_template = original
+    # Contract after a successful repair: the two renders differ, and the
+    # "yes" render is a strict extension of the "no" render (we only
+    # appended content inside the new add_generation_prompt block).
+    return yes != no and yes.startswith(no)
+
+
+def _repair_string_template(tokenizer, chat_template, is_sharegpt):
+    """Core string-template repair. Returns the repaired template on success,
+    or None if repair was not possible / failed validation."""
+    candidate = _fix_chat_template(chat_template)
+    if not _has_add_generation_prompt_block(candidate):
+        return None
+    if not _validate_patched_template(tokenizer, candidate, is_sharegpt):
+        return None
+    return candidate
+
+
+def _fix_chat_template_for_tokenizer(tokenizer, chat_template):
+    """Entry point for a string chat_template. Runs the no==yes diagnostic,
+    attempts repair if needed, and returns the (possibly patched) template.
+
+    On repair failure, the behavior is controlled by
+    UNSLOTH_STRICT_CHAT_TEMPLATE: warn + return original (default) or raise
+    RuntimeError (strict)."""
+    name = getattr(tokenizer, "name_or_path", "unknown")
+
+    # Detect ShareGPT vs HF style by probing apply_chat_template.
+    is_sharegpt = None
+    try:
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Who are you?"}],
+            add_generation_prompt = False, tokenize = False,
+        )
+        is_sharegpt = False
+    except Exception:
+        try:
+            tokenizer.apply_chat_template(
+                [{"from": "human", "value": "Who are you?"}],
+                add_generation_prompt = False, tokenize = False,
+            )
+            is_sharegpt = True
+        except Exception:
+            is_sharegpt = None
+
+    if is_sharegpt is None:
+        return chat_template
+
+    messages = (
+        [{"from": "human", "value": "Who are you?"}]
+        if is_sharegpt
+        else [{"role": "user", "content": "Who are you?"}]
+    )
+    try:
+        no = tokenizer.apply_chat_template(
+            messages, add_generation_prompt = False, tokenize = False,
+        )
+        yes = tokenizer.apply_chat_template(
+            messages, add_generation_prompt = True, tokenize = False,
+        )
+    except Exception:
+        return chat_template
+
+    if no != yes:
+        # Template already responds to the flag; leave as is.
+        return chat_template
+
+    # no == yes: template ignores add_generation_prompt. Try to repair.
+    if _has_add_generation_prompt_block(chat_template):
+        # Template has the block but it does not change output. This is the
+        # "wasn't provided correctly" case from the pre-warn code path.
+        msg = _format_chat_template_message(name, repaired = False)
+        if _is_strict_chat_template_mode():
+            raise RuntimeError(msg)
+        logger.warning_once(msg)
+        return chat_template
+
+    repaired = _repair_string_template(tokenizer, chat_template, is_sharegpt)
+    if repaired is not None:
+        logger.warning_once(_format_chat_template_message(name, repaired = True))
+        return repaired
+
+    msg = _format_chat_template_message(name, repaired = False)
+    if _is_strict_chat_template_mode():
+        raise RuntimeError(msg)
+    logger.warning_once(msg)
     return chat_template
 
 
@@ -733,76 +988,55 @@ def fix_chat_template(tokenizer):
     if chat_template is None:
         return None
 
-    ### 1. Check if add_generation_prompt works
-    # Check for ShareGPT style first
-    is_sharegpt = None
-    try:
-        messages = [
-            {"role": "user", "content": "Who are you?"},
-        ]
-        tokenizer.apply_chat_template(
-            messages, add_generation_prompt = False, tokenize = False
-        )
-        is_sharegpt = False
-    except:
-        try:
-            messages = [
-                {"from": "human", "value": "Who are you?"},
-            ]
-            tokenizer.apply_chat_template(
-                messages, add_generation_prompt = False, tokenize = False
-            )
-            is_sharegpt = True
-        except:
-            is_sharegpt = None
-
-    # Not ShareGPT or HF style - just return
-    if is_sharegpt is None:
-        return chat_template
-
-    # Tokenize
-    messages = [
-        {"role": "user", "content": "Who are you?"}
-        if not is_sharegpt
-        else {"from": "human", "value": "Who are you?"}
-    ]
-    no = tokenizer.apply_chat_template(
-        messages, add_generation_prompt = False, tokenize = False
-    )
-    yes = tokenizer.apply_chat_template(
-        messages, add_generation_prompt = True, tokenize = False
-    )
-
-    if no == yes:
-        # SAME?! That's not good! We check for add_generation_prompt
-        if (
-            "{% if add_generation_prompt %}" not in chat_template
-            and "{%- if add_generation_prompt %}" not in chat_template
-        ):
-            # Try fixing it by adding it
-            new_chat_template = _fix_chat_template(chat_template)
-            if (
-                "{% if add_generation_prompt %}" not in new_chat_template
-                and "{%- if add_generation_prompt %}" not in new_chat_template
-            ):
-                raise RuntimeError(
-                    f"Unsloth: The tokenizer `{tokenizer.name_or_path}`\n"
-                    "does not have a {% if add_generation_prompt %} for generation purposes.\n"
-                    f"Please file a bug report to the maintainers of `{tokenizer.name_or_path}` - thanks!"
-                )
-            else:
+    # Multi-variant dict form (e.g. Hermes-3 {default, tool_use}): fix each
+    # variant independently. Without this branch, _fix_chat_template was
+    # called with a dict and raised AttributeError on .find() -- surfaced
+    # during PR 4426 testing.
+    if isinstance(chat_template, dict):
+        name = getattr(tokenizer, "name_or_path", "unknown")
+        fixed = {}
+        for key, tmpl in chat_template.items():
+            if not isinstance(tmpl, str):
+                fixed[key] = tmpl
+                continue
+            if _has_add_generation_prompt_block(tmpl):
+                fixed[key] = tmpl
+                continue
+            new_tmpl = _fix_chat_template(tmpl)
+            if _has_add_generation_prompt_block(new_tmpl):
                 logger.warning_once(
-                    "Unsloth: We successfully patched the tokenizer to add a {% if add_generation_prompt %} to the chat_template.\n"
-                    f"This is not a bug, but please notify the maintainers of `{tokenizer.name_or_path}` - thanks!"
+                    _format_chat_template_message(name, repaired = True)
+                    + " (variant='{key}')".format(key = key)
                 )
-                chat_template = new_chat_template
-        else:
-            raise RuntimeError(
-                f"Unsloth: The tokenizer `{tokenizer.name_or_path}`\n"
-                "has a {% if add_generation_prompt %} for generation purposes, but wasn't provided correctly.\n"
-                "Please file a bug report immediately - thanks!"
-            )
-    return chat_template
+                fixed[key] = new_tmpl
+            else:
+                fixed[key] = tmpl
+        return fixed
+
+    # List-of-dicts form (older HF multi-template style).
+    if isinstance(chat_template, list):
+        name = getattr(tokenizer, "name_or_path", "unknown")
+        fixed = []
+        for item in chat_template:
+            if not isinstance(item, dict) or "template" not in item:
+                fixed.append(item)
+                continue
+            tmpl = item["template"]
+            if not isinstance(tmpl, str) or _has_add_generation_prompt_block(tmpl):
+                fixed.append(item)
+                continue
+            new_tmpl = _fix_chat_template(tmpl)
+            if _has_add_generation_prompt_block(new_tmpl):
+                logger.warning_once(
+                    _format_chat_template_message(name, repaired = True)
+                    + " (variant='{key}')".format(key = item.get("name", "?"))
+                )
+                fixed.append({**item, "template": new_tmpl})
+            else:
+                fixed.append(item)
+        return fixed
+
+    return _fix_chat_template_for_tokenizer(tokenizer, chat_template)
 
 
 def check_tokenizer(

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -883,7 +883,10 @@ def _validate_patched_template(tokenizer, patched_template, is_sharegpt):
     )
     original = getattr(tokenizer, "chat_template", None)
     try:
-        tokenizer.chat_template = patched_template
+        try:
+            tokenizer.chat_template = patched_template
+        except Exception:
+            return False  # read-only tokenizer, skip validation
         try:
             yes = tokenizer.apply_chat_template(
                 msgs,
@@ -898,7 +901,10 @@ def _validate_patched_template(tokenizer, patched_template, is_sharegpt):
         except Exception:
             return False
     finally:
-        tokenizer.chat_template = original
+        try:
+            tokenizer.chat_template = original
+        except Exception:
+            pass  # best-effort restore
     # Contract after a successful repair: the two renders differ, and the
     # "yes" render is a strict extension of the "no" render (we only
     # appended content inside the new add_generation_prompt block).

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -652,9 +652,19 @@ def _find_end_position(template, endfor = None, endif = None):
     {%- ... -%}) and returns the rightmost match so multi-for templates are
     not locked onto the first loop. The `endfor`/`endif` kwargs are accepted
     for backward compatibility and ignored.
+
+    Jinja comments ({# ... #}) are replaced with equal-length padding before
+    matching so tokens like `{% endfor %}` or `{% endif %}` living inside
+    comments don't get picked up as real end tags. Positions in the padded
+    string still map 1:1 to positions in the original template.
     """
-    endfor_matches = list(_RE_ENDFOR.finditer(template))
-    endif_matches = list(_RE_ENDIF.finditer(template))
+    # Pad comments with spaces so their contents don't match as end tags but
+    # positions are preserved.
+    scrubbed = _RE_JINJA_COMMENT.sub(
+        lambda m: " " * len(m.group(0)), template
+    )
+    endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
+    endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
     last_endif = endif_matches[-1] if endif_matches else None
     candidates = [m for m in (last_endfor, last_endif) if m is not None]
@@ -701,10 +711,36 @@ def _template_ends_with_toplevel_for(chat_template):
     return False
 
 
+def _if_body_emits_content(if_node):
+    """Return True if the If's positive body contains at least one Output
+    node. We use this to distinguish a real generation-prompt block
+    (`{% if add_generation_prompt %}{{ "<|...assistant..." }}{% endif %}`,
+    body has an Output) from a header guard
+    (`{% if not add_generation_prompt is defined %}{% set ... %}{% endif %}`,
+    body is only Assign nodes, emits nothing). Nested control flow counts as
+    emitting if any reachable descendant is an Output."""
+    import jinja2.nodes
+
+    for node in if_node.body:
+        if isinstance(node, jinja2.nodes.Output):
+            return True
+        # Nested If / For / Macro / etc. -- walk descendants for any Output.
+        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
+            return True
+    return False
+
+
 def _has_add_generation_prompt_block(chat_template):
-    """Return True if the template contains an {% if add_generation_prompt %}
-    block. Uses Jinja AST so comments and whitespace-control variants cannot
-    fool the check. Falls back to a string scan if Jinja cannot parse.
+    """Return True if the template contains a *positive* generation-prompt
+    gate, i.e. an `{% if add_generation_prompt %}` (or equivalent) whose
+    body emits output. Uses Jinja AST so comments and whitespace-control
+    variants cannot fool the check. Falls back to a string scan if Jinja
+    cannot parse.
+
+    Rejects header guards like `{% if not add_generation_prompt is defined %}
+    {% set add_generation_prompt = false %}{% endif %}` -- these reference
+    the name but emit nothing, so they do not gate a generation block and
+    the template still needs repair.
     """
     try:
         import jinja2
@@ -717,11 +753,16 @@ def _has_add_generation_prompt_block(chat_template):
         test = if_node.test
         # `find_all` only walks descendants, so a bare Name test (the common
         # `{% if add_generation_prompt %}` form) needs an explicit check here.
+        references_agp = False
         if isinstance(test, jinja2.nodes.Name) and test.name == "add_generation_prompt":
+            references_agp = True
+        else:
+            for name_node in test.find_all(jinja2.nodes.Name):
+                if name_node.name == "add_generation_prompt":
+                    references_agp = True
+                    break
+        if references_agp and _if_body_emits_content(if_node):
             return True
-        for name_node in test.find_all(jinja2.nodes.Name):
-            if name_node.name == "add_generation_prompt":
-                return True
     return False
 
 
@@ -919,35 +960,39 @@ def _fix_chat_template(chat_template, is_sharegpt = False):
     if _RE_JINJA_COMMENT.sub(
         "", after_endfor
     ).strip() == "" and _template_ends_with_toplevel_for(chat_template):
-        scrubbed = _RE_JINJA_COMMENT.sub("", chat_template)
-        if "add_generation_prompt" not in scrubbed:
+        # Note: the fast path above (`_has_add_generation_prompt_block`)
+        # already confirmed there is no *positive* generation block, so we
+        # don't need another string-level "add_generation_prompt not in
+        # scrubbed" check here -- that would reject templates with a header
+        # guard like `{% if not add_generation_prompt is defined %}` that
+        # references the name but emits nothing.
+        assistant_prefix = _derive_assistant_prefix_by_render(
+            chat_template, is_sharegpt
+        )
+        # Dual-probe fallback: dict/list callers don't know the shape up
+        # front, and a template that expects ShareGPT-keyed messages will
+        # raise on HF-keyed probe. Try the other shape before giving up.
+        if assistant_prefix is None and not is_sharegpt:
             assistant_prefix = _derive_assistant_prefix_by_render(
-                chat_template, is_sharegpt
+                chat_template, is_sharegpt = True
             )
-            # Dual-probe fallback: dict/list callers don't know the shape up
-            # front, and a template that expects ShareGPT-keyed messages will
-            # raise on HF-keyed probe. Try the other shape before giving up.
-            if assistant_prefix is None and not is_sharegpt:
-                assistant_prefix = _derive_assistant_prefix_by_render(
-                    chat_template, is_sharegpt = True
-                )
-            if assistant_prefix is None:
-                return chat_template
-            # Double-quoted Jinja literal with \\, \n, and " escaped so the
-            # block is valid regardless of the derived prefix's content.
-            escaped = (
-                assistant_prefix.replace("\\", "\\\\")
-                .replace('"', '\\"')
-                .replace("\n", "\\n")
-            )
-            generation_block = (
-                open_tag("if add_generation_prompt")
-                + '{{ "'
-                + escaped
-                + '" }}'
-                + open_tag("endif")
-            )
-            return chat_template[: end["end"]] + generation_block
+        if assistant_prefix is None:
+            return chat_template
+        # Double-quoted Jinja literal with \\, \n, and " escaped so the
+        # block is valid regardless of the derived prefix's content.
+        escaped = (
+            assistant_prefix.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+        )
+        generation_block = (
+            open_tag("if add_generation_prompt")
+            + '{{ "'
+            + escaped
+            + '" }}'
+            + open_tag("endif")
+        )
+        return chat_template[: end["end"]] + generation_block
 
     return chat_template
 
@@ -1130,57 +1175,113 @@ def _fix_chat_template_for_tokenizer(tokenizer, chat_template):
     return chat_template
 
 
+class _VariantTokenizerProxy:
+    """Adapter that presents a single variant-template view of a multi-variant
+    tokenizer to `_fix_chat_template_for_tokenizer`. This routes each variant
+    through the same full lifecycle as a string template -- is_sharegpt
+    probe, no==yes diagnostic, warn/strict messaging, and
+    `_validate_patched_template()` -- instead of calling structural repair
+    directly and skipping those guarantees.
+
+    `apply_chat_template` is delegated to the base tokenizer after
+    temporarily swapping in the variant template, so access to tokenizer
+    globals (bos_token, custom filters, raise_exception, etc.) is
+    preserved. If the base is read-only, we fall back to bare-Jinja
+    rendering so the probe still works for stub tokenizers in tests.
+    """
+
+    def __init__(self, base_tokenizer, variant_template, variant_label = ""):
+        self._base = base_tokenizer
+        self._template = variant_template
+        self._label = variant_label
+        base_name = getattr(base_tokenizer, "name_or_path", "unknown")
+        # Append variant label so user-facing messages identify the variant.
+        self.name_or_path = (
+            f"{base_name} ({variant_label})" if variant_label else base_name
+        )
+
+    @property
+    def chat_template(self):
+        return self._template
+
+    @chat_template.setter
+    def chat_template(self, value):
+        self._template = value
+
+    def apply_chat_template(self, *args, **kwargs):
+        base_original = getattr(self._base, "chat_template", None)
+        swapped = False
+        try:
+            try:
+                self._base.chat_template = self._template
+                swapped = True
+            except Exception:
+                swapped = False
+            if swapped:
+                return self._base.apply_chat_template(*args, **kwargs)
+            # Base is read-only or cannot accept a string chat_template.
+            # Fall back to isolated Jinja rendering of the variant directly;
+            # this loses access to tokenizer globals but the probe still
+            # works for templates that don't depend on them.
+            import jinja2
+            env = jinja2.Environment(
+                autoescape = False, keep_trailing_newline = True,
+            )
+            messages = args[0] if args else kwargs.get("messages", [])
+            add_generation_prompt = kwargs.get("add_generation_prompt", False)
+            return env.from_string(self._template).render(
+                messages = messages,
+                add_generation_prompt = add_generation_prompt,
+            )
+        finally:
+            if swapped:
+                try:
+                    self._base.chat_template = base_original
+                except Exception:
+                    pass  # best-effort restore
+
+
 def fix_chat_template(tokenizer):
     chat_template = getattr(tokenizer, "chat_template", None)
     if chat_template is None:
         return None
 
-    # Multi-variant dict form (e.g. Hermes-3 {default, tool_use}): fix each
-    # variant independently. Without this branch, _fix_chat_template was
-    # called with a dict and raised AttributeError on .find() -- surfaced
-    # during PR 4426 testing.
+    # Multi-variant dict form (e.g. Hermes-3 {default, tool_use}): route each
+    # variant through `_fix_chat_template_for_tokenizer` so it honors the
+    # full repair contract (is_sharegpt probe, no==yes diagnostic, warn /
+    # strict messaging, and `_validate_patched_template`). The earlier
+    # implementation called `_fix_chat_template` directly per variant and
+    # silently bypassed these guards.
     if isinstance(chat_template, dict):
-        name = getattr(tokenizer, "name_or_path", "unknown")
         fixed = {}
         for key, tmpl in chat_template.items():
             if not isinstance(tmpl, str):
                 fixed[key] = tmpl
                 continue
-            if _has_add_generation_prompt_block(tmpl):
-                fixed[key] = tmpl
-                continue
-            new_tmpl = _fix_chat_template(tmpl)
-            if _has_add_generation_prompt_block(new_tmpl):
-                logger.warning_once(
-                    _format_chat_template_message(name, repaired = True)
-                    + " (variant='{key}')".format(key = key)
-                )
-                fixed[key] = new_tmpl
-            else:
-                fixed[key] = tmpl
+            proxy = _VariantTokenizerProxy(
+                tokenizer, tmpl, variant_label = f"variant='{key}'"
+            )
+            fixed[key] = _fix_chat_template_for_tokenizer(proxy, tmpl)
         return fixed
 
     # List-of-dicts form (older HF multi-template style).
     if isinstance(chat_template, list):
-        name = getattr(tokenizer, "name_or_path", "unknown")
         fixed = []
         for item in chat_template:
             if not isinstance(item, dict) or "template" not in item:
                 fixed.append(item)
                 continue
             tmpl = item["template"]
-            if not isinstance(tmpl, str) or _has_add_generation_prompt_block(tmpl):
+            if not isinstance(tmpl, str):
                 fixed.append(item)
                 continue
-            new_tmpl = _fix_chat_template(tmpl)
-            if _has_add_generation_prompt_block(new_tmpl):
-                logger.warning_once(
-                    _format_chat_template_message(name, repaired = True)
-                    + " (variant='{key}')".format(key = item.get("name", "?"))
-                )
-                fixed.append({**item, "template": new_tmpl})
-            else:
+            label = "variant='{key}'".format(key = item.get("name", "?"))
+            proxy = _VariantTokenizerProxy(tokenizer, tmpl, variant_label = label)
+            new_tmpl = _fix_chat_template_for_tokenizer(proxy, tmpl)
+            if new_tmpl is tmpl or new_tmpl == tmpl:
                 fixed.append(item)
+            else:
+                fixed.append({**item, "template": new_tmpl})
         return fixed
 
     return _fix_chat_template_for_tokenizer(tokenizer, chat_template)

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -648,7 +648,9 @@ def _find_end_position(template, endfor = None, endif = None):
     with start/end/text/dash_left/dash_right. Tokens inside Jinja comments
     are ignored. `endfor`/`endif` kwargs kept for back-compat, ignored."""
     # Space-pad comments so positions still map 1:1 to the original.
-    scrubbed = _RE_JINJA_COMMENT.sub(lambda m: " " * len(m.group(0)), template)
+    scrubbed = _RE_JINJA_COMMENT.sub(
+        lambda m: " " * len(m.group(0)), template
+    )
     endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
     endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
@@ -706,10 +708,7 @@ def _if_body_emits_content(if_node):
     for node in if_node.body:
         if isinstance(node, jinja2.nodes.Output):
             return True
-        if any(
-            isinstance(d, jinja2.nodes.Output)
-            for d in node.find_all(jinja2.nodes.Output)
-        ):
+        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
             return True
     return False
 
@@ -770,7 +769,7 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
     template is known to use this.
     """
     try:
-        import jinja2
+        from jinja2.sandbox import SandboxedEnvironment
     except Exception:
         return None
 
@@ -800,11 +799,10 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         if _RE_JINJA_COMMENT.sub("", after).strip() == "":
             probe_template = chat_template[: end["end"]]
 
-    # Sandboxed env: the probe renders at model-load time (before the user
-    # calls apply_chat_template), so a malicious template would execute
-    # eagerly. SandboxedEnvironment blocks attribute-chain exploits.
+    # Sandboxed: probe renders at load time, before user calls
+    # apply_chat_template. SandboxedEnvironment blocks attribute-chain exploits.
     try:
-        env = jinja2.sandbox.SandboxedEnvironment(
+        env = SandboxedEnvironment(
             autoescape = False,
             keep_trailing_newline = True,
         )
@@ -1149,12 +1147,10 @@ class _VariantTokenizerProxy:
                 swapped = False
             if swapped:
                 return self._base.apply_chat_template(*args, **kwargs)
-            # Read-only base: fall back to isolated Jinja.
-            import jinja2
-
-            env = jinja2.Environment(
-                autoescape = False,
-                keep_trailing_newline = True,
+            # Read-only base: fall back to sandboxed Jinja.
+            from jinja2.sandbox import SandboxedEnvironment
+            env = SandboxedEnvironment(
+                autoescape = False, keep_trailing_newline = True,
             )
             messages = args[0] if args else kwargs.get("messages", [])
             add_generation_prompt = kwargs.get("add_generation_prompt", False)

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -765,19 +765,13 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
 
     if is_sharegpt:
         base_msgs = [{"from": "human", "value": "Hi"}]
-        sent_a_msgs = base_msgs + [
-            {"from": "gpt", "value": _RENDER_DIFF_SENTINEL_A}
-        ]
-        sent_b_msgs = base_msgs + [
-            {"from": "gpt", "value": _RENDER_DIFF_SENTINEL_B}
-        ]
+        sent_a_msgs = base_msgs + [{"from": "gpt", "value": _RENDER_DIFF_SENTINEL_A}]
+        sent_b_msgs = base_msgs + [{"from": "gpt", "value": _RENDER_DIFF_SENTINEL_B}]
         # Negative cross-check: another *user* turn instead of an assistant
         # turn. If the derived prefix also appears before a user-role sentinel,
         # the template does not distinguish assistant turns from user turns
         # (e.g. a {% set %}-only template) and we must reject.
-        sent_c_msgs = base_msgs + [
-            {"from": "human", "value": _RENDER_DIFF_SENTINEL_C}
-        ]
+        sent_c_msgs = base_msgs + [{"from": "human", "value": _RENDER_DIFF_SENTINEL_C}]
     else:
         base_msgs = [{"role": "user", "content": "Hi"}]
         sent_a_msgs = base_msgs + [
@@ -786,9 +780,7 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         sent_b_msgs = base_msgs + [
             {"role": "assistant", "content": _RENDER_DIFF_SENTINEL_B}
         ]
-        sent_c_msgs = base_msgs + [
-            {"role": "user", "content": _RENDER_DIFF_SENTINEL_C}
-        ]
+        sent_c_msgs = base_msgs + [{"role": "user", "content": _RENDER_DIFF_SENTINEL_C}]
 
     # Trim trailing whitespace / Jinja comments that live AFTER the last
     # {% endfor %}/{% endif %}. Without this, a template like
@@ -801,7 +793,7 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
     probe_template = chat_template
     end = _find_end_position(chat_template)
     if end is not None:
-        after = chat_template[end["end"]:]
+        after = chat_template[end["end"] :]
         if _RE_JINJA_COMMENT.sub("", after).strip() == "":
             probe_template = chat_template[: end["end"]]
 
@@ -841,8 +833,8 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
     if not (out_a.startswith(out_base) and out_b.startswith(out_base)):
         return None
 
-    tail_a = out_a[len(out_base):]
-    tail_b = out_b[len(out_base):]
+    tail_a = out_a[len(out_base) :]
+    tail_b = out_b[len(out_base) :]
 
     # Both tails must be non-empty (template actually renders something for
     # an assistant turn).
@@ -850,14 +842,15 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         return None
 
     import os as _os
+
     prefix = _os.path.commonprefix([tail_a, tail_b])
 
     # Guard B: after stripping the common prefix, each tail must begin with
     # its own sentinel. This confirms the divergence point is exactly the
     # content-insertion site, not some earlier difference in the output.
     if not (
-        tail_a[len(prefix):].startswith(_RENDER_DIFF_SENTINEL_A)
-        and tail_b[len(prefix):].startswith(_RENDER_DIFF_SENTINEL_B)
+        tail_a[len(prefix) :].startswith(_RENDER_DIFF_SENTINEL_A)
+        and tail_b[len(prefix) :].startswith(_RENDER_DIFF_SENTINEL_B)
     ):
         return None
 
@@ -872,7 +865,7 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
     # role distinguishes turns (e.g. Gemma's `raise_exception` on
     # non-alternating roles), so we accept the derived prefix.
     if out_user_c is not None and out_user_c.startswith(out_base):
-        tail_c = out_user_c[len(out_base):]
+        tail_c = out_user_c[len(out_base) :]
         if tail_c.startswith(prefix) and prefix != "":
             return None
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -648,9 +648,7 @@ def _find_end_position(template, endfor = None, endif = None):
     with start/end/text/dash_left/dash_right. Tokens inside Jinja comments
     are ignored. `endfor`/`endif` kwargs kept for back-compat, ignored."""
     # Space-pad comments so positions still map 1:1 to the original.
-    scrubbed = _RE_JINJA_COMMENT.sub(
-        lambda m: " " * len(m.group(0)), template
-    )
+    scrubbed = _RE_JINJA_COMMENT.sub(lambda m: " " * len(m.group(0)), template)
     endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
     endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
@@ -708,7 +706,10 @@ def _if_body_emits_content(if_node):
     for node in if_node.body:
         if isinstance(node, jinja2.nodes.Output):
             return True
-        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
+        if any(
+            isinstance(d, jinja2.nodes.Output)
+            for d in node.find_all(jinja2.nodes.Output)
+        ):
             return True
     return False
 
@@ -1149,8 +1150,10 @@ class _VariantTokenizerProxy:
                 return self._base.apply_chat_template(*args, **kwargs)
             # Read-only base: fall back to sandboxed Jinja.
             from jinja2.sandbox import SandboxedEnvironment
+
             env = SandboxedEnvironment(
-                autoescape = False, keep_trailing_newline = True,
+                autoescape = False,
+                keep_trailing_newline = True,
             )
             messages = args[0] if args else kwargs.get("messages", [])
             add_generation_prompt = kwargs.get("add_generation_prompt", False)

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -660,9 +660,7 @@ def _find_end_position(template, endfor = None, endif = None):
     """
     # Pad comments with spaces so their contents don't match as end tags but
     # positions are preserved.
-    scrubbed = _RE_JINJA_COMMENT.sub(
-        lambda m: " " * len(m.group(0)), template
-    )
+    scrubbed = _RE_JINJA_COMMENT.sub(lambda m: " " * len(m.group(0)), template)
     endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
     endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
@@ -725,7 +723,10 @@ def _if_body_emits_content(if_node):
         if isinstance(node, jinja2.nodes.Output):
             return True
         # Nested If / For / Macro / etc. -- walk descendants for any Output.
-        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
+        if any(
+            isinstance(d, jinja2.nodes.Output)
+            for d in node.find_all(jinja2.nodes.Output)
+        ):
             return True
     return False
 
@@ -1224,8 +1225,10 @@ class _VariantTokenizerProxy:
             # this loses access to tokenizer globals but the probe still
             # works for templates that don't depend on them.
             import jinja2
+
             env = jinja2.Environment(
-                autoescape = False, keep_trailing_newline = True,
+                autoescape = False,
+                keep_trailing_newline = True,
             )
             messages = args[0] if args else kwargs.get("messages", [])
             add_generation_prompt = kwargs.get("add_generation_prompt", False)

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -648,9 +648,7 @@ def _find_end_position(template, endfor = None, endif = None):
     with start/end/text/dash_left/dash_right. Tokens inside Jinja comments
     are ignored. `endfor`/`endif` kwargs kept for back-compat, ignored."""
     # Space-pad comments so positions still map 1:1 to the original.
-    scrubbed = _RE_JINJA_COMMENT.sub(
-        lambda m: " " * len(m.group(0)), template
-    )
+    scrubbed = _RE_JINJA_COMMENT.sub(lambda m: " " * len(m.group(0)), template)
     endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
     endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
@@ -708,7 +706,10 @@ def _if_body_emits_content(if_node):
     for node in if_node.body:
         if isinstance(node, jinja2.nodes.Output):
             return True
-        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
+        if any(
+            isinstance(d, jinja2.nodes.Output)
+            for d in node.find_all(jinja2.nodes.Output)
+        ):
             return True
     return False
 
@@ -1141,8 +1142,10 @@ class _VariantTokenizerProxy:
                 return self._base.apply_chat_template(*args, **kwargs)
             # Read-only base: fall back to isolated Jinja.
             import jinja2
+
             env = jinja2.Environment(
-                autoescape = False, keep_trailing_newline = True,
+                autoescape = False,
+                keep_trailing_newline = True,
             )
             messages = args[0] if args else kwargs.get("messages", [])
             add_generation_prompt = kwargs.get("add_generation_prompt", False)

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -644,23 +644,13 @@ _RE_JINJA_COMMENT = re.compile(r"\{#.*?#\}", flags = re.DOTALL)
 
 
 def _find_end_position(template, endfor = None, endif = None):
-    """Return the last {% endfor %}/{% endif %} in the template (whichever is
-    further right), as a dict with start, end, dash_left, dash_right.
-
-    Unlike the older substring-based version, this accepts any of the four
-    Jinja whitespace-control variants ({% ... %}, {%- ... %}, {% ... -%},
-    {%- ... -%}) and returns the rightmost match so multi-for templates are
-    not locked onto the first loop. The `endfor`/`endif` kwargs are accepted
-    for backward compatibility and ignored.
-
-    Jinja comments ({# ... #}) are replaced with equal-length padding before
-    matching so tokens like `{% endfor %}` or `{% endif %}` living inside
-    comments don't get picked up as real end tags. Positions in the padded
-    string still map 1:1 to positions in the original template.
-    """
-    # Pad comments with spaces so their contents don't match as end tags but
-    # positions are preserved.
-    scrubbed = _RE_JINJA_COMMENT.sub(lambda m: " " * len(m.group(0)), template)
+    """Rightmost {% endfor %}/{% endif %} (any dash variant), as a dict
+    with start/end/text/dash_left/dash_right. Tokens inside Jinja comments
+    are ignored. `endfor`/`endif` kwargs kept for back-compat, ignored."""
+    # Space-pad comments so positions still map 1:1 to the original.
+    scrubbed = _RE_JINJA_COMMENT.sub(
+        lambda m: " " * len(m.group(0)), template
+    )
     endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
     endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
@@ -710,39 +700,25 @@ def _template_ends_with_toplevel_for(chat_template):
 
 
 def _if_body_emits_content(if_node):
-    """Return True if the If's positive body contains at least one Output
-    node. We use this to distinguish a real generation-prompt block
-    (`{% if add_generation_prompt %}{{ "<|...assistant..." }}{% endif %}`,
-    body has an Output) from a header guard
-    (`{% if not add_generation_prompt is defined %}{% set ... %}{% endif %}`,
-    body is only Assign nodes, emits nothing). Nested control flow counts as
-    emitting if any reachable descendant is an Output."""
+    """True if the If's body contains any Output node (directly or nested).
+    Distinguishes a real generation block from a header guard that only
+    does `{% set ... %}`."""
     import jinja2.nodes
 
     for node in if_node.body:
         if isinstance(node, jinja2.nodes.Output):
             return True
-        # Nested If / For / Macro / etc. -- walk descendants for any Output.
-        if any(
-            isinstance(d, jinja2.nodes.Output)
-            for d in node.find_all(jinja2.nodes.Output)
-        ):
+        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
             return True
     return False
 
 
 def _has_add_generation_prompt_block(chat_template):
-    """Return True if the template contains a *positive* generation-prompt
-    gate, i.e. an `{% if add_generation_prompt %}` (or equivalent) whose
-    body emits output. Uses Jinja AST so comments and whitespace-control
-    variants cannot fool the check. Falls back to a string scan if Jinja
-    cannot parse.
-
-    Rejects header guards like `{% if not add_generation_prompt is defined %}
-    {% set add_generation_prompt = false %}{% endif %}` -- these reference
-    the name but emit nothing, so they do not gate a generation block and
-    the template still needs repair.
-    """
+    """True if the template has a *positive* `{% if add_generation_prompt %}`
+    gate whose body emits output. Rejects header guards like
+    `{% if not add_generation_prompt is defined %}{% set ... %}{% endif %}`
+    that reference the name but emit nothing. AST-based; string-scan
+    fallback if Jinja fails to parse."""
     try:
         import jinja2
         import jinja2.nodes
@@ -752,8 +728,7 @@ def _has_add_generation_prompt_block(chat_template):
         return "if add_generation_prompt" in chat_template and "%}" in chat_template
     for if_node in ast.find_all(jinja2.nodes.If):
         test = if_node.test
-        # `find_all` only walks descendants, so a bare Name test (the common
-        # `{% if add_generation_prompt %}` form) needs an explicit check here.
+        # find_all skips the test root, so check bare Name tests explicitly.
         references_agp = False
         if isinstance(test, jinja2.nodes.Name) and test.name == "add_generation_prompt":
             references_agp = True
@@ -767,38 +742,27 @@ def _has_add_generation_prompt_block(chat_template):
     return False
 
 
-# Sentinels used by _derive_assistant_prefix_by_render. The first character of
-# each sentinel differs so os.path.commonprefix() cannot absorb them, and the
-# random-looking tail makes accidental collision with real template literals
-# vanishingly unlikely (tested as T18 in test_chat_template_followups.py).
+# Sentinels for _derive_assistant_prefix_by_render. Diverge at char 0 so
+# commonprefix can't absorb them; long random tail makes collision with real
+# template literals negligible (see T18).
 _RENDER_DIFF_SENTINEL_A = "AAAA_0123456789_UNSLOTH_RENDER_DIFF_SENTINEL"
 _RENDER_DIFF_SENTINEL_B = "BBBB_0123456789_UNSLOTH_RENDER_DIFF_SENTINEL"
 _RENDER_DIFF_SENTINEL_C = "CCCC_0123456789_UNSLOTH_RENDER_DIFF_SENTINEL"
 
 
 def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
-    """Return the exact assistant-turn prefix the template emits, derived by
-    rendering the template against two dialogs that differ only in assistant
-    content. The common prefix/suffix around the varying sentinel is the prefix
-    the template actually emits for an assistant turn.
+    """Return the assistant-turn prefix the template emits, derived by
+    rendering two dialogs that differ only in assistant content: the common
+    prefix of their tails (after the base [user]-only render) is what the
+    template emits for an assistant turn. None if any guard fails.
 
-    This replaces the earlier regex-based `_infer_assistant_separator`, which
-    only worked for ChatML-shaped templates and could be fooled by variables,
-    conditional prefixes, and unusual quoting. Render-diff derivation uses the
-    template itself as ground truth, so Llama-3 / Gemma / Phi-3 and other
-    non-ChatML shapes work as long as the assistant block is a literal the
-    template emits once per message.
+    Works for Llama-3 / Gemma / Phi-3 and other non-ChatML shapes; the
+    template is its own ground truth.
 
-    Returns the derived prefix string on success, or None if any guard fails
-    (ambiguous divergence, template cannot render without context, reordering
-    templates, or templates where role has no effect on output).
-
-    Known limitation: a template that emits the turn-end sentinel only for
-    non-last messages (`eos-on-non-last` pattern) would produce a consistent
-    but slightly wrong derived prefix. `_validate_patched_template` would not
-    catch it because the repaired template would still satisfy
-    `yes != no and yes.startswith(no)`. No real-world template is known to use
-    this pattern.
+    Known limitation: an `eos-on-non-last` pattern (turn-end sentinel only
+    emitted for non-last messages) would produce a consistent but wrong
+    prefix that `_validate_patched_template` can't catch. No real-world
+    template is known to use this.
     """
     try:
         import jinja2
@@ -809,10 +773,7 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         base_msgs = [{"from": "human", "value": "Hi"}]
         sent_a_msgs = base_msgs + [{"from": "gpt", "value": _RENDER_DIFF_SENTINEL_A}]
         sent_b_msgs = base_msgs + [{"from": "gpt", "value": _RENDER_DIFF_SENTINEL_B}]
-        # Negative cross-check: another *user* turn instead of an assistant
-        # turn. If the derived prefix also appears before a user-role sentinel,
-        # the template does not distinguish assistant turns from user turns
-        # (e.g. a {% set %}-only template) and we must reject.
+        # User-role cross-check (Guard C below).
         sent_c_msgs = base_msgs + [{"from": "human", "value": _RENDER_DIFF_SENTINEL_C}]
     else:
         base_msgs = [{"role": "user", "content": "Hi"}]
@@ -824,14 +785,9 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         ]
         sent_c_msgs = base_msgs + [{"role": "user", "content": _RENDER_DIFF_SENTINEL_C}]
 
-    # Trim trailing whitespace / Jinja comments that live AFTER the last
-    # {% endfor %}/{% endif %}. Without this, a template like
-    # `{% for m in messages %}...{% endfor %}   \n` renders base (1 message)
-    # as `MSG   \n` and render with 2 messages as `MSG1MSG2   \n` -- the
-    # trailing whitespace appears *after* the message loop in both, so
-    # out_a does not start with out_base. Since `_fix_chat_template` also
-    # discards that trailing content when it splices in the generation block,
-    # stripping it in the probe matches the eventual emitted behavior.
+    # Strip trailing whitespace/comments after the last endfor/endif: they
+    # appear after the message loop and would break Guard A. The splice in
+    # `_fix_chat_template` drops them too.
     probe_template = chat_template
     end = _find_end_position(chat_template)
     if end is not None:
@@ -839,13 +795,8 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         if _RE_JINJA_COMMENT.sub("", after).strip() == "":
             probe_template = chat_template[: end["end"]]
 
-    # Isolated Jinja environment. autoescape=False: chat templates are strings,
-    # not HTML. keep_trailing_newline=True: preserve final newline in the
-    # output so the diff captures it. No custom filters/globals/bos_token
-    # added on purpose: any template that relies on them will fail at render
-    # time and we'll return None, which is the correct outcome -- we don't
-    # want to silently fall back for a template the caller can't render
-    # either.
+    # Isolated env (no tokenizer globals/filters): a template that needs
+    # them will raise -> return None, which is the correct escalation.
     try:
         env = jinja2.Environment(
             autoescape = False,
@@ -858,28 +809,21 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
     except Exception:
         return None
 
-    # The user-cross-check render is best-effort: some templates enforce
-    # role alternation via `raise_exception` (e.g. Gemma), which means a
-    # [user, user] dialog deliberately fails to render. A render failure
-    # here is evidence that role matters -- the template rejects two
-    # consecutive users -- and we should *not* reject the derived prefix.
+    # Best-effort: alternation-enforcing templates (e.g. Gemma's
+    # raise_exception) will fail on [user, user]; that's a positive signal
+    # for Guard C, not a probe failure.
     out_user_c = None
     try:
         out_user_c = tmpl.render(messages = sent_c_msgs, add_generation_prompt = False)
     except Exception:
         pass
 
-    # Guard A: both assistant renders must be extensions of the base render
-    # (i.e. the template appends to produce the assistant turn, rather than
-    # reordering or deleting content).
+    # Guard A: assistant renders extend base (no reordering).
     if not (out_a.startswith(out_base) and out_b.startswith(out_base)):
         return None
 
     tail_a = out_a[len(out_base) :]
     tail_b = out_b[len(out_base) :]
-
-    # Both tails must be non-empty (template actually renders something for
-    # an assistant turn).
     if not tail_a or not tail_b:
         return None
 
@@ -887,25 +831,15 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
 
     prefix = _os.path.commonprefix([tail_a, tail_b])
 
-    # Guard B: after stripping the common prefix, each tail must begin with
-    # its own sentinel. This confirms the divergence point is exactly the
-    # content-insertion site, not some earlier difference in the output.
+    # Guard B: divergence is exactly at the content-insertion site.
     if not (
         tail_a[len(prefix) :].startswith(_RENDER_DIFF_SENTINEL_A)
         and tail_b[len(prefix) :].startswith(_RENDER_DIFF_SENTINEL_B)
     ):
         return None
 
-    # Guard C: negative user-role cross-check. Only run if the user-cross
-    # render succeeded. If a third render with a user sentinel produces the
-    # *same* prefix after the base, then role has no effect on output --
-    # the derived prefix is not assistant-specific and must be rejected.
-    # This catches templates like `{% set greeting = 'Hi' %}
-    # {% for m in messages %}{{ greeting }} {{ m.content }}{% endfor %}`
-    # where any new message gets the same "Hi " prefix regardless of role.
-    # A render failure on the user-cross render is ALSO evidence that
-    # role distinguishes turns (e.g. Gemma's `raise_exception` on
-    # non-alternating roles), so we accept the derived prefix.
+    # Guard C: reject if a [user, user] render also emits the same prefix
+    # (role-insensitive template, e.g. `{% set greeting='Hi' %}...`).
     if out_user_c is not None and out_user_c.startswith(out_base):
         tail_c = out_user_c[len(out_base) :]
         if tail_c.startswith(prefix) and prefix != "":
@@ -950,37 +884,27 @@ def _fix_chat_template(chat_template, is_sharegpt = False):
         )
         return chat_template[: end["end"]] + wrapped
 
-    # Case 2 (GH#4150): template ends at {% endfor %} with only whitespace or
-    # Jinja comments left. Inject an {% if add_generation_prompt %} block
-    # with the exact assistant-turn prefix the template emits, derived by
-    # render-diff probe (no regex / no hard ChatML token gate -- so Llama-3,
-    # Gemma, Phi-3 stripped templates work too). Require the top-level body
-    # to END in a For node so we don't inject inside a wider wrapper (e.g.
-    # Qwen3-Guard wraps the whole template in an outer If -- there the
-    # generation block would be out of place).
+    # Case 2 (GH#4150): template ends at {% endfor %} with only whitespace
+    # or comments left. Inject an {% if add_generation_prompt %} block with
+    # the assistant prefix derived by render-diff. The top-level-For gate
+    # keeps us out of outer-If wrappers (e.g. Qwen3-Guard).
     if _RE_JINJA_COMMENT.sub(
         "", after_endfor
     ).strip() == "" and _template_ends_with_toplevel_for(chat_template):
-        # Note: the fast path above (`_has_add_generation_prompt_block`)
-        # already confirmed there is no *positive* generation block, so we
-        # don't need another string-level "add_generation_prompt not in
-        # scrubbed" check here -- that would reject templates with a header
-        # guard like `{% if not add_generation_prompt is defined %}` that
-        # references the name but emits nothing.
+        # No redundant "agp not in scrubbed" check: the fast path already
+        # confirmed no *positive* block, and a mere reference (header
+        # guard) should still get repaired.
         assistant_prefix = _derive_assistant_prefix_by_render(
             chat_template, is_sharegpt
         )
-        # Dual-probe fallback: dict/list callers don't know the shape up
-        # front, and a template that expects ShareGPT-keyed messages will
-        # raise on HF-keyed probe. Try the other shape before giving up.
+        # Dual-probe: dict/list callers don't know the shape up front.
         if assistant_prefix is None and not is_sharegpt:
             assistant_prefix = _derive_assistant_prefix_by_render(
                 chat_template, is_sharegpt = True
             )
         if assistant_prefix is None:
             return chat_template
-        # Double-quoted Jinja literal with \\, \n, and " escaped so the
-        # block is valid regardless of the derived prefix's content.
+        # Escape for a double-quoted Jinja string literal.
         escaped = (
             assistant_prefix.replace("\\", "\\\\")
             .replace('"', '\\"')
@@ -1177,18 +1101,14 @@ def _fix_chat_template_for_tokenizer(tokenizer, chat_template):
 
 
 class _VariantTokenizerProxy:
-    """Adapter that presents a single variant-template view of a multi-variant
-    tokenizer to `_fix_chat_template_for_tokenizer`. This routes each variant
-    through the same full lifecycle as a string template -- is_sharegpt
-    probe, no==yes diagnostic, warn/strict messaging, and
-    `_validate_patched_template()` -- instead of calling structural repair
-    directly and skipping those guarantees.
+    """Single-variant view of a multi-variant tokenizer. Routes each variant
+    through `_fix_chat_template_for_tokenizer` so the full contract
+    (is_sharegpt probe, no==yes, warn/strict, `_validate_patched_template`)
+    applies instead of jumping straight to structural repair.
 
-    `apply_chat_template` is delegated to the base tokenizer after
-    temporarily swapping in the variant template, so access to tokenizer
-    globals (bos_token, custom filters, raise_exception, etc.) is
-    preserved. If the base is read-only, we fall back to bare-Jinja
-    rendering so the probe still works for stub tokenizers in tests.
+    `apply_chat_template` swaps `base.chat_template` to the variant before
+    calling so tokenizer globals (bos_token, filters, raise_exception) are
+    preserved; falls back to bare Jinja for read-only stubs.
     """
 
     def __init__(self, base_tokenizer, variant_template, variant_label = ""):
@@ -1196,7 +1116,6 @@ class _VariantTokenizerProxy:
         self._template = variant_template
         self._label = variant_label
         base_name = getattr(base_tokenizer, "name_or_path", "unknown")
-        # Append variant label so user-facing messages identify the variant.
         self.name_or_path = (
             f"{base_name} ({variant_label})" if variant_label else base_name
         )
@@ -1220,15 +1139,10 @@ class _VariantTokenizerProxy:
                 swapped = False
             if swapped:
                 return self._base.apply_chat_template(*args, **kwargs)
-            # Base is read-only or cannot accept a string chat_template.
-            # Fall back to isolated Jinja rendering of the variant directly;
-            # this loses access to tokenizer globals but the probe still
-            # works for templates that don't depend on them.
+            # Read-only base: fall back to isolated Jinja.
             import jinja2
-
             env = jinja2.Environment(
-                autoescape = False,
-                keep_trailing_newline = True,
+                autoescape = False, keep_trailing_newline = True,
             )
             messages = args[0] if args else kwargs.get("messages", [])
             add_generation_prompt = kwargs.get("add_generation_prompt", False)
@@ -1249,12 +1163,8 @@ def fix_chat_template(tokenizer):
     if chat_template is None:
         return None
 
-    # Multi-variant dict form (e.g. Hermes-3 {default, tool_use}): route each
-    # variant through `_fix_chat_template_for_tokenizer` so it honors the
-    # full repair contract (is_sharegpt probe, no==yes diagnostic, warn /
-    # strict messaging, and `_validate_patched_template`). The earlier
-    # implementation called `_fix_chat_template` directly per variant and
-    # silently bypassed these guards.
+    # Multi-variant dict (e.g. Hermes-3 {default, tool_use}): route each
+    # variant through the full repair contract via _VariantTokenizerProxy.
     if isinstance(chat_template, dict):
         fixed = {}
         for key, tmpl in chat_template.items():

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -681,6 +681,7 @@ def _template_ends_with_toplevel_for(chat_template):
     try:
         import jinja2
         import jinja2.nodes
+
         ast = jinja2.Environment().parse(chat_template)
     except Exception:
         return False
@@ -708,12 +709,10 @@ def _has_add_generation_prompt_block(chat_template):
     try:
         import jinja2
         import jinja2.nodes
+
         ast = jinja2.Environment().parse(chat_template)
     except Exception:
-        return (
-            "if add_generation_prompt" in chat_template
-            and "%}" in chat_template
-        )
+        return "if add_generation_prompt" in chat_template and "%}" in chat_template
     for if_node in ast.find_all(jinja2.nodes.If):
         test = if_node.test
         # `find_all` only walks descendants, so a bare Name test (the common
@@ -767,7 +766,7 @@ def _fix_chat_template(chat_template):
     if end is None:
         return chat_template
 
-    after_endfor = chat_template[end["end"]:]
+    after_endfor = chat_template[end["end"] :]
     dash_l = "-" if end["dash_left"] else ""
     dash_r = "-" if end["dash_right"] else ""
     open_tag = lambda body: "{%" + dash_l + " " + body + " " + dash_r + "%}"
@@ -795,10 +794,9 @@ def _fix_chat_template(chat_template):
     # don't inject inside a wider wrapper (e.g. Qwen3-Guard wraps the whole
     # template in an outer If -- there the generation block would be out of
     # place).
-    if (
-        _RE_JINJA_COMMENT.sub("", after_endfor).strip() == ""
-        and _template_ends_with_toplevel_for(chat_template)
-    ):
+    if _RE_JINJA_COMMENT.sub(
+        "", after_endfor
+    ).strip() == "" and _template_ends_with_toplevel_for(chat_template):
         scrubbed = _RE_JINJA_COMMENT.sub("", chat_template)
         if (
             "<|im_start|>" in scrubbed
@@ -813,7 +811,9 @@ def _fix_chat_template(chat_template):
             # the generation prefix.
             generation_block = (
                 open_tag("if add_generation_prompt")
-                + '{{ "' + assistant_prefix.replace('"', '\\"') + '" }}'
+                + '{{ "'
+                + assistant_prefix.replace('"', '\\"')
+                + '" }}'
                 + open_tag("endif")
             )
             return chat_template[: end["end"]] + generation_block
@@ -886,10 +886,14 @@ def _validate_patched_template(tokenizer, patched_template, is_sharegpt):
         tokenizer.chat_template = patched_template
         try:
             yes = tokenizer.apply_chat_template(
-                msgs, add_generation_prompt = True, tokenize = False,
+                msgs,
+                add_generation_prompt = True,
+                tokenize = False,
             )
             no = tokenizer.apply_chat_template(
-                msgs, add_generation_prompt = False, tokenize = False,
+                msgs,
+                add_generation_prompt = False,
+                tokenize = False,
             )
         except Exception:
             return False
@@ -926,14 +930,16 @@ def _fix_chat_template_for_tokenizer(tokenizer, chat_template):
     try:
         tokenizer.apply_chat_template(
             [{"role": "user", "content": "Who are you?"}],
-            add_generation_prompt = False, tokenize = False,
+            add_generation_prompt = False,
+            tokenize = False,
         )
         is_sharegpt = False
     except Exception:
         try:
             tokenizer.apply_chat_template(
                 [{"from": "human", "value": "Who are you?"}],
-                add_generation_prompt = False, tokenize = False,
+                add_generation_prompt = False,
+                tokenize = False,
             )
             is_sharegpt = True
         except Exception:
@@ -949,10 +955,14 @@ def _fix_chat_template_for_tokenizer(tokenizer, chat_template):
     )
     try:
         no = tokenizer.apply_chat_template(
-            messages, add_generation_prompt = False, tokenize = False,
+            messages,
+            add_generation_prompt = False,
+            tokenize = False,
         )
         yes = tokenizer.apply_chat_template(
-            messages, add_generation_prompt = True, tokenize = False,
+            messages,
+            add_generation_prompt = True,
+            tokenize = False,
         )
     except Exception:
         return chat_template

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -648,7 +648,9 @@ def _find_end_position(template, endfor = None, endif = None):
     with start/end/text/dash_left/dash_right. Tokens inside Jinja comments
     are ignored. `endfor`/`endif` kwargs kept for back-compat, ignored."""
     # Space-pad comments so positions still map 1:1 to the original.
-    scrubbed = _RE_JINJA_COMMENT.sub(lambda m: " " * len(m.group(0)), template)
+    scrubbed = _RE_JINJA_COMMENT.sub(
+        lambda m: " " * len(m.group(0)), template
+    )
     endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
     endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
@@ -706,10 +708,7 @@ def _if_body_emits_content(if_node):
     for node in if_node.body:
         if isinstance(node, jinja2.nodes.Output):
             return True
-        if any(
-            isinstance(d, jinja2.nodes.Output)
-            for d in node.find_all(jinja2.nodes.Output)
-        ):
+        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
             return True
     return False
 
@@ -729,6 +728,10 @@ def _has_add_generation_prompt_block(chat_template):
         return "if add_generation_prompt" in chat_template and "%}" in chat_template
     for if_node in ast.find_all(jinja2.nodes.If):
         test = if_node.test
+        # Reject negated gates: `{% if not add_generation_prompt %}` fires
+        # when agp=False, so it's not a generation block even if it emits.
+        if isinstance(test, jinja2.nodes.Not):
+            continue
         # find_all skips the test root, so check bare Name tests explicitly.
         references_agp = False
         if isinstance(test, jinja2.nodes.Name) and test.name == "add_generation_prompt":
@@ -796,10 +799,11 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         if _RE_JINJA_COMMENT.sub("", after).strip() == "":
             probe_template = chat_template[: end["end"]]
 
-    # Isolated env (no tokenizer globals/filters): a template that needs
-    # them will raise -> return None, which is the correct escalation.
+    # Sandboxed env: the probe renders at model-load time (before the user
+    # calls apply_chat_template), so a malicious template would execute
+    # eagerly. SandboxedEnvironment blocks attribute-chain exploits.
     try:
-        env = jinja2.Environment(
+        env = jinja2.sandbox.SandboxedEnvironment(
             autoescape = False,
             keep_trailing_newline = True,
         )
@@ -811,7 +815,7 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
         return None
 
     # Best-effort: alternation-enforcing templates (e.g. Gemma's
-    # raise_exception) will fail on [user, user]; that's a positive signal
+    # raise_exception) fail on [user, user]; that's a positive signal
     # for Guard C, not a probe failure.
     out_user_c = None
     try:
@@ -828,9 +832,7 @@ def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
     if not tail_a or not tail_b:
         return None
 
-    import os as _os
-
-    prefix = _os.path.commonprefix([tail_a, tail_b])
+    prefix = os.path.commonprefix([tail_a, tail_b])
 
     # Guard B: divergence is exactly at the content-insertion site.
     if not (
@@ -910,6 +912,7 @@ def _fix_chat_template(chat_template, is_sharegpt = False):
             assistant_prefix.replace("\\", "\\\\")
             .replace('"', '\\"')
             .replace("\n", "\\n")
+            .replace("\r", "\\r")
         )
         generation_block = (
             open_tag("if add_generation_prompt")
@@ -1019,9 +1022,15 @@ def _repair_string_template(tokenizer, chat_template, is_sharegpt):
     candidate = _fix_chat_template(chat_template, is_sharegpt = is_sharegpt)
     if not _has_add_generation_prompt_block(candidate):
         return None
-    if not _validate_patched_template(tokenizer, candidate, is_sharegpt):
-        return None
-    return candidate
+    # Validate with the caller's is_sharegpt first. If that fails, the
+    # dual-probe in _fix_chat_template may have fallen back to the other
+    # schema internally -- try validating with the opposite schema before
+    # giving up.
+    if _validate_patched_template(tokenizer, candidate, is_sharegpt):
+        return candidate
+    if _validate_patched_template(tokenizer, candidate, not is_sharegpt):
+        return candidate
+    return None
 
 
 def _fix_chat_template_for_tokenizer(tokenizer, chat_template):
@@ -1115,7 +1124,6 @@ class _VariantTokenizerProxy:
     def __init__(self, base_tokenizer, variant_template, variant_label = ""):
         self._base = base_tokenizer
         self._template = variant_template
-        self._label = variant_label
         base_name = getattr(base_tokenizer, "name_or_path", "unknown")
         self.name_or_path = (
             f"{base_name} ({variant_label})" if variant_label else base_name
@@ -1142,10 +1150,8 @@ class _VariantTokenizerProxy:
                 return self._base.apply_chat_template(*args, **kwargs)
             # Read-only base: fall back to isolated Jinja.
             import jinja2
-
             env = jinja2.Environment(
-                autoescape = False,
-                keep_trailing_newline = True,
+                autoescape = False, keep_trailing_newline = True,
             )
             messages = args[0] if args else kwargs.get("messages", [])
             add_generation_prompt = kwargs.get("add_generation_prompt", False)
@@ -1175,7 +1181,7 @@ def fix_chat_template(tokenizer):
                 fixed[key] = tmpl
                 continue
             proxy = _VariantTokenizerProxy(
-                tokenizer, tmpl, variant_label = f"variant='{key}'"
+                tokenizer, tmpl, variant_label = f"variant={key!r}"
             )
             fixed[key] = _fix_chat_template_for_tokenizer(proxy, tmpl)
         return fixed
@@ -1191,7 +1197,7 @@ def fix_chat_template(tokenizer):
             if not isinstance(tmpl, str):
                 fixed.append(item)
                 continue
-            label = "variant='{key}'".format(key = item.get("name", "?"))
+            label = f"variant={item.get('name', '?')!r}"
             proxy = _VariantTokenizerProxy(tokenizer, tmpl, variant_label = label)
             new_tmpl = _fix_chat_template_for_tokenizer(proxy, tmpl)
             if new_tmpl is tmpl or new_tmpl == tmpl:

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -725,36 +725,164 @@ def _has_add_generation_prompt_block(chat_template):
     return False
 
 
-def _infer_assistant_separator(scrubbed):
-    """Infer the separator that follows 'assistant' in a ChatML template.
+# Sentinels used by _derive_assistant_prefix_by_render. The first character of
+# each sentinel differs so os.path.commonprefix() cannot absorb them, and the
+# random-looking tail makes accidental collision with real template literals
+# vanishingly unlikely (tested as T18 in test_chat_template_followups.py).
+_RENDER_DIFF_SENTINEL_A = "AAAA_0123456789_UNSLOTH_RENDER_DIFF_SENTINEL"
+_RENDER_DIFF_SENTINEL_B = "BBBB_0123456789_UNSLOTH_RENDER_DIFF_SENTINEL"
+_RENDER_DIFF_SENTINEL_C = "CCCC_0123456789_UNSLOTH_RENDER_DIFF_SENTINEL"
 
-    Strategy: prefer an explicit '<|im_start|>assistant<sep>' literal; else
-    the unique `message['role'] + '<sep>'` from role concatenations; else
-    '<|im_sep|>' if present (Phi-4-mini mixes '\\n' for system with
-    '<|im_sep|>' for user/assistant); else '\\n'.
+
+def _derive_assistant_prefix_by_render(chat_template, is_sharegpt = False):
+    """Return the exact assistant-turn prefix the template emits, derived by
+    rendering the template against two dialogs that differ only in assistant
+    content. The common prefix/suffix around the varying sentinel is the prefix
+    the template actually emits for an assistant turn.
+
+    This replaces the earlier regex-based `_infer_assistant_separator`, which
+    only worked for ChatML-shaped templates and could be fooled by variables,
+    conditional prefixes, and unusual quoting. Render-diff derivation uses the
+    template itself as ground truth, so Llama-3 / Gemma / Phi-3 and other
+    non-ChatML shapes work as long as the assistant block is a literal the
+    template emits once per message.
+
+    Returns the derived prefix string on success, or None if any guard fails
+    (ambiguous divergence, template cannot render without context, reordering
+    templates, or templates where role has no effect on output).
+
+    Known limitation: a template that emits the turn-end sentinel only for
+    non-last messages (`eos-on-non-last` pattern) would produce a consistent
+    but slightly wrong derived prefix. `_validate_patched_template` would not
+    catch it because the repaired template would still satisfy
+    `yes != no and yes.startswith(no)`. No real-world template is known to use
+    this pattern.
     """
-    assistant_match = re.search(
-        r"""(['"])<\|im_start\|>assistant([^'"]*)\1""",
-        scrubbed,
-    )
-    role_seps = [
-        m.group(2)
-        for m in re.finditer(
-            r"""message(?:\[['"]role['"]\]|\.role)\s*\+\s*(['"])([^'"]*)\1""",
-            scrubbed,
+    try:
+        import jinja2
+    except Exception:
+        return None
+
+    if is_sharegpt:
+        base_msgs = [{"from": "human", "value": "Hi"}]
+        sent_a_msgs = base_msgs + [
+            {"from": "gpt", "value": _RENDER_DIFF_SENTINEL_A}
+        ]
+        sent_b_msgs = base_msgs + [
+            {"from": "gpt", "value": _RENDER_DIFF_SENTINEL_B}
+        ]
+        # Negative cross-check: another *user* turn instead of an assistant
+        # turn. If the derived prefix also appears before a user-role sentinel,
+        # the template does not distinguish assistant turns from user turns
+        # (e.g. a {% set %}-only template) and we must reject.
+        sent_c_msgs = base_msgs + [
+            {"from": "human", "value": _RENDER_DIFF_SENTINEL_C}
+        ]
+    else:
+        base_msgs = [{"role": "user", "content": "Hi"}]
+        sent_a_msgs = base_msgs + [
+            {"role": "assistant", "content": _RENDER_DIFF_SENTINEL_A}
+        ]
+        sent_b_msgs = base_msgs + [
+            {"role": "assistant", "content": _RENDER_DIFF_SENTINEL_B}
+        ]
+        sent_c_msgs = base_msgs + [
+            {"role": "user", "content": _RENDER_DIFF_SENTINEL_C}
+        ]
+
+    # Trim trailing whitespace / Jinja comments that live AFTER the last
+    # {% endfor %}/{% endif %}. Without this, a template like
+    # `{% for m in messages %}...{% endfor %}   \n` renders base (1 message)
+    # as `MSG   \n` and render with 2 messages as `MSG1MSG2   \n` -- the
+    # trailing whitespace appears *after* the message loop in both, so
+    # out_a does not start with out_base. Since `_fix_chat_template` also
+    # discards that trailing content when it splices in the generation block,
+    # stripping it in the probe matches the eventual emitted behavior.
+    probe_template = chat_template
+    end = _find_end_position(chat_template)
+    if end is not None:
+        after = chat_template[end["end"]:]
+        if _RE_JINJA_COMMENT.sub("", after).strip() == "":
+            probe_template = chat_template[: end["end"]]
+
+    # Isolated Jinja environment. autoescape=False: chat templates are strings,
+    # not HTML. keep_trailing_newline=True: preserve final newline in the
+    # output so the diff captures it. No custom filters/globals/bos_token
+    # added on purpose: any template that relies on them will fail at render
+    # time and we'll return None, which is the correct outcome -- we don't
+    # want to silently fall back for a template the caller can't render
+    # either.
+    try:
+        env = jinja2.Environment(
+            autoescape = False,
+            keep_trailing_newline = True,
         )
-    ]
-    unique_role_seps = list(dict.fromkeys(role_seps))
-    if assistant_match is not None and assistant_match.group(2):
-        return assistant_match.group(2)
-    if len(unique_role_seps) == 1:
-        return unique_role_seps[0]
-    if "<|im_sep|>" in scrubbed:
-        return "<|im_sep|>"
-    return "\\n"
+        tmpl = env.from_string(probe_template)
+        out_base = tmpl.render(messages = base_msgs, add_generation_prompt = False)
+        out_a = tmpl.render(messages = sent_a_msgs, add_generation_prompt = False)
+        out_b = tmpl.render(messages = sent_b_msgs, add_generation_prompt = False)
+    except Exception:
+        return None
+
+    # The user-cross-check render is best-effort: some templates enforce
+    # role alternation via `raise_exception` (e.g. Gemma), which means a
+    # [user, user] dialog deliberately fails to render. A render failure
+    # here is evidence that role matters -- the template rejects two
+    # consecutive users -- and we should *not* reject the derived prefix.
+    out_user_c = None
+    try:
+        out_user_c = tmpl.render(messages = sent_c_msgs, add_generation_prompt = False)
+    except Exception:
+        pass
+
+    # Guard A: both assistant renders must be extensions of the base render
+    # (i.e. the template appends to produce the assistant turn, rather than
+    # reordering or deleting content).
+    if not (out_a.startswith(out_base) and out_b.startswith(out_base)):
+        return None
+
+    tail_a = out_a[len(out_base):]
+    tail_b = out_b[len(out_base):]
+
+    # Both tails must be non-empty (template actually renders something for
+    # an assistant turn).
+    if not tail_a or not tail_b:
+        return None
+
+    import os as _os
+    prefix = _os.path.commonprefix([tail_a, tail_b])
+
+    # Guard B: after stripping the common prefix, each tail must begin with
+    # its own sentinel. This confirms the divergence point is exactly the
+    # content-insertion site, not some earlier difference in the output.
+    if not (
+        tail_a[len(prefix):].startswith(_RENDER_DIFF_SENTINEL_A)
+        and tail_b[len(prefix):].startswith(_RENDER_DIFF_SENTINEL_B)
+    ):
+        return None
+
+    # Guard C: negative user-role cross-check. Only run if the user-cross
+    # render succeeded. If a third render with a user sentinel produces the
+    # *same* prefix after the base, then role has no effect on output --
+    # the derived prefix is not assistant-specific and must be rejected.
+    # This catches templates like `{% set greeting = 'Hi' %}
+    # {% for m in messages %}{{ greeting }} {{ m.content }}{% endfor %}`
+    # where any new message gets the same "Hi " prefix regardless of role.
+    # A render failure on the user-cross render is ALSO evidence that
+    # role distinguishes turns (e.g. Gemma's `raise_exception` on
+    # non-alternating roles), so we accept the derived prefix.
+    if out_user_c is not None and out_user_c.startswith(out_base):
+        tail_c = out_user_c[len(out_base):]
+        if tail_c.startswith(prefix) and prefix != "":
+            return None
+
+    if not prefix:
+        return None
+
+    return prefix
 
 
-def _fix_chat_template(chat_template):
+def _fix_chat_template(chat_template, is_sharegpt = False):
     # Fast path: already has an {% if add_generation_prompt %} block, nothing
     # to do. This catches cases the old string-based check would miss (e.g.
     # templates that use {%- if add_generation_prompt -%} with both-side dash,
@@ -789,30 +917,40 @@ def _fix_chat_template(chat_template):
 
     # Case 2 (GH#4150): template ends at {% endfor %} with only whitespace or
     # Jinja comments left. Inject an {% if add_generation_prompt %} block
-    # with a model-specific assistant-turn separator inferred from the
-    # template body. Require the top-level body to END in a For node so we
-    # don't inject inside a wider wrapper (e.g. Qwen3-Guard wraps the whole
-    # template in an outer If -- there the generation block would be out of
-    # place).
+    # with the exact assistant-turn prefix the template emits, derived by
+    # render-diff probe (no regex / no hard ChatML token gate -- so Llama-3,
+    # Gemma, Phi-3 stripped templates work too). Require the top-level body
+    # to END in a For node so we don't inject inside a wider wrapper (e.g.
+    # Qwen3-Guard wraps the whole template in an outer If -- there the
+    # generation block would be out of place).
     if _RE_JINJA_COMMENT.sub(
         "", after_endfor
     ).strip() == "" and _template_ends_with_toplevel_for(chat_template):
         scrubbed = _RE_JINJA_COMMENT.sub("", chat_template)
-        if (
-            "<|im_start|>" in scrubbed
-            and "<|im_end|>" in scrubbed
-            and "add_generation_prompt" not in scrubbed
-        ):
-            separator = _infer_assistant_separator(scrubbed)
-            assistant_prefix = "<|im_start|>assistant" + separator
-            # Double-quoted Jinja literal so a single quote in the separator
-            # cannot break the block. Trailing whitespace/comments after
-            # endfor are dropped: they would render as stray output after
-            # the generation prefix.
+        if "add_generation_prompt" not in scrubbed:
+            assistant_prefix = _derive_assistant_prefix_by_render(
+                chat_template, is_sharegpt
+            )
+            # Dual-probe fallback: dict/list callers don't know the shape up
+            # front, and a template that expects ShareGPT-keyed messages will
+            # raise on HF-keyed probe. Try the other shape before giving up.
+            if assistant_prefix is None and not is_sharegpt:
+                assistant_prefix = _derive_assistant_prefix_by_render(
+                    chat_template, is_sharegpt = True
+                )
+            if assistant_prefix is None:
+                return chat_template
+            # Double-quoted Jinja literal with \\, \n, and " escaped so the
+            # block is valid regardless of the derived prefix's content.
+            escaped = (
+                assistant_prefix.replace("\\", "\\\\")
+                .replace('"', '\\"')
+                .replace("\n", "\\n")
+            )
             generation_block = (
                 open_tag("if add_generation_prompt")
                 + '{{ "'
-                + assistant_prefix.replace('"', '\\"')
+                + escaped
                 + '" }}'
                 + open_tag("endif")
             )
@@ -914,7 +1052,7 @@ def _validate_patched_template(tokenizer, patched_template, is_sharegpt):
 def _repair_string_template(tokenizer, chat_template, is_sharegpt):
     """Core string-template repair. Returns the repaired template on success,
     or None if repair was not possible / failed validation."""
-    candidate = _fix_chat_template(chat_template)
+    candidate = _fix_chat_template(chat_template, is_sharegpt = is_sharegpt)
     if not _has_add_generation_prompt_block(candidate):
         return None
     if not _validate_patched_template(tokenizer, candidate, is_sharegpt):

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -648,9 +648,7 @@ def _find_end_position(template, endfor = None, endif = None):
     with start/end/text/dash_left/dash_right. Tokens inside Jinja comments
     are ignored. `endfor`/`endif` kwargs kept for back-compat, ignored."""
     # Space-pad comments so positions still map 1:1 to the original.
-    scrubbed = _RE_JINJA_COMMENT.sub(
-        lambda m: " " * len(m.group(0)), template
-    )
+    scrubbed = _RE_JINJA_COMMENT.sub(lambda m: " " * len(m.group(0)), template)
     endfor_matches = list(_RE_ENDFOR.finditer(scrubbed))
     endif_matches = list(_RE_ENDIF.finditer(scrubbed))
     last_endfor = endfor_matches[-1] if endfor_matches else None
@@ -708,7 +706,10 @@ def _if_body_emits_content(if_node):
     for node in if_node.body:
         if isinstance(node, jinja2.nodes.Output):
             return True
-        if any(isinstance(d, jinja2.nodes.Output) for d in node.find_all(jinja2.nodes.Output)):
+        if any(
+            isinstance(d, jinja2.nodes.Output)
+            for d in node.find_all(jinja2.nodes.Output)
+        ):
             return True
     return False
 
@@ -1150,8 +1151,10 @@ class _VariantTokenizerProxy:
                 return self._base.apply_chat_template(*args, **kwargs)
             # Read-only base: fall back to isolated Jinja.
             import jinja2
+
             env = jinja2.Environment(
-                autoescape = False, keep_trailing_newline = True,
+                autoescape = False,
+                keep_trailing_newline = True,
             )
             messages = args[0] if args else kwargs.get("messages", [])
             add_generation_prompt = kwargs.get("add_generation_prompt", False)


### PR DESCRIPTION
Follow-up hardening on top of PR #4426 (which fixed the #4150 RuntimeError for ChatML LoRA reloads). Addresses the six follow-ups identified during the #4426 investigation.

## Behavior changes

### 1. Warn-by-default instead of RuntimeError

Before: if the tokenizer's chat_template ignored `add_generation_prompt` and `_fix_chat_template` could not repair it, `fix_chat_template` raised a hard RuntimeError that blocked model loading entirely. In the #4150 scenario this meant a tokenizer saved by a downstream tool (LlamaFactory, Axolotl) could not be reloaded at all.

After: repair failure emits a `logger.warning_once` and returns the original template. Model loading continues; the user can either manually set `tokenizer.chat_template` or supply their own prompt for inference. `UNSLOTH_STRICT_CHAT_TEMPLATE=1` restores the pre-warn hard fail for users who want it.

### 2. Local path vs HF hub distinguished in the message

Before: `Please file a bug report to the maintainers of <name_or_path>`. In the #4150 case `<name_or_path>` was the user's own `saves/Llama-3.1-8B-Instruct/lora/train_.../` folder -- the user could not file a bug against their own directory.

After: messages are branched on `os.path.isdir(name_or_path)`. Local paths get a message pointing at the likely downstream tool that re-serialized the tokenizer; HF hub IDs get a message pointing at the upstream model maintainers.

### 3. Dict / list chat_template now handled

Before: passing a tokenizer whose `chat_template` is a dict (e.g. Hermes-3 `{default, tool_use}`) or list to `_fix_chat_template` crashed with `AttributeError: 'dict' object has no attribute 'find'`. Surfaced during #4426 Phase 3 testing.

After: `fix_chat_template` detects dict / list shape and fixes each variant independently, preserving the outer structure.

## Internals

- `_find_end_position` now matches all four Jinja whitespace-control variants (`{% %}`, `{%- %}`, `{% -%}`, `{%- -%}`) and returns the rightmost endfor/endif. Previously `{%- endfor -%}` (both-side dash, used by Qwen3-Guard) was silently bypassed because the old `str.find` was only looking for two specific dash styles.

- `_has_add_generation_prompt_block` uses Jinja AST (`jinja2.nodes.If` / `Name` walk) instead of substring matching. Templates that mention `add_generation_prompt` only inside a comment are correctly classified as \"no block\"; templates that use whitespace-control variants on the `if`/`endif` tags are correctly classified as \"has block\".

- `_template_ends_with_toplevel_for` gates the GH#4150 ChatML repair on the AST: only fires when the last structural top-level node is a For loop (the standard ChatML shape), ignoring trailing pure-whitespace Output nodes. Templates wrapped in an outer If (Qwen3-Guard) are now explicitly skipped at the `_fix_chat_template` level, not just at `load_correct_tokenizer`'s name-based exemption. This means direct callers of `_fix_chat_template` also get correct behavior.

- `_validate_patched_template` renders the patched template with and without `add_generation_prompt` and confirms the patched output responds to the flag by appending (not replacing) content. If validation fails, the patch is discarded and the warn path is taken instead.

## Verification

Expanded regression suite across five test files (paths are in the workspace, not committed to this PR):

- `test_fix_chat_template_pr4426.py`: 42/42 template-matrix cells (Hermes, Magnum, Phi-4 single + multi-sep, dot-access, split-literal, trailing whitespace, trailing Jinja comment, two trap templates, already-fixed idempotency, Llama-3 / Gemma-3 / Qwen2.5 regressions).
- `test_load_correct_tokenizer_pr4426.py`: 5/5 integration loads including two synthetic broken stubs that would have crashed on main.
- `test_chat_template_followups.py`: 10/10 new tests covering each follow-up (dash variants, AST classification, dict + list handling, warn vs strict env var, local vs HF message, validation rejection, Qwen3-Guard NOP, dash-both ChatML repair).
- `test_mistral_pr4426.py`: 5 Mistral-family templates byte-identical (Mistral-7B-v0.3, Mistral-Nemo, Mistral-Small-24B, Mixtral).
- `test_qwen_pr4426.py`: 14 Qwen-family templates byte-identical (Qwen1.5, Qwen2, Qwen2.5-Instruct/Coder/Math/VL, Qwen3, Qwen3-Coder, QwQ-32B, Qwen3Guard-Gen).

No change to the ChatML repair heuristic itself: PR #4426 continues to repair the broken Hermes / Magnum / Phi-4 shapes exactly as before.

## Follow-ups intentionally NOT included

Replacing the string-surgery rewrite with a full Jinja AST unparse is a separate, larger change. Jinja2 has no built-in unparse, so it would require either a manual visitor that emits Jinja source for each node type, or using the AST only as a classifier (as this PR does for detection and gating) while keeping string surgery for the actual write. This PR takes the latter approach; a full unparse can be a later refactor.