### PR TITLE
Studio: parity of thinking trace icon with Think toggle icon

### DIFF
--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -19,10 +19,8 @@ import {
   useAuiState,
 } from "@assistant-ui/react";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
-import { Idea01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { type VariantProps, cva } from "class-variance-authority";
-import { ChevronDownIcon, CopyIcon, CheckIcon } from "lucide-react";
+import { CheckIcon, ChevronDownIcon, CopyIcon, LightbulbIcon } from "lucide-react";
 import {
   type CSSProperties,
   type ComponentProps,
@@ -128,10 +126,7 @@ function ReasoningTrigger({
       )}
       {...props}
     >
-      <HugeiconsIcon
-        icon={Idea01Icon}
-        className="aui-reasoning-trigger-icon size-4 shrink-0"
-      />
+      <LightbulbIcon className="aui-reasoning-trigger-icon size-4 shrink-0" />
       <span
         data-slot="reasoning-trigger-label"
         className="aui-reasoning-trigger-label-wrapper relative inline-block leading-none"


### PR DESCRIPTION
## Summary

The thinking trace used a different icon than the Think toggle, which made the UX feel inconsistent.

Before:
<img width="414" height="94" alt="image" src="https://github.com/user-attachments/assets/7b192fdb-46b9-4526-a4a9-1fe12f31ca13" />


After: 
<img width="477" height="96" alt="image" src="https://github.com/user-attachments/assets/6f31e9c5-956e-485c-be84-3b85dc7df631" />
