### PR TITLE
loader: import FORCE_FLOAT32 from unsloth_zoo (single source of truth)

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -99,9 +99,22 @@ from ._utils import (
     fast_inference_setup,
 )
 
-# Re-exported so callers doing `from unsloth.models.loader import FORCE_FLOAT32`
-# keep working. Single source of truth is unsloth_zoo.model_lists.
-from unsloth_zoo import FORCE_FLOAT32  # noqa: F401
+# Single source of truth is unsloth_zoo.model_lists. Re-exported so callers
+# doing `from unsloth.models.loader import FORCE_FLOAT32` keep working.
+# Fallback list mirrors zoo for users who upgrade unsloth without upgrading
+# unsloth_zoo (so this module never fails at import).
+try:
+    from unsloth_zoo import FORCE_FLOAT32  # noqa: F401
+except ImportError:
+    global FORCE_FLOAT32
+    # Forces float32 precision since float16 goes to infinity
+    FORCE_FLOAT32 = [
+        "gemma3,",  # Add comma bc gemma3 will match gemma3n
+        "gemma3text",  # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
+        "gemma3n",
+        "gpt_oss",
+        "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
+    ]
 
 global DISABLE_COMPILE_MODEL_NAMES
 # Must be alphabetically sorted for each entry

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -99,15 +99,9 @@ from ._utils import (
     fast_inference_setup,
 )
 
-global FORCE_FLOAT32
-# Forces float32 precision since float16 goes to infinity
-FORCE_FLOAT32 = [
-    "gemma3,",  # Add comma bc gemma3 will match gemma3n
-    "gemma3text",  # Gemma3TextModel (EmbeddingGemma, standalone text-only Gemma3)
-    "gemma3n",
-    "gpt_oss",
-    "qwen3_5",  # Qwen3.5 GDN layers produce NaN grad norms in float16 training
-]
+# Re-exported so callers doing `from unsloth.models.loader import FORCE_FLOAT32`
+# keep working. Single source of truth is unsloth_zoo.model_lists.
+from unsloth_zoo import FORCE_FLOAT32  # noqa: F401
 
 global DISABLE_COMPILE_MODEL_NAMES
 # Must be alphabetically sorted for each entry
@@ -1381,7 +1375,6 @@ class FastModel(FastBaseModel):
         for model_type_arch in model_types:
             if model_type_arch != "siglip":
                 break
-        global FORCE_FLOAT32
         for disable_name in FORCE_FLOAT32:
             # add comma to model_types_all matching in case of exact match for end
             if (


### PR DESCRIPTION
## Summary

The list of architectures that need bf16/fp32 (Gemma3 family, gpt_oss, Qwen3.5) currently lives in two places — \`unsloth/models/loader.py\` and (implicitly, via behavior duplication) the MLX loader in \`unsloth_zoo\`. This PR moves it to a single home in \`unsloth_zoo.model_lists.FORCE_FLOAT32\` (re-exported as the top-level \`unsloth_zoo.FORCE_FLOAT32\`) and switches \`unsloth/models/loader.py\` to import from there.

Companion to **unsloth-zoo PR #670** which:
- adds \`unsloth_zoo.model_lists.FORCE_FLOAT32\` (the new home)
- gates its bf16→fp16 downcast warning in \`FastMLXModel\` on that same list, so the MLX loader now uses the same set of architectures as the CUDA path.

After both PRs merge, a single edit to \`unsloth_zoo/model_lists.py\` flows through to both CUDA and MLX code paths.

## Verification

\`\`\`python
import unsloth.models.loader as L
import unsloth_zoo
assert L.FORCE_FLOAT32 is unsloth_zoo.FORCE_FLOAT32  # same object
\`\`\`

## Test plan

- [ ] Existing CUDA Gemma3 / gpt_oss / Qwen3.5 fp16 fallback continues to bind \`UNSLOTH_FORCE_FLOAT32=1\` (the local list contents and matching logic are unchanged; only the storage location moved).
- [ ] \`from unsloth.models.loader import FORCE_FLOAT32\` still works for external callers (kept as a re-export).