### PR TITLE
studio/frontend: swap Hugeicons spokes spinner for CSS ring

### DIFF
--- a/studio/frontend/src/components/ui/spinner.tsx
+++ b/studio/frontend/src/components/ui/spinner.tsx
@@ -2,12 +2,17 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { cn } from "@/lib/utils"
-import { HugeiconsIcon } from "@hugeicons/react"
-import { Loading03Icon } from "@hugeicons/core-free-icons"
 
 function Spinner({ className }: { className?: string }) {
   return (
-    <HugeiconsIcon icon={Loading03Icon} strokeWidth={2} role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} />
+    <span
+      role="status"
+      aria-label="Loading"
+      className={cn(
+        "inline-block size-4 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent",
+        className,
+      )}
+    />
   )
 }
 

--- a/studio/frontend/src/features/chat/components/model-load-status.tsx
+++ b/studio/frontend/src/features/chat/components/model-load-status.tsx
@@ -56,7 +56,7 @@ export function ModelLoadDescription({
   return (
     <div className="relative flex min-h-12 w-full items-stretch gap-2">
       <div className="flex h-full shrink-0 items-center self-center">
-        <Spinner className="size-4 text-foreground" />
+        <Spinner className="size-3.5 text-muted-foreground" />
       </div>
       <div className="min-w-0 flex-1 pr-5">
         {title ? <p className="text-foreground leading-5 font-semibold">{title}</p> : null}


### PR DESCRIPTION
## Summary
- Replaces the Hugeicons `Loading03Icon` spokes spinner with a small CSS border ring. The ring inherits the surrounding text color via `border-current` so callers keep full control with a Tailwind text utility.
- Tones the model load toast spinner down to `size-3.5` in `text-muted-foreground` so it sits with the toast typography instead of punching through it.

## Test plan
- [ ] Load a model in chat and confirm the "Starting model..." toast shows the new ring in muted grey.
- [ ] Dismiss the toast and confirm the inline header status renders the same ring shape and inherits muted-foreground from its parent.
- [ ] Spot-check other spinner sites (export dialog, dataset section, recipe runtime) for visual regressions.