### PR TITLE
studio/ci: harden HF_HOME cache against actions/cache v5 silent restore failures

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -78,8 +78,11 @@ jobs:
       # known flake where it logs "Cache hit for: <key>" and then exits
       # non-zero without actually extracting the archive (see
       # actions/cache#1621 and github community discussion #163260).
-      # continue-on-error masks that failure; the Prime step below
-      # re-downloads from HF, and the Save step re-uploads on the way out.
+      # continue-on-error on restore masks that failure so the Prime step
+      # below can re-download from HF and the job keeps running. Save then
+      # populates the cache key on a real miss only; cache keys are
+      # immutable, so a corrupted cached entry persists until the -v1
+      # suffix below is bumped.
       - name: Restore HF_HOME cache for ${{ env.GGUF_REPO }}
         id: cache-hf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -105,12 +105,8 @@ jobs:
         # Only write a fresh cache entry when we actually rebuilt the
         # directory (Prime ran and succeeded). Skipping when Prime is
         # skipped avoids "already exists" save warnings on the happy path.
-        # continue-on-error: a save-side flake (upload timeout, 5xx from
-        # the cache backend) is strictly recoverable -- next run just
-        # re-downloads -- so it should not fail the job.
         if: always() && steps.prime-hf.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        continue-on-error: true
         with:
           path: hf-cache
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v1
@@ -423,11 +419,8 @@ jobs:
             hf download "$GGUF_REPO" "$GGUF_FILE" --local-dir gguf-cache
 
       - name: Save GGUF model cache
-        # continue-on-error: see the matching block in the tool-calling job
-        # above for the full rationale. A save-side flake is recoverable.
         if: always() && steps.download-gguf.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        continue-on-error: true
         with:
           path: gguf-cache
           key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
@@ -839,11 +832,8 @@ jobs:
             hf download "$GGUF_REPO" "$MMPROJ_FILE"
 
       - name: Save HF_HOME cache for ${{ env.GGUF_REPO }} (model + mmproj)
-        # continue-on-error: see the matching block in the tool-calling job
-        # above for the full rationale. A save-side flake is recoverable.
         if: always() && steps.prime-hf.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        continue-on-error: true
         with:
           path: hf-cache
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v1

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -105,8 +105,12 @@ jobs:
         # Only write a fresh cache entry when we actually rebuilt the
         # directory (Prime ran and succeeded). Skipping when Prime is
         # skipped avoids "already exists" save warnings on the happy path.
+        # continue-on-error: a save-side flake (upload timeout, 5xx from
+        # the cache backend) is strictly recoverable -- next run just
+        # re-downloads -- so it should not fail the job.
         if: always() && steps.prime-hf.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
         with:
           path: hf-cache
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v1
@@ -419,8 +423,11 @@ jobs:
             hf download "$GGUF_REPO" "$GGUF_FILE" --local-dir gguf-cache
 
       - name: Save GGUF model cache
+        # continue-on-error: see the matching block in the tool-calling job
+        # above for the full rationale. A save-side flake is recoverable.
         if: always() && steps.download-gguf.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
         with:
           path: gguf-cache
           key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
@@ -832,8 +839,11 @@ jobs:
             hf download "$GGUF_REPO" "$MMPROJ_FILE"
 
       - name: Save HF_HOME cache for ${{ env.GGUF_REPO }} (model + mmproj)
+        # continue-on-error: see the matching block in the tool-calling job
+        # above for the full rationale. A save-side flake is recoverable.
         if: always() && steps.prime-hf.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
         with:
           path: hf-cache
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v1

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -73,15 +73,26 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Cache HF_HOME for ${{ env.GGUF_REPO }}
+      # Split restore + save (rather than the one-step actions/cache) so a
+      # transient restore-side failure does not kill the whole job. v5 has a
+      # known flake where it logs "Cache hit for: <key>" and then exits
+      # non-zero without actually extracting the archive (see
+      # actions/cache#1621 and github community discussion #163260).
+      # continue-on-error masks that failure; the Prime step below
+      # re-downloads from HF, and the Save step re-uploads on the way out.
+      - name: Restore HF_HOME cache for ${{ env.GGUF_REPO }}
         id: cache-hf
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
         with:
           path: hf-cache
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v1
 
       - name: Prime HF_HOME with the GGUF
-        if: steps.cache-hf.outputs.cache-hit != 'true'
+        id: prime-hf
+        # Run on a real cache miss AND on the silent-restore-failure mode
+        # described above (outcome != success).
+        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -89,6 +100,16 @@ jobs:
           mkdir -p hf-cache
           HF_HUB_ENABLE_HF_TRANSFER=1 \
             hf download "$GGUF_REPO" "$GGUF_FILE"
+
+      - name: Save HF_HOME cache for ${{ env.GGUF_REPO }}
+        # Only write a fresh cache entry when we actually rebuilt the
+        # directory (Prime ran and succeeded). Skipping when Prime is
+        # skipped avoids "already exists" save warnings on the happy path.
+        if: always() && steps.prime-hf.outcome == 'success'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: hf-cache
+          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v1
 
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh
@@ -375,15 +396,20 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Cache GGUF model file
+      # Split restore + save so a transient restore-side failure does not
+      # kill the whole job. See the matching block in the tool-calling job
+      # above for the full rationale (actions/cache#1621).
+      - name: Restore GGUF model cache
         id: cache-gguf
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
         with:
           path: gguf-cache
           key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
 
       - name: Download GGUF if cache miss
-        if: steps.cache-gguf.outputs.cache-hit != 'true'
+        id: download-gguf
+        if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -391,6 +417,13 @@ jobs:
           mkdir -p gguf-cache
           HF_HUB_ENABLE_HF_TRANSFER=1 \
             hf download "$GGUF_REPO" "$GGUF_FILE" --local-dir gguf-cache
+
+      - name: Save GGUF model cache
+        if: always() && steps.download-gguf.outcome == 'success'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: gguf-cache
+          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
 
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh
@@ -771,15 +804,23 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Cache HF_HOME for ${{ env.GGUF_REPO }} (model + mmproj)
+      # Split restore + save so a transient restore-side failure does not
+      # kill the whole job. See the matching block in the tool-calling job
+      # for the full rationale (actions/cache#1621). This is the block that
+      # actually broke in run 25713577488: "Cache hit for: <key>" was
+      # logged, the step exited non-zero in ~0.3 s without extracting the
+      # 3.4 GiB archive, and steps 6-15 were skipped.
+      - name: Restore HF_HOME cache for ${{ env.GGUF_REPO }} (model + mmproj)
         id: cache-hf
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
         with:
           path: hf-cache
           key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v1
 
       - name: Prime HF_HOME with the GGUF + mmproj
-        if: steps.cache-hf.outputs.cache-hit != 'true'
+        id: prime-hf
+        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -789,6 +830,13 @@ jobs:
             hf download "$GGUF_REPO" "$GGUF_FILE"
           HF_HUB_ENABLE_HF_TRANSFER=1 \
             hf download "$GGUF_REPO" "$MMPROJ_FILE"
+
+      - name: Save HF_HOME cache for ${{ env.GGUF_REPO }} (model + mmproj)
+        if: always() && steps.prime-hf.outcome == 'success'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: hf-cache
+          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v1
 
       - name: Pre-install Windows tweaks (npm 11 + Defender exclusions)
         shell: pwsh


### PR DESCRIPTION
## Summary

- Replace single-step `actions/cache@v5.0.5` usage in all three jobs of `studio-windows-inference-smoke.yml` with the documented `actions/cache/restore` + `actions/cache/save` split.
- Put `continue-on-error: true` on the restore side so a transient cache-restore failure no longer kills the job; the Prime/Download step re-runs and the save step writes a fresh entry on the way out.
- Same SHA-pinned action (v5.0.5), same cache keys, same paths -- existing cache entries keep matching.

## Why

`actions/cache@v5` has a recurring flake where it logs `Cache hit for: <key>` and then exits non-zero in well under a second without actually extracting the archive (tracked in [actions/cache#1621](https://github.com/actions/cache/issues/1621) and [community discussion #163260](https://github.com/orgs/community/discussions/163260)). When that hits the `JSON, images` job, the cache step is marked failure, every downstream step is skipped (only the `if: always()` ones run), and the job never even tries to install Studio.

Example: run [25713577488](https://github.com/unslothai/unsloth/actions/runs/25713577488) / job [75498714730](https://github.com/unslothai/unsloth/actions/runs/25713577488/job/75498714730) on PR #5341. Total job duration was 23 s and the cache step took ~0.66 s end to end -- nowhere near long enough to extract the ~3.4 GiB GGUF + mmproj archive that the prior run on the same branch had successfully cached 30 min earlier.

## What changed

For each of the three cache blocks (lines 76, 379, 774 of the original file):

```yaml
- name: Restore <foo> cache
  id: cache-foo
  uses: actions/cache/restore@<v5.0.5 sha>
  continue-on-error: true
  with: { path: ..., key: ... }

- name: Prime/Download <foo>
  id: prime-foo
  if: steps.cache-foo.outputs.cache-hit != 'true' || steps.cache-foo.outcome != 'success'
  run: ...

- name: Save <foo> cache
  if: always() && steps.prime-foo.outcome == 'success'
  uses: actions/cache/save@<v5.0.5 sha>
  with: { path: ..., key: ... }
```

The `outcome != 'success'` clause is what catches the silent-restore-failure case. The save step's `prime-foo.outcome == 'success'` guard avoids re-uploading on the happy path (no-op) and avoids writing an empty / partial cache on a Prime failure.

## Test plan

- [ ] Re-run `studio-windows-inference-smoke.yml` on this branch and confirm all three jobs (Tool calling, OpenAI + Anthropic, JSON + images) reach `Install Studio` without the cache step short-circuiting.
- [ ] Verify a forced cache miss (bump the key suffix in a scratch branch) still works: restore is a miss, Prime downloads, Save writes the entry.
- [ ] Verify a real cache hit on a follow-up run is fast (~seconds, not full re-download).