### PR TITLE
fix: set processor instead of tokenizer property for sentence-transformers v5.x (#5254)

### DIFF
--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1032,7 +1032,12 @@ class FastSentenceTransformer(FastModel):
             # Restore original functionality immediately
             AutoModel.from_pretrained = original_from_pretrained
 
-        transformer_module.tokenizer = tokenizer
+        # In sentence-transformers >= 5.0, 'tokenizer' is a read-only property
+        # that reads from 'self.processor', so we must set 'processor' directly.
+        if isinstance(getattr(type(transformer_module), 'tokenizer', None), property):
+            transformer_module.processor = tokenizer
+        else:
+            transformer_module.tokenizer = tokenizer
         transformer_module.do_lower_case = getattr(tokenizer, "do_lower_case", False)
 
         # sentence-transformers only passes along known keys to model.forward

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1034,7 +1034,7 @@ class FastSentenceTransformer(FastModel):
 
         # In sentence-transformers >= 5.0, 'tokenizer' is a read-only property
         # that reads from 'self.processor', so we must set 'processor' directly.
-        if isinstance(getattr(type(transformer_module), 'tokenizer', None), property):
+        if isinstance(getattr(type(transformer_module), "tokenizer", None), property):
             transformer_module.processor = tokenizer
         else:
             transformer_module.tokenizer = tokenizer


### PR DESCRIPTION
## Problem

When using `FastSentenceTransformer.from_pretrained()` with sentence-transformers >= 5.0 (e.g., v5.4.1), initialization fails with:

```
AttributeError: property 'tokenizer' of 'Transformer' object has no setter
```

This occurs in `_create_transformer_module` where the code attempts to set `transformer_module.tokenizer = tokenizer`.

## Root Cause

In sentence-transformers v5.x, the `Transformer` class refactored `tokenizer` from a regular attribute to a **read-only property** that reads from `self.processor`. There is no setter defined, so direct assignment raises `AttributeError`.

## Fix

Detect whether `tokenizer` is a property on the `Transformer` class. If it is (sentence-transformers >= 5.0), set `processor` directly instead, which is the underlying attribute the property reads from. For older versions where `tokenizer` is a regular attribute, the original code path is used.

## Testing

The fix is backward-compatible: for older sentence-transformers versions the original code path is used, and for v5.x setting `processor` correctly makes the `tokenizer` property return the expected value.

Fixes #5254
