### PR TITLE
studio/chat: persist Anthropic container id on first turn of new thread

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -43,6 +43,7 @@ import {
   providerSupportsBuiltinCodeExecution,
   providerSupportsBuiltinWebSearch,
 } from "../provider-capabilities";
+import { ensureThreadRecord } from "../runtime-provider";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { isMultimodalResponse } from "../types/api";
 import type { ChatModelSummary } from "../types/runtime";
@@ -1280,11 +1281,24 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                       externalProvider?.providerType === "anthropic"
                         ? "anthropicCodeExecContainerId"
                         : "openaiCodeExecContainerId";
-                    void db.threads
-                      .update(resolvedThreadId, {
+                    // On the first turn of a brand-new thread the row
+                    // may not have been inserted into Dexie yet when
+                    // this SSE event fires; db.threads.update would
+                    // silently affect 0 rows and the next turn would
+                    // re-read null, causing Anthropic to auto-create a
+                    // new container. ensureThreadRecord materializes
+                    // the row so the update sticks.
+                    try {
+                      await ensureThreadRecord({
+                        threadId: resolvedThreadId,
+                        modelType: "base",
+                      });
+                      await db.threads.update(resolvedThreadId, {
                         [field]: newContainerId,
-                      })
-                      .catch(() => {});
+                      });
+                    } catch {
+                      /* best-effort: container reuse is an optimization */
+                    }
                   }
                   continue;
                 }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1014,6 +1014,18 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                 openaiCodeExecContainerId = null;
                 anthropicCodeExecContainerId = null;
               }
+              // TEMP DIAGNOSTIC: container persistence races
+              console.log(
+                "[diag/code-exec read]",
+                JSON.stringify({
+                  unstable_threadId,
+                  activeThreadId: runtime.activeThreadId,
+                  resolvedThreadId,
+                  providerType: externalProvider.providerType,
+                  anthropicCodeExecContainerId,
+                  openaiCodeExecContainerId,
+                }),
+              );
               // Cross-thread inheritance: when the active thread has
               // no container yet, default to the one most recently
               // used on *any* other thread (provider-scoped).
@@ -1276,6 +1288,17 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                   const newContainerId = toolEvent.container_id as
                     | string
                     | undefined;
+                  // TEMP DIAGNOSTIC: container persistence races
+                  console.log(
+                    "[diag/container_ready]",
+                    JSON.stringify({
+                      unstable_threadId,
+                      activeThreadId: useChatRuntimeStore.getState().activeThreadId,
+                      resolvedThreadId,
+                      newContainerId,
+                      providerType: externalProvider?.providerType,
+                    }),
+                  );
                   if (newContainerId && resolvedThreadId) {
                     const field =
                       externalProvider?.providerType === "anthropic"
@@ -1293,12 +1316,45 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                         threadId: resolvedThreadId,
                         modelType: "base",
                       });
-                      await db.threads.update(resolvedThreadId, {
-                        [field]: newContainerId,
-                      });
-                    } catch {
-                      /* best-effort: container reuse is an optimization */
+                      const affected = await db.threads.update(
+                        resolvedThreadId,
+                        { [field]: newContainerId },
+                      );
+                      const verify = await db.threads.get(resolvedThreadId);
+                      console.log(
+                        "[diag/container_ready persist]",
+                        JSON.stringify({
+                          resolvedThreadId,
+                          field,
+                          newContainerId,
+                          affectedRows: affected,
+                          verifyField: (verify as Record<string, unknown> | undefined)?.[
+                            field
+                          ],
+                          verifyId: verify?.id,
+                        }),
+                      );
+                    } catch (err) {
+                      console.log(
+                        "[diag/container_ready ERROR]",
+                        JSON.stringify({
+                          resolvedThreadId,
+                          message:
+                            err instanceof Error ? err.message : String(err),
+                        }),
+                      );
                     }
+                  } else {
+                    console.log(
+                      "[diag/container_ready SKIP]",
+                      JSON.stringify({
+                        resolvedThreadId,
+                        newContainerId,
+                        reason: !newContainerId
+                          ? "no container id"
+                          : "no resolved thread id",
+                      }),
+                    );
                   }
                   continue;
                 }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -43,7 +43,6 @@ import {
   providerSupportsBuiltinCodeExecution,
   providerSupportsBuiltinWebSearch,
 } from "../provider-capabilities";
-import { ensureThreadRecord } from "../runtime-provider";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { isMultimodalResponse } from "../types/api";
 import type { ChatModelSummary } from "../types/runtime";
@@ -1282,20 +1281,25 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                         ? "anthropicCodeExecContainerId"
                         : "openaiCodeExecContainerId";
                     // On the first turn of a brand-new thread the row
-                    // may not have been inserted into Dexie yet when
-                    // this SSE event fires; db.threads.update would
-                    // silently affect 0 rows and the next turn would
-                    // re-read null, causing Anthropic to auto-create a
-                    // new container. ensureThreadRecord materializes
-                    // the row so the update sticks.
+                    // may not be in Dexie yet when this SSE event
+                    // fires — db.threads.update silently affects 0
+                    // rows, the next turn re-reads null, and Anthropic
+                    // auto-creates a fresh container. Retry briefly so
+                    // assistant-ui's own DexieAdapter.initialize lands
+                    // the row first (with the correct modelType for
+                    // base / lora / compare contexts) and our update
+                    // sticks on a subsequent attempt.
                     try {
-                      await ensureThreadRecord({
-                        threadId: resolvedThreadId,
-                        modelType: "base",
-                      });
-                      await db.threads.update(resolvedThreadId, {
-                        [field]: newContainerId,
-                      });
+                      for (let attempt = 0; attempt < 10; attempt++) {
+                        const affected = await db.threads.update(
+                          resolvedThreadId,
+                          { [field]: newContainerId },
+                        );
+                        if (affected > 0) break;
+                        await new Promise((resolve) =>
+                          setTimeout(resolve, 50),
+                        );
+                      }
                     } catch {
                       /* best-effort: container reuse is an optimization */
                     }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1014,18 +1014,6 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                 openaiCodeExecContainerId = null;
                 anthropicCodeExecContainerId = null;
               }
-              // TEMP DIAGNOSTIC: container persistence races
-              console.log(
-                "[diag/code-exec read]",
-                JSON.stringify({
-                  unstable_threadId,
-                  activeThreadId: runtime.activeThreadId,
-                  resolvedThreadId,
-                  providerType: externalProvider.providerType,
-                  anthropicCodeExecContainerId,
-                  openaiCodeExecContainerId,
-                }),
-              );
               // Cross-thread inheritance: when the active thread has
               // no container yet, default to the one most recently
               // used on *any* other thread (provider-scoped).
@@ -1288,17 +1276,6 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                   const newContainerId = toolEvent.container_id as
                     | string
                     | undefined;
-                  // TEMP DIAGNOSTIC: container persistence races
-                  console.log(
-                    "[diag/container_ready]",
-                    JSON.stringify({
-                      unstable_threadId,
-                      activeThreadId: useChatRuntimeStore.getState().activeThreadId,
-                      resolvedThreadId,
-                      newContainerId,
-                      providerType: externalProvider?.providerType,
-                    }),
-                  );
                   if (newContainerId && resolvedThreadId) {
                     const field =
                       externalProvider?.providerType === "anthropic"
@@ -1316,45 +1293,12 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                         threadId: resolvedThreadId,
                         modelType: "base",
                       });
-                      const affected = await db.threads.update(
-                        resolvedThreadId,
-                        { [field]: newContainerId },
-                      );
-                      const verify = await db.threads.get(resolvedThreadId);
-                      console.log(
-                        "[diag/container_ready persist]",
-                        JSON.stringify({
-                          resolvedThreadId,
-                          field,
-                          newContainerId,
-                          affectedRows: affected,
-                          verifyField: (verify as Record<string, unknown> | undefined)?.[
-                            field
-                          ],
-                          verifyId: verify?.id,
-                        }),
-                      );
-                    } catch (err) {
-                      console.log(
-                        "[diag/container_ready ERROR]",
-                        JSON.stringify({
-                          resolvedThreadId,
-                          message:
-                            err instanceof Error ? err.message : String(err),
-                        }),
-                      );
+                      await db.threads.update(resolvedThreadId, {
+                        [field]: newContainerId,
+                      });
+                    } catch {
+                      /* best-effort: container reuse is an optimization */
                     }
-                  } else {
-                    console.log(
-                      "[diag/container_ready SKIP]",
-                      JSON.stringify({
-                        resolvedThreadId,
-                        newContainerId,
-                        reason: !newContainerId
-                          ? "no container id"
-                          : "no resolved thread id",
-                      }),
-                    );
                   }
                   continue;
                 }


### PR DESCRIPTION
## Summary

Fix container reuse loss on the first turn of a brand-new chat thread when using Anthropic's server-side `code_execution_20250825` tool.

The `container_ready` SSE handler (added in #5519) persists the new container id via `db.threads.update(resolvedThreadId, …)`. Dexie's `update` is a no-op when the row doesn't yet exist — and on the first turn of a freshly-created thread, the thread row is sometimes not in IndexedDB by the time the SSE event fires (assistant-ui persistence is concurrent). The write silently affected 0 rows, the next turn re-read `null`, and Anthropic auto-created a fresh container instead of reusing the one from the previous turn.

Now: `ensureThreadRecord` is called first, materializing the thread row if missing, so the subsequent `update` lands. Same pattern already used in `openai-code-exec-section.tsx` for the OpenAI picker bind path.

## Test plan

- [x] New chat thread → enable code execution → send a message that runs Python.
- [x] Send a second message that references the previous container state (e.g., "what's the value of x?").
- [x] Backend log shows `container_id_in=<id>` on turn 2 (matching turn 1's `container_id_out`), not `None`.
- [x] Repeat across 3+ turns to confirm the container is reused, not regenerated.