### PR TITLE
fix: 3 patch_* helpers — fast_lora import, sft_trainer Union, openenv OSError

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2483,6 +2483,7 @@ def patch_tokenizer(model, tokenizer):
 
 def patch_fast_lora():
     import peft.tuners.lora.bnb
+    from ..kernels.fast_lora import fast_lora_forward
 
     peft.tuners.lora.bnb.Linear4bit.forward = fast_lora_forward
 

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -1780,7 +1780,20 @@ def openenv_vllm_reload_weights():
         patch_target_name = "generate_rollout_completions"
         patch_target = getattr(openenv_utils, patch_target_name)
 
-    src = inspect.getsource(patch_target)
+    # TRL 0.29.1+ ships some openenv helpers as compiled bytecode without
+    # accessible source on disk; inspect.getsource raises OSError("could
+    # not get source code") in that case. Skip the source-rewrite patch
+    # rather than crashing -- the core unsloth weight-reload path stays
+    # functional, only the wake_up tag rewrite is skipped.
+    try:
+        src = inspect.getsource(patch_target)
+    except OSError as e:
+        logger.warning(
+            f"Unsloth: Could not retrieve source for trl openenv "
+            f"{patch_target_name} ({e}); skipping rewrite. "
+            f"Weight reload still functional."
+        )
+        return
     src = textwrap.dedent(src)
     original_src = src
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -1580,6 +1580,12 @@ def patch_sft_trainer_tokenizer():
     except:
         return
     all_imports = dir(trl.trainer.sft_trainer)
+    # Make typing names available to the exec'd source bodies. TRL >= 1.x
+    # type-hints _prepare_dataset / _prepare_non_packed_dataloader with
+    # `Union[...]` and friends; without these imports in the exec namespace
+    # those become NameErrors at exec time. Mirrors the pattern used in
+    # unsloth/models/_utils.py:patch_linear_scaling.
+    from typing import Union, Optional, List, Any, Callable, Tuple, Dict, Iterator  # noqa: F401
 
     for (
         function_name,


### PR DESCRIPTION
## Summary

Three independent fixes for `patch_*` helpers, all surfaced by the new
consolidated CPU-CI matrix on #5312 that invokes every zero-arg
`patch_*` across `unsloth` + `unsloth_zoo@main` against three
`(transformers, trl)` combinations.

### 1. `patch_fast_lora` — `NameError: name 'fast_lora_forward' is not defined`

`unsloth/models/_utils.py:patch_fast_lora` references `fast_lora_forward`
as if it were imported, but the import was never added. Bug present
since `ddf118a8f` (2024-11-21). Function is defined at
`unsloth/kernels/fast_lora.py:652` and re-exported through
`unsloth/kernels/__init__.py:45`.

Fix: `from ..kernels.fast_lora import fast_lora_forward` inside the
function body. Importing inside (rather than at module top) keeps the
import surface narrow and avoids a circular-import risk.

### 2. `patch_sft_trainer_tokenizer` — `NameError: name 'Union' is not defined`

`unsloth/tokenizer_utils.py:patch_sft_trainer_tokenizer` rewrites the
source of TRL's `SFTTrainer._prepare_non_packed_dataloader` and
`_prepare_dataset` methods and re-execs them. With TRL 1.x those
methods carry `Union[...]` type hints in their signatures. The current
rewrite only injects identifiers found by `dir(trl.trainer.sft_trainer)`,
which does not include `Union`, so `exec(function, ...)` raises
NameError.

Fix: import `Union, Optional, List, Any, Callable, Tuple, Dict, Iterator`
inside the function. `exec` receives `locals()` as its globals, so
those names are visible to the executed source body. Same pattern as
`unsloth/models/_utils.py:patch_linear_scaling`'s `exec_code`.

### 3. `openenv_vllm_reload_weights` — `OSError: could not get source code`

`unsloth/models/rl_replacements.py:openenv_vllm_reload_weights` calls
`inspect.getsource(patch_target)` on a TRL openenv helper. TRL 0.29.1+
and the 1.x line ship some openenv helpers as compiled bytecode without
accessible source on disk; `inspect.getsource` raises OSError. The
unguarded call surfaces as a hard failure inside `patch_trl_openenv()`
and aborts the rest of the `RL_ADDITIONAL_FUNCTIONS["openenv"]`
iteration.

Fix: wrap the `getsource` call in a try/except OSError and log a
warning. Only the `wake_up(tags=...)` rewrite is skipped; the core
weight-reload patch path stays functional. With TRL 0.18.2-0.24.0 (the
range pyproject.toml currently pins) source is still accessible, so the
original code path runs unchanged.

## Test plan

- [x] Each fix locally re-validated by directly invoking the patcher.
  - `patch_fast_lora()` → returns without exception (import resolves).
  - `patch_sft_trainer_tokenizer()` → returns without `NameError`.
  - `openenv_vllm_reload_weights()` on TRL 0.29.1 → logs the warning
    and returns gracefully instead of raising.
- [ ] CI green on this PR.
- [ ] After merge, `Consolidated CPU tests` matrix cells on #5312 should
      drop these three from the failure ledger.