### PR TITLE
studio: respect prefers-reduced-motion across animations

### DIFF
--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1187,3 +1187,23 @@
 	color: var(--popover-foreground) !important;
 	border-color: var(--border) !important;
 }
+
+/*
+ * prefers-reduced-motion: honour the OS-level "reduce motion" preference.
+ * Tailwind animate-in/out, Radix open/close transforms, infinite shine/pulse
+ * keyframes, and Framer Motion layout transitions all ignore the media query
+ * by default. Forcing every animation/transition to ~0ms collapses zoom-ins,
+ * slide-ins, and continuous shimmers to a single frame without removing the
+ * end state. Hover colour changes become instant rather than fading, which is
+ * the documented WCAG outcome (motion is "minimised, not removed").
+ */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1196,6 +1196,12 @@
  * slide-ins, and continuous shimmers to a single frame without removing the
  * end state. Hover colour changes become instant rather than fading, which is
  * the documented WCAG outcome (motion is "minimised, not removed").
+ *
+ * .animate-spin is the exception: loading spinners are essential progress
+ * indicators across Studio (tool execution loaders, sonner toasts, Tauri
+ * startup / update screens, the <Spinner /> primitive). Freezing them
+ * removes the only visual signal that work is in flight, so they keep
+ * animating but at a slower, less aggressive 1.5s cadence.
  */
 @media (prefers-reduced-motion: reduce) {
 	*,
@@ -1205,5 +1211,10 @@
 		animation-iteration-count: 1 !important;
 		transition-duration: 0.01ms !important;
 		scroll-behavior: auto !important;
+	}
+
+	.animate-spin {
+		animation-duration: 1.5s !important;
+		animation-iteration-count: infinite !important;
 	}
 }


### PR DESCRIPTION
## Summary

- Tailwind `animate-in` / `animate-out` (Radix dialog/popover/sheet/dropdown zoom-in-95, slide-in-from-*, fade-in/out), the infinite `shine` / `shiny-text` keyframes, and the `icon-pop` scale-up all run at their full duration regardless of the user's `prefers-reduced-motion` setting.
- Adds the canonical universal-selector override in `index.css` so `animation-duration` / `animation-iteration-count` / `transition-duration` collapse to ~0ms when the preference is set. End states stay intact; only the in-between frames are skipped.

## Reproduction (before)

Playwright probe emulates both media-query states and compares computed styles:

```
no-preference settings_dialog: animationDur=0.1s  transitionDur=0.1s
reduce        settings_dialog: animationDur=0.1s  transitionDur=0.1s   <- identical
diff between modes: 0
```

Every measured transition (`send_btn`, `sidebar_nav_btn`, `composer_pill`, `radix_collapsible`) showed the same `0.15s` duration under both modes. WCAG / W3C Media Queries Level 5 expects motion to be minimised when `reduce` is set.

## After the patch

```
reduce settings_dialog: animationDur=1e-05s  transitionDur=1e-05s
diff between modes: 6 selectors now differ
```

Visual cross-check captures the dialog 50 ms after `Ctrl+,`:

| mode | 50ms screenshot size | settled size |
| - | - | - |
| no-preference | 86407 bytes (mid-scale-up visible) | 72746 bytes |
| reduce | 72746 bytes (already settled) | 72746 bytes |

The reduce-mode 50 ms shot is byte-identical to the settled shot, confirming the zoom-in collapsed to a single frame.

## Test plan

- [x] Probe asserts `prefers-reduced-motion: reduce` collapses all measured transitions/animations to 1e-05s.
- [x] Manual visual check: settings dialog opens instantly with no zoom-in under reduce.
- [x] Hover colour transitions still settle to the final state (no broken hovers).
- [x] No-preference mode is unaffected (control screenshots show animation in flight).