### PR TITLE
Fix unfused Mixtral LoRA target conversion

### DIFF
--- a/tests/test_moe_lora_targets.py
+++ b/tests/test_moe_lora_targets.py
@@ -1,0 +1,74 @@
+import ast
+import re
+from pathlib import Path
+from typing import List, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UTILS_PATH = REPO_ROOT / "unsloth" / "models" / "_utils.py"
+
+
+def _load_moe_helpers():
+    tree = ast.parse(UTILS_PATH.read_text())
+    names = {
+        "is_moe_model",
+        "_resolve_moe_parameter_name",
+        "get_moe_target_parameters",
+    }
+    body = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    module = ast.Module(body = body, type_ignores = [])
+    ast.fix_missing_locations(module)
+    namespace = {"Optional": Optional, "List": List, "re": re}
+    exec(compile(module, str(UTILS_PATH), "exec"), namespace)
+    return namespace
+
+
+get_moe_target_parameters = _load_moe_helpers()["get_moe_target_parameters"]
+
+
+class _Config:
+    model_type = "mixtral"
+    num_local_experts = 8
+
+
+class _UnfusedMixtralModel:
+    config = _Config()
+
+    def named_parameters(self):
+        for name in (
+            "model.layers.0.mlp.experts.0.w1.weight",
+            "model.layers.0.mlp.experts.0.w2.weight",
+            "model.layers.0.mlp.experts.0.w3.weight",
+        ):
+            yield name, None
+
+
+class _FusedMoeModel:
+    config = _Config()
+
+    def named_parameters(self):
+        for name in (
+            "model.layers.0.mlp.experts.gate_up_proj",
+            "model.layers.0.mlp.experts.down_proj",
+        ):
+            yield name, None
+
+
+def test_issue_5403_w_targets_do_not_create_fused_target_parameters():
+    assert (
+        get_moe_target_parameters(
+            _UnfusedMixtralModel(),
+            ["q_proj", "k_proj", "v_proj", "o_proj", "w1", "w2", "w3"],
+        )
+        is None
+    )
+
+
+def test_broad_fused_mlp_targets_still_create_fused_target_parameters():
+    assert get_moe_target_parameters(
+        _FusedMoeModel(), ["gate_proj", "up_proj", "down_proj"]
+    ) == ["mlp.experts.gate_up_proj", "mlp.experts.down_proj"]

--- a/tests/test_peft_weight_converter_compat.py
+++ b/tests/test_peft_weight_converter_compat.py
@@ -38,6 +38,7 @@ def _install_fake_peft(twc_namespace):
 
 @pytest.fixture(autouse = True)
 def _restore_peft_modules():
+    attr_missing = object()
     saved = {
         k: sys.modules.get(k)
         for k in (
@@ -46,12 +47,31 @@ def _restore_peft_modules():
             "peft.utils.transformers_weight_conversion",
         )
     }
+    saved_twc = saved["peft.utils.transformers_weight_conversion"]
+    saved_twc_attrs = {}
+    if saved_twc is not None:
+        for attr in (
+            "build_peft_weight_mapping",
+            "convert_peft_config_for_transformers",
+            "_unsloth_weight_converter_compat_patch",
+            "_unsloth_mixtral_unfused_target_patch",
+        ):
+            saved_twc_attrs[attr] = getattr(saved_twc, attr, attr_missing)
+
     yield
+
     for k, v in saved.items():
         if v is None:
             sys.modules.pop(k, None)
         else:
             sys.modules[k] = v
+    if saved_twc is not None:
+        for attr, value in saved_twc_attrs.items():
+            if value is attr_missing:
+                if hasattr(saved_twc, attr):
+                    delattr(saved_twc, attr)
+            else:
+                setattr(saved_twc, attr, value)
 
 
 class _LegacyConverter:
@@ -100,6 +120,64 @@ def _build_that_calls_init(weight_conversions, adapter_name, peft_config = None)
             )
         )
     return out
+
+
+class _FakePeftConfig:
+    def __init__(self, target_modules):
+        self.target_modules = target_modules
+        self.target_parameters = None
+        self.convert_calls = []
+
+
+class _FakeModelConfig:
+    model_type = "mixtral"
+
+
+class _FakeNonMixtralConfig:
+    model_type = "qwen3_moe"
+
+
+class _FakeUnfusedMixtralModel:
+    config = _FakeModelConfig()
+
+    def named_parameters(self):
+        for name in (
+            "model.layers.0.mlp.experts.0.w1.weight",
+            "model.layers.0.mlp.experts.0.w2.weight",
+            "model.layers.0.mlp.experts.0.w3.weight",
+        ):
+            yield name, object()
+
+
+class _FakeFusedMixtralModel:
+    config = _FakeModelConfig()
+
+    def named_parameters(self):
+        for name in (
+            "model.layers.0.mlp.experts.gate_up_proj",
+            "model.layers.0.mlp.experts.down_proj",
+        ):
+            yield name, object()
+
+
+class _FakeNonMixtralModel(_FakeUnfusedMixtralModel):
+    config = _FakeNonMixtralConfig()
+
+
+def _convert_that_fuses_mixtral(peft_config, model, conversions):
+    peft_config.convert_calls.append(
+        (
+            getattr(model.config, "model_type", None),
+            set(peft_config.target_modules or ()),
+            conversions,
+        )
+    )
+    if getattr(model.config, "model_type", None) == "mixtral":
+        target_modules = set(peft_config.target_modules or ())
+        if {"w1", "w3"}.intersection(target_modules):
+            target_modules.difference_update({"w1", "w2", "w3"})
+            peft_config.target_modules = target_modules
+            peft_config.target_parameters = {"gate_up_proj", "down_proj"}
 
 
 def test_two_arg_call_preserves_upstream_signature():
@@ -257,3 +335,150 @@ def test_empty_conversions_short_circuits_without_patching():
     out = twc.build_peft_weight_mapping([], "default", None)
     assert out == []
     assert _LegacyConverter.__init__ is pre_init
+
+
+def test_mixtral_unfused_targets_skip_peft_moe_conversion():
+    twc = _install_fake_peft(
+        {
+            "build_peft_weight_mapping": _build_that_calls_init,
+            "convert_peft_config_for_transformers": _convert_that_fuses_mixtral,
+        }
+    )
+    patch = _load_patch_function()
+    patch()
+
+    config = _FakePeftConfig(
+        target_modules = {"q_proj", "k_proj", "v_proj", "o_proj", "w1", "w2", "w3"}
+    )
+    twc.convert_peft_config_for_transformers(
+        config, _FakeUnfusedMixtralModel(), conversions = ["conversion"]
+    )
+
+    assert config.convert_calls == []
+    assert config.target_modules == {
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "w1",
+        "w2",
+        "w3",
+    }
+    assert config.target_parameters is None
+
+
+def test_mixtral_fused_layout_still_delegates_to_peft_conversion():
+    twc = _install_fake_peft(
+        {
+            "build_peft_weight_mapping": _build_that_calls_init,
+            "convert_peft_config_for_transformers": _convert_that_fuses_mixtral,
+        }
+    )
+    patch = _load_patch_function()
+    patch()
+
+    config = _FakePeftConfig(target_modules = {"w1", "w2", "w3"})
+    twc.convert_peft_config_for_transformers(
+        config, _FakeFusedMixtralModel(), conversions = ["conversion"]
+    )
+
+    assert config.convert_calls == [("mixtral", {"w1", "w2", "w3"}, ["conversion"])]
+    assert config.target_modules == set()
+    assert config.target_parameters == {"gate_up_proj", "down_proj"}
+
+
+def test_non_mixtral_layout_still_delegates_to_peft_conversion():
+    twc = _install_fake_peft(
+        {
+            "build_peft_weight_mapping": _build_that_calls_init,
+            "convert_peft_config_for_transformers": _convert_that_fuses_mixtral,
+        }
+    )
+    patch = _load_patch_function()
+    patch()
+
+    config = _FakePeftConfig(target_modules = {"w1", "w2", "w3"})
+    twc.convert_peft_config_for_transformers(
+        config, _FakeNonMixtralModel(), conversions = ["conversion"]
+    )
+
+    assert config.convert_calls == [("qwen3_moe", {"w1", "w2", "w3"}, ["conversion"])]
+    assert config.target_modules == {"w1", "w2", "w3"}
+    assert config.target_parameters is None
+
+
+def test_real_peft_keeps_lora_on_unfused_mixtral_w_modules():
+    torch = pytest.importorskip("torch")
+    peft = pytest.importorskip("peft")
+    from peft import LoraConfig, get_peft_model
+
+    patch = _load_patch_function()
+    patch()
+
+    class Config:
+        model_type = "mixtral"
+        num_local_experts = 2
+        tie_word_embeddings = False
+
+        def get(self, key, default = None):
+            return getattr(self, key, default)
+
+        def to_dict(self):
+            return {
+                "model_type": self.model_type,
+                "num_local_experts": self.num_local_experts,
+                "tie_word_embeddings": self.tie_word_embeddings,
+            }
+
+    class Expert(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w1 = torch.nn.Linear(8, 4, bias = False)
+            self.w2 = torch.nn.Linear(4, 8, bias = False)
+            self.w3 = torch.nn.Linear(8, 4, bias = False)
+
+    class Mlp(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.experts = torch.nn.ModuleList([Expert(), Expert()])
+
+    class Attention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = torch.nn.Linear(8, 8, bias = False)
+            self.k_proj = torch.nn.Linear(8, 8, bias = False)
+            self.v_proj = torch.nn.Linear(8, 8, bias = False)
+            self.o_proj = torch.nn.Linear(8, 8, bias = False)
+
+    class Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.self_attn = Attention()
+            self.mlp = Mlp()
+
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = Config()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([Layer()])
+
+        def forward(self, input_ids = None, **kwargs):
+            return None
+
+    config = LoraConfig(
+        r = 2,
+        lora_alpha = 2,
+        target_modules = ["q_proj", "k_proj", "v_proj", "o_proj", "w1", "w2", "w3"],
+    )
+    model = get_peft_model(Model(), config)
+    peft_config = model.peft_config["default"]
+    lora_names = [name for name, _ in model.named_parameters() if "lora_" in name]
+
+    assert peft.__version__
+    assert {"w1", "w2", "w3"}.issubset(peft_config.target_modules)
+    assert peft_config.target_parameters is None
+    assert any(".w1.lora_A." in name for name in lora_names)
+    assert any(".w2.lora_A." in name for name in lora_names)
+    assert any(".w3.lora_A." in name for name in lora_names)
+    assert not any("gate_up_proj" in name for name in lora_names)

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1741,9 +1741,7 @@ def _has_mixtral_unfused_expert_layout(model):
     try:
         for name, _ in named_parameters():
             found.update(
-                _MIXTRAL_UNFUSED_EXPERT_TARGETS.intersection(
-                    str(name).split(".")
-                )
+                _MIXTRAL_UNFUSED_EXPERT_TARGETS.intersection(str(name).split("."))
             )
             if found == _MIXTRAL_UNFUSED_EXPERT_TARGETS:
                 return True
@@ -1774,9 +1772,7 @@ def _patch_peft_mixtral_unfused_target_conversion(twc):
         return
 
     @functools.wraps(original_convert)
-    def _convert_peft_config_for_transformers_unsloth(
-        peft_config, model, conversions
-    ):
+    def _convert_peft_config_for_transformers_unsloth(peft_config, model, conversions):
         if _should_skip_peft_mixtral_moe_conversion(peft_config, model):
             return None
         return original_convert(peft_config, model, conversions)

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1641,6 +1641,8 @@ def patch_peft_weight_converter_compatibility():
     except (ImportError, AttributeError):
         return
 
+    _patch_peft_mixtral_unfused_target_conversion(twc)
+
     if getattr(twc, "_unsloth_weight_converter_compat_patch", False):
         return
 
@@ -1714,6 +1716,75 @@ def patch_peft_weight_converter_compatibility():
 
     twc.build_peft_weight_mapping = _build_peft_weight_mapping_compat
     twc._unsloth_weight_converter_compat_patch = True
+
+
+_MIXTRAL_UNFUSED_EXPERT_TARGETS = frozenset(("w1", "w2", "w3"))
+
+
+def _peft_target_module_leaves(peft_config):
+    target_modules = getattr(peft_config, "target_modules", None)
+    if isinstance(target_modules, str):
+        target_modules = (target_modules,)
+    return {
+        target.rsplit(".", 1)[-1]
+        for target in (target_modules or ())
+        if isinstance(target, str)
+    }
+
+
+def _has_mixtral_unfused_expert_layout(model):
+    named_parameters = getattr(model, "named_parameters", None)
+    if named_parameters is None:
+        return False
+
+    found = set()
+    try:
+        for name, _ in named_parameters():
+            found.update(
+                _MIXTRAL_UNFUSED_EXPERT_TARGETS.intersection(
+                    str(name).split(".")
+                )
+            )
+            if found == _MIXTRAL_UNFUSED_EXPERT_TARGETS:
+                return True
+    except Exception:
+        return False
+
+    return False
+
+
+def _should_skip_peft_mixtral_moe_conversion(peft_config, model):
+    config = getattr(model, "config", None)
+    if getattr(config, "model_type", None) != "mixtral":
+        return False
+
+    target_modules = _peft_target_module_leaves(peft_config)
+    if not _MIXTRAL_UNFUSED_EXPERT_TARGETS.intersection(target_modules):
+        return False
+
+    return _has_mixtral_unfused_expert_layout(model)
+
+
+def _patch_peft_mixtral_unfused_target_conversion(twc):
+    if getattr(twc, "_unsloth_mixtral_unfused_target_patch", False):
+        return
+
+    original_convert = getattr(twc, "convert_peft_config_for_transformers", None)
+    if original_convert is None:
+        return
+
+    @functools.wraps(original_convert)
+    def _convert_peft_config_for_transformers_unsloth(
+        peft_config, model, conversions
+    ):
+        if _should_skip_peft_mixtral_moe_conversion(peft_config, model):
+            return None
+        return original_convert(peft_config, model, conversions)
+
+    twc.convert_peft_config_for_transformers = (
+        _convert_peft_config_for_transformers_unsloth
+    )
+    twc._unsloth_mixtral_unfused_target_patch = True
 
 
 CAUSAL_CONV1D_BROKEN = False


### PR DESCRIPTION
## Summary
- skip PEFT's Mixtral fused-target conversion only when the live Mixtral layout exposes unfused expert parameters `w1`/`w2`/`w3`
- preserve PEFT conversion behavior for fused Mixtral and other MoE models
- add focused regression coverage for issue #5403, fused MoE conversion, dense models, and PEFT monkeypatch idempotency/restoration

Fixes #5403.

## Validation
- `python -m py_compile unsloth/import_fixes.py tests/test_peft_weight_converter_compat.py tests/test_moe_lora_targets.py`
- `CUDA_VISIBLE_DEVICES=7 PYTHONPATH=/home/datta0/repos/unsloth/worktrees/issue-5403-moe-unfused-targets python -m pytest tests/test_peft_weight_converter_compat.py tests/test_moe_lora_targets.py -q`
  - `15 passed, 16 warnings in 0.49s`
- `CUDA_VISIBLE_DEVICES=7 PYTHONPATH=/home/datta0/repos/unsloth/worktrees/issue-5403-moe-unfused-targets python -u /home/datta0/codes/ai/issue-5403-moe-unfused-targets/gpu_e2e.py`
  - PyTorch saw one device: `NVIDIA B200`
  - unfused Mixtral-shaped layout kept LoRA on `w1`/`w2`/`w3` and did not create fused `target_parameters`
  - dense Llama-shaped layout stayed on normal module targets
  - fused Mixtral and Qwen3 MoE conversions still produced fused `target_parameters`
- `CUDA_VISIBLE_DEVICES=7 PYTHONPATH=/home/datta0/repos/unsloth/worktrees/issue-5403-moe-unfused-targets python -u /home/datta0/codes/ai/issue-5403-moe-unfused-targets/real_model_classes_e2e.py`
  - real `MixtralForCausalLM`, `LlamaForCausalLM`, `Qwen3MoeForCausalLM`, `Qwen2MoeForCausalLM`, and `Llama4ForCausalLM` tiny configs completed GPU forward/backward/adapter-save
  - installed Transformers 5.6.2 `MixtralForCausalLM` is already fused, so the exact unfused `w1`/`w2`/`w3` issue layout is covered by the synthetic-layout E2E and unit tests rather than by an installed real Mixtral class

Note: Unsloth import emitted existing unrelated GPT-OSS Triton-kernel import errors for missing `triton_kernels.matmul_ogs` and `triton_kernels.swiglu`; the validation scripts completed successfully.