### PR TITLE
fix: [Studio] avoid Windows in-use unsloth.exe lock during update

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -906,11 +906,34 @@ shell.Run cmd, 0, False
         }
     }
 
+    # ── Stage standalone launcher outside the venv ──
+    # Copying the distlib-generated unsloth.exe to $LOCALAPPDATA\Unsloth Studio\bin
+    # (and prepending that dir to User PATH) means future `unsloth studio update`
+    # invocations run from the standalone copy, so pip/uv can freely rewrite
+    # the venv's in-use Scripts\unsloth.exe during dependency upgrades.
+    $VenvScriptsExe = Join-Path $VenvDir "Scripts\unsloth.exe"
+    $StandaloneBinDir = Join-Path $env:LOCALAPPDATA "Unsloth Studio\bin"
+    $StandaloneExe = Join-Path $StandaloneBinDir "unsloth.exe"
+    if (Test-Path $VenvScriptsExe) {
+        if (-not (Test-Path $StandaloneBinDir)) {
+            New-Item -ItemType Directory -Force $StandaloneBinDir | Out-Null
+        }
+        try { Copy-Item -LiteralPath $VenvScriptsExe -Destination $StandaloneExe -Force } catch {}
+        $_userPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+        if (-not $_userPath -or $_userPath -notlike "*$StandaloneBinDir*") {
+            $_newPath = if ($_userPath) { "$StandaloneBinDir;$_userPath" } else { $StandaloneBinDir }
+            [System.Environment]::SetEnvironmentVariable("Path", $_newPath, "User")
+            Refresh-SessionPath
+        }
+    }
+
     # ── Run studio setup ──
     # setup.ps1 will handle installing Git, CMake, Visual Studio Build Tools,
     # CUDA Toolkit, Node.js, and other dependencies automatically via winget.
     step "setup" "running unsloth studio setup..."
-    $UnslothExe = Join-Path $VenvDir "Scripts\unsloth.exe"
+    # Prefer the standalone launcher (so the running .exe is not inside the venv)
+    # and fall back to the venv copy if the staging step above did not succeed.
+    $UnslothExe = if (Test-Path $StandaloneExe) { $StandaloneExe } else { $VenvScriptsExe }
     if (-not (Test-Path $UnslothExe)) {
         Write-Host "[ERROR] unsloth CLI was not installed correctly." -ForegroundColor Red
         Write-Host "        Expected: $UnslothExe" -ForegroundColor Yellow

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1418,6 +1418,22 @@ $ErrorActionPreference = "Continue"
 $ActivateScript = Join-Path $VenvDir "Scripts\Activate.ps1"
 . $ActivateScript
 
+# ── Standalone launcher locations (Windows in-use .exe lock workaround) ──
+# Windows forbids DeleteFile on a mapped (running) .exe but permits
+# MoveFileEx.  Keeping the CLI launcher outside the venv means pip/uv
+# never fights a lock when it reinstalls the unsloth wheel during update.
+$StandaloneBinDir = Join-Path $env:LOCALAPPDATA "Unsloth Studio\bin"
+$StandaloneExe    = Join-Path $StandaloneBinDir "unsloth.exe"
+$VenvExe          = Join-Path $VenvDir "Scripts\unsloth.exe"
+
+# Sweep stale parked launchers left by prior migrations (safe: not in use)
+foreach ($_dir in @((Join-Path $VenvDir "Scripts"), $StandaloneBinDir)) {
+    if (Test-Path $_dir) {
+        Get-ChildItem $_dir -Filter "unsloth.exe.old-*" -ErrorAction SilentlyContinue |
+            ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
+    }
+}
+
 # Try to use uv (much faster than pip), fall back to pip if unavailable
 $UseUv = $false
 if (Get-Command uv -ErrorAction SilentlyContinue) {
@@ -1489,6 +1505,15 @@ if ($env:SKIP_STUDIO_BASE -ne "1" -and $env:STUDIO_LOCAL_INSTALL -ne "1") {
 # }
 
 if (-not $SkipPythonDeps) {
+
+# Migration: if there is no standalone launcher yet AND install.ps1 is not
+# the caller (SKIP_STUDIO_BASE != 1 => uv will reinstall the unsloth wheel),
+# park the (possibly-running) venv launcher so uv's reinstall succeeds.
+# Fresh-install flow leaves $VenvExe alone: install.ps1 creates the
+# standalone copy before invoking setup, so this branch is a no-op there.
+if (-not (Test-Path $StandaloneExe) -and (Test-Path $VenvExe) -and $env:SKIP_STUDIO_BASE -ne "1") {
+    try { Move-Item -LiteralPath $VenvExe -Destination "$VenvExe.old-$PID" -Force } catch {}
+}
 
 if ($script:UnslothVerbose) {
     Fast-Install --upgrade pip
@@ -1585,6 +1610,39 @@ if ($stackExit -ne 0) {
     step "python" "dependencies up to date"
     # Restore ErrorActionPreference (was lowered for pip/python section)
     $ErrorActionPreference = $prevEAP
+}
+
+# ── Sync standalone launcher and prepend its dir to user PATH ──
+# Runs unconditionally (both fast-path and reinstall branches) so that users
+# on an old layout migrate on the first update where no standalone exists.
+# Copy path uses park-and-replace (MoveFileEx) so even a currently-running
+# $StandaloneExe can be swapped when distlib's launcher bytes actually change.
+if (Test-Path $VenvExe) {
+    if (-not (Test-Path $StandaloneBinDir)) {
+        New-Item -ItemType Directory -Force $StandaloneBinDir | Out-Null
+    }
+    $needsCopy = -not (Test-Path $StandaloneExe)
+    if (-not $needsCopy) {
+        try {
+            $needsCopy = (Get-FileHash $VenvExe).Hash -ne (Get-FileHash $StandaloneExe).Hash
+        } catch {
+            $needsCopy = $true
+        }
+    }
+    if ($needsCopy) {
+        if (Test-Path $StandaloneExe) {
+            try { Move-Item -LiteralPath $StandaloneExe -Destination "$StandaloneExe.old-$PID" -Force } catch {}
+        }
+        try { Copy-Item -LiteralPath $VenvExe -Destination $StandaloneExe -Force } catch {}
+    }
+}
+
+if (Test-Path $StandaloneExe) {
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not $userPath -or $userPath -notlike "*$StandaloneBinDir*") {
+        $newPath = if ($userPath) { "$StandaloneBinDir;$userPath" } else { $StandaloneBinDir }
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    }
 }
 
 # ── Pre-install transformers 5.x into .venv_t5_530/ and .venv_t5_550/ ──


### PR DESCRIPTION
## Summary

- On Windows, `uv pip install --upgrade-package unsloth` during `unsloth studio update` tries to `DeleteFile` `%USERPROFILE%\.unsloth\studio\unsloth_studio\Scripts\unsloth.exe`, which is the parent launcher of the running `update` command. Windows forbids `DeleteFile` on a mapped running .exe (`ERROR_SHARING_VIOLATION`, `os error 32`), producing the user-reported `"failed to remove file ...: The process cannot access the file because it is being used by another process"`. The launcher itself is version-agnostic (`distlib` stub that spawns the venv's `python.exe`), so the removal serves no semantic purpose — it's just pip/uv's standard uninstall/reinstall protocol.
- Move the launcher out of the venv: `install.ps1` stages a standalone copy at `%LOCALAPPDATA%\Unsloth Studio\bin\unsloth.exe` (same app dir as `launch-studio.ps1`, `unsloth.ico`) and prepends that dir to User PATH before invoking `unsloth studio setup`. Shortcuts and the interactive launch call now target the standalone exe when present.
- Existing installs migrate on first `unsloth studio update`: `studio\setup.ps1` parks the venv launcher via `MoveFileEx` (permitted on a running .exe) when no standalone exists yet, lets uv rewrite the freed path cleanly, and then copies the fresh launcher out to the standalone location. A SHA256 compare keeps the post-update copy a no-op in steady state, so there are no orphan `unsloth.exe.old-<pid>` accumulations across updates. A sweep at the top of `setup.ps1` cleans any stragglers from prior runs.
- Linux/macOS paths are untouched — POSIX inode semantics have always made the same `unlink()` succeed silently there.

## Test plan

- [ ] Fresh Windows install via `irm https://unsloth.ai/install.ps1 | iex`: confirm `%LOCALAPPDATA%\Unsloth Studio\bin\unsloth.exe` is created, user PATH is prepended with that directory, Desktop + Start Menu shortcuts target the standalone exe, and `unsloth studio` runs.
- [ ] Existing install (pre-fix) running `unsloth studio update` with a version bump pending: verify the `"failed to remove file ... os error 32"` no longer appears, the venv launcher at `%USERPROFILE%\.unsloth\studio\unsloth_studio\Scripts\unsloth.exe` is replaced cleanly, and `%LOCALAPPDATA%\Unsloth Studio\bin\unsloth.exe` + PATH entry are created.
- [ ] Post-migration `unsloth studio update` (no version bump): confirm the SHA256 compare skips the copy, no `unsloth.exe.old-*` orphans are left in either `%USERPROFILE%\.unsloth\studio\unsloth_studio\Scripts\` or `%LOCALAPPDATA%\Unsloth Studio\bin\`, and PATH is unchanged.
- [ ] Post-migration `unsloth studio update` (with a version bump): confirm uv reinstalls the venv wheel without hitting the lock, and Block B detects no hash change (same distlib stub) and remains a no-op.
- [ ] `unsloth studio update --local` on Windows (`STUDIO_LOCAL_INSTALL=1` bypasses the fast-path): confirm rename-and-rewrite still functions on migrating hosts.
- [ ] Stale-venv rebuild path (Torch CUDA tag mismatch triggers `Remove-Item $VenvDir`): confirm the instruction-to-rerun-`install.ps1` message still surfaces and no standalone sync runs against a non-existent venv exe.
- [ ] `.\install.ps1 --no-torch`: confirm standalone staging still runs since `$VenvScriptsExe` exists before the no-torch dep install.
- [ ] Linux (`./install.sh`) and macOS Intel (`./install.sh --no-torch`): confirm no behavior change — the edited blocks are PowerShell-only.
