### PR TITLE
studio/frontend: reconcile stale must_change_password localStorage flag

### DIFF
--- a/studio/frontend/src/app/auth-guards.ts
+++ b/studio/frontend/src/app/auth-guards.ts
@@ -9,6 +9,7 @@ import {
   hasRefreshToken,
   mustChangePassword,
   refreshSession,
+  setMustChangePassword,
 } from "@/features/auth";
 
 async function hasActiveSession(): Promise<boolean> {
@@ -26,7 +27,13 @@ async function fetchAuthStatus(): Promise<AuthStatus> {
   try {
     const res = await fetch(apiUrl("/api/auth/status"));
     if (!res.ok) return { initialized: true, requires_password_change: mustChangePassword() };
-    return (await res.json()) as AuthStatus;
+    const status = (await res.json()) as AuthStatus;
+    // Reconcile stale localStorage flag with server truth so the change-password
+    // gate cannot trap a user whose password was already rotated elsewhere.
+    if (!status.requires_password_change && mustChangePassword()) {
+      setMustChangePassword(false);
+    }
+    return status;
   } catch {
     return { initialized: true, requires_password_change: mustChangePassword() };
   }
@@ -61,6 +68,9 @@ export async function requireGuest(): Promise<void> {
     throw redirect({ to: "/chat" });
   }
   if (!(await hasActiveSession())) return;
+  // Reconcile the localStorage flag before routing so a stale flag cannot
+  // bounce an authenticated user back onto /change-password.
+  await fetchAuthStatus();
   throw redirect({ to: getPostAuthRoute() });
 }
 

--- a/studio/frontend/src/app/auth-guards.ts
+++ b/studio/frontend/src/app/auth-guards.ts
@@ -28,9 +28,9 @@ async function fetchAuthStatus(): Promise<AuthStatus> {
     const res = await fetch(apiUrl("/api/auth/status"));
     if (!res.ok) return { initialized: true, requires_password_change: mustChangePassword() };
     const status = (await res.json()) as AuthStatus;
-    // Server truth wins; clear stale localStorage flag.
-    if (!status.requires_password_change && mustChangePassword()) {
-      setMustChangePassword(false);
+    // Server truth wins; keep localStorage in sync both ways.
+    if (status.requires_password_change !== mustChangePassword()) {
+      setMustChangePassword(status.requires_password_change);
     }
     return status;
   } catch {

--- a/studio/frontend/src/app/auth-guards.ts
+++ b/studio/frontend/src/app/auth-guards.ts
@@ -28,8 +28,7 @@ async function fetchAuthStatus(): Promise<AuthStatus> {
     const res = await fetch(apiUrl("/api/auth/status"));
     if (!res.ok) return { initialized: true, requires_password_change: mustChangePassword() };
     const status = (await res.json()) as AuthStatus;
-    // Reconcile stale localStorage flag with server truth so the change-password
-    // gate cannot trap a user whose password was already rotated elsewhere.
+    // Server truth wins; clear stale localStorage flag.
     if (!status.requires_password_change && mustChangePassword()) {
       setMustChangePassword(false);
     }
@@ -68,8 +67,7 @@ export async function requireGuest(): Promise<void> {
     throw redirect({ to: "/chat" });
   }
   if (!(await hasActiveSession())) return;
-  // Reconcile the localStorage flag before routing so a stale flag cannot
-  // bounce an authenticated user back onto /change-password.
+  // Reconcile localStorage before routing.
   await fetchAuthStatus();
   throw redirect({ to: getPostAuthRoute() });
 }

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -65,7 +65,12 @@ async function redirectToAuth(): Promise<void> {
     const res = await fetch(apiUrl("/api/auth/status"));
     if (res.ok) {
       const data = (await res.json()) as { requires_password_change: boolean };
-      if (data.requires_password_change || mustChangePassword()) target = "/change-password";
+      // Server is the source of truth; drop a stale localStorage flag so a
+      // prior install does not pin redirects on /change-password.
+      if (!data.requires_password_change && mustChangePassword()) {
+        setMustChangePassword(false);
+      }
+      if (data.requires_password_change) target = "/change-password";
     }
   } catch {
     // Fall through to /login on error

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -65,9 +65,9 @@ async function redirectToAuth(): Promise<void> {
     const res = await fetch(apiUrl("/api/auth/status"));
     if (res.ok) {
       const data = (await res.json()) as { requires_password_change: boolean };
-      // Server truth wins; clear stale localStorage flag.
-      if (!data.requires_password_change && mustChangePassword()) {
-        setMustChangePassword(false);
+      // Server truth wins; keep localStorage in sync both ways.
+      if (data.requires_password_change !== mustChangePassword()) {
+        setMustChangePassword(data.requires_password_change);
       }
       if (data.requires_password_change) target = "/change-password";
     }

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -65,8 +65,7 @@ async function redirectToAuth(): Promise<void> {
     const res = await fetch(apiUrl("/api/auth/status"));
     if (res.ok) {
       const data = (await res.json()) as { requires_password_change: boolean };
-      // Server is the source of truth; drop a stale localStorage flag so a
-      // prior install does not pin redirects on /change-password.
+      // Server truth wins; clear stale localStorage flag.
       if (!data.requires_password_change && mustChangePassword()) {
         setMustChangePassword(false);
       }

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -105,8 +105,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
           setInitialized(result.initialized);
           setRequiresPasswordChange(result.requires_password_change);
 
-          // Drop stale localStorage flag so a prior install cannot pin the user
-          // on /change-password after the server has cleared the requirement.
+          // Server truth wins; clear stale localStorage flag.
           if (!result.requires_password_change && mustChangePassword()) {
             setMustChangePassword(false);
           }

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -105,9 +105,9 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
           setInitialized(result.initialized);
           setRequiresPasswordChange(result.requires_password_change);
 
-          // Server truth wins; clear stale localStorage flag.
-          if (!result.requires_password_change && mustChangePassword()) {
-            setMustChangePassword(false);
+          // Server truth wins; keep localStorage in sync both ways.
+          if (result.requires_password_change !== mustChangePassword()) {
+            setMustChangePassword(result.requires_password_change);
           }
 
           // Redirect between login ↔ change-password based on server state

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -105,12 +105,18 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
           setInitialized(result.initialized);
           setRequiresPasswordChange(result.requires_password_change);
 
+          // Drop stale localStorage flag so a prior install cannot pin the user
+          // on /change-password after the server has cleared the requirement.
+          if (!result.requires_password_change && mustChangePassword()) {
+            setMustChangePassword(false);
+          }
+
           // Redirect between login ↔ change-password based on server state
           if (mode === "login" && result.requires_password_change) {
             navigate({ to: "/change-password" });
             return;
           }
-          if (mode === "change-password" && !result.requires_password_change && !mustChangePassword()) {
+          if (mode === "change-password" && !result.requires_password_change) {
             navigate({ to: "/login" });
             return;
           }
@@ -163,14 +169,14 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
   const blockedByState =
     initialized === false ||
     (mode === "login" && requiresPasswordChange) ||
-    (mode === "change-password" && !requiresPasswordChange && !mustChangePassword());
+    (mode === "change-password" && !requiresPasswordChange);
 
   let helperText: string | null = null;
   if (initialized === false) {
     helperText = "Auth is still bootstrapping the default admin account.";
   } else if (isLoginMode && requiresPasswordChange) {
     helperText = "Sign in once with the seeded credentials to change the password.";
-  } else if (!isLoginMode && !requiresPasswordChange && !mustChangePassword()) {
+  } else if (!isLoginMode && !requiresPasswordChange) {
     helperText = "Password already updated. Use the login screen.";
   }
   const title = isLoginMode ? "Welcome back" : "Setup your account";


### PR DESCRIPTION
## Summary
- The Studio frontend stores `unsloth_auth_must_change_password` in `localStorage` and OR's it against the server's `requires_password_change` on every routing decision, but never clears the flag when the server flips it back to `false`. A user whose default admin password was already rotated keeps that flag and gets stuck on `/change-password` with no escape: "Back to login" bounces straight back via `requireGuest` -> `hasActiveSession` (key presence only) -> `getPostAuthRoute` (reads the stale flag).
- Patch the four spots that compare the flag to the server: when the server reports `requires_password_change=false`, drop the stale localStorage flag in the same call so the next route decision uses server truth.

## Root cause
The local flag is set whenever a login or refresh returns `must_change_password: true`. It is cleared on a successful change-password submit and on `clearAuthTokens()`, but not when the server independently reports the requirement has been lifted (other-browser change, `unsloth studio reset-password`, recreated auth DB). The route guards then OR the stale flag into every decision, which traps the user.

Repro:
1. Open Studio with the default admin while `must_change_password=true`. Log in; the flag lands in `localStorage`.
2. From another browser or the CLI, change/reset the password so the server flips `requires_password_change=false`.
3. Reopen Studio in the original browser. The user lands on `/change-password`. Clicking "Back to login" sends them right back.

## Files
- `studio/frontend/src/app/auth-guards.ts` -- `fetchAuthStatus` clears the local flag when server says false; `requireGuest` now reconciles before routing.
- `studio/frontend/src/features/auth/components/auth-form.tsx` -- `initializeAuthForm` mirrors the reconcile; redundant `|| mustChangePassword()` clauses removed now that the server is the source of truth.
- `studio/frontend/src/features/auth/api.ts` -- `redirectToAuth` does the same reconcile in the network-error fallback path.

## Test plan
- [ ] Build the frontend (`cd studio/frontend && npm install && npm run build`). It type-checks and produces a clean bundle.
- [ ] Fresh install, set a new admin password, then in DevTools set `localStorage.setItem('unsloth_auth_must_change_password', '1')` and reload. Confirm the user lands on `/chat`, not `/change-password`.
- [ ] Force `requires_password_change=true` on the server (`UPDATE auth_user SET must_change_password=1 WHERE username='unsloth';`). Reload. Confirm the user lands on `/change-password` and the flag is reset to `true` in localStorage after the call.
- [ ] Click "Back to login" from the change-password page with a stale local flag. Confirm no redirect loop.
