### PR TITLE
studio: read Playwright default model from defaults.py without importing it

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -124,9 +124,14 @@ def expected_default_model():
     # the orchestrator -> structlog) and defaults.py's own
     # `import utils.hardware.hardware as hw` are both unavailable.
     import ast
+
     defaults_path = (
         Path(__file__).resolve().parents[2]
-        / "studio" / "backend" / "core" / "inference" / "defaults.py"
+        / "studio"
+        / "backend"
+        / "core"
+        / "inference"
+        / "defaults.py"
     )
     try:
         tree = ast.parse(defaults_path.read_text())

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -118,16 +118,37 @@ def expected_default_model():
     if override:
         return override
 
-    studio_backend = Path(__file__).resolve().parents[2] / "studio" / "backend"
-    if str(studio_backend) not in sys.path:
-        sys.path.insert(0, str(studio_backend))
+    # Parse DEFAULT_MODELS_GGUF as a literal out of defaults.py instead of
+    # importing it. The Playwright job installs Studio with --no-torch, so
+    # the studio.backend.core.inference package init (which eagerly imports
+    # the orchestrator -> structlog) and defaults.py's own
+    # `import utils.hardware.hardware as hw` are both unavailable.
+    import ast
+    defaults_path = (
+        Path(__file__).resolve().parents[2]
+        / "studio" / "backend" / "core" / "inference" / "defaults.py"
+    )
     try:
-        from core.inference.defaults import DEFAULT_MODELS_GGUF
+        tree = ast.parse(defaults_path.read_text())
     except Exception as exc:
-        fail(f"could not import DEFAULT_MODELS_GGUF: {exc}")
-    if not DEFAULT_MODELS_GGUF:
-        fail("DEFAULT_MODELS_GGUF is empty")
-    return DEFAULT_MODELS_GGUF[0]
+        fail(f"could not read {defaults_path}: {exc}")
+    models = None
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "DEFAULT_MODELS_GGUF"
+            for t in node.targets
+        ):
+            continue
+        try:
+            models = ast.literal_eval(node.value)
+        except Exception as exc:
+            fail(f"could not eval DEFAULT_MODELS_GGUF literal: {exc}")
+        break
+    if not models:
+        fail("DEFAULT_MODELS_GGUF not found or empty in defaults.py")
+    return models[0]
 
 
 def soft_fail(m):


### PR DESCRIPTION
## Summary
- The Chat UI CI step "Drive the chat UI with Playwright" has been red on Mac, Linux and Windows since #5589 landed. All three jobs die at the very top of `playwright_chat_ui.py` with `ModuleNotFoundError: No module named 'structlog'`.
- The new `expected_default_model()` helper does `from core.inference.defaults import DEFAULT_MODELS_GGUF`. That executes `studio/backend/core/inference/__init__.py`, which eagerly does `from .orchestrator import ...`, and `orchestrator.py` does `import structlog` at module top. `defaults.py` itself also does `import utils.hardware.hardware as hw`, which chains into the same `structlog`/`loggers` stack.
- The Playwright job installs Studio with `install.sh --local --no-torch`, a deliberately minimal venv that does not (and should not) carry the inference runtime stack. So the import path is wrong for this environment, not the env.

## Fix
- Parse `DEFAULT_MODELS_GGUF` as a literal directly out of `defaults.py` with `ast.literal_eval`. Zero side effects, no module init runs, no new test deps.
- `EXPECTED_DEFAULT_MODEL` env override still wins, exactly as before.

## Test plan
- [x] `ast.parse + literal_eval` returns the expected first model (`unsloth/Qwen3.6-27B-MTP-GGUF`).
- [x] Helper works in a clean Python that has no `structlog` / Studio backend deps installed.
- [x] `EXPECTED_DEFAULT_MODEL` override path still short-circuits.
- [ ] Mac / Linux / Windows Studio UI CI "Chat UI Tests" go green on this branch.