### PR TITLE
Studio: fix 7 failing studio_unit_tests on main

### DIFF
--- a/studio/backend/routes/data_recipe/validate.py
+++ b/studio/backend/routes/data_recipe/validate.py
@@ -151,6 +151,12 @@ def validate(payload: RecipePayload) -> ValidateResponse:
             return ValidateResponse(valid = False, errors = static_errors)
         try:
             build_config_builder(recipe)
+        except ImportError:
+            # data_designer is an optional runtime dep. Static validation already
+            # passed; live access + full config validation are deferred to run
+            # start (per _GITHUB_VALIDATE_NOTE), so a missing optional import
+            # at validate time should not block the recipe.
+            pass
         except Exception as exc:
             detail = str(exc).strip() or "Validation failed."
             return ValidateResponse(

--- a/studio/backend/routes/data_recipe/validate.py
+++ b/studio/backend/routes/data_recipe/validate.py
@@ -14,8 +14,10 @@ from core.data_recipe.service import (
     create_data_designer,
     validate_recipe,
 )
+from loggers import get_logger
 from models.data_recipe import RecipePayload, ValidateError, ValidateResponse
 
+logger = get_logger(__name__)
 router = APIRouter()
 
 _GITHUB_VALIDATE_NOTE = "Recipe shape is valid. GitHub access and rate limits are checked when the run starts."
@@ -151,12 +153,22 @@ def validate(payload: RecipePayload) -> ValidateResponse:
             return ValidateResponse(valid = False, errors = static_errors)
         try:
             build_config_builder(recipe)
-        except ImportError:
-            # data_designer is an optional runtime dep. Static validation already
-            # passed; live access + full config validation are deferred to run
-            # start (per _GITHUB_VALIDATE_NOTE), so a missing optional import
-            # at validate time should not block the recipe.
-            pass
+        except ModuleNotFoundError as exc:
+            # data_designer is an optional runtime dep. Static validation
+            # already passed; live access + full config validation are
+            # deferred to run start (per _GITHUB_VALIDATE_NOTE), so a missing
+            # optional import at validate time should not block the recipe.
+            # Restrict the bypass to the data_designer module specifically so
+            # other ImportErrors (e.g. broken internal imports or missing
+            # transitive deps after a package upgrade) still surface as
+            # validation failures instead of being silently swallowed.
+            if not (exc.name or "").startswith("data_designer"):
+                raise
+            logger.debug(
+                "data_designer not installed; deferring full config "
+                "validation to run start",
+                missing_module = exc.name,
+            )
         except Exception as exc:
             detail = str(exc).strip() or "Validation failed."
             return ValidateResponse(

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -246,7 +246,10 @@ def test_desktop_session_uses_real_admin_identity_for_api_keys():
     assert [row["name"] for row in rows] == ["desktop"]
 
 
-def test_local_recipe_token_preserves_desktop_marker(loaded_local_model):
+def test_local_recipe_token_authenticates_as_admin_for_desktop_user(loaded_local_model):
+    # _inject_local_providers mints an internal sk-unsloth-* API key (not a
+    # forwarded JWT). The unified API-key path validates as the real admin
+    # user regardless of whether the incoming session was desktop or web.
     from auth.authentication import create_access_token, get_current_subject
 
     seed_user(must_change_password = True)
@@ -260,13 +263,7 @@ def test_local_recipe_token_preserves_desktop_marker(loaded_local_model):
     jobs_route._inject_local_providers(recipe, local_recipe_request(incoming_token))
 
     local_token = recipe["model_providers"][0]["api_key"]
-    payload = jwt.decode(
-        local_token,
-        storage.get_jwt_secret(storage.DEFAULT_ADMIN_USERNAME),
-        algorithms = ["HS256"],
-    )
-    assert payload["sub"] == storage.DEFAULT_ADMIN_USERNAME
-    assert payload["desktop"] is True
+    assert local_token.startswith(storage.API_KEY_PREFIX)
     credentials = HTTPAuthorizationCredentials(
         scheme = "Bearer",
         credentials = local_token,
@@ -276,8 +273,10 @@ def test_local_recipe_token_preserves_desktop_marker(loaded_local_model):
     )
 
 
-def test_local_recipe_token_keeps_web_marker_absent(loaded_local_model):
-    from auth.authentication import create_access_token
+def test_local_recipe_token_authenticates_as_admin_for_web_user(loaded_local_model):
+    # Mirror of the desktop variant: API-key issuance is identical for web
+    # and desktop incoming tokens; auth via get_current_subject works the same.
+    from auth.authentication import create_access_token, get_current_subject
 
     seed_user(must_change_password = False)
     jobs_route = data_recipe_jobs_module()
@@ -287,13 +286,14 @@ def test_local_recipe_token_keeps_web_marker_absent(loaded_local_model):
     jobs_route._inject_local_providers(recipe, local_recipe_request(incoming_token))
 
     local_token = recipe["model_providers"][0]["api_key"]
-    payload = jwt.decode(
-        local_token,
-        storage.get_jwt_secret(storage.DEFAULT_ADMIN_USERNAME),
-        algorithms = ["HS256"],
+    assert local_token.startswith(storage.API_KEY_PREFIX)
+    credentials = HTTPAuthorizationCredentials(
+        scheme = "Bearer",
+        credentials = local_token,
     )
-    assert payload["sub"] == storage.DEFAULT_ADMIN_USERNAME
-    assert "desktop" not in payload
+    assert (
+        asyncio.run(get_current_subject(credentials)) == storage.DEFAULT_ADMIN_USERNAME
+    )
 
 
 def test_desktop_login_rejects_invalid_secret():
@@ -381,6 +381,7 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
         datasets_router = APIRouter(),
         export_router = APIRouter(),
         inference_router = APIRouter(),
+        inference_studio_router = APIRouter(),
         models_router = APIRouter(),
         training_history_router = APIRouter(),
         training_router = APIRouter(),

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -746,7 +746,15 @@ class TestRouteErrors(unittest.TestCase):
         ):
             with self.assertRaises(HTTPException) as exc_info:
                 asyncio.run(
-                    inference_route.load_model(request, current_subject = "test-user")
+                    inference_route.load_model(
+                        request,
+                        SimpleNamespace(
+                            app = SimpleNamespace(
+                                state = SimpleNamespace(llama_parallel_slots = 1),
+                            ),
+                        ),
+                        current_subject = "test-user",
+                    )
                 )
 
         self.assertEqual(exc_info.exception.status_code, 400)
@@ -886,7 +894,15 @@ class TestRouteErrors(unittest.TestCase):
         ):
             with self.assertRaises(HTTPException) as exc_info:
                 asyncio.run(
-                    inference_route.load_model(request, current_subject = "test-user")
+                    inference_route.load_model(
+                        request,
+                        SimpleNamespace(
+                            app = SimpleNamespace(
+                                state = SimpleNamespace(llama_parallel_slots = 1),
+                            ),
+                        ),
+                        current_subject = "test-user",
+                    )
                 )
 
         self.assertEqual(exc_info.exception.status_code, 400)
@@ -942,7 +958,15 @@ class TestRouteErrors(unittest.TestCase):
         ):
             with self.assertRaises(HTTPException) as exc_info:
                 asyncio.run(
-                    inference_route.load_model(request, current_subject = "test-user")
+                    inference_route.load_model(
+                        request,
+                        SimpleNamespace(
+                            app = SimpleNamespace(
+                                state = SimpleNamespace(llama_parallel_slots = 1),
+                            ),
+                        ),
+                        current_subject = "test-user",
+                    )
                 )
 
         self.assertEqual(exc_info.exception.status_code, 400)


### PR DESCRIPTION
## Summary

Seven `studio/backend/tests` cases were failing on `main` for reasons unrelated to any in-flight PR. This restores the suite by aligning six stale test cases with the current production code and fixing one real validation regression.

## Failures addressed

### 1. `test_health_response_reports_desktop_capability_fields`

The test stubbed `routes` with a `SimpleNamespace` that omitted `inference_studio_router`. Importing `studio.backend.main` then raised `ImportError: cannot import name 'inference_studio_router'`. Added the missing key to the stub.

### 2. `test_local_recipe_token_preserves_desktop_marker` and `test_local_recipe_token_keeps_web_marker_absent`

These decoded the local provider's `api_key` as a JWT, but `_inject_local_providers` now mints a unified `sk-unsloth-*` internal API key rather than a forwarded JWT, so `jwt.decode` raised `Not enough segments`. Renamed and rewrote both tests to validate the actual API-key contract:

- the issued token starts with `storage.API_KEY_PREFIX`
- `get_current_subject(...)` resolves it to the real admin user via the unified API-key path

The web vs desktop distinction is intentionally absent at this layer because internal API keys do not carry session flags.

### 3. `test_inference_route_rejects_gpu_ids_for_gguf`, `test_inference_route_returns_400_for_invalid_gpu_ids`, `test_inference_route_returns_400_for_uuid_parent_visibility_gpu_ids`

`routes/inference.load_model` gained a `fastapi_request: Request` positional argument (used to read `app.state.llama_parallel_slots` inside the GGUF path), but these three `TestRouteErrors` cases were not updated and failed with `TypeError: load_model() missing 1 required positional argument: 'fastapi_request'`. Pass a `SimpleNamespace` mock that satisfies the attribute path the production code reads. The validation under test fires before the mock is consumed, but supplying the realistic shape protects against regressions if the validation order changes.

### 4. `test_github_validate_skips_live_access_with_honest_note`

This was the only real production bug. `routes/data_recipe/validate.py` calls `build_config_builder(recipe)` for github-seed recipes, which lazy-imports the optional `data_designer` module. When `data_designer` is not installed, the bare `except Exception` blocked the recipe and returned `valid=False`, contradicting `_GITHUB_VALIDATE_NOTE` ("GitHub access and rate limits are checked when the run starts"). The fix catches `ImportError` specifically and treats it as a deferred check, so static validation alone is enough at this stage.

## Test plan

- [x] All 7 originally-failing tests pass after the changes
- [x] Full `studio/backend/tests/` suite: 611 passed, 4 skipped on a CPU-only host
- [x] Remaining failures are environment specific and not affected by this change: `test_anthropic_sdk` requires a running Studio server with a GPU model loaded (per its module docstring), and `test_parent_visibility_uses_cuda_visible_devices` is poisoned by torch CUDA-init pollution when the GPU-required E2E module is collected in the same pytest session