### PR TITLE
studio/frontend: cap auto-load cascade attempts

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -624,6 +624,17 @@ async function autoLoadSmallestModel(): Promise<{
       }
     }
 
+    // Cap also gates the default download so the total /api/inference/load
+    // budget across cached + fallback is MAX_AUTO_LOAD_ATTEMPTS, not +1.
+    if (loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS) {
+      toast.dismiss(toastId);
+      return {
+        loaded: false,
+        blockedByTrustRemoteCode:
+          blockedByTrustRemoteCode && !hadNonTrustFailure,
+      };
+    }
+
     // No cached models found — try downloading a small default GGUF
     toast("Downloading a small model…", {
       id: toastId,
@@ -642,6 +653,7 @@ async function autoLoadSmallestModel(): Promise<{
         toast.dismiss(toastId);
         return { loaded: false, blockedByTrustRemoteCode };
       }
+      loadAttempts += 1;
       const loadResp = await loadModel({
         model_path: "unsloth/gemma-4-E2B-it-GGUF",
         hf_token: hfToken,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -437,6 +437,10 @@ function waitForModelReady(abortSignal?: AbortSignal): Promise<void> {
  * without selecting one. Prefers GGUF (picks smallest cached variant),
  * falls back to smallest cached safetensors model.
  */
+// Cap the auto-load cascade so a folder of broken cached repos cannot fire
+// dozens of /api/inference/load POSTs in a row when every load throws.
+const MAX_AUTO_LOAD_ATTEMPTS = 3;
+
 async function autoLoadSmallestModel(): Promise<{
   loaded: boolean;
   blockedByTrustRemoteCode: boolean;
@@ -451,6 +455,7 @@ async function autoLoadSmallestModel(): Promise<{
   });
   let blockedByTrustRemoteCode = false;
   let hadNonTrustFailure = false;
+  let loadAttempts = 0;
 
   async function canAutoLoad(payload: {
     model_path: string;
@@ -481,6 +486,7 @@ async function autoLoadSmallestModel(): Promise<{
     if (ggufRepos.length > 0) {
       const sorted = [...ggufRepos].sort((a, b) => a.size_bytes - b.size_bytes);
       for (const repo of sorted) {
+        if (loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS) break;
         try {
           const variants = await listGgufVariants(repo.repo_id);
           const downloaded = variants.variants
@@ -498,6 +504,7 @@ async function autoLoadSmallestModel(): Promise<{
             ) {
               continue;
             }
+            loadAttempts += 1;
             const loadResp = await loadModel({
               model_path: repo.repo_id,
               hf_token: hfToken,
@@ -560,6 +567,7 @@ async function autoLoadSmallestModel(): Promise<{
     if (modelRepos.length > 0) {
       const sorted = [...modelRepos].sort((a, b) => a.size_bytes - b.size_bytes);
       for (const repo of sorted) {
+        if (loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS) break;
         try {
           if (
             !(await canAutoLoad({
@@ -571,6 +579,7 @@ async function autoLoadSmallestModel(): Promise<{
           ) {
             continue;
           }
+          loadAttempts += 1;
           const sfLoadResp = await loadModel({
             model_path: repo.repo_id,
             hf_token: hfToken,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -437,8 +437,7 @@ function waitForModelReady(abortSignal?: AbortSignal): Promise<void> {
  * without selecting one. Prefers GGUF (picks smallest cached variant),
  * falls back to smallest cached safetensors model.
  */
-// Cap the auto-load cascade so a folder of broken cached repos cannot fire
-// dozens of /api/inference/load POSTs in a row when every load throws.
+// Cap cascade so broken cached repos can't spam /api/inference/load.
 const MAX_AUTO_LOAD_ATTEMPTS = 3;
 
 async function autoLoadSmallestModel(): Promise<{


### PR DESCRIPTION
## Summary
- `autoLoadSmallestModel` in `studio/frontend/src/features/chat/api/chat-adapter.ts` walks every cached GGUF repo and every cached safetensors repo with a `try { loadModel } catch { continue }` cascade. If every load throws (broken cache, stale llama.cpp prebuilt, OOM, wrong CUDA), the user sees N consecutive `POST /api/inference/load` request_completed lines, each ~5s long because the backend always runs the HF metadata probe + DNS guard before short-circuiting on already-loaded.
- Cap the total `loadModel` calls inside this function at `MAX_AUTO_LOAD_ATTEMPTS = 3`. The two loops share the counter. The trust-remote-code skip and the validation pre-check still do not consume an attempt slot.

## Root cause
- `chat-adapter.ts:481-617` (auto-load cascade) and `inference.py:520-656` (the backend's `/api/inference/load` handler with its DNS-guarded HF metadata probe). No `setInterval` / `refetchInterval` / `retry: Infinity` is involved; the cascade is the entire spam source.

## Files
- `studio/frontend/src/features/chat/api/chat-adapter.ts` -- add `MAX_AUTO_LOAD_ATTEMPTS = 3`, count `loadModel` calls, break each cascade loop when the budget runs out.

## Test plan
- [ ] Frontend rebuild passes (`cd studio/frontend && npm install && npm run build`).
- [ ] With a cache of 10+ GGUF repos where every load returns 5xx, confirm at most 3 POSTs to `/api/inference/load` per send (was previously 1 per cached repo).
- [ ] Happy path: a healthy cached repo still loads on the first attempt, and the toast / store updates fire as before.
- [ ] `trust_remote_code = false` plus repos that require it: `canAutoLoad` returns false, no `/load` POST goes out, and the attempt budget is preserved.
