### PR TITLE
studio: engage MTP on *-MTP vision GGUF repos (temporary mmproj/vision bypass)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -485,6 +485,42 @@ def _extra_args_set_spec_type(extra_args: Optional[Iterable[str]]) -> bool:
     return False
 
 
+def _mtp_should_force_text_only(
+    *,
+    mtp_detected: bool,
+    effective_is_vision: bool,
+    supports_mtp: bool,
+    speculative_type: Optional[str],
+    extra_args: Optional[Iterable[str]],
+) -> bool:
+    """Temporary shim: should an MTP GGUF drop mmproj/vision to engage MTP?
+
+    llama.cpp MTP speculative decoding (``--spec-type draft-mtp``) does not
+    support ``--mmproj`` or ``-np > 1`` (llama.cpp #22673; the Qwen3.6 MTP
+    guide). Unsloth's ``*-MTP`` GGUF repos still ship an mmproj projector,
+    which pins ``effective_is_vision=True`` and therefore suppresses the
+    draft-mtp auto-promotion in ``load_model`` -- so the headline MTP
+    speedup never engages out of the box for those repos.
+
+    Return True only when we positively detect an MTP GGUF that would
+    otherwise be forced into vision mode, the bundled llama-server actually
+    advertises the MTP spec type, and the caller has not taken over
+    speculative decoding. Deliberately narrow so non-MTP GGUFs are never
+    affected, an explicit user ``--spec-type`` (or ``speculative_type``
+    other than auto/default/draft-mtp, including ``"off"``) opts out, and
+    an outdated binary falls back to today's behavior. Remove once
+    upstream llama.cpp supports mmproj + MTP together.
+    """
+    if not (mtp_detected and effective_is_vision and supports_mtp):
+        return False
+    spec = (speculative_type or "").strip().lower()
+    if spec not in ("", "default", "draft-mtp"):
+        return False
+    if _extra_args_set_spec_type(extra_args):
+        return False
+    return True
+
+
 class LlamaCppBackend:
     """
     Manages a llama-server subprocess for GGUF model inference.
@@ -2560,6 +2596,36 @@ class LlamaCppBackend:
                         "Vision-capable GGUF loaded without a usable mmproj; "
                         "image input will be disabled for this session"
                     )
+
+                # Temporary MTP/vision shim: llama.cpp MTP cannot run with
+                # --mmproj or -np > 1, but Unsloth *-MTP repos still ship an
+                # mmproj that would otherwise pin effective_is_vision=True and
+                # suppress draft-mtp auto-promotion below. When we positively
+                # detect an MTP GGUF, the binary supports MTP, and the caller
+                # has not taken over speculative decoding, fall back to
+                # text-only (no mmproj, single slot) so MTP can engage.
+                # Scoped so non-MTP GGUFs are untouched; drop once upstream
+                # supports mmproj + MTP. See llama.cpp #22673.
+                if _mtp_should_force_text_only(
+                    mtp_detected = bool(self._nextn_predict_layers)
+                    or _is_mtp_model_name(model_identifier, model_path),
+                    effective_is_vision = effective_is_vision,
+                    supports_mtp = bool(
+                        self.probe_server_capabilities(binary).get("supports_mtp")
+                    ),
+                    speculative_type = speculative_type,
+                    extra_args = extra_args,
+                ):
+                    logger.warning(
+                        "MTP GGUF detected: disabling mmproj/vision and "
+                        "forcing a single slot so --spec-type draft-mtp can "
+                        "engage (llama.cpp MTP does not support --mmproj or "
+                        "-np > 1). Image input is unavailable for this "
+                        "session; temporary until upstream supports both."
+                    )
+                    launch_mmproj_path = None
+                    effective_is_vision = False
+                    n_parallel = 1
 
                 cmd = [
                     binary,

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -54,6 +54,7 @@ from core.inference.llama_cpp import (
     LlamaCppBackend,
     _extra_args_set_spec_type,
     _is_mtp_model_name,
+    _mtp_should_force_text_only,
 )
 
 
@@ -494,3 +495,73 @@ def test_probe_server_capabilities_caches_by_mtime(tmp_path):
     caps2 = LlamaCppBackend.probe_server_capabilities(str(fake))
     assert caps2["mtp_token"] == "draft-mtp"
     assert caps2["supports_mtp"] is True
+
+
+# ── _mtp_should_force_text_only (temporary MTP/vision shim) ──────────
+
+
+def _shim(**over):
+    """Base = the case the shim exists for: MTP GGUF whose repo also
+    ships an mmproj, recent binary, no caller spec override."""
+    kw = dict(
+        mtp_detected=True,
+        effective_is_vision=True,
+        supports_mtp=True,
+        speculative_type=None,
+        extra_args=None,
+    )
+    kw.update(over)
+    return _mtp_should_force_text_only(**kw)
+
+
+def test_shim_engages_for_mtp_vision_repo_with_recent_binary():
+    assert _shim() is True
+
+
+@pytest.mark.parametrize("spec", [None, "", "default", "DEFAULT", "draft-mtp"])
+def test_shim_engages_for_auto_default_or_explicit_draft_mtp(spec):
+    assert _shim(speculative_type=spec) is True
+
+
+def test_shim_skips_non_mtp_model_entirely():
+    # The core guarantee: non-MTP GGUFs are never affected.
+    assert _shim(mtp_detected=False) is False
+
+
+def test_shim_skips_when_not_effective_vision():
+    # No mmproj would be attached anyway -> nothing to bypass; the
+    # existing draft-mtp auto-promotion already handles this case.
+    assert _shim(effective_is_vision=False) is False
+
+
+def test_shim_skips_when_binary_lacks_mtp():
+    # Outdated prebuilt: keep today's behavior (mmproj/vision), do not
+    # sacrifice image input for an MTP path the binary cannot run.
+    assert _shim(supports_mtp=False) is False
+
+
+def test_shim_opts_out_on_explicit_off():
+    assert _shim(speculative_type="off") is False
+
+
+@pytest.mark.parametrize("spec", ["ngram-mod", "ngram-simple", "something"])
+def test_shim_opts_out_on_explicit_non_mtp_spec(spec):
+    # User explicitly chose another speculative mode on a vision MTP
+    # model -> respect it, do not silently disable their mmproj.
+    assert _shim(speculative_type=spec) is False
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["--spec-type", "ngram-mod"],
+        ["--spec-type=draft-mtp"],
+        ["--spec-default"],
+    ],
+)
+def test_shim_opts_out_when_user_manages_spec_via_extra_args(extra_args):
+    assert _shim(extra_args=extra_args) is False
+
+
+def test_shim_passes_through_unrelated_extra_args():
+    assert _shim(extra_args=["--threads", "8", "--no-warmup"]) is True

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -504,11 +504,11 @@ def _shim(**over):
     """Base = the case the shim exists for: MTP GGUF whose repo also
     ships an mmproj, recent binary, no caller spec override."""
     kw = dict(
-        mtp_detected=True,
-        effective_is_vision=True,
-        supports_mtp=True,
-        speculative_type=None,
-        extra_args=None,
+        mtp_detected = True,
+        effective_is_vision = True,
+        supports_mtp = True,
+        speculative_type = None,
+        extra_args = None,
     )
     kw.update(over)
     return _mtp_should_force_text_only(**kw)
@@ -520,35 +520,35 @@ def test_shim_engages_for_mtp_vision_repo_with_recent_binary():
 
 @pytest.mark.parametrize("spec", [None, "", "default", "DEFAULT", "draft-mtp"])
 def test_shim_engages_for_auto_default_or_explicit_draft_mtp(spec):
-    assert _shim(speculative_type=spec) is True
+    assert _shim(speculative_type = spec) is True
 
 
 def test_shim_skips_non_mtp_model_entirely():
     # The core guarantee: non-MTP GGUFs are never affected.
-    assert _shim(mtp_detected=False) is False
+    assert _shim(mtp_detected = False) is False
 
 
 def test_shim_skips_when_not_effective_vision():
     # No mmproj would be attached anyway -> nothing to bypass; the
     # existing draft-mtp auto-promotion already handles this case.
-    assert _shim(effective_is_vision=False) is False
+    assert _shim(effective_is_vision = False) is False
 
 
 def test_shim_skips_when_binary_lacks_mtp():
     # Outdated prebuilt: keep today's behavior (mmproj/vision), do not
     # sacrifice image input for an MTP path the binary cannot run.
-    assert _shim(supports_mtp=False) is False
+    assert _shim(supports_mtp = False) is False
 
 
 def test_shim_opts_out_on_explicit_off():
-    assert _shim(speculative_type="off") is False
+    assert _shim(speculative_type = "off") is False
 
 
 @pytest.mark.parametrize("spec", ["ngram-mod", "ngram-simple", "something"])
 def test_shim_opts_out_on_explicit_non_mtp_spec(spec):
     # User explicitly chose another speculative mode on a vision MTP
     # model -> respect it, do not silently disable their mmproj.
-    assert _shim(speculative_type=spec) is False
+    assert _shim(speculative_type = spec) is False
 
 
 @pytest.mark.parametrize(
@@ -560,8 +560,8 @@ def test_shim_opts_out_on_explicit_non_mtp_spec(spec):
     ],
 )
 def test_shim_opts_out_when_user_manages_spec_via_extra_args(extra_args):
-    assert _shim(extra_args=extra_args) is False
+    assert _shim(extra_args = extra_args) is False
 
 
 def test_shim_passes_through_unrelated_extra_args():
-    assert _shim(extra_args=["--threads", "8", "--no-warmup"]) is True
+    assert _shim(extra_args = ["--threads", "8", "--no-warmup"]) is True


### PR DESCRIPTION
## Summary

llama.cpp MTP speculative decoding (`--spec-type draft-mtp`) does not support `--mmproj` or `-np > 1` (llama.cpp #22673; the Qwen3.6 MTP guide). Unsloth's `*-MTP` GGUF repos (for example `unsloth/Qwen3.6-27B-MTP-GGUF`) still ship an `mmproj-*.gguf` projector. On a normal load, `LlamaCppBackend.load_model` resolves that mmproj, sets `effective_is_vision=True`, and the existing draft-mtp auto-promotion (gated `not effective_is_vision`) is therefore suppressed.

Net effect today: the headline MTP speedup never engages out of the box for exactly the repos that advertise MTP. `--spec-type draft-mtp` is wired and tested, but for these vision-capable MTP repos the mmproj wins the gate and MTP is silently never used.

## Change

Add a narrowly-scoped, explicitly temporary shim. In `load_model`, right after `effective_is_vision` is computed and before the command is built: when we positively detect an MTP GGUF, the bundled llama-server actually advertises the MTP spec type, and the caller has not taken over speculative decoding, fall back to text-only for that session so draft-mtp can auto-enable:

- `launch_mmproj_path = None`
- `effective_is_vision = False`
- `n_parallel = 1`

A clear `logger.warning` states image input is unavailable for the session and that this is temporary until upstream supports mmproj + MTP together.

The decision is factored into a pure module-level helper `_mtp_should_force_text_only(...)` (same pattern as the existing `_is_mtp_model_name` / `_extra_args_set_spec_type`) so the contract is unit-testable without standing up a server.

## Why this cannot regress anything else

The helper returns `True` only when all of these hold, so it is inert outside the exact broken case:

- `mtp_detected` is true (`nextn_predict_layers` GGUF metadata or `-mtp` in the name). Non-MTP GGUFs short-circuit immediately and are never touched.
- `effective_is_vision` is true. If no usable mmproj would be attached there is nothing to bypass; the existing draft-mtp auto-promotion already handles that case unchanged.
- `supports_mtp` is true (probed from the bundled binary's `--help`). An outdated prebuilt keeps today's exact behavior (mmproj/vision preserved, existing outdated-binary warning still fires) rather than sacrificing image input for an MTP path the binary cannot run.
- The caller has not set `--spec-type`/`--spec-default` via `extra_args`, and `speculative_type` is one of auto/empty/`default`/`draft-mtp`. An explicit user spec choice, any non-MTP `speculative_type` (for example `ngram-mod`), or `"off"` opts out and preserves vision/mmproj.

## Testing

- 17 new gating cases in `studio/backend/tests/test_llama_cpp_mtp_detection.py` covering engage, the three skip conditions (non-MTP model, not effective-vision, binary lacks MTP), and the opt-outs (`off`, explicit non-MTP spec, user-managed `--spec-type`/`--spec-default` via extra args, plus unrelated extra args passing through).
- Full existing `test_llama_cpp_mtp_detection.py` + `test_llama_server_args.py` suites still green: 151 passed. `py_compile` clean.
- The exact llama-server command this shim produces (`-m <mtp.gguf> ... -np 1 --spec-type draft-mtp --spec-draft-n-max 6`, no `--mmproj`) was separately verified end to end on the bundled prebuilt binary (llama.cpp b9190) with `unsloth/Qwen3.6-27B-MTP-GGUF:UD-Q4_K_XL` on a B200: the server log confirms `creating MTP draft context` / `adding speculative implementation 'draft-mtp'` with draft acceptance around 0.93 and a measured decode-throughput gain over the baseline.

## Notes

This is deliberately a temporary shim (it disables image input for MTP vision repos). It should be removed once upstream llama.cpp supports `--mmproj` together with MTP. The scope is intentionally minimal so a future revert is a clean delete of one helper and one guarded block.

## Test plan

- [x] New unit tests pass on Python 3.13
- [x] Existing MTP + llama_server_args suites pass (151 passed), `py_compile` clean
- [x] Produced command verified to engage MTP end to end on the bundled binary with the Qwen3.6 MTP GGUF
- [ ] Maintainer review of the temporary-shim approach vs. a longer-term mmproj-aware MTP toggle
