### PR TITLE
Studio: make API key optional for local providers (llama.cpp/vLLM/Ollama)

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -201,17 +201,24 @@ class ExternalProviderClient:
         self._stream_timeout = httpx.Timeout(timeout, connect = 10.0, read = None)
 
     def _auth_headers(self) -> dict[str, str]:
-        """Build authentication headers using the provider's registry config."""
+        """Build authentication headers using the provider's registry config.
+
+        For self-hosted local providers (llama.cpp / vLLM / Ollama) the API key
+        is optional — the dialog explicitly labels it that way. Skip the
+        auth header entirely when no key is supplied so we don't send an
+        empty ``Bearer `` value, which httpx rejects with
+        ``Illegal header value b'Bearer '`` and which would otherwise look
+        like a malformed auth attempt to strict upstreams.
+        """
         from core.inference.providers import get_provider_info
 
         provider_info = get_provider_info(self.provider_type) or {}
         auth_header = provider_info.get("auth_header", "Authorization")
         auth_prefix = provider_info.get("auth_prefix", "Bearer ")
 
-        headers = {
-            "Content-Type": "application/json",
-            auth_header: f"{auth_prefix}{self.api_key}",
-        }
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers[auth_header] = f"{auth_prefix}{self.api_key}"
         # Merge any provider-specific extra headers (e.g. anthropic-version, OpenRouter attribution)
         headers.update(provider_info.get("extra_headers", {}))
         return headers

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -201,15 +201,7 @@ class ExternalProviderClient:
         self._stream_timeout = httpx.Timeout(timeout, connect = 10.0, read = None)
 
     def _auth_headers(self) -> dict[str, str]:
-        """Build authentication headers using the provider's registry config.
-
-        For self-hosted local providers (llama.cpp / vLLM / Ollama) the API key
-        is optional — the dialog explicitly labels it that way. Skip the
-        auth header entirely when no key is supplied so we don't send an
-        empty ``Bearer `` value, which httpx rejects with
-        ``Illegal header value b'Bearer '`` and which would otherwise look
-        like a malformed auth attempt to strict upstreams.
-        """
+        """Build authentication headers using the provider's registry config."""
         from core.inference.providers import get_provider_info
 
         provider_info = get_provider_info(self.provider_type) or {}
@@ -217,6 +209,8 @@ class ExternalProviderClient:
         auth_prefix = provider_info.get("auth_prefix", "Bearer ")
 
         headers = {"Content-Type": "application/json"}
+        # Skip auth header when api_key is empty (optional for local providers);
+        # httpx rejects an empty `Bearer ` value as "Illegal header value".
         if self.api_key:
             headers[auth_header] = f"{auth_prefix}{self.api_key}"
         # Merge any provider-specific extra headers (e.g. anthropic-version, OpenRouter attribution)

--- a/studio/backend/models/providers.py
+++ b/studio/backend/models/providers.py
@@ -95,8 +95,6 @@ class ProviderModelsRequest(BaseModel):
     """Request to list models from an external provider."""
 
     provider_type: str = Field(..., description = "Provider type from the registry")
-    # Optional: self-hosted custom providers (llama.cpp / vLLM / Ollama) often
-    # run without auth. The route skips decryption + the auth header when omitted.
     encrypted_api_key: Optional[str] = Field(
         None, description = "RSA-encrypted, base64-encoded API key (optional for local providers)"
     )
@@ -112,8 +110,6 @@ class ProviderTestRequest(BaseModel):
     """Request to test connectivity to an external provider."""
 
     provider_type: str = Field(..., description = "Provider type from the registry")
-    # Optional: self-hosted custom providers (llama.cpp / vLLM / Ollama) often
-    # run without auth. The route skips decryption + the auth header when omitted.
     encrypted_api_key: Optional[str] = Field(
         None, description = "RSA-encrypted, base64-encoded API key (optional for local providers)"
     )

--- a/studio/backend/models/providers.py
+++ b/studio/backend/models/providers.py
@@ -95,8 +95,10 @@ class ProviderModelsRequest(BaseModel):
     """Request to list models from an external provider."""
 
     provider_type: str = Field(..., description = "Provider type from the registry")
-    encrypted_api_key: str = Field(
-        ..., description = "RSA-encrypted, base64-encoded API key"
+    # Optional: self-hosted custom providers (llama.cpp / vLLM / Ollama) often
+    # run without auth. The route skips decryption + the auth header when omitted.
+    encrypted_api_key: Optional[str] = Field(
+        None, description = "RSA-encrypted, base64-encoded API key (optional for local providers)"
     )
     base_url: Optional[str] = Field(
         None, description = "Custom base URL (overrides registry default)"
@@ -110,8 +112,10 @@ class ProviderTestRequest(BaseModel):
     """Request to test connectivity to an external provider."""
 
     provider_type: str = Field(..., description = "Provider type from the registry")
-    encrypted_api_key: str = Field(
-        ..., description = "RSA-encrypted, base64-encoded API key"
+    # Optional: self-hosted custom providers (llama.cpp / vLLM / Ollama) often
+    # run without auth. The route skips decryption + the auth header when omitted.
+    encrypted_api_key: Optional[str] = Field(
+        None, description = "RSA-encrypted, base64-encoded API key (optional for local providers)"
     )
     base_url: Optional[str] = Field(
         None, description = "Custom base URL (overrides registry default)"

--- a/studio/backend/models/providers.py
+++ b/studio/backend/models/providers.py
@@ -96,7 +96,8 @@ class ProviderModelsRequest(BaseModel):
 
     provider_type: str = Field(..., description = "Provider type from the registry")
     encrypted_api_key: Optional[str] = Field(
-        None, description = "RSA-encrypted, base64-encoded API key (optional for local providers)"
+        None,
+        description = "RSA-encrypted, base64-encoded API key (optional for local providers)",
     )
     base_url: Optional[str] = Field(
         None, description = "Custom base URL (overrides registry default)"
@@ -111,7 +112,8 @@ class ProviderTestRequest(BaseModel):
 
     provider_type: str = Field(..., description = "Provider type from the registry")
     encrypted_api_key: Optional[str] = Field(
-        None, description = "RSA-encrypted, base64-encoded API key (optional for local providers)"
+        None,
+        description = "RSA-encrypted, base64-encoded API key (optional for local providers)",
     )
     base_url: Optional[str] = Field(
         None, description = "Custom base URL (overrides registry default)"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1554,15 +1554,19 @@ async def _proxy_to_external_provider(
             detail = f"Unknown provider type: {provider_type}",
         )
 
-    # Decrypt the API key
-    try:
-        api_key = decrypt_api_key(payload.encrypted_api_key)
-    except Exception as exc:
-        logger.warning("external_provider.decrypt_failed", error = str(exc))
-        raise HTTPException(
-            status_code = 400,
-            detail = "Failed to decrypt API key. The server key may have changed — try refreshing the page.",
-        )
+    # Decrypt the API key when present. The key is optional for self-hosted
+    # local providers (llama.cpp / vLLM / Ollama); the client downstream
+    # omits the Authorization header when ``api_key`` is empty.
+    api_key = ""
+    if payload.encrypted_api_key:
+        try:
+            api_key = decrypt_api_key(payload.encrypted_api_key)
+        except Exception as exc:
+            logger.warning("external_provider.decrypt_failed", error = str(exc))
+            raise HTTPException(
+                status_code = 400,
+                detail = "Failed to decrypt API key. The server key may have changed — try refreshing the page.",
+            )
 
     model = payload.external_model or payload.model
     if model == "default":
@@ -1646,7 +1650,12 @@ async def openai_chat_completions(
     - Other models → Unsloth/transformers via InferenceBackend
     """
     # ── External provider routing ────────────────────────────────
-    if payload.encrypted_api_key and (payload.provider_id or payload.provider_type):
+    # ``encrypted_api_key`` is optional: self-hosted custom providers
+    # (llama.cpp / vLLM / Ollama) frequently run without auth, and the
+    # connection dialog explicitly marks the key as optional for them.
+    # Route on provider identity alone — the proxy below skips auth
+    # headers when no key is supplied.
+    if payload.provider_id or payload.provider_type:
         return await _proxy_to_external_provider(payload, request)
 
     llama_backend = get_llama_cpp_backend()

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1554,9 +1554,6 @@ async def _proxy_to_external_provider(
             detail = f"Unknown provider type: {provider_type}",
         )
 
-    # Decrypt the API key when present. The key is optional for self-hosted
-    # local providers (llama.cpp / vLLM / Ollama); the client downstream
-    # omits the Authorization header when ``api_key`` is empty.
     api_key = ""
     if payload.encrypted_api_key:
         try:
@@ -1650,11 +1647,7 @@ async def openai_chat_completions(
     - Other models → Unsloth/transformers via InferenceBackend
     """
     # ── External provider routing ────────────────────────────────
-    # ``encrypted_api_key`` is optional: self-hosted custom providers
-    # (llama.cpp / vLLM / Ollama) frequently run without auth, and the
-    # connection dialog explicitly marks the key as optional for them.
-    # Route on provider identity alone — the proxy below skips auth
-    # headers when no key is supplied.
+    # encrypted_api_key is optional — local providers (llama.cpp / vLLM / Ollama) may run without auth.
     if payload.provider_id or payload.provider_type:
         return await _proxy_to_external_provider(payload, request)
 

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -205,7 +205,9 @@ async def test_provider(
         try:
             api_key = decrypt_api_key(payload.encrypted_api_key)
         except Exception as exc:
-            logger.warning("Failed to decrypt API key (%s): %s", type(exc).__name__, exc)
+            logger.warning(
+                "Failed to decrypt API key (%s): %s", type(exc).__name__, exc
+            )
             raise HTTPException(
                 status_code = 400,
                 detail = "Failed to decrypt API key. The public key may have changed — try refreshing the page.",
@@ -272,7 +274,9 @@ async def list_provider_models(
         try:
             api_key = decrypt_api_key(payload.encrypted_api_key)
         except Exception as exc:
-            logger.warning("Failed to decrypt API key (%s): %s", type(exc).__name__, exc)
+            logger.warning(
+                "Failed to decrypt API key (%s): %s", type(exc).__name__, exc
+            )
             raise HTTPException(
                 status_code = 400,
                 detail = "Failed to decrypt API key. The public key may have changed — try refreshing the page.",

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -200,14 +200,18 @@ async def test_provider(
             detail = f"Unknown provider type: {payload.provider_type}",
         )
 
-    try:
-        api_key = decrypt_api_key(payload.encrypted_api_key)
-    except Exception as exc:
-        logger.warning("Failed to decrypt API key (%s): %s", type(exc).__name__, exc)
-        raise HTTPException(
-            status_code = 400,
-            detail = "Failed to decrypt API key. The public key may have changed — try refreshing the page.",
-        )
+    # Key is optional for self-hosted local providers (llama.cpp / vLLM /
+    # Ollama). When omitted, the client skips the auth header.
+    api_key = ""
+    if payload.encrypted_api_key:
+        try:
+            api_key = decrypt_api_key(payload.encrypted_api_key)
+        except Exception as exc:
+            logger.warning("Failed to decrypt API key (%s): %s", type(exc).__name__, exc)
+            raise HTTPException(
+                status_code = 400,
+                detail = "Failed to decrypt API key. The public key may have changed — try refreshing the page.",
+            )
 
     base_url = payload.base_url or info["base_url"]
     client = ExternalProviderClient(
@@ -265,14 +269,18 @@ async def list_provider_models(
             detail = f"Unknown provider type: {payload.provider_type}",
         )
 
-    try:
-        api_key = decrypt_api_key(payload.encrypted_api_key)
-    except Exception as exc:
-        logger.warning("Failed to decrypt API key (%s): %s", type(exc).__name__, exc)
-        raise HTTPException(
-            status_code = 400,
-            detail = "Failed to decrypt API key. The public key may have changed — try refreshing the page.",
-        )
+    # Key is optional for self-hosted local providers (llama.cpp / vLLM /
+    # Ollama). When omitted, the client skips the auth header.
+    api_key = ""
+    if payload.encrypted_api_key:
+        try:
+            api_key = decrypt_api_key(payload.encrypted_api_key)
+        except Exception as exc:
+            logger.warning("Failed to decrypt API key (%s): %s", type(exc).__name__, exc)
+            raise HTTPException(
+                status_code = 400,
+                detail = "Failed to decrypt API key. The public key may have changed — try refreshing the page.",
+            )
 
     if info.get("model_list_mode") == "curated":
         return [

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -200,8 +200,6 @@ async def test_provider(
             detail = f"Unknown provider type: {payload.provider_type}",
         )
 
-    # Key is optional for self-hosted local providers (llama.cpp / vLLM /
-    # Ollama). When omitted, the client skips the auth header.
     api_key = ""
     if payload.encrypted_api_key:
         try:
@@ -269,8 +267,6 @@ async def list_provider_models(
             detail = f"Unknown provider type: {payload.provider_type}",
         )
 
-    # Key is optional for self-hosted local providers (llama.cpp / vLLM /
-    # Ollama). When omitted, the client skips the auth header.
     api_key = ""
     if payload.encrypted_api_key:
         try:

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -26,6 +26,7 @@ import type {
 } from "../types/api";
 import {
   getExternalProviderApiKey,
+  isCustomProviderType,
   loadExternalProviders,
   parseExternalModelId,
   supportsProviderPromptCaching,
@@ -748,7 +749,13 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         });
         throw new Error("External provider not found.");
       }
-      if (isExternalRequest && !externalApiKey) {
+      // Self-hosted custom providers (llama.cpp / vLLM / Ollama) frequently
+      // run without auth — the connection dialog already marks the key as
+      // optional for them. Only block hosted providers when the key is missing.
+      const externalProviderIsCustom = externalProvider
+        ? isCustomProviderType(externalProvider.providerType)
+        : false;
+      if (isExternalRequest && !externalApiKey && !externalProviderIsCustom) {
         toast.error("Missing API key for selected external provider.", {
           description: "Open Connections and set the API key again.",
         });
@@ -1028,10 +1035,17 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               provider_id: externalProvider.id,
               provider_type: externalBackendProviderType,
               external_model: externalSelection.modelId,
-              encrypted_api_key: await encryptProviderApiKey(
-                externalApiKey,
-                forceRefreshPublicKey,
-              ),
+              // Encrypt only when there's actually a key to send; the
+              // backend skips auth headers when ``encrypted_api_key`` is
+              // omitted (used for local llama.cpp / vLLM / Ollama).
+              ...(externalApiKey
+                ? {
+                    encrypted_api_key: await encryptProviderApiKey(
+                      externalApiKey,
+                      forceRefreshPublicKey,
+                    ),
+                  }
+                : {}),
               provider_base_url: externalProvider.baseUrl || null,
               ...(supportsProviderPromptCaching(externalProvider.providerType)
                 ? {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -749,9 +749,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         });
         throw new Error("External provider not found.");
       }
-      // Self-hosted custom providers (llama.cpp / vLLM / Ollama) frequently
-      // run without auth — the connection dialog already marks the key as
-      // optional for them. Only block hosted providers when the key is missing.
+      // Local providers (llama.cpp / vLLM / Ollama) allow an empty key — only block hosted providers.
       const externalProviderIsCustom = externalProvider
         ? isCustomProviderType(externalProvider.providerType)
         : false;
@@ -1035,9 +1033,6 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               provider_id: externalProvider.id,
               provider_type: externalBackendProviderType,
               external_model: externalSelection.modelId,
-              // Encrypt only when there's actually a key to send; the
-              // backend skips auth headers when ``encrypted_api_key`` is
-              // omitted (used for local llama.cpp / vLLM / Ollama).
               ...(externalApiKey
                 ? {
                     encrypted_api_key: await encryptProviderApiKey(

--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -178,10 +178,7 @@ async function withApiKeyEncryptionRetry<T>(
   plaintextApiKey: string,
   call: (encryptedApiKey: string | null) => Promise<T>,
 ): Promise<T> {
-  // Allow callers to pass an empty key for self-hosted local providers
-  // (llama.cpp / vLLM / Ollama). The backend treats a missing
-  // ``encrypted_api_key`` as "no auth header" rather than failing
-  // decryption on an empty ciphertext.
+  // Empty key (local providers): skip RSA round-trip and let the backend omit auth.
   if (!plaintextApiKey) {
     return await call(null);
   }

--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -176,8 +176,15 @@ export async function updateProviderConfig(
 
 async function withApiKeyEncryptionRetry<T>(
   plaintextApiKey: string,
-  call: (encryptedApiKey: string) => Promise<T>,
+  call: (encryptedApiKey: string | null) => Promise<T>,
 ): Promise<T> {
+  // Allow callers to pass an empty key for self-hosted local providers
+  // (llama.cpp / vLLM / Ollama). The backend treats a missing
+  // ``encrypted_api_key`` as "no auth header" rather than failing
+  // decryption on an empty ciphertext.
+  if (!plaintextApiKey) {
+    return await call(null);
+  }
   try {
     const encrypted = await encryptProviderApiKey(plaintextApiKey, false);
     return await call(encrypted);


### PR DESCRIPTION
## Summary

The dialog says the API key is "(optional)" for llama.cpp / vLLM / Ollama, but everything downstream still required it. This makes it actually optional for those three.

Hosted providers are unchanged on the wire the dialog still requires a key for non-custom, so they always send the encrypted key and hit the exact same backend code path as before.

Backend:
- `_auth_headers` skips the auth header when no key is set (httpx rejects empty `Bearer `).
- Chat route now routes to the external proxy on provider id/type alone, and only decrypts when a key is present.
- Same conditional decrypt in `/api/providers/test` + `/models`.
- `encrypted_api_key` is now `Optional` on both request schemas.

Frontend:
- chat-adapter: don't block the send when the provider is custom and the key is empty; omit `encrypted_api_key` from the body.
- providers-api: skip the RSA round-trip on empty key, send `null`.

<img width="3430" height="643" alt="image" src="https://github.com/user-attachments/assets/da4479c8-3232-4b4b-bb30-b5372fdae36b" />


## Test

- [x] llama.cpp / vLLM / Ollama: chat works with no key
- [x] Same three with a key: `Authorization` header sent
- [x] Hosted providers (OpenAI / Anthropic / etc.): chat, test, load models still work