### PR TITLE
Studio: Pin assistant-ui core for fresh installs

### DIFF
--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -16,6 +16,7 @@
     "biome:fix": "biome check . --write"
   },
   "dependencies": {
+    "@assistant-ui/core": "0.1.16",
     "@assistant-ui/react": "^0.12.19",
     "@assistant-ui/react-markdown": "^0.12.3",
     "@assistant-ui/react-streamdown": "^0.1.2",

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -16,7 +16,7 @@
     "biome:fix": "biome check . --write"
   },
   "dependencies": {
-    "@assistant-ui/core": "0.1.16",
+    "@assistant-ui/core": "0.1.17",
     "@assistant-ui/react": "^0.12.19",
     "@assistant-ui/react-markdown": "^0.12.3",
     "@assistant-ui/react-streamdown": "^0.1.2",

--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -16,7 +16,7 @@ import type {
  * delete + reload smoke tests; the path or API may change without a semver signal on “public”
  * surface area.
  */
-import { MessageRepository } from "@assistant-ui/core/runtime/utils/message-repository";
+import { MessageRepository } from "@assistant-ui/core/internal";
 import { db } from "@/features/chat/db";
 import type { MessageRecord } from "@/features/chat/types";
 


### PR DESCRIPTION
## Summary

Fixes #5224

Fixes the Studio frontend build failure caused by an upstream `assistant-ui` package export change.

- Adds an explicit `@assistant-ui/core@0.1.17` dependency.
- Updates the chat delete helper to import `MessageRepository` from `@assistant-ui/core/internal` instead of the blocked deep path.
- Keeps the existing chat delete behavior unchanged while avoiding the fresh install/build failure.