### PR TITLE
studio: add dismissable toasts with corner close button

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -291,7 +291,15 @@ export function AppProvider({ children }: AppProviderProps) {
       <TauriWrapper>
         {children}
       </TauriWrapper>
-      <Toaster position="top-right" visibleToasts={2} expand={true} />
+      <Toaster
+        position="top-right"
+        visibleToasts={2}
+        expand={true}
+        closeButton
+        // Sit at the header line, shifted left so toasts don't overlap the
+        // chat parameters / settings buttons on the right edge.
+        offset={{ top: 12, right: 64 }}
+      />
     </ThemeProvider>
   );
 }

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -295,9 +295,8 @@ export function AppProvider({ children }: AppProviderProps) {
         position="top-right"
         visibleToasts={2}
         expand={true}
-        closeButton
-        // Sit at the header line, shifted left so toasts don't overlap the
-        // chat parameters / settings buttons on the right edge.
+        closeButton={true}
+        // Clear the chat header buttons on the right.
         offset={{ top: 12, right: 64 }}
       />
     </ThemeProvider>

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -13,11 +13,13 @@ import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  // Use resolvedTheme so sonner's data-sonner-theme always matches the class
+  // next-themes puts on <html>; sonner-side "system" resolution can drift.
+  const { resolvedTheme } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={(resolvedTheme as ToasterProps["theme"]) ?? "light"}
       className="toaster group"
       duration={5000}
       icons={{

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -63,13 +63,19 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
           "--border-radius": "var(--radius)",
+          // Pin close button to the top-right corner inside the toast.
+          // Overrides sonner's default left placement and outside-corner
+          // translate; top offset is set via a rule in index.css since sonner
+          // hardcodes `top: 0` (not a CSS variable).
+          "--toast-close-button-start": "unset",
+          "--toast-close-button-end": "8px",
+          "--toast-close-button-transform": "none",
         } as React.CSSProperties
       }
       toastOptions={{
         classNames: {
           toast: "cn-toast",
           description: "!text-muted-foreground",
-          closeButton: "!top-3 !right-3 !translate-y-0",
         },
       }}
       {...props}

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -729,7 +729,6 @@ export function useChatModelRuntime() {
               cancelLoading,
             ),
             duration: Infinity,
-            closeButton: false,
             classNames: MODEL_LOAD_TOAST_CLASSNAMES,
             onDismiss: (dismissedToast) => {
               if (loadToastIdRef.current !== dismissedToast.id) {
@@ -852,7 +851,6 @@ export function useChatModelRuntime() {
                   cancelLoading,
                 ),
                 duration: Infinity,
-                closeButton: false,
                 classNames: MODEL_LOAD_TOAST_CLASSNAMES,
                 onDismiss: (dismissedToast) => {
                   if (loadToastIdRef.current !== dismissedToast.id) return;
@@ -892,7 +890,6 @@ export function useChatModelRuntime() {
                     cancelLoading,
                   ),
                   duration: Infinity,
-                  closeButton: false,
                   classNames: MODEL_LOAD_TOAST_CLASSNAMES,
                   onDismiss: (dismissedToast) => {
                     if (loadToastIdRef.current !== dismissedToast.id) return;
@@ -955,7 +952,6 @@ export function useChatModelRuntime() {
                 cancelLoading,
               ),
               duration: Infinity,
-              closeButton: false,
               classNames: MODEL_LOAD_TOAST_CLASSNAMES,
               onDismiss: (dismissedToast) => {
                 if (loadToastIdRef.current !== dismissedToast.id) return;
@@ -987,8 +983,7 @@ export function useChatModelRuntime() {
             toast.success(`${displayName} loaded`, {
               id: toastId,
               description: undefined,
-              closeButton: false,
-              duration: 2000,
+              duration: 8000,
             });
           }
           notifyNative({
@@ -1007,8 +1002,7 @@ export function useChatModelRuntime() {
               toast.error(message, {
                 id: toastId,
                 description: undefined,
-                closeButton: false,
-                duration: 5000,
+                duration: 8000,
               });
             }
             notifyNative({

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1131,3 +1131,9 @@
 	animation: none;
 	mix-blend-mode: normal;
 }
+
+/* Sonner hardcodes `top: 0` on the close button; pin it tight to the corner
+   so the X stays at the top of every toast regardless of toast height. */
+[data-sonner-toast][data-styled="true"] [data-close-button] {
+	top: 8px !important;
+}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1132,8 +1132,11 @@
 	mix-blend-mode: normal;
 }
 
-/* Sonner hardcodes `top: 0` on the close button; pin it tight to the corner
-   so the X stays at the top of every toast regardless of toast height. */
+/* Override sonner's hardcoded top: 0 on the toast close button. */
 [data-sonner-toast][data-styled="true"] [data-close-button] {
 	top: 8px !important;
+}
+/* Bump the X stroke so it stays visible against dark backgrounds. */
+[data-sonner-toast][data-styled="true"] [data-close-button] svg {
+	stroke-width: 2.25;
 }


### PR DESCRIPTION
## Summary

Lets users dismiss any toast on demand, and stops toasts from sitting on top of the chat header buttons. Previously the model load progress toast and the post-load success / failure toasts could only be auto-dismissed (the "Qwen loaded" success toast vanished after 2s), and the toaster anchored at the same top-right corner that the chat parameters and settings buttons live in.

### Changes

- Enable Sonner's `closeButton` globally on the `<Toaster>` so every toast gets an X. The chat-adapter error toast already opted in to a close button, so the styling and dismiss path are wired up in `components/ui/sonner.tsx` already; this just makes it the project default.
- Drop the six per-toast `closeButton: false` overrides in `use-chat-model-runtime.ts` so model load progress, model loaded success, and model load failure toasts all inherit the new default. The in-progress model load toast still has its existing Cancel button in the description; the new X uses the existing `onDismiss` handler that flips state to show the inline header status, so the X dismisses the toast without canceling the load.
- Pin the close button to the top-right corner inside the toast. Overrides Sonner's left-side default placement, outside-corner translate, and hardcoded `top: 0`. Top is set via a small rule in `index.css` because Sonner doesn't expose it as a CSS variable; the rest is set on the `<Toaster>` `style` prop.
- Offset the toaster on the y-axis so toasts sit at the chat header line shifted left of the parameters / settings buttons on the right edge, instead of stacking on top of them.
- Bump the post-load success duration from 2s to 8s and the failure duration from 5s to 8s so users have time to read the toast and click the new X before it auto-dismisses.

Net diff is small: 4 files, +24 / -10.

## Test plan

- [ ] Load a cached model: the `Starting model...` toast appears with both a Cancel button (in the description) and an X in the top-right corner. Clicking X hides the toast and the inline header status takes over while the load continues. Clicking Cancel aborts the load.
- [ ] Wait for load to complete: the `<model> loaded` success toast has an X and can be closed immediately. If left alone it auto-dismisses after 8 seconds instead of 2.
- [ ] Trigger a load error (e.g. bad HF id): the error toast has an X and stays for 8 seconds.
- [ ] Start a fresh (non-cached) download: `Downloading model...` toast has both Cancel and X across the download and mmap phases.
- [ ] Confirm toasts no longer obstruct the parameters or settings buttons in the chat header.
- [ ] Spot-check a non-chat toast (any success/info/warning elsewhere) to confirm the global close button applies.