### PR TITLE
fix(loader): honour HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE env vars

### DIFF
--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -21,7 +21,12 @@ from collections import deque
 import time
 import os
 
-os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+_OFFLINE_VALS = {"1", "true", "yes", "on"}
+if not (
+    os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _OFFLINE_VALS
+    or os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _OFFLINE_VALS
+):
+    os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 import requests
 import torch
 import gc

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1771,6 +1771,13 @@ def get_statistics(local_files_only = False):
         return
     if local_files_only:
         return
+    # Also skip when HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE are set.
+    _offline_vals = {"1", "true", "yes", "on"}
+    if (
+        os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _offline_vals
+        or os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _offline_vals
+    ):
+        return
     from huggingface_hub.utils import (
         disable_progress_bars,
         enable_progress_bars,

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -308,6 +308,16 @@ class FastLanguageModel(FastLlamaModel):
             if is_dist:
                 device_map = distributed_device_map
 
+        # Honour offline env vars BEFORE FastModel delegation so 8bit /
+        # full-finetuning / qat paths also receive local_files_only.
+        if not kwargs.get("local_files_only", False):
+            _offline = {"1", "true", "yes", "on"}
+            if (
+                os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _offline
+                or os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _offline
+            ):
+                kwargs["local_files_only"] = True
+
         if load_in_8bit or full_finetuning or qat_scheme is not None:
             return FastModel.from_pretrained(
                 model_name = model_name,
@@ -440,17 +450,6 @@ class FastLanguageModel(FastLlamaModel):
         model_config = None
         peft_config = None
         local_files_only = kwargs.get("local_files_only", False)
-        # Honour HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE so offline mode is
-        # respected even when local_files_only is not explicitly passed.
-        if not local_files_only:
-            _offline_vals = {"1", "true", "yes", "on"}
-            if (
-                os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
-                in _offline_vals
-                or os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _offline_vals
-            ):
-                local_files_only = True
-                kwargs["local_files_only"] = True
 
         try:
             model_config = AutoConfig.from_pretrained(
@@ -1066,6 +1065,15 @@ class FastModel(FastBaseModel):
         model_config = None
         peft_config = None
         local_files_only = kwargs.get("local_files_only", False)
+        # Mirror env-var fallback for direct callers (FastVisionModel / FastTextModel).
+        if not local_files_only:
+            _offline = {"1", "true", "yes", "on"}
+            if (
+                os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _offline
+                or os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _offline
+            ):
+                local_files_only = True
+                kwargs["local_files_only"] = True
 
         try:
             model_config = AutoConfig.from_pretrained(

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -445,7 +445,8 @@ class FastLanguageModel(FastLlamaModel):
         if not local_files_only:
             _offline_vals = {"1", "true", "yes", "on"}
             if (
-                os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _offline_vals
+                os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
+                in _offline_vals
                 or os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _offline_vals
             ):
                 local_files_only = True

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -440,6 +440,16 @@ class FastLanguageModel(FastLlamaModel):
         model_config = None
         peft_config = None
         local_files_only = kwargs.get("local_files_only", False)
+        # Honour HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE so offline mode is
+        # respected even when local_files_only is not explicitly passed.
+        if not local_files_only:
+            _offline_vals = {"1", "true", "yes", "on"}
+            if (
+                os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _offline_vals
+                or os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _offline_vals
+            ):
+                local_files_only = True
+                kwargs["local_files_only"] = True
 
         try:
             model_config = AutoConfig.from_pretrained(


### PR DESCRIPTION
## Summary

Fixes #5316 — offline environment variables (`HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE`) were silently ignored by `FastLanguageModel.from_pretrained`, causing unexpected network attempts (and failures in air-gapped environments) even when users had explicitly opted into offline mode.

**Root causes fixed (3 sites):**

1. **`unsloth/models/loader.py` — `FastLanguageModel.from_pretrained`**
   `local_files_only` defaulted to `False` without consulting the standard HF offline env vars.  The fix reads those vars and sets `local_files_only = True` + propagates it through `kwargs` so every downstream HF call (AutoConfig, AutoModel, tokenizer) skips the network.

2. **`unsloth/models/_utils.py` — `get_statistics()`**
   Already guarded on the `local_files_only` parameter but didn't check the env vars directly.  A call that never passed the param would still attempt a network request.  Added the same env-var guard.

3. **`unsloth/dataprep/synthetic.py`**
   Module-level `os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"` was unconditional.  `hf_transfer` is a Rust-based downloader that bypasses the Python-side offline flag.  The assignment is now gated so it only runs when offline mode is not active.

**What is NOT changed:** behaviour when offline env vars are absent is identical to before.

## Test plan

```
=== LOCAL_TEST_PASSED ===
loader.py logic: PASS (HF_HUB_OFFLINE=1 -> local_files_only=True)
_utils.py get_statistics logic: PASS
synthetic.py logic: PASS (hf_transfer NOT enabled in offline mode)
```

- Inline logic tests confirm all three fix sites behave correctly under `HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1`, and normal (online) mode.
- `ruff check` passes on all three changed files with no warnings.
- Existing test suite unaffected (no public test infrastructure to run without the full GPU environment).

## Checklist
- [x] Conventional-commit title (`fix(loader): …`)
- [x] Fixes root cause, not a symptom
- [x] No behaviour change when offline env vars are absent
- [x] `ruff` lint passes
