### PR TITLE
studio/frontend: show Generation stopped placeholder when cancelled mid-thinking

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -994,6 +994,26 @@ const GeneratingIndicator: FC = () => {
   return <span className="text-sm text-muted-foreground">Generating...</span>;
 };
 
+// Stop-before-visible-content terminal state. Without this, cancelling
+// while the model is still inside its think block leaves the bubble
+// empty except for the floating action row.
+const CancelledIndicator: FC = () => {
+  const show = useAuiState(
+    ({ message }) =>
+      message.content.length === 0 &&
+      message.status?.type === "incomplete" &&
+      message.status?.reason === "cancelled",
+  );
+  if (!show) {
+    return null;
+  }
+  return (
+    <span className="aui-cancelled-indicator text-sm italic text-muted-foreground">
+      Generation stopped.
+    </span>
+  );
+};
+
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root
@@ -1002,6 +1022,7 @@ const AssistantMessage: FC = () => {
     >
       <div className="aui-assistant-message-content wrap-break-word min-w-0 text-[#0d0d0d] dark:text-foreground leading-relaxed">
         <GeneratingIndicator />
+        <CancelledIndicator />
         <MessagePrimitive.Parts
           components={{
             Text: MarkdownText,

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -994,9 +994,7 @@ const GeneratingIndicator: FC = () => {
   return <span className="text-sm text-muted-foreground">Generating...</span>;
 };
 
-// Stop-before-visible-content terminal state. Without this, cancelling
-// while the model is still inside its think block leaves the bubble
-// empty except for the floating action row.
+// Placeholder when stop fires before any visible content (e.g. mid-think).
 const CancelledIndicator: FC = () => {
   const show = useAuiState(
     ({ message }) =>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1007,7 +1007,7 @@ const CancelledIndicator: FC = () => {
   }
   return (
     <span className="aui-cancelled-indicator text-sm italic text-muted-foreground">
-      Generation stopped.
+      Cancelled.
     </span>
   );
 };


### PR DESCRIPTION
Closes #5563.

## Summary

When the user clicks Stop before any visible content has streamed in (e.g. while the model is still inside its `<think>` block), the running indicator disappears but no Parts have rendered yet. The assistant bubble shows only the floating `AssistantActionBar` (Copy / Refresh / Delete / More) below the user prompt, with no message body and no terminal-state label. That is the exact failure mode behind the "tools work, but I don't see anything happening" bucket of reports.

## Fix

Add a sibling `CancelledIndicator` next to the existing `GeneratingIndicator` in `studio/frontend/src/components/assistant-ui/thread.tsx`. It fires when:

- `message.content.length === 0` AND
- `message.status?.type === "incomplete"` AND
- `message.status?.reason === "cancelled"`

and renders a muted italic `Generation stopped.` label. The terminal-state treatment is consistent with the existing patterns elsewhere in the codebase:

- `tool-fallback.tsx` already renders a `Cancelled tool` label when `status.reason === "cancelled"`.
- `reasoning.tsx` already collapses to a `Thought for N seconds` summary once streaming stops.

## Test plan

- [x] `bun install --frozen-lockfile` clean, `bun run build` succeeds (~2 s).
- [x] Manual repro: load `unsloth/Qwen3.5-4B-MTP-GGUF`, toggle Think on, send a long prompt, click Stop within ~3 s. Bubble now shows "Generation stopped." instead of just floating action buttons.
- [x] When cancellation happens after content has streamed in, `content.length > 0` short-circuits the indicator so it does not double up with the partial answer.
- [x] When the message finishes normally, `status.type !== "incomplete"` short-circuits the indicator.