### PR TITLE
install: overlay unsloth-zoo from git main on --local

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1089,6 +1089,12 @@ shell.Run cmd, 0, False
                 Write-Host "[ERROR] Failed to overlay local repo (exit code $overlayExit)" -ForegroundColor Red
                 return (Exit-InstallFailure "Failed to overlay local repo (exit code $overlayExit)" $overlayExit)
             }
+            substep "overlaying unsloth-zoo from git main..."
+            $zooOverlayExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth-zoo "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo" }
+            if ($zooOverlayExit -ne 0) {
+                Write-Host "[ERROR] Failed to overlay unsloth-zoo (exit code $zooOverlayExit)" -ForegroundColor Red
+                return (Exit-InstallFailure "Failed to overlay unsloth-zoo (exit code $zooOverlayExit)" $zooOverlayExit)
+            }
         }
     } elseif ($TorchIndexUrl) {
         if ($SkipTorch) {
@@ -1132,6 +1138,12 @@ shell.Run cmd, 0, False
                 Write-Host "[ERROR] Failed to overlay local repo (exit code $overlayExit)" -ForegroundColor Red
                 return (Exit-InstallFailure "Failed to overlay local repo (exit code $overlayExit)" $overlayExit)
             }
+            substep "overlaying unsloth-zoo from git main..."
+            $zooOverlayExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth-zoo "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo" }
+            if ($zooOverlayExit -ne 0) {
+                Write-Host "[ERROR] Failed to overlay unsloth-zoo (exit code $zooOverlayExit)" -ForegroundColor Red
+                return (Exit-InstallFailure "Failed to overlay unsloth-zoo (exit code $zooOverlayExit)" $zooOverlayExit)
+            }
         }
     } else {
         # Fallback: GPU detection failed to produce a URL -- let uv resolve torch
@@ -1148,6 +1160,12 @@ shell.Run cmd, 0, False
             if ($overlayExit -ne 0) {
                 Write-Host "[ERROR] Failed to overlay local repo (exit code $overlayExit)" -ForegroundColor Red
                 return (Exit-InstallFailure "Failed to overlay local repo (exit code $overlayExit)" $overlayExit)
+            }
+            substep "overlaying unsloth-zoo from git main..."
+            $zooOverlayExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth-zoo "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo" }
+            if ($zooOverlayExit -ne 0) {
+                Write-Host "[ERROR] Failed to overlay unsloth-zoo (exit code $zooOverlayExit)" -ForegroundColor Red
+                return (Exit-InstallFailure "Failed to overlay unsloth-zoo (exit code $zooOverlayExit)" $zooOverlayExit)
             }
         } else {
             $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --torch-backend=auto -- "$PackageName" }

--- a/install.sh
+++ b/install.sh
@@ -1501,6 +1501,10 @@ if [ "$_MIGRATED" = true ]; then
     if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
         substep "overlaying local repo (editable)..."
         run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
+        substep "overlaying unsloth-zoo from git main..."
+        run_install_cmd "overlay unsloth-zoo (git main)" uv pip install --python "$_VENV_PY" \
+            --no-deps --reinstall-package unsloth-zoo \
+            "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo"
     fi
     # AMD ROCm: install bitsandbytes even in migrated environments so
     # existing ROCm installs gain the AMD bitsandbytes build without a
@@ -1668,12 +1672,20 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
         if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
             substep "overlaying local repo (editable)..."
             run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
+            substep "overlaying unsloth-zoo from git main..."
+            run_install_cmd "overlay unsloth-zoo (git main)" uv pip install --python "$_VENV_PY" \
+                --no-deps --reinstall-package unsloth-zoo \
+                "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo"
         fi
     elif [ "$STUDIO_LOCAL_INSTALL" = true ]; then
         run_install_cmd "install unsloth (local)" uv pip install --python "$_VENV_PY" \
             --upgrade-package unsloth "unsloth>=2026.4.8" unsloth-zoo
         substep "overlaying local repo (editable)..."
         run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
+        substep "overlaying unsloth-zoo from git main..."
+        run_install_cmd "overlay unsloth-zoo (git main)" uv pip install --python "$_VENV_PY" \
+            --no-deps --reinstall-package unsloth-zoo \
+            "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo"
     else
         run_install_cmd "install unsloth" uv pip install --python "$_VENV_PY" \
             --upgrade-package unsloth -- "$PACKAGE_NAME"
@@ -1702,6 +1714,10 @@ else
         run_install_cmd "install unsloth (auto torch backend)" uv pip install --python "$_VENV_PY" unsloth-zoo "unsloth>=2026.4.8" --torch-backend=auto
         substep "overlaying local repo (editable)..."
         run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
+        substep "overlaying unsloth-zoo from git main..."
+        run_install_cmd "overlay unsloth-zoo (git main)" uv pip install --python "$_VENV_PY" \
+            --no-deps --reinstall-package unsloth-zoo \
+            "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo"
     else
         run_install_cmd "install unsloth (auto torch backend)" uv pip install --python "$_VENV_PY" --torch-backend=auto -- "$PACKAGE_NAME"
     fi


### PR DESCRIPTION
## Summary
- Under `--local`, after the existing `-e $REPO_ROOT --no-deps` overlay for unsloth, also overlay `unsloth-zoo` from the upstream `main` branch via `uv pip install --no-deps --reinstall-package unsloth-zoo "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo"`.
- Pairs an editable unsloth checkout with the latest unreleased unsloth-zoo, since the two repos often need to ship together.
- Applied to all four `--local` paths in `install.sh` (migrated, fresh no-torch, fresh with-torch, auto-torch fallback) and the three corresponding paths in `install.ps1`.

## Test plan
- [ ] `./install.sh --local` on Linux + NVIDIA — verify `unsloth-zoo` is reinstalled from `git+https://github.com/unslothai/unsloth-zoo` after PyPI resolves transitive deps
- [ ] `./install.sh --local --no-torch` — verify same overlay runs on the no-torch path
- [ ] `.\install.ps1 --local` on Windows — verify Windows fresh-install path runs the overlay
- [ ] Re-run `./install.sh --local` against an existing studio venv (migrated path) — verify the overlay still applies
- [ ] `./install.sh` (no `--local`) — verify `unsloth-zoo` still comes from PyPI (no behavior change for non-local installs)