### PR TITLE
fix(loader): respect HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE env vars (#5316)

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -122,6 +122,21 @@ def _strip_unsloth_bnb_4bit_suffix(model_name: str) -> str:
     return s
 
 
+def _is_hf_offline_env() -> bool:
+    """Return True if the user has opted into HF offline mode via env vars.
+
+    Without this, ``local_files_only`` defaults to ``False`` and is passed
+    explicitly to AutoConfig/PeftConfig, which overrides huggingface_hub's
+    own env-derived default and causes downloads despite ``HF_HUB_OFFLINE=1``
+    or ``TRANSFORMERS_OFFLINE=1``.
+    """
+    OFFLINE_TRUE = {"1", "true", "yes", "on"}
+    return (
+        os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in OFFLINE_TRUE
+        or os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in OFFLINE_TRUE
+    )
+
+
 DISABLE_COMPILE_MODEL_NAMES = [
     "aya_vision",
     "modernbert",
@@ -439,7 +454,7 @@ class FastLanguageModel(FastLlamaModel):
         peft_error = None
         model_config = None
         peft_config = None
-        local_files_only = kwargs.get("local_files_only", False)
+        local_files_only = kwargs.get("local_files_only", _is_hf_offline_env())
 
         try:
             model_config = AutoConfig.from_pretrained(
@@ -1054,7 +1069,7 @@ class FastModel(FastBaseModel):
         peft_error = None
         model_config = None
         peft_config = None
-        local_files_only = kwargs.get("local_files_only", False)
+        local_files_only = kwargs.get("local_files_only", _is_hf_offline_env())
 
         try:
             model_config = AutoConfig.from_pretrained(


### PR DESCRIPTION
## Summary

Fixes #5316. `FastLanguageModel.from_pretrained()` ignored
`HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` and would download the
model anyway.

## Why

`unsloth/models/loader.py` extracts `local_files_only` and explicitly
passes it to `AutoConfig.from_pretrained` / `PeftConfig.from_pretrained`:

```python
local_files_only = kwargs.get("local_files_only", False)  # default False!

model_config = AutoConfig.from_pretrained(
    model_name,
    ...
    local_files_only = local_files_only,  # explicit False overrides env
)
```

`huggingface_hub` already derives `local_files_only` from
`HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` when the caller omits the
arg. But once unsloth passes an explicit value, that env-derived
default is overridden, and `False` reaches the network layer.

## Fix

Default `local_files_only` to `_is_hf_offline_env()` instead of `False`
when the user hasn't passed it. An explicit `local_files_only=False`
kwarg still wins, so existing behavior is preserved for anyone who was
relying on the explicit-False path.

The helper reuses the same `OFFLINE_TRUE = {"1", "true", "yes", "on"}`
set already used by `models/_utils.py::has_internet()`, kept consistent
with the existing offline-detection pattern in this codebase.

Two call sites were touched (the LLM and vision loader entry points,
both in `loader.py`).

## Verification

```python
import os
os.environ["HF_HUB_OFFLINE"] = "1"

from unsloth.models.loader import _is_hf_offline_env
assert _is_hf_offline_env() is True
```

After this patch, with `HF_HUB_OFFLINE=1` set and the model not in
cache, `FastLanguageModel.from_pretrained(...)` raises a clear offline
error from huggingface_hub instead of downloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
