### PR TITLE
studio/frontend: rename per-message export to unsloth-message-<date>.md

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1152,7 +1152,15 @@ const AssistantActionBar: FC = () => {
           onCloseAutoFocus={(e) => e.preventDefault()}
           className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
         >
-          <ActionBarPrimitive.ExportMarkdown asChild={true}>
+          <ActionBarPrimitive.ExportMarkdown
+            asChild={true}
+            // Match Settings -> Chat -> Export's human-readable naming
+            // (``unsloth-chats-YYYY-MM-DD.json``) rather than
+            // assistant-ui's default ``message-<epoch-ms>.md``. The
+            // component re-renders often enough that the date stays
+            // fresh in practice.
+            filename={`unsloth-message-${new Date().toISOString().slice(0, 10)}.md`}
+          >
             <ActionBarMorePrimitive.Item className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
               <DownloadIcon strokeWidth={1.75} className="size-icon" />
               Export as Markdown


### PR DESCRIPTION
## Summary

The assistant message action bar's **Export as Markdown** path used the assistant-ui default filename `message-<epoch-ms>.md`, which is neither human-readable nor consistent with Studio's other export path: **Settings -> Chat -> Export** writes `unsloth-chats-YYYY-MM-DD.json` (see `frontend/src/features/chat/utils/export-chat-history.ts`).

A user who exports several messages during a session ends up with a Downloads folder of opaque epoch-stamp files (`message-1779203860025.md`, `message-1779203912104.md`, ...) and no way to tell which is which without opening each.

Pass a `filename` prop to `ActionBarPrimitive.ExportMarkdown` so the file lands as `unsloth-message-2026-05-19.md` instead, matching the JSON export's naming.

Cycle-29 probe (`scripts/r6_conversation_export_probe.py`) drove a fresh /chat through both export paths. Before this change: `message-1779203860025.md`. After: `unsloth-message-2026-05-19.md`.

## Test plan

- [ ] Send a prompt in /chat, click the assistant message's More menu, click "Export as Markdown".
- [ ] Confirm the downloaded file is named `unsloth-message-YYYY-MM-DD.md`.
- [ ] Confirm the file contents are unchanged (still the assistant message text).
- [ ] Settings -> Chat -> Export continues to produce `unsloth-chats-YYYY-MM-DD.json`.