### PR TITLE
fix(studio): use endswith for mmproj F16 variant selection

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1339,7 +1339,7 @@ class LlamaCppBackend:
             # Prefer F16 variant
             target = None
             for f in mmproj_files:
-                if "f16" in f.lower():
+                if f.lower().endswith("-f16.gguf"):
                     target = f
                     break
             if target is None:


### PR DESCRIPTION
"f16" in filename matched BF16 files because "bf16" contains "f16" as a substring. Switch to endswith("-f16.gguf") for an exact match.