### PR TITLE
studio/inference: break agentic loop early on context-budget overrun (#5562)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -56,6 +56,22 @@ _INTENT_SIGNAL = re.compile(
 )
 _MAX_REPROMPTS = 3
 
+# Token-budget guard for the agentic loop.  Without it, the tool loop
+# happily appends tool results until llama-server returns "request
+# (N tokens) exceeds the available context size" and the whole turn
+# dead-ends as a red banner with no answer (see issue #5562).  When the
+# estimated next prompt exceeds this fraction of the effective context
+# window, the loop breaks early and the existing post-loop synthesis
+# pass produces a final answer from whatever was already gathered.
+# 0.85 leaves ~15% headroom for the final non-tool generation.
+_CONTEXT_BUDGET_RATIO = 0.85
+# Conservative chars-per-token average across English + JSON tool
+# payloads, used only for the budget heuristic above.  /v1/tokenize
+# would be exact but adds a synchronous round-trip per iteration;
+# overestimating (early break) is safer than underestimating
+# (llama-server error).
+_CHARS_PER_TOKEN_ESTIMATE = 3.5
+
 # Without max_tokens, llama-server defaults to n_predict = n_ctx (up to
 # 262144 for Qwen3.5), producing many-minute zombie decodes when cancel
 # fails. t_max_predict_ms is a wall-clock backstop applied unconditionally,
@@ -75,6 +91,29 @@ _REPROMPT_MAX_CHARS = 2000
 # ── Pre-compiled patterns for GGUF shard detection ───────────
 _SHARD_FULL_RE = re.compile(r"^(.*)-(\d{5})-of-(\d{5})\.gguf$")
 _SHARD_RE = re.compile(r"^(.*)-\d{5}-of-\d{5}\.gguf$")
+
+
+def _estimate_conversation_tokens(
+    messages: list[dict],
+    tools: Optional[list] = None,
+) -> int:
+    """Cheap char-based token estimate for the agentic-loop budget guard.
+
+    Sums JSON-serialized message and tool payloads and divides by a
+    conservative chars-per-token average.  Used only to decide whether
+    the next tool round-trip would push the prompt past the context
+    window -- it does not need to be exact, just in the right ballpark.
+    """
+    try:
+        body = json.dumps(messages, ensure_ascii = False)
+    except (TypeError, ValueError):
+        body = "".join(str(m) for m in messages)
+    if tools:
+        try:
+            body += json.dumps(tools, ensure_ascii = False)
+        except (TypeError, ValueError):
+            body += str(tools)
+    return int(len(body) / _CHARS_PER_TOKEN_ESTIMATE)
 
 
 # ── Sliding-window-pattern resolver ───────────────────────────
@@ -4020,9 +4059,46 @@ class LlamaCppBackend:
         # consume the caller's tool-call budget.  Only add the
         # extra slot when tool iterations are actually allowed.
         _extra = _MAX_REPROMPTS if max_tool_iterations > 0 else 0
+        # Set when the loop breaks because the conversation got too
+        # close to the context cap; switches the post-loop nudge from
+        # "all tool calls used" to "context budget reached" so the
+        # synthesized answer is framed correctly.
+        _budget_exhausted = False
         for iteration in range(max_tool_iterations + _extra):
             if cancel_event is not None and cancel_event.is_set():
                 return
+
+            # ── Token-budget guard ─────────────────────────────────
+            # Skip on iteration 0 -- the initial prompt is the user's
+            # baseline and we always give the model at least one shot.
+            # From iteration 1 onward, if accumulated tool results have
+            # pushed the projected next prompt past the budget, break
+            # early and let the post-loop pass produce a synthesized
+            # answer rather than letting llama-server return "request
+            # exceeds context size".  See issue #5562.
+            if iteration > 0 and self._effective_context_length:
+                _projected_tokens = _estimate_conversation_tokens(
+                    conversation, tools
+                )
+                _budget_tokens = int(
+                    _CONTEXT_BUDGET_RATIO * self._effective_context_length
+                )
+                if _projected_tokens > _budget_tokens:
+                    logger.info(
+                        "Agentic loop: context budget reached "
+                        f"(~{_projected_tokens} of {_budget_tokens} "
+                        f"budgeted, n_ctx={self._effective_context_length}) "
+                        f"after iteration {iteration}; synthesizing final answer."
+                    )
+                    yield {
+                        "type": "status",
+                        "text": (
+                            "Context budget reached; synthesizing final "
+                            "answer from gathered context..."
+                        ),
+                    }
+                    _budget_exhausted = True
+                    break
 
             # Build payload -- stream: True so we detect tool signals
             # in the first 1-2 chunks without a non-streaming penalty.
@@ -4669,19 +4745,28 @@ class LlamaCppBackend:
                     return
                 raise
 
-        # ── Tool iteration cap reached -- synthesize final answer ──
-        # The model used all iterations without producing a final text
-        # response. Inject a nudge so the final streaming pass produces
-        # a useful answer instead of continuing to request tools.
+        # ── Loop exit -- synthesize final answer ──
+        # The model either used all iterations or the context-budget
+        # guard tripped.  Either way, inject a nudge so the final
+        # streaming pass produces a useful answer instead of
+        # continuing to request tools.
         if max_tool_iterations > 0:
+            if _budget_exhausted:
+                _final_nudge = (
+                    "The conversation has reached its context budget. "
+                    "Based on everything you have found so far, provide "
+                    "your final answer now. Do not call any more tools."
+                )
+            else:
+                _final_nudge = (
+                    "You have used all available tool calls. Based on "
+                    "everything you have found so far, provide your final "
+                    "answer now. Do not call any more tools."
+                )
             conversation.append(
                 {
                     "role": "user",
-                    "content": (
-                        "You have used all available tool calls. Based on "
-                        "everything you have found so far, provide your final "
-                        "answer now. Do not call any more tools."
-                    ),
+                    "content": _final_nudge,
                 }
             )
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4077,9 +4077,7 @@ class LlamaCppBackend:
             # answer rather than letting llama-server return "request
             # exceeds context size".  See issue #5562.
             if iteration > 0 and self._effective_context_length:
-                _projected_tokens = _estimate_conversation_tokens(
-                    conversation, tools
-                )
+                _projected_tokens = _estimate_conversation_tokens(conversation, tools)
                 _budget_tokens = int(
                     _CONTEXT_BUDGET_RATIO * self._effective_context_length
                 )

--- a/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
+++ b/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
@@ -21,35 +21,57 @@ _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
-_loggers_stub = _types.ModuleType("loggers")
-_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
-sys.modules.setdefault("loggers", _loggers_stub)
+# Optional-dependency stubs.  Use `setdefault`-on-failed-import instead
+# of an unconditional `sys.modules.setdefault(...)` so we never shadow a
+# real module that just has not been imported yet -- otherwise later
+# tests in the same pytest session that do `import httpx` (etc.) would
+# receive our stub and fail with AttributeError on real-API access.
+def _install_stub_if_missing(name: str, factory) -> None:
+    try:
+        __import__(name)
+    except ImportError:
+        sys.modules[name] = factory()
 
-_structlog_stub = _types.ModuleType("structlog")
-_structlog_stub.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
-sys.modules.setdefault("structlog", _structlog_stub)
 
-_httpx_stub = _types.ModuleType("httpx")
-for _exc in (
-    "ConnectError",
-    "TimeoutException",
-    "ReadTimeout",
-    "ReadError",
-    "RemoteProtocolError",
-    "CloseError",
-):
-    setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
-_httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
-_httpx_stub.Client = type(
-    "C",
-    (),
-    {
-        "__init__": lambda s, **kw: None,
-        "__enter__": lambda s: s,
-        "__exit__": lambda s, *a: None,
-    },
-)
-sys.modules.setdefault("httpx", _httpx_stub)
+def _build_loggers_stub() -> _types.ModuleType:
+    mod = _types.ModuleType("loggers")
+    mod.get_logger = lambda name: __import__("logging").getLogger(name)
+    return mod
+
+
+def _build_structlog_stub() -> _types.ModuleType:
+    mod = _types.ModuleType("structlog")
+    mod.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
+    return mod
+
+
+def _build_httpx_stub() -> _types.ModuleType:
+    mod = _types.ModuleType("httpx")
+    for _exc in (
+        "ConnectError",
+        "TimeoutException",
+        "ReadTimeout",
+        "ReadError",
+        "RemoteProtocolError",
+        "CloseError",
+    ):
+        setattr(mod, _exc, type(_exc, (Exception,), {}))
+    mod.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
+    mod.Client = type(
+        "C",
+        (),
+        {
+            "__init__": lambda s, **kw: None,
+            "__enter__": lambda s: s,
+            "__exit__": lambda s, *a: None,
+        },
+    )
+    return mod
+
+
+_install_stub_if_missing("loggers", _build_loggers_stub)
+_install_stub_if_missing("structlog", _build_structlog_stub)
+_install_stub_if_missing("httpx", _build_httpx_stub)
 
 import pytest
 

--- a/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
+++ b/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for the agentic-loop context-budget guard added for issue #5562.
+
+The guard's contract:
+  * a cheap char-based token estimate over a JSON-serialized conversation
+  * a constant ratio (default 0.85) of effective context length
+  * once estimated tokens exceed ratio * n_ctx, the agentic loop breaks
+    early so the post-loop synthesis pass can produce a final answer
+    instead of llama-server returning "request exceeds context size"
+"""
+
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+
+_structlog_stub = _types.ModuleType("structlog")
+_structlog_stub.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
+sys.modules.setdefault("structlog", _structlog_stub)
+
+_httpx_stub = _types.ModuleType("httpx")
+for _exc in (
+    "ConnectError",
+    "TimeoutException",
+    "ReadTimeout",
+    "ReadError",
+    "RemoteProtocolError",
+    "CloseError",
+):
+    setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
+_httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
+_httpx_stub.Client = type(
+    "C",
+    (),
+    {
+        "__init__": lambda s, **kw: None,
+        "__enter__": lambda s: s,
+        "__exit__": lambda s, *a: None,
+    },
+)
+sys.modules.setdefault("httpx", _httpx_stub)
+
+import pytest
+
+from core.inference.llama_cpp import (
+    _CHARS_PER_TOKEN_ESTIMATE,
+    _CONTEXT_BUDGET_RATIO,
+    _estimate_conversation_tokens,
+)
+
+
+# Constants -- pin the budget ratio so a silent change to "be safe and
+# leave 50% headroom" doesn't ship without an explicit decision.
+
+
+def test_context_budget_ratio_leaves_headroom():
+    # Must leave enough room for a real final answer (>= 10% of ctx),
+    # but not so much that small conversations trigger it (<= 30%).
+    assert 0.70 < _CONTEXT_BUDGET_RATIO < 0.95
+
+
+def test_chars_per_token_estimate_in_reasonable_range():
+    # 2.0 is too aggressive (over-counts); 5.0 under-counts and lets
+    # llama-server error out. 3-4 is the safe band for English + JSON.
+    assert 2.5 < _CHARS_PER_TOKEN_ESTIMATE < 5.0
+
+
+# Helper -- handles the JSON-serializable common case.
+
+
+def test_estimate_tokens_empty_conversation():
+    assert _estimate_conversation_tokens([]) == 0
+
+
+def test_estimate_tokens_small_conversation_is_small():
+    msgs = [{"role": "user", "content": "hi"}]
+    est = _estimate_conversation_tokens(msgs)
+    # Sanity: well under any realistic context window.
+    assert 0 < est < 100
+
+
+def test_estimate_tokens_scales_with_content_length():
+    short = [{"role": "user", "content": "hello world"}]
+    long = [{"role": "user", "content": "hello world " * 1000}]
+    short_est = _estimate_conversation_tokens(short)
+    long_est = _estimate_conversation_tokens(long)
+    # The long message should produce a meaningfully larger estimate.
+    assert long_est > short_est * 100
+
+
+def test_estimate_tokens_includes_tool_definitions():
+    msgs = [{"role": "user", "content": "search for cats"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web for a query. " * 50,
+                "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+            },
+        }
+    ]
+    bare = _estimate_conversation_tokens(msgs)
+    with_tools = _estimate_conversation_tokens(msgs, tools)
+    assert with_tools > bare
+
+
+def test_estimate_tokens_handles_tool_role_messages():
+    # The realistic case we are guarding against: many tool round-trips
+    # with large search payloads accumulating in the conversation.
+    msgs = [{"role": "user", "content": "list 2015 Billboard #3 songs"}]
+    for i in range(10):
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call_{i}",
+                        "type": "function",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": '{"q": "billboard hot 100 2015 number 3"}',
+                        },
+                    }
+                ],
+            }
+        )
+        msgs.append(
+            {
+                "role": "tool",
+                "name": "web_search",
+                "tool_call_id": f"call_{i}",
+                "content": "Result snippet about a song that charted. " * 200,
+            }
+        )
+    est = _estimate_conversation_tokens(msgs)
+    # 10 tool results of ~200 reps of a ~40-char snippet ≈ 80k chars / 3.5
+    # ≈ 20k tokens.  Well above a 16k context budget, which is exactly
+    # the case the loop guard catches.
+    assert est > 15000
+
+
+def test_estimate_tokens_falls_back_on_non_serializable():
+    # Pre-existing conversation state should never crash the helper --
+    # the loop relies on it on every iteration.  Custom objects without
+    # a JSON representation must degrade to a length-based estimate.
+    class _Opaque:
+        def __str__(self):
+            return "x" * 100
+
+    msgs = [{"role": "user", "obj": _Opaque()}]
+    est = _estimate_conversation_tokens(msgs)
+    # Some non-zero estimate must be returned, not an exception.
+    assert est > 0
+
+
+# Budget threshold semantics -- the exact arithmetic the loop applies.
+
+
+@pytest.mark.parametrize(
+    "ctx_length,prompt_chars,expect_trip",
+    [
+        # 16k ctx, small prompt: never trips.
+        (16384, 1000, False),
+        # 16k ctx, prompt at ~60% of budget: does not trip.
+        (16384, int(0.60 * 16384 * _CHARS_PER_TOKEN_ESTIMATE), False),
+        # 16k ctx, prompt at ~90% of budget: trips.
+        (16384, int(0.90 * 16384 * _CHARS_PER_TOKEN_ESTIMATE), True),
+        # 4k ctx, near-full prompt: trips.
+        (4096, int(0.95 * 4096 * _CHARS_PER_TOKEN_ESTIMATE), True),
+    ],
+)
+def test_budget_threshold_matches_loop_arithmetic(ctx_length, prompt_chars, expect_trip):
+    msgs = [{"role": "user", "content": "x" * prompt_chars}]
+    projected = _estimate_conversation_tokens(msgs)
+    budget = int(_CONTEXT_BUDGET_RATIO * ctx_length)
+    assert (projected > budget) is expect_trip

--- a/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
+++ b/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
@@ -21,6 +21,7 @@ _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
+
 # Optional-dependency stubs.  Use `setdefault`-on-failed-import instead
 # of an unconditional `sys.modules.setdefault(...)` so we never shadow a
 # real module that just has not been imported yet -- otherwise later

--- a/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
+++ b/studio/backend/tests/test_llama_cpp_agentic_context_budget.py
@@ -107,7 +107,10 @@ def test_estimate_tokens_includes_tool_definitions():
             "function": {
                 "name": "web_search",
                 "description": "Search the web for a query. " * 50,
-                "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                "parameters": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
             },
         }
     ]
@@ -182,7 +185,9 @@ def test_estimate_tokens_falls_back_on_non_serializable():
         (4096, int(0.95 * 4096 * _CHARS_PER_TOKEN_ESTIMATE), True),
     ],
 )
-def test_budget_threshold_matches_loop_arithmetic(ctx_length, prompt_chars, expect_trip):
+def test_budget_threshold_matches_loop_arithmetic(
+    ctx_length, prompt_chars, expect_trip
+):
     msgs = [{"role": "user", "content": "x" * prompt_chars}]
     projected = _estimate_conversation_tokens(msgs)
     budget = int(_CONTEXT_BUDGET_RATIO * ctx_length)


### PR DESCRIPTION
## Summary

Closes #5562.

The Studio agentic tool loop appended tool results indefinitely and dead-ended with `request (N tokens) exceeds the available context size` once the conversation crossed `n_ctx`. The chat surfaced this as a red banner plus a "Context limit reached" toast, with no synthesized answer and no way to recover except bumping context length or starting a new chat.

This PR adds the smallest-blast-radius half of the fix proposed in the issue: a per-iteration **token-budget guard** that breaks the loop early so the existing post-loop synthesis pass can produce a final answer from whatever was already gathered.

## Root cause

`generate_chat_completion_with_tools` in `studio/backend/core/inference/llama_cpp.py` has a tool-iteration cap (`max_tool_iterations=25`) and re-prompt caps (`_MAX_REPROMPTS=3`), but no token-budget check. Each round-trip appends the assistant's tool-call message and the full tool result (web_search responses commonly run 500-2000 tokens each). Past ~12 iterations on a 16k context this overflows `n_ctx` and llama-server returns 500, which `_friendly_error` translates into a banner — losing all of the work the model already did.

## Changes

`studio/backend/core/inference/llama_cpp.py`
- Add module-level constants `_CONTEXT_BUDGET_RATIO = 0.85` and `_CHARS_PER_TOKEN_ESTIMATE = 3.5`.
- Add `_estimate_conversation_tokens(messages, tools=None)` — char-based heuristic over JSON-serialized payloads. Conservative on purpose (overestimate → early break, underestimate → server error) and avoids a synchronous `/v1/tokenize` round-trip per iteration.
- At the top of each agentic-loop iteration (skipping iteration 0 so the model always gets one shot), check `projected_tokens > 0.85 * effective_context_length`. If so: emit a status event and `break`. A `_budget_exhausted` flag is set so the post-loop synthesis nudge is framed as "context budget reached" rather than "all tool calls used".
- The existing post-loop final-answer streaming pass is unchanged and naturally handles the new break path.

`studio/backend/tests/test_llama_cpp_agentic_context_budget.py` (new)
- 12 tests: budget-ratio sanity, char-per-token sanity, empty/small/large conversations, scaling, tool-definition inclusion, realistic multi-round tool conversation, non-serializable fallback, and a parameterized check that the budget arithmetic matches what the loop applies for 16k and 4k contexts.

## What this does **not** do (intentional follow-ups)

- Trimming oldest `tool`-role messages when a single tool result is already huge (Part 2 of the issue's suggested fix). Part 1 alone resolves the dead-end at low blast radius; trimming is a larger refactor with its own UX questions (which round-trips to keep, whether to surface "trimmed N earlier results" in the UI) and is better as a separate PR.
- Swapping the heuristic for a `/v1/tokenize` round-trip when the server supports it. Heuristic is cheap, deterministic, and only needs to be in the right ballpark to decide when to break.

## Test plan

- [x] `python3 -m pytest studio/backend/tests/test_llama_cpp_agentic_context_budget.py -v` — 12/12 pass
- [x] `python3 -m pytest studio/backend/tests/test_llama_cpp_mtp_detection.py studio/backend/tests/test_llama_cpp_context_fit.py studio/backend/tests/test_tool_policy_state.py` — 90/90 pass (regression check on neighboring tests)
- [x] `python3 -c "import ast; ast.parse(open('studio/backend/core/inference/llama_cpp.py').read())"` — syntax clean
- [x] `npm run typecheck` (studio/frontend) — clean (no frontend changes, sanity only)
- [ ] Manual repro from the issue: Qwen3.5-4B-MTP-GGUF at 16384 ctx, all toggles on, Billboard prompt — verify the loop now produces a final answer (with whatever was gathered) instead of the "Message too long" banner. *Unable to run locally — no MTP-capable GPU available in this env.*