### PR TITLE
studio: add --local to setup.sh + overlay unsloth-zoo from git main

### DIFF
--- a/studio/Unsloth_Studio_Colab.ipynb
+++ b/studio/Unsloth_Studio_Colab.ipynb
@@ -64,7 +64,7 @@
     "id": "27e68f91"
    },
    "outputs": [],
-   "source": "!git clone --depth 1 --branch main https://github.com/unslothai/unsloth.git\n%cd /content/unsloth\n!chmod +x studio/setup.sh && ./studio/setup.sh"
+   "source": "!git clone --depth 1 --branch main https://github.com/unslothai/unsloth.git\n%cd /content/unsloth\n!chmod +x studio/setup.sh && ./studio/setup.sh --local"
   },
   {
    "cell_type": "markdown",

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -980,6 +980,14 @@ def install_python_stack() -> int:
                 local_repo,
                 constrain = False,
             )
+            pip_install(
+                "Overlaying unsloth-zoo from git main",
+                "--no-cache-dir",
+                "--no-deps",
+                "--force-reinstall",
+                "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo",
+                constrain = False,
+            )
     elif local_repo:
         # Local dev install: update deps from base.txt, then overlay the
         # local checkout as an editable install (--no-deps so torch is
@@ -1000,6 +1008,14 @@ def install_python_stack() -> int:
             "--no-deps",
             "-e",
             local_repo,
+            constrain = False,
+        )
+        pip_install(
+            "Overlaying unsloth-zoo from git main",
+            "--no-cache-dir",
+            "--no-deps",
+            "--force-reinstall",
+            "unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo",
             constrain = False,
         )
     elif package_name != "unsloth":

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -972,6 +972,7 @@ def install_python_stack() -> int:
             req = REQ_ROOT / "no-torch-runtime.txt",
         )
         if local_repo:
+            _step(_LABEL, f"overlaying local repo (editable): {local_repo}")
             pip_install(
                 "Overlaying local repo (editable)",
                 "--no-cache-dir",
@@ -980,6 +981,7 @@ def install_python_stack() -> int:
                 local_repo,
                 constrain = False,
             )
+            _step(_LABEL, "overlaying unsloth-zoo from git main")
             pip_install(
                 "Overlaying unsloth-zoo from git main",
                 "--no-cache-dir",
@@ -1002,6 +1004,7 @@ def install_python_stack() -> int:
             "unsloth-zoo",
             req = REQ_ROOT / "base.txt",
         )
+        _step(_LABEL, f"overlaying local repo (editable): {local_repo}")
         pip_install(
             "Overlaying local repo (editable)",
             "--no-cache-dir",
@@ -1010,6 +1013,7 @@ def install_python_stack() -> int:
             local_repo,
             constrain = False,
         )
+        _step(_LABEL, "overlaying unsloth-zoo from git main")
         pip_install(
             "Overlaying unsloth-zoo from git main",
             "--no-cache-dir",

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -12,14 +12,16 @@ RULE=$(printf '\342\224\200%.0s' {1..52})
 # --local: install from the local repo checkout (overlays unsloth as editable
 # and unsloth-zoo from git main). Mirrors install.sh --local for the Colab
 # path that runs setup.sh directly without going through install.sh.
-for _arg in "$@"; do
-    case "$_arg" in
-        --local)
-            export STUDIO_LOCAL_INSTALL=1
-            export STUDIO_LOCAL_REPO="$REPO_ROOT"
-            ;;
-    esac
-done
+if [ "$#" -gt 0 ]; then
+    for _arg in "$@"; do
+        case "$_arg" in
+            --local)
+                export STUDIO_LOCAL_INSTALL=1
+                export STUDIO_LOCAL_REPO="$REPO_ROOT"
+                ;;
+        esac
+    done
+fi
 
 # ── Maintainer-editable defaults ──────────────────────────────────────────
 # Change these in the GitHub-hosted script so all users get updated defaults.
@@ -182,6 +184,9 @@ verbose_substep "verbose diagnostics enabled"
 _LLAMA_ONLY="${UNSLOTH_STUDIO_LLAMA_ONLY:-0}"
 if [ "$_LLAMA_ONLY" = "1" ]; then
     substep "llama.cpp only mode"
+fi
+if [ "${STUDIO_LOCAL_INSTALL:-0}" = "1" ]; then
+    substep "local mode: overlaying $REPO_ROOT (editable) + unsloth-zoo from git main"
 fi
 # ── Clean up stale caches ──
 rm -rf "$REPO_ROOT/unsloth_compiled_cache"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -8,6 +8,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RULE=$(printf '\342\224\200%.0s' {1..52})
 
+# ── Parse flags ──
+# --local: install from the local repo checkout (overlays unsloth as editable
+# and unsloth-zoo from git main). Mirrors install.sh --local for the Colab
+# path that runs setup.sh directly without going through install.sh.
+for _arg in "$@"; do
+    case "$_arg" in
+        --local)
+            export STUDIO_LOCAL_INSTALL=1
+            export STUDIO_LOCAL_REPO="$REPO_ROOT"
+            ;;
+    esac
+done
+
 # ── Maintainer-editable defaults ──────────────────────────────────────────
 # Change these in the GitHub-hosted script so all users get updated defaults.
 # User environment variables always override these baked-in values.


### PR DESCRIPTION
## Summary
Extends the `--local` behavior introduced in #5242 (which added it to `install.sh` / `install.ps1`) to `studio/setup.sh`, so the Colab path that runs `setup.sh` directly — bypassing `install.sh` — gets the same overlay treatment.

- `studio/setup.sh`: parses `--local` and exports `STUDIO_LOCAL_INSTALL=1` + `STUDIO_LOCAL_REPO=$REPO_ROOT`. Prints a visible substep when local mode is active.
- `studio/install_python_stack.py`: in both `local_repo` branches (no-torch and with-torch), overlays `unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo` after the editable unsloth overlay (`--no-deps --force-reinstall`). Adds `_step` lines so overlay progress is visible in the static log instead of being overwritten by the in-place progress bar.
- `studio/Unsloth_Studio_Colab.ipynb`: install cell now invokes `./studio/setup.sh --local` so the cloned repo is used in editable mode and `unsloth-zoo` tracks `main`.

`install.sh --local` behavior is unchanged: it still exports `SKIP_STUDIO_BASE=1`, which short-circuits the `local_repo` branches in `install_python_stack.py`, so the overlay is not run twice.

## Test plan
- [x] Verified on Colab: `git clone --branch fix/setup-sh-local ... && ./studio/setup.sh --local` shows the new visible overlay lines and produces an editable unsloth + git-main unsloth-zoo
- [x] `./install.sh --local` on a Linux/NVIDIA VM — verify only one overlay runs (in install.sh) and `install_python_stack.py` short-circuits via `SKIP_STUDIO_BASE=1`
- [x] `./install.sh` (no `--local`) — verify behavior unchanged (PyPI unsloth-zoo)
- [x] `./studio/setup.sh` (no `--local`) on a non-Colab VM — verify the existing update path still works

## Solves
#5208