### PR TITLE
tests: raise pwsh/bash subprocess timeout from 10s to 60s

### DIFF
--- a/tests/studio/install/test_llama_pr_force_and_source.py
+++ b/tests/studio/install/test_llama_pr_force_and_source.py
@@ -35,9 +35,11 @@ requires_pwsh = pytest.mark.skipif(not PWSH_AVAILABLE, reason = "pwsh not availa
 # Helpers
 # ---------------------------------------------------------------------------
 def run_bash(
-    script: str, *, timeout: int = 10, env: dict | None = None
+    script: str, *, timeout: int = 60, env: dict | None = None
 ) -> subprocess.CompletedProcess:
-    """Run a bash script fragment and return the CompletedProcess."""
+    """Run a bash script fragment and return the CompletedProcess.
+    60s default tolerates slow shell startup on heavily-loaded CI
+    runners; the scripts themselves run in well under a second."""
     run_env = os.environ.copy()
     if env:
         run_env.update(env)
@@ -51,9 +53,12 @@ def run_bash(
 
 
 def run_pwsh(
-    script: str, *, timeout: int = 10, env: dict | None = None
+    script: str, *, timeout: int = 60, env: dict | None = None
 ) -> subprocess.CompletedProcess:
-    """Run a PowerShell script fragment and return the CompletedProcess."""
+    """Run a PowerShell script fragment and return the CompletedProcess.
+    60s default tolerates slow pwsh startup on heavily-loaded CI
+    runners; the scripts themselves run in well under a second.
+    A 10s budget previously surfaced as a flaky TimeoutExpired."""
     run_env = os.environ.copy()
     run_env["NO_COLOR"] = "1"
     if env:


### PR DESCRIPTION
## Summary
- \`TestPwshPrForcePromotion.test_baked_in_pr_force_promotes\` flakes on Linux \"Repo tests (CPU)\" with \`subprocess.TimeoutExpired\` after 10s on \`/usr/bin/pwsh\` startup. The scripts under test run in well under a second; the 10s budget only covered pwsh / bash launch time, which spikes on heavily-loaded GitHub-hosted runners.
- Raise the default helper timeout to 60s for both \`run_bash\` and \`run_pwsh\`. Real bugs in the script logic still surface as wrong output or non-zero exit; this just absorbs runner-side launch jitter.

## Test plan
- [ ] \"Repo tests (CPU)\" no longer flakes on \`test_baked_in_pr_force_promotes\` across the affected PRs.