### PR TITLE
Fix local model scanner to handle ollama cloud models

### DIFF
--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -623,7 +623,7 @@ def _scan_ollama_dir(
             gguf_link_path: Optional[str] = None
             quant = f"-{file_type}" if file_type else ""
             safe_name = repo_name.replace("/", "-")
-            for layer in manifest.get("layers", []):
+            for layer in (manifest.get("layers") or []):
                 media = layer.get("mediaType", "")
                 digest = layer.get("digest", "")
                 if not digest:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -623,7 +623,7 @@ def _scan_ollama_dir(
             gguf_link_path: Optional[str] = None
             quant = f"-{file_type}" if file_type else ""
             safe_name = repo_name.replace("/", "-")
-            for layer in (manifest.get("layers") or []):
+            for layer in manifest.get("layers") or []:
                 media = layer.get("mediaType", "")
                 digest = layer.get("digest", "")
                 if not digest:


### PR DESCRIPTION
Fixes #5219

Ollama clouds models _do_ have `layers` but it's set to `None` which breaks `for layer in manifest.get("layers", [])`.

| Before | After |
|---|---|
| ![Screenshot 1](https://github.com/user-attachments/assets/ef015008-f199-406d-9bcd-f9d33af89717) | ![Screenshot 2](https://github.com/user-attachments/assets/ce7a507c-9f33-4587-bc9b-5dd993525333) |
