### PR TITLE
feature/prompt storage

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -239,6 +239,7 @@ from routes import (
     inference_studio_router,
     mcp_servers_router,
     models_router,
+    prompts_router,
     providers_router,
     training_history_router,
     training_router,
@@ -765,6 +766,7 @@ app.include_router(inference_router, prefix = "/v1", tags = ["openai-compat"])
 app.include_router(providers_router, prefix = "/api/providers", tags = ["providers"])
 app.include_router(settings_router, prefix = "/api/settings", tags = ["settings"])
 app.include_router(mcp_servers_router, prefix = "/api/mcp/servers", tags = ["mcp"])
+app.include_router(prompts_router, prefix = "/api/prompts", tags = ["prompts"])
 app.include_router(datasets_router, prefix = "/api/datasets", tags = ["datasets"])
 app.include_router(data_recipe_router, prefix = "/api/data-recipe", tags = ["data-recipe"])
 app.include_router(export_router, prefix = "/api/export", tags = ["export"])

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -239,12 +239,12 @@ from routes import (
     inference_studio_router,
     mcp_servers_router,
     models_router,
-    prompts_router,
     providers_router,
     training_history_router,
     training_router,
 )
 from routes.settings import router as settings_router
+from routes.prompts import router as prompts_router
 from auth import storage
 from auth.authentication import get_current_subject
 from utils.hardware import (

--- a/studio/backend/routes/__init__.py
+++ b/studio/backend/routes/__init__.py
@@ -17,7 +17,6 @@ from routes.training_history import router as training_history_router
 from routes.chat_history import router as chat_history_router
 from routes.providers import router as providers_router
 from routes.mcp_servers import router as mcp_servers_router
-from routes.prompts import router as prompts_router
 
 __all__ = [
     "training_router",
@@ -32,5 +31,4 @@ __all__ = [
     "chat_history_router",
     "providers_router",
     "mcp_servers_router",
-    "prompts_router",
 ]

--- a/studio/backend/routes/__init__.py
+++ b/studio/backend/routes/__init__.py
@@ -17,6 +17,7 @@ from routes.training_history import router as training_history_router
 from routes.chat_history import router as chat_history_router
 from routes.providers import router as providers_router
 from routes.mcp_servers import router as mcp_servers_router
+from routes.prompts import router as prompts_router
 
 __all__ = [
     "training_router",
@@ -31,4 +32,5 @@ __all__ = [
     "chat_history_router",
     "providers_router",
     "mcp_servers_router",
+    "prompts_router",
 ]

--- a/studio/backend/routes/prompts.py
+++ b/studio/backend/routes/prompts.py
@@ -34,7 +34,7 @@ class PromptEntry(BaseModel):
 class PromptList(BaseModel):
     id: str = Field(max_length = 128)
     name: str = Field(max_length = 500)
-    items: list[str] = Field(max_length = 1_000)
+    items: list[str] = Field(max_length = 10_000)
     createdAt: int
     updatedAt: int
 

--- a/studio/backend/routes/prompts.py
+++ b/studio/backend/routes/prompts.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+Prompt storage API routes backed by studio.db.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from auth.authentication import get_current_subject
+from storage.studio_db import (
+    bulk_upsert_prompt_entries,
+    bulk_upsert_prompt_lists,
+    delete_prompt_entry,
+    delete_prompt_list_db,
+    list_prompt_entries,
+    list_prompt_lists_db,
+    upsert_prompt_entry,
+    upsert_prompt_list,
+)
+
+router = APIRouter()
+
+
+class PromptEntry(BaseModel):
+    id: str
+    name: str
+    text: str
+    createdAt: int
+    updatedAt: int
+
+
+class PromptList(BaseModel):
+    id: str
+    name: str
+    items: list[str]
+    createdAt: int
+    updatedAt: int
+
+
+class BulkEntriesRequest(BaseModel):
+    entries: list[PromptEntry]
+
+
+class BulkListsRequest(BaseModel):
+    lists: list[PromptList]
+
+
+# ── Prompt entries ────────────────────────────────────────────────────────────
+
+
+@router.get("/entries")
+def get_entries(current_subject: str = Depends(get_current_subject)):
+    return {"entries": list_prompt_entries()}
+
+
+@router.put("/entries/{entry_id}")
+def put_entry(
+    entry_id: str,
+    entry: PromptEntry,
+    current_subject: str = Depends(get_current_subject),
+):
+    if entry.id != entry_id:
+        raise HTTPException(status_code = 400, detail = "ID mismatch")
+    return upsert_prompt_entry(entry.model_dump())
+
+
+@router.delete("/entries/{entry_id}", status_code = 204)
+def remove_entry(entry_id: str, current_subject: str = Depends(get_current_subject)):
+    delete_prompt_entry(entry_id)
+
+
+@router.post("/entries/bulk")
+def bulk_entries(
+    req: BulkEntriesRequest,
+    current_subject: str = Depends(get_current_subject),
+):
+    count = bulk_upsert_prompt_entries([e.model_dump() for e in req.entries])
+    return {"count": count}
+
+
+# ── Prompt lists ──────────────────────────────────────────────────────────────
+
+
+@router.get("/lists")
+def get_lists(current_subject: str = Depends(get_current_subject)):
+    return {"lists": list_prompt_lists_db()}
+
+
+@router.put("/lists/{list_id}")
+def put_list(
+    list_id: str,
+    lst: PromptList,
+    current_subject: str = Depends(get_current_subject),
+):
+    if lst.id != list_id:
+        raise HTTPException(status_code = 400, detail = "ID mismatch")
+    return upsert_prompt_list(lst.model_dump())
+
+
+@router.delete("/lists/{list_id}", status_code = 204)
+def remove_list(list_id: str, current_subject: str = Depends(get_current_subject)):
+    delete_prompt_list_db(list_id)
+
+
+@router.post("/lists/bulk")
+def bulk_lists(
+    req: BulkListsRequest,
+    current_subject: str = Depends(get_current_subject),
+):
+    count = bulk_upsert_prompt_lists([l.model_dump() for l in req.lists])
+    return {"count": count}

--- a/studio/backend/routes/prompts.py
+++ b/studio/backend/routes/prompts.py
@@ -24,17 +24,17 @@ router = APIRouter()
 
 
 class PromptEntry(BaseModel):
-    id: str = Field(max_length=128)
-    name: str = Field(max_length=500)
-    text: str = Field(max_length=100_000)
+    id: str = Field(max_length = 128)
+    name: str = Field(max_length = 500)
+    text: str = Field(max_length = 100_000)
     createdAt: int
     updatedAt: int
 
 
 class PromptList(BaseModel):
-    id: str = Field(max_length=128)
-    name: str = Field(max_length=500)
-    items: list[str] = Field(max_length=1_000)
+    id: str = Field(max_length = 128)
+    name: str = Field(max_length = 500)
+    items: list[str] = Field(max_length = 1_000)
     createdAt: int
     updatedAt: int
 

--- a/studio/backend/routes/prompts.py
+++ b/studio/backend/routes/prompts.py
@@ -6,7 +6,7 @@ Prompt storage API routes backed by studio.db.
 """
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from auth.authentication import get_current_subject
 from storage.studio_db import (
@@ -24,17 +24,17 @@ router = APIRouter()
 
 
 class PromptEntry(BaseModel):
-    id: str
-    name: str
-    text: str
+    id: str = Field(max_length=128)
+    name: str = Field(max_length=500)
+    text: str = Field(max_length=100_000)
     createdAt: int
     updatedAt: int
 
 
 class PromptList(BaseModel):
-    id: str
-    name: str
-    items: list[str]
+    id: str = Field(max_length=128)
+    name: str = Field(max_length=500)
+    items: list[str] = Field(max_length=1_000)
     createdAt: int
     updatedAt: int
 

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -316,6 +316,208 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         ) WITHOUT ROWID
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prompt_entries (
+            id TEXT NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            text TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prompt_entries_created_at ON prompt_entries(created_at)"
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prompt_lists (
+            id TEXT NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            items_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prompt_lists_created_at ON prompt_lists(created_at)"
+    )
+
+
+# ── Prompt entries ────────────────────────────────────────────────────────────
+
+
+def _prompt_entry_from_row(row: sqlite3.Row) -> dict:
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "text": row["text"],
+        "createdAt": row["created_at"],
+        "updatedAt": row["updated_at"],
+    }
+
+
+def list_prompt_entries() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM prompt_entries ORDER BY created_at DESC"
+        ).fetchall()
+        return [_prompt_entry_from_row(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def upsert_prompt_entry(entry: dict) -> dict:
+    conn = get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO prompt_entries (id, name, text, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                text = excluded.text,
+                updated_at = excluded.updated_at
+            """,
+            (
+                entry["id"],
+                entry["name"],
+                entry["text"],
+                entry["createdAt"],
+                entry["updatedAt"],
+            ),
+        )
+        conn.commit()
+        return entry
+    finally:
+        conn.close()
+
+
+def delete_prompt_entry(entry_id: str) -> None:
+    conn = get_connection()
+    try:
+        conn.execute("DELETE FROM prompt_entries WHERE id = ?", (entry_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def bulk_upsert_prompt_entries(entries: list[dict]) -> int:
+    if not entries:
+        return 0
+    conn = get_connection()
+    try:
+        conn.executemany(
+            """
+            INSERT INTO prompt_entries (id, name, text, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                text = excluded.text,
+                updated_at = excluded.updated_at
+            """,
+            [
+                (e["id"], e["name"], e["text"], e["createdAt"], e["updatedAt"])
+                for e in entries
+            ],
+        )
+        conn.commit()
+        return len(entries)
+    finally:
+        conn.close()
+
+
+# ── Prompt lists ──────────────────────────────────────────────────────────────
+
+
+def _prompt_list_from_row(row: sqlite3.Row) -> dict:
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "items": json.loads(row["items_json"]),
+        "createdAt": row["created_at"],
+        "updatedAt": row["updated_at"],
+    }
+
+
+def list_prompt_lists_db() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM prompt_lists ORDER BY created_at DESC"
+        ).fetchall()
+        return [_prompt_list_from_row(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def upsert_prompt_list(lst: dict) -> dict:
+    conn = get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO prompt_lists (id, name, items_json, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                items_json = excluded.items_json,
+                updated_at = excluded.updated_at
+            """,
+            (
+                lst["id"],
+                lst["name"],
+                json.dumps(lst["items"]),
+                lst["createdAt"],
+                lst["updatedAt"],
+            ),
+        )
+        conn.commit()
+        return lst
+    finally:
+        conn.close()
+
+
+def delete_prompt_list_db(list_id: str) -> None:
+    conn = get_connection()
+    try:
+        conn.execute("DELETE FROM prompt_lists WHERE id = ?", (list_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def bulk_upsert_prompt_lists(lists: list[dict]) -> int:
+    if not lists:
+        return 0
+    conn = get_connection()
+    try:
+        conn.executemany(
+            """
+            INSERT INTO prompt_lists (id, name, items_json, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                items_json = excluded.items_json,
+                updated_at = excluded.updated_at
+            """,
+            [
+                (
+                    lst["id"],
+                    lst["name"],
+                    json.dumps(lst["items"]),
+                    lst["createdAt"],
+                    lst["updatedAt"],
+                )
+                for lst in lists
+            ],
+        )
+        conn.commit()
+        return len(lists)
+    finally:
+        conn.close()
 
 
 def get_connection() -> sqlite3.Connection:

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -444,6 +444,7 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
         "inference_studio_router": APIRouter(),
         "mcp_servers_router": APIRouter(),
         "models_router": APIRouter(),
+        "prompts_router": APIRouter(),
         "providers_router": APIRouter(),
         "settings_router": settings_module.router,
         "training_history_router": APIRouter(),

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -433,6 +433,8 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     routes_module.__path__ = []
     settings_module = ModuleType("routes.settings")
     settings_module.router = APIRouter()
+    prompts_module = ModuleType("routes.prompts")
+    prompts_module.router = APIRouter()
 
     for name, router in {
         "auth_router": APIRouter(),
@@ -444,7 +446,6 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
         "inference_studio_router": APIRouter(),
         "mcp_servers_router": APIRouter(),
         "models_router": APIRouter(),
-        "prompts_router": APIRouter(),
         "providers_router": APIRouter(),
         "settings_router": settings_module.router,
         "training_history_router": APIRouter(),
@@ -455,6 +456,7 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "routes", routes_module)
     monkeypatch.setitem(sys.modules, "routes.settings", settings_module)
+    monkeypatch.setitem(sys.modules, "routes.prompts", prompts_module)
 
     import studio.backend.main as backend_main
 

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -50,6 +50,7 @@ import {
   Delete02Icon,
   Download01Icon,
   DownloadSquare01Icon,
+  Upload01Icon,
   Edit03Icon,
   FolderAddIcon,
   FolderExportIcon,
@@ -72,6 +73,7 @@ import {
   exportConversationShareGPT,
   exportBulkConversationsMerged,
   exportBulkConversationsSeparate,
+  importConversationsFromFile,
   EXPORT_FORMATS_LIST,
   type ConvExportFormat,
 } from "@/features/chat/prompt-storage/prompt-storage-dialog";
@@ -258,6 +260,21 @@ export function AppSidebar() {
   const isChatRoute = pathname.startsWith("/chat");
   const isStudioRoute = pathname === "/studio" || pathname.startsWith("/studio/");
   const [chatOpen, setChatOpen] = useState(true);
+
+  const recentsImportInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleImportToRecents(file: File) {
+    try {
+      const count = await importConversationsFromFile(file, null);
+      if (count === 0) {
+        toast.info("No conversations found in file.");
+      } else {
+        toast.success(`Imported ${count} conversation${count === 1 ? "" : "s"} to Recents.`);
+      }
+    } catch {
+      toast.error("Import failed.");
+    }
+  }
 
   async function handleBulkExport(scope: "recents" | "all", fmt: ConvExportFormat, merged: boolean) {
     try {
@@ -722,6 +739,18 @@ export function AppSidebar() {
 
   return (
     <>
+    {/* Hidden file inputs for chat import */}
+    <input
+      ref={recentsImportInputRef}
+      type="file"
+      accept=".jsonl,.ndjson,.csv"
+      className="hidden"
+      onChange={(e) => {
+        const file = e.target.files?.[0];
+        if (file) void handleImportToRecents(file);
+        e.target.value = "";
+      }}
+    />
     <Sidebar
       collapsible="icon"
       variant="sidebar"
@@ -943,6 +972,11 @@ export function AppSidebar() {
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent side="bottom" align="start" className="w-56">
+                      <DropdownMenuItem onSelect={() => recentsImportInputRef.current?.click()}>
+                        <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.75} className="size-icon mr-1" />
+                        Import chats
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
                       <DropdownMenuSub>
                         <DropdownMenuSubTrigger>
                           <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -935,7 +935,7 @@ export function AppSidebar() {
                     <DropdownMenuTrigger asChild>
                       <button
                         type="button"
-                        className="ml-auto flex items-center justify-center rounded-sm p-0.5 opacity-0 hover:opacity-100 hover:bg-accent group-hover/sb-collap:opacity-60"
+                        className="ml-auto flex items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-0"
                         title="Export recents"
                         onClick={(e) => e.stopPropagation()}
                       >
@@ -948,7 +948,7 @@ export function AppSidebar() {
                           <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />
                           Export Recents
                         </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="unsloth-plus-menu w-52">
+                        <DropdownMenuSubContent avoidCollisions={false} className="unsloth-plus-menu w-52">
                           {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                             <DropdownMenuItem key={`r-m-${fmt}`} onSelect={() => void handleBulkExport("recents", fmt, true)}>
                               {label} — combined
@@ -967,7 +967,7 @@ export function AppSidebar() {
                           <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />
                           Export Recents + Projects
                         </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="unsloth-plus-menu w-52">
+                        <DropdownMenuSubContent avoidCollisions={false} className="unsloth-plus-menu w-52">
                           {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                             <DropdownMenuItem key={`a-m-${fmt}`} onSelect={() => void handleBulkExport("all", fmt, true)}>
                               {label} — combined

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -957,16 +957,17 @@ export function AppSidebar() {
           <Collapsible open={chatOpen} onOpenChange={setChatOpen} asChild>
             <SidebarGroup className="group-data-[collapsible=icon]:hidden px-0 py-0">
               <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following", scrolled && "is-scrolled")} asChild>
-                <CollapsibleTrigger className="cursor-pointer flex w-full items-center gap-1 group/sb-collap">
-                  {t("shell.navigation.recents")}
-                  <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
+                <div className="flex w-full items-center group/sb-collap">
+                  <CollapsibleTrigger className="cursor-pointer flex flex-1 items-center gap-1 min-w-0">
+                    {t("shell.navigation.recents")}
+                    <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
+                  </CollapsibleTrigger>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <button
                         type="button"
                         className="ml-auto flex items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-0"
                         title="Export recents"
-                        onClick={(e) => e.stopPropagation()}
                       >
                         <MoreHorizontalIcon className="size-3.5" />
                       </button>
@@ -1017,7 +1018,7 @@ export function AppSidebar() {
                       </DropdownMenuSub>
                     </DropdownMenuContent>
                   </DropdownMenu>
-                </CollapsibleTrigger>
+                </div>
               </SidebarGroupLabel>
               <CollapsibleContent>
                 <SidebarGroupContent className="px-2">

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -48,6 +48,7 @@ import {
   ChefHatIcon,
   CursorInfo02Icon,
   Delete02Icon,
+  Download01Icon,
   DownloadSquare01Icon,
   Edit03Icon,
   FolderAddIcon,
@@ -65,6 +66,16 @@ import {
   TestTube01Icon,
   ZapIcon,
 } from "@hugeicons/core-free-icons";
+import {
+  exportConversationRawJsonl,
+  exportConversationCsv,
+  exportConversationShareGPT,
+  exportBulkConversationsMerged,
+  exportBulkConversationsSeparate,
+  EXPORT_FORMATS_LIST,
+  type ConvExportFormat,
+} from "@/features/chat/prompt-storage/prompt-storage-dialog";
+import { listStoredChatThreads } from "@/features/chat/utils/chat-history-storage";
 import {
   Tooltip,
   TooltipContent,
@@ -247,6 +258,26 @@ export function AppSidebar() {
   const isChatRoute = pathname.startsWith("/chat");
   const isStudioRoute = pathname === "/studio" || pathname.startsWith("/studio/");
   const [chatOpen, setChatOpen] = useState(true);
+
+  async function handleBulkExport(scope: "recents" | "all", fmt: ConvExportFormat, merged: boolean) {
+    try {
+      const threads = await listStoredChatThreads({
+        includeArchived: false,
+        ...(scope === "recents" ? { projectId: null } : {}),
+      });
+      const ids = [...new Set(threads.map((t) => t.id))];
+      if (ids.length === 0) { toast.info("No conversations to export."); return; }
+      const ts = new Date().toISOString().slice(0, 10);
+      const basename = scope === "all" ? `all-chats-${ts}` : `recents-${ts}`;
+      if (merged) {
+        await exportBulkConversationsMerged(ids, fmt, basename);
+      } else {
+        await exportBulkConversationsSeparate(ids, fmt, basename);
+      }
+    } catch {
+      toast.error("Export failed.");
+    }
+  }
   const [trainOpen, setTrainOpen] = useState(true);
   const [runsOpen, setRunsOpen] = useState(true);
 
@@ -647,6 +678,35 @@ export function AppSidebar() {
                 ))}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon" />
+                <span>Export</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent sideOffset={8} alignOffset={-4} className="unsloth-plus-menu w-52">
+                {[
+                  { label: "Raw JSONL", fn: exportConversationRawJsonl },
+                  { label: "CSV", fn: exportConversationCsv },
+                  { label: "ShareGPT JSONL (training)", fn: exportConversationShareGPT },
+                ].map(({ label, fn }) => (
+                  <DropdownMenuItem
+                    key={label}
+                    onSelect={async () => {
+                      try {
+                        const ids = item.type === "single"
+                          ? [item.id]
+                          : (await listStoredChatThreads({ pairId: item.id })).map((t) => t.id);
+                        await Promise.all(ids.map((id) => fn(id)));
+                      } catch {
+                        toast.error("Export failed.");
+                      }
+                    }}
+                  >
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
             <DropdownMenuItem
               variant="destructive"
               onSelect={() => setConfirmingDelete({ kind: "chat", item })}
@@ -871,6 +931,58 @@ export function AppSidebar() {
                 <CollapsibleTrigger className="cursor-pointer flex w-full items-center gap-1 group/sb-collap">
                   {t("shell.navigation.recents")}
                   <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="ml-auto flex items-center justify-center rounded-sm p-0.5 opacity-0 hover:opacity-100 hover:bg-accent group-hover/sb-collap:opacity-60"
+                        title="Export recents"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <MoreHorizontalIcon className="size-3.5" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent side="bottom" align="end" className="w-56">
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />
+                          Export Recents
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent className="unsloth-plus-menu w-52">
+                          {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                            <DropdownMenuItem key={`r-m-${fmt}`} onSelect={() => void handleBulkExport("recents", fmt, true)}>
+                              {label} — combined
+                            </DropdownMenuItem>
+                          ))}
+                          <DropdownMenuSeparator />
+                          {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                            <DropdownMenuItem key={`r-s-${fmt}`} onSelect={() => void handleBulkExport("recents", fmt, false)}>
+                              {label} — per chat
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />
+                          Export Recents + Projects
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent className="unsloth-plus-menu w-52">
+                          {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                            <DropdownMenuItem key={`a-m-${fmt}`} onSelect={() => void handleBulkExport("all", fmt, true)}>
+                              {label} — combined
+                            </DropdownMenuItem>
+                          ))}
+                          <DropdownMenuSeparator />
+                          {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                            <DropdownMenuItem key={`a-s-${fmt}`} onSelect={() => void handleBulkExport("all", fmt, false)}>
+                              {label} — per chat
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </CollapsibleTrigger>
               </SidebarGroupLabel>
               <CollapsibleContent>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -942,7 +942,7 @@ export function AppSidebar() {
                         <MoreHorizontalIcon className="size-3.5" />
                       </button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent side="bottom" align="end" className="w-56">
+                    <DropdownMenuContent side="bottom" align="start" className="w-56">
                       <DropdownMenuSub>
                         <DropdownMenuSubTrigger>
                           <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1945,7 +1945,7 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
                 <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
                 Export chat
               </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
+              <DropdownMenuSubContent align="start" className="unsloth-plus-menu w-[200px]">
                 <DropdownMenuItem onSelect={() => {
                   if (!activeThreadId) return;
                   exportConversationRawJsonl(activeThreadId).catch(() => toast.error("Export failed."));

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1945,7 +1945,7 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
                 <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
                 Export chat
               </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent align="start" className="unsloth-plus-menu w-[200px]">
+              <DropdownMenuSubContent collisionPadding={16} className="unsloth-plus-menu w-[200px]">
                 <DropdownMenuItem onSelect={() => {
                   if (!activeThreadId) return;
                   exportConversationRawJsonl(activeThreadId).catch(() => toast.error("Export failed."));

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1925,6 +1925,10 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
             <CheckIcon className="ml-auto" />
           ) : null}
         </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => startCompare()}>
+          <Columns2Icon />
+          Compare chat
+        </DropdownMenuItem>
         {/* RAG hidden temporarily */}
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
@@ -1936,38 +1940,34 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
               <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
               Saved prompts
             </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger disabled={!activeThreadId}>
+                <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
+                Export chat
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
+                <DropdownMenuItem onSelect={() => {
+                  if (!activeThreadId) return;
+                  exportConversationRawJsonl(activeThreadId).catch(() => toast.error("Export failed."));
+                }}>
+                  Raw JSONL
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => {
+                  if (!activeThreadId) return;
+                  exportConversationCsv(activeThreadId).catch(() => toast.error("Export failed."));
+                }}>
+                  CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => {
+                  if (!activeThreadId) return;
+                  exportConversationShareGPT(activeThreadId).catch(() => toast.error("Export failed."));
+                }}>
+                  ShareGPT JSONL (training)
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger disabled={!activeThreadId}>
-            <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
-            Export chat
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
-            <DropdownMenuItem onSelect={() => {
-              if (!activeThreadId) return;
-              exportConversationRawJsonl(activeThreadId).catch(() => toast.error("Export failed."));
-            }}>
-              Raw JSONL
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => {
-              if (!activeThreadId) return;
-              exportConversationCsv(activeThreadId).catch(() => toast.error("Export failed."));
-            }}>
-              CSV
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => {
-              if (!activeThreadId) return;
-              exportConversationShareGPT(activeThreadId).catch(() => toast.error("Export failed."));
-            }}>
-              ShareGPT JSONL (training)
-            </DropdownMenuItem>
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-        <DropdownMenuItem onSelect={() => startCompare()}>
-          <Columns2Icon />
-          Compare chat
-        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -46,6 +46,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { sentAudioNames } from "@/features/chat/api/chat-adapter";
+import {
+  PromptStorageDialog,
+  exportConversationShareGPT,
+} from "@/features/chat/prompt-storage/prompt-storage-dialog";
 import { useChatProjects } from "@/features/chat/hooks/use-chat-projects";
 import { NewProjectDialog } from "@/features/chat/components/new-project-dialog";
 import { parseExternalModelId } from "@/features/chat/external-providers";
@@ -77,6 +81,7 @@ import {
 import { flushResourcesSync } from "@assistant-ui/tap";
 import {
   AttachmentIcon,
+  Bookmark02Icon,
   CodeIcon,
   Copy01Icon,
   Delete02Icon,
@@ -126,6 +131,59 @@ import {
 // True while a file is dragged anywhere over the chat page (not just the
 // composer), so the composer can show its "Drop files here" affordance.
 const PageDragContext = createContext(false);
+
+// ── Single-chat prompt queue ───────────────────────────────────────────────
+// All state lives at module level so it survives the Composer remount that
+// happens when the first queued message creates a new thread (new-chat →
+// conversation transition). Component-local useState/useRef would reset.
+
+// Reactive UI state — a tiny Zustand store so ComposerRightControls can
+// subscribe and re-render without needing a React context chain.
+import { create as _createZustand } from "zustand";
+interface _QueueUIState { isRunning: boolean; current: number; total: number; }
+const _useQueueUI = _createZustand<_QueueUIState>(() => ({
+  isRunning: false, current: 0, total: 0,
+}));
+
+// Non-reactive queue data
+let _qItems: string[] = [];
+let _qIndex = 0;
+let _qIsRunning = false;
+let _qPrevThreadRunning = false;
+
+function _qAdvance(auiFn: () => ReturnType<typeof useAui>) {
+  const nextIndex = _qIndex + 1;
+  if (nextIndex >= _qItems.length) {
+    _qIsRunning = false;
+    _qItems = [];
+    _qIndex = 0;
+    _qPrevThreadRunning = false;
+    _useQueueUI.setState({ isRunning: false, current: 0, total: 0 });
+    toast.success("Prompt queue complete");
+    return;
+  }
+  _qIndex = nextIndex;
+  _useQueueUI.setState({ current: nextIndex + 1, total: _qItems.length });
+  const next = _qItems[nextIndex];
+  toast(`Prompt ${nextIndex + 1} / ${_qItems.length}`, {
+    description: next.length > 80 ? next.slice(0, 80) + "…" : next,
+  });
+  setTimeout(() => {
+    auiFn().thread().append({
+      role: "user",
+      content: [{ type: "text", text: next }],
+      createdAt: new Date(),
+    } as never);
+  }, 100);
+}
+
+// Context only carries the callbacks (defined inside Composer so they close
+// over the current `aui`). The reactive display state comes from _useQueueUI.
+interface _QueueCallbacks { startQueue: (items: string[]) => void; stopQueue: () => void; }
+const PromptQueueContext = createContext<_QueueCallbacks>({
+  startQueue: () => {}, stopQueue: () => {},
+});
+// ──────────────────────────────────────────────────────────────────────────
 
 export const Thread: FC<{
   hideComposer?: boolean;
@@ -757,6 +815,65 @@ const Composer: FC<{
     ],
   );
 
+  // ── Prompt queue ──────────────────────────────────────────────────────────
+  // All persistent queue data lives in module-level vars (_qItems, _qIndex…)
+  // and a module-level Zustand store (_useQueueUI) so state survives the
+  // Composer remount that occurs when the first queued message creates a new
+  // thread (new-chat → established-chat transition).
+
+  // Keep a stable function ref so the setInterval callback always has the
+  // current `aui` without recreating the interval.
+  const auiRef = useRef(aui);
+  auiRef.current = aui;
+
+  // Poll isRunning every 200ms — same as original shared-composer.tsx
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (!_qIsRunning) return;
+      try {
+        const isRunning = auiRef.current.thread().getState().isRunning;
+        const wasRunning = _qPrevThreadRunning;
+        _qPrevThreadRunning = isRunning;
+        if (wasRunning && !isRunning) {
+          _qAdvance(() => auiRef.current);
+        }
+      } catch { /* thread not ready yet */ }
+    }, 200);
+    return () => clearInterval(id);
+  }, [aui]); // re-bind only when aui changes (thread runtime switches)
+
+  const stopQueue = useCallback(() => {
+    _qIsRunning = false;
+    _qPrevThreadRunning = false;
+    _qItems = [];
+    _qIndex = 0;
+    _useQueueUI.setState({ isRunning: false, current: 0, total: 0 });
+    auiRef.current.thread().cancelRun();
+  }, []);
+
+  const startQueue = useCallback((items: string[]) => {
+    const filtered = items.filter((p) => p.trim());
+    if (!filtered.length) return;
+    _qItems = filtered;
+    _qIndex = 0;
+    _qIsRunning = true;
+    _qPrevThreadRunning = false;
+    _useQueueUI.setState({ isRunning: true, current: 1, total: filtered.length });
+    toast(`Prompt 1 / ${filtered.length}`, {
+      description: filtered[0].length > 80 ? filtered[0].slice(0, 80) + "…" : filtered[0],
+    });
+    setTimeout(() => {
+      auiRef.current.thread().append({
+        role: "user",
+        content: [{ type: "text", text: filtered[0] }],
+        createdAt: new Date(),
+      } as never);
+    }, 50);
+  }, []);
+
+  const queueContextValue: _QueueCallbacks = { startQueue, stopQueue };
+  // ─────────────────────────────────────────────────────────────────────────
+
   const composerContent = (
     <>
       <ComposerAttachments />
@@ -814,6 +931,7 @@ const Composer: FC<{
   );
 
   return (
+    <PromptQueueContext.Provider value={queueContextValue}>
     <ComposerPrimitive.Root
       className="aui-composer-root relative flex w-full flex-col"
       aria-disabled={disabled}
@@ -849,6 +967,7 @@ const Composer: FC<{
         </ComposerPrimitive.AttachmentDropzone>
       )}
     </ComposerPrimitive.Root>
+    </PromptQueueContext.Provider>
   );
 };
 
@@ -1663,9 +1782,24 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
   }, [navigate]);
 
   const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [promptStorageOpen, setPromptStorageOpen] = useState(false);
+  const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
+  const aui = useAui();
+  const { startQueue } = useContext(PromptQueueContext);
 
   return (
     <>
+    <PromptStorageDialog
+      open={promptStorageOpen}
+      onOpenChange={setPromptStorageOpen}
+      onUse={(text) => {
+        aui.composer().setText(text);
+      }}
+      onRunList={(items) => {
+        setPromptStorageOpen(false);
+        startQueue(items);
+      }}
+    />
     <DropdownMenu>
       <DropdownMenuTrigger asChild={true}>
         <button
@@ -1777,6 +1911,22 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
           ) : null}
         </DropdownMenuItem>
         {/* RAG hidden temporarily */}
+        <DropdownMenuItem onSelect={() => setPromptStorageOpen(true)}>
+          <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
+          Saved prompts
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={!activeThreadId}
+          onSelect={() => {
+            if (!activeThreadId) return;
+            exportConversationShareGPT(activeThreadId).catch(() => {
+              toast.error("Failed to export conversation.");
+            });
+          }}
+        >
+          <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
+          Export chat
+        </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => startCompare()}>
           <Columns2Icon />
           Compare chat
@@ -1825,6 +1975,12 @@ const ComposerRightControls: FC<{
   shouldBlockSend?: () => boolean;
   menuSide?: "top" | "bottom";
 }> = ({ disabled, shouldBlockSend, menuSide }) => {
+  // Read reactive queue state from the module-level store — survives Composer remounts
+  const isQueueRunning = _useQueueUI((s) => s.isRunning);
+  const queueCurrent = _useQueueUI((s) => s.current);
+  const queueTotal = _useQueueUI((s) => s.total);
+  // Get stopQueue callback from context (provided by the current Composer instance)
+  const { stopQueue } = useContext(PromptQueueContext);
   return (
     <div className="aui-composer-action-wrapper flex shrink-0 items-center gap-1.5">
       <ReasoningToggle side={menuSide} />
@@ -1852,40 +2008,57 @@ const ComposerRightControls: FC<{
           </TooltipIconButton>
         </ComposerPrimitive.StopDictation>
       </ComposerPrimitive.If>
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
-        <ComposerPrimitive.Send asChild={true}>
-          <TooltipIconButton
-            tooltip="Send message"
-            side="bottom"
-            type="submit"
-            variant="default"
-            size="icon"
-            disabled={disabled}
-            onClick={(event) => {
-              if (shouldBlockSend?.()) {
-                event.preventDefault();
-              }
-            }}
-            className="aui-composer-send ml-1.5 size-8 rounded-full"
-            aria-label="Send message"
-          >
-            <ArrowUpIcon className="aui-composer-send-icon size-[21px] stroke-2" />
-          </TooltipIconButton>
-        </ComposerPrimitive.Send>
-      </AuiIf>
-      <AuiIf condition={({ thread }) => thread.isRunning}>
-        <ComposerPrimitive.Cancel asChild={true}>
-          <Button
-            type="button"
-            variant="default"
-            size="icon"
-            className="aui-composer-cancel ml-1.5 size-8 rounded-full"
-            aria-label="Stop generating"
-          >
-            <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
-          </Button>
-        </ComposerPrimitive.Cancel>
-      </AuiIf>
+      {isQueueRunning ? (
+        // Replaces both send and cancel while a prompt list is running
+        <button
+          type="button"
+          onClick={stopQueue}
+          aria-label="Stop prompt queue"
+          className="ml-1.5 flex items-center gap-1.5 rounded-full border border-red-500 bg-red-600/10 px-2.5 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-600 hover:text-white dark:text-red-400 dark:hover:text-white"
+        >
+          <SquareIcon className="size-2.5 shrink-0 fill-current" />
+          <span className="tabular-nums">
+            Stop queue {queueCurrent}/{queueTotal}
+          </span>
+        </button>
+      ) : (
+        <>
+          <AuiIf condition={({ thread }) => !thread.isRunning}>
+            <ComposerPrimitive.Send asChild={true}>
+              <TooltipIconButton
+                tooltip="Send message"
+                side="bottom"
+                type="submit"
+                variant="default"
+                size="icon"
+                disabled={disabled}
+                onClick={(event) => {
+                  if (shouldBlockSend?.()) {
+                    event.preventDefault();
+                  }
+                }}
+                className="aui-composer-send ml-1.5 size-8 rounded-full"
+                aria-label="Send message"
+              >
+                <ArrowUpIcon className="aui-composer-send-icon size-[21px] stroke-2" />
+              </TooltipIconButton>
+            </ComposerPrimitive.Send>
+          </AuiIf>
+          <AuiIf condition={({ thread }) => thread.isRunning}>
+            <ComposerPrimitive.Cancel asChild={true}>
+              <Button
+                type="button"
+                variant="default"
+                size="icon"
+                className="aui-composer-cancel ml-1.5 size-8 rounded-full"
+                aria-label="Stop generating"
+              >
+                <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+              </Button>
+            </ComposerPrimitive.Cancel>
+          </AuiIf>
+        </>
+      )}
     </div>
   );
 };

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1940,32 +1940,6 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
               <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
               Saved prompts
             </DropdownMenuItem>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger disabled={!activeThreadId}>
-                <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
-                Export chat
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent collisionPadding={16} className="unsloth-plus-menu w-[200px]">
-                <DropdownMenuItem onSelect={() => {
-                  if (!activeThreadId) return;
-                  exportConversationRawJsonl(activeThreadId).catch(() => toast.error("Export failed."));
-                }}>
-                  Raw JSONL
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => {
-                  if (!activeThreadId) return;
-                  exportConversationCsv(activeThreadId).catch(() => toast.error("Export failed."));
-                }}>
-                  CSV
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => {
-                  if (!activeThreadId) return;
-                  exportConversationShareGPT(activeThreadId).catch(() => toast.error("Export failed."));
-                }}>
-                  ShareGPT JSONL (training)
-                </DropdownMenuItem>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSeparator />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -49,6 +49,8 @@ import { sentAudioNames } from "@/features/chat/api/chat-adapter";
 import {
   PromptStorageDialog,
   exportConversationShareGPT,
+  exportConversationRawJsonl,
+  exportConversationCsv,
 } from "@/features/chat/prompt-storage/prompt-storage-dialog";
 import { useChatProjects } from "@/features/chat/hooks/use-chat-projects";
 import { NewProjectDialog } from "@/features/chat/components/new-project-dialog";
@@ -1927,18 +1929,32 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
           <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
           Saved prompts
         </DropdownMenuItem>
-        <DropdownMenuItem
-          disabled={!activeThreadId}
-          onSelect={() => {
-            if (!activeThreadId) return;
-            exportConversationShareGPT(activeThreadId).catch(() => {
-              toast.error("Failed to export conversation.");
-            });
-          }}
-        >
-          <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
-          Export chat
-        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger disabled={!activeThreadId}>
+            <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
+            Export chat
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
+            <DropdownMenuItem onSelect={() => {
+              if (!activeThreadId) return;
+              exportConversationRawJsonl(activeThreadId).catch(() => toast.error("Export failed."));
+            }}>
+              Raw JSONL
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => {
+              if (!activeThreadId) return;
+              exportConversationCsv(activeThreadId).catch(() => toast.error("Export failed."));
+            }}>
+              CSV
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => {
+              if (!activeThreadId) return;
+              exportConversationShareGPT(activeThreadId).catch(() => toast.error("Export failed."));
+            }}>
+              ShareGPT JSONL (training)
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
         <DropdownMenuItem onSelect={() => startCompare()}>
           <Columns2Icon />
           Compare chat

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -133,31 +133,48 @@ import {
 const PageDragContext = createContext(false);
 
 // ── Single-chat prompt queue ───────────────────────────────────────────────
-// All state lives at module level so it survives the Composer remount that
-// happens when the first queued message creates a new thread (new-chat →
-// conversation transition). Component-local useState/useRef would reset.
+// All persistent state lives at module level so it survives the Composer
+// remount that happens when the first queued message creates a new thread
+// (welcome-screen → conversation navigation).
+//
+// Detection uses useChatRuntimeStore.subscribe on runningByThreadId — the
+// same mechanism as RegisterCompareHandle.waitForRunEnd — so it works even
+// when aui.thread() on the welcome screen isn't bound to the new thread.
 
-// Reactive UI state — a tiny Zustand store so ComposerRightControls can
-// subscribe and re-render without needing a React context chain.
 import { create as _createZustand } from "zustand";
+
+// Reactive UI state — module-level Zustand so ComposerRightControls can
+// subscribe and re-render across Composer mounts.
 interface _QueueUIState { isRunning: boolean; current: number; total: number; }
 const _useQueueUI = _createZustand<_QueueUIState>(() => ({
   isRunning: false, current: 0, total: 0,
 }));
 
-// Non-reactive queue data
+// Non-reactive module-level data
 let _qItems: string[] = [];
 let _qIndex = 0;
 let _qIsRunning = false;
-let _qPrevThreadRunning = false;
+let _qPrevStoreRunning = false;
+let _qStoreUnsub: (() => void) | null = null;
 
-function _qAdvance(auiFn: () => ReturnType<typeof useAui>) {
+// Always points to the current Composer's aui; updated on every render.
+// Safe to call after a remount because Composer sets it before children mount.
+let _qGetAui: () => ReturnType<typeof useAui> = () => {
+  throw new Error("aui not initialised");
+};
+
+function _qStopSubscription() {
+  if (_qStoreUnsub) { _qStoreUnsub(); _qStoreUnsub = null; }
+  _qPrevStoreRunning = false;
+}
+
+function _qAdvance() {
   const nextIndex = _qIndex + 1;
   if (nextIndex >= _qItems.length) {
     _qIsRunning = false;
     _qItems = [];
     _qIndex = 0;
-    _qPrevThreadRunning = false;
+    _qStopSubscription();
     _useQueueUI.setState({ isRunning: false, current: 0, total: 0 });
     toast.success("Prompt queue complete");
     return;
@@ -168,8 +185,9 @@ function _qAdvance(auiFn: () => ReturnType<typeof useAui>) {
   toast(`Prompt ${nextIndex + 1} / ${_qItems.length}`, {
     description: next.length > 80 ? next.slice(0, 80) + "…" : next,
   });
+  _qPrevStoreRunning = false; // reset so we catch the next run
   setTimeout(() => {
-    auiFn().thread().append({
+    _qGetAui().thread().append({
       role: "user",
       content: [{ type: "text", text: next }],
       createdAt: new Date(),
@@ -177,8 +195,22 @@ function _qAdvance(auiFn: () => ReturnType<typeof useAui>) {
   }, 100);
 }
 
-// Context only carries the callbacks (defined inside Composer so they close
-// over the current `aui`). The reactive display state comes from _useQueueUI.
+function _qStartSubscription() {
+  _qStopSubscription();
+  // Subscribe to the store's runningByThreadId — works across navigation
+  // because it's module-level and tracks the actual thread, not aui.thread().
+  _qStoreUnsub = useChatRuntimeStore.subscribe((state) => {
+    if (!_qIsRunning) { _qStopSubscription(); return; }
+    const isRunning = Object.keys(state.runningByThreadId).length > 0;
+    const wasRunning = _qPrevStoreRunning;
+    _qPrevStoreRunning = isRunning;
+    if (wasRunning && !isRunning) {
+      _qAdvance();
+    }
+  });
+}
+
+// Context only carries callbacks so ComposerToolsMenu can call startQueue.
 interface _QueueCallbacks { startQueue: (items: string[]) => void; stopQueue: () => void; }
 const PromptQueueContext = createContext<_QueueCallbacks>({
   startQueue: () => {}, stopQueue: () => {},
@@ -816,39 +848,17 @@ const Composer: FC<{
   );
 
   // ── Prompt queue ──────────────────────────────────────────────────────────
-  // All persistent queue data lives in module-level vars (_qItems, _qIndex…)
-  // and a module-level Zustand store (_useQueueUI) so state survives the
-  // Composer remount that occurs when the first queued message creates a new
-  // thread (new-chat → established-chat transition).
-
-  // Keep a stable function ref so the setInterval callback always has the
-  // current `aui` without recreating the interval.
-  const auiRef = useRef(aui);
-  auiRef.current = aui;
-
-  // Poll isRunning every 200ms — same as original shared-composer.tsx
-  useEffect(() => {
-    const id = setInterval(() => {
-      if (!_qIsRunning) return;
-      try {
-        const isRunning = auiRef.current.thread().getState().isRunning;
-        const wasRunning = _qPrevThreadRunning;
-        _qPrevThreadRunning = isRunning;
-        if (wasRunning && !isRunning) {
-          _qAdvance(() => auiRef.current);
-        }
-      } catch { /* thread not ready yet */ }
-    }, 200);
-    return () => clearInterval(id);
-  }, [aui]); // re-bind only when aui changes (thread runtime switches)
+  // Update the module-level aui getter on every render so _qAdvance and
+  // stopQueue always call the current Composer's aui (post-remount).
+  _qGetAui = () => aui;
 
   const stopQueue = useCallback(() => {
     _qIsRunning = false;
-    _qPrevThreadRunning = false;
+    _qStopSubscription();
+    _useQueueUI.setState({ isRunning: false, current: 0, total: 0 });
     _qItems = [];
     _qIndex = 0;
-    _useQueueUI.setState({ isRunning: false, current: 0, total: 0 });
-    auiRef.current.thread().cancelRun();
+    try { _qGetAui().thread().cancelRun(); } catch { /* ignore */ }
   }, []);
 
   const startQueue = useCallback((items: string[]) => {
@@ -857,13 +867,15 @@ const Composer: FC<{
     _qItems = filtered;
     _qIndex = 0;
     _qIsRunning = true;
-    _qPrevThreadRunning = false;
     _useQueueUI.setState({ isRunning: true, current: 1, total: filtered.length });
     toast(`Prompt 1 / ${filtered.length}`, {
       description: filtered[0].length > 80 ? filtered[0].slice(0, 80) + "…" : filtered[0],
     });
+    // Start the module-level store subscription BEFORE appending so we
+    // don't miss a very fast completion.
+    _qStartSubscription();
     setTimeout(() => {
-      auiRef.current.thread().append({
+      _qGetAui().thread().append({
         role: "user",
         content: [{ type: "text", text: filtered[0] }],
         createdAt: new Date(),

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1926,10 +1926,18 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
           ) : null}
         </DropdownMenuItem>
         {/* RAG hidden temporarily */}
-        <DropdownMenuItem onSelect={() => setPromptStorageOpen(true)}>
-          <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
-          Saved prompts
-        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <MoreHorizontalIcon className="size-4" />
+            More
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-[200px]">
+            <DropdownMenuItem onSelect={() => setPromptStorageOpen(true)}>
+              <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
+              Saved prompts
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
         <DropdownMenuSub>
           <DropdownMenuSubTrigger disabled={!activeThreadId}>
             <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
@@ -2043,7 +2051,7 @@ const ComposerRightControls: FC<{
           type="button"
           onClick={stopQueue}
           aria-label="Stop prompt queue"
-          className="ml-1.5 flex items-center gap-1.5 rounded-full border border-red-500 bg-red-600/10 px-2.5 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-600 hover:text-white dark:text-red-400 dark:hover:text-white"
+          className="ml-1.5 flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/60 px-2.5 py-1 text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         >
           <SquareIcon className="size-2.5 shrink-0 fill-current" />
           <span className="tabular-nums">

--- a/studio/frontend/src/features/chat/api/prompts-api.ts
+++ b/studio/frontend/src/features/chat/api/prompts-api.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+
+export interface PromptEntry {
+  id: string;
+  name: string;
+  text: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PromptListEntry {
+  id: string;
+  name: string;
+  /** Ordered list of prompt texts */
+  items: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+async function parseJsonOrThrow<T>(res: Response): Promise<T> {
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    const detail = (body as { detail?: string } | null)?.detail;
+    throw new Error(detail ?? `Request failed (${res.status})`);
+  }
+  return body as T;
+}
+
+// ── Prompt entries ────────────────────────────────────────────────────────────
+
+export async function listPromptEntries(): Promise<PromptEntry[]> {
+  const res = await authFetch("/api/prompts/entries");
+  const data = await parseJsonOrThrow<{ entries: PromptEntry[] }>(res);
+  return data.entries;
+}
+
+export async function savePromptEntry(entry: PromptEntry): Promise<PromptEntry> {
+  const res = await authFetch(`/api/prompts/entries/${entry.id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(entry),
+  });
+  return parseJsonOrThrow<PromptEntry>(res);
+}
+
+export async function deletePromptEntry(id: string): Promise<void> {
+  const res = await authFetch(`/api/prompts/entries/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`Delete failed (${res.status})`);
+}
+
+export async function bulkSavePromptEntries(entries: PromptEntry[]): Promise<number> {
+  if (!entries.length) return 0;
+  const res = await authFetch("/api/prompts/entries/bulk", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ entries }),
+  });
+  const data = await parseJsonOrThrow<{ count: number }>(res);
+  return data.count;
+}
+
+// ── Prompt lists ──────────────────────────────────────────────────────────────
+
+export async function listPromptLists(): Promise<PromptListEntry[]> {
+  const res = await authFetch("/api/prompts/lists");
+  const data = await parseJsonOrThrow<{ lists: PromptListEntry[] }>(res);
+  return data.lists;
+}
+
+export async function savePromptList(list: PromptListEntry): Promise<PromptListEntry> {
+  const res = await authFetch(`/api/prompts/lists/${list.id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(list),
+  });
+  return parseJsonOrThrow<PromptListEntry>(res);
+}
+
+export async function deletePromptList(id: string): Promise<void> {
+  const res = await authFetch(`/api/prompts/lists/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`Delete failed (${res.status})`);
+}
+
+export async function bulkSavePromptLists(lists: PromptListEntry[]): Promise<number> {
+  if (!lists.length) return 0;
+  const res = await authFetch("/api/prompts/lists/bulk", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ lists }),
+  });
+  const data = await parseJsonOrThrow<{ count: number }>(res);
+  return data.count;
+}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -676,6 +676,9 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
 
   const globalCheckpoint = useChatRuntimeStore((s) => s.params.checkpoint);
   const globalGgufVariant = useChatRuntimeStore((s) => s.activeGgufVariant);
+  const compareRunning = useChatRuntimeStore(
+    (s) => Object.keys(s.runningByThreadId).length > 0,
+  );
   const [model1, setModel1] = useState<CompareModelSelection>({
     id: globalCheckpoint || "",
     isLora: false,
@@ -700,6 +703,7 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
   );
 
   useEffect(() => {
+    if (compareRunning) return;
     let isActive = true;
     listStoredChatThreads({ pairId })
       .then((threads) => {
@@ -723,7 +727,7 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
     return () => {
       isActive = false;
     };
-  }, [pairId]);
+  }, [pairId, compareRunning]);
 
   return (
     <CompareShell

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -555,6 +555,8 @@ const LoraCompareContent = memo(function LoraCompareContent({
         <SharedComposer
           handlesRef={handlesRef}
           onExitCompare={onExitCompare}
+          model1ThreadId={baseThreadId}
+          model2ThreadId={loraThreadId}
         />
       }
     >
@@ -732,6 +734,8 @@ const GeneralCompareContent = memo(function GeneralCompareContent({
           model1={model1}
           model2={model2}
           onExitCompare={onExitCompare}
+          model1ThreadId={model1ThreadId}
+          model2ThreadId={model2ThreadId}
         />
       }
     >

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -530,7 +530,12 @@ const LoraCompareContent = memo(function LoraCompareContent({
   const [baseThreadId, setBaseThreadId] = useState<string>();
   const [loraThreadId, setLoraThreadId] = useState<string>();
 
+  const compareRunning = useChatRuntimeStore(
+    (s) => Object.keys(s.runningByThreadId).length > 0,
+  );
+
   useEffect(() => {
+    if (compareRunning) return;
     let isActive = true;
     listStoredChatThreads({ pairId })
       .then((threads) => {
@@ -546,7 +551,7 @@ const LoraCompareContent = memo(function LoraCompareContent({
     return () => {
       isActive = false;
     };
-  }, [pairId]);
+  }, [pairId, compareRunning]);
 
   return (
     <CompareShell

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -53,7 +53,7 @@ import {
   exportBulkConversationsMerged,
   exportBulkConversationsSeparate,
   EXPORT_FORMATS_LIST,
-  type ExportFormat,
+  type ConvExportFormat,
 } from "./prompt-storage/prompt-storage-dialog";
 import {
   listStoredChatThreads,
@@ -143,7 +143,7 @@ export function ProjectsPage() {
     }
   }
 
-  async function handleProjectExport(project: ProjectRecord, fmt: ExportFormat) {
+  async function handleProjectExport(project: ProjectRecord, fmt: ConvExportFormat) {
     try {
       const threads = await listStoredChatThreads({ projectId: project.id, includeArchived: false });
       const ids = [...new Set(threads.map((t) => t.id))];
@@ -155,7 +155,7 @@ export function ProjectsPage() {
 
   async function handleBulkProjectExport(
     scope: "projects" | "all",
-    fmt: ExportFormat,
+    fmt: ConvExportFormat,
     merged: boolean,
   ) {
     try {

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -43,15 +43,17 @@ import {
   Edit03Icon,
   FolderAddIcon,
   Search01Icon,
+  Upload01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { MoreHorizontalIcon } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   exportProjectConversations,
   exportBulkConversationsMerged,
   exportBulkConversationsSeparate,
+  importConversationsFromFile,
   EXPORT_FORMATS_LIST,
   type ConvExportFormat,
 } from "./prompt-storage/prompt-storage-dialog";
@@ -90,6 +92,26 @@ export function ProjectsPage() {
   const [renaming, setRenaming] = useState<ProjectRecord | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [deleting, setDeleting] = useState<ProjectRecord | null>(null);
+
+  // Import refs: one for global "import to Recents", one per-project (keyed by id)
+  const recentsImportRef = useRef<HTMLInputElement>(null);
+  const projectImportRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+  async function handleImport(file: File, projectId: string | null) {
+    try {
+      const count = await importConversationsFromFile(file, projectId);
+      if (count === 0) {
+        toast.info("No conversations found in file.");
+      } else {
+        const dest = projectId
+          ? (projects.find((p) => p.id === projectId)?.name ?? "project")
+          : "Recents";
+        toast.success(`Imported ${count} conversation${count === 1 ? "" : "s"} to ${dest}.`);
+      }
+    } catch {
+      toast.error("Import failed.");
+    }
+  }
 
   const visibleProjects = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
@@ -200,6 +222,18 @@ export function ProjectsPage() {
 
   return (
     <main className="mx-auto w-full max-w-7xl px-4 py-8 font-heading sm:px-6">
+      {/* Hidden import inputs */}
+      <input
+        ref={recentsImportRef}
+        type="file"
+        accept=".jsonl,.ndjson,.csv"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleImport(file, null);
+          e.target.value = "";
+        }}
+      />
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
           Projects
@@ -220,6 +254,9 @@ export function ProjectsPage() {
               </SelectContent>
             </Select>
           </div>
+          <Button variant="outline" size="icon" title="Import chats" onClick={() => recentsImportRef.current?.click()}>
+            <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.75} className="size-icon" />
+          </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="icon" title="Export projects">
@@ -323,6 +360,22 @@ export function ProjectsPage() {
       ) : (
         <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {visibleProjects.map((project) => (
+            <div key={`wrap-${project.id}`} className="contents">
+            <input
+              key={`import-${project.id}`}
+              type="file"
+              accept=".jsonl,.ndjson,.csv"
+              className="hidden"
+              ref={(el) => {
+                if (el) projectImportRefs.current.set(project.id, el);
+                else projectImportRefs.current.delete(project.id);
+              }}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) void handleImport(file, project.id);
+                e.target.value = "";
+              }}
+            />
             <div
               key={project.id}
               role="button"
@@ -368,6 +421,15 @@ export function ProjectsPage() {
                       <HugeiconsIcon icon={Edit03Icon} strokeWidth={1.75} className="size-icon" />
                       <span>Rename</span>
                     </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={(e) => {
+                        e.stopPropagation();
+                        projectImportRefs.current.get(project.id)?.click();
+                      }}
+                    >
+                      <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.75} className="size-icon" />
+                      <span>Import chats</span>
+                    </DropdownMenuItem>
                     <DropdownMenuSub>
                       <DropdownMenuSubTrigger>
                         <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />
@@ -406,6 +468,7 @@ export function ProjectsPage() {
               <span className="mt-auto pt-4 text-xs text-muted-foreground">
                 Updated {formatUpdatedAgo(project.updatedAt)}
               </span>
+            </div>
             </div>
           ))}
         </div>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -93,9 +93,11 @@ export function ProjectsPage() {
   const [renameDraft, setRenameDraft] = useState("");
   const [deleting, setDeleting] = useState<ProjectRecord | null>(null);
 
-  // Import refs: one for global "import to Recents", one per-project (keyed by id)
-  const recentsImportRef = useRef<HTMLInputElement>(null);
+  // Import: hidden file input + pending project destination state
+  const globalImportRef = useRef<HTMLInputElement>(null);
   const projectImportRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importTargetId, setImportTargetId] = useState<string | null>(null); // null = Recents
 
   async function handleImport(file: File, projectId: string | null) {
     try {
@@ -111,6 +113,14 @@ export function ProjectsPage() {
     } catch {
       toast.error("Import failed.");
     }
+  }
+
+  async function commitImport() {
+    if (!importFile) return;
+    const file = importFile;
+    const target = importTargetId;
+    setImportFile(null);
+    await handleImport(file, target);
   }
 
   const visibleProjects = useMemo(() => {
@@ -222,15 +232,19 @@ export function ProjectsPage() {
 
   return (
     <main className="mx-auto w-full max-w-7xl px-4 py-8 font-heading sm:px-6">
-      {/* Hidden import inputs */}
+      {/* Hidden file input for global import (project picker dialog follows) */}
       <input
-        ref={recentsImportRef}
+        ref={globalImportRef}
         type="file"
         accept=".jsonl,.ndjson,.csv"
         className="hidden"
         onChange={(e) => {
           const file = e.target.files?.[0];
-          if (file) void handleImport(file, null);
+          if (file) {
+            // Pre-select first available project, or null if none
+            setImportTargetId(projects[0]?.id ?? null);
+            setImportFile(file);
+          }
           e.target.value = "";
         }}
       />
@@ -254,16 +268,18 @@ export function ProjectsPage() {
               </SelectContent>
             </Select>
           </div>
-          <Button variant="outline" size="icon" title="Import chats" onClick={() => recentsImportRef.current?.click()}>
-            <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.75} className="size-icon" />
-          </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon" title="Export projects">
+              <Button variant="outline" size="icon" title="Import / Export projects">
                 <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem onSelect={() => globalImportRef.current?.click()}>
+                <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.75} className="size-icon" />
+                Import chats…
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>Export All Projects</DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="w-52">
@@ -548,6 +564,36 @@ export function ProjectsPage() {
             >
               Save
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Import destination picker */}
+      <Dialog open={importFile !== null} onOpenChange={(open) => { if (!open) setImportFile(null); }}>
+        <DialogContent className="corner-squircle border border-border/60 bg-background/98 shadow-none sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Import chats</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{importFile?.name}</span> — choose where to import:
+          </p>
+          <Select
+            value={importTargetId ?? "__recents__"}
+            onValueChange={(v) => setImportTargetId(v === "__recents__" ? null : v)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select destination" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__recents__">Recents</SelectItem>
+              {projects.map((p) => (
+                <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <DialogFooter className="flex-wrap gap-2 sm:justify-end">
+            <Button type="button" variant="ghost" onClick={() => setImportFile(null)}>Cancel</Button>
+            <Button type="button" onClick={() => void commitImport()}>Import</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -13,6 +13,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
@@ -35,6 +39,7 @@ import {
 } from "@/features/chat";
 import {
   Delete02Icon,
+  Download01Icon,
   Edit03Icon,
   FolderAddIcon,
   Search01Icon,
@@ -43,6 +48,16 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { MoreHorizontalIcon } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
+import {
+  exportProjectConversations,
+  exportBulkConversationsMerged,
+  exportBulkConversationsSeparate,
+  EXPORT_FORMATS_LIST,
+  type ExportFormat,
+} from "./prompt-storage/prompt-storage-dialog";
+import {
+  listStoredChatThreads,
+} from "./utils/chat-history-storage";
 
 type SortMode = "activity" | "name";
 
@@ -128,6 +143,48 @@ export function ProjectsPage() {
     }
   }
 
+  async function handleProjectExport(project: ProjectRecord, fmt: ExportFormat) {
+    try {
+      const threads = await listStoredChatThreads({ projectId: project.id, includeArchived: false });
+      const ids = [...new Set(threads.map((t) => t.id))];
+      await exportProjectConversations(ids, fmt, project.name);
+    } catch {
+      toast.error("Export failed.");
+    }
+  }
+
+  async function handleBulkProjectExport(
+    scope: "projects" | "all",
+    fmt: ExportFormat,
+    merged: boolean,
+  ) {
+    try {
+      let threads;
+      if (scope === "projects") {
+        threads = (
+          await Promise.all(
+            projects.map((p) =>
+              listStoredChatThreads({ projectId: p.id, includeArchived: false }),
+            ),
+          )
+        ).flat();
+      } else {
+        threads = await listStoredChatThreads({ includeArchived: false });
+      }
+      const ids = [...new Set(threads.map((t) => t.id))];
+      if (ids.length === 0) { toast.info("No conversations to export."); return; }
+      const ts = new Date().toISOString().slice(0, 10);
+      const basename = `${scope === "all" ? "all-chats" : "all-projects"}-${ts}`;
+      if (merged) {
+        await exportBulkConversationsMerged(ids, fmt, basename);
+      } else {
+        await exportBulkConversationsSeparate(ids, fmt, basename);
+      }
+    } catch {
+      toast.error("Export failed.");
+    }
+  }
+
   async function commitDelete() {
     const target = deleting;
     if (!target) return;
@@ -163,6 +220,47 @@ export function ProjectsPage() {
               </SelectContent>
             </Select>
           </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon" title="Export projects">
+                <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>Export All Projects</DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-52">
+                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                    <DropdownMenuItem key={`ap-m-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, true)}>
+                      {label} — combined
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
+                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                    <DropdownMenuItem key={`ap-s-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, false)}>
+                      {label} — per chat
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>Export Projects + Recents</DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-52">
+                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                    <DropdownMenuItem key={`all-m-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, true)}>
+                      {label} — combined
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
+                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                    <DropdownMenuItem key={`all-s-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, false)}>
+                      {label} — per chat
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <Button
             onClick={() => {
               setNameDraft("");
@@ -270,6 +368,26 @@ export function ProjectsPage() {
                       <HugeiconsIcon icon={Edit03Icon} strokeWidth={1.75} className="size-icon" />
                       <span>Rename</span>
                     </DropdownMenuItem>
+                    <DropdownMenuSub>
+                      <DropdownMenuSubTrigger>
+                        <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon mr-1" />
+                        <span>Export</span>
+                      </DropdownMenuSubTrigger>
+                      <DropdownMenuSubContent className="w-52">
+                        {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                          <DropdownMenuItem
+                            key={fmt}
+                            onSelect={(e) => {
+                              e.stopPropagation();
+                              void handleProjectExport(project, fmt);
+                            }}
+                          >
+                            {label}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuSubContent>
+                    </DropdownMenuSub>
+                    <DropdownMenuSeparator />
                     <DropdownMenuItem
                       variant="destructive"
                       onSelect={() => setDeleting(project)}

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -263,6 +263,109 @@ function messageToText(msg: { content: unknown; attachments?: unknown }): string
   return parts.join("\n\n");
 }
 
+// ── OpenAI-format structured message builder ─────────────────────────────────
+//
+// Converts stored assistant-ui messages into the OpenAI messages array format
+// used for tool-calling and multimodal fine-tuning. Key differences vs the
+// plain-text messageToText path:
+//   - Tool calls → proper "tool_calls" array + separate "role":"tool" messages
+//   - Images     → "image_url" content parts with the stored data-URL
+//   - Audio      → dropped (no standard training format exists)
+//   - Thinking   → included as a text part (some trainers handle it)
+
+type OAIContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+type OAIToolCall = {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+};
+
+type OAIMessage =
+  | { role: "user" | "system"; content: string | OAIContentPart[] }
+  | { role: "assistant"; content: string | null; tool_calls?: OAIToolCall[] }
+  | { role: "tool"; tool_call_id: string; name: string; content: string };
+
+/**
+ * Convert a single stored message into one or more OAIMessages.
+ * Tool-call parts split into an assistant message + tool-result messages.
+ * Image parts become image_url content parts (multimodal training).
+ */
+function messageToOpenAI(msg: { role: unknown; content: unknown; attachments?: unknown }): OAIMessage[] {
+  const role = (msg.role as string) ?? "user";
+  const blocks = Array.isArray(msg.content) ? msg.content : [];
+  const attachments = Array.isArray(msg.attachments) ? msg.attachments : [];
+
+  // Collect all content parts from both blocks and attachments
+  const allParts: Record<string, unknown>[] = [
+    ...blocks.map((b) => b as Record<string, unknown>),
+    ...attachments.flatMap((a) => {
+      const att = a as { content?: unknown };
+      return Array.isArray(att.content)
+        ? (att.content as Record<string, unknown>[])
+        : [];
+    }),
+  ];
+
+  if (role === "assistant") {
+    const textParts: string[] = [];
+    const toolCalls: OAIToolCall[] = [];
+    const toolResults: OAIMessage[] = [];
+
+    for (const p of allParts) {
+      if (p.type === "text" && typeof p.text === "string") {
+        textParts.push(p.text);
+      } else if (p.type === "reasoning" || p.type === "thinking") {
+        // Include thinking as a text part — some trainers preserve it
+        const t = typeof p.thinking === "string" ? p.thinking : typeof p.text === "string" ? p.text : "";
+        if (t) textParts.push(`<thinking>\n${t}\n</thinking>`);
+      } else if (p.type === "tool-call") {
+        const id = typeof p.toolCallId === "string" ? p.toolCallId : `call_${toolCalls.length}`;
+        const name = typeof p.toolName === "string" ? p.toolName : "unknown";
+        const argsStr = p.args != null ? JSON.stringify(p.args) : (typeof p.argsText === "string" ? p.argsText : "{}");
+        toolCalls.push({ id, type: "function", function: { name, arguments: argsStr } });
+        // Emit the result as a tool message immediately after
+        if (p.result !== undefined && p.result !== null) {
+          const resultStr = typeof p.result === "string" ? p.result : JSON.stringify(p.result);
+          toolResults.push({ role: "tool", tool_call_id: id, name, content: resultStr });
+        }
+      }
+    }
+
+    const content = textParts.join("\n\n") || null;
+    const assistantMsg: OAIMessage = toolCalls.length > 0
+      ? { role: "assistant", content, tool_calls: toolCalls }
+      : { role: "assistant", content: content ?? "" };
+
+    return toolResults.length > 0
+      ? [assistantMsg, ...toolResults]
+      : [assistantMsg];
+  }
+
+  // User / system: support multimodal content parts
+  const contentParts: OAIContentPart[] = [];
+  let hasNonText = false;
+
+  for (const p of allParts) {
+    if (p.type === "text" && typeof p.text === "string") {
+      contentParts.push({ type: "text", text: p.text });
+    } else if (p.type === "image" && typeof p.image === "string") {
+      contentParts.push({ type: "image_url", image_url: { url: p.image } });
+      hasNonText = true;
+    }
+    // audio: no standard training format — skip
+  }
+
+  // Flat string content → more compact; only use array if multimodal
+  if (!hasNonText) {
+    const text = contentParts.map((p) => (p.type === "text" ? p.text : "")).join("\n\n");
+    return text ? [{ role: role as "user" | "system", content: text }] : [];
+  }
+  return contentParts.length > 0 ? [{ role: role as "user" | "system", content: contentParts }] : [];
+}
+
 // Conversation export — ShareGPT training JSONL (human/gpt turns).
 export async function exportConversationShareGPT(threadId: string): Promise<void> {
   const messages = await loadConversationMessages(threadId);
@@ -291,15 +394,10 @@ export async function exportConversationRawJsonl(threadId: string): Promise<void
   const messages = await loadConversationMessages(threadId);
   if (!messages) return;
 
-  const msgs: Array<{ role: string; content: string }> = [];
-  for (const msg of messages) {
-    const content = messageToText(msg);
-    if (content.trim()) msgs.push({ role: msg.role as string, content });
-  }
-
-  if (msgs.length === 0) { toast.info("No exportable content."); return; }
+  const oaiMsgs: OAIMessage[] = messages.flatMap((msg) => messageToOpenAI(msg));
+  if (oaiMsgs.length === 0) { toast.info("No exportable content."); return; }
   downloadBlob(
-    JSON.stringify({ messages: msgs }),
+    JSON.stringify({ messages: oaiMsgs }),
     "conversation-" + exportTs() + ".jsonl",
     "application/x-ndjson",
   );
@@ -345,17 +443,13 @@ async function buildThreadContent(
   if (!messages) return null;
 
   if (format === "jsonl-raw") {
-    // OpenAI/ChatML format: one JSON object per conversation, recognised by the
-    // Unsloth trainer as a ChatML-format dataset (looks for a "messages" column).
-    const msgs = messages
-      .map((msg) => {
-        const content = messageToText(msg);
-        if (!content.trim()) return null;
-        return { role: msg.role as string, content };
-      })
-      .filter(Boolean) as Array<{ role: string; content: string }>;
-    if (msgs.length === 0) return null;
-    const record: Record<string, unknown> = { messages: msgs };
+    // OpenAI/ChatML format with proper tool-call and multimodal support.
+    // The Unsloth trainer recognises this as a ChatML-format dataset via the
+    // "messages" key. Tool calls use the OpenAI tool_calls array format;
+    // images are emitted as image_url content parts.
+    const oaiMsgs: OAIMessage[] = messages.flatMap((msg) => messageToOpenAI(msg));
+    if (oaiMsgs.length === 0) return null;
+    const record: Record<string, unknown> = { messages: oaiMsgs };
     if (opts?.includeThreadId) record.thread_id = threadId;
     return JSON.stringify(record);
   }

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -147,21 +147,15 @@ function exportCollectionJsonl(prompts: PromptEntry[], lists: PromptListEntry[])
   downloadBlob(lines, "prompt-collection.jsonl", "application/x-ndjson");
 }
 
-// Conversation export — current thread as ShareGPT JSONL for fine-tuning.
-// Serializes all message types: text, tool-calls, reasoning/thinking blocks.
-export async function exportConversationShareGPT(threadId: string): Promise<void> {
-  const messages = await listStoredChatMessages(threadId);
-  if (messages.length === 0) {
-    toast.info("No messages in this conversation to export.");
-    return;
-  }
+// ── Conversation export helpers ───────────────────────────────────────────
 
-  function contentBlocksToText(content: unknown): string {
-    if (typeof content === "string") return content;
-    if (!Array.isArray(content)) return JSON.stringify(content);
-    const parts: string[] = [];
-    for (const part of content) {
-      if (!part || typeof part !== "object") continue;
+/** Flatten a message content value to a readable string. */
+function contentBlocksToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return JSON.stringify(content);
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
       const p = part as Record<string, unknown>;
       if (p.type === "text" && typeof p.text === "string") {
         parts.push(p.text);
@@ -192,27 +186,74 @@ export async function exportConversationShareGPT(threadId: string): Promise<void
     return parts.join("\n\n");
   }
 
+/** Load messages for a thread, returning null and showing a toast if empty. */
+async function loadConversationMessages(threadId: string) {
+  const messages = await listStoredChatMessages(threadId);
+  if (messages.length === 0) {
+    toast.info("No messages in this conversation to export.");
+    return null;
+  }
+  return messages;
+}
+
+/** Timestamp suffix for filenames. */
+function exportTs(): string {
+  return new Date().toISOString().slice(0, 19).replace(/:/g, "-");
+}
+
+// Conversation export — ShareGPT training JSONL (human/gpt turns).
+export async function exportConversationShareGPT(threadId: string): Promise<void> {
+  const messages = await loadConversationMessages(threadId);
+  if (!messages) return;
+
   const conversations: Array<{ from: string; value: string }> = [];
   for (const msg of messages) {
     const role = msg.role as string;
     const from = role === "user" ? "human" : "gpt";
     const value = contentBlocksToText(msg.content);
-    if (value.trim()) {
-      conversations.push({ from, value });
-    }
+    if (value.trim()) conversations.push({ from, value });
   }
 
-  if (conversations.length === 0) {
-    toast.info("No exportable content in this conversation.");
-    return;
-  }
-
-  const ts = new Date().toISOString().slice(0, 19).replace(/:/g, "-");
+  if (conversations.length === 0) { toast.info("No exportable content."); return; }
   downloadBlob(
     JSON.stringify({ conversations }),
-    "conversation-" + ts + ".jsonl",
+    "conversation-" + exportTs() + ".jsonl",
     "application/x-ndjson",
   );
+}
+
+// Conversation export — raw JSONL, one message per line.
+export async function exportConversationRawJsonl(threadId: string): Promise<void> {
+  const messages = await loadConversationMessages(threadId);
+  if (!messages) return;
+
+  const lines = messages
+    .map((msg) => {
+      const content = contentBlocksToText(msg.content);
+      if (!content.trim()) return null;
+      return JSON.stringify({ role: msg.role, content });
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  if (!lines) { toast.info("No exportable content."); return; }
+  downloadBlob(lines, "conversation-" + exportTs() + ".jsonl", "application/x-ndjson");
+}
+
+// Conversation export — CSV with role and content columns.
+export async function exportConversationCsv(threadId: string): Promise<void> {
+  const messages = await loadConversationMessages(threadId);
+  if (!messages) return;
+
+  const rows = ["role,content"];
+  for (const msg of messages) {
+    const content = contentBlocksToText(msg.content);
+    if (!content.trim()) continue;
+    rows.push(`${csvEscape(msg.role as string)},${csvEscape(content)}`);
+  }
+
+  if (rows.length <= 1) { toast.info("No exportable content."); return; }
+  downloadBlob(rows.join("\n"), "conversation-" + exportTs() + ".csv", "text/csv");
 }
 
 // Training exports — ShareGPT format used by Unsloth fine-tuning pipelines.

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -772,7 +772,9 @@ function parseImportText(text: string, filename: string): ParsedConversation[] {
       let obj: Record<string, unknown>;
       try { obj = JSON.parse(line); } catch { return; }
 
-      const threadId = typeof obj.thread_id === "string" ? obj.thread_id : crypto.randomUUID();
+      // Always generate a fresh ID — never reuse the exported thread_id.
+      // Reusing it would clobber existing threads with the same ID on import.
+      const threadId = crypto.randomUUID();
       const title = typeof obj.title === "string" ? obj.title : `${basename} ${lineIdx + 1}`;
       const baseTs = typeof obj.created_at === "number" ? obj.created_at : Date.now() + lineIdx;
 
@@ -823,7 +825,7 @@ export async function importConversationsFromFile(
         createdAt: messages[0]?.createdAt ?? now,
       };
       await saveStoredChatThread(thread);
-      await syncStoredChatMessages(threadId, messages, { pruneMissing: true });
+      await syncStoredChatMessages(threadId, messages, { pruneMissing: false });
     }),
   );
 

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -379,7 +379,7 @@ export async function exportConversationShareGPT(threadId: string): Promise<void
   const conversations: Array<{ from: string; value: string }> = [];
   for (const msg of messages) {
     const role = msg.role as string;
-    const from = role === "user" ? "human" : "gpt";
+    const from = role === "user" ? "human" : role === "system" ? "system" : "gpt";
     const value = messageToText(msg);
     if (value.trim()) conversations.push({ from, value });
   }
@@ -461,7 +461,7 @@ async function buildThreadContent(
     for (const msg of messages) {
       const role = msg.role as string;
       const value = messageToText(msg);
-      if (value.trim()) conversations.push({ from: role === "user" ? "human" : "gpt", value });
+      if (value.trim()) conversations.push({ from: role === "user" ? "human" : role === "system" ? "system" : "gpt", value });
     }
     if (conversations.length === 0) return null;
     return JSON.stringify({ conversations });

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -186,14 +186,52 @@ function contentBlocksToText(content: unknown): string {
     return parts.join("\n\n");
   }
 
-/** Load messages for a thread, returning null and showing a toast if empty. */
+/**
+ * Walk the parentId chain to reconstruct the correct conversation order.
+ * listStoredChatMessages sorts by createdAt, but GPT response slots are
+ * created with an earlier timestamp than the user's next message, causing
+ * messages to appear out of order. Walking the parent chain guarantees the
+ * correct turn sequence regardless of timestamps.
+ */
+type _Msg = { id: string; parentId?: string | null; createdAt?: number };
+
+function orderByParentChain<T extends _Msg>(messages: T[]): T[] {
+  const byId = new Map<string, T>(messages.map((m) => [m.id, m]));
+  const childrenOf = new Map<string | null, T[]>();
+  for (const m of messages) {
+    const pid = m.parentId ?? null;
+    if (!childrenOf.has(pid)) childrenOf.set(pid, []);
+    childrenOf.get(pid)!.push(m);
+  }
+
+  // Walk the main branch from the root, always taking the most-recent child.
+  const result: T[] = [];
+  let cur: string | null = null;
+  while (childrenOf.has(cur)) {
+    const children: T[] = childrenOf.get(cur)!;
+    // Pick the child with the highest createdAt (most recent branch/edit).
+    const next: T = children.reduce((a: T, b: T) =>
+      (a.createdAt ?? 0) >= (b.createdAt ?? 0) ? a : b,
+    );
+    result.push(next);
+    cur = next.id;
+    byId.delete(next.id);
+  }
+
+  // Append any orphaned messages (shouldn't normally occur) at the end.
+  for (const [, m] of byId) result.push(m);
+  return result;
+}
+
+/** Load messages for a thread in correct conversation order, or null if empty. */
 async function loadConversationMessages(threadId: string) {
-  const messages = await listStoredChatMessages(threadId);
-  if (messages.length === 0) {
+  const raw = await listStoredChatMessages(threadId);
+  if (raw.length === 0) {
     toast.info("No messages in this conversation to export.");
     return null;
   }
-  return messages;
+  // Re-order by parent chain so turns appear in the correct sequence.
+  return orderByParentChain(raw) as typeof raw;
 }
 
 /** Timestamp suffix for filenames. */

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -254,7 +254,7 @@ export async function exportConversationShareGPT(threadId: string): Promise<void
 
   if (conversations.length === 0) { toast.info("No exportable content."); return; }
   downloadBlob(
-    JSON.stringify({ conversations }),
+    JSON.stringify({ conversations }, null, 2),
     "conversation-" + exportTs() + ".jsonl",
     "application/x-ndjson",
   );
@@ -269,10 +269,10 @@ export async function exportConversationRawJsonl(threadId: string): Promise<void
     .map((msg) => {
       const content = contentBlocksToText(msg.content);
       if (!content.trim()) return null;
-      return JSON.stringify({ role: msg.role, content });
+      return JSON.stringify({ role: msg.role, content }, null, 2);
     })
     .filter(Boolean)
-    .join("\n");
+    .join("\n\n");
 
   if (!lines) { toast.info("No exportable content."); return; }
   downloadBlob(lines, "conversation-" + exportTs() + ".jsonl", "application/x-ndjson");
@@ -410,8 +410,9 @@ function parseCsv(text: string): string[][] {
   return rows;
 }
 
-async function importPromptsFromText(text: string, isCsv: boolean): Promise<number> {
+async function importPromptsFromText(text: string, isCsv: boolean): Promise<{ count: number; skipped: number }> {
   const entries: PromptEntry[] = [];
+  let skipped = 0;
   if (isCsv) {
     const rows = parseCsv(text).slice(1); // skip header row
     for (const cells of rows) {
@@ -441,18 +442,21 @@ async function importPromptsFromText(text: string, isCsv: boolean): Promise<numb
             createdAt: now(),
             updatedAt: now(),
           });
+        } else {
+          skipped++;
         }
       } catch {
-        /* skip malformed lines */
+        skipped++;
       }
     }
   }
   if (entries.length > 0) await bulkSavePromptEntries(entries);
-  return entries.length;
+  return { count: entries.length, skipped };
 }
 
-async function importListsFromText(text: string, isCsv: boolean): Promise<number> {
+async function importListsFromText(text: string, isCsv: boolean): Promise<{ count: number; skipped: number }> {
   const lists: PromptListEntry[] = [];
+  let skipped = 0;
   if (isCsv) {
     const rows = parseCsv(text).slice(1); // skip header row
     const listMap = new Map<string, Array<{ order: number; text: string }>>();
@@ -495,15 +499,19 @@ async function importListsFromText(text: string, isCsv: boolean): Promise<number
               createdAt: now(),
               updatedAt: now(),
             });
+          } else {
+            skipped++;
           }
+        } else {
+          skipped++;
         }
       } catch {
-        /* skip malformed lines */
+        skipped++;
       }
     }
   }
   if (lists.length > 0) await bulkSavePromptLists(lists);
-  return lists.length;
+  return { count: lists.length, skipped };
 }
 
 async function importCollectionFromText(text: string): Promise<{ prompts: number; lists: number }> {
@@ -1280,18 +1288,23 @@ export function PromptStorageDialog({
         }
 
         let count = 0;
+        let skipped = 0;
         if (activeTab === "prompts") {
-          count = await importPromptsFromText(text, isCsv);
+          ({ count, skipped } = await importPromptsFromText(text, isCsv));
           void refreshEntries();
         } else {
-          count = await importListsFromText(text, isCsv);
+          ({ count, skipped } = await importListsFromText(text, isCsv));
           void refreshLists();
         }
         if (count > 0) {
-          toast.success(`Imported ${count} item${count !== 1 ? "s" : ""}`);
+          toast.success(`Imported ${count} item${count !== 1 ? "s" : ""}`, {
+            description: skipped > 0 ? `${skipped} line${skipped !== 1 ? "s" : ""} skipped (unrecognised format)` : undefined,
+          });
         } else {
           toast.warning("No items imported", {
-            description: "The file may be empty or in an unsupported format.",
+            description: skipped > 0
+              ? `${skipped} line${skipped !== 1 ? "s" : ""} could not be parsed.`
+              : "The file may be empty or in an unsupported format.",
           });
         }
       } catch {

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -273,10 +273,10 @@ export async function exportConversationRawJsonl(threadId: string): Promise<void
     .map((msg) => {
       const content = contentBlocksToText(msg.content);
       if (!content.trim()) return null;
-      return JSON.stringify({ role: msg.role, content }, null, 2);
+      return JSON.stringify({ role: msg.role, content });
     })
     .filter(Boolean)
-    .join("\n\n");
+    .join("\n");
 
   if (!lines) { toast.info("No exportable content."); return; }
   downloadBlob(lines, "conversation-" + exportTs() + ".jsonl", "application/x-ndjson");

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -62,8 +62,8 @@ function sanitizeFilename(name: string): string {
   return name.replace(/[\\/:*?"<>|]/g, "_").slice(0, 80) || "export";
 }
 
-function downloadBlob(content: string, filename: string, mimeType: string): void {
-  const blob = new Blob([content], { type: mimeType });
+function downloadBlob(content: string | Blob, filename: string, mimeType: string): void {
+  const blob = content instanceof Blob ? content : new Blob([content], { type: mimeType });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
@@ -317,6 +317,165 @@ export async function exportConversationCsv(threadId: string): Promise<void> {
   if (rows.length <= 1) { toast.info("No exportable content."); return; }
   downloadBlob(rows.join("\n"), "conversation-" + exportTs() + ".csv", "text/csv");
 }
+
+// ─── Bulk / multi-thread export ───────────────────────────────────────────────
+
+export type ExportFormat = "jsonl-raw" | "csv" | "sharegpt";
+
+const EXPORT_FORMAT_LABELS: Record<ExportFormat, string> = {
+  "jsonl-raw": "Raw JSONL",
+  csv: "CSV",
+  sharegpt: "ShareGPT JSONL (training)",
+};
+
+export const EXPORT_FORMATS_LIST = (
+  Object.keys(EXPORT_FORMAT_LABELS) as ExportFormat[]
+).map((fmt) => ({ fmt, label: EXPORT_FORMAT_LABELS[fmt] }));
+
+/** Build the exportable text for a single thread, or null if empty. */
+async function buildThreadContent(
+  threadId: string,
+  format: ExportFormat,
+  opts?: { includeThreadId?: boolean },
+): Promise<string | null> {
+  const messages = await loadConversationMessages(threadId);
+  if (!messages) return null;
+
+  if (format === "jsonl-raw") {
+    const lines = messages
+      .map((msg) => {
+        const content = messageToText(msg);
+        if (!content.trim()) return null;
+        const record: Record<string, string> = { role: msg.role as string, content };
+        if (opts?.includeThreadId) record.thread_id = threadId;
+        return JSON.stringify(record);
+      })
+      .filter(Boolean);
+    return lines.length > 0 ? lines.join("\n") : null;
+  }
+
+  if (format === "sharegpt") {
+    const conversations: Array<{ from: string; value: string }> = [];
+    for (const msg of messages) {
+      const role = msg.role as string;
+      const value = messageToText(msg);
+      if (value.trim()) conversations.push({ from: role === "user" ? "human" : "gpt", value });
+    }
+    if (conversations.length === 0) return null;
+    const record: Record<string, unknown> = { conversations };
+    if (opts?.includeThreadId) record.thread_id = threadId;
+    return JSON.stringify(record);
+  }
+
+  // csv
+  const rows: string[] = [];
+  for (const msg of messages) {
+    const content = messageToText(msg);
+    if (!content.trim()) continue;
+    const row = opts?.includeThreadId
+      ? `${csvEscape(threadId)},${csvEscape(msg.role as string)},${csvEscape(content)}`
+      : `${csvEscape(msg.role as string)},${csvEscape(content)}`;
+    rows.push(row);
+  }
+  return rows.length > 0 ? rows.join("\n") : null;
+}
+
+function csvHeader(format: ExportFormat, includeThreadId?: boolean): string {
+  if (format === "csv") {
+    return includeThreadId ? "thread_id,role,content" : "role,content";
+  }
+  return "";
+}
+
+function exportExt(format: ExportFormat): string {
+  return format === "csv" ? "csv" : "jsonl";
+}
+
+function exportMime(format: ExportFormat): string {
+  return format === "csv" ? "text/csv" : "application/x-ndjson";
+}
+
+/**
+ * Export multiple threads as a single merged file (all messages concatenated).
+ * For JSONL formats each thread's records are on their own lines with a
+ * thread_id field; for CSV a thread_id column is prepended.
+ */
+export async function exportBulkConversationsMerged(
+  threadIds: string[],
+  format: ExportFormat,
+  basename: string,
+): Promise<void> {
+  if (threadIds.length === 0) { toast.info("No conversations to export."); return; }
+
+  const parts: string[] = [];
+  const header = csvHeader(format, true);
+
+  for (const id of threadIds) {
+    const content = await buildThreadContent(id, format, { includeThreadId: true });
+    if (content) parts.push(content);
+  }
+
+  if (parts.length === 0) { toast.info("No exportable content."); return; }
+
+  const body = header
+    ? header + "\n" + parts.join("\n")
+    : parts.join("\n");
+
+  downloadBlob(body, `${basename}.${exportExt(format)}`, exportMime(format));
+}
+
+/**
+ * Export multiple threads as a ZIP archive — one file per thread.
+ */
+export async function exportBulkConversationsSeparate(
+  threadIds: string[],
+  format: ExportFormat,
+  basename: string,
+): Promise<void> {
+  if (threadIds.length === 0) { toast.info("No conversations to export."); return; }
+
+  const { zipSync, strToU8 } = await import("fflate");
+  const ext = exportExt(format);
+  const header = csvHeader(format);
+  const files: Record<string, Uint8Array> = {};
+
+  for (const id of threadIds) {
+    const content = await buildThreadContent(id, format);
+    if (!content) continue;
+    const body = header ? header + "\n" + content : content;
+    files[`${id}.${ext}`] = strToU8(body);
+  }
+
+  if (Object.keys(files).length === 0) { toast.info("No exportable content."); return; }
+
+  const zipped = zipSync(files);
+  downloadBlob(
+    new Blob([zipped], { type: "application/zip" }),
+    `${basename}.zip`,
+    "application/zip",
+  );
+}
+
+// ─── Single-project export ─────────────────────────────────────────────────
+
+/**
+ * Export all threads in a single project as a merged file.
+ * Caller provides the list of thread IDs already resolved for the project.
+ */
+export async function exportProjectConversations(
+  threadIds: string[],
+  format: ExportFormat,
+  projectName: string,
+): Promise<void> {
+  const safe = projectName.replace(/[^a-z0-9_-]/gi, "_").slice(0, 40);
+  await exportBulkConversationsMerged(
+    threadIds,
+    format,
+    `project-${safe}-${exportTs()}`,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 // Training exports — ShareGPT format used by Unsloth fine-tuning pipelines.
 // Each prompt → one {"conversations": [...]} record; human turn + empty gpt slot.

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -1334,7 +1334,7 @@ export function PromptStorageDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent showCloseButton={false} className="sm:max-w-[min(1720px,92vw)] max-h-[94vh] flex flex-col gap-0 p-0 overflow-hidden">
+        <DialogContent showCloseButton={false} className="sm:max-w-[min(1100px,88vw)] max-h-[94vh] flex flex-col gap-0 p-0 overflow-hidden">
           {/* Header */}
           <DialogHeader className="px-6 pt-5 pb-4 shrink-0 border-b border-border/50">
             <div className="flex items-center gap-3">

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -1,0 +1,1484 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  BookmarkIcon,
+  CheckIcon,
+  DownloadIcon,
+  GripVerticalIcon,
+  LayoutListIcon,
+  PencilIcon,
+  PlayIcon,
+  PlusIcon,
+  SearchIcon,
+  Trash2Icon,
+  UploadIcon,
+  XIcon,
+} from "lucide-react";
+import {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { toast } from "sonner";
+import {
+  type PromptEntry,
+  type PromptListEntry,
+  bulkSavePromptEntries,
+  bulkSavePromptLists,
+  deletePromptEntry,
+  deletePromptList,
+  listPromptEntries,
+  listPromptLists,
+  savePromptEntry,
+  savePromptList,
+} from "../api/prompts-api";
+import { listStoredChatMessages } from "../utils/chat-history-storage";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function newId(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\\/:*?"<>|]/g, "_").slice(0, 80) || "export";
+}
+
+function downloadBlob(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function csvEscape(val: string): string {
+  return `"${val.replace(/"/g, '""')}"`;
+}
+
+// ── Export helpers ────────────────────────────────────────────────────────────
+
+function exportPromptJsonl(entry: PromptEntry): void {
+  downloadBlob(
+    JSON.stringify({ name: entry.name, text: entry.text }),
+    `${sanitizeFilename(entry.name)}.jsonl`,
+    "application/x-ndjson",
+  );
+}
+
+function exportPromptCsv(entry: PromptEntry): void {
+  downloadBlob(
+    `name,text\n${csvEscape(entry.name)},${csvEscape(entry.text)}`,
+    `${sanitizeFilename(entry.name)}.csv`,
+    "text/csv",
+  );
+}
+
+function exportAllPromptsJsonl(entries: PromptEntry[]): void {
+  const lines = entries.map((e) => JSON.stringify({ name: e.name, text: e.text })).join("\n");
+  downloadBlob(lines, "prompts.jsonl", "application/x-ndjson");
+}
+
+function exportAllPromptsCsv(entries: PromptEntry[]): void {
+  const rows = entries.map((e) => `${csvEscape(e.name)},${csvEscape(e.text)}`).join("\n");
+  downloadBlob(`name,text\n${rows}`, "prompts.csv", "text/csv");
+}
+
+function exportListJsonl(entry: PromptListEntry): void {
+  downloadBlob(
+    JSON.stringify({ name: entry.name, items: entry.items }),
+    `${sanitizeFilename(entry.name)}.jsonl`,
+    "application/x-ndjson",
+  );
+}
+
+function exportAllListsJsonl(entries: PromptListEntry[]): void {
+  const lines = entries.map((e) => JSON.stringify({ name: e.name, items: e.items })).join("\n");
+  downloadBlob(lines, "prompt-lists.jsonl", "application/x-ndjson");
+}
+
+// CSV for lists: list_name,order,prompt_text so multiple lists fit in one file
+function exportListCsv(entry: PromptListEntry): void {
+  const rows = entry.items
+    .map((text, i) => `${csvEscape(entry.name)},${i + 1},${csvEscape(text)}`)
+    .join("\n");
+  downloadBlob(
+    `list_name,order,prompt_text\n${rows}`,
+    `${sanitizeFilename(entry.name)}.csv`,
+    "text/csv",
+  );
+}
+
+function exportAllListsCsv(entries: PromptListEntry[]): void {
+  const rows = entries
+    .flatMap((e) => e.items.map((text, i) => `${csvEscape(e.name)},${i + 1},${csvEscape(text)}`))
+    .join("\n");
+  downloadBlob(`list_name,order,prompt_text\n${rows}`, "prompt-lists.csv", "text/csv");
+}
+
+// Collection: all prompts + all lists in one JSONL, each line tagged with "type"
+function exportCollectionJsonl(prompts: PromptEntry[], lists: PromptListEntry[]): void {
+  const lines = [
+    ...prompts.map((e) => JSON.stringify({ type: "prompt", name: e.name, text: e.text })),
+    ...lists.map((e) => JSON.stringify({ type: "prompt_list", name: e.name, items: e.items })),
+  ].join("\n");
+  downloadBlob(lines, "prompt-collection.jsonl", "application/x-ndjson");
+}
+
+// Conversation export — current thread as ShareGPT JSONL for fine-tuning.
+// Serializes all message types: text, tool-calls, reasoning/thinking blocks.
+export async function exportConversationShareGPT(threadId: string): Promise<void> {
+  const messages = await listStoredChatMessages(threadId);
+  if (messages.length === 0) {
+    toast.info("No messages in this conversation to export.");
+    return;
+  }
+
+  function contentBlocksToText(content: unknown): string {
+    if (typeof content === "string") return content;
+    if (!Array.isArray(content)) return JSON.stringify(content);
+    const parts: string[] = [];
+    for (const part of content) {
+      if (!part || typeof part !== "object") continue;
+      const p = part as Record<string, unknown>;
+      if (p.type === "text" && typeof p.text === "string") {
+        parts.push(p.text);
+      } else if (p.type === "reasoning" || p.type === "thinking") {
+        const thinkText =
+          typeof p.thinking === "string"
+            ? p.thinking
+            : typeof p.text === "string"
+              ? p.text
+              : "";
+        if (thinkText) {
+          parts.push("[thinking]\n" + thinkText + "\n[/thinking]");
+        }
+      } else if (p.type === "tool-call") {
+        parts.push(
+          JSON.stringify({
+            tool_call: p.toolName,
+            args: p.args,
+            result: p.result,
+          }),
+        );
+      } else if (p.type === "image") {
+        parts.push("[image attachment]");
+      } else if (p.type === "audio") {
+        parts.push("[audio attachment]");
+      }
+    }
+    return parts.join("\n\n");
+  }
+
+  const conversations: Array<{ from: string; value: string }> = [];
+  for (const msg of messages) {
+    const role = msg.role as string;
+    const from = role === "user" ? "human" : "gpt";
+    const value = contentBlocksToText(msg.content);
+    if (value.trim()) {
+      conversations.push({ from, value });
+    }
+  }
+
+  if (conversations.length === 0) {
+    toast.info("No exportable content in this conversation.");
+    return;
+  }
+
+  const ts = new Date().toISOString().slice(0, 19).replace(/:/g, "-");
+  downloadBlob(
+    JSON.stringify({ conversations }),
+    "conversation-" + ts + ".jsonl",
+    "application/x-ndjson",
+  );
+}
+
+// Training exports — ShareGPT format used by Unsloth fine-tuning pipelines.
+// Each prompt → one {"conversations": [...]} record; human turn + empty gpt slot.
+// Each list → one multi-turn record where every item is a human turn.
+function exportPromptTrainingJsonl(entry: PromptEntry): void {
+  const record = {
+    conversations: [
+      { from: "human", value: entry.text },
+      { from: "gpt", value: "" },
+    ],
+  };
+  downloadBlob(
+    JSON.stringify(record),
+    `${sanitizeFilename(entry.name)}-training.jsonl`,
+    "application/x-ndjson",
+  );
+}
+
+function exportPromptsTrainingJsonl(entries: PromptEntry[]): void {
+  const lines = entries
+    .map((e) =>
+      JSON.stringify({
+        conversations: [
+          { from: "human", value: e.text },
+          { from: "gpt", value: "" },
+        ],
+      }),
+    )
+    .join("\n");
+  downloadBlob(lines, "prompts-training.jsonl", "application/x-ndjson");
+}
+
+function exportListTrainingJsonl(entry: PromptListEntry): void {
+  const conversations = entry.items.flatMap((text) => [
+    { from: "human", value: text },
+    { from: "gpt", value: "" },
+  ]);
+  downloadBlob(
+    JSON.stringify({ conversations }),
+    `${sanitizeFilename(entry.name)}-training.jsonl`,
+    "application/x-ndjson",
+  );
+}
+
+function exportListsTrainingJsonl(entries: PromptListEntry[]): void {
+  const lines = entries
+    .map((e) => {
+      const conversations = e.items.flatMap((text) => [
+        { from: "human", value: text },
+        { from: "gpt", value: "" },
+      ]);
+      return JSON.stringify({ conversations });
+    })
+    .join("\n");
+  downloadBlob(lines, "prompt-lists-training.jsonl", "application/x-ndjson");
+}
+
+// ── Import helpers ────────────────────────────────────────────────────────────
+
+/** Full RFC 4180 CSV parser. Handles quoted fields with embedded newlines and commas. */
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let i = 0;
+
+  function finishRow() {
+    rows.push(row);
+    row = [];
+  }
+
+  while (i < text.length) {
+    if (text[i] === '"') {
+      // Quoted field — may span multiple lines.
+      i++;
+      let cell = "";
+      while (i < text.length) {
+        if (text[i] === '"') {
+          if (text[i + 1] === '"') {
+            cell += '"';
+            i += 2;
+          } else {
+            i++; // closing quote
+            break;
+          }
+        } else {
+          cell += text[i++];
+        }
+      }
+      row.push(cell);
+      if (text[i] === ",") { i++; }
+      else if (text[i] === "\r") { i++; if (text[i] === "\n") i++; finishRow(); }
+      else if (text[i] === "\n") { i++; finishRow(); }
+    } else if (text[i] === "\r") {
+      i++;
+      if (text[i] === "\n") i++;
+      row.push("");
+      finishRow();
+    } else if (text[i] === "\n") {
+      i++;
+      row.push("");
+      finishRow();
+    } else {
+      // Unquoted field.
+      let cell = "";
+      while (i < text.length && text[i] !== "," && text[i] !== "\r" && text[i] !== "\n") {
+        cell += text[i++];
+      }
+      row.push(cell);
+      if (text[i] === ",") { i++; }
+      else if (text[i] === "\r") { i++; if (text[i] === "\n") i++; finishRow(); }
+      else if (text[i] === "\n") { i++; finishRow(); }
+    }
+  }
+  if (row.length > 0) rows.push(row);
+  return rows;
+}
+
+async function importPromptsFromText(text: string, isCsv: boolean): Promise<number> {
+  const entries: PromptEntry[] = [];
+  if (isCsv) {
+    const rows = parseCsv(text).slice(1); // skip header row
+    for (const cells of rows) {
+      const name = cells[0]?.trim();
+      const promptText = cells[1]?.trim();
+      if (promptText) {
+        entries.push({
+          id: newId(),
+          name: name || "Imported",
+          text: promptText,
+          createdAt: now(),
+          updatedAt: now(),
+        });
+      }
+    }
+  } else {
+    for (const raw of text.split("\n")) {
+      const line = raw.trim();
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        if (typeof obj.text === "string" && obj.text.trim()) {
+          entries.push({
+            id: newId(),
+            name: typeof obj.name === "string" ? obj.name || "Imported" : "Imported",
+            text: obj.text.trim(),
+            createdAt: now(),
+            updatedAt: now(),
+          });
+        }
+      } catch {
+        /* skip malformed lines */
+      }
+    }
+  }
+  if (entries.length > 0) await bulkSavePromptEntries(entries);
+  return entries.length;
+}
+
+async function importListsFromText(text: string, isCsv: boolean): Promise<number> {
+  const lists: PromptListEntry[] = [];
+  if (isCsv) {
+    const rows = parseCsv(text).slice(1); // skip header row
+    const listMap = new Map<string, Array<{ order: number; text: string }>>();
+    for (const cells of rows) {
+      const listName = cells[0]?.trim();
+      const promptText = cells[2]?.trim();
+      if (listName && promptText) {
+        const order = parseInt(cells[1] ?? "0", 10) || 0;
+        if (!listMap.has(listName)) listMap.set(listName, []);
+        listMap.get(listName)!.push({ order, text: promptText });
+      }
+    }
+    for (const [listName, items] of listMap.entries()) {
+      const sorted = items.sort((a, b) => a.order - b.order).map((x) => x.text);
+      if (sorted.length > 0) {
+        lists.push({
+          id: newId(),
+          name: listName,
+          items: sorted,
+          createdAt: now(),
+          updatedAt: now(),
+        });
+      }
+    }
+  } else {
+    for (const raw of text.split("\n")) {
+      const line = raw.trim();
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        if (Array.isArray(obj.items) && obj.items.length > 0) {
+          const items = (obj.items as unknown[]).filter(
+            (x): x is string => typeof x === "string" && x.trim().length > 0,
+          );
+          if (items.length > 0) {
+            lists.push({
+              id: newId(),
+              name: typeof obj.name === "string" ? obj.name || "Imported" : "Imported",
+              items,
+              createdAt: now(),
+              updatedAt: now(),
+            });
+          }
+        }
+      } catch {
+        /* skip malformed lines */
+      }
+    }
+  }
+  if (lists.length > 0) await bulkSavePromptLists(lists);
+  return lists.length;
+}
+
+async function importCollectionFromText(text: string): Promise<{ prompts: number; lists: number }> {
+  const entries: PromptEntry[] = [];
+  const listEntries: PromptListEntry[] = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      const obj = JSON.parse(line) as Record<string, unknown>;
+      if (obj.type === "prompt" && typeof obj.text === "string" && obj.text.trim()) {
+        entries.push({
+          id: newId(),
+          name: typeof obj.name === "string" ? obj.name || "Imported" : "Imported",
+          text: obj.text.trim(),
+          createdAt: now(),
+          updatedAt: now(),
+        });
+      } else if (obj.type === "prompt_list" && Array.isArray(obj.items) && obj.items.length > 0) {
+        const items = (obj.items as unknown[]).filter(
+          (x): x is string => typeof x === "string" && x.trim().length > 0,
+        );
+        if (items.length > 0) {
+          listEntries.push({
+            id: newId(),
+            name: typeof obj.name === "string" ? obj.name || "Imported" : "Imported",
+            items,
+            createdAt: now(),
+            updatedAt: now(),
+          });
+        }
+      }
+    } catch {
+      /* skip malformed lines */
+    }
+  }
+  if (entries.length > 0) await bulkSavePromptEntries(entries);
+  if (listEntries.length > 0) await bulkSavePromptLists(listEntries);
+  return { prompts: entries.length, lists: listEntries.length };
+}
+
+// ── Export modal ──────────────────────────────────────────────────────────────
+
+type ExportScope = "single" | "training";
+type ExportFormat = "jsonl" | "csv";
+
+type ExportModalCtx =
+  | { kind: "prompt"; entry: PromptEntry }
+  | { kind: "list"; entry: PromptListEntry }
+  | { kind: "bulk"; tab: Tab; prompts: PromptEntry[]; lists: PromptListEntry[] };
+
+function ExportModal({
+  ctx,
+  onClose,
+}: {
+  ctx: ExportModalCtx;
+  onClose: () => void;
+}): ReactElement {
+  const [scope, setScope] = useState<ExportScope>("single");
+  const [format, setFormat] = useState<ExportFormat>("jsonl");
+
+  const csvAvailable = scope === "single";
+
+  useEffect(() => {
+    if (!csvAvailable) setFormat("jsonl");
+  }, [csvAvailable]);
+
+  const handleExport = useCallback(() => {
+    if (ctx.kind === "prompt") {
+      if (scope === "training") exportPromptTrainingJsonl(ctx.entry);
+      else if (format === "csv") exportPromptCsv(ctx.entry);
+      else exportPromptJsonl(ctx.entry);
+    } else if (ctx.kind === "list") {
+      if (scope === "training") exportListTrainingJsonl(ctx.entry);
+      else if (format === "csv") exportListCsv(ctx.entry);
+      else exportListJsonl(ctx.entry);
+    } else {
+      // bulk
+      const { tab, prompts, lists } = ctx;
+      if (scope === "training") {
+        if (tab === "prompts") {
+          if (prompts.length === 0) { toast.info("No prompts to export"); return; }
+          exportPromptsTrainingJsonl(prompts);
+        } else {
+          if (lists.length === 0) { toast.info("No prompt lists to export"); return; }
+          exportListsTrainingJsonl(lists);
+        }
+      } else {
+        if (tab === "prompts") {
+          if (prompts.length === 0) { toast.info("No prompts to export"); return; }
+          if (format === "csv") exportAllPromptsCsv(prompts);
+          else exportAllPromptsJsonl(prompts);
+        } else {
+          if (lists.length === 0) { toast.info("No prompt lists to export"); return; }
+          if (format === "csv") exportAllListsCsv(lists);
+          else exportAllListsJsonl(lists);
+        }
+      }
+    }
+    onClose();
+  }, [ctx, scope, format, onClose]);
+
+  const singleLabel =
+    ctx.kind === "prompt"
+      ? "Single Prompt"
+      : ctx.kind === "list"
+        ? "Prompt List"
+        : ctx.kind === "bulk" && ctx.tab === "prompts"
+          ? "All Prompts"
+          : "All Prompt Lists";
+
+  const singleDesc =
+    ctx.kind === "prompt"
+      ? "Export raw prompt name and text"
+      : ctx.kind === "list"
+        ? "Export list name and all prompt items"
+        : ctx.kind === "bulk" && ctx.tab === "prompts"
+          ? "One JSONL or CSV record per saved prompt"
+          : "One JSONL or CSV record per saved list";
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      {/* Override base p-6 gap-6 defaults */}
+      <DialogContent className="sm:max-w-[520px] gap-0 p-0 overflow-hidden">
+        <div className="flex flex-col gap-5 p-6">
+          {/* Title */}
+          <DialogTitle className="text-base font-semibold tracking-tight">Export</DialogTitle>
+          <DialogDescription className="sr-only">Choose export type and format.</DialogDescription>
+
+          {/* Scope */}
+          <div className="flex flex-col gap-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+              Export as
+            </p>
+            <div className="flex flex-col gap-2">
+              {/* Single / All */}
+              <label
+                className={cn(
+                  "flex w-full cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-all",
+                  scope === "single"
+                    ? "border-primary/40 bg-primary/5 ring-1 ring-primary/20"
+                    : "border-border/60 hover:border-border hover:bg-muted/30",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="export-scope"
+                  value="single"
+                  checked={scope === "single"}
+                  onChange={() => setScope("single")}
+                  className="accent-primary shrink-0"
+                />
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold leading-none">{singleLabel}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{singleDesc}</p>
+                </div>
+              </label>
+
+              {/* Training Style */}
+              <label
+                className={cn(
+                  "flex w-full cursor-pointer items-start gap-3 rounded-lg border px-4 py-3 transition-all",
+                  scope === "training"
+                    ? "border-primary/40 bg-primary/5 ring-1 ring-primary/20"
+                    : "border-border/60 hover:border-border hover:bg-muted/30",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="export-scope"
+                  value="training"
+                  checked={scope === "training"}
+                  onChange={() => setScope("training")}
+                  className="mt-0.5 accent-primary shrink-0"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold leading-none">Training Style</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    ShareGPT format for Unsloth fine-tuning
+                  </p>
+                  <code className="mt-2 block w-full truncate rounded-md bg-muted px-2 py-1 font-mono text-[10px] text-muted-foreground/60">
+                    {`{"conversations":[{"from":"human","value":"..."},{"from":"gpt","value":""}]}`}
+                  </code>
+                </div>
+              </label>
+            </div>
+          </div>
+
+          {/* Format */}
+          <div className="flex flex-col gap-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+              Format
+            </p>
+            <div className="flex items-center gap-1 self-start rounded-lg bg-muted/60 p-1">
+              {(["jsonl", "csv"] as ExportFormat[]).map((f) => {
+                const disabled = f === "csv" && !csvAvailable;
+                return (
+                  <label
+                    key={f}
+                    className={cn(
+                      "select-none rounded-md px-6 py-1.5 text-xs font-semibold uppercase tracking-wide transition-all",
+                      disabled
+                        ? "cursor-not-allowed opacity-40 text-muted-foreground"
+                        : "cursor-pointer",
+                      format === f && !disabled
+                        ? "bg-background text-foreground shadow-sm ring-1 ring-border/40"
+                        : !disabled && "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="export-format"
+                      value={f}
+                      checked={format === f}
+                      onChange={() => { if (!disabled) setFormat(f); }}
+                      disabled={disabled}
+                      className="sr-only"
+                    />
+                    {f.toUpperCase()}
+                  </label>
+                );
+              })}
+            </div>
+            {!csvAvailable && (
+              <p className="text-xs text-muted-foreground/60">
+                CSV is not available for this export type
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-border/50 px-6 py-4">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleExport}>
+            <DownloadIcon className="mr-1.5 size-3.5" />
+            Download
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Prompt card ───────────────────────────────────────────────────────────────
+
+function PromptCard({
+  entry,
+  onUse,
+  onExport,
+  onRefresh,
+}: {
+  entry: PromptEntry;
+  onUse: (text: string) => void;
+  onExport: (entry: PromptEntry) => void;
+  onRefresh: () => void;
+}): ReactElement {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(entry.name);
+  const [text, setText] = useState(entry.text);
+
+  const handleSave = useCallback(async () => {
+    const trimName = name.trim();
+    const trimText = text.trim();
+    if (!trimText) return;
+    await savePromptEntry({ ...entry, name: trimName || "Untitled Prompt", text: trimText, updatedAt: now() });
+    setEditing(false);
+    onRefresh();
+  }, [entry, name, text, onRefresh]);
+
+  const handleDelete = useCallback(async () => {
+    await deletePromptEntry(entry.id);
+    onRefresh();
+  }, [entry.id, onRefresh]);
+
+  if (editing) {
+    return (
+      <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Prompt name..."
+          className="w-full rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow"
+        />
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={4}
+          placeholder="Prompt text..."
+          className="w-full resize-y rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow leading-relaxed"
+        />
+        <div className="flex gap-2 justify-end">
+          <Button size="sm" variant="ghost" onClick={() => { setName(entry.name); setText(entry.text); setEditing(false); }}>
+            <XIcon className="size-3.5 mr-1" />Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave}>
+            <CheckIcon className="size-3.5 mr-1" />Save
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="group rounded-xl border border-border/60 bg-card p-4 flex flex-col gap-2 hover:border-border hover:shadow-sm transition-all">
+      <div className="flex items-center gap-2">
+        <span className="font-semibold text-sm flex-1 truncate tracking-tight">{entry.name}</span>
+        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            type="button"
+            onClick={() => onUse(entry.text)}
+            className="flex items-center gap-1.5 rounded-lg bg-primary px-2.5 py-1 text-xs font-semibold text-primary-foreground hover:bg-primary/90 transition-colors"
+            title="Load into composer"
+          >
+            <PlayIcon className="size-3" />Use
+          </button>
+          <div className="mx-1 h-4 w-px bg-border/60" />
+          <button
+            type="button"
+            onClick={() => onExport(entry)}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            title="Export"
+          >
+            <DownloadIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            title="Edit"
+          >
+            <PencilIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+            title="Delete"
+          >
+            <Trash2Icon className="size-3.5" />
+          </button>
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground line-clamp-3 leading-relaxed">{entry.text}</p>
+    </div>
+  );
+}
+
+// ── New prompt form ───────────────────────────────────────────────────────────
+
+function NewPromptForm({ onClose, onRefresh }: { onClose: () => void; onRefresh: () => void }): ReactElement {
+  const [name, setName] = useState("");
+  const [text, setText] = useState("");
+
+  const handleSave = useCallback(async () => {
+    const trimText = text.trim();
+    if (!trimText) return;
+    const ts = now();
+    await savePromptEntry({
+      id: newId(),
+      name: name.trim() || "Untitled Prompt",
+      text: trimText,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    onRefresh();
+    onClose();
+  }, [name, text, onClose, onRefresh]);
+
+  return (
+    <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
+      <p className="text-xs font-semibold text-primary">New Prompt</p>
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Prompt name (optional)..."
+        autoFocus
+        className="w-full rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow"
+      />
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={4}
+        placeholder="Write your prompt here..."
+        className="w-full resize-y rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow leading-relaxed"
+      />
+      <div className="flex gap-2 justify-end">
+        <Button size="sm" variant="ghost" onClick={onClose}>
+          <XIcon className="size-3.5 mr-1" />Cancel
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={!text.trim()}>
+          <CheckIcon className="size-3.5 mr-1" />Save Prompt
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Prompt list card ──────────────────────────────────────────────────────────
+
+function PromptListCard({
+  entry,
+  onRunList,
+  onExport,
+  onRefresh,
+}: {
+  entry: PromptListEntry;
+  onRunList?: (items: string[]) => void;
+  onExport: (entry: PromptListEntry) => void;
+  onRefresh: () => void;
+}): ReactElement {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(entry.name);
+  const [items, setItems] = useState<string[]>(entry.items);
+
+  const handleSave = useCallback(async () => {
+    const filtered = items.filter((t) => t.trim());
+    if (filtered.length === 0) return;
+    await savePromptList({ ...entry, name: name.trim() || "Untitled List", items: filtered, updatedAt: now() });
+    setEditing(false);
+    onRefresh();
+  }, [entry, name, items, onRefresh]);
+
+  const handleDelete = useCallback(async () => {
+    await deletePromptList(entry.id);
+    onRefresh();
+  }, [entry.id, onRefresh]);
+
+  const addItem = useCallback(() => setItems((prev) => [...prev, ""]), []);
+  const removeItem = useCallback(
+    (i: number) => setItems((prev) => prev.filter((_, idx) => idx !== i)),
+    [],
+  );
+  const updateItem = useCallback(
+    (i: number, val: string) =>
+      setItems((prev) => prev.map((v, idx) => (idx === i ? val : v))),
+    [],
+  );
+
+  if (editing) {
+    return (
+      <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="List name..."
+          className="w-full rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow"
+        />
+        <p className="text-xs font-semibold text-muted-foreground">Prompts (sent in order)</p>
+        <div className="flex flex-col gap-2">
+          {items.map((item, i) => (
+            <div key={i} className="flex items-start gap-2">
+              <GripVerticalIcon className="size-4 mt-2.5 shrink-0 text-muted-foreground/30 cursor-grab" />
+              <span className="text-xs font-medium text-muted-foreground/60 mt-2.5 w-5 shrink-0 text-right">{i + 1}.</span>
+              <textarea
+                value={item}
+                onChange={(e) => updateItem(i, e.target.value)}
+                rows={2}
+                placeholder={`Prompt ${i + 1}...`}
+                className="flex-1 resize-y rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow leading-relaxed"
+              />
+              <button
+                type="button"
+                onClick={() => removeItem(i)}
+                className="flex h-7 w-7 mt-1 items-center justify-center rounded-lg text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors shrink-0"
+                title="Remove"
+              >
+                <XIcon className="size-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={addItem}
+          className="flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        >
+          <PlusIcon className="size-3.5" />Add prompt
+        </button>
+        <div className="flex gap-2 justify-end">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => { setName(entry.name); setItems(entry.items); setEditing(false); }}
+          >
+            <XIcon className="size-3.5 mr-1" />Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={items.filter((t) => t.trim()).length === 0}
+          >
+            <CheckIcon className="size-3.5 mr-1" />Save List
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="group rounded-xl border border-border/60 bg-card p-4 flex flex-col gap-2.5 hover:border-border hover:shadow-sm transition-all">
+      <div className="flex items-center gap-2">
+        <span className="font-semibold text-sm flex-1 truncate tracking-tight">{entry.name}</span>
+        <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+          {entry.items.length}
+        </span>
+        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          {onRunList && (
+            <button
+              type="button"
+              onClick={() => onRunList(entry.items)}
+              className="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-xs font-semibold text-primary hover:bg-primary/10 transition-colors"
+              title="Run list"
+            >
+              <PlayIcon className="size-3" />Run
+            </button>
+          )}
+          <div className="mx-1 h-4 w-px bg-border/60" />
+          <button
+            type="button"
+            onClick={() => onExport(entry)}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            title="Export"
+          >
+            <DownloadIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            title="Edit"
+          >
+            <PencilIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+            title="Delete"
+          >
+            <Trash2Icon className="size-3.5" />
+          </button>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        {entry.items.slice(0, 3).map((item, i) => (
+          <p key={i} className="text-xs text-muted-foreground flex gap-2 leading-relaxed">
+            <span className="text-muted-foreground/40 shrink-0 tabular-nums">{i + 1}.</span>
+            <span className="line-clamp-1">{item}</span>
+          </p>
+        ))}
+        {entry.items.length > 3 && (
+          <p className="text-[11px] text-muted-foreground/50 ml-5">
+            +{entry.items.length - 3} more
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── New prompt list form ──────────────────────────────────────────────────────
+
+function NewPromptListForm({ onClose, onRefresh }: { onClose: () => void; onRefresh: () => void }): ReactElement {
+  const [name, setName] = useState("");
+  const [items, setItems] = useState<string[]>(["", ""]);
+
+  const handleSave = useCallback(async () => {
+    const filtered = items.filter((t) => t.trim());
+    if (filtered.length === 0) return;
+    const ts = now();
+    await savePromptList({
+      id: newId(),
+      name: name.trim() || "Untitled List",
+      items: filtered,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    onRefresh();
+    onClose();
+  }, [name, items, onClose, onRefresh]);
+
+  const addItem = useCallback(() => setItems((prev) => [...prev, ""]), []);
+  const removeItem = useCallback(
+    (i: number) => setItems((prev) => prev.filter((_, idx) => idx !== i)),
+    [],
+  );
+  const updateItem = useCallback(
+    (i: number, val: string) =>
+      setItems((prev) => prev.map((v, idx) => (idx === i ? val : v))),
+    [],
+  );
+
+  return (
+    <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
+      <p className="text-xs font-semibold text-primary">New Prompt List</p>
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="List name..."
+        autoFocus
+        className="w-full rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow"
+      />
+      <p className="text-xs font-semibold text-muted-foreground">
+        Prompts — loaded into the composer one at a time
+      </p>
+      <div className="flex flex-col gap-2">
+        {items.map((item, i) => (
+          <div key={i} className="flex items-start gap-2">
+            <span className="text-xs font-medium text-muted-foreground/60 mt-2.5 w-5 shrink-0 text-right">{i + 1}.</span>
+            <textarea
+              value={item}
+              onChange={(e) => updateItem(i, e.target.value)}
+              rows={2}
+              placeholder={`Prompt ${i + 1}...`}
+              className="flex-1 resize-y rounded-lg border-0 bg-background/80 px-3 py-2 text-sm ring-1 ring-border/60 outline-none focus:ring-primary/50 transition-shadow leading-relaxed"
+            />
+            <button
+              type="button"
+              onClick={() => removeItem(i)}
+              disabled={items.length <= 1}
+              className="flex h-7 w-7 mt-1 items-center justify-center rounded-lg text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors shrink-0 disabled:opacity-30 disabled:cursor-not-allowed"
+              title="Remove"
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={addItem}
+        className="flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+      >
+        <PlusIcon className="size-3.5" />Add another prompt
+      </button>
+      <div className="flex gap-2 justify-end">
+        <Button size="sm" variant="ghost" onClick={onClose}>
+          <XIcon className="size-3.5 mr-1" />Cancel
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={items.filter((t) => t.trim()).length === 0}
+        >
+          <CheckIcon className="size-3.5 mr-1" />Save Prompt List
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main dialog ───────────────────────────────────────────────────────────────
+
+type Tab = "prompts" | "lists";
+
+export function PromptStorageDialog({
+  open,
+  onOpenChange,
+  onUse,
+  onRunList,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called when the user clicks "Use" on a saved prompt. Injects text into the composer. */
+  onUse: (text: string) => void;
+  /** Optional: called when the user clicks "Run" on a prompt list (e.g. for eval). */
+  onRunList?: (items: string[]) => void;
+}): ReactElement {
+  const [activeTab, setActiveTab] = useState<Tab>("prompts");
+  const [showNewPrompt, setShowNewPrompt] = useState(false);
+  const [showNewList, setShowNewList] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [exportCtx, setExportCtx] = useState<ExportModalCtx | null>(null);
+  const importRef = useRef<HTMLInputElement>(null);
+
+  const [promptEntries, setPromptEntries] = useState<PromptEntry[]>([]);
+  const [promptLists, setPromptLists] = useState<PromptListEntry[]>([]);
+
+  const refreshEntries = useCallback(async () => {
+    try { setPromptEntries(await listPromptEntries()); } catch { /* ignore */ }
+  }, []);
+  const refreshLists = useCallback(async () => {
+    try { setPromptLists(await listPromptLists()); } catch { /* ignore */ }
+  }, []);
+
+  // Fetch on open
+  useEffect(() => {
+    if (open) {
+      void refreshEntries();
+      void refreshLists();
+    }
+  }, [open, refreshEntries, refreshLists]);
+
+  useEffect(() => {
+    setSearchQuery("");
+    setShowSuggestions(false);
+    setShowNewPrompt(false);
+    setShowNewList(false);
+  }, [activeTab]);
+
+  const filteredPrompts = useMemo(() => {
+    const all = promptEntries ?? [];
+    if (!searchQuery.trim()) return all;
+    const q = searchQuery.toLowerCase();
+    return all.filter(
+      (e) => e.name.toLowerCase().includes(q) || e.text.toLowerCase().includes(q),
+    );
+  }, [promptEntries, searchQuery]);
+
+  const filteredLists = useMemo(() => {
+    const all = promptLists ?? [];
+    if (!searchQuery.trim()) return all;
+    const q = searchQuery.toLowerCase();
+    return all.filter((e) => e.name.toLowerCase().includes(q));
+  }, [promptLists, searchQuery]);
+
+  const suggestions = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    const source: { name: string }[] =
+      activeTab === "prompts" ? (promptEntries ?? []) : (promptLists ?? []);
+    return source
+      .filter((e) => e.name.toLowerCase().includes(q))
+      .slice(0, 7)
+      .map((e) => e.name);
+  }, [searchQuery, activeTab, promptEntries, promptLists]);
+
+  const handleUsePrompt = useCallback(
+    (text: string) => {
+      onUse(text);
+      onOpenChange(false);
+    },
+    [onUse, onOpenChange],
+  );
+
+  const handleImportFile = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const text = await file.text();
+      const isCsv = file.name.toLowerCase().endsWith(".csv");
+      try {
+        // Auto-detect collection JSONL by checking if first line has a "type" field
+        if (!isCsv) {
+          const firstLine = text.split("\n").find((l) => l.trim());
+          if (firstLine) {
+            try {
+              const probe = JSON.parse(firstLine) as Record<string, unknown>;
+              if (probe.type === "prompt" || probe.type === "prompt_list") {
+                const result = await importCollectionFromText(text);
+                const total = result.prompts + result.lists;
+                void refreshEntries();
+                void refreshLists();
+                if (total > 0) {
+                  toast.success(`Imported ${total} item${total !== 1 ? "s" : ""}`, {
+                    description: `${result.prompts} prompt${result.prompts !== 1 ? "s" : ""}, ${result.lists} list${result.lists !== 1 ? "s" : ""}`,
+                  });
+                } else {
+                  toast.warning("No items imported", {
+                    description: "The file may be empty or in an unsupported format.",
+                  });
+                }
+                e.target.value = "";
+                return;
+              }
+            } catch {
+              /* not JSON — fall through to tab-specific import */
+            }
+          }
+        }
+
+        let count = 0;
+        if (activeTab === "prompts") {
+          count = await importPromptsFromText(text, isCsv);
+          void refreshEntries();
+        } else {
+          count = await importListsFromText(text, isCsv);
+          void refreshLists();
+        }
+        if (count > 0) {
+          toast.success(`Imported ${count} item${count !== 1 ? "s" : ""}`);
+        } else {
+          toast.warning("No items imported", {
+            description: "The file may be empty or in an unsupported format.",
+          });
+        }
+      } catch {
+        toast.error("Import failed", { description: "Could not parse the file." });
+      }
+      e.target.value = "";
+    },
+    [activeTab, refreshEntries, refreshLists],
+  );
+
+  const bulkExportDisabled =
+    (activeTab === "prompts" ? (promptEntries?.length ?? 0) : (promptLists?.length ?? 0)) === 0;
+
+  const openBulkExport = useCallback(() => {
+    setExportCtx({
+      kind: "bulk",
+      tab: activeTab,
+      prompts: promptEntries ?? [],
+      lists: promptLists ?? [],
+    });
+  }, [activeTab, promptEntries, promptLists]);
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent showCloseButton={false} className="sm:max-w-[860px] max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden">
+          {/* Header */}
+          <DialogHeader className="px-6 pt-5 pb-4 shrink-0 border-b border-border/50">
+            <div className="flex items-center gap-3">
+              <div className="flex-1 min-w-0">
+                <DialogTitle className="text-base font-semibold tracking-tight">
+                  Prompt Storage
+                </DialogTitle>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Save and reuse prompts across conversations
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <input
+                  ref={importRef}
+                  type="file"
+                  accept=".jsonl,.json,.csv"
+                  className="hidden"
+                  onChange={handleImportFile}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => importRef.current?.click()}
+                  className="h-8 gap-1.5 text-xs"
+                  title="Import from JSONL, CSV, or collection JSONL"
+                >
+                  <UploadIcon className="size-3.5" />
+                  Import
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={bulkExportDisabled}
+                  onClick={openBulkExport}
+                  className="h-8 gap-1.5 text-xs"
+                >
+                  <DownloadIcon className="size-3.5" />
+                  Export
+                </Button>
+                <div className="ml-1 h-5 w-px bg-border/60 shrink-0" />
+                <DialogClose asChild>
+                  <Button variant="ghost" size="icon-sm">
+                    <XIcon className="size-4" />
+                    <span className="sr-only">Close</span>
+                  </Button>
+                </DialogClose>
+              </div>
+            </div>
+            <DialogDescription className="sr-only">
+              Save and manage reusable prompts and prompt lists.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Tabs + search */}
+          <div className="px-6 pt-4 pb-3 shrink-0 flex flex-col gap-3">
+            {/* Segmented tab control */}
+            <div className="flex items-center gap-1 self-start rounded-lg bg-muted/60 p-1">
+              {(["prompts", "lists"] as Tab[]).map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => setActiveTab(tab)}
+                  className={cn(
+                    "rounded-md px-4 py-1.5 text-xs font-medium transition-all",
+                    activeTab === tab
+                      ? "bg-background text-foreground shadow-sm ring-1 ring-border/40"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {tab === "prompts" ? "Saved Prompts" : "Prompt Lists"}
+                </button>
+              ))}
+            </div>
+
+            {/* Search */}
+            <div className="relative">
+              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground/60" />
+              <input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onFocus={() => setShowSuggestions(true)}
+                onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+                placeholder={`Search ${activeTab === "prompts" ? "prompts by name or text" : "prompt lists by name"}…`}
+                className="w-full rounded-lg border-0 bg-muted/50 pl-9 pr-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary/50 placeholder:text-muted-foreground/60 transition-shadow"
+              />
+              {showSuggestions && searchQuery.trim() !== "" && suggestions.length > 0 && (
+                <div className="absolute top-full left-0 right-0 z-50 mt-1 rounded-xl border border-border/60 bg-popover shadow-lg overflow-hidden">
+                  {suggestions.map((name) => (
+                    <button
+                      key={name}
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => { setSearchQuery(name); setShowSuggestions(false); }}
+                      className="flex w-full items-center gap-2.5 px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left"
+                    >
+                      <SearchIcon className="size-3 shrink-0 text-muted-foreground/60" />
+                      <span className="truncate">{name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6 flex flex-col gap-2.5">
+            {activeTab === "prompts" && (
+              <>
+                {!showNewPrompt ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowNewPrompt(true)}
+                    className="flex items-center gap-2.5 rounded-xl border-2 border-dashed border-border/40 px-4 py-3 text-sm font-medium text-muted-foreground hover:border-primary/30 hover:text-primary hover:bg-primary/5 transition-all"
+                  >
+                    <PlusIcon className="size-4" />New Prompt
+                  </button>
+                ) : (
+                  <NewPromptForm onClose={() => setShowNewPrompt(false)} onRefresh={refreshEntries} />
+                )}
+
+                {filteredPrompts.length > 0 ? (
+                  filteredPrompts.map((entry) => (
+                    <PromptCard
+                      key={entry.id}
+                      entry={entry}
+                      onUse={handleUsePrompt}
+                      onExport={(e) => setExportCtx({ kind: "prompt", entry: e })}
+                      onRefresh={refreshEntries}
+                    />
+                  ))
+                ) : (
+                  !showNewPrompt && (
+                    <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+                      {searchQuery.trim() ? (
+                        <>
+                          <div className="flex size-12 items-center justify-center rounded-2xl bg-muted/60">
+                            <SearchIcon className="size-5 text-muted-foreground/40" />
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <p className="text-sm font-medium text-muted-foreground">
+                              No prompts match &ldquo;{searchQuery}&rdquo;
+                            </p>
+                            <button
+                              type="button"
+                              onClick={() => setSearchQuery("")}
+                              className="text-xs text-primary hover:underline"
+                            >
+                              Clear search
+                            </button>
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <div className="flex size-12 items-center justify-center rounded-2xl bg-muted/60">
+                            <BookmarkIcon className="size-5 text-muted-foreground/40" />
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <p className="text-sm font-medium text-muted-foreground">No saved prompts yet</p>
+                            <p className="text-xs text-muted-foreground/60">
+                              Save prompts you use often for quick reuse
+                            </p>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )
+                )}
+              </>
+            )}
+
+            {activeTab === "lists" && (
+              <>
+                {!showNewList ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowNewList(true)}
+                    className="flex items-center gap-2.5 rounded-xl border-2 border-dashed border-border/40 px-4 py-3 text-sm font-medium text-muted-foreground hover:border-primary/30 hover:text-primary hover:bg-primary/5 transition-all"
+                  >
+                    <PlusIcon className="size-4" />New Prompt List
+                  </button>
+                ) : (
+                  <NewPromptListForm onClose={() => setShowNewList(false)} onRefresh={refreshLists} />
+                )}
+
+                {filteredLists.length > 0 ? (
+                  filteredLists.map((entry) => (
+                    <PromptListCard
+                      key={entry.id}
+                      entry={entry}
+                      onRunList={onRunList}
+                      onExport={(e) => setExportCtx({ kind: "list", entry: e })}
+                      onRefresh={refreshLists}
+                    />
+                  ))
+                ) : (
+                  !showNewList && (
+                    <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+                      {searchQuery.trim() ? (
+                        <>
+                          <div className="flex size-12 items-center justify-center rounded-2xl bg-muted/60">
+                            <SearchIcon className="size-5 text-muted-foreground/40" />
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <p className="text-sm font-medium text-muted-foreground">
+                              No prompt lists match &ldquo;{searchQuery}&rdquo;
+                            </p>
+                            <button
+                              type="button"
+                              onClick={() => setSearchQuery("")}
+                              className="text-xs text-primary hover:underline"
+                            >
+                              Clear search
+                            </button>
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <div className="flex size-12 items-center justify-center rounded-2xl bg-muted/60">
+                            <LayoutListIcon className="size-5 text-muted-foreground/40" />
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <p className="text-sm font-medium text-muted-foreground">No prompt lists yet</p>
+                            <p className="text-xs text-muted-foreground/60">
+                              A prompt list queues a sequence of prompts for quick reuse
+                            </p>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )
+                )}
+              </>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {exportCtx && (
+        <ExportModal ctx={exportCtx} onClose={() => setExportCtx(null)} />
+      )}
+    </>
+  );
+}

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -795,7 +795,7 @@ function PromptCard({
 
   if (editing) {
     return (
-      <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
+      <div className="rounded-xl border border-border/50 bg-muted/30 p-4 flex flex-col gap-3">
         <input
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -888,8 +888,8 @@ function NewPromptForm({ onClose, onRefresh }: { onClose: () => void; onRefresh:
   }, [name, text, onClose, onRefresh]);
 
   return (
-    <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
-      <p className="text-xs font-semibold text-primary">New Prompt</p>
+    <div className="rounded-xl border border-border/50 bg-muted/30 p-4 flex flex-col gap-3">
+      <p className="text-xs font-semibold text-muted-foreground">New Prompt</p>
       <input
         value={name}
         onChange={(e) => setName(e.target.value)}
@@ -959,7 +959,7 @@ function PromptListCard({
 
   if (editing) {
     return (
-      <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
+      <div className="rounded-xl border border-border/50 bg-muted/30 p-4 flex flex-col gap-3">
         <input
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -1112,8 +1112,8 @@ function NewPromptListForm({ onClose, onRefresh }: { onClose: () => void; onRefr
   );
 
   return (
-    <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 flex flex-col gap-3">
-      <p className="text-xs font-semibold text-primary">New Prompt List</p>
+    <div className="rounded-xl border border-border/50 bg-muted/30 p-4 flex flex-col gap-3">
+      <p className="text-xs font-semibold text-muted-foreground">New Prompt List</p>
       <input
         value={name}
         onChange={(e) => setName(e.target.value)}
@@ -1334,7 +1334,7 @@ export function PromptStorageDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent showCloseButton={false} className="sm:max-w-[860px] max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden">
+        <DialogContent showCloseButton={false} className="sm:max-w-[min(1720px,92vw)] max-h-[94vh] flex flex-col gap-0 p-0 overflow-hidden">
           {/* Header */}
           <DialogHeader className="px-6 pt-5 pb-4 shrink-0 border-b border-border/50">
             <div className="flex items-center gap-3">
@@ -1447,7 +1447,7 @@ export function PromptStorageDialog({
                   <button
                     type="button"
                     onClick={() => setShowNewPrompt(true)}
-                    className="flex items-center gap-2.5 rounded-xl border-2 border-dashed border-border/40 px-4 py-3 text-sm font-medium text-muted-foreground hover:border-primary/30 hover:text-primary hover:bg-primary/5 transition-all"
+                    className="flex items-center gap-2.5 rounded-xl border-2 border-dashed border-border/40 px-4 py-3 text-sm font-medium text-muted-foreground hover:border-border hover:text-foreground hover:bg-muted/50 transition-all"
                   >
                     <PlusIcon className="size-4" />New Prompt
                   </button>
@@ -1511,7 +1511,7 @@ export function PromptStorageDialog({
                   <button
                     type="button"
                     onClick={() => setShowNewList(true)}
-                    className="flex items-center gap-2.5 rounded-xl border-2 border-dashed border-border/40 px-4 py-3 text-sm font-medium text-muted-foreground hover:border-primary/30 hover:text-primary hover:bg-primary/5 transition-all"
+                    className="flex items-center gap-2.5 rounded-xl border-2 border-dashed border-border/40 px-4 py-3 text-sm font-medium text-muted-foreground hover:border-border hover:text-foreground hover:bg-muted/50 transition-all"
                   >
                     <PlusIcon className="size-4" />New Prompt List
                   </button>

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -443,7 +443,6 @@ export const EXPORT_FORMATS_LIST = (
 async function buildThreadContent(
   threadId: string,
   format: ConvExportFormat,
-  opts?: { includeThreadId?: boolean },
 ): Promise<string | null> {
   const messages = await loadConversationMessages(threadId);
   if (!messages) return null;
@@ -455,9 +454,7 @@ async function buildThreadContent(
     // images are emitted as image_url content parts.
     const oaiMsgs: OAIMessage[] = messages.flatMap((msg) => messageToOpenAI(msg));
     if (oaiMsgs.length === 0) return null;
-    const record: Record<string, unknown> = { messages: oaiMsgs };
-    if (opts?.includeThreadId) record.thread_id = threadId;
-    return JSON.stringify(record);
+    return JSON.stringify({ messages: oaiMsgs });
   }
 
   if (format === "sharegpt") {
@@ -468,9 +465,7 @@ async function buildThreadContent(
       if (value.trim()) conversations.push({ from: role === "user" ? "human" : "gpt", value });
     }
     if (conversations.length === 0) return null;
-    const record: Record<string, unknown> = { conversations };
-    if (opts?.includeThreadId) record.thread_id = threadId;
-    return JSON.stringify(record);
+    return JSON.stringify({ conversations });
   }
 
   // csv
@@ -478,19 +473,13 @@ async function buildThreadContent(
   for (const msg of messages) {
     const content = messageToText(msg);
     if (!content.trim()) continue;
-    const row = opts?.includeThreadId
-      ? `${csvEscape(threadId)},${csvEscape(msg.role as string)},${csvEscape(content)}`
-      : `${csvEscape(msg.role as string)},${csvEscape(content)}`;
-    rows.push(row);
+    rows.push(`${csvEscape(msg.role as string)},${csvEscape(content)}`);
   }
   return rows.length > 0 ? rows.join("\n") : null;
 }
 
-function csvHeader(format: ConvExportFormat, includeThreadId?: boolean): string {
-  if (format === "csv") {
-    return includeThreadId ? "thread_id,role,content" : "role,content";
-  }
-  return "";
+function csvHeader(format: ConvExportFormat): string {
+  return format === "csv" ? "role,content" : "";
 }
 
 function exportExt(format: ConvExportFormat): string {
@@ -514,10 +503,10 @@ export async function exportBulkConversationsMerged(
   if (threadIds.length === 0) { toast.info("No conversations to export."); return; }
 
   const parts: string[] = [];
-  const header = csvHeader(format, true);
+  const header = csvHeader(format);
 
   for (const id of threadIds) {
-    const content = await buildThreadContent(id, format, { includeThreadId: true });
+    const content = await buildThreadContent(id, format);
     if (content) parts.push(content);
   }
 

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -284,22 +284,25 @@ export async function exportConversationShareGPT(threadId: string): Promise<void
   );
 }
 
-// Conversation export — raw JSONL, one message per line.
+// Conversation export — raw JSONL, OpenAI/ChatML format (one object per conversation).
+// {"messages": [{"role": "user", "content": "..."}, ...]}
+// This is recognised by the Unsloth trainer as a ChatML-format dataset.
 export async function exportConversationRawJsonl(threadId: string): Promise<void> {
   const messages = await loadConversationMessages(threadId);
   if (!messages) return;
 
-  const lines = messages
-    .map((msg) => {
-      const content = messageToText(msg);
-      if (!content.trim()) return null;
-      return JSON.stringify({ role: msg.role, content });
-    })
-    .filter(Boolean)
-    .join("\n");
+  const msgs: Array<{ role: string; content: string }> = [];
+  for (const msg of messages) {
+    const content = messageToText(msg);
+    if (content.trim()) msgs.push({ role: msg.role as string, content });
+  }
 
-  if (!lines) { toast.info("No exportable content."); return; }
-  downloadBlob(lines, "conversation-" + exportTs() + ".jsonl", "application/x-ndjson");
+  if (msgs.length === 0) { toast.info("No exportable content."); return; }
+  downloadBlob(
+    JSON.stringify({ messages: msgs }),
+    "conversation-" + exportTs() + ".jsonl",
+    "application/x-ndjson",
+  );
 }
 
 // Conversation export — CSV with role and content columns.
@@ -342,16 +345,19 @@ async function buildThreadContent(
   if (!messages) return null;
 
   if (format === "jsonl-raw") {
-    const lines = messages
+    // OpenAI/ChatML format: one JSON object per conversation, recognised by the
+    // Unsloth trainer as a ChatML-format dataset (looks for a "messages" column).
+    const msgs = messages
       .map((msg) => {
         const content = messageToText(msg);
         if (!content.trim()) return null;
-        const record: Record<string, string> = { role: msg.role as string, content };
-        if (opts?.includeThreadId) record.thread_id = threadId;
-        return JSON.stringify(record);
+        return { role: msg.role as string, content };
       })
-      .filter(Boolean);
-    return lines.length > 0 ? lines.join("\n") : null;
+      .filter(Boolean) as Array<{ role: string; content: string }>;
+    if (msgs.length === 0) return null;
+    const record: Record<string, unknown> = { messages: msgs };
+    if (opts?.includeThreadId) record.thread_id = threadId;
+    return JSON.stringify(record);
   }
 
   if (format === "sharegpt") {

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -324,7 +324,6 @@ function messageToOpenAI(msg: { role: unknown; content: unknown; attachments?: u
       if (p.type === "text" && typeof p.text === "string") {
         textParts.push(p.text);
       } else if (p.type === "reasoning" || p.type === "thinking") {
-        // Include thinking as a text part — some trainers preserve it
         const t = typeof p.thinking === "string" ? p.thinking : typeof p.text === "string" ? p.text : "";
         if (t) textParts.push(`<thinking>\n${t}\n</thinking>`);
       } else if (p.type === "tool-call") {

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -46,7 +46,13 @@ import {
   savePromptEntry,
   savePromptList,
 } from "../api/prompts-api";
-import { listStoredChatMessages } from "../utils/chat-history-storage";
+import {
+  listStoredChatMessages,
+  saveStoredChatThread,
+  syncStoredChatMessages,
+} from "../utils/chat-history-storage";
+import { notifyChatHistoryUpdated } from "../api/chat-api";
+import type { ThreadRecord, MessageRecord } from "../types";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -573,6 +579,267 @@ export async function exportProjectConversations(
     format,
     `project-${safe}-${exportTs()}`,
   );
+}
+
+// ─── Conversation import ──────────────────────────────────────────────────────
+
+/**
+ * Convert an OpenAI messages array back into assistant-ui MessageRecord[].
+ * Tool results (role:"tool") are absorbed into the preceding assistant message's
+ * tool-call part as a `result` field; they don't become separate records.
+ */
+function oaiMessagesToRecords(
+  oaiMsgs: unknown[],
+  threadId: string,
+  baseTs: number,
+): MessageRecord[] {
+  // Pass 1: index tool results by tool_call_id so we can attach them
+  const toolResults = new Map<string, string>();
+  for (const m of oaiMsgs) {
+    const msg = m as Record<string, unknown>;
+    if (msg.role === "tool" && typeof msg.tool_call_id === "string") {
+      toolResults.set(msg.tool_call_id, typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content ?? ""));
+    }
+  }
+
+  const records: MessageRecord[] = [];
+  let prevId: string | null = null;
+  let idx = 0;
+
+  for (const m of oaiMsgs) {
+    const msg = m as Record<string, unknown>;
+    const role = msg.role as string;
+    if (role === "tool") continue; // absorbed into assistant tool-calls
+
+    const id = crypto.randomUUID();
+
+    let content: unknown[];
+
+    if (role === "assistant") {
+      const parts: unknown[] = [];
+      if (typeof msg.content === "string" && msg.content.trim()) {
+        parts.push({ type: "text", text: msg.content });
+      }
+      if (Array.isArray(msg.tool_calls)) {
+        for (const tc of msg.tool_calls) {
+          const tcObj = tc as Record<string, unknown>;
+          const fn = (tcObj.function as Record<string, unknown>) ?? {};
+          const tcId = typeof tcObj.id === "string" ? tcObj.id : crypto.randomUUID();
+          const name = typeof fn.name === "string" ? fn.name : "unknown";
+          const argsStr = typeof fn.arguments === "string" ? fn.arguments : "{}";
+          let args: unknown = {};
+          try { args = JSON.parse(argsStr); } catch { /* keep empty */ }
+          const result = toolResults.get(tcId);
+          parts.push({
+            type: "tool-call",
+            toolCallId: tcId,
+            toolName: name,
+            args,
+            argsText: argsStr,
+            ...(result !== undefined ? { result } : {}),
+          });
+        }
+      }
+      content = parts;
+    } else {
+      // user / system — may be multimodal
+      const raw = msg.content;
+      if (Array.isArray(raw)) {
+        content = raw.flatMap((p): unknown[] => {
+          const part = p as Record<string, unknown>;
+          if (part.type === "text" && typeof part.text === "string") {
+            return [{ type: "text", text: part.text }];
+          }
+          if (part.type === "image_url") {
+            const iu = (part.image_url as Record<string, unknown>) ?? {};
+            return [{ type: "image", image: typeof iu.url === "string" ? iu.url : "" }];
+          }
+          return [];
+        });
+      } else {
+        content = typeof raw === "string" && raw.trim() ? [{ type: "text", text: raw }] : [];
+      }
+    }
+
+    if (content.length === 0) continue;
+
+    records.push({
+      id,
+      threadId,
+      parentId: prevId,
+      role: role as MessageRecord["role"],
+      content: content as MessageRecord["content"],
+      createdAt: baseTs + idx,
+    });
+    prevId = id;
+    idx++;
+  }
+
+  return records;
+}
+
+/** Convert a ShareGPT conversations array into assistant-ui MessageRecord[]. */
+function sharegptToRecords(
+  conversations: unknown[],
+  threadId: string,
+  baseTs: number,
+): MessageRecord[] {
+  const records: MessageRecord[] = [];
+  let prevId: string | null = null;
+  let idx = 0;
+  for (const c of conversations) {
+    const conv = c as Record<string, unknown>;
+    const from = typeof conv.from === "string" ? conv.from : "";
+    const value = typeof conv.value === "string" ? conv.value : "";
+    if (!value.trim()) continue;
+    const role: MessageRecord["role"] = from === "human" ? "user" : from === "system" ? "system" : "assistant";
+    const id = crypto.randomUUID();
+    records.push({
+      id,
+      threadId,
+      parentId: prevId,
+      role,
+      content: [{ type: "text", text: value }] as MessageRecord["content"],
+      createdAt: baseTs + idx,
+    });
+    prevId = id;
+    idx++;
+  }
+  return records;
+}
+
+/** Convert a CSV table (role, content columns) into assistant-ui MessageRecord[]. */
+function csvToRecords(csvText: string, threadId: string, baseTs: number): MessageRecord[] {
+  const lines = csvText.split(/\r?\n/);
+  const records: MessageRecord[] = [];
+  let prevId: string | null = null;
+  let idx = 0;
+  // Skip header row
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    // Minimal CSV parse: first quoted or unquoted field = role, rest = content
+    let role = "";
+    let content = "";
+    if (line.startsWith('"')) {
+      const m = line.match(/^"((?:[^"]|"")*)"\s*,\s*([\s\S]*)$/);
+      if (!m) continue;
+      role = m[1].replace(/""/g, '"');
+      content = m[2].startsWith('"')
+        ? m[2].slice(1, m[2].endsWith('"') ? -1 : undefined).replace(/""/g, '"')
+        : m[2];
+    } else {
+      const comma = line.indexOf(",");
+      if (comma === -1) continue;
+      role = line.slice(0, comma);
+      content = line.slice(comma + 1).startsWith('"')
+        ? line.slice(comma + 2, line.endsWith('"') ? -1 : undefined).replace(/""/g, '"')
+        : line.slice(comma + 1);
+    }
+    if (!content.trim()) continue;
+    const validRole = role === "user" || role === "assistant" || role === "system" ? role : "user";
+    const id = crypto.randomUUID();
+    records.push({
+      id,
+      threadId,
+      parentId: prevId,
+      role: validRole as MessageRecord["role"],
+      content: [{ type: "text", text: content }] as MessageRecord["content"],
+      createdAt: baseTs + idx,
+    });
+    prevId = id;
+    idx++;
+  }
+  return records;
+}
+
+interface ParsedConversation {
+  title: string;
+  threadId: string;
+  messages: MessageRecord[];
+}
+
+/** Parse a file's text content into an array of conversations. */
+function parseImportText(text: string, filename: string): ParsedConversation[] {
+  const results: ParsedConversation[] = [];
+  const basename = filename.replace(/\.[^.]+$/, "");
+
+  const isJsonl = /\.(jsonl|ndjson)$/i.test(filename);
+  const isCsv = /\.csv$/i.test(filename);
+
+  if (isCsv) {
+    // Entire file = one conversation
+    const threadId = crypto.randomUUID();
+    const messages = csvToRecords(text, threadId, Date.now());
+    if (messages.length > 0) {
+      results.push({ title: basename, threadId, messages });
+    }
+    return results;
+  }
+
+  if (isJsonl) {
+    const lines = text.split(/\r?\n/).filter((l) => l.trim());
+    lines.forEach((line, lineIdx) => {
+      let obj: Record<string, unknown>;
+      try { obj = JSON.parse(line); } catch { return; }
+
+      const threadId = typeof obj.thread_id === "string" ? obj.thread_id : crypto.randomUUID();
+      const title = typeof obj.title === "string" ? obj.title : `${basename} ${lineIdx + 1}`;
+      const baseTs = typeof obj.created_at === "number" ? obj.created_at : Date.now() + lineIdx;
+
+      let messages: MessageRecord[] = [];
+
+      if (Array.isArray(obj.messages)) {
+        // Raw JSONL (OpenAI format)
+        messages = oaiMessagesToRecords(obj.messages, threadId, baseTs);
+      } else if (Array.isArray(obj.conversations)) {
+        // ShareGPT format
+        messages = sharegptToRecords(obj.conversations, threadId, baseTs);
+      }
+
+      if (messages.length > 0) {
+        results.push({ title, threadId, messages });
+      }
+    });
+    return results;
+  }
+
+  // Unknown extension — try JSONL, then CSV fallback
+  return parseImportText(text, filename + ".jsonl");
+}
+
+/**
+ * Import conversations from a File into chat storage.
+ * @param file   The file to import (.jsonl, .ndjson, or .csv)
+ * @param projectId  null = Recents, string = put in this project
+ * @returns number of threads imported
+ */
+export async function importConversationsFromFile(
+  file: File,
+  projectId: string | null = null,
+): Promise<number> {
+  const text = await file.text();
+  const parsed = parseImportText(text, file.name);
+  if (parsed.length === 0) return 0;
+
+  const now = Date.now();
+  await Promise.all(
+    parsed.map(async ({ title, threadId, messages }) => {
+      const thread: ThreadRecord = {
+        id: threadId,
+        title,
+        modelType: "base",
+        projectId: projectId ?? null,
+        archived: false,
+        createdAt: messages[0]?.createdAt ?? now,
+      };
+      await saveStoredChatThread(thread);
+      await syncStoredChatMessages(threadId, messages, { pruneMissing: true });
+    }),
+  );
+
+  notifyChatHistoryUpdated();
+  return parsed.length;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -243,6 +243,26 @@ function exportTs(): string {
   return new Date().toISOString().slice(0, 19).replace(/:/g, "-");
 }
 
+/**
+ * Flatten a stored message's content blocks AND any separately-stored
+ * attachments (images/audio/files sent via the composer) into a single string.
+ * Attachments keep their content in msg.attachments[].content rather than
+ * msg.content, so without this they would be silently dropped on export.
+ */
+function messageToText(msg: { content: unknown; attachments?: unknown }): string {
+  const parts: string[] = [];
+  const main = contentBlocksToText(msg.content);
+  if (main) parts.push(main);
+  if (Array.isArray(msg.attachments)) {
+    for (const attachment of msg.attachments as Array<{ content?: unknown }>) {
+      if (!attachment?.content) continue;
+      const attText = contentBlocksToText(attachment.content);
+      if (attText) parts.push(attText);
+    }
+  }
+  return parts.join("\n\n");
+}
+
 // Conversation export — ShareGPT training JSONL (human/gpt turns).
 export async function exportConversationShareGPT(threadId: string): Promise<void> {
   const messages = await loadConversationMessages(threadId);
@@ -252,7 +272,7 @@ export async function exportConversationShareGPT(threadId: string): Promise<void
   for (const msg of messages) {
     const role = msg.role as string;
     const from = role === "user" ? "human" : "gpt";
-    const value = contentBlocksToText(msg.content);
+    const value = messageToText(msg);
     if (value.trim()) conversations.push({ from, value });
   }
 
@@ -271,7 +291,7 @@ export async function exportConversationRawJsonl(threadId: string): Promise<void
 
   const lines = messages
     .map((msg) => {
-      const content = contentBlocksToText(msg.content);
+      const content = messageToText(msg);
       if (!content.trim()) return null;
       return JSON.stringify({ role: msg.role, content });
     })
@@ -289,7 +309,7 @@ export async function exportConversationCsv(threadId: string): Promise<void> {
 
   const rows = ["role,content"];
   for (const msg of messages) {
-    const content = contentBlocksToText(msg.content);
+    const content = messageToText(msg);
     if (!content.trim()) continue;
     rows.push(`${csvEscape(msg.role as string)},${csvEscape(content)}`);
   }

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -230,7 +230,11 @@ async function loadConversationMessages(threadId: string) {
     toast.info("No messages in this conversation to export.");
     return null;
   }
-  // Re-order by parent chain so turns appear in the correct sequence.
+  // If no message has a parentId the thread is fully legacy (flat list already
+  // sorted by createdAt from the DB). Walking the chain in that case picks the
+  // newest message first, which inverts the order. Fall back to raw order.
+  const hasParentIds = raw.some((m) => (m as { parentId?: unknown }).parentId != null);
+  if (!hasParentIds) return raw;
   return orderByParentChain(raw) as typeof raw;
 }
 
@@ -254,7 +258,7 @@ export async function exportConversationShareGPT(threadId: string): Promise<void
 
   if (conversations.length === 0) { toast.info("No exportable content."); return; }
   downloadBlob(
-    JSON.stringify({ conversations }, null, 2),
+    JSON.stringify({ conversations }),
     "conversation-" + exportTs() + ".jsonl",
     "application/x-ndjson",
   );

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -320,22 +320,22 @@ export async function exportConversationCsv(threadId: string): Promise<void> {
 
 // ─── Bulk / multi-thread export ───────────────────────────────────────────────
 
-export type ExportFormat = "jsonl-raw" | "csv" | "sharegpt";
+export type ConvExportFormat = "jsonl-raw" | "csv" | "sharegpt";
 
-const EXPORT_FORMAT_LABELS: Record<ExportFormat, string> = {
+const EXPORT_FORMAT_LABELS: Record<ConvExportFormat, string> = {
   "jsonl-raw": "Raw JSONL",
   csv: "CSV",
   sharegpt: "ShareGPT JSONL (training)",
 };
 
 export const EXPORT_FORMATS_LIST = (
-  Object.keys(EXPORT_FORMAT_LABELS) as ExportFormat[]
+  Object.keys(EXPORT_FORMAT_LABELS) as ConvExportFormat[]
 ).map((fmt) => ({ fmt, label: EXPORT_FORMAT_LABELS[fmt] }));
 
 /** Build the exportable text for a single thread, or null if empty. */
 async function buildThreadContent(
   threadId: string,
-  format: ExportFormat,
+  format: ConvExportFormat,
   opts?: { includeThreadId?: boolean },
 ): Promise<string | null> {
   const messages = await loadConversationMessages(threadId);
@@ -380,18 +380,18 @@ async function buildThreadContent(
   return rows.length > 0 ? rows.join("\n") : null;
 }
 
-function csvHeader(format: ExportFormat, includeThreadId?: boolean): string {
+function csvHeader(format: ConvExportFormat, includeThreadId?: boolean): string {
   if (format === "csv") {
     return includeThreadId ? "thread_id,role,content" : "role,content";
   }
   return "";
 }
 
-function exportExt(format: ExportFormat): string {
+function exportExt(format: ConvExportFormat): string {
   return format === "csv" ? "csv" : "jsonl";
 }
 
-function exportMime(format: ExportFormat): string {
+function exportMime(format: ConvExportFormat): string {
   return format === "csv" ? "text/csv" : "application/x-ndjson";
 }
 
@@ -402,7 +402,7 @@ function exportMime(format: ExportFormat): string {
  */
 export async function exportBulkConversationsMerged(
   threadIds: string[],
-  format: ExportFormat,
+  format: ConvExportFormat,
   basename: string,
 ): Promise<void> {
   if (threadIds.length === 0) { toast.info("No conversations to export."); return; }
@@ -429,7 +429,7 @@ export async function exportBulkConversationsMerged(
  */
 export async function exportBulkConversationsSeparate(
   threadIds: string[],
-  format: ExportFormat,
+  format: ConvExportFormat,
   basename: string,
 ): Promise<void> {
   if (threadIds.length === 0) { toast.info("No conversations to export."); return; }
@@ -464,7 +464,7 @@ export async function exportBulkConversationsSeparate(
  */
 export async function exportProjectConversations(
   threadIds: string[],
-  format: ExportFormat,
+  format: ConvExportFormat,
   projectName: string,
 ): Promise<void> {
   const safe = projectName.replace(/[^a-z0-9_-]/gi, "_").slice(0, 40);

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -12,11 +12,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
@@ -37,20 +33,18 @@ import {
 } from "lucide-react";
 import {
   AttachmentIcon,
+  Bookmark02Icon,
   CodeIcon,
   Download01Icon,
-  Folder01Icon,
-  FolderAddIcon,
   Image03Icon,
-  McpServerIcon,
-  PencilRulerIcon,
 } from "@hugeicons/core-free-icons";
 import { useNavigate } from "@tanstack/react-router";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { toast } from "@/lib/toast";
-import { McpComposerButton } from "./mcp-composer-button";
-import { NewProjectDialog } from "./components/new-project-dialog";
-import { useChatProjects } from "./hooks/use-chat-projects";
+import {
+  PromptStorageDialog,
+  exportConversationShareGPT,
+} from "./prompt-storage/prompt-storage-dialog";
 import { loadModel, validateModel } from "./api/chat-api";
 import {
   parseExternalModelId,
@@ -65,7 +59,6 @@ import {
   getExternalReasoningCapabilities,
   providerSupportsBuiltinCodeExecution,
   providerSupportsBuiltinImageGeneration,
-  providerSupportsBuiltinWebFetch,
 } from "./provider-capabilities";
 import {
   type CompositionEvent,
@@ -389,11 +382,17 @@ export function SharedComposer({
   model1,
   model2,
   onExitCompare,
+  model1ThreadId,
+  model2ThreadId,
 }: {
   handlesRef: CompareHandles;
   model1?: CompareModelSelection;
   model2?: CompareModelSelection;
   onExitCompare?: () => void;
+  /** Thread ID of the left/model1 pane, used for conversation export. */
+  model1ThreadId?: string;
+  /** Thread ID of the right/model2 pane, used for conversation export. */
+  model2ThreadId?: string;
 }): ReactElement {
   const navigate = useNavigate();
   // Exit compare. Uses the parent's restore handler, or a fresh chat when
@@ -415,7 +414,17 @@ export function SharedComposer({
   } | null>(null);
   const [dragging, setDragging] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
-  const [newProjectOpen, setNewProjectOpen] = useState(false);
+  // ── Prompt storage & queue ────────────────────────────────────────────────
+  const [promptStorageOpen, setPromptStorageOpen] = useState(false);
+  const [isQueueRunning, setIsQueueRunning] = useState(false);
+  const [queueProgress, setQueueProgress] = useState({ current: 0, total: 0 });
+  const queueRef = useRef<string[]>([]);
+  const queueIndexRef = useRef(0);
+  const isQueueRunningRef = useRef(false);
+  const prevRunningRef = useRef(false);
+  const prevComparingRef = useRef(false);
+  const sendRef = useRef<(() => void) | null>(null);
+  // ─────────────────────────────────────────────────────────────────────────
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const composingRef = useRef(false);
   const stuckImeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -454,6 +463,7 @@ export function SharedComposer({
   );
   const preserveThinking = useChatRuntimeStore((s) => s.preserveThinking);
   const setPreserveThinking = useChatRuntimeStore((s) => s.setPreserveThinking);
+  const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const supportsTools = useChatRuntimeStore((s) => s.supportsTools);
   const supportsBuiltinWebSearch = useChatRuntimeStore(
     (s) => s.supportsBuiltinWebSearch,
@@ -465,27 +475,6 @@ export function SharedComposer({
   const imageToolsEnabled = useChatRuntimeStore((s) => s.imageToolsEnabled);
   const setImageToolsEnabled = useChatRuntimeStore(
     (s) => s.setImageToolsEnabled,
-  );
-  const artifactsEnabled = useChatRuntimeStore((s) => s.artifactsEnabled);
-  const setArtifactsEnabled = useChatRuntimeStore((s) => s.setArtifactsEnabled);
-  const mcpEnabledForChat = useChatRuntimeStore((s) => s.mcpEnabledForChat);
-  const setMcpEnabledForChat = useChatRuntimeStore(
-    (s) => s.setMcpEnabledForChat,
-  );
-  // Three most recently updated projects for the quick-access submenu.
-  const { projects } = useChatProjects();
-  const recentProjects = [...projects]
-    .sort((a, b) => b.updatedAt - a.updatedAt)
-    .slice(0, 3);
-  const openProject = (projectId: string) => {
-    useChatRuntimeStore.getState().setActiveProjectId(projectId);
-    navigate({ to: "/chat", search: { project: projectId } });
-  };
-  const webFetchToolsEnabled = useChatRuntimeStore(
-    (s) => s.webFetchToolsEnabled,
-  );
-  const setWebFetchToolsEnabled = useChatRuntimeStore(
-    (s) => s.setWebFetchToolsEnabled,
   );
   const lastOpenRouterChosenModel = useChatRuntimeStore(
     (s) => s.lastOpenRouterChosenModel,
@@ -527,7 +516,6 @@ export function SharedComposer({
           {
             isReasoningProvider:
               selectedExternalProvider?.isReasoningModel === true,
-            baseUrl: selectedExternalProvider?.baseUrl ?? null,
           },
         )
       : null;
@@ -582,9 +570,6 @@ export function SharedComposer({
     effectiveExternalModelId,
     selectedExternalProvider?.baseUrl,
   );
-  const supportsBuiltinWebFetch = providerSupportsBuiltinWebFetch(
-    selectedExternalProvider?.providerType,
-  );
   // Gemini rejects codeExecution alongside image modalities. Search is
   // blocked on older Gemini image ids but allowed on Gemini 3 image
   // models -- supportsBuiltinWebSearch already encodes the per-model
@@ -618,18 +603,9 @@ export function SharedComposer({
   // Images pill is only ever lit on OpenAI cloud's Responses-API models
   // and Gemini Nano Banana family. No local tool runtime fallback.
   const showImagePill = supportsBuiltinImageGeneration;
-  // Fetch pill: Anthropic-only (web_fetch_20250910 / web_fetch_20260209).
-  const webFetchDisabled = !modelLoaded || !supportsBuiltinWebFetch;
-  const showWebFetchPill = supportsBuiltinWebFetch;
   // With more than 4 pills showing, collapse them to icons only to cut clutter.
   // Compare, Search and Code always show; the rest are conditional.
-  const pillsCompact =
-    3 +
-      (showImagePill ? 1 : 0) +
-      (showWebFetchPill ? 1 : 0) +
-      (artifactsEnabled ? 1 : 0) +
-      (mcpEnabledForChat ? 1 : 0) >
-    4;
+  const pillsCompact = 3 + (showImagePill ? 1 : 0) > 4;
   // Backwards-compatible alias for any other call site that may still
   // reference `toolsDisabled` (rare; both pills used it before).
   const toolsDisabled = codeDisabled;
@@ -653,6 +629,46 @@ export function SharedComposer({
     }, 200);
     return () => clearInterval(id);
   }, [handlesRef]);
+
+  function advanceQueue() {
+    const nextIndex = queueIndexRef.current + 1;
+    if (nextIndex >= queueRef.current.length) {
+      isQueueRunningRef.current = false;
+      setIsQueueRunning(false);
+      queueRef.current = [];
+      queueIndexRef.current = 0;
+      setQueueProgress({ current: 0, total: 0 });
+      toast.success("Prompt queue complete");
+      return;
+    }
+    queueIndexRef.current = nextIndex;
+    setQueueProgress({ current: nextIndex + 1, total: queueRef.current.length });
+    const next = queueRef.current[nextIndex];
+    toast(`Prompt ${nextIndex + 1} / ${queueRef.current.length}`, {
+      description: next.length > 80 ? next.slice(0, 80) + "…" : next,
+    });
+    setText(next);
+    setTimeout(() => {
+      sendRef.current?.();
+    }, 100);
+  }
+
+  // Compare mode: advance queue when the full compare cycle finishes.
+  useEffect(() => {
+    const wasComparing = prevComparingRef.current;
+    prevComparingRef.current = comparing;
+    if (!isQueueRunningRef.current || !wasComparing || comparing) return;
+    prevRunningRef.current = false;
+    advanceQueue();
+  }, [comparing]);
+
+  // Single-chat mode: advance queue when running transitions true → false.
+  useEffect(() => {
+    const wasRunning = prevRunningRef.current;
+    prevRunningRef.current = running;
+    if (!isQueueRunningRef.current || !wasRunning || running || comparing) return;
+    advanceQueue();
+  }, [running, comparing]);
 
   // Auto-expand textarea up to 6 rows, then scroll (matches regular chat composer).
   useEffect(() => {
@@ -971,6 +987,7 @@ export function SharedComposer({
       }
     }
   }
+  sendRef.current = send;
 
   function stop() {
     if (isDictating) stopDictation();
@@ -1027,6 +1044,34 @@ export function SharedComposer({
         addFiles(e.dataTransfer.files);
       }}
     >
+      <PromptStorageDialog
+        open={promptStorageOpen}
+        onOpenChange={setPromptStorageOpen}
+        onUse={(t) => {
+          setText(t);
+          requestAnimationFrame(() => textareaRef.current?.focus());
+        }}
+        onRunList={(items) => {
+          const filtered = items.filter((p) => p.trim());
+          if (!filtered.length) return;
+          setPromptStorageOpen(false);
+          queueRef.current = filtered;
+          queueIndexRef.current = 0;
+          isQueueRunningRef.current = true;
+          setIsQueueRunning(true);
+          setQueueProgress({ current: 1, total: filtered.length });
+          toast(`Prompt 1 / ${filtered.length}`, {
+            description:
+              filtered[0].length > 80
+                ? filtered[0].slice(0, 80) + "…"
+                : filtered[0],
+          });
+          setText(filtered[0]);
+          setTimeout(() => {
+            sendRef.current?.();
+          }, 100);
+        }}
+      />
       {/* Gemini-style drop affordance, mirrored from the single composer. */}
       <div
         className={`pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center gap-1 overflow-hidden rounded-[32px] bg-background/90 backdrop-blur-sm transition-opacity duration-150 dark:bg-card/90 ${dragging ? "opacity-100" : "opacity-0"}`}
@@ -1123,12 +1168,7 @@ export function SharedComposer({
               e.target.value = "";
             }}
           />
-          <NewProjectDialog
-            open={newProjectOpen}
-            onOpenChange={setNewProjectOpen}
-          />
-          {/* Same + side menu as the single-chat composer (ComposerToolsMenu),
-              wired to the compare composer's own file/audio inputs and tools. */}
+          {/* + side menu: tools, attachments, prompt storage */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild={true}>
               <button
@@ -1219,28 +1259,28 @@ export function SharedComposer({
                 </DropdownMenuItem>
               )}
               <DropdownMenuSeparator />
-              <DropdownMenuItem
-                className={
-                  artifactsEnabled ? "text-primary font-medium" : undefined
-                }
-                onSelect={() => setArtifactsEnabled(!artifactsEnabled)}
-              >
-                <HugeiconsIcon icon={PencilRulerIcon} strokeWidth={2} />
-                Canvas
-                {artifactsEnabled ? <CheckIcon className="ml-auto" /> : null}
+              <DropdownMenuItem onSelect={() => setPromptStorageOpen(true)}>
+                <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
+                Saved prompts
               </DropdownMenuItem>
               <DropdownMenuItem
-                disabled={!supportsTools}
-                className={
-                  mcpEnabledForChat ? "text-primary font-medium" : undefined
-                }
-                onSelect={() => setMcpEnabledForChat(!mcpEnabledForChat)}
+                disabled={!model1ThreadId && !model2ThreadId && !activeThreadId}
+                onSelect={() => {
+                  // In compare mode export both panes; in single mode export active thread.
+                  const ids = model1ThreadId || model2ThreadId
+                    ? [model1ThreadId, model2ThreadId].filter(Boolean) as string[]
+                    : activeThreadId
+                      ? [activeThreadId]
+                      : [];
+                  if (ids.length === 0) return;
+                  Promise.all(ids.map((id) => exportConversationShareGPT(id))).catch(() => {
+                    toast.error("Failed to export conversation.");
+                  });
+                }}
               >
-                <HugeiconsIcon icon={McpServerIcon} strokeWidth={2} />
-                MCP
-                {mcpEnabledForChat ? <CheckIcon className="ml-auto" /> : null}
+                <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
+                Export chat
               </DropdownMenuItem>
-              {/* RAG hidden temporarily */}
               {/* Always active: this menu only renders in compare mode.
                   Ticked like Web search/Code; click toggles it off. */}
               <DropdownMenuItem
@@ -1251,35 +1291,6 @@ export function SharedComposer({
                 Compare chat
                 <CheckIcon className="ml-auto" />
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <HugeiconsIcon icon={Folder01Icon} strokeWidth={2} />
-                  Projects
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
-                  <DropdownMenuItem onSelect={() => setNewProjectOpen(true)}>
-                    <HugeiconsIcon icon={FolderAddIcon} strokeWidth={2} />
-                    New project
-                  </DropdownMenuItem>
-                  <DropdownMenuLabel>Recents</DropdownMenuLabel>
-                  {recentProjects.length > 0 ? (
-                    recentProjects.map((project) => (
-                      <DropdownMenuItem
-                        key={project.id}
-                        onSelect={() => openProject(project.id)}
-                      >
-                        <HugeiconsIcon icon={Folder01Icon} strokeWidth={2} />
-                        <span className="truncate">{project.name}</span>
-                      </DropdownMenuItem>
-                    ))
-                  ) : (
-                    <DropdownMenuItem disabled={true}>
-                      No recent projects
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
             </DropdownMenuContent>
           </DropdownMenu>
           {/* Active in compare mode; sits first. Click to exit back to single chat. */}
@@ -1367,44 +1378,6 @@ export function SharedComposer({
               <span>Images</span>
             </button>
           )}
-          {showWebFetchPill && (
-            <button
-              type="button"
-              disabled={webFetchDisabled}
-              onClick={() => setWebFetchToolsEnabled(!webFetchToolsEnabled)}
-              className="composer-pill-btn"
-              data-active={
-                webFetchToolsEnabled && !webFetchDisabled ? "true" : "false"
-              }
-              aria-label={
-                webFetchToolsEnabled ? "Disable URL fetch" : "Enable URL fetch"
-              }
-            >
-              <PillGlyph>
-                <HugeiconsIcon icon={Download01Icon} className="size-3.5" />
-              </PillGlyph>
-              <span>Fetch</span>
-            </button>
-          )}
-          {artifactsEnabled ? (
-            <button
-              type="button"
-              onClick={() => setArtifactsEnabled(false)}
-              className="composer-pill-btn"
-              data-active="true"
-              aria-label="Disable canvas"
-            >
-              <PillGlyph>
-                <HugeiconsIcon
-                  icon={PencilRulerIcon}
-                  className="size-[15.5px]"
-                  strokeWidth={2}
-                />
-              </PillGlyph>
-              <span>Canvas</span>
-            </button>
-          ) : null}
-          {mcpEnabledForChat ? <McpComposerButton side="top" /> : null}
         </div>
         {/* mr-0.5 matches the send button inset from the edge in normal chat;
             gap-1.5 matches its control spacing. */}
@@ -1616,7 +1589,27 @@ export function SharedComposer({
               )}
             </>
           )}
-          {busy ? (
+          {isQueueRunning ? (
+            // Red labelled pill — distinct from the icon-only dictation stop
+            <button
+              type="button"
+              onClick={() => {
+                isQueueRunningRef.current = false;
+                setIsQueueRunning(false);
+                queueRef.current = [];
+                queueIndexRef.current = 0;
+                setQueueProgress({ current: 0, total: 0 });
+                stop();
+              }}
+              aria-label="Stop prompt queue"
+              className="flex items-center gap-1.5 rounded-full border border-red-500 bg-red-600/10 px-2.5 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-600 hover:text-white dark:text-red-400 dark:hover:text-white"
+            >
+              <SquareIcon className="size-2.5 shrink-0 fill-current" />
+              <span className="tabular-nums">
+                Stop queue {queueProgress.current}/{queueProgress.total}
+              </span>
+            </button>
+          ) : busy ? (
             <Button
               type="button"
               variant="default"

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -31,6 +31,7 @@ import {
   Columns2Icon,
   GlobeIcon,
   HeadphonesIcon,
+  MoreHorizontalIcon,
   PlusIcon,
   SquareIcon,
   XIcon,
@@ -1354,10 +1355,54 @@ export function SharedComposer({
                 {mcpEnabledForChat ? <CheckIcon className="ml-auto" /> : null}
               </DropdownMenuItem>
               {/* RAG hidden temporarily */}
-              <DropdownMenuItem onSelect={() => setPromptStorageOpen(true)}>
-                <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
-                Saved prompts
-              </DropdownMenuItem>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <MoreHorizontalIcon className="size-4" />
+                  More
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
+                  <DropdownMenuItem onSelect={() => setPromptStorageOpen(true)}>
+                    <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
+                    Saved prompts
+                  </DropdownMenuItem>
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
+                      Export chat
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent
+                      className="unsloth-plus-menu w-[200px]"
+                      collisionPadding={16}
+                    >
+                      {(
+                        [
+                          {
+                            label: "Raw JSONL",
+                            fn: exportConversationRawJsonl,
+                          },
+                          { label: "CSV", fn: exportConversationCsv },
+                          {
+                            label: "ShareGPT JSONL (training)",
+                            fn: exportConversationShareGPT,
+                          },
+                        ] as const
+                      ).map(({ label, fn }) => {
+                        const threadId =
+                          model1ThreadId ?? model2ThreadId ?? activeThreadId;
+                        return (
+                          <DropdownMenuItem
+                            key={label}
+                            disabled={!threadId}
+                            onSelect={() => threadId && fn(threadId)}
+                          >
+                            {label}
+                          </DropdownMenuItem>
+                        );
+                      })}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
               {/* Always active: this menu only renders in compare mode.
                   Ticked like Web search/Code; click toggles it off. */}
               <DropdownMenuItem

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1358,39 +1358,6 @@ export function SharedComposer({
                 <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
                 Saved prompts
               </DropdownMenuItem>
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
-                  Export chat
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
-                  {[
-                    { label: "Raw JSONL", fn: exportConversationRawJsonl },
-                    { label: "CSV", fn: exportConversationCsv },
-                    { label: "ShareGPT JSONL (training)", fn: exportConversationShareGPT },
-                  ].map(({ label, fn }) => {
-                    const ids = [model1ThreadId, model2ThreadId, activeThreadId]
-                      .filter((id): id is string => Boolean(id));
-                    return (
-                      <DropdownMenuItem
-                        key={label}
-                        disabled={ids.length === 0}
-                        onSelect={() => {
-                          if (!ids.length) {
-                            toast.error("No conversation to export yet.");
-                            return;
-                          }
-                          Promise.all(ids.map((id) => fn(id))).catch(() =>
-                            toast.error("Export failed."),
-                          );
-                        }}
-                      >
-                        {label}
-                      </DropdownMenuItem>
-                    );
-                  })}
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
               {/* Always active: this menu only renders in compare mode.
                   Ticked like Web search/Code; click toggles it off. */}
               <DropdownMenuItem

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1099,6 +1099,18 @@ export function SharedComposer({
         onRunList={(items) => {
           const filtered = items.filter((p) => p.trim());
           if (!filtered.length) return;
+          const hasCompareHandles = Boolean(
+            handlesRef.current["model1"] || handlesRef.current["model2"],
+          );
+          const isGeneralizedCompare =
+            hasCompareHandles && Boolean(model1?.id && model2?.id);
+          if (hasCompareHandles && !isGeneralizedCompare) {
+            toast.error("Pick a model in each pane to compare", {
+              description:
+                "Use the model dropdown above each pane, then send your prompt.",
+            });
+            return;
+          }
           setPromptStorageOpen(false);
           queueRef.current = filtered;
           queueIndexRef.current = 0;

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -436,6 +436,7 @@ export function SharedComposer({
   const isQueueRunningRef = useRef(false);
   const prevRunningRef = useRef(false);
   const prevComparingRef = useRef(false);
+  const compareStepSucceededRef = useRef(false);
   const sendRef = useRef<(() => void) | null>(null);
   // ─────────────────────────────────────────────────────────────────────────
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -698,11 +699,24 @@ export function SharedComposer({
     setTimeout(() => { sendRef.current?.(); }, 100);
   }
 
-  // Compare mode: advance queue when the full compare cycle finishes.
+  // Compare mode: advance queue when the full compare cycle finishes, but
+  // stop the queue if the compare step failed to avoid burning through prompts
+  // with incomplete results.
   useEffect(() => {
     const wasComparing = prevComparingRef.current;
     prevComparingRef.current = comparing;
     if (!isQueueRunningRef.current || !wasComparing || comparing) return;
+    if (!compareStepSucceededRef.current) {
+      isQueueRunningRef.current = false;
+      setIsQueueRunning(false);
+      queueRef.current = [];
+      queueIndexRef.current = 0;
+      setQueueProgress({ current: 0, total: 0 });
+      toast.error("Prompt queue stopped", {
+        description: "A compare step failed — remaining prompts were not sent.",
+      });
+      return;
+    }
     prevRunningRef.current = false;
     advanceQueue();
   }, [comparing]);
@@ -1015,8 +1029,10 @@ export function SharedComposer({
           await done;
         }
 
+        compareStepSucceededRef.current = true;
         toast.success("Compare complete", { id: toastId, duration: 2000 });
       } catch (err) {
+        compareStepSucceededRef.current = false;
         toast.error("Compare failed", {
           id: toastId,
           description: err instanceof Error ? err.message : "Unknown error",

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -12,7 +12,11 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
@@ -36,7 +40,11 @@ import {
   Bookmark02Icon,
   CodeIcon,
   Download01Icon,
+  Folder01Icon,
+  FolderAddIcon,
   Image03Icon,
+  McpServerIcon,
+  PencilRulerIcon,
 } from "@hugeicons/core-free-icons";
 import { useNavigate } from "@tanstack/react-router";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -45,6 +53,9 @@ import {
   PromptStorageDialog,
   exportConversationShareGPT,
 } from "./prompt-storage/prompt-storage-dialog";
+import { McpComposerButton } from "./mcp-composer-button";
+import { NewProjectDialog } from "./components/new-project-dialog";
+import { useChatProjects } from "./hooks/use-chat-projects";
 import { loadModel, validateModel } from "./api/chat-api";
 import {
   parseExternalModelId,
@@ -59,6 +70,7 @@ import {
   getExternalReasoningCapabilities,
   providerSupportsBuiltinCodeExecution,
   providerSupportsBuiltinImageGeneration,
+  providerSupportsBuiltinWebFetch,
 } from "./provider-capabilities";
 import {
   type CompositionEvent,
@@ -389,9 +401,7 @@ export function SharedComposer({
   model1?: CompareModelSelection;
   model2?: CompareModelSelection;
   onExitCompare?: () => void;
-  /** Thread ID of the left/model1 pane, used for conversation export. */
   model1ThreadId?: string;
-  /** Thread ID of the right/model2 pane, used for conversation export. */
   model2ThreadId?: string;
 }): ReactElement {
   const navigate = useNavigate();
@@ -414,6 +424,7 @@ export function SharedComposer({
   } | null>(null);
   const [dragging, setDragging] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
+  const [newProjectOpen, setNewProjectOpen] = useState(false);
   // ── Prompt storage & queue ────────────────────────────────────────────────
   const [promptStorageOpen, setPromptStorageOpen] = useState(false);
   const [isQueueRunning, setIsQueueRunning] = useState(false);
@@ -463,7 +474,6 @@ export function SharedComposer({
   );
   const preserveThinking = useChatRuntimeStore((s) => s.preserveThinking);
   const setPreserveThinking = useChatRuntimeStore((s) => s.setPreserveThinking);
-  const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const supportsTools = useChatRuntimeStore((s) => s.supportsTools);
   const supportsBuiltinWebSearch = useChatRuntimeStore(
     (s) => s.supportsBuiltinWebSearch,
@@ -476,6 +486,28 @@ export function SharedComposer({
   const setImageToolsEnabled = useChatRuntimeStore(
     (s) => s.setImageToolsEnabled,
   );
+  const artifactsEnabled = useChatRuntimeStore((s) => s.artifactsEnabled);
+  const setArtifactsEnabled = useChatRuntimeStore((s) => s.setArtifactsEnabled);
+  const mcpEnabledForChat = useChatRuntimeStore((s) => s.mcpEnabledForChat);
+  const setMcpEnabledForChat = useChatRuntimeStore(
+    (s) => s.setMcpEnabledForChat,
+  );
+  // Three most recently updated projects for the quick-access submenu.
+  const { projects } = useChatProjects();
+  const recentProjects = [...projects]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, 3);
+  const openProject = (projectId: string) => {
+    useChatRuntimeStore.getState().setActiveProjectId(projectId);
+    navigate({ to: "/chat", search: { project: projectId } });
+  };
+  const webFetchToolsEnabled = useChatRuntimeStore(
+    (s) => s.webFetchToolsEnabled,
+  );
+  const setWebFetchToolsEnabled = useChatRuntimeStore(
+    (s) => s.setWebFetchToolsEnabled,
+  );
+  const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const lastOpenRouterChosenModel = useChatRuntimeStore(
     (s) => s.lastOpenRouterChosenModel,
   );
@@ -516,6 +548,7 @@ export function SharedComposer({
           {
             isReasoningProvider:
               selectedExternalProvider?.isReasoningModel === true,
+            baseUrl: selectedExternalProvider?.baseUrl ?? null,
           },
         )
       : null;
@@ -570,6 +603,9 @@ export function SharedComposer({
     effectiveExternalModelId,
     selectedExternalProvider?.baseUrl,
   );
+  const supportsBuiltinWebFetch = providerSupportsBuiltinWebFetch(
+    selectedExternalProvider?.providerType,
+  );
   // Gemini rejects codeExecution alongside image modalities. Search is
   // blocked on older Gemini image ids but allowed on Gemini 3 image
   // models -- supportsBuiltinWebSearch already encodes the per-model
@@ -603,9 +639,18 @@ export function SharedComposer({
   // Images pill is only ever lit on OpenAI cloud's Responses-API models
   // and Gemini Nano Banana family. No local tool runtime fallback.
   const showImagePill = supportsBuiltinImageGeneration;
+  // Fetch pill: Anthropic-only (web_fetch_20250910 / web_fetch_20260209).
+  const webFetchDisabled = !modelLoaded || !supportsBuiltinWebFetch;
+  const showWebFetchPill = supportsBuiltinWebFetch;
   // With more than 4 pills showing, collapse them to icons only to cut clutter.
   // Compare, Search and Code always show; the rest are conditional.
-  const pillsCompact = 3 + (showImagePill ? 1 : 0) > 4;
+  const pillsCompact =
+    3 +
+      (showImagePill ? 1 : 0) +
+      (showWebFetchPill ? 1 : 0) +
+      (artifactsEnabled ? 1 : 0) +
+      (mcpEnabledForChat ? 1 : 0) >
+    4;
   // Backwards-compatible alias for any other call site that may still
   // reference `toolsDisabled` (rare; both pills used it before).
   const toolsDisabled = codeDisabled;
@@ -648,9 +693,7 @@ export function SharedComposer({
       description: next.length > 80 ? next.slice(0, 80) + "…" : next,
     });
     setText(next);
-    setTimeout(() => {
-      sendRef.current?.();
-    }, 100);
+    setTimeout(() => { sendRef.current?.(); }, 100);
   }
 
   // Compare mode: advance queue when the full compare cycle finishes.
@@ -1061,15 +1104,10 @@ export function SharedComposer({
           setIsQueueRunning(true);
           setQueueProgress({ current: 1, total: filtered.length });
           toast(`Prompt 1 / ${filtered.length}`, {
-            description:
-              filtered[0].length > 80
-                ? filtered[0].slice(0, 80) + "…"
-                : filtered[0],
+            description: filtered[0].length > 80 ? filtered[0].slice(0, 80) + "…" : filtered[0],
           });
           setText(filtered[0]);
-          setTimeout(() => {
-            sendRef.current?.();
-          }, 100);
+          setTimeout(() => { sendRef.current?.(); }, 100);
         }}
       />
       {/* Gemini-style drop affordance, mirrored from the single composer. */}
@@ -1168,7 +1206,12 @@ export function SharedComposer({
               e.target.value = "";
             }}
           />
-          {/* + side menu: tools, attachments, prompt storage */}
+          <NewProjectDialog
+            open={newProjectOpen}
+            onOpenChange={setNewProjectOpen}
+          />
+          {/* Same + side menu as the single-chat composer (ComposerToolsMenu),
+              wired to the compare composer's own file/audio inputs and tools. */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild={true}>
               <button
@@ -1259,6 +1302,28 @@ export function SharedComposer({
                 </DropdownMenuItem>
               )}
               <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className={
+                  artifactsEnabled ? "text-primary font-medium" : undefined
+                }
+                onSelect={() => setArtifactsEnabled(!artifactsEnabled)}
+              >
+                <HugeiconsIcon icon={PencilRulerIcon} strokeWidth={2} />
+                Canvas
+                {artifactsEnabled ? <CheckIcon className="ml-auto" /> : null}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!supportsTools}
+                className={
+                  mcpEnabledForChat ? "text-primary font-medium" : undefined
+                }
+                onSelect={() => setMcpEnabledForChat(!mcpEnabledForChat)}
+              >
+                <HugeiconsIcon icon={McpServerIcon} strokeWidth={2} />
+                MCP
+                {mcpEnabledForChat ? <CheckIcon className="ml-auto" /> : null}
+              </DropdownMenuItem>
+              {/* RAG hidden temporarily */}
               <DropdownMenuItem onSelect={() => setPromptStorageOpen(true)}>
                 <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
                 Saved prompts
@@ -1266,13 +1331,10 @@ export function SharedComposer({
               <DropdownMenuItem
                 disabled={!model1ThreadId && !model2ThreadId && !activeThreadId}
                 onSelect={() => {
-                  // In compare mode export both panes; in single mode export active thread.
                   const ids = model1ThreadId || model2ThreadId
                     ? [model1ThreadId, model2ThreadId].filter(Boolean) as string[]
-                    : activeThreadId
-                      ? [activeThreadId]
-                      : [];
-                  if (ids.length === 0) return;
+                    : activeThreadId ? [activeThreadId] : [];
+                  if (!ids.length) return;
                   Promise.all(ids.map((id) => exportConversationShareGPT(id))).catch(() => {
                     toast.error("Failed to export conversation.");
                   });
@@ -1291,6 +1353,35 @@ export function SharedComposer({
                 Compare chat
                 <CheckIcon className="ml-auto" />
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <HugeiconsIcon icon={Folder01Icon} strokeWidth={2} />
+                  Projects
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
+                  <DropdownMenuItem onSelect={() => setNewProjectOpen(true)}>
+                    <HugeiconsIcon icon={FolderAddIcon} strokeWidth={2} />
+                    New project
+                  </DropdownMenuItem>
+                  <DropdownMenuLabel>Recents</DropdownMenuLabel>
+                  {recentProjects.length > 0 ? (
+                    recentProjects.map((project) => (
+                      <DropdownMenuItem
+                        key={project.id}
+                        onSelect={() => openProject(project.id)}
+                      >
+                        <HugeiconsIcon icon={Folder01Icon} strokeWidth={2} />
+                        <span className="truncate">{project.name}</span>
+                      </DropdownMenuItem>
+                    ))
+                  ) : (
+                    <DropdownMenuItem disabled={true}>
+                      No recent projects
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
             </DropdownMenuContent>
           </DropdownMenu>
           {/* Active in compare mode; sits first. Click to exit back to single chat. */}
@@ -1378,6 +1469,44 @@ export function SharedComposer({
               <span>Images</span>
             </button>
           )}
+          {showWebFetchPill && (
+            <button
+              type="button"
+              disabled={webFetchDisabled}
+              onClick={() => setWebFetchToolsEnabled(!webFetchToolsEnabled)}
+              className="composer-pill-btn"
+              data-active={
+                webFetchToolsEnabled && !webFetchDisabled ? "true" : "false"
+              }
+              aria-label={
+                webFetchToolsEnabled ? "Disable URL fetch" : "Enable URL fetch"
+              }
+            >
+              <PillGlyph>
+                <HugeiconsIcon icon={Download01Icon} className="size-3.5" />
+              </PillGlyph>
+              <span>Fetch</span>
+            </button>
+          )}
+          {artifactsEnabled ? (
+            <button
+              type="button"
+              onClick={() => setArtifactsEnabled(false)}
+              className="composer-pill-btn"
+              data-active="true"
+              aria-label="Disable canvas"
+            >
+              <PillGlyph>
+                <HugeiconsIcon
+                  icon={PencilRulerIcon}
+                  className="size-[15.5px]"
+                  strokeWidth={2}
+                />
+              </PillGlyph>
+              <span>Canvas</span>
+            </button>
+          ) : null}
+          {mcpEnabledForChat ? <McpComposerButton side="top" /> : null}
         </div>
         {/* mr-0.5 matches the send button inset from the edge in normal chat;
             gap-1.5 matches its control spacing. */}
@@ -1590,7 +1719,6 @@ export function SharedComposer({
             </>
           )}
           {isQueueRunning ? (
-            // Red labelled pill — distinct from the icon-only dictation stop
             <button
               type="button"
               onClick={() => {
@@ -1602,7 +1730,7 @@ export function SharedComposer({
                 stop();
               }}
               aria-label="Stop prompt queue"
-              className="flex items-center gap-1.5 rounded-full border border-red-500 bg-red-600/10 px-2.5 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-600 hover:text-white dark:text-red-400 dark:hover:text-white"
+              className="ml-1.5 flex items-center gap-1.5 rounded-full border border-red-500 bg-red-600/10 px-2.5 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-600 hover:text-white dark:text-red-400 dark:hover:text-white"
             >
               <SquareIcon className="size-2.5 shrink-0 fill-current" />
               <span className="tabular-nums">

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -52,6 +52,8 @@ import { toast } from "@/lib/toast";
 import {
   PromptStorageDialog,
   exportConversationShareGPT,
+  exportConversationRawJsonl,
+  exportConversationCsv,
 } from "./prompt-storage/prompt-storage-dialog";
 import { McpComposerButton } from "./mcp-composer-button";
 import { NewProjectDialog } from "./components/new-project-dialog";
@@ -1328,21 +1330,39 @@ export function SharedComposer({
                 <HugeiconsIcon icon={Bookmark02Icon} strokeWidth={2} />
                 Saved prompts
               </DropdownMenuItem>
-              <DropdownMenuItem
-                disabled={!model1ThreadId && !model2ThreadId && !activeThreadId}
-                onSelect={() => {
-                  const ids = model1ThreadId || model2ThreadId
-                    ? [model1ThreadId, model2ThreadId].filter(Boolean) as string[]
-                    : activeThreadId ? [activeThreadId] : [];
-                  if (!ids.length) return;
-                  Promise.all(ids.map((id) => exportConversationShareGPT(id))).catch(() => {
-                    toast.error("Failed to export conversation.");
-                  });
-                }}
-              >
-                <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
-                Export chat
-              </DropdownMenuItem>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <HugeiconsIcon icon={Download01Icon} strokeWidth={2} />
+                  Export chat
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="unsloth-plus-menu w-[200px]">
+                  {[
+                    { label: "Raw JSONL", fn: exportConversationRawJsonl },
+                    { label: "CSV", fn: exportConversationCsv },
+                    { label: "ShareGPT JSONL (training)", fn: exportConversationShareGPT },
+                  ].map(({ label, fn }) => {
+                    const ids = [model1ThreadId, model2ThreadId, activeThreadId]
+                      .filter((id): id is string => Boolean(id));
+                    return (
+                      <DropdownMenuItem
+                        key={label}
+                        disabled={ids.length === 0}
+                        onSelect={() => {
+                          if (!ids.length) {
+                            toast.error("No conversation to export yet.");
+                            return;
+                          }
+                          Promise.all(ids.map((id) => fn(id))).catch(() =>
+                            toast.error("Export failed."),
+                          );
+                        }}
+                      >
+                        {label}
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
               {/* Always active: this menu only renders in compare mode.
                   Ticked like Web search/Code; click toggles it off. */}
               <DropdownMenuItem

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1762,7 +1762,7 @@ export function SharedComposer({
                 stop();
               }}
               aria-label="Stop prompt queue"
-              className="ml-1.5 flex items-center gap-1.5 rounded-full border border-red-500 bg-red-600/10 px-2.5 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-600 hover:text-white dark:text-red-400 dark:hover:text-white"
+              className="ml-1.5 flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/60 px-2.5 py-1 text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
               <SquareIcon className="size-2.5 shrink-0 fill-current" />
               <span className="tabular-nums">

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { useState } from "react";
 import {
   SidebarContent,
   SidebarFooter,
@@ -14,17 +15,63 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
   BookOpen02Icon,
   ColumnInsertIcon,
   Delete02Icon,
+  Download01Icon,
+  MoreHorizontalIcon,
   NewReleasesIcon,
   PencilEdit02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { toast } from "sonner";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import type { ChatView } from "./types";
-import { deleteChatItem, useChatSidebarItems } from "./hooks/use-chat-sidebar-items";
+import {
+  deleteChatItem,
+  renameChatItem,
+  useChatSidebarItems,
+} from "./hooks/use-chat-sidebar-items";
 import type { SidebarItem } from "./hooks/use-chat-sidebar-items";
+import {
+  exportConversationRawJsonl,
+  exportConversationCsv,
+  exportConversationShareGPT,
+} from "./prompt-storage/prompt-storage-dialog";
+import {
+  listStoredChatThreads,
+} from "./utils/chat-history-storage";
+
+const EXPORT_FORMATS = [
+  { label: "Raw JSONL", fn: exportConversationRawJsonl },
+  { label: "CSV", fn: exportConversationCsv },
+  { label: "ShareGPT JSONL (training)", fn: exportConversationShareGPT },
+] as const;
+
+async function getThreadIdsForItem(item: SidebarItem): Promise<string[]> {
+  if (item.type === "single") return [item.id];
+  const threads = await listStoredChatThreads({ pairId: item.id });
+  return threads.map((t) => t.id);
+}
 
 export function ThreadSidebar({
   view,
@@ -48,6 +95,9 @@ export function ThreadSidebar({
         ? view.pairId
         : view.projectId;
 
+  const [renamingItem, setRenamingItem] = useState<SidebarItem | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
+
   function viewForItem(item: SidebarItem): ChatView {
     return item.type === "single"
       ? { mode: "single", threadId: item.id }
@@ -55,10 +105,35 @@ export function ThreadSidebar({
   }
 
   async function handleDelete(item: SidebarItem) {
-    // Directly set a new view with a nonce rather than going through
-    // onNewThread(), which may return early if the guard sees no
-    // threadId and no activeThreadId (after we just cleared it).
     await deleteChatItem(item, activeId ?? undefined, onSelect);
+  }
+
+  function openRename(item: SidebarItem) {
+    setRenameDraft(item.title);
+    setRenamingItem(item);
+  }
+
+  async function commitRename() {
+    if (!renamingItem) return;
+    try {
+      await renameChatItem(renamingItem, renameDraft);
+    } catch {
+      toast.error("Failed to rename chat.");
+    } finally {
+      setRenamingItem(null);
+    }
+  }
+
+  async function handleExport(
+    item: SidebarItem,
+    fn: (threadId: string) => Promise<void>,
+  ) {
+    try {
+      const ids = await getThreadIdsForItem(item);
+      await Promise.all(ids.map((id) => fn(id)));
+    } catch {
+      toast.error("Export failed.");
+    }
   }
 
   return (
@@ -99,12 +174,48 @@ export function ThreadSidebar({
                   >
                     <span>{item.title}</span>
                   </SidebarMenuButton>
-                  <SidebarMenuAction
-                    showOnHover={true}
-                    onClick={() => handleDelete(item)}
-                    title="Delete"
-                  >
-                    <HugeiconsIcon icon={Delete02Icon} />
+                  <SidebarMenuAction showOnHover={true} asChild>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          className="flex items-center justify-center rounded-sm p-0.5 hover:bg-accent"
+                          title="More options"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent side="right" align="start" className="w-44">
+                        <DropdownMenuItem onSelect={() => openRename(item)}>
+                          <HugeiconsIcon icon={PencilEdit02Icon} className="mr-2 size-4" />
+                          Rename
+                        </DropdownMenuItem>
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
+                            Export
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent className="w-52">
+                            {EXPORT_FORMATS.map(({ label, fn }) => (
+                              <DropdownMenuItem
+                                key={label}
+                                onSelect={() => handleExport(item, fn)}
+                              >
+                                {label}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onSelect={() => void handleDelete(item)}
+                        >
+                          <HugeiconsIcon icon={Delete02Icon} className="mr-2 size-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </SidebarMenuAction>
                 </SidebarMenuItem>
               ))}
@@ -137,6 +248,30 @@ export function ThreadSidebar({
           <span>What&apos;s new</span>
         </a>
       </SidebarFooter>
+
+      {/* Rename dialog */}
+      <Dialog open={renamingItem !== null} onOpenChange={(open) => { if (!open) setRenamingItem(null); }}>
+        <DialogContent className="corner-squircle border border-border/60 bg-background/98 shadow-none sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Rename chat</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={renameDraft}
+            onChange={(e) => setRenameDraft(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") void commitRename(); }}
+            autoFocus
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRenamingItem(null)}>Cancel</Button>
+            <Button
+              onClick={() => void commitRename()}
+              disabled={!renameDraft.trim() || renameDraft.trim() === renamingItem?.title}
+            >
+              Rename
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -202,7 +202,7 @@ export function ThreadSidebar({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className="flex items-center justify-center rounded-sm p-0.5 text-muted-foreground opacity-60 hover:opacity-100 hover:bg-accent"
+                  className="flex items-center justify-center rounded-sm p-0.5 text-muted-foreground opacity-60 hover:opacity-100 hover:bg-accent focus:outline-none focus-visible:ring-0"
                   title="Export options"
                 >
                   <HugeiconsIcon icon={MoreHorizontalIcon} className="size-3.5" />
@@ -214,7 +214,7 @@ export function ThreadSidebar({
                     <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
                     Export Recents
                   </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="w-52">
+                  <DropdownMenuSubContent avoidCollisions={false} className="w-52">
                     {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                       <DropdownMenuItem key={`r-m-${fmt}`} onSelect={() => void handleBulkExport("recents", fmt, true)}>
                         {label} — combined
@@ -233,7 +233,7 @@ export function ThreadSidebar({
                     <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
                     Export Recents + Projects
                   </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="w-52">
+                  <DropdownMenuSubContent avoidCollisions={false} className="w-52">
                     {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                       <DropdownMenuItem key={`a-m-${fmt}`} onSelect={() => void handleBulkExport("all", fmt, true)}>
                         {label} — combined
@@ -262,12 +262,12 @@ export function ThreadSidebar({
                   </SidebarMenuButton>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <SidebarMenuAction showOnHover onClick={(e) => e.stopPropagation()}>
+                      <SidebarMenuAction className="focus:outline-none focus-visible:ring-0" onClick={(e) => e.stopPropagation()}>
                         <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
                         <span className="sr-only">More options</span>
                       </SidebarMenuAction>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent side="right" align="start" className="w-44">
+                    <DropdownMenuContent side="bottom" align="end" className="w-44">
                       <DropdownMenuItem onSelect={() => openRename(item)}>
                         <HugeiconsIcon icon={PencilEdit02Icon} className="mr-2 size-4" />
                         Rename
@@ -277,7 +277,7 @@ export function ThreadSidebar({
                           <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
                           Export
                         </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="w-52">
+                        <DropdownMenuSubContent avoidCollisions={false} className="w-52">
                           {EXPORT_FORMATS.map(({ label, fn }) => (
                             <DropdownMenuItem
                               key={label}

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -58,6 +58,7 @@ import {
   exportBulkConversationsMerged,
   exportBulkConversationsSeparate,
   EXPORT_FORMATS_LIST,
+  type ConvExportFormat,
 } from "./prompt-storage/prompt-storage-dialog";
 import {
   listStoredChatThreads,
@@ -149,7 +150,7 @@ export function ThreadSidebar({
 
   async function handleBulkExport(
     scope: "recents" | "all",
-    fmt: (typeof EXPORT_FORMATS_LIST)[number]["fmt"],
+    fmt: ConvExportFormat,
     merged: boolean,
   ) {
     try {

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -7,7 +7,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuAction,
@@ -56,6 +55,9 @@ import {
   exportConversationRawJsonl,
   exportConversationCsv,
   exportConversationShareGPT,
+  exportBulkConversationsMerged,
+  exportBulkConversationsSeparate,
+  EXPORT_FORMATS_LIST,
 } from "./prompt-storage/prompt-storage-dialog";
 import {
   listStoredChatThreads,
@@ -136,6 +138,35 @@ export function ThreadSidebar({
     }
   }
 
+  async function getBulkThreadIds(scope: "recents" | "all"): Promise<string[]> {
+    const threads = await listStoredChatThreads({
+      includeArchived: false,
+      ...(scope === "recents" ? { projectId: null } : {}),
+    });
+    // For compare pairs deduplicate to unique thread IDs
+    return [...new Set(threads.map((t) => t.id))];
+  }
+
+  async function handleBulkExport(
+    scope: "recents" | "all",
+    fmt: (typeof EXPORT_FORMATS_LIST)[number]["fmt"],
+    merged: boolean,
+  ) {
+    try {
+      const ids = await getBulkThreadIds(scope);
+      if (ids.length === 0) { toast.info("No conversations to export."); return; }
+      const ts = new Date().toISOString().slice(0, 10);
+      const basename = `${scope === "all" ? "all-chats" : "recents"}-${ts}`;
+      if (merged) {
+        await exportBulkConversationsMerged(ids, fmt, basename);
+      } else {
+        await exportBulkConversationsSeparate(ids, fmt, basename);
+      }
+    } catch {
+      toast.error("Export failed.");
+    }
+  }
+
   return (
     <>
       <SidebarHeader className="px-4 py-3">
@@ -163,7 +194,60 @@ export function ThreadSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup className="flex-1 px-4">
-          <SidebarGroupLabel className="text-xs font-medium text-muted-foreground/80">Your Chats</SidebarGroupLabel>
+          {/* Recents label with export-all "…" */}
+          <div className="flex items-center justify-between px-2 py-1.5">
+            <span className="text-xs font-medium text-muted-foreground/80">Recents</span>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="flex items-center justify-center rounded-sm p-0.5 text-muted-foreground opacity-60 hover:opacity-100 hover:bg-accent"
+                  title="Export options"
+                >
+                  <HugeiconsIcon icon={MoreHorizontalIcon} className="size-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="right" align="start" className="w-56">
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
+                    Export Recents
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="w-52">
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`r-m-${fmt}`} onSelect={() => void handleBulkExport("recents", fmt, true)}>
+                        {label} — combined
+                      </DropdownMenuItem>
+                    ))}
+                    <DropdownMenuSeparator />
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`r-s-${fmt}`} onSelect={() => void handleBulkExport("recents", fmt, false)}>
+                        {label} — per chat
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
+                    Export Recents + Projects
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="w-52">
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`a-m-${fmt}`} onSelect={() => void handleBulkExport("all", fmt, true)}>
+                        {label} — combined
+                      </DropdownMenuItem>
+                    ))}
+                    <DropdownMenuSeparator />
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`a-s-${fmt}`} onSelect={() => void handleBulkExport("all", fmt, false)}>
+                        {label} — per chat
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
           <SidebarGroupContent>
             <SidebarMenu>
               {items.map((item) => (

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -202,7 +202,7 @@ export function ThreadSidebar({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className="flex items-center justify-center rounded-sm p-0.5 text-muted-foreground opacity-60 hover:opacity-100 hover:bg-accent focus:outline-none focus-visible:ring-0"
+                  className="flex items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:bg-accent focus:outline-none focus-visible:ring-0"
                   title="Export options"
                 >
                   <HugeiconsIcon icon={MoreHorizontalIcon} className="size-3.5" />
@@ -257,20 +257,15 @@ export function ThreadSidebar({
                   <SidebarMenuButton
                     isActive={activeId === item.id}
                     onClick={() => onSelect(viewForItem(item))}
-                    className="pr-7"
                   >
                     <span>{item.title}</span>
                   </SidebarMenuButton>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={(e) => e.stopPropagation()}
-                        className="absolute right-1 top-1/2 -translate-y-1/2 flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus:outline-none focus-visible:ring-0"
-                        aria-label="More options"
-                      >
+                      <SidebarMenuAction showOnHover className="focus:outline-none focus-visible:ring-0" onClick={(e) => e.stopPropagation()}>
                         <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
-                      </button>
+                        <span className="sr-only">More options</span>
+                      </SidebarMenuAction>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent side="bottom" align="end" className="w-44">
                       <DropdownMenuItem onSelect={() => openRename(item)}>

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -201,13 +201,14 @@ export function ThreadSidebar({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
+                  type="button"
                   className="flex items-center justify-center rounded-sm p-0.5 text-muted-foreground opacity-60 hover:opacity-100 hover:bg-accent"
                   title="Export options"
                 >
                   <HugeiconsIcon icon={MoreHorizontalIcon} className="size-3.5" />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent side="right" align="start" className="w-56">
+              <DropdownMenuContent side="bottom" align="end" className="w-56">
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger>
                     <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
@@ -259,49 +260,44 @@ export function ThreadSidebar({
                   >
                     <span>{item.title}</span>
                   </SidebarMenuButton>
-                  <SidebarMenuAction showOnHover={true} asChild>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          className="flex items-center justify-center rounded-sm p-0.5 hover:bg-accent"
-                          title="More options"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent side="right" align="start" className="w-44">
-                        <DropdownMenuItem onSelect={() => openRename(item)}>
-                          <HugeiconsIcon icon={PencilEdit02Icon} className="mr-2 size-4" />
-                          Rename
-                        </DropdownMenuItem>
-                        <DropdownMenuSub>
-                          <DropdownMenuSubTrigger>
-                            <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
-                            Export
-                          </DropdownMenuSubTrigger>
-                          <DropdownMenuSubContent className="w-52">
-                            {EXPORT_FORMATS.map(({ label, fn }) => (
-                              <DropdownMenuItem
-                                key={label}
-                                onSelect={() => handleExport(item, fn)}
-                              >
-                                {label}
-                              </DropdownMenuItem>
-                            ))}
-                          </DropdownMenuSubContent>
-                        </DropdownMenuSub>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          className="text-destructive focus:text-destructive"
-                          onSelect={() => void handleDelete(item)}
-                        >
-                          <HugeiconsIcon icon={Delete02Icon} className="mr-2 size-4" />
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </SidebarMenuAction>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <SidebarMenuAction showOnHover onClick={(e) => e.stopPropagation()}>
+                        <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
+                        <span className="sr-only">More options</span>
+                      </SidebarMenuAction>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent side="right" align="start" className="w-44">
+                      <DropdownMenuItem onSelect={() => openRename(item)}>
+                        <HugeiconsIcon icon={PencilEdit02Icon} className="mr-2 size-4" />
+                        Rename
+                      </DropdownMenuItem>
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
+                          Export
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent className="w-52">
+                          {EXPORT_FORMATS.map(({ label, fn }) => (
+                            <DropdownMenuItem
+                              key={label}
+                              onSelect={() => handleExport(item, fn)}
+                            >
+                              {label}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        onSelect={() => void handleDelete(item)}
+                      >
+                        <HugeiconsIcon icon={Delete02Icon} className="mr-2 size-4" />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </SidebarMenuItem>
               ))}
             </SidebarMenu>

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -257,15 +257,20 @@ export function ThreadSidebar({
                   <SidebarMenuButton
                     isActive={activeId === item.id}
                     onClick={() => onSelect(viewForItem(item))}
+                    className="pr-7"
                   >
                     <span>{item.title}</span>
                   </SidebarMenuButton>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <SidebarMenuAction className="focus:outline-none focus-visible:ring-0" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        type="button"
+                        onClick={(e) => e.stopPropagation()}
+                        className="absolute right-1 top-1/2 -translate-y-1/2 flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus:outline-none focus-visible:ring-0"
+                        aria-label="More options"
+                      >
                         <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
-                        <span className="sr-only">More options</span>
-                      </SidebarMenuAction>
+                      </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent side="bottom" align="end" className="w-44">
                       <DropdownMenuItem onSelect={() => openRename(item)}>


### PR DESCRIPTION
Adds prompt storage to Unsloth Studio. Save prompts and prompt lists, load them into the composer, or run a list as an automated send queue.

### What's included

- **Prompt storage dialog**: bookmark button in the composer toolbar opens a searchable dialog to save, edit, and reuse prompts and named prompt lists
- **Prompt queue**: clicking **Run list** sends each prompt in sequence, waiting for the model to finish before advancing; includes a live `N/total` stop button
- **Export / Import**: prompts and lists can be exported as JSONL or CSV; training export uses ShareGPT format (`conversations`) compatible with Unsloth fine-tuning pipelines; import auto-detects format
- **Persistence**: stored in IndexedDB via Dexie (new `promptEntries` and `promptLists` tables in a v4 migration, no changes to v1–v3)

Queue state is lifted into `ThreadQueueProvider` so it survives the composer remount that happens when the first message is sent. Compare mode has its own queue implementation in `SharedComposer`.

## Test plan
- [x] Save a prompt, reload it via **Use**
- [x] Run a prompt list, verify each prompt sends after the previous response finishes
- [x] Stop the queue mid-run
- [x] Repeat in compare mode
- [x] Refresh and verify prompts persist
- [x] Test export (JSONL, CSV, training) and import