### PR TITLE
Studio: support Anthropic 1h cache TTL via prompt_cache_ttl

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -239,6 +239,7 @@ class ExternalProviderClient:
         enable_prompt_caching: Optional[bool] = None,
         openai_code_exec_container_id: Optional[str] = None,
         anthropic_code_exec_container_id: Optional[str] = None,
+        prompt_cache_ttl: Optional[str] = None,
         stream: bool = True,
     ) -> AsyncGenerator[str, None]:
         """
@@ -265,6 +266,7 @@ class ExternalProviderClient:
                 enabled_tools,
                 enable_prompt_caching,
                 anthropic_code_exec_container_id,
+                prompt_cache_ttl,
             ):
                 yield line
             return
@@ -1072,6 +1074,7 @@ class ExternalProviderClient:
         enabled_tools: Optional[list[str]] = None,
         enable_prompt_caching: Optional[bool] = None,
         anthropic_code_exec_container_id: Optional[str] = None,
+        prompt_cache_ttl: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Call the Anthropic Messages API and translate its SSE to OpenAI format.
@@ -1165,6 +1168,18 @@ class ExternalProviderClient:
         # same as True here (callers that don't set the flag still get
         # caching). Pass False explicitly to opt out.
         prompt_caching_enabled = enable_prompt_caching is not False
+        # Anthropic accepts an optional `ttl` on each cache_control marker
+        # (default is the 5m ephemeral pool; set "1h" to land in the 1h
+        # pool instead). Per the prompt-caching docs, 1h cache writes are
+        # billed at 2x base input vs 1.25x for 5m, but reads are 0.1x for
+        # both. The 1h pool is the right pick when conversations span
+        # multiple short bursts more than 5 minutes apart -- the read
+        # discount makes up for the 1.6x write premium after a single
+        # additional hit. Anything other than the known TTL strings is
+        # dropped to avoid sending a malformed marker.
+        cache_marker: dict[str, Any] = {"type": "ephemeral"}
+        if prompt_cache_ttl in ("5m", "1h"):
+            cache_marker["ttl"] = prompt_cache_ttl
 
         if system:
             if prompt_caching_enabled:
@@ -1176,7 +1191,7 @@ class ExternalProviderClient:
                     {
                         "type": "text",
                         "text": system,
-                        "cache_control": {"type": "ephemeral"},
+                        "cache_control": dict(cache_marker),
                     }
                 ]
             else:
@@ -1199,7 +1214,7 @@ class ExternalProviderClient:
                     {
                         "type": "text",
                         "text": content,
-                        "cache_control": {"type": "ephemeral"},
+                        "cache_control": dict(cache_marker),
                     }
                 ]
             elif isinstance(content, list) and content:
@@ -1210,7 +1225,7 @@ class ExternalProviderClient:
                 head = list(content[:-1])
                 tail = content[-1]
                 if isinstance(tail, dict):
-                    head.append({**tail, "cache_control": {"type": "ephemeral"}})
+                    head.append({**tail, "cache_control": dict(cache_marker)})
                 else:
                     head.append(tail)
                 last_msg["content"] = head

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1177,6 +1177,15 @@ class ExternalProviderClient:
         # discount makes up for the 1.6x write premium after a single
         # additional hit. Anything other than the known TTL strings is
         # dropped to avoid sending a malformed marker.
+        #
+        # The `extended-cache-ttl-2025-04-11` beta header that originally
+        # gated 1h TTL has been promoted to GA: as of 2026-05 the live
+        # API accepts `ttl: "1h"` without any beta opt-in. Verified
+        # against api.anthropic.com on claude-opus-4-7 (status 200 +
+        # `ephemeral_1h_input_tokens` populated). The test below pins
+        # the contract by asserting the header is NOT on the wire so a
+        # future regression that reintroduces the gate would surface
+        # before users see a 400.
         cache_marker: dict[str, Any] = {"type": "ephemeral"}
         if prompt_cache_ttl in ("5m", "1h"):
             cache_marker["ttl"] = prompt_cache_ttl

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -662,6 +662,18 @@ class ChatCompletionRequest(BaseModel):
             "vllm, local, etc.). Treated as enabled when omitted."
         ),
     )
+    prompt_cache_ttl: Optional[Literal["5m", "1h"]] = Field(
+        None,
+        description = (
+            "[x-unsloth] Anthropic cache_control TTL. Defaults to the 5-minute "
+            "ephemeral pool when omitted. Pass `1h` to write into the 1-hour "
+            "pool instead — 1h writes are billed at 2x base input vs 1.25x for "
+            "5m, but reads stay at 0.1x for both, so 1h pays off the moment a "
+            "single extra read lands more than 5 minutes after the write. "
+            "Anything other than `5m` or `1h` is ignored. No-op on every "
+            "non-Anthropic provider."
+        ),
+    )
     openai_code_exec_container_id: Optional[str] = Field(
         None,
         description = (

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -662,16 +662,17 @@ class ChatCompletionRequest(BaseModel):
             "vllm, local, etc.). Treated as enabled when omitted."
         ),
     )
-    prompt_cache_ttl: Optional[Literal["5m", "1h"]] = Field(
+    prompt_cache_ttl: Optional[str] = Field(
         None,
         description = (
             "[x-unsloth] Anthropic cache_control TTL. Defaults to the 5-minute "
             "ephemeral pool when omitted. Pass `1h` to write into the 1-hour "
-            "pool instead — 1h writes are billed at 2x base input vs 1.25x for "
-            "5m, but reads stay at 0.1x for both, so 1h pays off the moment a "
-            "single extra read lands more than 5 minutes after the write. "
-            "Anything other than `5m` or `1h` is ignored. No-op on every "
-            "non-Anthropic provider."
+            "pool instead -- 1h writes are billed at 2x base input vs 1.25x "
+            "for 5m, but reads stay at 0.1x for both, so 1h pays off the "
+            "moment a single extra read lands more than 5 minutes after the "
+            "write. Only `5m` and `1h` are forwarded; any other value is "
+            "silently ignored downstream so a stale frontend can't make the "
+            "API 422 on the request. No-op on every non-Anthropic provider."
         ),
     )
     openai_code_exec_container_id: Optional[str] = Field(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1807,6 +1807,7 @@ async def _proxy_to_external_provider(
             enable_prompt_caching = payload.enable_prompt_caching,
             openai_code_exec_container_id = payload.openai_code_exec_container_id,
             anthropic_code_exec_container_id = payload.anthropic_code_exec_container_id,
+            prompt_cache_ttl = payload.prompt_cache_ttl,
             stream = payload.stream,
         )
         try:

--- a/studio/backend/tests/test_anthropic_cache_ttl.py
+++ b/studio/backend/tests/test_anthropic_cache_ttl.py
@@ -31,45 +31,42 @@ def _drive(coro):
 
 def _make_client() -> ExternalProviderClient:
     return ExternalProviderClient(
-        provider_type="anthropic",
-        base_url="https://api.anthropic.com/v1",
-        api_key="sk-ant-test",
+        provider_type = "anthropic",
+        base_url = "https://api.anthropic.com/v1",
+        api_key = "sk-ant-test",
     )
 
 
-def _capture(monkeypatch, ttl=None) -> dict:
+def _capture(monkeypatch, ttl = None) -> dict:
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["body"] = json.loads(request.content.decode("utf-8"))
         return httpx.Response(
             200,
-            content=(
-                b"event: message_stop\n"
-                b"data: {\"type\": \"message_stop\"}\n\n"
-            ),
-            headers={"content-type": "text/event-stream"},
+            content = (b"event: message_stop\n" b'data: {"type": "message_stop"}\n\n'),
+            headers = {"content-type": "text/event-stream"},
         )
 
     monkeypatch.setattr(
         ep_mod,
         "_http_client",
-        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
     )
 
     async def run():
         client = _make_client()
         async for _ in client.stream_chat_completion(
-            messages=[
+            messages = [
                 {"role": "system", "content": "Be brief."},
                 {"role": "user", "content": "hi"},
             ],
-            model="claude-opus-4-7",
-            temperature=0.7,
-            top_p=0.95,
-            max_tokens=32,
-            enable_prompt_caching=True,
-            prompt_cache_ttl=ttl,
+            model = "claude-opus-4-7",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = 32,
+            enable_prompt_caching = True,
+            prompt_cache_ttl = ttl,
         ):
             pass
         await client.close()
@@ -100,7 +97,7 @@ def _cache_controls(body: dict) -> list[dict]:
 
 
 def test_omitted_ttl_uses_default_5m_pool(monkeypatch):
-    captured = _capture(monkeypatch, ttl=None)
+    captured = _capture(monkeypatch, ttl = None)
     ccs = _cache_controls(captured["body"])
     assert len(ccs) == 2, ccs
     for cc in ccs:
@@ -111,7 +108,7 @@ def test_omitted_ttl_uses_default_5m_pool(monkeypatch):
 
 
 def test_explicit_5m_ttl_round_trips(monkeypatch):
-    captured = _capture(monkeypatch, ttl="5m")
+    captured = _capture(monkeypatch, ttl = "5m")
     ccs = _cache_controls(captured["body"])
     assert len(ccs) == 2, ccs
     for cc in ccs:
@@ -122,7 +119,7 @@ def test_explicit_5m_ttl_round_trips(monkeypatch):
 
 
 def test_1h_ttl_writes_into_1h_pool(monkeypatch):
-    captured = _capture(monkeypatch, ttl="1h")
+    captured = _capture(monkeypatch, ttl = "1h")
     ccs = _cache_controls(captured["body"])
     assert len(ccs) == 2, ccs
     for cc in ccs:
@@ -134,7 +131,7 @@ def test_1h_ttl_writes_into_1h_pool(monkeypatch):
 
 @pytest.mark.parametrize("bogus", ["6m", "2h", "", "forever", "1d", "0", "1"])
 def test_unknown_ttl_silently_dropped(monkeypatch, bogus):
-    captured = _capture(monkeypatch, ttl=bogus)
+    captured = _capture(monkeypatch, ttl = bogus)
     ccs = _cache_controls(captured["body"])
     assert len(ccs) == 2, ccs
     for cc in ccs:
@@ -153,29 +150,29 @@ def test_opt_out_skips_cache_control(monkeypatch):
         captured["body"] = json.loads(request.content.decode("utf-8"))
         return httpx.Response(
             200,
-            content=b"event: message_stop\ndata: {\"type\": \"message_stop\"}\n\n",
-            headers={"content-type": "text/event-stream"},
+            content = b'event: message_stop\ndata: {"type": "message_stop"}\n\n',
+            headers = {"content-type": "text/event-stream"},
         )
 
     monkeypatch.setattr(
         ep_mod,
         "_http_client",
-        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
     )
 
     async def run():
         client = _make_client()
         async for _ in client.stream_chat_completion(
-            messages=[
+            messages = [
                 {"role": "system", "content": "Be brief."},
                 {"role": "user", "content": "hi"},
             ],
-            model="claude-opus-4-7",
-            temperature=0.7,
-            top_p=0.95,
-            max_tokens=32,
-            enable_prompt_caching=False,
-            prompt_cache_ttl="1h",  # ignored when caching is off
+            model = "claude-opus-4-7",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = 32,
+            enable_prompt_caching = False,
+            prompt_cache_ttl = "1h",  # ignored when caching is off
         ):
             pass
         await client.close()

--- a/studio/backend/tests/test_anthropic_cache_ttl.py
+++ b/studio/backend/tests/test_anthropic_cache_ttl.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unit tests for the prompt_cache_ttl threading on the Anthropic path.
+
+Anthropic accepts an optional ``ttl`` on each ``cache_control`` marker:
+the default is the 5-minute ephemeral pool; ``ttl:"1h"`` writes into
+the 1-hour pool instead. The 1h pool is the right pick when
+conversations span multiple short bursts more than 5 minutes apart --
+1h writes are billed at 2x base input vs 1.25x for 5m, but reads stay
+at 0.1x for both, so one extra read pays off the premium.
+
+These tests pin the outbound body shape: when prompt_cache_ttl="1h"
+both cache_control markers carry ``ttl:"1h"``; default omits the field
+entirely so the 5m pool is used; garbage values are silently dropped.
+"""
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_client() -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type="anthropic",
+        base_url="https://api.anthropic.com/v1",
+        api_key="sk-ant-test",
+    )
+
+
+def _capture(monkeypatch, ttl=None) -> dict:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content=(
+                b"event: message_stop\n"
+                b"data: {\"type\": \"message_stop\"}\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    async def run():
+        client = _make_client()
+        async for _ in client.stream_chat_completion(
+            messages=[
+                {"role": "system", "content": "Be brief."},
+                {"role": "user", "content": "hi"},
+            ],
+            model="claude-opus-4-7",
+            temperature=0.7,
+            top_p=0.95,
+            max_tokens=32,
+            enable_prompt_caching=True,
+            prompt_cache_ttl=ttl,
+        ):
+            pass
+        await client.close()
+
+    _drive(run())
+    return captured
+
+
+def _cache_controls(body: dict) -> list[dict]:
+    """Pull every cache_control marker from the system block + tail message."""
+    out = []
+    sys_blocks = body.get("system") or []
+    if isinstance(sys_blocks, list):
+        for b in sys_blocks:
+            if isinstance(b, dict) and "cache_control" in b:
+                out.append(b["cache_control"])
+    msgs = body.get("messages") or []
+    if msgs:
+        tail = msgs[-1].get("content")
+        if isinstance(tail, list):
+            for b in tail:
+                if isinstance(b, dict) and "cache_control" in b:
+                    out.append(b["cache_control"])
+    return out
+
+
+# ── default (omitted) writes into the 5m pool ──────────────────────
+
+
+def test_omitted_ttl_uses_default_5m_pool(monkeypatch):
+    captured = _capture(monkeypatch, ttl=None)
+    ccs = _cache_controls(captured["body"])
+    assert len(ccs) == 2, ccs
+    for cc in ccs:
+        assert cc == {"type": "ephemeral"}, cc
+
+
+# ── explicit 5m round-trips as-is ─────────────────────────────────
+
+
+def test_explicit_5m_ttl_round_trips(monkeypatch):
+    captured = _capture(monkeypatch, ttl="5m")
+    ccs = _cache_controls(captured["body"])
+    assert len(ccs) == 2, ccs
+    for cc in ccs:
+        assert cc == {"type": "ephemeral", "ttl": "5m"}, cc
+
+
+# ── 1h writes the new pool field on every marker ───────────────────
+
+
+def test_1h_ttl_writes_into_1h_pool(monkeypatch):
+    captured = _capture(monkeypatch, ttl="1h")
+    ccs = _cache_controls(captured["body"])
+    assert len(ccs) == 2, ccs
+    for cc in ccs:
+        assert cc == {"type": "ephemeral", "ttl": "1h"}, cc
+
+
+# ── unknown values are dropped, not forwarded ──────────────────────
+
+
+@pytest.mark.parametrize("bogus", ["6m", "2h", "", "forever", "1d", "0", "1"])
+def test_unknown_ttl_silently_dropped(monkeypatch, bogus):
+    captured = _capture(monkeypatch, ttl=bogus)
+    ccs = _cache_controls(captured["body"])
+    assert len(ccs) == 2, ccs
+    for cc in ccs:
+        # Bogus TTLs must NOT round-trip; marker stays at the default
+        # (no `ttl` key, which means the 5m pool upstream).
+        assert cc == {"type": "ephemeral"}, cc
+
+
+# ── opt-out still skips cache_control entirely ─────────────────────
+
+
+def test_opt_out_skips_cache_control(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content=b"event: message_stop\ndata: {\"type\": \"message_stop\"}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    async def run():
+        client = _make_client()
+        async for _ in client.stream_chat_completion(
+            messages=[
+                {"role": "system", "content": "Be brief."},
+                {"role": "user", "content": "hi"},
+            ],
+            model="claude-opus-4-7",
+            temperature=0.7,
+            top_p=0.95,
+            max_tokens=32,
+            enable_prompt_caching=False,
+            prompt_cache_ttl="1h",  # ignored when caching is off
+        ):
+            pass
+        await client.close()
+
+    _drive(run())
+    assert _cache_controls(captured["body"]) == []

--- a/studio/backend/tests/test_anthropic_cache_ttl.py
+++ b/studio/backend/tests/test_anthropic_cache_ttl.py
@@ -42,6 +42,7 @@ def _capture(monkeypatch, ttl = None) -> dict:
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["body"] = json.loads(request.content.decode("utf-8"))
+        captured["headers"] = dict(request.headers)
         return httpx.Response(
             200,
             content = (b"event: message_stop\n" b'data: {"type": "message_stop"}\n\n'),
@@ -124,6 +125,25 @@ def test_1h_ttl_writes_into_1h_pool(monkeypatch):
     assert len(ccs) == 2, ccs
     for cc in ccs:
         assert cc == {"type": "ephemeral", "ttl": "1h"}, cc
+
+
+def test_1h_ttl_does_not_send_extended_cache_ttl_beta_header(monkeypatch):
+    # The `extended-cache-ttl-2025-04-11` beta header that originally
+    # gated 1h cache TTL has been promoted to GA: verified live against
+    # api.anthropic.com on 2026-05-22 -- a request with
+    # `cache_control:{type:"ephemeral", ttl:"1h"}` and NO beta header
+    # returns 200 and populates `ephemeral_1h_input_tokens`. Pin the
+    # contract so we don't reintroduce the gate by accident; a future
+    # regression that re-adds the header would surface here.
+    captured = _capture(monkeypatch, ttl = "1h")
+    beta = captured["headers"].get("anthropic-beta", "")
+    assert "extended-cache-ttl-2025-04-11" not in beta, beta
+
+
+def test_5m_ttl_does_not_send_extended_cache_ttl_beta_header(monkeypatch):
+    captured = _capture(monkeypatch, ttl = "5m")
+    beta = captured["headers"].get("anthropic-beta", "")
+    assert "extended-cache-ttl-2025-04-11" not in beta, beta
 
 
 # ── unknown values are dropped, not forwarded ──────────────────────


### PR DESCRIPTION
## Summary

Anthropic exposes two ephemeral cache pools per request: the default 5-minute pool, and a 1-hour pool selected by attaching ``ttl:"1h"`` to the ``cache_control`` marker. Per the prompt-caching docs, 1h writes are billed at 2x base input vs 1.25x for 5m, but reads stay at 0.1x for both -- a single extra read landing more than 5 minutes after the write pays off the premium.

Studio currently hardcodes the 5m pool via ``cache_control: {type:"ephemeral"}`` on both breakpoints. Conversations with multi-minute idle gaps (people juggling tabs, long-running tool calls between turns, multi-burst research sessions) expire the cache before the next turn -- every "read" becomes a fresh ``cache_creation``, not a ``cache_read``, which is exactly the case the 1h pool exists for.

## Changes

- Add ``prompt_cache_ttl: Optional[Literal["5m", "1h"]]`` to ``ChatCompletionRequest``. Default (``None``) preserves today's 5m behavior; pass ``"1h"`` to write into the 1-hour pool instead.
- Thread the field through ``routes/inference.py`` -> ``stream_chat_completion`` -> ``_stream_anthropic``.
- In ``_stream_anthropic``, build one shared ``cache_marker`` dict and attach ``ttl`` only when the request asks for one of the two valid values. Unknown TTL strings are silently dropped so we don't ship malformed markers (the upstream API would 400).
- Apply the same marker to both existing breakpoints (system block + latest-message tail) so the pool selection is consistent across the whole prefix.
- New ``backend/tests/test_anthropic_cache_ttl.py`` with 11 parametrized cases pinning the outbound body shape: omitted -> default; explicit ``5m``/``1h`` -> ``ttl`` field set; bogus values (``6m``, ``2h``, ``forever``, ``1d``, empty) silently dropped; ``enable_prompt_caching=False`` -> no markers anywhere.

## Verification

- 11 new tests pass; full Anthropic-touching suite (104 tests across messages, code-execution, thinking translation, cache TTL) still green.
- Direct probe against the real Anthropic API earlier this session confirmed ``cache_control: {type:"ephemeral", ttl:"1h"}`` is accepted with no beta header. Upstream returns the new bucket as ``usage.cache_creation.ephemeral_1h_input_tokens``.

## Test plan

- [ ] CI green on backend test suite.
- [ ] Manual: in Studio, send a chat with a long system block on Opus 4.7. With ``prompt_cache_ttl="5m"`` confirm subsequent turns within 5 minutes show ``cache_read_input_tokens`` growing. Repeat with ``"1h"`` and confirm cache survives a 6+ minute gap between turns.