### PR TITLE
fix(studio/worker): inject --gcc-install-dir for HIP source builds on Ubuntu 24.04

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -259,10 +259,9 @@ def _install_package_wheel_first(
             _gcc_dir = _hipcc_gcc_install_dir()
             if _gcc_dir is not None:
                 _appended = (f"{_existing_flags} --gcc-install-dir={_gcc_dir}").strip()
-                _run_kwargs["env"] = {
-                    **os.environ,
-                    "HIPCC_COMPILE_FLAGS_APPEND": _appended,
-                }
+                _env = _run_kwargs.get("env", os.environ).copy()
+                _env["HIPCC_COMPILE_FLAGS_APPEND"] = _appended
+                _run_kwargs["env"] = _env
                 logger.info(
                     "HIP source build for %s: appended "
                     "--gcc-install-dir=%s to HIPCC_COMPILE_FLAGS_APPEND",

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -258,9 +258,7 @@ def _install_package_wheel_first(
         if "--gcc-install-dir" not in _existing_flags:
             _gcc_dir = _hipcc_gcc_install_dir()
             if _gcc_dir is not None:
-                _appended = (
-                    f"{_existing_flags} --gcc-install-dir={_gcc_dir}"
-                ).strip()
+                _appended = (f"{_existing_flags} --gcc-install-dir={_gcc_dir}").strip()
                 _run_kwargs["env"] = {
                     **os.environ,
                     "HIPCC_COMPILE_FLAGS_APPEND": _appended,

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -77,6 +77,38 @@ def _model_wants_causal_conv1d(model_name: str) -> bool:
     )
 
 
+def _hipcc_gcc_install_dir() -> str | None:
+    """Return the highest-numbered ``/usr/lib/gcc/x86_64-linux-gnu/<N>`` that has
+    BOTH the gcc runtime dir AND the corresponding ``/usr/include/c++/<N>`` C++
+    headers, or ``None`` if no match (or non-Linux / non-x86_64).
+
+    Ubuntu 24.04 ships ``/usr/lib/gcc/x86_64-linux-gnu/14/`` (gcc-14 runtime
+    objects) but does NOT ship ``/usr/include/c++/14`` in its default apt set;
+    libstdc++ headers come from ``libstdc++-13-dev``. ROCm clang-20 picks the
+    highest-numbered runtime dir by default, finds no ``<cstdlib>``, and the
+    HIP source build fails with::
+
+        /opt/rocm-X.Y/lib/llvm/lib/clang/20/include/__clang_hip_runtime_wrapper.h:112:10:
+          fatal error: 'cstdlib' file not found
+
+    Returning a path lets the caller pass ``--gcc-install-dir=<path>`` to clang
+    via ``HIPCC_COMPILE_FLAGS_APPEND``. Mirrors the same loop ``bbf004c`` added
+    to ``studio/setup.sh`` for the llama.cpp HIP build branch (PR #5301).
+    """
+    if not sys.platform.startswith("linux"):
+        return None
+    import platform as _platform
+
+    if _platform.machine().lower() != "x86_64":
+        return None
+    for _ver in (14, 13, 12, 11):
+        _runtime = f"/usr/lib/gcc/x86_64-linux-gnu/{_ver}/include"
+        _headers = f"/usr/include/c++/{_ver}"
+        if os.path.isdir(_runtime) and os.path.isdir(_headers):
+            return f"/usr/lib/gcc/x86_64-linux-gnu/{_ver}"
+    return None
+
+
 def _install_package_wheel_first(
     *,
     event_queue: Any,
@@ -212,6 +244,33 @@ def _install_package_wheel_first(
     }
     if is_hip:
         _run_kwargs["timeout"] = 1800
+        # On Ubuntu 24.04 + ROCm clang-20, the HIP source build (causal-conv1d,
+        # mamba-ssm source fallback, flash-attn source fallback) defaults to
+        # /usr/lib/gcc/x86_64-linux-gnu/14/ which has the runtime dir but no
+        # /usr/include/c++/14 headers, and dies at:
+        #   __clang_hip_runtime_wrapper.h:112:10:
+        #     fatal error: 'cstdlib' file not found
+        # Inject --gcc-install-dir for a gcc whose C++ headers actually exist.
+        # Respect any pre-existing --gcc-install-dir in HIPCC_COMPILE_FLAGS_APPEND
+        # (user knows best); otherwise append. Mirrors the same fix bbf004c
+        # added to studio/setup.sh for the llama.cpp HIP build (PR #5301).
+        _existing_flags = os.environ.get("HIPCC_COMPILE_FLAGS_APPEND", "")
+        if "--gcc-install-dir" not in _existing_flags:
+            _gcc_dir = _hipcc_gcc_install_dir()
+            if _gcc_dir is not None:
+                _appended = (
+                    f"{_existing_flags} --gcc-install-dir={_gcc_dir}"
+                ).strip()
+                _run_kwargs["env"] = {
+                    **os.environ,
+                    "HIPCC_COMPILE_FLAGS_APPEND": _appended,
+                }
+                logger.info(
+                    "HIP source build for %s: appended "
+                    "--gcc-install-dir=%s to HIPCC_COMPILE_FLAGS_APPEND",
+                    display_name,
+                    _gcc_dir,
+                )
 
     try:
         result = _sp.run(pypi_cmd, **_run_kwargs)

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import builtins
 import subprocess
 import sys
+from typing import Any
 from unittest import mock
 
 from core.training import worker
@@ -16,6 +17,17 @@ def _missing_flash_attn_import():
 
     def fake_import(name, globals = None, locals = None, fromlist = (), level = 0):
         if name == "flash_attn":
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    return fake_import
+
+
+def _missing_module_import(missing: str):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals = None, locals = None, fromlist = (), level = 0):
+        if name == missing:
             raise ImportError
         return real_import(name, globals, locals, fromlist, level)
 
@@ -193,3 +205,282 @@ def test_mamba_ssm_path_preserves_wheel_first_install_args(monkeypatch):
         release_tag = worker._MAMBA_SSM_RELEASE_TAG,
         release_base_url = "https://github.com/state-spaces/mamba/releases/download",
     )
+
+
+# ────────────────────────────────────────────────────────────────────
+# HIP source-build gcc-install-dir coverage (h34v3nzc0dex Strix Halo).
+# Ubuntu 24.04 ships gcc-14's runtime dir without /usr/include/c++/14,
+# so ROCm clang-20 picks it and fails with 'cstdlib' file not found
+# when building causal-conv1d (or any other HIP source fallback).
+# _hipcc_gcc_install_dir() finds a gcc dir that has both halves; the
+# _install_package_wheel_first HIP branch passes it to clang via
+# HIPCC_COMPILE_FLAGS_APPEND. Parallel to bbf004c's setup.sh fix for
+# the llama.cpp HIP build (PR #5301).
+# ────────────────────────────────────────────────────────────────────
+
+
+def _isdir_for_layout(*existing: str):
+    """Return an os.path.isdir replacement that only treats the given
+    absolute paths as directories. Lets a test simulate exactly which
+    gcc runtime dirs and C++ header dirs exist on the host."""
+    valid = set(existing)
+
+    def fake_isdir(path: str) -> bool:
+        return path in valid
+
+    return fake_isdir
+
+
+def test_hipcc_gcc_install_dir_picks_highest_with_headers(monkeypatch):
+    """gcc-14 has runtime but no /usr/include/c++/14; loop falls through
+    to gcc-13 which has both. This is the exact Ubuntu 24.04 layout."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    import platform as _platform
+
+    monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        worker.os.path,
+        "isdir",
+        _isdir_for_layout(
+            "/usr/lib/gcc/x86_64-linux-gnu/14/include",  # runtime present
+            # but no /usr/include/c++/14 — typical Ubuntu 24.04 default
+            "/usr/lib/gcc/x86_64-linux-gnu/13/include",
+            "/usr/include/c++/13",  # libstdc++-13-dev installed
+        ),
+    )
+    assert worker._hipcc_gcc_install_dir() == "/usr/lib/gcc/x86_64-linux-gnu/13"
+
+
+def test_hipcc_gcc_install_dir_picks_14_when_headers_exist(monkeypatch):
+    """If the user has libstdc++-14-dev installed, prefer gcc-14."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    import platform as _platform
+
+    monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        worker.os.path,
+        "isdir",
+        _isdir_for_layout(
+            "/usr/lib/gcc/x86_64-linux-gnu/14/include",
+            "/usr/include/c++/14",
+        ),
+    )
+    assert worker._hipcc_gcc_install_dir() == "/usr/lib/gcc/x86_64-linux-gnu/14"
+
+
+def test_hipcc_gcc_install_dir_returns_none_when_no_match(monkeypatch):
+    """No gcc dir has both halves → return None and skip the env injection
+    rather than guessing wrong and surfacing a confusing build failure."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    import platform as _platform
+
+    monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(worker.os.path, "isdir", lambda path: False)
+    assert worker._hipcc_gcc_install_dir() is None
+
+
+def test_hipcc_gcc_install_dir_returns_none_on_non_linux(monkeypatch):
+    """Don't probe gcc layout on macOS / Windows — early-return."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    def _isdir_should_not_be_called(_path):
+        raise AssertionError("isdir should not be called on non-Linux")
+
+    monkeypatch.setattr(worker.os.path, "isdir", _isdir_should_not_be_called)
+    assert worker._hipcc_gcc_install_dir() is None
+
+
+def test_hipcc_gcc_install_dir_returns_none_on_non_x86_64(monkeypatch):
+    """ROCm clang-20 on aarch64 has a different libstdc++ layout."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    import platform as _platform
+
+    monkeypatch.setattr(_platform, "machine", lambda: "aarch64")
+    assert worker._hipcc_gcc_install_dir() is None
+
+
+def _make_hip_install_env(monkeypatch, *, gcc_dir: str | None):
+    """Common scaffolding for tests that exercise the HIP source-build
+    branch of _install_package_wheel_first end-to-end. The package isn't
+    installed yet, no prebuilt wheel exists, hipcc is on PATH, and the
+    fake env reports an HIP torch."""
+    monkeypatch.setattr(
+        builtins, "__import__", _missing_module_import("causal_conv1d")
+    )
+    monkeypatch.setattr(
+        worker,
+        "probe_torch_wheel_env",
+        lambda timeout = 30: {
+            "hip_version": "7.13.26176",
+            "python_tag": "cp312",
+            "torch_mm": "2.11",
+            "cxx11abi": "TRUE",
+            "platform_tag": "linux_x86_64",
+        },
+    )
+    monkeypatch.setattr(worker, "direct_wheel_url", lambda **kw: None)
+    monkeypatch.setattr(
+        worker.shutil,
+        "which",
+        lambda name: "/opt/rocm/bin/hipcc" if name == "hipcc" else None,
+    )
+    monkeypatch.setattr(worker, "_send_status", lambda *a, **k: None)
+    monkeypatch.setattr(worker, "_hipcc_gcc_install_dir", lambda: gcc_dir)
+
+
+def test_install_injects_gcc_install_dir_on_hip_source_build(monkeypatch):
+    """HIP source-build with no user-set HIPCC_COMPILE_FLAGS_APPEND →
+    subprocess env carries --gcc-install-dir=<detected path>."""
+    monkeypatch.delenv("HIPCC_COMPILE_FLAGS_APPEND", raising = False)
+    _make_hip_install_env(
+        monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13"
+    )
+
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs.get("env") or {})
+        return subprocess.CompletedProcess(cmd, 0, "")
+
+    monkeypatch.setattr(worker._sp, "run", fake_run)
+
+    worker._install_package_wheel_first(
+        event_queue = [],
+        import_name = "causal_conv1d",
+        display_name = "causal-conv1d",
+        pypi_name = "causal-conv1d",
+        pypi_version = "1.6.2.post1",
+        filename_prefix = "causal_conv1d",
+        release_tag = "v1.6.2.post1",
+        release_base_url = "https://example.com",
+    )
+
+    assert (
+        captured.get("HIPCC_COMPILE_FLAGS_APPEND")
+        == "--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13"
+    )
+
+
+def test_install_appends_to_existing_hipcc_compile_flags(monkeypatch):
+    """User has HIPCC_COMPILE_FLAGS_APPEND='-O3 -DFOO' set → final value
+    keeps the user's flags AND adds --gcc-install-dir at the end."""
+    monkeypatch.setenv("HIPCC_COMPILE_FLAGS_APPEND", "-O3 -DFOO")
+    _make_hip_install_env(
+        monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13"
+    )
+
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs.get("env") or {})
+        return subprocess.CompletedProcess(cmd, 0, "")
+
+    monkeypatch.setattr(worker._sp, "run", fake_run)
+
+    worker._install_package_wheel_first(
+        event_queue = [],
+        import_name = "causal_conv1d",
+        display_name = "causal-conv1d",
+        pypi_name = "causal-conv1d",
+        pypi_version = "1.6.2.post1",
+        filename_prefix = "causal_conv1d",
+        release_tag = "v1.6.2.post1",
+        release_base_url = "https://example.com",
+    )
+
+    assert captured.get("HIPCC_COMPILE_FLAGS_APPEND") == (
+        "-O3 -DFOO --gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13"
+    )
+
+
+def test_install_respects_user_gcc_install_dir(monkeypatch):
+    """User explicitly set --gcc-install-dir=… already → don't touch it.
+    Avoids two competing --gcc-install-dir flags on the clang command line."""
+    monkeypatch.setenv(
+        "HIPCC_COMPILE_FLAGS_APPEND",
+        "--gcc-install-dir=/opt/custom/gcc-13",
+    )
+    _make_hip_install_env(
+        monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13"
+    )
+
+    captured: dict[str, str] | None = {"_called": "no"}
+
+    def fake_run(cmd, **kwargs):
+        env = kwargs.get("env")
+        if env is not None:
+            captured.clear()
+            captured.update(env)
+        else:
+            captured["_called"] = "yes_no_env"
+        return subprocess.CompletedProcess(cmd, 0, "")
+
+    monkeypatch.setattr(worker._sp, "run", fake_run)
+
+    worker._install_package_wheel_first(
+        event_queue = [],
+        import_name = "causal_conv1d",
+        display_name = "causal-conv1d",
+        pypi_name = "causal-conv1d",
+        pypi_version = "1.6.2.post1",
+        filename_prefix = "causal_conv1d",
+        release_tag = "v1.6.2.post1",
+        release_base_url = "https://example.com",
+    )
+
+    # subprocess.run was invoked without env override (the user already
+    # set HIPCC_COMPILE_FLAGS_APPEND with --gcc-install-dir, so we left
+    # the env alone — the existing value is inherited normally).
+    assert captured == {"_called": "yes_no_env"}
+
+
+def test_install_does_not_inject_env_on_cuda(monkeypatch):
+    """CUDA path (no hip_version in env) → no env override at all."""
+    monkeypatch.delenv("HIPCC_COMPILE_FLAGS_APPEND", raising = False)
+    monkeypatch.setattr(
+        builtins, "__import__", _missing_module_import("causal_conv1d")
+    )
+    monkeypatch.setattr(
+        worker,
+        "probe_torch_wheel_env",
+        lambda timeout = 30: {
+            "python_tag": "cp312",
+            "torch_mm": "2.11",
+            "cuda_major": "12",
+            "cxx11abi": "TRUE",
+            "platform_tag": "linux_x86_64",
+        },
+    )
+    monkeypatch.setattr(worker, "direct_wheel_url", lambda **kw: None)
+    monkeypatch.setattr(worker.shutil, "which", lambda name: None)
+    monkeypatch.setattr(worker, "_send_status", lambda *a, **k: None)
+    # If _hipcc_gcc_install_dir were called on CUDA we'd want to know.
+    monkeypatch.setattr(
+        worker,
+        "_hipcc_gcc_install_dir",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("must not run on CUDA")
+        ),
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env_in_kwargs"] = "env" in kwargs
+        return subprocess.CompletedProcess(cmd, 0, "")
+
+    monkeypatch.setattr(worker._sp, "run", fake_run)
+
+    worker._install_package_wheel_first(
+        event_queue = [],
+        import_name = "causal_conv1d",
+        display_name = "causal-conv1d",
+        pypi_name = "causal-conv1d",
+        pypi_version = "1.6.2.post1",
+        filename_prefix = "causal_conv1d",
+        release_tag = "v1.6.2.post1",
+        release_base_url = "https://example.com",
+    )
+
+    # CUDA branch never sets the env, never invokes the gcc helper.
+    assert captured.get("env_in_kwargs") is False

--- a/studio/backend/tests/test_training_worker_flash_attn.py
+++ b/studio/backend/tests/test_training_worker_flash_attn.py
@@ -304,9 +304,7 @@ def _make_hip_install_env(monkeypatch, *, gcc_dir: str | None):
     branch of _install_package_wheel_first end-to-end. The package isn't
     installed yet, no prebuilt wheel exists, hipcc is on PATH, and the
     fake env reports an HIP torch."""
-    monkeypatch.setattr(
-        builtins, "__import__", _missing_module_import("causal_conv1d")
-    )
+    monkeypatch.setattr(builtins, "__import__", _missing_module_import("causal_conv1d"))
     monkeypatch.setattr(
         worker,
         "probe_torch_wheel_env",
@@ -332,9 +330,7 @@ def test_install_injects_gcc_install_dir_on_hip_source_build(monkeypatch):
     """HIP source-build with no user-set HIPCC_COMPILE_FLAGS_APPEND →
     subprocess env carries --gcc-install-dir=<detected path>."""
     monkeypatch.delenv("HIPCC_COMPILE_FLAGS_APPEND", raising = False)
-    _make_hip_install_env(
-        monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13"
-    )
+    _make_hip_install_env(monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13")
 
     captured: dict[str, str] = {}
 
@@ -365,9 +361,7 @@ def test_install_appends_to_existing_hipcc_compile_flags(monkeypatch):
     """User has HIPCC_COMPILE_FLAGS_APPEND='-O3 -DFOO' set → final value
     keeps the user's flags AND adds --gcc-install-dir at the end."""
     monkeypatch.setenv("HIPCC_COMPILE_FLAGS_APPEND", "-O3 -DFOO")
-    _make_hip_install_env(
-        monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13"
-    )
+    _make_hip_install_env(monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13")
 
     captured: dict[str, str] = {}
 
@@ -400,9 +394,7 @@ def test_install_respects_user_gcc_install_dir(monkeypatch):
         "HIPCC_COMPILE_FLAGS_APPEND",
         "--gcc-install-dir=/opt/custom/gcc-13",
     )
-    _make_hip_install_env(
-        monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13"
-    )
+    _make_hip_install_env(monkeypatch, gcc_dir = "/usr/lib/gcc/x86_64-linux-gnu/13")
 
     captured: dict[str, str] | None = {"_called": "no"}
 
@@ -437,9 +429,7 @@ def test_install_respects_user_gcc_install_dir(monkeypatch):
 def test_install_does_not_inject_env_on_cuda(monkeypatch):
     """CUDA path (no hip_version in env) → no env override at all."""
     monkeypatch.delenv("HIPCC_COMPILE_FLAGS_APPEND", raising = False)
-    monkeypatch.setattr(
-        builtins, "__import__", _missing_module_import("causal_conv1d")
-    )
+    monkeypatch.setattr(builtins, "__import__", _missing_module_import("causal_conv1d"))
     monkeypatch.setattr(
         worker,
         "probe_torch_wheel_env",
@@ -458,9 +448,7 @@ def test_install_does_not_inject_env_on_cuda(monkeypatch):
     monkeypatch.setattr(
         worker,
         "_hipcc_gcc_install_dir",
-        lambda: (_ for _ in ()).throw(
-            AssertionError("must not run on CUDA")
-        ),
+        lambda: (_ for _ in ()).throw(AssertionError("must not run on CUDA")),
     )
 
     captured: dict[str, Any] = {}


### PR DESCRIPTION
Per @danielhanchen's invitation in [#5434 comment](https://github.com/unslothai/unsloth/pull/5434#issuecomment-4469980122) — splitting the `causal-conv1d` (and any other HIP source-build fallback) cstdlib issue out of the FLA/tilelang PR.

## Problem

On Ubuntu 24.04 + ROCm clang-20, the HIP source-build fallback inside `_install_package_wheel_first` (`causal-conv1d`, `mamba-ssm` source fallback, `flash-attn` source fallback) dies at:

```
/opt/rocm-X.Y/lib/llvm/lib/clang/20/include/__clang_hip_runtime_wrapper.h:112:10:
  fatal error: 'cstdlib' file not found
```

Root cause: clang-20 picks the highest-numbered `/usr/lib/gcc/x86_64-linux-gnu/<N>` runtime dir by default. On 24.04 that's gcc-14, whose runtime objects ship in the `gcc-14` apt package, but whose C++ headers (`/usr/include/c++/14`) come from `libstdc++-14-dev` — **not** in the default apt set. `libstdc++-13-dev` **is** in the default set, so `/usr/include/c++/13` exists. clang has no way to discover that asymmetry, so the build fails.

Same root cause as the llama.cpp HIP build trip that [`bbf004c`](https://github.com/unslothai/unsloth/pull/5301/commits/bbf004c) fixed for `studio/setup.sh` in #5301.

## Fix

New `_hipcc_gcc_install_dir()` helper iterates gcc 14 → 11 and returns the first `/usr/lib/gcc/x86_64-linux-gnu/<N>` dir where **both** the runtime AND `/usr/include/c++/<N>` exist. The HIP branch of `_install_package_wheel_first` appends `--gcc-install-dir=<that path>` to `HIPCC_COMPILE_FLAGS_APPEND` in the subprocess env before invoking pip.

Properties of the env injection:
- **Respects user `--gcc-install-dir`** in `HIPCC_COMPILE_FLAGS_APPEND` (skip injection so the user-set path always wins — avoids two competing flags on the clang command line)
- **Preserves any other flags** the user has set (appends to the end, doesn't overwrite)
- **No-op on non-HIP** (CUDA path is unchanged)
- **No-op on non-Linux / non-x86_64** (different libstdc++ layouts; safer to leave alone than guess)
- **Returns None when no gcc dir has both halves** → skip injection, surface the original error rather than guess wrong

This mirrors the loop in `bbf004c`'s `setup.sh` fix; the difference is the delivery mechanism (env var vs `CMAKE_HIP_FLAGS`), because the worker path is pip-driven and can't pass CMake flags directly.

## Tested

On Ryzen AI MAX+ 395 / Radeon 8060S (`gfx1151`) / Ubuntu 24.04 / kernel 6.19.14 mainline / ROCm 7.13 nightly:

- `_hipcc_gcc_install_dir()` returns `/usr/lib/gcc/x86_64-linux-gnu/13` (gcc-14 runtime exists but no `/usr/include/c++/14`; gcc-13 has both — exact Ubuntu 24.04 default layout)
- Manually exporting `HIPCC_COMPILE_FLAGS_APPEND='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13'` before `pip install causal-conv1d` is what already lets the build succeed on this hardware (per the validation thread for #5434 — repro at <https://github.com/h34v3nzc0dex/strix-halo-llm-finetune-guide/tree/main/pr-5434-validation>). This PR just wires that workaround into the worker path automatically.
- After install, the resulting `causal_conv1d_fn` + `causal_conv1d_update` kernels run cleanly on gfx1151 (`B=1 D=512 T=8192 K=4 bf16` forward; `D=512 K=4 bf16` step-mode update).

## Test plan

- [x] `studio/backend/tests/test_training_worker_flash_attn.py` — 8 new tests covering the helper logic + env injection paths. CI Backend job will exercise them. (Local sanity: standalone replica of the helper returns the expected path; both modified files `py_compile` clean.)
- [x] Helper is fully mockable — no filesystem dependence at test time (`monkeypatch.setattr(worker.os.path, "isdir", ...)`).
- [x] CUDA path explicitly asserted no-op (`test_install_does_not_inject_env_on_cuda` raises if the helper is consulted).

## Scope notes

- **Out of scope:** the actual `causal-conv1d` auto-install path (predates this PR; it's been in Studio since before #5434). This PR only adds the env knob so the pre-existing path doesn't fail at compile time on 24.04+ROCm.
- **No interaction with #5434.** That PR adds `flash-linear-attention` + `tilelang` for the Qwen3.5 family; this PR is a no-op on either FLA or tilelang.
- **Bigger AMD platform refactor not touched.** Just the smallest gate that makes the existing HIP source-build branch succeed on a default Ubuntu 24.04 install.

Happy to iterate on the heuristic (e.g. also probe `/usr/lib/gcc/aarch64-linux-gnu/<N>` if anyone is doing HIP on aarch64) — currently aarch64 returns None and the env is left alone, matching today's behaviour.