### PR TITLE
ci: make compiler-cache shim test order-independent

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -1032,16 +1032,28 @@ jobs:
               """Spot-check on the three production-relevant families that
               the compile_every sweep also covers; this case verifies the
               emitted cache file has the model-specific RMSNorm class
-              attribute, not just that the file parses + imports."""
+              attribute, not just that the file parses + imports.
+
+              Note on test isolation: ``unsloth_compile_transformers``
+              early-returns when ``modeling.__UNSLOTH_PATCHED__`` is set,
+              so once an earlier test in the same collection patches the
+              module the next call won't re-emit the cache file. Drop the
+              marker (and any stale cache file) before invoking so this
+              test is order-independent."""
               import importlib as _il
               try:
-                  _il.import_module(
+                  modeling = _il.import_module(
                       f"transformers.models.{model_type}.modeling_{model_type}"
                   )
               except ModuleNotFoundError:
                   pytest.skip(
                       f"transformers build lacks model_type={model_type}"
                   )
+              if hasattr(modeling, "__UNSLOTH_PATCHED__"):
+                  delattr(modeling, "__UNSLOTH_PATCHED__")
+              combined = _CACHE / f"unsloth_compiled_module_{model_type}.py"
+              if combined.exists():
+                  combined.unlink()
               unsloth_compile_transformers(
                   model_type=model_type, fast_lora_forwards=False,
               )
@@ -1049,7 +1061,6 @@ jobs:
                   f"transformers.models.{model_type}.modeling_{model_type}"
               )
               assert getattr(modeling, "__UNSLOTH_PATCHED__", False) is True
-              combined = _CACHE / f"unsloth_compiled_module_{model_type}.py"
               _verify_file(combined, must_expose=[rms_class])
 
 


### PR DESCRIPTION
## Summary
Fixes the Core 4.57.6 matrix-cell failure on PRs 5427 / 5430 / 5432 / 5433 / 5434:

\`\`\`
FAILED .../test_compile_real_modeling_module[llama-LlamaRMSNorm]   compiler did not write ...
FAILED .../test_compile_real_modeling_module[qwen3-Qwen3RMSNorm]
FAILED .../test_compile_real_modeling_module[gemma3-Gemma3RMSNorm]
\`\`\`

## Root cause
\`unsloth_zoo.compiler.unsloth_compile_transformers\` (compiler.py:3318-3324) early-returns when the modeling module already has \`__UNSLOTH_PATCHED__\` set, **without re-emitting the cache file**.

The shim's preceding sweep test (\`test_compile_every_transformers_model_type\`) invokes \`unsloth_compile_transformers\` for every model_type in \`transformers.models.*\` -- which patches the three RMSNorm families and sets \`__UNSLOTH_PATCHED__=True\` on each modeling module.

When \`test_compile_real_modeling_module\` then runs, the function early-returns, the cache file is never (re-)written, and the \`_verify_file\` assertion fails.

## Fix
Drop the unsloth-added \`__UNSLOTH_PATCHED__\` marker (and any leftover cache file from the sweep) before invoking the compile, so the targeted test exercises a fresh emit regardless of pytest collection order. Marker-only fix in the workflow's inline shim test -- transformers version-agnostic, works on 4.57.6 + 5.x; doesn't touch zoo internals or any other test.

## Verification
Reproduced locally on transformers 4.57.6 + zoo @ main:
- 1st \`unsloth_compile_transformers(model_type='llama', ...)\` -> file written, \`__UNSLOTH_PATCHED__=True\`
- delete the file, call again -> file NOT written (matches CI failure)
- with this fix's pre-step (\`delattr\`) -> file re-emitted correctly

## Test plan
- [ ] Core matrix on this branch goes green on the three RMSNorm tests
- [ ] Sweep test_compile_every_transformers_model_type still passes (unchanged)
- [ ] PRs 5427 / 5430 / 5432 / 5433 / 5434 re-synced after merge pick up the fix on their Core jobs