### PR TITLE
Route Gemma-4 float16 through UNSLOTH_FORCE_FLOAT32

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -105,6 +105,7 @@ FORCE_FLOAT32 = [
     "gemma3,",  # Add comma bc gemma3 will match gemma3n
     "gemma3text",  # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
     "gemma3n",
+    "gemma4",  # Gemma-4 E2B/E4B GRPO NaNs under float16 (MLP gate*up overflow)
     "gpt_oss",
     "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
 ]


### PR DESCRIPTION
## Summary

Adds `"gemma4"` to `FORCE_FLOAT32` in `unsloth/models/loader.py`. When a user calls `FastVisionModel.from_pretrained(..., dtype=torch.float16)` on `unsloth/gemma-4-E2B-it` or `unsloth/gemma-4-E4B-it`, this flips `UNSLOTH_FORCE_FLOAT32=1` and swaps the load dtype to bfloat16, matching how Gemma-3 and Gemma-3n are handled today.

## Problem

Gemma-4 GRPO training with `dtype=torch.float16` crashes at step 2 with `CUDA error: device-side assert triggered`. Hooks show the first overflow is in `language_model.layers.0.mlp.down_proj`: gate_proj and up_proj outputs saturate at `fp16_max`, the product overflows on downcast, and down_proj's fp16 accumulator produces +inf. Generation with an inf residual stream produces NaN logits that trip the categorical sampler. bf16 training is unaffected.

Reproduction (see the paired unsloth-zoo PR for the full harness):

```
python scripts/gemma4_grpo_sudoku_repro.py --model unsloth/gemma-4-E2B-it --dtype float16 --max-steps 8 --grad-accum 4 --num-generations 2
```

## Fix

One-line change: append `"gemma4"` to the `FORCE_FLOAT32` list so the dispatch in `loader.py` lines 1360-1375 engages the Gemma-4 fp32 upcast patches. The actual numerical work lives in the paired PR on `unsloth-zoo` (unslothai/unsloth-zoo#600) which adds four text-decoder patches gated on `UNSLOTH_FORCE_FLOAT32=1`:

- `patch_Gemma4RMSNorm`
- `patch_Gemma4TextScaledWordEmbedding`
- `patch_Gemma4TextMLP`
- `patch_Gemma4TextAttention`

bf16 users are unaffected because the dispatch only fires when `dtype == torch.float16`.

## Verification

Runs on a B200 with `max_steps=8`, `grad_accum=4`, `num_generations=2`, `batch_size=1`, seed 3407:

| Model | dtype | Gradient Checkpointing | Result |
|-------|-------|-------------------------|--------|
| unsloth/gemma-4-E2B-it | bf16 | unsloth | 8 steps stable (baseline) |
| unsloth/gemma-4-E2B-it | fp16 without this change | unsloth | CUDA assert at step 2 |
| unsloth/gemma-4-E2B-it | fp16 with this change | unsloth | 8 steps stable |
| unsloth/gemma-4-E2B-it | fp16 with this change | off | 8 steps stable |
| unsloth/gemma-4-E4B-it | fp16 with this change | unsloth | 8 steps stable |

Loss trajectories for the fp16 patched runs match the bf16 baseline within the noise expected for a different accumulation dtype (differences on the order of 1e-6 to 1e-4 in loss, 0.1 to 0.3 in grad_norm).

## Notes

- `FORCE_FLOAT32` match semantics already cover both `model_type_arch == "gemma4"` and `"gemma4" in model_types_all`, so this single entry handles `Gemma4ForConditionalGeneration`, `Gemma4ForCausalLM`, and any siglip-wrapped variants.
- `UNSLOTH_HIGH_PRECISION_LAYERNORM=1` is already set for Gemma-4 earlier in `loader.py`, so norm modules continue to run at fp32 compute via the existing path.
- The one-line addition is intentionally minimal: without the companion patches in unsloth-zoo this change alone is a no-op on fp16 training correctness (it would only change the load dtype to bfloat16 and not fix the MLP overflow).