### PR TITLE
Fix GRPO text-only path treating logits as hidden states

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -1222,18 +1222,26 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
                                 :, -(logits_to_keep + max_left_pad + 1) :, :
                             ]
                             logits_chunk = logits_chunk[:, :-1, :]
-                            logprobs_chunk = (
-                                chunked_hidden_states_selective_log_softmax(
-                                    logits_chunk,
-                                    lm_head,
-                                    completion_input_ids_chunk,
-                                    chunks = input_ids_chunk.shape[0] * multiplier,
-                                    logit_scale_multiply = logit_scale_multiply,
-                                    logit_scale_divide = logit_scale_divide,
-                                    logit_softcapping = logit_softcapping,
-                                    temperature = temperature,
+                            # Guard: check if model returned hidden states or logits
+                            if logits_chunk.shape[-1] == lm_head.shape[1]:
+                                logprobs_chunk = (
+                                    chunked_hidden_states_selective_log_softmax(
+                                        logits_chunk,
+                                        lm_head,
+                                        completion_input_ids_chunk,
+                                        chunks = input_ids_chunk.shape[0] * multiplier,
+                                        logit_scale_multiply = logit_scale_multiply,
+                                        logit_scale_divide = logit_scale_divide,
+                                        logit_softcapping = logit_softcapping,
+                                        temperature = temperature,
+                                    )
                                 )
-                            )
+                            else:
+                                logprobs_chunk = chunked_selective_log_softmax(
+                                    logits_chunk,
+                                    completion_input_ids_chunk,
+                                    temperature,
+                                )
                         else:
                             # Essentially, for VLMs we do not go via the optimized path in models/,
                             # so we don't encounter the Flash Attn left-padding issue.


### PR DESCRIPTION
## Bug

Models like Qwen3.5 and Gemma 4 return vocab-sized logits from `.logits` even with `UNSLOTH_RETURN_HIDDEN_STATES=1`. In the text-only GRPO path, these logits are unconditionally passed into `chunked_hidden_states_selective_log_softmax`, which applies an extra `@ lm_head.t()` matmul, causing a shape mismatch crash at step 1:

```
Qwen3.5-2B:  logits.shape[-1]=248320, lm_head.shape=(248320, 2048)
Gemma4 E2B:  logits.shape[-1]=262144, lm_head.shape=(262144, 1536)
```

## Fix

The VLM branch already guards against this by checking `logits_chunk.shape[-1] == lm_head.shape[1]` to distinguish hidden states (hidden_dim) from logits (vocab_size). When the model returns logits directly, it routes to `chunked_selective_log_softmax` instead.

This adds the same guard to the text-only branch. The logic is identical to what's already working in the VLM path.

## Testing

The reporter confirmed a local patch with this same approach resolves the crash for both `unsloth/Qwen3.5-2B` and `unsloth/gemma-4-E2B-it-unsloth-bnb-4bit`.

Fixes #5121