### PR TITLE
fix: multi-GPU inference crash for bnb 4-bit/8-bit models

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2478,6 +2478,15 @@ class FastLlamaModel:
                     and not _head.weight.is_floating_point()
                 ):
                     _head.to(dtype)
+            # Attach dispatch hooks for bnb multi-device loads.
+            from unsloth.models.vision import _attach_bnb_multidevice_hooks
+            _attach_bnb_multidevice_hooks(
+                model,
+                load_in_4bit      = load_in_4bit,
+                load_in_8bit      = kwargs.get("load_in_8bit", False),
+                offload_embedding = False,
+                fast_inference    = fast_inference,
+            )
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(
                 model_name,
@@ -2496,7 +2505,7 @@ class FastLlamaModel:
             _attach_bnb_multidevice_hooks(
                 model,
                 load_in_4bit = load_in_4bit,
-                load_in_8bit = False,
+                load_in_8bit = kwargs.get("load_in_8bit", False),
                 offload_embedding = False,
                 fast_inference = False,
             )

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2480,12 +2480,13 @@ class FastLlamaModel:
                     _head.to(dtype)
             # Attach dispatch hooks for bnb multi-device loads.
             from unsloth.models.vision import _attach_bnb_multidevice_hooks
+
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit      = load_in_4bit,
-                load_in_8bit      = kwargs.get("load_in_8bit", False),
+                load_in_4bit = load_in_4bit,
+                load_in_8bit = kwargs.get("load_in_8bit", False),
                 offload_embedding = False,
-                fast_inference    = fast_inference,
+                fast_inference = fast_inference,
             )
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2492,12 +2492,13 @@ class FastLlamaModel:
             )
             # Attach dispatch hooks for bnb multi-device loads.
             from unsloth.models.vision import _attach_bnb_multidevice_hooks
+
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit      = load_in_4bit,
-                load_in_8bit      = False,
+                load_in_4bit = load_in_4bit,
+                load_in_8bit = False,
                 offload_embedding = False,
-                fast_inference    = False,
+                fast_inference = False,
             )
             model.fast_generate = make_fast_generate_wrapper(model.generate)
             model.fast_generate_batches = None

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2490,6 +2490,15 @@ class FastLlamaModel:
                 attn_implementation = preferred_attn_impl,
                 **kwargs,
             )
+            # Attach dispatch hooks for bnb multi-device loads.
+            from unsloth.models.vision import _attach_bnb_multidevice_hooks
+            _attach_bnb_multidevice_hooks(
+                model,
+                load_in_4bit      = load_in_4bit,
+                load_in_8bit      = False,
+                offload_embedding = False,
+                fast_inference    = False,
+            )
             model.fast_generate = make_fast_generate_wrapper(model.generate)
             model.fast_generate_batches = None
         else:

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -98,6 +98,7 @@ __all__ = [
     "FastBaseModel",
 ]
 
+
 def _infer_device_map_from_loaded_model(model):
     """Build a compact device_map by inspecting actual parameter placements."""
     device_map = {}
@@ -921,10 +922,10 @@ class FastBaseModel:
             # Attach dispatch hooks for bnb multi-device loads.
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit      = load_in_4bit,
-                load_in_8bit      = load_in_8bit,
+                load_in_4bit = load_in_4bit,
+                load_in_8bit = load_in_8bit,
                 offload_embedding = offload_embedding,
-                fast_inference    = fast_inference,
+                fast_inference = fast_inference,
             )
             if hasattr(model, "generate"):
                 model.fast_generate = make_fast_generate_wrapper(model.generate)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -75,6 +75,7 @@ import functools
 import os
 import gc
 import math
+import warnings
 from typing import Optional, Tuple, List, Union
 import re, inspect, sys
 import contextlib
@@ -96,6 +97,127 @@ from ..device_type import (
 __all__ = [
     "FastBaseModel",
 ]
+
+def _infer_device_map_from_loaded_model(model):
+    """Build a compact device_map by inspecting actual parameter placements."""
+    device_map = {}
+
+    def _assign(module, prefix):
+        params = list(module.named_parameters(remove_duplicate = False))
+        if not params:
+            bufs = list(module.named_buffers())
+            if bufs:
+                device_map[prefix] = bufs[0][1].device
+            return
+        devices = {p.device for _, p in params}
+        if len(devices) == 1:
+            device_map[prefix] = next(iter(devices))
+        else:
+            for child_name, child in module.named_children():
+                child_prefix = f"{prefix}.{child_name}" if prefix else child_name
+                _assign(child, child_prefix)
+            for pname, param in module.named_parameters(remove_duplicate = False):
+                if "." not in pname:
+                    full = f"{prefix}.{pname}" if prefix else pname
+                    if not any(
+                        full == k or full.startswith(k + ".") for k in device_map
+                    ):
+                        device_map[full] = param.device
+
+    _assign(model, "")
+    if "" in device_map and len(device_map) > 1:
+        device_map.pop("")
+    return device_map
+
+
+def _attach_bnb_multidevice_hooks(
+    model, load_in_4bit, load_in_8bit, offload_embedding, fast_inference
+):
+    """
+    Attach accelerate AlignDevicesHook on a bnb model loaded across multiple
+    devices (or a non-default device).  No-op for single-GPU cuda:0, non-bnb,
+    vLLM, or already-dispatched models.
+    """
+    if fast_inference:
+        return
+    if not (load_in_4bit or load_in_8bit):
+        return
+    if offload_embedding:
+        return
+    if getattr(model, "hf_device_map", None) is not None:
+        return  # already dispatched
+
+    try:
+        cuda_devs = {
+            p.device
+            for p in model.parameters()
+            if hasattr(p, "device") and p.device.type == "cuda"
+        }
+    except Exception as exc:
+        warnings.warn(
+            "Unsloth: Failed to determine CUDA devices from model parameters, "
+            f"so multi-GPU hooks cannot be attached. ({type(exc).__name__}: {exc})",
+            RuntimeWarning,
+            stacklevel = 2,
+        )
+        return
+
+    if not cuda_devs:
+        return
+
+    default_cuda = torch.device("cuda", 0)
+    if cuda_devs == {default_cuda}:
+        return
+
+    try:
+        from accelerate import dispatch_model
+    except ImportError:
+        return  # accelerate not available
+
+    try:
+        inferred_map = _infer_device_map_from_loaded_model(model)
+        if not inferred_map:
+            return
+
+        # bnb constructors reject _is_hf_initialized; strip before dispatch.
+        _extra_keys = ("_is_hf_initialized",)
+        _stripped = []
+        for _, param in model.named_parameters():
+            for key in _extra_keys:
+                if key in param.__dict__:
+                    _stripped.append((param, key, param.__dict__.pop(key)))
+
+        try:
+            # CUDA -> int index, non-CUDA -> type string ("cpu", "meta").
+            device_map_int = {
+                k: (v.index if v.type == "cuda" else v.type)
+                if isinstance(v, torch.device)
+                else v
+                for k, v in inferred_map.items()
+            }
+
+            # force_hooks=True: install hooks even for single-device maps.
+            dispatch_model(model, device_map = device_map_int, force_hooks = True)
+            desc = f"{len(inferred_map)} block(s) across {len(cuda_devs)} device(s)"
+        finally:
+            # Restore stripped keys.
+            for param, key, val in _stripped:
+                param.__dict__[key] = val
+
+        print(
+            f"Unsloth: Attached accelerate AlignDevicesHook ({desc}) "
+            f"for bnb multi-GPU inference."
+        )
+    except Exception as exc:
+        warnings.warn(
+            f"Unsloth: Could not attach multi-device dispatch hooks automatically "
+            f"({type(exc).__name__}: {exc}). "
+            "Cross-device inference may fail. Consider using a single GPU or "
+            "calling accelerate.dispatch_model() manually.",
+            RuntimeWarning,
+            stacklevel = 2,
+        )
+
 
 global NUM_LOGITS_TO_KEEP
 NUM_LOGITS_TO_KEEP = dict()
@@ -795,6 +917,14 @@ class FastBaseModel:
                 trust_remote_code = trust_remote_code,
                 # attn_implementation   = attn_implementation,
                 **kwargs,
+            )
+            # Attach dispatch hooks for bnb multi-device loads.
+            _attach_bnb_multidevice_hooks(
+                model,
+                load_in_4bit      = load_in_4bit,
+                load_in_8bit      = load_in_8bit,
+                offload_embedding = offload_embedding,
+                fast_inference    = fast_inference,
             )
             if hasattr(model, "generate"):
                 model.fast_generate = make_fast_generate_wrapper(model.generate)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -141,7 +141,14 @@ def _attach_bnb_multidevice_hooks(
     """
     if fast_inference:
         return
-    if not (load_in_4bit or load_in_8bit):
+    is_bnb = (
+        load_in_4bit
+        or load_in_8bit
+        or getattr(model, "is_loaded_in_4bit", False)
+        or getattr(model, "is_loaded_in_8bit", False)
+        or getattr(model, "quantization_method", None) == "bitsandbytes"
+    )
+    if not is_bnb:
         return
     if offload_embedding:
         return
@@ -149,25 +156,22 @@ def _attach_bnb_multidevice_hooks(
         return  # already dispatched
 
     try:
-        cuda_devs = {
-            p.device
-            for p in model.parameters()
-            if hasattr(p, "device") and p.device.type == "cuda"
-        }
+        all_devs = {p.device for p in model.parameters()}
     except Exception as exc:
         warnings.warn(
-            "Unsloth: Failed to determine CUDA devices from model parameters, "
+            "Unsloth: Failed to determine device placement from model parameters, "
             f"so multi-GPU hooks cannot be attached. ({type(exc).__name__}: {exc})",
             RuntimeWarning,
             stacklevel = 2,
         )
         return
 
+    cuda_devs = {d for d in all_devs if d.type == "cuda"}
     if not cuda_devs:
         return
 
     default_cuda = torch.device("cuda", 0)
-    if cuda_devs == {default_cuda}:
+    if all_devs == {default_cuda}:
         return
 
     try:
@@ -198,14 +202,26 @@ def _attach_bnb_multidevice_hooks(
             }
 
             # force_hooks=True: install hooks even for single-device maps.
-            dispatch_model(model, device_map = device_map_int, force_hooks = True)
+            main_device = device_map_int.get("")
+            if main_device in (None, "cpu", "disk"):
+                main_device = next(
+                    (d for d in device_map_int.values() if d not in ("cpu", "disk")),
+                    None,
+                )
+            dispatch_model(
+                model,
+                device_map = device_map_int,
+                main_device = main_device,
+                skip_keys = getattr(model, "_skip_keys_device_placement", None),
+                force_hooks = True,
+            )
             desc = f"{len(inferred_map)} block(s) across {len(cuda_devs)} device(s)"
         finally:
             # Restore stripped keys.
             for param, key, val in _stripped:
                 param.__dict__[key] = val
 
-        print(
+        logger.info(
             f"Unsloth: Attached accelerate AlignDevicesHook ({desc}) "
             f"for bnb multi-GPU inference."
         )


### PR DESCRIPTION
## Summary

- Fixes `RuntimeError: Expected all tensors to be on the same device` when running inference on bnb 4-bit/8-bit models that span multiple GPUs (e.g. Gemma-4-31B on 2x T4 16GB).
- The bitsandbytes loading path in transformers places weights on target CUDA devices but never calls `dispatch_model`, so no `AlignDevicesHook` is installed.
- After `from_pretrained` returns, we now infer a device map from post-load parameter placement and call `dispatch_model(force_hooks=True)` to install the missing hooks.

## Root cause

When `load_in_4bit=True` with `device_map="sequential"` and `max_memory` constraints that split the model across GPUs, the HF/bnb code path:
1. Places weights correctly on target CUDA devices
2. Never calls `accelerate.dispatch_model`
3. Leaves 0 modules with `_hf_hook` attached

The first `forward` call then crashes on cross-device tensor operations.

## Fix

Two helper functions added to `unsloth/models/vision.py`:

- `_infer_device_map_from_loaded_model(model)` -- walks the module tree to build a device map from actual parameter placements
- `_attach_bnb_multidevice_hooks(model, ...)` -- calls `dispatch_model(force_hooks=True)` to install hooks; complete no-op for single-GPU cuda:0

Call sites in both `FastBaseModel.from_pretrained` (vision.py) and `FastLlamaModel.from_pretrained` (llama.py).

Key details:
- `force_hooks=True` ensures hooks are installed even for single-device non-default GPU maps (e.g. all weights on cuda:1)
- Non-CUDA devices converted to type strings (`"cpu"`, `"meta"`) for accelerate compatibility
- `_is_hf_initialized` stripped from param `__dict__` before dispatch to avoid bnb TypeError, restored after

## Test plan

Tested on 2x B200 with OPT-125M and Llama-3.2-1B-Instruct:
- Single non-default GPU (all on cuda:1): forward + generate pass
- Multi-device split: forward pass
- `io_same_device`: output correctly routed back to input device
- Single GPU cuda:0: complete no-op (0 hooks)
- 79 unit tests (51 mock, 25 GPU, 3 isolated venv)