### PR TITLE
Studio: persist external checkpoint when picker uses setParams

### DIFF
--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -627,6 +627,17 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       if (state.settingsHydrated && hasKeys(changedParams)) {
         saveSettingsPatch({ inferenceParams: changedParams });
       }
+      // chat-page picks an external model by mutating `params.checkpoint`
+      // through this setter (not through `setCheckpoint`), so the
+      // localStorage mirror needs to be refreshed here too. Otherwise
+      // the persisted slot stays empty and a refresh falls back to
+      // whatever the backend's `/api/inference/status.active_model`
+      // returns -- usually the previously loaded local model.
+      if (params.checkpoint !== state.params.checkpoint) {
+        saveLastExternalCheckpoint(
+          isExternalModelId(params.checkpoint) ? params.checkpoint : null,
+        );
+      }
       return { params };
     }),
   setCustomPresets: (customPresets) =>


### PR DESCRIPTION
## Summary

Follow-up to #5697. The first pass wired the localStorage mirror into `setCheckpoint`, but the main chat-page picker actually selects an external model by calling `setParams({ ...store.params, checkpoint: value })`, not `setCheckpoint`. That path never touched the mirror, so the persisted slot stayed empty and a refresh fell back to whatever `/api/inference/status.active_model` returned -- the previously loaded local model (Qwen3.5 etc) or nothing (\"Select model\") when nothing was loaded locally.

## Fix

Mirror the persistence in `setParams` whenever `params.checkpoint` actually changes so every entry point converges on the same behavior. `setCheckpoint` still writes the key directly so the load paths that go through it (compare, GGUF auto-load, gemma fallback in `chat-adapter`) keep working.

## Test plan

- [x] `npx tsc -b --pretty false` clean
- [ ] Pick `gpt-5.5` (or any external) via the chat-page picker, refresh, picker still shows the same external model
- [ ] Have a local model loaded (Qwen3.5), pick an external model, refresh, picker stays on the external selection rather than reverting to Qwen3.5
- [ ] No local model loaded, pick an external model, refresh, picker stays on the external selection rather than reverting to \"Select model\"
- [ ] Switch back to a local model, refresh, picker correctly shows the local model (external slot cleared)