### PR TITLE
Add FORCE_BFLOAT16 for Gemma-4 fp16 NaN fix

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -105,6 +105,8 @@ FORCE_FLOAT32 = [
     "gemma3,",  # Add comma bc gemma3 will match gemma3n
     "gemma3text",  # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
     "gemma3n",
+    "gemma4,",  # Add comma bc gemma4 will match gemma4_text
+    "gemma4text",  # Gemma4TextModel (standalone text-only Gemma4)
     "gpt_oss",
     "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
 ]

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1384,10 +1384,14 @@ class FastModel(FastBaseModel):
         global FORCE_BFLOAT16
         for disable_name in FORCE_BFLOAT16:
             if (
-                disable_name.lower()
-                == model_type_arch.lower().replace("-", "").replace("_", "")
-                or disable_name.lower() in model_types_all
-            ) and dtype == torch.float16 and SUPPORTS_BFLOAT16:
+                (
+                    disable_name.lower()
+                    == model_type_arch.lower().replace("-", "").replace("_", "")
+                    or disable_name.lower() in model_types_all
+                )
+                and dtype == torch.float16
+                and SUPPORTS_BFLOAT16
+            ):
                 logger.warning_once(
                     f"Unsloth: {model_type_arch} does not support float16 training. "
                     f"Switching to bfloat16."

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -105,10 +105,15 @@ FORCE_FLOAT32 = [
     "gemma3,",  # Add comma bc gemma3 will match gemma3n
     "gemma3text",  # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
     "gemma3n",
-    "gemma4,",  # Add comma bc gemma4 will match gemma4_text
-    "gemma4text",  # Gemma4TextModel (standalone text-only Gemma4)
     "gpt_oss",
     "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
+]
+
+# Models that must use bfloat16 instead of float16.
+# torch.compile backward graphs overflow fp16 intermediates for these models.
+FORCE_BFLOAT16 = [
+    "gemma4,",  # Add comma bc gemma4 will match gemma4_text
+    "gemma4text",  # Gemma4TextModel (standalone text-only Gemma4)
 ]
 
 global DISABLE_COMPILE_MODEL_NAMES
@@ -1374,6 +1379,20 @@ class FastModel(FastBaseModel):
             ) and ((dtype == torch.float16) or not SUPPORTS_BFLOAT16):
                 os.environ["UNSLOTH_FORCE_FLOAT32"] = "1"
                 dtype = torch.bfloat16  # Change to bfloat16 loading
+                break
+        # Switch fp16 to bf16 for models whose torch.compile backward overflows fp16
+        global FORCE_BFLOAT16
+        for disable_name in FORCE_BFLOAT16:
+            if (
+                disable_name.lower()
+                == model_type_arch.lower().replace("-", "").replace("_", "")
+                or disable_name.lower() in model_types_all
+            ) and dtype == torch.float16 and SUPPORTS_BFLOAT16:
+                logger.warning_once(
+                    f"Unsloth: {model_type_arch} does not support float16 training. "
+                    f"Switching to bfloat16."
+                )
+                dtype = torch.bfloat16
                 break
         # Apply gradient checkpointing with smart heuristics
         use_gradient_checkpointing = apply_unsloth_gradient_checkpointing(


### PR DESCRIPTION
## Summary
- Adds a new `FORCE_BFLOAT16` list in `loader.py` with `gemma4,` and `gemma4text` entries
- When users request `dtype=torch.float16` for Gemma-4 on a bf16-capable device, silently switches to `torch.bfloat16`
- Prints a warning: "Unsloth: gemma4 does not support float16 training. Switching to bfloat16."
- Separate from `FORCE_FLOAT32` which has a different mechanism (load bf16, cast to fp16, disable autocast)

## Problem
Gemma-4 E2B GRPO training produces NaN at step 6 when `dtype=torch.float16`. Root cause: `torch.compile` fuses the backward graph and fp16 intermediate values overflow. This is NOT fixable by:
- Disabling individual compiled functions (attention, MLP, RMSNorm)
- Disabling gradient checkpointing
- Using float32 autocast (autocast doesn't upcast fp16 ops)
- Using `FORCE_FLOAT32` (loads bf16 but casts weights back to fp16, so compute is still fp16)

The only reliable fix is to keep the model in bfloat16, which has sufficient range (3.4e38 vs fp16's 65504).

## Why not FORCE_FLOAT32?
`FORCE_FLOAT32` loads in bf16 then casts all weights to fp16 via `patch_model_and_tokenizer`, with autocast disabled. The forward/backward pass still runs entirely in fp16, so NaN persists. A direct bf16 switch avoids this entirely.

## Test plan
- [x] Verify fp16 Gemma-4 E2B GRPO runs 12 steps NaN-free (switches to bf16)
- [ ] Verify bf16 Gemma-4 E2B GRPO is unaffected (no change in behavior)
- [ ] Verify other FORCE_FLOAT32 models (Gemma-3, gpt_oss, qwen3_5) are unaffected