### PR TITLE
Fix/full finetuning v100 dtype

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -804,7 +804,8 @@ shell.Run cmd, 0, False
     if (-not (Test-Path $VenvPython)) {
         step "venv" "creating Python $($DetectedPython.Version) virtual environment"
         substep "$VenvDir"
-        $venvExit = Invoke-InstallCommand { uv venv $VenvDir --python "$($DetectedPython.Path)" }
+        # Quoted to handle Windows usernames containing spaces (issue #4904)
+        $venvExit = Invoke-InstallCommand { uv venv "$VenvDir" --python "$($DetectedPython.Path)" }
         if ($venvExit -ne 0) {
             Write-Host "[ERROR] Failed to create virtual environment (exit code $venvExit)" -ForegroundColor Red
             return
@@ -912,15 +913,15 @@ shell.Run cmd, 0, False
         if ($SkipTorch) {
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
-            $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.4.5" unsloth-zoo }
+            $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.4.5" unsloth-zoo }
             if ($baseInstallExit -eq 0) {
                 $NoTorchReq = Find-NoTorchRuntimeFile
                 if ($NoTorchReq) {
-                    $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps -r $NoTorchReq }
+                    $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" --no-deps -r "$NoTorchReq" }
                 }
             }
         } else {
-            $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.4.5" unsloth-zoo }
+            $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.4.5" unsloth-zoo }
         }
         if ($baseInstallExit -ne 0) {
             Write-Host "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
@@ -928,7 +929,7 @@ shell.Run cmd, 0, False
         }
         if ($StudioLocalInstall) {
             substep "overlaying local repo (editable)..."
-            $overlayExit = Invoke-InstallCommand { uv pip install --python $VenvPython -e $RepoRoot --no-deps }
+            $overlayExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" -e "$RepoRoot" --no-deps }
             if ($overlayExit -ne 0) {
                 Write-Host "[ERROR] Failed to overlay local repo (exit code $overlayExit)" -ForegroundColor Red
                 return
@@ -939,7 +940,7 @@ shell.Run cmd, 0, False
             substep "skipping PyTorch (--no-torch flag set)." "Yellow"
         } else {
             substep "installing PyTorch ($TorchIndexUrl)..."
-            $torchInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython "torch>=2.4,<2.11.0" torchvision torchaudio --index-url $TorchIndexUrl }
+            $torchInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" "torch>=2.4,<2.11.0" torchvision torchaudio --index-url "$TorchIndexUrl" }
             if ($torchInstallExit -ne 0) {
                 Write-Host "[ERROR] Failed to install PyTorch (exit code $torchInstallExit)" -ForegroundColor Red
                 return
@@ -950,17 +951,17 @@ shell.Run cmd, 0, False
         if ($SkipTorch) {
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
-            $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.4.5" unsloth-zoo }
+            $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.4.5" unsloth-zoo }
             if ($baseInstallExit -eq 0) {
                 $NoTorchReq = Find-NoTorchRuntimeFile
                 if ($NoTorchReq) {
-                    $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps -r $NoTorchReq }
+                    $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" --no-deps -r "$NoTorchReq" }
                 }
             }
         } elseif ($StudioLocalInstall) {
-            $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.4.5" unsloth-zoo }
+            $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" --upgrade-package unsloth "unsloth>=2026.4.5" unsloth-zoo }
         } else {
-            $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --upgrade-package unsloth "$PackageName" }
+            $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" --upgrade-package unsloth "$PackageName" }
         }
         if ($baseInstallExit -ne 0) {
             Write-Host "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
@@ -969,7 +970,7 @@ shell.Run cmd, 0, False
 
         if ($StudioLocalInstall) {
             substep "overlaying local repo (editable)..."
-            $overlayExit = Invoke-InstallCommand { uv pip install --python $VenvPython -e $RepoRoot --no-deps }
+            $overlayExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" -e "$RepoRoot" --no-deps }
             if ($overlayExit -ne 0) {
                 Write-Host "[ERROR] Failed to overlay local repo (exit code $overlayExit)" -ForegroundColor Red
                 return
@@ -979,19 +980,19 @@ shell.Run cmd, 0, False
         # Fallback: GPU detection failed to produce a URL -- let uv resolve torch
         substep "installing unsloth (this may take a few minutes)..."
         if ($StudioLocalInstall) {
-            $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython unsloth-zoo "unsloth>=2026.4.5" --torch-backend=auto }
+            $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" unsloth-zoo "unsloth>=2026.4.5" --torch-backend=auto }
             if ($baseInstallExit -ne 0) {
                 Write-Host "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
                 return
             }
             substep "overlaying local repo (editable)..."
-            $overlayExit = Invoke-InstallCommand { uv pip install --python $VenvPython -e $RepoRoot --no-deps }
+            $overlayExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" -e "$RepoRoot" --no-deps }
             if ($overlayExit -ne 0) {
                 Write-Host "[ERROR] Failed to overlay local repo (exit code $overlayExit)" -ForegroundColor Red
                 return
             }
         } else {
-            $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython "$PackageName" --torch-backend=auto }
+            $baseInstallExit = Invoke-InstallCommand { uv pip install --python "$VenvPython" "$PackageName" --torch-backend=auto }
             if ($baseInstallExit -ne 0) {
                 Write-Host "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
                 return

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -381,8 +381,74 @@ def _resolve_trainer_params(trainer_class, init_fn):
             continue
     return set(params.keys())
 
+def _fix_full_finetuning_precision_on_non_bf16_gpu(trainer_kwargs):
+    """
+    Fix for issue #4082.
+
+    When full_finetuning=True on a non-BF16 GPU (V100, T4, P100):
+      - FastLanguageModel loads the model in float32 (not float16)
+      - The standard Unsloth pattern sets fp16=not is_bfloat16_supported() → True
+      - The compiled trainer check fires:
+            not force_float32 and (not float16 and use_fp16) → TypeError
+        because float32 is also "not float16"
+      - The UNSLOTH_FORCE_FLOAT32 escape hatch is useless here because the
+        compiled trainer guards it with "if not full_finetuning"
+
+    Fix: when model is float32 + full finetuning active + non-BF16 hardware,
+    set fp16=False so the check does not fire and training runs in float32.
+    """
+    import os
+    import torch
+    import warnings
+
+    # Only relevant for the full finetuning path
+    if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") != "1":
+        return
+
+    model = trainer_kwargs.get("model")
+    args  = trainer_kwargs.get("args")
+    if model is None or args is None:
+        return
+
+    # Check the actual loaded dtype
+    try:
+        actual_dtype = model.get_input_embeddings().weight.dtype
+    except Exception:
+        return
+
+    # Only act when model is genuinely float32
+    if actual_dtype != torch.float32:
+        return
+
+    # Only act on hardware that doesn't support BF16
+    from unsloth.models._utils import is_bfloat16_supported
+    if is_bfloat16_supported():
+        return
+
+    # Only act if mixed precision was requested
+    wants_fp16 = bool(getattr(args, "fp16", False))
+    wants_bf16 = bool(getattr(args, "bf16", False))
+    if not wants_fp16 and not wants_bf16:
+        return
+
+    # Override: train in pure float32
+    args.fp16 = False
+    args.bf16 = False
+
+    warnings.warn(
+        "Unsloth: GPU (CUDA compute capability "
+        f"{torch.cuda.get_device_capability()}) does not support BFloat16. "
+        "For full finetuning the model was loaded in float32. "
+        "Mixed precision (fp16) has been disabled automatically. "
+        "Training will proceed in pure float32. "
+        "To suppress this warning set fp16=False and bf16=False explicitly. "
+        "(fix for issue #4082)",
+        UserWarning,
+        stacklevel=4,
+    )
 
 def _backwards_compatible_trainer(trainer_class, config_class):
+    
     original_init = trainer_class.__init__
 
     @wraps(original_init)
@@ -449,6 +515,7 @@ def _backwards_compatible_trainer(trainer_class, config_class):
             # Reconstruct kwargs for Trainer
             kwargs = trainer_kwargs
             kwargs["args"] = config
+        _fix_full_finetuning_precision_on_non_bf16_gpu(kwargs)
         original_init(self, *args, **kwargs)
 
     return new_init

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -381,6 +381,7 @@ def _resolve_trainer_params(trainer_class, init_fn):
             continue
     return set(params.keys())
 
+
 def _fix_full_finetuning_precision_on_non_bf16_gpu(trainer_kwargs):
     """
     Fix for issue #4082.
@@ -406,7 +407,7 @@ def _fix_full_finetuning_precision_on_non_bf16_gpu(trainer_kwargs):
         return
 
     model = trainer_kwargs.get("model")
-    args  = trainer_kwargs.get("args")
+    args = trainer_kwargs.get("args")
     if model is None or args is None:
         return
 
@@ -422,6 +423,7 @@ def _fix_full_finetuning_precision_on_non_bf16_gpu(trainer_kwargs):
 
     # Only act on hardware that doesn't support BF16
     from unsloth.models._utils import is_bfloat16_supported
+
     if is_bfloat16_supported():
         return
 
@@ -444,11 +446,11 @@ def _fix_full_finetuning_precision_on_non_bf16_gpu(trainer_kwargs):
         "To suppress this warning set fp16=False and bf16=False explicitly. "
         "(fix for issue #4082)",
         UserWarning,
-        stacklevel=4,
+        stacklevel = 4,
     )
 
+
 def _backwards_compatible_trainer(trainer_class, config_class):
-    
     original_init = trainer_class.__init__
 
     @wraps(original_init)


### PR DESCRIPTION
## Problem

On V100/T4/P100 GPUs (non-BF16 hardware), using `full_finetuning=True`
with the standard Unsloth pattern:

    fp16 = not is_bfloat16_supported()  # → True on V100/T4
    bf16 = is_bfloat16_supported()       # → False on V100/T4

raises a TypeError inside the compiled trainer:

    TypeError: Unsloth: Model is in bfloat16 precision but you want
    to use float16 precision. Set fp16 to False and bf16 to True

The model is actually loaded in **float32** (not bfloat16) — the error
message itself is wrong. The compiled trainer's check:

    if not force_float32 and (not float16 and use_fp16): raise TypeError

fires because float32 is also "not float16". The UNSLOTH_FORCE_FLOAT32
escape hatch cannot help here because it is guarded by
`if not full_finetuning` in the compiled trainer.

## Fix

Added `_fix_full_finetuning_precision_on_non_bf16_gpu()` in
`trainer.py`. Before `original_init` is called in
`_backwards_compatible_trainer`, the function detects:

- `UNSLOTH_ENABLE_FULL_FINETUNING == 1` (full finetuning active)
- model weights are in float32
- hardware does not support BFloat16
- fp16 or bf16 mixed precision was requested

When all four conditions are true, it sets `fp16=False` and `bf16=False`
so training runs in pure float32, and emits a clear UserWarning
explaining what happened instead of the cryptic TypeError.

## Tests

5 mock tests covering:
- Core fix fires correctly on non-BF16 GPU
- Ampere/H100 hardware untouched
- LoRA path untouched
- fp16 already False — no warning emitted
- model=None — no crash

All 5 passed on Kaggle T4.

## Affected Hardware

Tesla V100 (CUDA cap 7.0), T4 (7.5), P100 (6.0) — any GPU where
`is_bfloat16_supported()` returns False.

## Note for Reviewer

The root logic bug is in the compiled trainer template in unsloth-zoo:
`not float16 and use_fp16` should be `dtype == torch.bfloat16 and use_fp16`.
This PR fixes the symptom in `trainer.py`. The unsloth-zoo template
can be patched separately for a complete fix.

Closes #4082