### PR TITLE
studio/frontend: fix onboarding CSP violations

### DIFF
--- a/studio/frontend/src/components/ui/confetti.tsx
+++ b/studio/frontend/src/components/ui/confetti.tsx
@@ -40,7 +40,7 @@ const ConfettiContext = createContext<Api>({} as Api);
 const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
   const {
     options,
-    globalOptions = { resize: true, useWorker: true },
+    globalOptions = { resize: true, useWorker: false },
     manualstart = false,
     children,
     ...rest

--- a/studio/frontend/src/components/ui/confetti.tsx
+++ b/studio/frontend/src/components/ui/confetti.tsx
@@ -34,11 +34,8 @@ export type ConfettiRef = Api | null;
 
 const ConfettiContext = createContext<Api>({} as Api);
 
-// Studio's CSP is `script-src 'self'` (no `blob:`, no `unsafe-eval`).
-// canvas-confetti's default `useWorker: true` spawns
-// `new Worker(URL.createObjectURL(new Blob([...])))`, which is blocked.
-// Force `useWorker: false` at every `confetti.create` callsite, and keep
-// the default object module-scoped so the prop default has a stable
+// Studio CSP blocks canvas-confetti's default blob: worker, so force
+// useWorker: false. Module-scoped so the prop default keeps stable
 // identity across renders (`canvasRef` depends on `globalOptions`).
 const DEFAULT_GLOBAL_OPTIONS: ConfettiGlobalOptions = {
   resize: true,
@@ -62,9 +59,8 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
         instanceRef.current = confetti.create(node, {
           ...globalOptions,
           resize: true,
-          // Always force `useWorker: false` regardless of what the caller
-          // passed in `globalOptions`; otherwise a caller that only sets
-          // `{ resize: true }` silently re-enables the worker and trips CSP.
+          // Force off after the spread so caller globalOptions can't
+          // re-enable the worker and trip CSP.
           useWorker: false,
         });
       } else {
@@ -117,7 +113,6 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
   );
 });
 
-// Set display name immediately
 ConfettiComponent.displayName = "Confetti";
 
 export const Confetti = ConfettiComponent;

--- a/studio/frontend/src/components/ui/confetti.tsx
+++ b/studio/frontend/src/components/ui/confetti.tsx
@@ -36,11 +36,38 @@ export type ConfettiRef = Api | null;
 
 const ConfettiContext = createContext<Api>({} as Api);
 
+// Studio's CSP is `script-src 'self'` (no `blob:`, no `unsafe-eval`).
+// canvas-confetti's default `useWorker: true` spawns
+// `new Worker(URL.createObjectURL(new Blob([...])))`, which is blocked.
+// Force `useWorker: false` at every callsite that ends up in `confetti.create`
+// (or in the global `confetti()` path via the shared instance below), and
+// keep the default object module-scoped so the prop default has a stable
+// identity across renders (`canvasRef` depends on `globalOptions`).
+const DEFAULT_GLOBAL_OPTIONS: ConfettiGlobalOptions = {
+  resize: true,
+  useWorker: false,
+};
+
+// Lazily-created CSP-safe singleton for callers that would otherwise reach
+// for the global `confetti()` (e.g. `ConfettiButton` below). Allocating a
+// dedicated overlay canvas once means even ad-hoc bursts honour our CSP.
+let _sharedFire: ConfettiInstance | null = null;
+function getSharedConfettiFire(): ConfettiInstance | null {
+  if (typeof document === "undefined") return null;
+  if (_sharedFire) return _sharedFire;
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText =
+    "position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:99999";
+  document.body.appendChild(canvas);
+  _sharedFire = confetti.create(canvas, DEFAULT_GLOBAL_OPTIONS);
+  return _sharedFire;
+}
+
 // Define component first
 const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
   const {
     options,
-    globalOptions = { resize: true, useWorker: false },
+    globalOptions = DEFAULT_GLOBAL_OPTIONS,
     manualstart = false,
     children,
     ...rest
@@ -54,6 +81,10 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
         instanceRef.current = confetti.create(node, {
           ...globalOptions,
           resize: true,
+          // Always force `useWorker: false` regardless of what the caller
+          // passed in `globalOptions`; otherwise a caller that only sets
+          // `{ resize: true }` silently re-enables the worker and trips CSP.
+          useWorker: false,
         });
       } else {
         if (instanceRef.current) {
@@ -126,7 +157,11 @@ const ConfettiButtonComponent = ({
       const rect = event.currentTarget.getBoundingClientRect();
       const x = rect.left + rect.width / 2;
       const y = rect.top + rect.height / 2;
-      await confetti({
+      // Route through the shared CSP-safe instance instead of the global
+      // `confetti()` so we never spawn a `blob:` worker.
+      const fire = getSharedConfettiFire();
+      if (!fire) return;
+      await fire({
         ...options,
         origin: {
           x: x / window.innerWidth,

--- a/studio/frontend/src/components/ui/confetti.tsx
+++ b/studio/frontend/src/components/ui/confetti.tsx
@@ -19,8 +19,6 @@ import {
   useRef,
 } from "react";
 
-import { Button } from "@/components/ui/button";
-
 type Api = {
   fire: (options?: ConfettiOptions) => void;
 };
@@ -39,31 +37,14 @@ const ConfettiContext = createContext<Api>({} as Api);
 // Studio's CSP is `script-src 'self'` (no `blob:`, no `unsafe-eval`).
 // canvas-confetti's default `useWorker: true` spawns
 // `new Worker(URL.createObjectURL(new Blob([...])))`, which is blocked.
-// Force `useWorker: false` at every callsite that ends up in `confetti.create`
-// (or in the global `confetti()` path via the shared instance below), and
-// keep the default object module-scoped so the prop default has a stable
+// Force `useWorker: false` at every `confetti.create` callsite, and keep
+// the default object module-scoped so the prop default has a stable
 // identity across renders (`canvasRef` depends on `globalOptions`).
 const DEFAULT_GLOBAL_OPTIONS: ConfettiGlobalOptions = {
   resize: true,
   useWorker: false,
 };
 
-// Lazily-created CSP-safe singleton for callers that would otherwise reach
-// for the global `confetti()` (e.g. `ConfettiButton` below). Allocating a
-// dedicated overlay canvas once means even ad-hoc bursts honour our CSP.
-let _sharedFire: ConfettiInstance | null = null;
-function getSharedConfettiFire(): ConfettiInstance | null {
-  if (typeof document === "undefined") return null;
-  if (_sharedFire) return _sharedFire;
-  const canvas = document.createElement("canvas");
-  canvas.style.cssText =
-    "position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:99999";
-  document.body.appendChild(canvas);
-  _sharedFire = confetti.create(canvas, DEFAULT_GLOBAL_OPTIONS);
-  return _sharedFire;
-}
-
-// Define component first
 const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
   const {
     options,
@@ -139,47 +120,4 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
 // Set display name immediately
 ConfettiComponent.displayName = "Confetti";
 
-// Export as Confetti
 export const Confetti = ConfettiComponent;
-
-interface ConfettiButtonProps extends React.ComponentProps<"button"> {
-  options?: ConfettiOptions &
-    ConfettiGlobalOptions & { canvas?: HTMLCanvasElement };
-}
-
-const ConfettiButtonComponent = ({
-  options,
-  children,
-  ...props
-}: ConfettiButtonProps) => {
-  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    try {
-      const rect = event.currentTarget.getBoundingClientRect();
-      const x = rect.left + rect.width / 2;
-      const y = rect.top + rect.height / 2;
-      // Route through the shared CSP-safe instance instead of the global
-      // `confetti()` so we never spawn a `blob:` worker.
-      const fire = getSharedConfettiFire();
-      if (!fire) return;
-      await fire({
-        ...options,
-        origin: {
-          x: x / window.innerWidth,
-          y: y / window.innerHeight,
-        },
-      });
-    } catch (error) {
-      console.error("Confetti button error:", error);
-    }
-  };
-
-  return (
-    <Button onClick={handleClick} {...props}>
-      {children}
-    </Button>
-  );
-};
-
-ConfettiButtonComponent.displayName = "ConfettiButton";
-
-export const ConfettiButton = ConfettiButtonComponent;

--- a/studio/frontend/src/features/onboarding/components/splash-screen.tsx
+++ b/studio/frontend/src/features/onboarding/components/splash-screen.tsx
@@ -20,7 +20,7 @@ export function SplashScreen({
         {/* Mascot */}
         <div className="flex justify-center">
           <motion.img
-            src="/Sloth emojis/Sloth loca pc.png"
+            src={`${import.meta.env.BASE_URL}Sloth emojis/Sloth loca pc.png`}
             alt="Sloth mascot"
             className="size-30"
             initial={{ opacity: 0, y: 40, scale: 0.95 }}

--- a/studio/frontend/src/features/onboarding/components/steps/dataset-step.tsx
+++ b/studio/frontend/src/features/onboarding/components/steps/dataset-step.tsx
@@ -151,7 +151,7 @@ export function DatasetStep() {
             className="flex-1"
           >
             <img
-              src="/huggingface.svg"
+              src={`${import.meta.env.BASE_URL}huggingface.svg`}
               alt=""
               className="size-4 invert"
               data-icon="inline-start"

--- a/studio/frontend/src/features/onboarding/components/wizard-content.tsx
+++ b/studio/frontend/src/features/onboarding/components/wizard-content.tsx
@@ -19,11 +19,11 @@ const STEP_COMPONENTS = {
 } as const;
 
 const STEP_MASCOTS: Record<StepNumber, string> = {
-  1: "/Sloth emojis/large sloth wave.png",
-  2: "/Sloth emojis/sloth magnify final.png",
-  3: "/Sloth emojis/sloth huglove large.png",
-  4: "/Sloth emojis/large sloth glasses.png",
-  5: "/Sloth emojis/large sloth yay.png",
+  1: `${import.meta.env.BASE_URL}Sloth emojis/large sloth wave.png`,
+  2: `${import.meta.env.BASE_URL}Sloth emojis/sloth magnify final.png`,
+  3: `${import.meta.env.BASE_URL}Sloth emojis/sloth huglove large.png`,
+  4: `${import.meta.env.BASE_URL}Sloth emojis/large sloth glasses.png`,
+  5: `${import.meta.env.BASE_URL}Sloth emojis/large sloth yay.png`,
 };
 
 export function WizardContent() {

--- a/studio/frontend/src/features/onboarding/components/wizard-sidebar.tsx
+++ b/studio/frontend/src/features/onboarding/components/wizard-sidebar.tsx
@@ -18,7 +18,7 @@ export function WizardSidebar({ returnTo }: { returnTo: string }) {
     <aside className="w-full shrink-0 bg-muted/70 p-4 md:w-64 md:p-6">
       <div className="flex items-center gap-3 py-1 md:py-2">
         <img
-          src="/sticker.png"
+          src={`${import.meta.env.BASE_URL}sticker.png`}
           alt="Unsloth"
           className="size-12"
         />

--- a/studio/frontend/src/features/onboarding/components/wizard-sidebar.tsx
+++ b/studio/frontend/src/features/onboarding/components/wizard-sidebar.tsx
@@ -18,7 +18,7 @@ export function WizardSidebar({ returnTo }: { returnTo: string }) {
     <aside className="w-full shrink-0 bg-muted/70 p-4 md:w-64 md:p-6">
       <div className="flex items-center gap-3 py-1 md:py-2">
         <img
-          src="https://unsloth.ai/cgi/image/unsloth_sticker_no_shadow_ldN4V4iydw00qSIIWDCUv.png?width=96&quality=80&format=auto"
+          src="/sticker.png"
           alt="Unsloth"
           className="size-12"
         />

--- a/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
+++ b/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
@@ -25,19 +25,32 @@ type FireworksOpts = {
 const DEFAULT_FIREWORKS_Z_INDEX = 99999;
 let _sharedCanvas: HTMLCanvasElement | null = null;
 let _sharedFire: ConfettiInstance | null = null;
-async function getSharedFire(): Promise<ConfettiInstance | null> {
-  if (typeof document === "undefined") return null;
-  if (_sharedFire) return _sharedFire;
-  const confetti = (await import("canvas-confetti")).default;
-  _sharedCanvas = document.createElement("canvas");
-  _sharedCanvas.style.cssText =
-    `position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:${DEFAULT_FIREWORKS_Z_INDEX}`;
-  document.body.appendChild(_sharedCanvas);
-  _sharedFire = confetti.create(_sharedCanvas, {
-    resize: true,
-    useWorker: false,
-  });
-  return _sharedFire;
+// Cache the in-flight init promise so two same-tick calls don't both await
+// `import("canvas-confetti")` and append a second orphan canvas.
+let _sharedFirePromise: Promise<ConfettiInstance | null> | null = null;
+function getSharedFire(): Promise<ConfettiInstance | null> {
+  if (typeof document === "undefined") return Promise.resolve(null);
+  if (_sharedFire) return Promise.resolve(_sharedFire);
+  if (_sharedFirePromise) return _sharedFirePromise;
+  _sharedFirePromise = (async () => {
+    try {
+      const confetti = (await import("canvas-confetti")).default;
+      const canvas = document.createElement("canvas");
+      canvas.style.cssText =
+        `position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:${DEFAULT_FIREWORKS_Z_INDEX}`;
+      document.body.appendChild(canvas);
+      _sharedCanvas = canvas;
+      _sharedFire = confetti.create(canvas, {
+        resize: true,
+        useWorker: false,
+      });
+      return _sharedFire;
+    } catch (err) {
+      _sharedFirePromise = null;
+      throw err;
+    }
+  })();
+  return _sharedFirePromise;
 }
 
 export async function fireConfettiFireworks(opts: FireworksOpts = {}) {

--- a/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
+++ b/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
@@ -11,22 +11,14 @@ type FireworksOpts = {
   zIndex?: number;
 };
 
-// Studio CSP (`script-src 'self'`) blocks canvas-confetti's default
-// blob: worker, so we mount a dedicated overlay canvas once and drive it
-// via `confetti.create(...)` with `useWorker: false`. The shared instance
-// is reused across calls so we don't leak canvases per tour completion.
-//
-// Stacking note: when canvas-confetti runs against a caller-provided
-// canvas, the per-fire `zIndex` option no longer drives stacking; the
-// canvas element's own CSS `z-index` does. We therefore apply
-// `opts.zIndex` (or the default) to the shared canvas's style on each
-// call so callers that want to lower/raise the fireworks layer still
-// get that behavior.
+// CSP blocks canvas-confetti's default blob: worker, so reuse a single
+// overlay canvas via `confetti.create(..., { useWorker: false })`.
+// Caller-provided canvases ignore the per-fire `zIndex`; stacking is
+// driven by `_sharedCanvas.style.zIndex` instead (set in fireConfettiFireworks).
 const DEFAULT_FIREWORKS_Z_INDEX = 99999;
 let _sharedCanvas: HTMLCanvasElement | null = null;
 let _sharedFire: ConfettiInstance | null = null;
-// Cache the in-flight init promise so two same-tick calls don't both await
-// `import("canvas-confetti")` and append a second orphan canvas.
+// Cache the init promise so concurrent callers share one import + canvas.
 let _sharedFirePromise: Promise<ConfettiInstance | null> | null = null;
 function getSharedFire(): Promise<ConfettiInstance | null> {
   if (typeof document === "undefined") return Promise.resolve(null);
@@ -64,9 +56,7 @@ export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
     const fire = await getSharedFire();
     if (!fire || !_sharedCanvas) return;
 
-    // Honor `opts.zIndex` even though canvas-confetti's per-fire `zIndex`
-    // is ignored for caller-provided canvases (see note above): we drive
-    // stacking via the shared canvas's CSS instead of the per-fire option.
+    // Per-fire zIndex is ignored on a shared canvas; drive stacking via CSS.
     _sharedCanvas.style.zIndex = String(opts.zIndex ?? DEFAULT_FIREWORKS_Z_INDEX);
 
     const duration = opts.durationMs ?? 1200;

--- a/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
+++ b/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
@@ -52,9 +52,9 @@ export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
     if (!fire || !_sharedCanvas) return;
 
     // Honor `opts.zIndex` even though canvas-confetti's per-fire `zIndex`
-    // is ignored for caller-provided canvases (see note above).
-    const zIndex = opts.zIndex ?? DEFAULT_FIREWORKS_Z_INDEX;
-    _sharedCanvas.style.zIndex = String(zIndex);
+    // is ignored for caller-provided canvases (see note above): we drive
+    // stacking via the shared canvas's CSS instead of the per-fire option.
+    _sharedCanvas.style.zIndex = String(opts.zIndex ?? DEFAULT_FIREWORKS_Z_INDEX);
 
     const duration = opts.durationMs ?? 1200;
     const intervalMs = opts.intervalMs ?? 240;
@@ -63,7 +63,6 @@ export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
       startVelocity: 28,
       spread: 360,
       ticks: 58,
-      zIndex,
       disableForReducedMotion: true,
     } as const;
 

--- a/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
+++ b/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
@@ -15,6 +15,14 @@ type FireworksOpts = {
 // blob: worker, so we mount a dedicated overlay canvas once and drive it
 // via `confetti.create(...)` with `useWorker: false`. The shared instance
 // is reused across calls so we don't leak canvases per tour completion.
+//
+// Stacking note: when canvas-confetti runs against a caller-provided
+// canvas, the per-fire `zIndex` option no longer drives stacking; the
+// canvas element's own CSS `z-index` does. We therefore apply
+// `opts.zIndex` (or the default) to the shared canvas's style on each
+// call so callers that want to lower/raise the fireworks layer still
+// get that behavior.
+const DEFAULT_FIREWORKS_Z_INDEX = 99999;
 let _sharedCanvas: HTMLCanvasElement | null = null;
 let _sharedFire: ConfettiInstance | null = null;
 async function getSharedFire(): Promise<ConfettiInstance | null> {
@@ -23,7 +31,7 @@ async function getSharedFire(): Promise<ConfettiInstance | null> {
   const confetti = (await import("canvas-confetti")).default;
   _sharedCanvas = document.createElement("canvas");
   _sharedCanvas.style.cssText =
-    "position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:99999";
+    `position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:${DEFAULT_FIREWORKS_Z_INDEX}`;
   document.body.appendChild(_sharedCanvas);
   _sharedFire = confetti.create(_sharedCanvas, {
     resize: true,
@@ -41,7 +49,12 @@ export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
     if (prefersReduce) return;
 
     const fire = await getSharedFire();
-    if (!fire) return;
+    if (!fire || !_sharedCanvas) return;
+
+    // Honor `opts.zIndex` even though canvas-confetti's per-fire `zIndex`
+    // is ignored for caller-provided canvases (see note above).
+    const zIndex = opts.zIndex ?? DEFAULT_FIREWORKS_Z_INDEX;
+    _sharedCanvas.style.zIndex = String(zIndex);
 
     const duration = opts.durationMs ?? 1200;
     const intervalMs = opts.intervalMs ?? 240;
@@ -50,7 +63,7 @@ export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
       startVelocity: 28,
       spread: 360,
       ticks: 58,
-      zIndex: opts.zIndex ?? 99999,
+      zIndex,
       disableForReducedMotion: true,
     } as const;
 

--- a/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
+++ b/studio/frontend/src/features/tour/lib/confetti-fireworks.ts
@@ -3,11 +3,34 @@
 
 "use client";
 
+import type { CreateTypes as ConfettiInstance } from "canvas-confetti";
+
 type FireworksOpts = {
   durationMs?: number;
   intervalMs?: number;
   zIndex?: number;
 };
+
+// Studio CSP (`script-src 'self'`) blocks canvas-confetti's default
+// blob: worker, so we mount a dedicated overlay canvas once and drive it
+// via `confetti.create(...)` with `useWorker: false`. The shared instance
+// is reused across calls so we don't leak canvases per tour completion.
+let _sharedCanvas: HTMLCanvasElement | null = null;
+let _sharedFire: ConfettiInstance | null = null;
+async function getSharedFire(): Promise<ConfettiInstance | null> {
+  if (typeof document === "undefined") return null;
+  if (_sharedFire) return _sharedFire;
+  const confetti = (await import("canvas-confetti")).default;
+  _sharedCanvas = document.createElement("canvas");
+  _sharedCanvas.style.cssText =
+    "position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:99999";
+  document.body.appendChild(_sharedCanvas);
+  _sharedFire = confetti.create(_sharedCanvas, {
+    resize: true,
+    useWorker: false,
+  });
+  return _sharedFire;
+}
 
 export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
   try {
@@ -17,7 +40,8 @@ export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
       window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
     if (prefersReduce) return;
 
-    const confetti = (await import("canvas-confetti")).default;
+    const fire = await getSharedFire();
+    if (!fire) return;
 
     const duration = opts.durationMs ?? 1200;
     const intervalMs = opts.intervalMs ?? 240;
@@ -45,12 +69,12 @@ export async function fireConfettiFireworks(opts: FireworksOpts = {}) {
         Math.floor(36 * (timeLeft / duration)),
       );
 
-      confetti({
+      fire({
         ...defaults,
         particleCount,
         origin: { x: randomInRange(0.12, 0.3), y: Math.random() - 0.2 },
       });
-      confetti({
+      fire({
         ...defaults,
         particleCount,
         origin: { x: randomInRange(0.7, 0.88), y: Math.random() - 0.2 },


### PR DESCRIPTION
## Summary
- Replace the remote `unsloth.ai` brand sticker in the onboarding wizard sidebar with the bundled `/sticker.png` so the image actually renders under the Studio CSP `img-src` allowlist
- Default the `Confetti` component's `globalOptions.useWorker` to `false` so `canvas-confetti` doesn't try to spawn an OffscreenCanvas worker via `blob:` (blocked by `script-src 'self'`)

Both edits are one-line changes and avoid loosening the CSP allowlist.

Resolves #5657.

## Test plan
- [ ] Clear `localStorage.unsloth_onboarding_done`, visit `/onboarding`, click Start Onboarding, step to Summary -- console clean of `Creating a worker from 'blob:...' violates ... script-src 'self'` errors
- [ ] Wizard sidebar Unsloth sticker renders (not a broken image)
- [ ] Confetti animation still fires on the final wizard step (main-thread fallback)