### PR TITLE
Studio: stop currency escape from breaking inline LaTeX

### DIFF
--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -75,11 +75,95 @@ function isInCodeBlock(
 }
 
 /**
+ * A token (no whitespace) that looks purely like currency, e.g. `5`,
+ * `1,000`, `5.99`, `100K`, `3.5M`.
+ */
+const CURRENCY_BODY_RE = /^\d+(?:,\d{3})*(?:\.\d+)?[KMBkmb]?$/;
+
+/** Body characters that almost always indicate real LaTeX. */
+const LATEX_CHAR_RE = /[\\^_{}]/;
+
+/** Operators that strongly suggest a math expression. */
+const MATH_OP_RE = /[=+\-^_<>/*]/;
+
+/** Trailing prose punctuation we strip before the currency check. */
+const TRAIL_PUNCT_RE = /[.,;:!?]+$/;
+
+/**
+ * A standalone single letter (variable name) inside the body. We require
+ * that the letter is not part of a longer word so that prose like
+ * "5 to attend" doesn't get misread as a math expression with the
+ * variable `t`.
+ */
+const LONE_LETTER_RE = /(?<![a-zA-Z])[a-zA-Z](?![a-zA-Z])/;
+
+/**
+ * Return true if the substring between two `$` delimiters looks like a
+ * LaTeX expression rather than a span of prose between two currency
+ * tokens.
+ *
+ * Rule of thumb:
+ *   - `$30^\circ$`  -> math (LaTeX chars)
+ *   - `$x$`         -> math (single non-currency token)
+ *   - `$90 - x$`    -> math (math op + lone variable)
+ *   - `$5 to $10`   -> NOT math (multi-token prose, no math op)
+ *   - `$5, $10`     -> NOT math (currency-like token + trailing punct)
+ *   - `$1,000$`     -> NOT math (single currency-like token)
+ */
+function looksLikeMathBody(body: string): boolean {
+  if (LATEX_CHAR_RE.test(body)) return true;
+  const trimmed = body.trim().replace(TRAIL_PUNCT_RE, "");
+  if (!trimmed) return false;
+  if (CURRENCY_BODY_RE.test(trimmed)) return false;
+  if (!/\s/.test(trimmed)) return true;
+  if (!MATH_OP_RE.test(trimmed)) return false;
+  return LONE_LETTER_RE.test(trimmed);
+}
+
+/**
+ * Return true if the `$` at `offset` opens a balanced inline math span
+ * (`$...$`) on the same line. The closer must be unescaped, must not be
+ * part of `$$`, and must lie inside a 200-character window. The body
+ * must look like LaTeX so we don't pair two currency tokens that share
+ * a line (e.g. "$5 to $10"). Bold-wrapped spans (`**$X$**`) are always
+ * treated as math because LLMs reach for that pattern when they want
+ * "bold math" and the heuristic would otherwise reject prose-shaped
+ * bodies like "90 - x".
+ */
+function hasInlineMathCloser(content: string, offset: number): boolean {
+  const MAX_SPAN = 200;
+  const limit = Math.min(content.length, offset + 1 + MAX_SPAN);
+  for (let i = offset + 1; i < limit; i++) {
+    const c = content[i];
+    if (c === "\n") return false;
+    if (c !== "$") continue;
+    if (content[i - 1] === "\\") continue;
+    if (content[i + 1] === "$") {
+      i++;
+      continue;
+    }
+    if (
+      offset >= 2 &&
+      content.charCodeAt(offset - 1) === 0x2a /* * */ &&
+      content.charCodeAt(offset - 2) === 0x2a &&
+      content.charCodeAt(i + 1) === 0x2a &&
+      content.charCodeAt(i + 2) === 0x2a
+    ) {
+      return true;
+    }
+    return looksLikeMathBody(content.slice(offset + 1, i));
+  }
+  return false;
+}
+
+/**
  * Preprocess a markdown string to escape currency dollar signs so they are not
  * parsed as LaTeX math delimiters.
  *
  * - `$5` alone becomes `\$5` (currency, not math)
  * - `$\alpha$` is untouched (real LaTeX)
+ * - `$30^\circ$` is untouched (LaTeX whose body starts with a digit)
+ * - `**$30^\circ$**` is untouched (LaTeX wrapped in bold)
  * - `$$E = mc^2$$` is untouched (display math)
  * - Currency inside code blocks/spans is untouched
  */
@@ -90,6 +174,9 @@ export function preprocessLaTeX(content: string): string {
 
   return content.replace(CURRENCY_REGEX, (match, offset) => {
     if (isInCodeBlock(offset, codeRegions)) {
+      return match;
+    }
+    if (hasInlineMathCloser(content, offset)) {
       return match;
     }
     return "\\" + match;

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -107,6 +107,15 @@ const TRAIL_PUNCT_RE = /[.,;:!?\-/]+$/;
 const LONE_LETTER_RE = /(?<![a-zA-Z])[a-zA-Z](?![a-zA-Z])/;
 
 /**
+ * Numeric or single-letter operands joined by math operators, with
+ * optional whitespace. Matches `2 + 2`, `100 < 200`, `1,000 - 500`,
+ * `2.5 * 3`, `x + y`. Lets us recognise numeric-only expressions like
+ * `$2 + 2$` as math without forcing a lone variable token.
+ */
+const SIMPLE_MATH_RE =
+  /^(?:\d+(?:,\d{3})*(?:\.\d+)?|[a-zA-Z])(?:\s*[=+\-<>/*]\s*(?:\d+(?:,\d{3})*(?:\.\d+)?|[a-zA-Z]))+$/;
+
+/**
  * Return true if the substring between two `$` delimiters looks like a
  * LaTeX expression rather than a span of prose between two currency
  * tokens.
@@ -124,6 +133,9 @@ function looksLikeMathBody(body: string): boolean {
   const trimmed = body.trim().replace(TRAIL_PUNCT_RE, "");
   if (!trimmed) return false;
   if (CURRENCY_BODY_RE.test(trimmed)) return false;
+  // Numeric-only operator forms: `2 + 2`, `100 < 200`, `1,000 - 500`.
+  // Recognised without requiring a lone-variable letter.
+  if (SIMPLE_MATH_RE.test(trimmed)) return true;
   if (!/\s/.test(trimmed)) return true;
   if (!MATH_OP_RE.test(trimmed)) return false;
   return LONE_LETTER_RE.test(trimmed);
@@ -149,6 +161,13 @@ function hasInlineMathCloser(content: string, offset: number): boolean {
     if (content[i - 1] === "\\") continue;
     if (content[i + 1] === "$") {
       i++;
+      continue;
+    }
+    // A `$` immediately followed by a digit is far more likely the start
+    // of another currency token than the closer for the current span. Keep
+    // scanning so prose like `Starts at $5 + a $10 add-on` doesn't pair
+    // the two currency markers as a math span.
+    if (/\d/.test(content[i + 1] ?? "")) {
       continue;
     }
     if (offset >= 2) {

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -83,11 +83,20 @@ const CURRENCY_BODY_RE = /^\d+(?:,\d{3})*(?:\.\d+)?[KMBkmb]?$/;
 /** Body characters that almost always indicate real LaTeX. */
 const LATEX_CHAR_RE = /[\\^_{}]/;
 
-/** Operators that strongly suggest a math expression. */
-const MATH_OP_RE = /[=+\-^_<>/*]/;
+/**
+ * Operators that strongly suggest a math expression. We deliberately
+ * leave out `^` and `_` because `LATEX_CHAR_RE` already short-circuits
+ * on those before we ever consult this regex.
+ */
+const MATH_OP_RE = /[=+\-<>/*]/;
 
-/** Trailing prose punctuation we strip before the currency check. */
-const TRAIL_PUNCT_RE = /[.,;:!?]+$/;
+/**
+ * Trailing chars stripped before the currency check. Includes prose
+ * punctuation plus the connectors `-` and `/` that appear in compact
+ * currency ranges like `$5-$10` or `$5/$10`; without them the body
+ * `5-` or `5/` would slip through the single-token math shortcut.
+ */
+const TRAIL_PUNCT_RE = /[.,;:!?\-/]+$/;
 
 /**
  * A standalone single letter (variable name) inside the body. We require
@@ -125,10 +134,10 @@ function looksLikeMathBody(body: string): boolean {
  * (`$...$`) on the same line. The closer must be unescaped, must not be
  * part of `$$`, and must lie inside a 200-character window. The body
  * must look like LaTeX so we don't pair two currency tokens that share
- * a line (e.g. "$5 to $10"). Bold-wrapped spans (`**$X$**`) are always
- * treated as math because LLMs reach for that pattern when they want
- * "bold math" and the heuristic would otherwise reject prose-shaped
- * bodies like "90 - x".
+ * a line (e.g. "$5 to $10"). Bold-wrapped spans (`**$X$**` and the
+ * underscore equivalent `__$X$__`) are always treated as math because
+ * LLMs reach for that pattern when they want "bold math" and the
+ * heuristic would otherwise reject prose-shaped bodies like "90 - x".
  */
 function hasInlineMathCloser(content: string, offset: number): boolean {
   const MAX_SPAN = 200;
@@ -142,14 +151,16 @@ function hasInlineMathCloser(content: string, offset: number): boolean {
       i++;
       continue;
     }
-    if (
-      offset >= 2 &&
-      content.charCodeAt(offset - 1) === 0x2a /* * */ &&
-      content.charCodeAt(offset - 2) === 0x2a &&
-      content.charCodeAt(i + 1) === 0x2a &&
-      content.charCodeAt(i + 2) === 0x2a
-    ) {
-      return true;
+    if (offset >= 2) {
+      const op = content[offset - 1];
+      if (
+        (op === "*" || op === "_") &&
+        content[offset - 2] === op &&
+        content[i + 1] === op &&
+        content[i + 2] === op
+      ) {
+        return true;
+      }
     }
     return looksLikeMathBody(content.slice(offset + 1, i));
   }


### PR DESCRIPTION
Fixes #5164.

## Problem

The currency-escape preprocessor in `studio/frontend/src/lib/latex.ts` matches the opening `$` of any `$<digits>...$` span and inserts a backslash. The result is that text like `$30^\circ$` or `**$90 - x$**` renders as raw characters with stray dollar signs. The bold-wrap report from the issue is the most visible symptom; plain `$90 - x$` and `$30^\circ$` are also broken.

Root cause: the currency regex is `\d+(?:,\d{3})*(?:\.\d+)?[KMBkmb]?(?:\s|$|[^a-zA-Z\d])`. For `$30^\circ$`, the opening `$` matches because `30` then `^` satisfies `\d+ ... [^a-zA-Z\d]`. The escape inserts `\\$30^\\circ$`, breaking the math span.

## Fix

Two helpers gate the escape so a real math span passes through untouched:

- `hasInlineMathCloser(content, offset)` looks ahead up to 200 chars on the same line for an unescaped, non-doubled closing `$`. Bold-wrapped pairs (`**$X$**`) are always treated as math because LLMs reach for that pattern when they want bold math.
- `looksLikeMathBody(body)` filters out spans that look like prose between two currency tokens (`$5 to $10`, `$5, $10`) by checking for LaTeX characters, math operators, and a lone variable letter.

## Verified

- Issue body text from #5164 passes through unchanged.
- 111 inputs covering common LLM patterns (Greek vars, fractions, integrals, vectors, exponents), prose currency in lists and sentences, code blocks, and headings all behave as expected.
- Confirmed in browser against the rebuilt Studio frontend: `**$30^\circ$**` now renders as bold math; `Cost is $5` still escapes; `Buy at $5 and sell at $10` still escapes both currency tokens.

## Test plan

- [ ] Build the frontend (`bun run build` under `studio/frontend`).
- [ ] Open Studio chat, paste the example block from the issue, confirm bold math renders.
- [ ] Confirm prose currency (`Cost is $5`, `$1,000.50 cost`) still renders with literal dollar signs.
- [ ] Confirm display math (`$$E = mc^2$$`) and `$\alpha$` style spans are unaffected.