### PR TITLE
ci: install ipython so transformers.utils.notebook imports cleanly in zoo pytest

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -206,7 +206,8 @@ jobs:
             'numpy<3' pytest==9.0.3 pytest-asyncio httpx \
             protobuf sentencepiece triton \
             psutil packaging tqdm safetensors datasets \
-            'peft>=0.18,<0.20' 'accelerate>=0.34,<2'
+            'peft>=0.18,<0.20' 'accelerate>=0.34,<2' \
+            ipython
           # torchvision: unsloth_zoo.vision_utils imports it at module scope.
           pip install --index-url https://download.pytorch.org/whl/cpu \
             'torch>=2.4,<2.11' 'torchvision<0.26'


### PR DESCRIPTION
## Summary
- adds \`ipython\` to the Core matrix install list in \`.github/workflows/consolidated-tests-ci.yml\`
- unblocks \`unsloth_zoo\`'s drift detector \`tests/test_zoo_source_upstream_refs.py::test_logging_utils_utils_notebook\`, which resolves \`transformers.utils.notebook\` and that module does \`import IPython.display\` at module scope
- failure surfaced consistently on PRs 5427 / 5430 / 5432 / 5434 across the HF=4.57.6 / HF=default / HF=latest cells with:
  \`DRIFT DETECTED: transformers.utils.notebook exists but its imports fail on this install (ModuleNotFoundError: No module named 'IPython'). zoo references this dotted path -- a transitively-missing dep here is exactly the regression class this suite catches. Either install the dep in CI or remove the zoo reference.\`
- the test's own message specifies this remediation; keeping the detector functional rather than removing the upstream reference

## Test plan
- [ ] CI rerun shows the \`unsloth_zoo @ main — full pytest (CPU)\` step passes the \`test_logging_utils_utils_notebook\` case on all three transformers matrix cells