### PR TITLE
Add Qwen3.6 support

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -50,6 +50,8 @@ def _model_wants_causal_conv1d(model_name: str) -> bool:
         for key in (
             "qwen3.5",
             "qwen3_5",
+            "qwen3.6",
+            "qwen3_6",
             "qwen3-next",
             "qwen3_next",
             "nemotron_h",

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -133,6 +133,22 @@ def test_causal_conv1d_fast_path_preserves_wheel_first_install_args(monkeypatch)
     )
 
 
+def test_causal_conv1d_fast_path_includes_qwen3_6_variants(monkeypatch):
+    install_mock = mock.Mock(return_value = True)
+    monkeypatch.setattr(worker, "_install_package_wheel_first", install_mock)
+
+    worker._ensure_causal_conv1d_fast_path(
+        event_queue = [],
+        model_name = "unsloth/Qwen3.6-4B",
+    )
+    worker._ensure_causal_conv1d_fast_path(
+        event_queue = [],
+        model_name = "unsloth/Qwen3_6-4B",
+    )
+
+    assert install_mock.call_count == 2
+
+
 def test_mamba_ssm_path_preserves_wheel_first_install_args(monkeypatch):
     install_mock = mock.Mock(return_value = True)
     monkeypatch.setattr(worker, "_install_package_wheel_first", install_mock)

--- a/studio/backend/utils/datasets/model_mappings.py
+++ b/studio/backend/utils/datasets/model_mappings.py
@@ -364,6 +364,8 @@ TEMPLATE_TO_MODEL_MAPPER = {
         "unsloth/Qwen3-4B-Thinking-2507-bnb-4bit",
         "unsloth/Qwen3-30B-A3B-Thinking-2507",
         "Qwen/Qwen3-30B-A3B-Thinking-2507",
+        "Qwen/Qwen3.6-35B-A3B",
+        "unsloth/Qwen3.6-35B-A3B",
     ),
     "qwen3.5": (
         "unsloth/Qwen3.5-0.8B",
@@ -372,6 +374,8 @@ TEMPLATE_TO_MODEL_MAPPER = {
         "unsloth/Qwen3.5-9B",
         "unsloth/Qwen3.5-27B",
         "unsloth/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.6-27B",
+        "unsloth/Qwen3.6-27B",
     ),
     "zephyr": (
         "unsloth/zephyr-sft-bnb-4bit",

--- a/studio/backend/utils/datasets/model_mappings.py
+++ b/studio/backend/utils/datasets/model_mappings.py
@@ -375,7 +375,7 @@ TEMPLATE_TO_MODEL_MAPPER = {
         "unsloth/Qwen3.5-4B",
         "unsloth/Qwen3.5-9B",
         "unsloth/Qwen3.5-27B",
-        "unsloth/Qwen3.5-35B-A3B",   
+        "unsloth/Qwen3.5-35B-A3B",
     ),
     "zephyr": (
         "unsloth/zephyr-sft-bnb-4bit",

--- a/studio/backend/utils/datasets/model_mappings.py
+++ b/studio/backend/utils/datasets/model_mappings.py
@@ -366,6 +366,8 @@ TEMPLATE_TO_MODEL_MAPPER = {
         "Qwen/Qwen3-30B-A3B-Thinking-2507",
         "Qwen/Qwen3.6-35B-A3B",
         "unsloth/Qwen3.6-35B-A3B",
+        "Qwen/Qwen3.6-27B",
+        "unsloth/Qwen3.6-27B",
     ),
     "qwen3.5": (
         "unsloth/Qwen3.5-0.8B",
@@ -373,9 +375,7 @@ TEMPLATE_TO_MODEL_MAPPER = {
         "unsloth/Qwen3.5-4B",
         "unsloth/Qwen3.5-9B",
         "unsloth/Qwen3.5-27B",
-        "unsloth/Qwen3.5-35B-A3B",
-        "Qwen/Qwen3.6-27B",
-        "unsloth/Qwen3.6-27B",
+        "unsloth/Qwen3.5-35B-A3B",   
     ),
     "zephyr": (
         "unsloth/zephyr-sft-bnb-4bit",

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -63,6 +63,7 @@ TRANSFORMERS_5_MODEL_SUBSTRINGS: tuple[str, ...] = (
 TRANSFORMERS_550_MODEL_SUBSTRINGS: tuple[str, ...] = (
     "gemma-4",  # Gemma-4 (E2B-it, E4B-it, 31B-it, 26B-A4B-it)
     "gemma4",  # Gemma-4 alternate naming
+    "qwen3.6",
 )
 
 # Architecture classes / model_type values that require transformers 5.5.0.


### PR DESCRIPTION
## Summary

Adds Qwen3.6 model-name detection to the Studio training worker so Qwen3.6 / Qwen3_6 models trigger the causal-conv1d runtime setup path before training.
Adds Qwen3.6 to transformers 5.5.0 dynamic environment list.
Adds train on completion qwen3.6 entry

This solves https://github.com/unslothai/unsloth/issues/5237.

## Scope

- Adds `qwen3.6` and `qwen3_6` to `_model_wants_causal_conv1d`.
- Adds focused test coverage that both Qwen3.6 name variants enter the causal-conv1d install path.

## Notes

MoE training behavior is intentionally out of scope here and is being tracked separately in https://github.com/unslothai/unsloth-zoo/pull/618.

## Validation
