### PR TITLE
Add FORCE_LOGIT_UPCAST flag for Gemma-4 fp16 RL training

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -109,6 +109,16 @@ FORCE_FLOAT32 = [
     "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
 ]
 
+global FORCE_LOGIT_UPCAST
+# Forces float32 for the hidden_states @ lm_head matmul in RL training.
+# Prevents fp16 overflow / NaN in the GRPO logit projection for models
+# with large hidden state magnitudes.  Read by unsloth_zoo via
+# UNSLOTH_FORCE_LOGIT_UPCAST env var.
+FORCE_LOGIT_UPCAST = [
+    "gemma4,",  # Gemma-4 fp16 can NaN in RL training
+    "gemma4text",
+]
+
 global DISABLE_COMPILE_MODEL_NAMES
 # Must be alphabetically sorted for each entry
 
@@ -1372,6 +1382,17 @@ class FastModel(FastBaseModel):
             ) and ((dtype == torch.float16) or not SUPPORTS_BFLOAT16):
                 os.environ["UNSLOTH_FORCE_FLOAT32"] = "1"
                 dtype = torch.bfloat16  # Change to bfloat16 loading
+                break
+        # Set logit matmul upcast flag for RL training (Gemma-4 etc)
+        os.environ["UNSLOTH_FORCE_LOGIT_UPCAST"] = "0"
+        global FORCE_LOGIT_UPCAST
+        for disable_name in FORCE_LOGIT_UPCAST:
+            if (
+                disable_name.lower()
+                == model_type_arch.lower().replace("-", "").replace("_", "")
+                or disable_name.lower() in model_types_all
+            ) and (dtype == torch.float16):
+                os.environ["UNSLOTH_FORCE_LOGIT_UPCAST"] = "1"
                 break
         # Apply gradient checkpointing with smart heuristics
         use_gradient_checkpointing = apply_unsloth_gradient_checkpointing(


### PR DESCRIPTION
## Summary

- Adds a new `FORCE_LOGIT_UPCAST` list in `loader.py` (parallel to `FORCE_FLOAT32`)
- Sets `UNSLOTH_FORCE_LOGIT_UPCAST=1` env var during model loading when model type matches and dtype is float16
- Currently enabled for `gemma4` and `gemma4text`
- Read by unsloth-zoo's GRPO path to upcast the `hidden_states @ lm_head` matmul to float32

## How it works

During `from_pretrained`, after the existing `FORCE_FLOAT32` check, a second pass checks `FORCE_LOGIT_UPCAST`. If the model type matches (same matching logic as `FORCE_FLOAT32` -- exact match after stripping dashes/underscores, or substring in `model_types_all`) and the model is loaded in float16, the env var is set.

In the zoo (`unsloth_zoo/rl_replacements.py`), `grpo_accumulated_loss` reads `UNSLOTH_FORCE_LOGIT_UPCAST` and passes `logit_matmul_upcast=True` through to `chunked_hidden_states_selective_log_softmax`, which then does `hidden_states.float() @ lm_head.float().t()` instead of `hidden_states.to(lm_head.dtype) @ lm_head.t()`.

## Why not FORCE_FLOAT32?

`FORCE_FLOAT32` is too broad -- it switches the entire training to float32 mixed precision, affecting SFT/DPO users who can train Gemma-4 in fp16 without issues. This flag only affects the single matmul in the RL logit projection path.

## Companion PR

unslothai/unsloth-zoo#598 adds `logit_matmul_upcast: bool` parameter to the GRPO logit computation and reads this env var.

## Test plan

- [x] fp16 Gemma-4 E2B GRPO 10 steps with both PRs -- NaN-free
- [x] bf16 Gemma-4 E2B GRPO 10 steps -- unaffected (env var stays "0")
- [x] Non-Gemma-4 models -- unaffected (not in the list)