### PR TITLE
add UNSLOTH_ALLOW_CPU=1 path for CPU-only CI / source-inspection tests

### DIFF
--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -209,7 +209,7 @@ del fix_peft_transformers_weight_conversion_import
 del patch_peft_weight_converter_compatibility
 
 # Torch 2.4 has including_emulation
-if DEVICE_TYPE == "cuda":
+if DEVICE_TYPE == "cuda" and torch.cuda.is_available():
     major_version, minor_version = torch.cuda.get_device_capability()
     SUPPORTS_BFLOAT16 = major_version >= 8
 
@@ -233,12 +233,18 @@ elif DEVICE_TYPE == "xpu":
     # torch.xpu.is_bf16_supported() does not have including_emulation
     # set SUPPORTS_BFLOAT16 as torch.xpu.is_bf16_supported()
     SUPPORTS_BFLOAT16 = torch.xpu.is_bf16_supported()
+else:
+    # CPU-only CI under UNSLOTH_ALLOW_CPU=1. We can't probe device
+    # capability, so assume no bf16 -- training won't run on this host
+    # anyway, this branch only exists to let `import unsloth.trainer`
+    # succeed for source-inspection tests.
+    SUPPORTS_BFLOAT16 = False
 
 # For Gradio HF Spaces?
 # if "SPACE_AUTHOR_NAME" not in os.environ and "SPACE_REPO_NAME" not in os.environ:
 import triton
 
-if DEVICE_TYPE == "cuda":
+if DEVICE_TYPE == "cuda" and torch.cuda.is_available():
     libcuda_dirs = lambda: None
     if Version(triton.__version__) >= Version("3.0.0"):
         try:
@@ -349,5 +355,10 @@ from unsloth_zoo.rl_environments import (
     launch_openenv,
 )
 
-# Patch TRL trainers for backwards compatibility
-_patch_trl_trainer()
+# Patch TRL trainers for backwards compatibility.
+# Skipped under UNSLOTH_ALLOW_CPU=1 (CPU-only CI) because rebinding
+# trl.SFTTrainer.__init__ to a generic wrapper changes
+# inspect.getsource(SFTTrainer.__init__) and corrupts downstream
+# drift detectors that anchor on the pristine upstream source.
+if os.environ.get("UNSLOTH_ALLOW_CPU", "0") != "1":
+    _patch_trl_trainer()

--- a/unsloth/device_type.py
+++ b/unsloth/device_type.py
@@ -63,6 +63,10 @@ def get_device_type():
     # Check torch.accelerator
     if hasattr(torch, "accelerator"):
         if not torch.accelerator.is_available():
+            # Test-only CPU fallback. The env var is read exactly once per
+            # process because get_device_type is @functools.cache'd.
+            if os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1":
+                return "cuda"
             raise NotImplementedError(
                 "Unsloth cannot find any torch accelerator? You need a GPU."
             )
@@ -73,6 +77,8 @@ def get_device_type():
                 f"But `torch.accelerator.current_accelerator()` works with it being = `{accelerator}`\n"
                 f"Please reinstall torch - it's most likely broken :("
             )
+    if os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1":
+        return "cuda"
     raise NotImplementedError(
         "Unsloth currently only works on NVIDIA, AMD and Intel GPUs."
     )

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1193,7 +1193,7 @@ SUPPORTS_BFLOAT16 = False
 HAS_FLASH_ATTENTION = False
 HAS_FLASH_ATTENTION_SOFTCAPPING = False
 
-if DEVICE_TYPE == "cuda":
+if DEVICE_TYPE == "cuda" and torch.cuda.is_available():
     major_version, minor_version = torch.cuda.get_device_capability()
     torch.cuda.get_device_capability = functools.cache(torch.cuda.get_device_capability)
 

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -2270,6 +2270,11 @@ def patch_trl_vllm_generation():
 def PatchFastRL(algorithm = None, FastLanguageModel = None):
     if FastLanguageModel is not None:
         PatchRL(FastLanguageModel)
+    # Under UNSLOTH_ALLOW_CPU=1 (CPU-only CI), skip TRL trainer rewriting so
+    # downstream `inspect.getsource(trl.SFTTrainer)` drift detectors see the
+    # pristine upstream class, not the compiled Unsloth* wrappers.
+    if os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1":
+        return
     # Install the disable_gradient_checkpointing noop BEFORE
     # patch_trl_rl_trainers. patch_trl_rl_trainers imports extra trl.* trainer
     # submodules while generating the compiled cache; any new trl.* modules


### PR DESCRIPTION
## Summary

Adds an opt-in `UNSLOTH_ALLOW_CPU=1` env var so `import unsloth.trainer` succeeds on hosts without a CUDA/XPU/HIP accelerator. Pairs with unsloth-zoo PR #646, which runs source-inspection drift detectors on CPU-only CI runners and needs the import path to land.

The env var is read exactly once per process via `@functools.cache` on `get_device_type()`. Production hosts (with a real accelerator) pay zero runtime cost: the existing fast path runs unchanged.

## Changes

| File | Change |
|---|---|
| `unsloth/device_type.py:65-78` | Gate both `raise NotImplementedError` sites on `os.environ.get("UNSLOTH_ALLOW_CPU", "0") == "1"`; return `"cuda"` as the CPU sentinel. |
| `unsloth/_gpu_init.py:212` | `if DEVICE_TYPE == "cuda":` -> `if DEVICE_TYPE == "cuda" and torch.cuda.is_available():` so the bf16-support probe doesn't fault on CPU. |
| `unsloth/_gpu_init.py:247` | Same guard for the `libcuda_dirs()`/`bnb.functional.lib.*` block. |
| `unsloth/_gpu_init.py:359` | Gate `_patch_trl_trainer()` on `UNSLOTH_ALLOW_CPU != "1"`. Prevents `trl.{X}Trainer.__init__` from being rebound to `_backwards_compatible_trainer`, which corrupts `inspect.getsource(SFTTrainer.__init__)` for downstream drift detectors. |
| `unsloth/models/_utils.py:1196` | Same `torch.cuda.is_available()` guard for `get_device_capability` at import. |
| `unsloth/models/rl.py:PatchFastRL` | Early-return under `UNSLOTH_ALLOW_CPU=1`. Without this, `patch_trl_rl_trainers()` rebinds `trl.SFTTrainer` to the compiled `UnslothSFTTrainer` class and zoo's drift detectors trip on the wrapper source. |

## Test plan

* `UNSLOTH_ALLOW_CPU=1 python -c "import unsloth.trainer"` on a CPU-only venv -> succeeds.
* `trl.SFTTrainer.__init__.__qualname__` stays `SFTTrainer.__init__` (not `UnslothSFTTrainer.__init__`) under the env var.
* `inspect.getsource(trl.trainer.sft_trainer.SFTTrainer)` still contains `self._signature_columns` (drift detector anchor).
* Without the env var on a CUDA host, TRL is patched normally (`UnslothSFTTrainer.__init__`). No regression.

## Why "cuda" instead of a real "cpu" value

The sentinel `"cuda"` only needs to let `import unsloth.trainer` and downstream module imports succeed. Downstream branches that would actually fault (`get_device_capability`, `libcuda_dirs`) are now gated by `torch.cuda.is_available()`. Introducing a real `"cpu"` device type would touch a lot of code; not the goal here.

## Companion PR

* unsloth-zoo PR #646 sets this env var in its `tests/conftest.py` before importing unsloth, then the matrix can run source-inspection drift detectors against the pristine upstream TRL classes.