### PR TITLE
ci: enforce npm ci on Studio install paths (follow-up to #5604)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -361,14 +361,21 @@ jobs:
         with:
           node-version: 24
 
+      - name: Lockfile supply-chain audit (pre-install scan)
+        shell: bash
+        # Runs BEFORE any `npm ci` so the structural audit
+        # (lockfile_supply_chain_audit.py) catches an injection-pattern
+        # lockfile before any tarball-side lifecycle script runs. The
+        # `npm ci` invocations below consume committed lockfiles
+        # (shipped in #5604) so they refuse to deviate from the
+        # audited shape.
+        run: python3 scripts/lockfile_supply_chain_audit.py
+
       - name: Install pinned Tauri CLI
-        # Lifecycle scripts (esbuild native-binary postinstall, etc.) are
-        # required for `vite build`. The pre-install lockfile structural
-        # audit (lockfile_supply_chain_audit.py) is the practical defence
-        # against the npm postinstall-dropper class -- it fires BEFORE any
-        # tarball runs, on the injection pattern itself rather than an
-        # advisory-DB lookup.
-        run: npm install --save-dev --prefix studio @tauri-apps/cli@2.10.1 --no-fund --no-audit
+        # `npm ci --prefix studio` consumes the committed
+        # studio/package-lock.json (shipped in #5604) and refuses to
+        # install if the resolved tree drifts from that lockfile.
+        run: npm ci --prefix studio --no-fund --no-audit
 
       - name: Verify pinned Tauri CLI
         shell: bash
@@ -443,13 +450,11 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: studio/frontend
-        # Lifecycle scripts (esbuild native-binary postinstall, etc.) are
-        # required for `vite build`. The pre-install lockfile structural
-        # audit (lockfile_supply_chain_audit.py) is the practical defence
-        # against the npm postinstall-dropper class -- it fires BEFORE any
-        # tarball runs, on the injection pattern itself rather than an
-        # advisory-DB lookup.
-        run: npm install --no-fund --no-audit
+        # `npm ci` consumes the committed studio/frontend/package-lock.json
+        # and refuses to install if the resolved tree drifts from that
+        # lockfile. The pre-install audit step above already verified the
+        # lockfile shape before any lifecycle script runs.
+        run: npm ci --no-fund --no-audit
 
       # ── Rust ──
       - name: Install Rust stable

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -53,6 +53,10 @@ on:
       - 'studio/backend/requirements/**'
       - 'studio/frontend/package.json'
       - 'studio/frontend/package-lock.json'
+      - 'studio/backend/core/data_recipe/oxc-validator/package.json'
+      - 'studio/backend/core/data_recipe/oxc-validator/package-lock.json'
+      - 'studio/package.json'
+      - 'studio/package-lock.json'
       - 'studio/src-tauri/Cargo.toml'
       - 'studio/src-tauri/Cargo.lock'
       - 'pyproject.toml'
@@ -278,7 +282,7 @@ jobs:
           {
             echo "## Lockfile supply-chain audit"
             echo
-            echo "Scanned: studio/frontend/package-lock.json + studio/src-tauri/Cargo.lock"
+            echo "Scanned: studio/frontend/package-lock.json + studio/backend/core/data_recipe/oxc-validator/package-lock.json + studio/package-lock.json + studio/src-tauri/Cargo.lock"
             echo
             echo "No structural anomalies or known IOC strings."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -304,6 +308,42 @@ jobs:
             echo
             echo '```'
             tail -200 ../../logs-npm-audit.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ─────────────────────────────────────────────────────────────
+      # npm: oxc-validator runtime (data_recipe parser sandbox)
+      # ─────────────────────────────────────────────────────────────
+      - name: npm audit (oxc-validator runtime)
+        continue-on-error: true
+        working-directory: studio/backend/core/data_recipe/oxc-validator
+        run: |
+          set +e
+          npm audit --audit-level=high | tee ../../../../../logs-npm-audit-oxc.txt
+          npm audit --json > ../../../../../logs-npm-audit-oxc.json || true
+          {
+            echo "## npm audit (oxc-validator runtime)"
+            echo
+            echo '```'
+            tail -200 ../../../../../logs-npm-audit-oxc.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ─────────────────────────────────────────────────────────────
+      # npm: Studio Tauri CLI holder
+      # ─────────────────────────────────────────────────────────────
+      - name: npm audit (Studio Tauri CLI holder)
+        continue-on-error: true
+        working-directory: studio
+        run: |
+          set +e
+          npm audit --audit-level=high | tee ../logs-npm-audit-tauri-cli.txt
+          npm audit --json > ../logs-npm-audit-tauri-cli.json || true
+          {
+            echo "## npm audit (Studio Tauri CLI holder)"
+            echo
+            echo '```'
+            tail -200 ../logs-npm-audit-tauri-cli.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -348,6 +388,8 @@ jobs:
           /tmp/osv-scanner --version
           /tmp/osv-scanner scan source \
             --lockfile=studio/frontend/package-lock.json \
+            --lockfile=studio/backend/core/data_recipe/oxc-validator/package-lock.json \
+            --lockfile=studio/package-lock.json \
             --lockfile=studio/src-tauri/Cargo.lock \
             --lockfile=requirements.txt:audit-reqs/unsloth-deps.txt \
             --lockfile=requirements.txt:audit-reqs/studio.txt \
@@ -639,6 +681,10 @@ jobs:
             logs-pip-audit.txt
             logs-npm-audit.txt
             logs-npm-audit.json
+            logs-npm-audit-oxc.txt
+            logs-npm-audit-oxc.json
+            logs-npm-audit-tauri-cli.txt
+            logs-npm-audit-tauri-cli.json
             logs-cargo-audit.txt
             logs-osv-scanner.txt
             logs-semgrep.txt
@@ -1077,7 +1123,15 @@ jobs:
         working-directory: studio/frontend
         run: npm ci --ignore-scripts
 
-      - name: npm audit signatures (informational)
+      - name: Install oxc-validator deps (--ignore-scripts)
+        working-directory: studio/backend/core/data_recipe/oxc-validator
+        run: npm ci --ignore-scripts
+
+      - name: Install Studio Tauri CLI holder deps (--ignore-scripts)
+        working-directory: studio
+        run: npm ci --ignore-scripts
+
+      - name: npm audit signatures (Studio frontend, informational)
         # Surfaces unsigned / mis-signed packages from the npm
         # transparency log. continue-on-error during baseline-build
         # phase; promote to hard gate once the lockfile is fully
@@ -1089,7 +1143,37 @@ jobs:
           LOG=logs-audit-signatures.txt
           npm audit signatures 2>&1 | tee "$LOG"
           {
-            echo "## npm audit signatures"
+            echo "## npm audit signatures (Studio frontend)"
+            echo
+            echo '```'
+            tail -200 "$LOG"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: npm audit signatures (oxc-validator, informational)
+        working-directory: studio/backend/core/data_recipe/oxc-validator
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          LOG=logs-audit-signatures-oxc.txt
+          npm audit signatures 2>&1 | tee "$LOG"
+          {
+            echo "## npm audit signatures (oxc-validator)"
+            echo
+            echo '```'
+            tail -200 "$LOG"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: npm audit signatures (Studio Tauri CLI holder, informational)
+        working-directory: studio
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          LOG=logs-audit-signatures-tauri-cli.txt
+          npm audit signatures 2>&1 | tee "$LOG"
+          {
+            echo "## npm audit signatures (Studio Tauri CLI holder)"
             echo
             echo '```'
             tail -200 "$LOG"
@@ -1101,15 +1185,39 @@ jobs:
         run: |
           set -e
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          git show "$BASE_SHA:studio/frontend/package-lock.json" \
-            > /tmp/base-package-lock.json
+          # `|| echo '{}'` fallback covers PRs whose base predates the
+          # new lockfiles (they only landed in #5604); without it the
+          # diff step would crash trying to read a non-existent blob.
+          git show "$BASE_SHA:studio/frontend/package-lock.json" 2>/dev/null \
+            > /tmp/base-package-lock.json \
+            || echo '{}' > /tmp/base-package-lock.json
+          git show "$BASE_SHA:studio/backend/core/data_recipe/oxc-validator/package-lock.json" 2>/dev/null \
+            > /tmp/base-package-lock-oxc.json \
+            || echo '{}' > /tmp/base-package-lock-oxc.json
+          git show "$BASE_SHA:studio/package-lock.json" 2>/dev/null \
+            > /tmp/base-package-lock-tauri-cli.json \
+            || echo '{}' > /tmp/base-package-lock-tauri-cli.json
 
-      - name: Diff for newly-added install-script deps
+      - name: Diff for newly-added install-script deps (Studio frontend)
         if: github.event_name == 'pull_request'
         run: |
           python3 scripts/check_new_install_scripts.py \
             --base /tmp/base-package-lock.json \
             --head studio/frontend/package-lock.json
+
+      - name: Diff for newly-added install-script deps (oxc-validator)
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 scripts/check_new_install_scripts.py \
+            --base /tmp/base-package-lock-oxc.json \
+            --head studio/backend/core/data_recipe/oxc-validator/package-lock.json
+
+      - name: Diff for newly-added install-script deps (Studio Tauri CLI holder)
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 scripts/check_new_install_scripts.py \
+            --base /tmp/base-package-lock-tauri-cli.json \
+            --head studio/package-lock.json
 
       - name: Skip install-script diff (non-PR trigger)
         if: github.event_name != 'pull_request'
@@ -1121,6 +1229,9 @@ jobs:
         if: always()
         with:
           name: npm-audit-signatures-log
-          path: studio/frontend/logs-audit-signatures.txt
+          path: |
+            studio/frontend/logs-audit-signatures.txt
+            studio/backend/core/data_recipe/oxc-validator/logs-audit-signatures-oxc.txt
+            studio/logs-audit-signatures-tauri-cli.txt
           if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -60,23 +60,25 @@ jobs:
         with:
           workspaces: studio/src-tauri -> target
 
+      - name: Lockfile supply-chain audit (pre-install scan)
+        # Runs BEFORE any npm install / npm ci so the structural audit
+        # (lockfile_supply_chain_audit.py) catches an injection-pattern
+        # lockfile before a single postinstall script is executed.
+        run: python3 scripts/lockfile_supply_chain_audit.py
+
       - name: Install pinned Tauri CLI (matches release-desktop.yml)
-        # Lifecycle scripts (esbuild native-binary postinstall, etc.) are
-        # required for `vite build`. The pre-install lockfile structural
-        # audit (lockfile_supply_chain_audit.py) is the practical defence
-        # against the npm postinstall-dropper class -- it fires BEFORE any
-        # tarball runs, on the injection pattern itself rather than an
-        # advisory-DB lookup.
-        run: npm install --save-dev --prefix studio @tauri-apps/cli@2.10.1 --no-fund --no-audit
+        # `npm ci --prefix studio` consumes the committed
+        # studio/package-lock.json (shipped in #5604) and refuses to
+        # install if the resolved tree drifts from that lockfile. The
+        # pre-install audit above already verified the lockfile shape
+        # itself before any tarball-side lifecycle script runs.
+        run: npm ci --prefix studio --no-fund --no-audit
 
       - name: Verify pinned Tauri CLI version
         run: |
           out="$(npx --prefix studio tauri --version)"
           echo "$out"
           [ "$out" = "tauri-cli 2.10.1" ] || { echo "::error::expected tauri-cli 2.10.1, got $out"; exit 1; }
-
-      - name: Lockfile supply-chain audit (pre-install scan)
-        run: python3 scripts/lockfile_supply_chain_audit.py
 
       - name: Frontend build (npm ci, vite)
         working-directory: studio/frontend

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -87,6 +87,7 @@ jobs:
               n = z.namelist()
               checks = {
                 "lockfile shipped":      any(s.endswith("studio/frontend/package-lock.json") for s in n),
+                "oxc lockfile shipped":  any(s.endswith("oxc-validator/package-lock.json")   for s in n),
                 "frontend dist shipped": any(s.endswith("studio/frontend/dist/index.html")    for s in n),
                 "no node_modules":       not any("studio/frontend/node_modules/" in s for s in n),
                 "no bun.lock":           not any(s.endswith("studio/frontend/bun.lock")       for s in n),

--- a/build.sh
+++ b/build.sh
@@ -33,18 +33,24 @@ _restore_gitignores() {
 }
 trap _restore_gitignores EXIT
 
-# Use bun for install if available (faster), fall back to npm.
+# Lockfile-pinned install. Prefer bun when a bun.lock is checked in AND
+# bun is on PATH; otherwise use `npm ci`, which is non-mutating and
+# refuses to run unless the committed package-lock.json matches the
+# dependency tree byte-for-byte. The `[ -f bun.lock ]` gate keeps bun
+# off the path until a bun.lock is also committed -- without it,
+# `bun install --frozen-lockfile` would fail and the script would
+# still fall through to npm ci, so the gate just skips the noise.
 _install_ok=false
-if command -v bun &>/dev/null; then
-    if bun install; then
+if [ -f bun.lock ] && command -v bun &>/dev/null; then
+    if bun install --frozen-lockfile --no-progress; then
         _install_ok=true
     else
-        echo "⚠ bun install failed, falling back to npm"
+        echo "⚠ bun install --frozen-lockfile failed, falling back to npm ci"
         rm -rf node_modules
     fi
 fi
 if [ "$_install_ok" != "true" ]; then
-    if ! npm install; then
+    if ! npm ci --no-fund --no-audit; then
         echo "❌ ERROR: package install failed" >&2
         exit 1
     fi

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1321,13 +1321,19 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
         $WalkDir = Split-Path $WalkDir -Parent
     }
 
-    # Use bun if available (faster install), fall back to npm.
-    # Bun is used only as package manager; Node runs the actual build (Vite 8).
+    # Lockfile-pinned install. Prefer bun ONLY when a bun.lock is checked
+    # in AND bun is on PATH; otherwise use `npm ci`, which is non-mutating
+    # and refuses to run unless the committed package-lock.json matches
+    # the dependency tree byte-for-byte. The `Test-Path "bun.lock"` gate
+    # keeps bun off the path until a bun.lock is also committed -- the
+    # bun-fallback wiring (cache-clear retry + critical-binary
+    # verification) is kept intact so this script auto-upgrades when
+    # bun.lock eventually lands.
     $prevEAP_npm = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     Push-Location $FrontendDir
 
-    $UseBun = $null -ne (Get-Command bun -ErrorAction SilentlyContinue)
+    $UseBun = (Test-Path "bun.lock") -and ($null -ne (Get-Command bun -ErrorAction SilentlyContinue))
 
     # bun's package cache can become corrupt -- packages get stored with only
     # metadata but no actual content (bin/, lib/). When this happens bun install
@@ -1335,7 +1341,7 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
     # the cache + retry once before falling back to npm.
     if ($UseBun) {
         Write-Host "   Using bun for package install (faster)" -ForegroundColor DarkGray
-        $bunExit = Invoke-SetupCommand { bun install }
+        $bunExit = Invoke-SetupCommand { bun install --frozen-lockfile --no-progress }
         # On Windows, .bin/ entries vary by package manager:
         #   npm  → tsc, tsc.cmd, tsc.ps1
         #   bun  → tsc.exe, tsc.bunx
@@ -1349,18 +1355,18 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
                 Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue
             }
             Invoke-SetupCommand { bun pm cache rm } | Out-Null
-            $bunExit = Invoke-SetupCommand { bun install }
+            $bunExit = Invoke-SetupCommand { bun install --frozen-lockfile --no-progress }
             $hasTsc = (Test-Path "node_modules\.bin\tsc") -or (Test-Path "node_modules\.bin\tsc.cmd") -or (Test-Path "node_modules\.bin\tsc.exe") -or (Test-Path "node_modules\.bin\tsc.bunx")
             $hasVite = (Test-Path "node_modules\.bin\vite") -or (Test-Path "node_modules\.bin\vite.cmd") -or (Test-Path "node_modules\.bin\vite.exe") -or (Test-Path "node_modules\.bin\vite.bunx")
             if ($bunExit -ne 0 -or -not $hasTsc -or -not $hasVite) {
-                Write-Host "   bun retry failed, falling back to npm" -ForegroundColor Yellow
+                Write-Host "   bun retry failed, falling back to npm ci" -ForegroundColor Yellow
                 if (Test-Path "node_modules") {
                     Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue
                 }
                 $UseBun = $false
             }
         } else {
-            substep "bun install failed (exit $bunExit), falling back to npm" "Yellow"
+            substep "bun install --frozen-lockfile failed (exit $bunExit), falling back to npm ci" "Yellow"
             if (Test-Path "node_modules") {
                 Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue
             }
@@ -1368,13 +1374,13 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
         }
     }
     if (-not $UseBun) {
-        $npmExit = Invoke-SetupCommand { npm install }
+        $npmExit = Invoke-SetupCommand { npm ci --no-fund --no-audit }
         if ($npmExit -ne 0) {
             Pop-Location
             $ErrorActionPreference = $prevEAP_npm
             foreach ($gi in $HiddenGitignores) { Rename-Item -Path "$gi._twbuild" -NewName (Split-Path $gi -Leaf) -Force -ErrorAction SilentlyContinue }
-            Write-Host "[ERROR] npm install failed (exit code $npmExit)" -ForegroundColor Red
-            Write-Host "   Try running 'npm install' manually in frontend/ to see errors" -ForegroundColor Yellow
+            Write-Host "[ERROR] npm ci failed (exit code $npmExit)" -ForegroundColor Red
+            Write-Host "   Try running 'npm ci' manually in frontend/ to see errors" -ForegroundColor Yellow
             exit 1
         }
     }
@@ -1411,12 +1417,31 @@ if (Test-Path $OxcValidatorDir) {
     $prevEAP_oxc = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     Push-Location $OxcValidatorDir
-    $oxcInstallExit = Invoke-SetupCommand { npm install }
-    if ($oxcInstallExit -ne 0) {
-        Pop-Location
-        $ErrorActionPreference = $prevEAP_oxc
-        Write-Host "[ERROR] OXC validator npm install failed (exit code $oxcInstallExit)" -ForegroundColor Red
-        exit 1
+
+    # Same lockfile-pinned shape as the frontend block above: bun only
+    # when a bun.lock is checked in next to package.json (currently not
+    # the case), otherwise `npm ci` against the committed
+    # package-lock.json (shipped in #5604).
+    $UseOxcBun = (Test-Path "bun.lock") -and ($null -ne (Get-Command bun -ErrorAction SilentlyContinue))
+    $oxcInstallOk = $false
+    if ($UseOxcBun) {
+        $oxcBunExit = Invoke-SetupCommand { bun install --frozen-lockfile --no-progress }
+        if ($oxcBunExit -eq 0) {
+            $oxcInstallOk = $true
+        } else {
+            if (Test-Path "node_modules") {
+                Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    if (-not $oxcInstallOk) {
+        $oxcInstallExit = Invoke-SetupCommand { npm ci --no-fund --no-audit }
+        if ($oxcInstallExit -ne 0) {
+            Pop-Location
+            $ErrorActionPreference = $prevEAP_oxc
+            Write-Host "[ERROR] OXC validator npm ci failed (exit code $oxcInstallExit)" -ForegroundColor Red
+            exit 1
+        }
     }
     Pop-Location
     $ErrorActionPreference = $prevEAP_oxc

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -329,21 +329,23 @@ _restore_gitignores() {
 }
 trap _restore_gitignores EXIT
 
-# Use bun for install if available (faster), fall back to npm.
-# Build always uses npm (Node runtime -- avoids bun runtime issues on some platforms).
-# NOTE: We intentionally avoid run_quiet for the bun install attempt because
-# run_quiet calls exit on failure, which would kill the script before the npm
-# fallback can run. Instead we capture output manually and only show it on failure.
+# Lockfile-pinned install. Prefer bun ONLY when a bun.lock is checked in
+# AND bun is on PATH; otherwise use `npm ci`, which is non-mutating and
+# refuses to run unless the committed package-lock.json matches the
+# dependency tree byte-for-byte. The `[ -f bun.lock ]` gate keeps bun
+# off the path until a bun.lock is also committed -- the bun-fallback
+# wiring (cache-clear retry + critical-binary verification) is kept
+# intact so this script auto-upgrades when bun.lock eventually lands.
 #
-# IMPORTANT: bun's package cache can become corrupt -- packages get stored
-# with only metadata (package.json, README) but no actual content (bin/,
-# lib/). When this happens bun install exits 0 but leaves binaries missing.
-# We verify critical binaries after install. If missing, we clear the cache
-# and retry once before falling back to npm.
+# IMPORTANT: bun's package cache can become corrupt -- packages get
+# stored with only metadata (package.json, README) but no actual content
+# (bin/, lib/). When this happens bun install exits 0 but leaves
+# binaries missing. We verify critical binaries after install. If
+# missing, we clear the cache and retry once before falling back to npm.
 _try_bun_install() {
     local _log _exit_code=0
     _log=$(mktemp)
-    bun install >"$_log" 2>&1 || _exit_code=$?
+    bun install --frozen-lockfile --no-progress >"$_log" 2>&1 || _exit_code=$?
 
     # bun may create .exe shims on Windows (Git Bash / MSYS2) instead of plain scripts
     if [ "$_exit_code" -eq 0 ] \
@@ -355,7 +357,7 @@ _try_bun_install() {
 
     # Either bun install failed or it exited 0 but left packages missing
     if [ "$_exit_code" -ne 0 ]; then
-        echo "   bun install failed (exit code $_exit_code):"
+        echo "   bun install --frozen-lockfile failed (exit code $_exit_code):"
     else
         echo "   bun install exited 0 but critical binaries are missing:"
     fi
@@ -366,7 +368,7 @@ _try_bun_install() {
 }
 
 _bun_install_ok=false
-if command -v bun &>/dev/null; then
+if [ -f bun.lock ] && command -v bun &>/dev/null; then
     substep "using bun for package install (faster)"
     if _try_bun_install; then
         _bun_install_ok=true
@@ -381,7 +383,10 @@ if command -v bun &>/dev/null; then
     fi
 fi
 if [ "$_bun_install_ok" = false ]; then
-    run_quiet_no_exit "npm install" npm install --no-fund --no-audit --loglevel=error
+    # npm ci enforces the committed package-lock.json (refuses to install
+    # otherwise); --no-fund / --no-audit / --loglevel=error keep the
+    # output quiet during normal installs.
+    run_quiet_no_exit "npm ci" npm ci --no-fund --no-audit --loglevel=error
     _npm_install_rc=$?
     if [ "$_npm_install_rc" -ne 0 ]; then
         exit "$_npm_install_rc"
@@ -406,12 +411,26 @@ cd "$SCRIPT_DIR"
 fi  # end frontend build check
 
 # ── oxc-validator runtime ──
+# Same lockfile-pinned shape as the frontend block above: bun only when
+# a bun.lock is checked in next to package.json (currently not the
+# case), otherwise `npm ci` against the committed package-lock.json
+# (shipped in #5604).
 if [ -d "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator" ] && command -v npm &>/dev/null; then
     cd "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator"
-    run_quiet_no_exit "npm install (oxc validator runtime)" npm install --no-fund --no-audit --loglevel=error
-    _oxc_install_rc=$?
-    if [ "$_oxc_install_rc" -ne 0 ]; then
-        exit "$_oxc_install_rc"
+    _oxc_install_ok=false
+    if [ -f bun.lock ] && command -v bun &>/dev/null; then
+        if run_quiet_no_exit "bun install (oxc validator runtime)" bun install --frozen-lockfile --no-progress; then
+            _oxc_install_ok=true
+        else
+            rm -rf node_modules
+        fi
+    fi
+    if [ "$_oxc_install_ok" = false ]; then
+        run_quiet_no_exit "npm ci (oxc validator runtime)" npm ci --no-fund --no-audit --loglevel=error
+        _oxc_install_rc=$?
+        if [ "$_oxc_install_rc" -ne 0 ]; then
+            exit "$_oxc_install_rc"
+        fi
     fi
     cd "$SCRIPT_DIR"
 fi


### PR DESCRIPTION
## Summary

Follow-up to #5604. Now that the three Studio npm lockfiles are committed and audited, flip every install path that depends on them from `npm install` (mutates the lockfile, ignores integrity hashes) to `npm ci` (refuses to run unless the lockfile is exact). This closes the supply-chain gap between "the lockfile passes the audit" and "the install respected that lockfile".

## What changes

**Install scripts** (`build.sh`, `studio/setup.sh`, `studio/setup.ps1`)
- Frontend + OXC validator npm paths: `npm install` -> `npm ci --no-fund --no-audit`.
- Bun calls gated on `[ -f bun.lock ] && command -v bun` (`Test-Path` / `Get-Command` on Windows) plus `--frozen-lockfile --no-progress`. Forward-compatible for the eventual bun.lock PR; inert today (no bun.lock checked in -> the gate fails closed -> execution falls through to `npm ci`).
- Existing bun infrastructure (cache-corruption retry + critical-binary verification + npm fallback) kept intact so the auto-upgrade is clean when bun.lock eventually lands.

**Workflows**
- `release-desktop.yml`: 2 `npm install` -> `npm ci` swaps (Tauri CLI + frontend); new pre-install lockfile audit step.
- `studio-tauri-smoke.yml`: 1 `npm install` -> `npm ci` swap; audit step relocated to run before install.
- `wheel-smoke.yml`: single-line content-sanity assertion that `oxc-validator/package-lock.json` is shipped in the wheel.
- `security-audit.yml`: `paths` trigger gains 4 entries; OSV-scanner `--lockfile=` gains 2; two new `npm audit` steps (oxc + Tauri CLI holder); `npm audit signatures` block split into three (frontend / oxc / Tauri CLI), each preceded by `npm ci --ignore-scripts`; `check_new_install_scripts.py` extended to diff both new lockfiles with `git show … || echo '{}'` fallback for PRs whose base predates #5604; upload-artifact paths extended.

## Explicitly NOT in this PR

- No bun.lock files (deferred per the "we don't want the bun lockfile yet" decision).
- No `BUN_PIN_VERSION` / 3-attempt cache-corruption recovery ladders (would need committed bun.lock to be useful).
- No `unsloth.exe` rename-and-restore block changes in setup.ps1 (unrelated Windows pip-replace workaround).
- No `continue-on-error` policy flips on advisory audit jobs.
- No pyproject.toml, test file, or Studio source edits.

## Supersedes #5479

#5479 was a 41-file draft whose sequential `git merge main` operations had collateral reverts of files that exist on main (`studio/backend/core/tool_healing.py`, `tests/test_finetune_last_n_layers.py`, `tests/test_import_fixes_drift.py`, etc.). This PR is a clean re-derivation off latest `origin/main` containing only the install-path hardening.

## Test plan

- [x] `bash -n build.sh && bash -n studio/setup.sh` — clean
- [x] PowerShell parse: `[System.Management.Automation.Language.Parser]::ParseFile('studio/setup.ps1', ...)` — clean
- [x] YAML parse for all 4 edited workflow files — clean
- [x] Local `npm ci` in `studio/`, `studio/frontend/`, `studio/backend/core/data_recipe/oxc-validator/` — all 3 succeed, expected binaries present, no lockfile mutation
- [x] `npm run build` in `studio/frontend/` — produces `dist/index.html` + `dist/assets/*.css` + `dist/assets/index-*.js`
- [x] `unsloth.exe` rename-and-restore block in setup.ps1 still present (`grep -c 'unsloth.exe.deleteme' studio/setup.ps1` = 1)
- [x] `python3 scripts/lockfile_supply_chain_audit.py` — 0 findings on edited tree
- [ ] CI green on Linux / macOS / Windows runners