### PR TITLE
studio/frontend: show Loading fallback instead of blank pane on lazy route navigation

### DIFF
--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -108,7 +108,7 @@ function RootLayout() {
                   transition={{ duration: 0.15 }}
                   className={`flex min-h-0 min-w-0 flex-1 basis-0 flex-col ${isChatRoute ? "overflow-hidden" : "overflow-visible"}`}
                 >
-                  <Suspense fallback={null}>
+                  <Suspense fallback={RouteFallback}>
                     <Outlet />
                   </Suspense>
                 </motion.div>

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -18,10 +18,8 @@ import { AnimatePresence, motion } from "motion/react";
 import { Suspense, useEffect, type ReactNode } from "react";
 import { AppProvider } from "../provider";
 
-// Shown while a lazy-loaded route bundle (Train / Recipes / Export) is
-// still being fetched. /chat imports its page synchronously so this
-// fallback never fires there. The plain text matches the rest of the
-// muted-foreground style used elsewhere in the app.
+// Fallback while a lazy route bundle (Train/Recipes/Export) loads.
+// /chat is synchronous and never hits this.
 const RouteFallback: ReactNode = (
   <div className="flex h-full min-h-0 flex-1 items-center justify-center text-muted-foreground text-sm">
     Loading...

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -15,8 +15,18 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "motion/react";
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, type ReactNode } from "react";
 import { AppProvider } from "../provider";
+
+// Shown while a lazy-loaded route bundle (Train / Recipes / Export) is
+// still being fetched. /chat imports its page synchronously so this
+// fallback never fires there. The plain text matches the rest of the
+// muted-foreground style used elsewhere in the app.
+const RouteFallback: ReactNode = (
+  <div className="flex h-full min-h-0 flex-1 items-center justify-center text-muted-foreground text-sm">
+    Loading...
+  </div>
+);
 
 const CHAT_ONLY_ALLOWED = new Set([
   "/",
@@ -72,7 +82,7 @@ function RootLayout() {
       <SettingsDialog />
       {hideNavbar ? (
         <main className="flex-1">
-          <Suspense fallback={null}>
+          <Suspense fallback={RouteFallback}>
             <Outlet />
           </Suspense>
         </main>


### PR DESCRIPTION
Closes #5567.

## Summary

Train (`/studio`), Recipes (`/data-recipes`), and Export (`/export`) are imported via `React.lazy()` in their respective `createRoute` calls. The Suspense boundary around `<Outlet />` in `__root.tsx` passes `fallback={null}`, so during the route-chunk download the user sees a fully blank pane next to the sidebar for 1-3 seconds. That is the "looks stuck" failure mode reported in #5567.

`/chat` does not have this problem because `chat.tsx` imports `ChatPage` synchronously - the bundle is already loaded by the time the user clicks the sidebar item.

## Fix

Replace `fallback={null}` on both Suspense boundaries (the `hideNavbar` branch and the sidebar layout branch) with a small centered "Loading..." label. Synchronous routes (`/chat`) never trigger Suspense so they are unaffected. Lazy routes now show a terminal-state placeholder while their chunk loads, matching the muted-foreground style used elsewhere in the app.

```diff
-          <Suspense fallback={null}>
+          <Suspense fallback={RouteFallback}>
             <Outlet />
           </Suspense>
```

with `RouteFallback` defined once at module scope as a centered "Loading..." in a `flex` container that fills the available height.

## Test plan

- [x] `bun run build` clean (~2 s, no new warnings introduced).
- [x] Repro before patch: `/studio`, `/data-recipes`, `/export` all measured `body_text_len=123` at t=1s after navigation, then jumped to 1100+ chars by t=2-3s. Screen was visually blank during the gap.
- [x] After patch: same routes show "Loading..." during the bundle fetch instead of a blank pane.
- [x] `/chat` unaffected (synchronous import never suspends).