### PR TITLE
dependabot: group security updates and cover /studio/frontend npm advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+      actions-security:
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: "bun"
     directory: "/studio/frontend"
@@ -15,6 +18,9 @@ updates:
       interval: "weekly"
     groups:
       bun-frontend:
+        patterns: ["*"]
+      bun-frontend-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   - package-ecosystem: "npm"
@@ -24,11 +30,12 @@ updates:
     groups:
       npm-oxc-validator:
         patterns: ["*"]
+      npm-oxc-validator-security:
+        applies-to: security-updates
+        patterns: ["*"]
 
-  # pip + cargo so security advisories on Python deps + the Tauri shell
-  # auto-generate PRs alongside the github-actions / bun / npm updates.
-  # Grouped weekly so we don't get one PR per dep; security advisories
-  # bypass the group and open immediately.
+  # pip + cargo grouped weekly; the *-security siblings batch
+  # advisories that would otherwise each open their own PR.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -37,6 +44,9 @@ updates:
     groups:
       python:
         patterns: ["*"]
+      python-security:
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: "cargo"
     directory: "/studio/src-tauri"
@@ -44,5 +54,22 @@ updates:
       interval: "weekly"
     groups:
       cargo-tauri:
+        patterns: ["*"]
+      cargo-tauri-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # bun owns version updates for /studio/frontend (above); GitHub
+  # fires npm-package advisories under npm_and_yarn, so this entry
+  # catches and groups them. limit: 0 suppresses version-update
+  # PRs, security updates flow through regardless.
+  - package-ecosystem: "npm"
+    directory: "/studio/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-frontend-security:
+        applies-to: security-updates
         patterns: ["*"]
 ...


### PR DESCRIPTION
## Summary

We currently have 11 open Dependabot PRs (#5362, #5363, #5364, #5365, #5366, #5367, #5368, #5369, #5343, #5148, #4916). Five are the normal weekly grouped version bumps (one per ecosystem). The other six are individual security advisories that bypassed the existing group config and opened one PR per affected package.

Per the [Dependabot reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#applies-to), every \`groups:\` entry has an implicit \`applies-to: version-updates\`. To batch security updates as well, you need a sibling group with \`applies-to: security-updates\`. This PR adds those siblings to every ecosystem, plus a new \`npm\` entry covering \`/studio/frontend\` for cross-ecosystem advisories.

## Why this matters

- /studio/src-tauri opened four individual cargo PRs this week (#5366 openssl, #5367 rand, #5368 tauri, #5369 rustls-webpki) even though the \`cargo-tauri\` group covers \`patterns: [\"*\"]\` for that directory. They're advisories, so they bypassed the group.
- /studio/frontend opened one extra \`npm_and_yarn\` group PR (#5343, hono + ip-address) even though \`bun\` is the only ecosystem we configured for that directory. GitHub fires npm-package advisories under the \`npm_and_yarn\` ecosystem regardless of which package manager owns the lockfile; without an \`npm\` entry pointed at \`/studio/frontend\`, those advisories land outside any group config.

## Changes

1. **Sibling \`*-security\` groups** for every existing ecosystem (\`actions\`, \`bun-frontend\`, \`npm-oxc-validator\`, \`python\`, \`cargo-tauri\`) with \`applies-to: security-updates\` and the same \`patterns: [\"*\"]\` coverage. Security advisories now batch into one PR per ecosystem per week alongside the version-update group.
2. **New \`npm\` entry** at \`/studio/frontend\` with \`open-pull-requests-limit: 0\` (suppress version-update PRs since \`bun\` handles those) and a \`npm-frontend-security\` group. Security advisories on npm packages in that directory now batch into one PR. Per the docs, \`open-pull-requests-limit\` only governs version updates; security updates have a separate internal limit of 10 and still flow through.

## Out of scope

This does NOT retroactively regroup PRs already open. The existing 11 are unaffected and should be triaged separately:

- #5148 is stale (April 23, pre-dates the current group config; its \`cargo\` group label no longer exists). Recommend close.
- #5366-#5369 are this week's cargo advisories. Recommend merge in dependency order (rand, openssl, rustls-webpki, tauri), then \`@dependabot recreate\` on #5364 so the version-update group PR refreshes against the post-merge lockfile.
- #5343 (hono + ip-address) merges independently.
- #5362, #5363, #5365, #4916 are the standard weekly group PRs.

After this PR lands, next week's cycle should produce at most five PRs (one per ecosystem) regardless of whether CVEs are involved.

## Test plan

- [ ] Confirm YAML parses with \`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"\`. (Validated locally.)
- [ ] After merge, manually trigger a Dependabot check from the repo's Insights -> Dependency graph -> Dependabot page; confirm no validation errors against the new config.
- [ ] On the next weekly tick (or via manual \`@dependabot check-now\` flow), confirm that a freshly-opened security advisory lands inside the \`*-security\` group PR for its ecosystem rather than opening individually.