### PR TITLE
studio/frontend: add aria-label to Dictate / Stop dictation buttons

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -916,6 +916,7 @@ const ComposerAction: FC<{ disabled?: boolean; blockSend?: () => boolean }> = ({
           <ComposerPrimitive.Dictate asChild={true}>
             <TooltipIconButton
               tooltip="Dictate"
+              aria-label="Dictate"
               variant="ghost"
               className="size-8 rounded-full text-muted-foreground"
             >
@@ -927,6 +928,7 @@ const ComposerAction: FC<{ disabled?: boolean; blockSend?: () => boolean }> = ({
           <ComposerPrimitive.StopDictation asChild={true}>
             <TooltipIconButton
               tooltip="Stop dictation"
+              aria-label="Stop dictation"
               variant="ghost"
               className="size-8 rounded-full text-destructive"
             >


### PR DESCRIPTION
## Summary
- The composer's mic icon buttons in `thread.tsx` exposed only `tooltip=\"Dictate\"` / `\"Stop dictation\"` — no `aria-label`. Screen readers heard an empty SVG-only button.
- Every other composer icon button in Studio (`Send`, `Add Attachment`, audio buttons, the composer pills) already carries an explicit `aria-label`, and the sibling implementation in `shared-composer.tsx:1080` does too.
- Mirror that here so both code paths share the same accessibility contract.

## Discovery
A keyboard / screen-reader probe (Tab focus order audit on `/chat`) walked the composer:
- Tab 1: `TEXTAREA aria='Message input'` -- OK
- Tab 2: `BUTTON aria='Add Attachment'` -- OK
- **Tab 3: `BUTTON aria=None text='Dictate'`** -- missing
- Tab 4: `BUTTON aria='Send message'` -- OK

## Test plan
- [x] `bun run typecheck` passes
- [x] Composer mic button now exposes `aria-label=\"Dictate\"`
- [x] Stop-dictation button exposes `aria-label=\"Stop dictation\"`
- [x] No behaviour change for sighted users (tooltip wording identical)
- [ ] Manual: focus the composer with keyboard, Tab to the mic button, screen reader announces \"Dictate\"