### PR TITLE
Studio: Fix image-only chat requests failing validation

### DIFF
--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -396,7 +396,10 @@ class ChatMessage(BaseModel):
         if self.name is not None and self.role != "tool":
             raise ValueError('"name" is only valid on role="tool" messages.')
 
-        # Per-role content requirements.
+        # Per-role content requirements. OpenAI-compatible clients may send
+        # ``content=""`` for image-only turns when the image travels in a
+        # companion field such as Studio's ``image_base64`` extension, so treat
+        # empty strings as present content for user/system messages.
         if self.role == "tool":
             if not self.tool_call_id:
                 raise ValueError(
@@ -411,9 +414,9 @@ class ChatMessage(BaseModel):
                     'role="assistant" messages require either "content" or "tool_calls".'
                 )
         else:  # "user" | "system"
-            if not self.content:
+            if self.content is None or self.content == []:
                 raise ValueError(
-                    f'role="{self.role}" messages require non-empty "content".'
+                    f'role="{self.role}" messages require "content".'
                 )
         return self
 

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -415,9 +415,7 @@ class ChatMessage(BaseModel):
                 )
         else:  # "user" | "system"
             if self.content is None or self.content == []:
-                raise ValueError(
-                    f'role="{self.role}" messages require "content".'
-                )
+                raise ValueError(f'role="{self.role}" messages require "content".')
         return self
 
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -144,12 +144,9 @@ class TestChatMessageToolRoles:
 
     # ── Role-aware content requirements ────────────────────────────
 
-    def test_user_empty_string_content_allowed(self):
-        msg = ChatMessage(role = "user", content = "")
-        assert msg.content == ""
-
-    def test_system_empty_string_content_allowed(self):
-        msg = ChatMessage(role = "system", content = "")
+    @pytest.mark.parametrize("role", ["user", "system"])
+    def test_empty_string_content_allowed(self, role):
+        msg = ChatMessage(role = role, content = "")
         assert msg.content == ""
 
     def test_user_missing_content_rejected(self):

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -144,13 +144,17 @@ class TestChatMessageToolRoles:
 
     # ── Role-aware content requirements ────────────────────────────
 
-    def test_user_empty_content_rejected(self):
-        with pytest.raises(ValidationError):
-            ChatMessage(role = "user", content = "")
+    def test_user_empty_string_content_allowed(self):
+        msg = ChatMessage(role = "user", content = "")
+        assert msg.content == ""
 
-    def test_system_empty_content_rejected(self):
+    def test_system_empty_string_content_allowed(self):
+        msg = ChatMessage(role = "system", content = "")
+        assert msg.content == ""
+
+    def test_user_missing_content_rejected(self):
         with pytest.raises(ValidationError):
-            ChatMessage(role = "system", content = "")
+            ChatMessage(role = "user")
 
     def test_user_empty_list_content_rejected(self):
         with pytest.raises(ValidationError):
@@ -225,6 +229,14 @@ class TestChatCompletionRequestToolFields:
         assert req.tools is not None
         assert len(req.tools) == 1
         assert req.tools[0]["function"]["name"] == "get_weather"
+
+    def test_image_base64_allows_empty_user_text(self):
+        req = ChatCompletionRequest(
+            messages = [{"role": "user", "content": ""}],
+            image_base64 = "aW1hZ2U=",
+        )
+        assert req.messages[0].content == ""
+        assert req.image_base64 == "aW1hZ2U="
 
     def test_tool_choice_string_auto(self):
         assert self._make(tool_choice = "auto").tool_choice == "auto"


### PR DESCRIPTION
## Summary
- Allow OpenAI-compatible user/system chat messages to use `content: ""`
- Preserve validation for missing content and empty multimodal content lists
- Add regression coverage for image-only requests using `image_base64`

Before:
<img width="1716" height="521" alt="image" src="https://github.com/user-attachments/assets/3dfa54a2-535e-4b95-8769-2ba096689ddc" />

After:
<img width="1102" height="478" alt="image" src="https://github.com/user-attachments/assets/ca8b0c79-7977-40bd-8789-f5a5d68d4096" />

## Why
Image-only prompts from Studio send the image separately via `image_base64` and can produce an empty text `content` field. The backend rejected that at request validation time, causing a 422 before inference started.

## Tests
- `pytest studio/backend/tests/test_openai_tool_passthrough.py -q`
- `pytest studio/backend/tests/test_responses_api.py -q`
