### PR TITLE
fix(install): clear STUDIO_LOCAL_* env on POSIX normal install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1587,8 +1587,15 @@ if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
     UNSLOTH_NO_TORCH="$SKIP_TORCH" \
     bash "$SETUP_SH" </dev/null || _SETUP_EXIT=$?
 else
+    # Explicitly reset STUDIO_LOCAL_INSTALL / STUDIO_LOCAL_REPO so a stale
+    # value inherited from the parent shell (e.g. a previous --local run in
+    # the same session) does not silently flip a normal install onto the
+    # local-dev path in setup.sh and install_python_stack.py. Mirrors the
+    # reset already done in install.ps1 for PowerShell.
     SKIP_STUDIO_BASE="$_SKIP_BASE" \
     STUDIO_PACKAGE_NAME="$PACKAGE_NAME" \
+    STUDIO_LOCAL_INSTALL=0 \
+    STUDIO_LOCAL_REPO= \
     UNSLOTH_NO_TORCH="$SKIP_TORCH" \
     bash "$SETUP_SH" </dev/null || _SETUP_EXIT=$?
 fi


### PR DESCRIPTION
## Summary

`install.sh`'s normal-install branch passed the inherited parent-shell environment to `setup.sh` without resetting `STUDIO_LOCAL_INSTALL` or `STUDIO_LOCAL_REPO`. Both are treated as truthy by downstream consumers, so a stale export from a previous `--local` run in the same shell silently flipped a supposedly normal install (and, once the desktop wrapper lands, a desktop-managed install) onto the local-dev path.

## Details

Leak site:

- `install.sh` normal branch did not set `STUDIO_LOCAL_INSTALL` / `STUDIO_LOCAL_REPO` in the env prefix that invokes `setup.sh`.

Consumers:

- `studio/setup.sh:491` gates the PyPI freshness check on `STUDIO_LOCAL_INSTALL != "1"`. A stale `"1"` skips the version check entirely.
- `studio/install_python_stack.py:868` reads `STUDIO_LOCAL_REPO`; any non-empty value triggers an editable overlay pointing at whatever the old export pointed to.

Net effect: normal installs that should install the latest PyPI release instead picked up whatever editable path was stuck in the user's shell, with no version check and no user-visible signal.

Windows was already correct: `install.ps1:1082-1087` explicitly resets both variables in the same session. This change mirrors that behavior on POSIX.

## Fix

One hunk in `install.sh`: add `STUDIO_LOCAL_INSTALL=0` and `STUDIO_LOCAL_REPO=` to the env prefix of the non-local branch. The prefix assignment overrides any parent-shell export for the child process, so `setup.sh` always sees a clean state.

## Test plan

- [x] `bash -n install.sh` parses.
- [ ] Reproducer: `STUDIO_LOCAL_INSTALL=1 STUDIO_LOCAL_REPO=/some/stale/path bash install.sh` (without --local) should NOT take the local-dev path.
- [ ] `bash install.sh --local` still takes the local-dev path (unchanged).
- [ ] `install.ps1` behavior unchanged on Windows.