### PR TITLE
ci: merge duplicate `with:` keys in notebooks-ci checkout steps

### DIFF
--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-        with: { path: unsloth }
+          path: unsloth
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: unslothai/notebooks
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-        with: { path: unsloth }
+          path: unsloth
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: unslothai/notebooks
@@ -352,7 +352,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-        with: { path: unsloth }
+          path: unsloth
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: unslothai/notebooks

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-        with: { path: unsloth }
+          path: unsloth
       - name: Clone unsloth-zoo @ main
         run: |
           # github.com occasionally 500s on the git fetch; retry so a


### PR DESCRIPTION
## Summary
- Three `actions/checkout` steps in `.github/workflows/notebooks-ci.yml` had two `with:` mapping keys on the same step.
- GitHub's workflow loader rejected the file, so every Notebooks CI run on affected branches failed at load time with zero jobs executed (e.g. run [25916231419](https://github.com/unslothai/unsloth/actions/runs/25916231419)).
- Under YAML "last key wins" the duplicate also silently dropped `persist-credentials: false`, leaving the GH token persisted on disk — a regression flagged by zizmor.
- Fix: merge each pair into a single `with:` block (sites at lines 200-203, 246-249, 352-355).

## Test plan
- [x] Notebooks CI run completes load (jobs leave the queued state) on this branch's PR build
- [x] No new zizmor findings on the affected steps