### PR TITLE
studio: drop unused max_grad_value schema + route plumbing

### DIFF
--- a/scripts/verify_comment_only_diff.py
+++ b/scripts/verify_comment_only_diff.py
@@ -35,6 +35,7 @@ Example:
     git diff --name-only origin/main..HEAD \\
       | xargs python scripts/verify_comment_only_diff.py --base origin/main
 """
+
 from __future__ import annotations
 
 import argparse
@@ -49,7 +50,9 @@ import yaml
 
 def _git_show(rev: str, path: str) -> str:
     return subprocess.check_output(
-        ["git", "show", f"{rev}:{path}"], text = True, stderr = subprocess.DEVNULL,
+        ["git", "show", f"{rev}:{path}"],
+        text = True,
+        stderr = subprocess.DEVNULL,
     )
 
 
@@ -145,8 +148,7 @@ def _walk_yaml_diff(b: Any, a: Any, prefix: str = "") -> None:
     elif isinstance(b, list):
         if len(b) != len(a):
             print(
-                f"     list len at {prefix or '/'}: "
-                f"{len(b)} -> {len(a)}",
+                f"     list len at {prefix or '/'}: " f"{len(b)} -> {len(a)}",
             )
         for i, (bi, ai) in enumerate(zip(b, a)):
             _walk_yaml_diff(bi, ai, f"{prefix}[{i}]")

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -215,7 +215,6 @@ class TrainingBackend:
             "save_steps": kwargs.get("save_steps", 0),
             "weight_decay": kwargs.get("weight_decay", 0.001),
             "max_grad_norm": kwargs.get("max_grad_norm", 0.0),
-            "max_grad_value": kwargs.get("max_grad_value"),
             "random_seed": kwargs.get("random_seed", 3407),
             "packing": kwargs.get("packing", False),
             "optim": kwargs.get("optim", "adamw_8bit"),

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -267,14 +267,6 @@ class TrainingStartRequest(BaseModel):
         ge = 0,
         description = "Global gradient norm clipping threshold. Set 0 to disable.",
     )
-    max_grad_value: Optional[float] = Field(
-        None,
-        ge = 0,
-        description = (
-            "Elementwise gradient value clipping threshold. Set 0 to disable. "
-            "If omitted, MLX defaults to 1 unless max_grad_norm is set."
-        ),
-    )
     random_seed: int = Field(42, description = "Random seed")
     packing: bool = Field(False, description = "Enable sequence packing")
     optim: str = Field("adamw_8bit", description = "Optimizer")

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -216,7 +216,6 @@ async def start_training(
             "save_steps": request.save_steps,
             "weight_decay": request.weight_decay,
             "max_grad_norm": request.max_grad_norm,
-            "max_grad_value": request.max_grad_value,
             "random_seed": request.random_seed,
             "packing": request.packing,
             "optim": request.optim,

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -107,12 +107,10 @@ class TestTrainingRawSupport(unittest.TestCase):
                 model_name = "unsloth/test",
                 training_type = "LoRA/QLoRA",
                 max_grad_norm = 0.7,
-                max_grad_value = 0.0,
             )
 
         config = mock_process.call_args.kwargs["kwargs"]["config"]
         self.assertEqual(config["max_grad_norm"], 0.7)
-        self.assertEqual(config["max_grad_value"], 0.0)
 
     def test_training_route_forwards_embedding_learning_rate(self):
         training_route = _load_route_module(


### PR DESCRIPTION
## Summary
- Removes the now-unused `max_grad_value` field from `TrainingStartRequest`, the route forwarder in `routes/training.py`, and the kwarg threading in `core/training/training.py`. PR #5340 already hardcoded the MLX worker to `(max_grad_norm=0.0, max_grad_value=5.0)` and dropped the field from the frontend payload, so all the surviving references just shuffle `None` through unused dict keys.
- Updates `test_training_backend_forwards_grad_clipping_controls` to no longer pass or assert on the removed field.
- API contract preserved: older clients that still POST `max_grad_value: 1.0` are silently accepted (Pydantic extra=ignore default).

## Test plan
- [x] `python -m pytest studio/backend/tests/test_training_raw_support.py -v` (6/6 green).
- [ ] Studio API + Auth tests on CI.
- [ ] Wheel build + import smoke (the field is private to Studio backend; should be a no-op for non-Studio users).