### PR TITLE
Fix Studio fresh install chat runtime adapters

### DIFF
--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@assistant-ui/core": "0.1.17",
-    "@assistant-ui/react": "^0.12.19",
-    "@assistant-ui/react-markdown": "^0.12.3",
-    "@assistant-ui/react-streamdown": "^0.1.2",
+    "@assistant-ui/react": "0.12.19",
+    "@assistant-ui/react-markdown": "0.12.3",
+    "@assistant-ui/react-streamdown": "0.1.2",
     "@base-ui/react": "^1.2.0",
     "@dagrejs/dagre": "^2.0.4",
     "@dagrejs/graphlib": "^3.0.4",

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -232,7 +232,6 @@ function ComparePane({
           modelType={modelType}
           pairId={pairId}
           initialThreadId={initialThreadId}
-          syncActiveThreadId={false}
         >
           <RegisterCompareHandle name={handleName} />
           <Thread hideComposer={true} hideWelcome={true} />

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -9,7 +9,6 @@ import {
   ExportedMessageRepository,
   type ExportedMessageRepositoryItem,
   type PendingAttachment,
-  RuntimeAdapterProvider,
   Suggestions,
   type ThreadHistoryAdapter,
   type ThreadMessage,
@@ -75,7 +74,7 @@ type TitleResponse = {
 };
 
 class VisionImageAdapter implements AttachmentAdapter {
-  accept = "image/jpeg,image/png,image/webp,image/gif";
+  accept = ".jpg,.jpeg,.png,.webp,.gif,image/jpeg,image/png,image/webp,image/gif";
 
   async add({ file }: { file: File }): Promise<PendingAttachment> {
     const maxSize = 20 * 1024 * 1024;
@@ -124,7 +123,7 @@ class VisionImageAdapter implements AttachmentAdapter {
 }
 
 class PDFAttachmentAdapter implements AttachmentAdapter {
-  accept = "application/pdf";
+  accept = ".pdf,application/pdf";
 
   add({ file }: { file: File }): Promise<PendingAttachment> {
     return Promise.resolve({
@@ -157,7 +156,7 @@ class PDFAttachmentAdapter implements AttachmentAdapter {
 }
 
 class TextAttachmentAdapter implements AttachmentAdapter {
-  accept = "text/plain,text/markdown,text/csv,text/xml,text/json,text/css";
+  accept = ".txt,.md,.csv,.xml,.json,.css,text/plain,text/markdown,text/csv,text/xml,text/json,text/css";
 
   async add({ file }: { file: File }): Promise<PendingAttachment> {
     return {
@@ -190,7 +189,7 @@ class TextAttachmentAdapter implements AttachmentAdapter {
 }
 
 class HtmlAttachmentAdapter implements AttachmentAdapter {
-  accept = "text/html";
+  accept = ".html,.htm,text/html";
 
   async add({ file }: { file: File }): Promise<PendingAttachment> {
     return {
@@ -229,7 +228,7 @@ class HtmlAttachmentAdapter implements AttachmentAdapter {
 
 class DocxAttachmentAdapter implements AttachmentAdapter {
   accept =
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    ".docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
   add({ file }: { file: File }): Promise<PendingAttachment> {
     return Promise.resolve({
@@ -583,9 +582,7 @@ function createDexieAdapter(
   };
 }
 
-function ThreadHistoryProvider({
-  children,
-}: { children?: ReactNode }): ReactElement {
+function useDexieRuntimeAdapters() {
   const aui = useAui();
 
   const history = useMemo<ThreadHistoryAdapter>(
@@ -711,51 +708,13 @@ function ThreadHistoryProvider({
     [history, dictation, attachments],
   );
 
-  return (
-    <RuntimeAdapterProvider adapters={adapters}>
-      {children}
-    </RuntimeAdapterProvider>
-  );
+  return adapters;
 }
 
 const chatAdapter = createOpenAIStreamAdapter();
 
 function useRuntimeHook(): ReturnType<typeof useLocalRuntime> {
-  return useLocalRuntime(chatAdapter);
-}
-
-function ThreadAutoSwitch({
-  threadId,
-  syncActiveThreadId = true,
-}: {
-  threadId: string;
-  syncActiveThreadId?: boolean;
-}): ReactElement | null {
-  const aui = useAui();
-  const isLoading = useAuiState(({ threads }) => threads.isLoading);
-  const mainThreadId = useAuiState(({ threads }) => threads.mainThreadId);
-
-  useEffect(() => {
-    if (!isLoading && mainThreadId !== threadId) {
-      const switchResult = aui.threads().switchToThread(threadId) as unknown;
-      if (switchResult && typeof (switchResult as Promise<void>).catch === "function") {
-        void (switchResult as Promise<void>).catch(() => {
-          if (syncActiveThreadId) {
-            useChatRuntimeStore.getState().setActiveThreadId(null);
-          }
-        });
-      }
-    }
-  }, [aui, isLoading, mainThreadId, syncActiveThreadId, threadId]);
-
-  useEffect(() => {
-    if (!syncActiveThreadId || isLoading || mainThreadId !== threadId) {
-      return;
-    }
-    useChatRuntimeStore.getState().setActiveThreadId(threadId);
-  }, [isLoading, mainThreadId, syncActiveThreadId, threadId]);
-
-  return null;
+  return useLocalRuntime(chatAdapter, { adapters: useDexieRuntimeAdapters() });
 }
 
 function ThreadNewChatSwitch({
@@ -887,21 +846,17 @@ export function ChatRuntimeProvider({
   pairId,
   initialThreadId,
   newThreadNonce,
-  syncActiveThreadId = true,
 }: {
   children: ReactNode;
   modelType?: ModelType;
   pairId?: string;
   initialThreadId?: string;
   newThreadNonce?: string;
-  syncActiveThreadId?: boolean;
 }): ReactElement {
   const runtime = useRemoteThreadListRuntime({
     runtimeHook: useRuntimeHook,
-    adapter: {
-      ...createDexieAdapter(modelType, pairId),
-      unstable_Provider: ThreadHistoryProvider,
-    },
+    adapter: createDexieAdapter(modelType, pairId),
+    threadId: newThreadNonce ? undefined : initialThreadId,
   });
 
   const aui = useAui({
@@ -911,16 +866,10 @@ export function ChatRuntimeProvider({
   return (
     <AssistantRuntimeProvider runtime={runtime} aui={aui}>
       <ActiveThreadSync
-        enabled={modelType === "base" && !pairId && !newThreadNonce && !initialThreadId}
+        enabled={modelType === "base" && !pairId && !newThreadNonce}
       />
       <ThreadDexieAutosave modelType={modelType} pairId={pairId} />
       <CancelRegistrar />
-      {initialThreadId && (
-        <ThreadAutoSwitch
-          threadId={initialThreadId}
-          syncActiveThreadId={syncActiveThreadId}
-        />
-      )}
       {!initialThreadId && newThreadNonce && (
         <ThreadNewChatSwitch nonce={newThreadNonce} />
       )}

--- a/tests/studio/test_frontend_dependency_pins.py
+++ b/tests/studio/test_frontend_dependency_pins.py
@@ -7,7 +7,7 @@ FRONTEND_PACKAGE_JSON = WORKDIR / "studio" / "frontend" / "package.json"
 
 
 def test_assistant_ui_dependencies_are_pinned():
-    package = json.loads(FRONTEND_PACKAGE_JSON.read_text(encoding="utf-8"))
+    package = json.loads(FRONTEND_PACKAGE_JSON.read_text(encoding = "utf-8"))
     dependencies = package["dependencies"]
 
     assert dependencies["@assistant-ui/core"] == "0.1.17"

--- a/tests/studio/test_frontend_dependency_pins.py
+++ b/tests/studio/test_frontend_dependency_pins.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+
+WORKDIR = Path(__file__).resolve().parents[2]
+FRONTEND_PACKAGE_JSON = WORKDIR / "studio" / "frontend" / "package.json"
+
+
+def test_assistant_ui_dependencies_are_pinned():
+    package = json.loads(FRONTEND_PACKAGE_JSON.read_text(encoding="utf-8"))
+    dependencies = package["dependencies"]
+
+    assert dependencies["@assistant-ui/core"] == "0.1.17"
+    assert dependencies["@assistant-ui/react"] == "0.12.19"
+    assert dependencies["@assistant-ui/react-markdown"] == "0.12.3"
+    assert dependencies["@assistant-ui/react-streamdown"] == "0.1.2"


### PR DESCRIPTION
## Summary

Fixes a fresh-install Studio regression where chat history clicks could hang or load extremely slowly, and chat attachments such as images/PDFs could not be uploaded.

The issue only showed up on fresh installs because the chat runtime adapters were being registered too late through `unstable_Provider`. Existing installs could miss this because their local built frontend/runtime state differed from a clean install.

## Changes

- Register Dexie history, dictation, and attachment adapters directly in `useLocalRuntime(...)`.
- Pass `initialThreadId` directly to `useRemoteThreadListRuntime(...)` instead of manually switching threads after runtime creation.
- Remove the manual thread auto-switch shim.
- Make attachment accept strings include file extensions as well as MIME types for images, PDFs, text, HTML, and DOCX.
- Pin assistant-ui frontend dependencies so fresh installs cannot drift to incompatible patch/minor behavior.
- Add a regression test to keep assistant-ui dependency pins exact.

