### PR TITLE
studio/frontend: horizontal-scroll long lines inside code blocks

### DIFF
--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -990,25 +990,23 @@
 	.aui-thread-root [data-streamdown="code-block"] {
 		content-visibility: visible !important;
 		contain-intrinsic-size: none !important;
+		/* Long lines inside fenced code blocks should scroll
+		 * horizontally within the block, not push the chat column
+		 * wider. Streamdown's default <pre> ships with
+		 * `overflow-x: visible` + `white-space: pre` +
+		 * `word-break: normal`, so an unbreakable run (long URL,
+		 * hex string, single-line curl command) escapes the
+		 * bubble to the right and reflows the message column.
+		 * Cap the wrapper width and clip overflow so the scrollbar
+		 * appears on the inner <pre> below. */
+		max-width: 100%;
+		overflow-x: hidden;
 	}
 	.aui-thread-root [data-streamdown="code-block"] [data-sd-animate] {
 		animation: none !important;
 	}
-
-	/* Long lines inside fenced code blocks should scroll horizontally
-	 * within the block, not push the chat column wider. Streamdown's
-	 * default <pre> ships with `overflow-x: visible` + `white-space:
-	 * pre` + `word-break: normal`, so an unbreakable run (long URL,
-	 * hex string, single-line curl command) escapes the bubble to the
-	 * right and reflows the message column. Switch the inner <pre> to
-	 * `overflow-x: auto` so the scrollbar appears on the code block
-	 * itself; the parent stays clipped so it cannot widen the bubble. */
 	.aui-thread-root [data-streamdown="code-block"] pre {
 		overflow-x: auto;
-	}
-	.aui-thread-root [data-streamdown="code-block"] {
-		max-width: 100%;
-		overflow-x: hidden;
 	}
 }
 

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -994,6 +994,22 @@
 	.aui-thread-root [data-streamdown="code-block"] [data-sd-animate] {
 		animation: none !important;
 	}
+
+	/* Long lines inside fenced code blocks should scroll horizontally
+	 * within the block, not push the chat column wider. Streamdown's
+	 * default <pre> ships with `overflow-x: visible` + `white-space:
+	 * pre` + `word-break: normal`, so an unbreakable run (long URL,
+	 * hex string, single-line curl command) escapes the bubble to the
+	 * right and reflows the message column. Switch the inner <pre> to
+	 * `overflow-x: auto` so the scrollbar appears on the code block
+	 * itself; the parent stays clipped so it cannot widen the bubble. */
+	.aui-thread-root [data-streamdown="code-block"] pre {
+		overflow-x: auto;
+	}
+	.aui-thread-root [data-streamdown="code-block"] {
+		max-width: 100%;
+		overflow-x: hidden;
+	}
 }
 
 /* Lighter shadow + tighter vertical padding than Sonner's defaults; !important because Sonner injects its base rules at runtime. */


### PR DESCRIPTION
## Summary

Cycle-33 probe `scripts/r6_code_block_wrap_probe.py` renders an assistant message with four code fences containing unbreakable runs:

| fence | content |
|---|---|
| python | 200-char hex string assigned to a variable |
| bash | single-line curl with many flags |
| json | object whose value is a long URL |
| (plain) | 300-char ascii blob |

All four blocks measured `overflow-x: visible`, `white-space: pre`, `word-break: normal` — streamdown's default `<pre>` styling. The content's `scrollWidth` exceeded `clientWidth` by 2-3x (1696, 2177, 2447 px inside a 710 px chat column), so the long lines escaped the bubble laterally and pushed the message column wider than the rest of the chat.

## Fix

Two scoped CSS rules in `index.css`, in the existing streamdown hardening section:

- The inner `<pre>` switches to `overflow-x: auto` so a horizontal scrollbar appears inside the code block.
- The outer `[data-streamdown=\"code-block\"]` wrapper gets `max-width: 100%; overflow-x: hidden` so even if a downstream library tweak undoes the pre styling, the bubble cannot widen.

Code indentation is preserved (no wrap), the scrollbar appears only when needed, the rest of the column layout stays put.

## Test plan

- [ ] In /chat, ask the model to paste a long URL or 100-char hex string inside a code fence.
- [ ] The code block stays inside the bubble; a horizontal scrollbar appears at the bottom of the block.
- [ ] Multi-line code with normal-length lines is unchanged.
- [ ] Probe: `python scripts/r6_code_block_wrap_probe.py --port 8890 --password <pw>`; expect `overflow_styles` to include `"auto"` after the fix.