### PR TITLE
Studio composer action pill styling

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -557,14 +557,10 @@ const ReasoningToggle: FC = () => {
           <button
             type="button"
             disabled={disabled}
-            className={cn(
-              "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
-              disabled
-                ? "cursor-not-allowed opacity-40"
-                : effectiveReasoningVisualEnabled
-                  ? "bg-primary/10 text-primary hover:bg-primary/20"
-                  : "text-muted-foreground hover:bg-muted-foreground/15",
-            )}
+            className="composer-pill-btn"
+            data-active={
+              effectiveReasoningVisualEnabled && !disabled ? "true" : "false"
+            }
             aria-label={`Reasoning effort: ${reasoningEffort}`}
           >
             {effectiveReasoningVisualEnabled ? (
@@ -675,14 +671,8 @@ const PreserveThinkingToggle: FC = () => {
       type="button"
       disabled={disabled}
       onClick={() => setPreserveThinking(!preserveThinking)}
-      className={cn(
-        "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
-        disabled
-          ? "cursor-not-allowed opacity-40"
-          : preserveThinking
-            ? "bg-primary/10 text-primary hover:bg-primary/20"
-            : "bg-muted text-muted-foreground hover:bg-muted-foreground/15",
-      )}
+      className="composer-pill-btn"
+      data-active={preserveThinking && !disabled ? "true" : "false"}
       aria-label={
         preserveThinking ? "Disable preserve think" : "Enable preserve think"
       }

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -557,10 +557,14 @@ const ReasoningToggle: FC = () => {
           <button
             type="button"
             disabled={disabled}
-            className="composer-pill-btn"
-            data-active={
-              effectiveReasoningVisualEnabled && !disabled ? "true" : "false"
-            }
+            className={cn(
+              "flex items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors",
+              disabled
+                ? "cursor-not-allowed opacity-40"
+                : effectiveReasoningVisualEnabled
+                  ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
+                  : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
+            )}
             aria-label={`Reasoning effort: ${reasoningEffort}`}
           >
             {effectiveReasoningVisualEnabled ? (
@@ -671,8 +675,14 @@ const PreserveThinkingToggle: FC = () => {
       type="button"
       disabled={disabled}
       onClick={() => setPreserveThinking(!preserveThinking)}
-      className="composer-pill-btn"
-      data-active={preserveThinking && !disabled ? "true" : "false"}
+      className={cn(
+        "flex items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors",
+        disabled
+          ? "cursor-not-allowed opacity-40"
+          : preserveThinking
+            ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
+            : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
+      )}
       aria-label={
         preserveThinking ? "Disable preserve think" : "Enable preserve think"
       }

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -838,7 +838,7 @@ const ComposerAction: FC<{ disabled?: boolean; blockSend?: () => boolean }> = ({
 }) => {
   return (
     <div className="aui-composer-action-wrapper composer-action-wrapper">
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-0.5">
         <ComposerAddAttachment />
         <ComposerAudioUpload />
         <ReasoningToggle />

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -4,7 +4,6 @@
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { CodeToggleIcon } from "@/components/assistant-ui/code-toggle-icon";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -750,14 +749,12 @@ export function SharedComposer({
                 <button
                   type="button"
                   disabled={reasoningDisabled}
-                  className={cn(
-                    "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
-                    reasoningDisabled
-                      ? "cursor-not-allowed opacity-40"
-                      : effectiveReasoningVisualEnabled
-                        ? "bg-primary/10 text-primary hover:bg-primary/20"
-                        : "text-muted-foreground hover:bg-muted-foreground/15",
-                  )}
+                  className="composer-pill-btn"
+                  data-active={
+                    effectiveReasoningVisualEnabled && !reasoningDisabled
+                      ? "true"
+                      : "false"
+                  }
                   aria-label={`Reasoning effort: ${reasoningEffort}`}
                 >
                   {effectiveReasoningVisualEnabled ? (
@@ -840,16 +837,12 @@ export function SharedComposer({
                   setToolsEnabled(false);
                 }
               }}
-              className={cn(
-                "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
-                reasoningLockedOn
-                  ? "cursor-not-allowed bg-primary/10 text-primary"
-                  : reasoningDisabled
-                    ? "cursor-not-allowed opacity-40"
-                    : effectiveReasoningEnabled
-                      ? "bg-primary/10 text-primary hover:bg-primary/20"
-                      : "bg-muted text-muted-foreground hover:bg-muted-foreground/15",
-              )}
+              className="composer-pill-btn"
+              data-active={
+                reasoningLockedOn || (effectiveReasoningEnabled && !reasoningDisabled)
+                  ? "true"
+                  : "false"
+              }
               aria-label={
                 reasoningLockedOn
                   ? "Thinking is required for this model"
@@ -873,14 +866,8 @@ export function SharedComposer({
               type="button"
               disabled={!modelLoaded}
               onClick={() => setPreserveThinking(!preserveThinking)}
-              className={cn(
-                "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
-                !modelLoaded
-                  ? "cursor-not-allowed opacity-40"
-                  : preserveThinking
-                    ? "bg-primary/10 text-primary hover:bg-primary/20"
-                    : "bg-muted text-muted-foreground hover:bg-muted-foreground/15",
-              )}
+              className="composer-pill-btn"
+              data-active={preserveThinking && modelLoaded ? "true" : "false"}
               aria-label={
                 preserveThinking ? "Disable preserve think" : "Enable preserve think"
               }

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -4,6 +4,7 @@
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { CodeToggleIcon } from "@/components/assistant-ui/code-toggle-icon";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -749,12 +750,14 @@ export function SharedComposer({
                 <button
                   type="button"
                   disabled={reasoningDisabled}
-                  className="composer-pill-btn"
-                  data-active={
-                    effectiveReasoningVisualEnabled && !reasoningDisabled
-                      ? "true"
-                      : "false"
-                  }
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors",
+                    reasoningDisabled
+                      ? "cursor-not-allowed opacity-40"
+                      : effectiveReasoningVisualEnabled
+                        ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
+                        : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
+                  )}
                   aria-label={`Reasoning effort: ${reasoningEffort}`}
                 >
                   {effectiveReasoningVisualEnabled ? (
@@ -837,12 +840,16 @@ export function SharedComposer({
                   setToolsEnabled(false);
                 }
               }}
-              className="composer-pill-btn"
-              data-active={
-                reasoningLockedOn || (effectiveReasoningEnabled && !reasoningDisabled)
-                  ? "true"
-                  : "false"
-              }
+              className={cn(
+                "flex items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors",
+                reasoningLockedOn
+                  ? "cursor-not-allowed text-primary"
+                  : reasoningDisabled
+                    ? "cursor-not-allowed opacity-40"
+                    : effectiveReasoningEnabled
+                      ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
+                      : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
+              )}
               aria-label={
                 reasoningLockedOn
                   ? "Thinking is required for this model"
@@ -866,8 +873,14 @@ export function SharedComposer({
               type="button"
               disabled={!modelLoaded}
               onClick={() => setPreserveThinking(!preserveThinking)}
-              className="composer-pill-btn"
-              data-active={preserveThinking && modelLoaded ? "true" : "false"}
+              className={cn(
+                "flex items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors",
+                !modelLoaded
+                  ? "cursor-not-allowed opacity-40"
+                  : preserveThinking
+                    ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
+                    : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
+              )}
               aria-label={
                 preserveThinking ? "Disable preserve think" : "Enable preserve think"
               }

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -694,7 +694,7 @@ export function SharedComposer({
         dir="auto"
       />
       <div className="composer-action-wrapper">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-0.5">
           <input
             ref={fileInputRef}
             type="file"

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -799,7 +799,7 @@
 	}
 
 	.composer-pill-btn {
-		@apply flex items-center gap-1.5 rounded-full px-2 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-40;
+		@apply flex items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-40;
 	}
 	.composer-pill-btn[data-active="true"] {
 		color: var(--primary);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -799,7 +799,7 @@
 	}
 
 	.composer-pill-btn {
-		@apply flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-40;
+		@apply flex items-center gap-1.5 rounded-full px-2 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-40;
 	}
 	.composer-pill-btn[data-active="true"] {
 		color: var(--primary);


### PR DESCRIPTION
## Summary
- Align Think and Preserve Think with the shared composer pill styling used by Search and Code.
- Remove filled active backgrounds from composer action pills while preserving active green text/icon state.
- Tighten shared pill padding so action spacing is more even.

Before: 
<img width="1640" height="284" alt="image" src="https://github.com/user-attachments/assets/47023e8f-d67f-48c2-8946-1192c9168422" />

After:
<img width="1285" height="233" alt="image" src="https://github.com/user-attachments/assets/b1d0efc1-f565-4284-af78-1d88b95779cb" />
