### PR TITLE
Studio: add Anthropic and OpenAI prompt guards for disabled tools

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -857,14 +857,22 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         }
       }
       if (disabledToolGuard) {
-        if (
-          outboundMessages[0]?.role === "system" &&
-          typeof outboundMessages[0].content === "string"
-        ) {
-          outboundMessages[0] = {
-            ...outboundMessages[0],
-            content: `${outboundMessages[0].content}\n\n${disabledToolGuard}`,
-          };
+        const firstMessage = outboundMessages[0];
+        if (firstMessage?.role === "system") {
+          if (typeof firstMessage.content === "string") {
+            outboundMessages[0] = {
+              ...firstMessage,
+              content: `${firstMessage.content}\n\n${disabledToolGuard}`,
+            };
+          } else {
+            outboundMessages[0] = {
+              ...firstMessage,
+              content: [
+                ...firstMessage.content,
+                { type: "text", text: `\n\n${disabledToolGuard}` },
+              ],
+            };
+          }
         } else {
           outboundMessages.unshift({
             role: "system",

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -886,6 +886,20 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               externalProvider.baseUrl,
             ),
         );
+      // web_fetch shares the Search pill with web_search (no separate
+      // UI toggle), so it follows toolsEnabled. Anthropic is the only
+      // provider that ships it today; on others providerSupportsBuiltinWebFetch
+      // returns false and this stays inert.
+      const webFetchEnabledForThisTurn =
+        Boolean(
+          externalProvider &&
+            toolsEnabled &&
+            providerSupportsBuiltinWebFetch(externalProvider.providerType),
+        );
+      const providerShipsWebFetch = Boolean(
+        externalProvider &&
+          providerSupportsBuiltinWebFetch(externalProvider.providerType),
+      );
 
       const outboundMessages = messages
         .map(toOpenAIMessage)
@@ -907,16 +921,19 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         disabledToolGuardProviderType === "anthropic" ||
         disabledToolGuardProviderType === "openai"
       ) {
+        const webLabel = providerShipsWebFetch
+          ? "web search or web fetch"
+          : "web search";
         if (!webSearchEnabledForThisTurn && !codeExecEnabledForThisTurn) {
           disabledToolGuard =
-            "You do not have web search or code execution tools in this conversation. " +
+            `You do not have ${webLabel} or code execution tools in this conversation. ` +
             "Answer from your own knowledge. " +
             "If a request genuinely requires tool use, live data fetch or running code, " +
             "inform the user that you do not have access to these capabilities. " +
             "Do not return tool-call syntax inside your response.";
         } else if (!webSearchEnabledForThisTurn) {
           disabledToolGuard =
-            "You do not have web search tools in this conversation. " +
+            `You do not have ${webLabel} tools in this conversation. ` +
             "You may still use code execution tools when they are available and useful. " +
             "If a request genuinely requires live data fetch or web search tool use, " +
             "inform the user that you do not have access to these capabilities. " +
@@ -924,7 +941,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         } else if (!codeExecEnabledForThisTurn) {
           disabledToolGuard =
             "You do not have code execution tools in this conversation. " +
-            "You may still use web search tools when they are available and useful. " +
+            `You may still use ${webLabel} tools when they are available and useful. ` +
             "If a request genuinely requires running code or code execution tool use, " +
             "inform the user that you do not have access to these capabilities. " +
             "Do not return tool-call syntax inside your response.";
@@ -1377,7 +1394,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               // translates enabled_tools into each provider's tool
               // schema — for Anthropic that's the entries appended to
               // body["tools"] inside _stream_anthropic.
-              ...(webSearchEnabledForThisTurn || codeExecEnabledForThisTurn
+              ...(webSearchEnabledForThisTurn ||
+              webFetchEnabledForThisTurn ||
+              codeExecEnabledForThisTurn
                 ? {
                     enable_tools: true,
                     enabled_tools: [
@@ -1389,12 +1408,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                       // surface a citation but cannot quote from the
                       // page body, which is the whole point of the
                       // tool. There is no separate UI toggle yet.
-                      ...(webSearchEnabledForThisTurn &&
-                      providerSupportsBuiltinWebFetch(
-                        externalProvider.providerType,
-                      )
-                        ? ["web_fetch"]
-                        : []),
+                      ...(webFetchEnabledForThisTurn ? ["web_fetch"] : []),
                       ...(codeExecEnabledForThisTurn ? ["code_execution"] : []),
                     ],
                   }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -843,17 +843,23 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           disabledToolGuard =
             "You do not have web search or code execution tools in this conversation. " +
             "Answer from your own knowledge. " +
-            "If a request genuinely requires live data or running code, say so plainly, instead of emitting tool-call syntax.";
+            "If a request genuinely requires tool use, live data fetch or running code, " +
+            "inform the user that you do not have access to these capabilities. " +
+            "Do not return tool-call syntax inside your response.";
         } else if (!webSearchEnabledForThisTurn) {
           disabledToolGuard =
             "You do not have web search tools in this conversation. " +
             "You may still use code execution tools when they are available and useful. " +
-            "If a request genuinely requires live data, say so plainly, instead of emitting web-search tool-call syntax.";
+            "If a request genuinely requires live data fetch or web search tool use, " +
+            "inform the user that you do not have access to these capabilities. " +
+            "Do not return tool-call syntax inside your response.";
         } else if (!codeExecEnabledForThisTurn) {
           disabledToolGuard =
             "You do not have code execution tools in this conversation. " +
             "You may still use web search tools when they are available and useful. " +
-            "If a request genuinely requires running code, say so plainly, instead of emitting code-execution tool-call syntax.";
+            "If a request genuinely requires running code or code execution tool use, " +
+            "inform the user that you do not have access to these capabilities. " +
+            "Do not return tool-call syntax inside your response.";
         }
       }
       if (disabledToolGuard) {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -847,13 +847,13 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         } else if (!webSearchEnabledForThisTurn) {
           disabledToolGuard =
             "You do not have web search tools in this conversation. " +
-            "Answer from your own knowledge. " +
-            "If a request genuinely requires live data, say so plainly, instead of emitting tool-call syntax.";
+            "You may still use code execution tools when they are available and useful. " +
+            "If a request genuinely requires live data, say so plainly, instead of emitting web-search tool-call syntax.";
         } else if (!codeExecEnabledForThisTurn) {
           disabledToolGuard =
             "You do not have code execution tools in this conversation. " +
-            "Answer from your own knowledge. " +
-            "If a request genuinely requires running code, say so plainly, instead of emitting tool-call syntax.";
+            "You may still use web search tools when they are available and useful. " +
+            "If a request genuinely requires running code, say so plainly, instead of emitting code-execution tool-call syntax.";
         }
       }
       if (disabledToolGuard) {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -805,6 +805,24 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         throw new Error("Missing connection API key.");
       }
 
+      const webSearchEnabledForThisTurn =
+        Boolean(
+          externalProvider &&
+            toolsEnabled &&
+            providerSupportsBuiltinWebSearch(externalProvider.providerType),
+        );
+      const codeExecEnabledForThisTurn =
+        Boolean(
+          externalProvider &&
+            externalSelection &&
+            codeToolsEnabled &&
+            providerSupportsBuiltinCodeExecution(
+              externalProvider.providerType,
+              externalSelection.modelId,
+              externalProvider.baseUrl,
+            ),
+        );
+
       const outboundMessages = messages
         .map(toOpenAIMessage)
         .filter((message): message is NonNullable<typeof message> =>
@@ -818,6 +836,41 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           role: "system",
           content: safeSystemPrompt.trim(),
         });
+      }
+      let disabledToolGuard: string | null = null;
+      if (externalProvider?.providerType === "anthropic") {
+        if (!webSearchEnabledForThisTurn && !codeExecEnabledForThisTurn) {
+          disabledToolGuard =
+            "You do not have web search or code execution tools in this conversation. " +
+            "Answer from your own knowledge. " +
+            "If a request genuinely requires live data or running code, say so plainly, instead of emitting tool-call syntax.";
+        } else if (!webSearchEnabledForThisTurn) {
+          disabledToolGuard =
+            "You do not have web search tools in this conversation. " +
+            "Answer from your own knowledge. " +
+            "If a request genuinely requires live data, say so plainly, instead of emitting tool-call syntax.";
+        } else if (!codeExecEnabledForThisTurn) {
+          disabledToolGuard =
+            "You do not have code execution tools in this conversation. " +
+            "Answer from your own knowledge. " +
+            "If a request genuinely requires running code, say so plainly, instead of emitting tool-call syntax.";
+        }
+      }
+      if (disabledToolGuard) {
+        if (
+          outboundMessages[0]?.role === "system" &&
+          typeof outboundMessages[0].content === "string"
+        ) {
+          outboundMessages[0] = {
+            ...outboundMessages[0],
+            content: `${outboundMessages[0].content}\n\n${disabledToolGuard}`,
+          };
+        } else {
+          outboundMessages.unshift({
+            role: "system",
+            content: disabledToolGuard,
+          });
+        }
       }
       const imageBase64 = findLatestUserImageBase64(messages);
       const audioBase64 = findLatestUserAudioBase64(messages);
@@ -1068,13 +1121,6 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             // (sent as `container` on /v1/messages).
             let openaiCodeExecContainerId: string | null = null;
             let anthropicCodeExecContainerId: string | null = null;
-            const codeExecEnabledForThisTurn =
-              codeToolsEnabled &&
-              providerSupportsBuiltinCodeExecution(
-                externalProvider.providerType,
-                externalSelection.modelId,
-                externalProvider.baseUrl,
-              );
             if (codeExecEnabledForThisTurn && resolvedThreadId) {
               try {
                 const thread = await db.threads.get(resolvedThreadId);
@@ -1252,31 +1298,12 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               // translates enabled_tools into each provider's tool
               // schema — for Anthropic that's the entries appended to
               // body["tools"] inside _stream_anthropic.
-              ...((toolsEnabled &&
-                providerSupportsBuiltinWebSearch(externalProvider.providerType)) ||
-              (codeToolsEnabled &&
-                providerSupportsBuiltinCodeExecution(
-                  externalProvider.providerType,
-                  externalSelection.modelId,
-                  externalProvider.baseUrl,
-                ))
+              ...(webSearchEnabledForThisTurn || codeExecEnabledForThisTurn
                 ? {
                     enable_tools: true,
                     enabled_tools: [
-                      ...(toolsEnabled &&
-                      providerSupportsBuiltinWebSearch(
-                        externalProvider.providerType,
-                      )
-                        ? ["web_search"]
-                        : []),
-                      ...(codeToolsEnabled &&
-                      providerSupportsBuiltinCodeExecution(
-                        externalProvider.providerType,
-                        externalSelection.modelId,
-                        externalProvider.baseUrl,
-                      )
-                        ? ["code_execution"]
-                        : []),
+                      ...(webSearchEnabledForThisTurn ? ["web_search"] : []),
+                      ...(codeExecEnabledForThisTurn ? ["code_execution"] : []),
                     ],
                   }
                 : {}),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -838,7 +838,11 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         });
       }
       let disabledToolGuard: string | null = null;
-      if (externalProvider?.providerType === "anthropic") {
+      const disabledToolGuardProviderType = externalProvider?.providerType;
+      if (
+        disabledToolGuardProviderType === "anthropic" ||
+        disabledToolGuardProviderType === "openai"
+      ) {
         if (!webSearchEnabledForThisTurn && !codeExecEnabledForThisTurn) {
           disabledToolGuard =
             "You do not have web search or code execution tools in this conversation. " +


### PR DESCRIPTION
## Summary

Anthropic and OpenAI models can sometimes emit tool-call-like text when a user asks for unavailable capabilities. These guards make the unavailable tool state explicit in the system prompt so the model answers normally or tells the user it lacks access, instead of hallucinating tool-call syntax in the assistant reply.

- Adds system prompt guards for **Anthropic** and **OpenAI** external providers when web search and/or code execution are disabled for a chat turn
- **Concatenates** the guard with any user-defined system prompt from the sidepanel (appended to the existing system message, not replaced)
- Uses separate guard text for:
  - both web search and code execution disabled
  - web search disabled only (code execution may still be used)
  - code execution disabled only (web search may still be used)

