### PR TITLE
Move uninstall scripts into scripts/ and fix references

### DIFF
--- a/.github/workflows/studio-mac-update-smoke.yml
+++ b/.github/workflows/studio-mac-update-smoke.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
     paths:
       - 'install.sh'
-      - 'uninstall.sh'
+      - 'scripts/uninstall.sh'
       - 'studio/setup.sh'
       - 'studio/install_python_stack.py'
       - 'studio/install_llama_prebuilt.py'
@@ -139,20 +139,20 @@ jobs:
           echo "post-update Studio /api/health OK"
 
       - name: Uninstall and verify clean
-        # Round-trip through uninstall.sh on real macOS. As a side effect
-        # this exercises the macOS-only .app bundle + Launch Services
+        # Round-trip through scripts/uninstall.sh on real macOS. As a side
+        # effect this exercises the macOS-only .app bundle + Launch Services
         # removal path (~/Applications/Unsloth Studio.app, lsregister -u)
         # which is not testable from a Linux runner. Skips gracefully if
-        # uninstall.sh has not landed yet (lets this workflow merge
+        # scripts/uninstall.sh has not landed yet (lets this workflow merge
         # before #5497).
         run: |
           set -o pipefail
-          if [ ! -f uninstall.sh ]; then
-            echo "uninstall.sh not present in this tree; skipping round-trip"
+          if [ ! -f scripts/uninstall.sh ]; then
+            echo "scripts/uninstall.sh not present in this tree; skipping round-trip"
             : > logs/uninstall.log
             exit 0
           fi
-          sh uninstall.sh 2>&1 | tee logs/uninstall.log
+          sh scripts/uninstall.sh 2>&1 | tee logs/uninstall.log
           leak=0
           for p in \
             "$HOME/.unsloth/studio" \
@@ -166,8 +166,8 @@ jobs:
             fi
           done
           [ "$leak" -eq 0 ] || exit 1
-          sh uninstall.sh 2>&1 | tail -5
-          sh uninstall.sh 2>&1 | tail -5
+          sh scripts/uninstall.sh 2>&1 | tail -5
+          sh scripts/uninstall.sh 2>&1 | tail -5
           echo "PASS: mac install -> update -> uninstall round-trip clean"
 
       - name: Upload update logs

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -15,7 +15,7 @@ on:
   pull_request:
     paths:
       - 'install.sh'
-      - 'uninstall.sh'
+      - 'scripts/uninstall.sh'
       - 'studio/setup.sh'
       - 'studio/install_python_stack.py'
       - 'studio/install_llama_prebuilt.py'
@@ -141,22 +141,22 @@ jobs:
           echo "post-update Studio /api/health OK"
 
       - name: Uninstall and verify clean
-        # Round-trip the installer through uninstall.sh: confirms the
+        # Round-trip the installer through scripts/uninstall.sh: confirms the
         # uninstaller actually finds and removes everything install.sh +
         # update wrote. Safety-guard scenarios (refuse-$HOME etc.) belong
         # in a separate fast smoke job; this is the happy-path cleanup
         # assertion that catches regressions where install.sh starts
-        # writing to a new location and uninstall.sh hasn't caught up.
-        # Skips gracefully if uninstall.sh has not landed yet (lets this
-        # workflow merge before #5497).
+        # writing to a new location and scripts/uninstall.sh hasn't caught up.
+        # Skips gracefully if scripts/uninstall.sh has not landed yet (lets
+        # this workflow merge before #5497).
         run: |
           set -o pipefail
-          if [ ! -f uninstall.sh ]; then
-            echo "uninstall.sh not present in this tree; skipping round-trip"
+          if [ ! -f scripts/uninstall.sh ]; then
+            echo "scripts/uninstall.sh not present in this tree; skipping round-trip"
             : > logs/uninstall.log
             exit 0
           fi
-          sh uninstall.sh 2>&1 | tee logs/uninstall.log
+          sh scripts/uninstall.sh 2>&1 | tee logs/uninstall.log
           leak=0
           for p in \
             "$HOME/.unsloth/studio" \
@@ -171,8 +171,8 @@ jobs:
           done
           [ "$leak" -eq 0 ] || exit 1
           # Idempotent: re-runs exit 0 on an empty $HOME.
-          sh uninstall.sh 2>&1 | tail -5
-          sh uninstall.sh 2>&1 | tail -5
+          sh scripts/uninstall.sh 2>&1 | tail -5
+          sh scripts/uninstall.sh 2>&1 | tail -5
           echo "PASS: install -> update -> uninstall round-trip clean"
 
       - name: Upload update logs

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths:
       - 'install.ps1'
-      - 'uninstall.ps1'
+      - 'scripts/uninstall.ps1'
       - 'studio/setup.ps1'
       - 'studio/setup.bat'
       - 'studio/install_python_stack.py'
@@ -268,21 +268,22 @@ jobs:
           echo "post-update Studio /api/health OK"
 
       - name: Uninstall and verify clean
-        # Round-trip through uninstall.ps1 against the default install
-        # tree at %USERPROFILE%\.unsloth\studio. Catches regressions
-        # where install.ps1 starts writing under a new key (registry,
-        # Start Menu, %APPDATA%) and uninstall.ps1 has not been updated
-        # to match. Skips gracefully if uninstall.ps1 has not landed yet
-        # (lets this workflow merge before #5513).
+        # Round-trip through scripts/uninstall.ps1 against the default
+        # install tree at %USERPROFILE%\.unsloth\studio. Catches
+        # regressions where install.ps1 starts writing under a new key
+        # (registry, Start Menu, %APPDATA%) and scripts/uninstall.ps1 has
+        # not been updated to match. Skips gracefully if
+        # scripts/uninstall.ps1 has not landed yet (lets this workflow
+        # merge before #5513).
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
-          if (-not (Test-Path "$PWD\uninstall.ps1")) {
-            Write-Host "uninstall.ps1 not present in this tree; skipping round-trip"
+          if (-not (Test-Path "$PWD\scripts\uninstall.ps1")) {
+            Write-Host "scripts/uninstall.ps1 not present in this tree; skipping round-trip"
             "" | Set-Content logs/uninstall.log
             exit 0
           }
-          pwsh -NoProfile -File "$PWD\uninstall.ps1" *>&1 | Tee-Object -FilePath logs/uninstall.log
+          pwsh -NoProfile -File "$PWD\scripts\uninstall.ps1" *>&1 | Tee-Object -FilePath logs/uninstall.log
           $leak = 0
           foreach ($p in @(
             "$env:USERPROFILE\.unsloth\studio",
@@ -296,8 +297,8 @@ jobs:
           }
           if ($leak -gt 0) { exit 1 }
           # Idempotency.
-          pwsh -NoProfile -File "$PWD\uninstall.ps1" *>&1 | Select-Object -Last 5
-          pwsh -NoProfile -File "$PWD\uninstall.ps1" *>&1 | Select-Object -Last 5
+          pwsh -NoProfile -File "$PWD\scripts\uninstall.ps1" *>&1 | Select-Object -Last 5
+          pwsh -NoProfile -File "$PWD\scripts\uninstall.ps1" *>&1 | Select-Object -Last 5
           Write-Host "PASS: windows install -> update -> uninstall round-trip clean"
 
       - name: Upload update logs

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ unsloth studio -p 8888
 #### Uninstall
 The recommended way to fully remove Unsloth Studio is the matching uninstall script for your OS. It stops any running servers, removes the install dir, the launcher data dir, the desktop shortcut, and any platform-specific entries (macOS `.app` bundle + Launch Services on Mac; Start Menu, `HKCU\Software\Unsloth` registry key and user `PATH` entries on Windows):
 
-* ​ **MacOS, WSL, Linux:** `curl -fsSL https://unsloth.ai/uninstall.sh | sh`
-* ​ **Windows (PowerShell):** `irm https://unsloth.ai/uninstall.ps1 | iex`
+* ​ **MacOS, WSL, Linux:** `curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.sh | sh`
+* ​ **Windows (PowerShell):** `irm https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.ps1 | iex`
 
 If you only want to drop the install dir and keep the launcher/shortcut for a later reinstall, you can instead run `rm -rf ~/.unsloth/studio` (Mac/Linux/WSL) or `Remove-Item -Recurse -Force "$HOME\.unsloth\studio"` (Windows). The model cache at `~/.cache/huggingface` is not touched by any of these.
 

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -5,7 +5,7 @@
 # at install time (read back from share\studio.conf).
 #
 # Usage:  irm https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.ps1 | iex
-# Local:  Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; .\uninstall.ps1
+# Local:  Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; .\scripts\uninstall.ps1
 
 function Uninstall-UnslothStudio {
     $ErrorActionPreference = "Continue"
@@ -345,7 +345,7 @@ function Uninstall-UnslothStudio {
         Write-Host "If you installed Unsloth Studio with UNSLOTH_STUDIO_HOME or STUDIO_HOME"
         Write-Host "pointing at a custom directory, re-run this script with the same variable"
         Write-Host "set to also remove that install tree, e.g.:"
-        Write-Host "  `$env:UNSLOTH_STUDIO_HOME = 'C:\your\path'; .\uninstall.ps1"
+        Write-Host "  `$env:UNSLOTH_STUDIO_HOME = 'C:\your\path'; irm https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.ps1 | iex"
     }
 }
 

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -4,7 +4,7 @@
 # registry key. Honors custom roots set via UNSLOTH_STUDIO_HOME / STUDIO_HOME
 # at install time (read back from share\studio.conf).
 #
-# Usage:  irm https://raw.githubusercontent.com/unslothai/unsloth/main/uninstall.ps1 | iex
+# Usage:  irm https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.ps1 | iex
 # Local:  Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; .\uninstall.ps1
 
 function Uninstall-UnslothStudio {

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,7 +5,7 @@
 # Honors custom roots set via UNSLOTH_STUDIO_HOME / STUDIO_HOME at
 # install time (read back from studio.conf).
 #
-# Usage: curl -fsSL https://unsloth.ai/uninstall.sh | sh
+# Usage: curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.sh | sh
 
 set -e
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -279,5 +279,5 @@ if [ -z "${UNSLOTH_STUDIO_HOME:-}" ] && [ -z "${STUDIO_HOME:-}" ]; then
     echo "If you installed Unsloth Studio with UNSLOTH_STUDIO_HOME or STUDIO_HOME"
     echo "pointing at a custom directory, re-run this script with the same variable"
     echo "set to also remove that install tree, e.g.:"
-    echo "  UNSLOTH_STUDIO_HOME=/your/path sh uninstall.sh"
+    echo "  UNSLOTH_STUDIO_HOME=/your/path sh -c \"\$(curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.sh)\""
 fi


### PR DESCRIPTION
## Summary

- Relocates `uninstall.sh` and `uninstall.ps1` from the repo root into the existing `scripts/` directory, alongside the other helper scripts.
- Updates every reference (README, in-script `Usage:` headers, and the three studio update-smoke workflows) to point at the new `scripts/` path.
- Switches the `README.md` Studio uninstall snippets from `unsloth.ai/uninstall.{sh,ps1}` to the working `raw.githubusercontent.com/unslothai/unsloth/main/scripts/...` URLs (the `unsloth.ai` short URLs currently 404, unlike `unsloth.ai/install.sh` which 301s to raw GitHub).

## Changes

- `uninstall.sh` -> `scripts/uninstall.sh` (git rename)
- `uninstall.ps1` -> `scripts/uninstall.ps1` (git rename)
- `scripts/uninstall.sh`: `Usage:` header URL now points at `raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.sh`.
- `scripts/uninstall.ps1`: `Usage:` header URL now points at `raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.ps1`.
- `README.md`: Studio uninstall instructions updated to the raw GitHub URLs under `scripts/`.
- `.github/workflows/studio-update-smoke.yml`: `paths:` trigger and the round-trip step now use `scripts/uninstall.sh` for the existence check, `tee`, and idempotency re-runs.
- `.github/workflows/studio-mac-update-smoke.yml`: same updates for the macOS round-trip step.
- `.github/workflows/studio-windows-update-smoke.yml`: `paths:` trigger and round-trip step now use `scripts/uninstall.ps1` (`Test-Path` + `pwsh -NoProfile -File`).

## Intentionally not changed

- In-script help hints inside `scripts/uninstall.sh` (`sh uninstall.sh`) and `scripts/uninstall.ps1` (`.\uninstall.ps1`) are user-facing reminders printed after the user has already downloaded / curl-piped the script. The basename form is correct regardless of which directory the user dropped the file into, so these are left as-is.

## Follow-up for unsloth.ai

Once this lands, please configure the `unsloth.ai/uninstall.sh` and `unsloth.ai/uninstall.ps1` redirects to point at `https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.sh` and `.../scripts/uninstall.ps1` respectively (matching the existing `unsloth.ai/install.sh` -> raw GitHub redirect pattern). Once those redirects are live, the README snippets can optionally be swapped back to the shorter `unsloth.ai/...` form in a follow-up.

## Test plan

- [ ] CI: Studio Update CI (Linux), Mac Studio Update CI, Windows Studio Update CI all trigger on this PR (their `paths:` triggers now include `scripts/uninstall.sh` / `scripts/uninstall.ps1`) and complete the install -> update -> uninstall round-trip cleanly.
- [ ] `grep -rn 'uninstall\.\(sh\|ps1\)' .` shows no remaining repo-root references outside the in-script help hints.
- [ ] `curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.sh | sh` works on macOS / Linux / WSL after merge.
- [ ] `irm https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.ps1 | iex` works on Windows after merge.