### PR TITLE
studio/frontend: widen settings sidebar so 'Connections' label fits

### DIFF
--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -110,7 +110,7 @@ export function SettingsDialog() {
           Manage your Unsloth Studio preferences.
         </DialogDescription>
         <div className="flex h-full min-h-0 max-sm:flex-col">
-          <aside className="font-heading flex w-[200px] shrink-0 flex-col border-r border-border bg-muted/20 p-2 max-sm:w-full max-sm:border-r-0 max-sm:border-b">
+          <aside className="font-heading flex w-[216px] shrink-0 flex-col border-r border-border bg-muted/20 p-2 max-sm:w-full max-sm:border-r-0 max-sm:border-b">
             <nav className="flex flex-col gap-0.5 max-sm:flex-row max-sm:overflow-x-auto">
               {TABS.map((tab) => {
                 const active = activeTab === tab.id;


### PR DESCRIPTION
## Summary
- The settings dialog sidebar was fixed at `w-[200px]`, which left only ~92px of horizontal space for tab labels after the icon (16px) + gap-2.5 + 'New' badge (~36px) + `px-2.5` padding.
- 'Connections' (11 chars at the 14.5px font weight medium) overflows that space and renders as 'Connectio...'. 'API' (3 chars) still fits. This matches the paper-cut reported earlier in issue #5572.
- Bump the sidebar to `w-[216px]` -- 16 more pixels of label space, fully within the existing 820px dialog and unchanged on mobile (`max-sm:w-full` still drives the responsive layout).

## Before / after
Before: `Connectio...` truncated next to the `New` badge.
After: full `Connections` text + `New` badge both visible.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` produces clean output
- [x] Re-ran settings-tabs probe -- 'Connections' label renders in full at every tab state
- [x] No change at mobile (max-sm:w-full still wins)