### PR TITLE
studio/setup.ps1: fall back to py.exe Launcher when python on PATH is unsupported

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1148,42 +1148,83 @@ if ($IsPipInstall) {
 # ============================================
 # 1g. Python (>= 3.11 and < 3.14, matching setup.sh)
 # ============================================
+# This is an early presence check only -- Phase 3 below performs the
+# authoritative Python selection (using the py.exe Launcher to find a
+# valid 3.11-3.13 even when `python` on PATH is a newer/unsupported
+# release). So here we accept either:
+#   - `python` on PATH that is 3.11-3.13, OR
+#   - `py.exe` with at least one registered 3.11-3.13 interpreter.
 $HasPython = $null -ne (Get-Command python -ErrorAction SilentlyContinue)
 $PythonOk = $false
+$PyVerStr = $null
+# Resolved interpreter that passed the early check (used downstream for the
+# user-site Scripts dir lookup, so it doesn't fall back to a 3.14 `python`
+# on PATH when only `py -3.12` was actually validated).
+$EarlyPythonExe = $null
 
 if ($HasPython) {
-    $PyVer = python --version 2>&1
-    if ($PyVer -match "(\d+)\.(\d+)") {
+    $PyVerStr = (python --version 2>&1 | Out-String).Trim()
+    if ($PyVerStr -match "(\d+)\.(\d+)") {
         $PyMajor = [int]$Matches[1]; $PyMinor = [int]$Matches[2]
         if ($PyMajor -eq 3 -and $PyMinor -ge 11 -and $PyMinor -lt 14) {
-            substep "Python $PyVer"
+            substep "Python $PyVerStr"
             $PythonOk = $true
-        } else {
-            Write-Host "[ERROR] Python $PyVer is outside supported range (need >= 3.11 and < 3.14)." -ForegroundColor Red
-            Write-Host "        Install Python 3.12 from https://python.org/downloads/" -ForegroundColor Yellow
-            exit 1
+            $EarlyPythonExe = (Get-Command python).Source
         }
     }
-} else {
-    # No Python at all -- install 3.12
-    Write-Host "Python not found -- installing Python 3.12 via winget..." -ForegroundColor Yellow
-    $HasWinget = $null -ne (Get-Command winget -ErrorAction SilentlyContinue)
-    if ($HasWinget) {
-        winget install -e --id Python.Python.3.12 --source winget --accept-package-agreements --accept-source-agreements
-        Refresh-Environment
+}
+
+if (-not $PythonOk) {
+    # `python` on PATH is missing or unsupported -- look for a usable
+    # interpreter via the py.exe Launcher (matches Phase 3 logic).
+    $pyLauncherCmd = Get-Command py -CommandType Application -ErrorAction SilentlyContinue
+    if ($pyLauncherCmd) {
+        foreach ($minor in @("3.13", "3.12", "3.11")) {
+            try {
+                $launcherVer = (& $pyLauncherCmd.Source "-$minor" --version 2>&1 | Out-String).Trim()
+                if ($launcherVer -match 'Python 3\.(\d+)') {
+                    substep "Python $launcherVer (via py -$minor)"
+                    $PythonOk = $true
+                    # Resolve the actual exe so callers below don't have to
+                    # re-run the launcher every time.
+                    $resolved = (& $pyLauncherCmd.Source "-$minor" -c "import sys; print(sys.executable)" 2>$null | Out-String).Trim()
+                    if ($resolved -and (Test-Path $resolved)) { $EarlyPythonExe = $resolved }
+                    break
+                }
+            } catch { }
+        }
     }
-    $HasPython = $null -ne (Get-Command python -ErrorAction SilentlyContinue)
-    if (-not $HasPython) {
-        Write-Host "[ERROR] Python could not be installed automatically." -ForegroundColor Red
+}
+
+if (-not $PythonOk) {
+    if ($HasPython -and $PyVerStr) {
+        Write-Host "[ERROR] Python $PyVerStr is outside supported range (need >= 3.11 and < 3.14) and no py.exe Launcher fallback found." -ForegroundColor Red
+    } else {
+        Write-Host "Python not found -- installing Python 3.12 via winget..." -ForegroundColor Yellow
+        $HasWinget = $null -ne (Get-Command winget -ErrorAction SilentlyContinue)
+        if ($HasWinget) {
+            winget install -e --id Python.Python.3.12 --source winget --accept-package-agreements --accept-source-agreements
+            Refresh-Environment
+            $HasPython = $null -ne (Get-Command python -ErrorAction SilentlyContinue)
+            if ($HasPython) {
+                step "python" "$(python --version 2>&1)"
+                $PythonOk = $true
+                $EarlyPythonExe = (Get-Command python).Source
+            }
+        }
+    }
+    if (-not $PythonOk) {
         Write-Host "        Install Python 3.12 from https://python.org/downloads/" -ForegroundColor Yellow
         exit 1
     }
-    step "python" "$(python --version 2>&1)"
-    $PythonOk = $true
 }
 
 # Add user-scheme Python Scripts dir to PATH (nt_user only, no venv fallback).
-$ScriptsDir = python -c "import os, sysconfig; p = sysconfig.get_path('scripts', 'nt_user'); print(p if os.path.exists(p) else '')"
+# Use the interpreter that passed the early check above ($EarlyPythonExe) rather
+# than bare `python`, so this resolves to the supported Python's user-site even
+# when an unsupported `python` (e.g., 3.14) is first on PATH.
+$EarlyPyForScripts = if ($EarlyPythonExe) { $EarlyPythonExe } else { "python" }
+$ScriptsDir = & $EarlyPyForScripts -c "import os, sysconfig; p = sysconfig.get_path('scripts', 'nt_user'); print(p if os.path.exists(p) else '')"
 if ($LASTEXITCODE -eq 0 -and $ScriptsDir -and (Test-Path $ScriptsDir)) {
     # Append (not Prepend) -- this dir has other pip scripts; shim handles unsloth.
     if (Add-ToUserPath -Directory $ScriptsDir) {


### PR DESCRIPTION
## Summary

`unsloth studio update` (i.e. `studio/setup.ps1`) bails out with

```
[ERROR] Python Python 3.14.x is outside supported range (need >= 3.11 and < 3.14).
        Install Python 3.12 from https://python.org/downloads/
```

even when the user already has a perfectly good 3.11/3.12/3.13 available via the **py.exe Launcher** (and even when the studio venv at `~/.unsloth/studio/unsloth_studio` is a supported version).

The bug is purely in **Phase 1** of `setup.ps1` (the early prerequisite check at line ~932). It runs `python --version` and exits if the result is outside 3.11-3.13. **Phase 3** of the same script (line ~1186) already has the correct detection — it probes `py -3.13/-3.12/-3.11` via the Launcher, skips conda Python, and falls back to scanning `Get-Command -All` — but it never gets to run because Phase 1 bails first.

This PR makes Phase 1 use the same Launcher-aware detection so the script doesn't fail when the only thing wrong is that an unsupported `python` happens to be first on PATH.

### Changes

- **Phase 1 Python check (`studio/setup.ps1` ~line 932):** now accepts *either* a supported `python` on PATH, *or* a registered `py.exe` Launcher entry for 3.11–3.13. The error path / winget install only triggers if **neither** is found.
- **Secondary fix (~line 968):** the `python -c "import sysconfig..."` call used to compute the user-site Scripts dir now uses the interpreter that actually passed the early check (`$EarlyPythonExe`), instead of bare `python` from PATH. Otherwise, on a system with `python` = 3.14 but the validated Python being `py -3.12`, the user-site Scripts dir would still be resolved against 3.14.

### Why not just bump the upper bound to 3.14?

That's a separate (larger) change — torch / unsloth-zoo wheels for 3.14 aren't broadly available yet, which is why the supported range in `setup.sh` is still `>= 3.11 and < 3.14`. This PR keeps the supported range identical and only fixes the detection so the script can find a supported Python that's already installed.

### Related

- Closes #4469 (reporter hits exactly this error: "Python Python 3.14.0 is outside supported range" while having a working 3.13 install).

## Test plan

- [x] `pwsh -c "[System.Management.Automation.Language.Parser]::ParseFile('studio/setup.ps1', [ref]\$null, [ref]\$err); \$err"` — script parses cleanly, no syntax errors.
- [x] Reproduced original failure on Windows 11 with system `python` = 3.14.2 and `py -3.12` available; got the original error pre-patch.
- [x] After patch, Phase 1 reports `[OK] Python 3.12.x (via py -3.12)` and proceeds into Phase 3 as expected.
- [ ] Maintainers: please verify on a system with **no** `py.exe` and only an unsupported `python` — the error path should still fire (and the winget-install fallback path should still work for the no-Python-at-all case).
- [ ] Maintainers: please verify on a system with `python` already in 3.11-3.13 — behavior should be unchanged (the early check passes on the first branch, just like before).

No new tests added; the change is a small fix to an early gating check and existing test files (`tests/studio/install/test_pr4562_bugfixes.py`) don't assert on the patched lines.