### PR TITLE
fix(tests/sh): accept pinned tokenizers line after #5359

### DIFF
--- a/tests/sh/test_torch_constraint.sh
+++ b/tests/sh/test_torch_constraint.sh
@@ -109,14 +109,28 @@ assert_eq "hardcoded torch>=2.4 appears exactly once" "1" "$_hardcoded"
 echo ""
 echo "=== Structural: tokenizers in no-torch-runtime.txt ==="
 
-# Accept bare `tokenizers` or version-pinned forms (e.g. `tokenizers<=0.23.0`).
-# Per #5359 the line is pinned because unpinned resolves to 0.23.1+ which
-# transformers rejects at import time.
-_has_tokenizers=$(grep -cE '^tokenizers([<>=!,~ ]|$)' "$NO_TORCH_RT" || true)
-assert_eq "tokenizers present as standalone or pinned line" "1" "$_has_tokenizers"
+# Package-name boundary is anything not valid in a PEP 508 name, or EOL.
+# Covers `tokenizers`, `tokenizers<=0.23.0`, `tokenizers[extra]`,
+# `tokenizers; python_version<"3.13"`, etc., but NOT `tokenizers-foo`.
+_TOK_RE='^tokenizers([^a-zA-Z0-9._-]|$)'
+
+_has_tokenizers=$(grep -cE "$_TOK_RE" "$NO_TORCH_RT" || true)
+assert_eq "tokenizers package listed" "1" "$_has_tokenizers"
+
+# Regression guard for #5359: the tokenizers line must carry an upper
+# bound that excludes 0.23.1+. transformers in the allowed 4.56..5.3
+# window rejects 0.23.1 at import time with
+#   `tokenizers<=0.23.0,>=0.22.0 is required, but found 0.23.1`.
+# Accept both `<=0.23.0` and the functionally equivalent `<0.23.1`.
+# Two-stage grep: pick lines that start with the tokenizers package
+# name (PEP 508 name boundary), then require a safe upper bound.
+_has_safe_pin=$(grep -E "$_TOK_RE" "$NO_TORCH_RT" \
+    | grep -cE '(<=[[:space:]]*0\.23\.0|<[[:space:]]*0\.23\.1)' \
+    || true)
+assert_eq "tokenizers pinned with upper bound excluding 0.23.1+" "1" "$_has_safe_pin"
 
 # tokenizers before transformers
-_tok_line=$(grep -nE '^tokenizers([<>=!,~ ]|$)' "$NO_TORCH_RT" | head -1 | cut -d: -f1)
+_tok_line=$(grep -nE "$_TOK_RE" "$NO_TORCH_RT" | head -1 | cut -d: -f1)
 _tf_line=$(grep -n '^transformers' "$NO_TORCH_RT" | head -1 | cut -d: -f1)
 _tok_first=$([ "$_tok_line" -lt "$_tf_line" ] && echo "yes" || echo "no")
 assert_eq "tokenizers before transformers" "yes" "$_tok_first"

--- a/tests/sh/test_torch_constraint.sh
+++ b/tests/sh/test_torch_constraint.sh
@@ -109,11 +109,14 @@ assert_eq "hardcoded torch>=2.4 appears exactly once" "1" "$_hardcoded"
 echo ""
 echo "=== Structural: tokenizers in no-torch-runtime.txt ==="
 
-_has_tokenizers=$(grep -c '^tokenizers$' "$NO_TORCH_RT" || true)
-assert_eq "tokenizers present as standalone line" "1" "$_has_tokenizers"
+# Accept bare `tokenizers` or version-pinned forms (e.g. `tokenizers<=0.23.0`).
+# Per #5359 the line is pinned because unpinned resolves to 0.23.1+ which
+# transformers rejects at import time.
+_has_tokenizers=$(grep -cE '^tokenizers([<>=!,~ ]|$)' "$NO_TORCH_RT" || true)
+assert_eq "tokenizers present as standalone or pinned line" "1" "$_has_tokenizers"
 
 # tokenizers before transformers
-_tok_line=$(grep -n '^tokenizers$' "$NO_TORCH_RT" | head -1 | cut -d: -f1)
+_tok_line=$(grep -nE '^tokenizers([<>=!,~ ]|$)' "$NO_TORCH_RT" | head -1 | cut -d: -f1)
 _tf_line=$(grep -n '^transformers' "$NO_TORCH_RT" | head -1 | cut -d: -f1)
 _tok_first=$([ "$_tok_line" -lt "$_tf_line" ] && echo "yes" || echo "no")
 assert_eq "tokenizers before transformers" "yes" "$_tok_first"


### PR DESCRIPTION
Follow-up to #5359. That PR pinned the tokenizers line in `studio/backend/requirements/no-torch-runtime.txt` from bare `tokenizers` to `tokenizers<=0.23.0` to stop pip from resolving to 0.23.1+ (which transformers rejects at import time).

`tests/sh/test_torch_constraint.sh` was still asserting the literal `^tokenizers$` regex, so it now fails on main. Surfaced first on #5312's Backend CI Repo tests (CPU) step (https://github.com/unslothai/unsloth/actions/runs/25662435376/job/75326242237):

```
=== Structural: tokenizers in no-torch-runtime.txt ===
  FAIL: tokenizers present as standalone line (expected '1', got '0')
  FAIL: tokenizers before transformers (expected 'yes', got 'no')
```

Relax the regex to `^tokenizers([<>=!,~ ]|$)` so it matches both bare and version-constrained forms. Preserves the original intent (verify the tokenizers package is listed in the file, before transformers).

## Test plan

- [x] `bash tests/sh/test_torch_constraint.sh` locally: 24 PASS, 0 FAIL on current `main` (which contains #5359's pin).
- [x] The two relaxed regexes still match a hypothetical bare `tokenizers` line as well (so the contract holds in either direction).
- [ ] CI green on this PR.