### PR TITLE
Remove legacy venv Scripts entry from User PATH on upgrade

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1042,6 +1042,38 @@ shell.Run cmd, 0, False
     # We do NOT add the venv Scripts dir to PATH (it also holds python.exe
     # and pip.exe, which would hijack the user's system interpreter).
     # Hardlink preferred; falls back to copy if cross-volume or non-NTFS.
+    #
+    # Remove the legacy venv Scripts PATH entry that older installers wrote.
+    $LegacyScriptsDir = Join-Path $VenvDir "Scripts"
+    try {
+        $legacyKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
+        try {
+            $rawPath = $legacyKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            if ($rawPath) {
+                [string[]]$pathEntries = $rawPath -split ';'
+                $normalLegacy = $LegacyScriptsDir.Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
+                $expNormalLegacy = [Environment]::ExpandEnvironmentVariables($LegacyScriptsDir).Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
+                $filtered = @($pathEntries | Where-Object {
+                    $stripped = $_.Trim().Trim('"')
+                    $rawNorm = $stripped.TrimEnd('\').ToLowerInvariant()
+                    $expNorm = [Environment]::ExpandEnvironmentVariables($stripped).TrimEnd('\').ToLowerInvariant()
+                    ($rawNorm -ne $normalLegacy -and $rawNorm -ne $expNormalLegacy) -and
+                    ($expNorm -ne $normalLegacy -and $expNorm -ne $expNormalLegacy)
+                })
+                $cleanedPath = $filtered -join ';'
+                if ($cleanedPath -ne $rawPath) {
+                    $legacyKey.SetValue('Path', $cleanedPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+                    try {
+                        $d = "UnslothPathRefresh_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+                        [Environment]::SetEnvironmentVariable($d, '1', 'User')
+                        [Environment]::SetEnvironmentVariable($d, [NullString]::Value, 'User')
+                    } catch { }
+                }
+            }
+        } finally {
+            $legacyKey.Close()
+        }
+    } catch { }
     $ShimDir = Join-Path $StudioHome "bin"
     New-Item -ItemType Directory -Force -Path $ShimDir | Out-Null
     $ShimExe = Join-Path $ShimDir "unsloth.exe"


### PR DESCRIPTION
## Summary

- On upgrade from a pre-#4961 install, the old `$VenvDir\Scripts` entry persists in User PATH because #4961 only added the new shim dir without removing the legacy entry
- Result: `where.exe python` still resolves to the unsloth venv interpreter first, hijacking the user's system python and pip in every new shell
- Confirmed on a real Windows machine (RTX 5060 Ti, Python 3.13, CUDA 13.2)

## Fix

Before creating the shim, read the current User PATH from the registry, filter out any entry matching `$VenvDir\Scripts` (using the same symmetric raw+expanded dedup comparison as `Add-ToUserPath`), and write back if changed. No-op on fresh installs where the legacy entry was never written.

## Test plan

- [ ] Fresh install on a clean Windows machine: no legacy entry exists, cleanup is a no-op, shim created normally
- [ ] Upgrade from a pre-#4961 install: legacy `...\unsloth_studio\Scripts` entry removed, `where.exe python` resolves to system Python, `where.exe unsloth` resolves to shim dir
- [ ] Re-run after upgrade: cleanup finds nothing to remove (idempotent), shim refresh works