### PR TITLE
fix: guard resolve_model_class fallback against unresolvable transformers AutoModel entries

### DIFF
--- a/tests/test_resolve_model_class.py
+++ b/tests/test_resolve_model_class.py
@@ -1,0 +1,112 @@
+from unsloth.models._utils import resolve_model_class
+
+
+class _AutoModelLike:
+    def __init__(self, mapping):
+        self._model_mapping = mapping
+
+
+class _FakeLazyMapping:
+    def __init__(self, entries, extra_content=None, broken_keys=()):
+        self._entries = dict(entries)
+        self._config_mapping = {k: f"Cfg_{k}" for k in self._entries}
+        self._model_mapping = {k: f"Mdl_{k}" for k in self._entries}
+        self._extra_content = dict(extra_content or {})
+        self._broken_keys = set(broken_keys)
+
+    def __getitem__(self, key):
+        if key in self._extra_content:
+            return self._extra_content[key]
+        for k, (cfg_cls, mdl_cls) in self._entries.items():
+            if k in self._broken_keys:
+                raise ValueError(f"broken entry {k}")
+            if cfg_cls is key:
+                return mdl_cls
+        raise KeyError(key)
+
+    def _load_attr_from_module(self, key, attr):
+        if key in self._broken_keys:
+            raise ValueError(f"broken entry {key}")
+        cfg_cls, mdl_cls = self._entries[key]
+        if attr == self._config_mapping[key]:
+            return cfg_cls
+        if attr == self._model_mapping[key]:
+            return mdl_cls
+        raise KeyError(attr)
+
+
+class CfgA: pass
+class CfgB: pass
+class CfgBChild(CfgB): pass
+class ModelA: pass
+class ModelB: pass
+class RegBase: pass
+class RegChild(RegBase): pass
+class RegModel: pass
+class UnknownCfg: pass
+
+
+def test_fast_path_exact_match():
+    m = _FakeLazyMapping({"a": (CfgA, ModelA), "b": (CfgB, ModelB)})
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, CfgA()) is ModelA
+
+
+def test_fallback_subclass_match_via_lazy_mapping():
+    m = _FakeLazyMapping({"a": (CfgA, ModelA), "b": (CfgB, ModelB)})
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, CfgBChild()) is ModelB
+
+
+def test_broken_lazy_entry_does_not_crash():
+    m = _FakeLazyMapping(
+        {"broken": (CfgA, ModelA), "b": (CfgB, ModelB)},
+        broken_keys=("broken",),
+    )
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, CfgBChild()) is ModelB
+
+
+def test_unknown_config_returns_none():
+    m = _FakeLazyMapping({"a": (CfgA, ModelA)})
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, UnknownCfg()) is None
+
+
+def test_extra_content_subclass_fallback():
+    m = _FakeLazyMapping(
+        {"a": (CfgA, ModelA)},
+        extra_content={RegBase: RegModel},
+    )
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, RegChild()) is RegModel
+
+
+def test_extra_content_exact_match_fast_path():
+    m = _FakeLazyMapping(
+        {"a": (CfgA, ModelA)},
+        extra_content={RegBase: RegModel},
+    )
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, RegBase()) is RegModel
+
+
+def test_broken_entry_with_extra_content_subclass():
+    m = _FakeLazyMapping(
+        {"broken": (CfgA, ModelA)},
+        extra_content={RegBase: RegModel},
+        broken_keys=("broken",),
+    )
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, RegChild()) is RegModel
+
+
+def test_plain_dict_mapping_is_not_required():
+    am = _AutoModelLike({CfgA: ModelA})
+    assert resolve_model_class(am, CfgA()) is ModelA
+
+
+def test_tuple_result_unwrapped():
+    m = _FakeLazyMapping({"a": (CfgA, (ModelA, "extra"))})
+    am = _AutoModelLike(m)
+    assert resolve_model_class(am, CfgA()) is ModelA

--- a/tests/test_resolve_model_class.py
+++ b/tests/test_resolve_model_class.py
@@ -7,7 +7,7 @@ class _AutoModelLike:
 
 
 class _FakeLazyMapping:
-    def __init__(self, entries, extra_content=None, broken_keys=()):
+    def __init__(self, entries, extra_content = None, broken_keys = ()):
         self._entries = dict(entries)
         self._config_mapping = {k: f"Cfg_{k}" for k in self._entries}
         self._model_mapping = {k: f"Mdl_{k}" for k in self._entries}
@@ -35,15 +35,40 @@ class _FakeLazyMapping:
         raise KeyError(attr)
 
 
-class CfgA: pass
-class CfgB: pass
-class CfgBChild(CfgB): pass
-class ModelA: pass
-class ModelB: pass
-class RegBase: pass
-class RegChild(RegBase): pass
-class RegModel: pass
-class UnknownCfg: pass
+class CfgA:
+    pass
+
+
+class CfgB:
+    pass
+
+
+class CfgBChild(CfgB):
+    pass
+
+
+class ModelA:
+    pass
+
+
+class ModelB:
+    pass
+
+
+class RegBase:
+    pass
+
+
+class RegChild(RegBase):
+    pass
+
+
+class RegModel:
+    pass
+
+
+class UnknownCfg:
+    pass
 
 
 def test_fast_path_exact_match():
@@ -61,7 +86,7 @@ def test_fallback_subclass_match_via_lazy_mapping():
 def test_broken_lazy_entry_does_not_crash():
     m = _FakeLazyMapping(
         {"broken": (CfgA, ModelA), "b": (CfgB, ModelB)},
-        broken_keys=("broken",),
+        broken_keys = ("broken",),
     )
     am = _AutoModelLike(m)
     assert resolve_model_class(am, CfgBChild()) is ModelB
@@ -76,7 +101,7 @@ def test_unknown_config_returns_none():
 def test_extra_content_subclass_fallback():
     m = _FakeLazyMapping(
         {"a": (CfgA, ModelA)},
-        extra_content={RegBase: RegModel},
+        extra_content = {RegBase: RegModel},
     )
     am = _AutoModelLike(m)
     assert resolve_model_class(am, RegChild()) is RegModel
@@ -85,7 +110,7 @@ def test_extra_content_subclass_fallback():
 def test_extra_content_exact_match_fast_path():
     m = _FakeLazyMapping(
         {"a": (CfgA, ModelA)},
-        extra_content={RegBase: RegModel},
+        extra_content = {RegBase: RegModel},
     )
     am = _AutoModelLike(m)
     assert resolve_model_class(am, RegBase()) is RegModel
@@ -94,8 +119,8 @@ def test_extra_content_exact_match_fast_path():
 def test_broken_entry_with_extra_content_subclass():
     m = _FakeLazyMapping(
         {"broken": (CfgA, ModelA)},
-        extra_content={RegBase: RegModel},
-        broken_keys=("broken",),
+        extra_content = {RegBase: RegModel},
+        broken_keys = ("broken",),
     )
     am = _AutoModelLike(m)
     assert resolve_model_class(am, RegChild()) is RegModel

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -429,7 +429,9 @@ def resolve_model_class(auto_model, config):
             except Exception:
                 continue
         if result is None:
-            for extra_cls, extra_model in getattr(mapping, "_extra_content", {}).items():
+            for extra_cls, extra_model in getattr(
+                mapping, "_extra_content", {}
+            ).items():
                 try:
                     if isinstance(config, extra_cls):
                         result = extra_model

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -416,14 +416,15 @@ def resolve_model_class(auto_model, config):
         result = mapping[config.__class__]
     except Exception:
         result = None
-        for config_class in (
-            list(mapping._config_mapping.values())
-            if hasattr(mapping, "_config_mapping")
-            else []
-        ):
+        for key in list(getattr(mapping, "_model_mapping", {})):
             try:
+                config_class = mapping._load_attr_from_module(
+                    key, mapping._config_mapping[key]
+                )
                 if isinstance(config, config_class):
-                    result = mapping[config_class]
+                    result = mapping._load_attr_from_module(
+                        key, mapping._model_mapping[key]
+                    )
                     break
             except Exception:
                 continue

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -411,21 +411,25 @@ def _set_attn_impl(config, impl):
 
 
 def resolve_model_class(auto_model, config):
-     mapping = getattr(auto_model, "_model_mapping", {})
-     try:
-         result = mapping[config.__class__]
-     except Exception:
-         result = None
-         for config_class in list(mapping._config_mapping.values()) if hasattr(mapping, "_config_mapping") else []:
-             try:
-                 if isinstance(config, config_class):
-                     result = mapping[config_class]
-                     break
-             except Exception:
-                 continue
-         if result is None:
-             return None
-     return result[0] if isinstance(result, (list, tuple)) else result
+    mapping = getattr(auto_model, "_model_mapping", {})
+    try:
+        result = mapping[config.__class__]
+    except Exception:
+        result = None
+        for config_class in (
+            list(mapping._config_mapping.values())
+            if hasattr(mapping, "_config_mapping")
+            else []
+        ):
+            try:
+                if isinstance(config, config_class):
+                    result = mapping[config_class]
+                    break
+            except Exception:
+                continue
+        if result is None:
+            return None
+    return result[0] if isinstance(result, (list, tuple)) else result
 
 
 def resolve_attention_implementation(

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -429,6 +429,14 @@ def resolve_model_class(auto_model, config):
             except Exception:
                 continue
         if result is None:
+            for extra_cls, extra_model in getattr(mapping, "_extra_content", {}).items():
+                try:
+                    if isinstance(config, extra_cls):
+                        result = extra_model
+                        break
+                except Exception:
+                    continue
+        if result is None:
             return None
     return result[0] if isinstance(result, (list, tuple)) else result
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -411,18 +411,21 @@ def _set_attn_impl(config, impl):
 
 
 def resolve_model_class(auto_model, config):
-    mapping = getattr(auto_model, "_model_mapping", {})
-    try:
-        result = mapping[config.__class__]
-    except Exception:
-        for config_class, model_class in mapping.items():
-            if isinstance(config, config_class):
-                result = model_class
-                break
-        else:
-            return None
-
-    return result[0] if isinstance(result, (list, tuple)) else result
+     mapping = getattr(auto_model, "_model_mapping", {})
+     try:
+         result = mapping[config.__class__]
+     except Exception:
+         result = None
+         for config_class in list(mapping._config_mapping.values()) if hasattr(mapping, "_config_mapping") else []:
+             try:
+                 if isinstance(config, config_class):
+                     result = mapping[config_class]
+                     break
+             except Exception:
+                 continue
+         if result is None:
+             return None
+     return result[0] if isinstance(result, (list, tuple)) else result
 
 
 def resolve_attention_implementation(


### PR DESCRIPTION
`FastVisionModel.from_pretrained(..., trust_remote_code=True)` was crashing for custom models like DeepseekOCR2 with:

```
ValueError: Could not find PerceptionEncoder neither in transformers.models.perception_lm nor in transformers!
```

Traced it back to `resolve_model_class` in `unsloth/models/_utils.py` (added in #5051).

What happens:
1. Custom config (`DeepseekOCR2Config` from `trust_remote_code`) isn't in transformers' static config map -> `mapping[config.__class__]` raises `KeyError`
2. The fallback then iterates `mapping.items()`, which force-loads every AutoModel class
3. On transformers `4.56.2`, the `perception_lm` entry is broken (registered but not exported), so the lazy-load blows up and takes the whole lookup with it

Built-in models don't hit this because their config is in the static map - the first lookup succeeds and the fallback never runs. Also fine on transformers 5.x where perception_lm is fixed. So it only bites the (trust_remote_code + older transformers) combo, which is why it was quiet for a bit.

Fix: wrap the per-entry access in try/except so one bad transformers entry doesn't kill the whole resolution, and return `None` cleanly when nothing matches so `vision.py` can fall through to the normal `AutoModel` path.

Repro before the fix:
```python
from unsloth import FastVisionModel
model, tok = FastVisionModel.from_pretrained(
    "./deepseek_ocr2",
    trust_remote_code=True,
    load_in_4bit=False,
)
```

Fixes #5132 https://github.com/unslothai/unsloth/issues/5120