### PR TITLE
studio/frontend: stop showing Generating spinner on empty welcome view

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -66,7 +66,6 @@ import {
   HeadphonesIcon,
   LightbulbIcon,
   LightbulbOffIcon,
-  LoaderIcon,
   MicIcon,
   MoreHorizontalIcon,
   RefreshCwIcon,
@@ -246,24 +245,8 @@ const ThreadWelcome: FC<{ hideComposer?: boolean }> = ({ hideComposer }) => {
               Run GGUFs, safetensors, vision and audio models
             </p>
           </div>
-          <GeneratingSpinner />
           {!hideComposer && <ComposerAnimated />}
         </div>
-      </div>
-    </div>
-  );
-};
-
-const GeneratingSpinner: FC = () => {
-  const status = useChatRuntimeStore((s) => s.generatingStatus);
-  if (!status) {
-    return null;
-  }
-  return (
-    <div className="mx-auto flex w-full max-w-(--thread-max-width) items-center justify-center py-2">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <LoaderIcon className="size-3.5 animate-spin" />
-        <span>Generating</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The `GeneratingSpinner` rendered inside `ThreadWelcome` (the empty "Chat with your model" surface) subscribed to the **global** `generatingStatus` value from `chat-runtime-store`. That value is set 450 ms into any in-flight request by the chat-adapter warmup timer, so it leaked across threads (and across reloads, when a prior run failed to clear it).

The result: opening a fresh chat, or just typing in the composer on the welcome screen, would intermittently show a `Generating` spinner under the headline even though nothing was actually generating for the current thread.

On the normal path the welcome view is replaced the moment the user submits, because the optimistic user message flips `thread.isEmpty` to false. By the time the 450 ms warmup fires, the assistant bubble is already mounted and is rendering its own correctly scoped `GeneratingIndicator` (which reads `message.status?.type === "running"` from the per-message AUI state). So the welcome-screen spinner only ever showed in the leaky case.

This PR removes the spinner from `ThreadWelcome`, drops the now-unused `GeneratingSpinner` component, and removes the now-unused `LoaderIcon` import. No store changes are needed: the global `generatingStatus` is still useful elsewhere, it just should not be the source of truth for a per-thread empty-state UI.

## What changed

- `studio/frontend/src/components/assistant-ui/thread.tsx`
  - Drop `<GeneratingSpinner />` from `ThreadWelcome`.
  - Delete the `GeneratingSpinner` component.
  - Remove the `LoaderIcon` import (still imported separately by the tool UIs that need it).

Net diff: 17 deletions, 0 additions in a single file.

## Test plan

- [ ] `bun run typecheck` in `studio/frontend` (passes locally).
- [ ] `bun run dev`, open the app on a fresh empty thread, type a query without submitting. Confirm no `Generating` text appears under the sloth headline.
- [ ] Start a generation, while it is still streaming click "New chat" to switch to a fresh thread. Confirm the welcome view on the new thread is clean (no leaked spinner from the still-running thread).
- [ ] Submit a real prompt and confirm the in-message `Generating...` indicator still appears in the assistant bubble until the first token arrives (this is the separate `GeneratingIndicator`, untouched by this PR).
- [ ] Cancel a generation, then start a new chat. Confirm the welcome view is clean even if the prior cancel path missed clearing the global status.