### PR TITLE
studio/frontend: grow chat composer to 16 rows and inset scrollbar

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -324,7 +324,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
         placeholder="Send a message..."
         className="aui-composer-input composer-input"
         minRows={1}
-        maxRows={16}
+        maxRows={12}
         autoFocus={!disabled}
         disabled={disabled}
         aria-label="Message input"

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -324,7 +324,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
         placeholder="Send a message..."
         className="aui-composer-input composer-input"
         minRows={1}
-        maxRows={6}
+        maxRows={16}
         autoFocus={!disabled}
         disabled={disabled}
         aria-label="Message input"

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -806,7 +806,7 @@
 	}
 
 	.composer-input {
-		@apply mt-2 mb-1 mr-3 min-h-12 w-[calc(100%-0.75rem)] resize-none overflow-y-auto bg-transparent pl-5 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0;
+		@apply mt-2 mb-1 mx-3 min-h-12 w-[calc(100%-1.5rem)] resize-none overflow-y-auto bg-transparent pl-5 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0;
 	}
 
 	.composer-action-wrapper {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -806,7 +806,7 @@
 	}
 
 	.composer-input {
-		@apply mb-1 min-h-12 w-full resize-none overflow-y-auto bg-transparent pl-5 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0;
+		@apply mt-2 mb-1 mr-3 min-h-12 w-[calc(100%-0.75rem)] resize-none overflow-y-auto bg-transparent pl-5 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0;
 	}
 
 	.composer-action-wrapper {


### PR DESCRIPTION
## Summary
- Raise the chat composer textarea cap from `maxRows={6}` to `maxRows={12}` so the input keeps growing as you type longer prompts before scrolling kicks in. 12 is conservative enough that a fully expanded composer does not cover the scroll-to-bottom button or a large slice of recent messages.
- Add `mt-2` and `mr-3` to `.composer-input` so the internal scrollbar sits inset from the rounded corners of the composer surface instead of butting up against them.

## Files
- `studio/frontend/src/components/assistant-ui/thread.tsx`
- `studio/frontend/src/index.css`

## Test plan
- [ ] `cd studio/frontend && bun run build` succeeds.
- [ ] Open the chat page, type a long multi-line prompt, and confirm the composer grows up to 12 visible rows before scrolling.
- [ ] When the textarea scrolls, the scrollbar visibly sits inside the rounded edge (not flush top or right).
- [ ] Existing short prompts still render at the minimum row height with no layout shift.