### PR TITLE
Fix CSM depth decoder generation kwargs

### DIFF
--- a/tests/test_csm_generation_patch.py
+++ b/tests/test_csm_generation_patch.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import logging
+from pathlib import Path
+
+
+def _load_csm_generation_module():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "unsloth"
+        / "models"
+        / "_csm_generation.py"
+    )
+    spec = importlib.util.spec_from_file_location("_csm_generation", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_csm_depth_decoder_generation_signature_accepts_backbone_state():
+    module = _load_csm_generation_module()
+
+    class DepthDecoder:
+        def __init__(self):
+            self.forwarded_kwargs = None
+
+        def forward(self, *args, **kwargs):
+            return None
+
+        def prepare_inputs_for_generation(
+            self,
+            input_ids,
+            next_sequence_length = None,
+            past_key_values = None,
+            attention_mask = None,
+            inputs_embeds = None,
+            **kwargs,
+        ):
+            self.forwarded_kwargs = kwargs
+            return input_ids, kwargs
+
+    class Model:
+        def __init__(self):
+            self.depth_decoder = DepthDecoder()
+
+    model = Model()
+    module.patch_csm_depth_decoder_generate(model)
+
+    prepare_parameters = inspect.signature(
+        model.depth_decoder.prepare_inputs_for_generation
+    ).parameters
+    forward_parameters = inspect.signature(model.depth_decoder.forward).parameters
+    model_args = set(prepare_parameters)
+    if "kwargs" in model_args or "model_kwargs" in model_args:
+        model_args |= set(forward_parameters)
+
+    assert "backbone_last_hidden_state" in model_args
+
+    input_ids = object()
+    assert model.depth_decoder.prepare_inputs_for_generation(
+        input_ids,
+        backbone_last_hidden_state = "hidden-state",
+        vision_specific_arg = "passed-through",
+        extra = "kept",
+    ) == (
+        input_ids,
+        {
+            "backbone_last_hidden_state": "hidden-state",
+            "vision_specific_arg": "passed-through",
+            "extra": "kept",
+        },
+    )
+    assert model.depth_decoder.forwarded_kwargs == {
+        "backbone_last_hidden_state": "hidden-state",
+        "vision_specific_arg": "passed-through",
+        "extra": "kept",
+    }
+
+
+def test_csm_depth_decoder_generation_signature_inspection_failure_is_logged(caplog):
+    module = _load_csm_generation_module()
+
+    class DepthDecoder:
+        prepare_inputs_for_generation = object()
+
+    class Model:
+        def __init__(self):
+            self.depth_decoder = DepthDecoder()
+
+    caplog.set_level(logging.DEBUG, logger = "_csm_generation")
+
+    model = Model()
+    module.patch_csm_depth_decoder_generate(model)
+
+    assert not getattr(model.depth_decoder, "_unsloth_csm_generation_patched", False)
+    assert "Could not inspect CSM depth decoder generation signature." in caplog.text

--- a/unsloth/models/_csm_generation.py
+++ b/unsloth/models/_csm_generation.py
@@ -1,0 +1,61 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import logging
+import types
+
+
+logger = logging.getLogger(__name__)
+
+
+def patch_csm_depth_decoder_generate(model):
+    depth_decoder = getattr(model, "depth_decoder", None)
+    if depth_decoder is None or getattr(
+        depth_decoder, "_unsloth_csm_generation_patched", False
+    ):
+        return
+
+    prepare_inputs_for_generation = getattr(
+        depth_decoder, "prepare_inputs_for_generation", None
+    )
+    if prepare_inputs_for_generation is None:
+        return
+
+    try:
+        parameters = inspect.signature(prepare_inputs_for_generation).parameters
+    except (TypeError, ValueError):
+        logger.debug(
+            "Could not inspect CSM depth decoder generation signature.",
+            exc_info = True,
+        )
+        return
+    if "backbone_last_hidden_state" in parameters:
+        depth_decoder._unsloth_csm_generation_patched = True
+        return
+
+    def _prepare_inputs_for_generation(
+        self,
+        *args,
+        backbone_last_hidden_state = None,
+        **kwargs,
+    ):
+        if backbone_last_hidden_state is not None:
+            kwargs["backbone_last_hidden_state"] = backbone_last_hidden_state
+        return prepare_inputs_for_generation(*args, **kwargs)
+
+    depth_decoder.prepare_inputs_for_generation = types.MethodType(
+        _prepare_inputs_for_generation, depth_decoder
+    )
+    depth_decoder._unsloth_csm_generation_patched = True

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -66,6 +66,7 @@ from unsloth_zoo.hf_utils import (
 )
 from unsloth_zoo.patching_utils import patch_model_and_tokenizer
 from unsloth_zoo.training_utils import prepare_model_for_training
+from ._csm_generation import patch_csm_depth_decoder_generate
 
 from unsloth_zoo.utils import Version
 from transformers import __version__ as transformers_version
@@ -1310,6 +1311,8 @@ class FastBaseModel:
         m.is_loaded_in_8bit = True if not full_finetuning else False
 
         # Patch generate
+        if hasattr(model, "generate"):
+            patch_csm_depth_decoder_generate(model)
         if os.environ.get("UNSLOTH_DISABLE_FAST_GENERATION", "0") == "0" and hasattr(
             model, "generate"
         ):


### PR DESCRIPTION
## Summary
- Allow CSM depth decoder generation to accept `backbone_last_hidden_state` after forward signature wrapping.
- Apply the compatibility shim during FastModel setup and cover the validator behavior with a regression test.

Fixes #5533

## Tests
- `python -m pytest tests/test_csm_generation_patch.py -q`
- `python -m py_compile unsloth/models/_csm_generation.py unsloth/models/vision.py tests/test_csm_generation_patch.py`
- Direct Transformers validator smoke check: rejected before the shim, accepted after it.