### PR TITLE
intel-gpu: pin unsloth_zoo>=2026.5.2 (fixes #5494)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ triton = [
 ]
 
 huggingfacenotorch = [
+    "unsloth_zoo>=2026.5.2",
     "wheel>=0.42.0",
     "packaging",
     "numpy",


### PR DESCRIPTION
## Summary

Fixes #5494. Installing any `intel-gpu-torch*` extra currently lets the resolver fall back to a stale `unsloth_zoo` (the reporter saw `2026.3.6` from `.[intelgputorch2120]`) because no version floor is enforced on `unsloth_zoo[intelgpu]` in those blocks, and the `unsloth` package itself has no `unsloth_zoo` constraint in its base dependencies.

This PR adds a single `unsloth_zoo>=2026.5.2` line at the top of `huggingfacenotorch`, which every intel-gpu-torch* extra, plus `amd` and `huggingface`, already includes. One source of truth, propagates to every affected path.

## Why 2026.5.2

unsloth_zoo 2026.5.2 (unslothai/unsloth-zoo#658, merged today) relaxes its own torch upper cap from `<2.11.0` to `<2.13.0`. Without that release, pinning `unsloth_zoo>=2026.5.1` would make the resolver fail outright on the new `intelgputorch2110` / `intelgputorch2120` extras shipped in #5484 (because their pinned `torch-2.11.0+xpu` / `torch-2.12.0+xpu` wheels violate unsloth_zoo 2026.5.1's `torch<2.11.0` cap).

The chain:
1. unslothai/unsloth-zoo#658 (merged) - cap relax + version bump to 2026.5.2.
2. unsloth_zoo 2026.5.2 published to PyPI (manual release step).
3. This PR mergeable.

## Test plan

Once 2026.5.2 is on PyPI, run `uv pip compile pyproject.toml --extra <EXTRA> --python-version 3.11 --python-platform x86_64-unknown-linux-gnu` for every intel-gpu-torch* extra and confirm:

- All 9 blocks resolve cleanly.
- All 9 resolve to `unsloth_zoo==2026.5.2` (or newer), not a stale older release.

Draft until 2026.5.2 lands on PyPI so CI can run on a satisfiable graph.

Closes #5494.