### PR TITLE
ci: bump Mac json-images timeout 30 -> 45 min (cache-miss path)

### DIFF
--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -668,7 +668,14 @@ jobs:
   json-images:
     name: JSON, images
     runs-on: macos-14
-    timeout-minutes: 30
+    # 45 min, not 30. The job downloads ~4 GB on a cache miss
+    # (3 GB gemma-4 GGUF + ~1 GB mmproj) over shared macos-14 NAT,
+    # plus Studio install + boot + JSON/image smoke. The previous
+    # 30 min cap timed out cache-miss runs mid-download (run
+    # 25950714888 / PR #5430). Once the cache is warm it lands in
+    # ~10 min; the headroom only matters on the first run after a
+    # cache key bump (v1->v2 in #5459).
+    timeout-minutes: 45
     env:
       GGUF_REPO: unsloth/gemma-4-E2B-it-GGUF
       # Linux smoke uses UD-IQ3_XXS, but on Mac Metal that gemma-4


### PR DESCRIPTION
## Summary

- The `JSON, images` job in `studio-mac-inference-smoke.yml` (Job 3 of Mac Studio GGUF CI) downloads ~4 GB on a cache miss: 3 GB `gemma-4-E2B-it-UD-Q4_K_XL.gguf` + ~1 GB `mmproj-F16.gguf`. The 30 min cap was tight even with `HF_HUB_ENABLE_HF_TRANSFER=1` and parallel downloads, and timed out the cache-miss run on PR #5430 mid-download ([run 25950714888 / job 76287879942](https://github.com/unslothai/unsloth/actions/runs/25950714888/job/76287879942)) before Studio install or the smoke assertions ran.
- Bumps `timeout-minutes` from 30 to 45 for headroom on the first run after a cache-key bump (the v1 -> v2 bump in #5459 is what produced this miss).
- Jobs 1 (openai-anthropic, 270M model) and 2 (tool-calling, ~1.5 GB model) are not bumped -- their 25 min cap has been comfortable.

## Test plan

- [ ] CI on this PR is green.
- [ ] Re-sync the 5 open PRs (#5427, #5430, #5432, #5433, #5434) after this lands; confirm Mac json-images no longer times out on cache-miss.