### PR TITLE
Studio: chat IME composition lockup

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -21,6 +21,7 @@ import {
   IntentAwareScrollProvider,
   useIntentAwareAutoScroll,
   useIsThreadAtBottom,
+  useOnScrollThreadToBottom,
   useScrollThreadToBottom,
 } from "@/components/assistant-ui/use-intent-aware-autoscroll";
 import { Button } from "@/components/ui/button";
@@ -294,6 +295,7 @@ const StudioComposerInput: FC<TextareaAutosizeProps> = ({
   onChange,
   onCompositionEnd,
   onCompositionStart,
+  onInput,
   onKeyDown,
   onPaste,
   ...props
@@ -349,6 +351,8 @@ const StudioComposerInput: FC<TextareaAutosizeProps> = ({
     return aui.on("threadListItem.switchedTo", focusInput);
   }, [aui, autoFocus, focusInput]);
 
+  useOnScrollThreadToBottom(focusInput);
+
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       onChange?.(event);
@@ -369,7 +373,10 @@ const StudioComposerInput: FC<TextareaAutosizeProps> = ({
       if (hadStaleComposition) {
         clearStaleComposition(event.currentTarget.value);
       }
-      if (hadStaleComposition && event.key === "Enter") return;
+      if (hadStaleComposition && event.key === "Enter") {
+        event.preventDefault();
+        return;
+      }
       if (nativeComposing || isComposingRef.current) return;
 
       if (event.key === "Escape" && aui.composer().getState().canCancel) {
@@ -443,6 +450,7 @@ const StudioComposerInput: FC<TextareaAutosizeProps> = ({
         setComposerText(event.currentTarget.value);
       }}
       onInput={(event) => {
+        onInput?.(event);
         const nativeEvent = event.nativeEvent as { isComposing?: boolean };
         if (nativeEvent.isComposing === false) {
           clearStaleComposition(event.currentTarget.value);

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -72,13 +72,19 @@ import {
 import { Copy01Icon, Delete02Icon, Edit03Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+  type ChangeEvent,
+  type ClipboardEvent,
   type FC,
   type FormEvent,
+  type KeyboardEvent,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from "react";
+import TextareaAutosize, {
+  type TextareaAutosizeProps,
+} from "react-textarea-autosize";
 import { toast } from "sonner";
 
 export const Thread: FC<{
@@ -281,6 +287,173 @@ const PendingAudioChip: FC = () => {
   );
 };
 
+const StudioComposerInput: FC<TextareaAutosizeProps> = ({
+  autoFocus,
+  disabled,
+  onBlur,
+  onChange,
+  onCompositionEnd,
+  onCompositionStart,
+  onKeyDown,
+  onPaste,
+  ...props
+}) => {
+  const aui = useAui();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
+  const value = useAuiState((s) => {
+    if (!s.composer.isEditing) return "";
+    return s.composer.text;
+  });
+  const inputDisabled =
+    useAuiState(
+      (s) => s.thread.isDisabled || s.composer.dictation?.inputDisabled,
+    ) || disabled;
+
+  const setComposerText = useCallback(
+    (text: string) => {
+      if (!aui.composer().getState().isEditing) return;
+      aui.composer().setText(text);
+    },
+    [aui],
+  );
+
+  const clearStaleComposition = useCallback(
+    (text: string) => {
+      if (!isComposingRef.current) return;
+      isComposingRef.current = false;
+      setComposerText(text);
+    },
+    [setComposerText],
+  );
+
+  const focusInput = useCallback(() => {
+    if (!autoFocus || inputDisabled) return;
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.focus({ preventScroll: true });
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+  }, [autoFocus, inputDisabled]);
+
+  useEffect(() => {
+    focusInput();
+  }, [focusInput]);
+
+  useEffect(() => {
+    if (!autoFocus) return;
+    return aui.on("thread.runStart", focusInput);
+  }, [aui, autoFocus, focusInput]);
+
+  useEffect(() => {
+    if (!autoFocus) return;
+    return aui.on("threadListItem.switchedTo", focusInput);
+  }, [aui, autoFocus, focusInput]);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      onChange?.(event);
+      setComposerText(event.target.value);
+    },
+    [onChange, setComposerText],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented || inputDisabled) return;
+
+      const nativeEvent = event.nativeEvent as { isComposing?: boolean };
+      const nativeComposing = nativeEvent.isComposing === true;
+      const hadStaleComposition =
+        isComposingRef.current && !nativeComposing && event.key !== "Process";
+      if (hadStaleComposition) {
+        clearStaleComposition(event.currentTarget.value);
+      }
+      if (hadStaleComposition && event.key === "Enter") return;
+      if (nativeComposing || isComposingRef.current) return;
+
+      if (event.key === "Escape" && aui.composer().getState().canCancel) {
+        aui.composer().cancel();
+        event.preventDefault();
+        return;
+      }
+
+      if (event.key !== "Enter") return;
+      const threadState = aui.thread().getState();
+      const composerState = aui.composer().getState();
+      if (
+        event.shiftKey &&
+        (event.ctrlKey || event.metaKey) &&
+        threadState.capabilities.queue &&
+        !composerState.isEmpty
+      ) {
+        event.preventDefault();
+        aui.composer().send({ steer: true });
+        return;
+      }
+      if (event.shiftKey) return;
+      if (threadState.isRunning && !threadState.capabilities.queue) return;
+
+      event.preventDefault();
+      textareaRef.current?.closest("form")?.requestSubmit();
+    },
+    [aui, clearStaleComposition, inputDisabled, onKeyDown],
+  );
+
+  const handlePaste = useCallback(
+    async (event: ClipboardEvent<HTMLTextAreaElement>) => {
+      onPaste?.(event);
+      clearStaleComposition(event.currentTarget.value);
+      if (event.defaultPrevented) return;
+
+      const files = Array.from(event.clipboardData?.files || []);
+      if (!aui.thread().getState().capabilities.attachments || files.length === 0) {
+        return;
+      }
+
+      try {
+        event.preventDefault();
+        await Promise.all(files.map((file) => aui.composer().addAttachment(file)));
+      } catch (error) {
+        console.error("Error adding attachment:", error);
+      }
+    },
+    [aui, clearStaleComposition, onPaste],
+  );
+
+  return (
+    <TextareaAutosize
+      name="input"
+      {...props}
+      ref={textareaRef}
+      value={value}
+      disabled={inputDisabled}
+      onBlur={(event) => {
+        onBlur?.(event);
+        clearStaleComposition(event.currentTarget.value);
+      }}
+      onChange={handleChange}
+      onCompositionStart={(event) => {
+        onCompositionStart?.(event);
+        isComposingRef.current = true;
+      }}
+      onCompositionEnd={(event) => {
+        onCompositionEnd?.(event);
+        isComposingRef.current = false;
+        setComposerText(event.currentTarget.value);
+      }}
+      onInput={(event) => {
+        const nativeEvent = event.nativeEvent as { isComposing?: boolean };
+        if (nativeEvent.isComposing === false) {
+          clearStaleComposition(event.currentTarget.value);
+        }
+      }}
+      onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
+    />
+  );
+};
+
 const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -296,7 +469,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
       <ComposerAttachments />
       <PendingAudioChip />
       <ToolStatusDisplay />
-      <ComposerPrimitive.Input
+      <StudioComposerInput
         placeholder="Send a message..."
         className="aui-composer-input composer-input"
         minRows={1}
@@ -916,7 +1089,7 @@ const EditComposer: FC = () => {
   return (
     <MessagePrimitive.Root className="aui-edit-composer-wrapper mx-auto flex w-full max-w-(--thread-content-max-width) flex-col py-3">
       <ComposerPrimitive.Root className="aui-edit-composer-root ml-auto flex w-full max-w-[85%] flex-col rounded-2xl bg-muted">
-        <ComposerPrimitive.Input
+        <StudioComposerInput
           className="aui-edit-composer-input min-h-14 w-full resize-none bg-transparent p-4 text-foreground text-sm font-[450] outline-none"
           autoFocus={true}
         />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -337,21 +337,26 @@ const StudioComposerInput: FC<TextareaAutosizeProps> = ({
     textarea.setSelectionRange(textarea.value.length, textarea.value.length);
   }, [autoFocus, inputDisabled]);
 
+  const focusThreadInput = useCallback(() => {
+    if (aui.composer().getState().type !== "thread") return;
+    focusInput();
+  }, [aui, focusInput]);
+
   useEffect(() => {
     focusInput();
   }, [focusInput]);
 
   useEffect(() => {
     if (!autoFocus) return;
-    return aui.on("thread.runStart", focusInput);
-  }, [aui, autoFocus, focusInput]);
+    return aui.on("thread.runStart", focusThreadInput);
+  }, [aui, autoFocus, focusThreadInput]);
 
   useEffect(() => {
     if (!autoFocus) return;
-    return aui.on("threadListItem.switchedTo", focusInput);
-  }, [aui, autoFocus, focusInput]);
+    return aui.on("threadListItem.switchedTo", focusThreadInput);
+  }, [aui, autoFocus, focusThreadInput]);
 
-  useOnScrollThreadToBottom(focusInput);
+  useOnScrollThreadToBottom(focusThreadInput);
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {

--- a/studio/frontend/src/components/assistant-ui/use-intent-aware-autoscroll.tsx
+++ b/studio/frontend/src/components/assistant-ui/use-intent-aware-autoscroll.tsx
@@ -10,6 +10,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useSyncExternalStore,
@@ -75,6 +76,7 @@ export type ScrollToBottom = (behavior?: ScrollBehavior) => void;
 
 type AutoScrollContextValue = {
   scrollToBottom: ScrollToBottom;
+  onScrollToBottom: (listener: () => void) => () => void;
   getIsAtBottom: () => boolean;
   subscribe: (listener: () => void) => () => void;
 };
@@ -82,6 +84,9 @@ type AutoScrollContextValue = {
 const noopContext: AutoScrollContextValue = {
   scrollToBottom: () => {
     /* no viewport mounted */
+  },
+  onScrollToBottom: () => () => {
+    /* no-op */
   },
   getIsAtBottom: () => true,
   subscribe: () => () => {
@@ -109,6 +114,11 @@ export function useScrollThreadToBottom(): ScrollToBottom {
   return useContext(AutoScrollContext).scrollToBottom;
 }
 
+export function useOnScrollThreadToBottom(listener: () => void): void {
+  const { onScrollToBottom } = useContext(AutoScrollContext);
+  useEffect(() => onScrollToBottom(listener), [listener, onScrollToBottom]);
+}
+
 export function useIsThreadAtBottom(): boolean {
   const ctx = useContext(AutoScrollContext);
   return useSyncExternalStore(ctx.subscribe, ctx.getIsAtBottom, () => true);
@@ -125,6 +135,7 @@ export function useIntentAwareAutoScroll(): {
 
   const isAtBottomRef = useRef(true);
   const listenersRef = useRef<Set<() => void>>(new Set());
+  const scrollToBottomListenersRef = useRef<Set<() => void>>(new Set());
 
   const scrollImplRef = useRef<ScrollToBottom>(() => {
     /* no viewport mounted */
@@ -149,8 +160,18 @@ export function useIntentAwareAutoScroll(): {
     }
   }, []);
 
+  const onScrollToBottom = useCallback((listener: () => void) => {
+    scrollToBottomListenersRef.current.add(listener);
+    return () => {
+      scrollToBottomListenersRef.current.delete(listener);
+    };
+  }, []);
+
   const scrollToBottom = useCallback<ScrollToBottom>((behavior) => {
     scrollImplRef.current(behavior);
+    for (const listener of scrollToBottomListenersRef.current) {
+      listener();
+    }
   }, []);
 
   const attach = useCallback(
@@ -576,8 +597,8 @@ export function useIntentAwareAutoScroll(): {
   );
 
   const context = useMemo<AutoScrollContextValue>(
-    () => ({ scrollToBottom, getIsAtBottom, subscribe }),
-    [scrollToBottom, getIsAtBottom, subscribe],
+    () => ({ scrollToBottom, onScrollToBottom, getIsAtBottom, subscribe }),
+    [scrollToBottom, onScrollToBottom, getIsAtBottom, subscribe],
   );
 
   return { ref, context };


### PR DESCRIPTION
## Summary

Fixes #5262 #5318

Fixes the Studio chat composer becoming unusable after activating non-English IMEs such as Japanese, Chinese, or Korean.

The root issue was that some browser/IME combinations emit repeated `compositionstart` events without a matching `compositionend`. The assistant-ui composer input then remained stuck in composing mode and ignored future input, even after switching back to English.

This replaces the main chat composer input with a Studio-owned IME-safe textarea wrapper that still writes to assistant-ui composer state, while defensively recovering from stale composition state.

Tested with Japanese and Korean.

After:
<img width="1681" height="739" alt="image" src="https://github.com/user-attachments/assets/eb739e0b-9b40-4415-8050-2fa354029f41" />

## Changes

- Add `StudioComposerInput` for the chat composer.
- Clear stale IME composition state on blur, paste, and non-composing key/input events.
- Preserve expected composer behavior:
  - Enter to send
  - Shift+Enter newline
  - Escape cancel
  - Ctrl/Cmd+Shift+Enter queue/steer
  - paste attachments
  - focus recovery on run start/thread switch
- Apply the same IME-safe input to message editing.