### PR TITLE
Coerce TRL's tuple-cached _*_available flags to bool

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -137,6 +137,7 @@ from .import_fixes import (
     fix_vllm_aimv2_issue,
     check_vllm_torch_sm100_compatibility,
     fix_vllm_guided_decoding_params,
+    fix_trl_vllm_ascend,
     fix_vllm_pdl_blackwell,
     fix_triton_compiled_kernel_missing_attrs,
     patch_trunc_normal_precision_issue,
@@ -159,6 +160,7 @@ fix_vllm_aimv2_issue()
 # Check vLLM + torch < 2.9.0 + SM100 compatibility BEFORE importing vLLM
 check_vllm_torch_sm100_compatibility()
 fix_vllm_guided_decoding_params()
+fix_trl_vllm_ascend()
 fix_vllm_pdl_blackwell()
 fix_triton_compiled_kernel_missing_attrs()
 patch_trunc_normal_precision_issue()
@@ -179,6 +181,7 @@ del fix_xformers_performance_issue
 del fix_vllm_aimv2_issue
 del check_vllm_torch_sm100_compatibility
 del fix_vllm_guided_decoding_params
+del fix_trl_vllm_ascend
 del fix_vllm_pdl_blackwell
 del fix_triton_compiled_kernel_missing_attrs
 del patch_trunc_normal_precision_issue

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -489,6 +489,32 @@ def fix_vllm_guided_decoding_params():
         )
 
 
+def fix_trl_vllm_ascend():
+    # transformers >= 4.48's `_is_package_available(name)` returns a tuple
+    # (bool, version_or_None). TRL caches that tuple in module-level
+    # `_*_available` flags and the matching `is_*_available()` accessors
+    # return the tuple directly. A non-empty tuple is always truthy, so
+    # `if is_X_available():` fires even when X is absent, triggering an
+    # unconditional `import X` that fails. The surfaced case is
+    # `vllm_ascend` (blocks `from trl import GRPOConfig, GRPOTrainer`
+    # outside Huawei Ascend hosts); `llm_blender`, `deepspeed`, `joblib`
+    # share the same shape. Coerce every tuple-cached flag in
+    # trl.import_utils to bool; the existing accessors that just return
+    # the cached value then naturally yield a bool.
+    if importlib.util.find_spec("trl") is None:
+        return
+    try:
+        import trl.import_utils as tiu
+    except Exception:
+        return
+    for attr in list(vars(tiu)):
+        if not (attr.startswith("_") and attr.endswith("_available")):
+            continue
+        cached = getattr(tiu, attr)
+        if isinstance(cached, tuple):
+            setattr(tiu, attr, bool(cached and cached[0]))
+
+
 def ignore_logger_messages():
     # Ignore Environment variable `HF_TOKEN` is set
     try:


### PR DESCRIPTION
## Summary

- `transformers >= 4.48`'s `_is_package_available(name)` returns a tuple `(bool, version_or_None)`. TRL's `trl.import_utils` caches that tuple directly in module-level `_*_available` flags and the matching `is_*_available()` accessors return the tuple unchanged.
- A non-empty tuple is always truthy, so `if is_vllm_ascend_available():` in `trl/extras/vllm_client.py` fires even when `vllm_ascend` is not installed, triggering an unconditional `from vllm_ascend...` import that fails outside Huawei Ascend hosts. That blocks `from trl import GRPOConfig, GRPOTrainer` on transformers >= 5 + any TRL in Unsloth's pinned range (0.18.2 - 0.24.0).
- Same shape bites `is_llm_blender_available()` -> `import llm_blender` in `trl/trainer/judges.py` (and the other `_*_available` flags `_deepspeed_available`, `_joblib_available`).
- Add `fix_trl_vllm_ascend()` to `unsloth/import_fixes.py` and call it from `unsloth/__init__.py` before any `from .trainer import *` that would eagerly `import trl`. The fix walks `trl.import_utils` once and coerces every `_*_available` tuple to a bool; the existing accessors then naturally return a bool.

## Why not upstream in TRL

- This fix unblocks users immediately without waiting for a TRL release. Unsloth's `import_fixes` is the standard ship path for this sort of cross-library glue (it already carries `fix_vllm_guided_decoding_params`, `disable_broken_wandb`, etc.). Upstream TRL can catch up asynchronously.

## Verification

- Pristine `trl==0.22.2` import reproduces the failure:
  ```
  from trl import GRPOConfig, GRPOTrainer
  ```
  raises `ModuleNotFoundError: No module named 'vllm_ascend'`.
- With this PR installed:
  ```
  import unsloth
  from trl import GRPOConfig, GRPOTrainer  # ok
  ```
- Phase-1 MoE GRPO smoke on `unsloth/Qwen3-30B-A3B-Instruct-2507` + LoRA rank 8 completes under both `UNSLOTH_MOE_BACKEND=native_torch` and `UNSLOTH_MOE_BACKEND=grouped_mm` (the latter also needs the pair fix in `unslothai/unsloth-zoo` PR #605).

## Test plan

- [x] `import unsloth; from trl import GRPOConfig, GRPOTrainer` works on pristine `trl==0.22.2`.
- [x] `tests/moe_grpo_hf_smoke.py --backend native_torch` and `--backend grouped_mm` both train 2 steps end-to-end with no hand-patches to `site-packages/trl/import_utils.py`.
- [x] `tests/flex_lazy_batch_smoke.py` still passes (no unrelated regressions).