### PR TITLE
fix(install): harden AMD ROCm GPU detection for multi-GPU and env-filtered setups

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1195,7 +1195,7 @@ _has_amd_rocm_gpu() {
         return 0
     elif [ -e /dev/kfd ] && \
          awk '/gpu_id/{ if ($2+0 > 0) found=1 } END{ exit !found }' \
-             /sys/class/kfd/kfd/topology/nodes/*/gpu_id 2>/dev/null; then
+             /sys/class/kfd/kfd/topology/nodes/*/properties 2>/dev/null; then
         return 0
     fi
     return 1

--- a/install.sh
+++ b/install.sh
@@ -1182,14 +1182,20 @@ _find_no_torch_runtime() {
 
 # ── AMD ROCm GPU detection helper ──
 # Returns 0 (true) if an actual AMD GPU is present, 1 (false) otherwise.
-# Checks rocminfo for gfx[1-9]* (excludes gfx000 CPU agent) and
-# amd-smi list for GPU data rows (excludes header-only output).
+# Checks rocminfo for gfx[1-9][0-9]+ (excludes gfx000 CPU agent),
+# amd-smi list for GPU data rows, and falls back to sysfs KFD topology
+# which is env-var-independent (works even when HIP_VISIBLE_DEVICES or
+# ROCR_VISIBLE_DEVICES hides devices from rocminfo/amd-smi).
 _has_amd_rocm_gpu() {
     if command -v rocminfo >/dev/null 2>&1 && \
-       rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx[0-9]/ && !/Name:[[:space:]]*gfx000/{found=1} END{exit !found}'; then
+       rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx[1-9][0-9]/{found=1} END{exit !found}'; then
         return 0
     elif command -v amd-smi >/dev/null 2>&1 && \
          amd-smi list 2>/dev/null | awk '/^GPU[[:space:]]*[:\[][[:space:]]*[0-9]/{ found=1 } END{ exit !found }'; then
+        return 0
+    elif [ -e /dev/kfd ] && \
+         awk '/gpu_id/{ if ($2+0 > 0) found=1 } END{ exit !found }' \
+             /sys/class/kfd/kfd/topology/nodes/*/gpu_id 2>/dev/null; then
         return 0
     fi
     return 1


### PR DESCRIPTION
## Summary

Fixes AMD ROCm GPU detection failures on machines where `HIP_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES` is used to mask an integrated GPU alongside a discrete GPU (e.g. gfx1201 + iGPU).

The previous `rocminfo` awk pattern could fail in two ways:
1. If the env vars filtering the iGPU are not propagated into the install script subprocess, `rocminfo` may return no usable device — detection returns false even though a discrete GPU is present
2. The pattern `/gfx[0-9]/ && !/gfx000/` is unnecessarily complex — replaced with `/gfx[1-9][0-9]/` which is simpler and correctly excludes the CPU agent (gfx000) without a negative lookahead

A sysfs KFD topology fallback is added as a third detection path. `/sys/class/kfd/kfd/topology/nodes/*/gpu_id` is a kernel-level view that is unaffected by `HIP_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES`, and `gpu_id > 0` reliably identifies a discrete GPU node vs. a CPU agent.

Reported by Chains (Discord) on a machine with gfx1201 + CPU iGPU where env var exclusion of the iGPU caused `_has_amd_rocm_gpu()` to return false, blocking the entire install from entering the ROCm path.

## Changes

- `install.sh` — tighten `rocminfo` awk pattern + add sysfs KFD fallback in `_has_amd_rocm_gpu()`

## Test plan
- [ ] Verify install correctly detects ROCm on a multi-GPU AMD machine where `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` is set to exclude the iGPU
- [ ] Verify single-GPU AMD setups are unaffected
- [ ] Verify CPU-only and NVIDIA hosts still return false from `_has_amd_rocm_gpu()`