### PR TITLE
tests/openai: patch httpx.AsyncClient ctor so delete tests hit mock

### DIFF
--- a/studio/backend/tests/test_openai_container_crud.py
+++ b/studio/backend/tests/test_openai_container_crud.py
@@ -28,8 +28,20 @@ def _drive(coro):
 
 
 def _mock_http_client(monkeypatch, handler):
+    """Wire `handler` for both the shared `_http_client` AND any
+    per-call `httpx.AsyncClient(...)` instances. delete_openai_container
+    intentionally creates a fresh AsyncClient (see comment in
+    external_provider.delete_openai_container) so the test must
+    also intercept that constructor."""
     transport = httpx.MockTransport(handler)
     monkeypatch.setattr(ep_mod, "_http_client", httpx.AsyncClient(transport = transport))
+    real_async_client = httpx.AsyncClient
+
+    def _patched_async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(ep_mod.httpx, "AsyncClient", _patched_async_client)
 
 
 def _make_client() -> ExternalProviderClient:


### PR DESCRIPTION
delete_openai_container intentionally creates a fresh httpx.AsyncClient per call (see external_provider docstring: shared pool produced false 'deleted: true' responses while the container survived). The existing _mock_http_client only swapped the shared module-level _http_client, so the four delete tests bypassed the mock entirely and hit the real OpenAI API, returning 401 Unauthorized on Python 3.10 / 3.12 / 3.13.

Extend the helper to also monkey-patch httpx.AsyncClient itself to a factory that injects the test's MockTransport into any freshly constructed client. List/create paths still use the shared client and pass unchanged.

Verified locally: pytest tests/test_openai_container_crud.py -> 8 passed.