### PR TITLE
Studio: replace qwen suggested with MTP variant and fix vram fitting badge

### DIFF
--- a/studio/backend/core/inference/defaults.py
+++ b/studio/backend/core/inference/defaults.py
@@ -6,15 +6,16 @@
 import utils.hardware.hardware as hw
 
 DEFAULT_MODELS_GGUF = [
+    "unsloth/Qwen3.6-27B-MTP-GGUF",
+    "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
     "unsloth/gemma-4-E2B-it-GGUF",
     "unsloth/gemma-4-E4B-it-GGUF",
     "unsloth/gemma-4-31B-it-GGUF",
     "unsloth/gemma-4-26B-A4B-it-GGUF",
-    "unsloth/Qwen3.6-35B-A3B-GGUF",
-    "unsloth/Qwen3.5-4B-GGUF",
-    "unsloth/Qwen3.5-9B-GGUF",
-    "unsloth/Qwen3.5-35B-A3B-GGUF",
-    "unsloth/Qwen3.5-0.8B-GGUF",
+    "unsloth/Qwen3.5-4B-MTP-GGUF",
+    "unsloth/Qwen3.5-9B-MTP-GGUF",
+    "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
+    "unsloth/Qwen3.5-0.8B-MTP-GGUF",
     "unsloth/Llama-3.2-1B-Instruct-GGUF",
     "unsloth/Llama-3.2-3B-Instruct-GGUF",
     "unsloth/Llama-3.1-8B-Instruct-GGUF",
@@ -24,15 +25,16 @@ DEFAULT_MODELS_GGUF = [
 ]
 
 DEFAULT_MODELS_STANDARD = [
+    "unsloth/Qwen3.6-27B-MTP-GGUF",
+    "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
     "unsloth/gemma-4-E2B-it-GGUF",
     "unsloth/gemma-4-E4B-it-GGUF",
     "unsloth/gemma-4-31B-it-GGUF",
     "unsloth/gemma-4-26B-A4B-it-GGUF",
-    "unsloth/Qwen3.6-35B-A3B-GGUF",
-    "unsloth/Qwen3.5-4B-GGUF",
-    "unsloth/Qwen3.5-9B-GGUF",
-    "unsloth/Qwen3.5-35B-A3B-GGUF",
-    "unsloth/Qwen3.5-0.8B-GGUF",
+    "unsloth/Qwen3.5-4B-MTP-GGUF",
+    "unsloth/Qwen3.5-9B-MTP-GGUF",
+    "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
+    "unsloth/Qwen3.5-0.8B-MTP-GGUF",
     "unsloth/gemma-4-E2B-it",
     "unsloth/gemma-4-E4B-it",
     "unsloth/gemma-4-31B-it",

--- a/studio/frontend/src/hooks/use-gpu-info.ts
+++ b/studio/frontend/src/hooks/use-gpu-info.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { apiUrl } from "@/lib/api-base";
+import { authFetch } from "@/features/auth";
 import { useEffect, useState } from "react";
 
 export interface GpuInfo {
@@ -28,7 +28,7 @@ async function fetchGpuOnce(): Promise<GpuInfo> {
 
   fetchPromise = (async () => {
     try {
-      const res = await fetch(apiUrl("/api/system"));
+      const res = await authFetch("/api/system");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       const gpuData = data?.gpu;


### PR DESCRIPTION
## Summary

- Point default Studio inference model lists at Unsloth `Qwen3.5-*-MTP-GGUF` repos (4B, 9B, 35B-A3B, 0.8B) instead of the non-MTP `-GGUF` names.


<img width="687" height="613" alt="image" src="https://github.com/user-attachments/assets/7e15fe73-dae6-481d-9553-7219f5f08d47" />

also fixed vram fitting badge: 
<img width="732" height="621" alt="image" src="https://github.com/user-attachments/assets/94145131-cdc9-4510-8bf7-e0db67998dfb" />


