### PR TITLE
studio/frontend: keep tool activity visible during multi-call bursts

### DIFF
--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -317,8 +317,6 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
       return false;
     }
 
-    // Streaming = group has reasoning AND no answer text after.
-    // Tool calls between reasoning and text keep the panel visible.
     let groupHasReasoning = false;
     for (let i = startIndex; i <= endIndex && i < len; i += 1) {
       if (parts[i]?.type === "reasoning") {
@@ -326,10 +324,16 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
         break;
       }
     }
-    if (!groupHasReasoning) return false;
+    if (!groupHasReasoning) {
+      return false;
+    }
+    // After this group ends, any non-tool-call part means a fresh
+    // segment has started (text answer or a later reasoning group),
+    // so this group is no longer the active stream.
     for (let i = endIndex + 1; i < len; i += 1) {
-      const t = parts[i]?.type;
-      if (t === "text") return false;
+      if (parts[i]?.type !== "tool-call") {
+        return false;
+      }
     }
     return true;
   });

--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -317,6 +317,8 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
       return false;
     }
 
+    // Streaming = group has reasoning AND no answer text after.
+    // Tool calls between reasoning and text keep the panel visible.
     let groupHasReasoning = false;
     for (let i = startIndex; i <= endIndex && i < len; i += 1) {
       if (parts[i]?.type === "reasoning") {
@@ -324,13 +326,10 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
         break;
       }
     }
-    if (!groupHasReasoning) {
-      return false;
-    }
+    if (!groupHasReasoning) return false;
     for (let i = endIndex + 1; i < len; i += 1) {
-      if (parts[i]?.type !== "tool-call") {
-        return false;
-      }
+      const t = parts[i]?.type;
+      if (t === "text") return false;
     }
     return true;
   });

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1020,6 +1020,11 @@ const CancelledIndicator: FC = () => {
 // doesn't look frozen during the gap between "model wrote intent" and
 // "tool actually invoked", or between back-to-back tool calls.
 //
+// Scope: only fires for tool-using responses. Plain text-only answers
+// keep using GeneratingIndicator (while content is empty) and then
+// nothing -- otherwise every text streaming response would get a
+// misleading "Working..." row.
+//
 // Return value is a string ("tool:<name>" | "working" | "") rather than
 // an object so useAuiState's referential-equality memoization holds
 // across renders -- returning a fresh object each render would invalidate
@@ -1028,19 +1033,24 @@ const RunningToolIndicator: FC = () => {
   const signal = useAuiState(({ message }) => {
     if (message.status?.type !== "running") return "";
     const parts = message.parts;
+    let sawToolCall = false;
+    let runningTool: string | null = null;
+    // Single pass: find any tool-call part (signals tools-are-in-play)
+    // and the most-recent running one (drives the specific indicator).
     for (let i = parts.length - 1; i >= 0; i -= 1) {
       const p = parts[i] as
         | { type?: string; toolName?: string; status?: { type?: string } }
         | undefined;
-      if (p?.type === "tool-call" && p.status?.type === "running") {
-        return `tool:${p.toolName ?? "tool"}`;
+      if (p?.type !== "tool-call") continue;
+      sawToolCall = true;
+      if (!runningTool && p.status?.type === "running") {
+        runningTool = p.toolName ?? "tool";
       }
     }
-    // No tool currently running, but message is still streaming.
-    // GeneratingIndicator hides once content.length > 0, so once any
-    // text has rendered we lose its dots. Surface a generic "Working..."
-    // so the chat doesn't go silent between phases.
-    if (parts.length > 0) return "working";
+    if (runningTool) return `tool:${runningTool}`;
+    // Only fall back to "Working..." if tools have been in play. A pure
+    // text-only response (no tool-call part ever) skips the fallback.
+    if (sawToolCall) return "working";
     return "";
   });
   if (!signal) return null;

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -699,9 +699,11 @@ const ReasoningToggle: FC = () => {
       aria-label={
         reasoningLockedOn
           ? "Thinking is required for this model"
-          : effectiveReasoningEnabled
-            ? "Disable thinking"
-            : "Enable thinking"
+          : disabled
+            ? "Thinking (model not loaded)"
+            : effectiveReasoningEnabled
+              ? "Disable thinking"
+              : "Enable thinking"
       }
     >
       {reasoningLockedOn || (effectiveReasoningEnabled && !disabled) ? (
@@ -1014,6 +1016,40 @@ const CancelledIndicator: FC = () => {
   );
 };
 
+// Pins the running tool's name to the bottom of the assistant bubble
+// so activity stays visible after the tool group scrolls off-screen.
+const RunningToolIndicator: FC = () => {
+  const running = useAuiState(({ message }) => {
+    if (message.status?.type !== "running") return null;
+    const parts = message.parts;
+    for (let i = parts.length - 1; i >= 0; i -= 1) {
+      const p = parts[i] as
+        | { type?: string; toolName?: string; status?: { type?: string } }
+        | undefined;
+      if (p?.type === "tool-call" && p.status?.type === "running") {
+        return p.toolName ?? "tool";
+      }
+    }
+    return null;
+  });
+  if (!running) return null;
+  return (
+    <div
+      data-slot="running-tool-indicator"
+      className="aui-running-tool-indicator mt-2 flex items-center gap-2 text-sm text-muted-foreground"
+      aria-live="polite"
+    >
+      <span
+        aria-hidden
+        className="aui-running-tool-indicator-dot inline-block size-2 animate-pulse rounded-full bg-muted-foreground/60"
+      />
+      <span>
+        Running <span className="font-mono text-xs">{running}</span>...
+      </span>
+    </div>
+  );
+};
+
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root
@@ -1042,6 +1078,7 @@ const AssistantMessage: FC = () => {
           }}
         />
         <SourcesGroup />
+        <RunningToolIndicator />
         <MessageError />
       </div>
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -987,15 +987,59 @@ const MessageError: FC = () => {
   );
 };
 
+// Heuristic: text the model emits before a tool actually starts often
+// includes the opening of one of the tool-call markup shapes the
+// backend strips. When that shape appears in the assistant's
+// content but no tool-call PART has landed yet (because the backend
+// only emits tool_start after the markup parses cleanly), the user
+// otherwise stares at a frozen "Generating..." for the whole time it
+// takes the model to finish writing the tool call.
+const TOOL_CALL_PROBE = /<tool_call>|<function=|<\|tool_call>|<\|python_tag\|>|\[TOOL_CALLS\]/i;
+
 const GeneratingIndicator: FC = () => {
-  const show = useAuiState(
-    ({ message }) =>
-      message.content.length === 0 && message.status?.type === "running",
-  );
-  if (!show) {
+  const phase = useAuiState(({ message }) => {
+    if (message.status?.type !== "running") return null;
+    const content = message.content;
+    if (!content || content.length === 0) return "generating";
+    // If every part is empty (placeholder text added but no chars yet)
+    // we still want to surface generating activity.
+    let allEmpty = true;
+    let sawToolSignal = false;
+    for (const p of content) {
+      const t = (p as { type?: string }).type;
+      if (t === "text" || t === "reasoning") {
+        const text = ((p as { text?: string }).text ?? "");
+        if (text.length > 0) {
+          allEmpty = false;
+          if (TOOL_CALL_PROBE.test(text)) {
+            sawToolSignal = true;
+          }
+        }
+      } else {
+        // tool-call / source / etc. mean a real part exists; the
+        // RunningToolIndicator or message body handles those.
+        return null;
+      }
+    }
+    if (sawToolSignal) return "calling-tool";
+    if (allEmpty) return "generating";
     return null;
-  }
-  return <span className="text-sm text-muted-foreground">Generating...</span>;
+  });
+  if (!phase) return null;
+  return (
+    <span
+      data-slot="generating-indicator"
+      data-phase={phase}
+      className="aui-generating-indicator inline-flex items-center gap-2 text-sm text-muted-foreground"
+      aria-live="polite"
+    >
+      <span
+        aria-hidden
+        className="aui-generating-indicator-dot inline-block size-2 animate-pulse rounded-full bg-muted-foreground/60"
+      />
+      <span>{phase === "calling-tool" ? "Calling tool..." : "Generating..."}</span>
+    </span>
+  );
 };
 
 // Placeholder when stop fires before any visible content (e.g. mid-think).

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1019,34 +1019,32 @@ const CancelledIndicator: FC = () => {
 // Pins activity to the bottom of the assistant bubble so the chat
 // doesn't look frozen during the gap between "model wrote intent" and
 // "tool actually invoked", or between back-to-back tool calls.
-// - When a tool-call part is currently `running`, shows the tool name.
-// - When the message is still streaming but no tool is mid-execution
-//   (e.g. model is generating the tool-call decision tokens, or has
-//   just rendered the lead-in text "Let me build it:"), falls back to
-//   a neutral "Working..." so the user sees that work is still happening.
+//
+// Return value is a string ("tool:<name>" | "working" | "") rather than
+// an object so useAuiState's referential-equality memoization holds
+// across renders -- returning a fresh object each render would invalidate
+// equality and force the component to rerender every frame.
 const RunningToolIndicator: FC = () => {
-  const state = useAuiState(({ message }) => {
-    if (message.status?.type !== "running") return null;
+  const signal = useAuiState(({ message }) => {
+    if (message.status?.type !== "running") return "";
     const parts = message.parts;
-    // Most recent running tool wins, if any.
     for (let i = parts.length - 1; i >= 0; i -= 1) {
       const p = parts[i] as
         | { type?: string; toolName?: string; status?: { type?: string } }
         | undefined;
       if (p?.type === "tool-call" && p.status?.type === "running") {
-        return { kind: "tool" as const, name: p.toolName ?? "tool" };
+        return `tool:${p.toolName ?? "tool"}`;
       }
     }
-    // No tool currently running, but message itself is still streaming.
-    // GeneratingIndicator only shows while content.length === 0, so once
-    // any text has rendered we lose its dots. Surface a generic "Working..."
+    // No tool currently running, but message is still streaming.
+    // GeneratingIndicator hides once content.length > 0, so once any
+    // text has rendered we lose its dots. Surface a generic "Working..."
     // so the chat doesn't go silent between phases.
-    if (parts.length > 0) {
-      return { kind: "working" as const };
-    }
-    return null;
+    if (parts.length > 0) return "working";
+    return "";
   });
-  if (!state) return null;
+  if (!signal) return null;
+  const toolName = signal.startsWith("tool:") ? signal.slice(5) : null;
   return (
     <div
       data-slot="running-tool-indicator"
@@ -1057,9 +1055,9 @@ const RunningToolIndicator: FC = () => {
         aria-hidden
         className="aui-running-tool-indicator-dot inline-block size-2 animate-pulse rounded-full bg-muted-foreground/60"
       />
-      {state.kind === "tool" ? (
+      {toolName ? (
         <span>
-          Running <span className="font-mono text-xs">{state.name}</span>...
+          Running <span className="font-mono text-xs">{toolName}</span>...
         </span>
       ) : (
         <span>Working...</span>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1020,10 +1020,10 @@ const CancelledIndicator: FC = () => {
 // doesn't look frozen during the gap between "model wrote intent" and
 // "tool actually invoked", or between back-to-back tool calls.
 //
-// Scope: only fires for tool-using responses. Plain text-only answers
-// keep using GeneratingIndicator (while content is empty) and then
-// nothing -- otherwise every text streaming response would get a
-// misleading "Working..." row.
+// Scope: only fires when the tail of the message has no streaming
+// answer content yet. Once the model has emitted reasoning or non-empty
+// text after the last tool, those parts already visibly show progress
+// and the "Working..." row would be misleading.
 //
 // Return value is a string ("tool:<name>" | "working" | "") rather than
 // an object so useAuiState's referential-equality memoization holds
@@ -1033,24 +1033,31 @@ const RunningToolIndicator: FC = () => {
   const signal = useAuiState(({ message }) => {
     if (message.status?.type !== "running") return "";
     const parts = message.parts;
-    let sawToolCall = false;
-    let runningTool: string | null = null;
-    // Single pass: find any tool-call part (signals tools-are-in-play)
-    // and the most-recent running one (drives the specific indicator).
+    // Walk from the tail. The first meaningful part decides what's
+    // currently visible to the user: a streaming text/reasoning part
+    // means the answer is already moving and the indicator must stay
+    // hidden; a tool-call part means we're either mid-tool (specific
+    // "Running ..." label) or in a pending gap before the next answer
+    // segment ("Working...").
     for (let i = parts.length - 1; i >= 0; i -= 1) {
       const p = parts[i] as
-        | { type?: string; toolName?: string; status?: { type?: string } }
+        | { type?: string; text?: string; toolName?: string; status?: { type?: string } }
         | undefined;
-      if (p?.type !== "tool-call") continue;
-      sawToolCall = true;
-      if (!runningTool && p.status?.type === "running") {
-        runningTool = p.toolName ?? "tool";
+      const t = p?.type;
+      if (t === "text") {
+        // Non-empty text after the last tool -> model is streaming the
+        // final answer. Skip empty text placeholders that some adapters
+        // emit before the first delta.
+        if (typeof p?.text === "string" && p.text.length > 0) return "";
+        continue;
       }
+      if (t === "reasoning") return "";
+      if (t === "tool-call") {
+        if (p?.status?.type === "running") return `tool:${p.toolName ?? "tool"}`;
+        return "working";
+      }
+      // Other part types (source attachments, etc.) -- keep walking.
     }
-    if (runningTool) return `tool:${runningTool}`;
-    // Only fall back to "Working..." if tools have been in play. A pure
-    // text-only response (no tool-call part ever) skips the fallback.
-    if (sawToolCall) return "working";
     return "";
   });
   if (!signal) return null;

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1016,23 +1016,37 @@ const CancelledIndicator: FC = () => {
   );
 };
 
-// Pins the running tool's name to the bottom of the assistant bubble
-// so activity stays visible after the tool group scrolls off-screen.
+// Pins activity to the bottom of the assistant bubble so the chat
+// doesn't look frozen during the gap between "model wrote intent" and
+// "tool actually invoked", or between back-to-back tool calls.
+// - When a tool-call part is currently `running`, shows the tool name.
+// - When the message is still streaming but no tool is mid-execution
+//   (e.g. model is generating the tool-call decision tokens, or has
+//   just rendered the lead-in text "Let me build it:"), falls back to
+//   a neutral "Working..." so the user sees that work is still happening.
 const RunningToolIndicator: FC = () => {
-  const running = useAuiState(({ message }) => {
+  const state = useAuiState(({ message }) => {
     if (message.status?.type !== "running") return null;
     const parts = message.parts;
+    // Most recent running tool wins, if any.
     for (let i = parts.length - 1; i >= 0; i -= 1) {
       const p = parts[i] as
         | { type?: string; toolName?: string; status?: { type?: string } }
         | undefined;
       if (p?.type === "tool-call" && p.status?.type === "running") {
-        return p.toolName ?? "tool";
+        return { kind: "tool" as const, name: p.toolName ?? "tool" };
       }
+    }
+    // No tool currently running, but message itself is still streaming.
+    // GeneratingIndicator only shows while content.length === 0, so once
+    // any text has rendered we lose its dots. Surface a generic "Working..."
+    // so the chat doesn't go silent between phases.
+    if (parts.length > 0) {
+      return { kind: "working" as const };
     }
     return null;
   });
-  if (!running) return null;
+  if (!state) return null;
   return (
     <div
       data-slot="running-tool-indicator"
@@ -1043,9 +1057,13 @@ const RunningToolIndicator: FC = () => {
         aria-hidden
         className="aui-running-tool-indicator-dot inline-block size-2 animate-pulse rounded-full bg-muted-foreground/60"
       />
-      <span>
-        Running <span className="font-mono text-xs">{running}</span>...
-      </span>
+      {state.kind === "tool" ? (
+        <span>
+          Running <span className="font-mono text-xs">{state.name}</span>...
+        </span>
+      ) : (
+        <span>Working...</span>
+      )}
     </div>
   );
 };

--- a/studio/frontend/src/components/assistant-ui/tool-fallback.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-fallback.tsx
@@ -314,8 +314,12 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
 
+  // Auto-open while running so args + streaming result are visible.
+  const defaultOpen = status?.type === "running";
+
   return (
     <ToolFallbackRoot
+      defaultOpen={defaultOpen}
       className={cn(isCancelled && "bg-muted/30")}
     >
       <ToolFallbackTrigger toolName={toolName} status={status} />

--- a/studio/frontend/src/components/assistant-ui/tool-group.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-group.tsx
@@ -3,11 +3,13 @@
 import {
   memo,
   useCallback,
+  useEffect,
   useRef,
   useState,
   type FC,
   type PropsWithChildren,
 } from "react";
+import { useAuiState } from "@assistant-ui/react";
 import { ChevronDownIcon, LoaderIcon } from "lucide-react";
 import { Wrench01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -210,14 +212,44 @@ const ToolGroupImpl: FC<
 > = ({ children, startIndex, endIndex }) => {
   const toolCount = endIndex - startIndex + 1;
 
-  // Single tool call — render directly without wrapper
+  // Any tool in this group running. Drives auto-open + trigger spin.
+  const hasRunning = useAuiState(({ message }) => {
+    const parts = message.parts;
+    for (let i = startIndex; i <= endIndex && i < parts.length; i += 1) {
+      const p = parts[i] as { type?: string; status?: { type?: string } } | undefined;
+      if (p?.type === "tool-call" && p.status?.type === "running") {
+        return true;
+      }
+    }
+    return false;
+  });
+
+  // Owning message still streaming. Keeps group sticky-open across
+  // back-to-back tool bursts where hasRunning flickers.
+  const messageStreaming = useAuiState(
+    ({ message }) => message.status?.type === "running",
+  );
+
+  const hasEverRunRef = useRef(false);
+  // Mutate ref in effect, not render, for StrictMode/concurrent safety.
+  useEffect(() => {
+    if (hasRunning) hasEverRunRef.current = true;
+    if (!messageStreaming) hasEverRunRef.current = false;
+  }, [hasRunning, messageStreaming]);
+
+  // Auto-follow sticky predicate until user clicks to override.
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+  const autoOpen = hasRunning || (messageStreaming && hasEverRunRef.current);
+  const isOpen = userOpen ?? autoOpen;
+
+  // Single tool call: render directly without wrapper.
   if (toolCount <= 1) {
     return <>{children}</>;
   }
 
   return (
-    <ToolGroupRoot>
-      <ToolGroupTrigger count={toolCount} />
+    <ToolGroupRoot open={isOpen} onOpenChange={setUserOpen}>
+      <ToolGroupTrigger count={toolCount} active={hasRunning} />
       <ToolGroupContent>{children}</ToolGroupContent>
     </ToolGroupRoot>
   );

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -523,19 +523,7 @@ export function SharedComposer({
       handlesRef.current["model1"] || handlesRef.current["model2"],
     );
     const isGeneralizedCompare =
-      hasCompareHandles && Boolean(model1?.id && model2?.id);
-
-    // Generalized compare requires both panes to have a model. A
-    // half-selected send either races to an empty bubble with bogus
-    // tok/s (#5569) or leaves the empty pane with a dangling prompt.
-    // hasCompareHandles is true only in GeneralCompareContent, so
-    // LoraCompare and single-pane chats are unaffected.
-    if (hasCompareHandles && !isGeneralizedCompare) {
-      toast.error("Pick a model in each pane to compare", {
-        description: "Use the model dropdown above each pane, then send your prompt.",
-      });
-      return;
-    }
+      hasCompareHandles && Boolean(model1?.id || model2?.id);
 
     if (pendingImages.length > 0 && !isGeneralizedCompare && imageUnavailableReason) {
       // Single mode: the loaded model's runtime capability is known
@@ -989,9 +977,11 @@ export function SharedComposer({
               aria-label={
                 reasoningLockedOn
                   ? "Thinking is required for this model"
-                  : effectiveReasoningEnabled
-                    ? "Disable thinking"
-                    : "Enable thinking"
+                  : reasoningDisabled
+                    ? "Thinking (model not loaded)"
+                    : effectiveReasoningEnabled
+                      ? "Disable thinking"
+                      : "Enable thinking"
               }
             >
               {reasoningLockedOn ||
@@ -1047,7 +1037,13 @@ export function SharedComposer({
             }}
             className="composer-pill-btn"
             data-active={toolsEnabled && !searchDisabled ? "true" : "false"}
-            aria-label={toolsEnabled ? "Disable web search" : "Enable web search"}
+            aria-label={
+              searchDisabled
+                ? "Web search (unavailable)"
+                : toolsEnabled
+                  ? "Disable web search"
+                  : "Enable web search"
+            }
           >
             <GlobeIcon className="size-3.5" />
             <span>Search</span>
@@ -1058,7 +1054,13 @@ export function SharedComposer({
             onClick={() => setCodeToolsEnabled(!codeToolsEnabled)}
             className="composer-pill-btn"
             data-active={codeToolsEnabled && !codeDisabled ? "true" : "false"}
-            aria-label={codeToolsEnabled ? "Disable code execution" : "Enable code execution"}
+            aria-label={
+              codeDisabled
+                ? "Code execution (unavailable)"
+                : codeToolsEnabled
+                  ? "Disable code execution"
+                  : "Enable code execution"
+            }
           >
             <CodeToggleIcon className="size-3.5" />
             <span>Code</span>

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -523,7 +523,19 @@ export function SharedComposer({
       handlesRef.current["model1"] || handlesRef.current["model2"],
     );
     const isGeneralizedCompare =
-      hasCompareHandles && Boolean(model1?.id || model2?.id);
+      hasCompareHandles && Boolean(model1?.id && model2?.id);
+
+    // Generalized compare requires both panes to have a model. A
+    // half-selected send either races to an empty bubble with bogus
+    // tok/s (#5569) or leaves the empty pane with a dangling prompt.
+    // hasCompareHandles is true only in GeneralCompareContent, so
+    // LoraCompare and single-pane chats are unaffected.
+    if (hasCompareHandles && !isGeneralizedCompare) {
+      toast.error("Pick a model in each pane to compare", {
+        description: "Use the model dropdown above each pane, then send your prompt.",
+      });
+      return;
+    }
 
     if (pendingImages.length > 0 && !isGeneralizedCompare && imageUnavailableReason) {
       // Single mode: the loaded model's runtime capability is known


### PR DESCRIPTION
## Summary

Tool-heavy responses can leave the chat area looking blank for tens of seconds with only an "N tool calls" counter ticking up, and a few small accessibility regressions in the composer compound the "stuck" feeling. This PR groups the safe UI fixes from the original scope; the two behaviour-changing pieces (autoscroll heuristic + chat-adapter `<think>` re-injection) have been split out for separate review.

## What'\''s in this PR

| File | Behavior before | Behavior after |
|---|---|---|
| `components/assistant-ui/reasoning.tsx` | Thinking panel hidden as soon as any text part trailed the reasoning block | Panel renders whenever a reasoning part exists in the group |
| `components/assistant-ui/thread.tsx` | No bottom-of-bubble activity indicator; Think aria-label read "Disable thinking" while disabled | New `RunningToolIndicator` row + correct `"Thinking (model not loaded)"` aria-label |
| `components/assistant-ui/tool-group.tsx` | Group flickered closed between back-to-back tool calls; defaulted closed otherwise | Sticky open while the assistant message is streaming and any tool has run; user click still overrides |
| `components/assistant-ui/tool-fallback.tsx` | Each tool row defaulted closed even while running | `defaultOpen` when `status.type === "running"` |
| `features/chat/shared-composer.tsx` | Think / Search / Code pills aria-labels inverted while disabled | Pre-load aria-labels read `"Thinking (model not loaded)"` / `"Web search (unavailable)"` / `"Code execution (unavailable)"` |

## What'\''s NOT in this PR (held back for separate review)

- **`use-intent-aware-autoscroll.tsx` heuristic rewrite** -- this would be the 6th scroll-behaviour fix in 2 months (#4543, #4545, #4587, #5089, #5127, now would be #5550). The heuristic is a fragile surface and codex caught two regressions on it during review (downward-wheel arming, no keyboard / scrollbar gesture). Splitting it lets that change land or revert independently.
- **`chat-adapter.ts` `<think>` re-injection on the local llama.cpp path** -- template-dependent. Most reasoning chat templates (Qwen3.5 default, DeepSeek-R1, etc.) intentionally strip prior `<think>` blocks; Qwen3.6'\''s `preserve_thinking` is the explicit escape hatch. Injecting unconditionally for the local path bypasses that per-model intent. A tighter version should gate the injection on the loaded model'\''s `supports_preserve_thinking` flag.

## Test plan

- [x] `bun run build` clean (2.06s).
- [x] Pre-model-load aria snapshot of composer pills reads `"Thinking (model not loaded)"` / `"Web search (unavailable)"` / `"Code execution (unavailable)"`.
- [x] During multi-tool bursts: tool-group `data-state` stays `"open"`, `RunningToolIndicator` renders the current tool name with one pulsing dot, disappears when no tool is running.
- [x] No conflicts with PR 5565 (`CancelledIndicator`) or PR 5599 (Dictate aria-label) which both touch `thread.tsx` and have already merged to main.