### PR TITLE
Studio: stop default-capping responses at 4096 tokens (follow-up to #5069)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2582,8 +2582,8 @@ class LlamaCppBackend:
                 payload["chat_template_kwargs"] = {"enable_thinking": enable_thinking}
             payload["max_tokens"] = (
                 max_tokens
-            if max_tokens is not None
-            else (self._effective_context_length or _DEFAULT_MAX_TOKENS_FLOOR)
+                if max_tokens is not None
+                else (self._effective_context_length or _DEFAULT_MAX_TOKENS_FLOOR)
             )
             payload["t_max_predict_ms"] = _DEFAULT_T_MAX_PREDICT_MS
             if stop:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -56,8 +56,17 @@ _MAX_REPROMPTS = 3
 
 # Without max_tokens, llama-server defaults to n_predict = n_ctx (up to
 # 262144 for Qwen3.5), producing many-minute zombie decodes when cancel
-# fails. t_max_predict_ms is a wall-clock backstop applied unconditionally.
-_DEFAULT_MAX_TOKENS = 4096
+# fails. t_max_predict_ms is a wall-clock backstop applied unconditionally,
+# but the llama.cpp README notes it ONLY fires after a newline has been
+# generated -- a model stuck in a long unbroken non-newline sequence is
+# unbounded by it. So we still want a token cap as the front-line limiter.
+#
+# The cap is the model's effective context length when we know it,
+# falling back to a generous floor when metadata is unavailable. 4096 was
+# too low: Qwen3 / gpt-oss reasoning traces routinely exceed it, and any
+# OpenAI-API caller that omits max_tokens (langchain, llama-index, raw
+# curl) sees responses silently truncated mid-sentence.
+_DEFAULT_MAX_TOKENS_FLOOR = 32768
 _DEFAULT_T_MAX_PREDICT_MS = 600_000  # 10 min
 _REPROMPT_MAX_CHARS = 2000
 
@@ -2351,7 +2360,9 @@ class LlamaCppBackend:
         if self._supports_reasoning and enable_thinking is not None:
             payload["chat_template_kwargs"] = {"enable_thinking": enable_thinking}
         payload["max_tokens"] = (
-            max_tokens if max_tokens is not None else _DEFAULT_MAX_TOKENS
+            max_tokens
+            if max_tokens is not None
+            else (self._effective_context_length or _DEFAULT_MAX_TOKENS_FLOOR)
         )
         payload["t_max_predict_ms"] = _DEFAULT_T_MAX_PREDICT_MS
         if stop:
@@ -2570,7 +2581,9 @@ class LlamaCppBackend:
             if self._supports_reasoning and enable_thinking is not None:
                 payload["chat_template_kwargs"] = {"enable_thinking": enable_thinking}
             payload["max_tokens"] = (
-                max_tokens if max_tokens is not None else _DEFAULT_MAX_TOKENS
+                max_tokens
+            if max_tokens is not None
+            else (self._effective_context_length or _DEFAULT_MAX_TOKENS_FLOOR)
             )
             payload["t_max_predict_ms"] = _DEFAULT_T_MAX_PREDICT_MS
             if stop:
@@ -3227,7 +3240,9 @@ class LlamaCppBackend:
                 "enable_thinking": enable_thinking
             }
         stream_payload["max_tokens"] = (
-            max_tokens if max_tokens is not None else _DEFAULT_MAX_TOKENS
+            max_tokens
+            if max_tokens is not None
+            else (self._effective_context_length or _DEFAULT_MAX_TOKENS_FLOOR)
         )
         stream_payload["t_max_predict_ms"] = _DEFAULT_T_MAX_PREDICT_MS
         if stop:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2711,7 +2711,9 @@ async def _responses_stream(
             ),
         )
 
-    body = _build_openai_passthrough_body(chat_req, backend_ctx = llama_backend.context_length)
+    body = _build_openai_passthrough_body(
+        chat_req, backend_ctx = llama_backend.context_length
+    )
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
 
     async def event_generator():
@@ -3918,7 +3920,9 @@ async def _openai_passthrough_stream(
     observes a standard OpenAI response.
     """
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
-    body = _build_openai_passthrough_body(payload, backend_ctx = llama_backend.context_length)
+    body = _build_openai_passthrough_body(
+        payload, backend_ctx = llama_backend.context_length
+    )
 
     _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
     _tracker = _TrackedCancel(cancel_event, *_cancel_keys)
@@ -4054,7 +4058,9 @@ async def _openai_passthrough_non_streaming(
     token counts.
     """
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
-    body = _build_openai_passthrough_body(payload, backend_ctx = llama_backend.context_length)
+    body = _build_openai_passthrough_body(
+        payload, backend_ctx = llama_backend.context_length
+    )
 
     try:
         async with httpx.AsyncClient() as client:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -115,7 +115,7 @@ try:
     from core.inference import get_inference_backend
     from core.inference.llama_cpp import (
         LlamaCppBackend,
-        _DEFAULT_MAX_TOKENS,
+        _DEFAULT_MAX_TOKENS_FLOOR,
         _DEFAULT_T_MAX_PREDICT_MS,
     )
     from utils.models import ModelConfig
@@ -128,7 +128,7 @@ except ImportError:
     from core.inference import get_inference_backend
     from core.inference.llama_cpp import (
         LlamaCppBackend,
-        _DEFAULT_MAX_TOKENS,
+        _DEFAULT_MAX_TOKENS_FLOOR,
         _DEFAULT_T_MAX_PREDICT_MS,
     )
     from utils.models import ModelConfig
@@ -2711,7 +2711,7 @@ async def _responses_stream(
             ),
         )
 
-    body = _build_openai_passthrough_body(chat_req)
+    body = _build_openai_passthrough_body(chat_req, backend_ctx = llama_backend.context_length)
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
 
     async def event_generator():
@@ -3557,6 +3557,7 @@ def _build_passthrough_payload(
     repetition_penalty = None,
     presence_penalty = None,
     tool_choice = "auto",
+    backend_ctx = None,
 ):
     body = {
         "messages": openai_messages,
@@ -3569,7 +3570,11 @@ def _build_passthrough_payload(
     }
     if stream:
         body["stream_options"] = {"include_usage": True}
-    body["max_tokens"] = max_tokens if max_tokens is not None else _DEFAULT_MAX_TOKENS
+    body["max_tokens"] = (
+        max_tokens
+        if max_tokens is not None
+        else (backend_ctx or _DEFAULT_MAX_TOKENS_FLOOR)
+    )
     body["t_max_predict_ms"] = _DEFAULT_T_MAX_PREDICT_MS
     if stop:
         body["stop"] = stop
@@ -3618,6 +3623,7 @@ async def _anthropic_passthrough_stream(
         repetition_penalty = repetition_penalty,
         presence_penalty = presence_penalty,
         tool_choice = tool_choice,
+        backend_ctx = llama_backend.context_length,
     )
 
     _tracker = _TrackedCancel(cancel_event, session_id, message_id)
@@ -3747,6 +3753,7 @@ async def _anthropic_passthrough_non_streaming(
         repetition_penalty = repetition_penalty,
         presence_penalty = presence_penalty,
         tool_choice = tool_choice,
+        backend_ctx = llama_backend.context_length,
     )
 
     async with httpx.AsyncClient() as client:
@@ -3868,7 +3875,7 @@ def _openai_messages_for_passthrough(payload) -> list[dict]:
     return messages
 
 
-def _build_openai_passthrough_body(payload) -> dict:
+def _build_openai_passthrough_body(payload, backend_ctx = None) -> dict:
     """Assemble the llama-server request body from a ChatCompletionRequest.
 
     Only explicitly-known OpenAI / llama-server fields are forwarded so that
@@ -3890,6 +3897,7 @@ def _build_openai_passthrough_body(payload) -> dict:
         repetition_penalty = payload.repetition_penalty,
         presence_penalty = payload.presence_penalty,
         tool_choice = tool_choice,
+        backend_ctx = backend_ctx,
     )
 
 
@@ -3910,7 +3918,7 @@ async def _openai_passthrough_stream(
     observes a standard OpenAI response.
     """
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
-    body = _build_openai_passthrough_body(payload)
+    body = _build_openai_passthrough_body(payload, backend_ctx = llama_backend.context_length)
 
     _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
     _tracker = _TrackedCancel(cancel_event, *_cancel_keys)
@@ -4046,7 +4054,7 @@ async def _openai_passthrough_non_streaming(
     token counts.
     """
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
-    body = _build_openai_passthrough_body(payload)
+    body = _build_openai_passthrough_body(payload, backend_ctx = llama_backend.context_length)
 
     try:
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Follow-up to #5069. Stacked on top of `fix/studio-stop-button` so it merges cleanly once that PR lands.

## Problem

PR #5069 introduced `_DEFAULT_MAX_TOKENS = 4096` as a runaway-decode defense. The Studio chat UI is fine because it sets `params.maxTokens = loadResp.context_length` after a GGUF load (`studio/frontend/src/features/chat/api/chat-adapter.ts:367`), but every other consumer is silently capped at 4096:

- OpenAI-API direct callers (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`, `/v1/completions`) where the OpenAI default is effectively unlimited per response. langchain, llama-index, raw `curl`, and the openai SDK all rely on that.
- Reasoning models. Qwen3 / gpt-oss reasoning traces routinely exceed 4096 tokens before the model emits a single visible content token. The user sees the trace cut off mid-thought.
- Long-form generation ("write a chapter", "produce a full SVG").

Reproduced on the PR head, gemma-4-E2B-it-GGUF Q8_0, no `max_tokens`, prompt: `"Write a 10000-word story about a dragon and a wizard. Be very verbose."`:

```
finish_reason: stop          (misleading; should be 'length')
content_chars: 19772
content_tail: ...'a comforting, yet immense, pressure.\n\n*"'
```

19772 chars is right at the 4096 token mark for English prose. Body ends mid-sentence on a stray opening quote.

## Fix

Rename the constant to `_DEFAULT_MAX_TOKENS_FLOOR` and set it to 32768. Each call site now uses the model's effective context length when known, falling back to the floor:

```python
default_cap = self._effective_context_length or _DEFAULT_MAX_TOKENS_FLOOR
payload["max_tokens"] = max_tokens if max_tokens is not None else default_cap
```

The 10-minute `t_max_predict_ms` wall-clock backstop from #5069 is preserved as the second line of defense, so runaway protection is unchanged.

Plumbed the same defaulting through `_build_passthrough_payload` and `_build_openai_passthrough_body` so the Anthropic and OpenAI passthrough paths also respect the model's context length (each caller already has `llama_backend` in scope).

## Verified

Same request after this patch:

```
finish_reason: stop          (now truthful -- model stopped on its own)
content_chars: 38357
content_tail: ...'held in a perfect, dynamic equilibrium.'
```

38357 chars, ends with a complete sentence. The model now reaches its natural stop instead of being silently cut.

## Out of scope but worth a follow-up

Same code path also reports `finish_reason: "stop"` instead of `"length"` when truncation does fire, and zeroes out `usage` for non-streaming responses. Both are independent UX bugs that mask this kind of issue from callers. Happy to take them in a separate PR.

## Test plan

- [x] gemma-4-E2B-it-GGUF, prompt above, no `max_tokens`: full natural completion (38357 chars), no mid-sentence cut.
- [x] gemma-4-E2B-it-GGUF, prompt above, explicit `max_tokens=2048`: truncated at 2048 as requested (user override still wins).
- [ ] Reasoning model (Qwen3 or gpt-oss) hard-prompt that produces a long thinking trace: no thinking-trace truncation.
- [ ] Stop button still works (uses the same code path; `t_max_predict_ms` and the cancel registry from #5069 are untouched).
