### PR TITLE
studio/frontend: settings dialog fits viewport at tablet widths

### DIFF
--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -104,7 +104,7 @@ export function SettingsDialog() {
           // `w-[820px]` overflows by 26px on each side.
           "!max-w-[min(820px,calc(100vw-2rem))] h-[560px] w-[min(820px,calc(100vw-2rem))] p-0 overflow-hidden",
           "shadow-border rounded-xl border-border",
-          "max-sm:h-dvh max-sm:w-dvw max-sm:max-w-none max-sm:rounded-none",
+          "max-sm:h-dvh max-sm:w-dvw max-sm:!max-w-none max-sm:rounded-none",
         )}
       >
         <DialogTitle className="sr-only">Settings</DialogTitle>

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -99,10 +99,12 @@ export function SettingsDialog() {
         showCloseButton={false}
         overlayClassName="bg-background/40"
         className={cn(
-          "!max-w-none h-[560px] w-[820px] p-0 overflow-hidden",
+          // Cap at 820px but shrink to the viewport so we don't clip
+          // on iPad-portrait widths (640-820px) where the fixed
+          // `w-[820px]` overflows by 26px on each side.
+          "!max-w-[min(820px,calc(100vw-2rem))] h-[560px] w-[min(820px,calc(100vw-2rem))] p-0 overflow-hidden",
           "shadow-border rounded-xl border-border",
-          "sm:h-[560px] sm:w-[820px]",
-          "max-sm:h-dvh max-sm:w-dvw max-sm:rounded-none",
+          "max-sm:h-dvh max-sm:w-dvw max-sm:max-w-none max-sm:rounded-none",
         )}
       >
         <DialogTitle className="sr-only">Settings</DialogTitle>


### PR DESCRIPTION
## Summary
- `SettingsDialog` used `w-[820px]` and `sm:w-[820px]` (with `max-sm:w-dvw` only firing below 640px), so iPad-portrait (768x1024) and any 640-820px viewport rendered an 820px-wide dialog that overflowed the visible area by 26px on each side.
- Replace the hard width with `min(820px, calc(100vw - 2rem))` on both `max-w` and `w` so the dialog caps at 820px on desktop and shrinks to fit on tablets, keeping a 1rem gutter.
- `max-sm` still drives the full-bleed `h-dvh w-dvw` layout below 640px.

## Discovery
A responsive-viewport probe captured the dialog at six widths and measured `rect.right - clientWidth`:

| Viewport | Before | After |
|---|---|---|
| 375 x 800 (mobile) | dialog 375px, 0px overflow | dialog 343px, 0px overflow |
| 400 x 812 (mobile) | dialog 400px, 0px overflow | dialog 368px, 0px overflow |
| **768 x 1024 (tablet)** | **dialog 820px, 26px overflow each side** | **dialog 736px, 0px overflow** |
| 1280 x 720 | dialog 820px, 0 | dialog 820px, 0 |
| 1440 x 900 | dialog 820px, 0 | dialog 820px, 0 |
| 2560 x 1080 (ultrawide) | dialog 820px, 0 | dialog 820px, 0 |

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` produces clean output
- [x] Re-ran the responsive probe -- 0 horizontal overflow at every viewport from 375 up to 2560
- [x] Desktop dialog still renders at the original 820px