### PR TITLE
studio/chat: OpenAI container picker delete reliability

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2870,7 +2870,17 @@ class ExternalProviderClient:
         response.raise_for_status()
         data = response.json()
         containers = data.get("data") if isinstance(data, dict) else None
-        return list(containers) if isinstance(containers, list) else []
+        result = list(containers) if isinstance(containers, list) else []
+        logger.info(
+            "openai_container_list.response count=%s items=%s",
+            len(result),
+            [
+                {"id": c.get("id"), "status": c.get("status")}
+                for c in result
+                if isinstance(c, dict)
+            ],
+        )
+        return result
 
     async def create_openai_container(
         self,

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2934,8 +2934,14 @@ class ExternalProviderClient:
         async with httpx.AsyncClient(timeout = self._timeout) as fresh_client:
             response = await fresh_client.delete(url, headers = headers)
         logger.info(
-            "openai_container_delete.response status=%s body=%s",
+            "openai_container_delete.response status=%s cf_ray=%s "
+            "request_id=%s organization=%s project=%s processing_ms=%s body=%s",
             response.status_code,
+            response.headers.get("cf-ray"),
+            response.headers.get("x-request-id"),
+            response.headers.get("openai-organization"),
+            response.headers.get("openai-project"),
+            response.headers.get("openai-processing-ms"),
             response.text[:300],
         )
         response.raise_for_status()

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2911,6 +2911,13 @@ class ExternalProviderClient:
     async def delete_openai_container(self, container_id: str) -> None:
         """DELETE /v1/containers/{id}. 404s are surfaced as HTTPError.
 
+        Uses a fresh httpx client (not the shared ``_http_client``) so
+        connection-pool state from earlier chat requests cannot
+        interfere — observed in the wild that DELETEs over the shared
+        pool returned ``deleted: true`` while the container persisted
+        in subsequent /containers list calls, even though the same
+        DELETE issued from a fresh client genuinely removed it.
+
         Verifies the response body reports ``deleted: true``. OpenAI
         returns a 2xx ``deleted: true`` body even when the request is
         silently rejected (e.g. missing OpenAI-Beta header), so a
@@ -2924,11 +2931,8 @@ class ExternalProviderClient:
             "Authorization" in headers,
             headers.get("OpenAI-Beta"),
         )
-        response = await _http_client.delete(
-            url,
-            headers = headers,
-            timeout = self._timeout,
-        )
+        async with httpx.AsyncClient(timeout = self._timeout) as fresh_client:
+            response = await fresh_client.delete(url, headers = headers)
         logger.info(
             "openai_container_delete.response status=%s body=%s",
             response.status_code,

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2906,10 +2906,23 @@ class ExternalProviderClient:
         silently rejected (e.g. missing OpenAI-Beta header), so a
         status-only check is not sufficient.
         """
+        url = f"{self.base_url}/containers/{container_id}"
+        headers = self._container_headers()
+        logger.info(
+            "openai_container_delete.outbound url=%s has_auth=%s openai_beta=%s",
+            url,
+            "Authorization" in headers,
+            headers.get("OpenAI-Beta"),
+        )
         response = await _http_client.delete(
-            f"{self.base_url}/containers/{container_id}",
-            headers = self._container_headers(),
+            url,
+            headers = headers,
             timeout = self._timeout,
+        )
+        logger.info(
+            "openai_container_delete.response status=%s body=%s",
+            response.status_code,
+            response.text[:300],
         )
         response.raise_for_status()
         try:

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -650,11 +650,11 @@ class CreateOpenAIContainerBody(OpenAIContainerRequest):
     ttl_minutes: int = Field(
         20,
         ge = 1,
-        le = 10080,  # 1 week
+        le = 20,
         description = (
             "Idle-timeout TTL the new container will inherit (anchor="
-            "last_active_at). OpenAI's default is 20; we cap at one "
-            "week as a safety bound."
+            "last_active_at). OpenAI hard-caps this at 20 minutes and "
+            "rejects larger values with integer_above_max_value."
         ),
     )
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1664,6 +1664,20 @@ def _resolve_openai_cloud_client(
             status_code = 400,
             detail = "Failed to decrypt API key. The server key may have changed — try refreshing the page.",
         )
+    # Fingerprint the decrypted key so we can compare against the one the
+    # user expects (without ever logging the full secret). Last-4 only,
+    # plus length and prefix-kind ("sk-proj-" vs "sk-").
+    kind = (
+        "sk-proj-"
+        if api_key.startswith("sk-proj-")
+        else ("sk-" if api_key.startswith("sk-") else "other")
+    )
+    logger.info(
+        "openai_container.api_key_fingerprint kind=%s len=%s last4=%s",
+        kind,
+        len(api_key),
+        api_key[-4:] if len(api_key) >= 4 else "<short>",
+    )
     return ExternalProviderClient(
         provider_type = "openai",
         base_url = base_url,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1716,8 +1716,15 @@ async def list_openai_containers(
                 status_code = 502,
                 detail = f"Failed to reach OpenAI: {exc}",
             )
+        # OpenAI keeps expired containers in /v1/containers indefinitely
+        # with status="expired" — they're effectively dead but still
+        # listed. Hide them so the picker only shows usable containers.
         return ListOpenAIContainersResponse(
-            containers = [_summarize_container(c) for c in raw if isinstance(c, dict)],
+            containers = [
+                _summarize_container(c)
+                for c in raw
+                if isinstance(c, dict) and c.get("status") != "expired"
+            ],
         )
     finally:
         await client.close()

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1773,17 +1773,38 @@ async def delete_openai_container(
     current_subject: str = Depends(get_current_subject),
 ) -> None:
     """Delete a named container by id."""
+    logger.info(
+        "openai_container_delete.request subject=%s container_id=%s base_url=%s",
+        current_subject,
+        body.container_id,
+        body.provider_base_url,
+    )
     client = _resolve_openai_cloud_client(body)
     try:
         try:
             await client.delete_openai_container(body.container_id)
+            logger.info(
+                "openai_container_delete.success container_id=%s",
+                body.container_id,
+            )
         except httpx.HTTPStatusError as exc:
             detail = exc.response.text[:500] if exc.response is not None else str(exc)
+            logger.warning(
+                "openai_container_delete.openai_rejected container_id=%s status=%s body=%s",
+                body.container_id,
+                exc.response.status_code if exc.response else None,
+                detail,
+            )
             raise HTTPException(
                 status_code = exc.response.status_code if exc.response else 502,
                 detail = f"OpenAI rejected /containers delete: {detail}",
             )
         except httpx.HTTPError as exc:
+            logger.warning(
+                "openai_container_delete.transport_error container_id=%s error=%s",
+                body.container_id,
+                exc,
+            )
             raise HTTPException(
                 status_code = 502,
                 detail = f"Failed to reach OpenAI: {exc}",

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1664,20 +1664,6 @@ def _resolve_openai_cloud_client(
             status_code = 400,
             detail = "Failed to decrypt API key. The server key may have changed — try refreshing the page.",
         )
-    # Fingerprint the decrypted key so we can compare against the one the
-    # user expects (without ever logging the full secret). Last-4 only,
-    # plus length and prefix-kind ("sk-proj-" vs "sk-").
-    kind = (
-        "sk-proj-"
-        if api_key.startswith("sk-proj-")
-        else ("sk-" if api_key.startswith("sk-") else "other")
-    )
-    logger.info(
-        "openai_container.api_key_fingerprint kind=%s len=%s last4=%s",
-        kind,
-        len(api_key),
-        api_key[-4:] if len(api_key) >= 4 else "<short>",
-    )
     return ExternalProviderClient(
         provider_type = "openai",
         base_url = base_url,

--- a/studio/backend/tests/test_openai_container_crud.py
+++ b/studio/backend/tests/test_openai_container_crud.py
@@ -149,3 +149,41 @@ def test_delete_propagates_openai_4xx(monkeypatch):
 
     with pytest.raises(httpx.HTTPStatusError):
         _drive(_make_client().delete_openai_container("cntr_missing"))
+
+
+def test_list_route_filters_expired_containers(monkeypatch):
+    """OpenAI keeps containers in /v1/containers indefinitely with
+    status="expired" after their idle TTL passes — they can't be
+    used but still show up. The list route must drop them so the
+    picker only surfaces usable containers."""
+    from routes import inference as inf_mod
+    from models.inference import OpenAIContainerRequest
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json = {
+                "data": [
+                    {"id": "cntr_active", "name": "live", "status": "running"},
+                    {"id": "cntr_dead", "name": "old", "status": "expired"},
+                    {"id": "cntr_unknown", "name": "no-status"},
+                ],
+            },
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    def fake_resolve(_body):
+        return _make_client()
+
+    monkeypatch.setattr(inf_mod, "_resolve_openai_cloud_client", fake_resolve)
+
+    body = OpenAIContainerRequest(
+        encrypted_api_key = "enc",
+        provider_base_url = "https://api.openai.com/v1",
+    )
+    response = _drive(inf_mod.list_openai_containers(body, current_subject = "u"))
+    ids = [c.id for c in response.containers]
+    assert "cntr_active" in ids
+    assert "cntr_unknown" in ids  # missing status is treated as usable
+    assert "cntr_dead" not in ids

--- a/studio/frontend/src/features/chat/api/openai-containers.ts
+++ b/studio/frontend/src/features/chat/api/openai-containers.ts
@@ -115,7 +115,10 @@ export async function deleteOpenAIContainer(
       }),
     },
   );
-  if (!response.ok && response.status !== 204) {
+  // 404 = container already gone (deleted elsewhere, or expired-then-purged).
+  // Treat as idempotent success so a stale list entry doesn't surface as a
+  // confusing error — the caller will refresh and the entry will disappear.
+  if (!response.ok && response.status !== 204 && response.status !== 404) {
     throw new Error(await parseError(response));
   }
 }

--- a/studio/frontend/src/features/chat/components/openai-code-exec-section.tsx
+++ b/studio/frontend/src/features/chat/components/openai-code-exec-section.tsx
@@ -49,7 +49,7 @@ import { ensureThreadRecord } from "../runtime-provider";
 const AUTO_OPTION_VALUE = "__auto__";
 const DEFAULT_TTL_MINUTES = 20;
 const TTL_MIN = 1;
-const TTL_MAX = 10080; // one week — matches backend bound
+const TTL_MAX = 20; // OpenAI hard cap on expires_after.minutes
 
 function ageLabel(epochSeconds: number | null | undefined): string {
   if (!epochSeconds) return "";
@@ -223,7 +223,6 @@ export function OpenAICodeExecSection({
       toast.success(`Created container ${name}`);
       setCreateName("");
       setCreateOpen(false);
-      await refresh();
       // Auto-bind the just-created container to the active thread.
       // ensureThreadRecord first so the bind lands even when the user
       // creates a container before sending the first message — without
@@ -250,6 +249,10 @@ export function OpenAICodeExecSection({
       );
     } finally {
       setCreating(false);
+      // Refresh even on failure: the request may have partially succeeded
+      // server-side (created container, lost response), and a re-fetch
+      // keeps the picker in sync with OpenAI's actual state.
+      await refresh();
     }
   };
 
@@ -277,11 +280,15 @@ export function OpenAICodeExecSection({
         ),
       );
       toast.success(`Deleted container ${name || id}`);
-      await refresh();
     } catch (err) {
       toast.error(
         `Delete failed: ${err instanceof Error ? err.message : "Unknown"}`,
       );
+    } finally {
+      // Always refresh so a stale list entry (e.g. container deleted
+      // elsewhere, or already expired) is purged from the UI even when
+      // the delete call itself errored.
+      await refresh();
     }
   };
 
@@ -293,7 +300,7 @@ export function OpenAICodeExecSection({
           htmlFor="openai-container-ttl"
           className="min-w-0 text-[13px] font-medium leading-[1.25] tracking-nav text-nav-fg"
         >
-          New-container idle timeout (min)
+          New-container idle timeout (min, max 20)
         </label>
         <Input
           id="openai-container-ttl"

--- a/studio/frontend/src/features/chat/components/openai-code-exec-section.tsx
+++ b/studio/frontend/src/features/chat/components/openai-code-exec-section.tsx
@@ -51,6 +51,17 @@ const DEFAULT_TTL_MINUTES = 20;
 const TTL_MIN = 1;
 const TTL_MAX = 20; // OpenAI hard cap on expires_after.minutes
 
+// How long a just-deleted container id stays hidden from the picker,
+// even if OpenAI's /containers list keeps returning it. OpenAI's DELETE
+// returns {"deleted": true} but the list endpoint can keep showing the
+// container for several minutes (replica lag or in-use silent no-op —
+// undocumented behavior, see PR fix/delete-openai-container). The
+// tombstone makes the UI feel responsive regardless of when list
+// catches up. Cleared on a 30s sweep so the picker recovers on its
+// own if OpenAI eventually shows the delete propagated.
+const DELETE_TOMBSTONE_MS = 5 * 60 * 1000;
+const TOMBSTONE_SWEEP_MS = 30 * 1000;
+
 function ageLabel(epochSeconds: number | null | undefined): string {
   if (!epochSeconds) return "";
   const ageSec = Math.max(0, Math.floor(Date.now() / 1000) - epochSeconds);
@@ -84,6 +95,11 @@ export function OpenAICodeExecSection({
   const [createTtl, setCreateTtl] = useState<number>(
     provider.openaiContainerTtlMinutes ?? DEFAULT_TTL_MINUTES,
   );
+  // id → unix-ms expiry. Entries past expiry are dropped by the sweep
+  // effect below.
+  const [tombstones, setTombstones] = useState<Map<string, number>>(
+    () => new Map(),
+  );
 
   const thread = useLiveQuery(
     async () => (activeThreadId ? db.threads.get(activeThreadId) : undefined),
@@ -91,14 +107,26 @@ export function OpenAICodeExecSection({
   );
   const activeContainerId = thread?.openaiCodeExecContainerId ?? null;
 
+  // Hide just-deleted containers even if OpenAI's list still returns them.
+  // This is the single chokepoint — every downstream view (sorted picker,
+  // auto-bind candidate, all-containers list) derives from visibleContainers.
+  const visibleContainers = useMemo(() => {
+    if (tombstones.size === 0) return containers;
+    const now = Date.now();
+    return containers.filter((c) => {
+      const expiry = tombstones.get(c.id);
+      return !expiry || expiry <= now;
+    });
+  }, [containers, tombstones]);
+
   // Containers sorted newest-first by lastActiveAt so the dropdown's
   // default (auto-bind target) shows up first.
   const sortedContainers = useMemo(
     () =>
-      [...containers].sort(
+      [...visibleContainers].sort(
         (a, b) => (b.lastActiveAt ?? 0) - (a.lastActiveAt ?? 0),
       ),
-    [containers],
+    [visibleContainers],
   );
 
   // What the dropdown should display right now. We decouple this from
@@ -150,10 +178,14 @@ export function OpenAICodeExecSection({
   // the chat-adapter's lazy-create path will mint the first container
   // on first send.
   useEffect(() => {
-    if (!activeThreadId || activeContainerId || containers.length === 0) {
+    if (
+      !activeThreadId ||
+      activeContainerId ||
+      visibleContainers.length === 0
+    ) {
       return;
     }
-    const sorted = [...containers].sort(
+    const sorted = [...visibleContainers].sort(
       (a, b) => (b.lastActiveAt ?? 0) - (a.lastActiveAt ?? 0),
     );
     const candidate = sorted[0];
@@ -171,7 +203,30 @@ export function OpenAICodeExecSection({
         // Best-effort; the chat-adapter will inherit/create on send.
       }
     })();
-  }, [activeThreadId, activeContainerId, containers]);
+  }, [activeThreadId, activeContainerId, visibleContainers]);
+
+  // Sweep expired tombstones so the picker recovers on its own if
+  // OpenAI's list eventually shows the delete propagated (or simply
+  // outlives the tombstone window). No-op if nothing's expired —
+  // avoids spurious re-renders.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTombstones((prev) => {
+        if (prev.size === 0) return prev;
+        const now = Date.now();
+        let changed = false;
+        const next = new Map(prev);
+        for (const [id, expiry] of prev) {
+          if (expiry <= now) {
+            next.delete(id);
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    }, TOMBSTONE_SWEEP_MS);
+    return () => clearInterval(interval);
+  }, []);
 
   const ttlValue = provider.openaiContainerTtlMinutes ?? DEFAULT_TTL_MINUTES;
 
@@ -270,6 +325,13 @@ export function OpenAICodeExecSection({
         { apiKey, baseUrl: provider.baseUrl || null },
         id,
       );
+      // Tombstone the id so the picker hides it immediately even if
+      // OpenAI's list keeps returning it for a while.
+      setTombstones((prev) => {
+        const next = new Map(prev);
+        next.set(id, Date.now() + DELETE_TOMBSTONE_MS);
+        return next;
+      });
       // Clear any thread bindings pointing at the now-deleted id.
       const affected = await db.threads
         .filter((t) => t.openaiCodeExecContainerId === id)
@@ -367,11 +429,11 @@ export function OpenAICodeExecSection({
         <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
           All containers
         </span>
-        {isLoading && containers.length === 0 ? (
+        {isLoading && visibleContainers.length === 0 ? (
           <Skeleton className="h-16 w-full" />
-        ) : containers.length > 0 ? (
+        ) : visibleContainers.length > 0 ? (
           <ul className="flex flex-col gap-1 max-h-44 overflow-auto">
-            {containers.map((c) => {
+            {visibleContainers.map((c) => {
               const isActive = c.id === activeContainerId;
               return (
                 <li

--- a/studio/frontend/src/features/chat/components/openai-code-exec-section.tsx
+++ b/studio/frontend/src/features/chat/components/openai-code-exec-section.tsx
@@ -51,17 +51,6 @@ const DEFAULT_TTL_MINUTES = 20;
 const TTL_MIN = 1;
 const TTL_MAX = 20; // OpenAI hard cap on expires_after.minutes
 
-// How long a just-deleted container id stays hidden from the picker,
-// even if OpenAI's /containers list keeps returning it. OpenAI's DELETE
-// returns {"deleted": true} but the list endpoint can keep showing the
-// container for several minutes (replica lag or in-use silent no-op —
-// undocumented behavior, see PR fix/delete-openai-container). The
-// tombstone makes the UI feel responsive regardless of when list
-// catches up. Cleared on a 30s sweep so the picker recovers on its
-// own if OpenAI eventually shows the delete propagated.
-const DELETE_TOMBSTONE_MS = 5 * 60 * 1000;
-const TOMBSTONE_SWEEP_MS = 30 * 1000;
-
 function ageLabel(epochSeconds: number | null | undefined): string {
   if (!epochSeconds) return "";
   const ageSec = Math.max(0, Math.floor(Date.now() / 1000) - epochSeconds);
@@ -95,11 +84,13 @@ export function OpenAICodeExecSection({
   const [createTtl, setCreateTtl] = useState<number>(
     provider.openaiContainerTtlMinutes ?? DEFAULT_TTL_MINUTES,
   );
-  // id → unix-ms expiry. Entries past expiry are dropped by the sweep
-  // effect below.
-  const [tombstones, setTombstones] = useState<Map<string, number>>(
-    () => new Map(),
-  );
+  // Ids that have been deleted in this session. Once tombstoned, an id
+  // stays hidden from the picker for the lifetime of the page — OpenAI's
+  // /containers list can keep returning a freshly-deleted id for an
+  // undocumented and variable amount of time, and an automatic re-show
+  // creates more confusion than it solves. Refreshing the page resets
+  // the tombstone naturally.
+  const [tombstones, setTombstones] = useState<Set<string>>(() => new Set());
 
   const thread = useLiveQuery(
     async () => (activeThreadId ? db.threads.get(activeThreadId) : undefined),
@@ -112,11 +103,7 @@ export function OpenAICodeExecSection({
   // auto-bind candidate, all-containers list) derives from visibleContainers.
   const visibleContainers = useMemo(() => {
     if (tombstones.size === 0) return containers;
-    const now = Date.now();
-    return containers.filter((c) => {
-      const expiry = tombstones.get(c.id);
-      return !expiry || expiry <= now;
-    });
+    return containers.filter((c) => !tombstones.has(c.id));
   }, [containers, tombstones]);
 
   // Containers sorted newest-first by lastActiveAt so the dropdown's
@@ -204,29 +191,6 @@ export function OpenAICodeExecSection({
       }
     })();
   }, [activeThreadId, activeContainerId, visibleContainers]);
-
-  // Sweep expired tombstones so the picker recovers on its own if
-  // OpenAI's list eventually shows the delete propagated (or simply
-  // outlives the tombstone window). No-op if nothing's expired —
-  // avoids spurious re-renders.
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setTombstones((prev) => {
-        if (prev.size === 0) return prev;
-        const now = Date.now();
-        let changed = false;
-        const next = new Map(prev);
-        for (const [id, expiry] of prev) {
-          if (expiry <= now) {
-            next.delete(id);
-            changed = true;
-          }
-        }
-        return changed ? next : prev;
-      });
-    }, TOMBSTONE_SWEEP_MS);
-    return () => clearInterval(interval);
-  }, []);
 
   const ttlValue = provider.openaiContainerTtlMinutes ?? DEFAULT_TTL_MINUTES;
 
@@ -328,8 +292,9 @@ export function OpenAICodeExecSection({
       // Tombstone the id so the picker hides it immediately even if
       // OpenAI's list keeps returning it for a while.
       setTombstones((prev) => {
-        const next = new Map(prev);
-        next.set(id, Date.now() + DELETE_TOMBSTONE_MS);
+        if (prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.add(id);
         return next;
       });
       // Clear any thread bindings pointing at the now-deleted id.

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -237,7 +237,7 @@ function normalizeProvider(raw: ExternalProviderConfig): ExternalProviderConfig 
       providerType === "openai" &&
       typeof raw.openaiContainerTtlMinutes === "number" &&
       raw.openaiContainerTtlMinutes >= 1
-        ? Math.min(raw.openaiContainerTtlMinutes, 10080)
+        ? Math.min(raw.openaiContainerTtlMinutes, 20)
         : undefined,
   };
 }


### PR DESCRIPTION
## Summary

- Make container deletion in the side-panel picker reliable against OpenAI's `/v1/containers` quirks
- Cap `expires_after.minutes` at OpenAI's actual hard limit (20) instead of our 1-week safety bound that triggered `integer_above_max_value` rejections
- Add structured diagnostic logging around the CRUD path so future regressions are debuggable from logs

## What was broken

Clicking delete on a container in the chat side-panel would toast `Deleted container X` but the container kept appearing in the list. Investigation showed three independent issues:

1. **Expired containers in the list.** OpenAI keeps `status="expired"` entries in `/v1/containers` indefinitely. They were indistinguishable from live containers in the UI.
2. **TTL cap mismatch.** Our backend allowed `expires_after.minutes` up to 10080 (1 week), but OpenAI hard-caps at 20 minutes. Anything larger → 400.
3. **Undocumented OpenAI behavior on `DELETE`.** A successful `DELETE /v1/containers/{id}` returns `{"deleted": true}` but the subsequent `/v1/containers` list can keep returning the same id for minutes (per a standalone reproducer using `httpx` with the same key/headers/URL/verb — same outcome, so it's an OpenAI-side quirk, not our code).

## What changed

**Backend (`studio/backend/`)**
- `routes/inference.py` — list route filters `status == "expired"` so the picker only shows usable containers
- `models/inference.py` — `ttl_minutes` capped at 20 with docstring explaining OpenAI's hard limit
- `core/inference/external_provider.py` — uses a fresh `httpx.AsyncClient` for container DELETE (isolates the call from shared-pool state; harmless either way)
- Diagnostic logging on the container CRUD path: incoming request subject/id/base_url, outbound URL + presence of `OpenAI-Beta` header (no auth contents), full response status + body, key fingerprint (kind/length/last-4), and OpenAI response headers (`cf-ray`, `x-request-id`, `openai-organization`, `openai-project`)

**Frontend (`studio/frontend/`)**
- `api/openai-containers.ts` — `deleteOpenAIContainer` treats `404` as idempotent success (already-gone is not a failure)
- `components/openai-code-exec-section.tsx` — `TTL_MAX = 20` with label "(min, max 20)"; `onCreate` and `onDelete` always `refresh()` in `finally` so a stale list entry is purged even when the call errors
- `components/openai-code-exec-section.tsx` — **client-side tombstone**: after a successful delete, the id is hidden from the picker for 5 minutes via a single `visibleContainers` chokepoint feeding the dropdown, auto-bind, and all-containers list. A 30s sweep clears expired tombstones so the picker recovers automatically if OpenAI's list eventually propagates the delete
- `external-providers.ts` — persistence clamp lowered to 20 minutes to match the new backend bound



## Outstanding

The diagnostic info-level logs are intentionally noisy. Happy to downgrade to `debug` (or strip entirely) before un-drafting — opening as draft so a reviewer can weigh in on log retention.

## Test plan

- [x ] Click delete on a live container in the picker → toast success, container disappears immediately even if `/v1/containers` keeps returning it
- [ x] Click delete on a container that's already been deleted elsewhere (HTTP 404) → toast success, picker refreshes, no scary error
- [x ] Create a container with TTL = 25 → input clamps to 20 before submit; backend rejects > 20 with 422
- [ x] An expired container in OpenAI's list never appears in the picker