### PR TITLE
Studio: stop truncating long log lines as suspected base64

### DIFF
--- a/studio/backend/loggers/handlers.py
+++ b/studio/backend/loggers/handlers.py
@@ -78,7 +78,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 
 
 def filter_sensitive_data(logger, method_name, event_dict):
-    """Structlog processor to filter out base64 data from logs."""
+    """Structlog processor to redact native path leases from logs."""
 
     def filter_value(value):
         if isinstance(value, str):
@@ -87,13 +87,7 @@ def filter_sensitive_data(logger, method_name, event_dict):
             except Exception:
                 pass
             value = _NATIVE_PATH_LEASE_RE.sub(r"\1<redacted native path lease>", value)
-        if (
-            isinstance(value, str)
-            and len(value) > 100
-            and ("," in value or "/" in value)
-        ):
-            # Likely base64 data, truncate it
-            return value[:20] + "..."
+            return value
         elif isinstance(value, dict):
             return {
                 k: "<redacted native path lease>"

--- a/studio/backend/tests/test_log_filter_no_truncation.py
+++ b/studio/backend/tests/test_log_filter_no_truncation.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+Regression tests for studio.backend.loggers.handlers.filter_sensitive_data.
+
+Context: filter_sensitive_data was originally written with a base64-detection
+heuristic that truncated any string >100 chars containing ',' or '/' down to
+20 chars + '...'. The block was dormant until PR #5246 wired the processor
+into the structlog chain to redact native-path leases. Once active, the
+heuristic ate normal log lines emitted by llama_cpp_backend (GGUF size
+summary, mmproj selection, the full llama-server command line) and any
+exception traceback that happened to contain a file path.
+
+These tests pin two properties:
+
+1. Long, comma- or slash-bearing log messages flow through filter_sensitive_data
+   unchanged. The exact strings exercised match the call sites at
+   studio/backend/core/inference/llama_cpp.py:2117, :2283, and :2312 that
+   were truncated in the original bug report.
+
+2. PR #5246's native-path lease redaction still fires for both the inline
+   ``native_path_lease=...`` regex form and the ``nativePathLease`` dict-key
+   form. This guards against future regressions that strip redaction along
+   with the truncation block.
+"""
+
+from loggers.handlers import filter_sensitive_data
+
+
+def _run(event_dict):
+    return filter_sensitive_data(logger = None, method_name = "info", event_dict = event_dict)
+
+
+class TestNoTruncation:
+    def test_gguf_size_summary_survives(self):
+        # Mirrors the f-string at studio/backend/core/inference/llama_cpp.py:2117
+        event = (
+            "GGUF size: 232.9 GB, est. KV cache: 87.0 GB, context: 259072, "
+            "GPUs free: [(0, 80000), (1, 80000)], selected: [0, 1], fit: False"
+        )
+        out = _run({"event": event})
+        assert out["event"] == event
+        assert "..." not in out["event"]
+
+    def test_mmproj_path_survives(self):
+        # Mirrors logger.info at studio/backend/core/inference/llama_cpp.py:2283
+        event = (
+            "Using mmproj for vision: "
+            "/home/user/.cache/unsloth/models/some-vision-model-uncensored-r1-distill/mmproj-F16.gguf"
+        )
+        out = _run({"event": event})
+        assert out["event"] == event
+
+    def test_llama_server_command_survives(self):
+        # Mirrors logger.info at studio/backend/core/inference/llama_cpp.py:2312
+        event = (
+            "Starting llama-server: /home/user/.unsloth/studio/llama.cpp/build/bin/llama-server "
+            "-m /home/user/.cache/unsloth/models/foo.gguf --port 8090 -c 259072 --parallel 1 "
+            "--flash-attn on --mmproj /home/user/.cache/unsloth/models/mmproj-F16.gguf"
+        )
+        out = _run({"event": event})
+        assert out["event"] == event
+
+    def test_traceback_with_paths_survives(self):
+        traceback_str = (
+            "Traceback (most recent call last):\n"
+            '  File "/home/user/.unsloth/studio/unsloth_studio/lib/python3.11/site-packages/'
+            'studio/backend/core/inference/llama_cpp.py", line 2312, in start\n'
+            '    raise RuntimeError("llama-server crashed: bad alloc, /dev/shm full")\n'
+            "RuntimeError: llama-server crashed: bad alloc, /dev/shm full"
+        )
+        out = _run({"event": "llama-server crashed", "exception": traceback_str})
+        assert out["exception"] == traceback_str
+        assert "..." not in out["exception"]
+
+    def test_nested_long_string_in_dict_survives(self):
+        long_value = (
+            "/very/long/path/with,many,commas,and/slashes/that/used/to/get/"
+            "chopped/to/twenty/chars/file.gguf"
+        )
+        out = _run({"event": "load", "details": {"path": long_value}})
+        assert out["details"]["path"] == long_value
+
+
+class TestNativePathLeaseRedactionStillWorks:
+    """Guards PR #5246's redaction from being lost alongside the truncation block."""
+
+    def test_inline_native_path_lease_value_redacted(self):
+        event = (
+            "rejected request: native_path_lease=AAAAAA.BBBBBB extra context "
+            "with /some/path,values"
+        )
+        out = _run({"event": event})
+        assert "AAAAAA.BBBBBB" not in out["event"]
+        assert "<redacted native path lease>" in out["event"]
+
+    def test_camelcase_native_path_lease_dict_key_redacted(self):
+        out = _run({"event": "load", "nativePathLease": "AAAAAA.BBBBBB"})
+        assert out["nativePathLease"] == "<redacted native path lease>"
+
+    def test_snakecase_native_path_lease_dict_key_redacted(self):
+        out = _run({"event": "load", "native_path_lease": "AAAAAA.BBBBBB"})
+        assert out["native_path_lease"] == "<redacted native path lease>"
+
+    def test_nested_native_path_lease_key_redacted(self):
+        out = _run({"event": "load", "payload": {"nativePathLease": "AAAAAA.BBBBBB"}})
+        assert out["payload"]["nativePathLease"] == "<redacted native path lease>"


### PR DESCRIPTION
## Summary

- `filter_sensitive_data` in `studio/backend/loggers/handlers.py` carried a heuristic that truncated any string >100 chars containing `,` or `/` to `value[:20] + "..."`. The block was dormant since the original Studio import — `filter_sensitive_data` was defined but never registered in the structlog processor chain.
- #5246 wired `filter_sensitive_data` into the processor chain in `studio/backend/loggers/config.py` to redact native-path leases. That activated the dormant truncation block as a side effect, and normal log lines started rendering as a 20-char prefix.
- Affected call sites in `studio/backend/core/inference/llama_cpp.py`: the GGUF size + GPU selection summary (line 2117), the mmproj selection log (line 2283), the full `llama-server` command line (line 2312), and any exception traceback containing a file path. This made llama-server failures and GPU selection effectively undebuggable from logs.
- Drop the base64 truncation block. No call site in the repo logs raw base64; if one ever does, it should truncate at the source rather than in a global filter. Native-path lease redaction added by #5246 is preserved unchanged (`redact_native_paths`, `_NATIVE_PATH_LEASE_RE`, the `nativePathLease` key match in dicts and the top-level `event_dict`).

## Test plan

- [x] `studio/backend/tests/test_log_filter_no_truncation.py` passes — pins that the three exact log-line shapes from the bug report and an exception traceback flow through `filter_sensitive_data` unchanged.
- [x] Same test file's `TestNativePathLeaseRedactionStillWorks` class passes — guards #5246's redaction (inline regex form + `nativePathLease` / `native_path_lease` dict keys, top-level and nested).
- [x] E2E: load a GGUF in Studio and confirm the `GGUF size: ...`, `Using mmproj for vision: ...`, and `Starting llama-server: ...` lines print in full in the backend logs.

## solves 
#5348 
#5382