### PR TITLE
fix(studio): require opt-in for stdio MCP providers 

### DIFF
--- a/studio/backend/core/data_recipe/service.py
+++ b/studio/backend/core/data_recipe/service.py
@@ -171,6 +171,25 @@ def _validate_recipe_runtime_support(
         raise ValueError("Add a Provider connection block before running this recipe.")
 
 
+_STDIO_MCP_OPT_IN_ENV = "UNSLOTH_STUDIO_ALLOW_STDIO_MCP"
+
+
+def _stdio_mcp_enabled() -> bool:
+    """Return True if local stdio MCP providers are explicitly opted into.
+
+    Local stdio MCP providers spawn an arbitrary subprocess whose command,
+    arguments, and environment all come from the recipe payload. Recipe
+    payloads are accepted from any client that can reach the Studio API
+    (including the local UI), so silently honouring stdio entries lets a
+    recipe author execute arbitrary commands on the host running Studio
+    (CWE-78). Require the operator to opt in explicitly via
+    ``UNSLOTH_STUDIO_ALLOW_STDIO_MCP=1`` before we build such a provider.
+    """
+    return os.environ.get(_STDIO_MCP_OPT_IN_ENV, "0").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
 def build_mcp_providers(
     recipe: dict[str, Any],
 ) -> list:
@@ -182,6 +201,13 @@ def build_mcp_providers(
             continue
         provider_type = provider.get("provider_type")
         if provider_type == "stdio":
+            # Refuse to materialise a stdio provider unless the operator
+            # has explicitly opted in. The command/args/env fields are
+            # attacker-controllable via the recipe payload and are passed
+            # straight to a subprocess by data_designer, so honouring
+            # them by default is a remote-code-execution sink (CWE-78).
+            if not _stdio_mcp_enabled():
+                continue
             env = provider.get("env")
             if not isinstance(env, dict):
                 env = {}

--- a/studio/backend/core/data_recipe/service.py
+++ b/studio/backend/core/data_recipe/service.py
@@ -186,7 +186,10 @@ def _stdio_mcp_enabled() -> bool:
     ``UNSLOTH_STUDIO_ALLOW_STDIO_MCP=1`` before we build such a provider.
     """
     return os.environ.get(_STDIO_MCP_OPT_IN_ENV, "0").strip().lower() in (
-        "1", "true", "yes", "on",
+        "1",
+        "true",
+        "yes",
+        "on",
     )
 
 


### PR DESCRIPTION
## Vulnerability Summary

The `build_mcp_providers` function in `studio/backend/core/data_recipe/service.py` accepts recipe payloads containing `mcp_providers` entries with `provider_type: "stdio"`. For stdio providers, the `command`, `args`, and `env` fields from the payload are passed directly to `LocalStdioMCPProvider`, which spawns a subprocess on the host.

The Studio API does not require authentication. When Studio is bound to `0.0.0.0` (which happens by default in Google Colab and remote setups), any network client can submit a crafted recipe payload and achieve arbitrary command execution on the host machine.

**CWE-78 (OS Command Injection)** — Severity: High

**Affected function:** `build_mcp_providers()` in `studio/backend/core/data_recipe/service.py`

**Data flow:**
1. Client sends POST request with a recipe payload containing `mcp_providers[].command`, `mcp_providers[].args`, `mcp_providers[].env`
2. `build_mcp_providers()` reads these fields and passes them to `LocalStdioMCPProvider(command=..., args=..., env=...)`
3. `LocalStdioMCPProvider` spawns the specified command as a subprocess — no validation, no allowlist

## Proof of Concept

```bash
# With Studio running on a remote host (e.g. Colab with 0.0.0.0 binding):
curl -X POST http://<studio-host>:7501/api/data-recipe/run \
  -H "Content-Type: application/json" \
  -d '{
    "mcp_providers": [{
      "provider_type": "stdio",
      "name": "pwned",
      "command": "/bin/sh",
      "args": ["-c", "id > /tmp/pwned.txt"],
      "env": {}
    }],
    "steps": []
  }'
```

This executes `/bin/sh -c "id > /tmp/pwned.txt"` on the host running Studio. The attacker controls the full command line and environment.

## Fix Description

This PR adds an environment-variable opt-in gate (`UNSLOTH_STUDIO_ALLOW_STDIO_MCP=1`) that must be explicitly set by the operator before stdio MCP providers are honoured. Without the opt-in, stdio provider entries in recipe payloads are silently skipped — the rest of the recipe (including SSE-based MCP providers) continues to work normally.

**Rationale:** Rather than attempting to sanitize or allowlist commands (which is fragile and breaks legitimate use cases), this fix follows a secure-by-default pattern: the dangerous capability is disabled unless the operator makes a conscious decision to enable it. This is the same pattern used by tools like Jupyter (`--allow-root`), Docker (`--privileged`), etc.

The change is minimal — one new helper function (`_stdio_mcp_enabled()`) and a three-line guard in `build_mcp_providers()`. No existing tests break, and SSE-based MCP providers are unaffected.

## Testing

- Verified the fix applies cleanly on current `main`
- Confirmed that without `UNSLOTH_STUDIO_ALLOW_STDIO_MCP=1`, stdio MCP providers are skipped and recipes with only SSE providers still work
- Confirmed that with `UNSLOTH_STUDIO_ALLOW_STDIO_MCP=1`, stdio providers are created as before (backward-compatible)
- Reviewed that the `os.environ.get` call handles missing/empty values safely, defaulting to disabled

## Adversarial Review

Before submitting, we attempted to disprove this finding. We considered whether existing mitigations would prevent exploitation: Studio has no authentication layer, no CORS restrictions that would block non-browser clients, and no input validation on the `command`/`args` fields. The only precondition is network access to the Studio API, which is satisfied whenever Studio is bound to a non-localhost address (the default in Colab and common remote-development workflows). We also verified that `LocalStdioMCPProvider` does in fact spawn the command as a subprocess without any sandboxing.