### PR TITLE
studio/frontend: compare composer blocks send when no model picked

### DIFF
--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -523,15 +523,21 @@ export function SharedComposer({
       handlesRef.current["model1"] || handlesRef.current["model2"],
     );
     const isGeneralizedCompare =
-      hasCompareHandles && Boolean(model1?.id || model2?.id);
+      hasCompareHandles && Boolean(model1?.id && model2?.id);
 
-    // Compare mode with neither pane having a model selected: the
-    // SharedComposer would otherwise fall through to the per-handle
-    // append branch, which races both panes into auto-loading the same
-    // model and leaves one pane with an empty bubble + 1000000 tok/s
-    // (issue #5569). Stop here and tell the user to pick models first
-    // so the per-pane picker state stays the source of truth.
-    if (hasCompareHandles && !isGeneralizedCompare && model1 !== undefined && model2 !== undefined) {
+    // Generalized compare mode requires BOTH panes to have a model
+    // selected. If either is empty:
+    //   - the per-handle racing dispatch produces an empty bubble + a
+    //     1000000 tok/s readout on the empty side (issue #5569).
+    //   - the half-selected case (one model picked, one empty) clears
+    //     the composer and leaves the empty pane with a dangling user
+    //     prompt and no response because startRun is only called for
+    //     the side with an id.
+    // Both are confusing UX, so block the send and tell the user to
+    // pick a model in each pane. hasCompareHandles is true only inside
+    // GeneralCompareContent, so LoraCompare and single-pane chats are
+    // unaffected.
+    if (hasCompareHandles && !isGeneralizedCompare) {
       toast.error("Pick a model in each pane to compare", {
         description: "Use the model dropdowns at the top of each pane, then send your prompt.",
       });

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -525,18 +525,11 @@ export function SharedComposer({
     const isGeneralizedCompare =
       hasCompareHandles && Boolean(model1?.id && model2?.id);
 
-    // Generalized compare mode requires BOTH panes to have a model
-    // selected. If either is empty:
-    //   - the per-handle racing dispatch produces an empty bubble + a
-    //     1000000 tok/s readout on the empty side (issue #5569).
-    //   - the half-selected case (one model picked, one empty) clears
-    //     the composer and leaves the empty pane with a dangling user
-    //     prompt and no response because startRun is only called for
-    //     the side with an id.
-    // Both are confusing UX, so block the send and tell the user to
-    // pick a model in each pane. hasCompareHandles is true only inside
-    // GeneralCompareContent, so LoraCompare and single-pane chats are
-    // unaffected.
+    // Generalized compare requires both panes to have a model. A
+    // half-selected send either races to an empty bubble with bogus
+    // tok/s (#5569) or leaves the empty pane with a dangling prompt.
+    // hasCompareHandles is true only in GeneralCompareContent, so
+    // LoraCompare and single-pane chats are unaffected.
     if (hasCompareHandles && !isGeneralizedCompare) {
       toast.error("Pick a model in each pane to compare", {
         description: "Use the model dropdowns at the top of each pane, then send your prompt.",

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -532,7 +532,7 @@ export function SharedComposer({
     // LoraCompare and single-pane chats are unaffected.
     if (hasCompareHandles && !isGeneralizedCompare) {
       toast.error("Pick a model in each pane to compare", {
-        description: "Use the model dropdowns at the top of each pane, then send your prompt.",
+        description: "Use the model dropdown above each pane, then send your prompt.",
       });
       return;
     }

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -525,6 +525,19 @@ export function SharedComposer({
     const isGeneralizedCompare =
       hasCompareHandles && Boolean(model1?.id || model2?.id);
 
+    // Compare mode with neither pane having a model selected: the
+    // SharedComposer would otherwise fall through to the per-handle
+    // append branch, which races both panes into auto-loading the same
+    // model and leaves one pane with an empty bubble + 1000000 tok/s
+    // (issue #5569). Stop here and tell the user to pick models first
+    // so the per-pane picker state stays the source of truth.
+    if (hasCompareHandles && !isGeneralizedCompare && model1 !== undefined && model2 !== undefined) {
+      toast.error("Pick a model in each pane to compare", {
+        description: "Use the model dropdowns at the top of each pane, then send your prompt.",
+      });
+      return;
+    }
+
     if (pendingImages.length > 0 && !isGeneralizedCompare && imageUnavailableReason) {
       // Single mode: the loaded model's runtime capability is known
       // here. Compare mode defers — each ensureModelLoaded below sets


### PR DESCRIPTION
## Summary

Resolves the racing-handle half of #5569. In Compare mode (GeneralCompare shell with model1/model2 props), sending a prompt before picking models in either pane previously fell through to the per-handle append branch, raced both panes into `autoLoadSmallestModel`, and left one pane with an empty bubble + `1000000.0 tok/s`. Per-pane picker state never observed the global checkpoint change either, so both pickers stayed at `Select model`.

Add a guard before the content build: when `handlesRef` has `model1` / `model2` keys but both selections are empty, surface a `Pick a model in each pane to compare` toast, leave the text in the composer for retry, and never enter the racing dispatch path. Keeps per-pane state as the source of truth for which model is on each side. The unphysical `tok/s` readout that the same path produced is separately covered by #5570.

## Test plan

- [x] tsc -b clean.
- [x] bun run build clean.
- [x] Deployed locally and re-ran `scripts/r6_compare_picker_probe.py`: confirmed the toast surfaces, no empty bubble appears, the composer keeps the typed prompt for retry. Screenshot in `outputs/studio_diag_r6/scenarios/compare_picker/shots/01_t02s.png`.
- [ ] Pick models in both panes and confirm the existing generalized-compare send path still works.
- [ ] LoraCompare flow (handles named `base` / `lora`) is unaffected because `handlesRef.current["model1"] || handlesRef.current["model2"]` stays false there.