### PR TITLE
Studio: Preserve chat history during autosave

### DIFF
--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -81,10 +81,11 @@ export async function syncExportedRepositoryToDexie(
   await db.transaction("rw", db.messages, async () => {
     if (options.pruneMissing) {
       const keepIds = new Set(exp.messages.map((x) => x.message.id));
-      const existing = await db.messages.where("threadId").equals(remoteId).toArray();
-      const idsToDelete = existing
-        .filter((m) => !keepIds.has(m.id))
-        .map((m) => m.id);
+      const existingIds = await db.messages
+        .where("threadId")
+        .equals(remoteId)
+        .primaryKeys();
+      const idsToDelete = existingIds.filter((id) => !keepIds.has(String(id)));
       if (idsToDelete.length > 0) {
         await db.messages.bulkDelete(idsToDelete);
       }

--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -71,21 +71,23 @@ function exportedItemToRecord(
 }
 
 /**
- * Persist the exact message list represented by `exp` for this thread, removing
- * Dexie rows that are no longer present (e.g. after a delete).
+ * Persist exported messages, pruning only for explicit delete flows.
  */
 export async function syncExportedRepositoryToDexie(
   remoteId: string,
   exp: ExportedMessageRepository,
+  options: { pruneMissing?: boolean } = {},
 ): Promise<void> {
   await db.transaction("rw", db.messages, async () => {
-    const keepIds = new Set(exp.messages.map((x) => x.message.id));
-    const existing = await db.messages.where("threadId").equals(remoteId).toArray();
-    const idsToDelete = existing
-      .filter((m) => !keepIds.has(m.id))
-      .map((m) => m.id);
-    if (idsToDelete.length > 0) {
-      await db.messages.bulkDelete(idsToDelete);
+    if (options.pruneMissing) {
+      const keepIds = new Set(exp.messages.map((x) => x.message.id));
+      const existing = await db.messages.where("threadId").equals(remoteId).toArray();
+      const idsToDelete = existing
+        .filter((m) => !keepIds.has(m.id))
+        .map((m) => m.id);
+      if (idsToDelete.length > 0) {
+        await db.messages.bulkDelete(idsToDelete);
+      }
     }
     await db.messages.bulkPut(
       exp.messages.map(({ message, parentId }) =>
@@ -115,7 +117,7 @@ export async function deleteThreadMessage(args: {
   repo.deleteMessage(messageId);
   const next = repo.export();
   if (remoteId) {
-    await syncExportedRepositoryToDexie(remoteId, next);
+    await syncExportedRepositoryToDexie(remoteId, next, { pruneMissing: true });
   }
   thread.import(next);
 }


### PR DESCRIPTION
## Summary

Follow-up to #5256.

Autosave and explicit message deletion shared the same sync path, so autosave could treat an in-progress assistant-ui snapshot as authoritative. This keeps autosave non-destructive and limits message pruning to explicit delete flows.

- Prevent autosave from pruning persisted chat messages during run lifecycle snapshots
- Keep destructive pruning scoped to explicit message deletion
- Preserve chat history when reopening threads from Recents after starting a New Chat
