### PR TITLE
studio: move toast notifications to bottom-right

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -291,7 +291,7 @@ export function AppProvider({ children }: AppProviderProps) {
       <TauriWrapper>
         {children}
       </TauriWrapper>
-      <Toaster position="top-right" visibleToasts={2} expand={true} />
+      <Toaster position="bottom-right" visibleToasts={2} expand={true} />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary

Moves the Sonner toaster anchor in Unsloth Studio from `top-right` to `bottom-right` so model load/download/cancel toasts no longer overlap the model selector, header controls, and right-side panel triggers.

The toaster sat in the same corner as the header buttons, which made it easy to misclick the toast (or its Cancel) when reaching for the menu, and obscured the model name during a switch. Bottom-right is also Sonner's own default and keeps the chat area visually clean.

Single line change in `studio/frontend/src/app/provider.tsx`.

## Test plan

- [ ] Start Studio, switch models, confirm the \"Starting model... / Loading cached model into memory.\" toast appears in the bottom-right
- [ ] Confirm Cancel on the load toast still works
- [ ] Confirm success and error toasts (load complete, load failure) also render bottom-right
- [ ] Confirm stacked toasts still respect `visibleToasts={2}` and `expand`