### PR TITLE
Studio: soften tool-use nudge for small models + synthesise directive

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2453,6 +2453,7 @@ class LlamaCppBackend:
         auto_heal_tool_calls: bool = True,
         tool_call_timeout: int = 300,
         session_id: Optional[str] = None,
+        synthesise_after_tool_result: bool = False,
     ) -> Generator[dict, None, None]:
         """
         Agentic loop: let the model call tools, execute them, and continue.
@@ -3173,9 +3174,11 @@ class LlamaCppBackend:
 
                 # First successful tool result of the loop: tell the model
                 # to synthesise an answer rather than continue searching.
+                # Only enabled for small models (via synthesise_after_tool_result)
+                # since large models handle multi-step tool use well.
                 # Skip if every tool call in this batch errored -- let the
                 # model retry or try a different approach instead.
-                if _any_tool_succeeded:
+                if synthesise_after_tool_result and _any_tool_succeeded:
                     _apply_synthesise_nudge()
 
                 # Clear tool status badge before next generation iteration

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3041,6 +3041,7 @@ class LlamaCppBackend:
                     assistant_msg["tool_calls"] = tool_calls
                 conversation.append(assistant_msg)
 
+                _any_tool_succeeded = False
                 for tc in tool_calls or []:
                     func = tc.get("function", {})
                     tool_name = func.get("name", "")
@@ -3146,6 +3147,8 @@ class LlamaCppBackend:
                         _error_prefixes
                     )
                     _tool_call_history.append((_tc_key, _is_error))
+                    if not _is_error:
+                        _any_tool_succeeded = True
                     # Strip image sentinel before feeding result to the LLM
                     # (the full result with sentinel is still yielded via
                     # tool_end so the frontend can extract image paths).
@@ -3168,9 +3171,12 @@ class LlamaCppBackend:
                         tool_msg["tool_call_id"] = tool_call_id
                     conversation.append(tool_msg)
 
-                # First tool result of the loop: tell the model to
-                # synthesise an answer rather than continue searching.
-                _apply_synthesise_nudge()
+                # First successful tool result of the loop: tell the model
+                # to synthesise an answer rather than continue searching.
+                # Skip if every tool call in this batch errored -- let the
+                # model retry or try a different approach instead.
+                if _any_tool_succeeded:
+                    _apply_synthesise_nudge()
 
                 # Clear tool status badge before next generation iteration
                 yield {"type": "status", "text": ""}

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2473,6 +2473,39 @@ class LlamaCppBackend:
         _accumulated_predicted_ms = 0.0
         _accumulated_predicted_n = 0
 
+        # Flipped once a tool result has been appended to the conversation
+        # and the system message updated with a synthesise-now directive.
+        # Small models otherwise keep honouring the initial "prefer tools"
+        # nudge and loop on search forever, even when the result they need
+        # is already in context.
+        _synthesise_nudge_applied = False
+        # Phrased as a concrete action rather than an opt-out clause --
+        # the "do not call more tools" wording actively harmed small-model
+        # synthesis rate in our benchmarks.
+        _SYNTHESISE_NUDGE = (
+            " Tool results have been gathered. Now write the final answer to the"
+            " user's original question using what you have. Tool calls are no"
+            " longer needed for this turn."
+        )
+
+        def _apply_synthesise_nudge() -> None:
+            nonlocal _synthesise_nudge_applied
+            if _synthesise_nudge_applied:
+                return
+            for _msg in conversation:
+                if _msg.get("role") == "system":
+                    _content = _msg.get("content") or ""
+                    if _SYNTHESISE_NUDGE.strip() not in _content:
+                        _msg["content"] = _content.rstrip() + _SYNTHESISE_NUDGE
+                    _synthesise_nudge_applied = True
+                    return
+            # No system message yet: insert one
+            conversation.insert(
+                0,
+                {"role": "system", "content": _SYNTHESISE_NUDGE.lstrip()},
+            )
+            _synthesise_nudge_applied = True
+
         def _strip_tool_markup(text: str, *, final: bool = False) -> str:
             if not auto_heal_tool_calls:
                 return text
@@ -3134,6 +3167,10 @@ class LlamaCppBackend:
                     if tool_call_id:
                         tool_msg["tool_call_id"] = tool_call_id
                     conversation.append(tool_msg)
+
+                # First tool result of the loop: tell the model to
+                # synthesise an answer rather than continue searching.
+                _apply_synthesise_nudge()
 
                 # Clear tool status badge before next generation iteration
                 yield {"type": "status", "text": ""}

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -155,6 +155,24 @@ _TOOL_SYNTHESISE_NUDGE = (
     " longer needed for this turn."
 )
 
+
+def _has_tool_result_in_current_turn(messages: list[dict]) -> bool:
+    """Check if the current turn (after the last user message) has tool results.
+
+    Scans backwards from the end -- if we find a tool result before hitting
+    a user message, the current turn has tool results. If we hit a user
+    message first (or the list is empty), the tool results are from prior
+    turns and should not trigger the synthesis nudge.
+    """
+    for msg in reversed(messages):
+        role = msg.get("role")
+        if role == "tool":
+            return True
+        if role == "user":
+            return False
+    return False
+
+
 # Regex for stripping leaked tool-call XML from assistant messages/stream
 _TOOL_XML_RE = _re.compile(
     r"<tool_call>.*?</tool_call>|<function=\w+>.*?</function>",
@@ -1273,12 +1291,12 @@ async def openai_chat_completions(
                 _nudge += (
                     _TOOL_ACTION_NUDGE_SMALL if _is_small_model else _TOOL_ACTION_NUDGE
                 )
-                # If the current conversation already has a tool result
-                # message, append the synthesise-now directive. Covers
-                # forked chats and long-running sessions where the prior
-                # "prefer tools" line keeps biasing the model into search
-                # loops instead of answering from what it already has.
-                if any(m.get("role") == "tool" for m in chat_messages):
+                # If the current turn (after the last user message) has
+                # tool results, append the synthesise directive. Only
+                # scoped to the current turn so that historical tool
+                # results from earlier questions do not suppress
+                # legitimate new tool calls.
+                if _has_tool_result_in_current_turn(chat_messages):
                     _nudge += _TOOL_SYNTHESISE_NUDGE
                 # Append nudge to system prompt (preserve user's prompt)
                 if system_prompt:
@@ -2508,7 +2526,7 @@ async def anthropic_messages(
             _nudge += (
                 _TOOL_ACTION_NUDGE_SMALL if _is_small_model else _TOOL_ACTION_NUDGE
             )
-            if any(m.get("role") == "tool" for m in openai_messages):
+            if _has_tool_result_in_current_turn(openai_messages):
                 _nudge += _TOOL_SYNTHESISE_NUDGE
             # Inject into system prompt
             if openai_messages and openai_messages[0].get("role") == "system":

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -127,6 +127,34 @@ _TOOL_ACTION_NUDGE = (
     " Do NOT output code blocks -- use the python tool instead."
 )
 
+# Softer variant for small models (<9B). The aggressive ALWAYS-CALL-TOOLS
+# phrasing above causes small models to pick web_search on every factual
+# question even when the answer sits in their training data, and to keep
+# calling search after each result instead of synthesising. See
+# tests/test_tool_loop_with_nudge.py for the measured behaviour.
+_TOOL_ACTION_NUDGE_SMALL = (
+    " Call tools only when you need current information or a specific"
+    " calculation. For questions within your knowledge, answer directly."
+    " Issue one tool call at a time rather than queuing several at once."
+)
+
+# Appended whenever the current conversation already contains a tool
+# result, to counteract the "prefer tools" nudge and push the model
+# toward synthesising a final answer from what it has. Matters most for
+# small models where the initial "prefer tools" directive is still
+# dominating on the second and subsequent turns.
+#
+# Phrasing matters a lot here -- "do not call more tools" as an opt-out
+# clause is actually worse than no nudge (measured 33% vs 57% synthesis
+# rate on Qwen3.5-4B UD-Q4_K_XL). Reframing as a concrete action ("write
+# the final answer to the user's original question using what you have")
+# is what moves the needle: the same bench run jumps to 90% synthesis.
+_TOOL_SYNTHESISE_NUDGE = (
+    " Tool results have been gathered. Now write the final answer to the"
+    " user's original question using what you have. Tool calls are no"
+    " longer needed for this turn."
+)
+
 # Regex for stripping leaked tool-call XML from assistant messages/stream
 _TOOL_XML_RE = _re.compile(
     r"<tool_call>.*?</tool_call>|<function=\w+>.*?</function>",
@@ -1242,7 +1270,16 @@ async def openai_chat_completions(
                 _nudge = ""
 
             if _nudge:
-                _nudge += _TOOL_ACTION_NUDGE
+                _nudge += (
+                    _TOOL_ACTION_NUDGE_SMALL if _is_small_model else _TOOL_ACTION_NUDGE
+                )
+                # If the current conversation already has a tool result
+                # message, append the synthesise-now directive. Covers
+                # forked chats and long-running sessions where the prior
+                # "prefer tools" line keeps biasing the model into search
+                # loops instead of answering from what it already has.
+                if any(m.get("role") == "tool" for m in chat_messages):
+                    _nudge += _TOOL_SYNTHESISE_NUDGE
                 # Append nudge to system prompt (preserve user's prompt)
                 if system_prompt:
                     system_prompt = system_prompt.rstrip() + "\n\n" + _nudge
@@ -2468,7 +2505,11 @@ async def anthropic_messages(
             _nudge = ""
 
         if _nudge:
-            _nudge += _TOOL_ACTION_NUDGE
+            _nudge += (
+                _TOOL_ACTION_NUDGE_SMALL if _is_small_model else _TOOL_ACTION_NUDGE
+            )
+            if any(m.get("role") == "tool" for m in openai_messages):
+                _nudge += _TOOL_SYNTHESISE_NUDGE
             # Inject into system prompt
             if openai_messages and openai_messages[0].get("role") == "system":
                 openai_messages[0]["content"] = (

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -156,18 +156,34 @@ _TOOL_SYNTHESISE_NUDGE = (
 )
 
 
-def _has_tool_result_in_current_turn(messages: list[dict]) -> bool:
-    """Check if the current turn (after the last user message) has tool results.
+_TOOL_ERROR_PREFIXES = (
+    "Error",
+    "Search failed",
+    "Execution error",
+    "Blocked:",
+    "Exit code",
+    "Failed to fetch",
+    "Failed to resolve",
+    "No query provided",
+)
 
-    Scans backwards from the end -- if we find a tool result before hitting
-    a user message, the current turn has tool results. If we hit a user
-    message first (or the list is empty), the tool results are from prior
-    turns and should not trigger the synthesis nudge.
+
+def _has_successful_tool_result_in_current_turn(messages: list[dict]) -> bool:
+    """Check if the current turn has at least one successful tool result.
+
+    Scans backwards from the end of the message list. Only returns True
+    when a non-error tool result appears after the last user message.
+    Error-only tool results (timeouts, failed fetches, etc.) return False
+    so the model can retry rather than being forced to synthesise.
     """
     for msg in reversed(messages):
         role = msg.get("role")
         if role == "tool":
-            return True
+            content = (msg.get("content") or "").lstrip()
+            if not content.startswith(_TOOL_ERROR_PREFIXES):
+                return True
+            # Error tool result -- keep scanning for a successful one
+            continue
         if role == "user":
             return False
     return False
@@ -1291,12 +1307,12 @@ async def openai_chat_completions(
                 _nudge += (
                     _TOOL_ACTION_NUDGE_SMALL if _is_small_model else _TOOL_ACTION_NUDGE
                 )
-                # If the current turn (after the last user message) has
-                # tool results, append the synthesise directive. Only
-                # scoped to the current turn so that historical tool
-                # results from earlier questions do not suppress
-                # legitimate new tool calls.
-                if _has_tool_result_in_current_turn(chat_messages):
+                # Small models loop on tool calls instead of answering.
+                # If the current turn already has a successful tool
+                # result, nudge the model to synthesise a final answer.
+                # Large models handle multi-step tool use well, so this
+                # is gated to small models only.
+                if _is_small_model and _has_successful_tool_result_in_current_turn(chat_messages):
                     _nudge += _TOOL_SYNTHESISE_NUDGE
                 # Append nudge to system prompt (preserve user's prompt)
                 if system_prompt:
@@ -1339,6 +1355,7 @@ async def openai_chat_completions(
                     if payload.tool_call_timeout is not None
                     else 300,
                     session_id = payload.session_id,
+                    synthesise_after_tool_result = _is_small_model,
                 )
 
             _tool_sentinel = object()
@@ -2526,7 +2543,11 @@ async def anthropic_messages(
             _nudge += (
                 _TOOL_ACTION_NUDGE_SMALL if _is_small_model else _TOOL_ACTION_NUDGE
             )
-            if _has_tool_result_in_current_turn(openai_messages):
+            # Only nudge small models to synthesise -- see comment in
+            # /chat/completions for rationale.  (The OpenAI-compat schema
+            # does not yet accept role="tool", so this branch is currently
+            # unreachable; kept for when the schema is extended.)
+            if _is_small_model and _has_successful_tool_result_in_current_turn(openai_messages):
                 _nudge += _TOOL_SYNTHESISE_NUDGE
             # Inject into system prompt
             if openai_messages and openai_messages[0].get("role") == "system":
@@ -2558,6 +2579,7 @@ async def anthropic_messages(
                 auto_heal_tool_calls = True,
                 tool_call_timeout = 300,
                 session_id = payload.session_id,
+                synthesise_after_tool_result = _is_small_model,
             )
 
         if payload.stream:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1312,7 +1312,9 @@ async def openai_chat_completions(
                 # result, nudge the model to synthesise a final answer.
                 # Large models handle multi-step tool use well, so this
                 # is gated to small models only.
-                if _is_small_model and _has_successful_tool_result_in_current_turn(chat_messages):
+                if _is_small_model and _has_successful_tool_result_in_current_turn(
+                    chat_messages
+                ):
                     _nudge += _TOOL_SYNTHESISE_NUDGE
                 # Append nudge to system prompt (preserve user's prompt)
                 if system_prompt:
@@ -2547,7 +2549,9 @@ async def anthropic_messages(
             # /chat/completions for rationale.  (The OpenAI-compat schema
             # does not yet accept role="tool", so this branch is currently
             # unreachable; kept for when the schema is extended.)
-            if _is_small_model and _has_successful_tool_result_in_current_turn(openai_messages):
+            if _is_small_model and _has_successful_tool_result_in_current_turn(
+                openai_messages
+            ):
                 _nudge += _TOOL_SYNTHESISE_NUDGE
             # Inject into system prompt
             if openai_messages and openai_messages[0].get("role") == "system":


### PR DESCRIPTION
## Summary

Two small changes to Studio's tool-use system prompt, based on measured behaviour. Addresses a failure mode where smaller GGUF models (like Qwen3.5-4B) take Studio's current "For any factual question, call web_search" nudge literally and loop on searches instead of answering from the information they already have.

## Problem

The current `_TOOL_ACTION_NUDGE` in `studio/backend/routes/inference.py` is always appended to the system prompt whenever tools are available:

```
IMPORTANT: Always call tools directly -- never write code yourself.
Never describe what you plan to do -- just call the tool immediately.
For any code request, call the python tool. For any factual question, call web_search.
Do NOT output code blocks -- use the python tool instead.
```

On small models (<9B) this causes two measurable failure modes.

**First turn**: the model calls `web_search` on questions it could answer directly from training data, often queuing several parallel searches in one assistant message. Measured on Qwen3.5-4B with the query `"How do you fine-tune an audio model with Unsloth?"` (n=30 each):

| model | tool_call rate |
| --- | --- |
| `unsloth/Qwen3.5-4B-GGUF` UD-Q4_K_XL | 28/30 (93%) |
| `lmstudio-community/Qwen3.5-4B-GGUF` Q4_K_M | 30/30 (100%) |

With no system prompt at all, the same model answers the question directly 100% of the time.

**Subsequent turns**: once a tool result is in context, the "prefer tools" framing keeps dominating. The model searches again rather than synthesising. Measured with one `web_search` result already present (same query, same models):

| model | tool_call rate on second turn |
| --- | --- |
| UD-Q4_K_XL | 23/30 (77%) |

This is the loop users see where the UI fills with raw search results but no model response ever arrives.

## Fix

### 1. Softer nudge for small models

`_TOOL_ACTION_NUDGE_SMALL` replaces the aggressive version for models under 9B. Larger models keep the original wording because they were not the ones over-triggering.

```python
_TOOL_ACTION_NUDGE_SMALL = (
    " Call tools only when you need current information or a specific"
    " calculation. For questions within your knowledge, answer directly."
    " Issue one tool call at a time rather than queuing several at once."
)
```

### 2. Synthesise directive once a tool result is present

`_TOOL_SYNTHESISE_NUDGE` is appended whenever the conversation already has a tool result, both at the HTTP request entry (for forked/replayed chats) and inside the internal tool-call loop in `llama_cpp.py` after the first tool result lands.

Phrasing is load-bearing. Framing this as an opt-out clause ("do not call more tools unless the existing results are clearly insufficient") was actually worse than no nudge at all on UD-Q4_K_XL (33% synthesis rate vs 57% for the bare softer first-turn nudge). Framing it as a concrete action works:

```python
_TOOL_SYNTHESISE_NUDGE = (
    " Tool results have been gathered. Now write the final answer to the"
    " user's original question using what you have. Tool calls are no"
    " longer needed for this turn."
)
```

A/B test across four phrasings on the UD-Q4_K_XL second-turn scenario (n=30):

| variant | answer rate |
| --- | --- |
| no synthesis nudge | 17/30 (57%) |
| "Synthesise a final answer... Do not call more tools unless..." | 10/30 (33%) |
| "You have enough information... Do NOT call any more tools" | 15/30 (50%) |
| "Your next response MUST be a final answer... You MUST NOT emit another tool call" | 12/30 (40%) |
| "Tool results have been gathered. Now write the final answer..." | **27/30 (90%)** |

## Results

End-to-end, same query, n=30 per cell:

**`unsloth/Qwen3.5-4B-GGUF` UD-Q4_K_XL**

|  | OLD | NEW |
| --- | --- | --- |
| first turn tool_call | 28/30 (93%) | 2/30 (7%) |
| first turn answer | 2/30 | 28/30 |
| second turn tool_call | 23/30 (77%) | 6/30 (20%) |
| second turn answer | 7/30 | 24/30 |

**Qwen3.5-4B Q4_K_M (LM Studio)**

|  | OLD | NEW |
| --- | --- | --- |
| first turn tool_call | 30/30 (100%) | 0/30 (0%) |
| first turn answer | 0/30 | 30/30 |
| second turn tool_call | 2/30 | 0/30 |
| second turn answer | 28/30 | 30/30 |

No regression on the second turn for LM Studio (already at ceiling) and the UD-Q4_K_XL loop effectively goes away. First-turn over-eagerness is essentially eliminated on both quants.

## Test plan

- [x] `python tests/test_ab_nudge.py 30` on both Qwen3.5-4B quants, numbers above
- [x] `python tests/test_stronger_synth.py 30` to pick the synthesis phrasing
- [x] No changes for models >= 9B (they still get `_TOOL_ACTION_NUDGE`)
- [x] Synthesise directive goes in at the HTTP entry (`/v1/chat/completions` and `/chat/completions` OpenAI-compat route) and inside the `generate_chat_completion_with_tools` loop after the first tool result
- [x] Whether the nudge has been applied is tracked in a flag so we don't append it repeatedly as more tool results arrive