### PR TITLE
Studio: restore Studio API and Help menu UI

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -37,12 +37,13 @@ import {
   Delete02Icon,
   Download03Icon,
   GemIcon,
+  Globe02Icon,
+  HelpCircleIcon,
   Search01Icon,
   PowerIcon,
   PencilEdit02Icon,
   LayoutAlignLeftIcon,
   Settings02Icon,
-  SourceCodeSquareIcon,
   ZapIcon,
 } from "@hugeicons/core-free-icons";
 import {
@@ -527,7 +528,7 @@ export function AppSidebar() {
                   </div>
                   <div className="flex flex-col gap-0.5 leading-tight group-data-[collapsible=icon]:hidden">
                     <span className="truncate font-heading text-[13px] tracking-[0.02em] font-semibold text-[#383835] dark:text-[#c7c7c4]">{displayTitle}</span>
-                    <span className="truncate text-[11px] tracking-[0.01em] text-muted-foreground">Studio</span>
+                    <span className="truncate text-[11px] tracking-[0.01em] text-muted-foreground">Unsloth</span>
                   </div>
                   <ChevronsUpDown strokeWidth={1.25} className="ml-auto size-4 text-muted-foreground group-data-[collapsible=icon]:hidden" />
                 </SidebarMenuButton>
@@ -548,8 +549,8 @@ export function AppSidebar() {
                   <DropdownMenuItem
                     onSelect={() => useSettingsDialogStore.getState().openDialog("api-keys")}
                   >
-                    <HugeiconsIcon icon={SourceCodeSquareIcon} strokeWidth={1.75} className="size-[18px]" />
-                    <span>Developer</span>
+                    <HugeiconsIcon icon={Globe02Icon} strokeWidth={1.75} className="size-[18px]" />
+                    <span>API</span>
                     <span className="ml-auto rounded-[6px] border border-emerald-500/25 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] leading-none font-semibold text-emerald-700 dark:text-emerald-300">
                       New
                     </span>
@@ -578,6 +579,12 @@ export function AppSidebar() {
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator className="mx-2.5! my-2.5! h-0! border-t border-border/70 bg-transparent!" />
+                <DropdownMenuItem
+                  onSelect={() => useSettingsDialogStore.getState().openDialog("about")}
+                >
+                  <HugeiconsIcon icon={HelpCircleIcon} strokeWidth={1.75} className="size-[18px]" />
+                  <span>Help</span>
+                </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setShutdownOpen(true)}>
                   <HugeiconsIcon icon={PowerIcon} strokeWidth={1.75} className="size-[18px]" />
                   <span>Shutdown</span>

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -10,11 +10,11 @@ import {
 import { cn } from "@/lib/utils";
 import {
   Cancel01Icon,
+  Globe02Icon,
+  HelpCircleIcon,
   Message01Icon,
   PaintBrush02Icon,
   Settings02Icon,
-  SourceCodeSquareIcon,
-  SparklesIcon,
   UserIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -40,8 +40,8 @@ const TABS: TabDef[] = [
   { id: "profile", label: "Profile", icon: UserIcon },
   { id: "appearance", label: "Appearance", icon: PaintBrush02Icon },
   { id: "chat", label: "Chat", icon: Message01Icon },
-  { id: "api-keys", label: "Developer", icon: SourceCodeSquareIcon, badge: "New" },
-  { id: "about", label: "Help", icon: SparklesIcon },
+  { id: "api-keys", label: "API", icon: Globe02Icon, badge: "New" },
+  { id: "about", label: "Help", icon: HelpCircleIcon },
 ];
 
 function renderTab(tab: SettingsTab) {

--- a/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
@@ -63,7 +63,7 @@ export function ApiKeysTab() {
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-1">
-        <h1 className="text-lg font-semibold font-heading">Developer</h1>
+        <h1 className="text-lg font-semibold font-heading">API</h1>
         <p className="text-xs text-muted-foreground">
           Access Unsloth programmatically via the OpenAI-compatible API.{" "}
           <a


### PR DESCRIPTION
## Summary

Restores the Studio settings/account menu UI that was accidentally overwritten by a later main merge.

Restored: 
<img width="1264" height="870" alt="image" src="https://github.com/user-attachments/assets/e6159bd9-0803-42d3-9dd7-67d120277c10" />
<img width="392" height="450" alt="image" src="https://github.com/user-attachments/assets/75b09ab4-58ae-4cbd-9274-f47a6e69ec90" />


## Changes

- Rename the settings API tab and API page heading from `Developer` back to `API`
- Restore the globe icon for the API menu/settings entry
- Restore the Help settings icon to `HelpCircleIcon`
- Restore the Help item in the account dropdown
- Restore the account subtitle from `Studio` back to `Unsloth`

## Testing

- `npm run typecheck`
