### PR TITLE
Studio: anthropic effort by model family

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -21,6 +21,11 @@ logger = logging.getLogger(__name__)
 # still accept it. Match the 4-7 line specifically so we keep the knob
 # live on every other Claude generation.
 _ANTHROPIC_TOP_K_DEPRECATED = re.compile(r"^claude-(?:opus|sonnet|haiku)-4-7(?:[-.]|$)")
+_ANTHROPIC_ADAPTIVE_THINKING = re.compile(
+    r"^claude-(?:opus|sonnet|haiku)-4-[67](?:[-.]|$)"
+)
+_ANTHROPIC_MANUAL_THINKING = re.compile(r"^claude-(?:opus|sonnet|haiku)-4-5(?:[-.]|$)")
+_ANTHROPIC_XHIGH_EFFORT = re.compile(r"^claude-opus-4-7(?:[-.]|$)")
 
 # Shared client reused across all requests for HTTP connection pooling.
 # Auth headers and timeouts are passed per-request, so a single client
@@ -92,7 +97,14 @@ class ExternalProviderClient:
         """
         if not self._is_openai_compatible():
             async for line in self._stream_anthropic(
-                messages, model, temperature, top_p, max_tokens, top_k
+                messages,
+                model,
+                temperature,
+                top_p,
+                max_tokens,
+                top_k,
+                enable_thinking,
+                reasoning_effort,
             ):
                 yield line
             return
@@ -226,6 +238,8 @@ class ExternalProviderClient:
         top_p: float,
         max_tokens: Optional[int],
         top_k: Optional[int] = None,
+        enable_thinking: Optional[bool] = None,
+        reasoning_effort: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Call the Anthropic Messages API and translate its SSE to OpenAI format.
@@ -314,6 +328,29 @@ class ExternalProviderClient:
             body["top_k"] = top_k
         if system:
             body["system"] = system
+        allowed_efforts = (
+            ("none", "low", "medium", "high", "xhigh")
+            if _ANTHROPIC_XHIGH_EFFORT.match(model)
+            else ("none", "low", "medium", "high")
+        )
+        effort = reasoning_effort if reasoning_effort in allowed_efforts else None
+        if effort is None:
+            if enable_thinking is False:
+                effort = "none"
+            elif enable_thinking is True:
+                effort = "medium"
+        # Normalize one semantic Thinking control into Anthropic's two model-era
+        # APIs: adaptive effort on Claude 4.6/4.7, manual budget_tokens on 4.5.
+        if effort and effort != "none":
+            if _ANTHROPIC_ADAPTIVE_THINKING.match(model):
+                body["thinking"] = {"type": "adaptive"}
+                body["output_config"] = {"effort": effort}
+            elif _ANTHROPIC_MANUAL_THINKING.match(model):
+                budget_tokens = {"low": 1024, "medium": 2048, "high": 4096}[effort]
+                body["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": budget_tokens,
+                }
 
         url = f"{self.base_url}/messages"
         completion_id = f"chatcmpl-anthropic-{model.replace('/', '-')}"

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -315,7 +315,6 @@ class ExternalProviderClient:
             "messages": filtered,
             "max_tokens": max_tokens or 1024,  # required by Anthropic
             "temperature": temperature,
-            # Anthropic rejects requests that set both temperature and top_p
             "stream": True,
         }
         # top_k is deprecated on Claude 4.7 (Opus/Sonnet/Haiku) — the API
@@ -352,6 +351,8 @@ class ExternalProviderClient:
             body.pop("top_k", None)
             # Anthropic requires temperature=1 whenever thinking is enabled.
             body["temperature"] = 1
+            # Anthropic thinking supports top_p in the 0.95..1.0 range.
+            body["top_p"] = max(0.95, min(float(top_p), 1.0))
             if _ANTHROPIC_ADAPTIVE_THINKING.match(model):
                 body["thinking"] = {"type": "adaptive"}
                 body["output_config"] = {"effort": effort}
@@ -361,6 +362,10 @@ class ExternalProviderClient:
                     "type": "enabled",
                     "budget_tokens": budget_tokens,
                 }
+                # Anthropic requires max_tokens to be strictly greater than
+                # thinking.budget_tokens on the manual-thinking path.
+                if body.get("max_tokens", 0) <= budget_tokens:
+                    body["max_tokens"] = budget_tokens + 1024
 
         url = f"{self.base_url}/messages"
         completion_id = f"chatcmpl-anthropic-{model.replace('/', '-')}"

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -26,6 +26,7 @@ _ANTHROPIC_ADAPTIVE_THINKING = re.compile(
 )
 _ANTHROPIC_MANUAL_THINKING = re.compile(r"^claude-(?:opus|sonnet|haiku)-4-5(?:[-.]|$)")
 _ANTHROPIC_XHIGH_EFFORT = re.compile(r"^claude-opus-4-7(?:[-.]|$)")
+_ANTHROPIC_MAX_EFFORT = re.compile(r"^claude-(?:opus-4-6|sonnet-4-6)(?:[-.]|$)")
 
 # Shared client reused across all requests for HTTP connection pooling.
 # Auth headers and timeouts are passed per-request, so a single client
@@ -330,10 +331,12 @@ class ExternalProviderClient:
             body["system"] = system
         allowed_efforts = (
             ("none", "low", "medium", "high", "xhigh")
-            if _ANTHROPIC_XHIGH_EFFORT.match(model)
+            if (_ANTHROPIC_XHIGH_EFFORT.match(model) or _ANTHROPIC_MAX_EFFORT.match(model))
             else ("none", "low", "medium", "high")
         )
         effort = reasoning_effort if reasoning_effort in allowed_efforts else None
+        if effort == "xhigh" and _ANTHROPIC_MAX_EFFORT.match(model):
+            effort = "max"
         if effort is None:
             if enable_thinking is False:
                 effort = "none"
@@ -342,6 +345,10 @@ class ExternalProviderClient:
         # Normalize one semantic Thinking control into Anthropic's two model-era
         # APIs: adaptive effort on Claude 4.6/4.7, manual budget_tokens on 4.5.
         if effort and effort != "none":
+            # Anthropic rejects top_k whenever thinking is enabled.
+            body.pop("top_k", None)
+            # Anthropic requires temperature=1 whenever thinking is enabled.
+            body["temperature"] = 1
             if _ANTHROPIC_ADAPTIVE_THINKING.match(model):
                 body["thinking"] = {"type": "adaptive"}
                 body["output_config"] = {"effort": effort}

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -331,7 +331,10 @@ class ExternalProviderClient:
             body["system"] = system
         allowed_efforts = (
             ("none", "low", "medium", "high", "xhigh")
-            if (_ANTHROPIC_XHIGH_EFFORT.match(model) or _ANTHROPIC_MAX_EFFORT.match(model))
+            if (
+                _ANTHROPIC_XHIGH_EFFORT.match(model)
+                or _ANTHROPIC_MAX_EFFORT.match(model)
+            )
             else ("none", "low", "medium", "high")
         )
         effort = reasoning_effort if reasoning_effort in allowed_efforts else None

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -489,6 +489,8 @@ const ReasoningToggle: FC = () => {
     reasoningStyle === "reasoning_effort" && !effectiveSupportsReasoningOff
       ? true
       : reasoningEnabled;
+  const effectiveReasoningVisualEnabled =
+    effectiveReasoningEnabled && reasoningEffort !== "none";
   const disabled = !(modelLoaded && supportsReasoning);
   const effortLabel =
     reasoningEffort === "xhigh"
@@ -506,17 +508,19 @@ const ReasoningToggle: FC = () => {
               "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
               disabled
                 ? "cursor-not-allowed opacity-40"
-                : "bg-primary/10 text-primary hover:bg-primary/20",
+                : effectiveReasoningVisualEnabled
+                  ? "bg-primary/10 text-primary hover:bg-primary/20"
+                  : "text-muted-foreground hover:bg-muted-foreground/15",
             )}
             aria-label={`Reasoning effort: ${reasoningEffort}`}
           >
-            {effectiveReasoningEnabled ? (
+            {effectiveReasoningVisualEnabled ? (
               <LightbulbIcon className="size-3.5" />
             ) : (
               <LightbulbOffIcon className="size-3.5" />
             )}
             <span>
-              Think: {effectiveReasoningEnabled ? effortLabel : "None"}
+              Think: {effectiveReasoningVisualEnabled ? effortLabel : "None"}
             </span>
           </button>
         </DropdownMenuTrigger>
@@ -529,7 +533,7 @@ const ReasoningToggle: FC = () => {
               }}
             >
               None
-              {!effectiveReasoningEnabled ? " \u2713" : ""}
+              {!effectiveReasoningVisualEnabled ? " \u2713" : ""}
             </DropdownMenuItem>
           )}
           {effectiveReasoningEffortLevels
@@ -546,7 +550,7 @@ const ReasoningToggle: FC = () => {
               {level === "xhigh"
                 ? "Extra High"
                 : level.charAt(0).toUpperCase() + level.slice(1)}
-              {effectiveReasoningEnabled && reasoningEffort === level ? " \u2713" : ""}
+              {effectiveReasoningVisualEnabled && reasoningEffort === level ? " \u2713" : ""}
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -492,10 +492,18 @@ const ReasoningToggle: FC = () => {
   const effectiveReasoningVisualEnabled =
     effectiveReasoningEnabled && reasoningEffort !== "none";
   const disabled = !(modelLoaded && supportsReasoning);
-  const effortLabel =
-    reasoningEffort === "xhigh"
-      ? "Extra High"
-      : reasoningEffort.charAt(0).toUpperCase() + reasoningEffort.slice(1);
+  const formatEffortLabel = (level: typeof reasoningEffort): string => {
+    if (level !== "xhigh") return level.charAt(0).toUpperCase() + level.slice(1);
+    const normalized = externalSelection?.modelId?.trim().toLowerCase() ?? "";
+    if (
+      normalized.startsWith("claude-opus-4-6") ||
+      normalized.startsWith("claude-sonnet-4-6")
+    ) {
+      return "Max";
+    }
+    return "Extra High";
+  };
+  const effortLabel = formatEffortLabel(reasoningEffort);
 
   if (reasoningStyle === "reasoning_effort") {
     return (
@@ -547,9 +555,7 @@ const ReasoningToggle: FC = () => {
                 applyQwenThinkingParams(true);
               }}
             >
-              {level === "xhigh"
-                ? "Extra High"
-                : level.charAt(0).toUpperCase() + level.slice(1)}
+              {formatEffortLabel(level)}
               {effectiveReasoningVisualEnabled && reasoningEffort === level ? " \u2713" : ""}
             </DropdownMenuItem>
           ))}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -623,14 +623,37 @@ export function ChatPage(): ReactElement {
     () => isExternalModelId(inferenceParams.checkpoint),
     [inferenceParams.checkpoint],
   );
+  const reasoningEnabled = useChatRuntimeStore((s) => s.reasoningEnabled);
+  const reasoningStyle = useChatRuntimeStore((s) => s.reasoningStyle);
+  const reasoningEffort = useChatRuntimeStore((s) => s.reasoningEffort);
+  const supportsReasoningOff = useChatRuntimeStore((s) => s.supportsReasoningOff);
   const activeProviderCapabilities = useMemo(() => {
     const selection = parseExternalModelId(inferenceParams.checkpoint);
     if (!selection) return null;
     const provider = externalProviders.find(
       (p) => p.id === selection.providerId,
     );
-    return getProviderCapabilities(provider?.providerType);
-  }, [externalProviders, inferenceParams.checkpoint]);
+    const baseCapabilities = getProviderCapabilities(provider?.providerType);
+    if (!baseCapabilities) return baseCapabilities;
+    const anthropicThinkingEnabled =
+      provider?.providerType === "anthropic" &&
+      reasoningStyle === "reasoning_effort" &&
+      (supportsReasoningOff ? reasoningEnabled : true) &&
+      reasoningEffort !== "none";
+    if (!anthropicThinkingEnabled) return baseCapabilities;
+    return {
+      ...baseCapabilities,
+      temperature: false,
+      topK: false,
+    };
+  }, [
+    externalProviders,
+    inferenceParams.checkpoint,
+    reasoningEnabled,
+    reasoningStyle,
+    reasoningEffort,
+    supportsReasoningOff,
+  ]);
   useEffect(() => {
     const selection = parseExternalModelId(inferenceParams.checkpoint);
     if (!selection) return;

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -61,6 +61,7 @@ const CUSTOM_PROVIDER_TYPE = "custom";
 const CUSTOM_BACKEND_PROVIDER_TYPE = "openai";
 const CUSTOM_PROVIDER_MISSING_KEY_MESSAGE =
   "No API key found, please make sure API key is added and valid for this provider.";
+const ANTHROPIC_DATED_SNAPSHOT_SUFFIX = /-\d{8}$/;
 
 function normalizeUrl(input: string): string {
   return input.trim().replace(/\/+$/, "");
@@ -114,6 +115,11 @@ function parseManualModelIds(text: string): string[] {
     out.push(id);
   }
   return out;
+}
+
+function pruneProviderModelIds(providerType: string, modelIds: string[]): string[] {
+  if (providerType !== "anthropic") return modelIds;
+  return modelIds.filter((id) => !ANTHROPIC_DATED_SNAPSHOT_SUFFIX.test(id));
 }
 
 function formatModelSummary(models: string[]): string {
@@ -264,7 +270,10 @@ export function ChatProvidersSettings({
             const updatedAt = Number.isFinite(Date.parse(config.updated_at))
               ? Date.parse(config.updated_at)
               : Date.now();
-            const existingModels = existing?.models ?? [];
+            const existingModels = pruneProviderModelIds(
+              uiProviderType,
+              existing?.models ?? [],
+            );
             return {
               id: config.id,
               providerType: uiProviderType,
@@ -398,14 +407,14 @@ export function ChatProvidersSettings({
       // Union of registry defaults + fetched models, defaults first so any
       // curated picks (e.g. claude-haiku-4-5) always show even when the
       // provider's /models endpoint omits them.
-      const modelIds = [
+      const modelIds = pruneProviderModelIds(providerType, [
         ...new Set(
           [
             ...registryDefaults,
             ...models.map((model) => model.id.trim()),
           ].filter((id) => id.length > 0),
         ),
-      ];
+      ]);
       setAvailableModels(modelIds);
       setSelectedModelIds((prev) =>
         prev.filter((id) => modelIds.includes(id)),
@@ -444,14 +453,17 @@ export function ChatProvidersSettings({
     }
     const curated = selectedRegistryEntry?.model_list_mode === "curated";
     const manualModels = isCustomProvider || curated;
-    const modelsToSave = manualModels
+    const modelsToSave = pruneProviderModelIds(
+      providerType,
+      manualModels
       ? [
           ...new Set([
             ...selectedModelIds,
             ...parseManualModelIds(manualModelIds),
           ]),
         ]
-      : [...selectedModelIds];
+      : [...selectedModelIds],
+    );
     if (manualModels) {
       if (modelsToSave.length === 0) {
         toast.error("Add at least one model ID.");
@@ -491,7 +503,9 @@ export function ChatProvidersSettings({
         name: created.display_name,
         baseUrl: created.base_url ?? "",
         models: modelsToSave,
-        availableModels: manualModels ? [] : availableModels,
+        availableModels: manualModels
+          ? []
+          : pruneProviderModelIds(providerType, availableModels),
         createdAt,
         updatedAt,
       };
@@ -531,14 +545,17 @@ export function ChatProvidersSettings({
     const entry = registryByType.get(existing.providerType);
     const curated = entry?.model_list_mode === "curated";
     const manualModels = isEditingCustomProvider || curated;
-    const modelsToSave = manualModels
+    const modelsToSave = pruneProviderModelIds(
+      existing.providerType,
+      manualModels
       ? [
           ...new Set([
             ...selectedModelIds,
             ...parseManualModelIds(manualModelIds),
           ]),
         ]
-      : [...selectedModelIds];
+      : [...selectedModelIds],
+    );
     if (manualModels) {
       if (modelsToSave.length === 0) {
         toast.error("Add at least one model ID.");
@@ -584,7 +601,9 @@ export function ChatProvidersSettings({
                 name: updated.display_name,
                 baseUrl: updated.base_url ?? "",
                 models: modelsToSave,
-                availableModels: manualModels ? [] : availableModels,
+                availableModels: manualModels
+                  ? []
+                  : pruneProviderModelIds(existing.providerType, availableModels),
                 updatedAt,
               }
             : provider,
@@ -627,15 +646,17 @@ export function ChatProvidersSettings({
     } else {
       const shortlist = entry?.default_models ?? [];
       const cachedCatalog = provider.availableModels ?? [];
-      const mergedModels = [
+      const mergedModels = pruneProviderModelIds(provider.providerType, [
         ...new Set(
           [...shortlist, ...cachedCatalog, ...provider.models]
             .map((model) => model.trim())
             .filter((model) => model.length > 0),
         ),
-      ];
+      ]);
       setAvailableModels(mergedModels);
-      setSelectedModelIds([...provider.models]);
+      setSelectedModelIds(
+        provider.models.filter((model) => mergedModels.includes(model)),
+      );
       setManualModelIds("");
     }
   }

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -170,12 +170,20 @@ function resolveAnthropicReasoningEffortCapabilities(modelId: string): {
       reasoningEffortLevels: ["none", "low", "medium", "high", "xhigh"],
     };
   }
+  if (
+    normalized.startsWith("claude-opus-4-6") ||
+    normalized.startsWith("claude-sonnet-4-6")
+  ) {
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: true,
+      reasoningEffortLevels: ["none", "low", "medium", "high", "xhigh"],
+    };
+  }
   // Claude 4.7 and 4.6 use adaptive thinking with effort controls.
   if (
     normalized.startsWith("claude-sonnet-4-7") ||
     normalized.startsWith("claude-haiku-4-7") ||
-    normalized.startsWith("claude-opus-4-6") ||
-    normalized.startsWith("claude-sonnet-4-6") ||
     normalized.startsWith("claude-haiku-4-6")
   ) {
     return {

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -157,6 +157,53 @@ export function getProviderCapabilities(
 
 const DEFAULT_EFFORT_LEVELS = ["low", "medium", "high"] as const;
 
+function resolveAnthropicReasoningEffortCapabilities(modelId: string): {
+  supportsReasoning: boolean;
+  supportsReasoningOff: boolean;
+  reasoningEffortLevels: ExternalReasoningCapabilities["reasoningEffortLevels"];
+} {
+  const normalized = modelId.trim().toLowerCase();
+  if (normalized.startsWith("claude-opus-4-7")) {
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: true,
+      reasoningEffortLevels: ["none", "low", "medium", "high", "xhigh"],
+    };
+  }
+  // Claude 4.7 and 4.6 use adaptive thinking with effort controls.
+  if (
+    normalized.startsWith("claude-sonnet-4-7") ||
+    normalized.startsWith("claude-haiku-4-7") ||
+    normalized.startsWith("claude-opus-4-6") ||
+    normalized.startsWith("claude-sonnet-4-6") ||
+    normalized.startsWith("claude-haiku-4-6")
+  ) {
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: true,
+      reasoningEffortLevels: ["none", "low", "medium", "high"],
+    };
+  }
+  // Claude 4.5 still uses manual thinking budgets; we keep the same semantic
+  // UI levels and map them server-side.
+  if (
+    normalized.startsWith("claude-opus-4-5") ||
+    normalized.startsWith("claude-sonnet-4-5") ||
+    normalized.startsWith("claude-haiku-4-5")
+  ) {
+    return {
+      supportsReasoning: true,
+      supportsReasoningOff: true,
+      reasoningEffortLevels: ["none", "low", "medium", "high"],
+    };
+  }
+  return {
+    supportsReasoning: false,
+    supportsReasoningOff: false,
+    reasoningEffortLevels: DEFAULT_EFFORT_LEVELS,
+  };
+}
+
 function resolveOpenAIReasoningEffortCapabilities(modelId: string): {
   supportsReasoning: boolean;
   supportsReasoningOff: boolean;
@@ -222,12 +269,9 @@ function resolveOpenAIReasoningEffortCapabilities(modelId: string): {
 }
 
 /**
- * Resolve whether an external model should expose the chat "Think" control.
- *
- * OpenAI model families are not uniform:
- * - `o3*`, `gpt-5.4*`, and `gpt-5.5*` support `reasoning.effort`
- * - `gpt-5.3-codex` supports a boolean thinking toggle
- * - other OpenAI families in our picker should not receive reasoning params
+ * resolve external-model thinking capabilities.
+ * provider-specific matching lives in the OpenAI/Anthropic resolvers.
+ * other providers default to no reasoning controls.
  */
 export function getExternalReasoningCapabilities(
   providerType: string | null | undefined,
@@ -252,7 +296,8 @@ export function getExternalReasoningCapabilities(
       : normalizedModel;
 
   const isOpenAIProvider = normalizedProvider === "openai";
-  if (!isOpenAIProvider) {
+  const isAnthropicProvider = normalizedProvider === "anthropic";
+  if (!isOpenAIProvider && !isAnthropicProvider) {
     return {
       supportsReasoning: false,
       reasoningStyle: "enable_thinking",
@@ -262,14 +307,16 @@ export function getExternalReasoningCapabilities(
     };
   }
 
-  const openAICaps = resolveOpenAIReasoningEffortCapabilities(modelForMatching);
-  if (openAICaps.supportsReasoning) {
+  const providerCaps = isOpenAIProvider
+    ? resolveOpenAIReasoningEffortCapabilities(modelForMatching)
+    : resolveAnthropicReasoningEffortCapabilities(modelForMatching);
+  if (providerCaps.supportsReasoning) {
     return {
       supportsReasoning: true,
       reasoningStyle: "reasoning_effort",
       reasoningAlwaysOn: false,
-      supportsReasoningOff: openAICaps.supportsReasoningOff,
-      reasoningEffortLevels: openAICaps.reasoningEffortLevels,
+      supportsReasoningOff: providerCaps.supportsReasoningOff,
+      reasoningEffortLevels: providerCaps.reasoningEffortLevels,
     };
   }
 

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -72,8 +72,17 @@ function fileToBase64DataURL(file: File): Promise<string> {
   });
 }
 
-function formatReasoningEffortLabel(level: ReasoningEffort): string {
-  if (level === "xhigh") return "Extra High";
+function formatReasoningEffortLabel(level: ReasoningEffort, modelId?: string): string {
+  if (level === "xhigh") {
+    const normalized = modelId?.trim().toLowerCase() ?? "";
+    if (
+      normalized.startsWith("claude-opus-4-6") ||
+      normalized.startsWith("claude-sonnet-4-6")
+    ) {
+      return "Max";
+    }
+    return "Extra High";
+  }
   return level.charAt(0).toUpperCase() + level.slice(1);
 }
 
@@ -695,7 +704,10 @@ export function SharedComposer({
                   <span>
                     Think:{" "}
                     {effectiveReasoningVisualEnabled
-                      ? formatReasoningEffortLabel(reasoningEffort)
+                      ? formatReasoningEffortLabel(
+                          reasoningEffort,
+                          externalSelection?.modelId,
+                        )
                       : formatReasoningDisabledLabel(
                           effectiveSupportsReasoningOff,
                           isExternalOpenAIReasoning,
@@ -726,7 +738,7 @@ export function SharedComposer({
                       applyQwenThinkingParams(true);
                     }}
                   >
-                    {formatReasoningEffortLabel(level)}
+                    {formatReasoningEffortLabel(level, externalSelection?.modelId)}
                     {effectiveReasoningVisualEnabled && reasoningEffort === level ? " \u2713" : ""}
                   </DropdownMenuItem>
                 ))}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -313,6 +313,8 @@ export function SharedComposer({
     reasoningStyle === "reasoning_effort" && !effectiveSupportsReasoningOff
       ? true
       : reasoningEnabled;
+  const effectiveReasoningVisualEnabled =
+    effectiveReasoningEnabled && reasoningEffort !== "none";
   const reasoningDisabled = !modelLoaded || !supportsReasoning;
   const showReasoningControl = supportsReasoning || reasoningAlwaysOn;
   const toolsDisabled = !modelLoaded || !supportsTools;
@@ -679,18 +681,20 @@ export function SharedComposer({
                     "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
                     reasoningDisabled
                       ? "cursor-not-allowed opacity-40"
-                      : "bg-primary/10 text-primary hover:bg-primary/20",
+                      : effectiveReasoningVisualEnabled
+                        ? "bg-primary/10 text-primary hover:bg-primary/20"
+                        : "text-muted-foreground hover:bg-muted-foreground/15",
                   )}
                   aria-label={`Reasoning effort: ${reasoningEffort}`}
                 >
-                  {effectiveReasoningEnabled ? (
+                  {effectiveReasoningVisualEnabled ? (
                     <LightbulbIcon className="size-3.5" />
                   ) : (
                     <LightbulbOffIcon className="size-3.5" />
                   )}
                   <span>
                     Think:{" "}
-                    {effectiveReasoningEnabled
+                    {effectiveReasoningVisualEnabled
                       ? formatReasoningEffortLabel(reasoningEffort)
                       : formatReasoningDisabledLabel(
                           effectiveSupportsReasoningOff,
@@ -708,7 +712,7 @@ export function SharedComposer({
                     }}
                   >
                     {isExternalOpenAIReasoning ? "None" : "Off"}
-                    {!effectiveReasoningEnabled ? " \u2713" : ""}
+                    {!effectiveReasoningVisualEnabled ? " \u2713" : ""}
                   </DropdownMenuItem>
                 )}
                 {effectiveReasoningEffortLevels
@@ -723,7 +727,7 @@ export function SharedComposer({
                     }}
                   >
                     {formatReasoningEffortLabel(level)}
-                    {effectiveReasoningEnabled && reasoningEffort === level ? " \u2713" : ""}
+                    {effectiveReasoningVisualEnabled && reasoningEffort === level ? " \u2713" : ""}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>


### PR DESCRIPTION
## Summary

Clean up external-model thinking so chat exposes one simple `Think` control while provider-specific payload differences stay internal.

- normalize external reasoning UX onto semantic levels in chat
- map Anthropic Claude families server-side:
  - Claude 4.7 -> adaptive thinking + effort
  - Claude 4.6 -> adaptive thinking + effort
  - Claude 4.5 -> manual extended thinking budgets
- fix frontend/backend capability drift for Anthropic model families
- update stale reasoning capability docs/comments
- make `Think: None` read as muted but still interactive in both composer UIs

## Validation

Validated against live provider APIs with probe scripts

Notes:
- Claude 4.5 uses `thinking: { type: "enabled", budget_tokens: N }`, so semantic levels are a Studio mapping, not native Anthropic effort labels.
- Claude 4.6 uses adaptive thinking, but Anthropic expects `max` rather than `xhigh` 
