### PR TITLE
Studio: probe AMD GPUs in llama-server VRAM detection

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -624,9 +624,7 @@ class LlamaCppBackend:
             )
             if cvd and cvd.strip():
                 try:
-                    physical_ids = [
-                        int(x.strip()) for x in cvd.split(",") if x.strip()
-                    ]
+                    physical_ids = [int(x.strip()) for x in cvd.split(",") if x.strip()]
                 except ValueError:
                     physical_ids = None
             gpus = []

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -609,19 +609,23 @@ class LlamaCppBackend:
                 return []
             if not hasattr(torch.cuda, "mem_get_info"):
                 return []
-            # torch.cuda enumerates GPUs RELATIVE to CUDA_VISIBLE_DEVICES
-            # (or HIP_VISIBLE_DEVICES on ROCm). Downstream we feed these
-            # IDs back into CUDA_VISIBLE_DEVICES for the llama-server
-            # subprocess, so we must translate visible ordinals back to
-            # physical indices first; otherwise launching with
-            # ``CUDA_VISIBLE_DEVICES=2,3`` would get rewritten to
+            # torch.cuda enumerates GPUs RELATIVE to the visibility mask.
+            # On NVIDIA builds the mask is CUDA_VISIBLE_DEVICES; on AMD
+            # ROCm builds it is HIP_VISIBLE_DEVICES (or ROCR_VISIBLE_DEVICES
+            # if HIP is unset). Downstream we feed these IDs back into the
+            # llama-server subprocess as CVD, so we must translate visible
+            # ordinals back to physical indices first; otherwise launching
+            # with ``CUDA_VISIBLE_DEVICES=2,3`` would get rewritten to
             # ``CUDA_VISIBLE_DEVICES=0,1`` and target the wrong GPUs.
             physical_ids: Optional[list[int]] = None
-            cvd = (
-                os.environ.get("CUDA_VISIBLE_DEVICES")
-                or os.environ.get("HIP_VISIBLE_DEVICES")
-                or os.environ.get("ROCR_VISIBLE_DEVICES")
-            )
+            if getattr(torch.version, "hip", None) is not None:
+                cvd = (
+                    os.environ.get("HIP_VISIBLE_DEVICES")
+                    or os.environ.get("ROCR_VISIBLE_DEVICES")
+                    or os.environ.get("CUDA_VISIBLE_DEVICES")
+                )
+            else:
+                cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
             if cvd and cvd.strip():
                 try:
                     physical_ids = [int(x.strip()) for x in cvd.split(",") if x.strip()]
@@ -1792,9 +1796,20 @@ class LlamaCppBackend:
                     f"{new_ld}:{existing_ld}" if existing_ld else new_ld
                 )
 
-            # Pin to selected GPU(s) via CUDA_VISIBLE_DEVICES
+            # Pin to selected GPU(s). On ROCm, llama-server (and any torch
+            # in the subprocess) honors HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES;
+            # narrowing only CUDA_VISIBLE_DEVICES leaves an AMD child seeing
+            # the full HIP/ROCR set the parent inherited.
             if gpu_indices is not None:
-                env["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in gpu_indices)
+                pinned = ",".join(str(i) for i in gpu_indices)
+                env["CUDA_VISIBLE_DEVICES"] = pinned
+                try:
+                    import torch as _torch
+                    if getattr(_torch.version, "hip", None) is not None:
+                        env["HIP_VISIBLE_DEVICES"] = pinned
+                        env["ROCR_VISIBLE_DEVICES"] = pinned
+                except Exception:
+                    pass
 
             self._stdout_lines = []
             self._process = subprocess.Popen(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1834,8 +1834,10 @@ class LlamaCppBackend:
                     if getattr(_torch.version, "hip", None) is not None:
                         env["HIP_VISIBLE_DEVICES"] = pinned
                         env["ROCR_VISIBLE_DEVICES"] = pinned
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(
+                        "Failed to set ROCm visibility env vars for child: %s", e
+                    )
 
             self._stdout_lines = []
             self._process = subprocess.Popen(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -584,7 +584,12 @@ class LlamaCppBackend:
                 cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
                 if cvd is not None and cvd.strip():
                     try:
-                        allowed = set(int(x.strip()) for x in cvd.split(","))
+                        # `if x.strip()` filters trailing-comma masks like
+                        # "0,1," which would otherwise raise ValueError on
+                        # an empty token. Matches the torch fallback path.
+                        allowed = set(
+                            int(x.strip()) for x in cvd.split(",") if x.strip()
+                        )
                     except ValueError:
                         pass
                 gpus: list[tuple[int, int]] = []
@@ -596,6 +601,10 @@ class LlamaCppBackend:
                         if allowed is not None and idx not in allowed:
                             continue
                         gpus.append((idx, free_mib))
+                # Match the docstring's sort-by-id guarantee. nvidia-smi
+                # almost always returns sorted output, but driver order
+                # is not formally guaranteed.
+                gpus.sort(key = lambda g: g[0])
                 if gpus:
                     return gpus
         except Exception as e:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1805,6 +1805,7 @@ class LlamaCppBackend:
                 env["CUDA_VISIBLE_DEVICES"] = pinned
                 try:
                     import torch as _torch
+
                     if getattr(_torch.version, "hip", None) is not None:
                         env["HIP_VISIBLE_DEVICES"] = pinned
                         env["ROCR_VISIBLE_DEVICES"] = pinned

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -549,14 +549,24 @@ class LlamaCppBackend:
 
     @staticmethod
     def _get_gpu_free_memory() -> list[tuple[int, int]]:
-        """Query free memory per GPU via nvidia-smi.
+        """Query free memory per GPU.
 
-        Returns list of (gpu_index, free_mib) sorted by index.
-        Respects CUDA_VISIBLE_DEVICES if set.
-        Returns empty list if nvidia-smi is not available.
+        Order:
+          1. ``nvidia-smi`` (NVIDIA CUDA hosts) -- respects
+             ``CUDA_VISIBLE_DEVICES``.
+          2. ``torch.cuda.mem_get_info`` -- universal fallback that
+             works on AMD ROCm too because the HIP runtime
+             reuses the entire ``torch.cuda.*`` namespace. Covers the
+             AMD case for issue #5106 (nvidia-smi-only probe silently
+             returned [] on AMD hosts) and also rescues NVIDIA hosts
+             where ``nvidia-smi`` is missing from PATH.
+
+        Returns list of (gpu_index, free_mib) sorted by index. Empty
+        list if no supported GPU is reachable.
         """
         import os
 
+        # ── NVIDIA via nvidia-smi ────────────────────────────────────
         try:
             result = subprocess.run(
                 [
@@ -569,30 +579,42 @@ class LlamaCppBackend:
                 timeout = 10,
                 **_windows_hidden_subprocess_kwargs(),
             )
-            if result.returncode != 0:
+            if result.returncode == 0:
+                allowed: Optional[set[int]] = None
+                cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+                if cvd is not None and cvd.strip():
+                    try:
+                        allowed = set(int(x.strip()) for x in cvd.split(","))
+                    except ValueError:
+                        pass
+                gpus: list[tuple[int, int]] = []
+                for line in result.stdout.strip().splitlines():
+                    parts = line.split(",")
+                    if len(parts) == 2:
+                        idx = int(parts[0].strip())
+                        free_mib = int(parts[1].strip())
+                        if allowed is not None and idx not in allowed:
+                            continue
+                        gpus.append((idx, free_mib))
+                if gpus:
+                    return gpus
+        except Exception as e:
+            logger.debug(f"nvidia-smi probe failed: {e}")
+
+        # ── Torch fallback (covers AMD ROCm and missing nvidia-smi) ──
+        try:
+            import torch
+            if not hasattr(torch, "cuda") or not torch.cuda.is_available():
                 return []
-
-            # Parse which GPUs are allowed by existing CUDA_VISIBLE_DEVICES
-            allowed = None
-            cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-            if cvd is not None and cvd.strip():
-                try:
-                    allowed = set(int(x.strip()) for x in cvd.split(","))
-                except ValueError:
-                    pass  # Non-numeric (e.g., "GPU-uuid"), ignore filter
-
+            if not hasattr(torch.cuda, "mem_get_info"):
+                return []
             gpus = []
-            for line in result.stdout.strip().splitlines():
-                parts = line.split(",")
-                if len(parts) == 2:
-                    idx = int(parts[0].strip())
-                    free_mib = int(parts[1].strip())
-                    if allowed is not None and idx not in allowed:
-                        continue
-                    gpus.append((idx, free_mib))
+            for ordinal in range(torch.cuda.device_count()):
+                free_bytes, _total_bytes = torch.cuda.mem_get_info(ordinal)
+                gpus.append((ordinal, int(free_bytes // (1024 * 1024))))
             return gpus
         except Exception as e:
-            logger.debug(f"Failed to query GPU free memory via nvidia-smi: {e}")
+            logger.debug(f"torch GPU probe failed: {e}")
             return []
 
     @staticmethod

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -618,15 +618,25 @@ class LlamaCppBackend:
             # with ``CUDA_VISIBLE_DEVICES=2,3`` would get rewritten to
             # ``CUDA_VISIBLE_DEVICES=0,1`` and target the wrong GPUs.
             physical_ids: Optional[list[int]] = None
+            # Match the codebase convention in
+            # ``utils/hardware/hardware.py::_get_parent_visible_gpu_spec``:
+            # treat an explicitly empty mask (``HIP_VISIBLE_DEVICES=""``)
+            # as "set to no GPUs" rather than falling through to the next
+            # var. ``or`` would coerce empty string to falsy and silently
+            # promote the wrong source.
             if getattr(torch.version, "hip", None) is not None:
+                hip_v = os.environ.get("HIP_VISIBLE_DEVICES")
+                rocr_v = os.environ.get("ROCR_VISIBLE_DEVICES")
                 cvd = (
-                    os.environ.get("HIP_VISIBLE_DEVICES")
-                    or os.environ.get("ROCR_VISIBLE_DEVICES")
-                    or os.environ.get("CUDA_VISIBLE_DEVICES")
+                    hip_v
+                    if hip_v is not None
+                    else rocr_v
+                    if rocr_v is not None
+                    else os.environ.get("CUDA_VISIBLE_DEVICES")
                 )
             else:
                 cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-            if cvd and cvd.strip():
+            if cvd is not None and cvd.strip():
                 try:
                     physical_ids = [int(x.strip()) for x in cvd.split(",") if x.strip()]
                 except ValueError:
@@ -640,7 +650,8 @@ class LlamaCppBackend:
                     else ordinal
                 )
                 gpus.append((idx, free_bytes // (1024 * 1024)))
-            return gpus
+            # Match the nvidia-smi path's docstring guarantee of sorted-by-id.
+            return sorted(gpus, key = lambda g: g[0])
         except Exception as e:
             logger.debug(f"torch GPU probe failed: {e}")
             return []

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -582,11 +582,13 @@ class LlamaCppBackend:
             if result.returncode == 0:
                 allowed: Optional[set[int]] = None
                 cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-                if cvd is not None and cvd.strip():
+                if cvd is not None:
                     try:
                         # `if x.strip()` filters trailing-comma masks like
                         # "0,1," which would otherwise raise ValueError on
-                        # an empty token. Matches the torch fallback path.
+                        # an empty token. An explicitly empty mask (CVD="")
+                        # yields an empty `allowed` set so all GPUs are
+                        # filtered out, matching the codebase convention.
                         allowed = set(
                             int(x.strip()) for x in cvd.split(",") if x.strip()
                         )
@@ -645,8 +647,11 @@ class LlamaCppBackend:
                 )
             else:
                 cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-            if cvd is not None and cvd.strip():
+            if cvd is not None:
                 try:
+                    # Empty mask (CVD="") yields an empty list so the
+                    # below loop produces no GPUs, consistent with the
+                    # nvidia-smi path and utils/hardware/hardware.py.
                     physical_ids = [int(x.strip()) for x in cvd.split(",") if x.strip()]
                 except ValueError:
                     physical_ids = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -604,6 +604,7 @@ class LlamaCppBackend:
         # ── Torch fallback (covers AMD ROCm and missing nvidia-smi) ──
         try:
             import torch
+
             if not hasattr(torch, "cuda") or not torch.cuda.is_available():
                 return []
             if not hasattr(torch.cuda, "mem_get_info"):

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -609,10 +609,35 @@ class LlamaCppBackend:
                 return []
             if not hasattr(torch.cuda, "mem_get_info"):
                 return []
+            # torch.cuda enumerates GPUs RELATIVE to CUDA_VISIBLE_DEVICES
+            # (or HIP_VISIBLE_DEVICES on ROCm). Downstream we feed these
+            # IDs back into CUDA_VISIBLE_DEVICES for the llama-server
+            # subprocess, so we must translate visible ordinals back to
+            # physical indices first; otherwise launching with
+            # ``CUDA_VISIBLE_DEVICES=2,3`` would get rewritten to
+            # ``CUDA_VISIBLE_DEVICES=0,1`` and target the wrong GPUs.
+            physical_ids: Optional[list[int]] = None
+            cvd = (
+                os.environ.get("CUDA_VISIBLE_DEVICES")
+                or os.environ.get("HIP_VISIBLE_DEVICES")
+                or os.environ.get("ROCR_VISIBLE_DEVICES")
+            )
+            if cvd and cvd.strip():
+                try:
+                    physical_ids = [
+                        int(x.strip()) for x in cvd.split(",") if x.strip()
+                    ]
+                except ValueError:
+                    physical_ids = None
             gpus = []
             for ordinal in range(torch.cuda.device_count()):
                 free_bytes, _total_bytes = torch.cuda.mem_get_info(ordinal)
-                gpus.append((ordinal, int(free_bytes // (1024 * 1024))))
+                idx = (
+                    physical_ids[ordinal]
+                    if physical_ids is not None and ordinal < len(physical_ids)
+                    else ordinal
+                )
+                gpus.append((idx, free_bytes // (1024 * 1024)))
             return gpus
         except Exception as e:
             logger.debug(f"torch GPU probe failed: {e}")


### PR DESCRIPTION
Addresses #5106.

## Problem

`_get_gpu_free_memory` in `studio/backend/core/inference/llama_cpp.py` only queries `nvidia-smi`. On AMD ROCm hosts that returns nothing, so the GPU list is empty, the auto-fit logic falls into the no-gpus branch, and `llama-server` gets `--fit on` with no `-ngl` to anchor it. The model loads on CPU even though Studio's hardware probe (which uses `amd-smi`) detected the GPU correctly elsewhere.

This is asymmetric with the rest of Studio: `install.sh` already detects AMD via `rocminfo` / `amd-smi` and installs torch with ROCm wheels (`rocm6.0` through `rocm7.2`), and `studio/backend/utils/hardware/amd.py` has full `amd-smi` JSON-based monitoring. Only the llama-server VRAM probe was NVIDIA-only.

## Fix

Add a torch-based fallback that runs after `nvidia-smi` fails or returns empty:

```python
import torch
if torch.cuda.is_available() and hasattr(torch.cuda, "mem_get_info"):
    for ordinal in range(torch.cuda.device_count()):
        free, _total = torch.cuda.mem_get_info(ordinal)
        gpus.append((ordinal, free // (1024 * 1024)))
```

Works on AMD because the ROCm torch wheels Studio installs reuse the entire `torch.cuda.*` namespace via HIP. Also rescues NVIDIA hosts where `nvidia-smi` is missing from PATH (a secondary cause of the bug on Windows). Matches the convention `studio/backend/utils/hardware/hardware.py:412` already uses for the same fallback purpose.

## Verified

- NVIDIA path returns the expected GPU and free MiB.
- Torch fallback returns valid VRAM when `nvidia-smi` is forced to fail.
- AMD path is the same code; HIP routes through `torch.cuda.*` so the same query works on ROCm hosts.

## Related

#4874 is a draft taking a different approach (parsing `vulkaninfo` output). Complementary, not conflicting: this PR covers the AMD-with-ROCm-torch and missing-nvidia-smi cases via the existing torch dependency; #4874 covers Intel ARC and other Vulkan-only hardware. Either or both can land.

## Test plan

- [ ] On an AMD host, load a GGUF in Studio chat and confirm `llama-server` is launched with a non-empty `-ngl` based on the detected VRAM.
- [ ] On an NVIDIA host with `nvidia-smi` removed from PATH, repeat the above to confirm the torch fallback kicks in.
- [ ] On an NVIDIA host with `nvidia-smi` present, confirm the existing path still returns the same physical GPU index and free MiB.