### PR TITLE
studio: authenticate HF downloads across Studio CI workflows

### DIFF
--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache
@@ -331,6 +333,8 @@ jobs:
 
       - name: Download GGUF if cache miss
         if: steps.cache-gguf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p gguf-cache
@@ -637,6 +641,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF + mmproj
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache

--- a/.github/workflows/studio-mac-api-smoke.yml
+++ b/.github/workflows/studio-mac-api-smoke.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache
@@ -325,6 +327,8 @@ jobs:
 
       - name: Download GGUF if cache miss
         if: steps.cache-gguf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p gguf-cache
@@ -679,13 +683,24 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF + mmproj
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        # Authenticated + parallel: shared macos-14 NAT egress stalls
+        # multi-GB anonymous downloads.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache
           HF_HUB_ENABLE_HF_TRANSFER=1 \
-            hf download "$GGUF_REPO" "$GGUF_FILE"
+            hf download "$GGUF_REPO" "$GGUF_FILE" &
+          MODEL_PID=$!
           HF_HUB_ENABLE_HF_TRANSFER=1 \
-            hf download "$GGUF_REPO" "$MMPROJ_FILE"
+            hf download "$GGUF_REPO" "$MMPROJ_FILE" &
+          MMPROJ_PID=$!
+          wait "$MODEL_PID"
+          wait "$MMPROJ_PID"
+          # Fail loud on a partial download instead of in the next step.
+          find hf-cache -name "$GGUF_FILE" -o -name "$MMPROJ_FILE" \
+            | xargs -I{} ls -lhL {}
 
       - name: Install Studio (--local, --no-torch)
         env:

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache
@@ -382,6 +384,8 @@ jobs:
 
       - name: Download GGUF if cache miss
         if: steps.cache-gguf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p gguf-cache
@@ -776,6 +780,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF + mmproj
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         if: steps.cache-hf.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
           mkdir -p hf-cache


### PR DESCRIPTION
## Summary

- The Mac json-images job on run [25664825326](https://github.com/unslothai/unsloth/actions/runs/25664825326/job/75334476387) hit the 30 min step budget while downloading ~4 GiB of GGUF assets unauthenticated. The log shows the explicit `You are sending unauthenticated requests to the HF Hub` warning followed by 30 min of zero progress, then job cancellation.
- `macos-14`, `ubuntu-latest`, and `windows-latest` runners share NAT egress IP pools across the whole GitHub Actions fleet, so the anonymous per-IP rate limit kicks in well before the file size alone would suggest. An authenticated token shifts the budget to per-user accounting.
- This PR adds `HF_TOKEN: \${{ secrets.HF_TOKEN }}` to every `hf download` step across the nine Studio CI workflows that pull from HF. The env block is scoped to the download step only, not the job, so every other step still runs without `HF_TOKEN` in its environment and GitHub's secret masking handles log scrubbing.
- For the Mac json-images step specifically, the model and mmproj downloads now run in parallel under `wait`, and an `ls -lhL` after the wait surfaces a partial download as an obvious failure instead of a silent 30 min timeout on the next \`/api/inference/load\` call.

## Files touched

- \`.github/workflows/studio-api-smoke.yml\`
- \`.github/workflows/studio-mac-api-smoke.yml\`
- \`.github/workflows/studio-windows-api-smoke.yml\`
- \`.github/workflows/studio-inference-smoke.yml\`
- \`.github/workflows/studio-mac-inference-smoke.yml\`
- \`.github/workflows/studio-windows-inference-smoke.yml\`
- \`.github/workflows/studio-ui-smoke.yml\`
- \`.github/workflows/studio-mac-ui-smoke.yml\`
- \`.github/workflows/studio-windows-ui-smoke.yml\`

14 `hf download` invocation sites covered. The other Studio workflows (\`studio-backend-ci\`, \`studio-frontend-ci\`, \`studio-tauri-smoke\`, \`studio-update-smoke\`, \`studio-mac-update-smoke\`, \`studio-windows-update-smoke\`) do not download from HF and are not touched.

## Pre-requisite

\`HF_TOKEN\` repository secret must be set on \`unslothai/unsloth\`. A fine-grained token with zero scoped permissions is sufficient since every repo this workflow downloads from is public. If the secret is unset, the step still works (env value is empty) and behaves identically to today's anonymous path.

## Test plan

- [ ] Confirm the \`HF_TOKEN\` secret is registered under Settings -> Secrets and variables -> Actions.
- [ ] Re-run \`Mac Studio GGUF CI\` against this branch. The \`json-images\` job's \`Prime HF_HOME with the GGUF + mmproj\` step should complete in 1-3 min instead of timing out at 30 min, and the unauthenticated-warning line should be absent from the log.
- [ ] Re-run \`Studio GGUF CI\` (ubuntu) and \`Windows Studio GGUF CI\` against this branch. Cache-hit paths must still short-circuit via \`if: cache-hit != 'true'\`; only the cache-miss branch should pick up the new env.
- [ ] Spot-check one of the smaller workflows (\`studio-api-smoke\`) to confirm the new \`env:\` block does not alter the downloaded file (sha of \`gemma-3-270m-it-UD-Q4_K_XL.gguf\` unchanged).