### PR TITLE
Fix(Studio): Copy api key to clipboard button does not copy

### DIFF
--- a/studio/frontend/src/features/settings/components/key-reveal-card.tsx
+++ b/studio/frontend/src/features/settings/components/key-reveal-card.tsx
@@ -2,8 +2,9 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { Button } from "@/components/ui/button";
-import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { copyToClipboardAsync } from "@/lib/copy-to-clipboard";
 import { cn } from "@/lib/utils";
+import { toastError } from "@/shared/toast";
 import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
@@ -17,11 +18,14 @@ export function KeyRevealCard({
 }) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    if (copyToClipboard(rawKey)) {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
+  const handleCopy = async () => {
+    const ok = await copyToClipboardAsync(rawKey);
+    if (!ok) {
+      toastError("Copy failed", "Could not copy the API key.");
+      return;
     }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
   };
 
   return (


### PR DESCRIPTION
## Summary

  Fixes the copy button for newly generated API keys in `Settings -> API Keys`.

  Before this change, the copy to clipboard button beside a new API key would not actually copy to clipboard when pressed. It would silently fail while still keeping the prior clipboard contents.


  This change switches that flow to the existing async clipboard helper so the UI only shows success after the clipboard write actually succeeds. If the write fails, the user now sees an error toast instead of a false success message.

  ## Root cause

  The reveal card in `studio/frontend/src/features/settings/components/key-reveal-card.tsx` was using the older synchronous `copyToClipboard(...)`
  helper.

  In this dialog-based settings flow, that path could report success before the browser had actually confirmed the clipboard write. As a result, the component could enter the copied state even though the clipboard had not been updated.

  The repo already had an existing `copyToClipboardAsync(...)` helper for this kind of browser clipboard behavior, but this component was still using the synchronous path.

  ## Fix

  This PR updates the new-key reveal card to use `copyToClipboardAsync(...)` instead of `copyToClipboard(...)`.

  The handler now:

  - awaits the clipboard result before showing the copied state
  - only shows the green copied/checkmark success UI after a confirmed successful copy
  - shows `toastError("Copy failed", "Could not copy the API key.")` if the clipboard write fails


  ## Validation

  Validated locally with:

  - `npm run typecheck`
  - `npm run build`

  Manual verification:

  - open `Settings -> API Keys`
  - generate a new key
  - click the copy button on the reveal card
  - paste into another field or editor and confirm the raw key is copied
  - confirm that clipboard failures now show an error instead of a false success