### PR TITLE
ci: make Windows Stop Studio teardown tolerate Git Bash signal exit

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -345,9 +345,15 @@ jobs:
 
       - name: Stop Studio
         if: always()
+        # `set +e` + redirect everything: Git Bash on windows-latest
+        # has been observed to exit 143 from the kill/sleep block even
+        # when the upstream test work passed, masking a green run. The
+        # teardown does not gate correctness, so absorb any signal.
         run: |
-          kill "${STUDIO_PID}" 2>/dev/null || true
-          sleep 2
+          set +e
+          kill "${STUDIO_PID}" >/dev/null 2>&1 || true
+          sleep 2 >/dev/null 2>&1 || true
+          exit 0
 
       - name: Upload logs
         if: always()
@@ -762,9 +768,15 @@ jobs:
 
       - name: Stop Studio
         if: always()
+        # `set +e` + redirect everything: Git Bash on windows-latest
+        # has been observed to exit 143 from the kill/sleep block even
+        # when the upstream test work passed, masking a green run. The
+        # teardown does not gate correctness, so absorb any signal.
         run: |
-          kill "${STUDIO_PID}" 2>/dev/null || true
-          sleep 2
+          set +e
+          kill "${STUDIO_PID}" >/dev/null 2>&1 || true
+          sleep 2 >/dev/null 2>&1 || true
+          exit 0
 
       - name: Upload logs
         if: always()
@@ -1150,9 +1162,15 @@ jobs:
 
       - name: Stop Studio
         if: always()
+        # `set +e` + redirect everything: Git Bash on windows-latest
+        # has been observed to exit 143 from the kill/sleep block even
+        # when the upstream test work passed, masking a green run. The
+        # teardown does not gate correctness, so absorb any signal.
         run: |
-          kill "${STUDIO_PID}" 2>/dev/null || true
-          sleep 2
+          set +e
+          kill "${STUDIO_PID}" >/dev/null 2>&1 || true
+          sleep 2 >/dev/null 2>&1 || true
+          exit 0
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
## Summary
- The Windows-runner \"Stop Studio\" teardown step (\`kill \$STUDIO_PID; sleep 2\`) has been observed to exit 143 (SIGTERM) on Git Bash even when the upstream test work passed. Caught most recently on PR #5432 Job 3 \"JSON, images\": all four assertions (json_object, plain inference, image/openai, image/anthropic) printed PASS, then the kill step ran for ~2 seconds and exited 143, failing the job.
- Teardown does not gate correctness. Wrap all three Windows \"Stop Studio\" steps with \`set +e\` + redirected error streams + explicit \`exit 0\` so transient Git Bash signal weirdness no longer masks a green test run.

## Test plan
- [ ] Windows GGUF CI Job 3 (JSON, images) reaches green on dependent PRs.