### PR TITLE
Support follow-up edits for generated images

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2620,6 +2620,7 @@ class ExternalProviderClient:
         instructions_parts: list[str] = []
         input_items: list[dict[str, Any]] = []
         openai_replay_items: list[dict[str, Any]] = []
+        previous_response_id: Optional[str] = None
         for msg in messages:
             role = msg.get("role")
             content = msg.get("content", "")
@@ -2640,6 +2641,7 @@ class ExternalProviderClient:
 
             if isinstance(content, list):
                 translated_parts: list[dict[str, Any]] = []
+                message_sets_previous_response_id = False
                 for part in content:
                     part_type = part.get("type")
                     if part_type == "text":
@@ -2659,8 +2661,20 @@ class ExternalProviderClient:
                         if replay_item:
                             openai_replay_items.append(replay_item)
                     elif part_type == "image_generation_call":
+                        response_id = (
+                            part.get("response_id")
+                            or part.get("openai_response_id")
+                            or part.get("previous_response_id")
+                        )
                         call_id = part.get("id") or part.get("image_generation_call_id")
                         if isinstance(call_id, str) and call_id:
+                            if isinstance(response_id, str) and response_id:
+                                previous_response_id = response_id
+                                input_items = []
+                                translated_parts = []
+                                message_sets_previous_response_id = True
+                            else:
+                                previous_response_id = None
                             openai_replay_items.append(
                                 {"type": "image_generation_call", "id": call_id}
                             )
@@ -2701,10 +2715,17 @@ class ExternalProviderClient:
                         if filename:
                             block["filename"] = filename
                         translated_parts.append(block)
-                if translated_parts:
+                if translated_parts and not message_sets_previous_response_id:
                     input_items.append({"role": role, "content": translated_parts})
 
-        if (
+        if previous_response_id:
+            # OpenAI's documented multi-turn image generation path can use
+            # `previous_response_id` to carry the prior generated image and
+            # paired reasoning state. Prefer that over manual item replay when
+            # we captured the response id; keep replay below as a fallback for
+            # older stored turns that only have an image_generation_call id.
+            openai_replay_items = []
+        elif (
             _openai_image_replay_requires_reasoning(model)
             and reasoning_effort != "none"
             and enable_thinking is not False
@@ -2738,6 +2759,8 @@ class ExternalProviderClient:
             "input": input_items,
             "stream": True,
         }
+        if previous_response_id:
+            body["previous_response_id"] = previous_response_id
         # `summary: "auto"` is what makes /v1/responses emit reasoning
         # summary events — without it OpenAI returns no thinking text on
         # most reasoning models, the SSE handler has no <think>…</think>
@@ -3016,8 +3039,21 @@ class ExternalProviderClient:
                     # see.
                     latched_container_id: Optional[str] = None
                     container_id_emitted = False
+                    current_openai_response_id: Optional[str] = None
                     last_openai_reasoning_replay_item: Optional[dict[str, Any]] = None
                     openai_reasoning_replay_items: dict[str, dict[str, Any]] = {}
+
+                    def _record_openai_response_id(payload: dict[str, Any]) -> None:
+                        nonlocal current_openai_response_id
+                        response_obj = payload.get("response")
+                        candidates: list[Any] = []
+                        if isinstance(response_obj, dict):
+                            candidates.append(response_obj.get("id"))
+                        candidates.append(payload.get("response_id"))
+                        for candidate in candidates:
+                            if isinstance(candidate, str) and candidate:
+                                current_openai_response_id = candidate
+                                return
 
                     def _emit_tool_event(payload: dict[str, Any]) -> str:
                         chunk = {
@@ -3219,6 +3255,7 @@ class ExternalProviderClient:
                                 continue
 
                             event_type = event.get("type")
+                            _record_openai_response_id(event)
 
                             if event_type == "response.output_text.delta":
                                 delta_text = event.get("delta", "")
@@ -3439,6 +3476,10 @@ class ExternalProviderClient:
                                     if isinstance(raw_item_id, str) and raw_item_id:
                                         arguments["openai_image_generation_call_id"] = (
                                             raw_item_id
+                                        )
+                                    if current_openai_response_id:
+                                        arguments["openai_response_id"] = (
+                                            current_openai_response_id
                                         )
                                     if last_openai_reasoning_replay_item:
                                         arguments["openai_reasoning_item"] = (

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3120,11 +3120,17 @@ class ExternalProviderClient:
                                 return existing
                         summary_text = ""
                         part = payload.get("part")
-                        if isinstance(part, dict) and part.get("type") == "summary_text":
+                        if (
+                            isinstance(part, dict)
+                            and part.get("type") == "summary_text"
+                        ):
                             text = part.get("text")
                             if isinstance(text, str):
                                 summary_text = text
-                        elif payload.get("type") == "response.reasoning_summary_text.done":
+                        elif (
+                            payload.get("type")
+                            == "response.reasoning_summary_text.done"
+                        ):
                             text = payload.get("text")
                             if isinstance(text, str):
                                 summary_text = text
@@ -3136,9 +3142,14 @@ class ExternalProviderClient:
                                     "type": "summary_text",
                                     "text": summary_text,
                                 }
-                                if isinstance(summary_index, int) and summary_index >= 0:
+                                if (
+                                    isinstance(summary_index, int)
+                                    and summary_index >= 0
+                                ):
                                     while len(summary) <= summary_index:
-                                        summary.append({"type": "summary_text", "text": ""})
+                                        summary.append(
+                                            {"type": "summary_text", "text": ""}
+                                        )
                                     summary[summary_index] = summary_part
                                 else:
                                     summary.append(summary_part)
@@ -3462,11 +3473,13 @@ class ExternalProviderClient:
                                 isinstance(event_type, str)
                                 and "reasoning" in event_type
                             ):
-                                recorded_reasoning = _record_openai_reasoning_replay_item(
-                                    event
+                                recorded_reasoning = (
+                                    _record_openai_reasoning_replay_item(event)
                                 )
                                 if recorded_reasoning:
-                                    last_openai_reasoning_replay_item = recorded_reasoning
+                                    last_openai_reasoning_replay_item = (
+                                        recorded_reasoning
+                                    )
                                 reasoning_delta = _extract_reasoning_text(event)
                                 if reasoning_delta:
                                     if not reasoning_open:

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2611,9 +2611,7 @@ class ExternalProviderClient:
                                 {"type": "input_image", "image_url": url}
                             )
                     elif part_type == "image_generation_call":
-                        call_id = part.get("id") or part.get(
-                            "image_generation_call_id"
-                        )
+                        call_id = part.get("id") or part.get("image_generation_call_id")
                         if isinstance(call_id, str) and call_id:
                             if translated_parts:
                                 input_items.append(
@@ -3313,9 +3311,9 @@ class ExternalProviderClient:
                                         "prompt": prompt_in,
                                     }
                                     if isinstance(raw_item_id, str) and raw_item_id:
-                                        arguments[
-                                            "openai_image_generation_call_id"
-                                        ] = raw_item_id
+                                        arguments["openai_image_generation_call_id"] = (
+                                            raw_item_id
+                                        )
                                     yield _emit_tool_event(
                                         {
                                             "type": "tool_start",

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -70,6 +70,11 @@ _OPENAI_REASONING_SUMMARY_UNSUPPORTED = re.compile(r"^o3(?:[-.]|$)")
 _OPENAI_REASONING_STATUSES = {"in_progress", "completed", "incomplete"}
 
 
+def _openai_image_replay_requires_reasoning(model: str) -> bool:
+    normalized = model.strip().lower()
+    return normalized.startswith("gpt-5") or normalized.startswith("o")
+
+
 def _sanitize_openai_reasoning_replay_item(
     item: Any,
 ) -> Optional[dict[str, Any]]:
@@ -2699,6 +2704,23 @@ class ExternalProviderClient:
                 if translated_parts:
                     input_items.append({"role": role, "content": translated_parts})
 
+        if (
+            _openai_image_replay_requires_reasoning(model)
+            and reasoning_effort != "none"
+            and enable_thinking is not False
+        ):
+            filtered_replay_items: list[dict[str, Any]] = []
+            has_reasoning_replay = False
+            for item in openai_replay_items:
+                if item.get("type") == "reasoning":
+                    has_reasoning_replay = True
+                    filtered_replay_items.append(item)
+                elif item.get("type") == "image_generation_call":
+                    if has_reasoning_replay:
+                        filtered_replay_items.append(item)
+                else:
+                    filtered_replay_items.append(item)
+            openai_replay_items = filtered_replay_items
         input_items.extend(openai_replay_items)
 
         # NOTE: gpt-5.x / o3 / gpt-4.5 are reasoning-class models. They reject
@@ -2995,6 +3017,7 @@ class ExternalProviderClient:
                     latched_container_id: Optional[str] = None
                     container_id_emitted = False
                     last_openai_reasoning_replay_item: Optional[dict[str, Any]] = None
+                    openai_reasoning_replay_items: dict[str, dict[str, Any]] = {}
 
                     def _emit_tool_event(payload: dict[str, Any]) -> str:
                         chunk = {
@@ -3072,6 +3095,54 @@ class ExternalProviderClient:
                                 "snippet": snippet,
                             }
                         )
+
+                    def _record_openai_reasoning_replay_item(
+                        payload: Any,
+                    ) -> Optional[dict[str, Any]]:
+                        if not isinstance(payload, dict):
+                            return None
+                        item_id = payload.get("id") or payload.get("item_id")
+                        if not isinstance(item_id, str) or not item_id:
+                            return None
+                        existing = openai_reasoning_replay_items.setdefault(
+                            item_id,
+                            {
+                                "type": "reasoning",
+                                "id": item_id,
+                                "summary": [],
+                                "status": "completed",
+                            },
+                        )
+                        if payload.get("type") == "reasoning":
+                            sanitized = _sanitize_openai_reasoning_replay_item(payload)
+                            if sanitized:
+                                existing.update(sanitized)
+                                return existing
+                        summary_text = ""
+                        part = payload.get("part")
+                        if isinstance(part, dict) and part.get("type") == "summary_text":
+                            text = part.get("text")
+                            if isinstance(text, str):
+                                summary_text = text
+                        elif payload.get("type") == "response.reasoning_summary_text.done":
+                            text = payload.get("text")
+                            if isinstance(text, str):
+                                summary_text = text
+                        if summary_text:
+                            summary_index = payload.get("summary_index")
+                            summary = existing.setdefault("summary", [])
+                            if isinstance(summary, list):
+                                summary_part = {
+                                    "type": "summary_text",
+                                    "text": summary_text,
+                                }
+                                if isinstance(summary_index, int) and summary_index >= 0:
+                                    while len(summary) <= summary_index:
+                                        summary.append({"type": "summary_text", "text": ""})
+                                    summary[summary_index] = summary_part
+                                else:
+                                    summary.append(summary_part)
+                        return existing
 
                     def _extract_reasoning_text(payload: Any) -> str:
                         if payload is None:
@@ -3210,7 +3281,7 @@ class ExternalProviderClient:
                                     continue
                                 if item.get("type") == "reasoning":
                                     last_openai_reasoning_replay_item = (
-                                        _sanitize_openai_reasoning_replay_item(item)
+                                        _record_openai_reasoning_replay_item(item)
                                     )
                                     summary_text = _extract_reasoning_text(
                                         item.get("summary")
@@ -3391,6 +3462,11 @@ class ExternalProviderClient:
                                 isinstance(event_type, str)
                                 and "reasoning" in event_type
                             ):
+                                recorded_reasoning = _record_openai_reasoning_replay_item(
+                                    event
+                                )
+                                if recorded_reasoning:
+                                    last_openai_reasoning_replay_item = recorded_reasoning
                                 reasoning_delta = _extract_reasoning_text(event)
                                 if reasoning_delta:
                                     if not reasoning_open:

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2640,7 +2640,7 @@ class ExternalProviderClient:
 
             if isinstance(content, list):
                 translated_parts: list[dict[str, Any]] = []
-                message_sets_previous_response_id = False
+                used_previous_response_id = False
                 for part in content:
                     part_type = part.get("type")
                     if part_type == "text":
@@ -2671,7 +2671,7 @@ class ExternalProviderClient:
                                 previous_response_id = response_id
                                 input_items = []
                                 translated_parts = []
-                                message_sets_previous_response_id = True
+                                used_previous_response_id = True
                             else:
                                 previous_response_id = None
                             openai_replay_items.append(
@@ -2714,7 +2714,7 @@ class ExternalProviderClient:
                         if filename:
                             block["filename"] = filename
                         translated_parts.append(block)
-                if translated_parts and not message_sets_previous_response_id:
+                if translated_parts and not used_previous_response_id:
                     input_items.append({"role": role, "content": translated_parts})
 
         if previous_response_id:
@@ -2735,9 +2735,10 @@ class ExternalProviderClient:
                 if item.get("type") == "reasoning":
                     has_reasoning_replay = True
                     filtered_replay_items.append(item)
-                elif item.get("type") == "image_generation_call":
-                    if has_reasoning_replay:
-                        filtered_replay_items.append(item)
+                elif (
+                    item.get("type") == "image_generation_call" and has_reasoning_replay
+                ):
+                    filtered_replay_items.append(item)
                 else:
                     filtered_replay_items.append(item)
             openai_replay_items = filtered_replay_items
@@ -3209,6 +3210,21 @@ class ExternalProviderClient:
                                     summary.append(summary_part)
                         return existing
 
+                    def _image_generation_arguments(
+                        prompt: str,
+                        raw_item_id: Any,
+                    ) -> dict[str, Any]:
+                        arguments: dict[str, Any] = {"kind": "image", "prompt": prompt}
+                        if isinstance(raw_item_id, str) and raw_item_id:
+                            arguments["openai_image_generation_call_id"] = raw_item_id
+                        if current_openai_response_id:
+                            arguments["openai_response_id"] = current_openai_response_id
+                        if last_openai_reasoning_replay_item:
+                            arguments["openai_reasoning_item"] = (
+                                last_openai_reasoning_replay_item
+                            )
+                        return arguments
+
                     def _extract_reasoning_text(payload: Any) -> str:
                         if payload is None:
                             return ""
@@ -3341,21 +3357,10 @@ class ExternalProviderClient:
                                 ):
                                     raw_item_id = item.get("id")
                                     if isinstance(raw_item_id, str) and raw_item_id:
-                                        arguments: dict[str, Any] = {
-                                            "kind": "image",
-                                            "prompt": "",
-                                            "openai_image_generation_call_id": (
-                                                raw_item_id
-                                            ),
-                                        }
-                                        if current_openai_response_id:
-                                            arguments["openai_response_id"] = (
-                                                current_openai_response_id
-                                            )
-                                        if last_openai_reasoning_replay_item:
-                                            arguments["openai_reasoning_item"] = (
-                                                last_openai_reasoning_replay_item
-                                            )
+                                        arguments = _image_generation_arguments(
+                                            "",
+                                            raw_item_id,
+                                        )
                                         image_generation_calls_started.add(raw_item_id)
                                         yield _emit_tool_event(
                                             {
@@ -3512,22 +3517,10 @@ class ExternalProviderClient:
                                         or item.get("prompt")
                                         or ""
                                     )
-                                    done_arguments: dict[str, Any] = {
-                                        "kind": "image",
-                                        "prompt": prompt_in,
-                                    }
-                                    if isinstance(raw_item_id, str) and raw_item_id:
-                                        done_arguments[
-                                            "openai_image_generation_call_id"
-                                        ] = raw_item_id
-                                    if current_openai_response_id:
-                                        done_arguments["openai_response_id"] = (
-                                            current_openai_response_id
-                                        )
-                                    if last_openai_reasoning_replay_item:
-                                        done_arguments["openai_reasoning_item"] = (
-                                            last_openai_reasoning_replay_item
-                                        )
+                                    done_arguments = _image_generation_arguments(
+                                        prompt_in,
+                                        raw_item_id,
+                                    )
                                     if item_id not in image_generation_calls_started:
                                         yield _emit_tool_event(
                                             {

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2576,6 +2576,7 @@ class ExternalProviderClient:
         # translate user/assistant messages into the Responses input shape.
         instructions_parts: list[str] = []
         input_items: list[dict[str, Any]] = []
+        image_generation_call_refs: list[dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role")
             content = msg.get("content", "")
@@ -2613,12 +2614,7 @@ class ExternalProviderClient:
                     elif part_type == "image_generation_call":
                         call_id = part.get("id") or part.get("image_generation_call_id")
                         if isinstance(call_id, str) and call_id:
-                            if translated_parts:
-                                input_items.append(
-                                    {"role": role, "content": translated_parts}
-                                )
-                                translated_parts = []
-                            input_items.append(
+                            image_generation_call_refs.append(
                                 {"type": "image_generation_call", "id": call_id}
                             )
                     elif part_type == "input_document":
@@ -2660,6 +2656,8 @@ class ExternalProviderClient:
                         translated_parts.append(block)
                 if translated_parts:
                     input_items.append({"role": role, "content": translated_parts})
+
+        input_items.extend(image_generation_call_refs)
 
         # NOTE: gpt-5.x / o3 / gpt-4.5 are reasoning-class models. They reject
         # temperature and top_p with `Unsupported parameter` 400s on

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -67,6 +67,44 @@ _ANTHROPIC_4_7_SAMPLING_REMOVED = re.compile(
     r"^claude-(?:opus|sonnet|haiku)-4-7(?:[-.]|$)"
 )
 _OPENAI_REASONING_SUMMARY_UNSUPPORTED = re.compile(r"^o3(?:[-.]|$)")
+_OPENAI_REASONING_STATUSES = {"in_progress", "completed", "incomplete"}
+
+
+def _sanitize_openai_reasoning_replay_item(
+    item: Any,
+) -> Optional[dict[str, Any]]:
+    """Return a Responses input-safe reasoning item, if ``item`` is one.
+
+    OpenAI's image-generation docs allow follow-up edits by sending the
+    previous ``image_generation_call`` id. Reasoning models can additionally
+    require the paired ``reasoning`` output item in manually managed context,
+    so keep the public replay fields only and drop everything else.
+    """
+    if not isinstance(item, dict) or item.get("type") != "reasoning":
+        return None
+    item_id = item.get("id")
+    if not isinstance(item_id, str) or not item_id:
+        return None
+    summary_parts: list[dict[str, str]] = []
+    summary = item.get("summary")
+    if isinstance(summary, list):
+        for part in summary:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") != "summary_text":
+                continue
+            text = part.get("text")
+            if isinstance(text, str):
+                summary_parts.append({"type": "summary_text", "text": text})
+    replay_item: dict[str, Any] = {
+        "type": "reasoning",
+        "id": item_id,
+        "summary": summary_parts,
+    }
+    status = item.get("status")
+    if isinstance(status, str) and status in _OPENAI_REASONING_STATUSES:
+        replay_item["status"] = status
+    return replay_item
 
 
 class _AnthropicThinkingSpec(NamedTuple):
@@ -2576,7 +2614,7 @@ class ExternalProviderClient:
         # translate user/assistant messages into the Responses input shape.
         instructions_parts: list[str] = []
         input_items: list[dict[str, Any]] = []
-        image_generation_call_refs: list[dict[str, Any]] = []
+        openai_replay_items: list[dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role")
             content = msg.get("content", "")
@@ -2611,10 +2649,14 @@ class ExternalProviderClient:
                             translated_parts.append(
                                 {"type": "input_image", "image_url": url}
                             )
+                    elif part_type == "reasoning":
+                        replay_item = _sanitize_openai_reasoning_replay_item(part)
+                        if replay_item:
+                            openai_replay_items.append(replay_item)
                     elif part_type == "image_generation_call":
                         call_id = part.get("id") or part.get("image_generation_call_id")
                         if isinstance(call_id, str) and call_id:
-                            image_generation_call_refs.append(
+                            openai_replay_items.append(
                                 {"type": "image_generation_call", "id": call_id}
                             )
                     elif part_type == "input_document":
@@ -2657,7 +2699,7 @@ class ExternalProviderClient:
                 if translated_parts:
                     input_items.append({"role": role, "content": translated_parts})
 
-        input_items.extend(image_generation_call_refs)
+        input_items.extend(openai_replay_items)
 
         # NOTE: gpt-5.x / o3 / gpt-4.5 are reasoning-class models. They reject
         # temperature and top_p with `Unsupported parameter` 400s on
@@ -2952,6 +2994,7 @@ class ExternalProviderClient:
                     # see.
                     latched_container_id: Optional[str] = None
                     container_id_emitted = False
+                    last_openai_reasoning_replay_item: Optional[dict[str, Any]] = None
 
                     def _emit_tool_event(payload: dict[str, Any]) -> str:
                         chunk = {
@@ -3166,6 +3209,9 @@ class ExternalProviderClient:
                                 if not isinstance(item, dict):
                                     continue
                                 if item.get("type") == "reasoning":
+                                    last_openai_reasoning_replay_item = (
+                                        _sanitize_openai_reasoning_replay_item(item)
+                                    )
                                     summary_text = _extract_reasoning_text(
                                         item.get("summary")
                                     )
@@ -3311,6 +3357,10 @@ class ExternalProviderClient:
                                     if isinstance(raw_item_id, str) and raw_item_id:
                                         arguments["openai_image_generation_call_id"] = (
                                             raw_item_id
+                                        )
+                                    if last_openai_reasoning_replay_item:
+                                        arguments["openai_reasoning_item"] = (
+                                            last_openai_reasoning_replay_item
                                         )
                                     yield _emit_tool_event(
                                         {

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -120,19 +120,19 @@ class _AnthropicThinkingSpec(NamedTuple):
 
 _ANTHROPIC_THINKING_SPECS = (
     _AnthropicThinkingSpec(
-        prefixes=("claude-opus-4-7",),
-        kind="adaptive",
-        efforts=("none", "low", "medium", "high", "xhigh", "max"),
+        prefixes = ("claude-opus-4-7",),
+        kind = "adaptive",
+        efforts = ("none", "low", "medium", "high", "xhigh", "max"),
     ),
     _AnthropicThinkingSpec(
-        prefixes=("claude-opus-4-6", "claude-sonnet-4-6"),
-        kind="adaptive",
-        efforts=("none", "low", "medium", "high", "xhigh", "max"),
+        prefixes = ("claude-opus-4-6", "claude-sonnet-4-6"),
+        kind = "adaptive",
+        efforts = ("none", "low", "medium", "high", "xhigh", "max"),
     ),
     _AnthropicThinkingSpec(
-        prefixes=("claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"),
-        kind="manual",
-        efforts=("none", "low", "medium", "high"),
+        prefixes = ("claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"),
+        kind = "manual",
+        efforts = ("none", "low", "medium", "high"),
     ),
 )
 
@@ -228,13 +228,13 @@ class _MistralThinkingSpec(NamedTuple):
 
 _MISTRAL_THINKING_SPECS = (
     _MistralThinkingSpec(
-        models=("magistral-medium-latest",),
-        style="prompt_mode",
+        models = ("magistral-medium-latest",),
+        style = "prompt_mode",
     ),
     _MistralThinkingSpec(
-        models=("mistral-small-latest", "mistral-vibe-cli-latest"),
-        style="reasoning_effort",
-        efforts=("none", "high"),
+        models = ("mistral-small-latest", "mistral-vibe-cli-latest"),
+        style = "reasoning_effort",
+        efforts = ("none", "high"),
     ),
 )
 
@@ -252,7 +252,7 @@ def _mistral_thinking_spec(model: str) -> _MistralThinkingSpec:
     for spec in _MISTRAL_THINKING_SPECS:
         if model in spec.models:
             return spec
-    return _MistralThinkingSpec(models=(), style="disabled")
+    return _MistralThinkingSpec(models = (), style = "disabled")
 
 
 def _apply_mistral_reasoning_controls(
@@ -339,7 +339,7 @@ class ExternalProviderClient:
         self.provider_type = provider_type
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
-        self._timeout = httpx.Timeout(timeout, connect=10.0)
+        self._timeout = httpx.Timeout(timeout, connect = 10.0)
         # Separate timeout for SSE streams: reasoning-heavy providers
         # (Anthropic Opus 4.7 with adaptive thinking, OpenAI gpt-5.x via
         # /v1/responses) can pause for tens of seconds between bytes
@@ -348,7 +348,7 @@ class ExternalProviderClient:
         # disabling it lets long thinks complete without cutting the
         # stream prematurely. connect/write/pool keep the 10s / 120s
         # bounds so genuine network failures still surface.
-        self._stream_timeout = httpx.Timeout(timeout, connect=10.0, read=None)
+        self._stream_timeout = httpx.Timeout(timeout, connect = 10.0, read = None)
 
     def _auth_headers(self) -> dict[str, str]:
         """Build authentication headers using the provider's registry config."""
@@ -580,18 +580,18 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json=body,
-                headers=self._auth_headers(),
-                timeout=self._stream_timeout,
+                json = body,
+                headers = self._auth_headers(),
+                timeout = self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors="replace")
+                    error_text = error_body.decode("utf-8", errors = "replace")
                     error_text = _friendly_provider_error_text(
                         self.provider_type,
                         response.status_code,
                         error_text,
-                        model=model,
+                        model = model,
                     )
                     logger.error(
                         "External provider returned %d: %s",
@@ -911,13 +911,13 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json=body,
-                headers=self._auth_headers(),
-                timeout=self._stream_timeout,
+                json = body,
+                headers = self._auth_headers(),
+                timeout = self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors="replace")
+                    error_text = error_body.decode("utf-8", errors = "replace")
                     logger.error(
                         "Kimi first-call returned %d: %s",
                         response.status_code,
@@ -1005,13 +1005,13 @@ class ExternalProviderClient:
                 async with _http_client.stream(
                     "POST",
                     url,
-                    json=fallback_body,
-                    headers=self._auth_headers(),
-                    timeout=self._stream_timeout,
+                    json = fallback_body,
+                    headers = self._auth_headers(),
+                    timeout = self._stream_timeout,
                 ) as response:
                     if response.status_code != 200:
                         error_body = await response.aread()
-                        error_text = error_body.decode("utf-8", errors="replace")
+                        error_text = error_body.decode("utf-8", errors = "replace")
                         logger.error(
                             "Kimi fallback returned %d: %s",
                             response.status_code,
@@ -1123,13 +1123,13 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json=followup_body,
-                headers=self._auth_headers(),
-                timeout=self._stream_timeout,
+                json = followup_body,
+                headers = self._auth_headers(),
+                timeout = self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors="replace")
+                    error_text = error_body.decode("utf-8", errors = "replace")
                     logger.error(
                         "Kimi second-call returned %d: %s",
                         response.status_code,
@@ -1718,13 +1718,13 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json=body,
-                headers=request_headers,
-                timeout=self._stream_timeout,
+                json = body,
+                headers = request_headers,
+                timeout = self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors="replace")
+                    error_text = error_body.decode("utf-8", errors = "replace")
                     logger.error(
                         "Anthropic returned %d: %s",
                         response.status_code,
@@ -2333,7 +2333,7 @@ class ExternalProviderClient:
                                     except Exception:
                                         logger.debug(
                                             "Failed to parse web_fetch input_json",
-                                            buffer=buffer,
+                                            buffer = buffer,
                                         )
                                         url = ""
                                 tool_use_id = current_web_fetch_use["id"]
@@ -2972,13 +2972,13 @@ class ExternalProviderClient:
                 async with _http_client.stream(
                     "POST",
                     url,
-                    json=attempt_body,
-                    headers=self._auth_headers(),
-                    timeout=self._stream_timeout,
+                    json = attempt_body,
+                    headers = self._auth_headers(),
+                    timeout = self._stream_timeout,
                 ) as response:
                     if response.status_code != 200:
                         error_body = await response.aread()
-                        error_text = error_body.decode("utf-8", errors="replace")
+                        error_text = error_body.decode("utf-8", errors = "replace")
                         logger.error(
                             "OpenAI Responses returned %d: %s",
                             response.status_code,
@@ -3857,9 +3857,9 @@ class ExternalProviderClient:
 
         response = await _http_client.post(
             f"{self.base_url}/chat/completions",
-            json=body,
-            headers=self._auth_headers(),
-            timeout=self._timeout,
+            json = body,
+            headers = self._auth_headers(),
+            timeout = self._timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -3878,8 +3878,8 @@ class ExternalProviderClient:
         try:
             response = await _http_client.get(
                 f"{self.base_url}/models",
-                headers=self._auth_headers(),
-                timeout=self._timeout,
+                headers = self._auth_headers(),
+                timeout = self._timeout,
             )
             response.raise_for_status()
             data = response.json()
@@ -3902,8 +3902,8 @@ class ExternalProviderClient:
         root = self.base_url.removesuffix("/v1").rstrip("/")
         response = await _http_client.get(
             f"{root}/api/tags",
-            headers=self._auth_headers(),
-            timeout=self._timeout,
+            headers = self._auth_headers(),
+            timeout = self._timeout,
         )
         response.raise_for_status()
         payload = response.json()
@@ -3930,12 +3930,12 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "GET",
                 url,
-                headers=self._auth_headers(),
-                timeout=self._timeout,
+                headers = self._auth_headers(),
+                timeout = self._timeout,
             ) as response:
                 if response.status_code != 200:
                     response.raise_for_status()
-                async for _chunk in response.aiter_bytes(chunk_size=2048):
+                async for _chunk in response.aiter_bytes(chunk_size = 2048):
                     break
         except httpx.HTTPError as exc:
             logger.error(
@@ -3972,8 +3972,8 @@ class ExternalProviderClient:
         """
         response = await _http_client.get(
             f"{self.base_url}/containers",
-            headers=self._container_headers(),
-            timeout=self._timeout,
+            headers = self._container_headers(),
+            timeout = self._timeout,
         )
         response.raise_for_status()
         data = response.json()
@@ -4009,9 +4009,9 @@ class ExternalProviderClient:
         }
         response = await _http_client.post(
             f"{self.base_url}/containers",
-            json=body,
-            headers=self._container_headers(),
-            timeout=self._timeout,
+            json = body,
+            headers = self._container_headers(),
+            timeout = self._timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -4039,8 +4039,8 @@ class ExternalProviderClient:
             "Authorization" in headers,
             headers.get("OpenAI-Beta"),
         )
-        async with httpx.AsyncClient(timeout=self._timeout) as fresh_client:
-            response = await fresh_client.delete(url, headers=headers)
+        async with httpx.AsyncClient(timeout = self._timeout) as fresh_client:
+            response = await fresh_client.delete(url, headers = headers)
         logger.info(
             "openai_container_delete.response status=%s cf_ray=%s "
             "request_id=%s organization=%s project=%s processing_ms=%s body=%s",

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2610,6 +2610,19 @@ class ExternalProviderClient:
                             translated_parts.append(
                                 {"type": "input_image", "image_url": url}
                             )
+                    elif part_type == "image_generation_call":
+                        call_id = part.get("id") or part.get(
+                            "image_generation_call_id"
+                        )
+                        if isinstance(call_id, str) and call_id:
+                            if translated_parts:
+                                input_items.append(
+                                    {"role": role, "content": translated_parts}
+                                )
+                                translated_parts = []
+                            input_items.append(
+                                {"type": "image_generation_call", "id": call_id}
+                            )
                     elif part_type == "input_document":
                         # OpenAI Responses accepts PDFs / docs as
                         # `{type:"input_file", file_data:"data:application/pdf;base64,..."}`
@@ -3288,23 +3301,27 @@ class ExternalProviderClient:
                                     # millisecond resolution so synthesised
                                     # ids stay unique even when two image
                                     # generations resolve in the same ms.
-                                    item_id = item.get("id", "") or (
-                                        f"img_{time.time_ns()}"
-                                    )
+                                    raw_item_id = item.get("id")
+                                    item_id = raw_item_id or f"img_{time.time_ns()}"
                                     prompt_in = (
                                         item.get("revised_prompt")
                                         or item.get("prompt")
                                         or ""
                                     )
+                                    arguments = {
+                                        "kind": "image",
+                                        "prompt": prompt_in,
+                                    }
+                                    if isinstance(raw_item_id, str) and raw_item_id:
+                                        arguments[
+                                            "openai_image_generation_call_id"
+                                        ] = raw_item_id
                                     yield _emit_tool_event(
                                         {
                                             "type": "tool_start",
                                             "tool_name": "image_generation",
                                             "tool_call_id": item_id,
-                                            "arguments": {
-                                                "kind": "image",
-                                                "prompt": prompt_in,
-                                            },
+                                            "arguments": arguments,
                                         }
                                     )
                                     b64 = (

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -111,6 +111,7 @@ def _sanitize_openai_reasoning_replay_item(
         replay_item["status"] = status
     return replay_item
 
+
 # OpenAI Responses inline citation markers: `citeSOURCE_ID[id2...][LOCATOR]`
 # using private-use codepoints (see
 # https://developers.openai.com/api/docs/guides/citation-formatting).

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -120,19 +120,19 @@ class _AnthropicThinkingSpec(NamedTuple):
 
 _ANTHROPIC_THINKING_SPECS = (
     _AnthropicThinkingSpec(
-        prefixes = ("claude-opus-4-7",),
-        kind = "adaptive",
-        efforts = ("none", "low", "medium", "high", "xhigh", "max"),
+        prefixes=("claude-opus-4-7",),
+        kind="adaptive",
+        efforts=("none", "low", "medium", "high", "xhigh", "max"),
     ),
     _AnthropicThinkingSpec(
-        prefixes = ("claude-opus-4-6", "claude-sonnet-4-6"),
-        kind = "adaptive",
-        efforts = ("none", "low", "medium", "high", "xhigh", "max"),
+        prefixes=("claude-opus-4-6", "claude-sonnet-4-6"),
+        kind="adaptive",
+        efforts=("none", "low", "medium", "high", "xhigh", "max"),
     ),
     _AnthropicThinkingSpec(
-        prefixes = ("claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"),
-        kind = "manual",
-        efforts = ("none", "low", "medium", "high"),
+        prefixes=("claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"),
+        kind="manual",
+        efforts=("none", "low", "medium", "high"),
     ),
 )
 
@@ -228,13 +228,13 @@ class _MistralThinkingSpec(NamedTuple):
 
 _MISTRAL_THINKING_SPECS = (
     _MistralThinkingSpec(
-        models = ("magistral-medium-latest",),
-        style = "prompt_mode",
+        models=("magistral-medium-latest",),
+        style="prompt_mode",
     ),
     _MistralThinkingSpec(
-        models = ("mistral-small-latest", "mistral-vibe-cli-latest"),
-        style = "reasoning_effort",
-        efforts = ("none", "high"),
+        models=("mistral-small-latest", "mistral-vibe-cli-latest"),
+        style="reasoning_effort",
+        efforts=("none", "high"),
     ),
 )
 
@@ -252,7 +252,7 @@ def _mistral_thinking_spec(model: str) -> _MistralThinkingSpec:
     for spec in _MISTRAL_THINKING_SPECS:
         if model in spec.models:
             return spec
-    return _MistralThinkingSpec(models = (), style = "disabled")
+    return _MistralThinkingSpec(models=(), style="disabled")
 
 
 def _apply_mistral_reasoning_controls(
@@ -339,7 +339,7 @@ class ExternalProviderClient:
         self.provider_type = provider_type
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
-        self._timeout = httpx.Timeout(timeout, connect = 10.0)
+        self._timeout = httpx.Timeout(timeout, connect=10.0)
         # Separate timeout for SSE streams: reasoning-heavy providers
         # (Anthropic Opus 4.7 with adaptive thinking, OpenAI gpt-5.x via
         # /v1/responses) can pause for tens of seconds between bytes
@@ -348,7 +348,7 @@ class ExternalProviderClient:
         # disabling it lets long thinks complete without cutting the
         # stream prematurely. connect/write/pool keep the 10s / 120s
         # bounds so genuine network failures still surface.
-        self._stream_timeout = httpx.Timeout(timeout, connect = 10.0, read = None)
+        self._stream_timeout = httpx.Timeout(timeout, connect=10.0, read=None)
 
     def _auth_headers(self) -> dict[str, str]:
         """Build authentication headers using the provider's registry config."""
@@ -564,8 +564,7 @@ class ExternalProviderClient:
                     plugins.append({"id": "web"})
                 body["plugins"] = plugins
                 logger.info(
-                    "OpenRouter web_search: attached plugins=[{id: 'web'}] "
-                    "(model=%s)",
+                    "OpenRouter web_search: attached plugins=[{id: 'web'}] (model=%s)",
                     body.get("model"),
                 )
 
@@ -581,18 +580,18 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json = body,
-                headers = self._auth_headers(),
-                timeout = self._stream_timeout,
+                json=body,
+                headers=self._auth_headers(),
+                timeout=self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors = "replace")
+                    error_text = error_body.decode("utf-8", errors="replace")
                     error_text = _friendly_provider_error_text(
                         self.provider_type,
                         response.status_code,
                         error_text,
-                        model = model,
+                        model=model,
                     )
                     logger.error(
                         "External provider returned %d: %s",
@@ -912,13 +911,13 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json = body,
-                headers = self._auth_headers(),
-                timeout = self._stream_timeout,
+                json=body,
+                headers=self._auth_headers(),
+                timeout=self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors = "replace")
+                    error_text = error_body.decode("utf-8", errors="replace")
                     logger.error(
                         "Kimi first-call returned %d: %s",
                         response.status_code,
@@ -1006,13 +1005,13 @@ class ExternalProviderClient:
                 async with _http_client.stream(
                     "POST",
                     url,
-                    json = fallback_body,
-                    headers = self._auth_headers(),
-                    timeout = self._stream_timeout,
+                    json=fallback_body,
+                    headers=self._auth_headers(),
+                    timeout=self._stream_timeout,
                 ) as response:
                     if response.status_code != 200:
                         error_body = await response.aread()
-                        error_text = error_body.decode("utf-8", errors = "replace")
+                        error_text = error_body.decode("utf-8", errors="replace")
                         logger.error(
                             "Kimi fallback returned %d: %s",
                             response.status_code,
@@ -1124,13 +1123,13 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json = followup_body,
-                headers = self._auth_headers(),
-                timeout = self._stream_timeout,
+                json=followup_body,
+                headers=self._auth_headers(),
+                timeout=self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors = "replace")
+                    error_text = error_body.decode("utf-8", errors="replace")
                     logger.error(
                         "Kimi second-call returned %d: %s",
                         response.status_code,
@@ -1637,7 +1636,7 @@ class ExternalProviderClient:
             and compaction_threshold > 0
             and _anthropic_supports_compaction(model)
         )
-        if compaction_active:
+        if compaction_active and compaction_threshold is not None:
             trigger_value = max(
                 int(compaction_threshold),
                 _ANTHROPIC_COMPACTION_MIN,
@@ -1719,13 +1718,13 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "POST",
                 url,
-                json = body,
-                headers = request_headers,
-                timeout = self._stream_timeout,
+                json=body,
+                headers=request_headers,
+                timeout=self._stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors = "replace")
+                    error_text = error_body.decode("utf-8", errors="replace")
                     logger.error(
                         "Anthropic returned %d: %s",
                         response.status_code,
@@ -2334,7 +2333,7 @@ class ExternalProviderClient:
                                     except Exception:
                                         logger.debug(
                                             "Failed to parse web_fetch input_json",
-                                            buffer = buffer,
+                                            buffer=buffer,
                                         )
                                         url = ""
                                 tool_use_id = current_web_fetch_use["id"]
@@ -2742,6 +2741,13 @@ class ExternalProviderClient:
                 else:
                     filtered_replay_items.append(item)
             openai_replay_items = filtered_replay_items
+        image_generation_has_reference = bool(
+            previous_response_id
+            or any(
+                isinstance(item, dict) and item.get("type") == "image_generation_call"
+                for item in openai_replay_items
+            )
+        )
         input_items.extend(openai_replay_items)
 
         # NOTE: gpt-5.x / o3 / gpt-4.5 are reasoning-class models. They reject
@@ -2866,6 +2872,17 @@ class ExternalProviderClient:
         image_generation_enabled_openai = bool(
             enabled_tools and "image_generation" in enabled_tools and is_openai_cloud
         )
+
+        def _openai_image_generation_tool() -> dict[str, Any]:
+            tool: dict[str, Any] = {"type": "image_generation"}
+            if image_generation_has_reference:
+                # OpenAI's Responses image tool defaults to `auto`. For
+                # Studio's explicit follow-up edit flow, force edit mode so
+                # the provider uses the previous response / call id as image
+                # context instead of treating the text as a fresh generation.
+                tool["action"] = "edit"
+            return tool
+
         if enabled_tools:
             tools_array: list[dict[str, Any]] = []
             if "web_search" in enabled_tools:
@@ -2893,7 +2910,7 @@ class ExternalProviderClient:
                     shell_env = {"type": "container_auto"}
                 tools_array.append({"type": "shell", "environment": shell_env})
             if image_generation_enabled_openai:
-                tools_array.append({"type": "image_generation"})
+                tools_array.append(_openai_image_generation_tool())
             if tools_array:
                 body["tools"] = tools_array
 
@@ -2925,7 +2942,7 @@ class ExternalProviderClient:
                         {"type": "shell", "environment": env_attempt}
                     )
                 if image_generation_enabled_openai:
-                    tools_array_attempt.append({"type": "image_generation"})
+                    tools_array_attempt.append(_openai_image_generation_tool())
                 if tools_array_attempt:
                     attempt_body["tools"] = tools_array_attempt
                 else:
@@ -2955,13 +2972,13 @@ class ExternalProviderClient:
                 async with _http_client.stream(
                     "POST",
                     url,
-                    json = attempt_body,
-                    headers = self._auth_headers(),
-                    timeout = self._stream_timeout,
+                    json=attempt_body,
+                    headers=self._auth_headers(),
+                    timeout=self._stream_timeout,
                 ) as response:
                     if response.status_code != 200:
                         error_body = await response.aread()
-                        error_text = error_body.decode("utf-8", errors = "replace")
+                        error_text = error_body.decode("utf-8", errors="replace")
                         logger.error(
                             "OpenAI Responses returned %d: %s",
                             response.status_code,
@@ -3042,6 +3059,7 @@ class ExternalProviderClient:
                     current_openai_response_id: Optional[str] = None
                     last_openai_reasoning_replay_item: Optional[dict[str, Any]] = None
                     openai_reasoning_replay_items: dict[str, dict[str, Any]] = {}
+                    image_generation_calls_started: set[str] = set()
 
                     def _record_openai_response_id(payload: dict[str, Any]) -> None:
                         nonlocal current_openai_response_id
@@ -3277,11 +3295,6 @@ class ExternalProviderClient:
                                     _record_url_citation(ann)
 
                             elif event_type == "response.output_item.added":
-                                # Track the call early but do NOT emit tool_start
-                                # yet — action.query is not reliably populated on
-                                # added across OpenAI API versions, and the
-                                # frontend's tool_start is a one-shot push (no
-                                # update mechanism). Wait for output_item.done.
                                 item = event.get("item", {})
                                 if (
                                     isinstance(item, dict)
@@ -3322,6 +3335,36 @@ class ExternalProviderClient:
                                             and latched_container_id is None
                                         ):
                                             latched_container_id = probe
+                                if (
+                                    isinstance(item, dict)
+                                    and item.get("type") == "image_generation_call"
+                                ):
+                                    raw_item_id = item.get("id")
+                                    if isinstance(raw_item_id, str) and raw_item_id:
+                                        arguments: dict[str, Any] = {
+                                            "kind": "image",
+                                            "prompt": "",
+                                            "openai_image_generation_call_id": (
+                                                raw_item_id
+                                            ),
+                                        }
+                                        if current_openai_response_id:
+                                            arguments["openai_response_id"] = (
+                                                current_openai_response_id
+                                            )
+                                        if last_openai_reasoning_replay_item:
+                                            arguments["openai_reasoning_item"] = (
+                                                last_openai_reasoning_replay_item
+                                            )
+                                        image_generation_calls_started.add(raw_item_id)
+                                        yield _emit_tool_event(
+                                            {
+                                                "type": "tool_start",
+                                                "tool_name": "image_generation",
+                                                "tool_call_id": raw_item_id,
+                                                "arguments": arguments,
+                                            }
+                                        )
 
                             elif event_type == "response.output_item.done":
                                 item = event.get("item", {})
@@ -3469,30 +3512,31 @@ class ExternalProviderClient:
                                         or item.get("prompt")
                                         or ""
                                     )
-                                    arguments = {
+                                    done_arguments: dict[str, Any] = {
                                         "kind": "image",
                                         "prompt": prompt_in,
                                     }
                                     if isinstance(raw_item_id, str) and raw_item_id:
-                                        arguments["openai_image_generation_call_id"] = (
-                                            raw_item_id
-                                        )
+                                        done_arguments[
+                                            "openai_image_generation_call_id"
+                                        ] = raw_item_id
                                     if current_openai_response_id:
-                                        arguments["openai_response_id"] = (
+                                        done_arguments["openai_response_id"] = (
                                             current_openai_response_id
                                         )
                                     if last_openai_reasoning_replay_item:
-                                        arguments["openai_reasoning_item"] = (
+                                        done_arguments["openai_reasoning_item"] = (
                                             last_openai_reasoning_replay_item
                                         )
-                                    yield _emit_tool_event(
-                                        {
-                                            "type": "tool_start",
-                                            "tool_name": "image_generation",
-                                            "tool_call_id": item_id,
-                                            "arguments": arguments,
-                                        }
-                                    )
+                                    if item_id not in image_generation_calls_started:
+                                        yield _emit_tool_event(
+                                            {
+                                                "type": "tool_start",
+                                                "tool_name": "image_generation",
+                                                "tool_call_id": item_id,
+                                                "arguments": done_arguments,
+                                            }
+                                        )
                                     b64 = (
                                         item.get("result") or item.get("b64_json") or ""
                                     )
@@ -3502,11 +3546,13 @@ class ExternalProviderClient:
                                             "type": "tool_end",
                                             "tool_call_id": item_id,
                                             "result": "",
+                                            "arguments": done_arguments,
                                             "image_b64": b64,
                                             "image_mime": (f"image/{output_format}"),
                                             "size": item.get("size"),
                                             "quality": item.get("quality"),
                                             "background": item.get("background"),
+                                            "prompt": prompt_in,
                                         }
                                     )
 
@@ -3585,8 +3631,7 @@ class ExternalProviderClient:
                                     blocks: list[str] = []
                                     for cit in all_url_citations:
                                         line = (
-                                            f"Title: {cit['title']}\n"
-                                            f"URL: {cit['url']}"
+                                            f"Title: {cit['title']}\nURL: {cit['url']}"
                                         )
                                         if cit.get("snippet"):
                                             line += f"\nSnippet: {cit['snippet']}"
@@ -3641,8 +3686,7 @@ class ExternalProviderClient:
                                     blocks = []
                                     for cit in all_url_citations:
                                         line = (
-                                            f"Title: {cit['title']}\n"
-                                            f"URL: {cit['url']}"
+                                            f"Title: {cit['title']}\nURL: {cit['url']}"
                                         )
                                         if cit.get("snippet"):
                                             line += f"\nSnippet: {cit['snippet']}"
@@ -3813,9 +3857,9 @@ class ExternalProviderClient:
 
         response = await _http_client.post(
             f"{self.base_url}/chat/completions",
-            json = body,
-            headers = self._auth_headers(),
-            timeout = self._timeout,
+            json=body,
+            headers=self._auth_headers(),
+            timeout=self._timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -3834,8 +3878,8 @@ class ExternalProviderClient:
         try:
             response = await _http_client.get(
                 f"{self.base_url}/models",
-                headers = self._auth_headers(),
-                timeout = self._timeout,
+                headers=self._auth_headers(),
+                timeout=self._timeout,
             )
             response.raise_for_status()
             data = response.json()
@@ -3858,8 +3902,8 @@ class ExternalProviderClient:
         root = self.base_url.removesuffix("/v1").rstrip("/")
         response = await _http_client.get(
             f"{root}/api/tags",
-            headers = self._auth_headers(),
-            timeout = self._timeout,
+            headers=self._auth_headers(),
+            timeout=self._timeout,
         )
         response.raise_for_status()
         payload = response.json()
@@ -3886,12 +3930,12 @@ class ExternalProviderClient:
             async with _http_client.stream(
                 "GET",
                 url,
-                headers = self._auth_headers(),
-                timeout = self._timeout,
+                headers=self._auth_headers(),
+                timeout=self._timeout,
             ) as response:
                 if response.status_code != 200:
                     response.raise_for_status()
-                async for _chunk in response.aiter_bytes(chunk_size = 2048):
+                async for _chunk in response.aiter_bytes(chunk_size=2048):
                     break
         except httpx.HTTPError as exc:
             logger.error(
@@ -3928,8 +3972,8 @@ class ExternalProviderClient:
         """
         response = await _http_client.get(
             f"{self.base_url}/containers",
-            headers = self._container_headers(),
-            timeout = self._timeout,
+            headers=self._container_headers(),
+            timeout=self._timeout,
         )
         response.raise_for_status()
         data = response.json()
@@ -3965,9 +4009,9 @@ class ExternalProviderClient:
         }
         response = await _http_client.post(
             f"{self.base_url}/containers",
-            json = body,
-            headers = self._container_headers(),
-            timeout = self._timeout,
+            json=body,
+            headers=self._container_headers(),
+            timeout=self._timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -3995,8 +4039,8 @@ class ExternalProviderClient:
             "Authorization" in headers,
             headers.get("OpenAI-Beta"),
         )
-        async with httpx.AsyncClient(timeout = self._timeout) as fresh_client:
-            response = await fresh_client.delete(url, headers = headers)
+        async with httpx.AsyncClient(timeout=self._timeout) as fresh_client:
+            response = await fresh_client.delete(url, headers=headers)
         logger.info(
             "openai_container_delete.response status=%s cf_ray=%s "
             "request_id=%s organization=%s project=%s processing_ms=%s body=%s",

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2614,6 +2614,11 @@ class ExternalProviderClient:
         """
         import json as _json
 
+        is_openai_cloud = _is_openai_family_cloud(self.base_url)
+        image_generation_requested = bool(
+            enabled_tools and "image_generation" in enabled_tools and is_openai_cloud
+        )
+
         # Split system messages out into a single `instructions` string and
         # translate user/assistant messages into the Responses input shape.
         instructions_parts: list[str] = []
@@ -2655,11 +2660,19 @@ class ExternalProviderClient:
                             translated_parts.append(
                                 {"type": "input_image", "image_url": url}
                             )
-                    elif part_type == "reasoning":
+                    elif (
+                        part_type == "reasoning"
+                        and role == "assistant"
+                        and image_generation_requested
+                    ):
                         replay_item = _sanitize_openai_reasoning_replay_item(part)
                         if replay_item:
                             openai_replay_items.append(replay_item)
-                    elif part_type == "image_generation_call":
+                    elif (
+                        part_type == "image_generation_call"
+                        and role == "assistant"
+                        and image_generation_requested
+                    ):
                         response_id = (
                             part.get("response_id")
                             or part.get("openai_response_id")
@@ -2731,17 +2744,27 @@ class ExternalProviderClient:
         ):
             filtered_replay_items: list[dict[str, Any]] = []
             has_reasoning_replay = False
+            dropped_image_replay_without_reasoning = False
             for item in openai_replay_items:
                 if item.get("type") == "reasoning":
                     has_reasoning_replay = True
                     filtered_replay_items.append(item)
-                elif (
-                    item.get("type") == "image_generation_call" and has_reasoning_replay
-                ):
-                    filtered_replay_items.append(item)
+                elif item.get("type") == "image_generation_call":
+                    if has_reasoning_replay:
+                        filtered_replay_items.append(item)
+                    else:
+                        dropped_image_replay_without_reasoning = True
                 else:
                     filtered_replay_items.append(item)
             openai_replay_items = filtered_replay_items
+            if dropped_image_replay_without_reasoning:
+                yield _error_sse_line(
+                    400,
+                    "OpenAI image edit reference is missing paired reasoning state. "
+                    "Regenerate the image, then retry the edit.",
+                    self.provider_type,
+                )
+                return
         image_generation_has_reference = bool(
             previous_response_id
             or any(
@@ -2749,7 +2772,13 @@ class ExternalProviderClient:
                 for item in openai_replay_items
             )
         )
-        input_items.extend(openai_replay_items)
+        if openai_replay_items:
+            insert_at = len(input_items)
+            for index in range(len(input_items) - 1, -1, -1):
+                if input_items[index].get("role") == "user":
+                    insert_at = index
+                    break
+            input_items[insert_at:insert_at] = openai_replay_items
 
         # NOTE: gpt-5.x / o3 / gpt-4.5 are reasoning-class models. They reject
         # temperature and top_p with `Unsupported parameter` 400s on
@@ -2824,7 +2853,6 @@ class ExternalProviderClient:
         # (ollama / llama.cpp / vLLM / "custom" preset) hit /v1/responses
         # without these extensions and would 400 on the unknown body
         # fields, so they intentionally fall outside this gate.
-        is_openai_cloud = _is_openai_family_cloud(self.base_url)
         if is_openai_cloud and enable_prompt_caching is not False:
             body["prompt_cache_retention"] = "24h"
 
@@ -2870,9 +2898,7 @@ class ExternalProviderClient:
         # plus gpt-4.1 / gpt-4o / o3 per the docs; restrict to cloud
         # OpenAI because the local llama.cpp / ollama backends don't
         # implement it and would 400.
-        image_generation_enabled_openai = bool(
-            enabled_tools and "image_generation" in enabled_tools and is_openai_cloud
-        )
+        image_generation_enabled_openai = image_generation_requested
 
         def _openai_image_generation_tool() -> dict[str, Any]:
             tool: dict[str, Any] = {"type": "image_generation"}

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -483,9 +483,7 @@ class ImageGenerationCallContentPart(BaseModel):
     """
 
     type: Literal["image_generation_call"]
-    id: str = Field(
-        ..., description = "OpenAI image_generation_call output item id."
-    )
+    id: str = Field(..., description = "OpenAI image_generation_call output item id.")
 
 
 class CompactionContentPart(BaseModel):

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -471,6 +471,21 @@ class InputDocumentContentPart(BaseModel):
     )
 
 
+class OpenAIReasoningContentPart(BaseModel):
+    """OpenAI Responses reasoning item paired with a tool output.
+
+    Reasoning models can require the previous ``reasoning`` output item
+    to be replayed immediately before an ``image_generation_call`` id
+    when manually managing Responses context. This part is OpenAI-only;
+    routes strip it for every other provider before proxying.
+    """
+
+    type: Literal["reasoning"]
+    id: str = Field(..., description = "OpenAI reasoning output item id.")
+    summary: list[dict[str, Any]] = Field(default_factory = list)
+    status: Optional[Literal["in_progress", "completed", "incomplete"]] = None
+
+
 class ImageGenerationCallContentPart(BaseModel):
     """OpenAI Responses image_generation call reference.
 
@@ -519,6 +534,7 @@ ContentPart = Annotated[
         Annotated[TextContentPart, Tag("text")],
         Annotated[ImageContentPart, Tag("image_url")],
         Annotated[InputDocumentContentPart, Tag("input_document")],
+        Annotated[OpenAIReasoningContentPart, Tag("reasoning")],
         Annotated[ImageGenerationCallContentPart, Tag("image_generation_call")],
         Annotated[CompactionContentPart, Tag("compaction")],
     ],

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -471,6 +471,23 @@ class InputDocumentContentPart(BaseModel):
     )
 
 
+class ImageGenerationCallContentPart(BaseModel):
+    """OpenAI Responses image_generation call reference.
+
+    OpenAI accepts prior ``image_generation_call`` items in the next
+    Responses ``input`` array so follow-up prompts can edit or refine a
+    generated image without resending the base64 payload. The frontend
+    forwards this as a synthetic assistant content part when building
+    the next OpenAI Responses request; ``external_provider`` translates
+    it back to the provider-specific top-level input item.
+    """
+
+    type: Literal["image_generation_call"]
+    id: str = Field(
+        ..., description = "OpenAI image_generation_call output item id."
+    )
+
+
 class CompactionContentPart(BaseModel):
     """Anthropic server-side compaction state, attached to an assistant
     message for round-tripping on the next turn.
@@ -504,6 +521,7 @@ ContentPart = Annotated[
         Annotated[TextContentPart, Tag("text")],
         Annotated[ImageContentPart, Tag("image_url")],
         Annotated[InputDocumentContentPart, Tag("input_document")],
+        Annotated[ImageGenerationCallContentPart, Tag("image_generation_call")],
         Annotated[CompactionContentPart, Tag("compaction")],
     ],
     Discriminator(_content_part_discriminator),

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -499,6 +499,10 @@ class ImageGenerationCallContentPart(BaseModel):
 
     type: Literal["image_generation_call"]
     id: str = Field(..., description = "OpenAI image_generation_call output item id.")
+    response_id: Optional[str] = Field(
+        None,
+        description = "OpenAI Responses response id to use as previous_response_id for follow-up edits.",
+    )
 
 
 class CompactionContentPart(BaseModel):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1736,7 +1736,9 @@ def _build_external_messages(
                                 "image_url": {"url": part.image_url.url},
                             }
                         )
-                    elif part.type == "reasoning" and openai and msg.role == "assistant":
+                    elif (
+                        part.type == "reasoning" and openai and msg.role == "assistant"
+                    ):
                         reasoning: dict[str, Any] = {
                             "type": "reasoning",
                             "id": part.id,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1701,6 +1701,9 @@ def _build_external_messages(
       see ``_INPUT_DOCUMENT_PROVIDERS``). For every other provider the
       part is stripped so the unknown content type doesn't reach generic
       /chat/completions passthrough and 400 the request.
+    - `image_generation_call`: OpenAI-only Responses image reference.
+      Forwarded ONLY when provider_type=="openai" so follow-up image
+      edits can reference prior generated images.
     - `compaction`: Anthropic-only synthetic part (round-trips server-side
       compaction state). Forwarded ONLY when provider_type=="anthropic";
       stripped for every other provider so the unknown part doesn't
@@ -1709,6 +1712,7 @@ def _build_external_messages(
     """
     document_provider = provider_type in _INPUT_DOCUMENT_PROVIDERS
     anthropic = provider_type == "anthropic"
+    openai = provider_type == "openai"
     result = []
     for msg in messages:
         if isinstance(msg.content, str):
@@ -1729,6 +1733,10 @@ def _build_external_messages(
                                 "image_url": {"url": part.image_url.url},
                             }
                         )
+                    elif part.type == "image_generation_call" and openai:
+                        # ExternalProviderClient maps this onto a top-level
+                        # Responses input item after the current user prompt.
+                        parts.append({"type": "image_generation_call", "id": part.id})
                     elif part.type == "input_document" and document_provider:
                         # ExternalProviderClient maps this onto
                         # Anthropic's `document` or OpenAI Responses'
@@ -1761,6 +1769,8 @@ def _build_external_messages(
                 for p in msg.content:
                     if p.type == "text":
                         preserved.append({"type": "text", "text": p.text})
+                    elif p.type == "image_generation_call" and openai:
+                        preserved.append({"type": "image_generation_call", "id": p.id})
                     elif p.type == "compaction" and anthropic:
                         preserved.append({"type": "compaction", "content": p.content})
                 if len(preserved) == 1 and preserved[0]["type"] == "text":

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1701,6 +1701,9 @@ def _build_external_messages(
       see ``_INPUT_DOCUMENT_PROVIDERS``). For every other provider the
       part is stripped so the unknown content type doesn't reach generic
       /chat/completions passthrough and 400 the request.
+    - `reasoning`: OpenAI-only Responses reasoning item paired with a
+      prior tool output. Forwarded ONLY when provider_type=="openai"
+      so follow-up image edits can replay the required reasoning item.
     - `image_generation_call`: OpenAI-only Responses image reference.
       Forwarded ONLY when provider_type=="openai" so follow-up image
       edits can reference prior generated images.
@@ -1733,6 +1736,15 @@ def _build_external_messages(
                                 "image_url": {"url": part.image_url.url},
                             }
                         )
+                    elif part.type == "reasoning" and openai:
+                        reasoning: dict[str, Any] = {
+                            "type": "reasoning",
+                            "id": part.id,
+                            "summary": part.summary,
+                        }
+                        if part.status:
+                            reasoning["status"] = part.status
+                        parts.append(reasoning)
                     elif part.type == "image_generation_call" and openai:
                         # ExternalProviderClient maps this onto a top-level
                         # Responses input item after the current user prompt.
@@ -1769,6 +1781,15 @@ def _build_external_messages(
                 for p in msg.content:
                     if p.type == "text":
                         preserved.append({"type": "text", "text": p.text})
+                    elif p.type == "reasoning" and openai:
+                        reasoning: dict[str, Any] = {
+                            "type": "reasoning",
+                            "id": p.id,
+                            "summary": p.summary,
+                        }
+                        if p.status:
+                            reasoning["status"] = p.status
+                        preserved.append(reasoning)
                     elif p.type == "image_generation_call" and openai:
                         preserved.append({"type": "image_generation_call", "id": p.id})
                     elif p.type == "compaction" and anthropic:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1736,7 +1736,7 @@ def _build_external_messages(
                                 "image_url": {"url": part.image_url.url},
                             }
                         )
-                    elif part.type == "reasoning" and openai:
+                    elif part.type == "reasoning" and openai and msg.role == "assistant":
                         reasoning: dict[str, Any] = {
                             "type": "reasoning",
                             "id": part.id,
@@ -1745,7 +1745,11 @@ def _build_external_messages(
                         if part.status:
                             reasoning["status"] = part.status
                         parts.append(reasoning)
-                    elif part.type == "image_generation_call" and openai:
+                    elif (
+                        part.type == "image_generation_call"
+                        and openai
+                        and msg.role == "assistant"
+                    ):
                         # ExternalProviderClient maps this onto a top-level
                         # Responses input item after the current user prompt,
                         # or onto `previous_response_id` when response_id is
@@ -1788,7 +1792,7 @@ def _build_external_messages(
                 for p in msg.content:
                     if p.type == "text":
                         preserved.append({"type": "text", "text": p.text})
-                    elif p.type == "reasoning" and openai:
+                    elif p.type == "reasoning" and openai and msg.role == "assistant":
                         reasoning: dict[str, Any] = {
                             "type": "reasoning",
                             "id": p.id,
@@ -1797,7 +1801,11 @@ def _build_external_messages(
                         if p.status:
                             reasoning["status"] = p.status
                         preserved.append(reasoning)
-                    elif p.type == "image_generation_call" and openai:
+                    elif (
+                        p.type == "image_generation_call"
+                        and openai
+                        and msg.role == "assistant"
+                    ):
                         image_ref = {"type": "image_generation_call", "id": p.id}
                         if getattr(p, "response_id", None):
                             image_ref["response_id"] = p.response_id

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1775,6 +1775,8 @@ def _build_external_messages(
                         # provider would 400 on the unknown part, so
                         # gate by provider_type.
                         parts.append({"type": "compaction", "content": part.content})
+                if msg.role == "assistant" and not parts:
+                    continue
                 result.append({"role": msg.role, "content": parts})
             else:
                 # Non-vision provider: strip images / documents, keep
@@ -1802,6 +1804,8 @@ def _build_external_messages(
                         preserved.append(image_ref)
                     elif p.type == "compaction" and anthropic:
                         preserved.append({"type": "compaction", "content": p.content})
+                if msg.role == "assistant" and not preserved:
+                    continue
                 if len(preserved) == 1 and preserved[0]["type"] == "text":
                     # Single text part collapses back to a string for
                     # providers that don't accept content arrays.

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1747,8 +1747,13 @@ def _build_external_messages(
                         parts.append(reasoning)
                     elif part.type == "image_generation_call" and openai:
                         # ExternalProviderClient maps this onto a top-level
-                        # Responses input item after the current user prompt.
-                        parts.append({"type": "image_generation_call", "id": part.id})
+                        # Responses input item after the current user prompt,
+                        # or onto `previous_response_id` when response_id is
+                        # available from the prior Responses turn.
+                        image_ref = {"type": "image_generation_call", "id": part.id}
+                        if getattr(part, "response_id", None):
+                            image_ref["response_id"] = part.response_id
+                        parts.append(image_ref)
                     elif part.type == "input_document" and document_provider:
                         # ExternalProviderClient maps this onto
                         # Anthropic's `document` or OpenAI Responses'
@@ -1791,7 +1796,10 @@ def _build_external_messages(
                             reasoning["status"] = p.status
                         preserved.append(reasoning)
                     elif p.type == "image_generation_call" and openai:
-                        preserved.append({"type": "image_generation_call", "id": p.id})
+                        image_ref = {"type": "image_generation_call", "id": p.id}
+                        if getattr(p, "response_id", None):
+                            image_ref["response_id"] = p.response_id
+                        preserved.append(image_ref)
                     elif p.type == "compaction" and anthropic:
                         preserved.append({"type": "compaction", "content": p.content})
                 if len(preserved) == 1 and preserved[0]["type"] == "text":

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -90,6 +90,9 @@ def _collect_tool_events(monkeypatch) -> list[dict]:
     event and return the parsed _toolEvent chunks."""
 
     sse = (
+        b"event: response.created\n"
+        b'data: {"type":"response.created",'
+        b'"response":{"id":"resp_abc","status":"in_progress"}}\n\n'
         b"event: response.reasoning_summary_text.done\n"
         b'data: {"type":"response.reasoning_summary_text.done",'
         b'"item_id":"rs_abc",'
@@ -208,7 +211,35 @@ def test_omitted_image_generation_pill_no_tool(monkeypatch):
     assert all(t.get("type") != "image_generation" for t in tools)
 
 
-# ── follow-up edits forward previous image_generation_call refs ──────
+# ── follow-up edits forward previous OpenAI image context ────────────
+
+
+def test_previous_response_id_forwarded_for_followup_edit(monkeypatch):
+    captured = _capture_body(
+        monkeypatch,
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["image_generation"],
+        messages = [
+            {"role": "user", "content": "generate a cat"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "image_generation_call",
+                        "id": "img_abc",
+                        "response_id": "resp_abc",
+                    },
+                ],
+            },
+            {"role": "user", "content": "make the cat's eyes blue"},
+        ],
+    )
+    assert captured["body"].get("previous_response_id") == "resp_abc"
+    input_items = captured["body"].get("input") or []
+    assert input_items == [
+        {"role": "user", "content": "make the cat's eyes blue"},
+    ]
+    assert {"type": "image_generation_call", "id": "img_abc"} not in input_items
 
 
 def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
@@ -277,7 +308,11 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
                     summary = [{"type": "summary_text", "text": "Need to edit."}],
                     status = "completed",
                 ),
-                SimpleNamespace(type = "image_generation_call", id = "img_abc"),
+                SimpleNamespace(
+                    type = "image_generation_call",
+                    id = "img_abc",
+                    response_id = "resp_abc",
+                ),
             ],
         ),
         SimpleNamespace(role = "user", content = "make it more realistic"),
@@ -297,7 +332,11 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
                     "summary": [{"type": "summary_text", "text": "Need to edit."}],
                     "status": "completed",
                 },
-                {"type": "image_generation_call", "id": "img_abc"},
+                {
+                    "type": "image_generation_call",
+                    "id": "img_abc",
+                    "response_id": "resp_abc",
+                },
             ],
         },
         {"role": "user", "content": "make it more realistic"},
@@ -332,6 +371,7 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
         "kind": "image",
         "prompt": "A photorealistic cat sitting",
         "openai_image_generation_call_id": "img_abc",
+        "openai_response_id": "resp_abc",
         "openai_reasoning_item": {
             "type": "reasoning",
             "id": "rs_abc",

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -19,26 +19,18 @@ non-cloud bases drop the tool silently.
 
 import asyncio
 import json
-from types import SimpleNamespace
 
 import httpx
 
 from core.inference import external_provider as ep_mod
 from core.inference.external_provider import ExternalProviderClient
-from models.inference import ChatCompletionRequest
 
 
 def _drive(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def _capture_body(
-    monkeypatch,
-    *,
-    base_url: str,
-    enabled_tools,
-    messages: list[dict] | None = None,
-) -> dict:
+def _capture_body(monkeypatch, *, base_url: str, enabled_tools) -> dict:
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -67,11 +59,7 @@ def _capture_body(
             api_key = "sk-test",
         )
         async for _ in client.stream_chat_completion(
-            messages = (
-                messages
-                if messages is not None
-                else [{"role": "user", "content": "draw a cat"}]
-            ),
+            messages = [{"role": "user", "content": "draw a cat"}],
             model = "gpt-5.5",
             temperature = 0.7,
             top_p = 0.95,
@@ -86,37 +74,12 @@ def _capture_body(
     return captured
 
 
-def _image_generation_events(events: list[dict]) -> list[dict]:
-    return [
-        event
-        for event in events
-        if event.get("tool_name") == "image_generation"
-        or (event.get("type") == "tool_end" and event.get("image_b64"))
-    ]
-
-
-def _collect_tool_events(monkeypatch, *, include_added: bool = False) -> list[dict]:
+def _collect_tool_events(monkeypatch) -> list[dict]:
     """Drive a Responses stream that emits one image_generation_call done
     event and return the parsed _toolEvent chunks."""
 
-    added_event = (
-        b"event: response.output_item.added\n"
-        b'data: {"type":"response.output_item.added",'
-        b'"item":{"type":"image_generation_call","id":"img_abc"}}\n\n'
-        if include_added
-        else b""
-    )
     sse = (
-        b"event: response.created\n"
-        b'data: {"type":"response.created",'
-        b'"response":{"id":"resp_abc","status":"in_progress"}}\n\n'
-        b"event: response.reasoning_summary_text.done\n"
-        b'data: {"type":"response.reasoning_summary_text.done",'
-        b'"item_id":"rs_abc",'
-        b'"summary_index":0,'
-        b'"text":"Need to draw a cat."}\n\n'
-        + added_event
-        + b"event: response.output_item.done\n"
+        b"event: response.output_item.done\n"
         b'data: {"type":"response.output_item.done",'
         b'"item":{"type":"image_generation_call",'
         b'"id":"img_abc",'
@@ -229,194 +192,17 @@ def test_omitted_image_generation_pill_no_tool(monkeypatch):
     assert all(t.get("type") != "image_generation" for t in tools)
 
 
-# ── follow-up edits forward previous OpenAI image context ────────────
-
-
-def test_previous_response_id_forwarded_for_followup_edit(monkeypatch):
-    captured = _capture_body(
-        monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["image_generation"],
-        messages = [
-            {"role": "user", "content": "generate a cat"},
-            {
-                "role": "assistant",
-                "content": [
-                    {
-                        "type": "image_generation_call",
-                        "id": "img_abc",
-                        "response_id": "resp_abc",
-                    },
-                ],
-            },
-            {"role": "user", "content": "make the cat's eyes blue"},
-        ],
-    )
-    assert captured["body"].get("previous_response_id") == "resp_abc"
-    assert {"type": "image_generation", "action": "edit"} in captured["body"].get(
-        "tools", []
-    )
-    input_items = captured["body"].get("input") or []
-    assert input_items == [
-        {"role": "user", "content": "make the cat's eyes blue"},
-    ]
-    assert {"type": "image_generation_call", "id": "img_abc"} not in input_items
-
-
-def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
-    captured = _capture_body(
-        monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["image_generation"],
-        messages = [
-            {
-                "role": "assistant",
-                "content": [
-                    {
-                        "type": "reasoning",
-                        "id": "rs_abc",
-                        "summary": [
-                            {"type": "summary_text", "text": "Need to edit."},
-                        ],
-                    },
-                    {"type": "image_generation_call", "id": "img_abc"},
-                ],
-            },
-            {"role": "user", "content": "make it more realistic"},
-        ],
-    )
-    assert {"type": "image_generation", "action": "edit"} in captured["body"].get(
-        "tools", []
-    )
-    input_items = captured["body"].get("input") or []
-    assert input_items[-3:] == [
-        {"role": "user", "content": "make it more realistic"},
-        {
-            "type": "reasoning",
-            "id": "rs_abc",
-            "summary": [{"type": "summary_text", "text": "Need to edit."}],
-        },
-        {"type": "image_generation_call", "id": "img_abc"},
-    ]
-
-
-def test_orphan_image_generation_ref_dropped_for_reasoning_models(monkeypatch):
-    captured = _capture_body(
-        monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["image_generation"],
-        messages = [
-            {
-                "role": "assistant",
-                "content": [
-                    {"type": "image_generation_call", "id": "img_legacy"},
-                ],
-            },
-            {"role": "user", "content": "do you have the original image?"},
-        ],
-    )
-    input_items = captured["body"].get("input") or []
-    assert {"type": "image_generation_call", "id": "img_legacy"} not in input_items
-
-
-def test_chat_completion_request_accepts_openai_image_generation_refs():
-    request = ChatCompletionRequest.model_validate(
-        {
-            "model": "gpt-5.5",
-            "messages": [
-                {
-                    "role": "assistant",
-                    "content": [
-                        {
-                            "type": "reasoning",
-                            "id": "rs_abc",
-                            "summary": [
-                                {"type": "summary_text", "text": "Need to edit."},
-                            ],
-                            "status": "completed",
-                        },
-                        {
-                            "type": "image_generation_call",
-                            "id": "img_abc",
-                            "response_id": "resp_abc",
-                        },
-                    ],
-                },
-                {"role": "user", "content": "make it more realistic"},
-            ],
-            "stream": True,
-        }
-    )
-
-    assert request.messages[0].role == "assistant"
-    content = request.messages[0].content
-    assert isinstance(content, list)
-    assert content[0].type == "reasoning"
-    assert content[1].type == "image_generation_call"
-
-
-def test_external_message_builder_preserves_openai_image_generation_refs():
-    from routes.inference import _build_external_messages
-
-    messages = [
-        SimpleNamespace(
-            role = "assistant",
-            content = [
-                SimpleNamespace(
-                    type = "reasoning",
-                    id = "rs_abc",
-                    summary = [{"type": "summary_text", "text": "Need to edit."}],
-                    status = "completed",
-                ),
-                SimpleNamespace(
-                    type = "image_generation_call",
-                    id = "img_abc",
-                    response_id = "resp_abc",
-                ),
-            ],
-        ),
-        SimpleNamespace(role = "user", content = "make it more realistic"),
-    ]
-
-    assert _build_external_messages(
-        messages,
-        supports_vision = True,
-        provider_type = "openai",
-    ) == [
-        {
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "reasoning",
-                    "id": "rs_abc",
-                    "summary": [{"type": "summary_text", "text": "Need to edit."}],
-                    "status": "completed",
-                },
-                {
-                    "type": "image_generation_call",
-                    "id": "img_abc",
-                    "response_id": "resp_abc",
-                },
-            ],
-        },
-        {"role": "user", "content": "make it more realistic"},
-    ]
-
-    assert _build_external_messages(
-        messages,
-        supports_vision = True,
-        provider_type = "anthropic",
-    ) == [
-        {"role": "user", "content": "make it more realistic"},
-    ]
-
-
 # ── output translation surfaces tool_start + tool_end ────────────────
 
 
 def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
     events = _collect_tool_events(monkeypatch)
-    image_events = _image_generation_events(events)
+    image_events = [
+        e
+        for e in events
+        if e.get("tool_name") == "image_generation"
+        or (e.get("type") == "tool_end" and e.get("image_b64"))
+    ]
     starts = [e for e in image_events if e.get("type") == "tool_start"]
     ends = [e for e in image_events if e.get("type") == "tool_end"]
     assert len(starts) == 1, image_events
@@ -424,46 +210,9 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
     assert starts[0]["arguments"] == {
         "kind": "image",
         "prompt": "A photorealistic cat sitting",
-        "openai_image_generation_call_id": "img_abc",
-        "openai_response_id": "resp_abc",
-        "openai_reasoning_item": {
-            "type": "reasoning",
-            "id": "rs_abc",
-            "summary": [
-                {"type": "summary_text", "text": "Need to draw a cat."},
-            ],
-            "status": "completed",
-        },
     }
-    assert ends[0]["arguments"] == starts[0]["arguments"]
     assert ends[0]["image_b64"] == "AAAA"
     assert ends[0]["image_mime"] == "image/png"
     assert ends[0]["size"] == "1024x1024"
     assert ends[0]["quality"] == "high"
     assert ends[0]["background"] == "opaque"
-
-
-def test_image_generation_added_emits_early_placeholder_start(monkeypatch):
-    events = _collect_tool_events(monkeypatch, include_added = True)
-    image_events = _image_generation_events(events)
-    starts = [e for e in image_events if e.get("type") == "tool_start"]
-    ends = [e for e in image_events if e.get("type") == "tool_end"]
-    assert len(starts) == 1, image_events
-    assert len(ends) == 1, image_events
-    assert starts[0]["arguments"] == {
-        "kind": "image",
-        "prompt": "",
-        "openai_image_generation_call_id": "img_abc",
-        "openai_response_id": "resp_abc",
-        "openai_reasoning_item": {
-            "type": "reasoning",
-            "id": "rs_abc",
-            "summary": [
-                {"type": "summary_text", "text": "Need to draw a cat."},
-            ],
-            "status": "completed",
-        },
-    }
-    assert ends[0]["arguments"]["prompt"] == "A photorealistic cat sitting"
-    assert ends[0]["arguments"]["openai_image_generation_call_id"] == "img_abc"
-    assert ends[0]["arguments"]["openai_response_id"] == "resp_abc"

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -30,7 +30,13 @@ def _drive(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def _capture_body(monkeypatch, *, base_url: str, enabled_tools) -> dict:
+def _capture_body(
+    monkeypatch,
+    *,
+    base_url: str,
+    enabled_tools,
+    messages: list[dict] | None = None,
+) -> dict:
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -59,7 +65,11 @@ def _capture_body(monkeypatch, *, base_url: str, enabled_tools) -> dict:
             api_key = "sk-test",
         )
         async for _ in client.stream_chat_completion(
-            messages = [{"role": "user", "content": "draw a cat"}],
+            messages = (
+                messages
+                if messages is not None
+                else [{"role": "user", "content": "draw a cat"}]
+            ),
             model = "gpt-5.5",
             temperature = 0.7,
             top_p = 0.95,
@@ -192,6 +202,29 @@ def test_omitted_image_generation_pill_no_tool(monkeypatch):
     assert all(t.get("type") != "image_generation" for t in tools)
 
 
+# ── follow-up edits forward previous image_generation_call refs ──────
+
+
+def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
+    captured = _capture_body(
+        monkeypatch,
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["image_generation"],
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "image_generation_call", "id": "img_abc"},
+                ],
+            },
+            {"role": "user", "content": "make it more realistic"},
+        ],
+    )
+    input_items = captured["body"].get("input") or []
+    assert {"type": "image_generation_call", "id": "img_abc"} in input_items
+    assert {"role": "user", "content": "make it more realistic"} in input_items
+
+
 # ── output translation surfaces tool_start + tool_end ────────────────
 
 
@@ -210,6 +243,7 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
     assert starts[0]["arguments"] == {
         "kind": "image",
         "prompt": "A photorealistic cat sitting",
+        "openai_image_generation_call_id": "img_abc",
     }
     assert ends[0]["image_b64"] == "AAAA"
     assert ends[0]["image_mime"] == "image/png"

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -92,6 +92,12 @@ def _collect_tool_events(monkeypatch) -> list[dict]:
     sse = (
         b"event: response.output_item.done\n"
         b'data: {"type":"response.output_item.done",'
+        b'"item":{"type":"reasoning",'
+        b'"id":"rs_abc",'
+        b'"summary":[{"type":"summary_text","text":"Need to draw a cat."}],'
+        b'"status":"completed"}}\n\n'
+        b"event: response.output_item.done\n"
+        b'data: {"type":"response.output_item.done",'
         b'"item":{"type":"image_generation_call",'
         b'"id":"img_abc",'
         b'"revised_prompt":"A photorealistic cat sitting",'
@@ -215,6 +221,13 @@ def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
             {
                 "role": "assistant",
                 "content": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_abc",
+                        "summary": [
+                            {"type": "summary_text", "text": "Need to edit."},
+                        ],
+                    },
                     {"type": "image_generation_call", "id": "img_abc"},
                 ],
             },
@@ -222,8 +235,13 @@ def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
         ],
     )
     input_items = captured["body"].get("input") or []
-    assert input_items[-2:] == [
+    assert input_items[-3:] == [
         {"role": "user", "content": "make it more realistic"},
+        {
+            "type": "reasoning",
+            "id": "rs_abc",
+            "summary": [{"type": "summary_text", "text": "Need to edit."}],
+        },
         {"type": "image_generation_call", "id": "img_abc"},
     ]
 
@@ -235,6 +253,12 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
         SimpleNamespace(
             role = "assistant",
             content = [
+                SimpleNamespace(
+                    type = "reasoning",
+                    id = "rs_abc",
+                    summary = [{"type": "summary_text", "text": "Need to edit."}],
+                    status = "completed",
+                ),
                 SimpleNamespace(type = "image_generation_call", id = "img_abc"),
             ],
         ),
@@ -248,8 +272,25 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
     ) == [
         {
             "role": "assistant",
-            "content": [{"type": "image_generation_call", "id": "img_abc"}],
+            "content": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_abc",
+                    "summary": [{"type": "summary_text", "text": "Need to edit."}],
+                    "status": "completed",
+                },
+                {"type": "image_generation_call", "id": "img_abc"},
+            ],
         },
+        {"role": "user", "content": "make it more realistic"},
+    ]
+
+    assert _build_external_messages(
+        messages,
+        supports_vision = True,
+        provider_type = "anthropic",
+    ) == [
+        {"role": "assistant", "content": []},
         {"role": "user", "content": "make it more realistic"},
     ]
 
@@ -273,6 +314,14 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
         "kind": "image",
         "prompt": "A photorealistic cat sitting",
         "openai_image_generation_call_id": "img_abc",
+        "openai_reasoning_item": {
+            "type": "reasoning",
+            "id": "rs_abc",
+            "summary": [
+                {"type": "summary_text", "text": "Need to draw a cat."},
+            ],
+            "status": "completed",
+        },
     }
     assert ends[0]["image_b64"] == "AAAA"
     assert ends[0]["image_mime"] == "image/png"

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -25,6 +25,7 @@ import httpx
 
 from core.inference import external_provider as ep_mod
 from core.inference.external_provider import ExternalProviderClient
+from models.inference import ChatCompletionRequest
 
 
 def _drive(coro):
@@ -44,39 +45,39 @@ def _capture_body(
         captured["body"] = json.loads(request.content.decode("utf-8"))
         return httpx.Response(
             200,
-            content = (
+            content=(
                 b"event: response.completed\n"
                 b'data: {"type":"response.completed",'
                 b'"response":{"output":[],"usage":{"input_tokens":0,'
                 b'"output_tokens":0}}}\n\n'
             ),
-            headers = {"content-type": "text/event-stream"},
+            headers={"content-type": "text/event-stream"},
         )
 
     monkeypatch.setattr(
         ep_mod,
         "_http_client",
-        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
     )
 
     async def run():
         client = ExternalProviderClient(
-            provider_type = "openai",
-            base_url = base_url,
-            api_key = "sk-test",
+            provider_type="openai",
+            base_url=base_url,
+            api_key="sk-test",
         )
         async for _ in client.stream_chat_completion(
-            messages = (
+            messages=(
                 messages
                 if messages is not None
                 else [{"role": "user", "content": "draw a cat"}]
             ),
-            model = "gpt-5.5",
-            temperature = 0.7,
-            top_p = 0.95,
-            max_tokens = 32,
-            reasoning_effort = "medium",
-            enabled_tools = enabled_tools,
+            model="gpt-5.5",
+            temperature=0.7,
+            top_p=0.95,
+            max_tokens=32,
+            reasoning_effort="medium",
+            enabled_tools=enabled_tools,
         ):
             pass
         await client.close()
@@ -85,10 +86,17 @@ def _capture_body(
     return captured
 
 
-def _collect_tool_events(monkeypatch) -> list[dict]:
+def _collect_tool_events(monkeypatch, *, include_added: bool = False) -> list[dict]:
     """Drive a Responses stream that emits one image_generation_call done
     event and return the parsed _toolEvent chunks."""
 
+    added_event = (
+        b"event: response.output_item.added\n"
+        b'data: {"type":"response.output_item.added",'
+        b'"item":{"type":"image_generation_call","id":"img_abc"}}\n\n'
+        if include_added
+        else b""
+    )
     sse = (
         b"event: response.created\n"
         b'data: {"type":"response.created",'
@@ -98,7 +106,8 @@ def _collect_tool_events(monkeypatch) -> list[dict]:
         b'"item_id":"rs_abc",'
         b'"summary_index":0,'
         b'"text":"Need to draw a cat."}\n\n'
-        b"event: response.output_item.done\n"
+        + added_event
+        + b"event: response.output_item.done\n"
         b'data: {"type":"response.output_item.done",'
         b'"item":{"type":"image_generation_call",'
         b'"id":"img_abc",'
@@ -117,32 +126,32 @@ def _collect_tool_events(monkeypatch) -> list[dict]:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
-            content = sse,
-            headers = {"content-type": "text/event-stream"},
+            content=sse,
+            headers={"content-type": "text/event-stream"},
         )
 
     monkeypatch.setattr(
         ep_mod,
         "_http_client",
-        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
     )
 
     events: list[dict] = []
 
     async def run():
         client = ExternalProviderClient(
-            provider_type = "openai",
-            base_url = "https://api.openai.com/v1",
-            api_key = "sk-test",
+            provider_type="openai",
+            base_url="https://api.openai.com/v1",
+            api_key="sk-test",
         )
         async for line in client.stream_chat_completion(
-            messages = [{"role": "user", "content": "draw a cat"}],
-            model = "gpt-5.5",
-            temperature = 0.7,
-            top_p = 0.95,
-            max_tokens = 32,
-            reasoning_effort = "medium",
-            enabled_tools = ["image_generation"],
+            messages=[{"role": "user", "content": "draw a cat"}],
+            model="gpt-5.5",
+            temperature=0.7,
+            top_p=0.95,
+            max_tokens=32,
+            reasoning_effort="medium",
+            enabled_tools=["image_generation"],
         ):
             if not line or not line.startswith("data:"):
                 continue
@@ -167,8 +176,8 @@ def _collect_tool_events(monkeypatch) -> list[dict]:
 def test_cloud_openai_appends_image_generation_tool(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["image_generation"],
+        base_url="https://api.openai.com/v1",
+        enabled_tools=["image_generation"],
     )
     tools = captured["body"].get("tools") or []
     assert {"type": "image_generation"} in tools, tools
@@ -177,8 +186,8 @@ def test_cloud_openai_appends_image_generation_tool(monkeypatch):
 def test_combined_with_web_search_and_code_execution(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["web_search", "code_execution", "image_generation"],
+        base_url="https://api.openai.com/v1",
+        enabled_tools=["web_search", "code_execution", "image_generation"],
     )
     tools = captured["body"].get("tools") or []
     tool_types = {t["type"] for t in tools if isinstance(t, dict)}
@@ -191,8 +200,8 @@ def test_combined_with_web_search_and_code_execution(monkeypatch):
 def test_non_cloud_base_drops_image_generation(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url = "http://127.0.0.1:11434/v1",
-        enabled_tools = ["image_generation"],
+        base_url="http://127.0.0.1:11434/v1",
+        enabled_tools=["image_generation"],
     )
     tools = captured["body"].get("tools") or []
     assert {"type": "image_generation"} not in tools, tools
@@ -204,8 +213,8 @@ def test_non_cloud_base_drops_image_generation(monkeypatch):
 def test_omitted_image_generation_pill_no_tool(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["web_search"],
+        base_url="https://api.openai.com/v1",
+        enabled_tools=["web_search"],
     )
     tools = captured["body"].get("tools") or []
     assert all(t.get("type") != "image_generation" for t in tools)
@@ -217,9 +226,9 @@ def test_omitted_image_generation_pill_no_tool(monkeypatch):
 def test_previous_response_id_forwarded_for_followup_edit(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["image_generation"],
-        messages = [
+        base_url="https://api.openai.com/v1",
+        enabled_tools=["image_generation"],
+        messages=[
             {"role": "user", "content": "generate a cat"},
             {
                 "role": "assistant",
@@ -235,6 +244,9 @@ def test_previous_response_id_forwarded_for_followup_edit(monkeypatch):
         ],
     )
     assert captured["body"].get("previous_response_id") == "resp_abc"
+    assert {"type": "image_generation", "action": "edit"} in captured["body"].get(
+        "tools", []
+    )
     input_items = captured["body"].get("input") or []
     assert input_items == [
         {"role": "user", "content": "make the cat's eyes blue"},
@@ -245,9 +257,9 @@ def test_previous_response_id_forwarded_for_followup_edit(monkeypatch):
 def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["image_generation"],
-        messages = [
+        base_url="https://api.openai.com/v1",
+        enabled_tools=["image_generation"],
+        messages=[
             {
                 "role": "assistant",
                 "content": [
@@ -264,6 +276,9 @@ def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
             {"role": "user", "content": "make it more realistic"},
         ],
     )
+    assert {"type": "image_generation", "action": "edit"} in captured["body"].get(
+        "tools", []
+    )
     input_items = captured["body"].get("input") or []
     assert input_items[-3:] == [
         {"role": "user", "content": "make it more realistic"},
@@ -279,9 +294,9 @@ def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
 def test_orphan_image_generation_ref_dropped_for_reasoning_models(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url = "https://api.openai.com/v1",
-        enabled_tools = ["image_generation"],
-        messages = [
+        base_url="https://api.openai.com/v1",
+        enabled_tools=["image_generation"],
+        messages=[
             {
                 "role": "assistant",
                 "content": [
@@ -295,33 +310,69 @@ def test_orphan_image_generation_ref_dropped_for_reasoning_models(monkeypatch):
     assert {"type": "image_generation_call", "id": "img_legacy"} not in input_items
 
 
+def test_chat_completion_request_accepts_openai_image_generation_refs():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "reasoning",
+                            "id": "rs_abc",
+                            "summary": [
+                                {"type": "summary_text", "text": "Need to edit."},
+                            ],
+                            "status": "completed",
+                        },
+                        {
+                            "type": "image_generation_call",
+                            "id": "img_abc",
+                            "response_id": "resp_abc",
+                        },
+                    ],
+                },
+                {"role": "user", "content": "make it more realistic"},
+            ],
+            "stream": True,
+        }
+    )
+
+    assert request.messages[0].role == "assistant"
+    content = request.messages[0].content
+    assert isinstance(content, list)
+    assert content[0].type == "reasoning"
+    assert content[1].type == "image_generation_call"
+
+
 def test_external_message_builder_preserves_openai_image_generation_refs():
     from routes.inference import _build_external_messages
 
     messages = [
         SimpleNamespace(
-            role = "assistant",
-            content = [
+            role="assistant",
+            content=[
                 SimpleNamespace(
-                    type = "reasoning",
-                    id = "rs_abc",
-                    summary = [{"type": "summary_text", "text": "Need to edit."}],
-                    status = "completed",
+                    type="reasoning",
+                    id="rs_abc",
+                    summary=[{"type": "summary_text", "text": "Need to edit."}],
+                    status="completed",
                 ),
                 SimpleNamespace(
-                    type = "image_generation_call",
-                    id = "img_abc",
-                    response_id = "resp_abc",
+                    type="image_generation_call",
+                    id="img_abc",
+                    response_id="resp_abc",
                 ),
             ],
         ),
-        SimpleNamespace(role = "user", content = "make it more realistic"),
+        SimpleNamespace(role="user", content="make it more realistic"),
     ]
 
     assert _build_external_messages(
         messages,
-        supports_vision = True,
-        provider_type = "openai",
+        supports_vision=True,
+        provider_type="openai",
     ) == [
         {
             "role": "assistant",
@@ -344,8 +395,8 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
 
     assert _build_external_messages(
         messages,
-        supports_vision = True,
-        provider_type = "anthropic",
+        supports_vision=True,
+        provider_type="anthropic",
     ) == [
         {"role": "assistant", "content": []},
         {"role": "user", "content": "make it more realistic"},
@@ -381,8 +432,40 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
             "status": "completed",
         },
     }
+    assert ends[0]["arguments"] == starts[0]["arguments"]
     assert ends[0]["image_b64"] == "AAAA"
     assert ends[0]["image_mime"] == "image/png"
     assert ends[0]["size"] == "1024x1024"
     assert ends[0]["quality"] == "high"
     assert ends[0]["background"] == "opaque"
+
+
+def test_image_generation_added_emits_early_placeholder_start(monkeypatch):
+    events = _collect_tool_events(monkeypatch, include_added=True)
+    image_events = [
+        e
+        for e in events
+        if e.get("tool_name") == "image_generation"
+        or (e.get("type") == "tool_end" and e.get("image_b64"))
+    ]
+    starts = [e for e in image_events if e.get("type") == "tool_start"]
+    ends = [e for e in image_events if e.get("type") == "tool_end"]
+    assert len(starts) == 1, image_events
+    assert len(ends) == 1, image_events
+    assert starts[0]["arguments"] == {
+        "kind": "image",
+        "prompt": "",
+        "openai_image_generation_call_id": "img_abc",
+        "openai_response_id": "resp_abc",
+        "openai_reasoning_item": {
+            "type": "reasoning",
+            "id": "rs_abc",
+            "summary": [
+                {"type": "summary_text", "text": "Need to draw a cat."},
+            ],
+            "status": "completed",
+        },
+    }
+    assert ends[0]["arguments"]["prompt"] == "A photorealistic cat sitting"
+    assert ends[0]["arguments"]["openai_image_generation_call_id"] == "img_abc"
+    assert ends[0]["arguments"]["openai_response_id"] == "resp_abc"

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -19,6 +19,7 @@ non-cloud bases drop the tool silently.
 
 import asyncio
 import json
+from types import SimpleNamespace
 
 import httpx
 
@@ -221,8 +222,36 @@ def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
         ],
     )
     input_items = captured["body"].get("input") or []
-    assert {"type": "image_generation_call", "id": "img_abc"} in input_items
-    assert {"role": "user", "content": "make it more realistic"} in input_items
+    assert input_items[-2:] == [
+        {"role": "user", "content": "make it more realistic"},
+        {"type": "image_generation_call", "id": "img_abc"},
+    ]
+
+
+def test_external_message_builder_preserves_openai_image_generation_refs():
+    from routes.inference import _build_external_messages
+
+    messages = [
+        SimpleNamespace(
+            role = "assistant",
+            content = [
+                SimpleNamespace(type = "image_generation_call", id = "img_abc"),
+            ],
+        ),
+        SimpleNamespace(role = "user", content = "make it more realistic"),
+    ]
+
+    assert _build_external_messages(
+        messages,
+        supports_vision = True,
+        provider_type = "openai",
+    ) == [
+        {
+            "role": "assistant",
+            "content": [{"type": "image_generation_call", "id": "img_abc"}],
+        },
+        {"role": "user", "content": "make it more realistic"},
+    ]
 
 
 # ── output translation surfaces tool_start + tool_end ────────────────

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -90,12 +90,11 @@ def _collect_tool_events(monkeypatch) -> list[dict]:
     event and return the parsed _toolEvent chunks."""
 
     sse = (
-        b"event: response.output_item.done\n"
-        b'data: {"type":"response.output_item.done",'
-        b'"item":{"type":"reasoning",'
-        b'"id":"rs_abc",'
-        b'"summary":[{"type":"summary_text","text":"Need to draw a cat."}],'
-        b'"status":"completed"}}\n\n'
+        b"event: response.reasoning_summary_text.done\n"
+        b'data: {"type":"response.reasoning_summary_text.done",'
+        b'"item_id":"rs_abc",'
+        b'"summary_index":0,'
+        b'"text":"Need to draw a cat."}\n\n'
         b"event: response.output_item.done\n"
         b'data: {"type":"response.output_item.done",'
         b'"item":{"type":"image_generation_call",'
@@ -244,6 +243,25 @@ def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
         },
         {"type": "image_generation_call", "id": "img_abc"},
     ]
+
+
+def test_orphan_image_generation_ref_dropped_for_reasoning_models(monkeypatch):
+    captured = _capture_body(
+        monkeypatch,
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["image_generation"],
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "image_generation_call", "id": "img_legacy"},
+                ],
+            },
+            {"role": "user", "content": "do you have the original image?"},
+        ],
+    )
+    input_items = captured["body"].get("input") or []
+    assert {"type": "image_generation_call", "id": "img_legacy"} not in input_items
 
 
 def test_external_message_builder_preserves_openai_image_generation_refs():

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -86,6 +86,15 @@ def _capture_body(
     return captured
 
 
+def _image_generation_events(events: list[dict]) -> list[dict]:
+    return [
+        event
+        for event in events
+        if event.get("tool_name") == "image_generation"
+        or (event.get("type") == "tool_end" and event.get("image_b64"))
+    ]
+
+
 def _collect_tool_events(monkeypatch, *, include_added: bool = False) -> list[dict]:
     """Drive a Responses stream that emits one image_generation_call done
     event and return the parsed _toolEvent chunks."""
@@ -407,12 +416,7 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
 
 def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
     events = _collect_tool_events(monkeypatch)
-    image_events = [
-        e
-        for e in events
-        if e.get("tool_name") == "image_generation"
-        or (e.get("type") == "tool_end" and e.get("image_b64"))
-    ]
+    image_events = _image_generation_events(events)
     starts = [e for e in image_events if e.get("type") == "tool_start"]
     ends = [e for e in image_events if e.get("type") == "tool_end"]
     assert len(starts) == 1, image_events
@@ -441,12 +445,7 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
 
 def test_image_generation_added_emits_early_placeholder_start(monkeypatch):
     events = _collect_tool_events(monkeypatch, include_added = True)
-    image_events = [
-        e
-        for e in events
-        if e.get("tool_name") == "image_generation"
-        or (e.get("type") == "tool_end" and e.get("image_b64"))
-    ]
+    image_events = _image_generation_events(events)
     starts = [e for e in image_events if e.get("type") == "tool_start"]
     ends = [e for e in image_events if e.get("type") == "tool_end"]
     assert len(starts) == 1, image_events

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -398,7 +398,6 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
         supports_vision=True,
         provider_type="anthropic",
     ) == [
-        {"role": "assistant", "content": []},
         {"role": "user", "content": "make it more realistic"},
     ]
 

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -45,39 +45,39 @@ def _capture_body(
         captured["body"] = json.loads(request.content.decode("utf-8"))
         return httpx.Response(
             200,
-            content=(
+            content = (
                 b"event: response.completed\n"
                 b'data: {"type":"response.completed",'
                 b'"response":{"output":[],"usage":{"input_tokens":0,'
                 b'"output_tokens":0}}}\n\n'
             ),
-            headers={"content-type": "text/event-stream"},
+            headers = {"content-type": "text/event-stream"},
         )
 
     monkeypatch.setattr(
         ep_mod,
         "_http_client",
-        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
     )
 
     async def run():
         client = ExternalProviderClient(
-            provider_type="openai",
-            base_url=base_url,
-            api_key="sk-test",
+            provider_type = "openai",
+            base_url = base_url,
+            api_key = "sk-test",
         )
         async for _ in client.stream_chat_completion(
-            messages=(
+            messages = (
                 messages
                 if messages is not None
                 else [{"role": "user", "content": "draw a cat"}]
             ),
-            model="gpt-5.5",
-            temperature=0.7,
-            top_p=0.95,
-            max_tokens=32,
-            reasoning_effort="medium",
-            enabled_tools=enabled_tools,
+            model = "gpt-5.5",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = 32,
+            reasoning_effort = "medium",
+            enabled_tools = enabled_tools,
         ):
             pass
         await client.close()
@@ -126,32 +126,32 @@ def _collect_tool_events(monkeypatch, *, include_added: bool = False) -> list[di
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
-            content=sse,
-            headers={"content-type": "text/event-stream"},
+            content = sse,
+            headers = {"content-type": "text/event-stream"},
         )
 
     monkeypatch.setattr(
         ep_mod,
         "_http_client",
-        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
     )
 
     events: list[dict] = []
 
     async def run():
         client = ExternalProviderClient(
-            provider_type="openai",
-            base_url="https://api.openai.com/v1",
-            api_key="sk-test",
+            provider_type = "openai",
+            base_url = "https://api.openai.com/v1",
+            api_key = "sk-test",
         )
         async for line in client.stream_chat_completion(
-            messages=[{"role": "user", "content": "draw a cat"}],
-            model="gpt-5.5",
-            temperature=0.7,
-            top_p=0.95,
-            max_tokens=32,
-            reasoning_effort="medium",
-            enabled_tools=["image_generation"],
+            messages = [{"role": "user", "content": "draw a cat"}],
+            model = "gpt-5.5",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = 32,
+            reasoning_effort = "medium",
+            enabled_tools = ["image_generation"],
         ):
             if not line or not line.startswith("data:"):
                 continue
@@ -176,8 +176,8 @@ def _collect_tool_events(monkeypatch, *, include_added: bool = False) -> list[di
 def test_cloud_openai_appends_image_generation_tool(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url="https://api.openai.com/v1",
-        enabled_tools=["image_generation"],
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["image_generation"],
     )
     tools = captured["body"].get("tools") or []
     assert {"type": "image_generation"} in tools, tools
@@ -186,8 +186,8 @@ def test_cloud_openai_appends_image_generation_tool(monkeypatch):
 def test_combined_with_web_search_and_code_execution(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url="https://api.openai.com/v1",
-        enabled_tools=["web_search", "code_execution", "image_generation"],
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["web_search", "code_execution", "image_generation"],
     )
     tools = captured["body"].get("tools") or []
     tool_types = {t["type"] for t in tools if isinstance(t, dict)}
@@ -200,8 +200,8 @@ def test_combined_with_web_search_and_code_execution(monkeypatch):
 def test_non_cloud_base_drops_image_generation(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url="http://127.0.0.1:11434/v1",
-        enabled_tools=["image_generation"],
+        base_url = "http://127.0.0.1:11434/v1",
+        enabled_tools = ["image_generation"],
     )
     tools = captured["body"].get("tools") or []
     assert {"type": "image_generation"} not in tools, tools
@@ -213,8 +213,8 @@ def test_non_cloud_base_drops_image_generation(monkeypatch):
 def test_omitted_image_generation_pill_no_tool(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url="https://api.openai.com/v1",
-        enabled_tools=["web_search"],
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["web_search"],
     )
     tools = captured["body"].get("tools") or []
     assert all(t.get("type") != "image_generation" for t in tools)
@@ -226,9 +226,9 @@ def test_omitted_image_generation_pill_no_tool(monkeypatch):
 def test_previous_response_id_forwarded_for_followup_edit(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url="https://api.openai.com/v1",
-        enabled_tools=["image_generation"],
-        messages=[
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["image_generation"],
+        messages = [
             {"role": "user", "content": "generate a cat"},
             {
                 "role": "assistant",
@@ -257,9 +257,9 @@ def test_previous_response_id_forwarded_for_followup_edit(monkeypatch):
 def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url="https://api.openai.com/v1",
-        enabled_tools=["image_generation"],
-        messages=[
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["image_generation"],
+        messages = [
             {
                 "role": "assistant",
                 "content": [
@@ -294,9 +294,9 @@ def test_image_generation_reference_forwarded_for_followup_edit(monkeypatch):
 def test_orphan_image_generation_ref_dropped_for_reasoning_models(monkeypatch):
     captured = _capture_body(
         monkeypatch,
-        base_url="https://api.openai.com/v1",
-        enabled_tools=["image_generation"],
-        messages=[
+        base_url = "https://api.openai.com/v1",
+        enabled_tools = ["image_generation"],
+        messages = [
             {
                 "role": "assistant",
                 "content": [
@@ -351,28 +351,28 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
 
     messages = [
         SimpleNamespace(
-            role="assistant",
-            content=[
+            role = "assistant",
+            content = [
                 SimpleNamespace(
-                    type="reasoning",
-                    id="rs_abc",
-                    summary=[{"type": "summary_text", "text": "Need to edit."}],
-                    status="completed",
+                    type = "reasoning",
+                    id = "rs_abc",
+                    summary = [{"type": "summary_text", "text": "Need to edit."}],
+                    status = "completed",
                 ),
                 SimpleNamespace(
-                    type="image_generation_call",
-                    id="img_abc",
-                    response_id="resp_abc",
+                    type = "image_generation_call",
+                    id = "img_abc",
+                    response_id = "resp_abc",
                 ),
             ],
         ),
-        SimpleNamespace(role="user", content="make it more realistic"),
+        SimpleNamespace(role = "user", content = "make it more realistic"),
     ]
 
     assert _build_external_messages(
         messages,
-        supports_vision=True,
-        provider_type="openai",
+        supports_vision = True,
+        provider_type = "openai",
     ) == [
         {
             "role": "assistant",
@@ -395,8 +395,8 @@ def test_external_message_builder_preserves_openai_image_generation_refs():
 
     assert _build_external_messages(
         messages,
-        supports_vision=True,
-        provider_type="anthropic",
+        supports_vision = True,
+        provider_type = "anthropic",
     ) == [
         {"role": "user", "content": "make it more realistic"},
     ]
@@ -440,7 +440,7 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
 
 
 def test_image_generation_added_emits_early_placeholder_start(monkeypatch):
-    events = _collect_tool_events(monkeypatch, include_added=True)
+    events = _collect_tool_events(monkeypatch, include_added = True)
     image_events = [
         e
         for e in events

--- a/studio/backend/tests/test_openai_image_generation.py
+++ b/studio/backend/tests/test_openai_image_generation.py
@@ -210,6 +210,7 @@ def test_image_generation_done_emits_tool_event_chunks(monkeypatch):
     assert starts[0]["arguments"] == {
         "kind": "image",
         "prompt": "A photorealistic cat sitting",
+        "openai_image_generation_call_id": "img_abc",
     }
     assert ends[0]["image_b64"] == "AAAA"
     assert ends[0]["image_mime"] == "image/png"

--- a/studio/frontend/src/components/assistant-ui/generated-image-overlay-context.tsx
+++ b/studio/frontend/src/components/assistant-ui/generated-image-overlay-context.tsx
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client";
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+export type GeneratedImageOverlayState = {
+  image: string;
+  title: string;
+  metadata: string;
+  filename?: string;
+};
+
+type GeneratedImageOverlayContextValue = {
+  overlay: GeneratedImageOverlayState | null;
+  openOverlay: (overlay: GeneratedImageOverlayState) => void;
+  closeOverlay: () => void;
+};
+
+const GeneratedImageOverlayContext =
+  createContext<GeneratedImageOverlayContextValue | null>(null);
+
+export function GeneratedImageOverlayProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [overlay, setOverlay] = useState<GeneratedImageOverlayState | null>(
+    null,
+  );
+
+  const openOverlay = useCallback((nextOverlay: GeneratedImageOverlayState) => {
+    setOverlay(nextOverlay);
+  }, []);
+
+  const closeOverlay = useCallback(() => {
+    setOverlay(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({ overlay, openOverlay, closeOverlay }),
+    [closeOverlay, openOverlay, overlay],
+  );
+
+  return (
+    <GeneratedImageOverlayContext.Provider value={value}>
+      {children}
+    </GeneratedImageOverlayContext.Provider>
+  );
+}
+
+export function useGeneratedImageOverlay(): GeneratedImageOverlayContextValue {
+  const context = useContext(GeneratedImageOverlayContext);
+  if (!context) {
+    throw new Error(
+      "useGeneratedImageOverlay must be used within GeneratedImageOverlayProvider.",
+    );
+  }
+  return context;
+}

--- a/studio/frontend/src/components/assistant-ui/generated-image-overlay-context.tsx
+++ b/studio/frontend/src/components/assistant-ui/generated-image-overlay-context.tsx
@@ -20,6 +20,7 @@ export type GeneratedImageOverlayState = {
   openaiImageGenerationCallId?: string;
   openaiResponseId?: string;
   openaiReasoningItem?: unknown;
+  threadId?: string | null;
 };
 
 type GeneratedImageOverlayContextValue = {
@@ -33,16 +34,21 @@ const GeneratedImageOverlayContext =
 
 export function GeneratedImageOverlayProvider({
   children,
+  threadId = null,
 }: {
   children: ReactNode;
+  threadId?: string | null;
 }) {
   const [overlay, setOverlay] = useState<GeneratedImageOverlayState | null>(
     null,
   );
 
-  const openOverlay = useCallback((nextOverlay: GeneratedImageOverlayState) => {
-    setOverlay(nextOverlay);
-  }, []);
+  const openOverlay = useCallback(
+    (nextOverlay: GeneratedImageOverlayState) => {
+      setOverlay({ ...nextOverlay, threadId: nextOverlay.threadId ?? threadId });
+    },
+    [threadId],
+  );
 
   const closeOverlay = useCallback(() => {
     setOverlay(null);

--- a/studio/frontend/src/components/assistant-ui/generated-image-overlay-context.tsx
+++ b/studio/frontend/src/components/assistant-ui/generated-image-overlay-context.tsx
@@ -17,6 +17,9 @@ export type GeneratedImageOverlayState = {
   title: string;
   metadata: string;
   filename?: string;
+  openaiImageGenerationCallId?: string;
+  openaiResponseId?: string;
+  openaiReasoningItem?: unknown;
 };
 
 type GeneratedImageOverlayContextValue = {

--- a/studio/frontend/src/components/assistant-ui/image.tsx
+++ b/studio/frontend/src/components/assistant-ui/image.tsx
@@ -449,6 +449,7 @@ function ImageActions({ part, onRegenerate, className }: ImageActionsProps) {
 
 const ImageImpl: ImageMessagePartComponent = (props) => {
   const { image, filename, status } = props;
+  const alt = filename || "Image content";
 
   if (status?.type === "running") {
     return (
@@ -469,8 +470,8 @@ const ImageImpl: ImageMessagePartComponent = (props) => {
 
   return (
     <ImageRoot>
-      <ImageZoom src={image} alt={filename || "Image content"}>
-        <ImagePreview src={image} alt={filename || "Image content"} />
+      <ImageZoom src={image} alt={alt}>
+        <ImagePreview src={image} alt={alt} />
       </ImageZoom>
       <ImageFilename>{filename}</ImageFilename>
     </ImageRoot>

--- a/studio/frontend/src/components/assistant-ui/image.tsx
+++ b/studio/frontend/src/components/assistant-ui/image.tsx
@@ -109,7 +109,7 @@ export const copyImagePart = async (
   const blob = part.image.startsWith("data:")
     ? dataUriToBlob(part.image)
     : await fetch(part.image).then((r) => r.blob());
-  const mime = mimeFromImage(part.image) ?? blob.type ?? "image/png";
+  const mime = mimeFromImage(part.image) || blob.type || "image/png";
   await navigator.clipboard.write([new ClipboardItem({ [mime]: blob })]);
 };
 

--- a/studio/frontend/src/components/assistant-ui/image.tsx
+++ b/studio/frontend/src/components/assistant-ui/image.tsx
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+//
+// Portions adapted from assistant-ui packages/ui/src/components/assistant-ui/image.tsx
+// MIT License, Copyright (c) 2025 AgentbaseAI Inc.
+// Source: https://github.com/assistant-ui/assistant-ui/blob/main/packages/ui/src/components/assistant-ui/image.tsx
+
+"use client";
+
+import { cn } from "@/lib/utils";
+import type {
+  ImageMessagePart,
+  ImageMessagePartComponent,
+} from "@assistant-ui/react";
+import { type VariantProps, cva } from "class-variance-authority";
+import {
+  CopyIcon,
+  DownloadIcon,
+  ImageIcon,
+  ImageOffIcon,
+  Loader2Icon,
+  RefreshCwIcon,
+  ShieldAlertIcon,
+} from "lucide-react";
+import {
+  type ComponentProps,
+  type PropsWithChildren,
+  memo,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+const extensionForMimeType = (mimeType?: string): string => {
+  switch (mimeType) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    case "image/svg+xml":
+      return "svg";
+    default:
+      return "png";
+  }
+};
+
+const DATA_URI_MIME_RE = /data:([^;]+)/;
+const DATA_URI_BASE64_RE = /;base64/i;
+const IMAGE_DATA_URI_MIME_RE = /^data:([^;,]+)/;
+
+export const dataUriToBlob = (dataUri: string): Blob => {
+  const [meta, data] = dataUri.split(",");
+  const mime = meta?.match(DATA_URI_MIME_RE)?.[1] ?? "application/octet-stream";
+  if (!DATA_URI_BASE64_RE.test(meta ?? "")) {
+    return new Blob([decodeURIComponent(data ?? "")], { type: mime });
+  }
+  const bytes = atob(data ?? "");
+  const arr = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) {
+    arr[i] = bytes.charCodeAt(i);
+  }
+  return new Blob([arr], { type: mime });
+};
+
+const mimeFromImage = (image: string): string | undefined =>
+  image.match(IMAGE_DATA_URI_MIME_RE)?.[1];
+
+export const downloadImagePart = (
+  part: Pick<ImageMessagePart, "image" | "filename">,
+): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const ext = extensionForMimeType(mimeFromImage(part.image));
+  const filename = part.filename ?? `image.${ext}`;
+  const isDataUri = part.image.startsWith("data:");
+  const objectUrl = isDataUri
+    ? URL.createObjectURL(dataUriToBlob(part.image))
+    : null;
+  const href = objectUrl ?? part.image;
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  if (objectUrl) {
+    URL.revokeObjectURL(objectUrl);
+  }
+};
+
+export const copyImagePart = async (
+  part: Pick<ImageMessagePart, "image">,
+): Promise<void> => {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.clipboard ||
+    typeof ClipboardItem === "undefined"
+  ) {
+    throw new Error("Clipboard API is not available in this environment.");
+  }
+  const blob = part.image.startsWith("data:")
+    ? dataUriToBlob(part.image)
+    : await fetch(part.image).then((r) => r.blob());
+  const mime = mimeFromImage(part.image) ?? blob.type ?? "image/png";
+  await navigator.clipboard.write([new ClipboardItem({ [mime]: blob })]);
+};
+
+const reportImageCopyError = (error: unknown): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent("assistant-ui:image-copy-error", { detail: error }),
+  );
+};
+
+const imageVariants = cva(
+  "aui-image-root relative overflow-hidden rounded-lg",
+  {
+    variants: {
+      variant: {
+        outline: "border border-border",
+        ghost: "",
+        muted: "bg-muted/50",
+      },
+      size: {
+        sm: "max-w-64",
+        default: "max-w-96",
+        lg: "max-w-[512px]",
+        full: "w-full",
+      },
+    },
+    defaultVariants: {
+      variant: "outline",
+      size: "default",
+    },
+  },
+);
+
+export type ImageRootProps = ComponentProps<"div"> &
+  VariantProps<typeof imageVariants>;
+
+function ImageRoot({
+  className,
+  variant,
+  size,
+  children,
+  ...props
+}: ImageRootProps) {
+  return (
+    <div
+      data-slot="image-root"
+      data-variant={variant}
+      data-size={size}
+      className={cn(imageVariants({ variant, size, className }))}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ImagePreviewProps = Omit<ComponentProps<"img">, "children"> & {
+  containerClassName?: string;
+};
+
+function ImagePreview({
+  className,
+  containerClassName,
+  onLoad,
+  onError,
+  alt = "Image content",
+  src,
+  ...props
+}: ImagePreviewProps) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [loadedSrc, setLoadedSrc] = useState<string | undefined>(undefined);
+  const [errorSrc, setErrorSrc] = useState<string | undefined>(undefined);
+
+  const loaded = loadedSrc === src;
+  const error = errorSrc === src;
+
+  useEffect(() => {
+    if (
+      typeof src === "string" &&
+      imgRef.current?.complete &&
+      imgRef.current.naturalWidth > 0
+    ) {
+      setLoadedSrc(src);
+    }
+  }, [src]);
+
+  return (
+    <div
+      data-slot="image-preview"
+      className={cn("relative min-h-32", containerClassName)}
+    >
+      {!(loaded || error) && (
+        <div
+          data-slot="image-preview-loading"
+          className="absolute inset-0 flex items-center justify-center bg-muted/50"
+        >
+          <ImageIcon className="size-8 animate-pulse text-muted-foreground" />
+        </div>
+      )}
+      {error ? (
+        <div
+          data-slot="image-preview-error"
+          className="flex min-h-32 items-center justify-center bg-muted/50 p-4"
+        >
+          <ImageOffIcon className="size-8 text-muted-foreground" />
+        </div>
+      ) : (
+        <img
+          {...props}
+          ref={imgRef}
+          src={src}
+          alt={alt}
+          className={cn(
+            "block h-auto w-full object-contain",
+            !loaded && "invisible",
+            className,
+          )}
+          onLoad={(e) => {
+            if (typeof src === "string") {
+              setLoadedSrc(src);
+            }
+            onLoad?.(e);
+          }}
+          onError={(e) => {
+            if (typeof src === "string") {
+              setErrorSrc(src);
+            }
+            onError?.(e);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ImageFilename({
+  className,
+  children,
+  ...props
+}: ComponentProps<"span">) {
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <span
+      data-slot="image-filename"
+      className={cn(
+        "block truncate px-2 py-1.5 text-muted-foreground text-xs",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+type ImageZoomProps = PropsWithChildren<{
+  src: string;
+  alt?: string;
+}>;
+
+function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="aui-image-zoom-trigger w-full cursor-zoom-in border-0 bg-transparent p-0 text-left"
+        aria-label="Click to zoom image"
+      >
+        {children}
+      </button>
+      {isOpen &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <button
+            type="button"
+            data-slot="image-zoom-overlay"
+            className="aui-image-zoom-overlay fade-in fixed inset-0 z-50 flex animate-in items-center justify-center border-0 bg-black/80 p-0 duration-200"
+            onClick={handleClose}
+            aria-label="Close zoomed image"
+          >
+            <img
+              data-slot="image-zoom-content"
+              src={src}
+              alt={alt}
+              className="aui-image-zoom-content fade-in zoom-in-95 max-h-[90vh] max-w-[90vw] animate-in cursor-zoom-out object-contain duration-200"
+            />
+          </button>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+function ImageGenerating({ className }: { className?: string }) {
+  return (
+    <div
+      data-slot="image-generating"
+      className={cn(
+        "flex min-h-32 items-center justify-center bg-muted/50 p-4",
+        className,
+      )}
+    >
+      <Loader2Icon className="size-8 animate-spin text-muted-foreground" />
+      <span className="sr-only">Generating image…</span>
+    </div>
+  );
+}
+
+function ImageContentFilterError({
+  className,
+  reason,
+}: {
+  className?: string;
+  reason?: string;
+}) {
+  return (
+    <div
+      data-slot="image-content-filter-error"
+      className={cn(
+        "flex min-h-32 flex-col items-center justify-center gap-2 bg-muted/50 p-4 text-center",
+        className,
+      )}
+    >
+      <ShieldAlertIcon className="size-8 text-muted-foreground" />
+      <p className="font-medium text-sm">Image could not be generated</p>
+      {reason && <p className="text-muted-foreground text-xs">{reason}</p>}
+    </div>
+  );
+}
+
+export type ImageActionsProps = {
+  part: ImageMessagePart;
+  /**
+   * Wire to your own generation call to show a regenerate button. The button
+   * renders only when this is set and the part carries a `prompt`.
+   */
+  onRegenerate?: () => void | Promise<void>;
+  className?: string;
+};
+
+function RegenerateButton({
+  onRegenerate,
+}: {
+  onRegenerate: () => void | Promise<void>;
+}) {
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        setIsRegenerating(true);
+        try {
+          await onRegenerate();
+        } finally {
+          setIsRegenerating(false);
+        }
+      }}
+      disabled={isRegenerating}
+      data-slot="image-regenerate"
+      aria-label="Regenerate image"
+      className="inline-flex size-7 items-center justify-center rounded hover:bg-muted disabled:opacity-50"
+    >
+      <RefreshCwIcon
+        className={cn("size-4", isRegenerating && "animate-spin")}
+      />
+    </button>
+  );
+}
+
+function ImageActions({ part, onRegenerate, className }: ImageActionsProps) {
+  return (
+    <div
+      data-slot="image-actions"
+      className={cn("flex items-center gap-1 p-1", className)}
+    >
+      <button
+        type="button"
+        onClick={() => downloadImagePart(part)}
+        data-slot="image-download"
+        aria-label="Download image"
+        className="inline-flex size-7 items-center justify-center rounded hover:bg-muted"
+      >
+        <DownloadIcon className="size-4" />
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          copyImagePart(part).catch((error) => {
+            reportImageCopyError(error);
+          });
+        }}
+        data-slot="image-copy"
+        aria-label="Copy image"
+        className="inline-flex size-7 items-center justify-center rounded hover:bg-muted"
+      >
+        <CopyIcon className="size-4" />
+      </button>
+      {onRegenerate && <RegenerateButton onRegenerate={onRegenerate} />}
+    </div>
+  );
+}
+
+const ImageImpl: ImageMessagePartComponent = (props) => {
+  const { image, filename, status } = props;
+
+  if (status?.type === "running") {
+    return (
+      <ImageRoot>
+        <ImageGenerating />
+        <ImageFilename>{filename}</ImageFilename>
+      </ImageRoot>
+    );
+  }
+
+  if (status?.type === "incomplete" && status.reason === "content-filter") {
+    return (
+      <ImageRoot>
+        <ImageContentFilterError reason="The provider blocked this image." />
+      </ImageRoot>
+    );
+  }
+
+  return (
+    <ImageRoot>
+      <ImageZoom src={image} alt={filename || "Image content"}>
+        <ImagePreview src={image} alt={filename || "Image content"} />
+      </ImageZoom>
+      <ImageFilename>{filename}</ImageFilename>
+    </ImageRoot>
+  );
+};
+
+const Image = memo(ImageImpl) as unknown as ImageMessagePartComponent & {
+  Root: typeof ImageRoot;
+  Preview: typeof ImagePreview;
+  Filename: typeof ImageFilename;
+  Zoom: typeof ImageZoom;
+  Actions: typeof ImageActions;
+  Generating: typeof ImageGenerating;
+  ContentFilterError: typeof ImageContentFilterError;
+};
+
+Image.displayName = "Image";
+Image.Root = ImageRoot;
+Image.Preview = ImagePreview;
+Image.Filename = ImageFilename;
+Image.Zoom = ImageZoom;
+Image.Actions = ImageActions;
+Image.Generating = ImageGenerating;
+Image.ContentFilterError = ImageContentFilterError;
+
+export {
+  Image,
+  ImageRoot,
+  ImagePreview,
+  ImageFilename,
+  ImageZoom,
+  ImageActions,
+  ImageGenerating,
+  ImageContentFilterError,
+  imageVariants,
+};

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -7,6 +7,11 @@ import {
   UserMessageAttachments,
 } from "@/components/assistant-ui/attachment";
 import { CodeToggleIcon } from "@/components/assistant-ui/code-toggle-icon";
+import {
+  GeneratedImageOverlayProvider,
+  useGeneratedImageOverlay,
+} from "@/components/assistant-ui/generated-image-overlay-context";
+import { downloadImagePart } from "@/components/assistant-ui/image";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { MessageTiming } from "@/components/assistant-ui/message-timing";
 import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
@@ -39,13 +44,14 @@ import {
 import { sentAudioNames } from "@/features/chat/api/chat-adapter";
 import { parseExternalModelId } from "@/features/chat/external-providers";
 import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
-import { useExternalProvidersStore } from "@/features/chat/stores/external-providers-store";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { useExternalProvidersStore } from "@/features/chat/stores/external-providers-store";
+import { deleteThreadMessage } from "@/features/chat/utils/delete-thread-message";
 import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
 import { isTauri } from "@/lib/api-base";
-import { deleteThreadMessage } from "@/features/chat/utils/delete-thread-message";
 import { AUDIO_ACCEPT, MAX_AUDIO_SIZE, fileToBase64 } from "@/lib/audio-utils";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
   ActionBarMorePrimitive,
@@ -79,30 +85,30 @@ import {
   TerminalIcon,
   XIcon,
 } from "lucide-react";
-import { Copy01Icon, Delete02Icon, Edit03Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import {
+  Copy01Icon,
+  Delete02Icon,
+  Edit03Icon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   type ChangeEvent,
+  type ComponentProps,
   type CompositionEvent,
   type FC,
-  type FormEvent,
   type KeyboardEvent,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from "react";
-import { toast } from "@/lib/toast";
 
 export const Thread: FC<{
   hideComposer?: boolean;
   hideWelcome?: boolean;
   targetThreadId?: string;
-}> = ({
-  hideComposer,
-  hideWelcome,
-  targetThreadId,
-}) => {
+}> = ({ hideComposer, hideWelcome, targetThreadId }) => {
   // Intent-aware autoscroll: replaces assistant-ui's built-in autoscroll
   // to prevent the streaming-mutation race that makes the viewport snap
   // back to the bottom while the user is scrolling up (see the hook for
@@ -115,83 +121,189 @@ export const Thread: FC<{
   );
 
   return (
-    <ThreadPrimitive.Root
-      className="aui-root aui-thread-root @container relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden"
-      style={{
-        ["--thread-max-width" as string]: "48rem",
-        ["--thread-content-max-width" as string]:
-          "calc(var(--thread-max-width) - 1.5rem)",
-      }}
-    >
-      <IntentAwareScrollProvider value={autoScrollContext}>
-        <ThreadPrimitive.Viewport
-          ref={viewportRef}
-          autoScroll={false}
-          scrollToBottomOnRunStart={false}
-          scrollToBottomOnInitialize={false}
-          scrollToBottomOnThreadSwitch={false}
-          className={cn(
-            "aui-thread-viewport aui-stream-viewport relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-x-auto overflow-y-auto scroll-smooth px-5",
-            hideComposer ? "pt-4" : "pt-[48px]",
-          )}
-        >
-          {!hideWelcome && (
-            <AuiIf condition={({ thread }) => thread.isEmpty && !thread.isLoading}>
-              <ThreadWelcome hideComposer={hideComposer} />
-            </AuiIf>
-          )}
+    <GeneratedImageOverlayProvider>
+      <ThreadPrimitive.Root
+        className="aui-root aui-thread-root @container relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden"
+        style={{
+          ["--thread-max-width" as string]: "48rem",
+          ["--thread-content-max-width" as string]:
+            "calc(var(--thread-max-width) - 1.5rem)",
+        }}
+      >
+        <IntentAwareScrollProvider value={autoScrollContext}>
+          <ThreadPrimitive.Viewport
+            ref={viewportRef}
+            autoScroll={false}
+            scrollToBottomOnRunStart={false}
+            scrollToBottomOnInitialize={false}
+            scrollToBottomOnThreadSwitch={false}
+            className={cn(
+              "aui-thread-viewport aui-stream-viewport relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-x-auto overflow-y-auto scroll-smooth px-5",
+              hideComposer ? "pt-4" : "pt-[48px]",
+            )}
+          >
+            {!hideWelcome && (
+              <AuiIf
+                condition={({ thread }) => thread.isEmpty && !thread.isLoading}
+              >
+                <ThreadWelcome hideComposer={hideComposer} />
+              </AuiIf>
+            )}
 
-          <ThreadPrimitive.Messages
-            components={{
-              UserMessage,
-              EditComposer,
-              AssistantMessage,
-            }}
-          />
+            <ThreadPrimitive.Messages
+              components={{
+                UserMessage,
+                EditComposer,
+                AssistantMessage,
+              }}
+            />
 
-          {/* Bottom slack so the last message has breathing room above the
+            {/* Bottom slack so the last message has breathing room above the
             sticky scroll-to-bottom button (and the floating composer in
             single mode). Without this, content would butt against the
             sticky footer and feel cramped. */}
-          <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
-            <div
-              className={cn("shrink-0", hideComposer ? "h-16" : "h-40")}
-              aria-hidden={true}
-            />
-          </AuiIf>
-
-          <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
-            <ThreadPrimitive.ViewportFooter
-              className={cn(
-                "aui-thread-viewport-footer pointer-events-none sticky z-20 flex w-full justify-center bg-transparent",
-                hideComposer ? "bottom-3" : "bottom-[140px]",
-              )}
-            >
-              <ThreadScrollToBottom />
-            </ThreadPrimitive.ViewportFooter>
-          </AuiIf>
-        </ThreadPrimitive.Viewport>
-
-        {!hideComposer && (
-          <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
-            <div className="aui-thread-composer-dock pointer-events-none absolute bottom-0 left-0 right-0 md:right-[10px] z-20">
+            <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
               <div
+                className={cn("shrink-0", hideComposer ? "h-16" : "h-40")}
                 aria-hidden={true}
-                className="absolute inset-x-0 bottom-0 top-[10px] bg-background"
               />
-              <div className="relative px-5 pb-2">
-                <div className="pointer-events-auto mx-auto w-full max-w-(--thread-max-width)">
-                  <ComposerAnimated disabled={isComposerAttachPending} />
-                </div>
-                <p className="composer-footer-note">
-                  LLMs can make mistakes. Double-check responses.
-                </p>
-              </div>
-            </div>
-          </AuiIf>
+            </AuiIf>
+
+            <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
+              <ThreadPrimitive.ViewportFooter
+                className={cn(
+                  "aui-thread-viewport-footer pointer-events-none sticky z-20 flex w-full justify-center bg-transparent",
+                  hideComposer ? "bottom-3" : "bottom-[140px]",
+                )}
+              >
+                <ThreadScrollToBottom />
+              </ThreadPrimitive.ViewportFooter>
+            </AuiIf>
+          </ThreadPrimitive.Viewport>
+
+          <GeneratedImageViewportOverlay hideComposer={hideComposer} />
+
+          {!hideComposer && (
+            <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
+              <ThreadComposerDock disabled={isComposerAttachPending} />
+            </AuiIf>
+          )}
+        </IntentAwareScrollProvider>
+      </ThreadPrimitive.Root>
+    </GeneratedImageOverlayProvider>
+  );
+};
+
+const GeneratedImageViewportOverlay: FC<{ hideComposer?: boolean }> = ({
+  hideComposer,
+}) => {
+  const { overlay, closeOverlay } = useGeneratedImageOverlay();
+
+  useEffect(() => {
+    if (!overlay) {
+      return;
+    }
+    document.querySelector<HTMLTextAreaElement>(".aui-composer-input")?.focus();
+  }, [overlay]);
+
+  if (!overlay) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-30">
+      <button
+        type="button"
+        className="pointer-events-auto absolute inset-0 bg-background/65 backdrop-blur-[1px] dark:bg-background/55"
+        onClick={closeOverlay}
+        aria-label="Close generated image preview"
+      />
+      <section
+        className={cn(
+          "pointer-events-none absolute inset-x-5 top-[48px] flex flex-col items-center",
+          hideComposer ? "bottom-4" : "bottom-[150px]",
         )}
-      </IntentAwareScrollProvider>
-    </ThreadPrimitive.Root>
+        aria-label="Generated image preview"
+      >
+        <div className="pointer-events-auto relative flex min-h-0 w-full max-w-[1100px] flex-1 items-center justify-center rounded-3xl bg-muted/10 p-3 ring-1 ring-border/20">
+          <div className="absolute inset-x-3 top-3 z-10 flex justify-end">
+            <div className="flex shrink-0 items-center gap-1 rounded-full bg-background/70 p-1 ring-1 ring-border/20 backdrop-blur-sm">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7 rounded-full"
+                onClick={() =>
+                  downloadImagePart({
+                    image: overlay.image,
+                    filename: overlay.filename,
+                  })
+                }
+                aria-label="Download generated image"
+              >
+                <DownloadIcon className="size-3.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7 rounded-full"
+                onClick={closeOverlay}
+                aria-label="Close generated image preview"
+              >
+                <XIcon className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+          <img
+            src={overlay.image}
+            alt={overlay.title}
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
+        <div className="mt-2 max-w-[min(100%,46rem)] text-center" title={overlay.title}>
+          <p className="truncate font-medium text-foreground/70 text-xs">
+            Generated image
+          </p>
+          {overlay.metadata ? (
+            <p className="truncate text-[11px] text-muted-foreground/75">
+              {overlay.metadata}
+            </p>
+          ) : null}
+        </div>
+        {hideComposer ? null : (
+          <p className="mt-1 text-center text-muted-foreground text-xs">
+            Type edits below, then send.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+const ThreadComposerDock: FC<{ disabled?: boolean }> = ({ disabled }) => {
+  const { overlay } = useGeneratedImageOverlay();
+
+  return (
+    <div
+      className={cn(
+        "aui-thread-composer-dock pointer-events-none absolute bottom-0 left-0 right-0 md:right-[10px]",
+        overlay ? "z-40" : "z-20",
+      )}
+    >
+      <div
+        aria-hidden={true}
+        className="absolute inset-x-0 bottom-0 top-[10px] bg-background"
+      />
+      <div className="relative px-5 pb-2">
+        <div className="pointer-events-auto mx-auto w-full max-w-(--thread-max-width)">
+          <ComposerAnimated disabled={disabled} />
+        </div>
+        <p className="composer-footer-note">
+          LLMs can make mistakes. Double-check responses.
+        </p>
+      </div>
+    </div>
   );
 };
 
@@ -225,7 +337,8 @@ const ThreadWelcome: FC<{ hideComposer?: boolean }> = ({ hideComposer }) => {
   useEffect(() => {
     const hour = new Date().getHours();
     if (hour >= 6 && hour < 12) setCurrentEmoji("large sloth drink.png");
-    else if (hour >= 12 && hour < 17) setCurrentEmoji("sloth magnify final.png");
+    else if (hour >= 12 && hour < 17)
+      setCurrentEmoji("sloth magnify final.png");
     else if (hour >= 17 && hour < 21) setCurrentEmoji("sloth shy large.png");
     else setCurrentEmoji("unsloth-gem.png");
   }, []);
@@ -240,11 +353,7 @@ const ThreadWelcome: FC<{ hideComposer?: boolean }> = ({ hideComposer }) => {
       <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-center pb-[48px]">
         <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-6 px-4">
           <div className="flex flex-col items-center gap-2 text-center">
-            <img
-              src={currentEmojiSrc}
-              alt="Sloth mascot"
-              className="size-20"
-            />
+            <img src={currentEmojiSrc} alt="Sloth mascot" className="size-20" />
             <h1 className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in font-heading font-semibold text-2xl tracking-[-0.02em] duration-200">
               Chat with your model
             </h1>
@@ -294,7 +403,13 @@ const PendingAudioChip: FC = () => {
 };
 
 const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
-  const { inputProps, isComposing, isComposingRef } = useImeComposerInputHandlers();
+  const aui = useAui();
+  const { overlay, closeOverlay } = useGeneratedImageOverlay();
+  const setImageToolsEnabled = useChatRuntimeStore(
+    (s) => s.setImageToolsEnabled,
+  );
+  const { inputProps, isComposing, isComposingRef } =
+    useImeComposerInputHandlers();
   const composerText = useAuiState(({ composer }) => composer.text);
   const hasAttachments = useAuiState(
     ({ composer }) => composer.attachments.length > 0,
@@ -304,12 +419,14 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
       (attachment) => attachment.status.type === "running",
     ),
   );
-  const hasPendingAudio = useChatRuntimeStore((s) => Boolean(s.pendingAudioName));
+  const hasPendingAudio = useChatRuntimeStore((s) =>
+    Boolean(s.pendingAudioName),
+  );
   const hasSendableContent =
     composerText.trim().length > 0 || hasAttachments || hasPendingAudio;
 
   const handleSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
+    (event: Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0]) => {
       if (
         disabled ||
         !hasSendableContent ||
@@ -317,9 +434,37 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
         hasPendingAttachments
       ) {
         event.preventDefault();
+        return;
+      }
+
+      if (overlay) {
+        const trimmed = composerText.trim();
+        if (!trimmed) {
+          event.preventDefault();
+          return;
+        }
+        setImageToolsEnabled(true);
+        flushResourcesSync(() => {
+          aui
+            .composer()
+            .setText(
+              `Use the previous generated image as the reference and apply this edit: ${trimmed}. Preserve everything else exactly.`,
+            );
+        });
+        closeOverlay();
       }
     },
-    [disabled, hasPendingAttachments, hasSendableContent, isComposingRef],
+    [
+      aui,
+      closeOverlay,
+      composerText,
+      disabled,
+      hasPendingAttachments,
+      hasSendableContent,
+      isComposingRef,
+      overlay,
+      setImageToolsEnabled,
+    ],
   );
 
   const composerContent = (
@@ -342,7 +487,10 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
       />
       <ComposerAction
         disabled={
-          disabled || !hasSendableContent || isComposing || hasPendingAttachments
+          disabled ||
+          !hasSendableContent ||
+          isComposing ||
+          hasPendingAttachments
         }
         blockSend={() =>
           !hasSendableContent || isComposingRef.current || hasPendingAttachments
@@ -553,7 +701,6 @@ const ComposerAudioUpload: FC = () => {
   );
 };
 
-
 const ReasoningToggle: FC = () => {
   const modelLoaded = useChatRuntimeStore(
     (s) => !!s.params.checkpoint && !s.modelLoading,
@@ -565,8 +712,12 @@ const ReasoningToggle: FC = () => {
   const setReasoningEnabled = useChatRuntimeStore((s) => s.setReasoningEnabled);
   const reasoningStyle = useChatRuntimeStore((s) => s.reasoningStyle);
   const reasoningEffort = useChatRuntimeStore((s) => s.reasoningEffort);
-  const supportsReasoningOff = useChatRuntimeStore((s) => s.supportsReasoningOff);
-  const reasoningEffortLevels = useChatRuntimeStore((s) => s.reasoningEffortLevels);
+  const supportsReasoningOff = useChatRuntimeStore(
+    (s) => s.supportsReasoningOff,
+  );
+  const reasoningEffortLevels = useChatRuntimeStore(
+    (s) => s.reasoningEffortLevels,
+  );
   const setReasoningEffort = useChatRuntimeStore((s) => s.setReasoningEffort);
   const lastOpenRouterChosenModel = useChatRuntimeStore(
     (s) => s.lastOpenRouterChosenModel,
@@ -619,7 +770,8 @@ const ReasoningToggle: FC = () => {
     effectiveReasoningEnabled && reasoningEffort !== "none";
   const disabled = !(modelLoaded && effectiveSupportsReasoning);
   const formatEffortLabel = (level: typeof reasoningEffort): string => {
-    if (level !== "xhigh") return level.charAt(0).toUpperCase() + level.slice(1);
+    if (level !== "xhigh")
+      return level.charAt(0).toUpperCase() + level.slice(1);
     const normalized = externalSelection?.modelId?.trim().toLowerCase() ?? "";
     if (
       normalized.startsWith("claude-opus-4-6") ||
@@ -677,23 +829,25 @@ const ReasoningToggle: FC = () => {
           {effectiveReasoningEffortLevels
             .filter((level) => level !== "none")
             .map((level) => (
-            <DropdownMenuItem
-              key={level}
-              onSelect={() => {
-                setReasoningEffort(level);
-                setReasoningEnabled(true);
-                applyQwenThinkingParams(true);
-                // Kimi's $web_search builtin forbids thinking, so
-                // enabling thinking flips the Search pill off.
-                if (isKimiExternal && toolsEnabled) {
-                  setToolsEnabled(false);
-                }
-              }}
-            >
-              {formatEffortLabel(level)}
-              {effectiveReasoningVisualEnabled && reasoningEffort === level ? " \u2713" : ""}
-            </DropdownMenuItem>
-          ))}
+              <DropdownMenuItem
+                key={level}
+                onSelect={() => {
+                  setReasoningEffort(level);
+                  setReasoningEnabled(true);
+                  applyQwenThinkingParams(true);
+                  // Kimi's $web_search builtin forbids thinking, so
+                  // enabling thinking flips the Search pill off.
+                  if (isKimiExternal && toolsEnabled) {
+                    setToolsEnabled(false);
+                  }
+                }}
+              >
+                {formatEffortLabel(level)}
+                {effectiveReasoningVisualEnabled && reasoningEffort === level
+                  ? " \u2713"
+                  : ""}
+              </DropdownMenuItem>
+            ))}
         </DropdownMenuContent>
       </DropdownMenu>
     );
@@ -808,8 +962,7 @@ const WebSearchToggle: FC = () => {
       ? externalProviders.find((p) => p.id === externalSelection.providerId)
       : undefined;
   const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
-  const disabled =
-    !modelLoaded || !(supportsTools || supportsBuiltinWebSearch);
+  const disabled = !modelLoaded || !(supportsTools || supportsBuiltinWebSearch);
 
   return (
     <button
@@ -899,7 +1052,9 @@ const ImagesToggle: FC = () => {
       className="composer-pill-btn"
       data-active={imageToolsEnabled && !disabled ? "true" : "false"}
       aria-label={
-        imageToolsEnabled ? "Disable image generation" : "Enable image generation"
+        imageToolsEnabled
+          ? "Disable image generation"
+          : "Enable image generation"
       }
     >
       <ImageIcon className="size-3.5" />
@@ -1284,7 +1439,11 @@ const UserActionBar: FC = () => {
       <CopyButton />
       <ActionBarPrimitive.Edit asChild={true}>
         <TooltipIconButton tooltip="Edit" className="aui-user-action-edit">
-          <HugeiconsIcon icon={Edit03Icon} strokeWidth={1.75} className="size-icon" />
+          <HugeiconsIcon
+            icon={Edit03Icon}
+            strokeWidth={1.75}
+            className="size-icon"
+          />
         </TooltipIconButton>
       </ActionBarPrimitive.Edit>
       <DeleteMessageButton />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -413,6 +413,9 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
   const setImageToolsEnabled = useChatRuntimeStore(
     (s) => s.setImageToolsEnabled,
   );
+  const setPendingImageEditReference = useChatRuntimeStore(
+    (s) => s.setPendingImageEditReference,
+  );
   const { inputProps, isComposing, isComposingRef } =
     useImeComposerInputHandlers();
   const composerText = useAuiState(({ composer }) => composer.text);
@@ -448,12 +451,28 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
           event.preventDefault();
           return;
         }
+        if (!overlay.openaiImageGenerationCallId) {
+          event.preventDefault();
+          toast.error("This generated image cannot be edited", {
+            description:
+              "The original image reference is missing. Generate the image again, then retry the edit.",
+          });
+          closeOverlay();
+          return;
+        }
         setImageToolsEnabled(true);
+        setPendingImageEditReference({
+          openaiImageGenerationCallId: overlay.openaiImageGenerationCallId,
+          ...(overlay.openaiResponseId
+            ? { openaiResponseId: overlay.openaiResponseId }
+            : {}),
+          openaiReasoningItem: overlay.openaiReasoningItem,
+        });
         flushResourcesSync(() => {
           aui
             .composer()
             .setText(
-              `Use the previous generated image as the reference and apply this edit: ${trimmed}. Preserve everything else exactly.`,
+              `Use the selected generated image as the reference and apply this edit: ${trimmed}. Preserve everything else exactly.`,
             );
         });
         closeOverlay();
@@ -469,6 +488,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
       isComposingRef,
       overlay,
       setImageToolsEnabled,
+      setPendingImageEditReference,
     ],
   );
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -225,7 +225,7 @@ const GeneratedImageViewportOverlay: FC<{ hideComposer?: boolean }> = ({
         )}
         aria-label="Generated image preview"
       >
-        <div className="pointer-events-auto relative flex min-h-0 w-full max-w-[1100px] flex-1 items-center justify-center rounded-3xl bg-muted/10 p-3 ring-1 ring-border/20">
+        <div className="pointer-events-auto relative flex min-h-0 w-full max-w-[1100px] flex-1 flex-col items-center justify-center gap-3 rounded-3xl bg-muted/10 p-3 ring-1 ring-border/20">
           <div className="absolute inset-x-3 top-3 z-10 flex justify-end">
             <div className="flex shrink-0 items-center gap-1 rounded-full bg-background/70 p-1 ring-1 ring-border/20 backdrop-blur-sm">
               <Button
@@ -255,27 +255,32 @@ const GeneratedImageViewportOverlay: FC<{ hideComposer?: boolean }> = ({
               </Button>
             </div>
           </div>
-          <img
-            src={overlay.image}
-            alt={overlay.title}
-            className="max-h-full max-w-full object-contain"
-          />
-        </div>
-        <div className="mt-2 max-w-[min(100%,46rem)] text-center" title={overlay.title}>
-          <p className="truncate font-medium text-foreground/70 text-xs">
-            Generated image
-          </p>
-          {overlay.metadata ? (
-            <p className="truncate text-[11px] text-muted-foreground/75">
-              {overlay.metadata}
+          <div className="flex min-h-0 flex-1 items-center justify-center pt-1">
+            <img
+              src={overlay.image}
+              alt={overlay.title}
+              className="max-h-full max-w-full object-contain"
+            />
+          </div>
+          <div
+            className="w-full max-w-[min(100%,46rem)] shrink-0 text-center"
+            title={overlay.title}
+          >
+            <p className="truncate font-medium text-foreground/70 text-xs">
+              Generated image
             </p>
-          ) : null}
+            {overlay.metadata ? (
+              <p className="truncate text-[11px] text-muted-foreground/75">
+                {overlay.metadata}
+              </p>
+            ) : null}
+            {hideComposer ? null : (
+              <p className="mt-1 text-muted-foreground text-xs">
+                Type edits below, then send.
+              </p>
+            )}
+          </div>
         </div>
-        {hideComposer ? null : (
-          <p className="mt-1 text-center text-muted-foreground text-xs">
-            Type edits below, then send.
-          </p>
-        )}
       </section>
     </div>
   );

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -146,7 +146,10 @@ export const Thread: FC<{
               <AuiIf
                 condition={({ thread }) => thread.isEmpty && !thread.isLoading}
               >
-                <ThreadWelcome hideComposer={hideComposer} />
+                <ThreadWelcome
+                  hideComposer={hideComposer}
+                  threadId={targetThreadId ?? null}
+                />
               </AuiIf>
             )}
 
@@ -185,7 +188,10 @@ export const Thread: FC<{
 
           {!hideComposer && (
             <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
-              <ThreadComposerDock disabled={isComposerAttachPending} />
+              <ThreadComposerDock
+                disabled={isComposerAttachPending}
+                threadId={targetThreadId ?? null}
+              />
             </AuiIf>
           )}
         </IntentAwareScrollProvider>
@@ -286,7 +292,10 @@ const GeneratedImageViewportOverlay: FC<{ hideComposer?: boolean }> = ({
   );
 };
 
-const ThreadComposerDock: FC<{ disabled?: boolean }> = ({ disabled }) => {
+const ThreadComposerDock: FC<{
+  disabled?: boolean;
+  threadId?: string | null;
+}> = ({ disabled, threadId }) => {
   const { overlay } = useGeneratedImageOverlay();
 
   return (
@@ -302,7 +311,7 @@ const ThreadComposerDock: FC<{ disabled?: boolean }> = ({ disabled }) => {
       />
       <div className="relative px-5 pb-2">
         <div className="pointer-events-auto mx-auto w-full max-w-(--thread-max-width)">
-          <ComposerAnimated disabled={disabled} />
+          <ComposerAnimated disabled={disabled} threadId={threadId} />
         </div>
         <p className="composer-footer-note">
           LLMs can make mistakes. Double-check responses.
@@ -336,7 +345,10 @@ const ThreadScrollToBottom: FC = () => {
   );
 };
 
-const ThreadWelcome: FC<{ hideComposer?: boolean }> = ({ hideComposer }) => {
+const ThreadWelcome: FC<{
+  hideComposer?: boolean;
+  threadId?: string | null;
+}> = ({ hideComposer, threadId }) => {
   const [currentEmoji, setCurrentEmoji] = useState("large sloth drink.png");
 
   useEffect(() => {
@@ -366,18 +378,21 @@ const ThreadWelcome: FC<{ hideComposer?: boolean }> = ({ hideComposer }) => {
               Run GGUFs, safetensors, vision and audio models
             </p>
           </div>
-          {!hideComposer && <ComposerAnimated />}
+          {!hideComposer && <ComposerAnimated threadId={threadId} />}
         </div>
       </div>
     </div>
   );
 };
 
-const ComposerAnimated: FC<{ disabled?: boolean }> = ({ disabled }) => {
+const ComposerAnimated: FC<{
+  disabled?: boolean;
+  threadId?: string | null;
+}> = ({ disabled, threadId }) => {
   return (
     <div className="relative mx-auto min-w-0 w-full max-w-(--thread-max-width)">
       <div className="relative z-10 w-full">
-        <Composer disabled={disabled} />
+        <Composer disabled={disabled} threadId={threadId} />
       </div>
     </div>
   );
@@ -407,12 +422,16 @@ const PendingAudioChip: FC = () => {
   );
 };
 
-const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
+const Composer: FC<{
+  disabled?: boolean;
+  threadId?: string | null;
+}> = ({ disabled, threadId }) => {
   const aui = useAui();
   const { overlay, closeOverlay } = useGeneratedImageOverlay();
   const setImageToolsEnabled = useChatRuntimeStore(
     (s) => s.setImageToolsEnabled,
   );
+  const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const setPendingImageEditReference = useChatRuntimeStore(
     (s) => s.setPendingImageEditReference,
   );
@@ -430,6 +449,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
   const hasPendingAudio = useChatRuntimeStore((s) =>
     Boolean(s.pendingAudioName),
   );
+  const referenceThreadId = threadId ?? activeThreadId ?? null;
   const hasSendableContent =
     composerText.trim().length > 0 || hasAttachments || hasPendingAudio;
   const shouldBlockSend = useCallback(
@@ -462,6 +482,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
         }
         setImageToolsEnabled(true);
         setPendingImageEditReference({
+          threadId: referenceThreadId,
           openaiImageGenerationCallId: overlay.openaiImageGenerationCallId,
           ...(overlay.openaiResponseId
             ? { openaiResponseId: overlay.openaiResponseId }
@@ -484,6 +505,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
       composerText,
       disabled,
       overlay,
+      referenceThreadId,
       setImageToolsEnabled,
       setPendingImageEditReference,
       shouldBlockSend,

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -119,9 +119,11 @@ export const Thread: FC<{
   const isComposerAttachPending = useAuiState(({ threads }) =>
     targetThreadId ? threads.mainThreadId !== targetThreadId : false,
   );
+  const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
+  const threadId = targetThreadId ?? activeThreadId ?? null;
 
   return (
-    <GeneratedImageOverlayProvider>
+    <GeneratedImageOverlayProvider key={threadId ?? "default"} threadId={threadId}>
       <ThreadPrimitive.Root
         className="aui-root aui-thread-root @container relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden"
         style={{
@@ -146,10 +148,7 @@ export const Thread: FC<{
               <AuiIf
                 condition={({ thread }) => thread.isEmpty && !thread.isLoading}
               >
-                <ThreadWelcome
-                  hideComposer={hideComposer}
-                  threadId={targetThreadId ?? null}
-                />
+                <ThreadWelcome hideComposer={hideComposer} threadId={threadId} />
               </AuiIf>
             )}
 
@@ -190,7 +189,7 @@ export const Thread: FC<{
             <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
               <ThreadComposerDock
                 disabled={isComposerAttachPending}
-                threadId={targetThreadId ?? null}
+                threadId={threadId}
               />
             </AuiIf>
           )}
@@ -480,9 +479,17 @@ const Composer: FC<{
           closeOverlay();
           return;
         }
+        if ((overlay.threadId ?? null) !== referenceThreadId) {
+          event.preventDefault();
+          toast.error("This generated image belongs to another chat", {
+            description: "Open the original chat and retry the edit.",
+          });
+          closeOverlay();
+          return;
+        }
         setImageToolsEnabled(true);
         setPendingImageEditReference({
-          threadId: referenceThreadId,
+          threadId: overlay.threadId ?? referenceThreadId,
           openaiImageGenerationCallId: overlay.openaiImageGenerationCallId,
           ...(overlay.openaiResponseId
             ? { openaiResponseId: overlay.openaiResponseId }

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -432,15 +432,15 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
   );
   const hasSendableContent =
     composerText.trim().length > 0 || hasAttachments || hasPendingAudio;
+  const shouldBlockSend = useCallback(
+    () =>
+      !hasSendableContent || isComposingRef.current || hasPendingAttachments,
+    [hasPendingAttachments, hasSendableContent, isComposingRef],
+  );
 
   const handleSubmit = useCallback(
     (event: Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0]) => {
-      if (
-        disabled ||
-        !hasSendableContent ||
-        isComposingRef.current ||
-        hasPendingAttachments
-      ) {
+      if (disabled || shouldBlockSend()) {
         event.preventDefault();
         return;
       }
@@ -483,12 +483,10 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
       closeOverlay,
       composerText,
       disabled,
-      hasPendingAttachments,
-      hasSendableContent,
-      isComposingRef,
       overlay,
       setImageToolsEnabled,
       setPendingImageEditReference,
+      shouldBlockSend,
     ],
   );
 
@@ -517,9 +515,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
           isComposing ||
           hasPendingAttachments
         }
-        blockSend={() =>
-          !hasSendableContent || isComposingRef.current || hasPendingAttachments
-        }
+        shouldBlockSend={shouldBlockSend}
       />
     </>
   );
@@ -1146,10 +1142,10 @@ const ToolStatusDisplay: FC = () => {
   );
 };
 
-const ComposerAction: FC<{ disabled?: boolean; blockSend?: () => boolean }> = ({
-  disabled,
-  blockSend,
-}) => {
+const ComposerAction: FC<{
+  disabled?: boolean;
+  shouldBlockSend?: () => boolean;
+}> = ({ disabled, shouldBlockSend }) => {
   return (
     <div className="aui-composer-action-wrapper composer-action-wrapper">
       <div className="flex items-center gap-0.5">
@@ -1196,7 +1192,7 @@ const ComposerAction: FC<{ disabled?: boolean; blockSend?: () => boolean }> = ({
               size="icon"
               disabled={disabled}
               onClick={(event) => {
-                if (blockSend?.()) {
+                if (shouldBlockSend?.()) {
                   event.preventDefault();
                 }
               }}

--- a/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
@@ -89,24 +89,33 @@ const imageFilenameFromPrompt = (prompt: string, mime: string): string => {
   return `${slug || "generated-image"}.${extensionForMime(mime)}`;
 };
 
-function GeneratedImagePlaceholder({ label }: { label: string }) {
-  const dots = Array.from({ length: 64 }, (_, index) => {
-    const row = Math.floor(index / 8);
-    const col = index % 8;
-    return (
-      <span
-        key={index}
-        className="generated-image-loading-dot"
-        style={
-          {
-            "--dot-row": row,
-            "--dot-col": col,
-          } as CSSProperties
-        }
-      />
-    );
-  });
+const formatGeneratedImageLabel = (prompt: string): string => {
+  if (!prompt) {
+    return "Generated image";
+  }
+  return prompt.length > 80
+    ? `Generated image: ${prompt.slice(0, 80)}…`
+    : `Generated image: ${prompt}`;
+};
 
+const loadingDots = Array.from({ length: 64 }, (_, index) => {
+  const row = Math.floor(index / 8);
+  const col = index % 8;
+  return (
+    <span
+      key={index}
+      className="generated-image-loading-dot"
+      style={
+        {
+          "--dot-row": row,
+          "--dot-col": col,
+        } as CSSProperties
+      }
+    />
+  );
+});
+
+function GeneratedImagePlaceholder({ label }: { label: string }) {
   return (
     <div
       className={cn(
@@ -118,7 +127,7 @@ function GeneratedImagePlaceholder({ label }: { label: string }) {
     >
       <span className="sr-only">{label}</span>
       <div className="generated-image-loading-wave" aria-hidden={true}>
-        {dots}
+        {loadingDots}
       </div>
     </div>
   );
@@ -168,11 +177,7 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
   const isPendingImage = !imagePart && status?.type === "running";
 
   const runningLabel = "Generating image…";
-  const completedLabel = prompt
-    ? prompt.length > 80
-      ? `Generated image: ${prompt.slice(0, 80)}…`
-      : `Generated image: ${prompt}`
-    : "Generated image";
+  const completedLabel = formatGeneratedImageLabel(prompt);
 
   const showPreview = () => {
     if (!imagePart) {
@@ -189,20 +194,22 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
     });
   };
 
-  const stopActionClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const stopOverlayActionPropagation = (
+    event: MouseEvent<HTMLButtonElement>,
+  ) => {
     event.preventDefault();
     event.stopPropagation();
   };
 
   const handleDownload = (event: MouseEvent<HTMLButtonElement>) => {
-    stopActionClick(event);
+    stopOverlayActionPropagation(event);
     if (imagePart) {
       downloadImagePart(imagePart);
     }
   };
 
   const handleEditClick = (event: MouseEvent<HTMLButtonElement>) => {
-    stopActionClick(event);
+    stopOverlayActionPropagation(event);
     showPreview();
   };
 

--- a/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
@@ -43,6 +43,9 @@ import {
 interface ImageGenerationArgs {
   prompt?: string;
   kind?: string;
+  openai_image_generation_call_id?: unknown;
+  openai_response_id?: unknown;
+  openai_reasoning_item?: unknown;
 }
 
 interface ImageGenerationResult {
@@ -145,6 +148,14 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
   const imageMetadata = [imageResult?.size, imageResult?.quality, mime]
     .filter(Boolean)
     .join(" · ");
+  const openaiImageGenerationCallId =
+    typeof parsedArgs.openai_image_generation_call_id === "string"
+      ? parsedArgs.openai_image_generation_call_id
+      : undefined;
+  const openaiResponseId =
+    typeof parsedArgs.openai_response_id === "string"
+      ? parsedArgs.openai_response_id
+      : undefined;
   const imagePart: GeneratedImagePart | null = imageSrc
     ? {
         type: "image",
@@ -172,6 +183,9 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
       title: imageTitle,
       metadata: imageMetadata,
       filename: imagePart.filename,
+      openaiImageGenerationCallId,
+      openaiResponseId,
+      openaiReasoningItem: parsedArgs.openai_reasoning_item,
     });
   };
 

--- a/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
@@ -3,9 +3,21 @@
 
 "use client";
 
-import { type ToolCallMessagePartComponent, useAuiState } from "@assistant-ui/react";
-import { ImageIcon, LoaderIcon } from "lucide-react";
-import { memo, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { useChatRuntimeStore } from "@/features/chat";
+import { cn } from "@/lib/utils";
+import { type ToolCallMessagePartComponent, useAui } from "@assistant-ui/react";
+import { DownloadIcon, ImageIcon, LoaderIcon, PencilIcon } from "lucide-react";
+import type { ComponentProps, MouseEvent } from "react";
+import { memo, useState } from "react";
+import { Image, downloadImagePart } from "./image";
 import {
   ToolFallbackContent,
   ToolFallbackRoot,
@@ -48,11 +60,38 @@ interface ImageGenerationResult {
   background?: string;
 }
 
+function GeneratedImagePlaceholder({ label }: { label: string }) {
+  return (
+    <div
+      className={cn(
+        "relative flex aspect-square w-[480px] max-w-full overflow-hidden rounded-2xl border border-border/70",
+        "bg-gradient-to-br from-primary/15 via-muted to-background",
+      )}
+      aria-busy="true"
+      aria-label={label}
+    >
+      <div className="absolute inset-0 animate-pulse bg-[linear-gradient(110deg,transparent_0%,rgba(255,255,255,0.24)_42%,transparent_70%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle,rgba(148,163,184,0.36)_1px,transparent_1px)] [background-size:22px_22px] opacity-45" />
+      <div className="relative z-10 m-auto flex flex-col items-center gap-3 rounded-2xl border border-border/60 bg-background/70 px-5 py-4 shadow-sm backdrop-blur-md">
+        <LoaderIcon className="size-5 animate-spin text-primary" />
+        <span className="text-sm font-medium text-foreground/85">{label}</span>
+        <span className="text-xs text-muted-foreground">
+          Preparing a 480×480 preview
+        </span>
+      </div>
+    </div>
+  );
+}
+
 const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
   args,
   result,
   status,
 }) => {
+  const aui = useAui();
+  const setImageToolsEnabled = useChatRuntimeStore(
+    (s) => s.setImageToolsEnabled,
+  );
   const parsedArgs = (args as ImageGenerationArgs) ?? {};
   const prompt = parsedArgs.prompt ?? "";
   const isRunning = status?.type === "running";
@@ -66,26 +105,13 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
   const imageSrc = imageResult?.image_b64
     ? `data:${mime};base64,${imageResult.image_b64}`
     : null;
+  const imagePart = imageSrc
+    ? { type: "image" as const, image: imageSrc }
+    : null;
 
-  // Collapse the card once the model has resumed streaming prose
-  // after the image. Mirrors CodeExecutionToolUI so the inline image
-  // doesn't collapse mid-stream and the user can click to re-expand.
-  const hasText = useAuiState(({ message }) =>
-    message.content.some(
-      (p) =>
-        p.type === "text" &&
-        "text" in p &&
-        (p as { text: string }).text.length > 0,
-    ),
-  );
   const [open, setOpen] = useState(true);
-  useEffect(() => {
-    if (isRunning) {
-      setOpen(true);
-    } else if (hasText && !imageSrc) {
-      setOpen(false);
-    }
-  }, [isRunning, hasText, imageSrc]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editText, setEditText] = useState("");
 
   const runningLabel = "Generating image…";
   const completedLabel = prompt
@@ -93,6 +119,46 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
       ? `Generated image: ${prompt.slice(0, 80)}…`
       : `Generated image: ${prompt}`
     : "Generated image";
+
+  const stopActionClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleDownload = (event: MouseEvent<HTMLButtonElement>) => {
+    stopActionClick(event);
+    if (imagePart) {
+      downloadImagePart(imagePart);
+    }
+  };
+
+  const handleEditClick = (event: MouseEvent<HTMLButtonElement>) => {
+    stopActionClick(event);
+    setDialogOpen(true);
+  };
+
+  const handleSubmitEdit: NonNullable<ComponentProps<"form">["onSubmit"]> = (
+    event,
+  ) => {
+    event.preventDefault();
+    const trimmed = editText.trim();
+    if (!trimmed) {
+      return;
+    }
+    setImageToolsEnabled(true);
+    aui.thread().append({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: `Use the previous generated image as the reference and apply this edit: ${trimmed}. Preserve everything else exactly.`,
+        },
+      ],
+      createdAt: new Date(),
+    } as never);
+    setEditText("");
+    setDialogOpen(false);
+  };
 
   return (
     <ToolFallbackRoot open={open} onOpenChange={setOpen}>
@@ -102,20 +168,92 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
         icon={ImageIcon}
       />
       <ToolFallbackContent>
-        {isRunning && !imageSrc ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <LoaderIcon className="size-3.5 animate-spin" />
-            <span>{runningLabel}</span>
-          </div>
-        ) : imageSrc ? (
-          <figure className="m-0 flex flex-col gap-1.5">
-            <img
-              src={imageSrc}
-              alt={prompt || "Generated image"}
-              className="max-w-full rounded-md border border-border/60"
-            />
+        {isRunning && !imagePart ? (
+          <GeneratedImagePlaceholder label={runningLabel} />
+        ) : imagePart ? (
+          <figure className="m-0 flex flex-col gap-2">
+            <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+              <div className="group/generated-image relative aspect-square w-[480px] max-w-full overflow-hidden rounded-2xl border border-border/70 bg-muted/30 shadow-sm">
+                <button
+                  type="button"
+                  className="block size-full cursor-zoom-in overflow-hidden rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  onClick={() => setDialogOpen(true)}
+                  aria-label="Open generated image preview"
+                >
+                  <Image.Preview
+                    src={imagePart.image}
+                    alt={prompt || "Generated image"}
+                    containerClassName="size-full min-h-0 bg-background"
+                    className="size-full object-contain"
+                  />
+                </button>
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-gradient-to-t from-black/55 via-black/20 to-transparent p-3 opacity-100 transition-opacity sm:opacity-0 sm:group-hover/generated-image:opacity-100 sm:group-focus-within/generated-image:opacity-100">
+                  <Button
+                    type="button"
+                    variant="dark"
+                    size="sm"
+                    className="pointer-events-auto h-8 rounded-full bg-black/70 text-white hover:bg-black/85"
+                    onClick={handleEditClick}
+                  >
+                    <PencilIcon className="size-3.5" />
+                    Edit
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="dark"
+                    size="icon-sm"
+                    className="pointer-events-auto rounded-full bg-black/70 text-white hover:bg-black/85"
+                    onClick={handleDownload}
+                    aria-label="Download generated image"
+                  >
+                    <DownloadIcon className="size-4" />
+                  </Button>
+                </div>
+              </div>
+              <DialogContent className="flex max-h-[calc(100vh-2rem)] max-w-[1100px] grid-rows-none flex-col gap-4 rounded-3xl p-4 sm:max-w-[1100px]">
+                <DialogTitle className="sr-only">
+                  Generated image preview
+                </DialogTitle>
+                <DialogDescription className="sr-only">
+                  Preview the generated image and describe follow-up edits.
+                </DialogDescription>
+                <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-2xl bg-muted/30">
+                  <img
+                    src={imagePart.image}
+                    alt={prompt || "Generated image"}
+                    className="max-h-[min(1100px,calc(100vh-12rem))] max-w-full object-contain"
+                  />
+                </div>
+                <form
+                  onSubmit={handleSubmitEdit}
+                  className="flex flex-col gap-2"
+                >
+                  <Textarea
+                    value={editText}
+                    onChange={(event) => setEditText(event.target.value)}
+                    placeholder="Describe edits…"
+                    fieldSizing="fixed"
+                    className="min-h-20 resize-none rounded-2xl bg-background/80"
+                  />
+                  <div className="flex items-center justify-between gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => imagePart && downloadImagePart(imagePart)}
+                    >
+                      <DownloadIcon className="size-4" />
+                      Download
+                    </Button>
+                    <Button type="submit" size="sm" disabled={!editText.trim()}>
+                      Apply edit
+                    </Button>
+                  </div>
+                </form>
+              </DialogContent>
+            </Dialog>
             {prompt ? (
-              <figcaption className="text-xs leading-snug text-muted-foreground">
+              <figcaption className="max-w-[480px] text-xs leading-snug text-muted-foreground">
                 {prompt}
               </figcaption>
             ) : null}

--- a/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
@@ -6,8 +6,8 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
-import { DownloadIcon, ImageIcon, LoaderIcon, PencilIcon } from "lucide-react";
-import type { MouseEvent } from "react";
+import { DownloadIcon, ImageIcon, PencilIcon } from "lucide-react";
+import type { CSSProperties, MouseEvent } from "react";
 import { memo, useState } from "react";
 import { useGeneratedImageOverlay } from "./generated-image-overlay-context";
 import { Image, downloadImagePart } from "./image";
@@ -87,23 +87,35 @@ const imageFilenameFromPrompt = (prompt: string, mime: string): string => {
 };
 
 function GeneratedImagePlaceholder({ label }: { label: string }) {
+  const dots = Array.from({ length: 64 }, (_, index) => {
+    const row = Math.floor(index / 8);
+    const col = index % 8;
+    return (
+      <span
+        key={index}
+        className="generated-image-loading-dot"
+        style={
+          {
+            "--dot-row": row,
+            "--dot-col": col,
+          } as CSSProperties
+        }
+      />
+    );
+  });
+
   return (
     <div
       className={cn(
-        "relative flex aspect-square w-[480px] max-w-full overflow-hidden rounded-2xl border border-border/70",
-        "bg-gradient-to-br from-primary/15 via-muted to-background",
+        "generated-image-loading-card flex aspect-square w-[480px] max-w-full items-center justify-center rounded-2xl border border-border/70 bg-muted/15",
       )}
       aria-busy="true"
       aria-label={label}
+      aria-live="polite"
     >
-      <div className="absolute inset-0 animate-pulse bg-[linear-gradient(110deg,transparent_0%,rgba(255,255,255,0.24)_42%,transparent_70%)]" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle,rgba(148,163,184,0.36)_1px,transparent_1px)] [background-size:22px_22px] opacity-45" />
-      <div className="relative z-10 m-auto flex flex-col items-center gap-3 rounded-2xl border border-border/60 bg-background/70 px-5 py-4 shadow-sm backdrop-blur-md">
-        <LoaderIcon className="size-5 animate-spin text-primary" />
-        <span className="text-sm font-medium text-foreground/85">{label}</span>
-        <span className="text-xs text-muted-foreground">
-          Preparing a 480×480 preview
-        </span>
+      <span className="sr-only">{label}</span>
+      <div className="generated-image-loading-wave" aria-hidden={true}>
+        {dots}
       </div>
     </div>
   );
@@ -180,17 +192,23 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
     showPreview();
   };
 
+  if (isPendingImage) {
+    return (
+      <div className="aui-tool-fallback-root w-full py-1">
+        <GeneratedImagePlaceholder label={runningLabel} />
+      </div>
+    );
+  }
+
   return (
     <ToolFallbackRoot open={open} onOpenChange={setOpen}>
       <ToolFallbackTrigger
-        toolName={isPendingImage || isRunning ? runningLabel : completedLabel}
-        status={isPendingImage ? { type: "running" } : status}
+        toolName={isRunning ? runningLabel : completedLabel}
+        status={status}
         icon={ImageIcon}
       />
       <ToolFallbackContent>
-        {isPendingImage ? (
-          <GeneratedImagePlaceholder label={runningLabel} />
-        ) : imagePart ? (
+        {imagePart ? (
           <figure className="m-0 flex flex-col gap-2">
             <div className="group/generated-image relative aspect-square w-[480px] max-w-full overflow-hidden rounded-2xl border border-border/70 bg-muted/30 shadow-sm">
               <button

--- a/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-image-generation.tsx
@@ -4,19 +4,12 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Textarea } from "@/components/ui/textarea";
-import { useChatRuntimeStore } from "@/features/chat";
 import { cn } from "@/lib/utils";
-import { type ToolCallMessagePartComponent, useAui } from "@assistant-ui/react";
+import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { DownloadIcon, ImageIcon, LoaderIcon, PencilIcon } from "lucide-react";
-import type { ComponentProps, MouseEvent } from "react";
+import type { MouseEvent } from "react";
 import { memo, useState } from "react";
+import { useGeneratedImageOverlay } from "./generated-image-overlay-context";
 import { Image, downloadImagePart } from "./image";
 import {
   ToolFallbackContent,
@@ -58,7 +51,40 @@ interface ImageGenerationResult {
   size?: string;
   quality?: string;
   background?: string;
+  prompt?: string;
 }
+
+type GeneratedImagePart = {
+  type: "image";
+  image: string;
+  filename?: string;
+};
+
+const extensionForMime = (mime: string): string => {
+  switch (mime.toLowerCase()) {
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    case "image/svg+xml":
+      return "svg";
+    default:
+      return "png";
+  }
+};
+
+const imageFilenameFromPrompt = (prompt: string, mime: string): string => {
+  const slug = prompt
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 48);
+  return `${slug || "generated-image"}.${extensionForMime(mime)}`;
+};
 
 function GeneratedImagePlaceholder({ label }: { label: string }) {
   return (
@@ -88,10 +114,7 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
   result,
   status,
 }) => {
-  const aui = useAui();
-  const setImageToolsEnabled = useChatRuntimeStore(
-    (s) => s.setImageToolsEnabled,
-  );
+  const { openOverlay } = useGeneratedImageOverlay();
   const parsedArgs = (args as ImageGenerationArgs) ?? {};
   const prompt = parsedArgs.prompt ?? "";
   const isRunning = status?.type === "running";
@@ -105,13 +128,21 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
   const imageSrc = imageResult?.image_b64
     ? `data:${mime};base64,${imageResult.image_b64}`
     : null;
-  const imagePart = imageSrc
-    ? { type: "image" as const, image: imageSrc }
+  const imageTitle =
+    imageResult?.prompt?.trim() || prompt.trim() || "Generated image";
+  const imageMetadata = [imageResult?.size, imageResult?.quality, mime]
+    .filter(Boolean)
+    .join(" · ");
+  const imagePart: GeneratedImagePart | null = imageSrc
+    ? {
+        type: "image",
+        image: imageSrc,
+        filename: imageFilenameFromPrompt(prompt, mime),
+      }
     : null;
 
   const [open, setOpen] = useState(true);
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editText, setEditText] = useState("");
+  const isPendingImage = !imagePart && status?.type === "running";
 
   const runningLabel = "Generating image…";
   const completedLabel = prompt
@@ -119,6 +150,18 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
       ? `Generated image: ${prompt.slice(0, 80)}…`
       : `Generated image: ${prompt}`
     : "Generated image";
+
+  const showPreview = () => {
+    if (!imagePart) {
+      return;
+    }
+    openOverlay({
+      image: imagePart.image,
+      title: imageTitle,
+      metadata: imageMetadata,
+      filename: imagePart.filename,
+    });
+  };
 
   const stopActionClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -134,124 +177,58 @@ const ImageGenerationToolUIImpl: ToolCallMessagePartComponent = ({
 
   const handleEditClick = (event: MouseEvent<HTMLButtonElement>) => {
     stopActionClick(event);
-    setDialogOpen(true);
-  };
-
-  const handleSubmitEdit: NonNullable<ComponentProps<"form">["onSubmit"]> = (
-    event,
-  ) => {
-    event.preventDefault();
-    const trimmed = editText.trim();
-    if (!trimmed) {
-      return;
-    }
-    setImageToolsEnabled(true);
-    aui.thread().append({
-      role: "user",
-      content: [
-        {
-          type: "text",
-          text: `Use the previous generated image as the reference and apply this edit: ${trimmed}. Preserve everything else exactly.`,
-        },
-      ],
-      createdAt: new Date(),
-    } as never);
-    setEditText("");
-    setDialogOpen(false);
+    showPreview();
   };
 
   return (
     <ToolFallbackRoot open={open} onOpenChange={setOpen}>
       <ToolFallbackTrigger
-        toolName={isRunning ? runningLabel : completedLabel}
-        status={status}
+        toolName={isPendingImage || isRunning ? runningLabel : completedLabel}
+        status={isPendingImage ? { type: "running" } : status}
         icon={ImageIcon}
       />
       <ToolFallbackContent>
-        {isRunning && !imagePart ? (
+        {isPendingImage ? (
           <GeneratedImagePlaceholder label={runningLabel} />
         ) : imagePart ? (
           <figure className="m-0 flex flex-col gap-2">
-            <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-              <div className="group/generated-image relative aspect-square w-[480px] max-w-full overflow-hidden rounded-2xl border border-border/70 bg-muted/30 shadow-sm">
-                <button
+            <div className="group/generated-image relative aspect-square w-[480px] max-w-full overflow-hidden rounded-2xl border border-border/70 bg-muted/30 shadow-sm">
+              <button
+                type="button"
+                className="block size-full cursor-zoom-in overflow-hidden rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                onClick={showPreview}
+                aria-label="Open generated image preview"
+              >
+                <Image.Preview
+                  src={imagePart.image}
+                  alt={imageTitle}
+                  containerClassName="size-full min-h-0 bg-background"
+                  className="size-full object-cover"
+                />
+              </button>
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-gradient-to-t from-black/55 via-black/20 to-transparent p-3 opacity-100 transition-opacity sm:opacity-0 sm:group-hover/generated-image:opacity-100 sm:group-focus-within/generated-image:opacity-100">
+                <Button
                   type="button"
-                  className="block size-full cursor-zoom-in overflow-hidden rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  onClick={() => setDialogOpen(true)}
-                  aria-label="Open generated image preview"
+                  variant="dark"
+                  size="sm"
+                  className="pointer-events-auto h-8 rounded-full bg-black/70 text-white hover:bg-black/85"
+                  onClick={handleEditClick}
                 >
-                  <Image.Preview
-                    src={imagePart.image}
-                    alt={prompt || "Generated image"}
-                    containerClassName="size-full min-h-0 bg-background"
-                    className="size-full object-contain"
-                  />
-                </button>
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 bg-gradient-to-t from-black/55 via-black/20 to-transparent p-3 opacity-100 transition-opacity sm:opacity-0 sm:group-hover/generated-image:opacity-100 sm:group-focus-within/generated-image:opacity-100">
-                  <Button
-                    type="button"
-                    variant="dark"
-                    size="sm"
-                    className="pointer-events-auto h-8 rounded-full bg-black/70 text-white hover:bg-black/85"
-                    onClick={handleEditClick}
-                  >
-                    <PencilIcon className="size-3.5" />
-                    Edit
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="dark"
-                    size="icon-sm"
-                    className="pointer-events-auto rounded-full bg-black/70 text-white hover:bg-black/85"
-                    onClick={handleDownload}
-                    aria-label="Download generated image"
-                  >
-                    <DownloadIcon className="size-4" />
-                  </Button>
-                </div>
+                  <PencilIcon className="size-3.5" />
+                  Edit
+                </Button>
+                <Button
+                  type="button"
+                  variant="dark"
+                  size="icon-sm"
+                  className="pointer-events-auto rounded-full bg-black/70 text-white hover:bg-black/85"
+                  onClick={handleDownload}
+                  aria-label="Download generated image"
+                >
+                  <DownloadIcon className="size-4" />
+                </Button>
               </div>
-              <DialogContent className="flex max-h-[calc(100vh-2rem)] max-w-[1100px] grid-rows-none flex-col gap-4 rounded-3xl p-4 sm:max-w-[1100px]">
-                <DialogTitle className="sr-only">
-                  Generated image preview
-                </DialogTitle>
-                <DialogDescription className="sr-only">
-                  Preview the generated image and describe follow-up edits.
-                </DialogDescription>
-                <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-2xl bg-muted/30">
-                  <img
-                    src={imagePart.image}
-                    alt={prompt || "Generated image"}
-                    className="max-h-[min(1100px,calc(100vh-12rem))] max-w-full object-contain"
-                  />
-                </div>
-                <form
-                  onSubmit={handleSubmitEdit}
-                  className="flex flex-col gap-2"
-                >
-                  <Textarea
-                    value={editText}
-                    onChange={(event) => setEditText(event.target.value)}
-                    placeholder="Describe edits…"
-                    fieldSizing="fixed"
-                    className="min-h-20 resize-none rounded-2xl bg-background/80"
-                  />
-                  <div className="flex items-center justify-between gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => imagePart && downloadImagePart(imagePart)}
-                    >
-                      <DownloadIcon className="size-4" />
-                      Download
-                    </Button>
-                    <Button type="submit" size="sm" disabled={!editText.trim()}>
-                      Apply edit
-                    </Button>
-                  </div>
-                </form>
-              </DialogContent>
-            </Dialog>
+            </div>
             {prompt ? (
               <figcaption className="max-w-[480px] text-xs leading-snug text-muted-foreground">
                 {prompt}

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1782,6 +1782,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                           size?: string;
                           quality?: string;
                           background?: string;
+                          prompt?: string;
                         };
                     const imageB64 = toolEvent.image_b64 as string | undefined;
                     if (
@@ -1803,6 +1804,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                         size: toolEvent.size as string | undefined,
                         quality: toolEvent.quality as string | undefined,
                         background: toolEvent.background as string | undefined,
+                        prompt: toolEvent.prompt as string | undefined,
                       };
                     } else if (imgIdx !== -1) {
                       const text = rawResult.slice(0, imgIdx);
@@ -1820,8 +1822,19 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                     } else {
                       parsedResult = rawResult;
                     }
+                    const nextArgs =
+                      toolEvent.arguments && typeof toolEvent.arguments === "object"
+                        ? (toolEvent.arguments as ToolCallMessagePart["args"])
+                        : undefined;
+                    const mergedArgs = nextArgs
+                      ? { ...(toolCallParts[idx].args ?? {}), ...nextArgs }
+                      : toolCallParts[idx].args;
                     toolCallParts[idx] = {
                       ...toolCallParts[idx],
+                      args: mergedArgs,
+                      argsText: mergedArgs
+                        ? JSON.stringify(mergedArgs)
+                        : toolCallParts[idx].argsText,
                       result: parsedResult,
                     };
                   }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -408,6 +408,9 @@ function toOpenAIMessage(
     };
   }
 
+  if (!textContent) {
+    return null;
+  }
   return { role: message.role, content: textContent };
 }
 
@@ -984,24 +987,45 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const webLabel = providerShipsWebFetch
           ? "web search or web fetch"
           : "web search";
-        if (!webSearchEnabledForThisTurn && !codeExecEnabledForThisTurn) {
+        if (
+          !webSearchEnabledForThisTurn &&
+          !codeExecEnabledForThisTurn &&
+          !imageGenerationEnabledForThisTurn
+        ) {
+          disabledToolGuard =
+            `You do not have ${webLabel}, code execution, or image generation tools in this conversation. ` +
+            "Answer from your own knowledge. " +
+            "If a request genuinely requires tool use, live data fetch, running code, or image generation, " +
+            "inform the user that you do not have access to these capabilities. " +
+            "Do not return tool-call syntax inside your response.";
+        } else if (!webSearchEnabledForThisTurn && !codeExecEnabledForThisTurn) {
           disabledToolGuard =
             `You do not have ${webLabel} or code execution tools in this conversation. ` +
-            "Answer from your own knowledge. " +
-            "If a request genuinely requires tool use, live data fetch or running code, " +
+            "You may still use image generation tools when they are available and useful. " +
+            "If a request genuinely requires live data fetch or running code, " +
             "inform the user that you do not have access to these capabilities. " +
             "Do not return tool-call syntax inside your response.";
         } else if (!webSearchEnabledForThisTurn) {
+          const availableTools = [
+            codeExecEnabledForThisTurn ? "code execution" : null,
+            imageGenerationEnabledForThisTurn ? "image generation" : null,
+          ].filter(Boolean);
           disabledToolGuard =
             `You do not have ${webLabel} tools in this conversation. ` +
-            "You may still use code execution tools when they are available and useful. " +
+            (availableTools.length > 0
+              ? `You may still use ${availableTools.join(" and ")} tools when they are available and useful. `
+              : "") +
             "If a request genuinely requires live data fetch or web search tool use, " +
             "inform the user that you do not have access to these capabilities. " +
             "Do not return tool-call syntax inside your response.";
         } else if (!codeExecEnabledForThisTurn) {
+          const availableTools = [
+            webLabel,
+            imageGenerationEnabledForThisTurn ? "image generation" : null,
+          ].filter(Boolean);
           disabledToolGuard =
             "You do not have code execution tools in this conversation. " +
-            `You may still use ${webLabel} tools when they are available and useful. ` +
+            `You may still use ${availableTools.join(" and ")} tools when they are available and useful. ` +
             "If a request genuinely requires running code or code execution tool use, " +
             "inform the user that you do not have access to these capabilities. " +
             "Do not return tool-call syntax inside your response.";

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -896,13 +896,24 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // Wait for in-progress model load to finish before inferring
       if (runtime.modelLoading) {
         toast.info("Waiting for model to finish loading…");
-        await waitForModelReady(abortSignal);
+        try {
+          await waitForModelReady(abortSignal);
+        } catch (error) {
+          clearSelectedImageEditReference();
+          throw error;
+        }
       }
 
       if (!useChatRuntimeStore.getState().params.checkpoint) {
         // Auto-load the smallest downloaded model
-        const { loaded, blockedByTrustRemoteCode } =
-          await autoLoadSmallestModel();
+        let loaded: boolean;
+        let blockedByTrustRemoteCode: boolean;
+        try {
+          ({ loaded, blockedByTrustRemoteCode } = await autoLoadSmallestModel());
+        } catch (error) {
+          clearSelectedImageEditReference();
+          throw error;
+        }
         if (!loaded) {
           toast.error(
             blockedByTrustRemoteCode
@@ -914,6 +925,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                 : "Pick a model in the top bar, then retry.",
             },
           );
+          clearSelectedImageEditReference();
           throw new Error("Load a model first.");
         }
       }
@@ -937,6 +949,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           description:
             "Turn on Enable connections in Settings → Connections to use hosted models.",
         });
+        clearSelectedImageEditReference();
         throw new Error("Connections disabled.");
       }
       const externalProvider = isExternalRequest
@@ -952,6 +965,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         toast.error("Connection not found.", {
           description: "Open Settings → Connections and add it again.",
         });
+        clearSelectedImageEditReference();
         throw new Error("Connection not found.");
       }
       // Local providers (llama.cpp / vLLM / Ollama) allow an empty key — only block hosted providers.
@@ -962,6 +976,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         toast.error("Missing API key for selected connection.", {
           description: "Open Settings → Connections and set the API key again.",
         });
+        clearSelectedImageEditReference();
         throw new Error("Missing connection API key.");
       }
 
@@ -1009,6 +1024,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       );
 
       if (selectedImageEditReference && !imageGenerationEnabledForThisTurn) {
+        clearSelectedImageEditReference();
         toast.error("Image editing is unavailable", {
           description:
             "Select an OpenAI image-generation model, then retry the edit.",
@@ -1026,6 +1042,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           selectedImageEditReference,
         );
         if (!referenceMessage) {
+          clearSelectedImageEditReference();
           toast.error("This generated image cannot be edited", {
             description:
               "The original image reference is missing. Generate the image again, then retry the edit.",
@@ -1160,6 +1177,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           const gatedThreadKey = resolvedThreadId || "__default";
           runtime.setThreadRunning(gatedThreadKey, true);
           runtime.setThreadRunning(gatedThreadKey, false);
+          clearSelectedImageEditReference();
           throw new Error(imageGateReason);
         }
       }
@@ -1683,10 +1701,15 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         let retriedWithRefreshedKey = false;
         while (true) {
           try {
-            const stream = streamChatCompletions(
-              await buildRequestPayload(retriedWithRefreshedKey),
-              abortSignal,
-            );
+            let requestPayload: OpenAIChatCompletionsRequest;
+            try {
+              requestPayload = await buildRequestPayload(retriedWithRefreshedKey);
+            } catch (error) {
+              clearSelectedImageEditReference();
+              throw error;
+            }
+            clearSelectedImageEditReference();
+            const stream = streamChatCompletions(requestPayload, abortSignal);
 
             for await (const chunk of stream) {
               // Handle tool status events
@@ -2050,8 +2073,6 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             cachedTokens: meta.timings?.cache_n ?? 0,
           });
         }
-
-        clearSelectedImageEditReference();
 
         const finalTiming = buildTiming(
           streamStartTime,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -38,7 +38,6 @@ import { isMultimodalResponse } from "../types/api";
 import type {
   OpenAIChatCompletionsRequest,
   OpenAIChatMessage,
-  OpenAIImageGenerationCallContentPart,
   OpenAIMessageContent,
   OpenAIReasoningContentPart,
 } from "../types/api";
@@ -376,66 +375,6 @@ function normalizeOpenAIReasoningItem(
   return normalized;
 }
 
-function openAIImageGenerationRequiresReasoningReplay(
-  modelId: string,
-): boolean {
-  const normalized = modelId.trim().toLowerCase();
-  return normalized.startsWith("gpt-5") || normalized.startsWith("o");
-}
-
-function collectOpenAIImageGenerationCallParts(
-  message: RunMessage,
-  options?: { requireReasoningReplay?: boolean },
-): Array<OpenAIReasoningContentPart | OpenAIImageGenerationCallContentPart> {
-  if (message.role !== "assistant") {
-    return [];
-  }
-  const parts: Array<
-    OpenAIReasoningContentPart | OpenAIImageGenerationCallContentPart
-  > = [];
-  const seenReasoningIds = new Set<string>();
-  for (const part of message.content ?? []) {
-    if (part.type !== "tool-call" || part.toolName !== "image_generation") {
-      continue;
-    }
-    const args = part.args as
-      | {
-          openai_image_generation_call_id?: unknown;
-          openai_reasoning_item?: unknown;
-          openai_response_id?: unknown;
-        }
-      | undefined;
-    const argsId =
-      typeof args?.openai_image_generation_call_id === "string"
-        ? args.openai_image_generation_call_id
-        : "";
-    const fallbackId = part.toolCallId;
-    const id = argsId || (/^img_\d{16,}$/.test(fallbackId) ? "" : fallbackId);
-    const responseId =
-      typeof args?.openai_response_id === "string"
-        ? args.openai_response_id
-        : "";
-    if (id) {
-      const reasoningItem = normalizeOpenAIReasoningItem(
-        args?.openai_reasoning_item,
-      );
-      if (options?.requireReasoningReplay && !reasoningItem && !responseId) {
-        continue;
-      }
-      if (reasoningItem && !seenReasoningIds.has(reasoningItem.id)) {
-        seenReasoningIds.add(reasoningItem.id);
-        parts.push(reasoningItem);
-      }
-      parts.push({
-        type: "image_generation_call",
-        id,
-        ...(responseId ? { response_id: responseId } : {}),
-      });
-    }
-  }
-  return parts;
-}
-
 function toOpenAIImageEditReferenceMessage(
   reference: PendingImageEditReference,
 ): OpenAIChatMessage | null {
@@ -459,13 +398,7 @@ function toOpenAIImageEditReferenceMessage(
   return { role: "assistant", content };
 }
 
-function toOpenAIMessage(
-  message: RunMessage,
-  options?: {
-    includeOpenAIImageGenerationCalls?: boolean;
-    requireOpenAIImageGenerationReasoning?: boolean;
-  },
-): {
+function toOpenAIMessage(message: RunMessage): {
   role: "system" | "user" | "assistant";
   content: OpenAIMessageContent;
 } | null {
@@ -488,18 +421,12 @@ function toOpenAIMessage(
   }
 
   const imageParts = collectImageParts(message);
-  const imageGenerationCallParts = options?.includeOpenAIImageGenerationCalls
-    ? collectOpenAIImageGenerationCallParts(message, {
-        requireReasoningReplay: options.requireOpenAIImageGenerationReasoning,
-      })
-    : [];
-  if (imageParts.length > 0 || imageGenerationCallParts.length > 0) {
+  if (imageParts.length > 0) {
     return {
       role: message.role,
       content: [
         ...(textContent ? [{ type: "text" as const, text: textContent }] : []),
         ...imageParts,
-        ...imageGenerationCallParts,
       ],
     };
   }
@@ -941,10 +868,21 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // the user switches chats while waiting for model load / auto-load.
       const resolvedThreadId =
         (unstable_threadId ?? runtime.activeThreadId) || undefined;
-      const pendingImageEditReferenceForRun = runtime.pendingImageEditReference;
-      if (pendingImageEditReferenceForRun) {
-        runtime.clearPendingImageEditReference();
-      }
+      const selectedImageEditReference = runtime.pendingImageEditReference;
+      const clearSelectedImageEditReference = () => {
+        if (!selectedImageEditReference) {
+          return;
+        }
+        const store = useChatRuntimeStore.getState();
+        const pending = store.pendingImageEditReference;
+        if (
+          pending?.openaiImageGenerationCallId ===
+            selectedImageEditReference.openaiImageGenerationCallId &&
+          pending.openaiResponseId === selectedImageEditReference.openaiResponseId
+        ) {
+          store.clearPendingImageEditReference();
+        }
+      };
 
       // Wait for in-progress model load to finish before inferring
       if (runtime.modelLoading) {
@@ -1061,10 +999,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           ),
       );
 
-      if (
-        pendingImageEditReferenceForRun &&
-        !imageGenerationEnabledForThisTurn
-      ) {
+      if (selectedImageEditReference && !imageGenerationEnabledForThisTurn) {
         toast.error("Image editing is unavailable", {
           description:
             "Select an OpenAI image-generation model, then retry the edit.",
@@ -1072,21 +1007,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         throw new Error("Image generation edit unavailable.");
       }
 
-      const selectedImageEditReference = pendingImageEditReferenceForRun;
       const outboundMessages = messages
-        .map((message) =>
-          toOpenAIMessage(message, {
-            includeOpenAIImageGenerationCalls:
-              imageGenerationEnabledForThisTurn && !selectedImageEditReference,
-            requireOpenAIImageGenerationReasoning: Boolean(
-              externalSelection &&
-                runtime.reasoningEnabled !== false &&
-                openAIImageGenerationRequiresReasoningReplay(
-                  externalSelection.modelId,
-                ),
-            ),
-          }),
-        )
+        .map((message) => toOpenAIMessage(message))
         .filter((message): message is NonNullable<typeof message> =>
           Boolean(message),
         );
@@ -2119,6 +2041,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             cachedTokens: meta.timings?.cache_n ?? 0,
           });
         }
+
+        clearSelectedImageEditReference();
 
         const finalTiming = buildTiming(
           streamStartTime,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -35,6 +35,7 @@ import { isMultimodalResponse } from "../types/api";
 import type {
   OpenAIChatCompletionsRequest,
   OpenAIMessageContent,
+  OpenAIReasoningContentPart,
 } from "../types/api";
 import type { ChatModelSummary } from "../types/runtime";
 import { getImageInputUnavailableReason } from "../utils/image-input-support";
@@ -340,19 +341,64 @@ function collectImageParts(
   return parts;
 }
 
+function normalizeOpenAIReasoningItem(
+  value: unknown,
+): OpenAIReasoningContentPart | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const item = value as Record<string, unknown>;
+  if (item.type !== "reasoning" || typeof item.id !== "string" || !item.id) {
+    return null;
+  }
+  const summary = Array.isArray(item.summary)
+    ? item.summary.flatMap((part) => {
+        if (!part || typeof part !== "object") {
+          return [];
+        }
+        const summaryPart = part as Record<string, unknown>;
+        return summaryPart.type === "summary_text" &&
+          typeof summaryPart.text === "string"
+          ? [{ type: "summary_text" as const, text: summaryPart.text }]
+          : [];
+      })
+    : [];
+  const normalized: OpenAIReasoningContentPart = {
+    type: "reasoning",
+    id: item.id,
+    summary,
+  };
+  if (
+    item.status === "in_progress" ||
+    item.status === "completed" ||
+    item.status === "incomplete"
+  ) {
+    normalized.status = item.status;
+  }
+  return normalized;
+}
+
 function collectOpenAIImageGenerationCallParts(
   message: RunMessage,
-): Array<{ type: "image_generation_call"; id: string }> {
+): Array<
+  OpenAIReasoningContentPart | { type: "image_generation_call"; id: string }
+> {
   if (message.role !== "assistant") {
     return [];
   }
-  const parts: Array<{ type: "image_generation_call"; id: string }> = [];
+  const parts: Array<
+    OpenAIReasoningContentPart | { type: "image_generation_call"; id: string }
+  > = [];
+  const seenReasoningIds = new Set<string>();
   for (const part of message.content ?? []) {
     if (part.type !== "tool-call" || part.toolName !== "image_generation") {
       continue;
     }
     const args = part.args as
-      | { openai_image_generation_call_id?: unknown }
+      | {
+          openai_image_generation_call_id?: unknown;
+          openai_reasoning_item?: unknown;
+        }
       | undefined;
     const argsId =
       typeof args?.openai_image_generation_call_id === "string"
@@ -362,6 +408,13 @@ function collectOpenAIImageGenerationCallParts(
     const id =
       argsId || (/^img_\d{16,}$/.test(fallbackId) ? "" : fallbackId);
     if (id) {
+      const reasoningItem = normalizeOpenAIReasoningItem(
+        args?.openai_reasoning_item,
+      );
+      if (reasoningItem && !seenReasoningIds.has(reasoningItem.id)) {
+        seenReasoningIds.add(reasoningItem.id);
+        parts.push(reasoningItem);
+      }
       parts.push({ type: "image_generation_call", id });
     }
   }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { getAuthToken } from "@/features/auth/session";
+import { getAuthToken } from "@/features/auth";
 import { apiUrl } from "@/lib/api-base";
 import { toast } from "@/lib/toast";
 import type { MessageTiming, ToolCallMessagePart } from "@assistant-ui/core";
@@ -38,6 +38,7 @@ import { isMultimodalResponse } from "../types/api";
 import type {
   OpenAIChatCompletionsRequest,
   OpenAIChatMessage,
+  OpenAIImageGenerationCallContentPart,
   OpenAIMessageContent,
   OpenAIReasoningContentPart,
 } from "../types/api";
@@ -307,37 +308,30 @@ function collectImageParts(
   message: RunMessage,
 ): Array<{ type: "image_url"; image_url: { url: string } }> {
   const parts: Array<{ type: "image_url"; image_url: { url: string } }> = [];
+  const pushImagePart = (part: { type: string }) => {
+    if (part.type !== "image" || !("image" in part)) {
+      return;
+    }
+    const src = (part as { image: string }).image;
+    if (!src) {
+      return;
+    }
+    parts.push({
+      type: "image_url",
+      image_url: {
+        url: src.startsWith("data:") ? src : `data:image/png;base64,${src}`,
+      },
+    });
+  };
 
   for (const part of message.content ?? []) {
-    if (part.type === "image" && "image" in part) {
-      const src = (part as { image: string }).image;
-      if (src) {
-        parts.push({
-          type: "image_url",
-          image_url: {
-            url: src.startsWith("data:") ? src : `data:image/png;base64,${src}`,
-          },
-        });
-      }
-    }
+    pushImagePart(part);
   }
 
   if ("attachments" in message && (message.attachments?.length ?? 0) > 0) {
     for (const attachment of message.attachments ?? []) {
       for (const part of attachment.content ?? []) {
-        if (part.type === "image" && "image" in part) {
-          const src = (part as { image: string }).image;
-          if (src) {
-            parts.push({
-              type: "image_url",
-              image_url: {
-                url: src.startsWith("data:")
-                  ? src
-                  : `data:image/png;base64,${src}`,
-              },
-            });
-          }
-        }
+        pushImagePart(part);
       }
     }
   }
@@ -392,16 +386,12 @@ function openAIImageGenerationRequiresReasoningReplay(
 function collectOpenAIImageGenerationCallParts(
   message: RunMessage,
   options?: { requireReasoningReplay?: boolean },
-): Array<
-  | OpenAIReasoningContentPart
-  | { type: "image_generation_call"; id: string; response_id?: string }
-> {
+): Array<OpenAIReasoningContentPart | OpenAIImageGenerationCallContentPart> {
   if (message.role !== "assistant") {
     return [];
   }
   const parts: Array<
-    | OpenAIReasoningContentPart
-    | { type: "image_generation_call"; id: string; response_id?: string }
+    OpenAIReasoningContentPart | OpenAIImageGenerationCallContentPart
   > = [];
   const seenReasoningIds = new Set<string>();
   for (const part of message.content ?? []) {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -387,13 +387,15 @@ function collectOpenAIImageGenerationCallParts(
   message: RunMessage,
   options?: { requireReasoningReplay?: boolean },
 ): Array<
-  OpenAIReasoningContentPart | { type: "image_generation_call"; id: string }
+  | OpenAIReasoningContentPart
+  | { type: "image_generation_call"; id: string; response_id?: string }
 > {
   if (message.role !== "assistant") {
     return [];
   }
   const parts: Array<
-    OpenAIReasoningContentPart | { type: "image_generation_call"; id: string }
+    | OpenAIReasoningContentPart
+    | { type: "image_generation_call"; id: string; response_id?: string }
   > = [];
   const seenReasoningIds = new Set<string>();
   for (const part of message.content ?? []) {
@@ -404,6 +406,7 @@ function collectOpenAIImageGenerationCallParts(
       | {
           openai_image_generation_call_id?: unknown;
           openai_reasoning_item?: unknown;
+          openai_response_id?: unknown;
         }
       | undefined;
     const argsId =
@@ -413,18 +416,26 @@ function collectOpenAIImageGenerationCallParts(
     const fallbackId = part.toolCallId;
     const id =
       argsId || (/^img_\d{16,}$/.test(fallbackId) ? "" : fallbackId);
+    const responseId =
+      typeof args?.openai_response_id === "string"
+        ? args.openai_response_id
+        : "";
     if (id) {
       const reasoningItem = normalizeOpenAIReasoningItem(
         args?.openai_reasoning_item,
       );
-      if (options?.requireReasoningReplay && !reasoningItem) {
+      if (options?.requireReasoningReplay && !reasoningItem && !responseId) {
         continue;
       }
       if (reasoningItem && !seenReasoningIds.has(reasoningItem.id)) {
         seenReasoningIds.add(reasoningItem.id);
         parts.push(reasoningItem);
       }
-      parts.push({ type: "image_generation_call", id });
+      parts.push({
+        type: "image_generation_call",
+        id,
+        ...(responseId ? { response_id: responseId } : {}),
+      });
     }
   }
   return parts;

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -29,11 +29,15 @@ import {
   providerSupportsBuiltinWebFetch,
   providerSupportsBuiltinWebSearch,
 } from "../provider-capabilities";
-import { useChatRuntimeStore } from "../stores/chat-runtime-store";
+import {
+  type PendingImageEditReference,
+  useChatRuntimeStore,
+} from "../stores/chat-runtime-store";
 import { useExternalProvidersStore } from "../stores/external-providers-store";
 import { isMultimodalResponse } from "../types/api";
 import type {
   OpenAIChatCompletionsRequest,
+  OpenAIChatMessage,
   OpenAIMessageContent,
   OpenAIReasoningContentPart,
 } from "../types/api";
@@ -378,7 +382,9 @@ function normalizeOpenAIReasoningItem(
   return normalized;
 }
 
-function openAIImageGenerationRequiresReasoningReplay(modelId: string): boolean {
+function openAIImageGenerationRequiresReasoningReplay(
+  modelId: string,
+): boolean {
   const normalized = modelId.trim().toLowerCase();
   return normalized.startsWith("gpt-5") || normalized.startsWith("o");
 }
@@ -414,8 +420,7 @@ function collectOpenAIImageGenerationCallParts(
         ? args.openai_image_generation_call_id
         : "";
     const fallbackId = part.toolCallId;
-    const id =
-      argsId || (/^img_\d{16,}$/.test(fallbackId) ? "" : fallbackId);
+    const id = argsId || (/^img_\d{16,}$/.test(fallbackId) ? "" : fallbackId);
     const responseId =
       typeof args?.openai_response_id === "string"
         ? args.openai_response_id
@@ -439,6 +444,29 @@ function collectOpenAIImageGenerationCallParts(
     }
   }
   return parts;
+}
+
+function toOpenAIImageEditReferenceMessage(
+  reference: PendingImageEditReference,
+): OpenAIChatMessage | null {
+  if (!reference.openaiImageGenerationCallId) {
+    return null;
+  }
+  const content: Exclude<OpenAIMessageContent, string> = [];
+  const reasoningItem = normalizeOpenAIReasoningItem(
+    reference.openaiReasoningItem,
+  );
+  if (reasoningItem) {
+    content.push(reasoningItem);
+  }
+  content.push({
+    type: "image_generation_call",
+    id: reference.openaiImageGenerationCallId,
+    ...(reference.openaiResponseId
+      ? { response_id: reference.openaiResponseId }
+      : {}),
+  });
+  return { role: "assistant", content };
 }
 
 function toOpenAIMessage(
@@ -923,6 +951,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // the user switches chats while waiting for model load / auto-load.
       const resolvedThreadId =
         (unstable_threadId ?? runtime.activeThreadId) || undefined;
+      const pendingImageEditReferenceForRun = runtime.pendingImageEditReference;
+      if (pendingImageEditReferenceForRun) {
+        runtime.clearPendingImageEditReference();
+      }
 
       // Wait for in-progress model load to finish before inferring
       if (runtime.modelLoading) {
@@ -952,7 +984,12 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // Re-read store after potential auto-load / model ready wait
       runtime = useChatRuntimeStore.getState();
       const { params } = runtime;
-      const { supportsTools, toolsEnabled, codeToolsEnabled, imageToolsEnabled } = runtime;
+      const {
+        supportsTools,
+        toolsEnabled,
+        codeToolsEnabled,
+        imageToolsEnabled,
+      } = runtime;
       const externalSelection = parseExternalModelId(params.checkpoint);
       const isExternalRequest = externalSelection !== null;
       if (
@@ -991,33 +1028,30 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         throw new Error("Missing connection API key.");
       }
 
-      const webSearchEnabledForThisTurn =
-        Boolean(
-          externalProvider &&
-            toolsEnabled &&
-            providerSupportsBuiltinWebSearch(externalProvider.providerType),
-        );
-      const codeExecEnabledForThisTurn =
-        Boolean(
-          externalProvider &&
-            externalSelection &&
-            codeToolsEnabled &&
-            providerSupportsBuiltinCodeExecution(
-              externalProvider.providerType,
-              externalSelection.modelId,
-              externalProvider.baseUrl,
-            ),
-        );
+      const webSearchEnabledForThisTurn = Boolean(
+        externalProvider &&
+          toolsEnabled &&
+          providerSupportsBuiltinWebSearch(externalProvider.providerType),
+      );
+      const codeExecEnabledForThisTurn = Boolean(
+        externalProvider &&
+          externalSelection &&
+          codeToolsEnabled &&
+          providerSupportsBuiltinCodeExecution(
+            externalProvider.providerType,
+            externalSelection.modelId,
+            externalProvider.baseUrl,
+          ),
+      );
       // web_fetch shares the Search pill with web_search (no separate
       // UI toggle), so it follows toolsEnabled. Anthropic is the only
       // provider that ships it today; on others providerSupportsBuiltinWebFetch
       // returns false and this stays inert.
-      const webFetchEnabledForThisTurn =
-        Boolean(
-          externalProvider &&
-            toolsEnabled &&
-            providerSupportsBuiltinWebFetch(externalProvider.providerType),
-        );
+      const webFetchEnabledForThisTurn = Boolean(
+        externalProvider &&
+          toolsEnabled &&
+          providerSupportsBuiltinWebFetch(externalProvider.providerType),
+      );
       const providerShipsWebFetch = Boolean(
         externalProvider &&
           providerSupportsBuiltinWebFetch(externalProvider.providerType),
@@ -1037,11 +1071,23 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           ),
       );
 
+      if (
+        pendingImageEditReferenceForRun &&
+        !imageGenerationEnabledForThisTurn
+      ) {
+        toast.error("Image editing is unavailable", {
+          description:
+            "Select an OpenAI image-generation model, then retry the edit.",
+        });
+        throw new Error("Image generation edit unavailable.");
+      }
+
+      const selectedImageEditReference = pendingImageEditReferenceForRun;
       const outboundMessages = messages
         .map((message) =>
           toOpenAIMessage(message, {
             includeOpenAIImageGenerationCalls:
-              imageGenerationEnabledForThisTurn,
+              imageGenerationEnabledForThisTurn && !selectedImageEditReference,
             requireOpenAIImageGenerationReasoning: Boolean(
               externalSelection &&
                 runtime.reasoningEnabled !== false &&
@@ -1054,6 +1100,26 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         .filter((message): message is NonNullable<typeof message> =>
           Boolean(message),
         );
+      if (selectedImageEditReference) {
+        const referenceMessage = toOpenAIImageEditReferenceMessage(
+          selectedImageEditReference,
+        );
+        if (!referenceMessage) {
+          toast.error("This generated image cannot be edited", {
+            description:
+              "The original image reference is missing. Generate the image again, then retry the edit.",
+          });
+          throw new Error("Generated image edit reference missing.");
+        }
+        let insertAt = outboundMessages.length;
+        for (let i = outboundMessages.length - 1; i >= 0; i -= 1) {
+          if (outboundMessages[i]?.role === "user") {
+            insertAt = i;
+            break;
+          }
+        }
+        outboundMessages.splice(insertAt, 0, referenceMessage);
+      }
 
       const safeSystemPrompt =
         typeof params.systemPrompt === "string" ? params.systemPrompt : "";
@@ -1083,7 +1149,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             "If a request genuinely requires tool use, live data fetch, running code, or image generation, " +
             "inform the user that you do not have access to these capabilities. " +
             "Do not return tool-call syntax inside your response.";
-        } else if (!webSearchEnabledForThisTurn && !codeExecEnabledForThisTurn) {
+        } else if (
+          !webSearchEnabledForThisTurn &&
+          !codeExecEnabledForThisTurn
+        ) {
           disabledToolGuard =
             `You do not have ${webLabel} or code execution tools in this conversation. ` +
             "You may still use image generation tools when they are available and useful. " +
@@ -1466,8 +1535,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                     ) {
                       void updateStoredChatThreadEventually(t.id, {
                         openaiCodeExecContainerId: null,
-                      })
-                        .catch(() => {});
+                      }).catch(() => {});
                       continue;
                     }
                     openaiCodeExecContainerId = t.openaiCodeExecContainerId;
@@ -1511,8 +1579,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                   openaiCodeExecContainerId = created.id;
                   void updateStoredChatThreadEventually(resolvedThreadId, {
                     openaiCodeExecContainerId: created.id,
-                  })
-                    .catch(() => {});
+                  }).catch(() => {});
                 } catch {
                   // Fall back to backend's container_auto path on
                   // failure — keeps the chat moving; the next turn
@@ -1625,7 +1692,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               // attaches `cache_control.ttl` when the value is one of
               // "5m" / "1h" (see external_provider.py near line 1375),
               // so unknown values are a no-op end-to-end.
-              ...(supportsProviderPromptCacheTtl(externalProvider.providerType) &&
+              ...(supportsProviderPromptCacheTtl(
+                externalProvider.providerType,
+              ) &&
               (externalProvider.enablePromptCaching ?? true) &&
               isPromptCacheTtl(externalProvider.promptCacheTtl)
                 ? { prompt_cache_ttl: externalProvider.promptCacheTtl }
@@ -1743,8 +1812,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                         : "openaiCodeExecContainerId";
                     void updateStoredChatThreadEventually(resolvedThreadId, {
                       [field]: null,
-                    })
-                      .catch(() => {});
+                    }).catch(() => {});
                   }
                   continue;
                 }
@@ -1823,7 +1891,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                       parsedResult = rawResult;
                     }
                     const nextArgs =
-                      toolEvent.arguments && typeof toolEvent.arguments === "object"
+                      toolEvent.arguments &&
+                      typeof toolEvent.arguments === "object"
                         ? (toolEvent.arguments as ToolCallMessagePart["args"])
                         : undefined;
                     const mergedArgs = nextArgs

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -868,7 +868,13 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // the user switches chats while waiting for model load / auto-load.
       const resolvedThreadId =
         (unstable_threadId ?? runtime.activeThreadId) || undefined;
-      const selectedImageEditReference = runtime.pendingImageEditReference;
+      const resolvedThreadKey = resolvedThreadId ?? null;
+      const pendingImageEditReferenceForRun = runtime.pendingImageEditReference;
+      const selectedImageEditReference =
+        (pendingImageEditReferenceForRun?.threadId ?? null) ===
+        resolvedThreadKey
+          ? pendingImageEditReferenceForRun
+          : null;
       const clearSelectedImageEditReference = () => {
         if (!selectedImageEditReference) {
           return;
@@ -878,7 +884,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         if (
           pending?.openaiImageGenerationCallId ===
             selectedImageEditReference.openaiImageGenerationCallId &&
-          pending.openaiResponseId === selectedImageEditReference.openaiResponseId
+          pending.openaiResponseId ===
+            selectedImageEditReference.openaiResponseId &&
+          (pending.threadId ?? null) ===
+            (selectedImageEditReference.threadId ?? null)
         ) {
           store.clearPendingImageEditReference();
         }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -378,8 +378,14 @@ function normalizeOpenAIReasoningItem(
   return normalized;
 }
 
+function openAIImageGenerationRequiresReasoningReplay(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  return normalized.startsWith("gpt-5") || normalized.startsWith("o");
+}
+
 function collectOpenAIImageGenerationCallParts(
   message: RunMessage,
+  options?: { requireReasoningReplay?: boolean },
 ): Array<
   OpenAIReasoningContentPart | { type: "image_generation_call"; id: string }
 > {
@@ -411,6 +417,9 @@ function collectOpenAIImageGenerationCallParts(
       const reasoningItem = normalizeOpenAIReasoningItem(
         args?.openai_reasoning_item,
       );
+      if (options?.requireReasoningReplay && !reasoningItem) {
+        continue;
+      }
       if (reasoningItem && !seenReasoningIds.has(reasoningItem.id)) {
         seenReasoningIds.add(reasoningItem.id);
         parts.push(reasoningItem);
@@ -423,7 +432,10 @@ function collectOpenAIImageGenerationCallParts(
 
 function toOpenAIMessage(
   message: RunMessage,
-  options?: { includeOpenAIImageGenerationCalls?: boolean },
+  options?: {
+    includeOpenAIImageGenerationCalls?: boolean;
+    requireOpenAIImageGenerationReasoning?: boolean;
+  },
 ): {
   role: "system" | "user" | "assistant";
   content: OpenAIMessageContent;
@@ -448,7 +460,9 @@ function toOpenAIMessage(
 
   const imageParts = collectImageParts(message);
   const imageGenerationCallParts = options?.includeOpenAIImageGenerationCalls
-    ? collectOpenAIImageGenerationCallParts(message)
+    ? collectOpenAIImageGenerationCallParts(message, {
+        requireReasoningReplay: options.requireOpenAIImageGenerationReasoning,
+      })
     : [];
   if (imageParts.length > 0 || imageGenerationCallParts.length > 0) {
     return {
@@ -1017,6 +1031,13 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           toOpenAIMessage(message, {
             includeOpenAIImageGenerationCalls:
               imageGenerationEnabledForThisTurn,
+            requireOpenAIImageGenerationReasoning: Boolean(
+              externalSelection &&
+                runtime.reasoningEnabled !== false &&
+                openAIImageGenerationRequiresReasoningReplay(
+                  externalSelection.modelId,
+                ),
+            ),
           }),
         )
         .filter((message): message is NonNullable<typeof message> =>

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -340,7 +340,38 @@ function collectImageParts(
   return parts;
 }
 
-function toOpenAIMessage(message: RunMessage): {
+function collectOpenAIImageGenerationCallParts(
+  message: RunMessage,
+): Array<{ type: "image_generation_call"; id: string }> {
+  if (message.role !== "assistant") {
+    return [];
+  }
+  const parts: Array<{ type: "image_generation_call"; id: string }> = [];
+  for (const part of message.content ?? []) {
+    if (part.type !== "tool-call" || part.toolName !== "image_generation") {
+      continue;
+    }
+    const args = part.args as
+      | { openai_image_generation_call_id?: unknown }
+      | undefined;
+    const argsId =
+      typeof args?.openai_image_generation_call_id === "string"
+        ? args.openai_image_generation_call_id
+        : "";
+    const fallbackId = part.toolCallId;
+    const id =
+      argsId || (/^img_\d{16,}$/.test(fallbackId) ? "" : fallbackId);
+    if (id) {
+      parts.push({ type: "image_generation_call", id });
+    }
+  }
+  return parts;
+}
+
+function toOpenAIMessage(
+  message: RunMessage,
+  options?: { includeOpenAIImageGenerationCalls?: boolean },
+): {
   role: "system" | "user" | "assistant";
   content: OpenAIMessageContent;
 } | null {
@@ -363,10 +394,17 @@ function toOpenAIMessage(message: RunMessage): {
   }
 
   const imageParts = collectImageParts(message);
-  if (imageParts.length > 0) {
+  const imageGenerationCallParts = options?.includeOpenAIImageGenerationCalls
+    ? collectOpenAIImageGenerationCallParts(message)
+    : [];
+  if (imageParts.length > 0 || imageGenerationCallParts.length > 0) {
     return {
       role: message.role,
-      content: [{ type: "text", text: textContent }, ...imageParts],
+      content: [
+        ...(textContent ? [{ type: "text" as const, text: textContent }] : []),
+        ...imageParts,
+        ...imageGenerationCallParts,
+      ],
     };
   }
 
@@ -919,7 +957,12 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       );
 
       const outboundMessages = messages
-        .map(toOpenAIMessage)
+        .map((message) =>
+          toOpenAIMessage(message, {
+            includeOpenAIImageGenerationCalls:
+              imageGenerationEnabledForThisTurn,
+          }),
+        )
         .filter((message): message is NonNullable<typeof message> =>
           Boolean(message),
         );

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -185,15 +185,21 @@ const OPENAI_CODE_EXECUTION_MODEL_PREFIXES = [
 
 /**
  * Strict check that a provider configuration points at OpenAI's
- * managed cloud (api.openai.com), as opposed to a custom OpenAI-compat
- * backend (ollama / llama.cpp / vLLM / generic "custom" preset). The
- * shell tool ONLY exists on OpenAI cloud; sending it to anything else
- * 400s the request. Mirror of the backend's
- * `is_openai_cloud = "api.openai.com" in self.base_url` guard.
+ * managed cloud (api.openai.com) or Azure OpenAI Foundry
+ * (*.openai.azure.com), as opposed to a custom OpenAI-compat backend
+ * (ollama / llama.cpp / vLLM / generic "custom" preset). The shell and
+ * image-generation tools only exist on cloud backends; sending them to
+ * anything else 400s the request. Mirror of the backend's
+ * `_is_openai_family_cloud` host check.
  */
 function isOpenAICloudBaseUrl(baseUrl: string | null | undefined): boolean {
   if (!baseUrl) return true; // No override → uses the default openai.com base.
-  return baseUrl.trim().toLowerCase().includes("api.openai.com");
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === "api.openai.com" || host.endsWith(".openai.azure.com");
+  } catch {
+    return false;
+  }
 }
 
 export function providerSupportsBuiltinCodeExecution(

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -63,6 +63,7 @@ function saveLastExternalCheckpoint(value: string | null): void {
 
 export type ReasoningStyle = "enable_thinking" | "reasoning_effort";
 export type PendingImageEditReference = {
+  threadId: string | null;
   openaiImageGenerationCallId: string;
   openaiResponseId?: string;
   openaiReasoningItem?: unknown;

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -62,6 +62,11 @@ function saveLastExternalCheckpoint(value: string | null): void {
 }
 
 export type ReasoningStyle = "enable_thinking" | "reasoning_effort";
+export type PendingImageEditReference = {
+  openaiImageGenerationCallId: string;
+  openaiResponseId?: string;
+  openaiReasoningItem?: unknown;
+};
 export type ReasoningEffort =
   | "none"
   | "minimal"
@@ -286,6 +291,7 @@ type ChatRuntimeStore = {
   settingsPanelOpen: boolean;
   pendingAudioBase64: string | null;
   pendingAudioName: string | null;
+  pendingImageEditReference: PendingImageEditReference | null;
   contextUsage: {
     promptTokens: number;
     completionTokens: number;
@@ -336,6 +342,10 @@ type ChatRuntimeStore = {
   setChatTemplateOverride: (template: string | null) => void;
   setPendingAudio: (base64: string, name: string) => void;
   clearPendingAudio: () => void;
+  setPendingImageEditReference: (
+    reference: PendingImageEditReference | null,
+  ) => void;
+  clearPendingImageEditReference: () => void;
   setContextUsage: (usage: ChatRuntimeStore["contextUsage"]) => void;
 };
 
@@ -587,6 +597,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   settingsPanelOpen: false,
   pendingAudioBase64: null,
   pendingAudioName: null,
+  pendingImageEditReference: null,
   contextUsage: null,
   modelLoading: false,
   activeNativePathToken: null,
@@ -759,6 +770,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       defaultChatTemplate: null,
       chatTemplateOverride: null,
       loadedChatTemplateOverride: null,
+      pendingImageEditReference: null,
     }));
   },
   setReasoningEnabled: (reasoningEnabled, options) =>
@@ -845,5 +857,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     set({ pendingAudioBase64: base64, pendingAudioName: name }),
   clearPendingAudio: () =>
     set({ pendingAudioBase64: null, pendingAudioName: null }),
+  setPendingImageEditReference: (pendingImageEditReference) =>
+    set({ pendingImageEditReference }),
+  clearPendingImageEditReference: () =>
+    set({ pendingImageEditReference: null }),
   setContextUsage: (contextUsage) => set({ contextUsage }),
 }));

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -197,6 +197,7 @@ export type OpenAIMessageContent =
   | Array<
       | { type: "text"; text: string }
       | { type: "image_url"; image_url: { url: string } }
+      | { type: "image_generation_call"; id: string }
     >;
 
 export interface OpenAIChatMessage {

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -204,14 +204,19 @@ export type OpenAIReasoningContentPart = {
   status?: "in_progress" | "completed" | "incomplete";
 };
 
-export type OpenAIMessageContent =
-  | string
-  | Array<
-      | { type: "text"; text: string }
-      | { type: "image_url"; image_url: { url: string } }
-      | OpenAIReasoningContentPart
-      | { type: "image_generation_call"; id: string; response_id?: string }
-    >;
+export type OpenAIImageGenerationCallContentPart = {
+  type: "image_generation_call";
+  id: string;
+  response_id?: string;
+};
+
+export type OpenAIMessageContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } }
+  | OpenAIReasoningContentPart
+  | OpenAIImageGenerationCallContentPart;
+
+export type OpenAIMessageContent = string | OpenAIMessageContentPart[];
 
 export interface OpenAIChatMessage {
   role: "system" | "user" | "assistant";

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -192,11 +192,24 @@ export interface AudioGenerationResponse {
   }>;
 }
 
+export type OpenAIReasoningSummaryPart = {
+  type: "summary_text";
+  text: string;
+};
+
+export type OpenAIReasoningContentPart = {
+  type: "reasoning";
+  id: string;
+  summary: OpenAIReasoningSummaryPart[];
+  status?: "in_progress" | "completed" | "incomplete";
+};
+
 export type OpenAIMessageContent =
   | string
   | Array<
       | { type: "text"; text: string }
       | { type: "image_url"; image_url: { url: string } }
+      | OpenAIReasoningContentPart
       | { type: "image_generation_call"; id: string }
     >;
 

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -210,7 +210,7 @@ export type OpenAIMessageContent =
       | { type: "text"; text: string }
       | { type: "image_url"; image_url: { url: string } }
       | OpenAIReasoningContentPart
-      | { type: "image_generation_call"; id: string }
+      | { type: "image_generation_call"; id: string; response_id?: string }
     >;
 
 export interface OpenAIChatMessage {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1188,6 +1188,53 @@
 	border-color: var(--border) !important;
 }
 
+.generated-image-loading-card {
+	position: relative;
+	overflow: hidden;
+	contain: paint;
+}
+
+.generated-image-loading-wave {
+	position: relative;
+	display: grid;
+	grid-template-columns: repeat(8, minmax(0, 1fr));
+	gap: 14px;
+	width: min(66%, 18rem);
+	padding: 1.5rem;
+	border-radius: 1.5rem;
+}
+
+.generated-image-loading-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 9999px;
+	background: color-mix(in oklch, var(--muted-foreground) 82%, var(--primary));
+	opacity: 0.12;
+	transform: translate3d(0, 4px, 0) scale(0.72);
+	animation: generated-image-dot-wave 1850ms var(--ease-out-quart) infinite;
+	animation-delay: calc((var(--dot-row) * 72ms) + (var(--dot-col) * 72ms));
+	will-change: transform, opacity;
+}
+
+@keyframes generated-image-dot-wave {
+	0%,
+	22%,
+	100% {
+		opacity: 0.1;
+		transform: translate3d(0, 4px, 0) scale(0.72);
+	}
+
+	46% {
+		opacity: 0.46;
+		transform: translate3d(0, -3px, 0) scale(0.96);
+	}
+
+	66% {
+		opacity: 0.2;
+		transform: translate3d(0, 0, 0) scale(0.82);
+	}
+}
+
 /*
  * prefers-reduced-motion: honour the OS-level "reduce motion" preference.
  * Tailwind animate-in/out, Radix open/close transforms, infinite shine/pulse


### PR DESCRIPTION
## Summary
- carry OpenAI image_generation_call ids through chat history
- send prior image_generation_call refs on follow-up image generation turns
- cover the request wiring and tool-event metadata in backend tests

## Testing
- cd studio/frontend && npm run typecheck
- python3 -m py_compile studio/backend/core/inference/external_provider.py studio/backend/models/inference.py studio/backend/tests/test_openai_image_generation.py
- ~/.unsloth/studio/unsloth_studio/bin/python -m pytest studio/backend/tests/test_openai_image_generation.py