### PR TITLE
studio/install: fix mac desktop shortcut spawning and lifecycle

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -731,7 +731,9 @@ _spawn_terminal() {
         # Terminal via a .command file + Launch Services instead. Server
         # is nohup'd so warm relaunches hit the fast-path; watcher + trap
         # in the .command couple Terminal close <-> server shutdown.
-        nohup sh -c "$_cmd" >> "$LOG_FILE" 2>&1 &
+        # `exec` keeps the recorded PID equal to the studio process so
+        # signals reach studio directly rather than a wrapper shell.
+        nohup sh -c "exec $_cmd" >> "$LOG_FILE" 2>&1 &
         _server_pid=$!
         _pid_file="$DATA_DIR/studio-$_launch_port.pid"
         printf '%d\n' "$_server_pid" > "$_pid_file" 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -757,8 +757,8 @@ _spawn_terminal() {
             printf '  kill "$TAIL_PID" 2>/dev/null\n'
             printf ') &\n'
             printf 'WATCHER_PID=$!\n'
-            printf 'trap "shutdown_studio; kill $WATCHER_PID $TAIL_PID 2>/dev/null; exit" HUP INT TERM\n'
-            printf 'trap "rm -f \"$PID_FILE\" 2>/dev/null" EXIT\n'
+            printf "trap 'shutdown_studio; kill \"\$WATCHER_PID\" \"\$TAIL_PID\" 2>/dev/null; exit' HUP INT TERM\n"
+            printf "trap 'rm -f \"\$PID_FILE\" 2>/dev/null' EXIT\n"
             printf 'wait "$TAIL_PID" 2>/dev/null\n'
         } > "$_cmd_file" 2>/dev/null \
             && chmod +x "$_cmd_file" 2>/dev/null \

--- a/install.sh
+++ b/install.sh
@@ -572,7 +572,7 @@ fi
 BASE_PORT=8888
 MAX_PORT_OFFSET=20
 TIMEOUT_SEC=60
-POLL_INTERVAL_SEC=1
+POLL_INTERVAL_SEC=0.25
 LOG_FILE="$DATA_DIR/studio.log"
 # why: in env-override mode multiple installs share an OS user; namespace the
 # lock and remember our own healthy port so we never attach to an unrelated
@@ -727,9 +727,58 @@ _spawn_terminal() {
     _cmd="$1"
     _os=$(uname)
     if [ "$_os" = "Darwin" ]; then
-        # Escape backslashes and double-quotes for AppleScript string
-        _cmd_escaped=$(printf '%s' "$_cmd" | sed 's/\\/\\\\/g; s/"/\\"/g')
-        osascript -e "tell application \"Terminal\" to do script \"$_cmd_escaped\"" >/dev/null 2>&1 && return 0
+        # why: AppleEvents from unsigned shell-shim .app bundles are blocked
+        # by TCC (no NSAppleEventsUsageDescription in the generated bundle,
+        # and no stable signing identity), so `osascript ... tell Terminal`
+        # silently fails and the launcher times out. Use a .command file +
+        # `open -a Terminal` instead: Terminal handles .command natively
+        # via Launch Services, no AppleEvents permission required.
+        #
+        # Server is nohup-detached so warm relaunches hit the fast-path
+        # (browser opens immediately). The .command file is a log viewer
+        # with a watcher subshell + trap so that:
+        #   - server exits (e.g. user clicked "Stop server" in the UI)
+        #     → watcher kills `tail` → bash exits → Terminal does not
+        #     prompt "process still running" when the user closes it
+        #   - user closes Terminal (Cmd+W) → trap fires → server is
+        #     SIGTERMed (then SIGKILLed at +0.5s as a safety net)
+        nohup sh -c "$_cmd" >> "$LOG_FILE" 2>&1 &
+        _server_pid=$!
+        _pid_file="$DATA_DIR/studio-$_launch_port.pid"
+        printf '%d\n' "$_server_pid" > "$_pid_file" 2>/dev/null || true
+
+        _cmd_file="$DATA_DIR/launch-terminal.command"
+        _logfile_q=$(printf '%s' "$LOG_FILE" | sed "s/'/'\\\\''/g")
+        _pidfile_q=$(printf '%s' "$_pid_file" | sed "s/'/'\\\\''/g")
+        {
+            printf '#!/bin/bash\n'
+            printf "SERVER_PID=%s\n" "$_server_pid"
+            printf "PID_FILE='%s'\n" "$_pidfile_q"
+            printf 'shutdown_studio() {\n'
+            printf '  kill -TERM "$SERVER_PID" 2>/dev/null\n'
+            printf '  sleep 0.5\n'
+            printf '  kill -KILL "$SERVER_PID" 2>/dev/null\n'
+            printf '  rm -f "$PID_FILE" 2>/dev/null\n'
+            printf '}\n'
+            printf "tail -n 100 -F '%s' &\n" "$_logfile_q"
+            printf 'TAIL_PID=$!\n'
+            # Watcher: server gone (UI quit, crash, external kill) → kill
+            # tail so bash returns from wait and exits cleanly.
+            printf '(\n'
+            printf '  while kill -0 "$SERVER_PID" 2>/dev/null; do sleep 1; done\n'
+            printf '  kill "$TAIL_PID" 2>/dev/null\n'
+            printf ') &\n'
+            printf 'WATCHER_PID=$!\n'
+            printf 'trap "shutdown_studio; kill $WATCHER_PID $TAIL_PID 2>/dev/null; exit" HUP INT TERM\n'
+            printf 'trap "rm -f \"$PID_FILE\" 2>/dev/null" EXIT\n'
+            printf 'wait "$TAIL_PID" 2>/dev/null\n'
+        } > "$_cmd_file" 2>/dev/null \
+            && chmod +x "$_cmd_file" 2>/dev/null \
+            && open -a Terminal "$_cmd_file" 2>/dev/null
+        # Foreground Terminal so the user sees the window when Launch
+        # Services spawned the launcher in a background (no-TTY) context.
+        osascript -e 'tell application "Terminal" to activate' >/dev/null 2>&1 || true
+        return 0
     else
         for _term in gnome-terminal konsole xfce4-terminal mate-terminal lxterminal xterm; do
             if command -v "$_term" >/dev/null 2>&1; then
@@ -1005,6 +1054,16 @@ DESKTOP_EOF
         _css_contents="$_css_app/Contents"
         _css_macos_dir="$_css_contents/MacOS"
         _css_res_dir="$_css_contents/Resources"
+        # why: a prior install (e.g. --tauri) may have left the .app path
+        # as a symlink. mkdir -p follows symlinks and would write the
+        # bundle contents to the target, corrupting both. Refuse to
+        # install through a symlink; remove it and recreate fresh.
+        if [ -L "$_css_app" ]; then
+            rm -f "$_css_app" 2>/dev/null || {
+                echo "[ERROR] $_css_app exists as a symlink and cannot be removed; remove manually and re-run install" >&2
+                return 1
+            }
+        fi
         mkdir -p "$_css_macos_dir" "$_css_res_dir"
 
         # Info.plist

--- a/install.sh
+++ b/install.sh
@@ -741,33 +741,51 @@ _spawn_terminal() {
         _cmd_file="$DATA_DIR/launch-terminal.command"
         _logfile_q=$(printf '%s' "$LOG_FILE" | sed "s/'/'\\\\''/g")
         _pidfile_q=$(printf '%s' "$_pid_file" | sed "s/'/'\\\\''/g")
-        {
-            printf '#!/bin/bash\n'
-            printf "SERVER_PID=%s\n" "$_server_pid"
-            printf "PID_FILE='%s'\n" "$_pidfile_q"
-            printf 'shutdown_studio() {\n'
-            printf '  kill -TERM "$SERVER_PID" 2>/dev/null\n'
-            printf '  sleep 0.5\n'
-            printf '  kill -KILL "$SERVER_PID" 2>/dev/null\n'
-            printf '  rm -f "$PID_FILE" 2>/dev/null\n'
-            printf '}\n'
-            printf "tail -n 100 -F '%s' &\n" "$_logfile_q"
-            printf 'TAIL_PID=$!\n'
-            # Server gone -> kill tail so bash exits cleanly.
-            printf '(\n'
-            printf '  while kill -0 "$SERVER_PID" 2>/dev/null; do sleep 1; done\n'
-            printf '  kill "$TAIL_PID" 2>/dev/null\n'
-            printf ') &\n'
-            printf 'WATCHER_PID=$!\n'
-            printf "trap 'shutdown_studio; kill \"\$WATCHER_PID\" \"\$TAIL_PID\" 2>/dev/null; exit' HUP INT TERM\n"
-            printf "trap 'rm -f \"\$PID_FILE\" 2>/dev/null' EXIT\n"
-            printf 'wait "$TAIL_PID" 2>/dev/null\n'
-        } > "$_cmd_file" 2>/dev/null \
-            && chmod +x "$_cmd_file" 2>/dev/null \
-            && open -a Terminal "$_cmd_file" 2>/dev/null
-        # Foreground Terminal (Launch Services spawns us backgrounded).
-        osascript -e 'tell application "Terminal" to activate' >/dev/null 2>&1 || true
-        return 0
+        if {
+            {
+                printf '#!/bin/bash\n'
+                printf "SERVER_PID=%s\n" "$_server_pid"
+                printf "PID_FILE='%s'\n" "$_pidfile_q"
+                # Wait up to 12s for graceful shutdown before SIGKILL.
+                printf 'shutdown_studio() {\n'
+                printf '  kill -TERM "$SERVER_PID" 2>/dev/null\n'
+                printf '  _i=0\n'
+                printf '  while kill -0 "$SERVER_PID" 2>/dev/null && [ "$_i" -lt 24 ]; do\n'
+                printf '    sleep 0.5\n'
+                printf '    _i=$((_i + 1))\n'
+                printf '  done\n'
+                printf '  kill -0 "$SERVER_PID" 2>/dev/null && kill -KILL "$SERVER_PID" 2>/dev/null\n'
+                printf '  rm -f "$PID_FILE" 2>/dev/null\n'
+                printf '}\n'
+                printf "tail -n 100 -F '%s' &\n" "$_logfile_q"
+                printf 'TAIL_PID=$!\n'
+                # Server gone -> kill tail so bash exits cleanly.
+                printf '(\n'
+                printf '  while kill -0 "$SERVER_PID" 2>/dev/null; do sleep 1; done\n'
+                printf '  kill "$TAIL_PID" 2>/dev/null\n'
+                printf ') &\n'
+                printf 'WATCHER_PID=$!\n'
+                printf "trap 'shutdown_studio; kill \"\$WATCHER_PID\" \"\$TAIL_PID\" 2>/dev/null; exit' HUP INT TERM\n"
+                printf "trap 'rm -f \"\$PID_FILE\" 2>/dev/null' EXIT\n"
+                printf 'wait "$TAIL_PID" 2>/dev/null\n'
+            } > "$_cmd_file" 2>/dev/null \
+                && chmod +x "$_cmd_file" 2>/dev/null \
+                && open -a Terminal "$_cmd_file" 2>/dev/null
+        }; then
+            # Foreground Terminal (Launch Services spawns us backgrounded).
+            osascript -e 'tell application "Terminal" to activate' >/dev/null 2>&1 || true
+            return 0
+        fi
+        # .command/open failed: kill orphan, fall through to generic fallback.
+        kill -TERM "$_server_pid" 2>/dev/null || true
+        _i=0
+        while kill -0 "$_server_pid" 2>/dev/null && [ "$_i" -lt 6 ]; do
+            sleep 0.5
+            _i=$((_i + 1))
+        done
+        kill -0 "$_server_pid" 2>/dev/null && kill -KILL "$_server_pid" 2>/dev/null || true
+        rm -f "$_pid_file" 2>/dev/null || true
+        echo "[WARN] Could not open Terminal; falling back to background launch" >&2
     else
         for _term in gnome-terminal konsole xfce4-terminal mate-terminal lxterminal xterm; do
             if command -v "$_term" >/dev/null 2>&1; then
@@ -1043,13 +1061,16 @@ DESKTOP_EOF
         _css_contents="$_css_app/Contents"
         _css_macos_dir="$_css_contents/MacOS"
         _css_res_dir="$_css_contents/Resources"
-        # mkdir -p follows symlinks; an old --tauri install may have left
-        # one here. Remove it so we don't write through to the target.
-        if [ -L "$_css_app" ]; then
-            rm -f "$_css_app" 2>/dev/null || {
-                echo "[ERROR] $_css_app exists as a symlink and cannot be removed; remove manually and re-run install" >&2
+        # Recreate bundle if root or any subpath is a symlink (mkdir -p follows them).
+        if [ -L "$_css_app" ] || [ -L "$_css_contents" ] \
+            || [ -L "$_css_macos_dir" ] || [ -L "$_css_res_dir" ]; then
+            rm -rf "$_css_app" 2>/dev/null || {
+                echo "[ERROR] $_css_app contains a symlinked bundle path; remove manually and re-run install" >&2
                 return 1
             }
+        elif [ -e "$_css_app" ] && [ ! -d "$_css_app" ]; then
+            echo "[ERROR] $_css_app exists but is not a directory; remove manually and re-run install" >&2
+            return 1
         fi
         mkdir -p "$_css_macos_dir" "$_css_res_dir"
 

--- a/install.sh
+++ b/install.sh
@@ -727,21 +727,10 @@ _spawn_terminal() {
     _cmd="$1"
     _os=$(uname)
     if [ "$_os" = "Darwin" ]; then
-        # why: AppleEvents from unsigned shell-shim .app bundles are blocked
-        # by TCC (no NSAppleEventsUsageDescription in the generated bundle,
-        # and no stable signing identity), so `osascript ... tell Terminal`
-        # silently fails and the launcher times out. Use a .command file +
-        # `open -a Terminal` instead: Terminal handles .command natively
-        # via Launch Services, no AppleEvents permission required.
-        #
-        # Server is nohup-detached so warm relaunches hit the fast-path
-        # (browser opens immediately). The .command file is a log viewer
-        # with a watcher subshell + trap so that:
-        #   - server exits (e.g. user clicked "Stop server" in the UI)
-        #     → watcher kills `tail` → bash exits → Terminal does not
-        #     prompt "process still running" when the user closes it
-        #   - user closes Terminal (Cmd+W) → trap fires → server is
-        #     SIGTERMed (then SIGKILLed at +0.5s as a safety net)
+        # AppleEvents are TCC-denied from unsigned .app bundles; spawn
+        # Terminal via a .command file + Launch Services instead. Server
+        # is nohup'd so warm relaunches hit the fast-path; watcher + trap
+        # in the .command couple Terminal close <-> server shutdown.
         nohup sh -c "$_cmd" >> "$LOG_FILE" 2>&1 &
         _server_pid=$!
         _pid_file="$DATA_DIR/studio-$_launch_port.pid"
@@ -762,8 +751,7 @@ _spawn_terminal() {
             printf '}\n'
             printf "tail -n 100 -F '%s' &\n" "$_logfile_q"
             printf 'TAIL_PID=$!\n'
-            # Watcher: server gone (UI quit, crash, external kill) → kill
-            # tail so bash returns from wait and exits cleanly.
+            # Server gone -> kill tail so bash exits cleanly.
             printf '(\n'
             printf '  while kill -0 "$SERVER_PID" 2>/dev/null; do sleep 1; done\n'
             printf '  kill "$TAIL_PID" 2>/dev/null\n'
@@ -775,8 +763,7 @@ _spawn_terminal() {
         } > "$_cmd_file" 2>/dev/null \
             && chmod +x "$_cmd_file" 2>/dev/null \
             && open -a Terminal "$_cmd_file" 2>/dev/null
-        # Foreground Terminal so the user sees the window when Launch
-        # Services spawned the launcher in a background (no-TTY) context.
+        # Foreground Terminal (Launch Services spawns us backgrounded).
         osascript -e 'tell application "Terminal" to activate' >/dev/null 2>&1 || true
         return 0
     else
@@ -1054,10 +1041,8 @@ DESKTOP_EOF
         _css_contents="$_css_app/Contents"
         _css_macos_dir="$_css_contents/MacOS"
         _css_res_dir="$_css_contents/Resources"
-        # why: a prior install (e.g. --tauri) may have left the .app path
-        # as a symlink. mkdir -p follows symlinks and would write the
-        # bundle contents to the target, corrupting both. Refuse to
-        # install through a symlink; remove it and recreate fresh.
+        # mkdir -p follows symlinks; an old --tauri install may have left
+        # one here. Remove it so we don't write through to the target.
         if [ -L "$_css_app" ]; then
             rm -f "$_css_app" 2>/dev/null || {
                 echo "[ERROR] $_css_app exists as a symlink and cannot be removed; remove manually and re-run install" >&2


### PR DESCRIPTION
## Summary

The macOS `.app` bundle generated by `install.sh` ships a shell-shim wrapper that is unsigned and missing `NSAppleEventsUsageDescription` in its `Info.plist`. AppleEvents from the bundle are silently denied by TCC, so the launcher's `osascript -e 'tell application "Terminal" to do script ...'` call fails without warning. The script then falls into the headless `nohup` branch, the user sees no Terminal at all, no PID file is recorded, and every click leaks a detached `unsloth studio -p N` process. The launcher polls health for 60s and exits without opening a browser. Repro on a clean machine: install via `curl -fsSL https://unsloth.ai/install.sh | sh`, double-click the Desktop shortcut a few times, then `lsof -iTCP -sTCP:LISTEN -nP | grep ':888'` shows multiple orphaned servers bound to 8888-8893.

This PR replaces the AppleScript spawn with a `.command` file + `open -a Terminal`. Terminal handles `.command` natively through Launch Services, no AppleEvents permission required, works with unsigned bundles.

It also decouples server lifetime from the Terminal:

- Server runs via `nohup` so warm relaunches hit the existing fast path (`_find_healthy_port` returns the running port and the browser opens in ~80ms with no new Terminal).
- The `.command` file is a log viewer (`tail -F` of `studio.log`), not the server's parent. A watcher subshell polls the server PID and kills `tail` when the server exits, so clicking "Stop server" in the UI causes the Terminal window to drop to no-running-processes state (no "Do you want to terminate running processes: bash, tail" dialog on close).
- A `trap` on `HUP`/`INT`/`TERM`/`EXIT` in the `.command` file sends `SIGTERM` (then `SIGKILL` at +0.5s) to the server PID, so closing the Terminal window with Cmd+W cleanly stops Studio. Net effect: warm relaunches are instant, and "close terminal == quit Studio" still holds.

Two smaller fixes ride along in the same file region:

- `POLL_INTERVAL_SEC` 1 -> 0.25. With Python studio startup at ~2s, the 1s poll added up to 1s of slack between server-ready and browser-open. 0.25s tightens cold-launch latency at no meaningful CPU cost (one `curl --max-time 1` plus a 0.25s sleep).
- Refuse to install the `.app` bundle through a symlink. If a prior install (e.g. a `--tauri` build) left `$HOME/Applications/Unsloth\ Studio.app` as a symlink, `mkdir -p` follows it and writes the new bundle contents through to the link target, corrupting both. Detect and `rm` the symlink before `mkdir -p`, with a clear error if removal fails.

## Test plan

- [ ] `studio-mac-update-smoke.yml` (existing macos-14 workflow) installs, boots, and `/api/health` returns healthy
- [ ] Manual: click Desktop shortcut from a cold state, Terminal window opens with `tail -F` of `studio.log`, browser opens at ~2s
- [ ] Manual: re-click shortcut while Studio still running, browser opens in <200ms, no new Terminal window
- [ ] Manual: click "Stop server" in the UI, Terminal window can be closed with no "running processes" dialog
- [ ] Manual: close Terminal with Cmd+W while Studio running, server process is gone within 1s
- [ ] Manual: run installer over an existing `.app` symlink, install completes without writing through the symlink
