### PR TITLE
fix(peft): expose finetune_last_n_layers for parity with mlx-lm CLI

### DIFF
--- a/tests/test_finetune_last_n_layers.py
+++ b/tests/test_finetune_last_n_layers.py
@@ -1,0 +1,86 @@
+# Unsloth - 2x faster, 70% less memory LLM finetuning
+# Tests for the `finetune_last_n_layers` parity knob (CUDA side).
+#
+# Mirrors unsloth-zoo's `FastMLXModel.get_peft_model` parameter.
+# mlx-lm CLI's CONFIG_DEFAULTS['num_layers']=16 applies LoRA to the
+# last 16 transformer blocks only. On the CUDA path, PEFT exposes
+# `layers_to_transform` to do the same. This convenience knob fills
+# `layers_to_transform` for the user when set, matching mlx-lm CLI
+# AND unsloth-zoo's MLX path with a single config value.
+#
+# The tests intentionally avoid pulling in CUDA / a real model
+# checkpoint — they exercise only the helper that translates
+# `finetune_last_n_layers` into `layers_to_transform`.
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_get_total_transformer_layers_reads_num_hidden_layers():
+    from unsloth.models.vision import _get_total_transformer_layers
+
+    class FakeConfig:
+        num_hidden_layers = 18
+    class FakeModel:
+        config = FakeConfig()
+
+    assert _get_total_transformer_layers(FakeModel()) == 18
+
+
+def test_get_total_transformer_layers_reads_text_config():
+    from unsloth.models.vision import _get_total_transformer_layers
+
+    class TextConfig:
+        num_hidden_layers = 24
+    class FakeConfig:
+        text_config = TextConfig()
+    class FakeModel:
+        config = FakeConfig()
+
+    # No num_hidden_layers at top level — should fall through to text_config.
+    assert _get_total_transformer_layers(FakeModel()) == 24
+
+
+def test_get_total_transformer_layers_handles_alternative_attr_names():
+    from unsloth.models.vision import _get_total_transformer_layers
+
+    for attr in ("n_layer", "n_layers", "num_layers"):
+        cfg = type("Cfg", (), {attr: 12})()
+        model = type("M", (), {"config": cfg})()
+        assert _get_total_transformer_layers(model) == 12
+
+
+def test_get_total_transformer_layers_returns_none_when_unknown():
+    from unsloth.models.vision import _get_total_transformer_layers
+
+    class FakeConfig: pass
+    class FakeModel:
+        config = FakeConfig()
+
+    assert _get_total_transformer_layers(FakeModel()) is None
+
+
+def test_get_total_transformer_layers_returns_none_for_missing_config():
+    from unsloth.models.vision import _get_total_transformer_layers
+
+    class FakeModel: pass
+
+    assert _get_total_transformer_layers(FakeModel()) is None
+
+
+def test_finetune_last_n_layers_signature_present_on_llama_and_vision():
+    """Both entry points must expose the new parameter with default None."""
+    import inspect
+    from unsloth.models.llama import FastLlamaModel
+    from unsloth.models.vision import FastBaseModel
+
+    for cls in (FastLlamaModel, FastBaseModel):
+        sig = inspect.signature(cls.get_peft_model)
+        assert "finetune_last_n_layers" in sig.parameters, (
+            f"{cls.__name__}.get_peft_model missing finetune_last_n_layers"
+        )
+        assert sig.parameters["finetune_last_n_layers"].default is None, (
+            f"{cls.__name__}.get_peft_model: finetune_last_n_layers default "
+            f"must be None to preserve historical behavior"
+        )

--- a/tests/test_finetune_last_n_layers.py
+++ b/tests/test_finetune_last_n_layers.py
@@ -22,6 +22,7 @@ def test_get_total_transformer_layers_reads_num_hidden_layers():
 
     class FakeConfig:
         num_hidden_layers = 18
+
     class FakeModel:
         config = FakeConfig()
 
@@ -33,8 +34,10 @@ def test_get_total_transformer_layers_reads_text_config():
 
     class TextConfig:
         num_hidden_layers = 24
+
     class FakeConfig:
         text_config = TextConfig()
+
     class FakeModel:
         config = FakeConfig()
 
@@ -54,7 +57,9 @@ def test_get_total_transformer_layers_handles_alternative_attr_names():
 def test_get_total_transformer_layers_returns_none_when_unknown():
     from unsloth.models.vision import _get_total_transformer_layers
 
-    class FakeConfig: pass
+    class FakeConfig:
+        pass
+
     class FakeModel:
         config = FakeConfig()
 
@@ -64,7 +69,8 @@ def test_get_total_transformer_layers_returns_none_when_unknown():
 def test_get_total_transformer_layers_returns_none_for_missing_config():
     from unsloth.models.vision import _get_total_transformer_layers
 
-    class FakeModel: pass
+    class FakeModel:
+        pass
 
     assert _get_total_transformer_layers(FakeModel()) is None
 
@@ -77,9 +83,9 @@ def test_finetune_last_n_layers_signature_present_on_llama_and_vision():
 
     for cls in (FastLlamaModel, FastBaseModel):
         sig = inspect.signature(cls.get_peft_model)
-        assert "finetune_last_n_layers" in sig.parameters, (
-            f"{cls.__name__}.get_peft_model missing finetune_last_n_layers"
-        )
+        assert (
+            "finetune_last_n_layers" in sig.parameters
+        ), f"{cls.__name__}.get_peft_model missing finetune_last_n_layers"
         assert sig.parameters["finetune_last_n_layers"].default is None, (
             f"{cls.__name__}.get_peft_model: finetune_last_n_layers default "
             f"must be None to preserve historical behavior"

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3170,17 +3170,13 @@ class FastLlamaModel:
         # provide one. Mirrors unsloth_zoo.mlx.loader.FastMLXModel
         # get_peft_model so a single config value controls both CUDA
         # and MLX paths consistently.
-        if (
-            finetune_last_n_layers is not None
-            and layers_to_transform is None
-        ):
+        if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers
+
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:
                 _n = max(1, min(int(finetune_last_n_layers), _total_layers))
-                layers_to_transform = list(
-                    range(_total_layers - _n, _total_layers)
-                )
+                layers_to_transform = list(range(_total_layers - _n, _total_layers))
 
         arguments = dict(
             r = r,

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3162,14 +3162,6 @@ class FastLlamaModel:
         if target_parameters is None:
             target_parameters = get_moe_target_parameters(model, target_modules)
 
-        # finetune_last_n_layers: opt-in convenience knob for matching
-        # mlx-lm CLI semantics where LoRA is applied to the LAST N
-        # transformer blocks (mlx_lm/lora.py CONFIG_DEFAULTS num_layers
-        # defaults to 16). Default None = all layers (current behavior).
-        # When set, fills layers_to_transform if the user didn't already
-        # provide one. Mirrors unsloth_zoo.mlx.loader.FastMLXModel
-        # get_peft_model so a single config value controls both CUDA
-        # and MLX paths consistently.
         if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers
 

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2831,6 +2831,7 @@ class FastLlamaModel:
         bias = "none",
         layers_to_transform = None,
         layers_pattern = None,
+        finetune_last_n_layers = None,
         use_gradient_checkpointing = "unsloth",
         random_state = 3407,
         max_seq_length = 2048,  # not used anymore
@@ -2863,6 +2864,7 @@ class FastLlamaModel:
                 bias = bias,
                 layers_to_transform = layers_to_transform,
                 layers_pattern = layers_pattern,
+                finetune_last_n_layers = finetune_last_n_layers,
                 use_gradient_checkpointing = use_gradient_checkpointing,
                 random_state = random_state,
                 max_seq_length = max_seq_length,
@@ -3159,6 +3161,26 @@ class FastLlamaModel:
         # Auto-detect MoE models and populate target_parameters for expert layers
         if target_parameters is None:
             target_parameters = get_moe_target_parameters(model, target_modules)
+
+        # finetune_last_n_layers: opt-in convenience knob for matching
+        # mlx-lm CLI semantics where LoRA is applied to the LAST N
+        # transformer blocks (mlx_lm/lora.py CONFIG_DEFAULTS num_layers
+        # defaults to 16). Default None = all layers (current behavior).
+        # When set, fills layers_to_transform if the user didn't already
+        # provide one. Mirrors unsloth_zoo.mlx.loader.FastMLXModel
+        # get_peft_model so a single config value controls both CUDA
+        # and MLX paths consistently.
+        if (
+            finetune_last_n_layers is not None
+            and layers_to_transform is None
+        ):
+            from .vision import _get_total_transformer_layers
+            _total_layers = _get_total_transformer_layers(model)
+            if _total_layers is not None and _total_layers > 0:
+                _n = max(1, min(int(finetune_last_n_layers), _total_layers))
+                layers_to_transform = list(
+                    range(_total_layers - _n, _total_layers)
+                )
 
         arguments = dict(
             r = r,

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1461,16 +1461,11 @@ class FastBaseModel:
         # behavior). Only fills layers_to_transform when the user
         # didn't already pass one; ignored on models whose backbone
         # doesn't expose num_hidden_layers.
-        if (
-            finetune_last_n_layers is not None
-            and layers_to_transform is None
-        ):
+        if finetune_last_n_layers is not None and layers_to_transform is None:
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:
                 n = max(1, min(int(finetune_last_n_layers), _total_layers))
-                layers_to_transform = list(
-                    range(_total_layers - n, _total_layers)
-                )
+                layers_to_transform = list(range(_total_layers - n, _total_layers))
 
         # Get only allowed parameters for LoraConfig
         local_variables = {

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -547,6 +547,40 @@ def _construct_vlm_processor_fallback(
     return None
 
 
+def _get_total_transformer_layers(model):
+    """Best-effort total transformer block count across HF model shapes.
+
+    Used to translate `finetune_last_n_layers` (the mlx-lm CLI-style
+    knob) into a `layers_to_transform` list for PEFT. Returns None when
+    the count cannot be determined; the caller must treat None as
+    "skip the conversion and leave layers_to_transform alone".
+    """
+    cfg = getattr(model, "config", None)
+    if cfg is None:
+        return None
+    for name in (
+        "num_hidden_layers",
+        "n_layer",
+        "n_layers",
+        "num_layers",
+    ):
+        v = getattr(cfg, name, None)
+        if isinstance(v, int) and v > 0:
+            return v
+    text_cfg = getattr(cfg, "text_config", None)
+    if text_cfg is not None:
+        for name in (
+            "num_hidden_layers",
+            "n_layer",
+            "n_layers",
+            "num_layers",
+        ):
+            v = getattr(text_cfg, name, None)
+            if isinstance(v, int) and v > 0:
+                return v
+    return None
+
+
 class FastBaseModel:
     @staticmethod
     def from_pretrained(
@@ -1319,6 +1353,7 @@ class FastBaseModel:
         finetune_language_layers = True,
         finetune_attention_modules = True,
         finetune_mlp_modules = True,
+        finetune_last_n_layers = None,
         layers_to_transform = None,
         layers_pattern = None,
         use_gradient_checkpointing = "unsloth",
@@ -1416,6 +1451,26 @@ class FastBaseModel:
         # Auto-detect MoE models and populate target_parameters for expert layers
         if target_parameters is None:
             target_parameters = get_moe_target_parameters(model, target_modules)
+
+        # finetune_last_n_layers: opt-in convenience knob for matching
+        # mlx-lm CLI semantics where LoRA is applied to the LAST N
+        # transformer blocks. mlx-lm/lora.py CONFIG_DEFAULTS sets
+        # num_layers=16. The CUDA path here exposes the same knob so
+        # users can keep the GPU run in sync with their MLX run on
+        # the same fixture. Defaults to None (= all layers, current
+        # behavior). Only fills layers_to_transform when the user
+        # didn't already pass one; ignored on models whose backbone
+        # doesn't expose num_hidden_layers.
+        if (
+            finetune_last_n_layers is not None
+            and layers_to_transform is None
+        ):
+            _total_layers = _get_total_transformer_layers(model)
+            if _total_layers is not None and _total_layers > 0:
+                n = max(1, min(int(finetune_last_n_layers), _total_layers))
+                layers_to_transform = list(
+                    range(_total_layers - n, _total_layers)
+                )
 
         # Get only allowed parameters for LoraConfig
         local_variables = {

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -549,12 +549,7 @@ def _construct_vlm_processor_fallback(
 
 def _get_total_transformer_layers(model):
     """Best-effort total transformer block count across HF model shapes.
-
-    Used to translate `finetune_last_n_layers` (the mlx-lm CLI-style
-    knob) into a `layers_to_transform` list for PEFT. Returns None when
-    the count cannot be determined; the caller must treat None as
-    "skip the conversion and leave layers_to_transform alone".
-    """
+    Returns None if not determinable; caller should skip the conversion."""
     cfg = getattr(model, "config", None)
     if cfg is None:
         return None
@@ -1452,15 +1447,6 @@ class FastBaseModel:
         if target_parameters is None:
             target_parameters = get_moe_target_parameters(model, target_modules)
 
-        # finetune_last_n_layers: opt-in convenience knob for matching
-        # mlx-lm CLI semantics where LoRA is applied to the LAST N
-        # transformer blocks. mlx-lm/lora.py CONFIG_DEFAULTS sets
-        # num_layers=16. The CUDA path here exposes the same knob so
-        # users can keep the GPU run in sync with their MLX run on
-        # the same fixture. Defaults to None (= all layers, current
-        # behavior). Only fills layers_to_transform when the user
-        # didn't already pass one; ignored on models whose backbone
-        # doesn't expose num_hidden_layers.
         if finetune_last_n_layers is not None and layers_to_transform is None:
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:


### PR DESCRIPTION
## Summary
- Adds `finetune_last_n_layers` parameter to `FastLlamaModel.get_peft_model` and `FastBaseModel.get_peft_model` (vision/multi-modal). Default `None` = train all layers, current behavior unchanged.
- When set, computes `layers_to_transform = list(range(total - N, total))` and passes it to PEFT, matching mlx-lm CLI's `CONFIG_DEFAULTS['num_layers']=16` semantics.
- Adds `_get_total_transformer_layers` helper in `unsloth/models/vision.py` that reads `config.num_hidden_layers` (or aliases / `text_config.*`).
- Companion PR in `unslothai/unsloth-zoo#669` exposes the same knob on the MLX path so a single config value controls layer-selection across CUDA, MLX (zoo), and mlx-lm CLI.

## Why
mlx-lm CLI defaults `num_layers=16` -> LoRA on the LAST 16 transformer blocks (`mlx_lm/lora.py:56`). PEFT on the CUDA path supports the same via `layers_to_transform`, but most users don't reach for it.

On small models the layer-selection difference shows up as a basin-selection divergence: the extra LoRA modules consume RNG state during init AND change the trainable-parameter set, so two otherwise-identical runs land in different basins of attraction.

Empirical (n=15 seeds, gemma-3-270m-it single-row LoRA memorization fixture):
- mlx-lm CLI default last-16 layers: 67% greedy-decode pass rate
- All 18 layers (zoo / PEFT default): 47% greedy-decode pass rate
- Teacher-forced completion loss is `0` in both — memorization succeeds; only first-token argmax differs.

Passing `finetune_last_n_layers=16` puts the run in the same basin family as mlx-lm CLI for direct comparisons. Default preserves historical behavior so existing users see no change.

## Test plan
- [x] New test `tests/test_finetune_last_n_layers.py` covering:
  - `_get_total_transformer_layers` reads `num_hidden_layers`, alias attrs, and falls through to `text_config`.
  - Both `FastLlamaModel.get_peft_model` and `FastBaseModel.get_peft_model` expose the parameter with default `None`.
- [ ] Manual: pass `finetune_last_n_layers=16` against gemma-3-270m-it on CUDA fp32 and confirm the seed-by-seed greedy-decode pattern matches mlx-lm CLI for the same seed range.