### PR TITLE
disable_torchcodec_if_broken: also patch datasets and clean sys.modules

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1289,7 +1289,7 @@ def patch_torchcodec_audio_decoder():
 
 
 def disable_torchcodec_if_broken():
-    """Disable torchcodec in transformers AND datasets if it cannot actually load.
+    """Make broken torchcodec behave as if it were uninstalled.
 
     transformers (>= 4.55) and datasets (>= 4.0) both sniff torchcodec via
     ``importlib.util.find_spec()``, which returns True even when the native
@@ -1297,24 +1297,31 @@ def disable_torchcodec_if_broken():
     matching FFmpeg, ABI mismatch with torch, etc). Downstream code then tries
     to actually use torchcodec and crashes with RuntimeError mid-import.
 
-    If the load test fails we:
-      * transformers < 5: flip the module-level ``_torchcodec_available`` flag.
-      * transformers >= 5: rebind the ``@lru_cache`` ``is_torchcodec_available``
-        function to ``lambda: False`` and clear its cache.
+    If the load test fails we treat torchcodec as uninstalled:
+      * transformers < 5: flip ``_torchcodec_available`` to False.
+      * transformers >= 5: rebind ``is_torchcodec_available`` to ``lambda: False``
+        and clear its lru_cache.
       * datasets >= 4.0: flip ``datasets.config.TORCHCODEC_AVAILABLE``, which
         gates every torchcodec call site inside datasets (audio.py, video.py,
         features.py, the three formatters, ...). Without this, transformers
         falls back to librosa but datasets still routes through torchcodec
         and re-raises the same RuntimeError -- see issue #5446.
       * sys.modules: drop half-loaded ``torchcodec*`` and the
-        ``datasets.features._torchcodec`` wrapper so later re-imports do not
-        re-trigger the failed native-library load.
+        ``datasets.features._torchcodec`` wrapper, then seat
+        ``sys.modules["torchcodec"] = None`` as a sentinel. After this, any
+        future ``import torchcodec`` or ``from torchcodec.X import Y`` raises
+        ``ModuleNotFoundError`` (subclass of ImportError) instead of the
+        broken-native-lib RuntimeError, so the unconditional torchcodec
+        imports inside datasets / torchaudio fall through their existing
+        ``except ImportError`` handlers cleanly. This also makes
+        ``find_spec("torchcodec")`` return None on re-entry so this function
+        is a no-op on the second call.
     """
     try:
         import importlib.util
 
         if importlib.util.find_spec("torchcodec") is None:
-            return  # not installed, nothing to do
+            return  # not installed (or already disabled by us)
 
         # Real load test. RuntimeError is what torchcodec raises on dlopen
         # failure; OSError covers chained "libavutil.so.X not found" shapes.
@@ -1350,7 +1357,10 @@ def disable_torchcodec_if_broken():
         except ImportError:
             pass
 
-        # Drop half-loaded torchcodec submodules + the datasets wrapper.
+        # Drop half-loaded torchcodec submodules + the datasets wrapper, then
+        # block any future import. ``sys.modules[name] = None`` is the
+        # standard "module is absent" sentinel: import torchcodec raises
+        # ModuleNotFoundError, find_spec returns None.
         for _stale in [
             n
             for n in list(sys.modules)
@@ -1359,6 +1369,7 @@ def disable_torchcodec_if_broken():
             or n == "datasets.features._torchcodec"
         ]:
             sys.modules.pop(_stale, None)
+        sys.modules["torchcodec"] = None
 
 
 def disable_broken_wandb():

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1352,7 +1352,8 @@ def disable_torchcodec_if_broken():
 
         # Drop half-loaded torchcodec submodules + the datasets wrapper.
         for _stale in [
-            n for n in list(sys.modules)
+            n
+            for n in list(sys.modules)
             if n == "torchcodec"
             or n.startswith("torchcodec.")
             or n == "datasets.features._torchcodec"

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1289,55 +1289,31 @@ def patch_torchcodec_audio_decoder():
 
 
 def disable_torchcodec_if_broken():
-    """Make broken torchcodec behave as if it were uninstalled.
+    """Make broken torchcodec behave as if uninstalled (#5446).
 
-    transformers (>= 4.55) and datasets (>= 4.0) both sniff torchcodec via
-    ``importlib.util.find_spec()``, which returns True even when the native
-    libtorchcodec / libavutil libraries cannot dlopen (Colab without the
-    matching FFmpeg, ABI mismatch with torch, etc). Downstream code then tries
-    to actually use torchcodec and crashes with RuntimeError mid-import.
-
-    If the load test fails we treat torchcodec as uninstalled:
-      * transformers < 5: flip ``_torchcodec_available`` to False.
-      * transformers >= 5: rebind ``is_torchcodec_available`` to ``lambda: False``
-        and clear its lru_cache.
-      * datasets >= 4.0: flip ``datasets.config.TORCHCODEC_AVAILABLE``, which
-        gates every torchcodec call site inside datasets (audio.py, video.py,
-        features.py, the three formatters, ...). Without this, transformers
-        falls back to librosa but datasets still routes through torchcodec
-        and re-raises the same RuntimeError -- see issue #5446.
-      * sys.modules: drop half-loaded ``torchcodec*`` and the
-        ``datasets.features._torchcodec`` wrapper, then seat
-        ``sys.modules["torchcodec"] = None`` as a sentinel. After this, any
-        future ``import torchcodec`` or ``from torchcodec.X import Y`` raises
-        ``ModuleNotFoundError`` (subclass of ImportError) instead of the
-        broken-native-lib RuntimeError, so the unconditional torchcodec
-        imports inside datasets / torchaudio fall through their existing
-        ``except ImportError`` handlers cleanly. This also makes
-        ``find_spec("torchcodec")`` return None on re-entry so this function
-        is a no-op on the second call.
+    transformers and datasets both detect torchcodec via find_spec, which
+    returns True even when the native libs cannot dlopen. We flip their
+    flags and seat a sys.modules sentinel so downstream imports fall through
+    their existing except ImportError handlers cleanly.
     """
     try:
         import importlib.util
 
         if importlib.util.find_spec("torchcodec") is None:
-            return  # not installed (or already disabled by us)
+            return  # absent or already disabled
 
-        # Real load test. RuntimeError is what torchcodec raises on dlopen
-        # failure; OSError covers chained "libavutil.so.X not found" shapes.
+        # RuntimeError on dlopen failure; OSError covers chained libavutil.so misses.
         from torchcodec.decoders import AudioDecoder
     except (ImportError, RuntimeError, OSError):
-        # Patch transformers' availability checks.
+        # transformers: flip flag (<5) and/or rebind lru_cache'd func (>=5).
         try:
             import transformers.utils.import_utils as tf_import_utils
 
-            # transformers < 5 path: module-level cached flag.
             try:
                 tf_import_utils._torchcodec_available = False
             except AttributeError:
                 pass
 
-            # transformers >= 5 path: lru_cache'd is_torchcodec_available().
             is_avail = getattr(tf_import_utils, "is_torchcodec_available", None)
             if is_avail is not None:
                 try:
@@ -1348,7 +1324,7 @@ def disable_torchcodec_if_broken():
         except ImportError:
             pass
 
-        # Patch datasets' availability flag (datasets >= 4.0).
+        # datasets >= 4.0: own flag gating audio/video/features/formatters.
         try:
             import datasets.config as datasets_config
 
@@ -1357,10 +1333,8 @@ def disable_torchcodec_if_broken():
         except ImportError:
             pass
 
-        # Drop half-loaded torchcodec submodules + the datasets wrapper, then
-        # block any future import. ``sys.modules[name] = None`` is the
-        # standard "module is absent" sentinel: import torchcodec raises
-        # ModuleNotFoundError, find_spec returns None.
+        # Drop half-loaded entries and seat the absence sentinel. After this,
+        # import torchcodec raises ModuleNotFoundError and find_spec returns None.
         for _stale in [
             n
             for n in list(sys.modules)

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1289,53 +1289,75 @@ def patch_torchcodec_audio_decoder():
 
 
 def disable_torchcodec_if_broken():
-    """Disable torchcodec in transformers if it cannot actually load.
+    """Disable torchcodec in transformers AND datasets if it cannot actually load.
 
-    transformers checks if torchcodec is installed via importlib.util.find_spec(),
-    but this returns True even when torchcodec cannot load its native libraries
-    (e.g., when FFmpeg is missing). This causes runtime errors when transformers
-    tries to use torchcodec for audio loading.
+    transformers (>= 4.55) and datasets (>= 4.0) both sniff torchcodec via
+    ``importlib.util.find_spec()``, which returns True even when the native
+    libtorchcodec / libavutil libraries cannot dlopen (Colab without the
+    matching FFmpeg, ABI mismatch with torch, etc). Downstream code then tries
+    to actually use torchcodec and crashes with RuntimeError mid-import.
 
-    This function tests if torchcodec can actually load and if not, patches
-    transformers to think torchcodec is unavailable so it falls back to librosa.
-
-    Two shapes to cover:
-      * transformers < 5: a module-level ``_torchcodec_available`` flag
-        cached in ``transformers.utils.import_utils``; flip it to False.
-      * transformers >= 5: a public ``is_torchcodec_available()`` callable
-        wrapped with ``functools.lru_cache``; replace it with a stub that
-        returns False and clear the cache so subsequent callers see it.
+    If the load test fails we:
+      * transformers < 5: flip the module-level ``_torchcodec_available`` flag.
+      * transformers >= 5: rebind the ``@lru_cache`` ``is_torchcodec_available``
+        function to ``lambda: False`` and clear its cache.
+      * datasets >= 4.0: flip ``datasets.config.TORCHCODEC_AVAILABLE``, which
+        gates every torchcodec call site inside datasets (audio.py, video.py,
+        features.py, the three formatters, ...). Without this, transformers
+        falls back to librosa but datasets still routes through torchcodec
+        and re-raises the same RuntimeError -- see issue #5446.
+      * sys.modules: drop half-loaded ``torchcodec*`` and the
+        ``datasets.features._torchcodec`` wrapper so later re-imports do not
+        re-trigger the failed native-library load.
     """
     try:
         import importlib.util
 
         if importlib.util.find_spec("torchcodec") is None:
-            return  # torchcodec not installed, nothing to do
+            return  # not installed, nothing to do
 
-        # Test if torchcodec can actually load
+        # Real load test. RuntimeError is what torchcodec raises on dlopen
+        # failure; OSError covers chained "libavutil.so.X not found" shapes.
         from torchcodec.decoders import AudioDecoder
     except (ImportError, RuntimeError, OSError):
-        # torchcodec cannot load - disable it in transformers
+        # Patch transformers' availability checks.
         try:
             import transformers.utils.import_utils as tf_import_utils
-        except ImportError:
-            return
 
-        # transformers < 5 path: module-level cached flag.
-        try:
-            tf_import_utils._torchcodec_available = False
-        except AttributeError:
-            pass
-
-        # transformers >= 5 path: public lru_cache'd function. Clear any
-        # cached True result then rebind to a stub that returns False.
-        is_avail = getattr(tf_import_utils, "is_torchcodec_available", None)
-        if is_avail is not None:
+            # transformers < 5 path: module-level cached flag.
             try:
-                is_avail.cache_clear()
+                tf_import_utils._torchcodec_available = False
             except AttributeError:
                 pass
-            tf_import_utils.is_torchcodec_available = lambda: False
+
+            # transformers >= 5 path: lru_cache'd is_torchcodec_available().
+            is_avail = getattr(tf_import_utils, "is_torchcodec_available", None)
+            if is_avail is not None:
+                try:
+                    is_avail.cache_clear()
+                except AttributeError:
+                    pass
+                tf_import_utils.is_torchcodec_available = lambda: False
+        except ImportError:
+            pass
+
+        # Patch datasets' availability flag (datasets >= 4.0).
+        try:
+            import datasets.config as datasets_config
+
+            if hasattr(datasets_config, "TORCHCODEC_AVAILABLE"):
+                datasets_config.TORCHCODEC_AVAILABLE = False
+        except ImportError:
+            pass
+
+        # Drop half-loaded torchcodec submodules + the datasets wrapper.
+        for _stale in [
+            n for n in list(sys.modules)
+            if n == "torchcodec"
+            or n.startswith("torchcodec.")
+            or n == "datasets.features._torchcodec"
+        ]:
+            sys.modules.pop(_stale, None)
 
 
 def disable_broken_wandb():


### PR DESCRIPTION
## Summary

Closes #5446.

`disable_torchcodec_if_broken` already flipped transformers' `_torchcodec_available` / `is_torchcodec_available` so transformers falls back to librosa when the native libtorchcodec / libavutil libraries cannot dlopen. The problem is that `datasets` (>= 4.0) keeps its own `datasets.config.TORCHCODEC_AVAILABLE` flag, sourced the same way (`importlib.util.find_spec("torchcodec") is not None`), which gates every torchcodec call site inside datasets:

- `datasets/features/audio.py:115` and `:184` (loads `_torchcodec.AudioDecoder`, which top-level imports `torchcodec.decoders`)
- `datasets/features/video.py:118`, `:178`, `:393`
- `datasets/features/features.py:316`, `:457`, `:460`
- `datasets/formatting/{torch,np,jax}_formatter.py`

So even with the transformers flag flipped, datasets still routes through torchcodec and re-raises the same `RuntimeError: Could not load libtorchcodec / OSError: libavutil.so.X: cannot open shared object file`. That is what users hit on fresh Colab runtimes where torchcodec is installed but the FFmpeg shared libs are missing.

## What changed

Inside the same `except (ImportError, RuntimeError, OSError):` block, after the existing transformers patches:

1. Patch `datasets.config.TORCHCODEC_AVAILABLE = False` when datasets is importable and the flag exists (gates the datasets call sites listed above).
2. Pop half-loaded `torchcodec*` submodules and `datasets.features._torchcodec` from `sys.modules` so a later re-import does not reuse a partially initialised cache entry and re-raise the same `RuntimeError`.

No behaviour change when torchcodec loads cleanly: the load test still short-circuits before the patch block runs.

## Verification

Live state on a Colab-like broken-torchcodec environment (`torchcodec` installed, `libavutil.so` missing, `datasets==4.8.5`, `transformers==4.57.x`):

Before this PR:
```
transformers._torchcodec_available     = False
transformers.is_torchcodec_available() = False
datasets.config.TORCHCODEC_AVAILABLE   = True   <-- still True, leaks RuntimeError downstream
```

After this PR:
```
transformers._torchcodec_available     = False
transformers.is_torchcodec_available() = False
datasets.config.TORCHCODEC_AVAILABLE   = False
stale torchcodec entries in sys.modules = []
```

`from unsloth import FastLanguageModel` continues to succeed when torchcodec is healthy and when torchcodec is broken.

## Supported versions covered

- transformers `4.55.x ... 4.57.x` (module-level `_torchcodec_available` bool) and `5.x` (lru_cache'd `is_torchcodec_available`) - both already handled.
- datasets `>= 4.0` (`TORCHCODEC_AVAILABLE` shipped from 4.0.0). 3.x has no flag, so the new `hasattr` check no-ops there.
- transformers `4.51.3 ... 4.54.x`: no torchcodec at all, also no-ops.

## Follow-up (not in this PR)

`av` (PyAV) and `decord` follow the same "`find_spec` returns True but the native lib fails to dlopen" pattern via the same FFmpeg dependency. Worth a small `disable_av_if_broken` / `disable_decord_if_broken` in a separate PR if we want to fully harden against Colab FFmpeg drift.

## Test plan

- [x] Manual repro on broken-torchcodec env: `from unsloth import FastLanguageModel` succeeds; transformers + datasets flags both False; no stale `torchcodec*` in `sys.modules`.
- [x] Healthy-torchcodec env: load test passes, patch block skipped, all four flags untouched.
- [ ] Verify on a fresh Colab T4 with the `DeepSeek_R1_0528_Qwen3_(8B)_GRPO` notebook from issue #5446.