### PR TITLE
studio/web: differentiate offline from backend-down in fetch error

### DIFF
--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -155,14 +155,9 @@ export async function authFetch(
     });
   } catch (err) {
     if (err instanceof TypeError) {
-      // A TypeError from fetch covers three distinct cases:
-      //   1. Browser is offline (web build only).
-      //   2. Backend is reachable but refused the connection (process down).
-      //   3. CORS / DNS / proxy misconfiguration.
-      // In Tauri we ship the backend in-process, so a TypeError almost
-      // always means the supervisor died; the original wording is right.
-      // In the web build, lying about a backend crash when the user is
-      // simply offline sends them on the wrong recovery path.
+      // fetch TypeError = offline | backend down | CORS/DNS. In Tauri
+      // it's always backend-down; in the web build distinguish offline
+      // so the user gets the right recovery path.
       if (!isTauri && typeof navigator !== "undefined" && navigator.onLine === false) {
         throw new Error(
           "You appear to be offline. Check your network connection and try again.",

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -155,6 +155,19 @@ export async function authFetch(
     });
   } catch (err) {
     if (err instanceof TypeError) {
+      // A TypeError from fetch covers three distinct cases:
+      //   1. Browser is offline (web build only).
+      //   2. Backend is reachable but refused the connection (process down).
+      //   3. CORS / DNS / proxy misconfiguration.
+      // In Tauri we ship the backend in-process, so a TypeError almost
+      // always means the supervisor died; the original wording is right.
+      // In the web build, lying about a backend crash when the user is
+      // simply offline sends them on the wrong recovery path.
+      if (!isTauri && typeof navigator !== "undefined" && navigator.onLine === false) {
+        throw new Error(
+          "You appear to be offline. Check your network connection and try again.",
+        );
+      }
       throw new Error("Studio isn't running -- please relaunch it.");
     }
     throw err;


### PR DESCRIPTION
## Summary

When the user's browser loses network connectivity mid-request, the
`authFetch` helper caught the resulting `TypeError` and surfaced the
toast "Generation failed: Studio isn't running -- please relaunch it."

In the Tauri desktop build that wording is accurate: the backend ships
in-process, so a `TypeError` from `fetch` almost always means the
supervisor died and a relaunch is the right recovery step.

In the web build the backend is a separate process (often on another
machine), so the same `TypeError` typically means the *user* went
offline, not that the server crashed. Telling a user to "relaunch
Studio" when their Wi-Fi dropped sends them on the wrong recovery path.

This change branches on `navigator.onLine === false` (web build only)
and shows "You appear to be offline. Check your network connection and
try again." instead. Tauri keeps the original message so its diagnosis
stays correct there.

## Repro

1. Open Studio in a web browser, load a model.
2. Open DevTools Network panel, toggle to Offline.
3. Type a prompt and press Enter.
4. Before: red bubble + toast 'Studio isn'\''t running -- please relaunch it.'
5. After: red bubble + toast 'You appear to be offline. Check your network connection and try again.'

Found while running a Playwright slow-network probe that toggled
`Network.emulateNetworkConditions {offline: true}` mid-stream.

## Test plan

- [x] tsc -b clean
- [x] Manual repro in headless Chromium via Playwright CDP Network.emulateNetworkConditions
- [ ] Tauri build still shows the original 'Studio isn'\''t running' wording (isTauri short-circuit)