### PR TITLE
Fix connected chat model selection after refresh

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -993,10 +993,7 @@ export function ChatPage(): ReactElement {
         const stillOnOpenRouterFree =
           selectedProvider?.providerType === "openrouter" &&
           selectedExternal?.modelId === "openrouter/free";
-        setInferenceParams({
-          ...store.params,
-          checkpoint: value,
-        });
+        store.setCheckpoint(value, null);
         const supportsBuiltinWebSearch = providerSupportsBuiltinWebSearch(
           selectedProvider?.providerType,
         );
@@ -1117,7 +1114,6 @@ export function ChatPage(): ReactElement {
       externalProvidersForChat,
       modelsFromStore,
       selectModel,
-      setInferenceParams,
       view,
     ],
   );

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -640,17 +640,6 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       if (state.settingsHydrated && hasKeys(changedParams)) {
         saveSettingsPatch({ inferenceParams: changedParams });
       }
-      // chat-page picks an external model by mutating `params.checkpoint`
-      // through this setter (not through `setCheckpoint`), so the
-      // localStorage mirror needs to be refreshed here too. Otherwise
-      // the persisted slot stays empty and a refresh falls back to
-      // whatever the backend's `/api/inference/status.active_model`
-      // returns -- usually the previously loaded local model.
-      if (params.checkpoint !== state.params.checkpoint) {
-        saveLastExternalCheckpoint(
-          isExternalModelId(params.checkpoint) ? params.checkpoint : null,
-        );
-      }
       return { params };
     }),
   setCustomPresets: (customPresets) =>


### PR DESCRIPTION
## Summary
- route connected provider model selection through the checkpoint setter
- remove the generic setParams checkpoint persistence workaround

## Testing
- npm run typecheck