### PR TITLE
fix(gh_client): fail fast on 401/403 auth errors instead of retrying forever (#5325)

### DIFF
--- a/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper.py
+++ b/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper.py
@@ -48,13 +48,31 @@ class ScrapeConfig:
     max_comments_per_item: int
 
 
-def _resolve_token(token: str) -> str:
-    tok = token or os.environ.get("GH_TOKEN", "") or os.environ.get("GITHUB_TOKEN", "")
-    if not tok:
-        raise ValueError(
-            "GitHub token is required. Set it in the recipe config or the GH_TOKEN / GITHUB_TOKEN env var."
+@dataclass(frozen = True)
+class ResolvedToken:
+    value: str
+    source: str
+
+
+def _resolve_token(token: str) -> ResolvedToken:
+    if token:
+        return ResolvedToken(
+            value = token,
+            source = "explicit token argument (recipe-level field)",
         )
-    return tok
+    if os.environ.get("GH_TOKEN"):
+        return ResolvedToken(
+            value = os.environ["GH_TOKEN"],
+            source = "GH_TOKEN environment variable",
+        )
+    if os.environ.get("GITHUB_TOKEN"):
+        return ResolvedToken(
+            value = os.environ["GITHUB_TOKEN"],
+            source = "GITHUB_TOKEN environment variable",
+        )
+    raise ValueError(
+        "GitHub token is required. Set it in the recipe config or the GH_TOKEN / GITHUB_TOKEN env var."
+    )
 
 
 def _read_jsonl(path: Path, max_rows: int | None = None):
@@ -155,7 +173,7 @@ def _flatten_commit_row(r: dict, repo: str) -> dict:
 def scrape(cfg: ScrapeConfig, base_dir: Path):
     token = _resolve_token(cfg.token)
     GitHubClient, RepoScraper = _load_impl()
-    client = GitHubClient(token = token)
+    client = GitHubClient(token = token.value, token_source = token.source)
     base_dir.mkdir(parents = True, exist_ok = True)
 
     # Per-resource trial limits. limit <= 0 means "all": use a very large cap.

--- a/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
+++ b/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
@@ -128,8 +128,8 @@ class GitHubClient:
             try:
                 r = self.session.post(
                     GRAPHQL_URL,
-                    json={"query": query, "variables": variables or {}},
-                    timeout=120,
+                    json = {"query": query, "variables": variables or {}},
+                    timeout = 120,
                 )
                 self.calls_graphql += 1
                 # Update rate info from response headers
@@ -208,7 +208,7 @@ class GitHubClient:
         for attempt in range(max_retries):
             try:
                 r = self.session.request(
-                    method, url, params=params, json=json_body, timeout=120
+                    method, url, params = params, json = json_body, timeout = 120
                 )
                 self.calls_rest += 1
                 rem = r.headers.get("X-RateLimit-Remaining")
@@ -259,7 +259,7 @@ class GitHubClient:
         params.setdefault("per_page", per_page)
         url = path
         while True:
-            r = self.rest("GET", url, params=params if url == path else None)
+            r = self.rest("GET", url, params = params if url == path else None)
             if r.status_code != 200:
                 log.error(
                     "REST paginate got %s at %s: %s", r.status_code, url, r.text[:200]

--- a/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
+++ b/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
@@ -31,7 +31,7 @@ class RateLimitError(Exception):
 
 class GitHubAuthError(RuntimeError):
     """Raised when GitHub returns 401/403 due to invalid or insufficient credentials."""
-    pass
+
 
 
 class GitHubClient:

--- a/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
+++ b/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
@@ -9,6 +9,8 @@ import json
 import os
 import time
 import logging
+from datetime import timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 import requests
@@ -33,15 +35,34 @@ class GitHubAuthError(RuntimeError):
     """Raised when GitHub returns 401/403 due to invalid or insufficient credentials."""
 
 
+def _retry_after_seconds(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        return max(0, int(value))
+    except ValueError:
+        pass
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo = timezone.utc)
+    return max(0, int(retry_at.timestamp() - time.time()))
+
+
 class GitHubClient:
     def __init__(
         self,
         min_remaining_graphql: int = 100,
         min_remaining_rest: int = 100,
         token: str | None = None,
+        token_source: str | None = None,
     ):
         if token:
-            self._token_source = "explicit token argument (recipe-level field)"
+            self._token_source = (
+                token_source or "explicit token argument (recipe-level field)"
+            )
         elif os.environ.get("GH_TOKEN"):
             self._token_source = "GH_TOKEN environment variable"
             token = os.environ["GH_TOKEN"]
@@ -49,7 +70,7 @@ class GitHubClient:
             self._token_source = "GITHUB_TOKEN environment variable"
             token = os.environ["GITHUB_TOKEN"]
         else:
-            raise RuntimeError("GH_TOKEN not set in environment")
+            raise RuntimeError("GH_TOKEN or GITHUB_TOKEN not set in environment")
         self.session = requests.Session()
         self.session.headers.update(
             {**BASE_HEADERS, "Authorization": f"Bearer {token}"}
@@ -70,31 +91,47 @@ class GitHubClient:
         log.warning("Rate limit hit. Sleeping %ds until reset.", wait)
         time.sleep(wait)
 
+    def _is_rate_limit_response(self, r: "requests.Response") -> bool:
+        if r.headers.get("Retry-After"):
+            return True
+        if r.headers.get("X-RateLimit-Remaining") == "0":
+            return True
+        body = (r.text or "").lower()
+        return any(
+            marker in body
+            for marker in (
+                "api rate limit exceeded",
+                "rate limit exceeded",
+                "secondary rate limit",
+                "secondary limit",
+                "abuse detection mechanism",
+                "abuse detection",
+            )
+        )
+
     def _is_auth_failure(self, r: "requests.Response") -> bool:
         """Distinguish auth failures from rate limiting on 401/403 responses.
 
         - 401: always an auth failure (invalid / expired / wrong-scope token).
         - 403: an auth failure UNLESS the response carries a clear rate-limit signal
-          (Retry-After header for secondary limits, or X-RateLimit-Remaining: 0
-          for primary limits).
+          (Retry-After header, X-RateLimit-Remaining: 0, or GitHub's secondary /
+          abuse rate-limit response text).
         """
         if r.status_code == 401:
             return True
         if r.status_code == 403:
-            if r.headers.get("Retry-After"):
-                return False
-            if r.headers.get("X-RateLimit-Remaining") == "0":
-                return False
-            return True
+            return not self._is_rate_limit_response(r)
         return False
 
     def _raise_auth_error(self, r: "requests.Response", endpoint: str) -> None:
         snippet = (r.text or "").strip()[:200]
+        request_id = r.headers.get("X-GitHub-Request-Id")
+        request_id_message = f" Request ID: {request_id}." if request_id else ""
         raise GitHubAuthError(
             f"GitHub {endpoint} returned {r.status_code} {r.reason}. "
             f"Token source: {self._token_source}. "
             f"The token is invalid, expired, or missing required scopes — "
-            f"retrying will not recover. Response: {snippet}"
+            f"retrying will not recover.{request_id_message} Response: {snippet}"
         )
 
     def _check_rate_and_wait(self, kind: str) -> None:
@@ -154,11 +191,10 @@ class GitHubClient:
                     self._raise_auth_error(r, "GraphQL")
                 if r.status_code == 403 or r.status_code == 429:
                     # Check for secondary/abuse
-                    retry_after = r.headers.get("Retry-After")
-                    if retry_after:
-                        t = int(retry_after)
-                        log.warning("Secondary rate limit. Sleep %ds.", t)
-                        time.sleep(t + 2)
+                    retry_after = _retry_after_seconds(r.headers.get("Retry-After"))
+                    if retry_after is not None:
+                        log.warning("Secondary rate limit. Sleep %ds.", retry_after)
+                        time.sleep(retry_after + 2)
                         continue
                     if self.graphql_reset:
                         self._sleep_until(self.graphql_reset)
@@ -231,11 +267,12 @@ class GitHubClient:
                 if self._is_auth_failure(r):
                     self._raise_auth_error(r, "REST")
                 if r.status_code in (403, 429):
-                    retry_after = r.headers.get("Retry-After")
-                    if retry_after:
-                        t = int(retry_after)
-                        log.warning("Secondary rate limit on REST. Sleep %ds.", t)
-                        time.sleep(t + 2)
+                    retry_after = _retry_after_seconds(r.headers.get("Retry-After"))
+                    if retry_after is not None:
+                        log.warning(
+                            "Secondary rate limit on REST. Sleep %ds.", retry_after
+                        )
+                        time.sleep(retry_after + 2)
                         continue
                     # Check if primary rate
                     if self.rest_remaining == 0 and self.rest_reset:

--- a/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
+++ b/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
@@ -33,7 +33,6 @@ class GitHubAuthError(RuntimeError):
     """Raised when GitHub returns 401/403 due to invalid or insufficient credentials."""
 
 
-
 class GitHubClient:
     def __init__(
         self,
@@ -129,8 +128,8 @@ class GitHubClient:
             try:
                 r = self.session.post(
                     GRAPHQL_URL,
-                    json = {"query": query, "variables": variables or {}},
-                    timeout = 120,
+                    json={"query": query, "variables": variables or {}},
+                    timeout=120,
                 )
                 self.calls_graphql += 1
                 # Update rate info from response headers
@@ -209,7 +208,7 @@ class GitHubClient:
         for attempt in range(max_retries):
             try:
                 r = self.session.request(
-                    method, url, params = params, json = json_body, timeout = 120
+                    method, url, params=params, json=json_body, timeout=120
                 )
                 self.calls_rest += 1
                 rem = r.headers.get("X-RateLimit-Remaining")
@@ -260,7 +259,7 @@ class GitHubClient:
         params.setdefault("per_page", per_page)
         url = path
         while True:
-            r = self.rest("GET", url, params = params if url == path else None)
+            r = self.rest("GET", url, params=params if url == path else None)
             if r.status_code != 200:
                 log.error(
                     "REST paginate got %s at %s: %s", r.status_code, url, r.text[:200]

--- a/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
+++ b/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py
@@ -29,6 +29,11 @@ class RateLimitError(Exception):
     pass
 
 
+class GitHubAuthError(RuntimeError):
+    """Raised when GitHub returns 401/403 due to invalid or insufficient credentials."""
+    pass
+
+
 class GitHubClient:
     def __init__(
         self,
@@ -36,8 +41,15 @@ class GitHubClient:
         min_remaining_rest: int = 100,
         token: str | None = None,
     ):
-        token = token or os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
-        if not token:
+        if token:
+            self._token_source = "explicit token argument (recipe-level field)"
+        elif os.environ.get("GH_TOKEN"):
+            self._token_source = "GH_TOKEN environment variable"
+            token = os.environ["GH_TOKEN"]
+        elif os.environ.get("GITHUB_TOKEN"):
+            self._token_source = "GITHUB_TOKEN environment variable"
+            token = os.environ["GITHUB_TOKEN"]
+        else:
             raise RuntimeError("GH_TOKEN not set in environment")
         self.session = requests.Session()
         self.session.headers.update(
@@ -58,6 +70,33 @@ class GitHubClient:
         wait = max(0, reset_ts - now) + buffer_s
         log.warning("Rate limit hit. Sleeping %ds until reset.", wait)
         time.sleep(wait)
+
+    def _is_auth_failure(self, r: "requests.Response") -> bool:
+        """Distinguish auth failures from rate limiting on 401/403 responses.
+
+        - 401: always an auth failure (invalid / expired / wrong-scope token).
+        - 403: an auth failure UNLESS the response carries a clear rate-limit signal
+          (Retry-After header for secondary limits, or X-RateLimit-Remaining: 0
+          for primary limits).
+        """
+        if r.status_code == 401:
+            return True
+        if r.status_code == 403:
+            if r.headers.get("Retry-After"):
+                return False
+            if r.headers.get("X-RateLimit-Remaining") == "0":
+                return False
+            return True
+        return False
+
+    def _raise_auth_error(self, r: "requests.Response", endpoint: str) -> None:
+        snippet = (r.text or "").strip()[:200]
+        raise GitHubAuthError(
+            f"GitHub {endpoint} returned {r.status_code} {r.reason}. "
+            f"Token source: {self._token_source}. "
+            f"The token is invalid, expired, or missing required scopes — "
+            f"retrying will not recover. Response: {snippet}"
+        )
 
     def _check_rate_and_wait(self, kind: str) -> None:
         if kind == "graphql":
@@ -112,6 +151,8 @@ class GitHubClient:
                     time.sleep(backoff)
                     backoff = min(backoff * 2, 60)
                     continue
+                if self._is_auth_failure(r):
+                    self._raise_auth_error(r, "GraphQL")
                 if r.status_code == 403 or r.status_code == 429:
                     # Check for secondary/abuse
                     retry_after = r.headers.get("Retry-After")
@@ -188,6 +229,8 @@ class GitHubClient:
                     time.sleep(backoff)
                     backoff = min(backoff * 2, 60)
                     continue
+                if self._is_auth_failure(r):
+                    self._raise_auth_error(r, "REST")
                 if r.status_code in (403, 429):
                     retry_after = r.headers.get("Retry-After")
                     if retry_after:


### PR DESCRIPTION
## What this PR does

Fixes #5325.

The Studio data-recipe GitHub Crawler treats `401 Unauthorized` from the
GitHub GraphQL API as a transient network error and keeps retrying. Because
the token is invalid (rotated, expired, or wrong scope), every retry returns
401, the job stays alive emitting `[WARNING] GraphQL network error: 401 ...
Retry.` lines, and the user has to notice and cancel it manually.

The same problem applies to `403 Forbidden` responses that aren't actually
rate-limited (the existing 403 branch already handles `Retry-After` and
`X-RateLimit-Remaining: 0`, but otherwise falls back to a permanent
`time.sleep(60); continue`).

### Root cause

`gh_client.py` only special-cases `502/503/504` and `403/429`. Any other
non-2xx — including `401` — falls through to `r.raise_for_status()`, which
raises `requests.HTTPError`. That gets caught by the outer
`except requests.RequestException` and logged as a "network error" — same
path as a real connection failure.

### Fix

1. New `GitHubAuthError(RuntimeError)` exception.
2. New `_is_auth_failure(response)` helper:
   - `401` → always auth failure.
   - `403` → auth failure **unless** the response carries `Retry-After`
     (secondary rate limit) or `X-RateLimit-Remaining: 0` (primary rate
     limit).
3. Auth-failure check inserted in both `.graphql()` and `.rest()` before the
   existing `403/429` rate-limit branch, so auth errors bypass the
   sleep-and-retry loop.
4. The token source resolved at construction time (recipe-level argument,
   `GH_TOKEN`, or `GITHUB_TOKEN`) is captured on `self._token_source` and
   embedded in the raised error message — so the user knows exactly which
   credential to rotate:

   ```
   GitHub GraphQL returned 401 Unauthorized. Token source: GH_TOKEN environment
   variable. The token is invalid, expired, or missing required scopes —
   retrying will not recover. Response: ...
   ```

### What does NOT change

- Genuine rate limiting (`Retry-After` or `X-RateLimit-Remaining: 0`) still
  takes the existing retry path.
- Transient network errors (`requests.ConnectionError` etc.) still retry
  through the existing `except requests.RequestException` branch.
  `GitHubAuthError` is a `RuntimeError`, not a `RequestException`, so it
  propagates up and aborts the job as intended.
- `5xx` upstream errors (`502/503/504`) still retry.

### Files

- `studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/gh_client.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
