### PR TITLE
fix(vision): make _gc_enable_reentrant accept gradient_checkpointing_kwargs positionally

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1584,7 +1584,7 @@ class FastBaseModel:
         if "gemma3n" in _model_type.lower() or "gemma4" in _model_type.lower():
             _original_gc_enable = model.gradient_checkpointing_enable
 
-            def _gc_enable_reentrant(gradient_checkpointing_kwargs=None, **kwargs):
+            def _gc_enable_reentrant(gradient_checkpointing_kwargs = None, **kwargs):
                 # Accept gradient_checkpointing_kwargs positionally or by keyword so
                 # callers like trl.models.utils.disable_gradient_checkpointing, which
                 # pass it positionally, do not raise TypeError.
@@ -1595,7 +1595,7 @@ class FastBaseModel:
                 ) or {}
                 gc_kwargs["use_reentrant"] = True
                 return _original_gc_enable(
-                    gradient_checkpointing_kwargs=gc_kwargs, **kwargs
+                    gradient_checkpointing_kwargs = gc_kwargs, **kwargs
                 )
 
             model.gradient_checkpointing_enable = _gc_enable_reentrant

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1588,11 +1588,7 @@ class FastBaseModel:
                 # Accept gradient_checkpointing_kwargs positionally or by keyword so
                 # callers like trl.models.utils.disable_gradient_checkpointing, which
                 # pass it positionally, do not raise TypeError.
-                gc_kwargs = (
-                    gradient_checkpointing_kwargs
-                    if gradient_checkpointing_kwargs is not None
-                    else kwargs.pop("gradient_checkpointing_kwargs", None)
-                ) or {}
+                gc_kwargs = gradient_checkpointing_kwargs or {}
                 gc_kwargs["use_reentrant"] = True
                 return _original_gc_enable(
                     gradient_checkpointing_kwargs = gc_kwargs, **kwargs

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1584,11 +1584,19 @@ class FastBaseModel:
         if "gemma3n" in _model_type.lower() or "gemma4" in _model_type.lower():
             _original_gc_enable = model.gradient_checkpointing_enable
 
-            def _gc_enable_reentrant(**kwargs):
-                gc_kwargs = kwargs.get("gradient_checkpointing_kwargs", {}) or {}
+            def _gc_enable_reentrant(gradient_checkpointing_kwargs=None, **kwargs):
+                # Accept gradient_checkpointing_kwargs positionally or by keyword so
+                # callers like trl.models.utils.disable_gradient_checkpointing, which
+                # pass it positionally, do not raise TypeError.
+                gc_kwargs = (
+                    gradient_checkpointing_kwargs
+                    if gradient_checkpointing_kwargs is not None
+                    else kwargs.pop("gradient_checkpointing_kwargs", None)
+                ) or {}
                 gc_kwargs["use_reentrant"] = True
-                kwargs["gradient_checkpointing_kwargs"] = gc_kwargs
-                return _original_gc_enable(**kwargs)
+                return _original_gc_enable(
+                    gradient_checkpointing_kwargs=gc_kwargs, **kwargs
+                )
 
             model.gradient_checkpointing_enable = _gc_enable_reentrant
 


### PR DESCRIPTION
## Summary

Fixes #4886

In `FastBaseModel.post_patch_model`, when the model type is `gemma3n` or `gemma4`, unsloth replaces `model.gradient_checkpointing_enable` with a wrapper that forces `use_reentrant=True`. The wrapper signature was:

```python
def _gc_enable_reentrant(**kwargs):
    ...
```

But TRL's `disable_gradient_checkpointing` calls it positionally:

```python
# trl/models/utils.py
model.gradient_checkpointing_enable(gradient_checkpointing_kwargs)
```

So under `GRPOTrainer` + `use_gradient_checkpointing="unsloth"`, training crashed with:

```
TypeError: FastBaseModel.post_patch_model.<locals>._gc_enable_reentrant() takes 0 positional arguments but 1 was given
```

## Fix

Accept `gradient_checkpointing_kwargs` as either positional or keyword argument so both call styles work. Behavior is otherwise unchanged: `use_reentrant=True` is still forced, and the original `gradient_checkpointing_enable` is still called with the merged kwargs.

```python
def _gc_enable_reentrant(gradient_checkpointing_kwargs=None, **kwargs):
    gc_kwargs = (
        gradient_checkpointing_kwargs
        if gradient_checkpointing_kwargs is not None
        else kwargs.pop("gradient_checkpointing_kwargs", None)
    ) or {}
    gc_kwargs["use_reentrant"] = True
    return _original_gc_enable(
        gradient_checkpointing_kwargs=gc_kwargs, **kwargs
    )
```

## Reproduction (from #4886)

```python
# Gemma3N or Gemma4 model with GRPOTrainer
peft_kwargs = {"use_gradient_checkpointing": "unsloth"}
trainer = GRPOTrainer(...)
trainer.train()  # raised TypeError before this fix
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
