### PR TITLE
studio: show close button on all toasts

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -296,9 +296,9 @@ export function AppProvider({ children }: AppProviderProps) {
         visibleToasts={2}
         expand={true}
         closeButton
-        // Offset clears the 48px chat header so toasts don't sit on top of
-        // the settings / right-side controls.
-        offset={{ top: 64, right: 16 }}
+        // Sit at the header line, shifted left so toasts don't overlap the
+        // chat parameters / settings buttons on the right edge.
+        offset={{ top: 12, right: 64 }}
       />
     </ThemeProvider>
   );

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -296,6 +296,9 @@ export function AppProvider({ children }: AppProviderProps) {
         visibleToasts={2}
         expand={true}
         closeButton
+        // Offset clears the 48px chat header so toasts don't sit on top of
+        // the settings / right-side controls.
+        offset={{ top: 64, right: 16 }}
       />
     </ThemeProvider>
   );

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -291,7 +291,12 @@ export function AppProvider({ children }: AppProviderProps) {
       <TauriWrapper>
         {children}
       </TauriWrapper>
-      <Toaster position="top-right" visibleToasts={2} expand={true} />
+      <Toaster
+        position="top-right"
+        visibleToasts={2}
+        expand={true}
+        closeButton
+      />
     </ThemeProvider>
   );
 }

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -63,18 +63,19 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
           "--border-radius": "var(--radius)",
-          // Anchor close button inside the toast, top-right (overrides sonner's
-          // default left placement and outside-corner translate).
+          // Anchor close button on the right inside the toast (overrides
+          // sonner's default left placement and outside-corner translate).
+          // Vertical centering of the button is done via a rule in index.css.
           "--toast-close-button-start": "unset",
           "--toast-close-button-end": "unset",
-          "--toast-close-button-transform": "none",
+          "--toast-close-button-transform": "translateY(-50%)",
         } as React.CSSProperties
       }
       toastOptions={{
         classNames: {
           toast: "cn-toast",
           description: "!text-muted-foreground",
-          closeButton: "!top-3 !right-3 !translate-y-0",
+          closeButton: "!right-3",
         },
       }}
       {...props}

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -63,6 +63,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
           "--border-radius": "var(--radius)",
+          // Anchor close button inside the toast, top-right (overrides sonner's
+          // default left placement and outside-corner translate).
+          "--toast-close-button-start": "unset",
+          "--toast-close-button-end": "unset",
+          "--toast-close-button-transform": "none",
         } as React.CSSProperties
       }
       toastOptions={{

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -63,10 +63,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
           "--border-radius": "var(--radius)",
-          // Pin close button to the top-right inside the toast (overrides
-          // sonner's default left placement and outside-corner translate).
+          // Pin close button to the top-right corner inside the toast.
+          // Overrides sonner's default left placement and outside-corner
+          // translate; top offset is set via a rule in index.css since sonner
+          // hardcodes `top: 0` (not a CSS variable).
           "--toast-close-button-start": "unset",
-          "--toast-close-button-end": "unset",
+          "--toast-close-button-end": "8px",
           "--toast-close-button-transform": "none",
         } as React.CSSProperties
       }
@@ -74,7 +76,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast: "cn-toast",
           description: "!text-muted-foreground",
-          closeButton: "!top-3 !right-3",
         },
       }}
       {...props}

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -68,7 +68,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           // translate; top offset is set via a rule in index.css since sonner
           // hardcodes `top: 0` (not a CSS variable).
           "--toast-close-button-start": "unset",
-          "--toast-close-button-end": "8px",
+          "--toast-close-button-end": "12px",
           "--toast-close-button-transform": "none",
         } as React.CSSProperties
       }

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -63,19 +63,18 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
           "--border-radius": "var(--radius)",
-          // Anchor close button on the right inside the toast (overrides
+          // Pin close button to the top-right inside the toast (overrides
           // sonner's default left placement and outside-corner translate).
-          // Vertical centering of the button is done via a rule in index.css.
           "--toast-close-button-start": "unset",
           "--toast-close-button-end": "unset",
-          "--toast-close-button-transform": "translateY(-50%)",
+          "--toast-close-button-transform": "none",
         } as React.CSSProperties
       }
       toastOptions={{
         classNames: {
           toast: "cn-toast",
           description: "!text-muted-foreground",
-          closeButton: "!right-3",
+          closeButton: "!top-3 !right-3",
         },
       }}
       {...props}

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -68,7 +68,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           // translate; top offset is set via a rule in index.css since sonner
           // hardcodes `top: 0` (not a CSS variable).
           "--toast-close-button-start": "unset",
-          "--toast-close-button-end": "16px",
+          "--toast-close-button-end": "8px",
           "--toast-close-button-transform": "none",
         } as React.CSSProperties
       }

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -68,7 +68,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           // translate; top offset is set via a rule in index.css since sonner
           // hardcodes `top: 0` (not a CSS variable).
           "--toast-close-button-start": "unset",
-          "--toast-close-button-end": "12px",
+          "--toast-close-button-end": "16px",
           "--toast-close-button-transform": "none",
         } as React.CSSProperties
       }

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -983,7 +983,7 @@ export function useChatModelRuntime() {
             toast.success(`${displayName} loaded`, {
               id: toastId,
               description: undefined,
-              duration: 2000,
+              duration: 8000,
             });
           }
           notifyNative({
@@ -1002,7 +1002,7 @@ export function useChatModelRuntime() {
               toast.error(message, {
                 id: toastId,
                 description: undefined,
-                duration: 5000,
+                duration: 8000,
               });
             }
             notifyNative({

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -729,7 +729,6 @@ export function useChatModelRuntime() {
               cancelLoading,
             ),
             duration: Infinity,
-            closeButton: false,
             classNames: MODEL_LOAD_TOAST_CLASSNAMES,
             onDismiss: (dismissedToast) => {
               if (loadToastIdRef.current !== dismissedToast.id) {
@@ -852,7 +851,6 @@ export function useChatModelRuntime() {
                   cancelLoading,
                 ),
                 duration: Infinity,
-                closeButton: false,
                 classNames: MODEL_LOAD_TOAST_CLASSNAMES,
                 onDismiss: (dismissedToast) => {
                   if (loadToastIdRef.current !== dismissedToast.id) return;
@@ -892,7 +890,6 @@ export function useChatModelRuntime() {
                     cancelLoading,
                   ),
                   duration: Infinity,
-                  closeButton: false,
                   classNames: MODEL_LOAD_TOAST_CLASSNAMES,
                   onDismiss: (dismissedToast) => {
                     if (loadToastIdRef.current !== dismissedToast.id) return;
@@ -955,7 +952,6 @@ export function useChatModelRuntime() {
                 cancelLoading,
               ),
               duration: Infinity,
-              closeButton: false,
               classNames: MODEL_LOAD_TOAST_CLASSNAMES,
               onDismiss: (dismissedToast) => {
                 if (loadToastIdRef.current !== dismissedToast.id) return;
@@ -987,7 +983,6 @@ export function useChatModelRuntime() {
             toast.success(`${displayName} loaded`, {
               id: toastId,
               description: undefined,
-              closeButton: false,
               duration: 2000,
             });
           }
@@ -1007,7 +1002,6 @@ export function useChatModelRuntime() {
               toast.error(message, {
                 id: toastId,
                 description: undefined,
-                closeButton: false,
                 duration: 5000,
               });
             }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1131,9 +1131,3 @@
 	animation: none;
 	mix-blend-mode: normal;
 }
-
-/* Sonner hardcodes `top: 0` on the close button; vertically center it inside
-   the toast box. Paired with --toast-close-button-transform in sonner.tsx. */
-[data-sonner-toast][data-styled="true"] [data-close-button] {
-	top: 50% !important;
-}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1131,3 +1131,9 @@
 	animation: none;
 	mix-blend-mode: normal;
 }
+
+/* Sonner hardcodes `top: 0` on the close button; vertically center it inside
+   the toast box. Paired with --toast-close-button-transform in sonner.tsx. */
+[data-sonner-toast][data-styled="true"] [data-close-button] {
+	top: 50% !important;
+}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1132,8 +1132,8 @@
 	mix-blend-mode: normal;
 }
 
-/* Sonner hardcodes `top: 0` on the close button; pin it 8px from the top
-   inside the toast. Paired with --toast-close-button-end in sonner.tsx. */
+/* Sonner hardcodes `top: 0` on the close button; pin it 12px from the top
+   to match the 12px right offset set via --toast-close-button-end. */
 [data-sonner-toast][data-styled="true"] [data-close-button] {
-	top: 8px !important;
+	top: 12px !important;
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1131,3 +1131,9 @@
 	animation: none;
 	mix-blend-mode: normal;
 }
+
+/* Sonner hardcodes `top: 0` on the close button; pin it 8px from the top
+   inside the toast. Paired with --toast-close-button-end in sonner.tsx. */
+[data-sonner-toast][data-styled="true"] [data-close-button] {
+	top: 8px !important;
+}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1132,8 +1132,8 @@
 	mix-blend-mode: normal;
 }
 
-/* Sonner hardcodes `top: 0` on the close button; pin it 12px from the top
-   to match the 12px right offset set via --toast-close-button-end. */
+/* Sonner hardcodes `top: 0` on the close button; pin it 16px from the top
+   to match the toast's own 16px padding and --toast-close-button-end. */
 [data-sonner-toast][data-styled="true"] [data-close-button] {
-	top: 12px !important;
+	top: 16px !important;
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1132,8 +1132,8 @@
 	mix-blend-mode: normal;
 }
 
-/* Sonner hardcodes `top: 0` on the close button; pin it 16px from the top
-   to match the toast's own 16px padding and --toast-close-button-end. */
+/* Sonner hardcodes `top: 0` on the close button; pin it tight to the corner
+   so the X stays at the top of every toast regardless of toast height. */
 [data-sonner-toast][data-styled="true"] [data-close-button] {
-	top: 16px !important;
+	top: 8px !important;
 }


### PR DESCRIPTION
## Summary

Lets users dismiss any toast on demand instead of waiting for the duration timer. Right now most Studio toasts only auto-dismiss (e.g. the `model loaded` success toast that disappears after ~2s), with no way to close them sooner. The chat-adapter error toast already opts in to a close button via `closeButton: true`, so the styling and dismiss path are already wired up in `components/ui/sonner.tsx`; this just makes it the project-wide default.

Changes:
- `app/provider.tsx`: pass `closeButton` to the global `<Toaster>` so every toast gets an X by default.
- `features/chat/hooks/use-chat-model-runtime.ts`: drop the six per-toast `closeButton: false` overrides so model load progress, model loaded success, and model load failure toasts all inherit the default.

For the in-progress model load toast specifically, the existing Cancel button (rendered inside the description) still aborts the load. The new X uses the existing `onDismiss` handler, which already flips state to show the inline header status, so users can hide the toast without canceling the load.

## Test plan

- [ ] Load a cached model: confirm the `Starting model...` toast has both Cancel and an X close button; clicking X hides the toast and the inline header status takes over while loading continues
- [ ] Wait for load to complete: confirm the `<model> loaded` success toast has an X and can be closed immediately instead of waiting 2s
- [ ] Trigger a load error (e.g. bad HF id): confirm the error toast has an X and can be closed immediately
- [ ] Start a fresh (non-cached) download: confirm the `Downloading model...` toast has both Cancel and X across the download + mmap phases
- [ ] Spot-check a non-chat toast (any success/info/warning elsewhere) to confirm the global default applies