### PR TITLE
Studio: Ollama support, recommended folders, Custom Folders UX polish

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1703,6 +1703,14 @@ class LlamaCppBackend:
             # Wait for llama-server to become healthy
             if not self._wait_for_health(timeout = 600.0):
                 self._kill_process()
+                _gguf = gguf_path or ""
+                if ".studio_links" in _gguf or (
+                    os.sep + ".cache" + os.sep + "ollama" + os.sep in _gguf
+                ):
+                    raise RuntimeError(
+                        "Some Ollama models do not work with llama.cpp. "
+                        "Try a different model, or use this model directly through Ollama instead."
+                    )
                 raise RuntimeError(
                     "llama-server failed to start. "
                     "Check that the GGUF file is valid and you have enough memory."

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1710,11 +1710,21 @@ class LlamaCppBackend:
                     or os.sep + ".cache" + os.sep + "ollama" + os.sep in _gguf
                     or (self._model_identifier or "").startswith("ollama/")
                 )
+                # Only show the Ollama-specific message when the server
+                # output indicates a GGUF compatibility issue, not for
+                # unrelated failures like OOM or missing binaries.
                 if _is_ollama:
-                    raise RuntimeError(
-                        "Some Ollama models do not work with llama.cpp. "
-                        "Try a different model, or use this model directly through Ollama instead."
+                    _output = "\n".join(self._stdout_lines[-50:]).lower()
+                    _gguf_compat_hints = (
+                        "key not found",
+                        "unknown model architecture",
+                        "failed to load model",
                     )
+                    if any(h in _output for h in _gguf_compat_hints):
+                        raise RuntimeError(
+                            "Some Ollama models do not work with llama.cpp. "
+                            "Try a different model, or use this model directly through Ollama instead."
+                        )
                 raise RuntimeError(
                     "llama-server failed to start. "
                     "Check that the GGUF file is valid and you have enough memory."

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1704,9 +1704,13 @@ class LlamaCppBackend:
             if not self._wait_for_health(timeout = 600.0):
                 self._kill_process()
                 _gguf = gguf_path or ""
-                if ".studio_links" in _gguf or (
-                    os.sep + ".cache" + os.sep + "ollama" + os.sep in _gguf
-                ):
+                _is_ollama = (
+                    ".studio_links" in _gguf
+                    or os.sep + "ollama_links" + os.sep in _gguf
+                    or os.sep + ".cache" + os.sep + "ollama" + os.sep in _gguf
+                    or (self._model_identifier or "").startswith("ollama/")
+                )
+                if _is_ollama:
                     raise RuntimeError(
                         "Some Ollama models do not work with llama.cpp. "
                         "Try a different model, or use this model directly through Ollama instead."

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -456,7 +456,9 @@ def _ollama_links_dir(ollama_dir: Path) -> Optional[Path]:
         return None
 
 
-def _scan_ollama_dir(ollama_dir: Path, limit: Optional[int] = None) -> List[LocalModelInfo]:
+def _scan_ollama_dir(
+    ollama_dir: Path, limit: Optional[int] = None
+) -> List[LocalModelInfo]:
     """Scan an Ollama models directory for downloaded models.
 
     Ollama stores models in a content-addressable layout::
@@ -716,9 +718,10 @@ async def list_local_models(
                     )
                     if ".studio_links" not in m.path
                 ]
-                custom_models = (_generic + _scan_ollama_dir(
-                    folder_path, limit=_MAX_MODELS_PER_FOLDER
-                ))[:_MAX_MODELS_PER_FOLDER]
+                custom_models = (
+                    _generic
+                    + _scan_ollama_dir(folder_path, limit = _MAX_MODELS_PER_FOLDER)
+                )[:_MAX_MODELS_PER_FOLDER]
             except OSError as e:
                 logger.warning("Skipping unreadable scan folder %s: %s", folder_path, e)
                 continue

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -438,8 +438,8 @@ def _ollama_links_dir(ollama_dir: Path) -> Optional[Path]:
         )
 
     # Fallback: namespace by a hash of the ollama_dir so two different
-    # Ollama roots don't collide. Use sha1 for speed -- this is a cache
-    # path, not a security boundary.
+    # Ollama roots don't collide. This is a cache path, not a security
+    # boundary.
     try:
         digest = hashlib.sha256(str(ollama_dir.resolve()).encode()).hexdigest()[:12]
     except OSError:
@@ -471,7 +471,7 @@ def _scan_ollama_dir(
     ``library`` (official models), but users can pull from custom
     namespaces (``mradermacher/llama3``) or entirely different hosts
     (``hf.co/org/repo:tag``).  We iterate all manifest files via
-    ``rglob`` so every layout is discovered.
+    targeted ``glob`` patterns so every layout is discovered.
 
     Each manifest is JSON with a ``layers`` array. The layer with
     ``mediaType == "application/vnd.ollama.image.model"`` contains the
@@ -487,7 +487,7 @@ def _scan_ollama_dir(
     the manifest path) so that ``detect_mmproj_file`` only sees the
     projector for *that* model.  Links are created as symlinks when
     possible, falling back to hardlinks (Windows without Developer
-    Mode) or file copies as a last resort.  The link dir lives under
+    Mode) as a last resort.  The link dir lives under
     ``<ollama_dir>/.studio_links/`` when writable, otherwise under
     Studio's own cache directory.
     """

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -763,7 +763,7 @@ async def list_local_models(
                         + _scan_hf_cache(folder_path)
                         + _scan_lmstudio_dir(folder_path)
                     )
-                    if ".studio_links" not in m.path
+                    if ".studio_links" not in m.path and "ollama_links" not in m.path
                 ]
                 custom_models = (
                     _generic

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -471,7 +471,7 @@ def _scan_ollama_dir(
     ``library`` (official models), but users can pull from custom
     namespaces (``mradermacher/llama3``) or entirely different hosts
     (``hf.co/org/repo:tag``).  We iterate all manifest files via
-    targeted ``glob`` patterns so every layout is discovered.
+    ``rglob`` so every layout depth is discovered.
 
     Each manifest is JSON with a ``layers`` array. The layer with
     ``mediaType == "application/vnd.ollama.image.model"`` contains the
@@ -519,17 +519,12 @@ def _scan_ollama_dir(
         link_path = link_dir / link_name
         resolved = target.resolve()
 
-        # Skip if the link/copy already points at the right target
+        # Skip if the link already points at the exact same blob.
+        # Only use samefile -- size-based checks can reuse stale links
+        # after `ollama pull` updates a tag to a same-sized blob.
         try:
-            if link_path.exists():
-                if os.path.samefile(str(link_path), str(resolved)):
-                    return str(link_path)
-                # Hardlink or copy -- same size is good enough
-                if (
-                    link_path.is_file()
-                    and link_path.stat().st_size == resolved.stat().st_size
-                ):
-                    return str(link_path)
+            if link_path.exists() and os.path.samefile(str(link_path), str(resolved)):
+                return str(link_path)
         except OSError as e:
             logger.debug("Error checking existing link %s: %s", link_path, e)
 
@@ -564,125 +559,117 @@ def _scan_ollama_dir(
             return None
 
     try:
-        # Ollama manifests live at depth 3-4 under manifests/:
-        #   host/model/tag           (3 levels)
-        #   host/namespace/model/tag (4 levels, e.g. registry.ollama.ai/library/...)
-        # Use targeted globs instead of rglob to avoid traversing
-        # unrelated subdirectories in large custom folders.
-        _seen_manifests: set[Path] = set()
-        for _depth_pattern in ("*/*/*", "*/*/*/*"):
-            for tag_file in manifests_root.glob(_depth_pattern):
-                if not tag_file.is_file() or tag_file in _seen_manifests:
-                    continue
-                _seen_manifests.add(tag_file)
+        for tag_file in manifests_root.rglob("*"):
+            if not tag_file.is_file():
+                continue
 
-                rel = tag_file.relative_to(manifests_root)
-                parts = rel.parts
-                if len(parts) < 3:
-                    continue
+            rel = tag_file.relative_to(manifests_root)
+            parts = rel.parts
+            if len(parts) < 3:
+                continue
 
-                host = parts[0]
-                repo_parts = list(parts[1:-1])
-                tag = parts[-1]
+            host = parts[0]
+            repo_parts = list(parts[1:-1])
+            tag = parts[-1]
 
-                if (
-                    host == "registry.ollama.ai"
-                    and repo_parts
-                    and repo_parts[0] == "library"
-                ):
-                    repo_name = "/".join(repo_parts[1:])
-                elif host == "registry.ollama.ai":
-                    repo_name = "/".join(repo_parts)
-                else:
-                    repo_name = "/".join([host] + repo_parts)
+            if (
+                host == "registry.ollama.ai"
+                and repo_parts
+                and repo_parts[0] == "library"
+            ):
+                repo_name = "/".join(repo_parts[1:])
+            elif host == "registry.ollama.ai":
+                repo_name = "/".join(repo_parts)
+            else:
+                repo_name = "/".join([host] + repo_parts)
 
-                if not repo_name:
-                    continue
+            if not repo_name:
+                continue
 
-                display = f"{repo_name}:{tag}"
+            display = f"{repo_name}:{tag}"
 
-                manifest_key = rel.as_posix()
-                stem_hash = hashlib.sha256(manifest_key.encode()).hexdigest()[:10]
+            manifest_key = rel.as_posix()
+            stem_hash = hashlib.sha256(manifest_key.encode()).hexdigest()[:10]
 
-                try:
-                    manifest = json.loads(tag_file.read_text())
-                except (json.JSONDecodeError, OSError) as e:
-                    logger.debug(
-                        "Skipping unreadable/invalid Ollama manifest %s: %s",
-                        tag_file,
-                        e,
-                    )
-                    continue
-
-                config_digest = manifest.get("config", {}).get("digest", "")
-                model_type = ""
-                file_type = ""
-                if config_digest and blobs_dir.is_dir():
-                    config_blob = blobs_dir / config_digest.replace(":", "-")
-                    if config_blob.is_file():
-                        try:
-                            cfg = json.loads(config_blob.read_text())
-                            model_type = cfg.get("model_type", "")
-                            file_type = cfg.get("file_type", "")
-                        except (json.JSONDecodeError, OSError) as e:
-                            logger.debug(
-                                "Could not parse Ollama config blob %s: %s",
-                                config_blob,
-                                e,
-                            )
-
-                model_link_dir = links_root / stem_hash
-
-                gguf_link_path: Optional[str] = None
-                quant = f"-{file_type}" if file_type else ""
-                safe_name = repo_name.replace("/", "-")
-                for layer in manifest.get("layers", []):
-                    media = layer.get("mediaType", "")
-                    digest = layer.get("digest", "")
-                    if not digest:
-                        continue
-
-                    if media == "application/vnd.ollama.image.model":
-                        candidate = blobs_dir / digest.replace(":", "-")
-                        if candidate.is_file():
-                            link_name = f"{safe_name}-{tag}{quant}.gguf"
-                            gguf_link_path = _make_link(
-                                model_link_dir, link_name, candidate
-                            )
-
-                    elif media == "application/vnd.ollama.image.projector":
-                        candidate = blobs_dir / digest.replace(":", "-")
-                        if candidate.is_file():
-                            mmproj_name = f"{safe_name}-{tag}-mmproj.gguf"
-                            _make_link(model_link_dir, mmproj_name, candidate)
-
-                if not gguf_link_path:
-                    continue
-
-                suffix = ""
-                if model_type:
-                    suffix += f" ({model_type}"
-                    if file_type:
-                        suffix += f" {file_type}"
-                    suffix += ")"
-
-                try:
-                    updated_at = tag_file.stat().st_mtime
-                except OSError:
-                    updated_at = None
-
-                found.append(
-                    LocalModelInfo(
-                        id = gguf_link_path,
-                        model_id = f"ollama/{repo_name}:{tag}",
-                        display_name = display + suffix,
-                        path = gguf_link_path,
-                        source = "custom",
-                        updated_at = updated_at,
-                    ),
+            try:
+                manifest = json.loads(tag_file.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                logger.debug(
+                    "Skipping unreadable/invalid Ollama manifest %s: %s",
+                    tag_file,
+                    e,
                 )
-                if limit is not None and len(found) >= limit:
-                    return found
+                continue
+
+            config_digest = manifest.get("config", {}).get("digest", "")
+            model_type = ""
+            file_type = ""
+            if config_digest and blobs_dir.is_dir():
+                config_blob = blobs_dir / config_digest.replace(":", "-")
+                if config_blob.is_file():
+                    try:
+                        cfg = json.loads(config_blob.read_text())
+                        model_type = cfg.get("model_type", "")
+                        file_type = cfg.get("file_type", "")
+                    except (json.JSONDecodeError, OSError) as e:
+                        logger.debug(
+                            "Could not parse Ollama config blob %s: %s",
+                            config_blob,
+                            e,
+                        )
+
+            model_link_dir = links_root / stem_hash
+
+            gguf_link_path: Optional[str] = None
+            quant = f"-{file_type}" if file_type else ""
+            safe_name = repo_name.replace("/", "-")
+            for layer in manifest.get("layers", []):
+                media = layer.get("mediaType", "")
+                digest = layer.get("digest", "")
+                if not digest:
+                    continue
+
+                if media == "application/vnd.ollama.image.model":
+                    candidate = blobs_dir / digest.replace(":", "-")
+                    if candidate.is_file():
+                        link_name = f"{safe_name}-{tag}{quant}.gguf"
+                        gguf_link_path = _make_link(
+                            model_link_dir, link_name, candidate
+                        )
+
+                elif media == "application/vnd.ollama.image.projector":
+                    candidate = blobs_dir / digest.replace(":", "-")
+                    if candidate.is_file():
+                        mmproj_name = f"{safe_name}-{tag}-mmproj.gguf"
+                        _make_link(model_link_dir, mmproj_name, candidate)
+
+            if not gguf_link_path:
+                continue
+
+            suffix = ""
+            if model_type:
+                suffix += f" ({model_type}"
+                if file_type:
+                    suffix += f" {file_type}"
+                suffix += ")"
+
+            try:
+                updated_at = tag_file.stat().st_mtime
+            except OSError:
+                updated_at = None
+
+            found.append(
+                LocalModelInfo(
+                    id = gguf_link_path,
+                    model_id = f"ollama/{repo_name}:{tag}",
+                    display_name = display + suffix,
+                    path = gguf_link_path,
+                    source = "custom",
+                    updated_at = updated_at,
+                ),
+            )
+            if limit is not None and len(found) >= limit:
+                return found
     except OSError as e:
         logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
     return found

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -5,6 +5,8 @@
 Model Management API routes
 """
 
+import hashlib
+import json
 import os
 import sys
 from pathlib import Path
@@ -438,8 +440,6 @@ def _ollama_links_dir(ollama_dir: Path) -> Optional[Path]:
     # Ollama roots don't collide. Use sha1 for speed -- this is a cache
     # path, not a security boundary.
     try:
-        import hashlib
-
         digest = hashlib.sha1(str(ollama_dir.resolve()).encode()).hexdigest()[:12]
     except OSError:
         digest = "default"
@@ -456,7 +456,7 @@ def _ollama_links_dir(ollama_dir: Path) -> Optional[Path]:
         return None
 
 
-def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
+def _scan_ollama_dir(ollama_dir: Path, limit: Optional[int] = None) -> List[LocalModelInfo]:
     """Scan an Ollama models directory for downloaded models.
 
     Ollama stores models in a content-addressable layout::
@@ -483,8 +483,6 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
     under ``<ollama_dir>/.studio_links/`` when writable, otherwise
     under Studio's own cache directory.
     """
-    import json as _json
-
     registry_root = ollama_dir / "manifests" / "registry.ollama.ai"
     if not registry_root.is_dir():
         return []
@@ -542,8 +540,8 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                         link_prefix = f"{namespace}-{model_name}-{tag}"
 
                     try:
-                        manifest = _json.loads(tag_file.read_text())
-                    except (_json.JSONDecodeError, OSError) as e:
+                        manifest = json.loads(tag_file.read_text())
+                    except (json.JSONDecodeError, OSError) as e:
                         logger.debug(
                             "Skipping unreadable/invalid Ollama manifest %s: %s",
                             tag_file,
@@ -559,10 +557,10 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                         config_blob = blobs_dir / config_digest.replace(":", "-")
                         if config_blob.is_file():
                             try:
-                                cfg = _json.loads(config_blob.read_text())
+                                cfg = json.loads(config_blob.read_text())
                                 model_type = cfg.get("model_type", "")
                                 file_type = cfg.get("file_type", "")
-                            except (_json.JSONDecodeError, OSError) as e:
+                            except (json.JSONDecodeError, OSError) as e:
                                 logger.debug(
                                     "Could not parse Ollama config blob %s: %s",
                                     config_blob,
@@ -617,6 +615,8 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                             updated_at = updated_at,
                         ),
                     )
+                    if limit is not None and len(found) >= limit:
+                        return found
     except OSError as e:
         logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
     return found
@@ -716,9 +716,9 @@ async def list_local_models(
                     )
                     if ".studio_links" not in m.path
                 ]
-                custom_models = (_generic + _scan_ollama_dir(folder_path))[
-                    :_MAX_MODELS_PER_FOLDER
-                ]
+                custom_models = (_generic + _scan_ollama_dir(
+                    folder_path, limit=_MAX_MODELS_PER_FOLDER
+                ))[:_MAX_MODELS_PER_FOLDER]
             except OSError as e:
                 logger.warning("Skipping unreadable scan folder %s: %s", folder_path, e)
                 continue

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -411,6 +411,51 @@ def _scan_lmstudio_dir(lm_dir: Path) -> List[LocalModelInfo]:
     return found
 
 
+def _ollama_links_dir(ollama_dir: Path) -> Optional[Path]:
+    """Return a writable directory for Ollama ``.gguf`` symlinks.
+
+    Prefers ``<ollama_dir>/.studio_links/`` so the links sit next to the
+    blobs they point at. Falls back to a per-ollama-dir namespace under
+    Studio's own cache when the models directory is read-only (common
+    for system installs under ``/usr/share/ollama`` or ``/var/lib/ollama``)
+    so we still surface Ollama models in those environments.
+    """
+    from utils.paths.storage_roots import cache_root
+
+    primary = ollama_dir / ".studio_links"
+    try:
+        primary.mkdir(exist_ok = True)
+        return primary
+    except OSError as e:
+        logger.debug(
+            "Ollama dir %s not writable for .studio_links (%s); "
+            "falling back to Studio cache",
+            ollama_dir,
+            e,
+        )
+
+    # Fallback: namespace by a hash of the ollama_dir so two different
+    # Ollama roots don't collide. Use sha1 for speed -- this is a cache
+    # path, not a security boundary.
+    try:
+        import hashlib
+
+        digest = hashlib.sha1(str(ollama_dir.resolve()).encode()).hexdigest()[:12]
+    except OSError:
+        digest = "default"
+    fallback = cache_root() / "ollama_links" / digest
+    try:
+        fallback.mkdir(parents = True, exist_ok = True)
+        return fallback
+    except OSError as e:
+        logger.warning(
+            "Could not create Ollama symlink cache at %s: %s",
+            fallback,
+            e,
+        )
+        return None
+
+
 def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
     """Scan an Ollama models directory for downloaded models.
 
@@ -424,9 +469,11 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
     GGUF weights. We read the config layer to extract family/size info.
 
     Since Ollama blobs lack a ``.gguf`` extension (which the GGUF
-    loading pipeline requires), we create symlinks with proper names
-    under ``<ollama_dir>/.studio_links/`` so that the existing
-    ``detect_gguf_model`` / llama-server ``-m`` path works unchanged.
+    loading pipeline requires), we create ``.gguf``-named symlinks
+    pointing at the blobs so the existing ``detect_gguf_model`` and
+    ``llama-server -m`` paths work unchanged. The symlinks live under
+    ``<ollama_dir>/.studio_links/`` when writable, otherwise under
+    Studio's own cache directory.
     """
     import json as _json
 
@@ -436,10 +483,15 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
 
     found: List[LocalModelInfo] = []
     blobs_dir = ollama_dir / "blobs"
-    links_dir = ollama_dir / ".studio_links"
-    try:
-        links_dir.mkdir(exist_ok = True)
-    except OSError:
+    links_dir = _ollama_links_dir(ollama_dir)
+    if links_dir is None:
+        # No writable spot for the .gguf symlinks; surfacing the raw
+        # sha256 blob path here would fail later because detect_gguf_model
+        # keys off the .gguf suffix.
+        logger.warning(
+            "Skipping Ollama scan for %s: no writable location for .gguf symlinks",
+            ollama_dir,
+        )
         return []
 
     try:
@@ -454,7 +506,12 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                 display = f"{model_name}:{tag}"
                 try:
                     manifest = _json.loads(tag_file.read_text())
-                except Exception:
+                except (_json.JSONDecodeError, OSError) as e:
+                    logger.debug(
+                        "Skipping unreadable/invalid Ollama manifest %s: %s",
+                        tag_file,
+                        e,
+                    )
                     continue
 
                 # Read the config blob for model_type / file_type metadata
@@ -468,8 +525,12 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                             cfg = _json.loads(config_blob.read_text())
                             model_type = cfg.get("model_type", "")
                             file_type = cfg.get("file_type", "")
-                        except Exception:
-                            pass
+                        except (_json.JSONDecodeError, OSError) as e:
+                            logger.debug(
+                                "Could not parse Ollama config blob %s: %s",
+                                config_blob,
+                                e,
+                            )
 
                 # Find the GGUF weights blob and create a .gguf symlink
                 gguf_link_path: Optional[str] = None
@@ -479,7 +540,7 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                         if digest:
                             candidate = blobs_dir / digest.replace(":", "-")
                             if candidate.is_file():
-                                # Create a symlink: .studio_links/gemma3-4b.gguf -> ../blobs/sha256-...
+                                # .studio_links/gemma3-4b-Q4_K_M.gguf -> ../blobs/sha256-...
                                 quant = f"-{file_type}" if file_type else ""
                                 link_name = f"{model_name}-{tag}{quant}.gguf"
                                 link_path = links_dir / link_name
@@ -487,11 +548,13 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                                     if link_path.is_symlink() or link_path.exists():
                                         link_path.unlink()
                                     link_path.symlink_to(candidate.resolve())
-                                except OSError:
-                                    # Fall back to raw blob path if symlink fails
-                                    gguf_link_path = str(candidate)
-                                    break
-                                gguf_link_path = str(link_path)
+                                    gguf_link_path = str(link_path)
+                                except OSError as e:
+                                    logger.debug(
+                                        "Could not create Ollama symlink %s: %s",
+                                        link_path,
+                                        e,
+                                    )
                         break
 
                 if not gguf_link_path:
@@ -519,8 +582,8 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
                         updated_at = updated_at,
                     ),
                 )
-    except OSError:
-        pass
+    except OSError as e:
+        logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
     return found
 
 
@@ -732,8 +795,8 @@ async def get_recommended_folders(
     try:
         for p in lmstudio_model_dirs():
             _add(p)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to scan for LM Studio model directories: %s", e)
 
     # Ollama model directories
     ollama_env = os.environ.get("OLLAMA_MODELS")

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -461,24 +461,32 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
 
     Ollama stores models in a content-addressable layout::
 
-        <ollama_dir>/manifests/registry.ollama.ai/library/<model>/<tag>
+        <ollama_dir>/manifests/registry.ollama.ai/<namespace>/<model>/<tag>
         <ollama_dir>/blobs/sha256-...
+
+    The default namespace is ``library`` (official models), but users
+    can pull from custom namespaces (e.g. ``mradermacher/llama3``).
+    We iterate over all namespaces under ``registry.ollama.ai/``.
 
     Each manifest is JSON with a ``layers`` array. The layer with
     ``mediaType == "application/vnd.ollama.image.model"`` contains the
-    GGUF weights. We read the config layer to extract family/size info.
+    GGUF weights. Vision models also have a projector layer
+    (``application/vnd.ollama.image.projector``). We read the config
+    layer to extract family/size info.
 
     Since Ollama blobs lack a ``.gguf`` extension (which the GGUF
     loading pipeline requires), we create ``.gguf``-named symlinks
     pointing at the blobs so the existing ``detect_gguf_model`` and
-    ``llama-server -m`` paths work unchanged. The symlinks live under
-    ``<ollama_dir>/.studio_links/`` when writable, otherwise under
-    Studio's own cache directory.
+    ``llama-server -m`` paths work unchanged. For vision models, a
+    companion ``-mmproj.gguf`` symlink is created so that
+    ``detect_mmproj_file`` can find the projector. The symlinks live
+    under ``<ollama_dir>/.studio_links/`` when writable, otherwise
+    under Studio's own cache directory.
     """
     import json as _json
 
-    manifests_root = ollama_dir / "manifests" / "registry.ollama.ai" / "library"
-    if not manifests_root.is_dir():
+    registry_root = ollama_dir / "manifests" / "registry.ollama.ai"
+    if not registry_root.is_dir():
         return []
 
     found: List[LocalModelInfo] = []
@@ -494,94 +502,121 @@ def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
         )
         return []
 
+    def _make_symlink(link_name: str, target: Path) -> Optional[str]:
+        """Create a symlink in links_dir, returning the path or None."""
+        link_path = links_dir / link_name
+        try:
+            if link_path.is_symlink() or link_path.exists():
+                link_path.unlink()
+            link_path.symlink_to(target.resolve())
+            return str(link_path)
+        except OSError as e:
+            logger.debug("Could not create Ollama symlink %s: %s", link_path, e)
+            return None
+
     try:
-        for model_dir in manifests_root.iterdir():
-            if not model_dir.is_dir():
+        # Iterate over all namespaces (e.g. library, mradermacher, etc.)
+        for namespace_dir in registry_root.iterdir():
+            if not namespace_dir.is_dir():
                 continue
-            model_name = model_dir.name
-            for tag_file in model_dir.iterdir():
-                if not tag_file.is_file():
+            namespace = namespace_dir.name  # "library", "mradermacher", etc.
+            for model_dir in namespace_dir.iterdir():
+                if not model_dir.is_dir():
                     continue
-                tag = tag_file.name
-                display = f"{model_name}:{tag}"
-                try:
-                    manifest = _json.loads(tag_file.read_text())
-                except (_json.JSONDecodeError, OSError) as e:
-                    logger.debug(
-                        "Skipping unreadable/invalid Ollama manifest %s: %s",
-                        tag_file,
-                        e,
-                    )
-                    continue
+                model_name = model_dir.name
+                for tag_file in model_dir.iterdir():
+                    if not tag_file.is_file():
+                        continue
+                    tag = tag_file.name
 
-                # Read the config blob for model_type / file_type metadata
-                config_digest = manifest.get("config", {}).get("digest", "")
-                model_type = ""
-                file_type = ""
-                if config_digest and blobs_dir.is_dir():
-                    config_blob = blobs_dir / config_digest.replace(":", "-")
-                    if config_blob.is_file():
-                        try:
-                            cfg = _json.loads(config_blob.read_text())
-                            model_type = cfg.get("model_type", "")
-                            file_type = cfg.get("file_type", "")
-                        except (_json.JSONDecodeError, OSError) as e:
-                            logger.debug(
-                                "Could not parse Ollama config blob %s: %s",
-                                config_blob,
-                                e,
-                            )
+                    # For the default "library" namespace, display as
+                    # "model:tag"; for custom namespaces, include the
+                    # namespace prefix to avoid collisions.
+                    if namespace == "library":
+                        display = f"{model_name}:{tag}"
+                        model_id_prefix = model_name
+                        link_prefix = f"{model_name}-{tag}"
+                    else:
+                        display = f"{namespace}/{model_name}:{tag}"
+                        model_id_prefix = f"{namespace}/{model_name}"
+                        link_prefix = f"{namespace}-{model_name}-{tag}"
 
-                # Find the GGUF weights blob and create a .gguf symlink
-                gguf_link_path: Optional[str] = None
-                for layer in manifest.get("layers", []):
-                    if layer.get("mediaType") == "application/vnd.ollama.image.model":
+                    try:
+                        manifest = _json.loads(tag_file.read_text())
+                    except (_json.JSONDecodeError, OSError) as e:
+                        logger.debug(
+                            "Skipping unreadable/invalid Ollama manifest %s: %s",
+                            tag_file,
+                            e,
+                        )
+                        continue
+
+                    # Read the config blob for model_type / file_type metadata
+                    config_digest = manifest.get("config", {}).get("digest", "")
+                    model_type = ""
+                    file_type = ""
+                    if config_digest and blobs_dir.is_dir():
+                        config_blob = blobs_dir / config_digest.replace(":", "-")
+                        if config_blob.is_file():
+                            try:
+                                cfg = _json.loads(config_blob.read_text())
+                                model_type = cfg.get("model_type", "")
+                                file_type = cfg.get("file_type", "")
+                            except (_json.JSONDecodeError, OSError) as e:
+                                logger.debug(
+                                    "Could not parse Ollama config blob %s: %s",
+                                    config_blob,
+                                    e,
+                                )
+
+                    # Find the GGUF weights blob and create a .gguf symlink
+                    gguf_link_path: Optional[str] = None
+                    for layer in manifest.get("layers", []):
+                        media = layer.get("mediaType", "")
                         digest = layer.get("digest", "")
-                        if digest:
+                        if not digest:
+                            continue
+
+                        if media == "application/vnd.ollama.image.model":
                             candidate = blobs_dir / digest.replace(":", "-")
                             if candidate.is_file():
-                                # .studio_links/gemma3-4b-Q4_K_M.gguf -> ../blobs/sha256-...
                                 quant = f"-{file_type}" if file_type else ""
-                                link_name = f"{model_name}-{tag}{quant}.gguf"
-                                link_path = links_dir / link_name
-                                try:
-                                    if link_path.is_symlink() or link_path.exists():
-                                        link_path.unlink()
-                                    link_path.symlink_to(candidate.resolve())
-                                    gguf_link_path = str(link_path)
-                                except OSError as e:
-                                    logger.debug(
-                                        "Could not create Ollama symlink %s: %s",
-                                        link_path,
-                                        e,
-                                    )
-                        break
+                                link_name = f"{link_prefix}{quant}.gguf"
+                                gguf_link_path = _make_symlink(link_name, candidate)
 
-                if not gguf_link_path:
-                    continue
+                        # Vision projector layer -- create an mmproj
+                        # symlink so detect_mmproj_file can find it.
+                        elif media == "application/vnd.ollama.image.projector":
+                            candidate = blobs_dir / digest.replace(":", "-")
+                            if candidate.is_file():
+                                mmproj_name = f"{link_prefix}-mmproj.gguf"
+                                _make_symlink(mmproj_name, candidate)
 
-                suffix = ""
-                if model_type:
-                    suffix += f" ({model_type}"
-                    if file_type:
-                        suffix += f" {file_type}"
-                    suffix += ")"
+                    if not gguf_link_path:
+                        continue
 
-                try:
-                    updated_at = tag_file.stat().st_mtime
-                except OSError:
-                    updated_at = None
+                    suffix = ""
+                    if model_type:
+                        suffix += f" ({model_type}"
+                        if file_type:
+                            suffix += f" {file_type}"
+                        suffix += ")"
 
-                found.append(
-                    LocalModelInfo(
-                        id = gguf_link_path,
-                        model_id = f"ollama/{model_name}:{tag}",
-                        display_name = display + suffix,
-                        path = gguf_link_path,
-                        source = "custom",
-                        updated_at = updated_at,
-                    ),
-                )
+                    try:
+                        updated_at = tag_file.stat().st_mtime
+                    except OSError:
+                        updated_at = None
+
+                    found.append(
+                        LocalModelInfo(
+                            id = gguf_link_path,
+                            model_id = f"ollama/{model_id_prefix}:{tag}",
+                            display_name = display + suffix,
+                            path = gguf_link_path,
+                            source = "custom",
+                            updated_at = updated_at,
+                        ),
+                    )
     except OSError as e:
         logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
     return found

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -610,16 +610,17 @@ async def list_local_models(
                 # Filter those from the generic scanners to avoid duplicates
                 # and leaking internal paths into the UI.
                 _generic = [
-                    m for m in (
+                    m
+                    for m in (
                         _scan_models_dir(folder_path, limit = _MAX_MODELS_PER_FOLDER)
                         + _scan_hf_cache(folder_path)
                         + _scan_lmstudio_dir(folder_path)
                     )
                     if ".studio_links" not in m.path
                 ]
-                custom_models = (
-                    _generic + _scan_ollama_dir(folder_path)
-                )[:_MAX_MODELS_PER_FOLDER]
+                custom_models = (_generic + _scan_ollama_dir(folder_path))[
+                    :_MAX_MODELS_PER_FOLDER
+                ]
             except OSError as e:
                 logger.warning("Skipping unreadable scan folder %s: %s", folder_path, e)
                 continue

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -511,11 +511,28 @@ def _scan_ollama_dir(
         Developer Mode when target is on the same filesystem), then
         falls back to a file copy as a last resort.  Uses atomic
         ``os.replace`` to avoid a race window where the path is missing.
+
+        Idempotent: skips recreation when a valid link/copy already exists
+        to avoid blocking the model-list API with multi-GB copies on every
+        scan.
         """
         link_dir.mkdir(parents = True, exist_ok = True)
         link_path = link_dir / link_name
-        tmp_path = link_dir / f".{link_name}.tmp-{os.getpid()}"
         resolved = target.resolve()
+
+        # Skip if the link/copy already points at the right target
+        try:
+            if link_path.exists():
+                if os.path.samefile(str(link_path), str(resolved)):
+                    return str(link_path)
+                # Hardlink or copy -- same size is good enough
+                if link_path.is_file() and link_path.stat().st_size == resolved.stat().st_size:
+                    return str(link_path)
+        except OSError as e:
+            logger.debug("Error checking existing link %s: %s", link_path, e)
+
+        import uuid
+        tmp_path = link_dir / f".{link_name}.tmp-{uuid.uuid4().hex[:8]}"
         try:
             if tmp_path.is_symlink() or tmp_path.exists():
                 tmp_path.unlink()
@@ -535,8 +552,8 @@ def _scan_ollama_dir(
             try:
                 if tmp_path.is_symlink() or tmp_path.exists():
                     tmp_path.unlink()
-            except OSError:
-                pass
+            except OSError as cleanup_err:
+                logger.debug("Could not clean up tmp path %s: %s", tmp_path, cleanup_err)
             return None
 
     try:
@@ -763,7 +780,8 @@ async def list_local_models(
                         + _scan_hf_cache(folder_path)
                         + _scan_lmstudio_dir(folder_path)
                     )
-                    if ".studio_links" not in m.path and "ollama_links" not in m.path
+                    if (os.sep + ".studio_links" + os.sep) not in m.path
+                    and (os.sep + "ollama_links" + os.sep) not in m.path
                 ]
                 custom_models = (
                     _generic

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -508,13 +508,11 @@ def _scan_ollama_dir(
         """Create a .gguf-named link to an Ollama blob.
 
         Tries symlink first, then hardlink (works on Windows without
-        Developer Mode when target is on the same filesystem), then
-        falls back to a file copy as a last resort.  Uses atomic
-        ``os.replace`` to avoid a race window where the path is missing.
+        Developer Mode when target is on the same filesystem).  Skips
+        the model if neither works -- a full file copy of a multi-GB
+        GGUF inside a synchronous API request would block the backend.
 
-        Idempotent: skips recreation when a valid link/copy already exists
-        to avoid blocking the model-list API with multi-GB copies on every
-        scan.
+        Idempotent: skips recreation when a valid link already exists.
         """
         link_dir.mkdir(parents = True, exist_ok = True)
         link_path = link_dir / link_name
@@ -546,9 +544,13 @@ def _scan_ollama_dir(
                 try:
                     os.link(str(resolved), str(tmp_path))
                 except OSError:
-                    import shutil
-
-                    shutil.copy2(str(resolved), str(tmp_path))
+                    logger.warning(
+                        "Could not create link for Ollama blob %s "
+                        "(symlinks and hardlinks both failed). "
+                        "Skipping model to avoid blocking the API.",
+                        target,
+                    )
+                    return None
             os.replace(str(tmp_path), str(link_path))
             return str(link_path)
         except OSError as e:
@@ -563,132 +565,125 @@ def _scan_ollama_dir(
             return None
 
     try:
-        for tag_file in manifests_root.rglob("*"):
-            if not tag_file.is_file():
-                continue
+        # Ollama manifests live at depth 3-4 under manifests/:
+        #   host/model/tag           (3 levels)
+        #   host/namespace/model/tag (4 levels, e.g. registry.ollama.ai/library/...)
+        # Use targeted globs instead of rglob to avoid traversing
+        # unrelated subdirectories in large custom folders.
+        _seen_manifests: set[Path] = set()
+        for _depth_pattern in ("*/*/*", "*/*/*/*"):
+            for tag_file in manifests_root.glob(_depth_pattern):
+                if not tag_file.is_file() or tag_file in _seen_manifests:
+                    continue
+                _seen_manifests.add(tag_file)
 
-            # Manifest path relative to manifests_root gives us:
-            # <host>/<namespace_or_org>/.../<model>/<tag>
-            # Minimum depth is 3: host/model/tag
-            rel = tag_file.relative_to(manifests_root)
-            parts = rel.parts
-            if len(parts) < 3:
-                continue
-
-            host = parts[0]
-            repo_parts = list(parts[1:-1])  # namespace/model or org/repo
-            tag = parts[-1]
-
-            # Build display name and model_id:
-            # - registry.ollama.ai/library/qwen2.5/0.5b -> "qwen2.5:0.5b"
-            # - registry.ollama.ai/mradermacher/llama3/latest -> "mradermacher/llama3:latest"
-            # - hf.co/NbAiLab/borealis/q4_K_M -> "hf.co/NbAiLab/borealis:q4_K_M"
-            if (
-                host == "registry.ollama.ai"
-                and repo_parts
-                and repo_parts[0] == "library"
-            ):
-                repo_name = "/".join(repo_parts[1:])
-            elif host == "registry.ollama.ai":
-                repo_name = "/".join(repo_parts)
-            else:
-                repo_name = "/".join([host] + repo_parts)
-
-            if not repo_name:
-                continue
-
-            display = f"{repo_name}:{tag}"
-
-            # Stable hash of the full manifest path to avoid filename
-            # collisions between models that would otherwise normalize
-            # to the same stem (e.g. library/foo-bar:baz vs foo/bar:baz).
-            manifest_key = rel.as_posix()
-            stem_hash = hashlib.sha1(manifest_key.encode()).hexdigest()[:10]
-
-            try:
-                manifest = json.loads(tag_file.read_text())
-            except (json.JSONDecodeError, OSError) as e:
-                logger.debug(
-                    "Skipping unreadable/invalid Ollama manifest %s: %s",
-                    tag_file,
-                    e,
-                )
-                continue
-
-            # Read the config blob for model_type / file_type metadata
-            config_digest = manifest.get("config", {}).get("digest", "")
-            model_type = ""
-            file_type = ""
-            if config_digest and blobs_dir.is_dir():
-                config_blob = blobs_dir / config_digest.replace(":", "-")
-                if config_blob.is_file():
-                    try:
-                        cfg = json.loads(config_blob.read_text())
-                        model_type = cfg.get("model_type", "")
-                        file_type = cfg.get("file_type", "")
-                    except (json.JSONDecodeError, OSError) as e:
-                        logger.debug(
-                            "Could not parse Ollama config blob %s: %s",
-                            config_blob,
-                            e,
-                        )
-
-            # Per-model subdirectory so detect_mmproj_file only sees
-            # the projector for this model, not siblings from other models.
-            model_link_dir = links_root / stem_hash
-
-            # Find the GGUF weights blob and create a .gguf link
-            gguf_link_path: Optional[str] = None
-            quant = f"-{file_type}" if file_type else ""
-            safe_name = repo_name.replace("/", "-")
-            for layer in manifest.get("layers", []):
-                media = layer.get("mediaType", "")
-                digest = layer.get("digest", "")
-                if not digest:
+                rel = tag_file.relative_to(manifests_root)
+                parts = rel.parts
+                if len(parts) < 3:
                     continue
 
-                if media == "application/vnd.ollama.image.model":
-                    candidate = blobs_dir / digest.replace(":", "-")
-                    if candidate.is_file():
-                        link_name = f"{safe_name}-{tag}{quant}.gguf"
-                        gguf_link_path = _make_link(
-                            model_link_dir, link_name, candidate
-                        )
+                host = parts[0]
+                repo_parts = list(parts[1:-1])
+                tag = parts[-1]
 
-                # Vision projector layer
-                elif media == "application/vnd.ollama.image.projector":
-                    candidate = blobs_dir / digest.replace(":", "-")
-                    if candidate.is_file():
-                        mmproj_name = f"{safe_name}-{tag}-mmproj.gguf"
-                        _make_link(model_link_dir, mmproj_name, candidate)
+                if (
+                    host == "registry.ollama.ai"
+                    and repo_parts
+                    and repo_parts[0] == "library"
+                ):
+                    repo_name = "/".join(repo_parts[1:])
+                elif host == "registry.ollama.ai":
+                    repo_name = "/".join(repo_parts)
+                else:
+                    repo_name = "/".join([host] + repo_parts)
 
-            if not gguf_link_path:
-                continue
+                if not repo_name:
+                    continue
 
-            suffix = ""
-            if model_type:
-                suffix += f" ({model_type}"
-                if file_type:
-                    suffix += f" {file_type}"
-                suffix += ")"
+                display = f"{repo_name}:{tag}"
 
-            try:
-                updated_at = tag_file.stat().st_mtime
-            except OSError:
-                updated_at = None
+                manifest_key = rel.as_posix()
+                stem_hash = hashlib.sha1(manifest_key.encode()).hexdigest()[:10]
 
-            found.append(
-                LocalModelInfo(
-                    id = gguf_link_path,
-                    model_id = f"ollama/{repo_name}:{tag}",
-                    display_name = display + suffix,
-                    path = gguf_link_path,
-                    source = "custom",
-                    updated_at = updated_at,
-                ),
-            )
-            if limit is not None and len(found) >= limit:
-                return found
+                try:
+                    manifest = json.loads(tag_file.read_text())
+                except (json.JSONDecodeError, OSError) as e:
+                    logger.debug(
+                        "Skipping unreadable/invalid Ollama manifest %s: %s",
+                        tag_file,
+                        e,
+                    )
+                    continue
+
+                config_digest = manifest.get("config", {}).get("digest", "")
+                model_type = ""
+                file_type = ""
+                if config_digest and blobs_dir.is_dir():
+                    config_blob = blobs_dir / config_digest.replace(":", "-")
+                    if config_blob.is_file():
+                        try:
+                            cfg = json.loads(config_blob.read_text())
+                            model_type = cfg.get("model_type", "")
+                            file_type = cfg.get("file_type", "")
+                        except (json.JSONDecodeError, OSError) as e:
+                            logger.debug(
+                                "Could not parse Ollama config blob %s: %s",
+                                config_blob,
+                                e,
+                            )
+
+                model_link_dir = links_root / stem_hash
+
+                gguf_link_path: Optional[str] = None
+                quant = f"-{file_type}" if file_type else ""
+                safe_name = repo_name.replace("/", "-")
+                for layer in manifest.get("layers", []):
+                    media = layer.get("mediaType", "")
+                    digest = layer.get("digest", "")
+                    if not digest:
+                        continue
+
+                    if media == "application/vnd.ollama.image.model":
+                        candidate = blobs_dir / digest.replace(":", "-")
+                        if candidate.is_file():
+                            link_name = f"{safe_name}-{tag}{quant}.gguf"
+                            gguf_link_path = _make_link(
+                                model_link_dir, link_name, candidate
+                            )
+
+                    elif media == "application/vnd.ollama.image.projector":
+                        candidate = blobs_dir / digest.replace(":", "-")
+                        if candidate.is_file():
+                            mmproj_name = f"{safe_name}-{tag}-mmproj.gguf"
+                            _make_link(model_link_dir, mmproj_name, candidate)
+
+                if not gguf_link_path:
+                    continue
+
+                suffix = ""
+                if model_type:
+                    suffix += f" ({model_type}"
+                    if file_type:
+                        suffix += f" {file_type}"
+                    suffix += ")"
+
+                try:
+                    updated_at = tag_file.stat().st_mtime
+                except OSError:
+                    updated_at = None
+
+                found.append(
+                    LocalModelInfo(
+                        id = gguf_link_path,
+                        model_id = f"ollama/{repo_name}:{tag}",
+                        display_name = display + suffix,
+                        path = gguf_link_path,
+                        source = "custom",
+                        updated_at = updated_at,
+                    ),
+                )
+                if limit is not None and len(found) >= limit:
+                    return found
     except OSError as e:
         logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
     return found
@@ -786,13 +781,17 @@ async def list_local_models(
                         + _scan_hf_cache(folder_path)
                         + _scan_lmstudio_dir(folder_path)
                     )
-                    if (os.sep + ".studio_links" + os.sep) not in m.path
-                    and (os.sep + "ollama_links" + os.sep) not in m.path
+                    if not any(
+                        p in (".studio_links", "ollama_links")
+                        for p in Path(m.path).parts
+                    )
                 ]
-                custom_models = (
-                    _generic
-                    + _scan_ollama_dir(folder_path, limit = _MAX_MODELS_PER_FOLDER)
-                )[:_MAX_MODELS_PER_FOLDER]
+                custom_models = _generic
+                if len(custom_models) < _MAX_MODELS_PER_FOLDER:
+                    custom_models += _scan_ollama_dir(
+                        folder_path,
+                        limit = _MAX_MODELS_PER_FOLDER - len(custom_models),
+                    )
             except OSError as e:
                 logger.warning("Skipping unreadable scan folder %s: %s", folder_path, e)
                 continue

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -512,7 +512,7 @@ def _scan_ollama_dir(
         falls back to a file copy as a last resort.  Uses atomic
         ``os.replace`` to avoid a race window where the path is missing.
         """
-        link_dir.mkdir(parents=True, exist_ok=True)
+        link_dir.mkdir(parents = True, exist_ok = True)
         link_path = link_dir / link_name
         tmp_path = link_dir / f".{link_name}.tmp-{os.getpid()}"
         resolved = target.resolve()
@@ -526,6 +526,7 @@ def _scan_ollama_dir(
                     os.link(str(resolved), str(tmp_path))
                 except OSError:
                     import shutil
+
                     shutil.copy2(str(resolved), str(tmp_path))
             os.replace(str(tmp_path), str(link_path))
             return str(link_path)
@@ -559,7 +560,11 @@ def _scan_ollama_dir(
             # - registry.ollama.ai/library/qwen2.5/0.5b -> "qwen2.5:0.5b"
             # - registry.ollama.ai/mradermacher/llama3/latest -> "mradermacher/llama3:latest"
             # - hf.co/NbAiLab/borealis/q4_K_M -> "hf.co/NbAiLab/borealis:q4_K_M"
-            if host == "registry.ollama.ai" and repo_parts and repo_parts[0] == "library":
+            if (
+                host == "registry.ollama.ai"
+                and repo_parts
+                and repo_parts[0] == "library"
+            ):
                 repo_name = "/".join(repo_parts[1:])
             elif host == "registry.ollama.ai":
                 repo_name = "/".join(repo_parts)
@@ -623,7 +628,9 @@ def _scan_ollama_dir(
                     candidate = blobs_dir / digest.replace(":", "-")
                     if candidate.is_file():
                         link_name = f"{safe_name}-{tag}{quant}.gguf"
-                        gguf_link_path = _make_link(model_link_dir, link_name, candidate)
+                        gguf_link_path = _make_link(
+                            model_link_dir, link_name, candidate
+                        )
 
                 # Vision projector layer
                 elif media == "application/vnd.ollama.image.projector":

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -463,12 +463,14 @@ def _scan_ollama_dir(
 
     Ollama stores models in a content-addressable layout::
 
-        <ollama_dir>/manifests/registry.ollama.ai/<namespace>/<model>/<tag>
+        <ollama_dir>/manifests/<host>/<namespace>/<model>/<tag>
         <ollama_dir>/blobs/sha256-...
 
-    The default namespace is ``library`` (official models), but users
-    can pull from custom namespaces (e.g. ``mradermacher/llama3``).
-    We iterate over all namespaces under ``registry.ollama.ai/``.
+    The default host is ``registry.ollama.ai`` with namespace
+    ``library`` (official models), but users can pull from custom
+    namespaces (``mradermacher/llama3``) or entirely different hosts
+    (``hf.co/org/repo:tag``).  We iterate all manifest files via
+    ``rglob`` so every layout is discovered.
 
     Each manifest is JSON with a ``layers`` array. The layer with
     ``mediaType == "application/vnd.ollama.image.model"`` contains the
@@ -477,148 +479,186 @@ def _scan_ollama_dir(
     layer to extract family/size info.
 
     Since Ollama blobs lack a ``.gguf`` extension (which the GGUF
-    loading pipeline requires), we create ``.gguf``-named symlinks
+    loading pipeline requires), we create ``.gguf``-named links
     pointing at the blobs so the existing ``detect_gguf_model`` and
-    ``llama-server -m`` paths work unchanged. For vision models, a
-    companion ``-mmproj.gguf`` symlink is created so that
-    ``detect_mmproj_file`` can find the projector. The symlinks live
-    under ``<ollama_dir>/.studio_links/`` when writable, otherwise
-    under Studio's own cache directory.
+    ``llama-server -m`` paths work unchanged. Each model gets its
+    own subdirectory under the links dir (keyed by a short hash of
+    the manifest path) so that ``detect_mmproj_file`` only sees the
+    projector for *that* model.  Links are created as symlinks when
+    possible, falling back to hardlinks (Windows without Developer
+    Mode) or file copies as a last resort.  The link dir lives under
+    ``<ollama_dir>/.studio_links/`` when writable, otherwise under
+    Studio's own cache directory.
     """
-    registry_root = ollama_dir / "manifests" / "registry.ollama.ai"
-    if not registry_root.is_dir():
+    manifests_root = ollama_dir / "manifests"
+    if not manifests_root.is_dir():
         return []
 
     found: List[LocalModelInfo] = []
     blobs_dir = ollama_dir / "blobs"
-    links_dir = _ollama_links_dir(ollama_dir)
-    if links_dir is None:
-        # No writable spot for the .gguf symlinks; surfacing the raw
-        # sha256 blob path here would fail later because detect_gguf_model
-        # keys off the .gguf suffix.
+    links_root = _ollama_links_dir(ollama_dir)
+    if links_root is None:
         logger.warning(
-            "Skipping Ollama scan for %s: no writable location for .gguf symlinks",
+            "Skipping Ollama scan for %s: no writable location for .gguf links",
             ollama_dir,
         )
         return []
 
-    def _make_symlink(link_name: str, target: Path) -> Optional[str]:
-        """Create a symlink in links_dir, returning the path or None."""
-        link_path = links_dir / link_name
+    def _make_link(link_dir: Path, link_name: str, target: Path) -> Optional[str]:
+        """Create a .gguf-named link to an Ollama blob.
+
+        Tries symlink first, then hardlink (works on Windows without
+        Developer Mode when target is on the same filesystem), then
+        falls back to a file copy as a last resort.  Uses atomic
+        ``os.replace`` to avoid a race window where the path is missing.
+        """
+        link_dir.mkdir(parents=True, exist_ok=True)
+        link_path = link_dir / link_name
+        tmp_path = link_dir / f".{link_name}.tmp-{os.getpid()}"
+        resolved = target.resolve()
         try:
-            if link_path.is_symlink() or link_path.exists():
-                link_path.unlink()
-            link_path.symlink_to(target.resolve())
+            if tmp_path.is_symlink() or tmp_path.exists():
+                tmp_path.unlink()
+            try:
+                tmp_path.symlink_to(resolved)
+            except OSError:
+                try:
+                    os.link(str(resolved), str(tmp_path))
+                except OSError:
+                    import shutil
+                    shutil.copy2(str(resolved), str(tmp_path))
+            os.replace(str(tmp_path), str(link_path))
             return str(link_path)
         except OSError as e:
-            logger.debug("Could not create Ollama symlink %s: %s", link_path, e)
+            logger.debug("Could not create Ollama link %s: %s", link_path, e)
+            try:
+                if tmp_path.is_symlink() or tmp_path.exists():
+                    tmp_path.unlink()
+            except OSError:
+                pass
             return None
 
     try:
-        # Iterate over all namespaces (e.g. library, mradermacher, etc.)
-        for namespace_dir in registry_root.iterdir():
-            if not namespace_dir.is_dir():
+        for tag_file in manifests_root.rglob("*"):
+            if not tag_file.is_file():
                 continue
-            namespace = namespace_dir.name  # "library", "mradermacher", etc.
-            for model_dir in namespace_dir.iterdir():
-                if not model_dir.is_dir():
-                    continue
-                model_name = model_dir.name
-                for tag_file in model_dir.iterdir():
-                    if not tag_file.is_file():
-                        continue
-                    tag = tag_file.name
 
-                    # For the default "library" namespace, display as
-                    # "model:tag"; for custom namespaces, include the
-                    # namespace prefix to avoid collisions.
-                    if namespace == "library":
-                        display = f"{model_name}:{tag}"
-                        model_id_prefix = model_name
-                        link_prefix = f"{model_name}-{tag}"
-                    else:
-                        display = f"{namespace}/{model_name}:{tag}"
-                        model_id_prefix = f"{namespace}/{model_name}"
-                        link_prefix = f"{namespace}-{model_name}-{tag}"
+            # Manifest path relative to manifests_root gives us:
+            # <host>/<namespace_or_org>/.../<model>/<tag>
+            # Minimum depth is 3: host/model/tag
+            rel = tag_file.relative_to(manifests_root)
+            parts = rel.parts
+            if len(parts) < 3:
+                continue
 
+            host = parts[0]
+            repo_parts = list(parts[1:-1])  # namespace/model or org/repo
+            tag = parts[-1]
+
+            # Build display name and model_id:
+            # - registry.ollama.ai/library/qwen2.5/0.5b -> "qwen2.5:0.5b"
+            # - registry.ollama.ai/mradermacher/llama3/latest -> "mradermacher/llama3:latest"
+            # - hf.co/NbAiLab/borealis/q4_K_M -> "hf.co/NbAiLab/borealis:q4_K_M"
+            if host == "registry.ollama.ai" and repo_parts and repo_parts[0] == "library":
+                repo_name = "/".join(repo_parts[1:])
+            elif host == "registry.ollama.ai":
+                repo_name = "/".join(repo_parts)
+            else:
+                repo_name = "/".join([host] + repo_parts)
+
+            if not repo_name:
+                continue
+
+            display = f"{repo_name}:{tag}"
+
+            # Stable hash of the full manifest path to avoid filename
+            # collisions between models that would otherwise normalize
+            # to the same stem (e.g. library/foo-bar:baz vs foo/bar:baz).
+            manifest_key = rel.as_posix()
+            stem_hash = hashlib.sha1(manifest_key.encode()).hexdigest()[:10]
+
+            try:
+                manifest = json.loads(tag_file.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                logger.debug(
+                    "Skipping unreadable/invalid Ollama manifest %s: %s",
+                    tag_file,
+                    e,
+                )
+                continue
+
+            # Read the config blob for model_type / file_type metadata
+            config_digest = manifest.get("config", {}).get("digest", "")
+            model_type = ""
+            file_type = ""
+            if config_digest and blobs_dir.is_dir():
+                config_blob = blobs_dir / config_digest.replace(":", "-")
+                if config_blob.is_file():
                     try:
-                        manifest = json.loads(tag_file.read_text())
+                        cfg = json.loads(config_blob.read_text())
+                        model_type = cfg.get("model_type", "")
+                        file_type = cfg.get("file_type", "")
                     except (json.JSONDecodeError, OSError) as e:
                         logger.debug(
-                            "Skipping unreadable/invalid Ollama manifest %s: %s",
-                            tag_file,
+                            "Could not parse Ollama config blob %s: %s",
+                            config_blob,
                             e,
                         )
-                        continue
 
-                    # Read the config blob for model_type / file_type metadata
-                    config_digest = manifest.get("config", {}).get("digest", "")
-                    model_type = ""
-                    file_type = ""
-                    if config_digest and blobs_dir.is_dir():
-                        config_blob = blobs_dir / config_digest.replace(":", "-")
-                        if config_blob.is_file():
-                            try:
-                                cfg = json.loads(config_blob.read_text())
-                                model_type = cfg.get("model_type", "")
-                                file_type = cfg.get("file_type", "")
-                            except (json.JSONDecodeError, OSError) as e:
-                                logger.debug(
-                                    "Could not parse Ollama config blob %s: %s",
-                                    config_blob,
-                                    e,
-                                )
+            # Per-model subdirectory so detect_mmproj_file only sees
+            # the projector for this model, not siblings from other models.
+            model_link_dir = links_root / stem_hash
 
-                    # Find the GGUF weights blob and create a .gguf symlink
-                    gguf_link_path: Optional[str] = None
-                    for layer in manifest.get("layers", []):
-                        media = layer.get("mediaType", "")
-                        digest = layer.get("digest", "")
-                        if not digest:
-                            continue
+            # Find the GGUF weights blob and create a .gguf link
+            gguf_link_path: Optional[str] = None
+            quant = f"-{file_type}" if file_type else ""
+            safe_name = repo_name.replace("/", "-")
+            for layer in manifest.get("layers", []):
+                media = layer.get("mediaType", "")
+                digest = layer.get("digest", "")
+                if not digest:
+                    continue
 
-                        if media == "application/vnd.ollama.image.model":
-                            candidate = blobs_dir / digest.replace(":", "-")
-                            if candidate.is_file():
-                                quant = f"-{file_type}" if file_type else ""
-                                link_name = f"{link_prefix}{quant}.gguf"
-                                gguf_link_path = _make_symlink(link_name, candidate)
+                if media == "application/vnd.ollama.image.model":
+                    candidate = blobs_dir / digest.replace(":", "-")
+                    if candidate.is_file():
+                        link_name = f"{safe_name}-{tag}{quant}.gguf"
+                        gguf_link_path = _make_link(model_link_dir, link_name, candidate)
 
-                        # Vision projector layer -- create an mmproj
-                        # symlink so detect_mmproj_file can find it.
-                        elif media == "application/vnd.ollama.image.projector":
-                            candidate = blobs_dir / digest.replace(":", "-")
-                            if candidate.is_file():
-                                mmproj_name = f"{link_prefix}-mmproj.gguf"
-                                _make_symlink(mmproj_name, candidate)
+                # Vision projector layer
+                elif media == "application/vnd.ollama.image.projector":
+                    candidate = blobs_dir / digest.replace(":", "-")
+                    if candidate.is_file():
+                        mmproj_name = f"{safe_name}-{tag}-mmproj.gguf"
+                        _make_link(model_link_dir, mmproj_name, candidate)
 
-                    if not gguf_link_path:
-                        continue
+            if not gguf_link_path:
+                continue
 
-                    suffix = ""
-                    if model_type:
-                        suffix += f" ({model_type}"
-                        if file_type:
-                            suffix += f" {file_type}"
-                        suffix += ")"
+            suffix = ""
+            if model_type:
+                suffix += f" ({model_type}"
+                if file_type:
+                    suffix += f" {file_type}"
+                suffix += ")"
 
-                    try:
-                        updated_at = tag_file.stat().st_mtime
-                    except OSError:
-                        updated_at = None
+            try:
+                updated_at = tag_file.stat().st_mtime
+            except OSError:
+                updated_at = None
 
-                    found.append(
-                        LocalModelInfo(
-                            id = gguf_link_path,
-                            model_id = f"ollama/{model_id_prefix}:{tag}",
-                            display_name = display + suffix,
-                            path = gguf_link_path,
-                            source = "custom",
-                            updated_at = updated_at,
-                        ),
-                    )
-                    if limit is not None and len(found) >= limit:
-                        return found
+            found.append(
+                LocalModelInfo(
+                    id = gguf_link_path,
+                    model_id = f"ollama/{repo_name}:{tag}",
+                    display_name = display + suffix,
+                    path = gguf_link_path,
+                    source = "custom",
+                    updated_at = updated_at,
+                ),
+            )
+            if limit is not None and len(found) >= limit:
+                return found
     except OSError as e:
         logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
     return found
@@ -825,7 +865,7 @@ async def get_recommended_folders(
             return
         if resolved in seen:
             return
-        if Path(resolved).is_dir():
+        if Path(resolved).is_dir() and os.access(resolved, os.R_OK | os.X_OK):
             seen.add(resolved)
             folders.append(resolved)
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -526,12 +526,16 @@ def _scan_ollama_dir(
                 if os.path.samefile(str(link_path), str(resolved)):
                     return str(link_path)
                 # Hardlink or copy -- same size is good enough
-                if link_path.is_file() and link_path.stat().st_size == resolved.stat().st_size:
+                if (
+                    link_path.is_file()
+                    and link_path.stat().st_size == resolved.stat().st_size
+                ):
                     return str(link_path)
         except OSError as e:
             logger.debug("Error checking existing link %s: %s", link_path, e)
 
         import uuid
+
         tmp_path = link_dir / f".{link_name}.tmp-{uuid.uuid4().hex[:8]}"
         try:
             if tmp_path.is_symlink() or tmp_path.exists():
@@ -553,7 +557,9 @@ def _scan_ollama_dir(
                 if tmp_path.is_symlink() or tmp_path.exists():
                     tmp_path.unlink()
             except OSError as cleanup_err:
-                logger.debug("Could not clean up tmp path %s: %s", tmp_path, cleanup_err)
+                logger.debug(
+                    "Could not clean up tmp path %s: %s", tmp_path, cleanup_err
+                )
             return None
 
     try:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import sys
+import uuid
 from pathlib import Path
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from typing import List, Optional
@@ -440,7 +441,7 @@ def _ollama_links_dir(ollama_dir: Path) -> Optional[Path]:
     # Ollama roots don't collide. Use sha1 for speed -- this is a cache
     # path, not a security boundary.
     try:
-        digest = hashlib.sha1(str(ollama_dir.resolve()).encode()).hexdigest()[:12]
+        digest = hashlib.sha256(str(ollama_dir.resolve()).encode()).hexdigest()[:12]
     except OSError:
         digest = "default"
     fallback = cache_root() / "ollama_links" / digest
@@ -532,8 +533,6 @@ def _scan_ollama_dir(
         except OSError as e:
             logger.debug("Error checking existing link %s: %s", link_path, e)
 
-        import uuid
-
         tmp_path = link_dir / f".{link_name}.tmp-{uuid.uuid4().hex[:8]}"
         try:
             if tmp_path.is_symlink() or tmp_path.exists():
@@ -603,7 +602,7 @@ def _scan_ollama_dir(
                 display = f"{repo_name}:{tag}"
 
                 manifest_key = rel.as_posix()
-                stem_hash = hashlib.sha1(manifest_key.encode()).hexdigest()[:10]
+                stem_hash = hashlib.sha256(manifest_key.encode()).hexdigest()[:10]
 
                 try:
                     manifest = json.loads(tag_file.read_text())

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -411,6 +411,119 @@ def _scan_lmstudio_dir(lm_dir: Path) -> List[LocalModelInfo]:
     return found
 
 
+def _scan_ollama_dir(ollama_dir: Path) -> List[LocalModelInfo]:
+    """Scan an Ollama models directory for downloaded models.
+
+    Ollama stores models in a content-addressable layout::
+
+        <ollama_dir>/manifests/registry.ollama.ai/library/<model>/<tag>
+        <ollama_dir>/blobs/sha256-...
+
+    Each manifest is JSON with a ``layers`` array. The layer with
+    ``mediaType == "application/vnd.ollama.image.model"`` contains the
+    GGUF weights. We read the config layer to extract family/size info.
+
+    Since Ollama blobs lack a ``.gguf`` extension (which the GGUF
+    loading pipeline requires), we create symlinks with proper names
+    under ``<ollama_dir>/.studio_links/`` so that the existing
+    ``detect_gguf_model`` / llama-server ``-m`` path works unchanged.
+    """
+    import json as _json
+
+    manifests_root = ollama_dir / "manifests" / "registry.ollama.ai" / "library"
+    if not manifests_root.is_dir():
+        return []
+
+    found: List[LocalModelInfo] = []
+    blobs_dir = ollama_dir / "blobs"
+    links_dir = ollama_dir / ".studio_links"
+    try:
+        links_dir.mkdir(exist_ok = True)
+    except OSError:
+        return []
+
+    try:
+        for model_dir in manifests_root.iterdir():
+            if not model_dir.is_dir():
+                continue
+            model_name = model_dir.name
+            for tag_file in model_dir.iterdir():
+                if not tag_file.is_file():
+                    continue
+                tag = tag_file.name
+                display = f"{model_name}:{tag}"
+                try:
+                    manifest = _json.loads(tag_file.read_text())
+                except Exception:
+                    continue
+
+                # Read the config blob for model_type / file_type metadata
+                config_digest = manifest.get("config", {}).get("digest", "")
+                model_type = ""
+                file_type = ""
+                if config_digest and blobs_dir.is_dir():
+                    config_blob = blobs_dir / config_digest.replace(":", "-")
+                    if config_blob.is_file():
+                        try:
+                            cfg = _json.loads(config_blob.read_text())
+                            model_type = cfg.get("model_type", "")
+                            file_type = cfg.get("file_type", "")
+                        except Exception:
+                            pass
+
+                # Find the GGUF weights blob and create a .gguf symlink
+                gguf_link_path: Optional[str] = None
+                for layer in manifest.get("layers", []):
+                    if layer.get("mediaType") == "application/vnd.ollama.image.model":
+                        digest = layer.get("digest", "")
+                        if digest:
+                            candidate = blobs_dir / digest.replace(":", "-")
+                            if candidate.is_file():
+                                # Create a symlink: .studio_links/gemma3-4b.gguf -> ../blobs/sha256-...
+                                quant = f"-{file_type}" if file_type else ""
+                                link_name = f"{model_name}-{tag}{quant}.gguf"
+                                link_path = links_dir / link_name
+                                try:
+                                    if link_path.is_symlink() or link_path.exists():
+                                        link_path.unlink()
+                                    link_path.symlink_to(candidate.resolve())
+                                except OSError:
+                                    # Fall back to raw blob path if symlink fails
+                                    gguf_link_path = str(candidate)
+                                    break
+                                gguf_link_path = str(link_path)
+                        break
+
+                if not gguf_link_path:
+                    continue
+
+                suffix = ""
+                if model_type:
+                    suffix += f" ({model_type}"
+                    if file_type:
+                        suffix += f" {file_type}"
+                    suffix += ")"
+
+                try:
+                    updated_at = tag_file.stat().st_mtime
+                except OSError:
+                    updated_at = None
+
+                found.append(
+                    LocalModelInfo(
+                        id = gguf_link_path,
+                        model_id = f"ollama/{model_name}:{tag}",
+                        display_name = display + suffix,
+                        path = gguf_link_path,
+                        source = "custom",
+                        updated_at = updated_at,
+                    ),
+                )
+    except OSError:
+        pass
+    return found
+
+
 @router.get("/local", response_model = LocalModelListResponse)
 async def list_local_models(
     models_dir: str = Query(
@@ -493,10 +606,19 @@ async def list_local_models(
         for folder in custom_folders:
             folder_path = Path(folder["path"])
             try:
+                # Ollama scanner creates .studio_links/ with .gguf symlinks.
+                # Filter those from the generic scanners to avoid duplicates
+                # and leaking internal paths into the UI.
+                _generic = [
+                    m for m in (
+                        _scan_models_dir(folder_path, limit = _MAX_MODELS_PER_FOLDER)
+                        + _scan_hf_cache(folder_path)
+                        + _scan_lmstudio_dir(folder_path)
+                    )
+                    if ".studio_links" not in m.path
+                ]
                 custom_models = (
-                    _scan_models_dir(folder_path, limit = _MAX_MODELS_PER_FOLDER)
-                    + _scan_hf_cache(folder_path)
-                    + _scan_lmstudio_dir(folder_path)
+                    _generic + _scan_ollama_dir(folder_path)
                 )[:_MAX_MODELS_PER_FOLDER]
             except OSError as e:
                 logger.warning("Skipping unreadable scan folder %s: %s", folder_path, e)
@@ -573,6 +695,57 @@ async def remove_scan_folder_endpoint(
     remove_scan_folder(folder_id)
     logger.info("Scan folder removed: id=%s", folder_id)
     return {"ok": True}
+
+
+@router.get("/recommended-folders")
+async def get_recommended_folders(
+    current_subject: str = Depends(get_current_subject),
+):
+    """Return well-known model directories that exist on this machine.
+
+    Lightweight alternative to ``browse-folders`` for showing quick-pick
+    chips without the overhead of enumerating a directory tree.  Returns
+    paths that actually exist on disk (HF cache, LM Studio, Ollama,
+    ``~/models``, etc.) so the frontend can offer them as one-click
+    "Recommended" shortcuts in the Custom Folders section.
+    """
+    from utils.paths.storage_roots import lmstudio_model_dirs
+
+    folders: list[str] = []
+    seen: set[str] = set()
+
+    def _add(p: Optional[Path]) -> None:
+        if p is None:
+            return
+        try:
+            resolved = str(p.resolve())
+        except OSError:
+            return
+        if resolved in seen:
+            return
+        if Path(resolved).is_dir():
+            seen.add(resolved)
+            folders.append(resolved)
+
+    # LM Studio model directories
+    try:
+        for p in lmstudio_model_dirs():
+            _add(p)
+    except Exception:
+        pass
+
+    # Ollama model directories
+    ollama_env = os.environ.get("OLLAMA_MODELS")
+    if ollama_env:
+        _add(Path(ollama_env).expanduser())
+    for candidate in (
+        Path.home() / ".ollama" / "models",
+        Path("/usr/share/ollama/.ollama/models"),
+        Path("/var/lib/ollama/.ollama/models"),
+    ):
+        _add(candidate)
+
+    return {"folders": folders}
 
 
 # Heuristic ceiling on how many children to stat when checking whether a

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1020,10 +1020,10 @@ def detect_gguf_model(path: str) -> Optional[str]:
     if p.suffix.lower() == ".gguf" and p.is_file():
         if _is_mmproj(p.name):
             return None
-        # Use abspath (not resolve) to preserve symlink names -- e.g.
+        # Use absolute (not resolve) to preserve symlink names -- e.g.
         # Ollama .studio_links/model.gguf -> blobs/sha256-... should
         # keep the readable symlink name, not the opaque blob hash.
-        return os.path.abspath(str(p))
+        return str(p.absolute())
 
     # Case 2: directory containing .gguf files (skip mmproj)
     if p.is_dir():

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -959,6 +959,20 @@ def detect_mmproj_file(path: str, search_root: Optional[str] = None) -> Optional
         scan_order.append(resolved)
 
     _add(start_dir)
+
+    # When ``path`` is a symlink (e.g. Ollama's ``.studio_links/...gguf``
+    # -> ``blobs/sha256-...``), the symlink's parent directory rarely
+    # contains the mmproj sibling; the real mmproj file lives next to
+    # the symlink target. Add the target's parent to the scan so vision
+    # GGUFs that are surfaced via symlinks are still recognised as
+    # vision models.
+    try:
+        if p.is_symlink() and p.is_file():
+            target_parent = p.resolve().parent
+            if target_parent.is_dir():
+                _add(target_parent)
+    except OSError:
+        pass
     if search_root is not None:
         try:
             root_resolved = Path(search_root).resolve()

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1006,7 +1006,10 @@ def detect_gguf_model(path: str) -> Optional[str]:
     if p.suffix.lower() == ".gguf" and p.is_file():
         if _is_mmproj(p.name):
             return None
-        return str(p.resolve())
+        # Use abspath (not resolve) to preserve symlink names -- e.g.
+        # Ollama .studio_links/model.gguf -> blobs/sha256-... should
+        # keep the readable symlink name, not the opaque blob hash.
+        return os.path.abspath(str(p))
 
     # Case 2: directory containing .gguf files (skip mmproj)
     if p.is_dir():

--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -27,6 +27,7 @@ import {
   listCachedModels,
   listGgufVariants,
   listLocalModels,
+  listRecommendedFolders,
   listScanFolders,
   removeScanFolder,
 } from "@/features/chat/api/chat-api";
@@ -49,7 +50,7 @@ import { checkVramFit, estimateLoadingVram } from "@/lib/vram";
 import { Add01Icon, Cancel01Icon, Folder02Icon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FolderBrowser } from "./folder-browser";
-import { Trash2Icon } from "lucide-react";
+import { ChevronDownIcon, ChevronRightIcon, DownloadIcon, StarIcon, Trash2Icon } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
@@ -73,10 +74,35 @@ function normalizeForSearch(s: string): string {
   return s.toLowerCase().replace(/[\s\-_\.]/g, "");
 }
 
-function ListLabel({ children }: { children: ReactNode }) {
+function ListLabel({
+  children,
+  icon,
+  collapsed,
+  onToggle,
+}: {
+  children: ReactNode;
+  icon?: ReactNode;
+  collapsed?: boolean;
+  onToggle?: () => void;
+}) {
   return (
-    <div className="px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-      {children}
+    <div className="flex items-center justify-between gap-1 px-2.5 py-1.5">
+      <span className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {icon}
+        {children}
+      </span>
+      {onToggle && (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label={collapsed ? "Expand section" : "Collapse section"}
+          className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:text-foreground"
+        >
+          {collapsed
+            ? <ChevronRightIcon className="size-3" />
+            : <ChevronDownIcon className="size-3" />}
+        </button>
+      )}
     </div>
   );
 }
@@ -489,6 +515,9 @@ export function HubModelPicker({
   // Delete confirmation dialog state
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [downloadedCollapsed, setDownloadedCollapsed] = useState(false);
+  const [customFoldersCollapsed, setCustomFoldersCollapsed] = useState(false);
+  const [recommendedCollapsed, setRecommendedCollapsed] = useState(false);
 
   // Cached (already downloaded) repos -- use module-level cache so
   // re-mounting the popover does not flash an empty "Downloaded" section.
@@ -514,6 +543,7 @@ export function HubModelPicker({
   const [showFolderInput, setShowFolderInput] = useState(false);
   const [folderLoading, setFolderLoading] = useState(false);
   const [showFolderBrowser, setShowFolderBrowser] = useState(false);
+  const [recommendedFolders, setRecommendedFolders] = useState<string[]>([]);
 
   const refreshLocalModelsList = useCallback(() => {
     listLocalModels()
@@ -616,6 +646,9 @@ export function HubModelPicker({
     // Always refresh LM Studio + custom folder models (not gated by alreadyCached)
     refreshLocalModelsList();
     refreshScanFolders();
+    listRecommendedFolders()
+      .then(setRecommendedFolders)
+      .catch(() => {});
 
     // Always refetch cached GGUF/model lists. The module-level caches give
     // an instant render with stale data (no spinner flash), but newly
@@ -893,8 +926,12 @@ export function HubModelPicker({
             (cachedGguf.length > 0 ||
               (!chatOnly && cachedModels.length > 0)) ? (
             <>
-              <ListLabel>Downloaded</ListLabel>
-              {cachedGguf.map((c) => (
+              <ListLabel
+                icon={<DownloadIcon className="size-3" />}
+                collapsed={downloadedCollapsed}
+                onToggle={() => setDownloadedCollapsed((v) => !v)}
+              >Downloaded</ListLabel>
+              {!downloadedCollapsed && cachedGguf.map((c) => (
                 <div key={c.repo_id}>
                   <ModelRow
                     label={c.repo_id}
@@ -922,7 +959,7 @@ export function HubModelPicker({
                   )}
                 </div>
               ))}
-              {!chatOnly &&
+              {!downloadedCollapsed && !chatOnly &&
                 cachedModels.map((c) => (
                   <div key={c.repo_id} className="flex items-center gap-0.5">
                     <div className="min-w-0 flex-1">
@@ -1001,20 +1038,12 @@ export function HubModelPicker({
 
           {!showHfSection ? (
             <>
-              <div className="flex items-center justify-between gap-1 px-2.5 py-1.5">
-                <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <div className="flex items-center gap-1 px-2.5 py-1.5">
+                <span className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  <HugeiconsIcon icon={Folder02Icon} className="size-3" />
                   Custom Folders
                 </span>
                 <div className="flex items-center gap-0.5">
-                  <button
-                    type="button"
-                    aria-label="Browse for a folder on the server"
-                    title="Browse folders on the server"
-                    onClick={() => setShowFolderBrowser(true)}
-                    className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:text-foreground"
-                  >
-                    <HugeiconsIcon icon={Search01Icon} className="size-3" />
-                  </button>
                   <button
                     type="button"
                     aria-label={showFolderInput ? "Cancel adding folder" : "Add scan folder by path"}
@@ -1029,11 +1058,33 @@ export function HubModelPicker({
                   >
                     <HugeiconsIcon icon={showFolderInput ? Cancel01Icon : Add01Icon} className="size-3" />
                   </button>
+                  <button
+                    type="button"
+                    aria-label="Browse for a folder on the server"
+                    title="Browse folders on the server"
+                    onClick={() => setShowFolderBrowser(true)}
+                    className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-foreground"
+                  >
+                    <HugeiconsIcon icon={Search01Icon} className="size-2.5" />
+                  </button>
+                </div>
+                <div className="ml-auto">
+                  <button
+                    type="button"
+                    aria-label={customFoldersCollapsed ? "Expand custom folders" : "Collapse custom folders"}
+                    title={customFoldersCollapsed ? "Expand" : "Collapse"}
+                    onClick={() => setCustomFoldersCollapsed((v) => !v)}
+                    className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:text-foreground"
+                  >
+                    {customFoldersCollapsed
+                      ? <ChevronRightIcon className="size-3" />
+                      : <ChevronDownIcon className="size-3" />}
+                  </button>
                 </div>
               </div>
 
               {/* Folder paths */}
-              {scanFolders.map((f) => (
+              {!customFoldersCollapsed && scanFolders.map((f) => (
                 <div
                   key={f.id}
                   className="group flex items-center gap-1.5 px-2.5 py-0.5"
@@ -1056,8 +1107,31 @@ export function HubModelPicker({
                 </div>
               ))}
 
+              {/* Recommended folders */}
+              {!customFoldersCollapsed && (() => {
+                const registered = new Set(scanFolders.map((f) => f.path));
+                const unregistered = recommendedFolders.filter((p) => !registered.has(p));
+                if (unregistered.length === 0) return null;
+                return (
+                  <div className="flex flex-wrap gap-1 px-2.5 pb-0.5">
+                    {unregistered.map((p) => (
+                      <button
+                        key={p}
+                        type="button"
+                        onClick={() => void handleAddFolder(p)}
+                        disabled={folderLoading}
+                        title={`Add ${p}`}
+                        className="rounded-full border border-dashed border-border/50 px-2 py-0.5 font-mono text-[10px] text-muted-foreground/70 transition-colors hover:border-foreground/30 hover:bg-accent hover:text-foreground disabled:opacity-40"
+                      >
+                        <span className="text-[11px] font-semibold">+</span> {p.length > 30 ? `...${p.slice(-27)}` : p}
+                      </button>
+                    ))}
+                  </div>
+                );
+              })()}
+
               {/* Add folder input */}
-              {showFolderInput && (
+              {!customFoldersCollapsed && showFolderInput && (
                 <div className="px-2.5 pb-1 pt-0.5">
                   <div className="flex items-center gap-1">
                     <HugeiconsIcon icon={Folder02Icon} className="size-3 shrink-0 text-muted-foreground/40" />
@@ -1114,11 +1188,15 @@ export function HubModelPicker({
 
 
               {/* Models from custom folders */}
-              {customFolderModels.map((m) => {
+              {!customFoldersCollapsed && customFolderModels.map((m) => {
+                const isGgufFile = m.path.toLowerCase().endsWith(".gguf");
                 const isGguf =
+                  isGgufFile ||
                   isGgufRepo(m.id) ||
-                  isGgufRepo(m.display_name) ||
-                  m.path.toLowerCase().endsWith(".gguf");
+                  isGgufRepo(m.display_name);
+                // Single .gguf files (e.g. Ollama blobs) load directly;
+                // GGUF repos/directories expand to pick a variant.
+                const isDirectGguf = isGgufFile;
                 return (
                   <div key={m.id}>
                     <ModelRow
@@ -1126,7 +1204,13 @@ export function HubModelPicker({
                       meta={isGguf ? "GGUF" : "Local"}
                       selected={value === m.id}
                       onClick={() => {
-                        if (isGguf) {
+                        if (isDirectGguf) {
+                          onSelect(m.id, {
+                            source: "local",
+                            isLora: false,
+                            isDownloaded: true,
+                          });
+                        } else if (isGguf) {
                           setExpandedGguf((prev) =>
                             prev === m.id ? null : m.id,
                           );
@@ -1158,8 +1242,12 @@ export function HubModelPicker({
 
           {!showHfSection && cachedReady ? (
             <>
-              <ListLabel>Recommended</ListLabel>
-              {visibleRecommendedIds.length === 0 ? (
+              <ListLabel
+                icon={<StarIcon className="size-3" />}
+                collapsed={recommendedCollapsed}
+                onToggle={() => setRecommendedCollapsed((v) => !v)}
+              >Recommended</ListLabel>
+              {recommendedCollapsed ? null : visibleRecommendedIds.length === 0 ? (
                 <div className="px-2.5 py-2 text-xs text-muted-foreground">
                   No default models.
                 </div>
@@ -1203,7 +1291,7 @@ export function HubModelPicker({
                   );
                 })
               )}
-              {hasMoreRecommended && (
+              {!recommendedCollapsed && hasMoreRecommended && (
                 <>
                   <div ref={recommendedSentinelRef} className="h-px" />
                   <div className="flex items-center justify-center py-2">
@@ -1216,7 +1304,7 @@ export function HubModelPicker({
 
           {showHfSection && filteredRecommendedIds.length > 0 ? (
             <>
-              <ListLabel>Recommended</ListLabel>
+              <ListLabel icon={<StarIcon className="size-3" />}>Recommended</ListLabel>
               {filteredRecommendedIds.map((id) => {
                 const vram = recommendedVramMap.get(id);
                 return (

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -262,6 +262,12 @@ export interface BrowseFoldersResponse {
   model_files_here?: number;
 }
 
+export async function listRecommendedFolders(): Promise<string[]> {
+  const response = await authFetch("/api/models/recommended-folders");
+  const data = await parseJsonOrThrow<{ folders: string[] }>(response);
+  return data.folders;
+}
+
 export async function browseFolders(
   path?: string,
   showHidden = false,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -437,9 +437,10 @@ export function useChatModelRuntime() {
             const { chatTemplateOverride, kvCacheDtype, customContextLength, ggufContextLength, speculativeType } = useChatRuntimeStore.getState();
             // GGUF: use custom context length, or 0 = model's native context
             // Non-GGUF: use the Max Seq Length slider value
+            const isDirectGgufFile = modelId.toLowerCase().endsWith(".gguf");
             const effectiveMaxSeqLength = customContextLength != null
               ? customContextLength
-              : ggufVariant != null ? (ggufContextLength ?? 0) : maxSeqLength;
+              : (ggufVariant != null || isDirectGgufFile) ? (ggufContextLength ?? 0) : maxSeqLength;
             const loadResponse = await loadModel({
               model_path: modelId,
               hf_token: hfToken,


### PR DESCRIPTION
## Summary

Adds first-class Ollama model support to the Studio model picker, a lightweight Recommended quick-add for LM Studio and Ollama folders, and a handful of Custom Folders UX fixes that came out of testing with both.

## What this does

### Ollama support

Previously, pointing the Custom Folders scanner at an Ollama models directory returned nothing, because Ollama uses a content-addressable layout:

```
<ollama_dir>/manifests/registry.ollama.ai/library/<model>/<tag>   (JSON manifest)
<ollama_dir>/blobs/sha256-...                                      (weight blobs)
```

There are no `.gguf`, `.safetensors`, or `config.json` files at the directory level, so none of the existing scanners (`_scan_models_dir`, `_scan_hf_cache`, `_scan_lmstudio_dir`) pick anything up.

This PR adds `_scan_ollama_dir` which:

1. Reads each manifest under `manifests/registry.ollama.ai/library/<model>/<tag>`
2. Resolves the weight layer (`mediaType == application/vnd.ollama.image.model`) to its blob
3. Creates a `.gguf` symlink under `<ollama_dir>/.studio_links/` pointing at the blob, so the rest of the GGUF pipeline (`detect_gguf_model`, `llama-server -m`) works unchanged
4. Reads the config blob for `model_type` and `file_type` metadata so the UI can show `gemma3:4b (4.3B Q4_K_M)` instead of just `gemma3:4b`

The generic scanners now filter anything under `.studio_links` so we never get duplicate rows or leaked internal paths in the UI.

### Recommended folders

New `GET /api/models/recommended-folders` endpoint returns LM Studio and Ollama model directories that currently exist on the machine:

- LM Studio: `lmstudio_model_dirs()` (settings.json override, `~/.lmstudio/models`, legacy `~/.cache/lm-studio/models`)
- Ollama: `OLLAMA_MODELS` env var, `~/.ollama/models`, `/usr/share/ollama/.ollama/models`, `/var/lib/ollama/.ollama/models`

The frontend shows any of these that are not already registered as `+ /path` chips directly under the Custom Folders header. Clicking a chip adds it as a scan folder in one click.

### Section header icons and collapsibles

`ListLabel` now accepts an optional leading icon and a collapse toggle. Applied to:

- Downloaded: download icon
- Custom Folders: folder icon
- Recommended: star icon

All three sections collapse to just the header. The Custom Folders header lays out the folder icon + title on the left, then `+` and search buttons grouped, with the collapse chevron pushed to the far right via `ml-auto` so it aligns with the Downloaded and Recommended chevrons.

### Direct GGUF file loading

Custom folder rows whose path ends in `.gguf` (e.g. Ollama symlinks) now load immediately via `onSelect` instead of opening the GGUF variant expander. The variant expander is designed for repos containing multiple quants; for a single file there is nothing to expand.

### Fix 4096 context length for direct GGUF files

Before: the chat runtime only passed `max_seq_length = 0` (native context) when a `ggufVariant` was present. Direct `.gguf` file loads fell through to the `maxSeqLength` slider default of 4096, so e.g. qwen2.5:0.5b loaded at 4096 instead of its native 32768.

After: direct `.gguf` file paths are also treated as "use native context", same as the variant path.

### Misc polish

- `detect_gguf_model` uses `os.path.abspath` instead of `Path.resolve`, so symlink names are preserved. Ollama models now display as `qwen2.5-0.5b-Q4_K_M` instead of `sha256-abc...`.
- llama-server failures where the path contains `.studio_links` or `.cache/ollama/` surface a friendlier message: "Some Ollama models do not work with llama.cpp. Try a different model, or use this model directly through Ollama instead." Some Ollama GGUFs use metadata keys that Studio's bundled llama.cpp doesn't understand (e.g. gemma3 is missing `gemma3.attention.layer_norm_rms_epsilon`), and the generic error wasn't useful.

## Test plan

- [x] `pip install unsloth && unsloth studio` (or `./install.sh --local`) on Colab
- [x] Install Ollama and `ollama pull qwen2.5:0.5b llama3.2:3b gemma3:4b`
- [x] Install LM Studio CLI (`lms`) and `lms get qwen/qwen3.5-4b google/gemma-3-4b`
- [x] `GET /api/models/recommended-folders` returns `/root/.lmstudio/models` and `/content/.cache/ollama`
- [x] Add both via the Recommended chips in Custom Folders
- [x] Ollama models appear as `ollama/<name>:<tag>` with size + quant suffix
- [x] Clicking `qwen2.5:0.5b` loads at 32768 context and responds correctly via llama-server
- [x] Clicking `gemma3:4b` fails with the friendly Ollama error message (expected, format incompatibility)
- [x] LM Studio models still load via the normal GGUF variant path
- [x] All three section headers collapse independently, chevrons align horizontally
- [x] `.studio_links` does not appear anywhere in the UI (hidden in folder browser by dot-prefix, and filtered out of custom folder model rows)