### PR TITLE
Studio: reconcile external providers across browsers after delete

### DIFF
--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -140,6 +140,13 @@ export async function deleteProviderConfig(providerId: string): Promise<void> {
   const response = await authFetch(`/api/providers/${providerId}`, {
     method: "DELETE",
   });
+  // Treat 404 as success: another browser (or tab) already deleted this
+  // provider on the backend, so locally pruning the stale cache is the
+  // correct follow-up. Without this, the caller would throw and the user
+  // would be stuck with an entry they cannot remove from the UI.
+  if (response.status === 404) {
+    return;
+  }
   if (!response.ok) {
     const body = await response.json().catch(() => null);
     throw new Error(parseErrorText(response.status, body));

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -345,15 +345,21 @@ export function ChatProvidersSettings({
 
   useEffect(() => {
     let isMounted = true;
-    const syncFromBackend = async () => {
-      setRegistryLoading(true);
-      setSyncingProviders(true);
+    const syncFromBackend = async ({
+      showSpinner = true,
+    }: { showSpinner?: boolean } = {}) => {
+      if (showSpinner) {
+        setRegistryLoading(true);
+        setSyncingProviders(true);
+      }
+      let syncSucceeded = false;
       try {
         const [registryRows, configRows] = await Promise.all([
           listProviderRegistry(),
           listProviderConfigs(),
         ]);
         if (!isMounted) return;
+        syncSucceeded = true;
         setRegistry(registryRows);
         setProviderType((current) => {
           if (
@@ -406,25 +412,45 @@ export function ChatProvidersSettings({
               updatedAt,
             };
           });
-        // Don't wipe localStorage providers when the server has no rows.
-        if (syncedProviders.length === 0 && providersRef.current.length > 0) {
-          return;
-        }
+        // Trust the backend response when it succeeds. An empty array means
+        // every connection was removed (often from another browser/tab) and
+        // the local cache should mirror that, otherwise the stale entries
+        // become un-removable in this browser until localStorage is cleared.
         onProvidersChange(syncedProviders);
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Unknown error";
-        toast.error(`Failed to load connections: ${message}`);
+        // Only surface a toast for real failures, not for the silent
+        // background re-sync on tab focus.
+        if (showSpinner) {
+          const message =
+            error instanceof Error ? error.message : "Unknown error";
+          toast.error(`Failed to load connections: ${message}`);
+        }
       } finally {
-        if (isMounted) {
+        if (isMounted && showSpinner) {
           setRegistryLoading(false);
           setSyncingProviders(false);
         }
       }
+      return syncSucceeded;
     };
     void syncFromBackend();
+    // Re-sync silently when the tab regains focus so deletes made in
+    // another browser propagate without forcing the user to reopen the
+    // dialog. Skip when the document is hidden to avoid background work.
+    const handleVisibilityChange = () => {
+      if (typeof document === "undefined" || document.hidden) return;
+      void syncFromBackend({ showSpinner: false });
+    };
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", handleVisibilityChange);
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+    }
     return () => {
       isMounted = false;
+      if (typeof window !== "undefined") {
+        window.removeEventListener("focus", handleVisibilityChange);
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+      }
     };
   }, [onProvidersChange]);
 


### PR DESCRIPTION
## Summary

Deleting a connection in one browser left the same connection stuck in every other browser/tab. The user could not delete or edit it from the second browser; clicks either no-op'd or threw on a missing-row backend response, and the only workaround was to clear the localStorage key by hand.

## Root cause

Two pieces conspired:

- `ChatProvidersSettings` ran its backend sync once on mount and silently kept localStorage providers whenever `listProviderConfigs` returned an empty array, on the assumption that an empty response had to be a transient glitch:
  \`\`\`ts
  // Don't wipe localStorage providers when the server has no rows.
  if (syncedProviders.length === 0 && providersRef.current.length > 0) {
    return;
  }
  \`\`\`
  That assumption is wrong when another browser removed the last connection. The local list never caught up.
- `deleteProviderConfig` threw on HTTP 404, so once Browser A had deleted a connection, Browser B's \"Delete\" click failed with a backend error and the local row stuck around. The catch handler showed a toast but did not prune the local cache.

## Fix

- Trust any successful API response in the sync path, including an empty list. Drop the \"don't wipe\" guard so a backend with zero rows reconciles the local cache to zero rows.
- Add a `focus` / `visibilitychange` listener that runs a silent re-sync (no spinner, no error toast) so the dialog catches up on deletes made in another browser without forcing the user to close and reopen it.
- Treat HTTP 404 from `deleteProviderConfig` as success. The server's job is already done and the caller only needs to prune the local cache.

## Test plan

- [x] Type-checks cleanly (`npx tsc -b --pretty false`)
- [ ] Two browsers connected to the same Studio: add a provider in A, refresh B and confirm it appears (existing behavior preserved)
- [ ] Delete the provider in A, focus B's tab, confirm the row disappears without reopening the dialog
- [ ] In a stale Browser B that still shows the row, click Delete and confirm it removes locally (no toast error) even though the server already returned 404
- [ ] Add multiple providers, delete one in A, confirm B's remaining rows are preserved