### PR TITLE
studio: add uninstall.sh and document it in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,12 @@ unsloth studio -p 8888
 ```
 
 #### Uninstall
-You can uninstall Unsloth Studio by deleting its install folder usually located under `$HOME/.unsloth/studio` on Mac/Linux/WSL and `%USERPROFILE%\.unsloth\studio` on Windows. Using the `rm -rf` commands will **delete everything**, including your history, cache:
+On Mac/Linux/WSL the recommended way to fully remove Unsloth Studio is the `uninstall.sh` script. It stops any running servers, removes the install dir, the launcher data dir, the desktop shortcut, the macOS `.app` bundle, and the Launch Services entry:
 
-* ​ **MacOS, WSL, Linux:** `rm -rf ~/.unsloth/studio`
+* ​ **MacOS, WSL, Linux:** `curl -fsSL https://unsloth.ai/uninstall.sh | sh`
 * ​ **Windows (PowerShell):** `Remove-Item -Recurse -Force "$HOME\.unsloth\studio"`
+
+If you only want to drop the install dir and keep the launcher/shortcut for a later reinstall, you can instead run `rm -rf ~/.unsloth/studio`. The model cache at `~/.cache/huggingface` is not touched by either command.
 
 For more info, [see our docs](https://unsloth.ai/docs/new/studio/install#uninstall).
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -27,6 +27,11 @@ _kill_pid_file() {
     rm -f "$_pid_file" 2>/dev/null || true
 }
 
+# BRE-escape a path so it can be embedded in a pkill -f regex.
+_pkill_escape() {
+    printf '%s' "$1" | sed -e 's:[][\\.^$*+?{|}()/]:\\&:g'
+}
+
 _pkill_studio() {
     # Prefer PID files written by _spawn_terminal so we only touch our own installs.
     for _data_dir in "$HOME/.local/share/unsloth" $(_custom_studio_data_dirs); do
@@ -36,25 +41,42 @@ _pkill_studio() {
         done
     done
 
-    if command -v pkill >/dev/null 2>&1; then
-        # Anchored patterns avoid matching `less notes.md` etc. Third pattern
-        # catches the post-exec `studio/backend/run.py --port N` form.
+    command -v pkill >/dev/null 2>&1 || return 0
+
+    # Scope fallback patterns to the install roots we are removing so a
+    # different Studio install (different UNSLOTH_STUDIO_HOME) is not touched.
+    _kill_roots="$HOME/.unsloth/studio"
+    _roots_from_conf=$(_custom_studio_roots 2>/dev/null || true)
+    [ -n "$_roots_from_conf" ] && _kill_roots="$_kill_roots
+$_roots_from_conf"
+
+    printf '%s\n' "$_kill_roots" | while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
+        [ -d "$_root" ] || continue
+        _re=$(_pkill_escape "$_root")
+        # `unsloth studio` (default port) + `-p N` + `--port N` forms, all
+        # anchored on the install root's venv path.
         for _pat in \
-            "/unsloth_studio/bin/.*unsloth[^/]* studio.*-p[ =][0-9]" \
-            "/unsloth_studio/bin/.*unsloth[^/]* studio.*--port[ =][0-9]" \
-            "studio/backend/run\.py.*--port[ =][0-9]"
+            "${_re}/unsloth_studio/bin/[^ ]* studio( |\$|.*-p[ =][0-9])" \
+            "${_re}/unsloth_studio/bin/[^ ]* studio.*--port[ =][0-9]" \
+            "${_re}/.*studio/backend/run\.py"
         do
             pkill -TERM -f "$_pat" 2>/dev/null || true
         done
-        sleep 0.5
+    done
+    sleep 0.5
+    printf '%s\n' "$_kill_roots" | while IFS= read -r _root; do
+        [ -n "$_root" ] || continue
+        [ -d "$_root" ] || continue
+        _re=$(_pkill_escape "$_root")
         for _pat in \
-            "/unsloth_studio/bin/.*unsloth[^/]* studio.*-p[ =][0-9]" \
-            "/unsloth_studio/bin/.*unsloth[^/]* studio.*--port[ =][0-9]" \
-            "studio/backend/run\.py.*--port[ =][0-9]"
+            "${_re}/unsloth_studio/bin/[^ ]* studio( |\$|.*-p[ =][0-9])" \
+            "${_re}/unsloth_studio/bin/[^ ]* studio.*--port[ =][0-9]" \
+            "${_re}/.*studio/backend/run\.py"
         do
             pkill -KILL -f "$_pat" 2>/dev/null || true
         done
-    fi
+    done
 }
 
 _remove_path() {
@@ -64,13 +86,15 @@ _remove_path() {
     fi
 }
 
-# Accept as Studio root only if Studio sentinels exist. Without this,
-# UNSLOTH_STUDIO_HOME=$HOME sh uninstall.sh would rm -rf $HOME.
+# Accept as Studio root only if Studio sentinels exist (matches install.sh's
+# env-mode ownership guard at install.sh:1358-1361). A bare unsloth_studio/
+# directory is NOT enough -- require the install-time owner marker so a user
+# directory that happens to contain a folder named "unsloth_studio" is safe.
 _is_studio_root() {
     _r="$1"
     [ -n "$_r" ] || return 1
     [ -f "$_r/share/studio.conf" ] && return 0
-    [ -d "$_r/unsloth_studio" ] && return 0
+    [ -f "$_r/unsloth_studio/.unsloth-studio-owned" ] && return 0
     if [ -L "$_r/bin/unsloth" ]; then
         _t=$(readlink "$_r/bin/unsloth" 2>/dev/null || true)
         case "$_t" in *unsloth_studio/bin/unsloth) return 0 ;; esac
@@ -176,7 +200,14 @@ _remove_path "$HOME/.local/share/unsloth"
 _remove_cli_shim
 
 echo "Removing desktop shortcut and launcher lock..."
-_remove_path "$HOME/Desktop/Unsloth Studio"
+# install.sh creates Desktop/Unsloth Studio as a symlink. If the user has an
+# unrelated regular directory by that name, leave it alone.
+_desktop_link="$HOME/Desktop/Unsloth Studio"
+if [ -L "$_desktop_link" ] || [ ! -e "$_desktop_link" ]; then
+    _remove_path "$_desktop_link"
+else
+    echo "  refusing to remove non-symlink Desktop path: $_desktop_link" >&2
+fi
 _remove_path "$HOME/Desktop/unsloth-studio.desktop"
 # Locks are namespaced per-uid; env-mode adds an extra suffix.
 _lock_glob="${XDG_RUNTIME_DIR:-/tmp}/unsloth-studio-launcher-${_uid}"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
-# Complete uninstaller for Unsloth Studio on macOS / Linux / WSL.
-# Removes the install dir, the launcher data dir, the desktop shortcut,
-# the macOS .app bundle, the Launch Services cache entry, and any
-# running studio server processes.
+# Unsloth Studio uninstaller (macOS / Linux / WSL).
+# Stops running servers and removes install dir, launcher data,
+# desktop shortcut, .app bundle, and Launch Services entry.
 #
 # Usage: curl -fsSL https://unsloth.ai/uninstall.sh | sh
-#    or: ./uninstall.sh
 
 set -e
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env sh
+# Complete uninstaller for Unsloth Studio on macOS / Linux / WSL.
+# Removes the install dir, the launcher data dir, the desktop shortcut,
+# the macOS .app bundle, the Launch Services cache entry, and any
+# running studio server processes.
+#
+# Usage: curl -fsSL https://unsloth.ai/uninstall.sh | sh
+#    or: ./uninstall.sh
+
+set -e
+
+_pkill_studio() {
+    if command -v pkill >/dev/null 2>&1; then
+        pkill -TERM -f "unsloth studio -p [0-9]" 2>/dev/null || true
+        sleep 0.5
+        pkill -KILL -f "unsloth studio -p [0-9]" 2>/dev/null || true
+    fi
+}
+
+_remove_path() {
+    _p="$1"
+    if [ -e "$_p" ] || [ -L "$_p" ]; then
+        rm -rf "$_p" 2>/dev/null && echo "  removed: $_p" || echo "  could not remove: $_p" >&2
+    fi
+}
+
+_uid=$(id -u 2>/dev/null || echo 0)
+_os=$(uname 2>/dev/null || echo unknown)
+
+echo "Stopping any running Unsloth Studio servers..."
+_pkill_studio
+
+echo "Removing data and install directories..."
+_remove_path "$HOME/.unsloth/studio"
+_remove_path "$HOME/.local/share/unsloth"
+
+echo "Removing desktop shortcut and launcher lock..."
+_remove_path "$HOME/Desktop/Unsloth Studio"
+_remove_path "$HOME/Desktop/unsloth-studio.desktop"
+# Locks are namespaced per-uid; env-mode adds an extra suffix.
+_lock_glob="${XDG_RUNTIME_DIR:-/tmp}/unsloth-studio-launcher-${_uid}"
+for _lock in "$_lock_glob".lock "$_lock_glob"-*.lock; do
+    [ -e "$_lock" ] && _remove_path "$_lock"
+done
+
+case "$_os" in
+    Darwin)
+        echo "Removing macOS .app bundle and Launch Services entry..."
+        _remove_path "$HOME/Applications/Unsloth Studio.app"
+        _lsr="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
+        if [ -x "$_lsr" ]; then
+            "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
+        fi
+        ;;
+    Linux)
+        echo "Removing Linux .desktop entry..."
+        _remove_path "$HOME/.local/share/applications/unsloth-studio.desktop"
+        if command -v update-desktop-database >/dev/null 2>&1; then
+            update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+        fi
+        ;;
+esac
+
+echo ""
+echo "Unsloth Studio uninstalled."
+echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
+echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,14 +9,49 @@
 
 set -e
 
+# Stop a Studio server via its PID file (written by install.sh's _spawn_terminal).
+_kill_pid_file() {
+    _pid_file="$1"
+    [ -f "$_pid_file" ] || return 0
+    _pid=$(sed -n '1s/[^0-9].*//p' "$_pid_file" 2>/dev/null || true)
+    if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+        kill -TERM "$_pid" 2>/dev/null || true
+        # Wait up to 10s for graceful shutdown.
+        _i=0
+        while kill -0 "$_pid" 2>/dev/null && [ "$_i" -lt 20 ]; do
+            sleep 0.5
+            _i=$((_i + 1))
+        done
+        kill -0 "$_pid" 2>/dev/null && kill -KILL "$_pid" 2>/dev/null || true
+    fi
+    rm -f "$_pid_file" 2>/dev/null || true
+}
+
 _pkill_studio() {
+    # Prefer PID files written by _spawn_terminal so we only touch our own installs.
+    for _data_dir in "$HOME/.local/share/unsloth" $(_custom_studio_data_dirs); do
+        [ -d "$_data_dir" ] || continue
+        for _pf in "$_data_dir"/studio-*.pid; do
+            [ -f "$_pf" ] && _kill_pid_file "$_pf"
+        done
+    done
+
     if command -v pkill >/dev/null 2>&1; then
-        # Cover both `-p PORT` and `--port PORT` invocation styles.
-        for _pat in "unsloth studio.*-p[ =][0-9]" "unsloth studio.*--port[ =][0-9]"; do
+        # Anchored patterns avoid matching `less notes.md` etc. Third pattern
+        # catches the post-exec `studio/backend/run.py --port N` form.
+        for _pat in \
+            "/unsloth_studio/bin/.*unsloth[^/]* studio.*-p[ =][0-9]" \
+            "/unsloth_studio/bin/.*unsloth[^/]* studio.*--port[ =][0-9]" \
+            "studio/backend/run\.py.*--port[ =][0-9]"
+        do
             pkill -TERM -f "$_pat" 2>/dev/null || true
         done
         sleep 0.5
-        for _pat in "unsloth studio.*-p[ =][0-9]" "unsloth studio.*--port[ =][0-9]"; do
+        for _pat in \
+            "/unsloth_studio/bin/.*unsloth[^/]* studio.*-p[ =][0-9]" \
+            "/unsloth_studio/bin/.*unsloth[^/]* studio.*--port[ =][0-9]" \
+            "studio/backend/run\.py.*--port[ =][0-9]"
+        do
             pkill -KILL -f "$_pat" 2>/dev/null || true
         done
     fi
@@ -27,6 +62,38 @@ _remove_path() {
     if [ -e "$_p" ] || [ -L "$_p" ]; then
         rm -rf "$_p" 2>/dev/null && echo "  removed: $_p" || echo "  could not remove: $_p" >&2
     fi
+}
+
+# Accept as Studio root only if Studio sentinels exist. Without this,
+# UNSLOTH_STUDIO_HOME=$HOME sh uninstall.sh would rm -rf $HOME.
+_is_studio_root() {
+    _r="$1"
+    [ -n "$_r" ] || return 1
+    [ -f "$_r/share/studio.conf" ] && return 0
+    [ -d "$_r/unsloth_studio" ] && return 0
+    if [ -L "$_r/bin/unsloth" ]; then
+        _t=$(readlink "$_r/bin/unsloth" 2>/dev/null || true)
+        case "$_t" in *unsloth_studio/bin/unsloth) return 0 ;; esac
+    fi
+    return 1
+}
+
+# Hard deny list: never delete /, $HOME, $HOME's parent, or system paths.
+_is_unsafe_root() {
+    _r="$1"
+    [ -z "$_r" ] && return 0
+    case "$_r" in /|""|"$HOME"|"$HOME/") return 0 ;; esac
+    case "$_r" in /bin|/sbin|/etc|/usr|/usr/*|/var|/var/*|/opt|/opt/*|/Library|/Library/*|/System|/System/*|/Applications|/Applications/*) return 0 ;; esac
+    _parent=$(dirname "$HOME" 2>/dev/null || echo "")
+    [ -n "$_parent" ] && [ "$_r" = "$_parent" ] && return 0
+    return 1
+}
+
+# Print share/ dirs of known custom roots (where PID files live).
+_custom_studio_data_dirs() {
+    _custom_studio_roots 2>/dev/null | while IFS= read -r _r; do
+        [ -d "$_r/share" ] && printf '%s\n' "$_r/share"
+    done
 }
 
 # Resolve a custom install root from any of:
@@ -92,7 +159,16 @@ _pkill_studio
 
 echo "Removing data and install directories..."
 _custom_studio_roots | while IFS= read -r _custom_root; do
-    [ -n "$_custom_root" ] && _remove_path "$_custom_root"
+    [ -n "$_custom_root" ] || continue
+    if _is_unsafe_root "$_custom_root"; then
+        echo "  refusing to remove unsafe path: $_custom_root" >&2
+        continue
+    fi
+    if ! _is_studio_root "$_custom_root"; then
+        echo "  refusing to remove non-Studio path: $_custom_root" >&2
+        continue
+    fi
+    _remove_path "$_custom_root"
 done
 _remove_path "$HOME/.unsloth/studio"
 _remove_path "$HOME/.local/share/unsloth"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env sh
 # Unsloth Studio uninstaller (macOS / Linux / WSL).
 # Stops running servers and removes install dir, launcher data,
-# desktop shortcut, .app bundle, and Launch Services entry.
+# CLI shim, desktop shortcut, .app bundle, and Launch Services entry.
+# Honors custom roots set via UNSLOTH_STUDIO_HOME / STUDIO_HOME at
+# install time (read back from studio.conf).
 #
 # Usage: curl -fsSL https://unsloth.ai/uninstall.sh | sh
 
@@ -9,9 +11,14 @@ set -e
 
 _pkill_studio() {
     if command -v pkill >/dev/null 2>&1; then
-        pkill -TERM -f "unsloth studio -p [0-9]" 2>/dev/null || true
+        # Cover both `-p PORT` and `--port PORT` invocation styles.
+        for _pat in "unsloth studio.*-p[ =][0-9]" "unsloth studio.*--port[ =][0-9]"; do
+            pkill -TERM -f "$_pat" 2>/dev/null || true
+        done
         sleep 0.5
-        pkill -KILL -f "unsloth studio -p [0-9]" 2>/dev/null || true
+        for _pat in "unsloth studio.*-p[ =][0-9]" "unsloth studio.*--port[ =][0-9]"; do
+            pkill -KILL -f "$_pat" 2>/dev/null || true
+        done
     fi
 }
 
@@ -22,15 +29,38 @@ _remove_path() {
     fi
 }
 
+# Read custom STUDIO_HOME from studio.conf if present. install.sh writes
+# UNSLOTH_EXE='<root>/unsloth_studio/bin/unsloth', so the install root is
+# three dirnames up. Used only to remove non-default-rooted installs.
+_custom_studio_home() {
+    _conf="$HOME/.local/share/unsloth/studio.conf"
+    [ -f "$_conf" ] || return 0
+    _exe=$(sed -n "s/^UNSLOTH_EXE='\(.*\)'$/\1/p" "$_conf" | head -n1)
+    [ -n "$_exe" ] || return 0
+    _root=$(dirname "$(dirname "$(dirname "$_exe")")")
+    case "$_root" in
+        "$HOME/.unsloth/studio"|"") ;;
+        *) printf '%s\n' "$_root" ;;
+    esac
+}
+
 _uid=$(id -u 2>/dev/null || echo 0)
 _os=$(uname 2>/dev/null || echo unknown)
+_is_wsl=0
+[ "$_os" = "Linux" ] && grep -qi microsoft /proc/version 2>/dev/null && _is_wsl=1
 
 echo "Stopping any running Unsloth Studio servers..."
 _pkill_studio
 
 echo "Removing data and install directories..."
+_custom_root=$(_custom_studio_home || true)
+if [ -n "$_custom_root" ]; then
+    _remove_path "$_custom_root"
+fi
 _remove_path "$HOME/.unsloth/studio"
 _remove_path "$HOME/.local/share/unsloth"
+# CLI shim (broken symlink once the venv is gone).
+_remove_path "$HOME/.local/bin/unsloth"
 
 echo "Removing desktop shortcut and launcher lock..."
 _remove_path "$HOME/Desktop/Unsloth Studio"
@@ -51,6 +81,26 @@ case "$_os" in
         fi
         ;;
     Linux)
+        if [ "$_is_wsl" = "1" ]; then
+            echo "Removing WSL Windows-side shortcuts..."
+            # install.sh creates 'Unsloth Studio.lnk' on the Windows Desktop and
+            # Start Menu Programs folder via powershell.exe; mirror that path.
+            if command -v powershell.exe >/dev/null 2>&1; then
+                # shellcheck disable=SC2016
+                # $env:APPDATA is a PowerShell expansion; intentionally literal at shell level.
+                powershell.exe -NoProfile -Command '
+                    $names = @("Desktop","StartMenu");
+                    $dirs = @(
+                        [Environment]::GetFolderPath("Desktop"),
+                        (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs")
+                    );
+                    foreach ($d in $dirs) {
+                        if (-not $d) { continue }
+                        $p = Join-Path $d "Unsloth Studio.lnk";
+                        if (Test-Path -LiteralPath $p) { Remove-Item -LiteralPath $p -Force }
+                    }' >/dev/null 2>&1 || true
+            fi
+        fi
         echo "Removing Linux .desktop entry..."
         _remove_path "$HOME/.local/share/applications/unsloth-studio.desktop"
         if command -v update-desktop-database >/dev/null 2>&1; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -132,6 +132,19 @@ _custom_studio_roots() {
     _emit() {
         _r="$1"
         [ -z "$_r" ] && return 0
+        # Tilde expansion (env vars are not subject to it on quoted assignment),
+        # matches install.sh's _resolve_studio_destinations. The literal "~/"
+        # pattern is intentional; SC2088 is a false positive here.
+        # shellcheck disable=SC2088
+        case "$_r" in
+            "~") _r="$HOME" ;;
+            "~/"*) _r="$HOME/${_r#'~/'}" ;;
+        esac
+        # Canonicalize so syntactic variants ($HOME/../$USER, trailing slash)
+        # resolve to the same path and hit the _is_unsafe_root deny list.
+        # shellcheck disable=SC1007
+        _canon=$(CDPATH= cd -P -- "$_r" 2>/dev/null && pwd -P)
+        [ -n "$_canon" ] && _r="$_canon"
         case "$_r" in "$HOME/.unsloth/studio"|/|"") return 0 ;; esac
         case ":$_seen:" in *":$_r:"*) return 0 ;; esac
         _seen="$_seen:$_r"
@@ -145,16 +158,17 @@ _custom_studio_roots() {
         [ -n "$_exe" ] || return 0
         _emit "$(dirname "$(dirname "$(dirname "$_exe")")")"
     }
-    # 1. env vars (UNSLOTH_STUDIO_HOME wins over STUDIO_HOME, matching install.sh).
+    # Mirror install.sh's precedence: UNSLOTH_STUDIO_HOME wins, STUDIO_HOME is
+    # ignored when both are set. Otherwise uninstalling install A could also
+    # delete install B if the user has STUDIO_HOME left over from B.
     if [ -n "${UNSLOTH_STUDIO_HOME:-}" ]; then
         _emit "$UNSLOTH_STUDIO_HOME"
         _from_conf "$UNSLOTH_STUDIO_HOME/share/studio.conf"
-    fi
-    if [ -n "${STUDIO_HOME:-}" ]; then
+    elif [ -n "${STUDIO_HOME:-}" ]; then
         _emit "$STUDIO_HOME"
         _from_conf "$STUDIO_HOME/share/studio.conf"
     fi
-    # 2. default-mode conf.
+    # Default-mode conf.
     _from_conf "$HOME/.local/share/unsloth/studio.conf"
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -29,18 +29,56 @@ _remove_path() {
     fi
 }
 
-# Read custom STUDIO_HOME from studio.conf if present. install.sh writes
-# UNSLOTH_EXE='<root>/unsloth_studio/bin/unsloth', so the install root is
-# three dirnames up. Used only to remove non-default-rooted installs.
-_custom_studio_home() {
-    _conf="$HOME/.local/share/unsloth/studio.conf"
-    [ -f "$_conf" ] || return 0
-    _exe=$(sed -n "s/^UNSLOTH_EXE='\(.*\)'$/\1/p" "$_conf" | head -n1)
-    [ -n "$_exe" ] || return 0
-    _root=$(dirname "$(dirname "$(dirname "$_exe")")")
-    case "$_root" in
-        "$HOME/.unsloth/studio"|"") ;;
-        *) printf '%s\n' "$_root" ;;
+# Resolve a custom install root from any of:
+#   1. UNSLOTH_STUDIO_HOME / STUDIO_HOME env vars at uninstall time
+#   2. Default-mode studio.conf at $HOME/.local/share/unsloth/studio.conf
+#   3. Env-mode studio.conf at $<root>/share/studio.conf (discovered via 1)
+# install.sh writes UNSLOTH_EXE='<root>/unsloth_studio/bin/unsloth', so
+# the install root is three dirnames up. Prints each discovered non-default
+# root on its own line; the caller iterates and de-duplicates.
+_custom_studio_roots() {
+    _seen=""
+    _emit() {
+        _r="$1"
+        [ -z "$_r" ] && return 0
+        case "$_r" in "$HOME/.unsloth/studio"|/|"") return 0 ;; esac
+        case ":$_seen:" in *":$_r:"*) return 0 ;; esac
+        _seen="$_seen:$_r"
+        printf '%s\n' "$_r"
+    }
+    _from_conf() {
+        [ -f "$1" ] || return 0
+        # Tolerate paths containing apostrophes (install.sh emits '\'' for them).
+        _exe=$(sed -n "s/^UNSLOTH_EXE='\(.*\)'\$/\1/p" "$1" | head -n1)
+        _exe=$(printf '%s' "$_exe" | sed "s/'\\\\''/'/g")
+        [ -n "$_exe" ] || return 0
+        _emit "$(dirname "$(dirname "$(dirname "$_exe")")")"
+    }
+    # 1. env vars (UNSLOTH_STUDIO_HOME wins over STUDIO_HOME, matching install.sh).
+    if [ -n "${UNSLOTH_STUDIO_HOME:-}" ]; then
+        _emit "$UNSLOTH_STUDIO_HOME"
+        _from_conf "$UNSLOTH_STUDIO_HOME/share/studio.conf"
+    fi
+    if [ -n "${STUDIO_HOME:-}" ]; then
+        _emit "$STUDIO_HOME"
+        _from_conf "$STUDIO_HOME/share/studio.conf"
+    fi
+    # 2. default-mode conf.
+    _from_conf "$HOME/.local/share/unsloth/studio.conf"
+}
+
+# Remove $HOME/.local/bin/unsloth only if it's a Studio-managed symlink.
+# Studio's install.sh writes this as a symlink into the studio venv
+# (install.sh: `ln -sfn "$VENV_DIR/bin/unsloth" "$_shim_path"`). A
+# pip-installed `unsloth` CLI is a regular file — leave it alone to avoid
+# wiping an unrelated install.
+_remove_cli_shim() {
+    _shim="$HOME/.local/bin/unsloth"
+    [ -L "$_shim" ] || return 0
+    _target=$(readlink "$_shim" 2>/dev/null || true)
+    case "$_target" in
+        */unsloth_studio/bin/unsloth) _remove_path "$_shim" ;;
+        *) ;;
     esac
 }
 
@@ -53,14 +91,13 @@ echo "Stopping any running Unsloth Studio servers..."
 _pkill_studio
 
 echo "Removing data and install directories..."
-_custom_root=$(_custom_studio_home || true)
-if [ -n "$_custom_root" ]; then
-    _remove_path "$_custom_root"
-fi
+_custom_studio_roots | while IFS= read -r _custom_root; do
+    [ -n "$_custom_root" ] && _remove_path "$_custom_root"
+done
 _remove_path "$HOME/.unsloth/studio"
 _remove_path "$HOME/.local/share/unsloth"
-# CLI shim (broken symlink once the venv is gone).
-_remove_path "$HOME/.local/bin/unsloth"
+# CLI shim: only the symlink Studio created, never a pip-installed file.
+_remove_cli_shim
 
 echo "Removing desktop shortcut and launcher lock..."
 _remove_path "$HOME/Desktop/Unsloth Studio"
@@ -113,3 +150,13 @@ echo ""
 echo "Unsloth Studio uninstalled."
 echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
 echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."
+# Env-mode installs leave no breadcrumb in $HOME, so a custom root can
+# only be located if the user re-exports the variable. Print a hint when
+# neither var is set so the bare `curl | sh` flow doesn't silently miss.
+if [ -z "${UNSLOTH_STUDIO_HOME:-}" ] && [ -z "${STUDIO_HOME:-}" ]; then
+    echo ""
+    echo "If you installed Unsloth Studio with UNSLOTH_STUDIO_HOME or STUDIO_HOME"
+    echo "pointing at a custom directory, re-run this script with the same variable"
+    echo "set to also remove that install tree, e.g.:"
+    echo "  UNSLOTH_STUDIO_HOME=/your/path sh uninstall.sh"
+fi


### PR DESCRIPTION
## Summary

The current uninstall guidance in `README.md` is `rm -rf ~/.unsloth/studio`, which only removes the install dir. Everything that lives outside that path is left behind:

- `~/.local/share/unsloth/` (launcher script, `studio.conf`, `studio.log`, icon assets)
- `~/Applications/Unsloth Studio.app` (macOS bundle, orphaned and broken after the install dir is gone)
- `~/Desktop/Unsloth Studio` (now a broken symlink)
- `~/Desktop/unsloth-studio.desktop` and `~/.local/share/applications/unsloth-studio.desktop` (Linux)
- `/tmp/unsloth-studio-launcher-<uid>*.lock` (lock dir, possibly stale)
- Launch Services cache entry for `ai.unsloth.studio` on macOS
- Any running `unsloth studio -p N` processes

Users who follow the documented uninstall and reinstall end up with the new launcher layered on top of stale state from the previous install, which has produced concrete reinstall bugs (one repro: a self-referential symlink inside the `.app` bundle, almost certainly from `mkdir -p` writing through a leftover symlink at the bundle path).

This PR adds `uninstall.sh` at the repo root that handles all of the above, and updates `README.md` to point at it as the recommended path. The plain `rm -rf ~/.unsloth/studio` line is kept as a "partial uninstall, keep launcher for a later reinstall" alternative. The model cache at `~/.cache/huggingface` is left in place, with a note in the script suggesting how to remove it.

## Behavior

- `pkill -TERM` then `-KILL` any running `unsloth studio -p N` process
- `rm -rf` the data and install directories
- `rm -f` desktop shortcuts (macOS symlink, Linux `.desktop`)
- `rm -rf` lock dirs matching the per-uid pattern (including the env-mode `-<keyhash>.lock` variant)
- macOS only: `rm -rf` the `.app`, then `lsregister -u` to drop the Launch Services entry
- Linux only: `rm -f` the user `.desktop` file, refresh the desktop database if available

Script is POSIX `sh`, idempotent (every removal is gated on existence and uses `2>/dev/null || true`). Windows is intentionally not covered here; the existing PowerShell `Remove-Item` line in `README.md` is kept for that.

## Test plan

- [ ] Manual: install Studio, run `./uninstall.sh`, confirm all the listed paths are gone, confirm the Desktop shortcut no longer appears, confirm no `unsloth studio` processes remain
- [ ] Manual: run `./uninstall.sh` twice in a row, second run succeeds with no errors (idempotency)
- [ ] Manual: install Studio, run `./uninstall.sh`, then reinstall; bundle and launcher come up clean with no orphaned state
- [ ] CI: a `tests/studio/install/` test could invoke `uninstall.sh` against a staged fake `$HOME` and assert the expected paths are removed; not included in this PR, happy to add if helpful
