### PR TITLE
studio: fix training page regressions from the security hardening pass

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -278,7 +278,7 @@ def _build_csp(script_nonce: "str | None" = None) -> str:
         "img-src 'self' data: blob: https://t0.gstatic.com "
         "https://t1.gstatic.com https://t2.gstatic.com "
         "https://t3.gstatic.com; "
-        "connect-src 'self'; "
+        "connect-src 'self' https://huggingface.co https://datasets-server.huggingface.co; "
         "style-src 'self' 'unsafe-inline'; "
         f"{script_src}; "
         "font-src 'self' data:; "

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -140,7 +140,7 @@ class TrainingStartRequest(BaseModel):
 
     @field_validator("max_steps")
     @classmethod
-    def _check_max_steps(cls, v):
+    def _check_max_steps(cls, v: Optional[int]) -> Optional[int]:
         # 0 is the frontend's sentinel for "use num_epochs instead".
         if v is None:
             return v
@@ -161,7 +161,7 @@ class TrainingStartRequest(BaseModel):
 
     @field_validator("warmup_steps")
     @classmethod
-    def _check_warmup_steps(cls, v):
+    def _check_warmup_steps(cls, v: Optional[int]) -> Optional[int]:
         if v is None:
             return v
         if not isinstance(v, int) or v < 0 or v > _MAX_STEPS:

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -130,20 +130,23 @@ class TrainingStartRequest(BaseModel):
     @field_validator("num_epochs")
     @classmethod
     def _check_num_epochs(cls, v: int) -> int:
+        # 0 is a sentinel meaning "use max_steps instead"; the frontend's
+        # steps-vs-epochs toggle sends it.
         if v is None:
             return 1
-        if v < 1 or v > _MAX_EPOCHS:
-            raise ValueError(f"num_epochs must be in [1, {_MAX_EPOCHS}] (got {v!r})")
+        if v < 0 or v > _MAX_EPOCHS:
+            raise ValueError(f"num_epochs must be in [0, {_MAX_EPOCHS}] (got {v!r})")
         return v
 
     @field_validator("max_steps")
     @classmethod
     def _check_max_steps(cls, v):
+        # 0 is the frontend's sentinel for "use num_epochs instead".
         if v is None:
             return v
-        if not isinstance(v, int) or v < 1 or v > _MAX_STEPS:
+        if not isinstance(v, int) or v < 0 or v > _MAX_STEPS:
             raise ValueError(
-                f"max_steps must be a positive int <= {_MAX_STEPS} (got {v!r})"
+                f"max_steps must be a non-negative int <= {_MAX_STEPS} (got {v!r})"
             )
         return v
 

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -324,6 +324,16 @@ class TrainingStartRequest(BaseModel):
         description = "Physical GPU indices to use, for example [0, 1]. Omit or pass [] to use automatic selection. Explicit gpu_ids are unsupported when the parent CUDA_VISIBLE_DEVICES uses UUID/MIG entries.",
     )
 
+    @model_validator(mode = "after")
+    def _check_steps_or_epochs(self) -> "TrainingStartRequest":
+        # num_epochs and max_steps each accept 0 as a "use the other one"
+        # sentinel. If both resolve to 0 there's nothing to train against.
+        if (self.max_steps is None or self.max_steps == 0) and self.num_epochs == 0:
+            raise ValueError(
+                "Either num_epochs or max_steps must be > 0; both cannot be 0."
+            )
+        return self
+
 
 class TrainingJobResponse(BaseModel):
     """Immediate response when training is initiated"""

--- a/studio/frontend/src/features/training/api/train-api.ts
+++ b/studio/frontend/src/features/training/api/train-api.ts
@@ -17,10 +17,41 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
+type FastApiValidationError = {
+  loc?: unknown[];
+  msg?: string;
+};
+
+function formatDetail(detail: unknown): string | null {
+  if (typeof detail === "string" && detail) return detail;
+  if (!Array.isArray(detail)) return null;
+  const parts = detail
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return "";
+      const { loc, msg } = entry as FastApiValidationError;
+      const path = Array.isArray(loc)
+        ? loc.filter((segment) => segment !== "body").join(".")
+        : "";
+      const message = typeof msg === "string" ? msg : "";
+      if (path && message) return `${path}: ${message}`;
+      return path || message;
+    })
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
 async function readError(response: Response): Promise<string> {
   try {
-    const payload = (await response.json()) as { detail?: string; message?: string };
-    return payload.detail || payload.message || `Request failed (${response.status})`;
+    const payload = (await response.json()) as {
+      detail?: unknown;
+      message?: string;
+    };
+    const formattedDetail = formatDetail(payload.detail);
+    if (formattedDetail) return formattedDetail;
+    if (typeof payload.message === "string" && payload.message) {
+      return payload.message;
+    }
+    return `Request failed (${response.status})`;
   } catch {
     return `Request failed (${response.status})`;
   }


### PR DESCRIPTION
## Summary

Four follow-up fixes to the hardening commit (`0881a7a5`) https://github.com/unslothai/unsloth/pull/5375 that left the Studio Training page broken on `main`:

- **CSP**: extend `connect-src` to allow `huggingface.co` and `datasets-server.huggingface.co` so the model picker and HF dataset subset/split dropdowns can talk to HF from the browser (`studio/backend/main.py`).
- **422 messaging**: format FastAPI's array-form `detail` in `readError` so the UI shows `field: msg` instead of `[object Object][object Object]` (`studio/frontend/src/features/training/api/train-api.ts`).
- **Steps/epochs sentinel**: relax `num_epochs` and `max_steps` validators to accept `0`, which Studio's steps-vs-epochs toggle uses as the "use the other counter" sentinel (`studio/backend/models/training.py`).
- **Cross-field guard**: add a model-level validator that rejects `num_epochs=0` AND `max_steps in (None, 0)` so a no-op training payload returns a clear 422 instead of silently producing an empty run.

## Test plan

- [x] Open Training page, type in the model picker — HF results appear (no CSP block in console).
- [x] Paste a public HF dataset id (e.g. `ibm/duorc`) — Subset and Train Split dropdowns populate.
- [x] Click Start Training with defaults — request reaches the worker (no 422).
- [x] Toggle to "Use Epochs" mode, click Start Training — request reaches the worker.
- [x] Send a payload with both `num_epochs=0` and `max_steps=0` — get 422 with "Either num_epochs or max_steps must be > 0" message rendered cleanly in the UI.