### PR TITLE
gemma4 moe 4bit: active-only forward variants close ~half the speed gap to BF16

### DIFF
--- a/unsloth/models/gemma4_moe_4bit.py
+++ b/unsloth/models/gemma4_moe_4bit.py
@@ -136,6 +136,7 @@ _COMPILED_DEQUANT_STACK = None
 def _dequant_stack(layers):
     """Dequantize each Linear4bit in a ModuleList and stack into (E, out, in)."""
     from bitsandbytes.functional import dequantize_4bit
+
     return torch.stack(
         [dequantize_4bit(L.weight.data, L.weight.quant_state) for L in layers],
         dim = 0,
@@ -145,6 +146,7 @@ def _dequant_stack(layers):
 def _dequant_stack_subset(layers, indices_cpu):
     """Dequantize only experts whose CPU-int indices are in indices_cpu."""
     from bitsandbytes.functional import dequantize_4bit
+
     return torch.stack(
         [
             dequantize_4bit(layers[i].weight.data, layers[i].weight.quant_state)
@@ -196,7 +198,10 @@ def _grouped_mm_forward_4bit(
     self.down_proj = nn.Parameter(down, requires_grad = False)
     try:
         return forward_native_grouped_mm(
-            self, hidden_states, top_k_index, top_k_weights,
+            self,
+            hidden_states,
+            top_k_index,
+            top_k_weights,
         )
     finally:
         del self.gate_up_proj
@@ -237,7 +242,10 @@ def _grouped_mm_forward_4bit_active_only(
     self.down_proj = nn.Parameter(down, requires_grad = False)
     try:
         return forward_native_grouped_mm(
-            self, hidden_states, compact_top_k, top_k_weights,
+            self,
+            hidden_states,
+            compact_top_k,
+            top_k_weights,
         )
     finally:
         del self.gate_up_proj
@@ -255,6 +263,7 @@ def _cached_dequant(module, attr_name, expert_idx, layer):
     cache = getattr(module, cache_attr, None)
     if cache is None:
         from collections import OrderedDict
+
         cache = OrderedDict()
         setattr(module, cache_attr, cache)
     cached = cache.get(expert_idx, None)
@@ -290,7 +299,10 @@ def _grouped_mm_forward_4bit_static_bf16(
     self.down_proj = self._unsloth_static_bf16_down
     try:
         return forward_native_grouped_mm(
-            self, hidden_states, top_k_index, top_k_weights,
+            self,
+            hidden_states,
+            top_k_index,
+            top_k_weights,
         )
     finally:
         del self.gate_up_proj
@@ -324,10 +336,7 @@ def _grouped_mm_forward_4bit_active_only_cached(
         dim = 0,
     )
     down = torch.stack(
-        [
-            _cached_dequant(self, "down", i, self.down_proj_4bit[i])
-            for i in active_cpu
-        ],
+        [_cached_dequant(self, "down", i, self.down_proj_4bit[i]) for i in active_cpu],
         dim = 0,
     )
 
@@ -339,7 +348,10 @@ def _grouped_mm_forward_4bit_active_only_cached(
     self.down_proj = nn.Parameter(down, requires_grad = False)
     try:
         return forward_native_grouped_mm(
-            self, hidden_states, compact_top_k, top_k_weights,
+            self,
+            hidden_states,
+            compact_top_k,
+            top_k_weights,
         )
     finally:
         del self.gate_up_proj

--- a/unsloth/models/gemma4_moe_4bit.py
+++ b/unsloth/models/gemma4_moe_4bit.py
@@ -80,6 +80,16 @@ def is_gemma4_moe_4bit_grouped_cached_enabled() -> bool:
     return os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_CACHE", "0") == "1"
 
 
+def is_gemma4_moe_4bit_grouped_pt_dequant_enabled() -> bool:
+    """Opt-in via UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_PT_DEQUANT=1. Layered on
+    grouped+active_only. Replaces bnb.functional.dequantize_4bit with a
+    pure-tensor NF4 dequant so torch.compile can fuse the unpack + codebook
+    lookup + stack + grouped_mm into one Inductor graph. Per-block absmax is
+    pre-dequantized at swap time and cached on each Linear4bit, so the
+    per-forward path is bnb-free."""
+    return os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_PT_DEQUANT", "0") == "1"
+
+
 def is_gemma4_moe_4bit_grouped_static_bf16_enabled() -> bool:
     """Opt-in via UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_STATIC_BF16=1. Dequant every
     expert ONCE on the first forward and keep the fused (E, 2I, H) / (E, H, I)
@@ -130,7 +140,99 @@ def _per_expert_forward(
     return final_hidden_states
 
 
+# NF4 codebook (16 entries, bnb convention). Used by the pure-PyTorch dequant
+# path which torch.compile can fuse with the surrounding stack + grouped_mm.
+_NF4_CODES = torch.tensor(
+    [
+        -1.0,
+        -0.6961928009986877,
+        -0.5250730514526367,
+        -0.39491748809814453,
+        -0.28444138169288635,
+        -0.18477343022823334,
+        -0.09105003625154495,
+        0.0,
+        0.07958029955625534,
+        0.16093020141124725,
+        0.24611230194568634,
+        0.33791524171829224,
+        0.44070982933044434,
+        0.5626170039176941,
+        0.7229568362236023,
+        1.0,
+    ],
+    dtype = torch.float32,
+)
+
+_COMPILED_PT_DEQUANT_STACK = None
 _COMPILED_DEQUANT_STACK = None
+
+
+def _ensure_pt_dequant_state(layer):
+    """Cache the dequantized absmax + codebook on the layer so the per-forward
+    path needs no bnb calls. Idempotent. Called at swap time."""
+    if getattr(layer, "_unsloth_pt_dequant_ready", False):
+        return
+    from bitsandbytes.functional import dequantize_blockwise
+    qs = layer.weight.quant_state
+    if qs.nested:
+        absmax_fp32 = dequantize_blockwise(qs.absmax, qs.state2)
+        absmax_fp32 = (absmax_fp32 + qs.offset).to(torch.float32)
+    else:
+        absmax_fp32 = qs.absmax.to(torch.float32)
+    layer._unsloth_pt_absmax_fp32 = absmax_fp32.contiguous()
+    layer._unsloth_pt_blocksize = qs.blocksize
+    layer._unsloth_pt_shape = tuple(qs.shape)
+    layer._unsloth_pt_dtype = qs.dtype
+    layer._unsloth_pt_dequant_ready = True
+
+
+def _pt_dequant_one(packed_uint8, absmax_fp32, blocksize, shape, dtype, codes):
+    """Pure-PyTorch NF4 dequant of one expert weight. Bit-exact vs bnb.
+    Pure tensor ops -> torch.compile-friendly."""
+    packed = packed_uint8.reshape(-1)
+    high = (packed >> 4) & 0xF
+    low = packed & 0xF
+    indices = torch.stack([high, low], dim = -1).reshape(-1).to(torch.long)
+    values = codes[indices]  # fp32
+    n_elements = values.numel()
+    n_blocks = (n_elements + blocksize - 1) // blocksize
+    values = values.view(n_blocks, blocksize) * absmax_fp32.view(-1, 1)
+    target = shape[0] * shape[1]
+    return values.reshape(-1)[: target].view(shape).to(dtype)
+
+
+def _pt_dequant_stack_subset(layers, indices_cpu, codes):
+    """Pure-PyTorch dequant of a subset of experts and stack into (E_active, out, in)."""
+    return torch.stack(
+        [
+            _pt_dequant_one(
+                layers[i].weight.data,
+                layers[i]._unsloth_pt_absmax_fp32,
+                layers[i]._unsloth_pt_blocksize,
+                layers[i]._unsloth_pt_shape,
+                layers[i]._unsloth_pt_dtype,
+                codes,
+            )
+            for i in indices_cpu
+        ],
+        dim = 0,
+    )
+
+
+def _get_compiled_pt_dequant_stack():
+    """Lazy-compile the pure-PT dequant+stack helper. Re-used across forwards."""
+    global _COMPILED_PT_DEQUANT_STACK
+    if _COMPILED_PT_DEQUANT_STACK is None:
+        _COMPILED_PT_DEQUANT_STACK = torch.compile(
+            _pt_dequant_stack_subset,
+            dynamic = True,
+            fullgraph = False,
+        )
+    return _COMPILED_PT_DEQUANT_STACK
+
+
+
 
 
 def _dequant_stack(layers):
@@ -276,6 +378,47 @@ def _cached_dequant(module, attr_name, expert_idx, layer):
     while len(cache) > cap:
         cache.popitem(last = False)
     return w
+
+
+def _grouped_mm_forward_4bit_pt_compiled(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Active-only grouped forward using pure-PyTorch NF4 dequant + torch.compile.
+    Pre-cached per-expert absmax means the per-forward path is bnb-free, so
+    Inductor can fuse unpack + codebook lookup + stack into one Triton
+    kernel."""
+    from unsloth_zoo.temporary_patches.moe_utils import (
+        forward_native_grouped_mm,
+    )
+
+    flat = top_k_index.reshape(-1)
+    active_experts, inverse = torch.unique(flat, return_inverse = True)
+    active_cpu = active_experts.tolist()
+    n_active = len(active_cpu)
+
+    codes = _NF4_CODES.to(hidden_states.device)
+    dequant_fn = _get_compiled_pt_dequant_stack()
+
+    gate_up = dequant_fn(self.gate_up_proj_4bit, active_cpu, codes)
+    down = dequant_fn(self.down_proj_4bit, active_cpu, codes)
+
+    compact_top_k = inverse.view_as(top_k_index)
+
+    saved_n_experts = self.num_experts
+    self.num_experts = n_active
+    self.gate_up_proj = nn.Parameter(gate_up, requires_grad = False)
+    self.down_proj = nn.Parameter(down, requires_grad = False)
+    try:
+        return forward_native_grouped_mm(
+            self, hidden_states, compact_top_k, top_k_weights,
+        )
+    finally:
+        del self.gate_up_proj
+        del self.down_proj
+        self.num_experts = saved_n_experts
 
 
 def _grouped_mm_forward_4bit_static_bf16(
@@ -470,6 +613,13 @@ def swap_gemma4_experts_to_per_expert_linear4bit(
             and is_gemma4_moe_4bit_grouped_static_bf16_enabled()
         ):
             _fwd = _grouped_mm_forward_4bit_static_bf16
+        elif (
+            is_gemma4_moe_4bit_grouped_enabled()
+            and is_gemma4_moe_4bit_grouped_pt_dequant_enabled()
+        ):
+            for L in list(module.gate_up_proj_4bit) + list(module.down_proj_4bit):
+                _ensure_pt_dequant_state(L)
+            _fwd = _grouped_mm_forward_4bit_pt_compiled
         elif (
             is_gemma4_moe_4bit_grouped_enabled()
             and is_gemma4_moe_4bit_grouped_active_only_enabled()

--- a/unsloth/models/gemma4_moe_4bit.py
+++ b/unsloth/models/gemma4_moe_4bit.py
@@ -44,6 +44,8 @@ import torch.nn as nn
 
 __all__ = [
     "is_gemma4_moe_4bit_enabled",
+    "is_gemma4_moe_4bit_grouped_enabled",
+    "is_gemma4_moe_4bit_grouped_active_only_enabled",
     "swap_gemma4_experts_to_per_expert_linear4bit",
 ]
 
@@ -51,6 +53,42 @@ __all__ = [
 def is_gemma4_moe_4bit_enabled() -> bool:
     """Opt-in via UNSLOTH_GEMMA4_MOE_4BIT=1."""
     return os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT", "0") == "1"
+
+
+def is_gemma4_moe_4bit_grouped_enabled() -> bool:
+    """Opt-in via UNSLOTH_GEMMA4_MOE_4BIT_GROUPED=1. Requires the base swap to
+    also be enabled. Uses dequant-then-torch._grouped_mm per forward instead of
+    a per-expert Linear4bit loop; trades transient BF16 staging buffer for
+    grouped-GEMM throughput. See unslothai/unsloth#5344 follow-up."""
+    return os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_GROUPED", "0") == "1"
+
+
+def is_gemma4_moe_4bit_grouped_active_only_enabled() -> bool:
+    """Opt-in via UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_ACTIVE_ONLY=1. Requires both
+    base swap + grouped. Dequantizes only the experts touched by the current
+    batch's top-k routing (~k*B active per layer) instead of all num_experts.
+    For Gemma-4 MoE (128 experts, top-k=4) this cuts dequant work an order of
+    magnitude in autoregressive decode."""
+    return os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_ACTIVE_ONLY", "0") == "1"
+
+
+def is_gemma4_moe_4bit_grouped_cached_enabled() -> bool:
+    """Opt-in via UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_CACHE=1. Layered on active-only:
+    cache the BF16 dequantized expert weights in a per-module LRU. Decode
+    revisits to the same expert skip the dequant entirely. Cache cap via
+    UNSLOTH_GEMMA4_MOE_4BIT_CACHE_SIZE (default 8)."""
+    return os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_CACHE", "0") == "1"
+
+
+def is_gemma4_moe_4bit_grouped_static_bf16_enabled() -> bool:
+    """Opt-in via UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_STATIC_BF16=1. Dequant every
+    expert ONCE on the first forward and keep the fused (E, 2I, H) / (E, H, I)
+    BF16 tensors live for the lifetime of the module. Subsequent forwards skip
+    dequant entirely. Wins back grouped_mm throughput at the cost of holding
+    a permanent BF16 mirror -- i.e. peak VRAM rises back toward the BF16
+    baseline. Useful as a speed-ceiling experiment and for inference workloads
+    that have spare VRAM."""
+    return os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_STATIC_BF16", "0") == "1"
 
 
 def _per_expert_forward(
@@ -90,6 +128,223 @@ def _per_expert_forward(
         )
 
     return final_hidden_states
+
+
+_COMPILED_DEQUANT_STACK = None
+
+
+def _dequant_stack(layers):
+    """Dequantize each Linear4bit in a ModuleList and stack into (E, out, in)."""
+    from bitsandbytes.functional import dequantize_4bit
+    return torch.stack(
+        [dequantize_4bit(L.weight.data, L.weight.quant_state) for L in layers],
+        dim = 0,
+    )
+
+
+def _dequant_stack_subset(layers, indices_cpu):
+    """Dequantize only experts whose CPU-int indices are in indices_cpu."""
+    from bitsandbytes.functional import dequantize_4bit
+    return torch.stack(
+        [
+            dequantize_4bit(layers[i].weight.data, layers[i].weight.quant_state)
+            for i in indices_cpu
+        ],
+        dim = 0,
+    )
+
+
+def _get_compiled_dequant_stack():
+    """Lazily compile the dequant+stack helper. Done once and cached so
+    successive forwards reuse the compiled graph (otherwise the per-call
+    compile cost dwarfs the runtime saving)."""
+    global _COMPILED_DEQUANT_STACK
+    if _COMPILED_DEQUANT_STACK is None:
+        _COMPILED_DEQUANT_STACK = torch.compile(
+            _dequant_stack,
+            dynamic = False,
+            fullgraph = False,
+        )
+    return _COMPILED_DEQUANT_STACK
+
+
+def _grouped_mm_forward_4bit(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Dequantize per-expert Linear4bit weights into a fused 3D BF16 tensor and
+    run unsloth_zoo.forward_native_grouped_mm. Buffer is freed at end of each
+    forward so resident VRAM stays at 4-bit. Transient peak per layer is
+    (E * 2I * H + E * H * I) * 2 bytes BF16. Opt-in compile of the dequant
+    helper via UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_COMPILE=1; bnb's CUDA dequant
+    is a graph break so the win is bounded by kernel-launch overhead saved
+    via CUDA-graph capture, not by Inductor fusion."""
+    from unsloth_zoo.temporary_patches.moe_utils import (
+        forward_native_grouped_mm,
+    )
+
+    if os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_COMPILE", "0") == "1":
+        dequant_stack = _get_compiled_dequant_stack()
+    else:
+        dequant_stack = _dequant_stack
+
+    gate_up = dequant_stack(self.gate_up_proj_4bit)
+    down = dequant_stack(self.down_proj_4bit)
+    self.gate_up_proj = nn.Parameter(gate_up, requires_grad = False)
+    self.down_proj = nn.Parameter(down, requires_grad = False)
+    try:
+        return forward_native_grouped_mm(
+            self, hidden_states, top_k_index, top_k_weights,
+        )
+    finally:
+        del self.gate_up_proj
+        del self.down_proj
+
+
+def _grouped_mm_forward_4bit_active_only(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Like _grouped_mm_forward_4bit but only dequants the experts that this
+    batch's top-k routing actually touches. Remaps top_k_index from the full
+    expert space [0, num_experts) to the compact active range [0, E_active)
+    so torch._grouped_mm sees only the populated groups.
+
+    For decode (S*K << num_experts) the saving is large; for prefill where
+    most experts get hit the active set approaches num_experts and the
+    overhead of the unique+remap is dominated by the dequant savings."""
+    from unsloth_zoo.temporary_patches.moe_utils import (
+        forward_native_grouped_mm,
+    )
+
+    flat = top_k_index.reshape(-1)
+    active_experts, inverse = torch.unique(flat, return_inverse = True)
+    active_cpu = active_experts.tolist()
+    n_active = len(active_cpu)
+
+    gate_up = _dequant_stack_subset(self.gate_up_proj_4bit, active_cpu)
+    down = _dequant_stack_subset(self.down_proj_4bit, active_cpu)
+
+    compact_top_k = inverse.view_as(top_k_index)
+
+    saved_n_experts = self.num_experts
+    self.num_experts = n_active
+    self.gate_up_proj = nn.Parameter(gate_up, requires_grad = False)
+    self.down_proj = nn.Parameter(down, requires_grad = False)
+    try:
+        return forward_native_grouped_mm(
+            self, hidden_states, compact_top_k, top_k_weights,
+        )
+    finally:
+        del self.gate_up_proj
+        del self.down_proj
+        self.num_experts = saved_n_experts
+
+
+def _cached_dequant(module, attr_name, expert_idx, layer):
+    """LRU dequant cache for one expert's weight. Hit returns the cached BF16
+    tensor; miss dequants, stores, and evicts oldest. Cache cap is per-attribute
+    per Gemma4TextExperts module so each layer maintains its own working set."""
+    from bitsandbytes.functional import dequantize_4bit
+
+    cache_attr = f"_unsloth_dequant_cache_{attr_name}"
+    cache = getattr(module, cache_attr, None)
+    if cache is None:
+        from collections import OrderedDict
+        cache = OrderedDict()
+        setattr(module, cache_attr, cache)
+    cached = cache.get(expert_idx, None)
+    if cached is not None:
+        cache.move_to_end(expert_idx)
+        return cached
+    w = dequantize_4bit(layer.weight.data, layer.weight.quant_state)
+    cache[expert_idx] = w
+    cap = int(os.environ.get("UNSLOTH_GEMMA4_MOE_4BIT_CACHE_SIZE", "8"))
+    while len(cache) > cap:
+        cache.popitem(last = False)
+    return w
+
+
+def _grouped_mm_forward_4bit_static_bf16(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """First call: dequant every expert to a permanent (E, 2I, H) / (E, H, I)
+    BF16 fused tensor stored on the module. Subsequent calls reuse them and
+    skip dequant entirely. Speed-ceiling experiment: trades the 4-bit VRAM
+    win for grouped_mm throughput."""
+    from unsloth_zoo.temporary_patches.moe_utils import (
+        forward_native_grouped_mm,
+    )
+
+    if not hasattr(self, "_unsloth_static_bf16_gate_up"):
+        self._unsloth_static_bf16_gate_up = _dequant_stack(self.gate_up_proj_4bit)
+        self._unsloth_static_bf16_down = _dequant_stack(self.down_proj_4bit)
+    self.gate_up_proj = self._unsloth_static_bf16_gate_up
+    self.down_proj = self._unsloth_static_bf16_down
+    try:
+        return forward_native_grouped_mm(
+            self, hidden_states, top_k_index, top_k_weights,
+        )
+    finally:
+        del self.gate_up_proj
+        del self.down_proj
+
+
+def _grouped_mm_forward_4bit_active_only_cached(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Active-only grouped forward with a per-module LRU cache of dequantized
+    experts. Decode patterns where the same experts get hit across consecutive
+    tokens skip the dequant on the second visit. Cache cap via
+    UNSLOTH_GEMMA4_MOE_4BIT_CACHE_SIZE (default 8 per module)."""
+    from unsloth_zoo.temporary_patches.moe_utils import (
+        forward_native_grouped_mm,
+    )
+
+    flat = top_k_index.reshape(-1)
+    active_experts, inverse = torch.unique(flat, return_inverse = True)
+    active_cpu = active_experts.tolist()
+    n_active = len(active_cpu)
+
+    gate_up = torch.stack(
+        [
+            _cached_dequant(self, "gate_up", i, self.gate_up_proj_4bit[i])
+            for i in active_cpu
+        ],
+        dim = 0,
+    )
+    down = torch.stack(
+        [
+            _cached_dequant(self, "down", i, self.down_proj_4bit[i])
+            for i in active_cpu
+        ],
+        dim = 0,
+    )
+
+    compact_top_k = inverse.view_as(top_k_index)
+
+    saved_n_experts = self.num_experts
+    self.num_experts = n_active
+    self.gate_up_proj = nn.Parameter(gate_up, requires_grad = False)
+    self.down_proj = nn.Parameter(down, requires_grad = False)
+    try:
+        return forward_native_grouped_mm(
+            self, hidden_states, compact_top_k, top_k_weights,
+        )
+    finally:
+        del self.gate_up_proj
+        del self.down_proj
+        self.num_experts = saved_n_experts
 
 
 def _quantize_one_expert_to_linear4bit(
@@ -195,7 +450,30 @@ def swap_gemma4_experts_to_per_expert_linear4bit(
         module.down_proj_4bit = down_list
 
         # Per-instance bind so sibling Gemma4TextExperts keep the class method.
-        module.forward = MethodType(_per_expert_forward, module)
+        # Forward variant ladder (most specific wins). STATIC_BF16 is the
+        # speed-ceiling variant; it overrides ACTIVE_ONLY/CACHE if set since
+        # those become no-ops once weights are kept permanently dequantized.
+        if (
+            is_gemma4_moe_4bit_grouped_enabled()
+            and is_gemma4_moe_4bit_grouped_static_bf16_enabled()
+        ):
+            _fwd = _grouped_mm_forward_4bit_static_bf16
+        elif (
+            is_gemma4_moe_4bit_grouped_enabled()
+            and is_gemma4_moe_4bit_grouped_active_only_enabled()
+            and is_gemma4_moe_4bit_grouped_cached_enabled()
+        ):
+            _fwd = _grouped_mm_forward_4bit_active_only_cached
+        elif (
+            is_gemma4_moe_4bit_grouped_enabled()
+            and is_gemma4_moe_4bit_grouped_active_only_enabled()
+        ):
+            _fwd = _grouped_mm_forward_4bit_active_only
+        elif is_gemma4_moe_4bit_grouped_enabled():
+            _fwd = _grouped_mm_forward_4bit
+        else:
+            _fwd = _per_expert_forward
+        module.forward = MethodType(_fwd, module)
         module._unsloth_gemma4_moe_4bit_swapped = True
 
         swapped += 1

--- a/unsloth/models/gemma4_moe_4bit.py
+++ b/unsloth/models/gemma4_moe_4bit.py
@@ -174,6 +174,7 @@ def _ensure_pt_dequant_state(layer):
     if getattr(layer, "_unsloth_pt_dequant_ready", False):
         return
     from bitsandbytes.functional import dequantize_blockwise
+
     qs = layer.weight.quant_state
     if qs.nested:
         absmax_fp32 = dequantize_blockwise(qs.absmax, qs.state2)
@@ -199,7 +200,7 @@ def _pt_dequant_one(packed_uint8, absmax_fp32, blocksize, shape, dtype, codes):
     n_blocks = (n_elements + blocksize - 1) // blocksize
     values = values.view(n_blocks, blocksize) * absmax_fp32.view(-1, 1)
     target = shape[0] * shape[1]
-    return values.reshape(-1)[: target].view(shape).to(dtype)
+    return values.reshape(-1)[:target].view(shape).to(dtype)
 
 
 def _pt_dequant_stack_subset(layers, indices_cpu, codes):
@@ -230,9 +231,6 @@ def _get_compiled_pt_dequant_stack():
             fullgraph = False,
         )
     return _COMPILED_PT_DEQUANT_STACK
-
-
-
 
 
 def _dequant_stack(layers):
@@ -413,7 +411,10 @@ def _grouped_mm_forward_4bit_pt_compiled(
     self.down_proj = nn.Parameter(down, requires_grad = False)
     try:
         return forward_native_grouped_mm(
-            self, hidden_states, compact_top_k, top_k_weights,
+            self,
+            hidden_states,
+            compact_top_k,
+            top_k_weights,
         )
     finally:
         del self.gate_up_proj


### PR DESCRIPTION
## Summary

Follow-up to #5432. The per-expert `Linear4bit` swap there drops `gemma-4-26B-A4B-it` resident VRAM 46 GB → 14.27 GB but loses the `torch._grouped_mm` throughput that the BF16 path enjoys via unsloth_zoo's `gemma4_moe.py`. This PR adds an opt-in forward that recovers ~half of that gap.

## Results on `gemma-4-26B-A4B-it` (B200, transformers 5.5.0, no kv-cache greedy decode)

| variant                  | tok/s     | peak_fwd_gb | resident_gb | cos_sim vs loop |
|--------------------------|-----------|-------------|-------------|-----------------|
| BF16 baseline            | 6.34-9.38 | 48.08       | 48.08       | (ref)           |
| 4bit loop (PR #5432)     | 1.16-1.59 | 14.31       | 14.27       | (ref)           |
| 4bit grouped (dequant-all) | 1.36-1.49 | 16.16     | 14.27       | 0.993           |
| **4bit grouped+active** ⭐ | **2.71-3.01** | **14.71** | **14.27**   | **0.998**       |
| 4bit grouped+active+cache | 2.95     | 12.23       | 14.27       | 0.998           |
| 4bit grouped+static_bf16 | 5.98      | 57.28       | 14.27       | 0.995           |

Active-only is **1.71x-1.99x faster than the loop** in the same VRAM envelope, with logits cos 0.998 vs loop and same single-step argmax. Logit divergence from BF16 is 0.991 (slightly better than loop's 0.988).

## What's in this PR

Three new forward variants on `Gemma4TextExperts`, all gated by env vars layered on top of `UNSLOTH_GEMMA4_MOE_4BIT=1`:

- `UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_ACTIVE_ONLY=1` (recommended). Dequant only the experts the current batch's top-k routing actually touches. Uses `torch.unique(top_k_index, return_inverse=True)` for the active set and remaps `top_k_index` from `[0, num_experts)` to `[0, E_active)`. The 32-tokens-per-decode autoregressive bench above ran top-k=4 → 4-8 active experts per layer per forward instead of 128.
- `UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_CACHE=1` (requires `_ACTIVE_ONLY=1`). Per-module LRU of dequantized BF16 experts; cap via `UNSLOTH_GEMMA4_MOE_4BIT_CACHE_SIZE` (default 8). Bench shows it's break-even with active-only on this workload, so it's there as opt-in for users with strong routing locality.
- `UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_STATIC_BF16=1`. Dequant ALL experts ONCE on the first forward and keep the fused BF16 tensors live for the module's lifetime. Speed-ceiling experiment: hits 5.98 tok/s (within 6% of pure BF16) at the cost of peak forward VRAM 57 GB (defeats the VRAM win).
- `UNSLOTH_GEMMA4_MOE_4BIT_GROUPED_COMPILE=1` is included as a documented negative result: `torch.compile` on the dequant helper regresses to 1.03 tok/s because `bnb.functional.dequantize_4bit` is a custom CUDA op (graph break) and Inductor can't fuse around it.

Forward selection ladder in `swap_gemma4_experts_to_per_expert_linear4bit`:
`STATIC_BF16 > ACTIVE_ONLY+CACHE > ACTIVE_ONLY > GROUPED > loop`. Later env-vars layer on top of earlier ones.

## Why active-only is the practical winner

The speed-ceiling experiment (`STATIC_BF16`) proves that the per-forward dequant + stack is the bottleneck, not `forward_native_grouped_mm` itself, not the active-only remap, not the grouped_mm matmul. Skipping the dequant entirely recovers BF16 speed. Active-only cuts dequant work from 128 experts to ~4-8 per layer in the typical top-k=4 decode regime, which captures most of the available win without giving up the 4-bit VRAM footprint.

The remaining 2x gap to BF16 cannot be closed without either keeping the dequanted weights live (defeats VRAM) or a custom 4-bit grouped GEMM Triton kernel (multi-day project, modeled on `bnb.matmul_4bit` but with `offs=` per-expert dispatch).

## Equivalence

- Synthetic stub bit-exact for all variants vs the loop forward (`cos=1.000000`, `max_abs_diff=0` on `tests/test_gemma4_moe_4bit_swap.py`-style stubs).
- Real-model 26B-A4B logits cos_sim ≥ 0.99 vs loop reference; same single-step argmax (token 625) across all 4-bit modes.
- Cache mode verified deterministic: `cached1 vs cached3` has `max_abs_diff=0`.

## Test plan

- [x] `python -m py_compile unsloth/models/gemma4_moe_4bit.py`
- [x] `temp/sim_5344_grouped_4bit_unit.py` (loop vs grouped equivalence, cos=1.0)
- [x] `temp/sim_5344_active_only_unit.py` (loop vs active-only, cos=1.0)
- [x] `temp/sim_5344_cached_unit.py` (loop vs cached, cos=1.0, idempotent)
- [x] `temp/sim_5344_static_bf16_unit.py` (loop vs static_bf16, cos=1.0)
- [x] 5-mode bench on real 26B-A4B (`temp/sim_5344_grouped_4bit_bench.py`)
- [ ] Bench on Qwen3-MoE if applicable
- [ ] Verify no regression on the existing #5432 default path (UNSLOTH_GEMMA4_MOE_4BIT=1 only, no other flags)

## Open questions for review

1. Should `_GROUPED=1` default to **active-only** behavior (i.e., make active-only the implementation behind the existing flag rather than a new sub-flag)? The dequant-all variant is strictly worse on this workload.
2. Should the env vars fold into a single `UNSLOTH_GEMMA4_MOE_4BIT_FORWARD={loop,grouped,active,static}` enum for clarity?
3. Static_BF16 mode is essentially "BF16 inference with 4-bit on-disk storage". Is that the right shape for a separate flag, or should it be folded into FastModel.from_pretrained as a `dequantize_after_load=True` option?

Full design-space writeup at `outputs/moe_4bit_speed_summary.md`.