### PR TITLE
studio/frontend: correct Think pill aria-label before model loads

### DIFF
--- a/studio/frontend/src/components/assistant-ui/think-aria-label.ts
+++ b/studio/frontend/src/components/assistant-ui/think-aria-label.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Shared aria-label helpers for the composer Think pill. Both the on/off
+// toggle (used when a model exposes a simple thinking flag) and the
+// reasoning-effort dropdown (Claude-style models with effort levels) need
+// the same pre-load / unsupported-model fallback wording, so factor it
+// once and reuse. Keeping the strings here also means the label set is
+// trivially auditable in a single file.
+
+export interface ThinkToggleState {
+  reasoningLockedOn: boolean;
+  modelLoaded: boolean;
+  reasoningDisabled: boolean;
+  effectiveReasoningEnabled: boolean;
+}
+
+export function thinkToggleAriaLabel(state: ThinkToggleState): string {
+  if (state.reasoningLockedOn) return "Thinking is required for this model";
+  if (!state.modelLoaded) return "Thinking (model not loaded)";
+  if (state.reasoningDisabled)
+    return "Thinking (not supported by this model)";
+  return state.effectiveReasoningEnabled
+    ? "Disable thinking"
+    : "Enable thinking";
+}
+
+export interface ThinkEffortState {
+  modelLoaded: boolean;
+  reasoningDisabled: boolean;
+  reasoningEffort: string;
+}
+
+// The reasoning-effort dropdown stays interactive in the locked-on case
+// (users can still pick an effort level), so locked-on is intentionally
+// not a special-case here -- only the truly-disabled states fall back to
+// the Thinking (...) wording.
+export function thinkEffortAriaLabel(state: ThinkEffortState): string {
+  if (!state.modelLoaded) return "Thinking (model not loaded)";
+  if (state.reasoningDisabled)
+    return "Thinking (not supported by this model)";
+  return `Reasoning effort: ${state.reasoningEffort}`;
+}

--- a/studio/frontend/src/components/assistant-ui/think-aria-label.ts
+++ b/studio/frontend/src/components/assistant-ui/think-aria-label.ts
@@ -1,12 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Shared aria-label helpers for the composer Think pill. Both the on/off
-// toggle (used when a model exposes a simple thinking flag) and the
-// reasoning-effort dropdown (Claude-style models with effort levels) need
-// the same pre-load / unsupported-model fallback wording, so factor it
-// once and reuse. Keeping the strings here also means the label set is
-// trivially auditable in a single file.
+// Shared aria-labels for the Think pill (toggle + effort dropdown) so both
+// controls use the same pre-load / unsupported-model wording.
 
 export interface ThinkToggleState {
   reasoningLockedOn: boolean;
@@ -31,10 +27,8 @@ export interface ThinkEffortState {
   reasoningEffort: string;
 }
 
-// The reasoning-effort dropdown stays interactive in the locked-on case
-// (users can still pick an effort level), so locked-on is intentionally
-// not a special-case here -- only the truly-disabled states fall back to
-// the Thinking (...) wording.
+// Locked-on isn't special-cased: the effort dropdown stays interactive
+// (users can still pick an effort level).
 export function thinkEffortAriaLabel(state: ThinkEffortState): string {
   if (!state.modelLoaded) return "Thinking (model not loaded)";
   if (state.reasoningDisabled)

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -703,9 +703,11 @@ const ReasoningToggle: FC = () => {
       aria-label={
         reasoningLockedOn
           ? "Thinking is required for this model"
-          : effectiveReasoningEnabled
-            ? "Disable thinking"
-            : "Enable thinking"
+          : disabled
+            ? "Thinking (model not loaded)"
+            : effectiveReasoningEnabled
+              ? "Disable thinking"
+              : "Enable thinking"
       }
     >
       {reasoningLockedOn || (effectiveReasoningEnabled && !disabled) ? (

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -703,11 +703,13 @@ const ReasoningToggle: FC = () => {
       aria-label={
         reasoningLockedOn
           ? "Thinking is required for this model"
-          : disabled
+          : !modelLoaded
             ? "Thinking (model not loaded)"
-            : effectiveReasoningEnabled
-              ? "Disable thinking"
-              : "Enable thinking"
+            : disabled
+              ? "Thinking (not supported by this model)"
+              : effectiveReasoningEnabled
+                ? "Disable thinking"
+                : "Enable thinking"
       }
     >
       {reasoningLockedOn || (effectiveReasoningEnabled && !disabled) ? (

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -11,6 +11,10 @@ import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { MessageTiming } from "@/components/assistant-ui/message-timing";
 import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
 import { Sources, SourcesGroup } from "@/components/assistant-ui/sources";
+import {
+  thinkEffortAriaLabel,
+  thinkToggleAriaLabel,
+} from "@/components/assistant-ui/think-aria-label";
 import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
 import { ToolGroup } from "@/components/assistant-ui/tool-group";
 import { CodeExecutionToolUI } from "@/components/assistant-ui/tool-ui-code-execution";
@@ -624,7 +628,11 @@ const ReasoningToggle: FC = () => {
                   ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
                   : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
             )}
-            aria-label={`Reasoning effort: ${reasoningEffort}`}
+            aria-label={thinkEffortAriaLabel({
+              modelLoaded,
+              reasoningDisabled: disabled,
+              reasoningEffort,
+            })}
           >
             {effectiveReasoningVisualEnabled ? (
               <LightbulbIcon className="size-3.5" />
@@ -700,17 +708,12 @@ const ReasoningToggle: FC = () => {
           ? "true"
           : "false"
       }
-      aria-label={
-        reasoningLockedOn
-          ? "Thinking is required for this model"
-          : !modelLoaded
-            ? "Thinking (model not loaded)"
-            : disabled
-              ? "Thinking (not supported by this model)"
-              : effectiveReasoningEnabled
-                ? "Disable thinking"
-                : "Enable thinking"
-      }
+      aria-label={thinkToggleAriaLabel({
+        reasoningLockedOn,
+        modelLoaded,
+        reasoningDisabled: disabled,
+        effectiveReasoningEnabled,
+      })}
     >
       {reasoningLockedOn || (effectiveReasoningEnabled && !disabled) ? (
         <LightbulbIcon className="size-3.5" />

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -3,6 +3,7 @@
 
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { CodeToggleIcon } from "@/components/assistant-ui/code-toggle-icon";
+import { thinkToggleAriaLabel } from "@/components/assistant-ui/think-aria-label";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
@@ -990,17 +991,12 @@ export function SharedComposer({
                       ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
                       : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
               )}
-              aria-label={
-                reasoningLockedOn
-                  ? "Thinking is required for this model"
-                  : !modelLoaded
-                    ? "Thinking (model not loaded)"
-                    : reasoningDisabled
-                      ? "Thinking (not supported by this model)"
-                      : effectiveReasoningEnabled
-                        ? "Disable thinking"
-                        : "Enable thinking"
-              }
+              aria-label={thinkToggleAriaLabel({
+                reasoningLockedOn,
+                modelLoaded,
+                reasoningDisabled,
+                effectiveReasoningEnabled,
+              })}
             >
               {reasoningLockedOn ||
               (effectiveReasoningEnabled && !reasoningDisabled) ? (

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -993,11 +993,13 @@ export function SharedComposer({
               aria-label={
                 reasoningLockedOn
                   ? "Thinking is required for this model"
-                  : reasoningDisabled
+                  : !modelLoaded
                     ? "Thinking (model not loaded)"
-                    : effectiveReasoningEnabled
-                      ? "Disable thinking"
-                      : "Enable thinking"
+                    : reasoningDisabled
+                      ? "Thinking (not supported by this model)"
+                      : effectiveReasoningEnabled
+                        ? "Disable thinking"
+                        : "Enable thinking"
               }
             >
               {reasoningLockedOn ||

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -3,7 +3,10 @@
 
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { CodeToggleIcon } from "@/components/assistant-ui/code-toggle-icon";
-import { thinkToggleAriaLabel } from "@/components/assistant-ui/think-aria-label";
+import {
+  thinkEffortAriaLabel,
+  thinkToggleAriaLabel,
+} from "@/components/assistant-ui/think-aria-label";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
@@ -899,7 +902,11 @@ export function SharedComposer({
                         ? "text-primary hover:bg-primary/10 dark:hover:bg-white/[0.08]"
                         : "hover:bg-primary/10 dark:hover:bg-white/[0.08]",
                   )}
-                  aria-label={`Reasoning effort: ${reasoningEffort}`}
+                  aria-label={thinkEffortAriaLabel({
+                    modelLoaded,
+                    reasoningDisabled,
+                    reasoningEffort,
+                  })}
                 >
                   {effectiveReasoningVisualEnabled ? (
                     <LightbulbIcon className="size-3.5" />

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -993,9 +993,11 @@ export function SharedComposer({
               aria-label={
                 reasoningLockedOn
                   ? "Thinking is required for this model"
-                  : effectiveReasoningEnabled
-                    ? "Disable thinking"
-                    : "Enable thinking"
+                  : reasoningDisabled
+                    ? "Thinking (model not loaded)"
+                    : effectiveReasoningEnabled
+                      ? "Disable thinking"
+                      : "Enable thinking"
               }
             >
               {reasoningLockedOn ||


### PR DESCRIPTION
## Summary

- The composer Think pill's `aria-label` reads "Disable thinking" before a model loads, even though the button is `disabled` and visibly OFF (the LightbulbOffIcon variant is shown, `data-active="false"`).
- Root cause: `reasoningEnabled` defaults to `true` in the chat-runtime store (`chat-runtime-store.ts:350,467`), so `effectiveReasoningEnabled` is `true` on first paint -- and the aria-label falls through to the `effectiveReasoningEnabled ? "Disable thinking" : "Enable thinking"` branch without considering the `disabled` (model-not-loaded) gate above it.
- Fix: insert a `disabled` branch between `reasoningLockedOn` and `effectiveReasoningEnabled` so the label reads "Thinking (model not loaded)" while the button is unreachable. Once the model is loaded, the existing enable/disable copy resumes. Same fix applied to the equivalent pill in `shared-composer.tsx` (where the disabled flag is named `reasoningDisabled`).
- Surfaced by a screen-reader-style probe over the welcome page. Users heard "Disable thinking" on a grayed-out unclickable button, which contradicts the visible state.

## Test plan

- [ ] Open Studio without a loaded model, focus the Think pill, run a screen reader (or check via DevTools Accessibility tree) -- the label should now read "Thinking (model not loaded)" instead of "Disable thinking".
- [ ] Load a model, verify the label flips to "Enable thinking" (default off) or "Disable thinking" (after the user toggles it on).
- [ ] For a reasoning-locked-on model (e.g. GPT-5 or similar where `supportsReasoningOff` is false), verify the label stays "Thinking is required for this model".
- [ ] Compose mode (shared-composer): same three states.