### PR TITLE
Add native notifications to the Tauri app

### DIFF
--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -44,6 +44,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -4,6 +4,12 @@
 import { createElement, useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { consumeNativePathToken } from "@/features/native-intents/api";
+import {
+  notifyNative,
+  primeNativeNotificationPermission,
+  safeNotificationLabel,
+  sanitizeNotificationBody,
+} from "@/lib/native-notifications";
 import { ModelLoadDescription } from "../components/model-load-status";
 import {
   getDownloadProgress,
@@ -168,6 +174,7 @@ export function useChatModelRuntime() {
   const loadAbortRef = useRef<AbortController | null>(null);
   const loadingModelRef = useRef<typeof loadingModel>(null);
   const loadToastIdRef = useRef<string | number | null>(null);
+  const loadAttemptRef = useRef(0);
   const loadToastDismissedRef = useRef(false);
   const cancelUnloadPendingRef = useRef(false);
 
@@ -369,6 +376,10 @@ export function useChatModelRuntime() {
       const isLora =
         explicitIsLora ?? model?.isLora ?? loraIsAdapter ?? false;
       const displayName = model?.name || lora?.name || modelId;
+      const loadAttemptId = ++loadAttemptRef.current;
+      primeNativeNotificationPermission().catch(() => undefined);
+      const notificationModelKey = `${modelId}:${ggufVariant ?? ""}:${loadAttemptId}`;
+      const safeModelName = safeNotificationLabel(displayName, "The model");
       const currentCheckpoint =
         useChatRuntimeStore.getState().params.checkpoint;
       const previousCheckpoint = currentCheckpoint;
@@ -813,6 +824,12 @@ export function useChatModelRuntime() {
                   },
                 });
               }
+              notifyNative({
+                key: `model-downloaded:${notificationModelKey}`,
+                title: "Model downloaded",
+                body: `${safeModelName} finished downloading and is loading into memory.`,
+                requestPermission: false,
+              }).catch(() => undefined);
               // Keep polling: the mmap branch below takes over from here.
             }
           } catch {
@@ -898,6 +915,12 @@ export function useChatModelRuntime() {
               duration: 2000,
             });
           }
+          notifyNative({
+            key: `model-loaded:${notificationModelKey}`,
+            title: "Model ready",
+            body: `${safeModelName} is loaded and ready to chat.`,
+            requestPermission: false,
+          }).catch(() => undefined);
         } catch (err) {
           if (!abortCtrl.signal.aborted) {
             const message =
@@ -912,6 +935,12 @@ export function useChatModelRuntime() {
                 duration: 5000,
               });
             }
+            notifyNative({
+              key: `model-load-failed:${notificationModelKey}`,
+              title: "Model failed to load",
+              body: sanitizeNotificationBody(message, "The model failed to load."),
+              requestPermission: false,
+            }).catch(() => undefined);
           }
           throw err;
         } finally {

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { primeNativeNotificationPermission } from "@/lib/native-notifications";
 import { useCallback } from "react";
+import { toast } from "sonner";
 import { checkDatasetFormat } from "../api/datasets-api";
 import { getTrainingRun } from "../api/history-api";
 import { buildTrainingStartPayload } from "../api/mappers";
-import { startTraining, stopTraining, resetTraining } from "../api/train-api";
+import { resetTraining, startTraining, stopTraining } from "../api/train-api";
 import { syncTrainingRuntimeFromBackend } from "../lib/sync-runtime";
 import { validateTrainingConfig } from "../lib/validation";
 import { useDatasetPreviewDialogStore } from "../stores/dataset-preview-dialog-store";
@@ -13,7 +15,6 @@ import { useTrainingConfigStore } from "../stores/training-config-store";
 import { useTrainingRuntimeStore } from "../stores/training-runtime-store";
 import type { TrainingStartRequest } from "../types/api";
 import type { TrainingConfigState } from "../types/config";
-import { toast } from "sonner";
 
 /** Chatml → format-specific role remap (only for formats that differ from chatml). */
 const ROLE_REMAP: Record<string, Record<string, string>> = {
@@ -49,6 +50,8 @@ export function useTrainingActions() {
       runtimeStore.setStartError(validation.message);
       return false;
     }
+
+    primeNativeNotificationPermission().catch(() => undefined);
 
     runtimeStore.setStartResources(
       config.selectedModel ?? null,
@@ -173,6 +176,8 @@ export function useTrainingActions() {
       if (!detail.run.can_resume || !outputDir) {
         throw new Error("Only stopped runs with a saved checkpoint can be resumed.");
       }
+
+      primeNativeNotificationPermission().catch(() => undefined);
 
       const config = useTrainingConfigStore.getState();
       const savedConfig = detail.config as Partial<TrainingStartRequest>;

--- a/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-runtime-lifecycle.ts
@@ -2,6 +2,11 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { hasAuthToken } from "@/features/auth";
+import {
+  notifyNative,
+  safeNotificationLabel,
+  sanitizeNotificationBody,
+} from "@/lib/native-notifications";
 import { useEffect } from "react";
 import {
   getTrainingMetrics,
@@ -9,6 +14,7 @@ import {
   isAbortError,
   streamTrainingProgress,
 } from "../api/train-api";
+import { useTrainingConfigStore } from "../stores/training-config-store";
 import { useTrainingRuntimeStore } from "../stores/training-runtime-store";
 import type { TrainingRuntimeStore } from "../types/runtime";
 
@@ -16,9 +22,76 @@ const STATUS_POLL_INTERVAL_MS = 3000;
 const METRICS_POLL_INTERVAL_MS = 5000;
 const IDLE_POLL_INTERVAL_MS = 30000;
 const STREAM_RECONNECT_DELAY_MS = 1500;
+const GENERIC_TRAINING_STREAM_ERROR = "Training stream error";
+const DEFAULT_TRAINING_ERROR_BODY = "Your training run stopped with an error.";
 
 function shouldUseLiveSync(state: TrainingRuntimeStore): boolean {
   return state.isTrainingRunning || state.phase === "training";
+}
+
+function getTrainingErrorBody(state: TrainingRuntimeStore): string {
+  return sanitizeNotificationBody(
+    state.error ?? state.message,
+    DEFAULT_TRAINING_ERROR_BODY,
+  );
+}
+
+function shouldNotifyTrainingError(
+  before: TrainingRuntimeStore,
+  after: TrainingRuntimeStore,
+): boolean {
+  if (after.phase !== "error") {
+    return false;
+  }
+  if (before.phase !== "error" || before.jobId !== after.jobId) {
+    return true;
+  }
+  if (before.error !== GENERIC_TRAINING_STREAM_ERROR) {
+    return false;
+  }
+
+  return getTrainingErrorBody(before) !== getTrainingErrorBody(after);
+}
+
+function maybeNotifyTrainingTerminalTransition(
+  before: TrainingRuntimeStore,
+  after: TrainingRuntimeStore,
+): void {
+  if (!after.jobId) {
+    return;
+  }
+  if (
+    before.stopRequested ||
+    after.stopRequested ||
+    after.phase === "stopped"
+  ) {
+    return;
+  }
+
+  const sameJob = before.jobId === after.jobId;
+  const samePhase = before.phase === after.phase;
+
+  if (after.phase === "completed" && !(sameJob && samePhase)) {
+    const model = safeNotificationLabel(
+      after.startModelName ?? useTrainingConfigStore.getState().selectedModel,
+      "Your training run",
+    );
+    notifyNative({
+      key: `training-completed:${after.jobId}`,
+      title: "Training finished",
+      body: `${model} is complete.`,
+      requestPermission: false,
+    }).catch(() => undefined);
+  }
+
+  if (shouldNotifyTrainingError(before, after)) {
+    notifyNative({
+      key: `training-error:${after.jobId}`,
+      title: "Training failed",
+      body: getTrainingErrorBody(after),
+      requestPermission: false,
+    }).catch(() => undefined);
+  }
 }
 
 export function useTrainingRuntimeLifecycle(): void {
@@ -62,7 +135,9 @@ export function useTrainingRuntimeLifecycle(): void {
       }
     };
 
-    const pollStatus = async () => {
+    const pollStatus = async (options?: {
+      suppressNativeNotifications?: boolean;
+    }) => {
       if (!hasAuthToken()) return;
       const gen = runtimeStore.getState().resetGeneration;
       try {
@@ -71,9 +146,13 @@ export function useTrainingRuntimeLifecycle(): void {
           return;
         }
 
+        const previousState = runtimeStore.getState();
         runtimeStore.getState().applyStatus(status);
 
         const nextState = runtimeStore.getState();
+        if (!options?.suppressNativeNotifications) {
+          maybeNotifyTrainingTerminalTransition(previousState, nextState);
+        }
         if (shouldUseLiveSync(nextState)) {
           void ensureStream();
         } else {
@@ -124,7 +203,7 @@ export function useTrainingRuntimeLifecycle(): void {
             }
 
             if (event.event === "error") {
-              liveStore.setRuntimeError("Training stream error");
+              liveStore.setRuntimeError(GENERIC_TRAINING_STREAM_ERROR);
               stopStream();
             }
           },
@@ -154,7 +233,10 @@ export function useTrainingRuntimeLifecycle(): void {
     const hydrate = async () => {
       runtimeStore.getState().setHydrating(true);
       try {
-        await Promise.all([pollStatus(), pollMetrics()]);
+        await Promise.all([
+          pollStatus({ suppressNativeNotifications: true }),
+          pollMetrics(),
+        ]);
       } finally {
         if (!disposed) {
           runtimeStore.getState().setHydrating(false);
@@ -172,7 +254,12 @@ export function useTrainingRuntimeLifecycle(): void {
 
     const statusTimer = setInterval(() => {
       const s = runtimeStore.getState();
-      if (isIdle() && s.hasHydrated) return;
+      if (!s.hasHydrated || s.isHydrating) {
+        return;
+      }
+      if (isIdle()) {
+        return;
+      }
       void pollStatus();
     }, STATUS_POLL_INTERVAL_MS);
 
@@ -187,7 +274,13 @@ export function useTrainingRuntimeLifecycle(): void {
     // Low-frequency background poll to recover from failed hydration or detect
     // out-of-band state changes (e.g. training started from another client).
     const idleTimer = setInterval(() => {
-      if (!isIdle()) return;
+      const s = runtimeStore.getState();
+      if (!s.hasHydrated || s.isHydrating) {
+        return;
+      }
+      if (!isIdle()) {
+        return;
+      }
       void pollStatus();
     }, IDLE_POLL_INTERVAL_MS);
 

--- a/studio/frontend/src/lib/native-notifications.ts
+++ b/studio/frontend/src/lib/native-notifications.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { isTauri } from "@/lib/api-base";
+
+const MAX_BODY_LENGTH = 200;
+const MAX_SENT_KEYS = 200;
+const HF_TOKEN_PATTERN = /\bhf_[A-Za-z0-9]{20,}\b/g;
+const GITHUB_TOKEN_PATTERN = /\bghp_[A-Za-z0-9_]{20,}\b/g;
+const GITHUB_PAT_PATTERN = /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g;
+const OPENAI_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{20,}\b/g;
+const UNIX_HOME_PATH_PATTERN =
+  /(^|[\s"'(=])(?:\/Users|\/home)\/[^\s"'<>),;]+/gi;
+const UNIX_ABSOLUTE_PATH_PATTERN = /(^|[\s"'(=])\/[^\s"'<>),;]+/g;
+const TILDE_PATH_PATTERN = /(^|[\s"'(=])~[\\/][^\s"'<>),;]+/g;
+const RELATIVE_PATH_PATTERN = /(^|[\s"'(=])\.{1,2}[\\/][^\s"'<>),;]+/g;
+const WINDOWS_DRIVE_PATH_PATTERN = /(^|[\s"'(=])[A-Za-z]:[\\/][^\s"'<>),;]+/g;
+const WINDOWS_UNC_PATH_PATTERN = /(^|[\s"'(=])\\\\[^\s"'<>),;]+/g;
+const WHITESPACE_PATTERN = /\s+/g;
+const LOCAL_PATH_PATTERN = /^(?:\/|~[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|\\\\)/;
+const PATH_SEPARATOR_PATTERN = /[\\/]/;
+const SENSITIVE_TOKEN_PATTERN =
+  /\bhf_[A-Za-z0-9]{20,}\b|\bghp_[A-Za-z0-9_]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b|\bsk-[A-Za-z0-9_-]{20,}\b/;
+
+type PermissionState = "unknown" | "granted" | "denied";
+
+let permissionState: PermissionState = "unknown";
+let permissionPrimeInFlight: Promise<void> | null = null;
+const inFlightKeys = new Set<string>();
+const sentKeys = new Set<string>();
+
+export interface NativeNotificationOptions {
+  key: string;
+  title: string;
+  body?: string;
+  requestPermission?: boolean;
+}
+
+function hasGrantedPermission(): boolean {
+  return permissionState === "granted";
+}
+
+function getBrowserNotificationApi(): typeof Notification | null {
+  if (typeof window === "undefined" || !("Notification" in window)) {
+    return null;
+  }
+
+  return window.Notification;
+}
+
+function rememberSentKey(key: string): void {
+  sentKeys.add(key);
+
+  if (sentKeys.size <= MAX_SENT_KEYS) {
+    return;
+  }
+
+  const oldestKey = sentKeys.values().next().value;
+  if (oldestKey) {
+    sentKeys.delete(oldestKey);
+  }
+}
+
+async function checkNativePermission(allowRequest: boolean): Promise<boolean> {
+  const notification = getBrowserNotificationApi();
+  if (notification?.permission === "granted") {
+    permissionState = "granted";
+    return true;
+  }
+
+  if (notification?.permission === "denied") {
+    permissionState = "denied";
+    return false;
+  }
+
+  if (allowRequest && notification?.permission === "default") {
+    const permission = await notification.requestPermission();
+    if (permission === "granted") {
+      permissionState = "granted";
+      return true;
+    }
+    if (permission === "denied") {
+      permissionState = "denied";
+    }
+    return false;
+  }
+
+  try {
+    const { isPermissionGranted } = await import(
+      "@tauri-apps/plugin-notification"
+    );
+    const granted = await isPermissionGranted();
+
+    if (granted) {
+      permissionState = "granted";
+    }
+
+    return granted;
+  } catch {
+    return false;
+  }
+}
+
+async function ensurePermission(allowRequest: boolean): Promise<boolean> {
+  if (!isTauri) {
+    return false;
+  }
+  if (permissionState !== "unknown") {
+    return hasGrantedPermission();
+  }
+
+  if (permissionPrimeInFlight) {
+    await permissionPrimeInFlight;
+    if (permissionState !== "unknown" || !allowRequest) {
+      return hasGrantedPermission();
+    }
+  }
+
+  return checkNativePermission(allowRequest);
+}
+
+export async function primeNativeNotificationPermission(): Promise<void> {
+  if (!isTauri || permissionState !== "unknown") {
+    return;
+  }
+
+  if (!permissionPrimeInFlight) {
+    permissionPrimeInFlight = checkNativePermission(true)
+      .then(() => undefined)
+      .finally(() => {
+        permissionPrimeInFlight = null;
+      });
+  }
+
+  await permissionPrimeInFlight;
+}
+
+export async function notifyNative(
+  options: NativeNotificationOptions,
+): Promise<void> {
+  if (!isTauri) {
+    return;
+  }
+  if (sentKeys.has(options.key) || inFlightKeys.has(options.key)) {
+    return;
+  }
+  inFlightKeys.add(options.key);
+
+  try {
+    const granted = await ensurePermission(options.requestPermission !== false);
+    if (!granted) {
+      return;
+    }
+
+    const body = options.body
+      ? sanitizeNotificationBody(options.body, "")
+      : undefined;
+    const { sendNotification } = await import(
+      "@tauri-apps/plugin-notification"
+    );
+    sendNotification({ title: options.title, body });
+    rememberSentKey(options.key);
+  } catch {
+    // Native notifications are non-critical UI side effects.
+  } finally {
+    inFlightKeys.delete(options.key);
+  }
+}
+
+export function sanitizeNotificationBody(
+  input: string | null | undefined,
+  fallback: string,
+): string {
+  const fallbackText = fallback.trim() || "Notification update.";
+  let text = typeof input === "string" ? input.trim() : "";
+
+  if (!text) {
+    text = fallbackText;
+  }
+
+  text = text
+    .replace(HF_TOKEN_PATTERN, "hf_[redacted]")
+    .replace(GITHUB_TOKEN_PATTERN, "ghp_[redacted]")
+    .replace(GITHUB_PAT_PATTERN, "github_pat_[redacted]")
+    .replace(OPENAI_KEY_PATTERN, "sk-[redacted]")
+    .replace(UNIX_HOME_PATH_PATTERN, "$1[path]")
+    .replace(UNIX_ABSOLUTE_PATH_PATTERN, "$1[path]")
+    .replace(TILDE_PATH_PATTERN, "$1[path]")
+    .replace(RELATIVE_PATH_PATTERN, "$1[path]")
+    .replace(WINDOWS_DRIVE_PATH_PATTERN, "$1[path]")
+    .replace(WINDOWS_UNC_PATH_PATTERN, "$1[path]")
+    .replace(WHITESPACE_PATTERN, " ")
+    .trim();
+
+  if (!text) {
+    text = fallbackText;
+  }
+
+  if (text.length > MAX_BODY_LENGTH) {
+    return `${text.slice(0, MAX_BODY_LENGTH - 1).trimEnd()}…`;
+  }
+
+  return text;
+}
+
+export function safeNotificationLabel(
+  input: string | null | undefined,
+  fallback: string,
+): string {
+  const fallbackText = fallback.trim() || "The item";
+  const raw = typeof input === "string" ? input.trim() : "";
+  if (!raw) {
+    return fallbackText;
+  }
+
+  const collapsed = raw.replace(WHITESPACE_PATTERN, " ");
+  const isLocalPath = LOCAL_PATH_PATTERN.test(collapsed);
+
+  if (isLocalPath) {
+    const basename =
+      collapsed.split(PATH_SEPARATOR_PATTERN).filter(Boolean).at(-1) ?? "";
+    if (
+      basename &&
+      basename !== "." &&
+      basename !== ".." &&
+      !SENSITIVE_TOKEN_PATTERN.test(basename)
+    ) {
+      return sanitizeNotificationBody(basename, fallbackText);
+    }
+    return fallbackText;
+  }
+
+  return sanitizeNotificationBody(collapsed, fallbackText);
+}

--- a/studio/src-tauri/Cargo.lock
+++ b/studio/src-tauri/Cargo.lock
@@ -2302,6 +2302,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,6 +2512,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdaf6120b9df005d37e58f6b75329be6255450453fbeba9ce4192324f921fb9"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -3273,6 +3299,15 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -3337,6 +3372,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
@@ -3367,6 +3412,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,6 +3437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4590,6 +4654,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4767,6 +4850,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -5296,6 +5391,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",

--- a/studio/src-tauri/Cargo.toml
+++ b/studio/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 rand = "0.10.0"
+tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/studio/src-tauri/capabilities/default.json
+++ b/studio/src-tauri/capabilities/default.json
@@ -20,6 +20,9 @@
     "core:window:allow-close",
     "core:tray:default",
     "process:default",
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify",
     {
       "identifier": "opener:allow-open-url",
       "allow": [{ "url": "https://*" }, { "url": "http://*" }, { "url": "mailto:*" }]

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -167,6 +167,7 @@ fn main() {
         }))
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())


### PR DESCRIPTION
This adds native desktop notifications for important Tauri app events.

It covers model download completion and model load results. It also covers training completion and training failure.

Native calls stay behind the existing Tauri check. Browser users keep the same web behavior.

The change uses the official Tauri notification plugin and keeps notification text safe.

Tested with frontend typecheck and frontend build and cargo check.