### PR TITLE
studio/frontend: keep theme classes mutually exclusive on <html>

### DIFF
--- a/studio/frontend/src/features/settings/stores/theme-store.ts
+++ b/studio/frontend/src/features/settings/stores/theme-store.ts
@@ -32,7 +32,16 @@ function resolveTheme(theme: Theme): ResolvedTheme {
 
 function applyToDocument(resolved: ResolvedTheme) {
   if (typeof document === "undefined") return;
-  document.documentElement.classList.toggle("dark", resolved === "dark");
+  // Keep "dark" and "light" mutually exclusive. The Sonner Toaster reads
+  // next-themes (mounted at provider.tsx with attribute="class"
+  // defaultTheme="light"), so on first mount next-themes adds a "light"
+  // class to <html>. When the user later picks Dark, only toggling "dark"
+  // here leaves the stale "light" alongside it (html.className = "light dark"),
+  // which is harmless in cascade but reads as a UI defect in devtools and
+  // can trip CSS-aware tooling that branches on class lists.
+  const cl = document.documentElement.classList;
+  cl.toggle("dark", resolved === "dark");
+  cl.toggle("light", resolved === "light");
 }
 
 const listeners = new Set<() => void>();

--- a/studio/frontend/src/features/settings/stores/theme-store.ts
+++ b/studio/frontend/src/features/settings/stores/theme-store.ts
@@ -32,13 +32,9 @@ function resolveTheme(theme: Theme): ResolvedTheme {
 
 function applyToDocument(resolved: ResolvedTheme) {
   if (typeof document === "undefined") return;
-  // Keep "dark" and "light" mutually exclusive. The Sonner Toaster reads
-  // next-themes (mounted at provider.tsx with attribute="class"
-  // defaultTheme="light"), so on first mount next-themes adds a "light"
-  // class to <html>. When the user later picks Dark, only toggling "dark"
-  // here leaves the stale "light" alongside it (html.className = "light dark"),
-  // which is harmless in cascade but reads as a UI defect in devtools and
-  // can trip CSS-aware tooling that branches on class lists.
+  // Keep "dark"/"light" mutually exclusive. next-themes (via Sonner)
+  // adds "light" on first mount; without the explicit toggle we'd end
+  // up with `class="light dark"` after a switch.
   const cl = document.documentElement.classList;
   cl.toggle("dark", resolved === "dark");
   cl.toggle("light", resolved === "light");


### PR DESCRIPTION
## Summary

Resolves #5579. Studio mounts both next-themes (provider.tsx:290, attribute=\"class\" defaultTheme=\"light\" so the Sonner Toaster's `useTheme` keeps resolving correctly) and its own theme store (features/settings/stores/theme-store.ts). The two systems agree on localStorage but not on the <html> class: next-themes seeds \"light\" on first mount, Studio's setTheme only toggles \"dark\". After picking Dark in Settings, html.className ends up \"light dark\".

Toggle \"light\" alongside \"dark\" in applyToDocument so the two classes stay mutually exclusive regardless of how next-themes seeded the initial class.

## Test plan

- [x] tsc -b clean.
- [x] bun run build clean.
- [x] scripts/r6_theme_direct.py: before the fix html.className was \"light dark\" after picking Dark; after the fix it is just \"dark\". Switching to Light gives just \"light\". (Probe output and screenshots in outputs/studio_diag_r6/scenarios/theme_direct/.)
- [ ] Sonner Toaster still reads next-themes' resolvedTheme correctly (Sonner uses useTheme from next-themes; localStorage stays the source of truth so Sonner's resolution is unchanged).