### PR TITLE
studio: comment out training_args.bin torch.load fallback in model_config

### DIFF
--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1696,20 +1696,21 @@ def get_base_model_from_checkpoint(checkpoint_path: str) -> Optional[str]:
                         )
                         return base_model
 
-        training_args_path = checkpoint_path_obj / "training_args.bin"
-        if training_args_path.exists():
-            try:
-                import torch
-
-                training_args = torch.load(training_args_path)
-                if hasattr(training_args, "model_name_or_path"):
-                    base_model = training_args.model_name_or_path
-                    logger.info(
-                        "Detected base model from training_args.bin: %s", base_model
-                    )
-                    return base_model
-            except Exception as e:
-                logger.warning(f"Could not load training_args.bin: {e}")
+        # TODO: torch.load default weights_only=True (torch >= 2.6) rejects pickled TrainingArguments; re-enable via safe_globals or weights_only=False once threat model allows.
+        # training_args_path = checkpoint_path_obj / "training_args.bin"
+        # if training_args_path.exists():
+        #     try:
+        #         import torch
+        #
+        #         training_args = torch.load(training_args_path)
+        #         if hasattr(training_args, "model_name_or_path"):
+        #             base_model = training_args.model_name_or_path
+        #             logger.info(
+        #                 "Detected base model from training_args.bin: %s", base_model
+        #             )
+        #             return base_model
+        #     except Exception as e:
+        #         logger.warning(f"Could not load training_args.bin: {e}")
 
         dir_name = checkpoint_path_obj.name
         if dir_name.startswith("unsloth_"):
@@ -1757,20 +1758,21 @@ def get_base_model_from_lora(lora_path: str) -> Optional[str]:
                     return base_model
 
         # Fallback: try training_args.bin (requires torch)
-        training_args_path = lora_path_obj / "training_args.bin"
-        if training_args_path.exists():
-            try:
-                import torch
-
-                training_args = torch.load(training_args_path)
-                if hasattr(training_args, "model_name_or_path"):
-                    base_model = training_args.model_name_or_path
-                    logger.info(
-                        f"Detected base model from training_args.bin: {base_model}"
-                    )
-                    return base_model
-            except Exception as e:
-                logger.warning(f"Could not load training_args.bin: {e}")
+        # TODO: torch.load default weights_only=True (torch >= 2.6) rejects pickled TrainingArguments; also an RCE sink for third-party LoRAs via this route, re-enable behind a trust check if needed.
+        # training_args_path = lora_path_obj / "training_args.bin"
+        # if training_args_path.exists():
+        #     try:
+        #         import torch
+        #
+        #         training_args = torch.load(training_args_path)
+        #         if hasattr(training_args, "model_name_or_path"):
+        #             base_model = training_args.model_name_or_path
+        #             logger.info(
+        #                 f"Detected base model from training_args.bin: {base_model}"
+        #             )
+        #             return base_model
+        #     except Exception as e:
+        #         logger.warning(f"Could not load training_args.bin: {e}")
 
         # Last resort: parse from directory name
         # Format: unsloth_Meta-Llama-3.1-8B-Instruct-bnb-4bit_timestamp


### PR DESCRIPTION
## Summary

In `studio/backend/utils/models/model_config.py`, the `get_base_model_from_checkpoint` and `get_base_model_from_lora` helpers both have a tertiary fallback that does `torch.load(training_args.bin)` to read `.model_name_or_path` off the pickled `TrainingArguments`. This PR comments both blocks out and leaves a TODO.

Reasons:

1. **Already non-functional on the torch versions Studio runs on.** `torch.load` defaults to `weights_only=True` since torch 2.6 (we ship 2.9 / 2.10). HF Trainer writes `training_args.bin` via `torch.save(self.args, ...)` where `self.args` is a `TrainingArguments` dataclass with nested enums (`IntervalStrategy`, `OptimizerNames`, `SchedulerType`, ...). The restricted unpickler rejects it with `UnpicklingError: GLOBAL transformers.training_args.TrainingArguments was not an allowed global by default`. Verified empirically on torch 2.9.1 / transformers 4.57.6. Adding `weights_only=True` does not help, you need a cascading `add_safe_globals` allowlist that breaks on every transformers bump.

2. **Already not producing answers in principle either.** Stock `TrainingArguments` does not define a `model_name_or_path` field, so even when the load used to succeed (torch < 2.6), the `hasattr(training_args, "model_name_or_path")` check returned `False` unless the training script subclassed `TrainingArguments` to add that field, which Studio itself does not do.

3. **The earlier fallback tiers already cover the real cases.** Both helpers try `adapter_config.json` (`base_model_name_or_path`) and `config.json` (`_name_or_path` / `model_name`) before this branch, and the directory-name parser after it. Those tiers handle every standard HF / PEFT LoRA and every Studio-written checkpoint.

4. **`get_base_model_from_lora` is reachable from a public route on third-party input.** `routes/models.py` exposes `GET /loras/{lora_path:path}/base-model` which passes the user-supplied path straight into `get_base_model_from_lora`, and `ModelConfig.from_identifier` / `from_ui_selection` / `from_lora_path` also feed it arbitrary LoRA paths (including third-party LoRAs pulled from HF). Any LoRA repo can ship a poisoned `training_args.bin`, so "fixing" the fallback with `weights_only=False` would re-introduce a pickle RCE sink on remote-supplied input. The current torch 2.6+ default behaviour is effectively a silent disable, which is safe but noisy in the logs.

Commenting (rather than deleting) keeps the original intent visible for whoever wants to re-enable this later with `torch.serialization.add_safe_globals` plus a proper trust check on the path.

## Behaviour change

None observable on torch 2.6 or newer. The blocks were already failing into the surrounding `except Exception` and falling through to the existing fallbacks. The only effective change is one fewer `Could not load training_args.bin: ...` warning in the logs and one fewer pickle deserialization sink exposed.

## Test plan

- [ ] Train a small LoRA in Studio and confirm `scan_trained_models` / the `/loras/.../base-model` route still resolves the base model via `adapter_config.json`.
- [ ] Load a non-Unsloth LoRA from HF and confirm `ModelConfig.from_lora_path` still resolves its base model.
- [ ] Confirm logs no longer contain `Could not load training_args.bin` warnings during model scans.