### PR TITLE
studio/frontend: set per-route document.title

### DIFF
--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -92,14 +92,21 @@ function RootLayout() {
     },
   });
 
+  // `/settings` is a modal deep link: its route throws `redirect` in
+  // `beforeLoad`, so by the time `useMatches` resolves we're on the
+  // post-auth route (usually `/chat`). Prefer "Settings" while the
+  // dialog is open so the tab title matches what the user sees.
+  const settingsDialogOpen = useSettingsDialogStore((s) => s.open);
+  const documentTitle = settingsDialogOpen ? "Settings" : matchedTitle;
+
   // `useLayoutEffect` so the tab title is updated synchronously before the
   // browser paints the new route. Using `useEffect` here let the previous
   // route's title flash for one frame during in-app navigation.
   useLayoutEffect(() => {
-    document.title = matchedTitle
-      ? `${matchedTitle} | ${DEFAULT_DOCUMENT_TITLE}`
+    document.title = documentTitle
+      ? `${documentTitle} - ${DEFAULT_DOCUMENT_TITLE}`
       : DEFAULT_DOCUMENT_TITLE;
-  }, [matchedTitle]);
+  }, [documentTitle]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -19,10 +19,8 @@ import { AnimatePresence, motion } from "motion/react";
 import { Suspense, useEffect, useLayoutEffect, type ReactNode } from "react";
 import { AppProvider } from "../provider";
 
-// Augment TanStack Router's empty `StaticDataRouteOption` interface so
-// `createRoute({ staticData: { title: "..." } })` is typed at every leaf
-// route and the layout below can read `match.staticData.title` without
-// an `as { staticData?: { title?: string } }` escape hatch.
+// Type `staticData.title` on every route so the matched-title selector
+// below stays type-safe without an inline cast.
 declare module "@tanstack/react-router" {
   interface StaticDataRouteOption {
     title?: string;
@@ -66,8 +64,7 @@ export const Route = createRootRoute({
 
 const HIDDEN_NAVBAR_ROUTES = ["/onboarding", "/login", "/change-password"];
 
-// Title shown when no matched route declares its own `staticData.title`
-// (e.g. the bare `/` redirect or an unknown path).
+// Fallback when no matched route declares a `staticData.title`.
 const DEFAULT_DOCUMENT_TITLE = "Unsloth Studio";
 
 function RootLayout() {
@@ -78,10 +75,7 @@ function RootLayout() {
 
   useTrainingUnloadGuard();
 
-  // Read the deepest matched route's `staticData.title` instead of carrying
-  // a centralized pathname -> title map in this file. Each route declares
-  // its own title in its `createRoute({ staticData: { title: "..." } })`
-  // so the layout stays decoupled from individual route names.
+  // Walk matches deepest-first; each route declares its own title.
   const matchedTitle = useMatches({
     select: (matches) => {
       for (let i = matches.length - 1; i >= 0; i--) {
@@ -92,16 +86,13 @@ function RootLayout() {
     },
   });
 
-  // `/settings` is a modal deep link: its route throws `redirect` in
-  // `beforeLoad`, so by the time `useMatches` resolves we're on the
-  // post-auth route (usually `/chat`). Prefer "Settings" while the
-  // dialog is open so the tab title matches what the user sees.
+  // `/settings` redirects in `beforeLoad`, so its route never stays
+  // matched; surface the modal's title via the store instead.
   const settingsDialogOpen = useSettingsDialogStore((s) => s.open);
   const documentTitle = settingsDialogOpen ? "Settings" : matchedTitle;
 
-  // `useLayoutEffect` so the tab title is updated synchronously before the
-  // browser paints the new route. Using `useEffect` here let the previous
-  // route's title flash for one frame during in-app navigation.
+  // useLayoutEffect updates the tab title before paint, avoiding a
+  // one-frame flash of the previous route's title on navigation.
   useLayoutEffect(() => {
     document.title = documentTitle
       ? `${documentTitle} - ${DEFAULT_DOCUMENT_TITLE}`

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -16,8 +16,18 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "motion/react";
-import { Suspense, useEffect, type ReactNode } from "react";
+import { Suspense, useEffect, useLayoutEffect, type ReactNode } from "react";
 import { AppProvider } from "../provider";
+
+// Augment TanStack Router's empty `StaticDataRouteOption` interface so
+// `createRoute({ staticData: { title: "..." } })` is typed at every leaf
+// route and the layout below can read `match.staticData.title` without
+// an `as { staticData?: { title?: string } }` escape hatch.
+declare module "@tanstack/react-router" {
+  interface StaticDataRouteOption {
+    title?: string;
+  }
+}
 
 // Fallback while a lazy route bundle (Train/Recipes/Export) loads.
 // /chat is synchronous and never hits this.
@@ -75,17 +85,19 @@ function RootLayout() {
   const matchedTitle = useMatches({
     select: (matches) => {
       for (let i = matches.length - 1; i >= 0; i--) {
-        const title = (matches[i] as { staticData?: { title?: string } })
-          .staticData?.title;
+        const title = matches[i].staticData.title;
         if (title) return title;
       }
       return null;
     },
   });
 
-  useEffect(() => {
+  // `useLayoutEffect` so the tab title is updated synchronously before the
+  // browser paints the new route. Using `useEffect` here let the previous
+  // route's title flash for one frame during in-app navigation.
+  useLayoutEffect(() => {
     document.title = matchedTitle
-      ? `${matchedTitle} - ${DEFAULT_DOCUMENT_TITLE}`
+      ? `${matchedTitle} | ${DEFAULT_DOCUMENT_TITLE}`
       : DEFAULT_DOCUMENT_TITLE;
   }, [matchedTitle]);
 

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -12,6 +12,7 @@ import {
   Outlet,
   createRootRoute,
   redirect,
+  useMatches,
   useRouterState,
 } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "motion/react";
@@ -55,23 +56,9 @@ export const Route = createRootRoute({
 
 const HIDDEN_NAVBAR_ROUTES = ["/onboarding", "/login", "/change-password"];
 
-const ROUTE_TITLES: Array<[string, string]> = [
-  ["/chat", "Chat"],
-  ["/studio", "Train"],
-  ["/data-recipes", "Data Recipes"],
-  ["/export", "Export"],
-  ["/settings", "Settings"],
-  ["/login", "Login"],
-  ["/onboarding", "Onboarding"],
-  ["/change-password", "Change Password"],
-];
-
-function routeTitle(pathname: string): string {
-  const match = ROUTE_TITLES.find(
-    ([p]) => pathname === p || pathname.startsWith(`${p}/`),
-  );
-  return match ? `${match[1]} - Unsloth Studio` : "Unsloth Studio";
-}
+// Title shown when no matched route declares its own `staticData.title`
+// (e.g. the bare `/` redirect or an unknown path).
+const DEFAULT_DOCUMENT_TITLE = "Unsloth Studio";
 
 function RootLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -81,9 +68,26 @@ function RootLayout() {
 
   useTrainingUnloadGuard();
 
+  // Read the deepest matched route's `staticData.title` instead of carrying
+  // a centralized pathname -> title map in this file. Each route declares
+  // its own title in its `createRoute({ staticData: { title: "..." } })`
+  // so the layout stays decoupled from individual route names.
+  const matchedTitle = useMatches({
+    select: (matches) => {
+      for (let i = matches.length - 1; i >= 0; i--) {
+        const title = (matches[i] as { staticData?: { title?: string } })
+          .staticData?.title;
+        if (title) return title;
+      }
+      return null;
+    },
+  });
+
   useEffect(() => {
-    document.title = routeTitle(pathname);
-  }, [pathname]);
+    document.title = matchedTitle
+      ? `${matchedTitle} - ${DEFAULT_DOCUMENT_TITLE}`
+      : DEFAULT_DOCUMENT_TITLE;
+  }, [matchedTitle]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -55,6 +55,24 @@ export const Route = createRootRoute({
 
 const HIDDEN_NAVBAR_ROUTES = ["/onboarding", "/login", "/change-password"];
 
+const ROUTE_TITLES: Array<[string, string]> = [
+  ["/chat", "Chat"],
+  ["/studio", "Train"],
+  ["/data-recipes", "Data Recipes"],
+  ["/export", "Export"],
+  ["/settings", "Settings"],
+  ["/login", "Login"],
+  ["/onboarding", "Onboarding"],
+  ["/change-password", "Change Password"],
+];
+
+function routeTitle(pathname: string): string {
+  const match = ROUTE_TITLES.find(
+    ([p]) => pathname === p || pathname.startsWith(`${p}/`),
+  );
+  return match ? `${match[1]} - Unsloth Studio` : "Unsloth Studio";
+}
+
 function RootLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const hideNavbar = HIDDEN_NAVBAR_ROUTES.includes(pathname);
@@ -62,6 +80,10 @@ function RootLayout() {
   const { pinned, setPinned, togglePinned } = useSidebarPin();
 
   useTrainingUnloadGuard();
+
+  useEffect(() => {
+    document.title = routeTitle(pathname);
+  }, [pathname]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/studio/frontend/src/app/routes/change-password.tsx
+++ b/studio/frontend/src/app/routes/change-password.tsx
@@ -15,6 +15,7 @@ const ChangePasswordPage = lazy(() =>
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/change-password",
+  staticData: { title: "Change Password" },
   beforeLoad: () => requirePasswordChangeFlow(),
   component: ChangePasswordPage,
 });

--- a/studio/frontend/src/app/routes/chat.tsx
+++ b/studio/frontend/src/app/routes/chat.tsx
@@ -15,6 +15,7 @@ export type ChatSearch = {
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/chat",
+  staticData: { title: "Chat" },
   beforeLoad: () => requireAuth(),
   validateSearch: (search: Record<string, unknown>): ChatSearch => ({
     thread: typeof search.thread === "string" ? search.thread : undefined,

--- a/studio/frontend/src/app/routes/data-recipes.$recipeId.tsx
+++ b/studio/frontend/src/app/routes/data-recipes.$recipeId.tsx
@@ -16,6 +16,7 @@ const EditRecipePage = lazy(() =>
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/data-recipes/$recipeId",
+  staticData: { title: "Data Recipes" },
   beforeLoad: () => requireAuth(),
   component: DataRecipeEditorRoute,
 });

--- a/studio/frontend/src/app/routes/data-recipes.tsx
+++ b/studio/frontend/src/app/routes/data-recipes.tsx
@@ -15,6 +15,7 @@ const DataRecipesPage = lazy(() =>
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/data-recipes",
+  staticData: { title: "Data Recipes" },
   beforeLoad: () => requireAuth(),
   component: DataRecipesPage,
 });

--- a/studio/frontend/src/app/routes/export.tsx
+++ b/studio/frontend/src/app/routes/export.tsx
@@ -15,6 +15,7 @@ const ExportPage = lazy(() =>
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/export",
+  staticData: { title: "Export" },
   beforeLoad: () => requireAuth(),
   component: ExportPage,
 });

--- a/studio/frontend/src/app/routes/login.tsx
+++ b/studio/frontend/src/app/routes/login.tsx
@@ -13,6 +13,7 @@ const LoginPage = lazy(() =>
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/login",
+  staticData: { title: "Login" },
   beforeLoad: () => requireGuest(),
   component: LoginPage,
 });

--- a/studio/frontend/src/app/routes/onboarding.tsx
+++ b/studio/frontend/src/app/routes/onboarding.tsx
@@ -17,6 +17,7 @@ const WizardLayout = lazy(() =>
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/onboarding",
+  staticData: { title: "Onboarding" },
   beforeLoad: () => requireAuth(),
   validateSearch: (search: Record<string, unknown>): OnboardingSearch => ({
     redirectTo: typeof search.redirectTo === "string" ? search.redirectTo : undefined,

--- a/studio/frontend/src/app/routes/settings.tsx
+++ b/studio/frontend/src/app/routes/settings.tsx
@@ -8,10 +8,9 @@ import { requireAuth } from "../auth-guards";
 import { Route as rootRoute } from "./__root";
 
 // /settings is a deep link to the modal. Open it, then redirect home.
-// `staticData.title` is for the rare case where `beforeLoad` returns
-// without throwing (e.g. future refactor); the live "Settings" tab
-// title while the dialog is visible is driven by `useSettingsDialogStore`
-// in `__root.tsx`, since the redirect means /settings never matches.
+// Tab title is driven by useSettingsDialogStore in __root.tsx since the
+// redirect means /settings never stays matched; staticData is just a
+// safety net if beforeLoad ever stops throwing.
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/settings",

--- a/studio/frontend/src/app/routes/settings.tsx
+++ b/studio/frontend/src/app/routes/settings.tsx
@@ -8,9 +8,14 @@ import { requireAuth } from "../auth-guards";
 import { Route as rootRoute } from "./__root";
 
 // /settings is a deep link to the modal. Open it, then redirect home.
+// `staticData.title` is for the rare case where `beforeLoad` returns
+// without throwing (e.g. future refactor); the live "Settings" tab
+// title while the dialog is visible is driven by `useSettingsDialogStore`
+// in `__root.tsx`, since the redirect means /settings never matches.
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/settings",
+  staticData: { title: "Settings" },
   beforeLoad: async () => {
     await requireAuth();
     useSettingsDialogStore.getState().openDialog();

--- a/studio/frontend/src/app/routes/studio.tsx
+++ b/studio/frontend/src/app/routes/studio.tsx
@@ -15,6 +15,7 @@ const StudioPage = lazy(() =>
 export const Route = createRoute({
   getParentRoute: () => rootRoute,
   path: "/studio",
+  staticData: { title: "Train" },
   beforeLoad: () => requireAuth(),
   component: StudioPage,
 });


### PR DESCRIPTION
## Summary
- Update `document.title` from the root layout based on the current pathname so users can distinguish Studio tabs in the browser tab strip
- Map known routes (Chat / Train / Data Recipes / Export / Settings / Login / Onboarding / Change Password) to "Label - Unsloth Studio"; unknown routes fall back to the existing "Unsloth Studio"

Resolves #5659.

## Test plan
- [ ] Open `/chat`, `/studio`, `/data-recipes`, `/export`, `/settings` and verify the browser tab title updates on each navigation
- [ ] Open `/onboarding`, `/login`, `/change-password` (which hide the navbar) and verify their tab titles also update
- [ ] Visit an unknown path -- tab title falls back to "Unsloth Studio"