### PR TITLE
ci: switch Windows Stop Studio to a cmd no-op marker

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -345,15 +345,13 @@ jobs:
 
       - name: Stop Studio
         if: always()
-        # `set +e` + redirect everything: Git Bash on windows-latest
-        # has been observed to exit 143 from the kill/sleep block even
-        # when the upstream test work passed, masking a green run. The
-        # teardown does not gate correctness, so absorb any signal.
-        run: |
-          set +e
-          kill "${STUDIO_PID}" >/dev/null 2>&1 || true
-          sleep 2 >/dev/null 2>&1 || true
-          exit 0
+        # Run as cmd so we are not running through the Git Bash shell;
+        # Git Bash on windows-latest has been observed to exit 143
+        # (SIGTERM) from any inline kill/sleep block, masking a green
+        # test run. The runner reclaims the Studio child process at
+        # job end either way, so just emit a marker and exit 0.
+        shell: cmd
+        run: echo Stop Studio (no-op; runner reclaims STUDIO_PID=%STUDIO_PID% at job end)
 
       - name: Upload logs
         if: always()
@@ -768,15 +766,13 @@ jobs:
 
       - name: Stop Studio
         if: always()
-        # `set +e` + redirect everything: Git Bash on windows-latest
-        # has been observed to exit 143 from the kill/sleep block even
-        # when the upstream test work passed, masking a green run. The
-        # teardown does not gate correctness, so absorb any signal.
-        run: |
-          set +e
-          kill "${STUDIO_PID}" >/dev/null 2>&1 || true
-          sleep 2 >/dev/null 2>&1 || true
-          exit 0
+        # Run as cmd so we are not running through the Git Bash shell;
+        # Git Bash on windows-latest has been observed to exit 143
+        # (SIGTERM) from any inline kill/sleep block, masking a green
+        # test run. The runner reclaims the Studio child process at
+        # job end either way, so just emit a marker and exit 0.
+        shell: cmd
+        run: echo Stop Studio (no-op; runner reclaims STUDIO_PID=%STUDIO_PID% at job end)
 
       - name: Upload logs
         if: always()
@@ -1162,15 +1158,13 @@ jobs:
 
       - name: Stop Studio
         if: always()
-        # `set +e` + redirect everything: Git Bash on windows-latest
-        # has been observed to exit 143 from the kill/sleep block even
-        # when the upstream test work passed, masking a green run. The
-        # teardown does not gate correctness, so absorb any signal.
-        run: |
-          set +e
-          kill "${STUDIO_PID}" >/dev/null 2>&1 || true
-          sleep 2 >/dev/null 2>&1 || true
-          exit 0
+        # Run as cmd so we are not running through the Git Bash shell;
+        # Git Bash on windows-latest has been observed to exit 143
+        # (SIGTERM) from any inline kill/sleep block, masking a green
+        # test run. The runner reclaims the Studio child process at
+        # job end either way, so just emit a marker and exit 0.
+        shell: cmd
+        run: echo Stop Studio (no-op; runner reclaims STUDIO_PID=%STUDIO_PID% at job end)
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
## Summary
- The prior \`set +e\` + redirect + \`exit 0\` fix in #5460 did not stop the Windows GGUF CI \"Stop Studio\" step from exiting 143 (SIGTERM) on Git Bash. The shell exits with SIGTERM before any inline guard executes, regardless of redirection — caught most recently on PR #5430 Job 3 \"JSON, images\" where the test assertions all PASSed and the teardown still failed the job.
- Switch the shell from Git Bash to \`cmd\` and emit a no-op marker line. The runner reclaims the Studio child process when the job ends, so the kill+sleep was never load-bearing.

## Test plan
- [ ] Job 3 (JSON, images) on dependent PRs reaches green when the test work succeeds.