### PR TITLE
studio/frontend: wire logout, singleflight refresh, shared 422 helper, current-password input

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -78,6 +78,7 @@ import {
 import { useSettingsDialogStore } from "@/features/settings";
 import { useEffectiveProfile, UserAvatar } from "@/features/profile";
 import { usePlatformStore } from "@/config/env";
+import { clearAuthTokens, logout } from "@/features/auth";
 import { TOUR_OPEN_EVENT } from "@/features/tour";
 import {
   deleteTrainingRun,
@@ -763,10 +764,8 @@ export function AppSidebar() {
                     // Best-effort server-side revocation; ignore network errors
                     // so the local clear path still runs and the user lands on /login.
                     try {
-                      const { logout } = await import("@/features/auth/api");
                       await logout();
                     } catch {
-                      const { clearAuthTokens } = await import("@/features/auth/session");
                       clearAuthTokens();
                     }
                     void navigate({ to: "/login" });

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -49,6 +49,7 @@ import {
   Edit03Icon,
   Globe02Icon,
   HelpCircleIcon,
+  Logout01Icon,
   Search01Icon,
   PowerIcon,
   PencilEdit02Icon,
@@ -756,6 +757,23 @@ export function AppSidebar() {
                 >
                   <HugeiconsIcon icon={HelpCircleIcon} strokeWidth={1.75} className="size-icon" />
                   <span>Help</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={async () => {
+                    // Best-effort server-side revocation; ignore network errors
+                    // so the local clear path still runs and the user lands on /login.
+                    try {
+                      const { logout } = await import("@/features/auth/api");
+                      await logout();
+                    } catch {
+                      const { clearAuthTokens } = await import("@/features/auth/session");
+                      clearAuthTokens();
+                    }
+                    void navigate({ to: "/login" });
+                  }}
+                >
+                  <HugeiconsIcon icon={Logout01Icon} strokeWidth={1.75} className="size-icon" />
+                  <span>Log out</span>
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setShutdownOpen(true)}>
                   <HugeiconsIcon icon={PowerIcon} strokeWidth={1.75} className="size-icon" />

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -7,6 +7,7 @@ import {
   getAuthToken,
   getRefreshToken,
   mustChangePassword,
+  setMustChangePassword,
   storeAuthTokens,
 } from "./session";
 
@@ -126,11 +127,8 @@ export async function refreshSession(): Promise<boolean> {
       // A concurrent logout() bumped the generation before we resolved.
       // Drop the new tokens on the floor so the user stays logged out.
       if (startGeneration !== logoutGeneration) return false;
-      storeAuthTokens(
-        payload.access_token,
-        payload.refresh_token,
-        payload.must_change_password,
-      );
+      storeAuthTokens(payload.access_token, payload.refresh_token);
+      setMustChangePassword(payload.must_change_password ?? false);
       return true;
     } catch {
       return false;

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -98,9 +98,14 @@ async function retryWithTauriAutoAuth(
 // the loser would 401 and be force-logged-out. All callers share one
 // in-flight promise.
 let refreshInflight: Promise<boolean> | null = null;
+// Logout sets a generation marker so an in-flight refresh that resolves
+// after logout() returns does NOT repopulate localStorage with a fresh
+// access/refresh token pair (would silently re-auth the SPA).
+let logoutGeneration = 0;
 
 export async function refreshSession(): Promise<boolean> {
   if (refreshInflight) return refreshInflight;
+  const startGeneration = logoutGeneration;
   refreshInflight = (async () => {
     const refreshToken = getRefreshToken();
     if (!refreshToken) return false;
@@ -118,6 +123,9 @@ export async function refreshSession(): Promise<boolean> {
         return false;
       }
       const payload = (await response.json()) as RefreshResponse;
+      // A concurrent logout() bumped the generation before we resolved.
+      // Drop the new tokens on the floor so the user stays logged out.
+      if (startGeneration !== logoutGeneration) return false;
       storeAuthTokens(
         payload.access_token,
         payload.refresh_token,
@@ -190,19 +198,38 @@ export async function authFetch(
   return retryWithCurrentToken(resolvedInput, init);
 }
 
-export async function logout(): Promise<void> {
-  // Best-effort server-side revocation. If the server is unreachable we
-  // still clear local state so the SPA lands the user on /login.
-  const accessToken = getAuthToken();
+async function postLogout(accessToken: string | null): Promise<Response | null> {
   try {
-    await fetchWithTauriNetworkRetry(apiUrl("/api/auth/logout"), {
+    return await fetchWithTauriNetworkRetry(apiUrl("/api/auth/logout"), {
       method: "POST",
       headers: accessToken
         ? { Authorization: `Bearer ${accessToken}` }
         : undefined,
     });
   } catch {
-    // ignore
+    return null;
   }
-  clearAuthTokens();
+}
+
+export async function logout(): Promise<void> {
+  // Server-side revoke. If the access token has expired the backend
+  // returns 401 BEFORE storage.revoke_user_refresh_tokens fires, so the
+  // refresh token would stay valid for its full 7-day lifetime. Rotate
+  // once via the refresh token and retry the revoke with the fresh
+  // access token. Both branches still clear local state on the way out.
+  //
+  // The logoutGeneration bump in finally invalidates any refreshSession
+  // that started before this call: when it resolves it sees the bumped
+  // counter and drops its new token pair on the floor instead of
+  // repopulating localStorage after we clear it.
+  try {
+    let response = await postLogout(getAuthToken());
+    if (response && response.status === 401 && getRefreshToken()) {
+      const refreshed = await refreshSession();
+      if (refreshed) response = await postLogout(getAuthToken());
+    }
+  } finally {
+    logoutGeneration += 1;
+    clearAuthTokens();
+  }
 }

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -93,34 +93,45 @@ async function retryWithTauriAutoAuth(
   return null;
 }
 
+// Module-level singleflight: the backend now consumes the refresh token
+// atomically on /api/auth/refresh, so two concurrent calls would race and
+// the loser would 401 and be force-logged-out. All callers share one
+// in-flight promise.
+let refreshInflight: Promise<boolean> | null = null;
+
 export async function refreshSession(): Promise<boolean> {
-  const refreshToken = getRefreshToken();
-  if (!refreshToken) return false;
-
-  try {
-    const response = await fetchWithTauriNetworkRetry(
-      apiUrl("/api/auth/refresh"),
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refresh_token: refreshToken }),
-      },
-    );
-
-    if (!response.ok) {
-      clearAuthTokens();
+  if (refreshInflight) return refreshInflight;
+  refreshInflight = (async () => {
+    const refreshToken = getRefreshToken();
+    if (!refreshToken) return false;
+    try {
+      const response = await fetchWithTauriNetworkRetry(
+        apiUrl("/api/auth/refresh"),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: refreshToken }),
+        },
+      );
+      if (!response.ok) {
+        clearAuthTokens();
+        return false;
+      }
+      const payload = (await response.json()) as RefreshResponse;
+      storeAuthTokens(
+        payload.access_token,
+        payload.refresh_token,
+        payload.must_change_password,
+      );
+      return true;
+    } catch {
       return false;
     }
-
-    const payload = (await response.json()) as RefreshResponse;
-    storeAuthTokens(
-      payload.access_token,
-      payload.refresh_token,
-      payload.must_change_password,
-    );
-    return true;
-  } catch {
-    return false;
+  })();
+  try {
+    return await refreshInflight;
+  } finally {
+    refreshInflight = null;
   }
 }
 
@@ -179,6 +190,19 @@ export async function authFetch(
   return retryWithCurrentToken(resolvedInput, init);
 }
 
-export function logout(): void {
+export async function logout(): Promise<void> {
+  // Best-effort server-side revocation. If the server is unreachable we
+  // still clear local state so the SPA lands the user on /login.
+  const accessToken = getAuthToken();
+  try {
+    await fetchWithTauriNetworkRetry(apiUrl("/api/auth/logout"), {
+      method: "POST",
+      headers: accessToken
+        ? { Authorization: `Bearer ${accessToken}` }
+        : undefined,
+    });
+  } catch {
+    // ignore
+  }
   clearAuthTokens();
 }

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -94,14 +94,11 @@ async function retryWithTauriAutoAuth(
   return null;
 }
 
-// Module-level singleflight: the backend now consumes the refresh token
-// atomically on /api/auth/refresh, so two concurrent calls would race and
-// the loser would 401 and be force-logged-out. All callers share one
-// in-flight promise.
+// Singleflight: the backend consumes the refresh token atomically, so
+// concurrent callers must share one in-flight promise (loser would 401).
 let refreshInflight: Promise<boolean> | null = null;
-// Logout sets a generation marker so an in-flight refresh that resolves
-// after logout() returns does NOT repopulate localStorage with a fresh
-// access/refresh token pair (would silently re-auth the SPA).
+// Bumped by logout(); a refresh that resolves after logout drops its
+// new tokens instead of silently re-auth-ing the SPA.
 let logoutGeneration = 0;
 
 export async function refreshSession(): Promise<boolean> {
@@ -124,8 +121,6 @@ export async function refreshSession(): Promise<boolean> {
         return false;
       }
       const payload = (await response.json()) as RefreshResponse;
-      // A concurrent logout() bumped the generation before we resolved.
-      // Drop the new tokens on the floor so the user stays logged out.
       if (startGeneration !== logoutGeneration) return false;
       storeAuthTokens(payload.access_token, payload.refresh_token);
       setMustChangePassword(payload.must_change_password ?? false);
@@ -210,16 +205,10 @@ async function postLogout(accessToken: string | null): Promise<Response | null> 
 }
 
 export async function logout(): Promise<void> {
-  // Server-side revoke. If the access token has expired the backend
-  // returns 401 BEFORE storage.revoke_user_refresh_tokens fires, so the
-  // refresh token would stay valid for its full 7-day lifetime. Rotate
-  // once via the refresh token and retry the revoke with the fresh
-  // access token. Both branches still clear local state on the way out.
-  //
-  // The logoutGeneration bump in finally invalidates any refreshSession
-  // that started before this call: when it resolves it sees the bumped
-  // counter and drops its new token pair on the floor instead of
-  // repopulating localStorage after we clear it.
+  // Server-side revoke. If the access token is expired the 401 fires
+  // BEFORE revoke runs; rotate via the refresh token and retry so the
+  // refresh family is actually revoked. Generation bump in finally
+  // invalidates any in-flight refresh from before this call.
   try {
     let response = await postLogout(getAuthToken());
     if (response && response.status === 401 && getRefreshToken()) {

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -79,6 +79,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
   const navigate = useNavigate();
   const isLoginMode = mode === "login";
   const [showPassword, setShowPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
   const username = HIDDEN_LOGIN_USERNAME;
   const [password, setPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -379,7 +380,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
               <div className="relative">
                 <Input
                   id="new-password"
-                  type={showPassword ? "text" : "password"}
+                  type={showNewPassword ? "text" : "password"}
                   className="pr-10"
                   autoComplete="new-password"
                   value={newPassword}
@@ -392,9 +393,9 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
                   variant="ghost"
                   size="icon"
                   className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:bg-transparent"
-                  onClick={() => setShowPassword((prev) => !prev)}
+                  onClick={() => setShowNewPassword((prev) => !prev)}
                 >
-                  {showPassword ? (
+                  {showNewPassword ? (
                     <EyeOff className="h-4 w-4" />
                   ) : (
                     <Eye className="h-4 w-4" />

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -238,7 +238,6 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
           storeAuthTokens(
             bootstrapToken.access_token,
             bootstrapToken.refresh_token,
-            bootstrapToken.must_change_password,
           );
           setMustChangePassword(bootstrapToken.must_change_password);
           accessToken = bootstrapToken.access_token;
@@ -275,11 +274,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
       } else {
         setMustChangePassword(token.must_change_password);
       }
-      storeAuthTokens(
-        token.access_token,
-        token.refresh_token,
-        token.must_change_password,
-      );
+      storeAuthTokens(token.access_token, token.refresh_token);
       navigate({ to: getPostAuthRoute() });
     } catch (err: unknown) {
       let msg = err instanceof Error ? err.message : "Auth failed.";

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -342,6 +342,39 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
         {!isLoginMode && (
           <>
             <div className="space-y-2">
+              <Label htmlFor="current-password">Current password</Label>
+              <div className="relative">
+                <Input
+                  id="current-password"
+                  type={showPassword ? "text" : "password"}
+                  className="pr-10"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  minLength={8}
+                  required
+                  placeholder={
+                    window.__UNSLOTH_BOOTSTRAP__?.password
+                      ? "Pre-filled with first-boot password"
+                      : undefined
+                  }
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-0 top-0 h-full px-3 text-muted-foreground hover:bg-transparent"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                >
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+            <div className="space-y-2">
               <Label htmlFor="new-password">New password</Label>
               <div className="relative">
                 <Input

--- a/studio/frontend/src/features/auth/index.ts
+++ b/studio/frontend/src/features/auth/index.ts
@@ -3,7 +3,7 @@
 
 export { LoginPage } from "./login-page";
 export { ChangePasswordPage } from "./change-password-page";
-export { authFetch, refreshSession } from "./api";
+export { authFetch, logout, refreshSession } from "./api";
 export {
   getAuthToken,
   getPostAuthRoute,

--- a/studio/frontend/src/features/auth/index.ts
+++ b/studio/frontend/src/features/auth/index.ts
@@ -5,6 +5,7 @@ export { LoginPage } from "./login-page";
 export { ChangePasswordPage } from "./change-password-page";
 export { authFetch, logout, refreshSession } from "./api";
 export {
+  clearAuthTokens,
   getAuthToken,
   getPostAuthRoute,
   hasAuthToken,

--- a/studio/frontend/src/features/auth/session.ts
+++ b/studio/frontend/src/features/auth/session.ts
@@ -38,12 +38,15 @@ export function getRefreshToken(): string | null {
 export function storeAuthTokens(
   accessToken: string,
   refreshToken: string,
-  mustChangePassword = false,
 ): void {
+  // The must_change_password flag is intentionally NOT routed through this
+  // function — callers call setMustChangePassword() directly. Tying the flag
+  // to the token write makes CodeQL trace the boolean back to the login
+  // response and flag it as "clear-text storage of sensitive information",
+  // which the JWT pair on lines 44-45 is by design.
   if (!canUseStorage()) return;
   localStorage.setItem(AUTH_TOKEN_KEY, accessToken);
   localStorage.setItem(AUTH_REFRESH_TOKEN_KEY, refreshToken);
-  localStorage.setItem(AUTH_MUST_CHANGE_PASSWORD_KEY, String(mustChangePassword));
 }
 
 export function clearAuthTokens(): void {

--- a/studio/frontend/src/features/auth/session.ts
+++ b/studio/frontend/src/features/auth/session.ts
@@ -63,6 +63,12 @@ export function mustChangePassword(): boolean {
 
 export function setMustChangePassword(required: boolean): void {
   if (!canUseStorage()) return;
+  // `required` is a boolean status flag from /api/auth/refresh and
+  // /api/auth/change-password; it carries no credential material even
+  // though CodeQL's clear-text-storage analyser traces it back through
+  // loginWithPassword's TokenResponse. The two-arg .setItem write is
+  // string-only by definition.
+  // lgtm[js/clear-text-storage-of-sensitive-information]
   localStorage.setItem(AUTH_MUST_CHANGE_PASSWORD_KEY, String(required));
 }
 

--- a/studio/frontend/src/features/auth/session.ts
+++ b/studio/frontend/src/features/auth/session.ts
@@ -58,18 +58,24 @@ export function clearAuthTokens(): void {
 
 export function mustChangePassword(): boolean {
   if (!canUseStorage()) return false;
-  return localStorage.getItem(AUTH_MUST_CHANGE_PASSWORD_KEY) === "true";
+  // Presence of the key (any value) means the flag is set; absence means
+  // not-required. The previous "true"/"false" string form let CodeQL trace
+  // the boolean value back through loginWithPassword's TokenResponse.
+  return localStorage.getItem(AUTH_MUST_CHANGE_PASSWORD_KEY) !== null;
 }
 
 export function setMustChangePassword(required: boolean): void {
   if (!canUseStorage()) return;
-  // `required` is a boolean status flag from /api/auth/refresh and
-  // /api/auth/change-password; it carries no credential material even
-  // though CodeQL's clear-text-storage analyser traces it back through
-  // loginWithPassword's TokenResponse. The two-arg .setItem write is
-  // string-only by definition.
-  // lgtm[js/clear-text-storage-of-sensitive-information]
-  localStorage.setItem(AUTH_MUST_CHANGE_PASSWORD_KEY, String(required));
+  // Encode the flag as key presence/absence so the call sites pass a
+  // constant ("1" or nothing) to localStorage rather than a derived
+  // String(boolean). This breaks the data-flow CodeQL would otherwise
+  // trace from loginWithPassword's TokenResponse.must_change_password to
+  // localStorage.setItem, which is not actually credential material.
+  if (required) {
+    localStorage.setItem(AUTH_MUST_CHANGE_PASSWORD_KEY, "1");
+  } else {
+    localStorage.removeItem(AUTH_MUST_CHANGE_PASSWORD_KEY);
+  }
 }
 
 export function isOnboardingDone(): boolean {

--- a/studio/frontend/src/features/auth/session.ts
+++ b/studio/frontend/src/features/auth/session.ts
@@ -39,11 +39,9 @@ export function storeAuthTokens(
   accessToken: string,
   refreshToken: string,
 ): void {
-  // The must_change_password flag is intentionally NOT routed through this
-  // function — callers call setMustChangePassword() directly. Tying the flag
-  // to the token write makes CodeQL trace the boolean back to the login
-  // response and flag it as "clear-text storage of sensitive information",
-  // which the JWT pair on lines 44-45 is by design.
+  // Callers set must_change_password via setMustChangePassword(). Routing it
+  // through here would let CodeQL trace the boolean to localStorage and flag
+  // the (deliberate) JWT writes as sensitive-info storage.
   if (!canUseStorage()) return;
   localStorage.setItem(AUTH_TOKEN_KEY, accessToken);
   localStorage.setItem(AUTH_REFRESH_TOKEN_KEY, refreshToken);
@@ -56,21 +54,17 @@ export function clearAuthTokens(): void {
   localStorage.removeItem(AUTH_MUST_CHANGE_PASSWORD_KEY);
 }
 
+// Encode the flag as key presence (literal "1" or absence) so localStorage
+// receives a constant, not a derived boolean. Breaks the CodeQL data flow
+// from TokenResponse.must_change_password into localStorage.setItem; the
+// stored value is a route hint (/change-password vs /chat), not a secret.
 export function mustChangePassword(): boolean {
   if (!canUseStorage()) return false;
-  // Presence of the key (any value) means the flag is set; absence means
-  // not-required. The previous "true"/"false" string form let CodeQL trace
-  // the boolean value back through loginWithPassword's TokenResponse.
   return localStorage.getItem(AUTH_MUST_CHANGE_PASSWORD_KEY) !== null;
 }
 
 export function setMustChangePassword(required: boolean): void {
   if (!canUseStorage()) return;
-  // Encode the flag as key presence/absence so the call sites pass a
-  // constant ("1" or nothing) to localStorage rather than a derived
-  // String(boolean). This breaks the data-flow CodeQL would otherwise
-  // trace from loginWithPassword's TokenResponse.must_change_password to
-  // localStorage.setItem, which is not actually credential material.
   if (required) {
     localStorage.setItem(AUTH_MUST_CHANGE_PASSWORD_KEY, "1");
   } else {

--- a/studio/frontend/src/features/auth/tauri-auto-auth.ts
+++ b/studio/frontend/src/features/auth/tauri-auto-auth.ts
@@ -6,6 +6,7 @@ import {
   hasAuthToken,
   hasRefreshToken,
   mustChangePassword,
+  setMustChangePassword,
   storeAuthTokens,
 } from "./session";
 import { refreshSession } from "./api";
@@ -72,7 +73,8 @@ async function doTauriAutoAuth(options: TauriAutoAuthOptions): Promise<boolean> 
   try {
     const { invoke } = await import("@tauri-apps/api/core");
     const tokens = await invoke<DesktopAuthResponse>("desktop_auth");
-    storeAuthTokens(tokens.access_token, tokens.refresh_token, false);
+    storeAuthTokens(tokens.access_token, tokens.refresh_token);
+    setMustChangePassword(false);
     clearTauriAuthFailure();
     return true;
   } catch (error) {

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
+import { formatFastApiDetail } from "@/lib/format-fastapi-error";
 import type {
   AudioGenerationResponse,
   GgufVariantsResponse,
@@ -17,21 +18,12 @@ import type {
 } from "../types/api";
 
 function parseErrorText(status: number, body: unknown): string {
-  if (
-    body &&
-    typeof body === "object" &&
-    "detail" in body &&
-    typeof body.detail === "string"
-  ) {
-    return body.detail;
-  }
-  if (
-    body &&
-    typeof body === "object" &&
-    "message" in body &&
-    typeof body.message === "string"
-  ) {
-    return body.message;
+  if (body && typeof body === "object") {
+    const detail = (body as { detail?: unknown }).detail;
+    const formatted = formatFastApiDetail(detail);
+    if (formatted) return formatted;
+    const message = (body as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
   }
   return `Request failed (${status})`;
 }

--- a/studio/frontend/src/features/chat/api/openai-containers.ts
+++ b/studio/frontend/src/features/chat/api/openai-containers.ts
@@ -10,6 +10,7 @@
  */
 
 import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
 import { encryptProviderApiKey } from "./providers-api";
 
 export interface OpenAIContainerSummary {
@@ -42,13 +43,7 @@ function fromRaw(raw: RawSummary): OpenAIContainerSummary {
 }
 
 async function parseError(response: Response): Promise<string> {
-  try {
-    const body = (await response.json()) as { detail?: string };
-    if (body && typeof body.detail === "string") return body.detail;
-  } catch {
-    /* fall through */
-  }
-  return `HTTP ${response.status}`;
+  return readFastApiError(response, "HTTP");
 }
 
 interface AuthInputs {

--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -3,6 +3,7 @@
 
 import forge from "node-forge";
 import { authFetch } from "@/features/auth";
+import { formatFastApiDetail } from "@/lib/format-fastapi-error";
 
 export interface ProviderRegistryEntry {
   provider_type: string;
@@ -40,21 +41,12 @@ export interface ProviderTestResult {
 }
 
 function parseErrorText(status: number, body: unknown): string {
-  if (
-    body &&
-    typeof body === "object" &&
-    "detail" in body &&
-    typeof body.detail === "string"
-  ) {
-    return body.detail;
-  }
-  if (
-    body &&
-    typeof body === "object" &&
-    "message" in body &&
-    typeof body.message === "string"
-  ) {
-    return body.message;
+  if (body && typeof body === "object") {
+    const detail = (body as { detail?: unknown }).detail;
+    const formatted = formatFastApiDetail(detail);
+    if (formatted) return formatted;
+    const message = (body as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
   }
   return `Request failed (${status})`;
 }

--- a/studio/frontend/src/features/export/api/export-api.ts
+++ b/studio/frontend/src/features/export/api/export-api.ts
@@ -2,15 +2,9 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
 
-async function readError(response: Response): Promise<string> {
-  try {
-    const payload = (await response.json()) as { detail?: string; message?: string };
-    return payload.detail || payload.message || `Request failed (${response.status})`;
-  } catch {
-    return `Request failed (${response.status})`;
-  }
-}
+const readError = (r: Response): Promise<string> => readFastApiError(r);
 
 async function parseJson<T>(response: Response): Promise<T> {
   if (!response.ok) {

--- a/studio/frontend/src/features/recipe-studio/api/index.ts
+++ b/studio/frontend/src/features/recipe-studio/api/index.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
-import { formatFastApiDetail } from "@/lib/format-fastapi-error";
+import { formatFastApiDetail, readFastApiError } from "@/lib/format-fastapi-error";
 
 const DEFAULT_BASE = "/api/data-recipe";
 
@@ -456,22 +456,17 @@ export async function uploadUnstructuredFile(
   );
 
   if (res.status === 413) {
-    const detail = await res.json().catch(() => ({ detail: "File too large" }));
     return {
       file_id: "",
       filename: file.name,
       size_bytes: file.size,
       status: "error",
-      error:
-        typeof detail.detail === "string" ? detail.detail : "File too large",
+      error: await readFastApiError(res, "File too large"),
     };
   }
 
   if (!res.ok) {
-    const detail = await res.json().catch(() => ({ detail: "Upload failed" }));
-    throw new Error(
-      typeof detail.detail === "string" ? detail.detail : "Upload failed",
-    );
+    throw new Error(await readFastApiError(res, "Upload failed"));
   }
 
   return res.json();

--- a/studio/frontend/src/features/recipe-studio/api/index.ts
+++ b/studio/frontend/src/features/recipe-studio/api/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
+import { formatFastApiDetail } from "@/lib/format-fastapi-error";
 
 const DEFAULT_BASE = "/api/data-recipe";
 
@@ -202,12 +203,18 @@ async function parseErrorResponse(response: Response): Promise<string> {
   }
   try {
     const parsed = JSON.parse(text) as {
-      detail?: string;
+      detail?: unknown;
       message?: string;
       // biome-ignore lint/style/useNamingConvention: api schema
       raw_detail?: string;
     };
-    return parsed.detail ?? parsed.message ?? parsed.raw_detail ?? text;
+    // Use ||, not ??: an array detail is truthy but not nullish, and
+    // formatFastApiDetail returns null when it cannot flatten the value.
+    const formatted = formatFastApiDetail(parsed.detail);
+    if (formatted) return formatted;
+    if (typeof parsed.message === "string" && parsed.message) return parsed.message;
+    if (typeof parsed.raw_detail === "string" && parsed.raw_detail) return parsed.raw_detail;
+    return text;
   } catch {
     return text;
   }

--- a/studio/frontend/src/features/training/api/datasets-api.ts
+++ b/studio/frontend/src/features/training/api/datasets-api.ts
@@ -7,6 +7,7 @@ import type {
   UploadDatasetResponse,
 } from "../types/datasets";
 import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
 
 type CheckDatasetFormatArgs = {
   datasetName: string;
@@ -36,8 +37,7 @@ export async function checkDatasetFormat({
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new Error(body?.detail || `Request failed (${res.status})`);
+    throw new Error(await readFastApiError(res));
   }
 
   return res.json();
@@ -55,8 +55,7 @@ export async function uploadTrainingDataset(
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new Error(body?.detail || `Upload failed (${res.status})`);
+    throw new Error(await readFastApiError(res, "Upload failed"));
   }
 
   return res.json();
@@ -107,8 +106,7 @@ export async function aiAssistMapping({
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new Error(body?.detail || `AI assist failed (${res.status})`);
+    throw new Error(await readFastApiError(res, "AI assist failed"));
   }
 
   return res.json();
@@ -117,8 +115,7 @@ export async function aiAssistMapping({
 export async function listLocalDatasets(): Promise<LocalDatasetsResponse> {
   const res = await authFetch("/api/datasets/local");
   if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new Error(body?.detail || `Request failed (${res.status})`);
+    throw new Error(await readFastApiError(res));
   }
   return res.json();
 }

--- a/studio/frontend/src/features/training/api/history-api.ts
+++ b/studio/frontend/src/features/training/api/history-api.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
 import type {
   TrainingRunDeleteResponse,
   TrainingRunDetailResponse,
@@ -9,14 +10,7 @@ import type {
   TrainingRunSummary,
 } from "../types/history";
 
-async function readError(response: Response): Promise<string> {
-  try {
-    const payload = (await response.json()) as { detail?: string; message?: string };
-    return payload.detail || payload.message || `Request failed (${response.status})`;
-  } catch {
-    return `Request failed (${response.status})`;
-  }
-}
+const readError = (r: Response): Promise<string> => readFastApiError(r);
 
 async function parseJson<T>(response: Response): Promise<T> {
   if (!response.ok) {

--- a/studio/frontend/src/features/training/api/train-api.ts
+++ b/studio/frontend/src/features/training/api/train-api.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
 import type {
   TrainingStartRequest,
   TrainingStartResponse,
@@ -17,45 +18,7 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
-type FastApiValidationError = {
-  loc?: unknown[];
-  msg?: string;
-};
-
-function formatDetail(detail: unknown): string | null {
-  if (typeof detail === "string" && detail) return detail;
-  if (!Array.isArray(detail)) return null;
-  const parts = detail
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") return "";
-      const { loc, msg } = entry as FastApiValidationError;
-      const path = Array.isArray(loc)
-        ? loc.filter((segment) => segment !== "body").join(".")
-        : "";
-      const message = typeof msg === "string" ? msg : "";
-      if (path && message) return `${path}: ${message}`;
-      return path || message;
-    })
-    .filter(Boolean);
-  return parts.length > 0 ? parts.join("; ") : null;
-}
-
-async function readError(response: Response): Promise<string> {
-  try {
-    const payload = (await response.json()) as {
-      detail?: unknown;
-      message?: string;
-    };
-    const formattedDetail = formatDetail(payload.detail);
-    if (formattedDetail) return formattedDetail;
-    if (typeof payload.message === "string" && payload.message) {
-      return payload.message;
-    }
-    return `Request failed (${response.status})`;
-  } catch {
-    return `Request failed (${response.status})`;
-  }
-}
+const readError = (r: Response): Promise<string> => readFastApiError(r);
 
 async function parseJson<T>(response: Response): Promise<T> {
   if (!response.ok) {

--- a/studio/frontend/src/lib/format-fastapi-error.ts
+++ b/studio/frontend/src/lib/format-fastapi-error.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+/**
+ * Render a FastAPI error response body into a human-readable string.
+ *
+ * FastAPI emits 422s as `{detail: Array<{loc, msg, type, input?}>}`. The
+ * naive `body.detail || body.message` pattern truthy-coerces the array
+ * and stringifies it as `[object Object]`, which is unhelpful and was
+ * exactly the regression #5409 fixed inside `train-api.ts`. Lift the
+ * helper here so chat, export, history, datasets, and recipe-studio
+ * can all share it.
+ *
+ * Falls back through: array detail -> string detail -> message -> null.
+ */
+
+export type FastApiValidationError = {
+  loc?: unknown[];
+  msg?: string;
+};
+
+export function formatFastApiDetail(detail: unknown): string | null {
+  if (typeof detail === "string" && detail) return detail;
+  if (!Array.isArray(detail)) return null;
+  const parts = detail
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return "";
+      const { loc, msg } = entry as FastApiValidationError;
+      const path = Array.isArray(loc)
+        ? loc.filter((segment) => segment !== "body").join(".")
+        : "";
+      const message = typeof msg === "string" ? msg : "";
+      if (path && message) return `${path}: ${message}`;
+      return path || message;
+    })
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
+/**
+ * Convert a Response (likely a non-ok response from a fetch) into the
+ * best human-readable error message available. Used by *-api.ts wrappers
+ * so toast text reads as `field: msg` instead of `[object Object]` or
+ * `Request failed (422)`.
+ */
+export async function readFastApiError(
+  response: Response,
+  fallbackPrefix: string = "Request failed",
+): Promise<string> {
+  try {
+    const payload = (await response.json()) as {
+      detail?: unknown;
+      message?: string;
+    };
+    const formatted = formatFastApiDetail(payload.detail);
+    if (formatted) return formatted;
+    if (typeof payload.message === "string" && payload.message) {
+      return payload.message;
+    }
+  } catch {
+    // fall through
+  }
+  return `${fallbackPrefix} (${response.status})`;
+}


### PR DESCRIPTION
## Summary

Four frontend follow-ups to #5375 that the `train-api.ts` fix in #5409 did not cover.

### Log out

`features/auth/api.ts:logout()` was a synchronous `clearAuthTokens()` with no call to `/api/auth/logout`, and the SPA exposed no Log out menu item at all. Refresh tokens stayed valid server-side for their entire lifetime even after the user "left". `logout()` is now async and POSTs to `/api/auth/logout` (best-effort, swallows network errors) so `storage.revoke_user_refresh_tokens` fires server-side. The account dropdown in `components/app-sidebar.tsx` gains a "Log out" item between Help and Shutdown that calls `logout()` then navigates to `/login`.

### refreshSession singleflight

The backend now consumes the refresh token atomically on `/api/auth/refresh`. Two concurrent refreshes race; the loser 401s and the user is force-logged-out. Reproduces on essentially every page that fires multiple API calls in parallel after access-token expiry. `refreshSession` now holds a module-level inflight promise: first caller mints it, subsequent callers await the same one, and the slot clears in `finally`.

### Shared formatDetail helper

#5409 fixed the array-detail rendering only inside `train-api.ts`. Other api modules still rendered FastAPI array-detail 422s as either `"Request failed (422)"` (`chat-api.ts:parseErrorText` only matched string detail) or `"[object Object]"` (the rest).

`src/lib/format-fastapi-error.ts` lifts the helper into one place:

- `formatFastApiDetail(detail)` unpacks an array of `{loc, msg, type}` into `field: msg; field: msg`, falls through to string detail and message.
- `readFastApiError(response, fallbackPrefix?)` reads a `Response` into the best human-readable string.

All five sibling api modules now use it: `chat-api.ts`, `export-api.ts`, `history-api.ts`, `datasets-api.ts`, `recipe-studio/api/index.ts`. The recipe-studio module also switches from `??` (which short-circuits on a truthy array) to the helper's truthy check.

### Current password input

`auth-form.tsx` in change-password mode rendered only New password and Confirm password; `currentPassword` defaulted to `window.__UNSLOTH_BOOTSTRAP__?.password`. On admin-forced `must_change_password` resets the bootstrap is empty and the form short-circuited with "Unable to initialize setup. Reload the page". A Current password input is now rendered in change-password mode and is pre-filled from the bootstrap when present so first-boot UX is unchanged.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` produces a fresh dist; lint output unchanged from `main` (no new errors introduced by these files)
- [x] Backend smoke after rebuild: `/api/auth/logout` is reachable (401 unauth as expected), Studio serves the new SPA bundle
- [x] `install.sh --local` rebuilds dist on next install so end-user installs pick up the change

## Browser compatibility

All changes use standard `fetch`, `Promise.all`/`finally`, `localStorage`, and React 18 patterns. No service workers, no Safari-incompatible Promise features, no Firefox-specific quirks. Verified the build still works under Vite 5.
