### PR TITLE
[codex] Fix Studio run-start persistence race

### DIFF
--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -4,6 +4,7 @@
 import {
   AssistantRuntimeProvider,
   type AttachmentAdapter,
+  type ChatModelAdapter,
   type CompleteAttachment,
   CompositeAttachmentAdapter,
   ExportedMessageRepository,
@@ -79,6 +80,8 @@ const DEFAULT_SUGGESTIONS = [
     prompt: "Draw an SVG of a cute sloth & show the code",
   },
 ];
+
+const pendingHistoryAppendByMessageId = new Map<string, Promise<void>>();
 
 type TitleResponse = {
   choices?: Array<{
@@ -719,6 +722,62 @@ function createDexieAdapter(
 
 type StudioRuntimeAdapters = NonNullable<LocalRuntimeOptions["adapters"]>;
 
+// assistant-ui does not await runStart listeners, so the stream is gated on
+// the history write that persists the just-submitted user message.
+function trackHistoryAppend(
+  messageId: string,
+  write: Promise<void>,
+): Promise<void> {
+  pendingHistoryAppendByMessageId.set(messageId, write);
+  const cleanup = () => {
+    setTimeout(() => {
+      if (pendingHistoryAppendByMessageId.get(messageId) === write) {
+        pendingHistoryAppendByMessageId.delete(messageId);
+      }
+    }, 30_000);
+  };
+  write.then(cleanup, cleanup);
+  return write;
+}
+
+async function waitForRunStartHistoryAppend(
+  messages: Parameters<ChatModelAdapter["run"]>[0]["messages"],
+): Promise<void> {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage || lastMessage.role !== "user") {
+    return;
+  }
+  const write = pendingHistoryAppendByMessageId.get(lastMessage.id);
+  if (!write) {
+    return;
+  }
+  try {
+    await write;
+  } finally {
+    if (pendingHistoryAppendByMessageId.get(lastMessage.id) === write) {
+      pendingHistoryAppendByMessageId.delete(lastMessage.id);
+    }
+  }
+}
+
+function createPersistedRunAdapter(adapter: ChatModelAdapter): ChatModelAdapter {
+  return {
+    ...adapter,
+    async *run(options) {
+      await waitForRunStartHistoryAppend(options.messages);
+      const result = adapter.run(options);
+      if (!result) {
+        return;
+      }
+      if (typeof result === "object" && Symbol.asyncIterator in result) {
+        yield* result;
+        return;
+      }
+      yield await result;
+    },
+  };
+}
+
 function useStudioRuntimeAdapters(): StudioRuntimeAdapters {
   const aui = useAui();
 
@@ -783,40 +842,43 @@ function useStudioRuntimeAdapters(): StudioRuntimeAdapters {
         return ExportedMessageRepository.fromArray(msgs.map(toThreadMessage));
       },
 
-      async append({ parentId, message }: ExportedMessageRepositoryItem) {
-        const { remoteId } = await aui.threadListItem().initialize();
-        if (isChatThreadDeleted(remoteId)) {
-          await deleteThreadRows(remoteId);
-          return;
-        }
-        // Keep single-chat runtime state in sync once a new chat is first
-        // persisted. Compare panes intentionally do not write global activeThreadId.
-        const thread = await db.threads.get(remoteId);
-        if (thread?.modelType === "base" && !thread.pairId) {
-          const store = useChatRuntimeStore.getState();
-          if (store.activeThreadId !== remoteId) {
-            store.setActiveThreadId(remoteId);
+      append({ parentId, message }: ExportedMessageRepositoryItem) {
+        const write = (async () => {
+          const { remoteId } = await aui.threadListItem().initialize();
+          if (isChatThreadDeleted(remoteId)) {
+            await deleteThreadRows(remoteId);
+            return;
           }
-        }
-        const content = cloneContent(message.content);
-        const attachments =
-          message.role === "user" ? cloneAttachments(message.attachments) : [];
-        const custom = message.metadata?.custom;
-        const existing = await db.messages.get(message.id);
-        const createdAt =
-          existing?.createdAt ??
-          message.createdAt?.getTime?.() ??
-          Date.now();
-        await db.messages.put({
-          id: message.id,
-          threadId: remoteId,
-          parentId: parentId ?? null,
-          role: message.role,
-          content,
-          ...(attachments.length > 0 && { attachments }),
-          ...(custom && Object.keys(custom).length > 0 && { metadata: custom }),
-          createdAt,
-        });
+          // Keep single-chat runtime state in sync once a new chat is first
+          // persisted. Compare panes intentionally do not write global activeThreadId.
+          const thread = await db.threads.get(remoteId);
+          if (thread?.modelType === "base" && !thread.pairId) {
+            const store = useChatRuntimeStore.getState();
+            if (store.activeThreadId !== remoteId) {
+              store.setActiveThreadId(remoteId);
+            }
+          }
+          const content = cloneContent(message.content);
+          const attachments =
+            message.role === "user" ? cloneAttachments(message.attachments) : [];
+          const custom = message.metadata?.custom;
+          const existing = await db.messages.get(message.id);
+          const createdAt =
+            existing?.createdAt ??
+            message.createdAt?.getTime?.() ??
+            Date.now();
+          await db.messages.put({
+            id: message.id,
+            threadId: remoteId,
+            parentId: parentId ?? null,
+            role: message.role,
+            content,
+            ...(attachments.length > 0 && { attachments }),
+            ...(custom && Object.keys(custom).length > 0 && { metadata: custom }),
+            createdAt,
+          });
+        })();
+        return trackHistoryAppend(message.id, write);
       },
     }),
     [aui],
@@ -853,7 +915,11 @@ const chatAdapter = createOpenAIStreamAdapter();
 
 function useRuntimeHook(): ReturnType<typeof useLocalRuntime> {
   const adapters = useStudioRuntimeAdapters();
-  return useLocalRuntime(chatAdapter, { adapters });
+  const persistedChatAdapter = useMemo(
+    () => createPersistedRunAdapter(chatAdapter),
+    [],
+  );
+  return useLocalRuntime(persistedChatAdapter, { adapters });
 }
 
 function ThreadAutoSwitch({


### PR DESCRIPTION
## Summary
- Track the Dexie history append for each submitted message.
- Wrap the Studio chat adapter so the streaming request waits for the pending user-message write before opening the stream.
- Leave the existing async runStart/runEnd autosaves in place for follow-up snapshots.

Fixes #5593.

## Root Cause
`thread.runStart` listeners are not awaited by assistant-ui, and the existing autosave chain was fire-and-forget. On a new thread, a hard refresh could happen after streaming began but before the Dexie thread/message write landed, losing both the prompt and partial response.

## Validation
- `npm run typecheck`
- `git diff --check`
- `npx eslint src/features/chat/runtime-provider.tsx` (passes with existing fast-refresh warning)

Repo-wide `npm run lint` and `npm run biome:check` still fail on existing unrelated frontend diagnostics.