### PR TITLE
Route CPU-only Linux x86_64 to ggml-org/llama.cpp prebuilts

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -582,11 +582,42 @@ _LLAMA_CPP_DEGRADED=false
 _LLAMA_FORCE_COMPILE="${UNSLOTH_LLAMA_FORCE_COMPILE:-0}"
 _REQUESTED_LLAMA_TAG="${UNSLOTH_LLAMA_TAG:-${_DEFAULT_LLAMA_TAG}}"
 _HOST_SYSTEM="$(uname -s 2>/dev/null || true)"
+_HOST_MACHINE="$(uname -m 2>/dev/null || true)"
+
+# Pick the release repo install_llama_prebuilt.py should plan against.
+#
+# macOS already routes to ggml-org/llama.cpp because that is where the
+# bin-macos-{arm64,x64}.tar.gz prebuilts live. Windows routes to ggml-org
+# from setup.ps1 for the same reason.
+#
+# On Linux we previously hard-coded unslothai/llama.cpp, which only
+# publishes Linux CUDA bundles (app-*-linux-x64-cuda*.tar.gz). That left
+# CPU-only Linux hosts (most CI runners, plenty of laptops, anyone without
+# a GPU) walking ~30 releases looking for a non-existent app-*-linux-x64-cpu
+# asset and falling through to a source build.
+#
+# Route CPU-only Linux x86_64 to ggml-org/llama.cpp so install_llama_prebuilt
+# picks up upstream's bin-ubuntu-x64.tar.gz. Hosts with NVIDIA (cuda bundle
+# from unslothai), AMD ROCm (source build with -DGGML_HIP=ON), arm64 Linux
+# (source build), and any other accelerator stay on the existing path.
+_LINUX_HAS_GPU=false
+for _GPU_TOOL in nvidia-smi rocminfo amd-smi hipconfig hipinfo; do
+    if command -v "$_GPU_TOOL" >/dev/null 2>&1; then
+        _LINUX_HAS_GPU=true
+        break
+    fi
+done
+
 if [ "$_HOST_SYSTEM" = "Darwin" ]; then
+    _HELPER_RELEASE_REPO="ggml-org/llama.cpp"
+elif [ "$_HOST_SYSTEM" = "Linux" ] \
+        && [ "$_HOST_MACHINE" = "x86_64" ] \
+        && [ "$_LINUX_HAS_GPU" = false ]; then
     _HELPER_RELEASE_REPO="ggml-org/llama.cpp"
 else
     _HELPER_RELEASE_REPO="unslothai/llama.cpp"
 fi
+unset _GPU_TOOL
 _LLAMA_PR="${UNSLOTH_LLAMA_PR:-}"
 _SKIP_PREBUILT_INSTALL=false
 _LLAMA_PR_FORCE="${UNSLOTH_LLAMA_PR_FORCE:-${_DEFAULT_LLAMA_PR_FORCE}}"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -584,22 +584,10 @@ _REQUESTED_LLAMA_TAG="${UNSLOTH_LLAMA_TAG:-${_DEFAULT_LLAMA_TAG}}"
 _HOST_SYSTEM="$(uname -s 2>/dev/null || true)"
 _HOST_MACHINE="$(uname -m 2>/dev/null || true)"
 
-# Pick the release repo install_llama_prebuilt.py should plan against.
-#
-# macOS already routes to ggml-org/llama.cpp because that is where the
-# bin-macos-{arm64,x64}.tar.gz prebuilts live. Windows routes to ggml-org
-# from setup.ps1 for the same reason.
-#
-# On Linux we previously hard-coded unslothai/llama.cpp, which only
-# publishes Linux CUDA bundles (app-*-linux-x64-cuda*.tar.gz). That left
-# CPU-only Linux hosts (most CI runners, plenty of laptops, anyone without
-# a GPU) walking ~30 releases looking for a non-existent app-*-linux-x64-cpu
-# asset and falling through to a source build.
-#
-# Route CPU-only Linux x86_64 to ggml-org/llama.cpp so install_llama_prebuilt
-# picks up upstream's bin-ubuntu-x64.tar.gz. Hosts with NVIDIA (cuda bundle
-# from unslothai), AMD ROCm (source build with -DGGML_HIP=ON), arm64 Linux
-# (source build), and any other accelerator stay on the existing path.
+# Pick the release repo install_llama_prebuilt.py plans against.
+# unslothai/llama.cpp ships only Linux CUDA bundles, so CPU-only Linux
+# x86_64 routes to ggml-org for bin-ubuntu-x64.tar.gz. Anything with a
+# GPU tool installed stays on unslothai (CUDA bundle / ROCm source build).
 _LINUX_HAS_GPU=false
 for _GPU_TOOL in nvidia-smi rocminfo amd-smi hipconfig hipinfo; do
     if command -v "$_GPU_TOOL" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

`studio/setup.sh` hard-coded `_HELPER_RELEASE_REPO=unslothai/llama.cpp` for every non-Darwin host. `unslothai/llama.cpp` only publishes Linux CUDA bundles (`app-*-linux-x64-cuda*.tar.gz`), so a CPU-only Linux host walked roughly 30 releases looking for a non-existent `app-*-linux-x64-cpu` asset, exited the prebuilt planner with `no compatible Linux prebuilt asset was found`, and fell through to a source build. This is what every free `ubuntu-latest` runner hits, and what every Linux laptop without an NVIDIA GPU pays a ~3 minute cmake + make cost on at first install.

`ggml-org/llama.cpp` publishes `llama-<tag>-bin-ubuntu-x64.tar.gz` on every release, and `studio/install_llama_prebuilt.py` already knows how to fetch it: when called with `--published-repo ggml-org/llama.cpp`, the `direct_upstream_release_plan` branch at `host.is_linux and host.is_x86_64 and not host.has_usable_nvidia` picks up that asset directly (`install_llama_prebuilt.py:1313-1326`). The bug was purely in the routing.

## Fix

Tighten the gate in `studio/setup.sh` so a Linux host routes to `ggml-org/llama.cpp` only when it is x86_64 and has no GPU detection tool installed (`nvidia-smi`, `rocminfo`, `amd-smi`, `hipconfig`, `hipinfo`). Everything else stays on the current path.

```bash
_LINUX_HAS_GPU=false
for _GPU_TOOL in nvidia-smi rocminfo amd-smi hipconfig hipinfo; do
    if command -v "$_GPU_TOOL" >/dev/null 2>&1; then
        _LINUX_HAS_GPU=true
        break
    fi
done

if [ "$_HOST_SYSTEM" = "Darwin" ]; then
    _HELPER_RELEASE_REPO="ggml-org/llama.cpp"
elif [ "$_HOST_SYSTEM" = "Linux" ] \
        && [ "$_HOST_MACHINE" = "x86_64" ] \
        && [ "$_LINUX_HAS_GPU" = false ]; then
    _HELPER_RELEASE_REPO="ggml-org/llama.cpp"
else
    _HELPER_RELEASE_REPO="unslothai/llama.cpp"
fi
```

## Routing matrix

Only one cell flips. Everything else is identity.

| Host + accelerator                  | Today                                                | After this PR                                        |
|-------------------------------------|------------------------------------------------------|------------------------------------------------------|
| macOS arm64 / x86_64                | ggml-org `bin-macos-{arm64,x64}.tar.gz`              | unchanged                                            |
| Windows + CPU                       | ggml-org `bin-win-cpu-x64.zip` (via setup.ps1)       | unchanged                                            |
| Windows + CUDA                      | ggml-org `bin-win-cuda-*.zip`                        | unchanged                                            |
| Windows + ROCm / HIP                | ggml-org `bin-win-hip-radeon-x64.zip`                | unchanged                                            |
| **Linux + CPU x86_64**              | **source build (~3 min)**                            | **ggml-org `bin-ubuntu-x64.tar.gz` (~10 sec)**       |
| Linux + CUDA                        | unslothai/llama.cpp `app-*-linux-x64-cuda*.tar.gz`   | unchanged (nvidia-smi -> unslothai)                  |
| Linux + ROCm / AMD                  | source build with `-DGGML_HIP=ON`                    | unchanged (rocminfo / amd-smi / hipconfig / hipinfo -> unslothai) |
| Linux + Intel / Vulkan / SYCL       | source build (CPU output)                            | upstream CPU asset (functionally equivalent, faster) |
| Linux arm64 / s390x                 | source build                                         | unchanged (not x86_64 -> unslothai -> source build)  |

Linux ROCm fast-path (`bin-ubuntu-rocm-7.2-x64.tar.gz`) is intentionally out of scope for this PR. The richer code path `resolve_upstream_asset_choice` at `install_llama_prebuilt.py:3124-3183` already knows how to pick the right ROCm minor against the host runtime; porting that into `direct_upstream_release_plan` so AMD users on Linux also get a prebuilt is a clean follow-up.

## Verification

Locally exercised the gate against synthetic `PATH`s covering every combination above. Routing matches the matrix, including the corner cases (`MINGW*` uname, aarch64 with NVIDIA tools, Darwin with NVIDIA tools).

`bash -n studio/setup.sh` passes.

## Test plan

- [ ] Free `ubuntu-latest` runner on a CPU job: `install.sh` log shows `prebuilt installed and validated` rather than `falling back to source build`.
- [ ] Linux NVIDIA host: still resolves to `unslothai/llama.cpp` and picks the existing CUDA bundle.
- [ ] Linux ROCm host: still resolves to `unslothai/llama.cpp`, prebuilt resolution fails as before, and falls through to the existing source build with `-DGGML_HIP=ON`.
- [ ] macOS arm64: unchanged (still `ggml-org/llama.cpp` via the Darwin branch).