### PR TITLE
studio/frontend: clear stale thread/compare search after sidebar nav

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -249,15 +249,16 @@ export function AppSidebar() {
 
   async function handleDeleteThread(item: Parameters<typeof deleteChatItem>[0]) {
     await deleteChatItem(item, activeThreadId, (view) => {
-      // Clear `thread`/`compare` explicitly: TanStack Router merges
-      // search params by default, so passing only `{new}` leaves the
-      // deleted thread id in the URL. The recovery useEffect in
-      // chat-page only fires on hard reload, which means the in-tab
-      // address bar stays stale until then.
-      navigate({
+      // Function-form search replaces (not merges) so the deleted
+      // thread / compare id can't survive in the URL. The recovery
+      // useEffect in chat-page only fires on hard reload, which is
+      // why the in-tab address bar stays stale otherwise.
+      setActiveThreadId(null);
+      void navigate({
         to: "/chat",
-        search: { new: view.newThreadNonce, thread: undefined, compare: undefined },
+        search: () => ({ new: view.newThreadNonce }),
       });
+      closeMobileIfOpen();
     });
   }
 
@@ -367,7 +368,7 @@ export function AppSidebar() {
               closeMobileIfOpen();
               void navigate({
                 to: "/chat",
-                search: { new: createNavigationNonce(), thread: undefined, compare: undefined },
+                search: () => ({ new: createNavigationNonce() }),
               });
             }}
             className="flex items-center gap-[6px] select-none"
@@ -447,7 +448,7 @@ export function AppSidebar() {
                 setActiveThreadId(null);
                 navigate({
                   to: "/chat",
-                  search: { new: createNavigationNonce(), thread: undefined, compare: undefined },
+                  search: () => ({ new: createNavigationNonce() }),
                 });
                 closeMobileIfOpen();
               }}

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -249,9 +249,14 @@ export function AppSidebar() {
 
   async function handleDeleteThread(item: Parameters<typeof deleteChatItem>[0]) {
     await deleteChatItem(item, activeThreadId, (view) => {
+      // Clear `thread`/`compare` explicitly: TanStack Router merges
+      // search params by default, so passing only `{new}` leaves the
+      // deleted thread id in the URL. The recovery useEffect in
+      // chat-page only fires on hard reload, which means the in-tab
+      // address bar stays stale until then.
       navigate({
         to: "/chat",
-        search: { new: view.newThreadNonce },
+        search: { new: view.newThreadNonce, thread: undefined, compare: undefined },
       });
     });
   }
@@ -362,7 +367,7 @@ export function AppSidebar() {
               closeMobileIfOpen();
               void navigate({
                 to: "/chat",
-                search: { new: createNavigationNonce() },
+                search: { new: createNavigationNonce(), thread: undefined, compare: undefined },
               });
             }}
             className="flex items-center gap-[6px] select-none"
@@ -440,7 +445,10 @@ export function AppSidebar() {
               onClick={() => {
                 if (chatDisabled) return;
                 setActiveThreadId(null);
-                navigate({ to: "/chat", search: { new: createNavigationNonce() } });
+                navigate({
+                  to: "/chat",
+                  search: { new: createNavigationNonce(), thread: undefined, compare: undefined },
+                });
                 closeMobileIfOpen();
               }}
             />


### PR DESCRIPTION
## Summary

- Three sidebar navigations (delete active chat, New Chat, Unsloth home logo) call `navigate({to: "/chat", search: {new: nonce}})`. TanStack Router merges search params by default, so the prior `?thread=<id>` (or `?compare=<id>`) survives.
- The recovery useEffect in `features/chat/chat-page.tsx:557-585` only fires when `search.thread` changes, so the in-tab URL stays stale until a hard reload.
- Pass `thread: undefined, compare: undefined` alongside `new` to actually remove the prior keys.

## Repro

```
python scripts/r6_repro_active_delete_url.py
# URL before: http://127.0.0.1:8890/chat?thread=AAA
#   +0.5s URL: http://127.0.0.1:8890/chat?thread=AAA
#   +5.0s URL: http://127.0.0.1:8890/chat?thread=AAA
# final URL:  http://127.0.0.1:8890/chat?thread=AAA   <- stale
# active_in_sidebar: False                            <- row gone
# (hard reload then redirects to /chat?new=<nonce>)
```

## Test plan

- [x] tsc clean
- [x] Probe scripts/r6_sidebar_delete_chat_probe.py expect delete_active_thread_navigates_away: True after patched build
- [ ] Manual: delete active chat then URL clears to ?new
- [ ] Manual: from /chat?thread=X click New Chat then URL becomes ?new without leftover thread
- [ ] Manual: from /chat?thread=X click Unsloth logo then URL becomes ?new