### PR TITLE
Studio: support images on /v1/messages (Anthropic-compat)

### DIFF
--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -13,11 +13,44 @@ import json
 from typing import Any, Optional, Union
 
 
+def _anthropic_image_block_to_openai_part(block: dict) -> Optional[dict]:
+    """Translate one Anthropic ``image`` block to an OpenAI ``image_url`` part.
+
+    Accepts both source shapes:
+      - ``{"type": "base64", "media_type": "image/jpeg", "data": "..."}``
+      - ``{"type": "url", "url": "https://..."}``
+
+    Returns ``None`` when the source is malformed so the caller can skip it.
+    """
+    source = block.get("source") or {}
+    stype = source.get("type")
+    if stype == "base64":
+        data = source.get("data")
+        if not data:
+            return None
+        media_type = source.get("media_type") or "image/jpeg"
+        return {
+            "type": "image_url",
+            "image_url": {"url": f"data:{media_type};base64,{data}"},
+        }
+    if stype == "url":
+        url = source.get("url")
+        if not url:
+            return None
+        return {"type": "image_url", "image_url": {"url": url}}
+    return None
+
+
 def anthropic_messages_to_openai(
     messages: list[dict],
     system: Optional[Union[str, list]] = None,
 ) -> list[dict]:
-    """Convert Anthropic messages + system to OpenAI-format message dicts."""
+    """Convert Anthropic messages + system to OpenAI-format message dicts.
+
+    User messages that carry ``image`` blocks are emitted as OpenAI
+    multimodal content arrays (``[{type: "text", ...}, {type: "image_url", ...}]``)
+    so they flow through llama-server's native vision pathway.
+    """
     result: list[dict] = []
 
     # System prompt
@@ -44,6 +77,7 @@ def anthropic_messages_to_openai(
 
         # Content is a list of blocks
         text_parts: list[str] = []
+        image_parts: list[dict] = []
         tool_calls: list[dict] = []
         tool_results: list[dict] = []
 
@@ -53,6 +87,10 @@ def anthropic_messages_to_openai(
 
             if btype == "text":
                 text_parts.append(b["text"])
+            elif btype == "image":
+                part = _anthropic_image_block_to_openai_part(b)
+                if part is not None:
+                    image_parts.append(part)
             elif btype == "tool_use":
                 tool_calls.append(
                     {
@@ -88,7 +126,16 @@ def anthropic_messages_to_openai(
                 msg_dict["tool_calls"] = tool_calls
             result.append(msg_dict)
         elif role == "user":
-            if text_parts:
+            if image_parts:
+                # Multimodal: emit a content-part array. Prepend a single
+                # joined text part so the model sees prompt + images in
+                # the order they were sent.
+                parts: list[dict] = []
+                if text_parts:
+                    parts.append({"type": "text", "text": "\n".join(text_parts)})
+                parts.extend(image_parts)
+                result.append({"role": "user", "content": parts})
+            elif text_parts:
                 result.append({"role": "user", "content": "\n".join(text_parts)})
             for tr in tool_results:
                 result.append(tr)

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -75,68 +75,76 @@ def anthropic_messages_to_openai(
             result.append({"role": role, "content": content})
             continue
 
-        # Content is a list of blocks
-        text_parts: list[str] = []
-        image_parts: list[dict] = []
-        tool_calls: list[dict] = []
-        tool_results: list[dict] = []
-
-        for block in content:
-            b = block if isinstance(block, dict) else block.model_dump()
-            btype = b.get("type", "")
-
-            if btype == "text":
-                text_parts.append(b["text"])
-            elif btype == "image":
-                part = _anthropic_image_block_to_openai_part(b)
-                if part is not None:
-                    image_parts.append(part)
-            elif btype == "tool_use":
-                tool_calls.append(
-                    {
-                        "id": b["id"],
-                        "type": "function",
-                        "function": {
-                            "name": b["name"],
-                            "arguments": json.dumps(b["input"]),
-                        },
-                    }
-                )
-            elif btype == "tool_result":
-                tc = b.get("content", "")
-                if isinstance(tc, list):
-                    tc = " ".join(
-                        p["text"]
-                        for p in tc
-                        if isinstance(p, dict) and p.get("type") == "text"
-                    )
-                tool_results.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": b["tool_use_id"],
-                        "content": str(tc),
-                    }
-                )
-
         if role == "assistant":
+            # Assistant content carries text + tool_use; images aren't
+            # part of Anthropic's assistant content model.
+            text_parts: list[str] = []
+            tool_calls: list[dict] = []
+            for block in content:
+                b = block if isinstance(block, dict) else block.model_dump()
+                btype = b.get("type", "")
+                if btype == "text":
+                    text_parts.append(b["text"])
+                elif btype == "tool_use":
+                    tool_calls.append(
+                        {
+                            "id": b["id"],
+                            "type": "function",
+                            "function": {
+                                "name": b["name"],
+                                "arguments": json.dumps(b["input"]),
+                            },
+                        }
+                    )
             msg_dict: dict[str, Any] = {"role": "assistant"}
             if text_parts:
                 msg_dict["content"] = "\n".join(text_parts)
             if tool_calls:
                 msg_dict["tool_calls"] = tool_calls
             result.append(msg_dict)
-        elif role == "user":
-            if image_parts:
-                # Multimodal: emit a content-part array. Prepend a single
-                # joined text part so the model sees prompt + images in
-                # the order they were sent.
-                parts: list[dict] = []
-                if text_parts:
-                    parts.append({"type": "text", "text": "\n".join(text_parts)})
-                parts.extend(image_parts)
-                result.append({"role": "user", "content": parts})
-            elif text_parts:
-                result.append({"role": "user", "content": "\n".join(text_parts)})
+            continue
+
+        if role == "user":
+            # Build an ordered part list so text/image interleaving is
+            # preserved (e.g. [text, image, text, image]). tool_result
+            # blocks become their own OpenAI "tool" role messages.
+            user_parts: list[dict] = []
+            has_image = False
+            tool_results: list[dict] = []
+            for block in content:
+                b = block if isinstance(block, dict) else block.model_dump()
+                btype = b.get("type", "")
+                if btype == "text":
+                    user_parts.append({"type": "text", "text": b["text"]})
+                elif btype == "image":
+                    part = _anthropic_image_block_to_openai_part(b)
+                    if part is not None:
+                        user_parts.append(part)
+                        has_image = True
+                elif btype == "tool_result":
+                    tc = b.get("content", "")
+                    if isinstance(tc, list):
+                        tc = " ".join(
+                            p["text"]
+                            for p in tc
+                            if isinstance(p, dict) and p.get("type") == "text"
+                        )
+                    tool_results.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": b["tool_use_id"],
+                            "content": str(tc),
+                        }
+                    )
+
+            if has_image:
+                result.append({"role": "user", "content": user_parts})
+            else:
+                # No images — collapse text parts to a plain string so
+                # existing text-only callers keep their simple shape.
+                text = "\n".join(p["text"] for p in user_parts)
+                if text:
+                    result.append({"role": "user", "content": text})
             for tr in tool_results:
                 result.append(tr)
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2866,6 +2866,67 @@ async def openai_responses(
 # =====================================================================
 
 
+def _normalize_anthropic_openai_images(
+    openai_messages: list[dict], is_vision: bool
+) -> None:
+    """Enforce the vision guard on translated Anthropic messages and
+    normalize any ``image_url`` parts with base64 data URLs to PNG.
+
+    llama-server's stb_image only handles a few formats (JPEG/PNG/BMP/…);
+    Anthropic clients commonly send JPEG or WebP, and Claude Code sends
+    WebP. Re-encoding everything to PNG mirrors the behavior of
+    `_openai_messages_for_passthrough` / the GGUF branch of
+    `/v1/chat/completions` so the two endpoints agree.
+
+    Mutates ``openai_messages`` in place. Raises HTTPException(400) when
+    images are present but the active model is not a vision model, or
+    when an image cannot be decoded.
+    """
+    has_image = any(
+        isinstance(m.get("content"), list)
+        and any(p.get("type") == "image_url" for p in m["content"])
+        for m in openai_messages
+    )
+    if not has_image:
+        return
+
+    if not is_vision:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Image provided but current GGUF model does not support vision.",
+        )
+
+    import base64 as _b64
+    from io import BytesIO as _BytesIO
+    from PIL import Image as _Image
+
+    for msg in openai_messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if part.get("type") != "image_url":
+                continue
+            url = (part.get("image_url") or {}).get("url", "")
+            if not url.startswith("data:"):
+                # Remote URLs are forwarded as-is; llama-server will
+                # fetch (or fail) per its own support matrix.
+                continue
+            try:
+                _, b64data = url.split(",", 1)
+                raw = _b64.b64decode(b64data)
+                img = _Image.open(_BytesIO(raw)).convert("RGB")
+                buf = _BytesIO()
+                img.save(buf, format = "PNG")
+                png_b64 = _b64.b64encode(buf.getvalue()).decode("ascii")
+            except Exception as e:
+                raise HTTPException(
+                    status_code = 400,
+                    detail = f"Failed to process image: {e}",
+                )
+            part["image_url"] = {"url": f"data:image/png;base64,{png_b64}"}
+
+
 @router.post("/messages")
 async def anthropic_messages(
     payload: AnthropicMessagesRequest,
@@ -2896,6 +2957,10 @@ async def anthropic_messages(
         payload.system,
     )
 
+    # Enforce vision guard + re-encode embedded images to PNG so the
+    # Anthropic endpoint matches the behavior of /v1/chat/completions.
+    _normalize_anthropic_openai_images(openai_messages, llama_backend.is_vision)
+
     temperature = payload.temperature if payload.temperature is not None else 0.6
     top_p = payload.top_p if payload.top_p is not None else 0.95
     top_k = payload.top_k if payload.top_k is not None else 20
@@ -2922,7 +2987,16 @@ async def anthropic_messages(
     # 1. enable_tools=true → server-side execution of built-in tools (Unsloth shorthand)
     # 2. tools=[...] only  → client-side pass-through (standard Anthropic behavior)
     # 3. neither           → plain chat
-    server_tools = payload.enable_tools and llama_backend.supports_tools
+    _has_image = any(
+        isinstance(m.get("content"), list)
+        and any(p.get("type") == "image_url" for p in m["content"])
+        for m in openai_messages
+    )
+    # Server-side agentic loop doesn't support multimodal input — matches
+    # the `not image_b64` gate in /v1/chat/completions.
+    server_tools = (
+        payload.enable_tools and llama_backend.supports_tools and not _has_image
+    )
     client_tools = (
         not server_tools
         and payload.tools

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2868,7 +2868,7 @@ async def openai_responses(
 
 def _normalize_anthropic_openai_images(
     openai_messages: list[dict], is_vision: bool
-) -> None:
+) -> bool:
     """Enforce the vision guard on translated Anthropic messages and
     normalize any ``image_url`` parts with base64 data URLs to PNG.
 
@@ -2878,28 +2878,14 @@ def _normalize_anthropic_openai_images(
     `_openai_messages_for_passthrough` / the GGUF branch of
     `/v1/chat/completions` so the two endpoints agree.
 
-    Mutates ``openai_messages`` in place. Raises HTTPException(400) when
-    images are present but the active model is not a vision model, or
-    when an image cannot be decoded.
+    Mutates ``openai_messages`` in place. Returns ``True`` when any
+    image part was seen (so the caller can skip a second scan). Raises
+    HTTPException(400) when images are present but the active model is
+    not a vision model, or when an image cannot be decoded.
     """
-    has_image = any(
-        isinstance(m.get("content"), list)
-        and any(p.get("type") == "image_url" for p in m["content"])
-        for m in openai_messages
-    )
-    if not has_image:
-        return
+    from PIL import Image
 
-    if not is_vision:
-        raise HTTPException(
-            status_code = 400,
-            detail = "Image provided but current GGUF model does not support vision.",
-        )
-
-    import base64 as _b64
-    from io import BytesIO as _BytesIO
-    from PIL import Image as _Image
-
+    has_image = False
     for msg in openai_messages:
         content = msg.get("content")
         if not isinstance(content, list):
@@ -2907,24 +2893,35 @@ def _normalize_anthropic_openai_images(
         for part in content:
             if part.get("type") != "image_url":
                 continue
+
+            has_image = True
+            if not is_vision:
+                raise HTTPException(
+                    status_code = 400,
+                    detail = "Image provided but current GGUF model does not support vision.",
+                )
+
             url = (part.get("image_url") or {}).get("url", "")
             if not url.startswith("data:"):
                 # Remote URLs are forwarded as-is; llama-server will
                 # fetch (or fail) per its own support matrix.
                 continue
+
             try:
                 _, b64data = url.split(",", 1)
-                raw = _b64.b64decode(b64data)
-                img = _Image.open(_BytesIO(raw)).convert("RGB")
-                buf = _BytesIO()
+                raw = base64.b64decode(b64data)
+                img = Image.open(io.BytesIO(raw)).convert("RGB")
+                buf = io.BytesIO()
                 img.save(buf, format = "PNG")
-                png_b64 = _b64.b64encode(buf.getvalue()).decode("ascii")
+                png_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
             except Exception as e:
                 raise HTTPException(
                     status_code = 400,
                     detail = f"Failed to process image: {e}",
                 )
             part["image_url"] = {"url": f"data:image/png;base64,{png_b64}"}
+
+    return has_image
 
 
 @router.post("/messages")
@@ -2959,7 +2956,9 @@ async def anthropic_messages(
 
     # Enforce vision guard + re-encode embedded images to PNG so the
     # Anthropic endpoint matches the behavior of /v1/chat/completions.
-    _normalize_anthropic_openai_images(openai_messages, llama_backend.is_vision)
+    _has_image = _normalize_anthropic_openai_images(
+        openai_messages, llama_backend.is_vision
+    )
 
     temperature = payload.temperature if payload.temperature is not None else 0.6
     top_p = payload.top_p if payload.top_p is not None else 0.95
@@ -2987,11 +2986,6 @@ async def anthropic_messages(
     # 1. enable_tools=true → server-side execution of built-in tools (Unsloth shorthand)
     # 2. tools=[...] only  → client-side pass-through (standard Anthropic behavior)
     # 3. neither           → plain chat
-    _has_image = any(
-        isinstance(m.get("content"), list)
-        and any(p.get("type") == "image_url" for p in m["content"])
-        for m in openai_messages
-    )
     # Server-side agentic loop doesn't support multimodal input — matches
     # the `not image_b64` gate in /v1/chat/completions.
     server_tools = (

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -335,6 +335,43 @@ class TestAnthropicMessagesToOpenAI:
         parts = result[0]["content"]
         assert parts[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
 
+    def test_image_text_order_preserved(self):
+        # [text1, image1, text2, image2] must not collapse to
+        # [text1+text2, image1, image2].
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "AA",
+                        },
+                    },
+                    {"type": "text", "text": "after"},
+                    {
+                        "type": "image",
+                        "source": {"type": "url", "url": "https://x/y.png"},
+                    },
+                ],
+            }
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        parts = result[0]["content"]
+        assert [p["type"] for p in parts] == [
+            "text",
+            "image_url",
+            "text",
+            "image_url",
+        ]
+        assert parts[0]["text"] == "before"
+        assert parts[2]["text"] == "after"
+        assert parts[1]["image_url"]["url"] == "data:image/png;base64,AA"
+        assert parts[3]["image_url"]["url"] == "https://x/y.png"
+
     def test_malformed_image_block_is_skipped(self):
         msgs = [
             {
@@ -896,8 +933,20 @@ def _jpeg_data_url() -> str:
 class TestNormalizeAnthropicOpenAIImages:
     def test_noop_when_no_images(self):
         msgs = [{"role": "user", "content": "hi"}]
-        _normalize_anthropic_openai_images(msgs, is_vision = False)
+        has_image = _normalize_anthropic_openai_images(msgs, is_vision = False)
+        assert has_image is False
         assert msgs == [{"role": "user", "content": "hi"}]
+
+    def test_returns_true_when_image_present(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": _jpeg_data_url()}},
+                ],
+            }
+        ]
+        assert _normalize_anthropic_openai_images(msgs, is_vision = True) is True
 
     def test_rejects_image_when_model_not_vision(self):
         msgs = [

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -10,6 +10,8 @@ import sys
 import os
 import json
 
+import pytest
+
 _backend = os.path.join(os.path.dirname(__file__), "..")
 sys.path.insert(0, _backend)
 
@@ -32,6 +34,10 @@ from core.inference.anthropic_compat import (
     AnthropicStreamEmitter,
     AnthropicPassthroughEmitter,
 )
+from routes.inference import _normalize_anthropic_openai_images
+from fastapi import HTTPException
+import base64 as _b64
+from io import BytesIO as _BytesIO
 
 
 # =====================================================================
@@ -245,6 +251,104 @@ class TestAnthropicMessagesToOpenAI:
         ]
         result = anthropic_messages_to_openai(msgs)
         assert result[0]["content"] == "Line 1 Line 2"
+
+    def test_image_base64_block_becomes_multimodal_part(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is this?"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/jpeg",
+                            "data": "AAAA",
+                        },
+                    },
+                ],
+            }
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        parts = result[0]["content"]
+        assert isinstance(parts, list)
+        assert parts[0] == {"type": "text", "text": "What is this?"}
+        assert parts[1]["type"] == "image_url"
+        assert parts[1]["image_url"]["url"] == "data:image/jpeg;base64,AAAA"
+
+    def test_image_url_block_forwarded_as_url(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe it"},
+                    {
+                        "type": "image",
+                        "source": {"type": "url", "url": "https://x/y.png"},
+                    },
+                ],
+            }
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        parts = result[0]["content"]
+        assert parts[1] == {
+            "type": "image_url",
+            "image_url": {"url": "https://x/y.png"},
+        }
+
+    def test_image_only_user_message_emits_no_text_part(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "ZZ",
+                        },
+                    },
+                ],
+            }
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        parts = result[0]["content"]
+        assert len(parts) == 1
+        assert parts[0]["type"] == "image_url"
+
+    def test_image_default_media_type_when_missing(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "data": "BB"},
+                    },
+                ],
+            }
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        parts = result[0]["content"]
+        assert parts[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    def test_malformed_image_block_is_skipped(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hi"},
+                    {"type": "image", "source": {"type": "base64"}},
+                    {"type": "image", "source": {"type": "url"}},
+                ],
+            }
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        # No image parts emitted; message falls back to plain text.
+        assert result[0] == {"role": "user", "content": "Hi"}
 
 
 # =====================================================================
@@ -772,3 +876,89 @@ class TestAnthropicPassthroughEmitter:
         parsed = self._parse(events[1])
         assert parsed["content_block"]["name"] == "Read"
         assert parsed["content_block"]["id"] == "c2"
+
+
+# =====================================================================
+# Vision guard + PNG normalization (/v1/messages)
+# =====================================================================
+
+
+def _jpeg_data_url() -> str:
+    from PIL import Image
+
+    img = Image.new("RGB", (2, 2), (255, 0, 0))
+    buf = _BytesIO()
+    img.save(buf, format = "JPEG")
+    b64 = _b64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/jpeg;base64,{b64}"
+
+
+class TestNormalizeAnthropicOpenAIImages:
+    def test_noop_when_no_images(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        _normalize_anthropic_openai_images(msgs, is_vision = False)
+        assert msgs == [{"role": "user", "content": "hi"}]
+
+    def test_rejects_image_when_model_not_vision(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": _jpeg_data_url()},
+                    },
+                ],
+            }
+        ]
+        with pytest.raises(HTTPException) as exc:
+            _normalize_anthropic_openai_images(msgs, is_vision = False)
+        assert exc.value.status_code == 400
+
+    def test_reencodes_jpeg_data_url_to_png(self):
+        original_url = _jpeg_data_url()
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "?"},
+                    {"type": "image_url", "image_url": {"url": original_url}},
+                ],
+            }
+        ]
+        _normalize_anthropic_openai_images(msgs, is_vision = True)
+        new_url = msgs[0]["content"][1]["image_url"]["url"]
+        assert new_url.startswith("data:image/png;base64,")
+        assert new_url != original_url
+
+    def test_remote_url_left_unchanged(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://x.example/y.png"},
+                    },
+                ],
+            }
+        ]
+        _normalize_anthropic_openai_images(msgs, is_vision = True)
+        assert msgs[0]["content"][0]["image_url"]["url"] == "https://x.example/y.png"
+
+    def test_bad_base64_raises_400(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/jpeg;base64,!!!not-b64!!!"},
+                    },
+                ],
+            }
+        ]
+        with pytest.raises(HTTPException) as exc:
+            _normalize_anthropic_openai_images(msgs, is_vision = True)
+        assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary

Adds multimodal (image) support to the Anthropic-compatible `/v1/messages` endpoint so Anthropic SDK clients (Claude Code, Anthropic Python SDK, etc.) can send images to vision-capable GGUFs running under Studio — matching the existing vision behavior of `/v1/chat/completions`.

Before this PR, `/v1/messages` silently dropped Anthropic `image` content blocks during the Anthropic→OpenAI translation. The Pydantic request models already accepted them (`AnthropicImageBlock`), but the translator never emitted a corresponding `image_url` part, so the image never reached llama-server.

## Changes

**1. Translator (`core/inference/anthropic_compat.py`)**

`anthropic_messages_to_openai` now translates user-message `image` blocks:

| Anthropic source | OpenAI `image_url` |
|---|---|
| `{"type":"base64","media_type":"image/jpeg","data":"..."}` | `{"url":"data:image/jpeg;base64,..."}` |
| `{"type":"url","url":"https://..."}` | `{"url":"https://..."}` (forwarded as-is) |

User messages with images are emitted as OpenAI multimodal content arrays (`[{type:"text"}, {type:"image_url"}, ...]`). Malformed sources (missing `data`/`url`) are skipped rather than throwing.

`media_type` defaults to `image/jpeg` when omitted (Anthropic SDK default).

**2. Route (`routes/inference.py`)**

New `_normalize_anthropic_openai_images(openai_messages, is_vision)` helper runs after translation and:

- Returns a 400 when any message contains an `image_url` part but the loaded GGUF is not a vision model — mirrors the existing guard at line 1257 of the chat/completions GGUF branch.
- Re-encodes embedded base64 data URLs to PNG (`llama-server`'s `stb_image` has limited format coverage — Anthropic clients routinely send JPEG/WebP; Claude Code sends WebP). Remote `http(s)://` URLs are forwarded unchanged.
- Raises 400 on PIL decode errors so the caller gets a clear error instead of an opaque llama-server 5xx.

Server-side agentic tool loop (`enable_tools=true`) is now disabled when images are present, matching the `not image_b64` gate in `/v1/chat/completions`. Client-side tool pass-through + images continues to work (tools go to llama-server, which handles vision + tools natively).

**3. Tests (`tests/test_anthropic_messages.py`)**

Offline unit tests, no GPU/server required:

- `TestAnthropicMessagesToOpenAI` — 6 new tests: base64 image block, URL image block, image-only message, default media_type, malformed sources skipped, text+image ordering.
- `TestNormalizeAnthropicOpenAIImages` — 5 tests: no-op without images, 400 on non-vision model, JPEG→PNG re-encode, remote URLs left unchanged, malformed base64 raises 400.

Run:
```bash
~/.unsloth/studio/unsloth_studio/bin/python -m pytest studio/backend/tests/test_anthropic_messages.py -v
```

## Manual smoke

**Base64 image, non-streaming:**
```bash
IMG=$(base64 -w0 < test.jpg)
curl -s http://127.0.0.1:8080/v1/messages \
  -H "Authorization: Bearer $UNSLOTH_KEY" \
  -H "Content-Type: application/json" \
  -d "{
    \"messages\":[{\"role\":\"user\",\"content\":[
      {\"type\":\"text\",\"text\":\"Describe the image.\"},
      {\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/jpeg\",\"data\":\"$IMG\"}}
    ]}],
    \"max_tokens\":200
  }"
```

**Anthropic Python SDK:**
```python
from anthropic import Anthropic
import base64
c = Anthropic(base_url="http://127.0.0.1:8080", api_key="dummy", default_headers={"Authorization": "Bearer sk-unsloth-..."} )
img = base64.standard_b64encode(open("test.jpg","rb").read()).decode()
r = c.messages.create(
    model="default", max_tokens=200,
    messages=[{"role":"user","content":[
        {"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":img}},
        {"type":"text","text":"What is this?"},
    ]}],
)
print(r.content[0].text)
```

**Vision guard:** same request against a text-only GGUF returns `400 {"detail":"Image provided but current GGUF model does not support vision."}`.

## Test plan

- [x] Offline unit tests pass (translator + normalizer)
- [x] `curl /v1/messages` with base64 image returns a valid description against a vision GGUF
- [x] Streaming (`stream: true`) emits correct Anthropic SSE with image input
- [x] Anthropic Python SDK works end-to-end
- [x] Text-only GGUF returns 400 when an image is sent
- [x] Existing text-only `/v1/messages` path unaffected (regression)
- [x] Client-side tool pass-through + images works (vision + function-calling)