### PR TITLE
studio/frontend: guard message-timing badge against unphysical tok/s

### DIFF
--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -38,9 +38,23 @@ export const MessageTiming: FC<{
   )?.custom as { serverTimings?: Record<string, number> } | undefined;
   const st = serverTimings?.serverTimings;
 
+  // Guard against unphysical readouts: llama.cpp can emit predicted_ms=0
+  // when a turn produced no real generation (e.g. a race-lost compare pane
+  // where the user message arrived after EOS), which makes
+  // predicted_per_second arithmetic explode into Infinity / 1000000+ tok/s.
+  // Require at least one predicted token AND a measurable ms before trusting
+  // the rate, and keep the value finite.
+  const predictedRate =
+    st?.predicted_per_second != null &&
+    Number.isFinite(st.predicted_per_second) &&
+    (st.predicted_n ?? 0) >= 1 &&
+    (st.predicted_ms ?? 0) >= 1
+      ? st.predicted_per_second
+      : undefined;
+
   // Badge text: show tok/s if available, otherwise total time
-  const badgeText = st?.predicted_per_second != null
-    ? `${st.predicted_per_second.toFixed(1)} tok/s`
+  const badgeText = predictedRate != null
+    ? `${predictedRate.toFixed(1)} tok/s`
     : formatTimingMs(timing.totalStreamTime);
 
   return (
@@ -93,11 +107,11 @@ export const MessageTiming: FC<{
                   </span>
                 </div>
               )}
-              {st?.predicted_per_second != null && (
+              {predictedRate != null && (
                 <div className="flex items-center justify-between gap-4">
                   <span className="text-muted-foreground">Speed</span>
                   <span className="font-mono tabular-nums">
-                    {st.predicted_per_second.toFixed(1)} tok/s
+                    {predictedRate.toFixed(1)} tok/s
                   </span>
                 </div>
               )}

--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -38,12 +38,8 @@ export const MessageTiming: FC<{
   )?.custom as { serverTimings?: Record<string, number> } | undefined;
   const st = serverTimings?.serverTimings;
 
-  // Guard against unphysical readouts: llama.cpp can emit predicted_ms=0
-  // when a turn produced no real generation (e.g. a race-lost compare pane
-  // where the user message arrived after EOS), which makes
-  // predicted_per_second arithmetic explode into Infinity / 1000000+ tok/s.
-  // Require at least one predicted token AND a measurable ms before trusting
-  // the rate, and keep the value finite.
+  // Guard unphysical tok/s: llama.cpp emits predicted_ms=0 on no-op
+  // turns, blowing the rate up to Infinity. Require >=1 token + >=1ms.
   const predictedRate =
     st?.predicted_per_second != null &&
     Number.isFinite(st.predicted_per_second) &&

--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -39,12 +39,11 @@ export const MessageTiming: FC<{
   const st = serverTimings?.serverTimings;
 
   // Guard unphysical tok/s: llama.cpp emits predicted_ms=0 on no-op
-  // turns, blowing the rate up to Infinity. Require >=1 token and a
-  // decode window of at least 10ms (real generation never finishes in
-  // less than that, so this filters race-lost panes without hiding
-  // legitimate fast paths like cache-hit single-token responses).
+  // turns, blowing the rate up to Infinity. Require >=1 token AND a
+  // non-zero decode window AND a finite rate. Fast cached single-token
+  // responses (sub-10ms) are legitimate and must stay visible.
   const hasPredicted =
-    (st?.predicted_n ?? 0) >= 1 && (st?.predicted_ms ?? 0) >= 10;
+    (st?.predicted_n ?? 0) >= 1 && (st?.predicted_ms ?? 0) > 0;
   const predictedRate =
     hasPredicted &&
     st?.predicted_per_second != null &&

--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -39,12 +39,16 @@ export const MessageTiming: FC<{
   const st = serverTimings?.serverTimings;
 
   // Guard unphysical tok/s: llama.cpp emits predicted_ms=0 on no-op
-  // turns, blowing the rate up to Infinity. Require >=1 token + >=1ms.
+  // turns, blowing the rate up to Infinity. Require >=1 token and a
+  // decode window of at least 10ms (real generation never finishes in
+  // less than that, so this filters race-lost panes without hiding
+  // legitimate fast paths like cache-hit single-token responses).
+  const hasPredicted =
+    (st?.predicted_n ?? 0) >= 1 && (st?.predicted_ms ?? 0) >= 10;
   const predictedRate =
+    hasPredicted &&
     st?.predicted_per_second != null &&
-    Number.isFinite(st.predicted_per_second) &&
-    (st.predicted_n ?? 0) >= 1 &&
-    (st.predicted_ms ?? 0) >= 1
+    Number.isFinite(st.predicted_per_second)
       ? st.predicted_per_second
       : undefined;
 
@@ -95,7 +99,7 @@ export const MessageTiming: FC<{
                   </span>
                 </div>
               )}
-              {st?.predicted_ms != null && (
+              {hasPredicted && st?.predicted_ms != null && (
                 <div className="flex items-center justify-between gap-4">
                   <span className="text-muted-foreground">Generation</span>
                   <span className="font-mono tabular-nums">


### PR DESCRIPTION
Guard MessageTiming badge against unphysical tok/s readings. llama.cpp can emit predicted_ms == 0 / predicted_n == 0 for a turn that produced no real generation (e.g. the race-lost Compare pane in #5569). The current code trusts predicted_per_second verbatim, so the empty bubble ends up advertising 1000000.0 tok/s. Require predicted_n >= 1, predicted_ms >= 1, and a finite rate before showing tok/s. Falls back to the formatted total stream time which already handles zero.