### PR TITLE
Add Gemma-4 to FORCE_FLOAT32 to fix fp16 NaN in RL

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -105,6 +105,8 @@ FORCE_FLOAT32 = [
     "gemma3,",  # Add comma bc gemma3 will match gemma3n
     "gemma3text",  # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
     "gemma3n",
+    "gemma4,",  # Gemma-4 fp16 produces NaN in RL training (same issue as Gemma-3)
+    "gemma4text",  # Gemma4TextModel (standalone text-only Gemma4)
     "gpt_oss",
     "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
 ]


### PR DESCRIPTION
## Summary

- Adds `gemma4,` and `gemma4text` to the `FORCE_FLOAT32` list in `unsloth/models/loader.py`
- Gemma-4 loaded in float16 produces NaN during GRPO/RL training, same behavior as Gemma-3/3n
- This makes Unsloth auto-switch to bfloat16 + float32 mixed precision when float16 is requested for Gemma-4

## Background

The Gemma-4 E2B Reinforcement Learning Sudoku notebook gets NaN loss around step 4-5 when `dtype=torch.float16`. bfloat16 works fine. Investigation showed the NaN originates from the torch.compile backward path under fp16 autocast -- forward hooks that fragment the compile graph prevent the NaN entirely.

The same pattern exists for Gemma-3 and Gemma-3n which are already in the `FORCE_FLOAT32` list. This PR adds Gemma-4 to match.

## Test plan

- [x] fp16 Gemma-4 E2B GRPO 10 steps with fix -- NaN-free, prints "Using float16 precision for gemma4 won't work! Using float32."
- [x] bf16 Gemma-4 E2B GRPO 10 steps -- unaffected, runs normally
- [x] Non-Gemma models -- unaffected (not in the list)