### PR TITLE
fix: respect user-set NVM_DIR instead of overriding with default

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -242,7 +242,11 @@ if [ "$NEED_NODE" = true ]; then
         curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash > /dev/null 2>&1
     fi
 
-    export NVM_DIR="$HOME/.nvm"
+    # Respect a user-specified NVM_DIR (e.g. $HOME/.config/nvm on non-default
+    # installations such as Distrobox or some system-managed nvm setups).
+    # The nvm install script above already honours the existing NVM_DIR, so
+    # unconditionally overriding it here would break sourcing on those systems.
+    export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
     set +u
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -242,12 +242,9 @@ if [ "$NEED_NODE" = true ]; then
         curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash > /dev/null 2>&1
     fi
 
-    # Mirror nvm's own install-directory selection (nvm_install_dir /
-    # nvm_default_install_dir in nvm v0.40.1 install.sh): an explicitly set
-    # NVM_DIR wins, otherwise $XDG_CONFIG_HOME/nvm if XDG_CONFIG_HOME is set
-    # (Distrobox / system-managed setups), otherwise $HOME/.nvm. The nvm
-    # install script above uses the same precedence, so we must match it
-    # here or the subsequent source path will point at the wrong directory.
+    # nvm's installer (nvm_default_install_dir, v0.40.1) picks
+    # NVM_DIR -> $XDG_CONFIG_HOME/nvm -> $HOME/.nvm; mirror that order
+    # so the source path matches the directory the installer wrote to.
     if [ -n "${NVM_DIR:-}" ]; then
         export NVM_DIR
     elif [ -n "${XDG_CONFIG_HOME:-}" ]; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -242,11 +242,19 @@ if [ "$NEED_NODE" = true ]; then
         curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash > /dev/null 2>&1
     fi
 
-    # Respect a user-specified NVM_DIR (e.g. $HOME/.config/nvm on non-default
-    # installations such as Distrobox or some system-managed nvm setups).
-    # The nvm install script above already honours the existing NVM_DIR, so
-    # unconditionally overriding it here would break sourcing on those systems.
-    export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+    # Mirror nvm's own install-directory selection (nvm_install_dir /
+    # nvm_default_install_dir in nvm v0.40.1 install.sh): an explicitly set
+    # NVM_DIR wins, otherwise $XDG_CONFIG_HOME/nvm if XDG_CONFIG_HOME is set
+    # (Distrobox / system-managed setups), otherwise $HOME/.nvm. The nvm
+    # install script above uses the same precedence, so we must match it
+    # here or the subsequent source path will point at the wrong directory.
+    if [ -n "${NVM_DIR:-}" ]; then
+        export NVM_DIR
+    elif [ -n "${XDG_CONFIG_HOME:-}" ]; then
+        export NVM_DIR="$XDG_CONFIG_HOME/nvm"
+    else
+        export NVM_DIR="$HOME/.nvm"
+    fi
     set +u
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 

--- a/tests/test_studio_nvm_dir_precedence.py
+++ b/tests/test_studio_nvm_dir_precedence.py
@@ -1,0 +1,104 @@
+"""studio/setup.sh must mirror nvm v0.40.1's install-directory selection
+when picking the NVM_DIR the parent shell sources from. nvm's own
+nvm_install_dir / nvm_default_install_dir use the precedence
+NVM_DIR -> $XDG_CONFIG_HOME/nvm -> $HOME/.nvm. If the script diverges
+the installer writes nvm to one path and the script sources from
+another, leaving `nvm install --lts` failing with exit 127 on
+Distrobox / XDG-style setups."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SETUP_SH = REPO_ROOT / "studio" / "setup.sh"
+
+
+def _extract_nvm_dir_block() -> str:
+    src = SETUP_SH.read_text()
+    m = re.search(
+        r'(    if \[ -n "\$\{NVM_DIR:-\}" \]; then\n.*?\n    fi\n)',
+        src,
+        re.DOTALL,
+    )
+    assert m, "Could not locate NVM_DIR selection block in studio/setup.sh"
+    return textwrap.dedent(m.group(1))
+
+
+def _run(block: str, env_setup: str) -> str:
+    script = f"set -eu\n{env_setup}\n{block}\nprintf '%s' \"$NVM_DIR\"\n"
+    out = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout
+
+
+def test_explicit_nvm_dir_is_preserved():
+    block = _extract_nvm_dir_block()
+    got = _run(block, 'export NVM_DIR="/opt/custom/nvm"\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"')
+    assert got == "/opt/custom/nvm", got
+
+
+def test_explicit_nvm_dir_wins_over_xdg():
+    block = _extract_nvm_dir_block()
+    got = _run(block, 'export NVM_DIR="/opt/custom/nvm"\nexport HOME="/home/u"\nunset XDG_CONFIG_HOME')
+    assert got == "/opt/custom/nvm", got
+
+
+def test_xdg_config_home_used_when_nvm_dir_unset():
+    block = _extract_nvm_dir_block()
+    got = _run(block, 'unset NVM_DIR\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"')
+    assert got == "/home/u/.config/nvm", got
+
+
+def test_xdg_config_home_used_when_nvm_dir_empty():
+    block = _extract_nvm_dir_block()
+    got = _run(block, 'export NVM_DIR=""\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"')
+    assert got == "/home/u/.config/nvm", got
+
+
+def test_home_nvm_fallback_when_both_unset():
+    block = _extract_nvm_dir_block()
+    got = _run(block, 'unset NVM_DIR\nunset XDG_CONFIG_HOME\nexport HOME="/home/u"')
+    assert got == "/home/u/.nvm", got
+
+
+def test_home_nvm_fallback_when_xdg_empty():
+    block = _extract_nvm_dir_block()
+    got = _run(block, 'unset NVM_DIR\nexport XDG_CONFIG_HOME=""\nexport HOME="/home/u"')
+    assert got == "/home/u/.nvm", got
+
+
+def test_block_runs_clean_under_set_u():
+    block = _extract_nvm_dir_block()
+    script = f'set -eu\nunset NVM_DIR\nunset XDG_CONFIG_HOME\nexport HOME="/home/u"\n{block}\nprintf "%s" "$NVM_DIR"\n'
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout == "/home/u/.nvm", out.stdout
+
+
+def test_setup_sh_does_not_unconditionally_overwrite_nvm_dir():
+    """Regression guard: the unconditional, top-level
+    `    export NVM_DIR="$HOME/.nvm"` (4-space indent, sibling of the
+    surrounding `if [ "$NEED_NODE" = true ]` body) that broke
+    Distrobox / XDG installations must not return."""
+    src = SETUP_SH.read_text()
+    pattern = re.compile(r'^    export NVM_DIR="\$HOME/\.nvm"$', re.MULTILINE)
+    assert not pattern.search(src), (
+        "studio/setup.sh contains an unconditional NVM_DIR override at "
+        "the outer NEED_NODE scope; this regresses the precedence fix."
+    )
+
+
+def test_setup_sh_block_mentions_xdg_config_home():
+    src = SETUP_SH.read_text()
+    assert "XDG_CONFIG_HOME" in src, (
+        "studio/setup.sh must honor XDG_CONFIG_HOME to match upstream "
+        "nvm v0.40.1's nvm_default_install_dir."
+    )

--- a/tests/test_studio_nvm_dir_precedence.py
+++ b/tests/test_studio_nvm_dir_precedence.py
@@ -32,34 +32,46 @@ def _run(block: str, env_setup: str) -> str:
     script = f"set -eu\n{env_setup}\n{block}\nprintf '%s' \"$NVM_DIR\"\n"
     out = subprocess.run(
         ["bash", "-c", script],
-        capture_output=True,
-        text=True,
-        check=True,
+        capture_output = True,
+        text = True,
+        check = True,
     )
     return out.stdout
 
 
 def test_explicit_nvm_dir_is_preserved():
     block = _extract_nvm_dir_block()
-    got = _run(block, 'export NVM_DIR="/opt/custom/nvm"\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"')
+    got = _run(
+        block,
+        'export NVM_DIR="/opt/custom/nvm"\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"',
+    )
     assert got == "/opt/custom/nvm", got
 
 
 def test_explicit_nvm_dir_wins_over_xdg():
     block = _extract_nvm_dir_block()
-    got = _run(block, 'export NVM_DIR="/opt/custom/nvm"\nexport HOME="/home/u"\nunset XDG_CONFIG_HOME')
+    got = _run(
+        block,
+        'export NVM_DIR="/opt/custom/nvm"\nexport HOME="/home/u"\nunset XDG_CONFIG_HOME',
+    )
     assert got == "/opt/custom/nvm", got
 
 
 def test_xdg_config_home_used_when_nvm_dir_unset():
     block = _extract_nvm_dir_block()
-    got = _run(block, 'unset NVM_DIR\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"')
+    got = _run(
+        block,
+        'unset NVM_DIR\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"',
+    )
     assert got == "/home/u/.config/nvm", got
 
 
 def test_xdg_config_home_used_when_nvm_dir_empty():
     block = _extract_nvm_dir_block()
-    got = _run(block, 'export NVM_DIR=""\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"')
+    got = _run(
+        block,
+        'export NVM_DIR=""\nexport HOME="/home/u"\nexport XDG_CONFIG_HOME="/home/u/.config"',
+    )
     assert got == "/home/u/.config/nvm", got
 
 
@@ -78,7 +90,7 @@ def test_home_nvm_fallback_when_xdg_empty():
 def test_block_runs_clean_under_set_u():
     block = _extract_nvm_dir_block()
     script = f'set -eu\nunset NVM_DIR\nunset XDG_CONFIG_HOME\nexport HOME="/home/u"\n{block}\nprintf "%s" "$NVM_DIR"\n'
-    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    out = subprocess.run(["bash", "-c", script], capture_output = True, text = True)
     assert out.returncode == 0, out.stderr
     assert out.stdout == "/home/u/.nvm", out.stdout
 


### PR DESCRIPTION
Fixes #5105

## Problem

When running `studio/setup.sh` (invoked during install or `unsloth studio update`), the script unconditionally overwrites `NVM_DIR` with `$HOME/.nvm`:

```bash
export NVM_DIR="$HOME/.nvm"
```

This breaks installations where nvm lives at a non-default path — most commonly:
- **Distrobox** environments where the home directory is remapped (e.g. `$HOME/.config/nvm`)
- Systems using a custom `NVM_DIR` set in the user's shell profile

Because nvm is a shell *function* (not a binary), it is sourced from `$NVM_DIR/nvm.sh`. Overriding `NVM_DIR` before sourcing means the source line points at the wrong (empty) directory, so `nvm` is not available and the subsequent `nvm install --lts` call exits with code 127 ("nvm: command not found").

Note: the upstream nvm installer (`curl ... nvm-sh/nvm/install.sh | bash`) already honours the caller's `NVM_DIR`, so it installs into the correct non-default location. Our override then breaks it.

## Solution

Use `${NVM_DIR:-$HOME/.nvm}` instead of the hard-coded path. This preserves any `NVM_DIR` already in the environment and only falls back to the conventional default when none is set.

## Testing

- Non-default `NVM_DIR` (e.g. `$HOME/.config/nvm`): nvm is sourced from the correct location and `nvm install --lts` succeeds.
- No `NVM_DIR` set: falls back to `$HOME/.nvm` as before — no behaviour change for standard installations.