### PR TITLE
Add a simple --version flag

### DIFF
--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -9,6 +9,7 @@ from unsloth_cli.commands.inference import inference
 from unsloth_cli.commands.export import export, list_checkpoints
 from unsloth_cli.commands.studio import run as studio_run, studio_app
 
+
 def _version_callback(value: bool):
     if value:
         try:
@@ -28,7 +29,9 @@ app = typer.Typer(
 @app.callback()
 def _main(
     version: bool = typer.Option(
-        False, "--version", "-V",
+        False,
+        "--version",
+        "-V",
         callback = _version_callback,
         is_eager = True,
         help = "Show version and exit.",

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -2,16 +2,38 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import typer
+from importlib.metadata import version as package_version, PackageNotFoundError
 
 from unsloth_cli.commands.train import train
 from unsloth_cli.commands.inference import inference
 from unsloth_cli.commands.export import export, list_checkpoints
 from unsloth_cli.commands.studio import run as studio_run, studio_app
 
+try:
+    _version = package_version("unsloth")
+except PackageNotFoundError:
+    _version = "unknown"
+
+def _version_callback(value: bool):
+    if value:
+        typer.echo(f"unsloth {_version}")
+        raise typer.Exit()
+
 app = typer.Typer(
     help = "Command-line interface for Unsloth training, inference, and export.",
     context_settings = {"help_option_names": ["-h", "--help"]},
 )
+
+@app.callback()
+def _main(
+    version: bool = typer.Option(
+        None, "--version", "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+):
+    pass
 
 app.command()(train)
 app.command()(inference)

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -4,13 +4,14 @@
 import typer
 from importlib.metadata import version as package_version, PackageNotFoundError
 
+
 from unsloth_cli.commands.train import train
 from unsloth_cli.commands.inference import inference
 from unsloth_cli.commands.export import export, list_checkpoints
 from unsloth_cli.commands.studio import run as studio_run, studio_app
 
 
-def _version_callback(value: bool):
+def show_version(value: bool):
     if value:
         try:
             version = package_version("unsloth")
@@ -27,12 +28,12 @@ app = typer.Typer(
 
 
 @app.callback()
-def _main(
+def main(
     version: bool = typer.Option(
-        False,
+        None,
         "--version",
         "-V",
-        callback = _version_callback,
+        callback = show_version,
         is_eager = True,
         help = "Show version and exit.",
     ),

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -14,26 +14,32 @@ try:
 except PackageNotFoundError:
     _version = "unknown"
 
+
 def _version_callback(value: bool):
     if value:
         typer.echo(f"unsloth {_version}")
         raise typer.Exit()
+
 
 app = typer.Typer(
     help = "Command-line interface for Unsloth training, inference, and export.",
     context_settings = {"help_option_names": ["-h", "--help"]},
 )
 
+
 @app.callback()
 def _main(
     version: bool = typer.Option(
-        None, "--version", "-V",
-        callback=_version_callback,
-        is_eager=True,
-        help="Show version and exit.",
+        None,
+        "--version",
+        "-V",
+        callback = _version_callback,
+        is_eager = True,
+        help = "Show version and exit.",
     ),
 ):
     pass
+
 
 app.command()(train)
 app.command()(inference)

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -9,15 +9,13 @@ from unsloth_cli.commands.inference import inference
 from unsloth_cli.commands.export import export, list_checkpoints
 from unsloth_cli.commands.studio import run as studio_run, studio_app
 
-try:
-    _version = package_version("unsloth")
-except PackageNotFoundError:
-    _version = "unknown"
-
-
 def _version_callback(value: bool):
     if value:
-        typer.echo(f"unsloth {_version}")
+        try:
+            version = package_version("unsloth")
+        except PackageNotFoundError:
+            version = "unknown"
+        typer.echo(f"unsloth {version}")
         raise typer.Exit()
 
 
@@ -30,9 +28,7 @@ app = typer.Typer(
 @app.callback()
 def _main(
     version: bool = typer.Option(
-        None,
-        "--version",
-        "-V",
+        False, "--version", "-V",
         callback = _version_callback,
         is_eager = True,
         help = "Show version and exit.",


### PR DESCRIPTION
Add a `--version` flag to the CLI tool, which will try to use the built-in package_version and exit (exit-code zero).

Fixes: https://github.com/unslothai/unsloth/issues/5515

See also: https://typer.tiangolo.com/tutorial/options/version/#first-version-of-version

----

Example:

```sh
python3 cli.py --version                    
unsloth 2026.5.2
```

----

Help output:

```sh
python3 cli.py --help   
                                                                                                                             
 Usage: cli.py [OPTIONS] COMMAND [ARGS]...                                                                                   
                                                                                                                             
 Command-line interface for Unsloth training, inference, and export.                                                         
                                                                                                                             
╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --version             -V        Show version and exit.                                                                    │
│ --install-completion            Install completion for the current shell.                                                 │
│ --show-completion               Show completion for the current shell, to copy it or customize the installation.          │
│ --help                -h        Show this message and exit.                                                               │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ train             Launch training using the existing Unsloth training backend.                                            │
│ inference         Run a single inference using the specified model.                                                       │
│ export            Export a checkpoint to various formats (merged, GGUF, LoRA adapter).                                    │
│ list-checkpoints  List checkpoints detected in the outputs directory.                                                     │
│ run               Alias for `unsloth studio run`.                                                                         │
│ studio            Unsloth Studio commands.                                                                                │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```