### PR TITLE
studio/frontend: include filename in attachment aria-label + img alt

### DIFF
--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -158,9 +158,8 @@ const AttachmentUI: FC = () => {
         throw new Error(`Unknown attachment type: ${type as string}`);
     }
   });
-  // Fold the filename into the accessible name so screen-reader users
-  // can tell three identically-typed attachments apart. Visual users
-  // still get the filename via the Radix tooltip below.
+  // Include filename in accessible name so screen readers distinguish
+  // same-typed attachments. Sighted users get it via the tooltip.
   const accessibleName = name
     ? `${typeLabel} attachment: ${name}`
     : `${typeLabel} attachment`;

--- a/studio/frontend/src/components/assistant-ui/attachment.tsx
+++ b/studio/frontend/src/components/assistant-ui/attachment.tsx
@@ -120,12 +120,13 @@ const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
 
 const AttachmentThumb: FC = () => {
   const src = useAttachmentSrc();
+  const name = useAuiState(({ attachment }) => attachment.name);
 
   if (src) {
     return (
       <img
         src={src}
-        alt="Attachment preview"
+        alt={name || "Attachment preview"}
         className="h-full w-full object-cover"
       />
     );
@@ -143,6 +144,7 @@ const AttachmentUI: FC = () => {
   const isComposer = aui.attachment.source === "composer";
 
   const isImage = useAuiState(({ attachment }) => attachment.type === "image");
+  const name = useAuiState(({ attachment }) => attachment.name);
   const typeLabel = useAuiState(({ attachment }) => {
     const type = attachment.type;
     switch (type) {
@@ -156,6 +158,12 @@ const AttachmentUI: FC = () => {
         throw new Error(`Unknown attachment type: ${type as string}`);
     }
   });
+  // Fold the filename into the accessible name so screen-reader users
+  // can tell three identically-typed attachments apart. Visual users
+  // still get the filename via the Radix tooltip below.
+  const accessibleName = name
+    ? `${typeLabel} attachment: ${name}`
+    : `${typeLabel} attachment`;
 
   return (
     <Tooltip>
@@ -175,7 +183,7 @@ const AttachmentUI: FC = () => {
                   "aui-attachment-tile-composer border-foreground/20",
               )}
               id="attachment-tile"
-              aria-label={`${typeLabel} attachment`}
+              aria-label={accessibleName}
               type="button"
             >
               <AttachmentThumb />


### PR DESCRIPTION
## Summary

When a chat has multiple attachments of the same kind, every tile
shares the same generic accessible name. Sighted hover users get the
filename from the Radix tooltip, but anyone else does not.

Repro on the rendered DOM:
```
Array.from(document.querySelectorAll('button[aria-label*=\"attachment\" i]'))
  .map(b => b.getAttribute('aria-label'))
// ["Image attachment", "Image attachment", "Image attachment", ...]
```

Three PNGs are indistinguishable to a screen-reader user, a
touch-device user (no hover), or a keyboard-only user whose tooltip
isn't always announced.

This change folds the filename into both `aria-label` and the
thumbnail `<img alt>` when the attachment has a name. Sighted UX is
unchanged - the same name already renders in the Radix tooltip on
hover.

After:
```
["Image attachment: test_red_circle.png",
 "Document attachment: notes.txt",
 "Add Attachment"]
```

## Test plan

- [x] tsc -b clean
- [x] Built frontend, rsynced dist/ into a running Studio, verified
      the rendered aria-labels via Playwright DOM query.
- [x] Tooltip filename text on hover still matches.
- [ ] Manual screen-reader pass on the composer attachment list.