### PR TITLE
fix: preserve tokenizer eos token on merged saves

### DIFF
--- a/tests/saving/test_preserve_tokenizer_eos_token.py
+++ b/tests/saving/test_preserve_tokenizer_eos_token.py
@@ -45,9 +45,7 @@ def test_preserve_tokenizer_eos_token_restores_gemma4_turn_token(tmp_path):
 def test_preserve_tokenizer_eos_token_supports_processor_tokenizer(tmp_path):
     preserve = _load_preserve_helper()
     tokenizer_config = tmp_path / "tokenizer_config.json"
-    tokenizer_config.write_text(
-        json.dumps({"eos_token": "<eos>"}), encoding = "utf-8"
-    )
+    tokenizer_config.write_text(json.dumps({"eos_token": "<eos>"}), encoding = "utf-8")
     processor = types.SimpleNamespace(
         tokenizer = types.SimpleNamespace(eos_token = "<turn|>")
     )

--- a/tests/saving/test_preserve_tokenizer_eos_token.py
+++ b/tests/saving/test_preserve_tokenizer_eos_token.py
@@ -54,3 +54,20 @@ def test_preserve_tokenizer_eos_token_supports_processor_tokenizer(tmp_path):
 
     saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
     assert saved_config["eos_token"] == "<turn|>"
+
+
+class _StringableToken:
+    def __str__(self):
+        return "<turn|>"
+
+
+def test_preserve_tokenizer_eos_token_serializes_stringable_tokens(tmp_path):
+    preserve = _load_preserve_helper()
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(json.dumps({"eos_token": "<eos>"}), encoding = "utf-8")
+    tokenizer = types.SimpleNamespace(eos_token = _StringableToken())
+
+    preserve(tokenizer, tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["eos_token"] == "<turn|>"

--- a/tests/saving/test_preserve_tokenizer_eos_token.py
+++ b/tests/saving/test_preserve_tokenizer_eos_token.py
@@ -1,0 +1,58 @@
+import ast
+import json
+import os
+import types
+from pathlib import Path
+
+
+class _Logger:
+    def warning_once(self, *args, **kwargs):
+        pass
+
+
+def _load_preserve_helper():
+    source = Path(__file__).parents[2] / "unsloth" / "save.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+    helper = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_preserve_tokenizer_eos_token"
+    )
+    module = ast.Module(body = [helper], type_ignores = [])
+    ast.fix_missing_locations(module)
+    namespace = {"json": json, "os": os, "logger": _Logger()}
+    exec(compile(module, str(source), "exec"), namespace)
+    return namespace["_preserve_tokenizer_eos_token"]
+
+
+def test_preserve_tokenizer_eos_token_restores_gemma4_turn_token(tmp_path):
+    preserve = _load_preserve_helper()
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(
+        json.dumps({"eos_token": "<eos>", "other": True}),
+        encoding = "utf-8",
+    )
+    tokenizer = types.SimpleNamespace(eos_token = "<turn|>")
+
+    preserve(tokenizer, tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["eos_token"] == "<turn|>"
+    assert saved_config["other"] is True
+
+
+def test_preserve_tokenizer_eos_token_supports_processor_tokenizer(tmp_path):
+    preserve = _load_preserve_helper()
+    tokenizer_config = tmp_path / "tokenizer_config.json"
+    tokenizer_config.write_text(
+        json.dumps({"eos_token": "<eos>"}), encoding = "utf-8"
+    )
+    processor = types.SimpleNamespace(
+        tokenizer = types.SimpleNamespace(eos_token = "<turn|>")
+    )
+
+    preserve(processor, tmp_path)
+
+    saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
+    assert saved_config["eos_token"] == "<turn|>"

--- a/tests/saving/test_preserve_tokenizer_eos_token.py
+++ b/tests/saving/test_preserve_tokenizer_eos_token.py
@@ -71,3 +71,36 @@ def test_preserve_tokenizer_eos_token_serializes_stringable_tokens(tmp_path):
 
     saved_config = json.loads(tokenizer_config.read_text(encoding = "utf-8"))
     assert saved_config["eos_token"] == "<turn|>"
+
+
+def test_preserve_tokenizer_eos_token_supports_filename_prefix(tmp_path):
+    preserve = _load_preserve_helper()
+    prefixed_config = tmp_path / "adapter-tokenizer_config.json"
+    prefixed_config.write_text(
+        json.dumps({"eos_token": "<eos>", "other": True}),
+        encoding = "utf-8",
+    )
+    tokenizer = types.SimpleNamespace(eos_token = "<turn|>")
+
+    preserve(tokenizer, tmp_path, filename_prefix = "adapter")
+
+    saved_config = json.loads(prefixed_config.read_text(encoding = "utf-8"))
+    assert saved_config["eos_token"] == "<turn|>"
+    assert saved_config["other"] is True
+    # Unprefixed file must not be created as a side effect.
+    assert not (tmp_path / "tokenizer_config.json").exists()
+
+
+def test_preserve_tokenizer_eos_token_filename_prefix_none_uses_default(tmp_path):
+    preserve = _load_preserve_helper()
+    default_config = tmp_path / "tokenizer_config.json"
+    default_config.write_text(
+        json.dumps({"eos_token": "<eos>"}),
+        encoding = "utf-8",
+    )
+    tokenizer = types.SimpleNamespace(eos_token = "<turn|>")
+
+    preserve(tokenizer, tmp_path, filename_prefix = None)
+
+    saved_config = json.loads(default_config.read_text(encoding = "utf-8"))
+    assert saved_config["eos_token"] == "<turn|>"

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -424,6 +424,49 @@ def fast_save_pickle(shard, name):
     return
 
 
+def _preserve_tokenizer_eos_token(tokenizer, save_directory):
+    """Restore tokenizer_config.json eos_token from the tokenizer passed to save.
+
+    Some merge paths may re-save or mutate tokenizer metadata after the tokenizer
+    is written. Gemma 4 instruct models use `<turn|>` as their chat EOS token;
+    if tokenizer_config.json is reset to the raw base `<eos>` token, runtimes such
+    as vLLM will not stop generation correctly. Keep the serialized metadata in
+    sync with the source tokenizer without failing the save if the config is not
+    present or cannot be edited.
+    """
+    if tokenizer is None or save_directory is None:
+        return
+
+    source_tokenizer = (
+        tokenizer.tokenizer if hasattr(tokenizer, "tokenizer") else tokenizer
+    )
+    eos_token = getattr(source_tokenizer, "eos_token", None)
+    if eos_token is None and source_tokenizer is not tokenizer:
+        eos_token = getattr(tokenizer, "eos_token", None)
+    if eos_token is None:
+        return
+
+    tokenizer_config = os.path.join(str(save_directory), "tokenizer_config.json")
+    if not os.path.isfile(tokenizer_config):
+        return
+
+    try:
+        with open(tokenizer_config, "r", encoding = "utf-8") as file:
+            config = json.load(file)
+
+        if config.get("eos_token") == eos_token:
+            return
+
+        config["eos_token"] = eos_token
+        with open(tokenizer_config, "w", encoding = "utf-8") as file:
+            json.dump(config, file, indent = 2, ensure_ascii = False)
+            file.write("\n")
+    except Exception as error:
+        logger.warning_once(
+            f"Unsloth: Could not preserve tokenizer eos_token in {tokenizer_config}: {error}"
+        )
+
+
 @torch.inference_mode
 def unsloth_save_model(
     model,
@@ -691,6 +734,9 @@ def unsloth_save_model(
             _tokenizer.padding_side = "left"
 
             tokenizer.save_pretrained(**tokenizer_save_settings)
+            _preserve_tokenizer_eos_token(
+                tokenizer, tokenizer_save_settings["save_directory"]
+            )
 
             # Revert back padding side
             _tokenizer.padding_side = old_padding_side
@@ -980,6 +1026,9 @@ def unsloth_save_model(
         _tokenizer.padding_side = "left"
 
         tokenizer.save_pretrained(**tokenizer_save_settings)
+        _preserve_tokenizer_eos_token(
+            tokenizer, tokenizer_save_settings["save_directory"]
+        )
 
         # Revert back padding side
         _tokenizer.padding_side = old_padding_side
@@ -1030,6 +1079,10 @@ def unsloth_save_model(
         )
     else:
         internal_model.save_pretrained(**save_pretrained_settings)
+
+    _preserve_tokenizer_eos_token(
+        tokenizer, save_pretrained_settings["save_directory"]
+    )
 
     # Revert config back
     original_model = model
@@ -3083,6 +3136,7 @@ def unsloth_generic_save(
                 old_padding_side = _tokenizer.padding_side
                 _tokenizer.padding_side = "left"
                 tokenizer.save_pretrained(save_directory)
+                _preserve_tokenizer_eos_token(tokenizer, save_directory)
                 _tokenizer.padding_side = old_padding_side
 
         print(f"Unsloth: Model saved successfully to '{save_directory}'")
@@ -3100,6 +3154,7 @@ def unsloth_generic_save(
             low_disk_space_usage = True,
             use_temp_file = False,
         )
+        _preserve_tokenizer_eos_token(tokenizer, save_directory)
 
     if push_to_hub and datasets:
         try:

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3576,7 +3576,9 @@ def patch_saving_functions(model, vision = False):
             token = kwargs.get("token", None),
         )
         _preserve_tokenizer_eos_token(
-            self, save_directory, filename_prefix = filename_prefix,
+            self,
+            save_directory,
+            filename_prefix = filename_prefix,
         )
         if push_to_hub:
             push_kwargs = dict(kwargs)

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -445,6 +445,7 @@ def _preserve_tokenizer_eos_token(tokenizer, save_directory):
         eos_token = getattr(tokenizer, "eos_token", None)
     if eos_token is None:
         return
+    eos_token = str(eos_token)
 
     tokenizer_config = os.path.join(str(save_directory), "tokenizer_config.json")
     if not os.path.isfile(tokenizer_config):
@@ -734,9 +735,6 @@ def unsloth_save_model(
             _tokenizer.padding_side = "left"
 
             tokenizer.save_pretrained(**tokenizer_save_settings)
-            _preserve_tokenizer_eos_token(
-                tokenizer, tokenizer_save_settings["save_directory"]
-            )
 
             # Revert back padding side
             _tokenizer.padding_side = old_padding_side
@@ -1079,8 +1077,6 @@ def unsloth_save_model(
         )
     else:
         internal_model.save_pretrained(**save_pretrained_settings)
-
-    _preserve_tokenizer_eos_token(tokenizer, save_pretrained_settings["save_directory"])
 
     # Revert config back
     original_model = model
@@ -3134,7 +3130,6 @@ def unsloth_generic_save(
                 old_padding_side = _tokenizer.padding_side
                 _tokenizer.padding_side = "left"
                 tokenizer.save_pretrained(save_directory)
-                _preserve_tokenizer_eos_token(tokenizer, save_directory)
                 _tokenizer.padding_side = old_padding_side
 
         print(f"Unsloth: Model saved successfully to '{save_directory}'")
@@ -3152,7 +3147,6 @@ def unsloth_generic_save(
             low_disk_space_usage = True,
             use_temp_file = False,
         )
-        _preserve_tokenizer_eos_token(tokenizer, save_directory)
 
     if push_to_hub and datasets:
         try:
@@ -3569,6 +3563,7 @@ def patch_saving_functions(model, vision = False):
             save_directory,
             token = kwargs.get("token", None),
         )
+        _preserve_tokenizer_eos_token(self, save_directory)
         if push_to_hub:
             push_kwargs = dict(kwargs)
             repo_id = push_kwargs.pop("repo_id", save_directory)

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -424,7 +424,7 @@ def fast_save_pickle(shard, name):
     return
 
 
-def _preserve_tokenizer_eos_token(tokenizer, save_directory):
+def _preserve_tokenizer_eos_token(tokenizer, save_directory, filename_prefix = None):
     """Restore tokenizer_config.json eos_token from the tokenizer passed to save.
 
     Some merge paths may re-save or mutate tokenizer metadata after the tokenizer
@@ -433,6 +433,11 @@ def _preserve_tokenizer_eos_token(tokenizer, save_directory):
     as vLLM will not stop generation correctly. Keep the serialized metadata in
     sync with the source tokenizer without failing the save if the config is not
     present or cannot be edited.
+
+    `filename_prefix` mirrors the same argument on Transformers'
+    `PreTrainedTokenizerBase.save_pretrained`: when provided, the tokenizer
+    config is written as `{filename_prefix}-tokenizer_config.json` instead of
+    `tokenizer_config.json`.
     """
     if tokenizer is None or save_directory is None:
         return
@@ -447,7 +452,12 @@ def _preserve_tokenizer_eos_token(tokenizer, save_directory):
         return
     eos_token = str(eos_token)
 
-    tokenizer_config = os.path.join(str(save_directory), "tokenizer_config.json")
+    tokenizer_config_name = (
+        f"{filename_prefix}-tokenizer_config.json"
+        if filename_prefix
+        else "tokenizer_config.json"
+    )
+    tokenizer_config = os.path.join(str(save_directory), tokenizer_config_name)
     if not os.path.isfile(tokenizer_config):
         return
 
@@ -1025,7 +1035,9 @@ def unsloth_save_model(
 
         tokenizer.save_pretrained(**tokenizer_save_settings)
         _preserve_tokenizer_eos_token(
-            tokenizer, tokenizer_save_settings["save_directory"]
+            tokenizer,
+            tokenizer_save_settings["save_directory"],
+            filename_prefix = tokenizer_save_settings.get("filename_prefix"),
         )
 
         # Revert back padding side
@@ -3563,7 +3575,9 @@ def patch_saving_functions(model, vision = False):
             save_directory,
             token = kwargs.get("token", None),
         )
-        _preserve_tokenizer_eos_token(self, save_directory)
+        _preserve_tokenizer_eos_token(
+            self, save_directory, filename_prefix = filename_prefix,
+        )
         if push_to_hub:
             push_kwargs = dict(kwargs)
             repo_id = push_kwargs.pop("repo_id", save_directory)

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1080,9 +1080,7 @@ def unsloth_save_model(
     else:
         internal_model.save_pretrained(**save_pretrained_settings)
 
-    _preserve_tokenizer_eos_token(
-        tokenizer, save_pretrained_settings["save_directory"]
-    )
+    _preserve_tokenizer_eos_token(tokenizer, save_pretrained_settings["save_directory"])
 
     # Revert config back
     original_model = model


### PR DESCRIPTION
## Summary
- Preserve the source tokenizer's `eos_token` in `tokenizer_config.json` after merged saves.
- Covers both tokenizer and processor-style wrappers so Gemma 4 `<turn|>` survives merge paths.
- Add regression tests for restoring a corrupted `<eos>` config back to `<turn|>`.

## Test plan
- `python3 -m pytest tests/saving/test_preserve_tokenizer_eos_token.py -q`
- `python3 -m py_compile unsloth/save.py tests/saving/test_preserve_tokenizer_eos_token.py`
- `git diff --check`

Fixes #5386