### PR TITLE
Studio: Chat thread autosave persistence

### DIFF
--- a/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
@@ -105,6 +105,9 @@ async function buildIndex(): Promise<ChatSearchItem[]> {
       const arr = byThreadId.get(tid);
       if (arr) merged.push(...arr);
     }
+    if (merged.length === 0) {
+      continue;
+    }
     merged.sort((a, b) => b.createdAt - a.createdAt);
 
     let preview = "";

--- a/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
@@ -4,6 +4,7 @@
 import { db, useLiveQuery } from "../db";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import type { ThreadRecord } from "../types";
+import { markChatThreadDeleted } from "../utils/chat-thread-tombstones";
 
 export interface SidebarItem {
   type: "single" | "compare";
@@ -80,6 +81,7 @@ export async function deleteChatItem(
   // Stop any in-flight streams before deleting, so the model doesn't keep
   // generating against a thread that no longer exists.
   for (const id of threadIds) cancelIfRunning(id);
+  for (const id of threadIds) markChatThreadDeleted(id);
 
   await db.transaction("rw", db.threads, db.messages, async () => {
     for (const id of threadIds) {

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -828,19 +828,19 @@ function ThreadDexieAutosave({
   pairId?: string;
 }): ReactElement | null {
   const aui = useAui();
-  const mainThreadId = useAuiState(({ threads }) => threads.mainThreadId);
   const saveChainRef = useRef(Promise.resolve());
 
-  const saveCurrentThread = useCallback(async (): Promise<void> => {
-    if (!mainThreadId) {
+  const saveThread = useCallback(async (threadId: string): Promise<void> => {
+    const runtime = aui.threads().__internal_getAssistantRuntime?.();
+    if (!runtime) {
       return;
     }
-    const exported = aui.thread().export();
+    const exported = runtime.threads.getById(threadId).export();
     if (exported.messages.length === 0) {
       return;
     }
 
-    const { remoteId } = await aui.threadListItem().initialize();
+    const { remoteId } = await runtime.threads.getItemById(threadId).initialize();
     if (isChatThreadDeleted(remoteId)) {
       await deleteThreadRows(remoteId);
       return;
@@ -853,27 +853,28 @@ function ThreadDexieAutosave({
 
     if (modelType === "base" && !pairId) {
       const store = useChatRuntimeStore.getState();
-      if (store.activeThreadId !== remoteId) {
+      const activeThreadId = runtime.threads.getState().mainThreadId;
+      if (activeThreadId === threadId && store.activeThreadId !== remoteId) {
         store.setActiveThreadId(remoteId);
       }
     }
-  }, [aui, mainThreadId, modelType, pairId]);
+  }, [aui, modelType, pairId]);
 
-  const queueSave = useCallback((): void => {
+  const queueSave = useCallback((threadId: string): void => {
     saveChainRef.current = saveChainRef.current
       .catch(() => {})
-      .then(() => saveCurrentThread())
+      .then(() => saveThread(threadId))
       .catch((error) => {
         console.error("Failed to autosave chat thread", error);
       });
-  }, [saveCurrentThread]);
+  }, [saveThread]);
 
-  useAuiEvent("thread.runEnd", () => {
-    queueSave();
+  useAuiEvent("thread.runEnd", ({ threadId }) => {
+    queueSave(threadId);
   });
 
-  useAuiEvent("thread.runStart", () => {
-    queueSave();
+  useAuiEvent("thread.runStart", ({ threadId }) => {
+    queueSave(threadId);
   });
 
   return null;

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -438,6 +438,13 @@ async function ensureThreadRecord({
   }
 }
 
+async function deleteThreadRows(threadId: string): Promise<void> {
+  await db.transaction("rw", db.threads, db.messages, async () => {
+    await db.messages.where("threadId").equals(threadId).delete();
+    await db.threads.delete(threadId);
+  });
+}
+
 function createDexieAdapter(
   modelType: ModelType,
   pairId?: string,
@@ -491,8 +498,7 @@ function createDexieAdapter(
 
     async delete(remoteId: string) {
       markChatThreadDeleted(remoteId);
-      await db.messages.where("threadId").equals(remoteId).delete();
-      await db.threads.delete(remoteId);
+      await deleteThreadRows(remoteId);
     },
 
     async generateTitle(remoteId: string, messages: readonly ThreadMessage[]) {
@@ -837,15 +843,17 @@ function ThreadDexieAutosave({
 
     const { remoteId } = await aui.threadListItem().initialize();
     if (isChatThreadDeleted(remoteId)) {
+      await deleteThreadRows(remoteId);
       return;
     }
     await ensureThreadRecord({ threadId: remoteId, modelType, pairId });
     if (isChatThreadDeleted(remoteId)) {
+      await deleteThreadRows(remoteId);
       return;
     }
     await syncExportedRepositoryToDexie(remoteId, exported);
     if (isChatThreadDeleted(remoteId)) {
-      await db.messages.where("threadId").equals(remoteId).delete();
+      await deleteThreadRows(remoteId);
       return;
     }
 

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -16,19 +16,32 @@ import {
   WebSpeechDictationAdapter,
   type unstable_RemoteThreadListAdapter,
   useAui,
+  useAuiEvent,
   useAuiState,
   useLocalRuntime,
   unstable_useRemoteThreadListRuntime as useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
 import { createAssistantStream } from "assistant-stream";
 import mammoth from "mammoth";
-import { type ReactElement, type ReactNode, useEffect, useMemo } from "react";
+import {
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { extractText, getDocumentProxy } from "unpdf";
 import { authFetch } from "@/features/auth";
 import { createOpenAIStreamAdapter } from "./api/chat-adapter";
 import { db } from "./db";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import type { MessageRecord, ModelType } from "./types";
+import {
+  isChatThreadDeleted,
+  markChatThreadDeleted,
+} from "./utils/chat-thread-tombstones";
+import { syncExportedRepositoryToDexie } from "./utils/delete-thread-message";
 
 const DEFAULT_SUGGESTIONS = [
   {
@@ -383,6 +396,48 @@ function toThreadMessage(m: MessageRecord): ThreadMessage {
   };
 }
 
+async function ensureThreadRecord({
+  threadId,
+  modelType,
+  pairId,
+}: {
+  threadId: string;
+  modelType: ModelType;
+  pairId?: string;
+}): Promise<void> {
+  if (isChatThreadDeleted(threadId)) {
+    return;
+  }
+  const existing = await db.threads.get(threadId);
+  if (existing) {
+    return;
+  }
+
+  const currentModelId =
+    useChatRuntimeStore.getState().params.checkpoint ?? "";
+  const record = {
+    id: threadId,
+    title: "New Chat",
+    modelType,
+    modelId: currentModelId,
+    pairId,
+    archived: false,
+    createdAt: Date.now(),
+  };
+
+  try {
+    await db.threads.add(record);
+  } catch (error) {
+    // assistant-ui can issue overlapping first-message persistence calls.
+    // If another call created the same thread while this one was waiting,
+    // treat initialization as successful and let the message write continue.
+    if (await db.threads.get(threadId)) {
+      return;
+    }
+    throw error;
+  }
+}
+
 function createDexieAdapter(
   modelType: ModelType,
   pairId?: string,
@@ -418,17 +473,7 @@ function createDexieAdapter(
     },
 
     async initialize(threadId: string) {
-      const currentModelId =
-        useChatRuntimeStore.getState().params.checkpoint ?? "";
-      await db.threads.add({
-        id: threadId,
-        title: "New Chat",
-        modelType,
-        modelId: currentModelId,
-        pairId,
-        archived: false,
-        createdAt: Date.now(),
-      });
+      await ensureThreadRecord({ threadId, modelType, pairId });
       return { remoteId: threadId, externalId: undefined };
     },
 
@@ -445,6 +490,7 @@ function createDexieAdapter(
     },
 
     async delete(remoteId: string) {
+      markChatThreadDeleted(remoteId);
       await db.messages.where("threadId").equals(remoteId).delete();
       await db.threads.delete(remoteId);
     },
@@ -599,6 +645,9 @@ function ThreadHistoryProvider({
 
       async append({ parentId, message }: ExportedMessageRepositoryItem) {
         const { remoteId } = await aui.threadListItem().initialize();
+        if (isChatThreadDeleted(remoteId)) {
+          return;
+        }
         // Keep single-chat runtime state in sync once a new chat is first
         // persisted. Compare panes intentionally do not write global activeThreadId.
         const thread = await db.threads.get(remoteId);
@@ -765,6 +814,69 @@ function CancelRegistrar(): ReactElement | null {
   return null;
 }
 
+function ThreadDexieAutosave({
+  modelType,
+  pairId,
+}: {
+  modelType: ModelType;
+  pairId?: string;
+}): ReactElement | null {
+  const aui = useAui();
+  const mainThreadId = useAuiState(({ threads }) => threads.mainThreadId);
+  const isLoading = useAuiState(({ thread }) => thread.isLoading);
+  const saveChainRef = useRef(Promise.resolve());
+
+  const saveCurrentThread = useCallback(async (): Promise<void> => {
+    if (isLoading || !mainThreadId) {
+      return;
+    }
+    const exported = aui.thread().export();
+    if (exported.messages.length === 0) {
+      return;
+    }
+
+    const { remoteId } = await aui.threadListItem().initialize();
+    if (isChatThreadDeleted(remoteId)) {
+      return;
+    }
+    await ensureThreadRecord({ threadId: remoteId, modelType, pairId });
+    if (isChatThreadDeleted(remoteId)) {
+      return;
+    }
+    await syncExportedRepositoryToDexie(remoteId, exported);
+    if (isChatThreadDeleted(remoteId)) {
+      await db.messages.where("threadId").equals(remoteId).delete();
+      return;
+    }
+
+    if (modelType === "base" && !pairId) {
+      const store = useChatRuntimeStore.getState();
+      if (store.activeThreadId !== remoteId) {
+        store.setActiveThreadId(remoteId);
+      }
+    }
+  }, [aui, isLoading, mainThreadId, modelType, pairId]);
+
+  const queueSave = useCallback((): void => {
+    saveChainRef.current = saveChainRef.current
+      .catch(() => {})
+      .then(() => saveCurrentThread())
+      .catch((error) => {
+        console.error("Failed to autosave chat thread", error);
+      });
+  }, [saveCurrentThread]);
+
+  useAuiEvent("thread.runEnd", () => {
+    queueSave();
+  });
+
+  useAuiEvent("thread.runStart", () => {
+    queueSave();
+  });
+
+  return null;
+}
+
 export function ChatRuntimeProvider({
   children,
   modelType = "base",
@@ -797,6 +909,7 @@ export function ChatRuntimeProvider({
       <ActiveThreadSync
         enabled={modelType === "base" && !pairId && !newThreadNonce && !initialThreadId}
       />
+      <ThreadDexieAutosave modelType={modelType} pairId={pairId} />
       <CancelRegistrar />
       {initialThreadId && (
         <ThreadAutoSwitch

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -652,6 +652,7 @@ function ThreadHistoryProvider({
       async append({ parentId, message }: ExportedMessageRepositoryItem) {
         const { remoteId } = await aui.threadListItem().initialize();
         if (isChatThreadDeleted(remoteId)) {
+          await deleteThreadRows(remoteId);
           return;
         }
         // Keep single-chat runtime state in sync once a new chat is first

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -829,11 +829,10 @@ function ThreadDexieAutosave({
 }): ReactElement | null {
   const aui = useAui();
   const mainThreadId = useAuiState(({ threads }) => threads.mainThreadId);
-  const isLoading = useAuiState(({ thread }) => thread.isLoading);
   const saveChainRef = useRef(Promise.resolve());
 
   const saveCurrentThread = useCallback(async (): Promise<void> => {
-    if (isLoading || !mainThreadId) {
+    if (!mainThreadId) {
       return;
     }
     const exported = aui.thread().export();
@@ -842,11 +841,6 @@ function ThreadDexieAutosave({
     }
 
     const { remoteId } = await aui.threadListItem().initialize();
-    if (isChatThreadDeleted(remoteId)) {
-      await deleteThreadRows(remoteId);
-      return;
-    }
-    await ensureThreadRecord({ threadId: remoteId, modelType, pairId });
     if (isChatThreadDeleted(remoteId)) {
       await deleteThreadRows(remoteId);
       return;
@@ -863,7 +857,7 @@ function ThreadDexieAutosave({
         store.setActiveThreadId(remoteId);
       }
     }
-  }, [aui, isLoading, mainThreadId, modelType, pairId]);
+  }, [aui, mainThreadId, modelType, pairId]);
 
   const queueSave = useCallback((): void => {
     saveChainRef.current = saveChainRef.current

--- a/studio/frontend/src/features/chat/utils/chat-thread-tombstones.ts
+++ b/studio/frontend/src/features/chat/utils/chat-thread-tombstones.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+const deletedThreadIds = new Set<string>();
+
+export function markChatThreadDeleted(threadId: string): void {
+  deletedThreadIds.add(threadId);
+}
+
+export function isChatThreadDeleted(threadId: string): boolean {
+  return deletedThreadIds.has(threadId);
+}

--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -19,8 +19,8 @@ import type {
  * surface area.
  */
 import { MessageRepository } from "@assistant-ui/core/internal";
-import { db } from "@/features/chat/db";
-import type { MessageRecord } from "@/features/chat/types";
+import { db } from "../db";
+import type { MessageRecord } from "../types";
 
 function cloneContent(content: ThreadMessage["content"]): ThreadMessage["content"] {
   if (typeof content === "string") {
@@ -74,7 +74,7 @@ function exportedItemToRecord(
  * Persist the exact message list represented by `exp` for this thread, removing
  * Dexie rows that are no longer present (e.g. after a delete).
  */
-async function syncExportedRepositoryToDexie(
+export async function syncExportedRepositoryToDexie(
   remoteId: string,
   exp: ExportedMessageRepository,
 ): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes #5250 

New chat threads not were appearing in Recents/export until a later mutation, such as deleting a message.

## Changes

- Make thread initialization idempotent.
- Sync the visible assistant-ui thread into Dexie at run start/end.
- Reuse the existing exported-message Dexie sync path.
- Guard in-flight saves from restoring deleted threads.
- Hide empty/orphaned threads from chat search.
