### PR TITLE
studio: reserve VRAM headroom for the MTP draft cache in auto-fit

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1695,6 +1695,7 @@ class LlamaCppBackend:
         kv_unified: bool = True,
         ctx_checkpoints: int = 0,
         kv_on_gpu: bool = True,
+        mtp_engaged: bool = False,
     ) -> int:
         """Return the largest context length that fits in GPU VRAM.
 
@@ -1708,6 +1709,12 @@ class LlamaCppBackend:
         the KV cache lives in CPU RAM and doesn't compete with weights
         for VRAM; the requested context is honored verbatim. The other
         keyword args mirror ``_estimate_kv_cache_bytes``.
+
+        ``mtp_engaged`` reserves extra VRAM for the MTP draft model's
+        KV cache + compute graph buffers. llama.cpp's MTP path keeps a
+        secondary cache sized off the target's KV; on tight VRAM tiers
+        (e.g. 32 GB) auto-fit at native context would otherwise spill
+        and force llama-server into a slower partial-offload path.
         """
         if not self._can_estimate_kv():
             logger.debug(
@@ -1728,7 +1735,9 @@ class LlamaCppBackend:
             ctx_checkpoints = ctx_checkpoints,
         )
 
-        budget_bytes = available_mib * 1024 * 1024 * 0.90
+        # MTP needs a tighter budget; drop from 0.90 to 0.85.
+        budget_frac = 0.85 if mtp_engaged else 0.90
+        budget_bytes = available_mib * 1024 * 1024 * budget_frac
         model_footprint = model_size_bytes
 
         # Check if requested context already fits
@@ -2614,6 +2623,22 @@ class LlamaCppBackend:
                     # GPU/VRAM-fit logic below may shrink this if hardware is limited.
                     max_available_ctx = self._context_length or effective_ctx
 
+                    # Will MTP engage on this load? If so, the auto-fit
+                    # budget needs to reserve extra VRAM for the draft
+                    # model's KV cache + compute graph.
+                    _normalized_spec = (
+                        speculative_type.lower().strip()
+                        if speculative_type else None
+                    )
+                    _mtp_will_engage = bool(
+                        (
+                            bool(self._nextn_predict_layers)
+                            or _is_mtp_model_name(model_identifier, model_path)
+                        )
+                        and _normalized_spec not in {"off"}
+                        and not _extra_args_set_spec_type(extra_args)
+                    )
+
                     # Auto-cap context to fit in GPU VRAM and select GPUs.
                     #
                     # Two policies depending on whether the user set n_ctx:
@@ -2649,6 +2674,7 @@ class LlamaCppBackend:
                                     model_size,
                                     cache_type_kv,
                                     n_parallel = n_parallel,
+                                    mtp_engaged = _mtp_will_engage,
                                 )
                                 kv = self._estimate_kv_cache_bytes(
                                     capped, cache_type_kv, n_parallel = n_parallel
@@ -2700,6 +2726,7 @@ class LlamaCppBackend:
                                     model_size,
                                     cache_type_kv,
                                     n_parallel = n_parallel,
+                                    mtp_engaged = _mtp_will_engage,
                                 )
                                 kv = self._estimate_kv_cache_bytes(
                                     capped, cache_type_kv, n_parallel = n_parallel

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2625,17 +2625,31 @@ class LlamaCppBackend:
 
                     # Will MTP engage on this load? If so, the auto-fit
                     # budget needs to reserve extra VRAM for the draft
-                    # model's KV cache + compute graph.
-                    _normalized_spec = (
-                        speculative_type.lower().strip() if speculative_type else None
+                    # model's KV cache + compute graph. Mirrors the
+                    # canonical-mode resolver in _build_speculative_flags:
+                    # forced mtp / mtp+ngram always engage; auto only
+                    # engages on an MTP GGUF >= 3B (sub-3B auto falls
+                    # back to ngram-mod which doesn't need headroom);
+                    # ngram / ngram-simple / off never engage MTP.
+                    _mtp_canonical = _canonicalize_spec_mode(speculative_type)
+                    _mtp_effective = _mtp_canonical or "auto"
+                    _mtp_size_for_fit = _extract_model_size_b(model_identifier)
+                    _mtp_sub_3b_for_fit = (
+                        _mtp_size_for_fit is not None and _mtp_size_for_fit < 3.0
                     )
                     _mtp_will_engage = bool(
-                        (
-                            bool(self._nextn_predict_layers)
-                            or _is_mtp_model_name(model_identifier, model_path)
+                        not _extra_args_set_spec_type(extra_args)
+                        and (
+                            _mtp_effective in ("mtp", "mtp+ngram")
+                            or (
+                                _mtp_effective == "auto"
+                                and (
+                                    bool(self._nextn_predict_layers)
+                                    or _is_mtp_model_name(model_identifier, model_path)
+                                )
+                                and not _mtp_sub_3b_for_fit
+                            )
                         )
-                        and _normalized_spec not in {"off"}
-                        and not _extra_args_set_spec_type(extra_args)
                     )
 
                     # Auto-cap context to fit in GPU VRAM and select GPUs.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2627,8 +2627,7 @@ class LlamaCppBackend:
                     # budget needs to reserve extra VRAM for the draft
                     # model's KV cache + compute graph.
                     _normalized_spec = (
-                        speculative_type.lower().strip()
-                        if speculative_type else None
+                        speculative_type.lower().strip() if speculative_type else None
                     )
                     _mtp_will_engage = bool(
                         (

--- a/studio/backend/tests/test_kv_cache_estimation.py
+++ b/studio/backend/tests/test_kv_cache_estimation.py
@@ -1558,6 +1558,33 @@ class TestServerFlags:
         )
         assert fitted < 32_768
 
+    def test_fit_mtp_engaged_returns_smaller_or_equal_context(self):
+        # MTP-engaged budget is 0.85 of available; non-MTP is 0.90.
+        # On a tight budget the MTP path must yield <= the non-MTP path.
+        b = self._gqa_backend()
+        common = dict(
+            requested_ctx = 32_768,
+            available_mib = 128,
+            model_size_bytes = 8 * 1024 * 1024,
+            cache_type_kv = "f16",
+        )
+        baseline = b._fit_context_to_vram(**common)
+        mtp = b._fit_context_to_vram(**common, mtp_engaged = True)
+        assert mtp <= baseline
+
+    def test_fit_mtp_engaged_unchanged_when_kv_off_gpu(self):
+        # kv_on_gpu=False short-circuits the fit; mtp_engaged is irrelevant.
+        b = self._gqa_backend()
+        fitted = b._fit_context_to_vram(
+            requested_ctx = 32_768,
+            available_mib = 1,
+            model_size_bytes = 100,
+            cache_type_kv = "f16",
+            kv_on_gpu = False,
+            mtp_engaged = True,
+        )
+        assert fitted == 32_768
+
     def test_fit_threads_swa_full_through_estimator(self):
         # SWA model, generous budget; both should fit but cache size differs.
         b = self._swa_backend()


### PR DESCRIPTION
## Summary

When MTP is going to engage on this load, `_fit_context_to_vram` now budgets 0.85 of available VRAM instead of 0.90, leaving room for llama.cpp's secondary MTP draft KV cache + compute graph buffers.

Detection mirrors the auto-promotion logic already in `load_model`: the GGUF advertises `nextn_predict_layers`, or the model identifier / local path matches the `-MTP` marker, and the user has not explicitly opted out via `speculative_type="off"` or `--spec-type` in `llama_extra_args`.

## Motivation

A user reported on RTX 5090 (32 GB) that `unsloth/Qwen3.6-27B-MTP-GGUF` UD-Q4_K_XL at native auto-context ran roughly half the speed of the same model with a slightly smaller context. The most parsimonious explanation is a VRAM cliff at the 32 GB tier: at native context the target's KV already eats the 90% budget, then llama-server allocates the draft cache + draft graph on top and spills into a slower partial-offload path.

Dropping the budget by 5% on MTP-engaged loads avoids the spill without penalising non-MTP loads. On hardware with abundant VRAM (B200, etc.) the fit is unchanged because the requested context already fits in the tighter budget too.

## Why 0.85 and not "subtract an explicit draft-cache estimate"

The exact draft footprint depends on the model's `nextn_predict_layers` count, hidden dim, n_parallel, cache_type_kv and the live llama-server draft graph buffers. A constant 5% headroom is conservative enough to cover the common case (Qwen3.6 *-MTP with 1 predict layer, hidden 5120, ctx 131072 -> roughly 2 GB on f16 KV) and falls below the user-visible context loss on hardware where the cliff does not exist. A more sophisticated explicit-estimate path is reasonable as a follow-up.

## Tests

- New: `test_fit_mtp_engaged_returns_smaller_or_equal_context` - tight budget, MTP path returns <= non-MTP path.
- New: `test_fit_mtp_engaged_unchanged_when_kv_off_gpu` - `--kv-offload` short-circuit is preserved regardless of `mtp_engaged`.
- Existing suite: 348 passed locally across `test_llama_cpp_mtp_detection.py`, `test_llama_server_args.py`, `test_llama_cpp_context_fit.py`, `test_native_context_length.py`, `test_kv_cache_estimation.py`, `test_llama_cpp_max_context_threshold.py`.

## Test plan

- [x] New regression tests pass
- [x] Existing fit-context + MTP suites stay green
- [ ] Maintainer review on a 32 GB / 24 GB GPU to confirm the cliff disappears