### PR TITLE
studio/install: strip top-level dir from repaired symlink target

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3447,7 +3447,11 @@ def extract_archive(archive_path: Path, destination: Path) -> None:
         (linkname starts with the top-level dir name but no following
         slash) and search archive entries under that dir for a real
         file whose basename ends with the mangled suffix. Only accept
-        when the suffix uniquely identifies a real archive entry."""
+        when the suffix uniquely identifies a real archive entry.
+        Returns the corrected linkname expressed relative to the
+        member's parent directory -- callers join it with
+        `target.parent`, so a full `top/file` path would double the
+        prefix into `top/top/file`."""
         if "/" not in member_name or "/" in link_name:
             return None
         top, _, _ = member_name.partition("/")
@@ -3466,7 +3470,10 @@ def extract_archive(archive_path: Path, destination: Path) -> None:
         ]
         if len(candidates) != 1:
             return None
-        return candidates[0]
+        # Strip the top-level dir so the caller's `target.parent / Path(...)`
+        # composition resolves inside the staging dir, not into a duplicate
+        # `top/top/...` path.
+        return candidates[0][len(prefix) :]
 
     def safe_link_target(
         base: Path,


### PR DESCRIPTION
Repair in 5465 returned the full archive entry name but safe_link_target joins it with target.parent which already lives under base/llama-b9165. The doubled prefix produced a path that never existed, so extract_tar_safely still raised 'tar archive contained unresolved link entries' and Mac CI kept falling back to source build.

Strip the top-level dir before returning so the linkname is relative to target.parent, mirroring how unmangled symlinks are stored in the tar (basename only).

Tested end-to-end against the upstream b9165 tarball: extraction succeeds and every symlink resolves.