### PR TITLE
studio/tests: make Playwright model-selector probe best-effort

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -479,8 +479,14 @@ with sync_playwright() as p:
         'button:has-text("Qwen"), '
         'button:has-text("Llama")'
     ).first
-    if selector_btn.count() > 0:
-        sel_text = (selector_btn.text_content() or "").strip()
+    # Best-effort: the selector re-mounts as /api/models/list resolves,
+    # so use a short timeout and skip the snapshot on miss.
+    sel_text = ""
+    try:
+        sel_text = (selector_btn.text_content(timeout = 2_000) or "").strip()
+    except Exception as _sel_err:
+        info(f"WARN: model-selector probe skipped: {type(_sel_err).__name__}: {_sel_err}")
+    if sel_text:
         info(f"model selector button text: {sel_text!r}")
         shoot("03b-default-model-button")
 

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -485,7 +485,9 @@ with sync_playwright() as p:
     try:
         sel_text = (selector_btn.text_content(timeout = 2_000) or "").strip()
     except Exception as _sel_err:
-        info(f"WARN: model-selector probe skipped: {type(_sel_err).__name__}: {_sel_err}")
+        info(
+            f"WARN: model-selector probe skipped: {type(_sel_err).__name__}: {_sel_err}"
+        )
     if sel_text:
         info(f"model selector button text: {sel_text!r}")
         shoot("03b-default-model-button")


### PR DESCRIPTION
## Summary

- The Mac Studio UI CI run [25664825320](https://github.com/unslothai/unsloth/actions/runs/25664825320/job/75334476211) failed at `tests/studio/playwright_chat_ui.py:483` with `Locator.text_content: Timeout 60000ms exceeded`. The job log timeline is:

  ```
  11:40:51  [ui] OK default_models[0] = unsloth/gemma-4-E2B-it-GGUF
  11:41:51  TimeoutError (exactly 60 s later)
  ```

- Root cause: `count()` and `text_content()` are two independent queries against the live DOM. The chat surface re-mounts the model selector while `/api/models/list` resolves the default-model badge, so the button matches the OR-selector at `count()` time but is briefly detached when `text_content()` re-queries. The page-wide default action timeout was bumped to 60 s on line 177, so the informational probe blocked for a full minute and then hard-failed.
- The block is clearly best-effort. It is gated on `if count() > 0` and the only side effects are `info(...)` and `shoot(...)`. New shape uses a short explicit `timeout = 2_000` inside `try`/`except`, matching the pattern this file already uses for `networkidle`, screenshot capture, and composer wait.

## Behavioural change

- Happy path: identical. Logs `[ui] model selector button text: ...` and snaps `03b-default-model-button`.
- Miss path (re-render race or selector absent): logs `[ui] WARN: model-selector probe skipped: ...` and the run continues to `/api/inference/load`.

## Files touched

- \`tests/studio/playwright_chat_ui.py\` (one block at line ~476-498)

## Test plan

- [ ] Re-run `Mac Studio UI CI` on this branch. The `Drive the chat UI with Playwright` step should no longer hit the 60 s timeout at the model-selector probe.
- [ ] When the selector is present, confirm the log still contains `[ui] model selector button text: ...` and the `03b-default-model-button` screenshot is captured.
- [ ] When the selector is briefly detached, confirm the WARN line appears and the test proceeds to `[ui] STEP load GGUF via /api/inference/load` without a 60 s gap.