### PR TITLE
studio: regenerate desktop launcher on `unsloth studio update` (macOS + Linux + Windows)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -873,13 +873,9 @@ shell.Run cmd, 0, False
         }
     }
 
-    # Regenerate Start Menu / Desktop .lnk shortcuts + launch-studio scripts
-    # without touching the venv. Used by `unsloth studio update` so updates
-    # pick up new launcher logic the same way a fresh install would.
+    # Regen .lnk + launcher only; used by `unsloth studio update`.
     if ($ShortcutsOnly) {
-        if ($TauriMode) {
-            return
-        }
+        if ($TauriMode) { return }
         $UnslothExe = Join-Path $VenvDir "Scripts\unsloth.exe"
         if (-not (Test-Path -LiteralPath $UnslothExe)) {
             Write-Host "[ERROR] unsloth.exe missing at $UnslothExe; run install.ps1 first." -ForegroundColor Red

--- a/install.ps1
+++ b/install.ps1
@@ -879,7 +879,8 @@ shell.Run cmd, 0, False
         $UnslothExe = Join-Path $VenvDir "Scripts\unsloth.exe"
         if (-not (Test-Path -LiteralPath $UnslothExe)) {
             Write-Host "[ERROR] unsloth.exe missing at $UnslothExe; run install.ps1 first." -ForegroundColor Red
-            return (Exit-InstallFailure "unsloth.exe missing")
+            # throw (not Exit-InstallFailure) so non-Tauri callers see rc != 0.
+            throw "unsloth.exe missing"
         }
         New-StudioShortcuts -UnslothExePath $UnslothExe
         return

--- a/install.ps1
+++ b/install.ps1
@@ -92,6 +92,7 @@ function Install-UnslothStudio {
     $RepoRoot = ""
     $TauriMode = $false
     $SkipTorch = $false
+    $ShortcutsOnly = $false
     $argList = $args
     for ($i = 0; $i -lt $argList.Count; $i++) {
         switch ($argList[$i]) {
@@ -100,6 +101,7 @@ function Install-UnslothStudio {
             "--no-torch" { $SkipTorch = $true }
             "--verbose"  { $script:UnslothVerbose = $true }
             "-v"         { $script:UnslothVerbose = $true }
+            "--shortcuts-only" { $ShortcutsOnly = $true }
             "--package"  {
                 $i++
                 if ($i -ge $argList.Count) {
@@ -869,6 +871,22 @@ shell.Run cmd, 0, False
         } catch {
             substep "shortcut setup failed; skipping shortcuts: $($_.Exception.Message)" "Yellow"
         }
+    }
+
+    # Regenerate Start Menu / Desktop .lnk shortcuts + launch-studio scripts
+    # without touching the venv. Used by `unsloth studio update` so updates
+    # pick up new launcher logic the same way a fresh install would.
+    if ($ShortcutsOnly) {
+        if ($TauriMode) {
+            return
+        }
+        $UnslothExe = Join-Path $VenvDir "Scripts\unsloth.exe"
+        if (-not (Test-Path -LiteralPath $UnslothExe)) {
+            Write-Host "[ERROR] unsloth.exe missing at $UnslothExe; run install.ps1 first." -ForegroundColor Red
+            return (Exit-InstallFailure "unsloth.exe missing")
+        }
+        New-StudioShortcuts -UnslothExePath $UnslothExe
+        return
     }
 
     # ── Check winget ──

--- a/install.sh
+++ b/install.sh
@@ -1239,15 +1239,15 @@ step "platform" "$OS"
 # `unsloth studio update` so updates pick up new launcher logic the same way a
 # fresh install would.
 if [ "$_SHORTCUTS_ONLY" = true ]; then
-    if [ "$TAURI_MODE" = true ]; then
-        exit 0
+    # Skip shortcut regen in Tauri mode (the desktop app owns its own shortcuts).
+    if [ "$TAURI_MODE" != true ]; then
+        VENV_ABS_BIN="$VENV_DIR/bin"
+        if [ ! -x "$VENV_ABS_BIN/unsloth" ]; then
+            echo "ERROR: unsloth binary missing at $VENV_ABS_BIN/unsloth; run install.sh first." >&2
+            exit 1
+        fi
+        create_studio_shortcuts "$VENV_ABS_BIN/unsloth" "$OS"
     fi
-    VENV_ABS_BIN="$VENV_DIR/bin"
-    if [ ! -x "$VENV_ABS_BIN/unsloth" ]; then
-        echo "ERROR: unsloth binary missing at $VENV_ABS_BIN/unsloth; run install.sh first." >&2
-        exit 1
-    fi
-    create_studio_shortcuts "$VENV_ABS_BIN/unsloth" "$OS"
     exit 0
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,7 @@ TAURI_MODE=false
 _USER_PYTHON=""
 _NO_TORCH_FLAG=false
 _VERBOSE=false
+_SHORTCUTS_ONLY=false
 _next_is_package=false
 _next_is_python=false
 for arg in "$@"; do
@@ -65,6 +66,7 @@ for arg in "$@"; do
         --python) _next_is_python=true ;;
         --no-torch) _NO_TORCH_FLAG=true ;;
         --verbose|-v) _VERBOSE=true ;;
+        --shortcuts-only) _SHORTCUTS_ONLY=true ;;
     esac
 done
 
@@ -1232,6 +1234,22 @@ elif grep -qi microsoft /proc/version 2>/dev/null; then
     OS="wsl"
 fi
 step "platform" "$OS"
+
+# Regenerate desktop launcher / .app bundle without touching the venv. Used by
+# `unsloth studio update` so updates pick up new launcher logic the same way a
+# fresh install would.
+if [ "$_SHORTCUTS_ONLY" = true ]; then
+    if [ "$TAURI_MODE" = true ]; then
+        exit 0
+    fi
+    VENV_ABS_BIN="$VENV_DIR/bin"
+    if [ ! -x "$VENV_ABS_BIN/unsloth" ]; then
+        echo "ERROR: unsloth binary missing at $VENV_ABS_BIN/unsloth; run install.sh first." >&2
+        exit 1
+    fi
+    create_studio_shortcuts "$VENV_ABS_BIN/unsloth" "$OS"
+    exit 0
+fi
 
 # ── Architecture detection & Python version ──
 _ARCH=$(uname -m)

--- a/install.sh
+++ b/install.sh
@@ -1241,7 +1241,7 @@ if [ "$_SHORTCUTS_ONLY" = true ]; then
     if [ "$TAURI_MODE" != true ]; then
         VENV_ABS_BIN="$VENV_DIR/bin"
         if [ ! -x "$VENV_ABS_BIN/unsloth" ]; then
-            echo "ERROR: unsloth binary missing at $VENV_ABS_BIN/unsloth; run install.sh first." >&2
+            echo "ERROR: unsloth binary missing at '$VENV_ABS_BIN/unsloth'; run install.sh first." >&2
             exit 1
         fi
         create_studio_shortcuts "$VENV_ABS_BIN/unsloth" "$OS"

--- a/install.sh
+++ b/install.sh
@@ -1235,11 +1235,9 @@ elif grep -qi microsoft /proc/version 2>/dev/null; then
 fi
 step "platform" "$OS"
 
-# Regenerate desktop launcher / .app bundle without touching the venv. Used by
-# `unsloth studio update` so updates pick up new launcher logic the same way a
-# fresh install would.
+# Regen launcher/shortcuts only; used by `unsloth studio update`.
 if [ "$_SHORTCUTS_ONLY" = true ]; then
-    # Skip shortcut regen in Tauri mode (the desktop app owns its own shortcuts).
+    # Tauri owns its own shortcuts.
     if [ "$TAURI_MODE" != true ]; then
         VENV_ABS_BIN="$VENV_DIR/bin"
         if [ ! -x "$VENV_ABS_BIN/unsloth" ]; then

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1842,10 +1842,7 @@ if ($CuTag -eq "cpu") {
     }
 }
 
-# Free the running unsloth.exe entry point so pip can replace it. Windows
-# refuses to delete a mapped .exe, but any process (including this one) can
-# rename it -- the path-to-inode mapping is updated even while the image is
-# loaded by an ancestor (the user's `unsloth.exe studio update`).
+# Rename running unsloth.exe so pip can replace it (Windows refuses to delete a mapped .exe).
 $VenvScriptsDir = Join-Path $VenvDir "Scripts"
 $RunningUnslothExe = Join-Path $VenvScriptsDir "unsloth.exe"
 if (Test-Path -LiteralPath $RunningUnslothExe -PathType Leaf) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1842,6 +1842,24 @@ if ($CuTag -eq "cpu") {
     }
 }
 
+# Free the running unsloth.exe entry point so pip can replace it. Windows
+# refuses to delete a mapped .exe, but any process (including this one) can
+# rename it -- the path-to-inode mapping is updated even while the image is
+# loaded by an ancestor (the user's `unsloth.exe studio update`).
+$VenvScriptsDir = Join-Path $VenvDir "Scripts"
+$RunningUnslothExe = Join-Path $VenvScriptsDir "unsloth.exe"
+if (Test-Path -LiteralPath $RunningUnslothExe -PathType Leaf) {
+    $StaleUnslothExe = "$RunningUnslothExe.deleteme"
+    if (Test-Path -LiteralPath $StaleUnslothExe) {
+        Remove-Item -LiteralPath $StaleUnslothExe -Force -ErrorAction SilentlyContinue
+    }
+    try {
+        Rename-Item -LiteralPath $RunningUnslothExe -NewName "unsloth.exe.deleteme" -Force -ErrorAction Stop
+    } catch {
+        substep "could not rename unsloth.exe ($($_.Exception.Message)); pip may fail with WinError 32" "Yellow"
+    }
+}
+
 # Ordered heavy dependency installation -- shared cross-platform script
 substep "running ordered dependency installation..."
 python "$PSScriptRoot\install_python_stack.py"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1866,6 +1866,16 @@ $ErrorActionPreference = $prevEAP
 if ($stackExit -ne 0) {
     Write-Host "[FAILED] Python dependency installation failed (exit code $stackExit)" -ForegroundColor Red
     Write-Host "   Re-run the installer or check the error above for details." -ForegroundColor Red
+    # Restore the pre-rename unsloth.exe so the user keeps a working CLI.
+    if ((Test-Path -LiteralPath "$RunningUnslothExe.deleteme") -and
+        -not (Test-Path -LiteralPath $RunningUnslothExe)) {
+        try {
+            Rename-Item -LiteralPath "$RunningUnslothExe.deleteme" -NewName "unsloth.exe" -Force -ErrorAction Stop
+            substep "restored unsloth.exe after failed install"
+        } catch {
+            substep "could not restore unsloth.exe ($($_.Exception.Message))" "Yellow"
+        }
+    }
     exit 1
 }
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1867,13 +1867,25 @@ if ($stackExit -ne 0) {
     Write-Host "[FAILED] Python dependency installation failed (exit code $stackExit)" -ForegroundColor Red
     Write-Host "   Re-run the installer or check the error above for details." -ForegroundColor Red
     # Restore the pre-rename unsloth.exe so the user keeps a working CLI.
-    if ((Test-Path -LiteralPath "$RunningUnslothExe.deleteme") -and
-        -not (Test-Path -LiteralPath $RunningUnslothExe)) {
-        try {
-            Rename-Item -LiteralPath "$RunningUnslothExe.deleteme" -NewName "unsloth.exe" -Force -ErrorAction Stop
-            substep "restored unsloth.exe after failed install"
-        } catch {
-            substep "could not restore unsloth.exe ($($_.Exception.Message))" "Yellow"
+    # Treat a zero-byte exe as "pip half-wrote a broken binary" -- prefer the
+    # stale-but-working copy in .deleteme.
+    if (Test-Path -LiteralPath "$RunningUnslothExe.deleteme") {
+        $needRestore = -not (Test-Path -LiteralPath $RunningUnslothExe)
+        if (-not $needRestore) {
+            try {
+                $needRestore = (Get-Item -LiteralPath $RunningUnslothExe -ErrorAction Stop).Length -eq 0
+            } catch { $needRestore = $true }
+        }
+        if ($needRestore) {
+            try {
+                if (Test-Path -LiteralPath $RunningUnslothExe) {
+                    Remove-Item -LiteralPath $RunningUnslothExe -Force -ErrorAction SilentlyContinue
+                }
+                Rename-Item -LiteralPath "$RunningUnslothExe.deleteme" -NewName "unsloth.exe" -Force -ErrorAction Stop
+                substep "restored unsloth.exe after failed install"
+            } catch {
+                substep "could not restore unsloth.exe ($($_.Exception.Message))" "Yellow"
+            }
         }
     }
     exit 1

--- a/studio/src-tauri/src/update.rs
+++ b/studio/src-tauri/src/update.rs
@@ -65,6 +65,10 @@ fn spawn_update(
     // the same install the desktop app uses, not an inherited custom root.
     cmd.env_remove("UNSLOTH_STUDIO_HOME");
     cmd.env_remove("STUDIO_HOME");
+    // Signal to unsloth_cli that this update was initiated by the Tauri
+    // desktop bundle so it skips re-creating CLI launchers/.app/.desktop
+    // shortcuts (Tauri owns its own bundle entries).
+    cmd.env("UNSLOTH_TAURI_UPDATE", "1");
 
     #[cfg(windows)]
     let mut child: Box<dyn ChildWrapper + Send> = {

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1176,8 +1176,11 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # Write to a UTF-8 BOM tempfile and use -File rather than -Command -.
         # `powershell.exe -Command -` reads stdin via [Console]::InputEncoding
         # (CP1252/OEM on most Windows boxes), which mangles box-drawing chars
-        # in install.ps1. -File reads the BOM and decodes correctly.
-        ps1_fd, ps1_path = tempfile.mkstemp(suffix = ".ps1")
+        # in install.ps1. -File reads the BOM and decodes correctly. The
+        # prefix gives AV/EDR engines (and grep'ing users) a clear identity.
+        ps1_fd, ps1_path = tempfile.mkstemp(
+            prefix = "unsloth-studio-refresh-", suffix = ".ps1",
+        )
         try:
             with os.fdopen(ps1_fd, "wb") as fh:
                 fh.write(b"\xef\xbb\xbf" + wrapper.encode("utf-8"))
@@ -1301,6 +1304,15 @@ def update(
         # produced a replacement; otherwise the user has no CLI for recovery.
         _restore_self_exe_lock_windows()
         raise
+    # On Windows clear the .deleteme orphan now that pip wrote a fresh
+    # unsloth.exe; on next update os.replace would overwrite it anyway,
+    # but leaving a stale binary around invites cross-version restore
+    # confusion from _restore_self_exe_lock_windows.
+    _cleanup_self_exe_lock_windows()
+    # Tauri desktop owns its own bundle entries; skip CLI launcher refresh
+    # so a Tauri-initiated update doesn't create duplicate shortcuts.
+    if os.environ.get("UNSLOTH_TAURI_UPDATE") == "1":
+        return
     _refresh_desktop_shortcuts(verbose = verbose)
 
 
@@ -1349,6 +1361,21 @@ def _restore_self_exe_lock_windows() -> None:
         os.replace(stale, exe)
     except OSError as e:
         print(f"[update] could not restore {stale.name} -> {exe.name}: {e}")
+
+
+def _cleanup_self_exe_lock_windows() -> None:
+    """Remove the .deleteme orphan after a successful update on Windows."""
+    if platform.system() != "Windows":
+        return
+    try:
+        venv_scripts = Path(sys.executable).resolve().parent
+    except OSError:
+        return
+    stale = (venv_scripts / "unsloth.exe").with_suffix(".exe.deleteme")
+    try:
+        stale.unlink(missing_ok = True)
+    except OSError:
+        pass
 
 
 # ── unsloth studio reset-password ────────────────────────────────────

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1179,7 +1179,8 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # in install.ps1. -File reads the BOM and decodes correctly. The
         # prefix gives AV/EDR engines (and grep'ing users) a clear identity.
         ps1_fd, ps1_path = tempfile.mkstemp(
-            prefix = "unsloth-studio-refresh-", suffix = ".ps1",
+            prefix = "unsloth-studio-refresh-",
+            suffix = ".ps1",
         )
         try:
             with os.fdopen(ps1_fd, "wb") as fh:

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1236,8 +1236,40 @@ def update(
     else:
         os.environ["STUDIO_LOCAL_INSTALL"] = "0"
         os.environ.pop("STUDIO_LOCAL_REPO", None)
+    _release_self_exe_lock_windows()
     _run_setup_script(verbose = verbose)
     _refresh_desktop_shortcuts(verbose = verbose)
+
+
+def _release_self_exe_lock_windows() -> None:
+    """Rename the running unsloth.exe out of the way so pip's reinstall can
+    drop a new copy on Windows.
+
+    Windows refuses to delete an .exe whose image is mapped into a running
+    process, but allows renaming it. pip's editable reinstall otherwise fails
+    with WinError 32 on the second `unsloth studio update` run inside the
+    same shim. The leftover *.exe.deleteme is unlinked at the start of the
+    next update once the shim it belonged to has exited.
+    """
+    if platform.system() != "Windows":
+        return
+    try:
+        venv_scripts = Path(sys.executable).resolve().parent
+    except OSError:
+        return
+    exe = venv_scripts / "unsloth.exe"
+    if not exe.exists():
+        return
+    stale = exe.with_suffix(".exe.deleteme")
+    try:
+        if stale.exists():
+            stale.unlink()
+    except OSError:
+        pass
+    try:
+        exe.rename(stale)
+    except OSError:
+        pass
 
 
 # ── unsloth studio reset-password ────────────────────────────────────

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1068,10 +1068,7 @@ def _run_setup_script(*, verbose: bool = False) -> None:
 
 
 def _print_windows_exe_lock_hint_if_relevant() -> None:
-    """When pip's reinstall fails because unsloth.exe is locked, point users
-    at the python -m workaround. Best-effort: detection looks for our running
-    unsloth.exe in the venv Scripts dir and assumes pip's WinError 32 lock.
-    """
+    """On WinError 32, point users at the python -c workaround."""
     if platform.system() != "Windows":
         return
     try:
@@ -1095,14 +1092,7 @@ _INSTALLER_URL_PWSH = "https://unsloth.ai/install.ps1"
 
 
 def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
-    """Re-run installer shortcut creation so updates refresh the launcher.
-
-    setup.sh / setup.ps1 only touch the venv; the macOS .app bundle, the Linux
-    .desktop entry, the Windows Start Menu / Desktop .lnk shortcuts, and the
-    shared launcher script all bake their paths at install time. Without this
-    call, `unsloth studio update` leaves the user's icon pointing at the old
-    install.
-    """
+    """Re-run installer with --shortcuts-only to refresh launchers post-update."""
     env = {**os.environ}
     if verbose:
         env["UNSLOTH_VERBOSE"] = "1"
@@ -1111,8 +1101,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
     installer_name = "install.ps1" if is_windows else "install.sh"
     installer_url = _INSTALLER_URL_PWSH if is_windows else _INSTALLER_URL_BASH
 
-    # Local install: reuse the installer from the same checkout (matches the
-    # behavior of `install.{sh,ps1} --local` and avoids a network fetch).
+    # Prefer local checkout, fall back to package dir, then network fetch.
     local_repo = (os.environ.get("STUDIO_LOCAL_REPO") or "").strip()
     candidates: list[Path] = []
     if local_repo:
@@ -1153,8 +1142,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
             except OSError:
                 continue
 
-        # PyPI installs do not ship install.ps1; fetch the upstream copy and
-        # invoke it from stdin via Invoke-Expression.
+        # PyPI installs lack install.ps1: fetch + pipe to powershell stdin.
         try:
             request = urllib.request.Request(
                 installer_url, headers = {"User-Agent": "unsloth-studio-update"}
@@ -1167,9 +1155,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
             )
             return
 
-        # install.ps1 wraps everything in Install-UnslothStudio and invokes it
-        # with @args at the bottom. From an Invoke-Expression-style stdin
-        # pipe, $args is empty, so append an explicit call with our flags.
+        # stdin-piped scripts have empty $args, so call Install-UnslothStudio explicitly.
         marker_args = " ".join(args)
         wrapper = installer + f"\nInstall-UnslothStudio {marker_args}\n"
         argv = list(ps_argv)
@@ -1195,7 +1181,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         except OSError:
             continue
 
-    # PyPI installs do not ship install.sh; fetch the upstream copy.
+    # PyPI installs lack install.sh: fetch upstream.
     try:
         request = urllib.request.Request(
             installer_url, headers = {"User-Agent": "unsloth-studio-update"}
@@ -1266,17 +1252,13 @@ def update(
 
 
 def _release_self_exe_lock_windows() -> None:
-    """Rename the running unsloth.exe out of the way so pip's reinstall can
-    drop a new copy on Windows. setup.ps1 also retries this from its own
-    PowerShell process, which is the truly reliable path.
-    """
+    """Rename running unsloth.exe so pip can replace it. setup.ps1 also retries."""
     if platform.system() != "Windows":
         return
     try:
         venv_scripts = Path(sys.executable).resolve().parent
     except OSError:
         return
-    # python.exe sits in the venv Scripts dir alongside unsloth.exe
     exe = venv_scripts / "unsloth.exe"
     if not exe.exists():
         return
@@ -1289,7 +1271,7 @@ def _release_self_exe_lock_windows() -> None:
     try:
         exe.rename(stale)
     except OSError as e:
-        # Not fatal -- setup.ps1 retries the rename from a sibling process.
+        # Not fatal; setup.ps1 retries from a sibling process.
         print(f"[update] could not rename {exe.name} -> {stale.name}: {e}")
 
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1064,29 +1064,7 @@ def _run_setup_script(*, verbose: bool = False) -> None:
         result = subprocess.run(["bash", str(script)], env = env)
 
     if result.returncode != 0:
-        _print_windows_exe_lock_hint_if_relevant()
         raise typer.Exit(result.returncode)
-
-
-def _print_windows_exe_lock_hint_if_relevant() -> None:
-    """On WinError 32, point users at the python -c workaround."""
-    if platform.system() != "Windows":
-        return
-    try:
-        venv_scripts = Path(sys.executable).resolve().parent
-    except OSError:
-        return
-    exe = venv_scripts / "unsloth.exe"
-    if not exe.exists():
-        return
-    typer.echo("")
-    typer.echo("Windows holds unsloth.exe open while it is running, so pip")
-    typer.echo("cannot replace it. Re-run the update via the venv python:")
-    typer.echo(
-        f'    {sys.executable} -c "from unsloth_cli import app; '
-        "app(['studio', 'update'])\""
-    )
-    typer.echo("(append '--local' inside the list if you installed from a checkout)")
 
 
 _INSTALLER_URL_BASH = "https://unsloth.ai/install.sh"
@@ -1179,8 +1157,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # in install.ps1. -File reads the BOM and decodes correctly. The
         # prefix gives AV/EDR engines (and grep'ing users) a clear identity.
         ps1_fd, ps1_path = tempfile.mkstemp(
-            prefix = "unsloth-studio-refresh-",
-            suffix = ".ps1",
+            prefix = "unsloth-studio-refresh-", suffix = ".ps1",
         )
         try:
             with os.fdopen(ps1_fd, "wb") as fh:
@@ -1313,6 +1290,8 @@ def update(
     # Tauri desktop owns its own bundle entries; skip CLI launcher refresh
     # so a Tauri-initiated update doesn't create duplicate shortcuts.
     if os.environ.get("UNSLOTH_TAURI_UPDATE") == "1":
+        if verbose:
+            typer.echo("  refresh-launcher  skipped (Tauri update)")
         return
     _refresh_desktop_shortcuts(verbose = verbose)
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1086,6 +1086,7 @@ def _print_windows_exe_lock_hint_if_relevant() -> None:
         f'    {sys.executable} -c "from unsloth_cli import app; '
         "app(['studio', 'update'])\""
     )
+    typer.echo("(append '--local' inside the list if you installed from a checkout)")
 
 
 _INSTALLER_URL_BASH = "https://unsloth.ai/install.sh"
@@ -1171,26 +1172,37 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # stdin-piped scripts have empty $args, so call Install-UnslothStudio explicitly.
         marker_args = " ".join(args)
         wrapper = installer + f"\nInstall-UnslothStudio {marker_args}\n"
-        argv = list(ps_argv)
-        argv.extend(["-ExecutionPolicy", "Bypass", "-Command", "-"])
+
+        # Write to a UTF-8 BOM tempfile and use -File rather than -Command -.
+        # `powershell.exe -Command -` reads stdin via [Console]::InputEncoding
+        # (CP1252/OEM on most Windows boxes), which mangles box-drawing chars
+        # in install.ps1. -File reads the BOM and decodes correctly.
+        ps1_fd, ps1_path = tempfile.mkstemp(suffix = ".ps1")
         try:
-            # encoding="utf-8" so box-drawing chars in the script body don't
-            # raise UnicodeEncodeError on CP1252-locale Windows boxes.
-            result = subprocess.run(
-                argv,
-                input = wrapper,
-                text = True,
-                encoding = "utf-8",
-                env = env,
-                check = False,
-                **_windows_hidden_subprocess_kwargs(),
-            )
-            if result.returncode != 0:
-                typer.echo(
-                    f"  refresh-launcher  fetched install.ps1 exited {result.returncode}"
+            with os.fdopen(ps1_fd, "wb") as fh:
+                fh.write(b"\xef\xbb\xbf" + wrapper.encode("utf-8"))
+            argv = list(ps_argv)
+            argv.extend(["-ExecutionPolicy", "Bypass", "-File", ps1_path])
+            try:
+                result = subprocess.run(
+                    argv,
+                    env = env,
+                    check = False,
+                    **_windows_hidden_subprocess_kwargs(),
                 )
-        except OSError as exc:
-            typer.echo(f"  refresh-launcher  skipped: powershell exec failed ({exc})")
+                if result.returncode != 0:
+                    typer.echo(
+                        f"  refresh-launcher  fetched install.ps1 exited {result.returncode}"
+                    )
+            except OSError as exc:
+                typer.echo(
+                    f"  refresh-launcher  skipped: powershell exec failed ({exc})"
+                )
+        finally:
+            try:
+                os.unlink(ps1_path)
+            except OSError:
+                pass
         return
 
     for script in candidates:
@@ -1305,19 +1317,16 @@ def _release_self_exe_lock_windows() -> None:
         return
     stale = exe.with_suffix(".exe.deleteme")
     try:
-        if stale.exists():
-            stale.unlink()
-    except OSError:
-        pass
-    try:
-        exe.rename(stale)
+        # os.replace is atomic-overwrite on Windows; os.rename would raise
+        # FileExistsError if a prior aborted update left a .deleteme behind.
+        os.replace(exe, stale)
     except OSError as e:
         # Not fatal; setup.ps1 retries from a sibling process.
         print(f"[update] could not rename {exe.name} -> {stale.name}: {e}")
 
 
 def _restore_self_exe_lock_windows() -> None:
-    """If setup failed before pip wrote a new unsloth.exe, restore .deleteme."""
+    """If setup failed before pip wrote a working unsloth.exe, restore .deleteme."""
     if platform.system() != "Windows":
         return
     try:
@@ -1326,10 +1335,18 @@ def _restore_self_exe_lock_windows() -> None:
         return
     exe = venv_scripts / "unsloth.exe"
     stale = exe.with_suffix(".exe.deleteme")
-    if exe.exists() or not stale.exists():
+    if not stale.exists():
         return
+    # Treat a missing or zero-byte exe as "pip didn't produce a usable
+    # replacement"; otherwise leave the new binary alone.
+    if exe.exists():
+        try:
+            if exe.stat().st_size > 0:
+                return
+        except OSError:
+            return
     try:
-        stale.rename(exe)
+        os.replace(stale, exe)
     except OSError as e:
         print(f"[update] could not restore {stale.name} -> {exe.name}: {e}")
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1113,8 +1113,10 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
                     argv = list(ps_argv)
                     argv.extend(
                         [
-                            "-ExecutionPolicy", "Bypass",
-                            "-Command", f"& '{quoted}' {' '.join(args)} *>&1",
+                            "-ExecutionPolicy",
+                            "Bypass",
+                            "-Command",
+                            f"& '{quoted}' {' '.join(args)} *>&1",
                         ]
                     )
                     subprocess.run(

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1066,37 +1066,100 @@ def _run_setup_script(*, verbose: bool = False) -> None:
         raise typer.Exit(result.returncode)
 
 
-_INSTALLER_URL = "https://unsloth.ai/install.sh"
+_INSTALLER_URL_BASH = "https://unsloth.ai/install.sh"
+_INSTALLER_URL_PWSH = "https://unsloth.ai/install.ps1"
 
 
 def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
     """Re-run installer shortcut creation so updates refresh the launcher.
 
-    setup.sh only touches the venv; the macOS .app bundle, the Linux .desktop
-    entry, and the shared launch-studio.sh stub bake their paths at install
-    time. Without this call, `unsloth studio update` leaves the user's icon
-    pointing at the old install.
+    setup.sh / setup.ps1 only touch the venv; the macOS .app bundle, the Linux
+    .desktop entry, the Windows Start Menu / Desktop .lnk shortcuts, and the
+    shared launcher script all bake their paths at install time. Without this
+    call, `unsloth studio update` leaves the user's icon pointing at the old
+    install.
     """
-    # Windows: setup.ps1 already owns Start Menu / Desktop .lnk creation on
-    # update, so no extra step is needed.
-    if platform.system() == "Windows":
-        return
-
     env = {**os.environ}
     if verbose:
         env["UNSLOTH_VERBOSE"] = "1"
 
-    # Local install: reuse the install.sh from the same checkout (matches the
-    # behavior of `install.sh --local` and avoids a network fetch).
+    is_windows = platform.system() == "Windows"
+    installer_name = "install.ps1" if is_windows else "install.sh"
+    installer_url = _INSTALLER_URL_PWSH if is_windows else _INSTALLER_URL_BASH
+
+    # Local install: reuse the installer from the same checkout (matches the
+    # behavior of `install.{sh,ps1} --local` and avoids a network fetch).
     local_repo = (os.environ.get("STUDIO_LOCAL_REPO") or "").strip()
     candidates: list[Path] = []
     if local_repo:
-        candidates.append(Path(local_repo) / "install.sh")
-    candidates.append(_PACKAGE_ROOT / "install.sh")
+        candidates.append(Path(local_repo) / installer_name)
+    candidates.append(_PACKAGE_ROOT / installer_name)
 
     args = ["--shortcuts-only"]
     if verbose:
         args.append("--verbose")
+
+    if is_windows:
+        ps_argv: list[str] = ["powershell.exe"]
+        if _should_hide_windows_subprocesses():
+            ps_argv.extend(
+                ["-NoLogo", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden"]
+            )
+
+        for script in candidates:
+            try:
+                if script.is_file():
+                    quoted = str(script).replace("'", "''")
+                    argv = list(ps_argv)
+                    argv.extend(
+                        [
+                            "-ExecutionPolicy", "Bypass",
+                            "-Command", f"& '{quoted}' {' '.join(args)} *>&1",
+                        ]
+                    )
+                    subprocess.run(
+                        argv,
+                        env = env,
+                        check = False,
+                        **_windows_hidden_subprocess_kwargs(),
+                    )
+                    return
+            except OSError:
+                continue
+
+        # PyPI installs do not ship install.ps1; fetch the upstream copy and
+        # invoke it from stdin via Invoke-Expression.
+        try:
+            request = urllib.request.Request(
+                installer_url, headers = {"User-Agent": "unsloth-studio-update"}
+            )
+            with urllib.request.urlopen(request, timeout = 30) as response:
+                installer = response.read().decode("utf-8", errors = "replace")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            typer.echo(
+                f"  refresh-launcher  skipped: could not fetch {installer_url} ({exc})"
+            )
+            return
+
+        # install.ps1 wraps everything in Install-UnslothStudio and invokes it
+        # with @args at the bottom. From an Invoke-Expression-style stdin
+        # pipe, $args is empty, so append an explicit call with our flags.
+        marker_args = " ".join(args)
+        wrapper = installer + f"\nInstall-UnslothStudio {marker_args}\n"
+        argv = list(ps_argv)
+        argv.extend(["-ExecutionPolicy", "Bypass", "-Command", "-"])
+        try:
+            subprocess.run(
+                argv,
+                input = wrapper,
+                text = True,
+                env = env,
+                check = False,
+                **_windows_hidden_subprocess_kwargs(),
+            )
+        except OSError as exc:
+            typer.echo(f"  refresh-launcher  skipped: powershell exec failed ({exc})")
+        return
 
     for script in candidates:
         try:
@@ -1109,13 +1172,13 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
     # PyPI installs do not ship install.sh; fetch the upstream copy.
     try:
         request = urllib.request.Request(
-            _INSTALLER_URL, headers = {"User-Agent": "unsloth-studio-update"}
+            installer_url, headers = {"User-Agent": "unsloth-studio-update"}
         )
         with urllib.request.urlopen(request, timeout = 30) as response:
             installer = response.read()
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         typer.echo(
-            f"  refresh-launcher  skipped: could not fetch {_INSTALLER_URL} ({exc})"
+            f"  refresh-launcher  skipped: could not fetch {installer_url} ({exc})"
         )
         return
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -13,6 +13,8 @@ import sys
 import tempfile
 import time
 import types
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -1064,6 +1066,70 @@ def _run_setup_script(*, verbose: bool = False) -> None:
         raise typer.Exit(result.returncode)
 
 
+_INSTALLER_URL = "https://unsloth.ai/install.sh"
+
+
+def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
+    """Re-run installer shortcut creation so updates refresh the launcher.
+
+    setup.sh only touches the venv; the macOS .app bundle, the Linux .desktop
+    entry, and the shared launch-studio.sh stub bake their paths at install
+    time. Without this call, `unsloth studio update` leaves the user's icon
+    pointing at the old install.
+    """
+    # Windows: setup.ps1 already owns Start Menu / Desktop .lnk creation on
+    # update, so no extra step is needed.
+    if platform.system() == "Windows":
+        return
+
+    env = {**os.environ}
+    if verbose:
+        env["UNSLOTH_VERBOSE"] = "1"
+
+    # Local install: reuse the install.sh from the same checkout (matches the
+    # behavior of `install.sh --local` and avoids a network fetch).
+    local_repo = (os.environ.get("STUDIO_LOCAL_REPO") or "").strip()
+    candidates: list[Path] = []
+    if local_repo:
+        candidates.append(Path(local_repo) / "install.sh")
+    candidates.append(_PACKAGE_ROOT / "install.sh")
+
+    args = ["--shortcuts-only"]
+    if verbose:
+        args.append("--verbose")
+
+    for script in candidates:
+        try:
+            if script.is_file():
+                subprocess.run(["bash", str(script), *args], env = env, check = False)
+                return
+        except OSError:
+            continue
+
+    # PyPI installs do not ship install.sh; fetch the upstream copy.
+    try:
+        request = urllib.request.Request(
+            _INSTALLER_URL, headers = {"User-Agent": "unsloth-studio-update"}
+        )
+        with urllib.request.urlopen(request, timeout = 30) as response:
+            installer = response.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        typer.echo(
+            f"  refresh-launcher  skipped: could not fetch {_INSTALLER_URL} ({exc})"
+        )
+        return
+
+    try:
+        subprocess.run(
+            ["bash", "-s", "--", *args],
+            input = installer,
+            env = env,
+            check = False,
+        )
+    except OSError as exc:
+        typer.echo(f"  refresh-launcher  skipped: bash exec failed ({exc})")
+
+
 @studio_app.command(hidden = True)
 def setup(
     verbose: bool = typer.Option(
@@ -1106,6 +1172,7 @@ def update(
         os.environ["STUDIO_LOCAL_INSTALL"] = "0"
         os.environ.pop("STUDIO_LOCAL_REPO", None)
     _run_setup_script(verbose = verbose)
+    _refresh_desktop_shortcuts(verbose = verbose)
 
 
 # ── unsloth studio reset-password ────────────────────────────────────

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1197,7 +1197,9 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         try:
             if script.is_file():
                 result = subprocess.run(
-                    ["bash", str(script), *args], env = env, check = False,
+                    ["bash", str(script), *args],
+                    env = env,
+                    check = False,
                 )
                 if result.returncode != 0:
                     typer.echo(

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1243,13 +1243,8 @@ def update(
 
 def _release_self_exe_lock_windows() -> None:
     """Rename the running unsloth.exe out of the way so pip's reinstall can
-    drop a new copy on Windows.
-
-    Windows refuses to delete an .exe whose image is mapped into a running
-    process, but allows renaming it. pip's editable reinstall otherwise fails
-    with WinError 32 on the second `unsloth studio update` run inside the
-    same shim. The leftover *.exe.deleteme is unlinked at the start of the
-    next update once the shim it belonged to has exited.
+    drop a new copy on Windows. setup.ps1 also retries this from its own
+    PowerShell process, which is the truly reliable path.
     """
     if platform.system() != "Windows":
         return
@@ -1257,6 +1252,7 @@ def _release_self_exe_lock_windows() -> None:
         venv_scripts = Path(sys.executable).resolve().parent
     except OSError:
         return
+    # python.exe sits in the venv Scripts dir alongside unsloth.exe
     exe = venv_scripts / "unsloth.exe"
     if not exe.exists():
         return
@@ -1268,8 +1264,9 @@ def _release_self_exe_lock_windows() -> None:
         pass
     try:
         exe.rename(stale)
-    except OSError:
-        pass
+    except OSError as e:
+        # Not fatal -- setup.ps1 retries the rename from a sibling process.
+        print(f"[update] could not rename {exe.name} -> {stale.name}: {e}")
 
 
 # ── unsloth studio reset-password ────────────────────────────────────

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1063,7 +1063,28 @@ def _run_setup_script(*, verbose: bool = False) -> None:
         result = subprocess.run(["bash", str(script)], env = env)
 
     if result.returncode != 0:
+        _print_windows_exe_lock_hint_if_relevant()
         raise typer.Exit(result.returncode)
+
+
+def _print_windows_exe_lock_hint_if_relevant() -> None:
+    """When pip's reinstall fails because unsloth.exe is locked, point users
+    at the python -m workaround. Best-effort: detection looks for our running
+    unsloth.exe in the venv Scripts dir and assumes pip's WinError 32 lock.
+    """
+    if platform.system() != "Windows":
+        return
+    try:
+        venv_scripts = Path(sys.executable).resolve().parent
+    except OSError:
+        return
+    exe = venv_scripts / "unsloth.exe"
+    if not exe.exists():
+        return
+    typer.echo("")
+    typer.echo("Windows holds unsloth.exe open while it is running, so pip")
+    typer.echo("cannot replace it. Re-run the update via the venv python:")
+    typer.echo(f"    {sys.executable} -m unsloth_cli studio update --local")
 
 
 _INSTALLER_URL_BASH = "https://unsloth.ai/install.sh"

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import secrets
 import sqlite3
 import subprocess
@@ -1083,7 +1084,7 @@ def _print_windows_exe_lock_hint_if_relevant() -> None:
     typer.echo("cannot replace it. Re-run the update via the venv python:")
     typer.echo(
         f'    {sys.executable} -c "from unsloth_cli import app; '
-        "app(['studio', 'update', '--local'])\""
+        "app(['studio', 'update'])\""
     )
 
 
@@ -1132,12 +1133,16 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
                             f"& '{quoted}' {' '.join(args)} *>&1",
                         ]
                     )
-                    subprocess.run(
+                    result = subprocess.run(
                         argv,
                         env = env,
                         check = False,
                         **_windows_hidden_subprocess_kwargs(),
                     )
+                    if result.returncode != 0:
+                        typer.echo(
+                            f"  refresh-launcher  install.ps1 exited {result.returncode}"
+                        )
                     return
             except OSError:
                 continue
@@ -1155,20 +1160,35 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
             )
             return
 
+        # install.ps1 auto-invokes `Install-UnslothStudio @args` at EOF; over
+        # stdin `$args` is empty so that triggers the full installer flow
+        # (deps, venv, prompts) before our shortcuts-only call. Strip it.
+        installer = re.sub(
+            r"(?m)^[ \t]*Install-UnslothStudio[ \t]+@args[ \t]*\r?\n?",
+            "",
+            installer,
+        )
         # stdin-piped scripts have empty $args, so call Install-UnslothStudio explicitly.
         marker_args = " ".join(args)
         wrapper = installer + f"\nInstall-UnslothStudio {marker_args}\n"
         argv = list(ps_argv)
         argv.extend(["-ExecutionPolicy", "Bypass", "-Command", "-"])
         try:
-            subprocess.run(
+            # encoding="utf-8" so box-drawing chars in the script body don't
+            # raise UnicodeEncodeError on CP1252-locale Windows boxes.
+            result = subprocess.run(
                 argv,
                 input = wrapper,
                 text = True,
+                encoding = "utf-8",
                 env = env,
                 check = False,
                 **_windows_hidden_subprocess_kwargs(),
             )
+            if result.returncode != 0:
+                typer.echo(
+                    f"  refresh-launcher  fetched install.ps1 exited {result.returncode}"
+                )
         except OSError as exc:
             typer.echo(f"  refresh-launcher  skipped: powershell exec failed ({exc})")
         return
@@ -1176,7 +1196,13 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
     for script in candidates:
         try:
             if script.is_file():
-                subprocess.run(["bash", str(script), *args], env = env, check = False)
+                result = subprocess.run(
+                    ["bash", str(script), *args], env = env, check = False,
+                )
+                if result.returncode != 0:
+                    typer.echo(
+                        f"  refresh-launcher  install.sh exited {result.returncode}"
+                    )
                 return
         except OSError:
             continue
@@ -1195,12 +1221,16 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         return
 
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["bash", "-s", "--", *args],
             input = installer,
             env = env,
             check = False,
         )
+        if result.returncode != 0:
+            typer.echo(
+                f"  refresh-launcher  fetched install.sh exited {result.returncode}"
+            )
     except OSError as exc:
         typer.echo(f"  refresh-launcher  skipped: bash exec failed ({exc})")
 
@@ -1250,7 +1280,13 @@ def update(
         os.environ["STUDIO_LOCAL_INSTALL"] = "0"
         os.environ.pop("STUDIO_LOCAL_REPO", None)
     _release_self_exe_lock_windows()
-    _run_setup_script(verbose = verbose)
+    try:
+        _run_setup_script(verbose = verbose)
+    except BaseException:
+        # Restore unsloth.exe from .deleteme if setup failed before pip
+        # produced a replacement; otherwise the user has no CLI for recovery.
+        _restore_self_exe_lock_windows()
+        raise
     _refresh_desktop_shortcuts(verbose = verbose)
 
 
@@ -1276,6 +1312,24 @@ def _release_self_exe_lock_windows() -> None:
     except OSError as e:
         # Not fatal; setup.ps1 retries from a sibling process.
         print(f"[update] could not rename {exe.name} -> {stale.name}: {e}")
+
+
+def _restore_self_exe_lock_windows() -> None:
+    """If setup failed before pip wrote a new unsloth.exe, restore .deleteme."""
+    if platform.system() != "Windows":
+        return
+    try:
+        venv_scripts = Path(sys.executable).resolve().parent
+    except OSError:
+        return
+    exe = venv_scripts / "unsloth.exe"
+    stale = exe.with_suffix(".exe.deleteme")
+    if exe.exists() or not stale.exists():
+        return
+    try:
+        stale.rename(exe)
+    except OSError as e:
+        print(f"[update] could not restore {stale.name} -> {exe.name}: {e}")
 
 
 # ── unsloth studio reset-password ────────────────────────────────────

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1234,6 +1234,9 @@ def update(
     ),
 ):
     """Update Unsloth Studio dependencies and rebuild."""
+    # Re-export UNSLOTH_STUDIO_HOME for env-mode installs so the refresh
+    # subprocess resolves the same install root the user originally chose.
+    _ensure_studio_env_exported()
     # Ensure SKIP_STUDIO_BASE is not inherited from a parent install.ps1 session
     os.environ.pop("SKIP_STUDIO_BASE", None)
     os.environ["STUDIO_PACKAGE_NAME"] = package

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1084,7 +1084,10 @@ def _print_windows_exe_lock_hint_if_relevant() -> None:
     typer.echo("")
     typer.echo("Windows holds unsloth.exe open while it is running, so pip")
     typer.echo("cannot replace it. Re-run the update via the venv python:")
-    typer.echo(f"    {sys.executable} -m unsloth_cli studio update --local")
+    typer.echo(
+        f"    {sys.executable} -c \"from unsloth_cli import app; "
+        "app(['studio', 'update', '--local'])\""
+    )
 
 
 _INSTALLER_URL_BASH = "https://unsloth.ai/install.sh"

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1085,7 +1085,7 @@ def _print_windows_exe_lock_hint_if_relevant() -> None:
     typer.echo("Windows holds unsloth.exe open while it is running, so pip")
     typer.echo("cannot replace it. Re-run the update via the venv python:")
     typer.echo(
-        f"    {sys.executable} -c \"from unsloth_cli import app; "
+        f'    {sys.executable} -c "from unsloth_cli import app; '
         "app(['studio', 'update', '--local'])\""
     )
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1157,7 +1157,8 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # in install.ps1. -File reads the BOM and decodes correctly. The
         # prefix gives AV/EDR engines (and grep'ing users) a clear identity.
         ps1_fd, ps1_path = tempfile.mkstemp(
-            prefix = "unsloth-studio-refresh-", suffix = ".ps1",
+            prefix = "unsloth-studio-refresh-",
+            suffix = ".ps1",
         )
         try:
             with os.fdopen(ps1_fd, "wb") as fh:


### PR DESCRIPTION
## Summary
- `unsloth studio update` only re-runs `studio/setup.sh` today, which mutates the venv but never touches the desktop launcher. The macOS `.app` bundle (`~/Applications/Unsloth Studio.app/Contents/MacOS/launch-studio`), the Linux `.desktop` file, and the shared `launch-studio.sh` stub all bake their paths and `studio_install_id` at install time. After `unsloth studio update`, the Dock / Applications icon keeps pointing at the old launcher; only a fresh `curl ... install.sh | sh` fixes it because that path re-enters `install.sh`'s `create_studio_shortcuts`.
- Wire the shortcut creator into the update path: add `install.sh --shortcuts-only` and have `unsloth studio update` call it after `setup.sh` succeeds.

## Root cause
- `create_studio_shortcuts()` lives in `install.sh:488-1216`. It is called exactly once, at `install.sh:2222`, gated on `TAURI_MODE != true`.
- `unsloth_cli/commands/studio.py:update()` shells out to `studio/setup.sh` via `_run_setup_script` (`1006-1064`). That script never touches the `.app` bundle, `Info.plist`, `launch-studio` stub, `.icns`, or the Desktop symlink, so the install-time bake stays in place.

Repro on macOS:
1. Install Studio via `curl -fsSL https://unsloth.ai/install.sh | sh`. Note the `~/Applications/Unsloth Studio.app/Contents/MacOS/launch-studio` shasum.
2. Run `unsloth studio update --local` (or plain `unsloth studio update`).
3. Recompute the shasum. It is identical: the bundle was never refreshed.

## Files
- `install.sh` -- add `--shortcuts-only`. After platform detection (line 1234), short-circuit to `create_studio_shortcuts "$VENV_DIR/bin/unsloth" "$OS"` and exit. The flag skips all install steps but reuses the full path-resolution logic so env-override / legacy-default / HOME-redirect modes pick the same DATA_DIR they did at install time.
- `unsloth_cli/commands/studio.py` -- new helper `_refresh_desktop_shortcuts(verbose)` invoked at the tail of `update()`. Preference order:
  1. `${STUDIO_LOCAL_REPO}/install.sh` (matches `--local`).
  2. `${_PACKAGE_ROOT}/install.sh` (editable installs).
  3. Fetch `https://unsloth.ai/install.sh` and pipe to `bash -s -- --shortcuts-only` (PyPI installs; the wheel does not ship `install.sh`).
- Windows: no change. `setup.ps1` already manages Start Menu / Desktop `.lnk` creation on update.

## Behavior in special modes
- `UNSLOTH_STUDIO_HOME` env-override: persistent `.desktop` / `.app` are still skipped (matches install-time behavior), but the launcher script + `studio.conf` are regenerated, which is the part that actually goes stale today.
- `--tauri`: short-circuits with rc 0, no shortcut work (matches install-time behavior).
- Local smoke test on Linux env-mode:
  ```
  UNSLOTH_STUDIO_HOME=/tmp/studio_home bash install.sh --shortcuts-only
  > platform linux
  > wrote launcher at /tmp/studio_home/share/launch-studio.sh (persistent shortcuts skipped in env-override mode)
  ```

## Test plan
- [ ] macOS: fresh install, then `unsloth studio update`. Confirm the `.app` `Contents/MacOS/launch-studio` shasum changes when the launcher generator changes; confirm the Dock icon launches the updated venv.
- [ ] Linux default mode: same, `.desktop` file rewritten with the current `Exec=` path.
- [ ] PyPI (no local install.sh): `unsloth studio update` falls through to the network fetch and runs `--shortcuts-only`. On no-network the helper logs `refresh-launcher skipped` and returns without raising.
- [ ] `--local` from a checkout: helper picks the local `install.sh` (no network call).
- [ ] `UNSLOTH_STUDIO_HOME=/some/path`: launcher regenerated under `$STUDIO_HOME/share/`; no `.app` written (intentional in env-mode).
