### PR TITLE
Studio: add SSL/TLS support for web UI and API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,10 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# Anchor `lib/` / `lib64/` to the project root so they only catch Python
+# build outputs and don't shadow legitimate frontend `src/**/lib/` dirs.
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -590,6 +590,52 @@ def clear_desktop_secret() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Generic app_secrets read/write helpers
+# ---------------------------------------------------------------------------
+#
+# Used by non-secret server-wide configuration (e.g. SSL paths, feature
+# toggles) that should survive restarts. Values are stored as TEXT;
+# callers serialize/deserialize their own structured types.
+
+
+def get_app_secret(key: str) -> Optional[str]:
+    """Return the value for *key* in ``app_secrets``, or ``None``."""
+    conn = get_connection()
+    try:
+        cur = conn.execute(
+            "SELECT value FROM app_secrets WHERE key = ?",
+            (key,),
+        )
+        row = cur.fetchone()
+        return row["value"] if row else None
+    finally:
+        conn.close()
+
+
+def set_app_secret(key: str, value: str) -> None:
+    """Insert or replace *key* with *value* in ``app_secrets``."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO app_secrets (key, value) VALUES (?, ?)",
+            (key, value),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def delete_app_secret(key: str) -> None:
+    """Remove *key* from ``app_secrets`` if present."""
+    conn = get_connection()
+    try:
+        conn.execute("DELETE FROM app_secrets WHERE key = ?", (key,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # API key management
 # ---------------------------------------------------------------------------
 

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -64,6 +64,7 @@ from routes import (
     inference_router,
     inference_studio_router,
     models_router,
+    settings_router,
     training_history_router,
     training_router,
 )
@@ -222,14 +223,20 @@ app.include_router(export_router, prefix = "/api/export", tags = ["export"])
 app.include_router(
     training_history_router, prefix = "/api/train", tags = ["training-history"]
 )
+app.include_router(settings_router, prefix = "/api/settings", tags = ["settings"])
 
 
 # ============ Health and System Endpoints ============
 
 
 @app.get("/api/health")
-async def health_check():
-    """Health check endpoint"""
+async def health_check(request: Request):
+    """Health check endpoint.
+
+    Reports ``scheme`` and ``port`` so the frontend restart-polling flow
+    can race ``http://`` vs ``https://`` after a settings change without
+    needing the answer up front.
+    """
     platform_map = {"darwin": "mac", "win32": "windows", "linux": "linux"}
     device_type = platform_map.get(sys.platform, sys.platform)
 
@@ -242,6 +249,12 @@ async def health_check():
         "chat_only": _hw_module.CHAT_ONLY,
         "desktop_protocol_version": 1,
         "supports_desktop_auth": True,
+        "scheme": getattr(request.app.state, "scheme", "http"),
+        "port": getattr(request.app.state, "server_port", None),
+        # Random per-process token regenerated on every module import.
+        # The frontend uses a change in this value as proof that the
+        # server has actually been replaced (see run.py:INSTANCE_ID).
+        "instance_id": getattr(request.app.state, "instance_id", None),
     }
 
 

--- a/studio/backend/routes/__init__.py
+++ b/studio/backend/routes/__init__.py
@@ -14,6 +14,7 @@ from routes.auth import router as auth_router
 from routes.data_recipe import router as data_recipe_router
 from routes.export import router as export_router
 from routes.training_history import router as training_history_router
+from routes.settings import router as settings_router
 
 __all__ = [
     "training_router",
@@ -25,4 +26,5 @@ __all__ = [
     "data_recipe_router",
     "export_router",
     "training_history_router",
+    "settings_router",
 ]

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+Server-side settings API.
+
+Exposes the SSL configuration so the frontend Settings → Server tab can
+read/update it. Settings are stored as rows in the ``app_secrets`` table
+and only take effect after the server restarts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import ssl
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field, model_validator
+
+from auth import storage
+from auth.authentication import get_current_subject
+from ssl_config import (
+    SSL_CERTFILE_KEY,
+    SSL_ENABLED_KEY,
+    SSL_KEYFILE_KEY,
+    SSL_SELF_SIGNED_KEY,
+    ensure_self_signed_cert,
+)
+
+
+router = APIRouter()
+
+
+class SslSettingsResponse(BaseModel):
+    """Saved SSL settings (paths only — never includes cert/key bytes)."""
+
+    ssl_enabled: bool = Field(
+        ..., description = "Whether SSL is enabled in saved settings"
+    )
+    ssl_self_signed: bool = Field(
+        ...,
+        description = "When true, a self-signed cert is generated/reused at startup",
+    )
+    ssl_certfile: Optional[str] = Field(
+        None, description = "Path to PEM cert (when not self-signed)"
+    )
+    ssl_keyfile: Optional[str] = Field(
+        None, description = "Path to PEM private key (when not self-signed)"
+    )
+    active_scheme: str = Field(
+        ...,
+        description = "Scheme the *running* server is currently bound to (http/https)",
+    )
+    active_port: Optional[int] = Field(
+        None, description = "Port the running server is currently bound to"
+    )
+    active_source: str = Field(
+        "default",
+        description = (
+            "Which precedence layer produced the active config: cli_no_ssl, "
+            "cli_paths, cli_self_signed, env_paths, env_self_signed, db_paths, "
+            "db_self_signed, or default."
+        ),
+    )
+    restart_supported: bool = Field(
+        ...,
+        description = "True when the backend can self-restart in place to apply changes",
+    )
+
+
+class SslSettingsUpdate(BaseModel):
+    """Payload to update SSL settings."""
+
+    ssl_enabled: bool
+    ssl_self_signed: bool = False
+    ssl_certfile: Optional[str] = None
+    ssl_keyfile: Optional[str] = None
+
+    @model_validator(mode = "after")
+    def _check_paths(self) -> "SslSettingsUpdate":
+        if self.ssl_enabled and not self.ssl_self_signed:
+            if not (self.ssl_certfile and self.ssl_keyfile):
+                raise ValueError(
+                    "ssl_certfile and ssl_keyfile are required when SSL is enabled "
+                    "without --ssl-self-signed."
+                )
+        return self
+
+
+class SslTestRequest(BaseModel):
+    """Payload to validate a cert/key pair before saving."""
+
+    ssl_certfile: str
+    ssl_keyfile: str
+
+
+class SslTestResponse(BaseModel):
+    ok: bool
+    error: Optional[str] = None
+
+
+class RestartResponse(BaseModel):
+    restarting: bool
+    supported: bool
+
+
+def _restart_supported() -> bool:
+    """Self-restart works on every platform we ship today, but expose this
+    as a flag so the frontend can degrade gracefully if that changes."""
+    return True
+
+
+@router.get("/server", response_model = SslSettingsResponse)
+async def get_server_settings(
+    request: Request,
+    current_subject: str = Depends(get_current_subject),
+) -> SslSettingsResponse:
+    """Return saved SSL settings + the scheme the live server is using."""
+    enabled_raw = storage.get_app_secret(SSL_ENABLED_KEY)
+    self_signed_raw = storage.get_app_secret(SSL_SELF_SIGNED_KEY)
+    certfile = storage.get_app_secret(SSL_CERTFILE_KEY)
+    keyfile = storage.get_app_secret(SSL_KEYFILE_KEY)
+
+    def _truthy(value: Optional[str]) -> bool:
+        return bool(value) and value.strip().lower() in ("1", "true", "yes", "on")
+
+    return SslSettingsResponse(
+        ssl_enabled = _truthy(enabled_raw),
+        ssl_self_signed = _truthy(self_signed_raw),
+        ssl_certfile = certfile or None,
+        ssl_keyfile = keyfile or None,
+        active_scheme = getattr(request.app.state, "scheme", "http"),
+        active_port = getattr(request.app.state, "server_port", None),
+        active_source = getattr(request.app.state, "ssl_source", "default"),
+        restart_supported = _restart_supported(),
+    )
+
+
+@router.post("/server", response_model = SslSettingsResponse)
+async def update_server_settings(
+    payload: SslSettingsUpdate,
+    request: Request,
+    current_subject: str = Depends(get_current_subject),
+) -> SslSettingsResponse:
+    """Persist SSL settings to ``app_secrets``. Takes effect on next restart."""
+    if payload.ssl_enabled and not payload.ssl_self_signed:
+        cert_path = Path(payload.ssl_certfile or "").expanduser()
+        key_path = Path(payload.ssl_keyfile or "").expanduser()
+        if not cert_path.is_file():
+            raise HTTPException(
+                status_code = status.HTTP_400_BAD_REQUEST,
+                detail = f"Certificate file not found: {cert_path}",
+            )
+        if not key_path.is_file():
+            raise HTTPException(
+                status_code = status.HTTP_400_BAD_REQUEST,
+                detail = f"Key file not found: {key_path}",
+            )
+        try:
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(certfile = str(cert_path), keyfile = str(key_path))
+        except ssl.SSLError as exc:
+            raise HTTPException(
+                status_code = status.HTTP_400_BAD_REQUEST,
+                detail = f"Certificate/key are not a valid pair: {exc}",
+            ) from exc
+
+    if payload.ssl_enabled and payload.ssl_self_signed:
+        # Pre-generate so the cert exists before the user restarts.
+        ensure_self_signed_cert(
+            bind_host = getattr(request.app.state, "bind_host", "0.0.0.0")
+        )
+
+    storage.set_app_secret(SSL_ENABLED_KEY, "1" if payload.ssl_enabled else "0")
+    storage.set_app_secret(SSL_SELF_SIGNED_KEY, "1" if payload.ssl_self_signed else "0")
+    if payload.ssl_certfile:
+        storage.set_app_secret(SSL_CERTFILE_KEY, payload.ssl_certfile)
+    else:
+        storage.delete_app_secret(SSL_CERTFILE_KEY)
+    if payload.ssl_keyfile:
+        storage.set_app_secret(SSL_KEYFILE_KEY, payload.ssl_keyfile)
+    else:
+        storage.delete_app_secret(SSL_KEYFILE_KEY)
+
+    return await get_server_settings(request, current_subject = current_subject)
+
+
+@router.post("/server/test", response_model = SslTestResponse)
+async def test_certificate(
+    payload: SslTestRequest,
+    current_subject: str = Depends(get_current_subject),
+) -> SslTestResponse:
+    """Validate a certfile/keyfile pair without saving anything."""
+    cert_path = Path(payload.ssl_certfile).expanduser()
+    key_path = Path(payload.ssl_keyfile).expanduser()
+    if not cert_path.is_file():
+        return SslTestResponse(ok = False, error = f"Cert file not found: {cert_path}")
+    if not key_path.is_file():
+        return SslTestResponse(ok = False, error = f"Key file not found: {key_path}")
+    try:
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile = str(cert_path), keyfile = str(key_path))
+    except ssl.SSLError as exc:
+        return SslTestResponse(ok = False, error = str(exc))
+    return SslTestResponse(ok = True)
+
+
+@router.post("/server/restart", response_model = RestartResponse)
+async def restart_server(
+    request: Request,
+    current_subject: str = Depends(get_current_subject),
+) -> RestartResponse:
+    """Re-exec the studio process so saved settings take effect.
+
+    The HTTP response is sent first; the actual restart happens on a
+    short delay so the client can finish reading the response.
+    """
+    if not _restart_supported():
+        return RestartResponse(restarting = False, supported = False)
+
+    async def _delayed_restart() -> None:
+        await asyncio.sleep(0.3)
+        from run import trigger_self_restart  # late import to avoid circular load
+
+        try:
+            trigger_self_restart()
+        except Exception:
+            # asyncio drops unhandled task exceptions into a logger few
+            # people watch — log it ourselves so a failed restart never
+            # looks like a silent no-op.
+            import structlog
+
+            structlog.get_logger(__name__).exception(
+                "trigger_self_restart raised; server is still running"
+            )
+
+    request.app.state._restart_task = asyncio.create_task(_delayed_restart())
+    return RestartResponse(restarting = True, supported = True)

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -12,9 +12,7 @@ and only take effect after the server restarts.
 from __future__ import annotations
 
 import asyncio
-import os
 import ssl
-import sys
 from pathlib import Path
 from typing import Optional
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -7,6 +7,7 @@ Works independently and can be moved to any directory.
 """
 
 import os
+import secrets
 import sys
 from pathlib import Path
 
@@ -24,9 +25,28 @@ if str(backend_dir) not in sys.path:
 import _platform_compat  # noqa: F401
 
 from loggers import get_logger
+from ssl_config import SslCliArgs, SslSettings, resolve_ssl_settings
 from startup_banner import print_studio_access_banner
 
 logger = get_logger(__name__)
+
+
+# Captured at module import so a self-restart can re-exec with the
+# same arguments the operator originally passed.
+#
+# `_ORIGINAL_ARGV[0]` is the *script path* (Python sets it to the entry
+# script, not the interpreter), so to re-launch we must explicitly pass
+# `_ORIGINAL_PYTHON` as the program — running execvp on a .py path
+# directly would fail with ENOEXEC on Unix.
+_ORIGINAL_PYTHON: str = sys.executable
+_ORIGINAL_ARGV: tuple[str, ...] = tuple(sys.argv)
+
+# Per-process instance ID, regenerated on every fresh module import.
+# After `os.execv` the new process re-imports this module and gets a
+# new ID, so the frontend can confirm a restart by watching for the ID
+# to change in /api/health. This sidesteps PID-reuse on Unix (execv
+# preserves PID) and avoids "saw down" timing heuristics.
+INSTANCE_ID: str = secrets.token_hex(8)
 
 
 def _resolve_external_ip() -> str:
@@ -250,6 +270,7 @@ def run_server(
     silent: bool = False,
     api_only: bool = False,
     llama_parallel_slots: int = 1,
+    ssl_cli: SslCliArgs | None = None,
 ):
     """
     Start the FastAPI server.
@@ -261,6 +282,9 @@ def run_server(
         silent: Suppress startup messages
         api_only: Run API server only, no frontend serving (for Tauri desktop app)
         llama_parallel_slots: Number of parallel slots for llama-server
+        ssl_cli: SSL CLI args resolved from argparse / typer; ``None`` is
+            treated as "no CLI overrides" so env vars and saved settings
+            still apply.
 
     Note:
         Signal handlers are NOT registered here so that embedders
@@ -306,9 +330,7 @@ def run_server(
             print("=" * 50)
             if blocker:
                 pid, name = blocker
-                print(
-                    f"Port {original_port} is already in use by " f"{name} (PID {pid})."
-                )
+                print(f"Port {original_port} is already in use by {name} (PID {pid}).")
             else:
                 print(f"Port {original_port} is already in use.")
             print(f"Unsloth Studio will use port {port} instead.")
@@ -316,9 +338,14 @@ def run_server(
             print("=" * 50)
             print("")
 
-    # Output port for Tauri to parse when in api-only mode
+    # Resolve SSL early so the api-only handshake to Tauri can include the
+    # scheme — Tauri uses this to build the correct base URL.
+    ssl_settings_preview = resolve_ssl_settings(ssl_cli or SslCliArgs(), bind_host = host)
+
+    # Output port (and scheme) for Tauri to parse when in api-only mode.
     if api_only:
         print(f"TAURI_PORT={port}", flush = True)
+        print(f"TAURI_SCHEME={ssl_settings_preview.scheme}", flush = True)
 
     # Setup frontend if path provided (skip in api-only mode)
     if frontend_path and not api_only:
@@ -329,9 +356,18 @@ def run_server(
             if not silent:
                 print(f"[WARNING] Frontend not found at {frontend_path}")
 
+    # Reuse the preview computed above so the cert is generated exactly once.
+    ssl_settings = ssl_settings_preview
+
     # Create the uvicorn server and expose it for signal handlers
     config = uvicorn.Config(
-        app, host = host, port = port, log_level = "info", access_log = False
+        app,
+        host = host,
+        port = port,
+        log_level = "info",
+        access_log = False,
+        ssl_keyfile = ssl_settings.keyfile,
+        ssl_certfile = ssl_settings.certfile,
     )
     _server = uvicorn.Server(config)
     _shutdown_event = Event()
@@ -343,6 +379,12 @@ def run_server(
     # binds (port==0) leave it unset and let request handlers fall back
     # to the ASGI request scope or request.base_url.
     app.state.server_port = port if port and port > 0 else None
+    app.state.bind_host = host
+    app.state.scheme = ssl_settings.scheme
+    app.state.ssl_source = ssl_settings.source
+    app.state.ssl_settings = ssl_settings
+    app.state.instance_id = INSTANCE_ID
+    app.state.original_argv = list(_ORIGINAL_ARGV)
     app.state.llama_parallel_slots = llama_parallel_slots
 
     # Run server in a daemon thread
@@ -373,9 +415,56 @@ def run_server(
             port = port,
             bind_host = host,
             display_host = display_host,
+            scheme = ssl_settings.scheme,
         )
 
     return app
+
+
+def trigger_self_restart() -> None:
+    """Re-exec the studio process with the same argv it was launched with.
+
+    Called by ``POST /api/settings/server/restart`` so an SSL setting
+    change can take effect without dropping the user back to a terminal.
+
+    On Unix we ``os.execv`` so the running PID is reused (the parent
+    shell sees the process keep running). On Windows ``execvp`` has
+    fragile semantics, so we spawn a detached child and exit the
+    current process.
+
+    Always runs the captured Python interpreter as the program — argv[0]
+    is the script path (Python's convention), so passing it to ``execvp``
+    directly would fail with ENOEXEC.
+    """
+    program = _ORIGINAL_PYTHON or sys.executable
+    args = [program, *_ORIGINAL_ARGV]
+    logger.info("Self-restart: re-exec %s %s", program, _ORIGINAL_ARGV)
+
+    _graceful_shutdown(_server)
+    _remove_pid_file()
+
+    # Best-effort: flush stdio so any pending output is visible.
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+    try:
+        if sys.platform == "win32":
+            import subprocess as _sp
+
+            try:
+                _sp.Popen(args, close_fds = True)
+            finally:
+                os._exit(0)
+        else:
+            os.execv(program, args)
+    except OSError:
+        # execv only returns on failure; log so the failure isn't silent
+        # and re-raise so the asyncio task surfaces it in server logs.
+        logger.exception("Self-restart failed; server stays on the old config")
+        raise
 
 
 # For direct execution (also invoked by CLI via os.execvp / subprocess)
@@ -406,11 +495,48 @@ if __name__ == "__main__":
         action = "store_true",
         help = "API server only, no frontend (for Tauri)",
     )
+    parser.add_argument(
+        "--ssl-certfile",
+        default = None,
+        help = "Path to a PEM-encoded SSL certificate (chain). Pair with --ssl-keyfile.",
+    )
+    parser.add_argument(
+        "--ssl-keyfile",
+        default = None,
+        help = "Path to a PEM-encoded SSL private key. Pair with --ssl-certfile.",
+    )
+    parser.add_argument(
+        "--ssl-self-signed",
+        action = "store_true",
+        help = (
+            "Generate (or reuse) a self-signed cert in ~/.unsloth/studio/ssl/. "
+            "Browsers will warn on first visit; click through to proceed."
+        ),
+    )
+    parser.add_argument(
+        "--no-ssl",
+        action = "store_true",
+        help = (
+            "Force HTTP, ignoring any saved SSL settings. Use this to recover "
+            "access if SSL was misconfigured via the UI."
+        ),
+    )
 
     args = parser.parse_args()
 
+    ssl_cli = SslCliArgs(
+        no_ssl = bool(args.no_ssl),
+        ssl_certfile = args.ssl_certfile,
+        ssl_keyfile = args.ssl_keyfile,
+        ssl_self_signed = bool(args.ssl_self_signed),
+    )
+
     kwargs = dict(
-        host = args.host, port = args.port, silent = args.silent, api_only = args.api_only
+        host = args.host,
+        port = args.port,
+        silent = args.silent,
+        api_only = args.api_only,
+        ssl_cli = ssl_cli,
     )
     if args.frontend is not None:
         kwargs["frontend_path"] = Path(args.frontend)

--- a/studio/backend/ssl_config.py
+++ b/studio/backend/ssl_config.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+Resolves SSL/TLS configuration from CLI args, environment variables, and
+the persistent ``app_secrets`` table, and generates a self-signed cert
+on demand.
+
+Precedence (highest first):
+  1. ``--no-ssl`` CLI flag → force HTTP regardless of every other source.
+  2. ``--ssl-certfile`` / ``--ssl-keyfile`` / ``--ssl-self-signed`` flags.
+  3. ``UNSLOTH_SSL_CERTFILE`` / ``UNSLOTH_SSL_KEYFILE`` / ``UNSLOTH_SSL_SELF_SIGNED`` env vars.
+  4. ``app_secrets`` rows written by the in-app Settings page.
+  5. Default → SSL disabled (HTTP).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import ssl
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+from utils.paths import ensure_dir, studio_root
+
+# ── app_secrets keys ───────────────────────────────────────────────────
+SSL_ENABLED_KEY = "ssl_enabled"
+SSL_CERTFILE_KEY = "ssl_certfile"
+SSL_KEYFILE_KEY = "ssl_keyfile"
+SSL_SELF_SIGNED_KEY = "ssl_self_signed"
+
+# ── env var names ──────────────────────────────────────────────────────
+ENV_CERTFILE = "UNSLOTH_SSL_CERTFILE"
+ENV_KEYFILE = "UNSLOTH_SSL_KEYFILE"
+ENV_SELF_SIGNED = "UNSLOTH_SSL_SELF_SIGNED"
+
+
+def ssl_root() -> Path:
+    """Directory holding the auto-generated self-signed cert + key."""
+    return studio_root() / "ssl"
+
+
+def _self_signed_cert_path() -> Path:
+    return ssl_root() / "cert.pem"
+
+
+def _self_signed_key_path() -> Path:
+    return ssl_root() / "key.pem"
+
+
+@dataclass(frozen = True)
+class SslSettings:
+    """Resolved SSL configuration handed to uvicorn.Config."""
+
+    enabled: bool
+    certfile: Optional[str]
+    keyfile: Optional[str]
+    # Which layer of the precedence chain produced this result. Used by
+    # the Settings UI to explain why "Active" can diverge from the saved
+    # toggle (e.g. running with --ssl-self-signed while DB has SSL off).
+    source: str = "default"
+
+    @property
+    def scheme(self) -> str:
+        return "https" if self.enabled else "http"
+
+
+def _truthy(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _read_db_settings() -> dict:
+    """Load SSL settings from ``app_secrets``. Returns an empty dict on failure
+    so missing/uninitialized auth.db never blocks server startup."""
+    try:
+        from auth.storage import get_app_secret
+    except Exception:
+        return {}
+    try:
+        return {
+            "enabled": _truthy(get_app_secret(SSL_ENABLED_KEY)),
+            "certfile": get_app_secret(SSL_CERTFILE_KEY) or None,
+            "keyfile": get_app_secret(SSL_KEYFILE_KEY) or None,
+            "self_signed": _truthy(get_app_secret(SSL_SELF_SIGNED_KEY)),
+        }
+    except Exception:
+        return {}
+
+
+@dataclass
+class SslCliArgs:
+    """Subset of argparse namespace consumed by the resolver."""
+
+    no_ssl: bool = False
+    ssl_certfile: Optional[str] = None
+    ssl_keyfile: Optional[str] = None
+    ssl_self_signed: bool = False
+
+
+def resolve_ssl_settings(
+    cli: SslCliArgs,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    bind_host: str = "0.0.0.0",
+) -> SslSettings:
+    """Walk the precedence chain and return the resolved settings.
+
+    Caller should pass ``bind_host`` so the self-signed cert can include
+    it in its SubjectAltName when it is a concrete address.
+    """
+    if env is None:
+        env = os.environ
+
+    # 1. Explicit escape hatch — overrides everything.
+    if cli.no_ssl:
+        return SslSettings(
+            enabled = False,
+            certfile = None,
+            keyfile = None,
+            source = "cli_no_ssl",
+        )
+
+    # 2. Resolve sources in priority order.
+    cli_has_paths = bool(cli.ssl_certfile and cli.ssl_keyfile)
+    cli_has_self_signed = bool(cli.ssl_self_signed)
+    env_certfile = env.get(ENV_CERTFILE)
+    env_keyfile = env.get(ENV_KEYFILE)
+    env_self_signed = _truthy(env.get(ENV_SELF_SIGNED))
+    env_has_paths = bool(env_certfile and env_keyfile)
+
+    db = _read_db_settings()
+
+    if cli_has_paths:
+        certfile = cli.ssl_certfile
+        keyfile = cli.ssl_keyfile
+        source = "cli_paths"
+    elif cli_has_self_signed:
+        certfile, keyfile = ensure_self_signed_cert(bind_host = bind_host)
+        source = "cli_self_signed"
+    elif env_has_paths:
+        certfile = env_certfile
+        keyfile = env_keyfile
+        source = "env_paths"
+    elif env_self_signed:
+        certfile, keyfile = ensure_self_signed_cert(bind_host = bind_host)
+        source = "env_self_signed"
+    elif db.get("enabled"):
+        if db.get("self_signed"):
+            certfile, keyfile = ensure_self_signed_cert(bind_host = bind_host)
+            source = "db_self_signed"
+        else:
+            certfile = db.get("certfile")
+            keyfile = db.get("keyfile")
+            source = "db_paths"
+            if not certfile or not keyfile:
+                raise RuntimeError(
+                    "SSL is enabled in saved settings but certfile/keyfile are "
+                    "missing. Re-open Settings → Server, or run "
+                    "`unsloth studio --no-ssl` to recover."
+                )
+    else:
+        return SslSettings(
+            enabled = False,
+            certfile = None,
+            keyfile = None,
+            source = "default",
+        )
+
+    _validate_cert_files(certfile, keyfile)
+    return SslSettings(
+        enabled = True,
+        certfile = certfile,
+        keyfile = keyfile,
+        source = source,
+    )
+
+
+def _validate_cert_files(certfile: str, keyfile: str) -> None:
+    """Raise ``RuntimeError`` if the cert/key cannot be loaded by OpenSSL."""
+    cert_path = Path(certfile).expanduser()
+    key_path = Path(keyfile).expanduser()
+    if not cert_path.is_file():
+        raise RuntimeError(f"SSL certificate file not found: {cert_path}")
+    if not key_path.is_file():
+        raise RuntimeError(f"SSL key file not found: {key_path}")
+    try:
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile = str(cert_path), keyfile = str(key_path))
+    except ssl.SSLError as exc:
+        raise RuntimeError(f"SSL certificate/key are not a valid pair: {exc}") from exc
+
+
+def ensure_self_signed_cert(*, bind_host: str = "0.0.0.0") -> tuple[str, str]:
+    """Return ``(certfile, keyfile)`` paths, generating them once if missing.
+
+    The generated cert is valid for 10 years. CN is ``localhost``;
+    SubjectAltName covers ``localhost``, ``127.0.0.1``, ``::1``, and
+    *bind_host* when it is a concrete (non-wildcard) IP.
+    """
+    cert_path = _self_signed_cert_path()
+    key_path = _self_signed_key_path()
+    if cert_path.is_file() and key_path.is_file():
+        return (str(cert_path), str(key_path))
+
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+    except ImportError as exc:
+        raise RuntimeError(
+            "Self-signed cert generation requires the `cryptography` package. "
+            "Install it (`pip install cryptography`) or pass --ssl-certfile / "
+            "--ssl-keyfile with your own cert."
+        ) from exc
+
+    import datetime as _dt
+
+    ensure_dir(ssl_root())
+
+    private_key = rsa.generate_private_key(public_exponent = 65537, key_size = 2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+
+    san_entries: list[x509.GeneralName] = [
+        x509.DNSName("localhost"),
+        x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
+        x509.IPAddress(ipaddress.IPv6Address("::1")),
+    ]
+    if bind_host and bind_host not in (
+        "0.0.0.0",
+        "::",
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    ):
+        try:
+            san_entries.append(x509.IPAddress(ipaddress.ip_address(bind_host)))
+        except ValueError:
+            san_entries.append(x509.DNSName(bind_host))
+
+    now = _dt.datetime.now(_dt.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(minutes = 5))
+        .not_valid_after(now + _dt.timedelta(days = 3650))
+        .add_extension(x509.SubjectAlternativeName(san_entries), critical = False)
+        .add_extension(x509.BasicConstraints(ca = False, path_length = None), critical = True)
+        .sign(private_key, hashes.SHA256())
+    )
+
+    key_path.write_bytes(
+        private_key.private_bytes(
+            encoding = serialization.Encoding.PEM,
+            format = serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm = serialization.NoEncryption(),
+        )
+    )
+    try:
+        os.chmod(key_path, 0o600)
+    except OSError:
+        pass
+
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+    return (str(cert_path), str(key_path))
+
+
+def regenerate_self_signed_cert(*, bind_host: str = "0.0.0.0") -> tuple[str, str]:
+    """Force-rotate the self-signed cert. Used by the Settings router."""
+    cert_path = _self_signed_cert_path()
+    key_path = _self_signed_key_path()
+    cert_path.unlink(missing_ok = True)
+    key_path.unlink(missing_ok = True)
+    return ensure_self_signed_cert(bind_host = bind_host)

--- a/studio/backend/ssl_config.py
+++ b/studio/backend/ssl_config.py
@@ -23,7 +23,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional
 
+from loggers import get_logger
 from utils.paths import ensure_dir, studio_root
+
+logger = get_logger(__name__)
 
 # ── app_secrets keys ───────────────────────────────────────────────────
 SSL_ENABLED_KEY = "ssl_enabled"
@@ -79,6 +82,13 @@ def _read_db_settings() -> dict:
     try:
         from auth.storage import get_app_secret
     except Exception:
+        # Auth storage isn't importable yet (e.g. very early startup or
+        # the package layout shifted). Fall back to "no DB settings" but
+        # leave a debug crumb for anyone investigating later.
+        logger.debug(
+            "Failed to import auth.storage for SSL settings",
+            exc_info = True,
+        )
         return {}
     try:
         return {
@@ -88,6 +98,10 @@ def _read_db_settings() -> dict:
             "self_signed": _truthy(get_app_secret(SSL_SELF_SIGNED_KEY)),
         }
     except Exception:
+        logger.debug(
+            "Failed to read SSL settings from app_secrets",
+            exc_info = True,
+        )
         return {}
 
 

--- a/studio/backend/startup_banner.py
+++ b/studio/backend/startup_banner.py
@@ -38,6 +38,7 @@ def print_studio_access_banner(
     port: int,
     bind_host: str,
     display_host: str,
+    scheme: str = "http",
 ) -> None:
     """Pretty-print URLs after the server is listening (beginner-friendly)."""
     use_color = stdout_supports_color()
@@ -52,15 +53,15 @@ def print_studio_access_banner(
 
     ipv6_bind = bind_host in ("::", "::1")
     if ipv6_bind:
-        loopback_url = f"http://[::1]:{port}"
-        alt_local = f"http://localhost:{port}"
+        loopback_url = f"{scheme}://[::1]:{port}"
+        alt_local = f"{scheme}://localhost:{port}"
     else:
-        loopback_url = f"http://127.0.0.1:{port}"
-        alt_local = f"http://localhost:{port}"
+        loopback_url = f"{scheme}://127.0.0.1:{port}"
+        alt_local = f"{scheme}://localhost:{port}"
     if ":" in display_host:
-        external_url = f"http://[{display_host}]:{port}"
+        external_url = f"{scheme}://[{display_host}]:{port}"
     else:
-        external_url = f"http://{display_host}:{port}"
+        external_url = f"{scheme}://{display_host}:{port}"
 
     listen_all = bind_host in ("0.0.0.0", "::")
     loopback_bind = bind_host in ("127.0.0.1", "localhost", "::1")
@@ -78,6 +79,14 @@ def print_studio_access_banner(
         style("  On this machine -- open this in your browser:", dim),
         style(f"    {primary_url}", local_url_style),
     ]
+
+    if scheme == "https":
+        lines.append(
+            style(
+                "  TLS enabled. Self-signed certs trigger a one-time browser warning.",
+                dim,
+            )
+        )
 
     if (listen_all or loopback_bind) and primary_url != alt_local:
         lines.append(style(f"    (same as {alt_local})", dim))

--- a/studio/frontend/biome.json
+++ b/studio/frontend/biome.json
@@ -119,6 +119,17 @@
       }
     },
     {
+      "include": [
+        "src/features/settings/api/server-settings.ts",
+        "src/features/settings/tabs/server-tab.tsx"
+      ],
+      "linter": {
+        "rules": {
+          "style": { "useNamingConvention": "off" }
+        }
+      }
+    },
+    {
       "include": ["src/components/assistant-ui/thread.tsx"],
       "linter": {
         "rules": {

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { apiUrl, isTauri } from "@/lib/api-base";
+import { awaitRestart, isRestarting } from "@/lib/restart-state";
 import {
   clearAuthTokens,
   getAuthToken,
@@ -99,7 +100,7 @@ export async function authFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
-  const resolvedInput = typeof input === 'string' ? apiUrl(input) : input;
+  const resolvedInput = typeof input === "string" ? apiUrl(input) : input;
   const headers = new Headers(init?.headers);
   const accessToken = getAuthToken();
   if (accessToken) {
@@ -110,6 +111,14 @@ export async function authFetch(
   try {
     response = await fetch(resolvedInput, { ...init, headers });
   } catch (err) {
+    // During a user-initiated restart, the backend goes down for ~5–15s.
+    // Park the request on the restart gate and replay it once the new
+    // server answers — that keeps the rest of the UI quiet instead of
+    // showering toasts and tripping the auth-redirect path.
+    if (err instanceof TypeError && isRestarting()) {
+      await awaitRestart();
+      return retryWithCurrentToken(resolvedInput, init);
+    }
     if (err instanceof TypeError) {
       throw new Error("Studio isn't running -- please relaunch it.");
     }
@@ -124,6 +133,14 @@ export async function authFetch(
     return response;
   }
   if (response.status !== 401) return response;
+
+  // 401 during a restart almost always means our request raced the new
+  // server's lifespan — wait it out and retry with the same token rather
+  // than tearing down the session and bouncing the user to /login.
+  if (isRestarting()) {
+    await awaitRestart();
+    return retryWithCurrentToken(resolvedInput, init);
+  }
 
   const refreshed = await refreshSession();
   if (!refreshed) {

--- a/studio/frontend/src/features/settings/api/server-settings.ts
+++ b/studio/frontend/src/features/settings/api/server-settings.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth/api";
+
+export type ActiveSslSource =
+  | "default"
+  | "cli_no_ssl"
+  | "cli_paths"
+  | "cli_self_signed"
+  | "env_paths"
+  | "env_self_signed"
+  | "db_paths"
+  | "db_self_signed";
+
+export interface ServerSslSettings {
+  ssl_enabled: boolean;
+  ssl_self_signed: boolean;
+  ssl_certfile: string | null;
+  ssl_keyfile: string | null;
+  active_scheme: "http" | "https";
+  active_port: number | null;
+  active_source: ActiveSslSource;
+  restart_supported: boolean;
+}
+
+export interface ServerSslUpdate {
+  ssl_enabled: boolean;
+  ssl_self_signed: boolean;
+  ssl_certfile: string | null;
+  ssl_keyfile: string | null;
+}
+
+export async function fetchServerSettings(): Promise<ServerSslSettings> {
+  const res = await authFetch("/api/settings/server");
+  if (!res.ok) {
+    throw new Error("Failed to load server settings");
+  }
+  return res.json();
+}
+
+export async function updateServerSettings(
+  payload: ServerSslUpdate,
+): Promise<ServerSslSettings> {
+  const res = await authFetch("/api/settings/server", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(detail || "Failed to update server settings");
+  }
+  return res.json();
+}
+
+export interface TestCertificateRequest {
+  ssl_certfile: string;
+  ssl_keyfile: string;
+}
+
+export async function testCertificate(
+  payload: TestCertificateRequest,
+): Promise<{ ok: boolean; error: string | null }> {
+  const res = await authFetch("/api/settings/server/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    return { ok: false, error: detail || `HTTP ${res.status}` };
+  }
+  return res.json();
+}
+
+export async function restartServer(): Promise<{
+  restarting: boolean;
+  supported: boolean;
+}> {
+  const res = await authFetch("/api/settings/server/restart", {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error("Failed to restart server");
+  }
+  return res.json();
+}

--- a/studio/frontend/src/features/settings/lib/restart-poll.ts
+++ b/studio/frontend/src/features/settings/lib/restart-poll.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { type ApiScheme, setApiBase } from "@/lib/api-base";
+
+interface ProbeResult {
+  scheme: ApiScheme;
+  port: number;
+  instanceId: string | null;
+}
+
+interface HealthPayload {
+  status?: string;
+  service?: string;
+  instance_id?: string | null;
+}
+
+/**
+ * Read /api/health once. Returns the parsed payload + which scheme
+ * answered. The HTTPS probe runs first so an SSL backend is detected
+ * even when the page itself is on HTTP (e.g. just-flipped-on flow).
+ * The HTTP probe is the fallback for backends running plain HTTP.
+ */
+export async function fetchBackendHealth(options: {
+  port: number;
+  host?: string;
+  timeoutMs?: number;
+}): Promise<ProbeResult | null> {
+  const host = options.host ?? defaultProbeHost();
+  const timeoutMs = options.timeoutMs ?? 1500;
+  for (const scheme of ["https", "http"] as ApiScheme[]) {
+    try {
+      const ctrl = new AbortController();
+      const t = setTimeout(() => ctrl.abort(), timeoutMs);
+      const url = `${scheme}://${host}:${options.port}/api/health`;
+      const res = await fetch(url, { signal: ctrl.signal });
+      clearTimeout(t);
+      if (!res.ok) {
+        continue;
+      }
+      const json = (await res.json()) as HealthPayload;
+      if (json.status !== "healthy" || json.service !== "Unsloth UI Backend") {
+        continue;
+      }
+      return {
+        scheme,
+        port: options.port,
+        instanceId: json.instance_id ?? null,
+      };
+    } catch {
+      // try next scheme
+    }
+  }
+  return null;
+}
+
+/**
+ * Default polling host. In browser mode this must match whatever the user
+ * has open in the address bar — self-signed cert exceptions are tracked
+ * per-hostname by browsers, so probing 127.0.0.1 from a localhost tab
+ * (or vice-versa) gets blocked even when the cert SAN covers both.
+ *
+ * Tauri keeps 127.0.0.1 because its webview origin (`tauri://...`) is
+ * unrelated to the backend address.
+ */
+function defaultProbeHost(): string {
+  if (typeof window === "undefined") {
+    return "127.0.0.1";
+  }
+  const isTauri = "__TAURI__" in window;
+  if (isTauri) {
+    return "127.0.0.1";
+  }
+  return window.location.hostname || "127.0.0.1";
+}
+
+/**
+ * Race http:// and https:// health probes against the same port until one
+ * responds 200. Used after a server restart triggered by the settings UI to
+ * detect the new scheme without needing the answer up front.
+ *
+ * Each scheme is probed once per cycle. The poll exits early on the first
+ * success so the UI can switch over fast; on timeout it returns null and
+ * the caller surfaces the recovery instructions.
+ */
+export async function pollUntilBackendReady(options: {
+  port: number;
+  host?: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+  signal?: AbortSignal;
+  /**
+   * The instance_id of the backend before the restart was triggered.
+   * Polling will only return a healthy probe whose `instance_id`
+   * differs from this value — that's the unambiguous signal that the
+   * Python process was actually replaced. When undefined or null
+   * (e.g. we couldn't read it pre-restart, or the backend version
+   * doesn't expose it), the poller falls back to the legacy "saw the
+   * server unreachable at least once" heuristic.
+   */
+  previousInstanceId?: string | null;
+}): Promise<ProbeResult | null> {
+  const host = options.host ?? defaultProbeHost();
+  // First-time restarts on a fresh box can spend 30-60s in matplotlib font
+  // cache build, hardware detect, and the GGUF pre-cache thread before the
+  // /api/health route is reachable. 90s covers that with headroom.
+  const timeoutMs = options.timeoutMs ?? 90_000;
+  const intervalMs = options.intervalMs ?? 1_000;
+  const deadline = Date.now() + timeoutMs;
+
+  const previousInstanceId = options.previousInstanceId ?? null;
+  // Fallback heuristic for backends that don't expose instance_id, or
+  // when we couldn't read it before the restart.
+  let sawDown = false;
+
+  while (Date.now() < deadline) {
+    if (options.signal?.aborted) {
+      return null;
+    }
+
+    const probe = await fetchBackendHealth({
+      port: options.port,
+      host,
+      timeoutMs: Math.min(intervalMs, 800),
+    });
+
+    if (probe) {
+      const idShifted =
+        previousInstanceId !== null &&
+        probe.instanceId !== null &&
+        probe.instanceId !== previousInstanceId;
+      if (idShifted) {
+        return probe;
+      }
+      // Same instance_id (or backend can't tell us) — only believe in
+      // the restart if we previously saw the server go down.
+      if (
+        sawDown &&
+        (probe.instanceId === null || previousInstanceId === null)
+      ) {
+        return probe;
+      }
+    } else {
+      sawDown = true;
+    }
+
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  return null;
+}
+
+/**
+ * Apply the discovered scheme to the API client. Returns whether the
+ * caller should reload — only true when the page itself is on the wrong
+ * scheme (HTTP↔HTTPS flipped during the restart) and a redirect is the
+ * only way to get there. When the scheme is unchanged we just update
+ * the API base; in-flight `authFetch` requests parked on the restart
+ * gate will resume against the new server without a page bounce, so
+ * modals and other in-memory UI state stay intact.
+ */
+export function applyDiscoveredBackend(result: ProbeResult): {
+  reloaded: boolean;
+} {
+  setApiBase(result.port, result.scheme);
+  if (typeof window === "undefined") {
+    return { reloaded: false };
+  }
+  const isTauri = "__TAURI__" in window;
+  if (isTauri) {
+    return { reloaded: false }; // Tauri uses absolute URLs, no reload needed.
+  }
+
+  const currentScheme =
+    window.location.protocol === "https:" ? "https" : "http";
+  if (currentScheme !== result.scheme) {
+    const target = `${result.scheme}://${window.location.host}${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.location.replace(target);
+    return { reloaded: true };
+  }
+  return { reloaded: false };
+}

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -13,19 +13,24 @@ import {
   Key01Icon,
   Message01Icon,
   PaintBrush02Icon,
+  ServerStack01Icon,
   Settings02Icon,
   SparklesIcon,
   UserIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { motion, useReducedMotion } from "motion/react";
-import { useSettingsDialogStore, type SettingsTab } from "./stores/settings-dialog-store";
+import {
+  type SettingsTab,
+  useSettingsDialogStore,
+} from "./stores/settings-dialog-store";
 import { AboutTab } from "./tabs/about-tab";
 import { ApiKeysTab } from "./tabs/api-keys-tab";
 import { AppearanceTab } from "./tabs/appearance-tab";
 import { ChatTab } from "./tabs/chat-tab";
 import { GeneralTab } from "./tabs/general-tab";
 import { ProfileTab } from "./tabs/profile-tab";
+import { ServerTab } from "./tabs/server-tab";
 
 interface TabDef {
   id: SettingsTab;
@@ -39,6 +44,7 @@ const TABS: TabDef[] = [
   { id: "appearance", label: "Appearance", icon: PaintBrush02Icon },
   { id: "chat", label: "Chat", icon: Message01Icon },
   { id: "api-keys", label: "API Keys", icon: Key01Icon },
+  { id: "server", label: "Server", icon: ServerStack01Icon },
   { id: "about", label: "About", icon: SparklesIcon },
 ];
 
@@ -54,6 +60,8 @@ function renderTab(tab: SettingsTab) {
       return <ChatTab />;
     case "api-keys":
       return <ApiKeysTab />;
+    case "server":
+      return <ServerTab />;
     case "about":
       return <AboutTab />;
   }

--- a/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
@@ -9,6 +9,7 @@ export type SettingsTab =
   | "appearance"
   | "chat"
   | "api-keys"
+  | "server"
   | "about";
 
 interface SettingsDialogState {
@@ -22,15 +23,27 @@ interface SettingsDialogState {
 const ACTIVE_TAB_KEY = "unsloth_settings_active_tab";
 
 function loadInitialTab(): SettingsTab {
-  if (typeof window === "undefined") return "general";
+  if (typeof window === "undefined") {
+    return "general";
+  }
   let stored: string | null = null;
   try {
     stored = window.localStorage.getItem(ACTIVE_TAB_KEY);
   } catch {
     return "general";
   }
-  const valid: SettingsTab[] = ["general", "profile", "appearance", "chat", "api-keys", "about"];
-  return valid.includes(stored as SettingsTab) ? (stored as SettingsTab) : "general";
+  const valid: SettingsTab[] = [
+    "general",
+    "profile",
+    "appearance",
+    "chat",
+    "api-keys",
+    "server",
+    "about",
+  ];
+  return valid.includes(stored as SettingsTab)
+    ? (stored as SettingsTab)
+    : "general";
 }
 
 export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({

--- a/studio/frontend/src/features/settings/tabs/server-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/server-tab.tsx
@@ -457,6 +457,14 @@ export function ServerTab() {
         </div>
       </div>
 
+      <p className="text-xs text-foreground">
+        <span className="font-semibold text-emerald-500">Note:</span>{" "}
+        HTTP and HTTPS are separate browser origins, so your chat history,
+        theme, and login session won't follow you across the switch.
+        Nothing is deleted — switching back makes them reappear — but on
+        the new scheme you'll re-sign in and re-pick preferences.
+      </p>
+
       <p className="text-xs text-muted-foreground">
         Locked out after a misconfigured cert? Run{" "}
         <code>unsloth studio --no-ssl</code> from a terminal to start the server

--- a/studio/frontend/src/features/settings/tabs/server-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/server-tab.tsx
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Switch } from "@/components/ui/switch";
+import { beginRestart } from "@/lib/restart-state";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  type ServerSslSettings,
+  fetchServerSettings,
+  restartServer,
+  testCertificate,
+  updateServerSettings,
+} from "../api/server-settings";
+import { SettingsRow } from "../components/settings-row";
+import { SettingsSection } from "../components/settings-section";
+import {
+  applyDiscoveredBackend,
+  fetchBackendHealth,
+  pollUntilBackendReady,
+} from "../lib/restart-poll";
+
+type CertMode = "self_signed" | "byo";
+
+/**
+ * Pick the radio default based on saved settings. When SSL has never
+ * been configured (the fresh-install case) we land on self-signed so
+ * toggling "Enable TLS" on shows the recommended option pre-selected.
+ * BYO is only the default when the user has already saved a non-self-
+ * signed configuration.
+ */
+function defaultCertMode(settings: ServerSslSettings): CertMode {
+  if (settings.ssl_enabled && !settings.ssl_self_signed) {
+    return "byo";
+  }
+  return "self_signed";
+}
+
+function describeActiveSource(settings: ServerSslSettings | null): string {
+  if (!settings) {
+    return "";
+  }
+  const httpsActive = settings.active_scheme === "https";
+  switch (settings.active_source) {
+    case "cli_no_ssl":
+      return "Running in plain HTTP because --no-ssl was passed. Saved settings will resume on next restart without that flag.";
+    case "cli_paths":
+      return "TLS is forced on by --ssl-certfile / --ssl-keyfile CLI flags. Saved settings below take over when the flags are dropped.";
+    case "cli_self_signed":
+      return "TLS is forced on by --ssl-self-signed. Saved settings below take over when the flag is dropped — toggle Enable TLS and save to make this persistent.";
+    case "env_paths":
+      return "TLS is forced on by UNSLOTH_SSL_CERTFILE / UNSLOTH_SSL_KEYFILE env vars. Saved settings take over when those are unset.";
+    case "env_self_signed":
+      return "TLS is forced on by UNSLOTH_SSL_SELF_SIGNED env var. Saved settings take over when it's unset.";
+    case "db_paths":
+    case "db_self_signed":
+      return httpsActive
+        ? "TLS is enabled from your saved settings."
+        : "Plain HTTP is currently in use.";
+    default:
+      return httpsActive
+        ? "TLS is currently enabled. Self-signed certs trigger a one-time browser warning on first visit."
+        : "Plain HTTP is currently in use. Enable TLS below to encrypt logins and API traffic.";
+  }
+}
+
+export function ServerTab() {
+  const [settings, setSettings] = useState<ServerSslSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [sslEnabled, setSslEnabled] = useState(false);
+  const [certMode, setCertMode] = useState<CertMode>("self_signed");
+  const [certfile, setCertfile] = useState("");
+  const [keyfile, setKeyfile] = useState("");
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [savedHint, setSavedHint] = useState<string | null>(null);
+
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{
+    ok: boolean;
+    error: string | null;
+  } | null>(null);
+
+  const [restarting, setRestarting] = useState(false);
+  const [restartError, setRestartError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchServerSettings()
+      .then((s) => {
+        if (cancelled) {
+          return;
+        }
+        setSettings(s);
+        setSslEnabled(s.ssl_enabled);
+        setCertMode(defaultCertMode(s));
+        setCertfile(s.ssl_certfile ?? "");
+        setKeyfile(s.ssl_keyfile ?? "");
+      })
+      .catch((e) => {
+        if (cancelled) {
+          return;
+        }
+        setLoadError(String(e?.message ?? e));
+      })
+      .finally(() => {
+        if (cancelled) {
+          return;
+        }
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // When TLS is off, certMode and the path inputs are meaningless —
+  // comparing them against the saved state would leave the form
+  // permanently "dirty" after disabling TLS.
+  const dirty =
+    settings !== null &&
+    (sslEnabled !== settings.ssl_enabled ||
+      (sslEnabled &&
+        ((certMode === "self_signed") !== settings.ssl_self_signed ||
+          (certMode === "byo" && certfile !== (settings.ssl_certfile ?? "")) ||
+          (certMode === "byo" && keyfile !== (settings.ssl_keyfile ?? "")))));
+
+  const requiresRestart =
+    settings !== null && sslEnabled !== (settings.active_scheme === "https");
+
+  async function handleTest() {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await testCertificate({
+        ssl_certfile: certfile,
+        ssl_keyfile: keyfile,
+      });
+      setTestResult(result);
+    } catch (e) {
+      setTestResult({ ok: false, error: String((e as Error)?.message ?? e) });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveError(null);
+    setSavedHint(null);
+    try {
+      const next = await updateServerSettings({
+        ssl_enabled: sslEnabled,
+        ssl_self_signed: sslEnabled && certMode === "self_signed",
+        ssl_certfile: sslEnabled && certMode === "byo" ? certfile : null,
+        ssl_keyfile: sslEnabled && certMode === "byo" ? keyfile : null,
+      });
+      setSettings(next);
+      setSavedHint("Saved. Restart the server to apply SSL changes.");
+    } catch (e) {
+      setSaveError(String((e as Error)?.message ?? e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRestart() {
+    if (!settings?.active_port) {
+      return;
+    }
+    setRestartError(null);
+    setSavedHint(null);
+    setRestarting(true);
+
+    // Capture the pre-restart instance_id so the poller can confirm the
+    // process was actually replaced (vs. answering us from the same
+    // uvicorn that hasn't shut down yet).
+    const before = await fetchBackendHealth({ port: settings.active_port });
+    const previousInstanceId = before?.instanceId ?? null;
+
+    // Open the gate so authFetch parks (rather than detonating) every
+    // request that races the restart. Released in `finally` so a thrown
+    // error or early return can never leave the rest of the UI frozen.
+    const releaseGate = beginRestart();
+    try {
+      const r = await restartServer();
+      if (!r.supported) {
+        setRestartError(
+          "This platform cannot self-restart. Please restart `unsloth studio` manually.",
+        );
+        return;
+      }
+
+      const result = await pollUntilBackendReady({
+        port: settings.active_port,
+        timeoutMs: 90_000,
+        previousInstanceId,
+      });
+      if (!result) {
+        setRestartError(
+          "The server did not come back online within 90 seconds. " +
+            "It may still be starting — try refreshing in a moment. " +
+            "If the UI is unreachable, run `unsloth studio --no-ssl` to recover.",
+        );
+        return;
+      }
+      const { reloaded } = applyDiscoveredBackend(result);
+      if (reloaded) {
+        // Page is bouncing to the new scheme; nothing else to do.
+        return;
+      }
+      // Same-scheme restart: refresh the displayed settings against the
+      // freshly booted server so "Active" reflects the new state.
+      try {
+        const next = await fetchServerSettings();
+        setSettings(next);
+        setSslEnabled(next.ssl_enabled);
+        setCertMode(defaultCertMode(next));
+        setCertfile(next.ssl_certfile ?? "");
+        setKeyfile(next.ssl_keyfile ?? "");
+      } catch {
+        // Non-fatal — the next render will fall back to the previous
+        // settings until the user navigates.
+      }
+      setSavedHint("Server restarted.");
+    } catch (e) {
+      setRestartError(String((e as Error)?.message ?? e));
+    } finally {
+      releaseGate();
+      setRestarting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-2">
+        <h1 className="text-lg font-semibold font-heading">Server</h1>
+        <p className="text-xs text-muted-foreground">
+          Loading server settings…
+        </p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-col gap-3">
+        <h1 className="text-lg font-semibold font-heading">Server</h1>
+        <Alert variant="destructive">
+          <AlertTitle>Could not load settings</AlertTitle>
+          <AlertDescription>{loadError}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-lg font-semibold font-heading">Server</h1>
+        <p className="text-xs text-muted-foreground">
+          Configure how the Unsloth Studio backend serves the web UI and API.
+          Changes apply on server restart.
+        </p>
+      </header>
+
+      <Alert>
+        <AlertTitle>
+          Active: {settings?.active_scheme === "https" ? "HTTPS" : "HTTP"}
+          {settings?.active_port ? ` on port ${settings.active_port}` : ""}
+        </AlertTitle>
+        <AlertDescription>
+          {describeActiveSource(settings)}
+        </AlertDescription>
+      </Alert>
+
+      <SettingsSection
+        title="TLS / SSL"
+        description="Encrypts the web UI, /api/*, and /v1/* endpoints. Off by default."
+      >
+        <SettingsRow
+          label="Enable TLS"
+          description="Turn on to serve HTTPS. Requires a server restart to take effect."
+        >
+          <Switch checked={sslEnabled} onCheckedChange={setSslEnabled} />
+        </SettingsRow>
+
+        {sslEnabled ? (
+          <div className="flex flex-col gap-4 py-3">
+            <RadioGroup
+              value={certMode}
+              onValueChange={(v) => setCertMode(v as CertMode)}
+              className="flex flex-col gap-3"
+            >
+              <div className="flex items-start gap-3">
+                <RadioGroupItem
+                  value="self_signed"
+                  id="ssl-self-signed"
+                  className="mt-0.5"
+                />
+                <Label
+                  htmlFor="ssl-self-signed"
+                  className="flex flex-col items-start gap-0.5 cursor-pointer text-left"
+                >
+                  <span className="text-sm font-medium">
+                    Self-signed certificate
+                  </span>
+                  <span className="text-xs text-muted-foreground leading-snug">
+                    Studio generates and reuses a cert in{" "}
+                    <code>~/.unsloth/studio/ssl/</code>. Browsers will show a
+                    one-time warning you can click through.
+                  </span>
+                </Label>
+              </div>
+              <div className="flex items-start gap-3">
+                <RadioGroupItem value="byo" id="ssl-byo" className="mt-0.5" />
+                <Label
+                  htmlFor="ssl-byo"
+                  className="flex flex-col items-start gap-0.5 cursor-pointer text-left"
+                >
+                  <span className="text-sm font-medium">
+                    Provide certificate files
+                  </span>
+                  <span className="text-xs text-muted-foreground leading-snug">
+                    Use a real cert (e.g. from Let's Encrypt) by pointing to PEM
+                    files.
+                  </span>
+                </Label>
+              </div>
+            </RadioGroup>
+
+            {certMode === "byo" ? (
+              <div className="flex flex-col gap-3 pl-7">
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="ssl-certfile" className="text-xs">
+                    Certificate file (PEM)
+                  </Label>
+                  <Input
+                    id="ssl-certfile"
+                    placeholder="/etc/ssl/certs/studio.pem"
+                    value={certfile}
+                    onChange={(e) => {
+                      setCertfile(e.target.value);
+                      setTestResult(null);
+                    }}
+                    className="h-8 font-mono text-xs"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="ssl-keyfile" className="text-xs">
+                    Private key file (PEM)
+                  </Label>
+                  <Input
+                    id="ssl-keyfile"
+                    placeholder="/etc/ssl/private/studio.key"
+                    value={keyfile}
+                    onChange={(e) => {
+                      setKeyfile(e.target.value);
+                      setTestResult(null);
+                    }}
+                    className="h-8 font-mono text-xs"
+                  />
+                </div>
+                <div className="flex items-center gap-3">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={testing || !certfile || !keyfile}
+                    onClick={handleTest}
+                  >
+                    {testing ? (
+                      <Loader2 className="size-3.5 animate-spin" />
+                    ) : (
+                      "Test certificate"
+                    )}
+                  </Button>
+                  {testResult ? (
+                    <span
+                      className={
+                        testResult.ok
+                          ? "text-xs text-emerald-500"
+                          : "text-xs text-destructive"
+                      }
+                    >
+                      {testResult.ok
+                        ? "Valid certificate/key pair."
+                        : `Error: ${testResult.error ?? "invalid"}`}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </SettingsSection>
+
+      {saveError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Could not save</AlertTitle>
+          <AlertDescription>{saveError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {restartError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Restart did not complete</AlertTitle>
+          <AlertDescription>{restartError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-3 border-t border-border/60 pt-4">
+        <span className="text-xs text-muted-foreground">
+          {savedHint ??
+            (dirty
+              ? "Unsaved changes — save before restarting to apply them."
+              : requiresRestart
+                ? "Saved settings differ from the running server. Restart to apply."
+                : "Settings match the running server.")}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSave}
+            disabled={saving || !dirty}
+          >
+            {saving ? <Loader2 className="size-3.5 animate-spin" /> : "Save"}
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleRestart}
+            disabled={restarting || !settings?.restart_supported}
+            title={
+              dirty
+                ? "Restart will use your last saved settings. Click Save first to include unsaved changes."
+                : "Restart the server now."
+            }
+          >
+            {restarting ? (
+              <>
+                <Loader2 className="size-3.5 animate-spin" />
+                <span className="ml-1.5">Restarting…</span>
+              </>
+            ) : (
+              "Restart server"
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Locked out after a misconfigured cert? Run{" "}
+        <code>unsloth studio --no-ssl</code> from a terminal to start the server
+        in plain HTTP and recover.
+      </p>
+    </div>
+  );
+}

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { clearTauriAuthFailure, getTauriAuthFailure } from "@/features/auth";
 import { isTauri, setApiBase } from "@/lib/api-base";
-import {
-  clearTauriAuthFailure,
-  getTauriAuthFailure,
-} from "@/features/auth";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export type BackendStatus =
   | "checking"
@@ -31,8 +28,13 @@ interface DesktopPreflightResult {
   disposition: DesktopPreflightDisposition;
   reason: string | null;
   port: number | null;
+  scheme: string | null;
   can_auto_repair: boolean;
   managed_bin: string | null;
+}
+
+function normalizeScheme(value: string | null | undefined): "http" | "https" {
+  return value === "https" ? "https" : "http";
 }
 
 export function useTauriBackend() {
@@ -46,6 +48,8 @@ export function useTauriBackend() {
   const mountedRef = useRef(false);
   // Track the discovered port from server-port event
   const portRef = useRef<number | null>(null);
+  // Track the discovered scheme from server-scheme event (TAURI_SCHEME stdout)
+  const schemeRef = useRef<"http" | "https">("http");
   const [currentStepIndex, setCurrentStepIndex] = useState(-1);
   const [elevationPackages, setElevationPackages] = useState<string[]>([]);
   const [progressDetail, setProgressDetail] = useState<string | null>(null);
@@ -59,7 +63,9 @@ export function useTauriBackend() {
   const elevationResumeRef = useRef<"install" | "repair" | null>(null);
 
   function setBackendStatus(nextStatus: BackendStatus) {
-    if (authFailureRef.current) return;
+    if (authFailureRef.current) {
+      return;
+    }
     statusRef.current = nextStatus;
     setStatus(nextStatus);
   }
@@ -68,14 +74,18 @@ export function useTauriBackend() {
     nextError: string,
     nextStatus: BackendStatus = "error",
   ) {
-    if (authFailureRef.current) return;
+    if (authFailureRef.current) {
+      return;
+    }
     statusRef.current = nextStatus;
     setStatus(nextStatus);
     setError(nextError);
   }
 
   function clearBackendError() {
-    if (authFailureRef.current) return;
+    if (authFailureRef.current) {
+      return;
+    }
     setError(null);
   }
 
@@ -108,18 +118,27 @@ export function useTauriBackend() {
     externalPollAbortedRef.current = false;
     let failures = 0;
     externalPollRef.current = setInterval(async () => {
-      if (externalPollAbortedRef.current) return;
+      if (externalPollAbortedRef.current) {
+        return;
+      }
       try {
         const { invoke } = await import("@tauri-apps/api/core");
-        const healthy = await invoke<boolean>("check_health", { port });
-        if (externalPollAbortedRef.current) return;
+        const healthy = await invoke<boolean>("check_health", {
+          port,
+          scheme: schemeRef.current,
+        });
+        if (externalPollAbortedRef.current) {
+          return;
+        }
         if (healthy) {
           failures = 0;
         } else {
           failures++;
         }
       } catch {
-        if (externalPollAbortedRef.current) return;
+        if (externalPollAbortedRef.current) {
+          return;
+        }
         failures++;
       }
       if (failures >= 3) {
@@ -139,27 +158,33 @@ export function useTauriBackend() {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
 
-      const preflight = await invoke<DesktopPreflightResult>("desktop_preflight");
+      const preflight =
+        await invoke<DesktopPreflightResult>("desktop_preflight");
       switch (preflight.disposition) {
         case "attached_ready": {
           if (!preflight.port) {
-            setBackendError("Desktop preflight found a backend without a port.");
+            setBackendError(
+              "Desktop preflight found a backend without a port.",
+            );
             return;
           }
-          setApiBase(preflight.port);
+          const detectedScheme = normalizeScheme(preflight.scheme);
+          schemeRef.current = detectedScheme;
+          setApiBase(preflight.port, detectedScheme);
           portRef.current = preflight.port;
           setIsExternalServer(true);
           setRunningStatus();
           startExternalServerPoll(preflight.port);
           return;
         }
-        case "managed_ready":
+        case "managed_ready": {
           setIsExternalServer(false);
           stopExternalServerPoll();
           setBackendStatus("starting");
           await startManagedServer();
           return;
-        case "managed_stale":
+        }
+        case "managed_stale": {
           setIsExternalServer(false);
           stopExternalServerPoll();
           if (preflight.can_auto_repair) {
@@ -170,9 +195,11 @@ export function useTauriBackend() {
             );
           }
           return;
-        case "not_installed":
+        }
+        case "not_installed": {
           setBackendStatus("not-installed");
           return;
+        }
       }
     } catch (e) {
       setBackendError(String(e));
@@ -181,7 +208,9 @@ export function useTauriBackend() {
 
   async function startManagedServer() {
     // Prevent double-start race condition
-    if (startingRef.current) return;
+    if (startingRef.current) {
+      return;
+    }
     startingRef.current = true;
 
     try {
@@ -196,9 +225,10 @@ export function useTauriBackend() {
         if (portRef.current) {
           const healthy = await invoke<boolean>("check_health", {
             port: portRef.current,
+            scheme: schemeRef.current,
           });
           if (healthy) {
-            setApiBase(portRef.current);
+            setApiBase(portRef.current, schemeRef.current);
             setRunningStatus();
             startingRef.current = false;
             return;
@@ -206,9 +236,9 @@ export function useTauriBackend() {
         }
         await new Promise((r) => setTimeout(r, 500));
       }
-      const message = !portRef.current
-        ? "Managed server started without reporting a port. Check the logs for details."
-        : "Server started but is not responding. Check the logs for details.";
+      const message = portRef.current
+        ? "Server started but is not responding. Check the logs for details."
+        : "Managed server started without reporting a port. Check the logs for details.";
       setBackendError(message);
     } catch (e) {
       const msg = String(e);
@@ -246,7 +276,9 @@ export function useTauriBackend() {
       await startManagedServer();
     } catch (e) {
       const msg = String(e);
-      if (msg.includes("NEEDS_ELEVATION")) return;
+      if (msg.includes("NEEDS_ELEVATION")) {
+        return;
+      }
       setBackendError(msg, "repair-error");
     }
   }
@@ -294,7 +326,9 @@ export function useTauriBackend() {
       // NEEDS_ELEVATION is not a real error — the Rust side also emits
       // install-needs-elevation which sets needs-elevation status.
       // Don't race with it by setting install-error here.
-      if (msg.includes("NEEDS_ELEVATION")) return;
+      if (msg.includes("NEEDS_ELEVATION")) {
+        return;
+      }
       setBackendError(msg, "install-error");
     }
   }
@@ -322,7 +356,10 @@ export function useTauriBackend() {
     setLogs([]);
     setElevationPackages([]);
     if (resume === "repair") {
-      setBackendError("Repair canceled before system packages were installed.", "repair-error");
+      setBackendError(
+        "Repair canceled before system packages were installed.",
+        "repair-error",
+      );
       return;
     }
     setBackendStatus("not-installed");
@@ -343,13 +380,18 @@ export function useTauriBackend() {
         await startInstall();
       }
     } catch (e) {
-      setBackendError(String(e), resume === "repair" ? "repair-error" : "install-error");
+      setBackendError(
+        String(e),
+        resume === "repair" ? "repair-error" : "install-error",
+      );
     }
   }, [elevationPackages]);
 
   // Initial check on mount (guarded against Strict Mode double-mount)
   useEffect(() => {
-    if (mountedRef.current) return;
+    if (mountedRef.current) {
+      return;
+    }
     mountedRef.current = true;
 
     if (!isTauri) {
@@ -361,7 +403,9 @@ export function useTauriBackend() {
 
   // Listen for Tauri events
   useEffect(() => {
-    if (!isTauri) return;
+    if (!isTauri) {
+      return;
+    }
     const cleanup: (() => void)[] = [];
     let disposed = false;
 
@@ -391,7 +435,9 @@ export function useTauriBackend() {
 
       register<string>("install-step", (e) => {
         const stepName = e.payload;
-        if (seenStepsRef.current.has(stepName)) return; // deduplicate
+        if (seenStepsRef.current.has(stepName)) {
+          return; // deduplicate
+        }
         seenStepsRef.current.add(stepName);
         setCurrentStepIndex((prev) => prev + 1);
         setProgressDetail(null);
@@ -422,18 +468,29 @@ export function useTauriBackend() {
       });
 
       register<void>("repair-complete", () => {
-        if (statusRef.current !== "repairing") return;
+        if (statusRef.current !== "repairing") {
+          return;
+        }
         setProgressDetail("Repair complete");
       });
 
       register<string>("repair-failed", (e) => {
-        if (statusRef.current !== "repairing") return;
+        if (statusRef.current !== "repairing") {
+          return;
+        }
         setBackendError(e.payload, "repair-error");
       });
 
       register<number>("server-port", (e) => {
         portRef.current = e.payload;
-        setApiBase(e.payload);
+        setApiBase(e.payload, schemeRef.current);
+      });
+
+      register<string>("server-scheme", (e) => {
+        schemeRef.current = normalizeScheme(e.payload);
+        if (portRef.current) {
+          setApiBase(portRef.current, schemeRef.current);
+        }
       });
 
       register<void>("server-crashed", () => {
@@ -466,7 +523,9 @@ export function useTauriBackend() {
     };
     window.addEventListener("tauri-auth-failed", onAuthFailed);
     const authFailure = getTauriAuthFailure();
-    if (authFailure) setAuthFailure(authFailure);
+    if (authFailure) {
+      setAuthFailure(authFailure);
+    }
     cleanup.push(() =>
       window.removeEventListener("tauri-auth-failed", onAuthFailed),
     );
@@ -479,9 +538,18 @@ export function useTauriBackend() {
   }, []);
 
   return {
-    status, logs, error, isExternalServer,
-    currentStepIndex, progressDetail, elevationPackages,
-    startServer, stopServer, startInstall,
-    retry, retryInstall, approveElevation,
+    status,
+    logs,
+    error,
+    isExternalServer,
+    currentStepIndex,
+    progressDetail,
+    elevationPackages,
+    startServer,
+    stopServer,
+    startInstall,
+    retry,
+    retryInstall,
+    approveElevation,
   };
 }

--- a/studio/frontend/src/lib/api-base.ts
+++ b/studio/frontend/src/lib/api-base.ts
@@ -1,30 +1,57 @@
 // Central API base URL for Tauri vs browser mode
-let apiBase = ''
+export type ApiScheme = "http" | "https";
 
-const isTauri = typeof window !== 'undefined' && '__TAURI__' in window
-const isViteDev = import.meta.env.DEV
+let apiBase = "";
+let apiScheme: ApiScheme = "http";
+let apiPort: number | null = null;
+
+const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
+const isViteDev = import.meta.env.DEV;
 
 if (isTauri && !isViteDev) {
-  apiBase = 'http://127.0.0.1:8888'
+  apiBase = "http://127.0.0.1:8888";
+  apiPort = 8888;
 }
 
-const initialApiBase = apiBase
+const initialApiBase = apiBase;
+const initialApiScheme: ApiScheme = apiScheme;
+const initialApiPort = apiPort;
 
 export function resetApiBase() {
-  apiBase = initialApiBase
+  apiBase = initialApiBase;
+  apiScheme = initialApiScheme;
+  apiPort = initialApiPort;
 }
 
-export function setApiBase(port: number) {
-  apiBase = `http://127.0.0.1:${port}`
+export function setApiBase(port: number, scheme: ApiScheme = apiScheme) {
+  apiScheme = scheme;
+  apiPort = port;
+  // Only rewrite apiBase in Tauri mode. In browser mode `apiBase` stays
+  // empty so requests resolve relative to the page origin — repointing
+  // it at 127.0.0.1 would break self-signed cert exceptions accepted
+  // for `localhost` (or any other hostname the user is browsing from).
+  if (isTauri) {
+    apiBase = `${scheme}://127.0.0.1:${port}`;
+  }
 }
 
 export function getApiBase(): string {
-  return apiBase
+  return apiBase;
+}
+
+export function getApiScheme(): ApiScheme {
+  return apiScheme;
+}
+
+export function getApiPort(): number | null {
+  return apiPort;
 }
 
 export function apiUrl(path: string): string {
-  if (path.startsWith('http')) return path
-  return `${apiBase}${path}`
+  if (path.startsWith("http")) {
+    return path;
+  }
+  return `${apiBase}${path}`;
 }
 
-export { isTauri }
+export { isTauri };

--- a/studio/frontend/src/lib/restart-state.ts
+++ b/studio/frontend/src/lib/restart-state.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Global gate flipped on while the user-initiated server restart is in
+ * flight (between `POST /api/settings/server/restart` and the new server
+ * answering /api/health).
+ *
+ * Why this exists: every in-flight `authFetch` during the ~5–15s window
+ * fails with TypeError, which the auth layer translates into the loud
+ * "Studio isn't running -- please relaunch it." banner + toasts, and a
+ * follow-up 401 can trigger `redirectToAuth()` which hard-navigates to
+ * /login and tears down the settings modal.
+ *
+ * With this gate set, callers can park their requests on `awaitRestart()`
+ * and resume against the new server, and the auth layer can suppress
+ * navigation while the server is intentionally bouncing.
+ */
+
+let pending: Promise<void> | null = null;
+let release: (() => void) | null = null;
+
+export function beginRestart(): () => void {
+  if (pending) {
+    return release ?? (() => {});
+  }
+  pending = new Promise<void>((resolve) => {
+    release = () => {
+      release = null;
+      pending = null;
+      resolve();
+    };
+  });
+  // release is set above by the executor (synchronous), but TS can't
+  // narrow that — assert here so the call site gets a non-null return.
+  // biome-ignore lint/style/noNonNullAssertion: executor is synchronous
+  return release!;
+}
+
+export function isRestarting(): boolean {
+  return pending !== null;
+}
+
+/**
+ * Park until the restart gate releases, or until the safety timeout
+ * elapses. The timeout exists purely as a deadlock guard: if the gate
+ * is never released (e.g. an unexpected throw past the `finally` that
+ * owns it), callers still recover instead of spinning forever.
+ */
+export async function awaitRestart(timeoutMs = 120_000): Promise<void> {
+  if (!pending) {
+    return;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const safety = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  try {
+    await Promise.race([pending, safety]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -135,9 +135,14 @@ pub fn stop_server(
 
 /// Check if a healthy Unsloth backend is running on the given port.
 /// Expects JSON response with status=="healthy" AND service=="Unsloth UI Backend".
+///
+/// When `scheme` is omitted the probe tries `http://` first and falls back to
+/// `https://` so SSL-enabled backends are detected without the caller having
+/// to know up front. The HTTPS probe accepts self-signed certs to support the
+/// `--ssl-self-signed` flow.
 #[tauri::command]
-pub async fn check_health(port: u16) -> Result<bool, String> {
-    match check_health_inner(port).await {
+pub async fn check_health(port: u16, scheme: Option<String>) -> Result<bool, String> {
+    match check_health_inner(port, scheme.as_deref()).await {
         Ok(healthy) => Ok(healthy),
         Err(e) => {
             // Network errors are not command errors — just means not healthy
@@ -147,26 +152,52 @@ pub async fn check_health(port: u16) -> Result<bool, String> {
     }
 }
 
-async fn check_health_inner(port: u16) -> Result<bool, reqwest::Error> {
-    let url = format!("http://127.0.0.1:{}/api/health", port);
+async fn check_health_inner(
+    port: u16,
+    scheme: Option<&str>,
+) -> Result<bool, reqwest::Error> {
     let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
         .timeout(std::time::Duration::from_secs(2))
         .build()?;
-    let resp = client.get(&url).send().await?;
-    let json: serde_json::Value = resp.json().await?;
 
-    let healthy = json
-        .get("status")
-        .and_then(|v| v.as_str())
-        .map(|s| s == "healthy")
-        .unwrap_or(false);
-    let correct_service = json
-        .get("service")
-        .and_then(|v| v.as_str())
-        .map(|s| s == "Unsloth UI Backend")
-        .unwrap_or(false);
+    let schemes: &[&str] = match scheme {
+        Some("https") => &["https"],
+        Some("http") => &["http"],
+        _ => &["http", "https"],
+    };
 
-    Ok(healthy && correct_service)
+    let mut last_err: Option<reqwest::Error> = None;
+    for s in schemes {
+        let url = format!("{s}://127.0.0.1:{}/api/health", port);
+        match client.get(&url).send().await {
+            Ok(resp) => match resp.json::<serde_json::Value>().await {
+                Ok(json) => {
+                    let healthy = json
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s == "healthy")
+                        .unwrap_or(false);
+                    let correct_service = json
+                        .get("service")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s == "Unsloth UI Backend")
+                        .unwrap_or(false);
+                    if healthy && correct_service {
+                        return Ok(true);
+                    }
+                }
+                Err(e) => last_err = Some(e),
+            },
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    if let Some(e) = last_err {
+        Err(e)
+    } else {
+        Ok(false)
+    }
 }
 
 /// Return buffered server logs.
@@ -433,12 +464,12 @@ async fn health_watchdog(app: AppHandle, state: BackendState, shutdown: Shutdown
             break;
         }
 
-        let (port, has_child) = {
+        let (port, scheme, has_child) = {
             let proc = match state.lock() {
                 Ok(p) => p,
                 Err(_) => break,
             };
-            (proc.port, proc.child.is_some())
+            (proc.port, proc.scheme.clone(), proc.child.is_some())
         };
 
         // Stop watching if the backend is gone
@@ -451,7 +482,7 @@ async fn health_watchdog(app: AppHandle, state: BackendState, shutdown: Shutdown
             continue; // Port not yet known
         };
 
-        match check_health_inner(port).await {
+        match check_health_inner(port, scheme.as_deref()).await {
             Ok(true) => {
                 consecutive_failures = 0;
             }

--- a/studio/src-tauri/src/desktop_auth.rs
+++ b/studio/src-tauri/src/desktop_auth.rs
@@ -30,9 +30,10 @@ enum PortSource {
     Discovered,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct BackendPort {
     port: u16,
+    scheme: String,
     source: PortSource,
 }
 
@@ -57,8 +58,8 @@ fn auth_secret_path(home: &Path, filename: &str) -> PathBuf {
         .join(filename)
 }
 
-fn auth_url(port: u16, route: &str) -> String {
-    format!("http://127.0.0.1:{port}/api/auth/{route}")
+fn auth_url(scheme: &str, port: u16, route: &str) -> String {
+    format!("{scheme}://127.0.0.1:{port}/api/auth/{route}")
 }
 
 fn home_dir() -> Result<PathBuf, String> {
@@ -84,14 +85,18 @@ fn read_secret_if_exists(path: &Path) -> Result<Option<String>, String> {
 async fn current_backend_port(
     state: &tauri::State<'_, BackendState>,
 ) -> Result<BackendPort, String> {
-    if let Some(port) = state.lock().map_err(|e| e.to_string())?.port {
-        return Ok(BackendPort {
-            port,
-            source: PortSource::Cached,
-        });
+    {
+        let proc = state.lock().map_err(|e| e.to_string())?;
+        if let Some(port) = proc.port {
+            return Ok(BackendPort {
+                port,
+                scheme: proc.scheme.clone().unwrap_or_else(|| "http".to_string()),
+                source: PortSource::Cached,
+            });
+        }
     }
 
-    let port = discover_compatible_backend_port()
+    let (port, scheme) = discover_compatible_backend()
         .await
         .ok_or_else(|| "Backend is not ready".to_string())?;
 
@@ -100,29 +105,42 @@ async fn current_backend_port(
         if proc.port.is_none() {
             proc.port = Some(port);
         }
+        if proc.scheme.is_none() {
+            proc.scheme = Some(scheme.clone());
+        }
     }
 
     Ok(BackendPort {
         port,
+        scheme,
         source: PortSource::Discovered,
     })
 }
 
-fn attached_ready_port(preflight: DesktopPreflightResult) -> Option<u16> {
+fn attached_ready_port(preflight: DesktopPreflightResult) -> Option<(u16, String)> {
     if preflight.disposition == DesktopPreflightDisposition::AttachedReady {
-        preflight.port
+        match (preflight.port, preflight.scheme) {
+            (Some(port), Some(scheme)) => Some((port, scheme)),
+            (Some(port), None) => Some((port, "http".to_string())),
+            _ => None,
+        }
     } else {
         None
     }
 }
 
-async fn discover_compatible_backend_port() -> Option<u16> {
+async fn discover_compatible_backend() -> Option<(u16, String)> {
     attached_ready_port(crate::preflight::desktop_preflight_result().await)
 }
 
-fn update_backend_port(state: &tauri::State<'_, BackendState>, port: u16) -> Result<(), String> {
+fn update_backend_port(
+    state: &tauri::State<'_, BackendState>,
+    port: u16,
+    scheme: &str,
+) -> Result<(), String> {
     let mut proc = state.lock().map_err(|e| e.to_string())?;
     proc.port = Some(port);
+    proc.scheme = Some(scheme.to_string());
     Ok(())
 }
 
@@ -144,11 +162,12 @@ fn should_retry_with_discovered_port(source: PortSource, error: &AuthError) -> b
 
 async fn exchange_desktop_secret(
     client: &Client,
+    scheme: &str,
     port: u16,
     secret: &str,
 ) -> Result<Option<DesktopAuthResponse>, AuthError> {
     let response = client
-        .post(auth_url(port, "desktop-login"))
+        .post(auth_url(scheme, port, "desktop-login"))
         .json(&DesktopAuthRequest {
             secret: secret.to_string(),
         })
@@ -219,18 +238,19 @@ async fn authenticate_with_stale_port_retry(
     backend: BackendPort,
     secret: &str,
 ) -> Result<(Option<DesktopAuthResponse>, BackendPort), String> {
-    match exchange_desktop_secret(client, backend.port, secret).await {
+    match exchange_desktop_secret(client, &backend.scheme, backend.port, secret).await {
         Ok(tokens) => Ok((tokens, backend)),
         Err(error) if should_retry_with_discovered_port(backend.source, &error) => {
-            let Some(port) = discover_compatible_backend_port().await else {
+            let Some((port, scheme)) = discover_compatible_backend().await else {
                 return Err(error.message());
             };
-            update_backend_port(state, port)?;
+            update_backend_port(state, port, &scheme)?;
             let backend = BackendPort {
                 port,
+                scheme: scheme.clone(),
                 source: PortSource::Discovered,
             };
-            exchange_desktop_secret(client, port, secret)
+            exchange_desktop_secret(client, &scheme, port, secret)
                 .await
                 .map(|tokens| (tokens, backend))
                 .map_err(AuthError::message)
@@ -245,7 +265,11 @@ pub async fn desktop_auth(
 ) -> Result<DesktopAuthResponse, String> {
     let _auth_guard = DESKTOP_AUTH_LOCK.lock().await;
     let mut backend = current_backend_port(&state).await?;
+    // Self-signed certs are part of the supported `--ssl-self-signed` flow,
+    // so accept invalid certs here. The desktop secret is the actual proof
+    // of trust between the desktop app and the local backend.
     let client = Client::builder()
+        .danger_accept_invalid_certs(true)
         .timeout(std::time::Duration::from_secs(5))
         .build()
         .map_err(|e| format!("Desktop auth failed: {}", e))?;
@@ -311,8 +335,12 @@ mod tests {
     #[test]
     fn auth_url_builds_local_endpoint() {
         assert_eq!(
-            auth_url(8890, "desktop-login"),
+            auth_url("http", 8890, "desktop-login"),
             "http://127.0.0.1:8890/api/auth/desktop-login"
+        );
+        assert_eq!(
+            auth_url("https", 8890, "desktop-login"),
+            "https://127.0.0.1:8890/api/auth/desktop-login"
         );
     }
 
@@ -338,15 +366,33 @@ mod tests {
             disposition: DesktopPreflightDisposition::AttachedReady,
             reason: None,
             port: Some(8890),
+            scheme: Some("https".to_string()),
             can_auto_repair: false,
             managed_bin: None,
         };
-        assert_eq!(attached_ready_port(compatible), Some(8890));
+        assert_eq!(
+            attached_ready_port(compatible),
+            Some((8890, "https".to_string()))
+        );
+
+        let missing_scheme = DesktopPreflightResult {
+            disposition: DesktopPreflightDisposition::AttachedReady,
+            reason: None,
+            port: Some(8890),
+            scheme: None,
+            can_auto_repair: false,
+            managed_bin: None,
+        };
+        assert_eq!(
+            attached_ready_port(missing_scheme),
+            Some((8890, "http".to_string()))
+        );
 
         let missing_port = DesktopPreflightResult {
             disposition: DesktopPreflightDisposition::AttachedReady,
             reason: None,
             port: None,
+            scheme: Some("http".to_string()),
             can_auto_repair: false,
             managed_bin: None,
         };
@@ -356,6 +402,7 @@ mod tests {
             disposition: DesktopPreflightDisposition::ManagedReady,
             reason: None,
             port: Some(8890),
+            scheme: Some("http".to_string()),
             can_auto_repair: false,
             managed_bin: None,
         };
@@ -365,7 +412,7 @@ mod tests {
     #[tokio::test]
     async fn exchange_desktop_secret_returns_none_for_unauthorized() {
         let port = login_server("401 Unauthorized").await;
-        let tokens = exchange_desktop_secret(&Client::new(), port, "desktop-stale")
+        let tokens = exchange_desktop_secret(&Client::new(), "http", port, "desktop-stale")
             .await
             .unwrap();
 
@@ -375,7 +422,7 @@ mod tests {
     #[tokio::test]
     async fn exchange_desktop_secret_reports_unsupported_backend_on_not_found() {
         let port = login_server("404 Not Found").await;
-        let error = exchange_desktop_secret(&Client::new(), port, "desktop-secret")
+        let error = exchange_desktop_secret(&Client::new(), "http", port, "desktop-secret")
             .await
             .unwrap_err()
             .message();

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -19,6 +19,9 @@ pub struct DesktopPreflightResult {
     pub disposition: DesktopPreflightDisposition,
     pub reason: Option<String>,
     pub port: Option<u16>,
+    /// "http" or "https" — the scheme the live backend reported.
+    /// Only populated for `AttachedReady`.
+    pub scheme: Option<String>,
     pub can_auto_repair: bool,
     pub managed_bin: Option<PathBuf>,
 }
@@ -33,7 +36,7 @@ enum ManagedProbe {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum BackendProbe {
     Missing,
-    Ready { port: u16 },
+    Ready { port: u16, scheme: String },
     Old { port: u16, reason: String },
 }
 
@@ -58,18 +61,22 @@ fn release_auto_repair() -> bool {
 
 fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPreflightResult {
     match (backend, managed) {
-        (BackendProbe::Ready { port }, ManagedProbe::Ready { bin }) => DesktopPreflightResult {
-            disposition: DesktopPreflightDisposition::AttachedReady,
-            reason: None,
-            port: Some(port),
-            can_auto_repair: false,
-            managed_bin: Some(bin),
-        },
+        (BackendProbe::Ready { port, scheme }, ManagedProbe::Ready { bin }) => {
+            DesktopPreflightResult {
+                disposition: DesktopPreflightDisposition::AttachedReady,
+                reason: None,
+                port: Some(port),
+                scheme: Some(scheme),
+                can_auto_repair: false,
+                managed_bin: Some(bin),
+            }
+        }
         (_, managed) => match managed {
             ManagedProbe::Ready { bin } => DesktopPreflightResult {
                 disposition: DesktopPreflightDisposition::ManagedReady,
                 reason: None,
                 port: None,
+                scheme: None,
                 can_auto_repair: false,
                 managed_bin: Some(bin),
             },
@@ -77,6 +84,7 @@ fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPref
                 disposition: DesktopPreflightDisposition::ManagedStale,
                 reason: Some(reason),
                 port: None,
+                scheme: None,
                 can_auto_repair: release_auto_repair(),
                 managed_bin: Some(bin),
             },
@@ -84,6 +92,7 @@ fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPref
                 disposition: DesktopPreflightDisposition::NotInstalled,
                 reason: None,
                 port: None,
+                scheme: None,
                 can_auto_repair: false,
                 managed_bin: None,
             },
@@ -215,47 +224,73 @@ pub async fn managed_install_ready() -> bool {
     matches!(probe_managed_install().await, ManagedProbe::Ready { .. })
 }
 
-async fn backend_health(client: &reqwest::Client, port: u16) -> Option<BackendHealth> {
-    let url = format!("http://127.0.0.1:{port}/api/health");
-    let response = client.get(url).send().await.ok()?;
-    if !response.status().is_success() {
-        return None;
-    }
-    let json = response.json::<serde_json::Value>().await.ok()?;
-    let healthy = json
-        .get("status")
-        .and_then(|v| v.as_str())
-        .map(|s| s == "healthy")
-        .unwrap_or(false);
-    let service = json
-        .get("service")
-        .and_then(|v| v.as_str())
-        .map(|s| s == "Unsloth UI Backend")
-        .unwrap_or(false);
-    if !healthy || !service {
-        return None;
-    }
-
-    let desktop_protocol_version = json
-        .get("desktop_protocol_version")
-        .and_then(|v| v.as_u64())
-        .and_then(|v| u16::try_from(v).ok());
-    let supports_desktop_auth = json.get("supports_desktop_auth").and_then(|v| v.as_bool());
-    if desktop_protocol_version.is_none() && supports_desktop_auth.is_none() {
-        return None;
-    }
-    let stale_reason = match supports_desktop_auth {
-        Some(false) => json
-            .get("desktop_auth_stale_reason")
+async fn backend_health(
+    client: &reqwest::Client,
+    port: u16,
+) -> Option<(String, BackendHealth)> {
+    // Try http first (existing behavior), fall back to https for SSL-enabled
+    // backends. The reqwest client must accept invalid certs so self-signed
+    // setups (the common --ssl-self-signed flow) can be detected.
+    for scheme in ["http", "https"] {
+        let url = format!("{scheme}://127.0.0.1:{port}/api/health");
+        let response = match client.get(&url).send().await {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if !response.status().is_success() {
+            continue;
+        }
+        let json = match response.json::<serde_json::Value>().await {
+            Ok(j) => j,
+            Err(_) => continue,
+        };
+        let healthy = json
+            .get("status")
             .and_then(|v| v.as_str())
-            .map(ToOwned::to_owned),
-        _ => None,
-    };
-    Some(BackendHealth {
-        desktop_protocol_version,
-        supports_desktop_auth,
-        stale_reason,
-    })
+            .map(|s| s == "healthy")
+            .unwrap_or(false);
+        let service = json
+            .get("service")
+            .and_then(|v| v.as_str())
+            .map(|s| s == "Unsloth UI Backend")
+            .unwrap_or(false);
+        if !healthy || !service {
+            continue;
+        }
+
+        let desktop_protocol_version = json
+            .get("desktop_protocol_version")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| u16::try_from(v).ok());
+        let supports_desktop_auth = json.get("supports_desktop_auth").and_then(|v| v.as_bool());
+        if desktop_protocol_version.is_none() && supports_desktop_auth.is_none() {
+            continue;
+        }
+        let stale_reason = match supports_desktop_auth {
+            Some(false) => json
+                .get("desktop_auth_stale_reason")
+                .and_then(|v| v.as_str())
+                .map(ToOwned::to_owned),
+            _ => None,
+        };
+        // Prefer the scheme reported by /api/health when present; falling
+        // back to the scheme that worked here covers older backends that
+        // do not yet emit the field.
+        let reported_scheme = json
+            .get("scheme")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| scheme.to_string());
+        return Some((
+            reported_scheme,
+            BackendHealth {
+                desktop_protocol_version,
+                supports_desktop_auth,
+                stale_reason,
+            },
+        ));
+    }
+    None
 }
 
 fn backend_capability_stale_reason(health: &BackendHealth) -> Option<String> {
@@ -282,13 +317,14 @@ struct DesktopLoginProbe<'a> {
 async fn backend_desktop_auth_status(
     client: &reqwest::Client,
     port: u16,
+    scheme: &str,
     health: &BackendHealth,
 ) -> BackendProbe {
     if let Some(reason) = backend_capability_stale_reason(health) {
         return BackendProbe::Old { port, reason };
     }
 
-    let url = format!("http://127.0.0.1:{port}/api/auth/desktop-login");
+    let url = format!("{scheme}://127.0.0.1:{port}/api/auth/desktop-login");
     let response = client
         .post(url)
         .json(&DesktopLoginProbe {
@@ -306,7 +342,10 @@ async fn backend_desktop_auth_status(
     };
 
     match response.status() {
-        reqwest::StatusCode::UNAUTHORIZED => BackendProbe::Ready { port },
+        reqwest::StatusCode::UNAUTHORIZED => BackendProbe::Ready {
+            port,
+            scheme: scheme.to_string(),
+        },
         reqwest::StatusCode::NOT_FOUND => BackendProbe::Old {
             port,
             reason: "desktop_login_not_found".to_string(),
@@ -320,7 +359,12 @@ async fn backend_desktop_auth_status(
 }
 
 async fn probe_existing_backends() -> BackendProbe {
+    // Allow self-signed certs so backends running with --ssl-self-signed
+    // are still discoverable. The probe never trusts user data, only
+    // verifies the studio service identity, so disabling cert validation
+    // here is safe and matches user intent.
     let client = match reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
         .timeout(Duration::from_secs(2))
         .build()
     {
@@ -337,20 +381,22 @@ async fn probe_existing_backends() -> BackendProbe {
         // (documented cheap). tokio::spawn needs 'static, so each task owns its own clone.
         let c = client.clone();
         health_futs.push(tokio::spawn(async move {
-            backend_health(&c, port).await.map(|h| (port, h))
+            backend_health(&c, port)
+                .await
+                .map(|(scheme, h)| (port, scheme, h))
         }));
     }
 
-    let mut candidates: Vec<(u16, BackendHealth)> = Vec::new();
+    let mut candidates: Vec<(u16, String, BackendHealth)> = Vec::new();
     for fut in health_futs {
-        if let Ok(Some(pair)) = fut.await {
-            candidates.push(pair);
+        if let Ok(Some(triple)) = fut.await {
+            candidates.push(triple);
         }
     }
 
     let mut first_old = None;
-    for (port, health) in candidates {
-        match backend_desktop_auth_status(&client, port, &health).await {
+    for (port, scheme, health) in candidates {
+        match backend_desktop_auth_status(&client, port, &scheme, &health).await {
             ready @ BackendProbe::Ready { .. } => return ready,
             old @ BackendProbe::Old { .. } if first_old.is_none() => first_old = Some(old),
             _ => {}
@@ -371,6 +417,13 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
+    fn ready_http(port: u16) -> BackendProbe {
+        BackendProbe::Ready {
+            port,
+            scheme: "http".to_string(),
+        }
+    }
+
     #[test]
     fn compatible_backend_does_not_win_over_stale_managed_install() {
         let result = choose_preflight(
@@ -378,7 +431,7 @@ mod tests {
                 bin: PathBuf::from("/managed/unsloth"),
                 reason: "old cli".to_string(),
             },
-            BackendProbe::Ready { port: 8000 },
+            ready_http(8000),
         );
 
         assert_eq!(
@@ -386,6 +439,7 @@ mod tests {
             DesktopPreflightDisposition::ManagedStale
         );
         assert_eq!(result.port, None);
+        assert_eq!(result.scheme, None);
         assert_eq!(result.reason, Some("old cli".to_string()));
         assert_eq!(result.can_auto_repair, release_auto_repair());
         assert_eq!(result.managed_bin, Some(PathBuf::from("/managed/unsloth")));
@@ -397,7 +451,7 @@ mod tests {
             ManagedProbe::Ready {
                 bin: PathBuf::from("/managed/unsloth"),
             },
-            BackendProbe::Ready { port: 8000 },
+            ready_http(8000),
         );
 
         assert_eq!(
@@ -405,13 +459,14 @@ mod tests {
             DesktopPreflightDisposition::AttachedReady
         );
         assert_eq!(result.port, Some(8000));
+        assert_eq!(result.scheme, Some("http".to_string()));
         assert_eq!(result.managed_bin, Some(PathBuf::from("/managed/unsloth")));
         assert!(!result.can_auto_repair);
     }
 
     #[test]
     fn compatible_backend_does_not_win_over_missing_managed_install() {
-        let result = choose_preflight(ManagedProbe::Missing, BackendProbe::Ready { port: 8000 });
+        let result = choose_preflight(ManagedProbe::Missing, ready_http(8000));
 
         assert_eq!(
             result.disposition,
@@ -733,8 +788,8 @@ exit 1
     ) -> BackendProbe {
         let port = backend_server(health_body, route_status).await;
         let client = reqwest::Client::new();
-        let health = backend_health(&client, port).await.unwrap();
-        backend_desktop_auth_status(&client, port, &health).await
+        let (scheme, health) = backend_health(&client, port).await.unwrap();
+        backend_desktop_auth_status(&client, port, &scheme, &health).await
     }
 
     #[tokio::test]
@@ -818,10 +873,10 @@ exit 1
         )
         .await;
         let client = reqwest::Client::new();
-        let health = backend_health(&client, port).await.unwrap();
+        let (scheme, health) = backend_health(&client, port).await.unwrap();
 
         assert!(matches!(
-            backend_desktop_auth_status(&client, port, &health).await,
+            backend_desktop_auth_status(&client, port, &scheme, &health).await,
             BackendProbe::Old {
                 reason,
                 ..

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -13,6 +13,8 @@ const MAX_LOG_LINES: usize = 1000;
 pub struct BackendProcess {
     pub child: Option<Box<dyn ChildWrapper + Send>>,
     pub port: Option<u16>,
+    /// "http" or "https" for the running backend. None until discovered.
+    pub scheme: Option<String>,
     pub logs: VecDeque<String>,
     pub intentional_stop: bool,
 }
@@ -22,6 +24,7 @@ impl Default for BackendProcess {
         Self {
             child: None,
             port: None,
+            scheme: None,
             logs: VecDeque::with_capacity(MAX_LOG_LINES),
             intentional_stop: false,
         }
@@ -257,6 +260,7 @@ pub fn start_backend(
             return Err("Backend is already running.".to_string());
         }
         proc.port = None;
+        proc.scheme = None;
         proc.logs.clear();
         proc.intentional_stop = false;
     }
@@ -345,6 +349,7 @@ fn read_output_stream<R: std::io::Read>(
 ) {
     let mut reader = std::io::BufReader::new(stream);
     let port_re = Regex::new(r"TAURI_PORT=(\d+)").unwrap();
+    let scheme_re = Regex::new(r"TAURI_SCHEME=(https?)").unwrap();
     let mut buf = Vec::new();
 
     loop {
@@ -359,7 +364,7 @@ fn read_output_stream<R: std::io::Read>(
                     text.clone()
                 };
 
-                // Check for TAURI_PORT on stdout only
+                // Check for TAURI_PORT / TAURI_SCHEME on stdout only
                 if !is_stderr {
                     if let Some(caps) = port_re.captures(&text) {
                         if let Some(port_str) = caps.get(1) {
@@ -370,6 +375,16 @@ fn read_output_stream<R: std::io::Read>(
                                 }
                                 let _ = app.emit("server-port", port);
                             }
+                        }
+                    }
+                    if let Some(caps) = scheme_re.captures(&text) {
+                        if let Some(scheme_match) = caps.get(1) {
+                            let scheme = scheme_match.as_str().to_string();
+                            info!("Detected backend scheme: {}", scheme);
+                            if let Ok(mut proc) = state.lock() {
+                                proc.scheme = Some(scheme.clone());
+                            }
+                            let _ = app.emit("server-scheme", scheme);
                         }
                     }
                 }

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -422,6 +422,32 @@ def studio_default(
         "--api-only",
         help = "Run API server only, no frontend serving (for Tauri desktop app)",
     ),
+    ssl_certfile: Optional[Path] = typer.Option(
+        None,
+        "--ssl-certfile",
+        help = "Path to a PEM-encoded SSL certificate (chain). Pair with --ssl-keyfile.",
+    ),
+    ssl_keyfile: Optional[Path] = typer.Option(
+        None,
+        "--ssl-keyfile",
+        help = "Path to a PEM-encoded SSL private key. Pair with --ssl-certfile.",
+    ),
+    ssl_self_signed: bool = typer.Option(
+        False,
+        "--ssl-self-signed",
+        help = (
+            "Generate (or reuse) a self-signed cert in ~/.unsloth/studio/ssl/. "
+            "Browsers will warn on first visit; click through to proceed."
+        ),
+    ),
+    no_ssl: bool = typer.Option(
+        False,
+        "--no-ssl",
+        help = (
+            "Force HTTP, ignoring any saved SSL settings. Use this to recover "
+            "access if SSL was misconfigured via the UI."
+        ),
+    ),
 ):
     """Launch the Unsloth Studio server."""
     if ctx.invoked_subcommand is not None:
@@ -451,6 +477,14 @@ def studio_default(
                 args.append("--silent")
             if api_only:
                 args.append("--api-only")
+            if ssl_certfile:
+                args.extend(["--ssl-certfile", str(ssl_certfile)])
+            if ssl_keyfile:
+                args.extend(["--ssl-keyfile", str(ssl_keyfile)])
+            if ssl_self_signed:
+                args.append("--ssl-self-signed")
+            if no_ssl:
+                args.append("--no-ssl")
             # On Windows, os.execvp() spawns a child but the parent lingers,
             # so Ctrl+C only kills the parent leaving the child orphaned.
             # Use subprocess.run() on Windows so the parent waits for the child.
@@ -481,14 +515,33 @@ def studio_default(
             raise typer.Exit(1)
 
     from studio.backend.run import run_server
+    from studio.backend.ssl_config import SslCliArgs
+
+    ssl_cli = SslCliArgs(
+        no_ssl = bool(no_ssl),
+        ssl_certfile = str(ssl_certfile) if ssl_certfile else None,
+        ssl_keyfile = str(ssl_keyfile) if ssl_keyfile else None,
+        ssl_self_signed = bool(ssl_self_signed),
+    )
 
     if not silent:
         from studio.backend.run import _resolve_external_ip
 
         display_host = _resolve_external_ip() if host == "0.0.0.0" else host
-        typer.echo(f"Starting Unsloth Studio on http://{display_host}:{port}")
+        # The actual scheme is decided inside run_server; this banner is
+        # just a "starting up" hint.
+        scheme_hint = (
+            "https" if (ssl_certfile or ssl_self_signed) and not no_ssl else "http"
+        )
+        typer.echo(f"Starting Unsloth Studio on {scheme_hint}://{display_host}:{port}")
 
-    run_kwargs = dict(host = host, port = port, silent = silent, api_only = api_only)
+    run_kwargs = dict(
+        host = host,
+        port = port,
+        silent = silent,
+        api_only = api_only,
+        ssl_cli = ssl_cli,
+    )
     if frontend is not None:
         run_kwargs["frontend_path"] = frontend
     run_server(**run_kwargs)


### PR DESCRIPTION
Closes #5177.

## Why

**HTTP is still the default to preserve parity.** Existing setups — scripts, integrations, ops runbooks pointing at `http://localhost:8888` — keep working unchanged after pulling this. Worth raising as a follow-up though: should HTTPS-via-self-signed become the recommended default for new installs, given the surface handles passwords, HF tokens, and API keys? The one-time cert warning is real first-time-user friction that doesn't exist today, so I left it opt-in for this PR — happy to flip the default if maintainers prefer the safer posture.

**Tauri wasn't tested end-to-end.** The Rust changes compile clean (`cargo check --tests` passes locally) and the preflight/scheme-probe/health paths all have unit tests, but a full desktop-app build round trip was more time and disk than I had to spare. Would appreciate a maintainer spot-check that (a) the desktop app still attaches to a running backend over both schemes, and (b) the desktop-secret auth flow works against an HTTPS backend with the self-signed cert (`danger_accept_invalid_certs(true)` is wired up in `desktop_auth.rs`).

**Future: shared preference storage (out of scope here).** Today theme, sidebar state, chat history (IndexedDB via Dexie), and the auth token all live in the browser, and browsers partition that data by *full origin* (`scheme + host + port`). So flipping HTTP↔HTTPS hides everything until the user switches back. The Server settings tab now calls this caveat out explicitly, but the proper fix is to migrate the high-pain keys (theme, sidebar, eventually chat threads) to a `/api/preferences` endpoint and per-user table on the backend.

That's a meaningful trade-off, not an obvious win:

- **Today — "single auth, per-browser bubble":** one Studio install, but each browser keeps its own preferences and chat history. Work-machine threads don't appear on the personal laptop. Some users actively prefer that isolation.
- **Centralized:** theme / threads / preferences follow the user across browsers, machines, and scheme switches. Closer to most cloud chat UIs, and survives reinstalls cleanly.

Worth flagging as the natural next step, ideally with an opt-in/opt-out toggle so users who depend on per-browser isolation keep it. Maybe consider a migration if anyone wants to keep their current local storage settings and transfer them to a persistent DB storage. I imagine going this route may introduce more tangible user accounts across the persistence layer (for the backend).

## Summary

- uvicorn terminates TLS in-process via `--ssl-certfile` / `--ssl-keyfile`, plus a `--ssl-self-signed` convenience flag that auto-generates and reuses a cert in `~/.unsloth/studio/ssl/`. **Off by default** to preserve parity with current HTTP behavior.
- Layered configuration (CLI > env vars > `app_secrets` > default) is surfaced in a new **Settings → Server** tab with save + in-place restart. Restart re-execs the Python process and confirms success via a per-instance ID exposed on `/api/health`.
- Global "restart in progress" gate so `authFetch` parks (rather than detonates) every request that races the restart window — modal stays open, no toast spam, no `/login` redirect cascade.
- `--no-ssl` is the documented escape hatch when SSL is misconfigured via the UI.
- Tauri preflight probes both schemes and threads the discovered scheme through the desktop auth flow with self-signed certs accepted.
- Anchors the Python build-artifact `lib/` / `lib64/` rules in `.gitignore` to the project root so they stop shadowing legitimate frontend `src/**/lib/` source directories.

## Why no ngrok / reverse proxy

uvicorn natively supports `ssl_keyfile` / `ssl_certfile`, so TLS terminates in-process. No ngrok, no nginx, no extra hop. Self-signed certs trigger the standard one-time browser warning that the user clicks through.

## Configuration precedence

| Priority | Source |
| --- | --- |
| 1 | `--no-ssl` flag (escape hatch — overrides everything) |
| 2 | `--ssl-certfile` / `--ssl-keyfile` / `--ssl-self-signed` CLI flags |
| 3 | `UNSLOTH_SSL_CERTFILE` / `UNSLOTH_SSL_KEYFILE` / `UNSLOTH_SSL_SELF_SIGNED` env vars |
| 4 | `app_secrets` rows written by the Settings UI |
| 5 | Default → SSL disabled (HTTP) |

The Settings tab calls out which layer is currently in effect (e.g. "TLS is forced on by --ssl-self-signed; saved settings take over when the flag is dropped") so users can tell why "Active" can diverge from the saved toggle.

## Test Points to Consider

- `unsloth studio` (default) → access banner shows `http://`, frontend loads, login works (regression)
- `unsloth studio --ssl-self-signed` → cert generated at `~/.unsloth/studio/ssl/`, banner shows `https://`, browser shows one-time self-signed warning that can be clicked through, UI loads, login works, SSE training progress and `/v1/chat/completions` streaming both work
- User-provided certs: `openssl req -x509 -newkey rsa:2048 -nodes -keyout /tmp/k.pem -out /tmp/c.pem -days 1 -subj "/CN=localhost"`, then `unsloth studio --ssl-certfile /tmp/c.pem --ssl-keyfile /tmp/k.pem` → HTTPS bound, no regeneration of stored cert
- `UNSLOTH_SSL_SELF_SIGNED=1 unsloth studio` → equivalent to `--ssl-self-signed`
- Settings → Server: enable TLS via UI → click Restart server → spinner shows for the actual restart window, then "Server restarted." appears (no page reload when scheme unchanged)
- Disable TLS via UI → Save → Save button correctly drops back to disabled (form is no longer dirty)
- `unsloth studio --no-ssl` after enabling SSL via UI → server starts on HTTP, banner reflects scheme, UI is reachable to fix misconfig
- `POST /api/settings/server/test` with bad path → returns `{ ok: false, error: "..." }` without crashing; valid pair → `{ ok: true }`
- Tauri desktop: build, enable SSL in Settings → Server, restart → preflight reports `scheme: "https"`, frontend connects via `https://127.0.0.1:<port>`

**Note**: I did not test the Tauri flow since I knew building out could take a while and I'm limited on resources. I'm hoping someone else can spot check it 🤞 

## Out of scope (intentional)

- ACME / Let's Encrypt automation — deferred. The resolver is structured so an `--ssl-acme-domain` source slots in as another precedence layer in a follow-up. Wanted to avoid extra dependencies, and likely use case for users hosting their own domain to expose this is low, meanwhile there's still a method for them to provide their own certs.
- Mutual TLS / client cert auth.
- HSTS, OCSP stapling, custom cipher suites — uvicorn defaults are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
