### PR TITLE
feat(studio): declare mlx on Apple Silicon so hardware detection flips to MLX

### DIFF
--- a/studio/backend/requirements/studio.txt
+++ b/studio/backend/requirements/studio.txt
@@ -15,3 +15,7 @@ huggingface-hub==0.36.2
 structlog>=24.1.0
 diceware
 ddgs
+# Apple Silicon GPU detection: hardware.py imports mlx.core to flip
+# DeviceType to MLX and report unified-memory stats. Without this dep,
+# Studio reports CPU on M-series Macs even though the MLX code path exists.
+mlx ; sys_platform == 'darwin' and platform_machine == 'arm64'


### PR DESCRIPTION
## Summary

Studio's hardware detection has a fully-wired \`DeviceType.MLX\` branch:

\`\`\`python
# studio/backend/utils/hardware/hardware.py
def _has_mlx() -> bool:
    try:
        import mlx.core
        return True
    except ImportError:
        return False

# ...
if is_apple_silicon() and _has_mlx():
    DEVICE = DeviceType.MLX
    print(f"Hardware detected: MLX — Apple Silicon ({chip})")
\`\`\`

But \`mlx\` is not declared in any requirements file and \`install.sh\` never installs it, so every Apple-Silicon Studio install falls through to CPU:

\`\`\`
Hardware detected: CPU (no GPU backend available)
\`\`\`

This PR declares \`mlx\` in \`studio/backend/requirements/studio.txt\` with an Apple-Silicon marker so the existing detection path actually activates.

## Scope (intentionally minimal)

- **Adds**: hardware detection flipping from CPU → MLX, and unified-memory reporting via the existing \`mlx.core\` calls in \`hardware.py\`.
- **Does not add**: MLX-backed inference or training. Inference still goes through the existing torch / llama.cpp paths. MLX training remains the broader "coming soon" item the README flags.
- **Marker**: \`sys_platform == 'darwin' and platform_machine == 'arm64'\` — installs only on Apple Silicon, so Linux/Windows/Intel-Mac installs are unaffected and add no wheel weight.
- Only \`mlx\` (the core array library) is declared, not \`mlx-lm\` / \`mlx-vlm\`. The codebase only imports \`mlx.core\` for detection and memory accounting; pulling in the LM/VLM packages prematurely would be unused weight until inference paths actually use them.

## Verified locally

Apple Silicon (M-series), \`./install.sh --local\`:

**Before:**
\`\`\`
Hardware detected: CPU (no GPU backend available)
\`\`\`

**After:**
\`\`\`
Hardware detected: MLX — Apple Silicon (arm)
\`\`\`

\`mlx==0.31.2\` (+ \`mlx-metal==0.31.2\`) installed; ~53 MiB.

## Test plan

- [ ] Apple Silicon — Studio reports \`Hardware detected: MLX — Apple Silicon (<chip>)\` and unified memory.
- [ ] Intel Mac — marker excludes \`mlx\`; existing CPU path unchanged.
- [ ] Linux (CUDA, ROCm, CPU) — marker excludes \`mlx\`; \`pip install\` unaffected.
- [ ] Windows — marker excludes \`mlx\`; \`pip install\` unaffected.