### PR TITLE
studio/frontend: keep shutdown dialog open when server-stop fails

### DIFF
--- a/studio/frontend/src/components/shutdown-dialog.tsx
+++ b/studio/frontend/src/components/shutdown-dialog.tsx
@@ -72,7 +72,15 @@ export function ShutdownDialog({
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
-            onClick={handleStop}
+            onClick={(event) => {
+              // AlertDialogAction auto-closes the dialog by default.
+              // On the shutdown error path we toast + reset `stopping`
+              // to let the user retry, which only works if the dialog
+              // stays open. preventDefault keeps it open; on success
+              // the handler replaces document.body anyway.
+              event.preventDefault();
+              void handleStop();
+            }}
             disabled={stopping}
             variant="destructive"
           >


### PR DESCRIPTION
## Summary

- Radix `AlertDialogAction` auto-closes the dialog on click. The shutdown error path then runs async (toast + reset \`stopping\`) but the dialog has already vanished, so the reset is a no-op and the user has to re-navigate the user-menu to retry.
- Call \`event.preventDefault()\` so the dialog stays open while the request is in flight. On success \`handleStop\` replaces \`document.body\` anyway, so dialog open-ness is moot. On failure the dialog stays open with the reset "Stop server" label, ready for retry.

## Repro / verification

\`scripts/r6_shutdown_dialog_probe.py\` intercepts \`POST /api/shutdown\` and returns 500 so the error path runs without actually killing the server.

Before the fix:
\`\`\`
in-flight label: Stopping…   (correct)
after error:
  dialog_still_open: False   <- BUG
  toast: "Failed to shut down server"
  body NOT replaced          (correct)
\`\`\`

After the fix the dialog stays open and the button resets to "Stop server".

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] Probe asserts \`error_keeps_dialog_open_with_reset_label: True\` after the patch
- [ ] Manual: open the user menu, click Shutdown, then in the dialog click "Stop server" with the backend stubbed to 500 — confirm the dialog remains visible and the button label resets