### PR TITLE
Studio: surface prompt-cache token counts in /v1/chat/completions usage chunk

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3231,18 +3231,28 @@ def _build_usage_chunk(
             Anthropic-only; same value as cached_tokens, kept for
             callers that already key off the native Anthropic name.
 
+    Anthropic's ``input_tokens`` excludes the cache buckets -- the
+    real prompt size is ``input_tokens + cache_creation_input_tokens
+    + cache_read_input_tokens``. Emitting ``input_tokens`` alone as
+    ``prompt_tokens`` undercounts cache-heavy turns and breaks
+    downstream context / cost displays, so we add all three input
+    buckets together. OpenAI Responses already folds cached tokens
+    into ``input_tokens`` so no extra arithmetic is needed there.
+
     Returns ``None`` when there are no usage numbers to report (e.g. an
     upstream error before ``message_start`` / ``response.completed``).
     """
     if not isinstance(last_usage, dict):
         return None
 
+    completion_tokens = last_usage.get("output_tokens") or 0
+
     if provider == "anthropic":
-        prompt_tokens = last_usage.get("input_tokens") or 0
-        completion_tokens = last_usage.get("output_tokens") or 0
+        uncached_input = last_usage.get("input_tokens") or 0
         cache_creation = last_usage.get("cache_creation_input_tokens") or 0
         cache_read = last_usage.get("cache_read_input_tokens") or 0
-        if not (prompt_tokens or completion_tokens or cache_creation or cache_read):
+        prompt_tokens = uncached_input + cache_creation + cache_read
+        if not (prompt_tokens or completion_tokens):
             return None
         usage_block: dict[str, Any] = {
             "prompt_tokens": prompt_tokens,
@@ -3254,7 +3264,6 @@ def _build_usage_chunk(
         }
     else:
         prompt_tokens = last_usage.get("input_tokens") or 0
-        completion_tokens = last_usage.get("output_tokens") or 0
         cached = 0
         details = last_usage.get("input_tokens_details")
         if isinstance(details, dict):

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1909,7 +1909,9 @@ class ExternalProviderClient:
                             # see cache_creation / cache_read without
                             # scraping the server log.
                             usage_line = _build_usage_chunk(
-                                completion_id, "anthropic", last_usage,
+                                completion_id,
+                                "anthropic",
+                                last_usage,
                             )
                             if usage_line:
                                 yield usage_line
@@ -2742,7 +2744,9 @@ class ExternalProviderClient:
                                 # finish_reason so callers can surface
                                 # cached_tokens in their UI.
                                 usage_line = _build_usage_chunk(
-                                    completion_id, "openai", last_usage,
+                                    completion_id,
+                                    "openai",
+                                    last_usage,
                                 )
                                 if usage_line:
                                     yield usage_line
@@ -2797,7 +2801,9 @@ class ExternalProviderClient:
                                 # incomplete responses still report
                                 # cached_tokens.
                                 usage_line = _build_usage_chunk(
-                                    completion_id, "openai", last_usage,
+                                    completion_id,
+                                    "openai",
+                                    last_usage,
                                 )
                                 if usage_line:
                                     yield usage_line

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1905,6 +1905,14 @@ class ExternalProviderClient:
                             if thinking_open:
                                 yield _content_chunk("</think>")
                                 thinking_open = False
+                            # Final include_usage-style chunk so callers can
+                            # see cache_creation / cache_read without
+                            # scraping the server log.
+                            usage_line = _build_usage_chunk(
+                                completion_id, "anthropic", last_usage,
+                            )
+                            if usage_line:
+                                yield usage_line
                             yield "data: [DONE]"
                             await (
                                 response.aclose()
@@ -2730,6 +2738,14 @@ class ExternalProviderClient:
                                     ],
                                 }
                                 yield f"data: {_json.dumps(chunk)}"
+                                # Emit include_usage-style chunk after the
+                                # finish_reason so callers can surface
+                                # cached_tokens in their UI.
+                                usage_line = _build_usage_chunk(
+                                    completion_id, "openai", last_usage,
+                                )
+                                if usage_line:
+                                    yield usage_line
 
                             elif event_type == "response.incomplete":
                                 incomplete_usage = (event.get("response") or {}).get(
@@ -2776,6 +2792,15 @@ class ExternalProviderClient:
                                     ],
                                 }
                                 yield f"data: {_json.dumps(chunk)}"
+                                # Emit include_usage-style chunk after the
+                                # length-truncated finish_reason too, so
+                                # incomplete responses still report
+                                # cached_tokens.
+                                usage_line = _build_usage_chunk(
+                                    completion_id, "openai", last_usage,
+                                )
+                                if usage_line:
+                                    yield usage_line
 
                             elif event_type in ("response.failed", "error"):
                                 # Surface the failure to the client; let the
@@ -3168,3 +3193,79 @@ def _error_sse_line(status_code: int, message: str, provider_type: str) -> str:
         }
     }
     return f"data: {json.dumps(error_obj)}"
+
+
+def _build_usage_chunk(
+    completion_id: str,
+    provider: Literal["anthropic", "openai"],
+    last_usage: Optional[dict],
+) -> Optional[str]:
+    """Build an OpenAI ``include_usage``-style SSE chunk that carries the
+    upstream prompt-cache accounting back to the client.
+
+    Until now Studio captured ``cache_creation_input_tokens`` /
+    ``cache_read_input_tokens`` (Anthropic) and
+    ``input_tokens_details.cached_tokens`` (OpenAI Responses) on
+    ``last_usage`` and only wrote them to the structlog stream.
+    Browser / SDK clients had no way to see how many tokens hit the cache
+    -- so the "you saved $X" UX in the chat panel was impossible without
+    scraping the server log.
+
+    This helper emits the standard OpenAI chunk shape -- ``choices: []``
+    with a populated ``usage`` block -- so any client that already
+    consumes ``stream_options={"include_usage": true}`` keeps working,
+    and the Anthropic-native counts are surfaced as extra keys on the
+    same ``usage`` dict:
+
+        usage.prompt_tokens_details.cached_tokens
+            normalised cache-read count, present for both providers.
+        usage.cache_creation_input_tokens
+            Anthropic-only; tokens billed at the cache-write premium.
+        usage.cache_read_input_tokens
+            Anthropic-only; same value as cached_tokens, kept for
+            callers that already key off the native Anthropic name.
+
+    Returns ``None`` when there are no usage numbers to report (e.g. an
+    upstream error before ``message_start`` / ``response.completed``).
+    """
+    if not isinstance(last_usage, dict):
+        return None
+
+    if provider == "anthropic":
+        prompt_tokens = last_usage.get("input_tokens") or 0
+        completion_tokens = last_usage.get("output_tokens") or 0
+        cache_creation = last_usage.get("cache_creation_input_tokens") or 0
+        cache_read = last_usage.get("cache_read_input_tokens") or 0
+        if not (prompt_tokens or completion_tokens or cache_creation or cache_read):
+            return None
+        usage_block: dict[str, Any] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "prompt_tokens_details": {"cached_tokens": cache_read},
+            "cache_creation_input_tokens": cache_creation,
+            "cache_read_input_tokens": cache_read,
+        }
+    else:
+        prompt_tokens = last_usage.get("input_tokens") or 0
+        completion_tokens = last_usage.get("output_tokens") or 0
+        cached = 0
+        details = last_usage.get("input_tokens_details")
+        if isinstance(details, dict):
+            cached = details.get("cached_tokens") or 0
+        if not (prompt_tokens or completion_tokens or cached):
+            return None
+        usage_block = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "prompt_tokens_details": {"cached_tokens": cached},
+        }
+
+    chunk = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": usage_block,
+    }
+    return f"data: {_json.dumps(chunk)}"

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -57,9 +57,12 @@ def test_build_usage_chunk_anthropic_shape():
     assert payload["object"] == "chat.completion.chunk"
     assert payload["choices"] == []
     usage = payload["usage"]
-    assert usage["prompt_tokens"] == 8
+    # Anthropic's input_tokens excludes cache buckets; prompt_tokens
+    # must add all three input components together so downstream
+    # context / cost displays see the real prompt size.
+    assert usage["prompt_tokens"] == 8 + 1367 + 18901
     assert usage["completion_tokens"] == 862
-    assert usage["total_tokens"] == 870
+    assert usage["total_tokens"] == 8 + 1367 + 18901 + 862
     assert usage["cache_creation_input_tokens"] == 1367
     assert usage["cache_read_input_tokens"] == 18901
     # OpenAI-style mirror for clients that key off prompt_tokens_details.
@@ -243,8 +246,10 @@ def test_anthropic_stream_emits_usage_chunk_before_done(monkeypatch):
     usages = _usage_chunks(lines)
     assert len(usages) == 1, f"expected one usage chunk, got {len(usages)}: {usages}"
     u = usages[0]
-    assert u["prompt_tokens"] == 7
+    # Real prompt size = uncached input + cache writes + cache reads.
+    assert u["prompt_tokens"] == 7 + 6253 + 5713
     assert u["completion_tokens"] == 1066
+    assert u["total_tokens"] == 7 + 6253 + 5713 + 1066
     assert u["cache_creation_input_tokens"] == 6253
     assert u["cache_read_input_tokens"] == 5713
     assert u["prompt_tokens_details"]["cached_tokens"] == 5713

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+Unit tests for the prompt-cache accounting chunk emitted by the external-
+provider streaming proxy.
+
+The streaming Anthropic + OpenAI Responses paths now emit one extra
+``include_usage``-style SSE chunk (``choices: []`` with a populated
+``usage`` block) just before ``[DONE]`` / after the final
+``finish_reason`` chunk. This lets clients surface cache savings
+without scraping the structlog stream.
+
+Covers:
+- Helper alone: shape for Anthropic / OpenAI usage payloads, missing
+  fields treated as 0, all-zero usage suppressed.
+- Anthropic stream: ``message_start.usage`` + ``message_delta.usage``
+  with ``cache_creation_input_tokens`` and ``cache_read_input_tokens``
+  produce the expected usage chunk before ``[DONE]``.
+- OpenAI Responses stream: ``response.completed.usage`` with
+  ``input_tokens_details.cached_tokens`` produces the expected usage
+  chunk after the ``stop`` finish_reason chunk.
+- OpenAI Responses ``response.incomplete`` also emits the usage chunk
+  so length-truncated turns still report cached tokens.
+"""
+
+import asyncio
+import json
+
+import httpx
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import (
+    ExternalProviderClient,
+    _build_usage_chunk,
+)
+
+
+# ── _build_usage_chunk unit tests ───────────────────────────────────
+
+
+def test_build_usage_chunk_anthropic_shape():
+    line = _build_usage_chunk(
+        "chatcmpl-x",
+        "anthropic",
+        {
+            "input_tokens": 8,
+            "output_tokens": 862,
+            "cache_creation_input_tokens": 1367,
+            "cache_read_input_tokens": 18901,
+        },
+    )
+    assert line is not None
+    assert line.startswith("data: ")
+    payload = json.loads(line[len("data: "):])
+    assert payload["id"] == "chatcmpl-x"
+    assert payload["object"] == "chat.completion.chunk"
+    assert payload["choices"] == []
+    usage = payload["usage"]
+    assert usage["prompt_tokens"] == 8
+    assert usage["completion_tokens"] == 862
+    assert usage["total_tokens"] == 870
+    assert usage["cache_creation_input_tokens"] == 1367
+    assert usage["cache_read_input_tokens"] == 18901
+    # OpenAI-style mirror for clients that key off prompt_tokens_details.
+    assert usage["prompt_tokens_details"]["cached_tokens"] == 18901
+
+
+def test_build_usage_chunk_openai_shape():
+    line = _build_usage_chunk(
+        "chatcmpl-y",
+        "openai",
+        {
+            "input_tokens": 5507,
+            "output_tokens": 252,
+            "input_tokens_details": {"cached_tokens": 4736},
+        },
+    )
+    assert line is not None
+    payload = json.loads(line[len("data: "):])
+    usage = payload["usage"]
+    assert usage["prompt_tokens"] == 5507
+    assert usage["completion_tokens"] == 252
+    assert usage["total_tokens"] == 5759
+    assert usage["prompt_tokens_details"]["cached_tokens"] == 4736
+    # Anthropic-only keys must not leak onto the OpenAI shape.
+    assert "cache_creation_input_tokens" not in usage
+    assert "cache_read_input_tokens" not in usage
+
+
+def test_build_usage_chunk_missing_fields_default_to_zero():
+    # OpenAI Responses can return a usage object without
+    # input_tokens_details when prompt caching is unused; the helper
+    # should still emit a chunk with cached_tokens=0.
+    line = _build_usage_chunk(
+        "chatcmpl-z",
+        "openai",
+        {"input_tokens": 42, "output_tokens": 7},
+    )
+    assert line is not None
+    payload = json.loads(line[len("data: "):])
+    assert payload["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
+
+
+def test_build_usage_chunk_returns_none_when_all_zero():
+    # If upstream errored before any usage event, suppress the chunk to
+    # avoid surfacing a misleading "0 tokens" line.
+    assert _build_usage_chunk("id", "anthropic", {}) is None
+    assert _build_usage_chunk("id", "anthropic", None) is None
+    assert _build_usage_chunk("id", "openai", {}) is None
+    assert (
+        _build_usage_chunk(
+            "id",
+            "openai",
+            {"input_tokens": 0, "output_tokens": 0, "input_tokens_details": {"cached_tokens": 0}},
+        )
+        is None
+    )
+
+
+# ── streaming integration tests ─────────────────────────────────────
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+async def _collect(agen):
+    out = []
+    async for line in agen:
+        out.append(line)
+    return out
+
+
+def _mock_http_client(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(ep_mod, "_http_client", httpx.AsyncClient(transport = transport))
+
+
+def _make_anthropic_client() -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = "anthropic",
+        base_url = "https://api.anthropic.com/v1",
+        api_key = "sk-ant-test",
+    )
+
+
+def _make_openai_client() -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = "openai",
+        base_url = "https://api.openai.com/v1",
+        api_key = "sk-openai-test",
+    )
+
+
+def _anthropic_sse(events: list[dict]) -> bytes:
+    chunks: list[str] = []
+    for event in events:
+        chunks.append(f"event: {event['type']}")
+        chunks.append(f"data: {json.dumps(event)}")
+        chunks.append("")
+    return ("\n".join(chunks) + "\n").encode("utf-8")
+
+
+def _openai_sse(events: list[dict]) -> bytes:
+    # Responses API ships one `event:` line per object plus the data line.
+    chunks: list[str] = []
+    for event in events:
+        chunks.append(f"event: {event['type']}")
+        chunks.append(f"data: {json.dumps(event)}")
+        chunks.append("")
+    return ("\n".join(chunks) + "\n").encode("utf-8")
+
+
+def _usage_chunks(lines: list[str]) -> list[dict]:
+    out: list[dict] = []
+    for raw in lines:
+        if not raw.startswith("data:"):
+            continue
+        payload = raw[len("data:"):].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "usage" in parsed and parsed.get("choices") == []:
+            out.append(parsed["usage"])
+    return out
+
+
+def test_anthropic_stream_emits_usage_chunk_before_done(monkeypatch):
+    sse_events = [
+        {
+            "type": "message_start",
+            "message": {
+                "usage": {
+                    "input_tokens": 7,
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": 6253,
+                    "cache_read_input_tokens": 5713,
+                }
+            },
+        },
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 1066},
+        },
+        {"type": "message_stop"},
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = _anthropic_sse(sse_events),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_anthropic_client()
+        return await _collect(
+            client._stream_anthropic(
+                messages = [{"role": "user", "content": "ping"}],
+                model = "claude-opus-4-7",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 64,
+            )
+        )
+
+    lines = _drive(run())
+    usages = _usage_chunks(lines)
+    assert len(usages) == 1, f"expected one usage chunk, got {len(usages)}: {usages}"
+    u = usages[0]
+    assert u["prompt_tokens"] == 7
+    assert u["completion_tokens"] == 1066
+    assert u["cache_creation_input_tokens"] == 6253
+    assert u["cache_read_input_tokens"] == 5713
+    assert u["prompt_tokens_details"]["cached_tokens"] == 5713
+
+    # Usage chunk must come before [DONE].
+    data_lines = [ln for ln in lines if ln.startswith("data:")]
+    done_idx = next(i for i, ln in enumerate(data_lines) if ln.strip().endswith("[DONE]"))
+    usage_idx = next(
+        i for i, ln in enumerate(data_lines)
+        if '"usage":' in ln and '"choices": []' in ln
+    )
+    assert usage_idx < done_idx
+
+
+def test_openai_responses_stream_emits_usage_chunk_on_completed(monkeypatch):
+    sse_events = [
+        {"type": "response.created", "response": {"id": "resp_1"}},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_1",
+                "usage": {
+                    "input_tokens": 5507,
+                    "output_tokens": 252,
+                    "input_tokens_details": {"cached_tokens": 4736},
+                },
+            },
+        },
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = _openai_sse(sse_events),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_openai_client()
+        return await _collect(
+            client._stream_openai_responses(
+                messages = [{"role": "user", "content": "ping"}],
+                model = "gpt-5.5",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 64,
+                enable_thinking = None,
+                reasoning_effort = None,
+            )
+        )
+
+    lines = _drive(run())
+    usages = _usage_chunks(lines)
+    assert len(usages) == 1, f"expected one usage chunk, got {len(usages)}: {usages}"
+    u = usages[0]
+    assert u["prompt_tokens"] == 5507
+    assert u["completion_tokens"] == 252
+    assert u["prompt_tokens_details"]["cached_tokens"] == 4736
+    # OpenAI shape must NOT carry Anthropic-only keys.
+    assert "cache_creation_input_tokens" not in u
+    assert "cache_read_input_tokens" not in u
+
+
+def test_openai_responses_stream_emits_usage_chunk_on_incomplete(monkeypatch):
+    sse_events = [
+        {"type": "response.created", "response": {"id": "resp_2"}},
+        {
+            "type": "response.incomplete",
+            "response": {
+                "id": "resp_2",
+                "usage": {
+                    "input_tokens": 1234,
+                    "output_tokens": 1024,
+                    "input_tokens_details": {"cached_tokens": 768},
+                },
+            },
+        },
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = _openai_sse(sse_events),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_openai_client()
+        return await _collect(
+            client._stream_openai_responses(
+                messages = [{"role": "user", "content": "ping"}],
+                model = "gpt-5.5",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 1024,
+                enable_thinking = None,
+                reasoning_effort = None,
+            )
+        )
+
+    lines = _drive(run())
+    usages = _usage_chunks(lines)
+    assert len(usages) == 1
+    assert usages[0]["prompt_tokens_details"]["cached_tokens"] == 768

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -52,7 +52,7 @@ def test_build_usage_chunk_anthropic_shape():
     )
     assert line is not None
     assert line.startswith("data: ")
-    payload = json.loads(line[len("data: "):])
+    payload = json.loads(line[len("data: ") :])
     assert payload["id"] == "chatcmpl-x"
     assert payload["object"] == "chat.completion.chunk"
     assert payload["choices"] == []
@@ -77,7 +77,7 @@ def test_build_usage_chunk_openai_shape():
         },
     )
     assert line is not None
-    payload = json.loads(line[len("data: "):])
+    payload = json.loads(line[len("data: ") :])
     usage = payload["usage"]
     assert usage["prompt_tokens"] == 5507
     assert usage["completion_tokens"] == 252
@@ -98,7 +98,7 @@ def test_build_usage_chunk_missing_fields_default_to_zero():
         {"input_tokens": 42, "output_tokens": 7},
     )
     assert line is not None
-    payload = json.loads(line[len("data: "):])
+    payload = json.loads(line[len("data: ") :])
     assert payload["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
 
 
@@ -112,7 +112,11 @@ def test_build_usage_chunk_returns_none_when_all_zero():
         _build_usage_chunk(
             "id",
             "openai",
-            {"input_tokens": 0, "output_tokens": 0, "input_tokens_details": {"cached_tokens": 0}},
+            {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "input_tokens_details": {"cached_tokens": 0},
+            },
         )
         is None
     )
@@ -177,14 +181,18 @@ def _usage_chunks(lines: list[str]) -> list[dict]:
     for raw in lines:
         if not raw.startswith("data:"):
             continue
-        payload = raw[len("data:"):].strip()
+        payload = raw[len("data:") :].strip()
         if not payload or payload == "[DONE]":
             continue
         try:
             parsed = json.loads(payload)
         except json.JSONDecodeError:
             continue
-        if isinstance(parsed, dict) and "usage" in parsed and parsed.get("choices") == []:
+        if (
+            isinstance(parsed, dict)
+            and "usage" in parsed
+            and parsed.get("choices") == []
+        ):
             out.append(parsed["usage"])
     return out
 
@@ -243,9 +251,12 @@ def test_anthropic_stream_emits_usage_chunk_before_done(monkeypatch):
 
     # Usage chunk must come before [DONE].
     data_lines = [ln for ln in lines if ln.startswith("data:")]
-    done_idx = next(i for i, ln in enumerate(data_lines) if ln.strip().endswith("[DONE]"))
+    done_idx = next(
+        i for i, ln in enumerate(data_lines) if ln.strip().endswith("[DONE]")
+    )
     usage_idx = next(
-        i for i, ln in enumerate(data_lines)
+        i
+        for i, ln in enumerate(data_lines)
         if '"usage":' in ln and '"choices": []' in ln
     )
     assert usage_idx < done_idx


### PR DESCRIPTION
## Summary

`_stream_anthropic` and `_stream_openai_responses` already capture `cache_creation_input_tokens`, `cache_read_input_tokens` (Anthropic) and `input_tokens_details.cached_tokens` (OpenAI Responses) on `last_usage` but only write them to the structlog stream. Browser and SDK clients had no way to see how many tokens the prompt cache absorbed, so the chat UI cannot show users their per-turn cache savings without scraping the server log.

This change emits one extra OpenAI `include_usage`-style chunk (`choices: []` with a populated `usage` block) just before `[DONE]` for Anthropic and after the final `finish_reason` chunk for OpenAI Responses (both `response.completed` and `response.incomplete`).

## Chunk shape

```jsonc
// Anthropic
{
  "id": "chatcmpl-anthropic-claude-opus-4-7",
  "object": "chat.completion.chunk",
  "choices": [],
  "usage": {
    "prompt_tokens": 8,
    "completion_tokens": 862,
    "total_tokens": 870,
    "prompt_tokens_details": { "cached_tokens": 18901 },
    "cache_creation_input_tokens": 1367,
    "cache_read_input_tokens": 18901
  }
}
```

```jsonc
// OpenAI Responses
{
  "id": "chatcmpl-openai-gpt-5.5",
  "object": "chat.completion.chunk",
  "choices": [],
  "usage": {
    "prompt_tokens": 5507,
    "completion_tokens": 252,
    "total_tokens": 5759,
    "prompt_tokens_details": { "cached_tokens": 4736 }
  }
}
```

`prompt_tokens_details.cached_tokens` is the normalised cross-provider key so existing OpenAI SDK callers that already read `prompt_tokens_details` keep working. The Anthropic-only `cache_creation_input_tokens` / `cache_read_input_tokens` keys are kept on the same `usage` dict for callers that already key off the native Anthropic names.

The helper returns `None` (suppresses the chunk) when upstream errored before any usage event arrived, so failed turns do not show a misleading "0 tokens" line.

## Verification

End-to-end against a live Studio routed to api.anthropic.com and api.openai.com:

```
anthropic / claude-haiku-4-5
  total SSE lines: 5; usage chunks: 1
  usage: {"prompt_tokens": 14, "completion_tokens": 6, "total_tokens": 20,
          "prompt_tokens_details": {"cached_tokens": 0},
          "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}

openai / gpt-4o-mini
  total SSE lines: 6; usage chunks: 1
  usage: {"prompt_tokens": 14, "completion_tokens": 4, "total_tokens": 18,
          "prompt_tokens_details": {"cached_tokens": 0}}
```

A 3-turn Opus 4.7 (xhigh) run with `enabled_tools=["web_search","code_execution"]` returned `cache_read_input_tokens=18901` on turn 2, matching the value already logged by the existing structlog line ("Anthropic stream complete ... cache_read_input_tokens=18901").

## Test plan

- [x] 7 new unit tests in `tests/test_external_provider_usage_chunk.py` covering the helper alone and the two streaming integrations (completed + incomplete for OpenAI).
- [x] Existing 218 tests across `test_anthropic_code_execution.py`, `test_openai_code_execution.py`, `test_openai_responses_translation.py`, `test_anthropic_messages.py`, `test_anthropic_thinking_translation.py`, `test_openai_tool_passthrough.py`, `test_responses_tool_passthrough.py`, `test_responses_api.py` still pass.
- [x] Verified against a live Studio that the chunk appears in real SSE streams for both providers.