### PR TITLE
studio: restore focus to opener when settings dialog closes

### DIFF
--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -74,6 +74,7 @@ export function SettingsDialog() {
   const activeTab = useSettingsDialogStore((s) => s.activeTab);
   const setActiveTab = useSettingsDialogStore((s) => s.setActiveTab);
   const closeDialog = useSettingsDialogStore((s) => s.closeDialog);
+  const opener = useSettingsDialogStore((s) => s.opener);
   const reduced = useReducedMotion();
   const tabButtonRefs = useRef<Record<SettingsTab, HTMLButtonElement | null>>({
     general: null,
@@ -98,6 +99,15 @@ export function SettingsDialog() {
       <DialogContent
         showCloseButton={false}
         overlayClassName="bg-background/40"
+        onCloseAutoFocus={(e) => {
+          // Restore focus to the element that triggered openDialog().
+          // Radix's FocusScope races our rAF-scheduled tab-button focus
+          // and loses the previous-focus reference, so we restore by hand.
+          if (opener && opener.isConnected) {
+            e.preventDefault();
+            opener.focus({ preventScroll: true });
+          }
+        }}
         className={cn(
           "!max-w-none h-[560px] w-[820px] p-0 overflow-hidden",
           "shadow-border rounded-xl border-border",

--- a/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
@@ -15,6 +15,11 @@ export type SettingsTab =
 interface SettingsDialogState {
   open: boolean;
   activeTab: SettingsTab;
+  // Element focused at the moment openDialog() ran. Radix's FocusScope
+  // would normally track this, but the rAF-scheduled focus() in
+  // settings-dialog.tsx races its previous-focus capture, leaving focus
+  // on <body> after close. We restore explicitly via onCloseAutoFocus.
+  opener: HTMLElement | null;
   openDialog: (tab?: SettingsTab) => void;
   closeDialog: () => void;
   setActiveTab: (tab: SettingsTab) => void;
@@ -47,11 +52,21 @@ function loadInitialTab(): SettingsTab {
 export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
   open: false,
   activeTab: loadInitialTab(),
+  opener: null,
   openDialog: (tab) =>
     set((state) => ({
       open: true,
       activeTab: tab ?? state.activeTab,
+      opener:
+        typeof document !== "undefined" &&
+        document.activeElement instanceof HTMLElement &&
+        document.activeElement !== document.body
+          ? document.activeElement
+          : null,
     })),
+  // Do NOT clear `opener` here. onCloseAutoFocus runs on the next render
+  // pass after `open: false` lands, so the opener must still be readable
+  // from the store at that point. The next openDialog() overwrites it.
   closeDialog: () => set({ open: false }),
   setActiveTab: (tab) => {
     try {


### PR DESCRIPTION
## Summary

- The settings dialog opens via a global Ctrl+, keydown handler in `app/routes/__root.tsx:61`, not via a `<DialogTrigger>`. Radix's `FocusScope` tries to capture `document.activeElement` at mount as the focus-restore target, but `settings-dialog.tsx:88-94` schedules a `requestAnimationFrame` that focuses the active tab button right after mount, racing FocusScope's previous-focus capture.
- On Escape or close-button click, focus then lands on `<body>` instead of the textarea (or wherever the user was before). This is a **WCAG 2.4.3 (Focus Order)** violation: keyboard-only users have to re-Tab from the start of the page after every settings visit.
- Capture `document.activeElement` in the Zustand store the moment `openDialog()` runs, then restore via `onCloseAutoFocus` on `DialogContent`. The `opener.isConnected` check lets a stale node fall back to Radix's default behaviour.

## Reproduction (before)

`scripts/r6_focus_management_probe.py` opens the settings dialog from a focused textarea, presses Tab 15 times (trap holds, never escapes), presses Escape, and inspects `document.activeElement`:

```
baseline focus: TEXTAREA[aria-label=Message input]
opened=True initial_focus=BUTTON[General] in_dialog=True
tab cycle escaped=False visited=16 unique=12
shift+tab escaped=False
after Escape: focus=BODY            <- restoration lost
focus_restored_to_opener=False
```

## After the patch

```
after Escape: focus=TEXTAREA[aria-label=Message input]
focus_restored_to_opener=True
```

Independent diag (`scripts/r6_focus_diag.py`) tags the opener with a `data-probe` attribute and checks identity across both close paths:

| close path | activeElement.tag | data-probe matches opener |
| - | - | - |
| Escape | TEXTAREA | yes |
| close button click | TEXTAREA | yes |

## Notes on what's NOT changed

- The Tab / Shift+Tab focus trap inside the dialog is Radix's built-in `FocusScope` and was already working. The probe verified it visited 16 elements without ever escaping.
- `closeDialog()` deliberately does **not** clear the `opener` slot. `onCloseAutoFocus` reads it on the render after `open=false`, so clearing in the same `set()` would null it before restoration. The next `openDialog()` overwrites the slot.
- Other dialogs in Studio open via `<DialogTrigger>` button clicks where Radix tracks the trigger automatically. This patch is scoped to the keyboard-opened settings dialog where the race occurs.

## Test plan

- [x] Probe asserts focus returns to opener after Escape close.
- [x] Probe asserts focus returns to opener after close-button click.
- [x] Probe asserts Tab / Shift+Tab trap still holds (16 visits, never escapes).
- [x] Initial focus on open still lands on the active tab button (unchanged).