### PR TITLE
studio: mark closed chat configuration aside as inert

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1500,6 +1500,13 @@ export function ChatSettingsPanel({
 
   return (
     <aside
+      // When `open` is false the aside collapses to width 0 with
+      // overflow:hidden, but its inner controls remain in the DOM
+      // (Configuration heading, Close button, sliders, etc). Without
+      // `inert`, keyboard users Tab into off-screen focusable controls
+      // and screen readers announce them as available. `inert` also
+      // sets aria-hidden semantics so AT skips the subtree entirely.
+      inert={!open}
       className={`relative z-50 shrink-0 h-full overflow-hidden bg-panel-surface text-panel-surface-fg font-heading ${open ? "w-[17rem] border-l border-sidebar-border" : "w-0"}`}
     >
       <div className="h-full w-full">{settingsContent}</div>


### PR DESCRIPTION
## Summary

- Add `inert={!open}` to the right-rail `<aside>` in `ChatSettingsPanel` so the closed configuration panel is removed from keyboard focus order and the accessibility tree.
- Open path is unchanged.

## Why

The desktop `ChatSettingsPanel` collapses the aside to `w-0` with `overflow:hidden` when closed, but the inner subtree (Configuration heading, Close button, every slider/switch/input, system-prompt editor trigger) stays mounted because the same element is animated open/closed. Without `inert`:

- Pressing Tab from the chat textarea lands focus on the off-screen "Close configuration" button after ~4 Tabs (verified at viewport 1280x800, panel content sits at x=1403 with the focus ring clipped by overflow).
- Screen readers walk the inert subtree and announce panel controls (e.g. "Close configuration button", "Configuration", sliders) as available when nothing is visible.
- The button's onClick is harmless (it calls setOpen(false) while already false) but the focus indicator is invisible and the announcement is wrong.

The mobile path uses Radix Sheet which already handles inert/aria semantics on its own, so the fix is desktop-only on the existing aside element.

## Test plan

- [x] tsc -b clean.
- [x] Headless Playwright probe: with the fix aside.inert === true when closed and focus never enters the panel across 60 Tabs (before: focus enters at Tab #4).
- [x] Open-path sanity check: aside.inert === false when open, click-to-close still works, Tab focus enters the panel after re-open.
- [x] No console errors during the round-trip.