### PR TITLE
Fix num_logits_to_keep regression on transformers >= 4.52

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2109,9 +2109,10 @@ def unsloth_fast_generate(
 
     # For newer HF
     kwargs["cache_implementation"] = "dynamic"
-    # transformers 4.51 renamed num_logits_to_keep -> logits_to_keep. Pick the
-    # spelling the actual runtime forward accepts so generation _validate_model_kwargs
-    # does not reject the legacy name.
+    # transformers 4.50 renamed num_logits_to_keep -> logits_to_keep
+    # (with @deprecate_kwarg through 4.51.x, removed in 4.52+). Pick the
+    # spelling the actual runtime forward accepts so generation
+    # _validate_model_kwargs does not reject the legacy name.
     num_logits_to_keep = kwargs.pop("num_logits_to_keep", None)
     logits_to_keep = kwargs.get("logits_to_keep", None)
     if num_logits_to_keep is not None and logits_to_keep is None:

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2109,11 +2109,23 @@ def unsloth_fast_generate(
 
     # For newer HF
     kwargs["cache_implementation"] = "dynamic"
-    # For num_logits_to_keep
-    num_logits_to_keep = kwargs.get("num_logits_to_keep", None)
+    # transformers 4.51 renamed num_logits_to_keep -> logits_to_keep. Pick the
+    # spelling the actual runtime forward accepts so generation _validate_model_kwargs
+    # does not reject the legacy name.
+    num_logits_to_keep = kwargs.pop("num_logits_to_keep", None)
     logits_to_keep = kwargs.get("logits_to_keep", None)
+    if num_logits_to_keep is not None and logits_to_keep is None:
+        kwargs["logits_to_keep"] = num_logits_to_keep
+        logits_to_keep = num_logits_to_keep
     if num_logits_to_keep is None and logits_to_keep is None:
-        kwargs["num_logits_to_keep"] = 1
+        try:
+            _fwd_params = inspect.signature(self.forward).parameters
+        except (TypeError, ValueError):
+            _fwd_params = {}
+        if "logits_to_keep" in _fwd_params:
+            kwargs["logits_to_keep"] = 1
+        elif "num_logits_to_keep" in _fwd_params:
+            kwargs["num_logits_to_keep"] = 1
 
     # Remove token_type_ids
     kwargs.pop("token_type_ids", None)

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1378,11 +1378,7 @@ class FastModel(FastBaseModel):
             use_gradient_checkpointing, max_seq_length, dtype
         )
         with redirector:
-            # UnslothForCausalLMLoss is tiny (label shift + Triton CE call);
-            # compiling it folds the elementwise prep into one launch and
-            # eliminates per-step Python overhead. Torch < 2.4 still routes
-            # through torch._disable_dynamo inside patch_loss_functions.
-            patch_loss_functions(torch_compile = True)
+            patch_loss_functions(torch_compile = False)
             model_types, supports_sdpa = unsloth_compile_transformers(
                 dtype = dtype,
                 model_name = model_name,

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1378,7 +1378,11 @@ class FastModel(FastBaseModel):
             use_gradient_checkpointing, max_seq_length, dtype
         )
         with redirector:
-            patch_loss_functions(torch_compile = False)
+            # UnslothForCausalLMLoss is tiny (label shift + Triton CE call);
+            # compiling it folds the elementwise prep into one launch and
+            # eliminates per-step Python overhead. Torch < 2.4 still routes
+            # through torch._disable_dynamo inside patch_loss_functions.
+            patch_loss_functions(torch_compile = True)
             model_types, supports_sdpa = unsloth_compile_transformers(
                 dtype = dtype,
                 model_name = model_name,


### PR DESCRIPTION
## Summary

Follow-up to `unslothai/unsloth-zoo#665`. Fixes the `num_logits_to_keep` regression in `unsloth_fast_generate` that surfaced on transformers >= 4.52. Pairs with `unslothai/unsloth-zoo#666` (single-matmul opt-in in the compiler templates).

## What was wrong

`unsloth/models/llama.py` `unsloth_fast_generate` unconditionally set `kwargs[\"num_logits_to_keep\"] = 1`. Transformers 4.50 renamed that forward parameter to `logits_to_keep` (with a `@deprecate_kwarg` shim that lived through 4.51.x), and removed the shim entirely in 4.52. From 4.52 onwards, `_validate_model_kwargs` raises:

```
ValueError: The following `model_kwargs` are not used by the model: ['num_logits_to_keep']
(note: typos in the generate arguments will also show up in this list)
```

blocking `model.generate(...)` on Llama / Mistral. Reproducible with a bare `FastLanguageModel.from_pretrained(\"unsloth/Llama-3.2-1B-Instruct\") + model.generate(...)`.

## Change

`unsloth/models/llama.py` (in `unsloth_fast_generate`):

```python
num_logits_to_keep = kwargs.pop(\"num_logits_to_keep\", None)
logits_to_keep = kwargs.get(\"logits_to_keep\", None)
if num_logits_to_keep is not None and logits_to_keep is None:
    kwargs[\"logits_to_keep\"] = num_logits_to_keep
    logits_to_keep = num_logits_to_keep
if num_logits_to_keep is None and logits_to_keep is None:
    try:
        _fwd_params = inspect.signature(self.forward).parameters
    except (TypeError, ValueError):
        _fwd_params = {}
    if \"logits_to_keep\" in _fwd_params:
        kwargs[\"logits_to_keep\"] = 1
    elif \"num_logits_to_keep\" in _fwd_params:
        kwargs[\"num_logits_to_keep\"] = 1
```

Inspects the actual runtime forward signature and uses whichever spelling it accepts. A caller still passing the legacy `num_logits_to_keep=N` gets it promoted to `logits_to_keep=N` (not dropped).

## Transformers version sweep

Verified the rename window directly against the GitHub source for `transformers/models/llama/modeling_llama.py`:

| Versions | Forward parameter | Accepts `num_logits_to_keep`? |
|---|---|---|
| 4.50.0, 4.51.0, 4.51.3 | `logits_to_keep` | yes (`@deprecate_kwarg(version=\"4.50\")` shim) |
| 4.52.0 - 4.55.x | `logits_to_keep` | no (shim removed) |
| **4.56.0, 4.56.1, 4.56.2** | `logits_to_keep` | no |
| **4.57.0, 4.57.1, 4.57.2, 4.57.3, 4.57.4, 4.57.5, 4.57.6** | `logits_to_keep` | no |
| main (dev) | `logits_to_keep` | no |

All currently shipping `transformers` releases >= 4.52 use `logits_to_keep`. The fix's `inspect.signature(self.forward)` path picks the correct spelling on every one of them.

## Caveat

`_validate_model_kwargs` (`transformers/generation/utils.py:1599`) merges `inspect.signature(self.forward).parameters` only when `prepare_inputs_for_generation` accepts `**kwargs`. On PEFT-wrapped models, `self.forward` may resolve to PEFT's wrapper with `(*args, **kwargs)` and hide the underlying signature. In that case my fix sets neither kwarg -- still correct for validation, but the decode-time keep-only-last-logit optimisation is lost. Pre-existing limitation; the old unconditional `kwargs[\"num_logits_to_keep\"] = 1` was what 4.52+ rejected. A follow-up can walk `self.get_base_model()` / `self.base_model.model` before inspecting if we want to recover the PEFT decode speedup.

## What dropped from this PR

Earlier revisions of this PR also flipped `patch_loss_functions(torch_compile=False)` -> `True` at `loader.py:1381`. Reverted in `82c2e69`. The loss function bottoms out at a Triton autograd.Function (`Fast_CrossEntropyLoss.apply`), which `torch.compile` treats as an opaque op and breaks the graph at. The only thing it can actually compile is three elementwise prep ops around the Triton call, and the per-call dynamo overhead is in the same order. Empirical Gemma3 1B GRPO smoke showed no meaningful delta (415s vs 409s, within noise) and risked dragging the outer compiled training step into recompiles. Keeping `torch_compile=False`.

## Test plan

- [x] Llama 3.2 1B + `model.generate(max_new_tokens=16)` no longer raises. Output: `\"The capital of France is Paris. The Eiffel Tower is located in Paris. The Eiffel\"`.
- [x] Gemma3 1B GRPO smoke (max_steps=3) returns bit-identical losses (0.256 / 0.4393 / 0.2031) vs pre-fix. Default path unchanged at the training-loop level.
- [x] unsloth-zoo regression suites pass on this combination: 96 passed across `test_fused_forward_install` + `test_compiler_rewriter_exhaustive`.

## Compatibility

- Existing callers that pass `num_logits_to_keep` continue to work: translated to `logits_to_keep` on transformers >= 4.50 rather than dropped.
- Defaults unchanged on transformers < 4.50 (legacy spelling still set when only `num_logits_to_keep` is in the runtime forward signature).
- No loss function compile flip in this revision.

Pairs with: `unslothai/unsloth-zoo daniel/three-followups-from-pr665` (#666, `compiler: single-matmul opt-in for UNSLOTH_RETURN_LOGITS=1`).