### PR TITLE
studio/ci: flat GGUF+mmproj cache for Mac json-images smoke, save partial caches on cancel

### DIFF
--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -4,8 +4,8 @@
 # Three end-to-end smoke jobs that boot a freshly-installed Studio and
 # exercise the surfaces real users hit through the OpenAI / Anthropic
 # SDKs and curl. Each job picks the smallest model that exercises the
-# behaviour under test, primes HF_HOME via actions/cache, and shares
-# the install.sh --local --no-torch bootstrap.
+# behaviour under test, primes a model cache via actions/cache, and
+# shares the install.sh --local --no-torch bootstrap.
 #
 #   1. OpenAI, Anthropic API tests
 #        gemma-3-270m-it UD-Q4_K_XL (~254 MiB).
@@ -40,7 +40,7 @@ on:
       - '.github/workflows/studio-mac-inference-smoke.yml'
   push:
     branches: [main, pip]
-  # Manual trigger for pre-warming HF_HOME caches on main, or re-running
+  # Manual trigger for pre-warming model caches on main, or re-running
   # against an arbitrary branch without pushing a no-op commit.
   workflow_dispatch:
 
@@ -100,8 +100,10 @@ jobs:
           HF_HUB_ENABLE_HF_TRANSFER=1 \
             hf download "$GGUF_REPO" "$GGUF_FILE"
 
+      # Save partial caches on cancel/timeout -- hf download resumes by
+      # content hash. `outcome != skipped` keeps cache-hit a no-op.
       - name: Save HF_HOME for ${{ env.GGUF_REPO }}
-        if: always() && steps.prime-hf.outcome == 'success'
+        if: always() && steps.prime-hf.outcome != 'skipped' && hashFiles('hf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: hf-cache
@@ -350,8 +352,9 @@ jobs:
           HF_HUB_ENABLE_HF_TRANSFER=1 \
             hf download "$GGUF_REPO" "$GGUF_FILE" --local-dir gguf-cache
 
+      # Save partial caches on cancel; next run resumes via content hash.
       - name: Save GGUF model file
-        if: always() && steps.download-gguf.outcome == 'success'
+        if: always() && steps.download-gguf.outcome != 'skipped' && hashFiles('gguf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: gguf-cache
@@ -681,7 +684,6 @@ jobs:
       GGUF_FILE: gemma-4-E2B-it-UD-Q4_K_XL.gguf
       MMPROJ_FILE: mmproj-F16.gguf
       STUDIO_PORT: '18899'
-      HF_HOME: ${{ github.workspace }}/hf-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -698,42 +700,47 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Restore HF_HOME for ${{ env.GGUF_REPO }} (model + mmproj)
-        id: cache-hf
+      # Cache flat .gguf + mmproj (Job 2's pattern). HF_HOME inflates
+      # ~3.6x via xet/blobs/snapshots, which made macOS saves never land.
+      # mmproj is auto-detected as a sibling via detect_mmproj_file
+      # (studio/backend/utils/models/model_config.py).
+      - name: Restore GGUF + mmproj files
+        id: cache-gguf
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         continue-on-error: true
         with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v1
+          path: gguf-cache
+          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-${{ env.MMPROJ_FILE }}-v1
 
-      - name: Prime HF_HOME with the GGUF + mmproj
-        id: prime-hf
-        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
+      - name: Download GGUF + mmproj if cache miss
+        id: download-gguf
+        if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         # Authenticated + parallel: shared macos-14 NAT egress stalls
         # multi-GB anonymous downloads.
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -m pip install --upgrade huggingface_hub hf_transfer
-          mkdir -p hf-cache
+          mkdir -p gguf-cache
           HF_HUB_ENABLE_HF_TRANSFER=1 \
-            hf download "$GGUF_REPO" "$GGUF_FILE" &
+            hf download "$GGUF_REPO" "$GGUF_FILE" --local-dir gguf-cache &
           MODEL_PID=$!
           HF_HUB_ENABLE_HF_TRANSFER=1 \
-            hf download "$GGUF_REPO" "$MMPROJ_FILE" &
+            hf download "$GGUF_REPO" "$MMPROJ_FILE" --local-dir gguf-cache &
           MMPROJ_PID=$!
           wait "$MODEL_PID"
           wait "$MMPROJ_PID"
           # Fail loud on a partial download instead of in the next step.
-          find hf-cache -name "$GGUF_FILE" -o -name "$MMPROJ_FILE" \
-            | xargs -I{} ls -lhL {}
+          ls -lh "gguf-cache/$GGUF_FILE" "gguf-cache/$MMPROJ_FILE"
 
-      - name: Save HF_HOME for ${{ env.GGUF_REPO }} (model + mmproj)
-        if: always() && steps.prime-hf.outcome == 'success'
+      # Save partial caches on cancel. hashFiles guard avoids a hard
+      # save failure when the download step exits with no files.
+      - name: Save GGUF + mmproj files
+        if: always() && steps.download-gguf.outcome != 'skipped' && hashFiles('gguf-cache/**/*.gguf') != ''
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v1
+          path: gguf-cache
+          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-${{ env.MMPROJ_FILE }}-v1
 
       - name: Install Studio (--local, --no-torch)
         env:
@@ -788,12 +795,17 @@ jobs:
             -H 'content-type: application/json' \
             -d "{\"username\":\"unsloth\",\"password\":\"$NEW\"}" | jq -r .access_token)
           echo "API_KEY=$TOKEN" >> "$GITHUB_ENV"
-          # Load the GGUF (mmproj is auto-detected via the HF repo
-          # lookup, the cached file is pulled out of HF_HOME).
+          # Load via local file path; mmproj sibling auto-detected by
+          # detect_mmproj_file (model_config.py). gguf_variant omitted
+          # -- it routes through _find_local_gguf_by_variant which
+          # expects a directory, not a file path.
+          GGUF_PATH="$GITHUB_WORKSPACE/gguf-cache/${GGUF_FILE}"
+          MMPROJ_PATH="$GITHUB_WORKSPACE/gguf-cache/${MMPROJ_FILE}"
+          ls -lh "$GGUF_PATH" "$MMPROJ_PATH"
           curl -fs -X POST "http://127.0.0.1:${STUDIO_PORT}/api/inference/load" \
             -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' \
             --max-time 900 \
-            -d "{\"model_path\":\"$GGUF_REPO\",\"gguf_variant\":\"$GGUF_VARIANT\",\"is_lora\":false,\"max_seq_length\":2048}" \
+            -d "{\"model_path\":\"$GGUF_PATH\",\"is_lora\":false,\"max_seq_length\":2048}" \
             | jq '{status, display_name, is_vision}'
 
       - name: JSON schema decoding + image input


### PR DESCRIPTION
## Summary

The `JSON, images` job on `macos-14` has been timing out at the 30 min `timeout-minutes` ceiling on cold cache, repeatedly. Two reinforcing causes, both addressed here.

Example slow runs (all the same job, all stuck in the same step):

| Run | Job | Stuck step | Duration | Outcome |
|---|---|---|---|---|
| [25854199999](https://github.com/unslothai/unsloth/actions/runs/25854199999/job/75967835562) | JSON, images | Prime HF_HOME with the GGUF + mmproj | 30:01 | `timeout-minutes: 30` |
| [25854000503](https://github.com/unslothai/unsloth/actions/runs/25854000503/job/75967163783) | JSON, images | Prime HF_HOME with the GGUF + mmproj | 30:00 | `timeout-minutes: 30` |
| [25848174628](https://github.com/unslothai/unsloth/actions/runs/25848174628/job/75948185930) | JSON, images | Prime HF_HOME with the GGUF + mmproj | 16:38 | concurrency cancel |

The other two jobs in those runs (`OpenAI/Anthropic`, `Tool calling`) finished green in 4-7 min each.

## Root causes

**1. The macOS HF_HOME cache for gemma-4-E2B-it never lands.** Listing `gh api repos/unslothai/unsloth/actions/caches`:

```
Windows-hf-unsloth/gemma-4-E2B-it-GGUF-UD-Q4_K_XL-mmproj-F16.gguf-v1   3344 MB  main
Linux-hf-unsloth/gemma-4-E2B-it-GGUF-UD-IQ3_XXS-mmproj-F16.gguf-v1     2556 MB  main
macOS-gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v1       1257 MB  main   <- job 2 OK
macOS-hf-unsloth/gemma-3-270m-it-GGUF-UD-Q4_K_XL-v1                    227  MB  main   <- job 1 OK
```

There is no macOS entry for the exact key the json-images job is asking for. The Save step is gated on `prime-hf.outcome == 'success'`; when prime is killed by `timeout-minutes: 30` or by `concurrency: cancel-in-progress`, its outcome is `cancelled`, save is skipped, the cache stays empty, the next run is cold, prime times out again. Self-perpetuating on busy branches like `feature/chat-api` where commits land every 5-15 min.

On top of that, the HF_HOME layout (xet chunks + blobs + snapshots) inflates ~3.6x off-disk per the comment already in job 2's env block, which makes a single entry approach the 10 GiB per-cache cap.

**2. macos-14 NAT egress is slow for multi-GB downloads.** The workflow already calls this out and goes parallel + authenticated, but 3.4 GiB (gemma-4-E2B Q4_K_XL ~2.4 GiB + mmproj-F16 ~986 MiB) still does not reliably fit in 30 min from cold.

## Changes

**Job 3 now uses the flat `--local-dir gguf-cache` pattern that Job 2 already uses.**

* Cache path: `hf-cache` becomes `gguf-cache`.
* Cache key: `${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v1` becomes `${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-${{ env.MMPROJ_FILE }}-v1`.
* Both `hf download` calls take `--local-dir gguf-cache`, parallel `&` + `wait` retained.
* `HF_HOME` dropped from `json-images.env`.
* Load step posts `model_path: $GITHUB_WORKSPACE/gguf-cache/${GGUF_FILE}` and drops `gguf_variant`. The mmproj is auto-detected as a sibling of the .gguf in the same directory by `detect_mmproj_file` (`studio/backend/utils/models/model_config.py`), so no API surface change is needed on `/api/inference/load`. `gguf_variant` is omitted on purpose: with a local file path the variant is encoded in the filename, and passing it would route through `_find_local_gguf_by_variant` which expects a directory.

**All three jobs save partial caches on cancel.**

Save guards relaxed from `if: always() && steps.<prime>.outcome == 'success'` to `if: always() && steps.<prime>.outcome != 'skipped' && hashFiles('<path>') != ''` (where `<path>` is the recursive `.gguf` glob under the cache dir).

`outcome != 'skipped'` keeps the cache-hit fast path a no-op (restore hits, download is skipped, save stays skipped). On `cancelled` / `failure` outcomes the save still runs as long as at least one `.gguf` landed, so the next run resumes via `hf download`'s content-hash resume. The `hashFiles` guard prevents `actions/cache/save` from hard-failing the job when the prime step exits with nothing on disk.

**Header comments updated** from `primes HF_HOME via actions/cache` to `primes a model cache via actions/cache` so they remain accurate now that two of three jobs use flat-file caching.

## Why mmproj still works

`ModelConfig.from_identifier` (`studio/backend/utils/models/model_config.py:2060`) calls `detect_mmproj_file(gguf_file, search_root=path)` whenever `model_path` resolves to a local `.gguf`. That function scans the file's parent directory for a sibling `mmproj*.gguf`. The resolved path flows through `config.gguf_mmproj_file` into `llama_cpp.py:2370` which adds `--mmproj <path>` to llama-server. Same code path the HF-repo-id flow used to hit, just sourced from the local filesystem instead of an HF download.

## Builds on

* #5396 (HF_HOME cache hardening against actions/cache v5 silent restore failures)
* #5399 (sweep across sibling smoke workflows)

## Test plan

- [ ] First run on this branch lands on a cold cache, primes `gguf-cache` with the two flat files, and the Save step writes a new `macOS-gguf-...gemma-4-E2B-it-GGUF-...-mmproj-F16.gguf-v1` entry.
- [ ] A second run on the same branch restores from that cache and skips the download step.
- [ ] Inference load succeeds with the local file path and `is_vision: true` in the response.
- [ ] OpenAI image / Anthropic image probes still complete (or land on the existing WARN path on Mac quant drift).
- [ ] If a run is cancelled mid-download, the next run resumes the partial files via `hf download`'s content-hash resume rather than starting from zero.
