### PR TITLE
Studio: fix stale test_exception_result_cached test for vision cache

### DIFF
--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -124,23 +124,50 @@ class TestVisionCacheSubprocessPath:
 
 
 class TestVisionCacheOnException:
-    """When detection raises an exception, _is_vision_model_uncached catches
-    it and returns False.  That False must be cached so subsequent calls don't
-    retry and fail again."""
+    """When detection raises an exception, _is_vision_model_uncached
+    distinguishes permanent failures (cached as False) from transient
+    failures (returned as None, not cached so the next call can retry).
+    Verify both contracts."""
+
+    @patch(
+        "utils.models.model_config.load_model_config",
+        side_effect = ValueError("bad config"),
+    )
+    @patch("utils.transformers_version.needs_transformers_5", return_value = False)
+    def test_permanent_exception_result_cached(self, mock_needs_t5, mock_load_config):
+        """A permanent failure (ValueError / RepositoryNotFoundError /
+        GatedRepoError / JSONDecodeError) should be caught, return False,
+        and that False should be cached so subsequent calls don't retry.
+
+        ValueError is used here because it's the simplest of the
+        code-path's cacheable exception types and does not require an
+        import of huggingface_hub errors (whose module path varies
+        across versions)."""
+        # First call: load_model_config raises -> except branch -> False.
+        assert is_vision_model("broken/model") is False
+        # Second call: cache hit, load_model_config not called again.
+        assert is_vision_model("broken/model") is False
+        mock_load_config.assert_called_once()
 
     @patch(
         "utils.models.model_config.load_model_config",
         side_effect = OSError("network down"),
     )
     @patch("utils.transformers_version.needs_transformers_5", return_value = False)
-    def test_exception_result_cached(self, mock_needs_t5, mock_load_config):
-        """A real exception inside _is_vision_model_uncached should be caught,
-        return False, and that False should be cached for subsequent calls."""
-        # First call: load_model_config raises → except branch → False
+    def test_transient_exception_not_cached(self, mock_needs_t5, mock_load_config):
+        """A transient failure (OSError, timeouts) should return None from
+        _is_vision_model_uncached, surface as False to the caller, and
+        NOT be cached, so the next call retries detection.  This matches
+        the documented behaviour on _vision_detection_cache:
+        'transient failures (network errors, timeouts) are NOT cached so
+        they can be retried.'"""
+        # First call: load_model_config raises OSError -> uncached None
+        # -> caller returns False without caching.
         assert is_vision_model("broken/model") is False
-        # Second call: cache hit, load_model_config not called again
+        # Second call: cache miss again, load_model_config called a
+        # second time.
         assert is_vision_model("broken/model") is False
-        mock_load_config.assert_called_once()
+        assert mock_load_config.call_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`studio/backend/tests/test_vision_cache.py::TestVisionCacheOnException::test_exception_result_cached` has been failing on `main` for a while with:

```
E   AssertionError: Expected 'load_model_config' to have been called once. Called 2 times.
E   Calls: [call('broken/model', use_auth=True, token=None),
E    call('broken/model', use_auth=True, token=None)].
```

The failure is not a regression introduced by any PR, it is a mismatch between the test and the code it is meant to cover. The test mocks `load_model_config` with `side_effect=OSError("network down")` and asserts `assert_called_once()`, but `_is_vision_model_uncached` in `studio/backend/utils/models/model_config.py` intentionally returns `None` for `OSError` so the caller does NOT cache the fallback and retries on the next invocation. The docstring on `_vision_detection_cache` is explicit:

> Only definitive results (True/False from successful detection) are cached; transient failures (network errors, timeouts) are NOT cached so they can be retried.

So the second call to `is_vision_model("broken/model")` correctly re-enters `_is_vision_model_uncached`, `load_model_config` is called a second time, and `assert_called_once()` trips. The test is stale, the code is correct.

## What this PR does

Splits `TestVisionCacheOnException` into the two contracts the code actually implements, instead of conflating them:

1. `test_permanent_exception_result_cached` keeps the original intent ("exception falls back to False and is cached") but switches the side-effect to `ValueError("bad config")`. `ValueError` is one of the exception types `_is_vision_model_uncached` treats as permanent (model_config.py:779), so the False gets cached and `assert_called_once()` passes. Using `ValueError` avoids importing `RepositoryNotFoundError` / `GatedRepoError`, which live at different module paths in different `huggingface_hub` versions.
2. `test_transient_exception_not_cached` pins the opposite contract with the original `OSError("network down")`: the call returns False but the second invocation re-runs detection (`call_count == 2`). This guards against a future regression where somebody caches transient failures and users with a flaky network silently get stuck with a wrong detection.

Both tests use `assert ... is False` on the public API and mock-count assertions on `load_model_config`. No private helpers are touched.

## Test plan

- [ ] `pytest studio/backend/tests/test_vision_cache.py -v` passes, including the two `TestVisionCacheOnException` tests.
- [ ] The rest of `TestVisionCache*` (subprocess path, direct path, etc.) continues to pass unchanged.