### PR TITLE
Remove dead chat suggestions wiring

### DIFF
--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -9,7 +9,6 @@ import {
   ExportedMessageRepository,
   type ExportedMessageRepositoryItem,
   type PendingAttachment,
-  Suggestions,
   type LocalRuntimeOptions,
   type ThreadHistoryAdapter,
   type ThreadMessage,
@@ -57,29 +56,6 @@ import {
 } from "./utils/chat-thread-tombstones";
 import { syncExportedRepositoryToDexie } from "./utils/delete-thread-message";
 import { getImageInputUnavailableReason } from "./utils/image-input-support";
-
-const DEFAULT_SUGGESTIONS = [
-  {
-    title: "How do you fine-tune an audio model with Unsloth?",
-    label: "Audio fine-tuning",
-    prompt: "How do you fine-tune an audio model with Unsloth?",
-  },
-  {
-    title: "Create a live weather dashboard in HTML using no API key. Show me the code",
-    label: "Weather dashboard",
-    prompt: "Create a live weather dashboard in HTML using no API key. Show me the code",
-  },
-  {
-    title: "Solve the integral of x·sin(x), and verify it",
-    label: "Integral",
-    prompt: "Solve the integral of x·sin(x), and verify it step by step",
-  },
-  {
-    title: "Draw an SVG of a cute sloth & show the code",
-    label: "SVG sloth",
-    prompt: "Draw an SVG of a cute sloth & show the code",
-  },
-];
 
 type TitleResponse = {
   choices?: Array<{
@@ -1034,9 +1010,7 @@ export function ChatRuntimeProvider({
     adapter: createDexieAdapter(modelType, pairId),
   });
 
-  const aui = useAui({
-    suggestions: Suggestions(DEFAULT_SUGGESTIONS),
-  });
+  const aui = useAui({});
 
   return (
     <AssistantRuntimeProvider runtime={runtime} aui={aui}>


### PR DESCRIPTION
Closes #5638.

## Summary
- Remove the unused default chat suggestions config from the runtime provider.
- Keep the explicit assistant-ui client wiring so runtime adapters and UI components continue to share the same provider state.

## Validation
- `npm run typecheck`
- `npm run build`