### PR TITLE
ci/install: retry transient github.com 5xx on unsloth-zoo git fetches

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -234,9 +234,23 @@ jobs:
         # tests/conftest.py spoof which handles that.
         run: |
           set -euxo pipefail
-          git clone --depth=1 --branch="$UNSLOTH_ZOO_REF" \
-            https://github.com/unslothai/unsloth-zoo \
-            "$RUNNER_TEMP/unsloth-zoo"
+          # github.com occasionally 500s on the git fetch; retry so a
+          # single upstream blip does not fail CI.
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/unsloth-zoo"
+            if git clone --depth=1 --branch="$UNSLOTH_ZOO_REF" \
+                https://github.com/unslothai/unsloth-zoo \
+                "$RUNNER_TEMP/unsloth-zoo"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::git clone unsloth-zoo failed after 3 attempts"
+              exit 1
+            fi
+            delay=$((5 * attempt))
+            echo "::warning::clone failed (attempt $attempt/3), retrying in ${delay}s..."
+            sleep "$delay"
+          done
           pip install -e "$RUNNER_TEMP/unsloth-zoo" --no-deps
           pip show unsloth_zoo
 
@@ -2040,9 +2054,23 @@ jobs:
         # main-branch fixes flow into the smoke without a release).
         run: |
           set -euxo pipefail
-          git clone --depth=1 --branch="$UNSLOTH_ZOO_REF" \
-            https://github.com/unslothai/unsloth-zoo \
-            "$RUNNER_TEMP/unsloth-zoo"
+          # github.com occasionally 500s on the git fetch; retry so a
+          # single upstream blip does not fail CI.
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/unsloth-zoo"
+            if git clone --depth=1 --branch="$UNSLOTH_ZOO_REF" \
+                https://github.com/unslothai/unsloth-zoo \
+                "$RUNNER_TEMP/unsloth-zoo"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::git clone unsloth-zoo failed after 3 attempts"
+              exit 1
+            fi
+            delay=$((5 * attempt))
+            echo "::warning::clone failed (attempt $attempt/3), retrying in ${delay}s..."
+            sleep "$delay"
+          done
           pip install -e "$RUNNER_TEMP/unsloth-zoo" --no-deps
           pip show unsloth_zoo
 

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -153,7 +153,20 @@ jobs:
             'httpx==0.28.1'
           pip install --index-url https://download.pytorch.org/whl/cpu \
             'torch==2.10.0'
-          pip install "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo"
+          # github.com occasionally 500s on the git fetch; retry the
+          # zoo install so a single upstream blip does not fail CI.
+          for attempt in 1 2 3; do
+            if pip install "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::pip install unsloth_zoo failed after 3 attempts"
+              exit 1
+            fi
+            delay=$((5 * attempt))
+            echo "::warning::unsloth_zoo install failed (attempt $attempt/3), retrying in ${delay}s..."
+            sleep "$delay"
+          done
           pip install -e . --no-deps
 
       # Real Apple Silicon sanity: confirm _IS_MLX activates on real

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -203,8 +203,22 @@ jobs:
         with: { path: unsloth }
       - name: Clone unsloth-zoo @ main
         run: |
-          git clone --depth=1 https://github.com/unslothai/unsloth-zoo \
-            "$RUNNER_TEMP/unsloth-zoo"
+          # github.com occasionally 500s on the git fetch; retry so a
+          # single upstream blip does not fail CI.
+          for attempt in 1 2 3; do
+            rm -rf "$RUNNER_TEMP/unsloth-zoo"
+            if git clone --depth=1 https://github.com/unslothai/unsloth-zoo \
+                "$RUNNER_TEMP/unsloth-zoo"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::git clone unsloth-zoo failed after 3 attempts"
+              exit 1
+            fi
+            delay=$((5 * attempt))
+            echo "::warning::clone failed (attempt $attempt/3), retrying in ${delay}s..."
+            sleep "$delay"
+          done
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'


### PR DESCRIPTION
## Summary

Windows Studio API CI run [25676130116](https://github.com/unslothai/unsloth/actions/runs/25676130116/job/75374388468) failed at "Install Studio (--local, --no-torch)" because github.com itself returned HTTP 500 mid-clone:

```
× Failed to download and build `unsloth-zoo @ git+https://github.com/unslothai/unsloth-zoo`
  ├─▶ Git operation failed
  ╰─▶ process didn't exit successfully: `git.exe fetch ...` (exit code: 128)
      --- stderr
      remote: Internal Server Error
      fatal: unable to access 'https://github.com/unslothai/unsloth-zoo/':
        The requested URL returned error: 500
```

The runner did nothing wrong. github.com served the same repo fine seconds before and after, and adjacent commits on `main` are green. Without a retry, every transient upstream blip turns one job red and forces a manual re-run.

## Changes

Retry layer added only at the points that actually hit github.com directly:

### `install.sh`

- New helper `run_install_cmd_with_retry` next to the existing `run_install_cmd`.
- Exponential backoff: 5s, 10s, 20s. Override via `UNSLOTH_INSTALL_RETRY_ATTEMPTS` and `UNSLOTH_INSTALL_RETRY_DELAY`.
- Pattern match on transient errors observed in the wild: `500 / 502 / 503 / 504`, `exit code: 128` from git, `Connection reset`, `Connection refused`, `Could not resolve host`, `Operation timed out`, `Temporary failure`, `RPC failed`, `early EOF`, `Empty reply from server`, `HTTP error 5[0-9][0-9]`.
- Non-transient failures (syntax errors in setup.py, missing pip, malformed spec, etc.) still abort on the first attempt -- the helper inspects stderr/stdout for the transient pattern and only retries when it matches.
- Wraps the four `uv pip install ... git+...unsloth-zoo` overlay sites.

### `install.ps1`

- Mirror function `Invoke-InstallCommandWithRetry` with the same transient-pattern matcher and the same env-var knobs.
- Wraps the three Windows zoo-overlay sites.

### `.github/workflows/{mlx-ci,version-compat-ci,consolidated-tests-ci}.yml`

- Inline 3-attempt retry loop around the four direct `git clone` / `pip install git+...unsloth-zoo` calls.
- Emits GitHub Actions `::warning::` on each retry and `::error::` on final exhaustion, so transient hits surface in the job summary.
- Cleans up the partial clone directory between attempts so a half-cloned dir does not poison the next try.

## What does NOT retry

Deliberately scoped to upstream-fetch steps only. The retry layer does not wrap:

- `pip install` of pypi-hosted packages (pip's own resolver already retries).
- HF model downloads (`hf download`) -- `huggingface_hub` retries internally and PR #5370 adds `HF_TOKEN` for rate-limit handling.
- `cargo build` / `bun install` / `npm install` -- each has its own resolver retry.

That keeps the change surface tight: only the call paths that have been observed to fail on a transient github.com 5xx get the retry, so the layer cannot mask a real package-resolution bug.

## Test plan

- [x] `bash -n install.sh` passes; `yaml.safe_load` passes on all three touched workflows.
- [x] Local unit-test of `run_install_cmd_with_retry`: simulated 2x transient-then-success returns 0 after two warnings; always-transient gives up after `_max` attempts; non-transient failure aborts on the first attempt without retrying. All three paths verified.
- [ ] CI run on this branch exercises the new helper on every Linux/Mac/Windows install path. Should be green; the retry should be invisible unless github.com is actually down during the run.
- [ ] Future transient blips on `main` get retried automatically and surface as `::warning::` instead of failing the job.
