### PR TITLE
fix(studio): set HIP_VISIBLE_DEVICES in apply_gpu_ids for ROCm training workers

### DIFF
--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1402,6 +1402,7 @@ def apply_gpu_ids(gpu_ids) -> None:
     if not _is_rocm:
         try:
             import torch as _torch
+
             _is_rocm = bool(getattr(_torch.version, "hip", None))
         except Exception:
             pass

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1391,14 +1391,25 @@ def apply_gpu_ids(gpu_ids) -> None:
     # parent process already set a ROCm visibility variable -- that
     # way a downstream ROCm process inherits the narrowed mask even
     # before Studio's hardware detection has classified the host.
+    # As a final fallback, probe torch.version.hip directly so spawned
+    # training workers on AMD hosts where the user never set HIP_VISIBLE_DEVICES
+    # still get the correct ROCm visibility mask (mirrors the llama_cpp.py
+    # approach for llama-server subprocess GPU pinning).
     _inherits_rocm_visibility = (
         "HIP_VISIBLE_DEVICES" in os.environ or "ROCR_VISIBLE_DEVICES" in os.environ
     )
-    if IS_ROCM or _inherits_rocm_visibility:
+    _is_rocm = IS_ROCM or _inherits_rocm_visibility
+    if not _is_rocm:
+        try:
+            import torch as _torch
+            _is_rocm = bool(getattr(_torch.version, "hip", None))
+        except Exception:
+            pass
+    if _is_rocm:
         os.environ["HIP_VISIBLE_DEVICES"] = value
         os.environ["ROCR_VISIBLE_DEVICES"] = value
     _visible_gpu_count = None
-    if IS_ROCM or _inherits_rocm_visibility:
+    if _is_rocm:
         logger.info("Applied gpu_ids: CUDA_VISIBLE_DEVICES='%s' (rocm)", value)
     else:
         logger.info("Applied gpu_ids: CUDA_VISIBLE_DEVICES='%s'", value)

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1400,12 +1400,24 @@ def apply_gpu_ids(gpu_ids) -> None:
     )
     _is_rocm = IS_ROCM or _inherits_rocm_visibility
     if not _is_rocm:
+        # Use ``is not None`` here to match the detect_hardware() check at
+        # module top -- torch ships HIP version as a non-empty string on
+        # ROCm builds and None on CUDA builds, so the two forms agree on
+        # every shipping torch wheel; the ``is not None`` form is the one
+        # the rest of the codebase reads for "this torch was built with
+        # HIP". Keep the broad ``except`` as a safety net (we never want
+        # apply_gpu_ids to crash a worker over a probe failure) but log at
+        # debug level so the skip is observable when needed.
         try:
             import torch as _torch
 
-            _is_rocm = bool(getattr(_torch.version, "hip", None))
-        except Exception:
-            pass
+            _is_rocm = getattr(_torch.version, "hip", None) is not None
+        except Exception as e:
+            logger.debug(
+                "apply_gpu_ids: torch.version.hip probe skipped (%s: %s)",
+                type(e).__name__,
+                e,
+            )
     if _is_rocm:
         os.environ["HIP_VISIBLE_DEVICES"] = value
         os.environ["ROCR_VISIBLE_DEVICES"] = value

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -599,7 +599,10 @@ def _get_parent_visible_gpu_spec() -> Dict[str, Any]:
     # Use explicit None checks (not `or`) so empty string "" is honoured
     # as "no visible GPUs" rather than falling through to CUDA_VISIBLE_DEVICES.
     cuda_visible = None
-    if IS_ROCM:
+    _is_rocm_spec = IS_ROCM or (
+        "HIP_VISIBLE_DEVICES" in os.environ or "ROCR_VISIBLE_DEVICES" in os.environ
+    )
+    if _is_rocm_spec:
         hip_vis = os.environ.get("HIP_VISIBLE_DEVICES")
         rocr_vis = os.environ.get("ROCR_VISIBLE_DEVICES")
         if hip_vis is not None:

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -1251,6 +1251,39 @@ class TestHardwareAmdBranching:
 
 
 # =============================================================================
+# TEST: hardware.py -- apply_gpu_ids ROCm fallback (issue #5180)
+# =============================================================================
+
+
+class TestApplyGpuIdsRocmFallback:
+    """Verify apply_gpu_ids sets HIP_VISIBLE_DEVICES on ROCm hosts even when
+    IS_ROCM is still False (worker subprocess before detect_hardware runs)."""
+
+    def test_apply_gpu_ids_source_checks_torch_version_hip(self):
+        """apply_gpu_ids should fall back to torch.version.hip when IS_ROCM is False."""
+        hw_path = (
+            PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
+        )
+        source = hw_path.read_text()
+        func_start = source.find("def apply_gpu_ids")
+        func_body = source[func_start : source.find("\ndef ", func_start + 1)]
+        assert 'getattr(_torch.version, "hip", None)' in func_body or \
+               "getattr(torch.version, 'hip', None)" in func_body or \
+               "torch.version.hip" in func_body
+
+    def test_apply_gpu_ids_source_sets_hip_visible_devices(self):
+        """apply_gpu_ids should set HIP_VISIBLE_DEVICES and ROCR_VISIBLE_DEVICES."""
+        hw_path = (
+            PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
+        )
+        source = hw_path.read_text()
+        func_start = source.find("def apply_gpu_ids")
+        func_body = source[func_start : source.find("\ndef ", func_start + 1)]
+        assert "HIP_VISIBLE_DEVICES" in func_body
+        assert "ROCR_VISIBLE_DEVICES" in func_body
+
+
+# =============================================================================
 # TEST: install_python_stack.py -- Windows AMD warning
 # =============================================================================
 

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -1259,28 +1259,37 @@ class TestApplyGpuIdsRocmFallback:
     """Verify apply_gpu_ids sets HIP_VISIBLE_DEVICES on ROCm hosts even when
     IS_ROCM is still False (worker subprocess before detect_hardware runs)."""
 
-    def test_apply_gpu_ids_source_checks_torch_version_hip(self):
-        """apply_gpu_ids should fall back to torch.version.hip when IS_ROCM is False."""
+    def test_apply_gpu_ids_falls_back_to_torch_version_hip(self):
+        """apply_gpu_ids should probe torch.version.hip when IS_ROCM is False and no ROCm env vars are set."""
         hw_path = (
             PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
         )
         source = hw_path.read_text()
         func_start = source.find("def apply_gpu_ids")
         func_body = source[func_start : source.find("\ndef ", func_start + 1)]
-        assert 'getattr(_torch.version, "hip", None)' in func_body or \
-               "getattr(torch.version, 'hip', None)" in func_body or \
-               "torch.version.hip" in func_body
+        assert 'getattr(_torch.version, "hip", None)' in func_body
 
-    def test_apply_gpu_ids_source_sets_hip_visible_devices(self):
-        """apply_gpu_ids should set HIP_VISIBLE_DEVICES and ROCR_VISIBLE_DEVICES."""
+    def test_apply_gpu_ids_sets_hip_and_rocr_visible_devices(self):
+        """apply_gpu_ids should set both HIP_VISIBLE_DEVICES and ROCR_VISIBLE_DEVICES on ROCm."""
         hw_path = (
             PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
         )
         source = hw_path.read_text()
         func_start = source.find("def apply_gpu_ids")
         func_body = source[func_start : source.find("\ndef ", func_start + 1)]
-        assert "HIP_VISIBLE_DEVICES" in func_body
-        assert "ROCR_VISIBLE_DEVICES" in func_body
+        assert 'os.environ["HIP_VISIBLE_DEVICES"] = value' in func_body
+        assert 'os.environ["ROCR_VISIBLE_DEVICES"] = value' in func_body
+
+    def test_apply_gpu_ids_rocm_fallback_is_guarded_by_try_except(self):
+        """torch import in apply_gpu_ids must be wrapped in try/except so a missing torch never crashes."""
+        hw_path = (
+            PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
+        )
+        source = hw_path.read_text()
+        func_start = source.find("def apply_gpu_ids")
+        func_body = source[func_start : source.find("\ndef ", func_start + 1)]
+        assert "import torch as _torch" in func_body
+        assert "except Exception" in func_body
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #5180.

Training workers spawned via multiprocessing can call `apply_gpu_ids()` before `detect_hardware()` has run, leaving `IS_ROCM = False`. When the user has not explicitly set `HIP_VISIBLE_DEVICES` in their shell, workers only have `CUDA_VISIBLE_DEVICES` configured. Since the HIP runtime prioritises `HIP_VISIBLE_DEVICES` over `CUDA_VISIBLE_DEVICES`, workers see the full device list and fail with "no usable HIP accelerator" errors.

The fix adds a `torch.version.hip` probe as a last-resort fallback inside `apply_gpu_ids()` — a safe build-time attribute readable before GPU initialisation, mirroring the existing pattern in `llama_cpp.py`.

## Changes

- `studio/backend/utils/hardware/hardware.py` — probe `torch.version.hip` in `apply_gpu_ids` when `IS_ROCM` is False and no ROCm visibility env vars are set
- `tests/studio/install/test_rocm_support.py` — regression tests covering the fallback path

## Test plan
- [ ] Verify training on AMD ROCm host where `HIP_VISIBLE_DEVICES` is not set in shell passes without "no usable HIP accelerator" error
- [ ] Verify NVIDIA hosts are unaffected (`torch.version.hip` is None on CUDA builds)