### PR TITLE
ci: add tx >=5,<6 slow compile model_types to KNOWN_BROKEN_COMPILE

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -962,6 +962,12 @@ jobs:
               # Category E: undefined name in emitted file.
               "perceiver":       "name 'AbstractPreprocessor' is not defined",
               "sam3_lite_text":  "name 'Sam3LiteTextLayerScaledResidual' is not defined",
+              # Category F: compile exceeds 60s budget on the runner.
+              # First seen on transformers >=5,<6; each represents a slow
+              # or recursive source-rewriter path the zoo can address.
+              "beit":            "TimeoutError: compile exceeds per-model budget",
+              "sam":             "TimeoutError: compile exceeds per-model budget",
+              "sam_hq":          "TimeoutError: compile exceeds per-model budget",
           }
 
 


### PR DESCRIPTION
## Summary
- The per-model SIGALRM cap (#5456) now exposes \`beit\` / \`sam\` / \`sam_hq\` as compile-too-slow on transformers >=5,<6 + trl >=1,<2 — each exceeds the 60s per-model budget. These are real slow paths in \`unsloth_compile_transformers\`'s source rewriter, not infra flakes.
- Bucket them into Category F (compile exceeds budget) so the sweep stays green and each is tracked for follow-up zoo fixes in the same shape as the existing 27 known-broken entries. New slow model_types continue to fail the cell with a \`TimeoutError\` tag.

## Test plan
- [ ] Core (HF=latest + TRL=latest) and (HF=default + TRL=default) on dependent PRs complete without listing beit/sam/sam_hq under new failures.