### PR TITLE
studio/mmproj: skip unwanted GGUF values via seek instead of read

### DIFF
--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -152,7 +152,9 @@ _FIXED_VTYPE_SIZES: Dict[int, int] = {
 
 
 def _skip_gguf_value(f, vtype: int) -> bool:
-    """Advance past one GGUF value. False on truncation or unknown type."""
+    """Advance past one GGUF value. ``f.seek(.., 1)`` past EOF is legal
+    on a regular file so truncation is detected on the next read; we
+    only return False for unknown types or sanity-bound overflow."""
     if vtype == 8:  # STRING
         slen_bytes = f.read(8)
         if len(slen_bytes) < 8:
@@ -160,7 +162,8 @@ def _skip_gguf_value(f, vtype: int) -> bool:
         slen = struct.unpack("<Q", slen_bytes)[0]
         if slen > 1 << 30:  # 1 GB sanity bound
             return False
-        return len(f.read(slen)) == slen
+        f.seek(slen, 1)
+        return True
     if vtype == 9:  # ARRAY
         head = f.read(12)
         if len(head) < 12:
@@ -176,18 +179,18 @@ def _skip_gguf_value(f, vtype: int) -> bool:
                 slen = struct.unpack("<Q", slen_bytes)[0]
                 if slen > 1 << 30:
                     return False
-                if len(f.read(slen)) != slen:
-                    return False
+                f.seek(slen, 1)
             return True
         sz = _FIXED_VTYPE_SIZES.get(atype)
         if sz is None:
             return False
-        total = sz * alen
-        return len(f.read(total)) == total
+        f.seek(sz * alen, 1)
+        return True
     sz = _FIXED_VTYPE_SIZES.get(vtype)
     if sz is None:
         return False
-    return len(f.read(sz)) == sz
+    f.seek(sz, 1)
+    return True
 
 
 def is_mmproj_by_metadata(meta: Optional[Dict[str, str]]) -> Optional[bool]:


### PR DESCRIPTION
## Summary

Follow-up perf fix on top of #5350. `_skip_gguf_value` walked past discarded values with `f.read(n)`, which allocates and immediately drops a Python bytes object. For weight GGUFs that carry `tokenizer.ggml.tokens` (~150K unicode strings) this wasted ~10 MB of allocation per cold call.

Switch the discard path to `f.seek(n, 1)`. The kernel never has to copy the bytes into userspace and Python never allocates. Truncation is now detected on the next read attempt rather than inline (an out-of-range seek on a regular file is legal and the next read returns short).

## Measured impact

Real downloaded GGUFs, median of 5 cold runs each, OS page cache cleared between runs:

| File | Size | Before | After | Bytes read before | Bytes read after |
|---|---|---|---|---|---|
| `unsloth/Qwen3.5-4B-GGUF` IQ2_XXS | 1.52 GB | 142 ms | 90 ms | 10.94 MB | 3.97 MB |
| `bartowski/Qwen_Qwen3.5-4B-GGUF` IQ2_M | 1.70 GB | 141 ms | 90 ms | 10.94 MB | 3.97 MB |
| `unsloth/Qwen3.5-4B-MTP-GGUF` IQ2_M | 1.94 GB | 145 ms | 90 ms | 10.94 MB | 3.97 MB |
| `unsloth/Qwen3.5-4B-GGUF` mmproj-F16 | 670 MB | ~30 ms | ~30 ms | minimal | minimal |

Mmproj reads are unaffected (no tokenizer to skip). Cached re-reads stay at ~50 microseconds.

## Test plan

- [x] `studio/backend/tests/test_gguf_metadata.py` (12 tests) pass
- [x] `studio/backend/tests/test_detect_mmproj_file.py` (25 tests) pass
- [x] All 161 backend tests pass under `studio-backend-ci.yml`'s exclusion list
- [x] 85-test isolated sandbox suite (`temp/sim_sandbox/`) passes, including truncation, oversized values, arrays of every value type, and concurrent reads

## Files changed

- `studio/backend/utils/models/gguf_metadata.py` (+10/-7)