### PR TITLE
studio/frontend: friendlier 404 fallback for unknown routes

### DIFF
--- a/studio/frontend/src/app/router.tsx
+++ b/studio/frontend/src/app/router.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { Link, createRouter } from "@tanstack/react-router";
+import { Link, createRouter, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Route as rootRoute } from "./routes/__root";
 import { Route as dataRecipesRoute } from "./routes/data-recipes";
@@ -31,10 +31,11 @@ const routeTree = rootRoute.addChildren([
 ]);
 
 function DefaultNotFound() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
       <img
-        src="/Sloth emojis/sloth shy large.png"
+        src="/Sloth%20emojis/sloth%20shy%20large.png"
         alt="Sloth mascot"
         className="size-24"
       />
@@ -42,8 +43,8 @@ function DefaultNotFound() {
         <h1 className="font-heading font-semibold text-2xl tracking-tight">
           Page not found
         </h1>
-        <p className="text-muted-foreground text-sm">
-          {typeof window !== "undefined" ? window.location.pathname : ""} does not exist.
+        <p className="text-muted-foreground text-sm break-all">
+          {pathname} does not exist.
         </p>
       </div>
       <Button asChild>

--- a/studio/frontend/src/app/router.tsx
+++ b/studio/frontend/src/app/router.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { createRouter } from "@tanstack/react-router";
+import { Link, createRouter } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
 import { Route as rootRoute } from "./routes/__root";
 import { Route as dataRecipesRoute } from "./routes/data-recipes";
 import { Route as dataRecipeRoute } from "./routes/data-recipes.$recipeId";
@@ -29,7 +30,33 @@ const routeTree = rootRoute.addChildren([
   dataRecipeRoute,
 ]);
 
-export const router = createRouter({ routeTree });
+function DefaultNotFound() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <img
+        src="/Sloth emojis/sloth shy large.png"
+        alt="Sloth mascot"
+        className="size-24"
+      />
+      <div className="flex flex-col items-center gap-1">
+        <h1 className="font-heading font-semibold text-2xl tracking-tight">
+          Page not found
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          {typeof window !== "undefined" ? window.location.pathname : ""} does not exist.
+        </p>
+      </div>
+      <Button asChild>
+        <Link to="/chat">Back to chat</Link>
+      </Button>
+    </div>
+  );
+}
+
+export const router = createRouter({
+  routeTree,
+  defaultNotFoundComponent: DefaultNotFound,
+});
 
 declare module "@tanstack/react-router" {
   interface Register {


### PR DESCRIPTION
## Summary
- Add a `DefaultNotFound` component to the router config so unknown paths render a sloth mascot, "Page not found" heading, the offending pathname, and a "Back to chat" button instead of the bare TanStack default
- Studio chrome (sidebar, navbar) continues to render around it via the root layout, so users keep the existing sidebar recovery affordances and now also get an in-content CTA

Resolves #5663.

## Test plan
- [ ] Visit any nonexistent path (typo, stale share link, an unknown URL) -- see the friendly fallback with the sloth mascot, the offending pathname, and a Back to chat button
- [ ] Click Back to chat -- TanStack navigates to chat without a full page reload
- [ ] Visit a known path (chat, studio, data recipes, export, settings) -- still renders normally, no regression
