### PR TITLE
Studio: expose Anthropic 5m vs 1h prompt cache TTL in Configuration

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -9,9 +9,11 @@ import type { ChatModelAdapter } from "@assistant-ui/react";
 import {
   getExternalProviderApiKey,
   isCustomProviderType,
+  isPromptCacheTtl,
   loadExternalProviders,
   parseExternalModelId,
   providerTypeSupportsVision,
+  supportsProviderPromptCacheTtl,
   supportsProviderPromptCaching,
   toExternalBackendProviderType,
 } from "../external-providers";
@@ -1441,6 +1443,17 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                     enable_prompt_caching:
                       externalProvider.enablePromptCaching ?? true,
                   }
+                : {}),
+              // Anthropic-only: pass the cache TTL the user picked in
+              // Configuration → Provider. Omitted = inherit the default
+              // 5-minute pool. The backend's `_stream_anthropic` only
+              // attaches `cache_control.ttl` when the value is one of
+              // "5m" / "1h" (see external_provider.py near line 1375),
+              // so unknown values are a no-op end-to-end.
+              ...(supportsProviderPromptCacheTtl(externalProvider.providerType) &&
+              (externalProvider.enablePromptCaching ?? true) &&
+              isPromptCacheTtl(externalProvider.promptCacheTtl)
+                ? { prompt_cache_ttl: externalProvider.promptCacheTtl }
                 : {}),
               ...(externalReasoningCaps.supportsReasoning
                 ? externalReasoningCaps.reasoningStyle === "reasoning_effort"

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -69,6 +69,7 @@ import {
   getExternalProviderApiKey,
   parseExternalModelId,
   supportsProviderPromptCaching,
+  supportsProviderPromptCacheTtl,
 } from "./external-providers";
 import {
   BUILTIN_PRESETS,
@@ -531,6 +532,10 @@ export function ChatSettingsPanel({
     Boolean(currentCheckpoint) &&
     modelRequiresTrustRemoteCode &&
     !(params.trustRemoteCode ?? false);
+  const showPromptCacheTtlControl = Boolean(
+    activeExternalProvider &&
+      supportsProviderPromptCacheTtl(activeExternalProvider.providerType),
+  );
   const showPromptCachingControl =
     activeExternalProvider != null &&
     supportsProviderPromptCaching(activeExternalProvider.providerType);
@@ -1110,6 +1115,43 @@ export function ChatSettingsPanel({
                 aria-label="Enable prompt caching"
               />
             </div>
+            {showPromptCacheTtlControl && promptCachingEnabled ? (
+              <div className="flex items-center justify-between gap-3 pt-3">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="min-w-0 text-[13px] font-medium leading-[1.25] tracking-nav text-nav-fg">
+                    Cache TTL
+                  </span>
+                  <InfoHint>
+                    Anthropic exposes a 5 minute and a 1 hour ephemeral
+                    cache pool. The 1 hour pool costs 2x base input on
+                    write vs 1.25x for 5 minute, but reads stay 0.1x for
+                    both, so a single read landing more than 5 minutes
+                    after the write pays off the premium.
+                  </InfoHint>
+                </div>
+                <Select
+                  value={activeExternalProvider.promptCacheTtl ?? "5m"}
+                  onValueChange={(value) => {
+                    if (value !== "5m" && value !== "1h") return;
+                    onExternalProviderChange?.({
+                      ...activeExternalProvider,
+                      promptCacheTtl: value,
+                    });
+                  }}
+                >
+                  <SelectTrigger
+                    className="panel-select-trigger h-8 w-[124px] shrink-0"
+                    aria-label="Prompt cache TTL"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="5m">5 minutes</SelectItem>
+                    <SelectItem value="1h">1 hour</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : null}
           </CollapsibleSection>
         ) : null}
 

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -16,6 +16,14 @@ export interface ExternalProviderConfig {
   availableModels?: string[];
   /** Whether to ask supported hosted providers to use prompt caching. */
   enablePromptCaching?: boolean;
+  /**
+   * Anthropic prompt-cache TTL bucket. Only meaningful when
+   * `enablePromptCaching` is true and the provider supports the choice
+   * (Anthropic today). Maps to `prompt_cache_ttl` on the backend, which
+   * attaches `cache_control.ttl` to the cache marker. Omitted = inherit
+   * Anthropic's default 5-minute pool, same as before this knob existed.
+   */
+  promptCacheTtl?: "5m" | "1h";
   /** User-pinned: the loaded vLLM model supports `enable_thinking`. */
   isReasoningModel?: boolean;
   /**
@@ -35,6 +43,28 @@ export function supportsProviderPromptCaching(
   providerType: string | null | undefined,
 ): boolean {
   return providerType != null && PROMPT_CACHING_PROVIDER_TYPES.has(providerType);
+}
+
+/**
+ * Whether the provider lets the user choose between a short and a long
+ * prompt-cache pool. Anthropic exposes both a 5m and a 1h ephemeral
+ * pool via `cache_control.ttl`; OpenAI's automatic prompt cache has no
+ * equivalent user-selectable knob, so it stays off the picker.
+ */
+const PROMPT_CACHE_TTL_PROVIDER_TYPES = new Set(["anthropic"]);
+
+export function supportsProviderPromptCacheTtl(
+  providerType: string | null | undefined,
+): boolean {
+  return (
+    providerType != null && PROMPT_CACHE_TTL_PROVIDER_TYPES.has(providerType)
+  );
+}
+
+const PROMPT_CACHE_TTL_VALUES = new Set<"5m" | "1h">(["5m", "1h"]);
+
+export function isPromptCacheTtl(value: unknown): value is "5m" | "1h" {
+  return typeof value === "string" && PROMPT_CACHE_TTL_VALUES.has(value as "5m" | "1h");
 }
 
 // Provider types that expose the connection-level "reasoning model"
@@ -289,6 +319,11 @@ function normalizeProvider(raw: ExternalProviderConfig): ExternalProviderConfig 
     enablePromptCaching: supportsProviderPromptCaching(providerType)
       ? raw.enablePromptCaching !== false
       : undefined,
+    promptCacheTtl:
+      supportsProviderPromptCacheTtl(providerType) &&
+      isPromptCacheTtl(raw.promptCacheTtl)
+        ? raw.promptCacheTtl
+        : undefined,
     isReasoningModel: supportsProviderReasoningToggle(providerType)
       ? raw.isReasoningModel === true
       : undefined,


### PR DESCRIPTION
## Summary

#5685 wired the backend to honor `prompt_cache_ttl` on the chat request, but there was no UI to actually pick it. Every Studio chat ended up on Anthropic's default 5 minute pool, which is exactly the case the 1 hour pool exists to solve (tab juggling, long tool calls, multi-burst research where the next turn lands 6+ minutes after the previous one).

This adds a Cache TTL selector to the chat settings sheet's Provider section, visible only when the provider supports the choice (Anthropic today) and Prompt caching is on.

## Pricing recap

Anthropic prices 1h cache writes at 2x base input vs 1.25x for 5m. Reads stay at 0.1x for both, so a single extra read landing more than 5 minutes after the write pays off the premium.

## Changes

- New `promptCacheTtl?: \"5m\" | \"1h\"` on `ExternalProviderConfig`. Normalizer drops the field on providers that don't support the choice so localStorage stays clean across provider swaps.
- `supportsProviderPromptCacheTtl` + `isPromptCacheTtl` helpers in `external-providers.ts` so the picker, normalizer, and adapter all agree on which values are valid.
- `chat-settings-sheet.tsx` renders a small Select (5 minutes / 1 hour) right under the Prompt caching switch when the toggle is on. Flipping it persists on the provider config like the other per-provider knobs.
- `chat-adapter.ts` passes `prompt_cache_ttl` on outbound requests when the value is valid; omitted otherwise so the backend keeps inheriting Anthropic's 5m default.

## Test plan

- [x] `npx tsc -b --pretty false` clean
- [ ] Connect Anthropic, open Configuration. Prompt caching is on by default. Confirm a new \"Cache TTL\" picker shows (5 minutes / 1 hour)
- [ ] Toggle Prompt caching off. Confirm the Cache TTL picker hides
- [ ] Pick 1 hour, send a message. Backend `_stream_anthropic` should attach `cache_control: {type:\"ephemeral\", ttl:\"1h\"}` to both breakpoints
- [ ] Switch to OpenAI. Cache TTL picker stays hidden (only Prompt caching switch shows)
- [ ] Refresh page. Selected TTL persists on the provider config