### PR TITLE
Studio: cloud openai reasoning level toggle

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -523,7 +523,7 @@ class ExternalProviderClient:
         if reasoning_effort in ("low", "medium", "high"):
             body["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
         elif enable_thinking is False:
-            body["reasoning"] = {"effort": "low", "summary": "auto"}
+            body["reasoning"] = {"effort": "none"}
         elif enable_thinking is True:
             body["reasoning"] = {"effort": "medium", "summary": "auto"}
         if instructions_parts:

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -75,6 +75,8 @@ class ExternalProviderClient:
         max_tokens: Optional[int] = None,
         presence_penalty: float = 0.0,
         top_k: Optional[int] = None,
+        enable_thinking: Optional[bool] = None,
+        reasoning_effort: Optional[str] = None,
         stream: bool = True,
     ) -> AsyncGenerator[str, None]:
         """
@@ -102,7 +104,13 @@ class ExternalProviderClient:
         # the frontend stays endpoint-agnostic.
         if self.provider_type == "openai":
             async for line in self._stream_openai_responses(
-                messages, model, temperature, top_p, max_tokens
+                messages,
+                model,
+                temperature,
+                top_p,
+                max_tokens,
+                enable_thinking,
+                reasoning_effort,
             ):
                 yield line
             return
@@ -428,6 +436,8 @@ class ExternalProviderClient:
         temperature: float,
         top_p: float,
         max_tokens: Optional[int],
+        enable_thinking: Optional[bool],
+        reasoning_effort: Optional[str],
     ) -> AsyncGenerator[str, None]:
         """
         Call OpenAI's /v1/responses endpoint and translate its SSE stream back
@@ -498,6 +508,12 @@ class ExternalProviderClient:
             "input": input_items,
             "stream": True,
         }
+        if reasoning_effort in ("low", "medium", "high"):
+            body["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
+        elif enable_thinking is False:
+            body["reasoning"] = {"effort": "low", "summary": "auto"}
+        elif enable_thinking is True:
+            body["reasoning"] = {"effort": "medium", "summary": "auto"}
         if instructions_parts:
             body["instructions"] = "\n\n".join(instructions_parts)
         if max_tokens is not None:
@@ -533,6 +549,46 @@ class ExternalProviderClient:
                 # see comment there for the GeneratorExit / aclose ordering.
                 lines_gen = response.aiter_lines().__aiter__()
                 done_emitted = False
+                reasoning_open = False
+
+                def _extract_reasoning_text(payload: Any) -> str:
+                    if payload is None:
+                        return ""
+                    if isinstance(payload, str):
+                        return payload
+                    if isinstance(payload, list):
+                        out: list[str] = []
+                        for item in payload:
+                            text = _extract_reasoning_text(item)
+                            if text:
+                                out.append(text)
+                        return "".join(out)
+                    if isinstance(payload, dict):
+                        # OpenAI responses may carry reasoning summaries in
+                        # different envelope fields across event variants.
+                        for key in ("text", "delta", "content", "summary"):
+                            if key in payload:
+                                text = _extract_reasoning_text(payload.get(key))
+                                if text:
+                                    return text
+                        if payload.get("type") == "summary_text":
+                            return _extract_reasoning_text(payload.get("text"))
+                    return ""
+
+                def _chunk_with_text(text: str) -> str:
+                    chunk = {
+                        "id": completion_id,
+                        "object": "chat.completion.chunk",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": text},
+                                "finish_reason": None,
+                            }
+                        ],
+                    }
+                    return f"data: {_json.dumps(chunk)}"
+
                 try:
                     while True:
                         try:
@@ -563,20 +619,33 @@ class ExternalProviderClient:
                         if event_type == "response.output_text.delta":
                             delta_text = event.get("delta", "")
                             if delta_text:
-                                chunk = {
-                                    "id": completion_id,
-                                    "object": "chat.completion.chunk",
-                                    "choices": [
-                                        {
-                                            "index": 0,
-                                            "delta": {"content": delta_text},
-                                            "finish_reason": None,
-                                        }
-                                    ],
-                                }
-                                yield f"data: {_json.dumps(chunk)}"
+                                if reasoning_open:
+                                    yield _chunk_with_text("</think>")
+                                    reasoning_open = False
+                                yield _chunk_with_text(delta_text)
+
+                        elif event_type == "response.output_item.done":
+                            item = event.get("item", {})
+                            if isinstance(item, dict) and item.get("type") == "reasoning":
+                                summary_text = _extract_reasoning_text(item.get("summary"))
+                                if summary_text:
+                                    if not reasoning_open:
+                                        summary_text = f"<think>{summary_text}"
+                                        reasoning_open = True
+                                    yield _chunk_with_text(summary_text)
+
+                        elif isinstance(event_type, str) and "reasoning" in event_type:
+                            reasoning_delta = _extract_reasoning_text(event)
+                            if reasoning_delta:
+                                if not reasoning_open:
+                                    reasoning_delta = f"<think>{reasoning_delta}"
+                                    reasoning_open = True
+                                yield _chunk_with_text(reasoning_delta)
 
                         elif event_type == "response.completed":
+                            if reasoning_open:
+                                yield _chunk_with_text("</think>")
+                                reasoning_open = False
                             chunk = {
                                 "id": completion_id,
                                 "object": "chat.completion.chunk",
@@ -591,6 +660,9 @@ class ExternalProviderClient:
                             yield f"data: {_json.dumps(chunk)}"
 
                         elif event_type == "response.incomplete":
+                            if reasoning_open:
+                                yield _chunk_with_text("</think>")
+                                reasoning_open = False
                             chunk = {
                                 "id": completion_id,
                                 "object": "chat.completion.chunk",

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -626,8 +626,13 @@ class ExternalProviderClient:
 
                         elif event_type == "response.output_item.done":
                             item = event.get("item", {})
-                            if isinstance(item, dict) and item.get("type") == "reasoning":
-                                summary_text = _extract_reasoning_text(item.get("summary"))
+                            if (
+                                isinstance(item, dict)
+                                and item.get("type") == "reasoning"
+                            ):
+                                summary_text = _extract_reasoning_text(
+                                    item.get("summary")
+                                )
                                 if summary_text:
                                     if not reasoning_open:
                                         summary_text = f"<think>{summary_text}"

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -520,8 +520,17 @@ class ExternalProviderClient:
             "input": input_items,
             "stream": True,
         }
-        if reasoning_effort in ("low", "medium", "high"):
-            body["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
+        if reasoning_effort in (
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+        ):
+            body["reasoning"] = {"effort": reasoning_effort}
+            if reasoning_effort != "none":
+                body["reasoning"]["summary"] = "auto"
         elif enable_thinking is False:
             body["reasoning"] = {"effort": "none"}
         elif enable_thinking is True:
@@ -562,6 +571,7 @@ class ExternalProviderClient:
                 lines_gen = response.aiter_lines().__aiter__()
                 done_emitted = False
                 reasoning_open = False
+                reasoning_emitted = False
 
                 def _extract_reasoning_text(payload: Any) -> str:
                     if payload is None:
@@ -645,11 +655,12 @@ class ExternalProviderClient:
                                 summary_text = _extract_reasoning_text(
                                     item.get("summary")
                                 )
-                                if summary_text:
+                                if summary_text and not reasoning_emitted:
                                     if not reasoning_open:
                                         summary_text = f"<think>{summary_text}"
                                         reasoning_open = True
                                     yield _chunk_with_text(summary_text)
+                                    reasoning_emitted = True
 
                         elif isinstance(event_type, str) and "reasoning" in event_type:
                             reasoning_delta = _extract_reasoning_text(event)
@@ -658,6 +669,7 @@ class ExternalProviderClient:
                                     reasoning_delta = f"<think>{reasoning_delta}"
                                     reasoning_open = True
                                 yield _chunk_with_text(reasoning_delta)
+                                reasoning_emitted = True
 
                         elif event_type == "response.completed":
                             if reasoning_open:

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -542,9 +542,11 @@ class ChatCompletionRequest(BaseModel):
         None,
         description = "[x-unsloth] Enable/disable thinking/reasoning mode for supported models",
     )
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = Field(
+    reasoning_effort: Optional[
+        Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+    ] = Field(
         None,
-        description = "[x-unsloth] Reasoning effort level ('low'|'medium'|'high') for Harmony-style reasoning models (e.g. gpt-oss). Overrides enable_thinking when the active model uses reasoning_effort style.",
+        description = "[x-unsloth] Reasoning effort level ('none'|'minimal'|'low'|'medium'|'high'|'xhigh'). OpenAI `/v1/responses` accepts model-dependent subsets; local Harmony/gpt-oss templates support low|medium|high.",
     )
     preserve_thinking: Optional[bool] = Field(
         None,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1593,6 +1593,8 @@ async def _proxy_to_external_provider(
             max_tokens = payload.max_tokens,
             presence_penalty = payload.presence_penalty,
             top_k = payload.top_k,
+            enable_thinking = payload.enable_thinking,
+            reasoning_effort = payload.reasoning_effort,
             stream = payload.stream,
         )
         try:

--- a/studio/backend/tests/test_openai_responses_translation.py
+++ b/studio/backend/tests/test_openai_responses_translation.py
@@ -286,6 +286,37 @@ def test_responses_reasoning_effort_included_when_requested(monkeypatch):
     assert captured["body"]["reasoning"] == {"effort": "high", "summary": "auto"}
 
 
+def test_responses_enable_thinking_false_maps_to_reasoning_none(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = _responses_sse([{"type": "response.completed", "response": {}}]),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        async for _ in client._stream_openai_responses(
+            messages = [{"role": "user", "content": "hi"}],
+            model = "gpt-5.5",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = None,
+            enable_thinking = False,
+            reasoning_effort = None,
+        ):
+            pass
+        await client.close()
+
+    _drive(run())
+    assert captured["body"]["reasoning"] == {"effort": "none"}
+
+
 def test_responses_reasoning_summary_wrapped_in_think_tags(monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
         events = [

--- a/studio/backend/tests/test_openai_responses_translation.py
+++ b/studio/backend/tests/test_openai_responses_translation.py
@@ -286,6 +286,68 @@ def test_responses_reasoning_effort_included_when_requested(monkeypatch):
     assert captured["body"]["reasoning"] == {"effort": "high", "summary": "auto"}
 
 
+def test_responses_reasoning_effort_none_omits_summary(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = _responses_sse([{"type": "response.completed", "response": {}}]),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        async for _ in client._stream_openai_responses(
+            messages = [{"role": "user", "content": "hi"}],
+            model = "gpt-5.5",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = None,
+            enable_thinking = None,
+            reasoning_effort = "none",
+        ):
+            pass
+        await client.close()
+
+    _drive(run())
+    assert captured["body"]["reasoning"] == {"effort": "none"}
+
+
+def test_responses_reasoning_effort_xhigh_passthrough(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = _responses_sse([{"type": "response.completed", "response": {}}]),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        async for _ in client._stream_openai_responses(
+            messages = [{"role": "user", "content": "hi"}],
+            model = "gpt-5.5",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = None,
+            enable_thinking = None,
+            reasoning_effort = "xhigh",
+        ):
+            pass
+        await client.close()
+
+    _drive(run())
+    assert captured["body"]["reasoning"] == {"effort": "xhigh", "summary": "auto"}
+
+
 def test_responses_enable_thinking_false_maps_to_reasoning_none(monkeypatch):
     captured: dict = {}
 

--- a/studio/backend/tests/test_openai_responses_translation.py
+++ b/studio/backend/tests/test_openai_responses_translation.py
@@ -86,6 +86,8 @@ def test_responses_request_body_uses_input_and_instructions(monkeypatch):
             temperature = 0.5,
             top_p = 0.9,
             max_tokens = 512,
+            enable_thinking = None,
+            reasoning_effort = None,
         ):
             pass
         await client.close()
@@ -142,6 +144,8 @@ def test_responses_translates_image_parts(monkeypatch):
             temperature = 0.7,
             top_p = 0.95,
             max_tokens = None,
+            enable_thinking = None,
+            reasoning_effort = None,
         ):
             pass
         await client.close()
@@ -183,6 +187,8 @@ def test_responses_sse_translates_to_chat_completions_chunks(monkeypatch):
                 temperature = 0.7,
                 top_p = 0.95,
                 max_tokens = None,
+                enable_thinking = None,
+                reasoning_effort = None,
             )
         )
         await client.close()
@@ -232,6 +238,8 @@ def test_responses_response_incomplete_maps_to_length_finish_reason(monkeypatch)
                 temperature = 0.7,
                 top_p = 0.95,
                 max_tokens = 4,
+                enable_thinking = None,
+                reasoning_effort = None,
             )
         )
         await client.close()
@@ -245,3 +253,87 @@ def test_responses_response_incomplete_maps_to_length_finish_reason(monkeypatch)
         and line[len("data:") :].strip() not in ("", "[DONE]")
     ]
     assert "length" in finish_reasons
+
+
+def test_responses_reasoning_effort_included_when_requested(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = _responses_sse([{"type": "response.completed", "response": {}}]),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        async for _ in client._stream_openai_responses(
+            messages = [{"role": "user", "content": "hi"}],
+            model = "gpt-5.5",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = None,
+            enable_thinking = None,
+            reasoning_effort = "high",
+        ):
+            pass
+        await client.close()
+
+    _drive(run())
+    assert captured["body"]["reasoning"] == {"effort": "high", "summary": "auto"}
+
+
+def test_responses_reasoning_summary_wrapped_in_think_tags(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        events = [
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "plan"}],
+                },
+            },
+            {"type": "response.output_text.delta", "delta": "answer"},
+            {"type": "response.completed", "response": {}},
+        ]
+        return httpx.Response(
+            200,
+            content = _responses_sse(events),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        lines = await _collect(
+            client._stream_openai_responses(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "gpt-5.5",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = None,
+                enable_thinking = None,
+                reasoning_effort = None,
+            )
+        )
+        await client.close()
+        return lines
+
+    lines = _drive(run())
+    data_lines = [
+        line[len("data:") :].strip()
+        for line in lines
+        if line.startswith("data:")
+        and line[len("data:") :].strip() not in ("", "[DONE]")
+    ]
+    payloads = [json.loads(raw) for raw in data_lines]
+    combined = "".join(
+        payload["choices"][0]["delta"].get("content", "")
+        for payload in payloads
+        if payload["choices"][0]["delta"]
+    )
+    assert "<think>plan</think>answer" in combined

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -31,6 +31,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { sentAudioNames } from "@/features/chat/api/chat-adapter";
+import { parseExternalModelId } from "@/features/chat/external-providers";
+import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
+import { useExternalProvidersStore } from "@/features/chat/stores/external-providers-store";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
 import { isTauri } from "@/lib/api-base";
@@ -459,13 +462,38 @@ const ReasoningToggle: FC = () => {
   const modelLoaded = useChatRuntimeStore(
     (s) => !!s.params.checkpoint && !s.modelLoading,
   );
+  const checkpoint = useChatRuntimeStore((s) => s.params.checkpoint);
   const supportsReasoning = useChatRuntimeStore((s) => s.supportsReasoning);
   const reasoningEnabled = useChatRuntimeStore((s) => s.reasoningEnabled);
   const setReasoningEnabled = useChatRuntimeStore((s) => s.setReasoningEnabled);
   const reasoningStyle = useChatRuntimeStore((s) => s.reasoningStyle);
   const reasoningEffort = useChatRuntimeStore((s) => s.reasoningEffort);
+  const supportsReasoningOff = useChatRuntimeStore((s) => s.supportsReasoningOff);
+  const reasoningEffortLevels = useChatRuntimeStore((s) => s.reasoningEffortLevels);
   const setReasoningEffort = useChatRuntimeStore((s) => s.setReasoningEffort);
+  const externalProviders = useExternalProvidersStore((s) => s.providers);
+  const externalSelection = parseExternalModelId(checkpoint);
+  const externalReasoningCaps =
+    externalSelection != null
+      ? getExternalReasoningCapabilities(
+          externalProviders.find((p) => p.id === externalSelection.providerId)
+            ?.providerType,
+          externalSelection.modelId,
+        )
+      : null;
+  const effectiveSupportsReasoningOff =
+    externalReasoningCaps?.supportsReasoningOff ?? supportsReasoningOff;
+  const effectiveReasoningEffortLevels =
+    externalReasoningCaps?.reasoningEffortLevels ?? reasoningEffortLevels;
+  const effectiveReasoningEnabled =
+    reasoningStyle === "reasoning_effort" && !effectiveSupportsReasoningOff
+      ? true
+      : reasoningEnabled;
   const disabled = !(modelLoaded && supportsReasoning);
+  const effortLabel =
+    reasoningEffort === "xhigh"
+      ? "Extra High"
+      : reasoningEffort.charAt(0).toUpperCase() + reasoningEffort.slice(1);
 
   if (reasoningStyle === "reasoning_effort") {
     return (
@@ -482,22 +510,43 @@ const ReasoningToggle: FC = () => {
             )}
             aria-label={`Reasoning effort: ${reasoningEffort}`}
           >
-            <LightbulbIcon className="size-3.5" />
+            {effectiveReasoningEnabled ? (
+              <LightbulbIcon className="size-3.5" />
+            ) : (
+              <LightbulbOffIcon className="size-3.5" />
+            )}
             <span>
-              Think:{" "}
-              {reasoningEffort.charAt(0).toUpperCase() +
-                reasoningEffort.slice(1)}
+              Think: {effectiveReasoningEnabled ? effortLabel : "None"}
             </span>
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {(["low", "medium", "high"] as const).map((level) => (
+          {effectiveSupportsReasoningOff && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setReasoningEnabled(false);
+                applyQwenThinkingParams(false);
+              }}
+            >
+              None
+              {!effectiveReasoningEnabled ? " \u2713" : ""}
+            </DropdownMenuItem>
+          )}
+          {effectiveReasoningEffortLevels
+            .filter((level) => level !== "none")
+            .map((level) => (
             <DropdownMenuItem
               key={level}
-              onSelect={() => setReasoningEffort(level)}
+              onSelect={() => {
+                setReasoningEffort(level);
+                setReasoningEnabled(true);
+                applyQwenThinkingParams(true);
+              }}
             >
-              {level.charAt(0).toUpperCase() + level.slice(1)}
-              {reasoningEffort === level ? " \u2713" : ""}
+              {level === "xhigh"
+                ? "Extra High"
+                : level.charAt(0).toUpperCase() + level.slice(1)}
+              {effectiveReasoningEnabled && reasoningEffort === level ? " \u2713" : ""}
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -917,7 +917,23 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                 supportsReasoning,
                 reasoningStyle,
                 reasoningAlwaysOn: false,
+                supportsReasoningOff: false,
+                reasoningEffortLevels: ["low", "medium", "high"] as const,
               };
+        const selectedExternalEffort = externalReasoningCaps.reasoningEffortLevels.includes(
+          reasoningEffort,
+        )
+          ? reasoningEffort
+          : externalReasoningCaps.reasoningEffortLevels[0] ?? "low";
+        const localReasoningEffort =
+          reasoningEffort === "low" || reasoningEffort === "medium" || reasoningEffort === "high"
+            ? reasoningEffort
+            : "low";
+        const externalReasoningEnabled =
+          externalReasoningCaps.reasoningStyle === "reasoning_effort" &&
+          !externalReasoningCaps.supportsReasoningOff
+            ? true
+            : reasoningEnabled;
         const buildRequestPayload = async (forceRefreshPublicKey = false) => {
           if (externalSelection && externalProvider) {
             return {
@@ -954,9 +970,14 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               provider_base_url: externalProvider.baseUrl || null,
               ...(externalReasoningCaps.supportsReasoning
                 ? externalReasoningCaps.reasoningStyle === "reasoning_effort"
-                  ? reasoningEnabled
-                    ? { reasoning_effort: reasoningEffort }
-                    : { enable_thinking: false }
+                  ? externalReasoningEnabled
+                    ? { reasoning_effort: selectedExternalEffort }
+                    : externalReasoningCaps.supportsReasoningOff
+                      ? { reasoning_effort: "none" }
+                      : {
+                          reasoning_effort:
+                            externalReasoningCaps.reasoningEffortLevels[0] ?? "low",
+                        }
                   : { enable_thinking: reasoningEnabled }
                 : {}),
             };
@@ -981,8 +1002,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             ...(supportsReasoning
               ? reasoningStyle === "reasoning_effort"
                 ? reasoningEnabled
-                  ? { reasoning_effort: reasoningEffort }
-                  : { enable_thinking: false }
+                  ? { reasoning_effort: localReasoningEffort }
+                  : {}
                 : { enable_thinking: reasoningEnabled }
               : {}),
             ...(supportsPreserveThinking ? { preserve_thinking: preserveThinking } : {}),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -20,7 +20,10 @@ import {
   isProviderKeyRotationError,
 } from "./providers-api";
 import { db } from "../db";
-import type { OpenAIMessageContent } from "../types/api";
+import type {
+  OpenAIChatCompletionsRequest,
+  OpenAIMessageContent,
+} from "../types/api";
 import {
   getExternalProviderApiKey,
   loadExternalProviders,
@@ -907,7 +910,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const externalCapabilities = getProviderCapabilities(
           externalProvider?.providerType,
         );
-        const externalReasoningCaps =
+        const externalReasoningCaps: ReturnType<
+          typeof getExternalReasoningCapabilities
+        > =
           externalSelection && externalProvider
             ? getExternalReasoningCapabilities(
                 externalProvider.providerType,
@@ -920,11 +925,17 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                 supportsReasoningOff: false,
                 reasoningEffortLevels: ["low", "medium", "high"] as const,
               };
-        const selectedExternalEffort = externalReasoningCaps.reasoningEffortLevels.includes(
-          reasoningEffort,
-        )
-          ? reasoningEffort
-          : externalReasoningCaps.reasoningEffortLevels[0] ?? "low";
+        type RequestReasoningEffort = Extract<
+          NonNullable<OpenAIChatCompletionsRequest["reasoning_effort"]>,
+          "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+        >;
+        const fallbackExternalEffort =
+          (externalReasoningCaps.reasoningEffortLevels[0] ??
+            "low") as RequestReasoningEffort;
+        const selectedExternalEffort: RequestReasoningEffort =
+          externalReasoningCaps.reasoningEffortLevels.includes(reasoningEffort)
+            ? reasoningEffort
+            : fallbackExternalEffort;
         const localReasoningEffort =
           reasoningEffort === "low" || reasoningEffort === "medium" || reasoningEffort === "high"
             ? reasoningEffort
@@ -934,7 +945,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           !externalReasoningCaps.supportsReasoningOff
             ? true
             : reasoningEnabled;
-        const buildRequestPayload = async (forceRefreshPublicKey = false) => {
+        const buildRequestPayload = async (
+          forceRefreshPublicKey = false,
+        ): Promise<OpenAIChatCompletionsRequest> => {
           if (externalSelection && externalProvider) {
             return {
               model: externalSelection.modelId,
@@ -975,8 +988,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                     : externalReasoningCaps.supportsReasoningOff
                       ? { reasoning_effort: "none" }
                       : {
-                          reasoning_effort:
-                            externalReasoningCaps.reasoningEffortLevels[0] ?? "low",
+                          reasoning_effort: fallbackExternalEffort,
                         }
                   : { enable_thinking: reasoningEnabled }
                 : {}),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -28,6 +28,7 @@ import {
 } from "../external-providers";
 import {
   EXTERNAL_MAX_OUTPUT_TOKENS,
+  getExternalReasoningCapabilities,
   getProviderCapabilities,
 } from "../provider-capabilities";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
@@ -906,6 +907,17 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const externalCapabilities = getProviderCapabilities(
           externalProvider?.providerType,
         );
+        const externalReasoningCaps =
+          externalSelection && externalProvider
+            ? getExternalReasoningCapabilities(
+                externalProvider.providerType,
+                externalSelection.modelId,
+              )
+            : {
+                supportsReasoning,
+                reasoningStyle,
+                reasoningAlwaysOn: false,
+              };
         const buildRequestPayload = async (forceRefreshPublicKey = false) => {
           if (externalSelection && externalProvider) {
             return {
@@ -940,6 +952,13 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                 forceRefreshPublicKey,
               ),
               provider_base_url: externalProvider.baseUrl || null,
+              ...(externalReasoningCaps.supportsReasoning
+                ? externalReasoningCaps.reasoningStyle === "reasoning_effort"
+                  ? reasoningEnabled
+                    ? { reasoning_effort: reasoningEffort }
+                    : { enable_thinking: false }
+                  : { enable_thinking: reasoningEnabled }
+                : {}),
             };
           }
 
@@ -961,7 +980,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             ...(useAdapter === undefined ? {} : { use_adapter: useAdapter }),
             ...(supportsReasoning
               ? reasoningStyle === "reasoning_effort"
-                ? { reasoning_effort: reasoningEffort }
+                ? reasoningEnabled
+                  ? { reasoning_effort: reasoningEffort }
+                  : { enable_thinking: false }
                 : { enable_thinking: reasoningEnabled }
               : {}),
             ...(supportsPreserveThinking ? { preserve_thinking: preserveThinking } : {}),

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -656,7 +656,7 @@ export function ChatPage(): ReactElement {
         ? reasoningCaps.supportsReasoningOff
           ? state.reasoningEnabled
           : true
-        : false,
+        : state.reasoningEnabled,
       supportsPreserveThinking: false,
     });
   }, [externalProviders, inferenceParams.checkpoint]);
@@ -788,7 +788,7 @@ export function ChatPage(): ReactElement {
             ? reasoningCaps.supportsReasoningOff
               ? store.reasoningEnabled
               : true
-            : false,
+            : store.reasoningEnabled,
           supportsPreserveThinking: false,
         });
         return;

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -640,12 +640,23 @@ export function ChatPage(): ReactElement {
       provider?.providerType,
       selection.modelId,
     );
+    const state = useChatRuntimeStore.getState();
+    const preferredEffort = state.reasoningEffort;
+    const effortLevels = reasoningCaps.reasoningEffortLevels;
+    const clampedEffort = effortLevels.includes(preferredEffort)
+      ? preferredEffort
+      : effortLevels[0] ?? "low";
     useChatRuntimeStore.setState({
       supportsReasoning: reasoningCaps.supportsReasoning,
       reasoningAlwaysOn: reasoningCaps.reasoningAlwaysOn,
       reasoningStyle: reasoningCaps.reasoningStyle,
+      supportsReasoningOff: reasoningCaps.supportsReasoningOff,
+      reasoningEffortLevels: effortLevels,
+      reasoningEffort: clampedEffort,
       reasoningEnabled: reasoningCaps.supportsReasoning
-        ? useChatRuntimeStore.getState().reasoningEnabled
+        ? reasoningCaps.supportsReasoningOff
+          ? state.reasoningEnabled
+          : true
         : false,
       supportsPreserveThinking: false,
     });
@@ -758,6 +769,11 @@ export function ChatPage(): ReactElement {
           selectedProvider?.providerType,
           selectedExternal?.modelId,
         );
+        const preferredEffort = store.reasoningEffort;
+        const effortLevels = reasoningCaps.reasoningEffortLevels;
+        const clampedEffort = effortLevels.includes(preferredEffort)
+          ? preferredEffort
+          : effortLevels[0] ?? "low";
         setInferenceParams({
           ...store.params,
           checkpoint: value,
@@ -766,8 +782,13 @@ export function ChatPage(): ReactElement {
           supportsReasoning: reasoningCaps.supportsReasoning,
           reasoningAlwaysOn: reasoningCaps.reasoningAlwaysOn,
           reasoningStyle: reasoningCaps.reasoningStyle,
+          supportsReasoningOff: reasoningCaps.supportsReasoningOff,
+          reasoningEffortLevels: effortLevels,
+          reasoningEffort: clampedEffort,
           reasoningEnabled: reasoningCaps.supportsReasoning
-            ? useChatRuntimeStore.getState().reasoningEnabled
+            ? reasoningCaps.supportsReasoningOff
+              ? store.reasoningEnabled
+              : true
             : false,
           supportsPreserveThinking: false,
         });

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -47,7 +47,10 @@ import {
   isExternalModelId,
   parseExternalModelId,
 } from "./external-providers";
-import { getProviderCapabilities } from "./provider-capabilities";
+import {
+  getExternalReasoningCapabilities,
+  getProviderCapabilities,
+} from "./provider-capabilities";
 import { useChatModelRuntime } from "./hooks/use-chat-model-runtime";
 import {
   clearTrainingCompareHandoff,
@@ -629,6 +632,24 @@ export function ChatPage(): ReactElement {
     );
     return getProviderCapabilities(provider?.providerType);
   }, [externalProviders, inferenceParams.checkpoint]);
+  useEffect(() => {
+    const selection = parseExternalModelId(inferenceParams.checkpoint);
+    if (!selection) return;
+    const provider = externalProviders.find((p) => p.id === selection.providerId);
+    const reasoningCaps = getExternalReasoningCapabilities(
+      provider?.providerType,
+      selection.modelId,
+    );
+    useChatRuntimeStore.setState({
+      supportsReasoning: reasoningCaps.supportsReasoning,
+      reasoningAlwaysOn: reasoningCaps.reasoningAlwaysOn,
+      reasoningStyle: reasoningCaps.reasoningStyle,
+      reasoningEnabled: reasoningCaps.supportsReasoning
+        ? useChatRuntimeStore.getState().reasoningEnabled
+        : false,
+      supportsPreserveThinking: false,
+    });
+  }, [externalProviders, inferenceParams.checkpoint]);
   const canCompare = useMemo(() => {
     return Boolean(inferenceParams.checkpoint) && !isExternalModel;
   }, [inferenceParams.checkpoint, isExternalModel]);
@@ -729,9 +750,26 @@ export function ChatPage(): ReactElement {
       )
         return;
       if (meta?.source === "external" || isExternalModelId(value)) {
+        const selectedExternal = parseExternalModelId(value);
+        const selectedProvider = selectedExternal
+          ? externalProviders.find((p) => p.id === selectedExternal.providerId)
+          : null;
+        const reasoningCaps = getExternalReasoningCapabilities(
+          selectedProvider?.providerType,
+          selectedExternal?.modelId,
+        );
         setInferenceParams({
           ...store.params,
           checkpoint: value,
+        });
+        useChatRuntimeStore.setState({
+          supportsReasoning: reasoningCaps.supportsReasoning,
+          reasoningAlwaysOn: reasoningCaps.reasoningAlwaysOn,
+          reasoningStyle: reasoningCaps.reasoningStyle,
+          reasoningEnabled: reasoningCaps.supportsReasoning
+            ? useChatRuntimeStore.getState().reasoningEnabled
+            : false,
+          supportsPreserveThinking: false,
         });
         return;
       }
@@ -771,7 +809,14 @@ export function ChatPage(): ReactElement {
         });
       })();
     },
-    [activeThreadId, modelsFromStore, selectModel, setInferenceParams, view],
+    [
+      activeThreadId,
+      externalProviders,
+      modelsFromStore,
+      selectModel,
+      setInferenceParams,
+      view,
+    ],
   );
   const handleEject = useCallback(() => {
     void ejectModel();

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -31,6 +31,7 @@ import {
 import {
   isMultimodalResponse,
 } from "../types/api";
+import { isExternalModelId } from "../external-providers";
 import type {
   ChatLoraSummary,
   ChatModelSummary,
@@ -221,7 +222,9 @@ export function useChatModelRuntime() {
       setModels(listRes.models.map(toChatModelSummary));
       setLoras(lorasRes.loras.map(toLoraSummary));
 
-      if (statusRes.active_model) {
+      const selectedCheckpoint = useChatRuntimeStore.getState().params.checkpoint;
+      const isExternalSelectionActive = isExternalModelId(selectedCheckpoint);
+      if (statusRes.active_model && !isExternalSelectionActive) {
         setCheckpoint(statusRes.active_model, statusRes.gguf_variant);
 
         // Apply inference defaults on reconnect (page refresh with model already loaded)
@@ -241,6 +244,10 @@ export function useChatModelRuntime() {
         const supportsReasoning = statusRes.supports_reasoning ?? false;
         const reasoningAlwaysOn = statusRes.reasoning_always_on ?? false;
         const reasoningStyle = statusRes.reasoning_style ?? "enable_thinking";
+        const reasoningEffortLevels =
+          reasoningStyle === "reasoning_effort"
+            ? (["low", "medium", "high"] as const)
+            : (["low", "medium", "high"] as const);
         const supportsPreserveThinking = statusRes.supports_preserve_thinking ?? false;
         const supportsTools = statusRes.supports_tools ?? false;
         const currentGgufContextLength = statusRes.is_gguf
@@ -262,6 +269,9 @@ export function useChatModelRuntime() {
         // Otherwise we'd clobber the values the load path just applied and
         // the UI would appear to revert the user's changes.
         const prevState = useChatRuntimeStore.getState();
+        const clampedReasoningEffort = reasoningEffortLevels.includes(prevState.reasoningEffort)
+          ? prevState.reasoningEffort
+          : "low";
         const nextDefaultChatTemplate =
           statusRes.chat_template === undefined
             ? prevState.defaultChatTemplate
@@ -270,6 +280,9 @@ export function useChatModelRuntime() {
           supportsReasoning,
           reasoningAlwaysOn,
           reasoningStyle,
+          supportsReasoningOff: reasoningStyle !== "reasoning_effort",
+          reasoningEffortLevels,
+          reasoningEffort: clampedReasoningEffort,
           supportsPreserveThinking,
           supportsTools,
           // Reset per-turn reasoning flag so models that do not support
@@ -313,7 +326,7 @@ export function useChatModelRuntime() {
           }
           useChatRuntimeStore.getState().setReasoningEnabled(reasoningDefault);
         }
-      } else {
+      } else if (!statusRes.active_model && !isExternalSelectionActive) {
         useChatRuntimeStore.setState({
           modelRequiresTrustRemoteCode: false,
           loadedIsMultimodal: false,
@@ -569,6 +582,17 @@ export function useChatModelRuntime() {
             // context state and display the backend-reported effective context.
             const keepCustomCtx = null;
             const reasoningAlwaysOn = loadResponse.reasoning_always_on ?? false;
+            const reasoningStyle = loadResponse.reasoning_style ?? "enable_thinking";
+            const reasoningEffortLevels =
+              reasoningStyle === "reasoning_effort"
+                ? (["low", "medium", "high"] as const)
+                : (["low", "medium", "high"] as const);
+            const existingReasoningEffort = useChatRuntimeStore.getState().reasoningEffort;
+            const clampedReasoningEffort = reasoningEffortLevels.includes(
+              existingReasoningEffort,
+            )
+              ? existingReasoningEffort
+              : "low";
             const ggufMaxContextLength = reportedMaxCtx;
             useChatRuntimeStore.setState({
               ggufContextLength: nativeCtx,
@@ -579,7 +603,10 @@ export function useChatModelRuntime() {
               supportsReasoning: loadResponse.supports_reasoning ?? false,
               reasoningAlwaysOn,
               reasoningEnabled: reasoningAlwaysOn ? true : reasoningDefault,
-              reasoningStyle: loadResponse.reasoning_style ?? "enable_thinking",
+              reasoningStyle,
+              supportsReasoningOff: reasoningStyle !== "reasoning_effort",
+              reasoningEffortLevels,
+              reasoningEffort: clampedReasoningEffort,
               supportsPreserveThinking: loadResponse.supports_preserve_thinking ?? false,
               supportsTools: loadResponse.supports_tools ?? false,
               toolsEnabled: loadResponse.supports_tools ?? false,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -23,7 +23,10 @@ import {
   validateModel,
 } from "../api/chat-api";
 import { formatEta, formatRate } from "../utils/format-transfer";
-import { useChatRuntimeStore } from "../stores/chat-runtime-store";
+import {
+  type ReasoningEffort,
+  useChatRuntimeStore,
+} from "../stores/chat-runtime-store";
 import {
   mergeBackendRecommendedInference,
   resolveLoadMaxSeqLength,
@@ -142,6 +145,15 @@ function normalizeSpeculativeType(v: string | null | undefined): string | null {
   if (v == null) return null;
   if (v === "default" || v === "off") return v;
   return "default";
+}
+
+type LocalReasoningEffort = Extract<ReasoningEffort, "low" | "medium" | "high">;
+
+function clampLocalReasoningEffort(value: ReasoningEffort): LocalReasoningEffort {
+  if (value === "low" || value === "medium" || value === "high") {
+    return value;
+  }
+  return "low";
 }
 
 export function useChatModelRuntime() {
@@ -269,9 +281,9 @@ export function useChatModelRuntime() {
         // Otherwise we'd clobber the values the load path just applied and
         // the UI would appear to revert the user's changes.
         const prevState = useChatRuntimeStore.getState();
-        const clampedReasoningEffort = reasoningEffortLevels.includes(prevState.reasoningEffort)
-          ? prevState.reasoningEffort
-          : "low";
+        const clampedReasoningEffort = clampLocalReasoningEffort(
+          prevState.reasoningEffort,
+        );
         const nextDefaultChatTemplate =
           statusRes.chat_template === undefined
             ? prevState.defaultChatTemplate
@@ -588,11 +600,9 @@ export function useChatModelRuntime() {
                 ? (["low", "medium", "high"] as const)
                 : (["low", "medium", "high"] as const);
             const existingReasoningEffort = useChatRuntimeStore.getState().reasoningEffort;
-            const clampedReasoningEffort = reasoningEffortLevels.includes(
+            const clampedReasoningEffort = clampLocalReasoningEffort(
               existingReasoningEffort,
-            )
-              ? existingReasoningEffort
-              : "low";
+            );
             const ggufMaxContextLength = reportedMaxCtx;
             useChatRuntimeStore.setState({
               ggufContextLength: nativeCtx,

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -31,6 +31,12 @@ export interface ProviderCapabilities {
   presencePenalty: boolean;
 }
 
+export type ExternalReasoningCapabilities = {
+  supportsReasoning: boolean;
+  reasoningStyle: "enable_thinking" | "reasoning_effort";
+  reasoningAlwaysOn: boolean;
+};
+
 /**
  * Output-token cap for any external provider request. Picked to stay below the
  * tightest declared limit across the providers we ship (Anthropic Claude Opus
@@ -125,4 +131,85 @@ export function getProviderCapabilities(
 ): ProviderCapabilities | null {
   if (!providerType) return null;
   return PROVIDER_CAPABILITIES[providerType] ?? DEFAULT_EXTERNAL_CAPABILITIES;
+}
+
+function isOpenAIReasoningEffortModel(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  return (
+    normalized.startsWith("o3") ||
+    normalized.startsWith("gpt-5.4") ||
+    normalized.startsWith("gpt-5.5")
+  );
+}
+
+/**
+ * Resolve whether an external model should expose the chat "Think" control.
+ *
+ * OpenAI model families are not uniform:
+ * - `o3*`, `gpt-5.4*`, and `gpt-5.5*` support `reasoning.effort`
+ * - `gpt-5.3-codex` supports a boolean thinking toggle
+ * - other OpenAI families in our picker should not receive reasoning params
+ */
+export function getExternalReasoningCapabilities(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): ExternalReasoningCapabilities {
+  const normalizedModel = modelId?.trim().toLowerCase() ?? "";
+  const normalizedProvider = providerType?.trim().toLowerCase() ?? "";
+  if (!normalizedModel) {
+    return {
+      supportsReasoning: false,
+      reasoningStyle: "enable_thinking",
+      reasoningAlwaysOn: false,
+    };
+  }
+
+  // OpenRouter ids are namespaced (e.g. "openai/gpt-5.5").
+  const modelForMatching =
+    normalizedProvider === "openrouter" && normalizedModel.includes("/")
+      ? normalizedModel.split("/").at(-1) ?? normalizedModel
+      : normalizedModel;
+
+  const isOpenAICompatProvider =
+    normalizedProvider === "openai" ||
+    normalizedProvider === "custom" ||
+    normalizedProvider === "openrouter";
+  if (!isOpenAICompatProvider) {
+    return {
+      supportsReasoning: false,
+      reasoningStyle: "enable_thinking",
+      reasoningAlwaysOn: false,
+    };
+  }
+
+  if (modelForMatching.startsWith("gpt-5.3-codex")) {
+    return {
+      supportsReasoning: true,
+      reasoningStyle: "enable_thinking",
+      reasoningAlwaysOn: false,
+    };
+  }
+
+  // Source-of-truth: gpt-5.3-chat-latest does not expose reasoning controls.
+  if (modelForMatching.startsWith("gpt-5.3-chat-latest")) {
+    return {
+      supportsReasoning: false,
+      reasoningStyle: "enable_thinking",
+      reasoningAlwaysOn: false,
+    };
+  }
+
+  if (isOpenAIReasoningEffortModel(modelForMatching)) {
+    return {
+      supportsReasoning: true,
+      reasoningStyle: "reasoning_effort",
+      reasoningAlwaysOn: false,
+    };
+  }
+
+  return {
+    supportsReasoning: false,
+    reasoningStyle: "enable_thinking",
+    reasoningAlwaysOn: false,
+  };
 }

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -35,6 +35,15 @@ export type ExternalReasoningCapabilities = {
   supportsReasoning: boolean;
   reasoningStyle: "enable_thinking" | "reasoning_effort";
   reasoningAlwaysOn: boolean;
+  supportsReasoningOff: boolean;
+  reasoningEffortLevels: readonly (
+    | "none"
+    | "minimal"
+    | "low"
+    | "medium"
+    | "high"
+    | "xhigh"
+  )[];
 };
 
 /**
@@ -146,13 +155,53 @@ export function getProviderCapabilities(
   return PROVIDER_CAPABILITIES[providerType] ?? DEFAULT_EXTERNAL_CAPABILITIES;
 }
 
-function isOpenAIReasoningEffortModel(modelId: string): boolean {
+const DEFAULT_EFFORT_LEVELS = ["low", "medium", "high"] as const;
+
+function resolveOpenAIReasoningEffortCapabilities(modelId: string): {
+  supportsReasoning: boolean;
+  supportsReasoningOff: boolean;
+  reasoningEffortLevels: ExternalReasoningCapabilities["reasoningEffortLevels"];
+} {
   const normalized = modelId.trim().toLowerCase();
-  return (
-    normalized.startsWith("o3") ||
-    normalized.startsWith("gpt-5.4") ||
-    normalized.startsWith("gpt-5.5")
-  );
+  if (normalized.startsWith("gpt-5.5") || normalized.startsWith("gpt-5.4")) {
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: true,
+      reasoningEffortLevels: ["none", "low", "medium", "high", "xhigh"],
+    };
+  }
+  if (normalized.startsWith("gpt-5.3-codex")) {
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: false,
+      reasoningEffortLevels: ["low", "medium", "high", "xhigh"],
+    };
+  }
+  if (
+    normalized === "gpt-5" ||
+    normalized.startsWith("gpt-5.1") ||
+    normalized.startsWith("gpt-5.2") ||
+    normalized.startsWith("gpt-5.3")
+  ) {
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: false,
+      reasoningEffortLevels: ["minimal", "low", "medium", "high"],
+    };
+  }
+  if (normalized.startsWith("o3")) {
+    // Keep o3 conservative until OpenAI publishes a per-model effort table.
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: false,
+      reasoningEffortLevels: DEFAULT_EFFORT_LEVELS,
+    };
+  }
+  return {
+    supportsReasoning: false,
+    supportsReasoningOff: false,
+    reasoningEffortLevels: DEFAULT_EFFORT_LEVELS,
+  };
 }
 
 /**
@@ -174,6 +223,8 @@ export function getExternalReasoningCapabilities(
       supportsReasoning: false,
       reasoningStyle: "enable_thinking",
       reasoningAlwaysOn: false,
+      supportsReasoningOff: false,
+      reasoningEffortLevels: DEFAULT_EFFORT_LEVELS,
     };
   }
 
@@ -183,23 +234,14 @@ export function getExternalReasoningCapabilities(
       ? normalizedModel.split("/").at(-1) ?? normalizedModel
       : normalizedModel;
 
-  const isOpenAICompatProvider =
-    normalizedProvider === "openai" ||
-    normalizedProvider === "custom" ||
-    normalizedProvider === "openrouter";
-  if (!isOpenAICompatProvider) {
+  const isOpenAIProvider = normalizedProvider === "openai";
+  if (!isOpenAIProvider) {
     return {
       supportsReasoning: false,
       reasoningStyle: "enable_thinking",
       reasoningAlwaysOn: false,
-    };
-  }
-
-  if (modelForMatching.startsWith("gpt-5.3-codex")) {
-    return {
-      supportsReasoning: true,
-      reasoningStyle: "enable_thinking",
-      reasoningAlwaysOn: false,
+      supportsReasoningOff: false,
+      reasoningEffortLevels: DEFAULT_EFFORT_LEVELS,
     };
   }
 
@@ -209,14 +251,19 @@ export function getExternalReasoningCapabilities(
       supportsReasoning: false,
       reasoningStyle: "enable_thinking",
       reasoningAlwaysOn: false,
+      supportsReasoningOff: false,
+      reasoningEffortLevels: DEFAULT_EFFORT_LEVELS,
     };
   }
 
-  if (isOpenAIReasoningEffortModel(modelForMatching)) {
+  const openAICaps = resolveOpenAIReasoningEffortCapabilities(modelForMatching);
+  if (openAICaps.supportsReasoning) {
     return {
       supportsReasoning: true,
       reasoningStyle: "reasoning_effort",
       reasoningAlwaysOn: false,
+      supportsReasoningOff: openAICaps.supportsReasoningOff,
+      reasoningEffortLevels: openAICaps.reasoningEffortLevels,
     };
   }
 
@@ -224,5 +271,7 @@ export function getExternalReasoningCapabilities(
     supportsReasoning: false,
     reasoningStyle: "enable_thinking",
     reasoningAlwaysOn: false,
+    supportsReasoningOff: false,
+    reasoningEffortLevels: DEFAULT_EFFORT_LEVELS,
   };
 }

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -272,6 +272,7 @@ export function SharedComposer({
   const codeToolsEnabled = useChatRuntimeStore((s) => s.codeToolsEnabled);
   const setCodeToolsEnabled = useChatRuntimeStore((s) => s.setCodeToolsEnabled);
   const reasoningDisabled = !modelLoaded || !supportsReasoning;
+  const showReasoningControl = supportsReasoning || reasoningAlwaysOn;
   const toolsDisabled = !modelLoaded || !supportsTools;
   const setPendingAudioStore = useChatRuntimeStore((s) => s.setPendingAudio);
   const clearPendingAudioStore = useChatRuntimeStore((s) => s.clearPendingAudio);
@@ -625,7 +626,8 @@ export function SharedComposer({
               </TooltipIconButton>
             </>
           )}
-          {reasoningStyle === "reasoning_effort" ? (
+          {showReasoningControl ? (
+            reasoningStyle === "reasoning_effort" ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild={true}>
                 <button
@@ -639,22 +641,41 @@ export function SharedComposer({
                   )}
                   aria-label={`Reasoning effort: ${reasoningEffort}`}
                 >
-                  <LightbulbIcon className="size-3.5" />
+                  {reasoningEnabled ? (
+                    <LightbulbIcon className="size-3.5" />
+                  ) : (
+                    <LightbulbOffIcon className="size-3.5" />
+                  )}
                   <span>
                     Think:{" "}
-                    {reasoningEffort.charAt(0).toUpperCase() +
-                      reasoningEffort.slice(1)}
+                    {reasoningEnabled
+                      ? reasoningEffort.charAt(0).toUpperCase() +
+                        reasoningEffort.slice(1)
+                      : "Off"}
                   </span>
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onSelect={() => {
+                    setReasoningEnabled(false);
+                    applyQwenThinkingParams(false);
+                  }}
+                >
+                  Off
+                  {!reasoningEnabled ? " \u2713" : ""}
+                </DropdownMenuItem>
                 {(["low", "medium", "high"] as const).map((level) => (
                   <DropdownMenuItem
                     key={level}
-                    onSelect={() => setReasoningEffort(level)}
+                    onSelect={() => {
+                      setReasoningEffort(level);
+                      setReasoningEnabled(true);
+                      applyQwenThinkingParams(true);
+                    }}
                   >
                     {level.charAt(0).toUpperCase() + level.slice(1)}
-                    {reasoningEffort === level ? " \u2713" : ""}
+                    {reasoningEnabled && reasoningEffort === level ? " \u2713" : ""}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>
@@ -686,7 +707,8 @@ export function SharedComposer({
               )}
               <span>Think</span>
             </button>
-          )}
+            )
+          ) : null}
           {supportsPreserveThinking && (
             <button
               type="button"

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -18,7 +18,13 @@ import { useAui } from "@assistant-ui/react";
 import { ArrowUpIcon, GlobeIcon, HeadphonesIcon, LightbulbIcon, LightbulbOffIcon, MicIcon, PlusIcon, SquareIcon, XIcon } from "lucide-react";
 import { toast } from "sonner";
 import { loadModel, validateModel } from "./api/chat-api";
-import { useChatRuntimeStore } from "./stores/chat-runtime-store";
+import { parseExternalModelId } from "./external-providers";
+import { useExternalProvidersStore } from "./stores/external-providers-store";
+import {
+  type ReasoningEffort,
+  useChatRuntimeStore,
+} from "./stores/chat-runtime-store";
+import { getExternalReasoningCapabilities } from "./provider-capabilities";
 import {
   type CompositionEvent,
   type KeyboardEvent,
@@ -64,6 +70,18 @@ function fileToBase64DataURL(file: File): Promise<string> {
     reader.onerror = () => reject(new Error("Failed to read image file"));
     reader.readAsDataURL(file);
   });
+}
+
+function formatReasoningEffortLabel(level: ReasoningEffort): string {
+  if (level === "xhigh") return "Extra High";
+  return level.charAt(0).toUpperCase() + level.slice(1);
+}
+
+function formatReasoningDisabledLabel(
+  supportsReasoningOff: boolean,
+  isExternalOpenAIReasoning: boolean,
+): "None" | "Off" {
+  return supportsReasoningOff && isExternalOpenAIReasoning ? "None" : "Off";
 }
 
 function useDictation(
@@ -253,6 +271,8 @@ export function SharedComposer({
     const checkpoint = s.params.checkpoint;
     return s.models.find((m) => m.id === checkpoint);
   });
+  const checkpoint = useChatRuntimeStore((s) => s.params.checkpoint);
+  const externalProviders = useExternalProvidersStore((s) => s.providers);
   const modelLoaded = useChatRuntimeStore(
     (s) => !!s.params.checkpoint && !s.modelLoading,
   );
@@ -262,6 +282,8 @@ export function SharedComposer({
   const setReasoningEnabled = useChatRuntimeStore((s) => s.setReasoningEnabled);
   const reasoningStyle = useChatRuntimeStore((s) => s.reasoningStyle);
   const reasoningEffort = useChatRuntimeStore((s) => s.reasoningEffort);
+  const supportsReasoningOff = useChatRuntimeStore((s) => s.supportsReasoningOff);
+  const reasoningEffortLevels = useChatRuntimeStore((s) => s.reasoningEffortLevels);
   const setReasoningEffort = useChatRuntimeStore((s) => s.setReasoningEffort);
   const supportsPreserveThinking = useChatRuntimeStore((s) => s.supportsPreserveThinking);
   const preserveThinking = useChatRuntimeStore((s) => s.preserveThinking);
@@ -271,6 +293,26 @@ export function SharedComposer({
   const setToolsEnabled = useChatRuntimeStore((s) => s.setToolsEnabled);
   const codeToolsEnabled = useChatRuntimeStore((s) => s.codeToolsEnabled);
   const setCodeToolsEnabled = useChatRuntimeStore((s) => s.setCodeToolsEnabled);
+  const externalSelection = parseExternalModelId(checkpoint);
+  const externalReasoningCaps =
+    externalSelection != null
+      ? getExternalReasoningCapabilities(
+          externalProviders.find((p) => p.id === externalSelection.providerId)
+            ?.providerType,
+          externalSelection.modelId,
+        )
+      : null;
+  const isExternalOpenAIReasoning =
+    externalReasoningCaps?.supportsReasoning === true &&
+    externalReasoningCaps.reasoningStyle === "reasoning_effort";
+  const effectiveSupportsReasoningOff =
+    externalReasoningCaps?.supportsReasoningOff ?? supportsReasoningOff;
+  const effectiveReasoningEffortLevels =
+    externalReasoningCaps?.reasoningEffortLevels ?? reasoningEffortLevels;
+  const effectiveReasoningEnabled =
+    reasoningStyle === "reasoning_effort" && !effectiveSupportsReasoningOff
+      ? true
+      : reasoningEnabled;
   const reasoningDisabled = !modelLoaded || !supportsReasoning;
   const showReasoningControl = supportsReasoning || reasoningAlwaysOn;
   const toolsDisabled = !modelLoaded || !supportsTools;
@@ -641,31 +683,37 @@ export function SharedComposer({
                   )}
                   aria-label={`Reasoning effort: ${reasoningEffort}`}
                 >
-                  {reasoningEnabled ? (
+                  {effectiveReasoningEnabled ? (
                     <LightbulbIcon className="size-3.5" />
                   ) : (
                     <LightbulbOffIcon className="size-3.5" />
                   )}
                   <span>
                     Think:{" "}
-                    {reasoningEnabled
-                      ? reasoningEffort.charAt(0).toUpperCase() +
-                        reasoningEffort.slice(1)
-                      : "Off"}
+                    {effectiveReasoningEnabled
+                      ? formatReasoningEffortLabel(reasoningEffort)
+                      : formatReasoningDisabledLabel(
+                          effectiveSupportsReasoningOff,
+                          isExternalOpenAIReasoning,
+                        )}
                   </span>
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onSelect={() => {
-                    setReasoningEnabled(false);
-                    applyQwenThinkingParams(false);
-                  }}
-                >
-                  Off
-                  {!reasoningEnabled ? " \u2713" : ""}
-                </DropdownMenuItem>
-                {(["low", "medium", "high"] as const).map((level) => (
+                {effectiveSupportsReasoningOff && (
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setReasoningEnabled(false);
+                      applyQwenThinkingParams(false);
+                    }}
+                  >
+                    {isExternalOpenAIReasoning ? "None" : "Off"}
+                    {!effectiveReasoningEnabled ? " \u2713" : ""}
+                  </DropdownMenuItem>
+                )}
+                {effectiveReasoningEffortLevels
+                  .filter((level) => level !== "none")
+                  .map((level) => (
                   <DropdownMenuItem
                     key={level}
                     onSelect={() => {
@@ -674,8 +722,8 @@ export function SharedComposer({
                       applyQwenThinkingParams(true);
                     }}
                   >
-                    {level.charAt(0).toUpperCase() + level.slice(1)}
-                    {reasoningEnabled && reasoningEffort === level ? " \u2713" : ""}
+                    {formatReasoningEffortLabel(level)}
+                    {effectiveReasoningEnabled && reasoningEffort === level ? " \u2713" : ""}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -26,13 +26,28 @@ const REASONING_EFFORT_KEY = "unsloth_reasoning_effort";
 const PRESERVE_THINKING_KEY = "unsloth_preserve_thinking";
 
 export type ReasoningStyle = "enable_thinking" | "reasoning_effort";
-export type ReasoningEffort = "low" | "medium" | "high";
+export type ReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
 
 function loadReasoningEffort(fallback: ReasoningEffort): ReasoningEffort {
   if (!canUseStorage()) return fallback;
   try {
     const raw = localStorage.getItem(REASONING_EFFORT_KEY);
-    if (raw === "low" || raw === "medium" || raw === "high") return raw;
+    if (
+      raw === "none" ||
+      raw === "minimal" ||
+      raw === "low" ||
+      raw === "medium" ||
+      raw === "high" ||
+      raw === "xhigh"
+    ) {
+      return raw;
+    }
     return fallback;
   } catch {
     return fallback;
@@ -198,6 +213,8 @@ type ChatRuntimeStore = {
   reasoningEnabled: boolean;
   reasoningStyle: ReasoningStyle;
   reasoningEffort: ReasoningEffort;
+  supportsReasoningOff: boolean;
+  reasoningEffortLevels: readonly ReasoningEffort[];
   supportsPreserveThinking: boolean;
   preserveThinking: boolean;
   supportsTools: boolean;
@@ -285,6 +302,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
   reasoningEnabled: true,
   reasoningStyle: "enable_thinking",
   reasoningEffort: loadReasoningEffort("medium"),
+  supportsReasoningOff: false,
+  reasoningEffortLevels: ["low", "medium", "high"],
   supportsPreserveThinking: false,
   preserveThinking: loadBool(PRESERVE_THINKING_KEY, false),
   supportsTools: false,
@@ -394,6 +413,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
       reasoningAlwaysOn: false,
       reasoningEnabled: true,
       reasoningStyle: "enable_thinking",
+      supportsReasoningOff: false,
+      reasoningEffortLevels: ["low", "medium", "high"],
       supportsPreserveThinking: false,
       supportsTools: false,
       toolsEnabled: false,

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -202,7 +202,14 @@ export interface OpenAIChatCompletionsRequest {
   audio_base64?: string;
   use_adapter?: boolean | string | null;
   enable_thinking?: boolean | null;
-  reasoning_effort?: "low" | "medium" | "high" | null;
+  reasoning_effort?:
+    | "none"
+    | "minimal"
+    | "low"
+    | "medium"
+    | "high"
+    | "xhigh"
+    | null;
   preserve_thinking?: boolean | null;
   enable_tools?: boolean | null;
   enabled_tools?: string[];


### PR DESCRIPTION
This PR fixes reasoning for external OpenAI models end to end. It passes reasoning settings through the frontend and backend correctly for /v1/responses, and updates stream translation so reasoning summaries render consistently.

It wires reasoning parameters through the frontend adapter and backend proxy, then maps them correctly for the OpenAI /v1/responses path. It also updates streaming translation so reasoning summary events are handled consistently in output.

It also fixes model-specific behavior in the UI: reasoning support is now resolved per model, state is refreshed when switching models, effort-style models support Off/Low/Medium/High. Unsupported models cannot enable thinking. 

## Changed files
- `studio/backend/core/inference/external_provider.py`
- `studio/backend/routes/inference.py`
- `studio/backend/tests/test_openai_responses_translation.py`
- `studio/frontend/src/features/chat/api/chat-adapter.ts`
- `studio/frontend/src/features/chat/chat-page.tsx`
- `studio/frontend/src/features/chat/provider-capabilities.ts`
- `studio/frontend/src/features/chat/shared-composer.tsx`

@rolandtannous 