### PR TITLE
studio/frontend: make toast and inline error text selectable and copyable

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -89,7 +89,7 @@ import {
 } from "@/features/training";
 import type { TrainingRunSummary } from "@/features/training";
 import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { ShutdownDialog } from "@/components/shutdown-dialog";
 
 function getTourId(pathname: string): string | null {

--- a/studio/frontend/src/components/assistant-ui/model-selector/model-delete-action.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/model-delete-action.tsx
@@ -14,7 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Trash2Icon } from "lucide-react";
 import { useCallback, useState, type ReactNode } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 interface ModelDeleteActionProps {
   ariaLabel: string;

--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -50,7 +50,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type {
   DeletedModelRef,
   LoraModelOption,

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -86,7 +86,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 export const Thread: FC<{
   hideComposer?: boolean;

--- a/studio/frontend/src/components/ui/copyable-error-chip.tsx
+++ b/studio/frontend/src/components/ui/copyable-error-chip.tsx
@@ -12,7 +12,7 @@ import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { cn } from "@/lib/utils";
 import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface CopyableErrorChipProps {
   message: string;
@@ -26,11 +26,22 @@ export function CopyableErrorChip({
   ariaLabel,
 }: CopyableErrorChipProps) {
   const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending reset on unmount to avoid a setState on an
+  // unmounted component.
+  useEffect(() => () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+  }, []);
 
   const handleCopy = async () => {
     if (await copyToClipboard(message)) {
       setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => {
+        setCopied(false);
+        resetTimer.current = null;
+      }, 1800);
     }
   };
 

--- a/studio/frontend/src/components/ui/copyable-error-chip.tsx
+++ b/studio/frontend/src/components/ui/copyable-error-chip.tsx
@@ -17,13 +17,11 @@ import { useEffect, useRef, useState } from "react";
 interface CopyableErrorChipProps {
   message: string;
   className?: string;
-  ariaLabel?: string;
 }
 
 export function CopyableErrorChip({
   message,
   className,
-  ariaLabel,
 }: CopyableErrorChipProps) {
   const [copied, setCopied] = useState(false);
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -48,9 +46,11 @@ export function CopyableErrorChip({
   return (
     <Popover>
       <PopoverTrigger asChild={true}>
+        {/* No aria-label override: the visible message text is the
+            button's accessible name, so screen readers announce the
+            full (untruncated) error. Truncation here is purely visual. */}
         <button
           type="button"
-          aria-label={ariaLabel ?? "Show full error message"}
           className={cn(
             "flex max-w-[28rem] min-w-0 cursor-pointer items-center rounded-md text-left text-xs text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             className,

--- a/studio/frontend/src/components/ui/copyable-error-chip.tsx
+++ b/studio/frontend/src/components/ui/copyable-error-chip.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { cn } from "@/lib/utils";
+import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+
+interface CopyableErrorChipProps {
+  message: string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function CopyableErrorChip({
+  message,
+  className,
+  ariaLabel,
+}: CopyableErrorChipProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (await copyToClipboard(message)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    }
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild={true}>
+        <button
+          type="button"
+          aria-label={ariaLabel ?? "Show full error message"}
+          className={cn(
+            "flex max-w-[28rem] min-w-0 cursor-pointer items-center rounded-md text-left text-xs text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+        >
+          <span className="min-w-0 flex-1 truncate">{message}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        className="w-[min(36rem,calc(100vw-1rem))] gap-2"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className="text-xs font-medium text-destructive">Error</span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={copied ? "Copied" : "Copy error message"}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-md border border-border/60 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              copied && "border-emerald-500/40 text-emerald-600 dark:text-emerald-500",
+            )}
+          >
+            <HugeiconsIcon
+              icon={copied ? Tick02Icon : Copy01Icon}
+              className="size-3.5"
+            />
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+        <p className="max-h-64 overflow-y-auto select-text whitespace-pre-wrap break-words text-xs text-destructive">
+          {message}
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -65,6 +65,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--border-radius": "var(--radius)",
         } as React.CSSProperties
       }
+      // No swipe gestures. Paired with `dismissible: false` from
+      // `@/lib/toast`, this keeps toast text selectable so users can
+      // copy errors and log messages.
+      swipeDirections={[]}
       toastOptions={{
         classNames: {
           toast: "cn-toast",

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -65,9 +65,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--border-radius": "var(--radius)",
         } as React.CSSProperties
       }
-      // No swipe gestures. Paired with `dismissible: false` from
-      // `@/lib/toast`, this keeps toast text selectable so users can
-      // copy errors and log messages.
+      // No swipe gestures; keeps toast text selectable.
       swipeDirections={[]}
       toastOptions={{
         classNames: {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -3,7 +3,7 @@
 
 import type { ChatModelAdapter } from "@assistant-ui/react";
 import type { MessageTiming, ToolCallMessagePart } from "@assistant-ui/core";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { getAuthToken } from "@/features/auth/session";
 import { apiUrl } from "@/lib/api-base";
 import {

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1380,10 +1380,7 @@ export function ChatPage(): ReactElement {
                 role="status"
                 aria-live="polite"
               >
-                <CopyableErrorChip
-                  message={modelsError}
-                  ariaLabel="Show full model error and copy"
-                />
+                <CopyableErrorChip message={modelsError} />
               </div>
             ) : null}
           </div>

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -34,10 +34,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { ChatSearch } from "@/app/routes/chat";
 import { listLocalModels } from "./api/chat-api";
 import { ChatSettingsPanel } from "./chat-settings-sheet";
+import { CopyableErrorChip } from "@/components/ui/copyable-error-chip";
 import { ContextUsageBar } from "./components/context-usage-bar";
 import { ModelLoadInlineStatus } from "./components/model-load-status";
 import { db } from "./db";
@@ -1375,12 +1376,14 @@ export function ChatPage(): ReactElement {
             ) : null}
             {!loadingModel && modelsError ? (
               <div
-                className="relative top-0.5 max-w-[28rem] truncate pl-0.5 text-xs text-destructive"
-                title={modelsError}
+                className="relative top-0.5 pl-0.5"
                 role="status"
                 aria-live="polite"
               >
-                {modelsError}
+                <CopyableErrorChip
+                  message={modelsError}
+                  ariaLabel="Show full model error and copy"
+                />
               </div>
             ) : null}
           </div>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -62,7 +62,7 @@ import { Tooltip as TooltipPrimitive } from "radix-ui";
 import { ChevronDown } from "lucide-react";
 import { Fragment, type ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import {
   type ExternalProviderConfig,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { createElement, useCallback, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { consumeNativePathToken } from "@/features/native-intents/api";
 import {
   notifyNative,

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -16,7 +16,7 @@ import { AUDIO_ACCEPT, MAX_AUDIO_SIZE, fileToBase64 } from "@/lib/audio-utils";
 import { isTauri } from "@/lib/api-base";
 import { useAui } from "@assistant-ui/react";
 import { ArrowUpIcon, GlobeIcon, HeadphonesIcon, LightbulbIcon, LightbulbOffIcon, MicIcon, PlusIcon, SquareIcon, XIcon } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { loadModel, validateModel } from "./api/chat-api";
 import { parseExternalModelId } from "./external-providers";
 import { useExternalProvidersStore } from "./stores/external-providers-store";

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { create } from "zustand";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   DEFAULT_INFERENCE_PARAMS,
   type ChatLoraSummary,

--- a/studio/frontend/src/features/native-intents/components/native-model-chip.tsx
+++ b/studio/frontend/src/features/native-intents/components/native-model-chip.tsx
@@ -3,7 +3,7 @@ import { useNativeIntentStore } from "../store";
 import type { NativeIntent } from "../types";
 import { XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 interface NativeModelChipProps {
   intent: NativeIntent;

--- a/studio/frontend/src/features/native-intents/use-native-dialogs.ts
+++ b/studio/frontend/src/features/native-intents/use-native-dialogs.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { pickNativeModel } from "./api";
 import { useNativeIntentStore } from "./store";
 import type { NativeIntent } from "./types";

--- a/studio/frontend/src/features/native-intents/use-native-drop.ts
+++ b/studio/frontend/src/features/native-intents/use-native-drop.ts
@@ -1,6 +1,6 @@
 import { isTauri } from "@/lib/api-base";
 import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { registerNativeModelPath } from "./api";
 import { useNativeIntentStore } from "./store";
 import type { NativeIntent } from "./types";

--- a/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
+++ b/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
@@ -3,7 +3,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { toastError } from "@/shared/toast";
 import {
   getInferenceStatus,

--- a/studio/frontend/src/features/studio/sections/dataset-section.tsx
+++ b/studio/frontend/src/features/studio/sections/dataset-section.tsx
@@ -67,7 +67,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useShallow } from "zustand/react/shallow";
 import { DocumentUploadRedirectDialog } from "./document-upload-redirect-dialog";
 

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -26,7 +26,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useRef } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 
 const chartConfig = {

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -3,7 +3,7 @@
 
 import { primeNativeNotificationPermission } from "@/lib/native-notifications";
 import { useCallback } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { checkDatasetFormat } from "../api/datasets-api";
 import { emitTrainingRunsChanged } from "../events";
 import { getTrainingRun } from "../api/history-api";

--- a/studio/frontend/src/features/training/hooks/use-training-history-sidebar.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-history-sidebar.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { listTrainingRuns } from "../api/history-api";
 import {
   onTrainingRunDeleted,

--- a/studio/frontend/src/hooks/use-tauri-update.ts
+++ b/studio/frontend/src/hooks/use-tauri-update.ts
@@ -7,7 +7,7 @@ import {
   copySupportDiagnostics,
   type CopySupportDiagnosticsResult,
 } from "@/lib/tauri-diagnostics";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 export type UpdateStatus =
   | "idle"

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -996,6 +996,28 @@
 	}
 }
 
+/* Toast text must be selectable so users can copy errors / logs.
+   Buttons stay non-selectable for clean clicks. */
+[data-sonner-toast],
+[data-sonner-toast] [data-content],
+[data-sonner-toast] [data-title],
+[data-sonner-toast] [data-description],
+[data-sonner-toast] p,
+[data-sonner-toast] span {
+	-webkit-user-select: text;
+	user-select: text;
+	cursor: text;
+}
+
+[data-sonner-toast] button,
+[data-sonner-toast] [data-button],
+[data-sonner-toast] [data-cancel],
+[data-sonner-toast] [data-close-button] {
+	-webkit-user-select: none;
+	user-select: none;
+	cursor: pointer;
+}
+
 /* Flat scrollbar chrome */
 * {
 	scrollbar-width: thin;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -996,8 +996,7 @@
 	}
 }
 
-/* Toast text must be selectable so users can copy errors / logs.
-   Buttons stay non-selectable for clean clicks. */
+/* Selectable toast text; non-selectable toast buttons. */
 [data-sonner-toast],
 [data-sonner-toast] [data-content],
 [data-sonner-toast] [data-title],

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1005,6 +1005,14 @@
 [data-sonner-toast] span {
 	-webkit-user-select: text;
 	user-select: text;
+}
+
+/* Text cursor only on actual text nodes, so the toast container does
+   not pretend to be an input. */
+[data-sonner-toast] [data-title],
+[data-sonner-toast] [data-description],
+[data-sonner-toast] p,
+[data-sonner-toast] span {
 	cursor: text;
 }
 

--- a/studio/frontend/src/lib/toast.ts
+++ b/studio/frontend/src/lib/toast.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * sonner `toast` wrapper that defaults `dismissible: false`.
+ *
+ * sonner's swipe-to-dismiss captures the pointer on mousedown, which
+ * blocks browser text selection inside the toast body. Setting
+ * `dismissible: false` skips that capture so users can highlight and
+ * copy error / log messages. Auto-dismiss, close buttons, and action
+ * buttons still work. Callers can opt back in with `dismissible: true`.
+ *
+ * Drop-in replacement: `import { toast } from "@/lib/toast"`.
+ */
+
+import { toast as sonnerToast, type ExternalToast } from "sonner";
+
+type AnyFn = (...args: unknown[]) => unknown;
+
+function withDismissibleFalse<F extends AnyFn>(fn: F): F {
+  return ((...args: unknown[]) => {
+    // Toast methods are `(message, options?)`. Decide by arity so
+    // React-element messages are not mistaken for options.
+    if (args.length <= 1) {
+      args.push({ dismissible: false } satisfies ExternalToast);
+    } else {
+      const lastIdx = args.length - 1;
+      const last = args[lastIdx];
+      if (last && typeof last === "object" && !Array.isArray(last)) {
+        const opts = last as ExternalToast;
+        if (!("dismissible" in opts)) {
+          args[lastIdx] = { dismissible: false, ...opts };
+        }
+      }
+    }
+    return fn(...args);
+  }) as F;
+}
+
+const wrappedCallable = withDismissibleFalse(
+  sonnerToast as unknown as AnyFn,
+) as typeof sonnerToast;
+
+// `promise`, `dismiss`, `getHistory`, `getToasts` don't take per-toast
+// options so they pass through unchanged.
+export const toast: typeof sonnerToast = Object.assign(wrappedCallable, {
+  success: withDismissibleFalse(sonnerToast.success.bind(sonnerToast) as AnyFn) as typeof sonnerToast.success,
+  info: withDismissibleFalse(sonnerToast.info.bind(sonnerToast) as AnyFn) as typeof sonnerToast.info,
+  warning: withDismissibleFalse(sonnerToast.warning.bind(sonnerToast) as AnyFn) as typeof sonnerToast.warning,
+  error: withDismissibleFalse(sonnerToast.error.bind(sonnerToast) as AnyFn) as typeof sonnerToast.error,
+  message: withDismissibleFalse(sonnerToast.message.bind(sonnerToast) as AnyFn) as typeof sonnerToast.message,
+  loading: withDismissibleFalse(sonnerToast.loading.bind(sonnerToast) as AnyFn) as typeof sonnerToast.loading,
+  custom: withDismissibleFalse(sonnerToast.custom.bind(sonnerToast) as AnyFn) as typeof sonnerToast.custom,
+  promise: sonnerToast.promise.bind(sonnerToast) as typeof sonnerToast.promise,
+  dismiss: sonnerToast.dismiss.bind(sonnerToast) as typeof sonnerToast.dismiss,
+  getHistory: sonnerToast.getHistory.bind(sonnerToast) as typeof sonnerToast.getHistory,
+  getToasts: sonnerToast.getToasts.bind(sonnerToast) as typeof sonnerToast.getToasts,
+});
+
+export type { ExternalToast } from "sonner";

--- a/studio/frontend/src/lib/toast.ts
+++ b/studio/frontend/src/lib/toast.ts
@@ -31,7 +31,17 @@ const wrappedCallable = withDismissibleFalse(
   sonnerToast as unknown as AnyFn,
 ) as typeof sonnerToast;
 
-// `promise`, `dismiss`, `getHistory`, `getToasts` take no options.
+// `promise(p, data?)` carries `dismissible` at the top of `data`,
+// covering loading / success / error states. `dismiss`, `getHistory`,
+// `getToasts` take no options.
+const wrappedPromise: typeof sonnerToast.promise = ((promise, data) => {
+  const merged =
+    data && typeof data === "object" && !("dismissible" in data)
+      ? { dismissible: false, ...data }
+      : (data ?? { dismissible: false });
+  return sonnerToast.promise(promise, merged);
+}) as typeof sonnerToast.promise;
+
 export const toast: typeof sonnerToast = Object.assign(wrappedCallable, {
   success: withDismissibleFalse(sonnerToast.success.bind(sonnerToast) as AnyFn) as typeof sonnerToast.success,
   info: withDismissibleFalse(sonnerToast.info.bind(sonnerToast) as AnyFn) as typeof sonnerToast.info,
@@ -40,7 +50,7 @@ export const toast: typeof sonnerToast = Object.assign(wrappedCallable, {
   message: withDismissibleFalse(sonnerToast.message.bind(sonnerToast) as AnyFn) as typeof sonnerToast.message,
   loading: withDismissibleFalse(sonnerToast.loading.bind(sonnerToast) as AnyFn) as typeof sonnerToast.loading,
   custom: withDismissibleFalse(sonnerToast.custom.bind(sonnerToast) as AnyFn) as typeof sonnerToast.custom,
-  promise: sonnerToast.promise.bind(sonnerToast) as typeof sonnerToast.promise,
+  promise: wrappedPromise,
   dismiss: sonnerToast.dismiss.bind(sonnerToast) as typeof sonnerToast.dismiss,
   getHistory: sonnerToast.getHistory.bind(sonnerToast) as typeof sonnerToast.getHistory,
   getToasts: sonnerToast.getToasts.bind(sonnerToast) as typeof sonnerToast.getToasts,

--- a/studio/frontend/src/lib/toast.ts
+++ b/studio/frontend/src/lib/toast.ts
@@ -1,17 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/**
- * sonner `toast` wrapper that defaults `dismissible: false`.
- *
- * sonner's swipe-to-dismiss captures the pointer on mousedown, which
- * blocks browser text selection inside the toast body. Setting
- * `dismissible: false` skips that capture so users can highlight and
- * copy error / log messages. Auto-dismiss, close buttons, and action
- * buttons still work. Callers can opt back in with `dismissible: true`.
- *
- * Drop-in replacement: `import { toast } from "@/lib/toast"`.
- */
+// sonner `toast` wrapper that defaults `dismissible: false` so swipe
+// capture doesn't block text selection. Drop-in for `from "sonner"`.
 
 import { toast as sonnerToast, type ExternalToast } from "sonner";
 
@@ -19,8 +10,7 @@ type AnyFn = (...args: unknown[]) => unknown;
 
 function withDismissibleFalse<F extends AnyFn>(fn: F): F {
   return ((...args: unknown[]) => {
-    // Toast methods are `(message, options?)`. Decide by arity so
-    // React-element messages are not mistaken for options.
+    // Branch by arity: React-element messages are objects too.
     if (args.length <= 1) {
       args.push({ dismissible: false } satisfies ExternalToast);
     } else {
@@ -41,8 +31,7 @@ const wrappedCallable = withDismissibleFalse(
   sonnerToast as unknown as AnyFn,
 ) as typeof sonnerToast;
 
-// `promise`, `dismiss`, `getHistory`, `getToasts` don't take per-toast
-// options so they pass through unchanged.
+// `promise`, `dismiss`, `getHistory`, `getToasts` take no options.
 export const toast: typeof sonnerToast = Object.assign(wrappedCallable, {
   success: withDismissibleFalse(sonnerToast.success.bind(sonnerToast) as AnyFn) as typeof sonnerToast.success,
   info: withDismissibleFalse(sonnerToast.info.bind(sonnerToast) as AnyFn) as typeof sonnerToast.info,

--- a/studio/frontend/src/shared/toast.ts
+++ b/studio/frontend/src/shared/toast.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 export function toastSuccess(message: string): void {
   toast.success(message);


### PR DESCRIPTION
## Summary

Sonner toasts and the inline model-load error in the chat header surface useful copyable content (backend tracebacks, model-load failures, log lines), but users could not select that text with the mouse. This PR fixes both, so the message can be highlighted and copied.

## Why text was unselectable

1. Sonner's swipe-to-dismiss handler calls `setPointerCapture` in `onPointerDown`, which preempts the browser's text-selection gesture. The capture only happens while `dismissible` is true, so CSS alone cannot work around it.
2. The inline model-load error in the chat header truncated the message with `text-overflow: ellipsis` and stored the full string in a native `title=` tooltip. Native `title` tooltips are an OS overlay and their text is not selectable in any browser.

## Changes

- New `@/lib/toast` wrapper around sonner's `toast` that defaults `dismissible: false` on every toast variant (callable plus `.success` / `.error` / `.info` / `.warning` / `.loading` / `.message` / `.custom`). The API is identical to sonner's, so the 18 call sites just swap their import path. Callers can opt back into swipe-to-dismiss explicitly with `dismissible: true`.
- `<Toaster>` sets `swipeDirections={[]}` to make the intent explicit at the toaster level.
- `index.css` forces `user-select: text` on toast text content and keeps `user-select: none` on toast buttons so clicks stay clean.
- New `<CopyableErrorChip>` component replaces the inline error chip in the chat header. The chip still shows the truncated message inline, but clicking it opens a popover with the full wrap-friendly selectable message and a one-click Copy button.

Toasts still auto-dismiss after their `duration`, close buttons and action buttons (Cancel, Stop, etc.) still work.

## Test plan

- [ ] Trigger a model-load failure in the chat header, hover the red inline error and confirm the popover opens with the full message
- [ ] Drag-select text inside the popover and copy with cmd/ctrl + C
- [ ] Click the Copy button in the popover and confirm the success state
- [ ] Trigger any toast (success, error, loading) and drag-select the title and description text, confirm cmd/ctrl + C works
- [ ] Confirm the Cancel button on the "Starting model..." loading toast still cancels the load
- [ ] Confirm toasts still auto-dismiss after the configured duration