### PR TITLE
Studio: rewrite OpenAI Responses citation markers to markdown links

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -78,9 +78,7 @@ _OPENAI_REASONING_SUMMARY_UNSUPPORTED = re.compile(r"^o3(?:[-.]|$)")
 # on this stream, or drop it silently when the source_id is unknown.
 # Group 1 is the source id; an optional `<locator>` suffix is
 # discarded (we link the whole source rather than per-line locators).
-_OPENAI_CITATION_MARKER = re.compile(
-    "cite([^]+)(?:[^]*)?"
-)
+_OPENAI_CITATION_MARKER = re.compile("cite([^]+)(?:[^]*)?")
 
 
 def _replace_openai_citation_markers(

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -68,21 +68,12 @@ _ANTHROPIC_4_7_SAMPLING_REMOVED = re.compile(
 )
 _OPENAI_REASONING_SUMMARY_UNSUPPORTED = re.compile(r"^o3(?:[-.]|$)")
 
-# OpenAI's Responses stream emits inline citation markers shaped like
-# `citeSOURCE_ID` (private-use codepoints, see
+# OpenAI Responses inline citation markers: `citeSOURCE_ID[id2...][LOCATOR]`
+# using private-use codepoints (see
 # https://developers.openai.com/api/docs/guides/citation-formatting).
-# Multi-source markers reuse the same delimiter: `citeid1id2`.
-# An optional `<locator>` suffix (e.g. `L8-L13` or a page number)
-# may follow the source id list. Most fonts render the codepoints
-# as garbled "E202" glyphs or empty boxes, and markdown layers
-# tend to strip them, leaving run-on text like
-# "citeturn1view0turn1view1...". We rewrite each marker into a
-# markdown link `[[N]](URL)` per resolvable source id, or drop the
-# marker silently when none of its ids are known. Group 1 captures
-# everything between the cite-open and stop bytes; we then split
-# on the delimiter and try every token against the annotation
-# table. Tokens that don't resolve (locators, unknown ids) are
-# dropped silently so no garbled glyph ever reaches the renderer.
+# Group 1 holds the delim-separated tokens; each resolvable token expands
+# to `[[N]](URL)`, unresolved tokens (locators, unknown ids) drop silently
+# so no garbled glyph reaches the renderer.
 _OPENAI_CITE_OPEN = "cite"
 _OPENAI_CITE_STOP = ""
 _OPENAI_CITE_DELIM = ""
@@ -96,9 +87,8 @@ def _build_citation_lookup(
 ) -> dict[str, tuple[int, str]]:
     """Map every known ``source_id`` alias to ``(citation_index, url)``.
 
-    Accepts both the singular ``source_id`` and plural ``source_ids``
-    citation shapes. First-seen wins on alias collision so an earlier
-    citation keeps its number.
+    Accepts singular ``source_id`` and plural ``source_ids``. First-seen
+    wins on alias collision so an earlier citation keeps its number.
     """
     by_source: dict[str, tuple[int, str]] = {}
     for idx, cit in enumerate(url_citations, start = 1):
@@ -121,30 +111,19 @@ def _replace_openai_citation_markers(
     text: str,
     url_citations: list[dict[str, Any]],
 ) -> str:
-    """Rewrite `\\ue200cite\\ue202SOURCE_ID[\\ue202LOCATOR]\\ue201` markers.
-
-    For each marker, look up the source_id against the running
-    ``url_citations`` list and replace with `[[N]](URL)` where N is
-    the 1-based index of that citation. Multi-source markers expand
-    into one `[[N]](URL)` per resolvable id. Unknown source_ids and
-    locator suffixes are dropped silently so garbled glyphs never
-    reach the renderer. Idempotent on text that contains no private-
-    use codepoints.
+    """Rewrite `\\ue200cite\\ue202SOURCE_ID[\\ue202LOCATOR]\\ue201` markers into
+    `[[N]](URL)` per resolvable id. Multi-source markers expand to one link
+    per id; unresolved tokens drop silently. Idempotent on text without
+    private-use codepoints.
     """
     if not text or _OPENAI_CITE_STOP not in text:
         return text
     by_source = _build_citation_lookup(url_citations)
 
     def _sub(match: re.Match[str]) -> str:
-        # The capture group contains either a single source id, a
-        # delim-separated list of source ids (multi-source markers),
-        # or a source id followed by a locator. We try every
-        # delim-split token against the lookup; unresolved tokens
-        # are dropped silently. That handles multi-source (every
-        # token resolves, every token expands) AND source+locator
-        # (only the first token resolves, the locator is dropped).
-        # When no tokens resolve, the whole marker is stripped so
-        # the user-facing text stays clean.
+        # Try every delim-split token; unresolved tokens drop silently.
+        # Handles multi-source (all resolve) and source+locator (only the
+        # id resolves, locator drops). Empty result strips the marker.
         rendered: list[str] = []
         for tok in match.group(1).split(_OPENAI_CITE_DELIM):
             if not tok:
@@ -163,21 +142,13 @@ def _rewrite_citation_markers_partial(
     text: str,
     url_citations: list[dict[str, Any]],
 ) -> tuple[str, bool]:
-    """Variant of ``_replace_openai_citation_markers`` that also
-    reports whether any marker in ``text`` referenced a source_id
-    that has not yet been recorded in ``url_citations``.
+    """Like ``_replace_openai_citation_markers`` but also reports whether
+    any marker referenced a source_id not yet in ``url_citations``.
 
-    OpenAI's ``response.output_text.annotation.added`` event for a
-    ``url_citation`` typically arrives AFTER the delta carrying
-    the inline marker that references it. The stateless rewriter
-    has no way to distinguish a pending annotation from a
-    genuinely bogus source_id, so it silently drops the marker --
-    losing the inline link even though the URL eventually shows
-    up in the sources panel. Callers that own a per-stream buffer
-    can use this helper to defer emission of a segment with an
-    unresolved token until a later event records the annotation.
-    Markers whose tokens did not all resolve are left verbatim so
-    a follow-up pass on the same segment still parses cleanly.
+    The ``annotation.added`` event for a url_citation typically arrives
+    AFTER the delta carrying the marker referencing it. Callers buffer the
+    segment until a later event records the annotation; unresolved markers
+    are left verbatim so a follow-up pass still parses cleanly.
     """
     if not text or _OPENAI_CITE_STOP not in text:
         return text, False
@@ -196,11 +167,9 @@ def _rewrite_citation_markers_partial(
                 continue
             idx, url = hit
             rendered.append(f"[[{idx}]]({url})")
-        # If even one token in a multi-source marker is unresolved,
-        # leave the whole marker verbatim so the caller buffers the
-        # segment and re-runs once the late annotation lands. Emitting
-        # just the resolved tokens would discard the unresolved ids
-        # for good when the caller no longer retains the source text.
+        # Leave the whole marker verbatim if any token is unresolved so the
+        # caller can re-run once the late annotation lands; partial emission
+        # would lose the unresolved ids once the source text is dropped.
         if any_unresolved:
             has_unresolved = True
             return match.group(0)
@@ -212,28 +181,19 @@ def _rewrite_citation_markers_partial(
 def _split_pending_citation_tail(text: str) -> tuple[str, str]:
     """Split ``text`` into ``(head, pending_tail)`` for streamed deltas.
 
-    OpenAI's Responses stream chunks text on byte-buffer boundaries
-    that have no awareness of the inline citation marker grammar,
-    so a marker can straddle two ``response.output_text.delta``
-    events (e.g. delta-1 ends with ``\\ue200citetu`` and delta-2
-    starts with ``rn0view0\\ue201``). Processing each delta in
-    isolation would leak the half-marker to the user. We hold the
-    unterminated tail and prepend it onto the next delta so the
-    rewriter sees a complete marker.
-
-    ``pending_tail`` is the longest suffix that begins with
-    ``\\ue200`` and contains NO stop byte ``\\ue201``. ``head`` is
-    the part that's safe to emit immediately. When ``text`` ends
-    with a fully closed marker (or no marker at all) the tail is
-    empty.
+    A citation marker can straddle two SSE deltas (e.g. delta-1 ends with
+    ``\\ue200citetu`` and delta-2 starts with ``rn0view0\\ue201``); the
+    unterminated tail is buffered and prepended onto the next delta so the
+    rewriter sees a complete marker. ``pending_tail`` is the longest suffix
+    starting with ``\\ue200`` and lacking ``\\ue201``; ``head`` is safe to
+    emit. Empty tail when ``text`` has no open marker or a fully closed one.
     """
     if not text:
         return text, ""
     last_open = text.rfind("")
     if last_open == -1:
         return text, ""
-    # If a stop byte appears after the last open byte, the marker
-    # closed inside this delta and nothing needs to be buffered.
+    # Stop byte after the last open byte means the marker closed in this delta.
     if _OPENAI_CITE_STOP in text[last_open:]:
         return text, ""
     return text[:last_open], text[last_open:]
@@ -3113,31 +3073,20 @@ class ExternalProviderClient:
                     # see.
                     latched_container_id: Optional[str] = None
                     container_id_emitted = False
-                    # Buffer for an unterminated citation marker that
-                    # straddles two ``response.output_text.delta``
-                    # events. See ``_split_pending_citation_tail`` for
-                    # why this is necessary. Always concatenated onto
-                    # the front of the next delta so the rewriter sees
-                    # a complete ``cite...`` marker
-                    # rather than half of one.
+                    # Buffer for a citation marker straddling two delta events;
+                    # prepended onto the next delta. See _split_pending_citation_tail.
                     pending_marker_tail: str = ""
-                    # Segments whose markers reference a source_id
-                    # we have not seen yet. Held in arrival order
-                    # so output stays in stream order: subsequent
-                    # clean text never leapfrogs an earlier deferred
-                    # segment. Flushed on annotation events and on
-                    # response.completed / incomplete / [DONE] (with
-                    # leftover markers stripped at end-of-stream so
-                    # no private-use codepoint leaks).
+                    # Segments deferred while their markers reference unseen
+                    # source_ids; held in arrival order so output never
+                    # leapfrogs an earlier deferred segment. Flushed on
+                    # annotation events and force-flushed at end-of-stream
+                    # with leftover private-use codepoints stripped.
                     pending_citation_segments: list[str] = []
 
                     def _drain_pending_segments(force: bool) -> str:
-                        """Re-attempt resolution on each buffered
-                        segment in order. Stops at the first segment
-                        that still has an unresolved token unless
-                        ``force`` is true (end-of-stream), in which
-                        case lingering markers are stripped so no
-                        garbled glyph reaches the renderer."""
+                        """Re-attempt resolution on buffered segments in order.
+                        Stops at the first still-unresolved segment unless
+                        ``force`` (end-of-stream), where lingering markers are stripped."""
                         out: list[str] = []
                         while pending_citation_segments:
                             seg = pending_citation_segments[0]
@@ -3159,49 +3108,28 @@ class ExternalProviderClient:
                         return "".join(out)
 
                     def _flush_pending_marker_tail(tail: str) -> str:
-                        """Render any leftover citation tail for emission.
+                        """Render any leftover citation tail at end-of-stream.
 
-                        ``pending_marker_tail`` starts at an unclosed
-                        opener by construction -- the split helper only
-                        buffers the suffix that lacks a closing stop
-                        byte. If the closing byte still has not arrived
-                        by end-of-stream the tail is meaningless
-                        without the annotation it would have referenced,
-                        so drop it. The user-visible prose before the
-                        opener was already emitted as ``head`` on the
-                        originating delta; only the marker fragment is
-                        held back. On the off chance the close arrives
-                        concatenated onto the tail (the stream finishes
-                        with a complete marker still in the buffer),
-                        run the rewriter against it one more time, then
-                        strip any leftover private-use bytes plus the
-                        literal ``cite``-prefixed source id so the
-                        renderer never sees raw markup. The sources
-                        panel is unaffected -- url_citations are
-                        aggregated separately and applied to the last
-                        web_search call's tool_end.
+                        Unterminated tails drop (no annotation to bind to). If the
+                        close byte arrived concatenated, rewrite then scrub any
+                        residual private-use bytes and any orphan ``cite<sid>``
+                        literal so the renderer never sees raw markup. url_citations
+                        are aggregated separately and applied to web_search tool_end.
                         """
                         if not tail:
                             return ""
                         if _OPENAI_CITE_STOP not in tail:
-                            # Truly unterminated: drop it. The
-                            # codepoints AND the residual "cite" +
-                            # source id would otherwise leak as plain
-                            # text once we stripped the private-use
-                            # bytes.
+                            # Unterminated: drop the whole tail, otherwise the
+                            # residual ``cite<sid>`` would leak as plain text.
                             return ""
                         rendered = _replace_openai_citation_markers(
                             tail, all_url_citations
                         )
-                        # Belt-and-braces: scrub any residual
-                        # private-use bytes the rewriter chose not to
-                        # touch (e.g. a leading partial opener).
+                        # Scrub residual private-use bytes (e.g. a partial opener).
                         for ch in ("", "", ""):
                             rendered = rendered.replace(ch, "")
-                        # Drop any orphan ``cite<sid>`` literal at the
-                        # head of the buffer -- without its closing
-                        # byte and matching url_citation it is
-                        # meaningless to the user.
+                        # Drop any orphan ``cite<sid>`` literal -- meaningless
+                        # without its closing byte and matching url_citation.
                         rendered = re.sub(r"^cite\S*", "", rendered)
                         return rendered
 
@@ -3355,11 +3283,8 @@ class ExternalProviderClient:
                             if not data_str:
                                 continue
                             if data_str == "[DONE]":
-                                # Flush any held-over partial citation
-                                # marker that never got its closing
-                                # `` -- strip the private-use
-                                # bytes so garbled glyphs don't reach
-                                # the renderer.
+                                # Flush any held-over partial marker; strip
+                                # private-use bytes so garbled glyphs don't leak.
                                 if pending_marker_tail:
                                     flushed = _flush_pending_marker_tail(
                                         pending_marker_tail
@@ -3370,10 +3295,8 @@ class ExternalProviderClient:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
                                         yield _chunk_with_text(flushed)
-                                # Force-drain any segment still
-                                # waiting for an annotation. Lingering
-                                # markers are stripped so no codepoint
-                                # leaks at end of stream.
+                                # Force-drain any segment still awaiting an
+                                # annotation; lingering codepoints are stripped.
                                 tail_flushed = _drain_pending_segments(
                                     force = True,
                                 )
@@ -3396,22 +3319,16 @@ class ExternalProviderClient:
 
                             if event_type == "response.output_text.delta":
                                 delta_text = event.get("delta", "")
-                                # Process inline annotations FIRST so that
-                                # any source_ids referenced by markers in
-                                # the same delta are already in the lookup
-                                # table when the rewriter runs below. Some
-                                # API versions inline url citations on the
-                                # delta event itself rather than as a
-                                # separate response.output_text.annotation
-                                # .added event.
+                                # Process inline annotations first so source_ids
+                                # referenced by same-delta markers are in the lookup
+                                # before the rewriter runs. Some API versions inline
+                                # url citations on the delta event itself.
                                 for ann in event.get("annotations") or []:
                                     if isinstance(ann, dict):
                                         _record_url_citation(ann)
                                 if delta_text or pending_marker_tail:
-                                    # Concatenate any unterminated marker
-                                    # tail held over from the previous
-                                    # delta so a marker that straddles
-                                    # two SSE events resolves cleanly.
+                                    # Prepend any held-over tail so a marker
+                                    # straddling two SSE events resolves cleanly.
                                     combined = pending_marker_tail + delta_text
                                     head, pending_marker_tail = (
                                         _split_pending_citation_tail(combined)
@@ -3420,11 +3337,9 @@ class ExternalProviderClient:
                                         if reasoning_open:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
-                                        # Re-attempt earlier deferred
-                                        # segments first so output stays
-                                        # in order. The annotation we
-                                        # need may have arrived inline
-                                        # on this same event above.
+                                        # Re-attempt earlier deferred segments first
+                                        # so output stays in order; the needed
+                                        # annotation may have arrived inline above.
                                         flushed = _drain_pending_segments(
                                             force = False,
                                         )
@@ -3711,10 +3626,8 @@ class ExternalProviderClient:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
                                         yield _chunk_with_text(flushed)
-                                # Force-drain any segment still
-                                # waiting for an annotation. Lingering
-                                # markers are stripped so no codepoint
-                                # leaks at end of stream.
+                                # Force-drain any segment still awaiting an
+                                # annotation; lingering codepoints are stripped.
                                 tail_flushed = _drain_pending_segments(
                                     force = True,
                                 )
@@ -3828,10 +3741,8 @@ class ExternalProviderClient:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
                                         yield _chunk_with_text(flushed)
-                                # Force-drain any segment still
-                                # waiting for an annotation. Lingering
-                                # markers are stripped so no codepoint
-                                # leaks at end of stream.
+                                # Force-drain any segment still awaiting an
+                                # annotation; lingering codepoints are stripped.
                                 tail_flushed = _drain_pending_segments(
                                     force = True,
                                 )

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -159,6 +159,49 @@ def _replace_openai_citation_markers(
     return _OPENAI_CITATION_MARKER.sub(_sub, text)
 
 
+def _rewrite_citation_markers_partial(
+    text: str,
+    url_citations: list[dict[str, Any]],
+) -> tuple[str, bool]:
+    """Variant of ``_replace_openai_citation_markers`` that also
+    reports whether any marker in ``text`` referenced a source_id
+    that has not yet been recorded in ``url_citations``.
+
+    OpenAI's ``response.output_text.annotation.added`` event for a
+    ``url_citation`` typically arrives AFTER the delta carrying
+    the inline marker that references it. The stateless rewriter
+    has no way to distinguish a pending annotation from a
+    genuinely bogus source_id, so it silently drops the marker --
+    losing the inline link even though the URL eventually shows
+    up in the sources panel. Callers that own a per-stream buffer
+    can use this helper to defer emission of a segment with an
+    unresolved token until a later event records the annotation.
+    Markers whose tokens did not all resolve are left verbatim so
+    a follow-up pass on the same segment still parses cleanly.
+    """
+    if not text or _OPENAI_CITE_STOP not in text:
+        return text, False
+    by_source = _build_citation_lookup(url_citations)
+    has_unresolved = False
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal has_unresolved
+        tokens = [t for t in match.group(1).split(_OPENAI_CITE_DELIM) if t]
+        rendered: list[str] = []
+        for tok in tokens:
+            hit = by_source.get(tok)
+            if hit is None:
+                continue
+            idx, url = hit
+            rendered.append(f"[[{idx}]]({url})")
+        if not rendered:
+            has_unresolved = True
+            return match.group(0)
+        return "".join(rendered)
+
+    return _OPENAI_CITATION_MARKER.sub(_sub, text), has_unresolved
+
+
 def _split_pending_citation_tail(text: str) -> tuple[str, str]:
     """Split ``text`` into ``(head, pending_tail)`` for streamed deltas.
 
@@ -3071,6 +3114,42 @@ class ExternalProviderClient:
                     # a complete ``cite...`` marker
                     # rather than half of one.
                     pending_marker_tail: str = ""
+                    # Segments whose markers reference a source_id
+                    # we have not seen yet. Held in arrival order
+                    # so output stays in stream order: subsequent
+                    # clean text never leapfrogs an earlier deferred
+                    # segment. Flushed on annotation events and on
+                    # response.completed / incomplete / [DONE] (with
+                    # leftover markers stripped at end-of-stream so
+                    # no private-use codepoint leaks).
+                    pending_citation_segments: list[str] = []
+
+                    def _drain_pending_segments(force: bool) -> str:
+                        """Re-attempt resolution on each buffered
+                        segment in order. Stops at the first segment
+                        that still has an unresolved token unless
+                        ``force`` is true (end-of-stream), in which
+                        case lingering markers are stripped so no
+                        garbled glyph reaches the renderer."""
+                        out: list[str] = []
+                        while pending_citation_segments:
+                            seg = pending_citation_segments[0]
+                            rewritten, unresolved = (
+                                _rewrite_citation_markers_partial(
+                                    seg, all_url_citations,
+                                )
+                            )
+                            if unresolved and not force:
+                                pending_citation_segments[0] = rewritten
+                                break
+                            if unresolved and force:
+                                rewritten = _replace_openai_citation_markers(
+                                    rewritten, all_url_citations,
+                                )
+                            pending_citation_segments.pop(0)
+                            if rewritten:
+                                out.append(rewritten)
+                        return "".join(out)
 
                     def _flush_pending_marker_tail(tail: str) -> str:
                         """Render any leftover citation tail for emission.
@@ -3269,6 +3348,18 @@ class ExternalProviderClient:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
                                         yield _chunk_with_text(flushed)
+                                # Force-drain any segment still
+                                # waiting for an annotation. Lingering
+                                # markers are stripped so no codepoint
+                                # leaks at end of stream.
+                                tail_flushed = _drain_pending_segments(
+                                    force = True,
+                                )
+                                if tail_flushed:
+                                    if reasoning_open:
+                                        yield _chunk_with_text("</think>")
+                                        reasoning_open = False
+                                    yield _chunk_with_text(tail_flushed)
                                 if not done_emitted:
                                     yield "data: [DONE]"
                                     done_emitted = True
@@ -3307,16 +3398,40 @@ class ExternalProviderClient:
                                         if reasoning_open:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
-                                        head = _replace_openai_citation_markers(
-                                            head, all_url_citations
+                                        # Re-attempt earlier deferred
+                                        # segments first so output stays
+                                        # in order. The annotation we
+                                        # need may have arrived inline
+                                        # on this same event above.
+                                        flushed = _drain_pending_segments(
+                                            force = False,
                                         )
-                                        if head:
-                                            yield _chunk_with_text(head)
+                                        if flushed:
+                                            yield _chunk_with_text(flushed)
+                                        head_rewritten, has_unresolved = (
+                                            _rewrite_citation_markers_partial(
+                                                head, all_url_citations,
+                                            )
+                                        )
+                                        if has_unresolved or pending_citation_segments:
+                                            pending_citation_segments.append(
+                                                head_rewritten
+                                            )
+                                        elif head_rewritten:
+                                            yield _chunk_with_text(head_rewritten)
 
                             elif event_type == "response.output_text.annotation.added":
                                 ann = event.get("annotation")
                                 if isinstance(ann, dict):
                                     _record_url_citation(ann)
+                                flushed = _drain_pending_segments(
+                                    force = False,
+                                )
+                                if flushed:
+                                    if reasoning_open:
+                                        yield _chunk_with_text("</think>")
+                                        reasoning_open = False
+                                    yield _chunk_with_text(flushed)
 
                             elif event_type == "response.output_item.added":
                                 # Track the call early but do NOT emit tool_start
@@ -3573,6 +3688,18 @@ class ExternalProviderClient:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
                                         yield _chunk_with_text(flushed)
+                                # Force-drain any segment still
+                                # waiting for an annotation. Lingering
+                                # markers are stripped so no codepoint
+                                # leaks at end of stream.
+                                tail_flushed = _drain_pending_segments(
+                                    force = True,
+                                )
+                                if tail_flushed:
+                                    if reasoning_open:
+                                        yield _chunk_with_text("</think>")
+                                        reasoning_open = False
+                                    yield _chunk_with_text(tail_flushed)
                                 if reasoning_open:
                                     yield _chunk_with_text("</think>")
                                     reasoning_open = False
@@ -3678,6 +3805,18 @@ class ExternalProviderClient:
                                             yield _chunk_with_text("</think>")
                                             reasoning_open = False
                                         yield _chunk_with_text(flushed)
+                                # Force-drain any segment still
+                                # waiting for an annotation. Lingering
+                                # markers are stripped so no codepoint
+                                # leaks at end of stream.
+                                tail_flushed = _drain_pending_segments(
+                                    force = True,
+                                )
+                                if tail_flushed:
+                                    if reasoning_open:
+                                        yield _chunk_with_text("</think>")
+                                        reasoning_open = False
+                                    yield _chunk_with_text(tail_flushed)
                                 if reasoning_open:
                                     yield _chunk_with_text("</think>")
                                     reasoning_open = False

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -95,12 +95,25 @@ def _replace_openai_citation_markers(
     """
     if not text or "" not in text:
         return text
+    # Each citation may carry several source_id aliases (the upstream
+    # stream emits multiple inline markers for the same URL when the
+    # model cites different spans/locators). Accept both the singular
+    # ``source_id`` and plural ``source_ids`` shapes. First-seen wins
+    # on collision so an earlier citation keeps its number.
     by_source: dict[str, tuple[int, str]] = {}
     for idx, cit in enumerate(url_citations, start = 1):
-        sid = cit.get("source_id")
         url = cit.get("url")
-        if isinstance(sid, str) and sid and isinstance(url, str) and url:
-            by_source.setdefault(sid, (idx, url))
+        if not isinstance(url, str) or not url:
+            continue
+        aliases: list[str] = []
+        sid = cit.get("source_id")
+        if isinstance(sid, str) and sid:
+            aliases.append(sid)
+        sids = cit.get("source_ids")
+        if isinstance(sids, list):
+            aliases.extend(s for s in sids if isinstance(s, str) and s)
+        for alias in aliases:
+            by_source.setdefault(alias, (idx, url))
 
     def _sub(match: re.Match[str]) -> str:
         sid = match.group(1)
@@ -3044,11 +3057,12 @@ class ExternalProviderClient:
 
                     def _record_url_citation(payload: dict[str, Any]) -> None:
                         """Append a url_citation onto the shared all_url_citations
-                        list. Dedup by URL. We also capture the ``source_id``
-                        the upstream stream uses inside its inline
-                        ``\\ue200cite\\ue202SOURCE_ID\\ue201`` markers so the
-                        delta-text rewriter can resolve markers to
-                        ``[N](URL)`` links. The id may live under
+                        list. Dedup by URL — the same URL can be cited many
+                        times under different ``source_id`` aliases (one per
+                        span/locator), so collect every alias we see onto
+                        the matching entry's ``source_ids`` list. The
+                        delta-text rewriter resolves any of those aliases
+                        back to this entry's URL. The id may live under
                         ``source_id``, ``id``, or ``locator`` across the
                         Responses API revisions."""
                         if payload.get("type") != "url_citation":
@@ -3062,14 +3076,16 @@ class ExternalProviderClient:
                             or payload.get("locator")
                             or ""
                         )
-                        if any(c["url"] == url for c in all_url_citations):
-                            # Backfill source_id on the existing entry if
-                            # the first annotation event omitted it.
+                        # Single pass: either backfill aliases onto an
+                        # existing URL entry (and return) or fall through
+                        # to append a fresh one.
+                        for c in all_url_citations:
+                            if c["url"] != url:
+                                continue
                             if source_id:
-                                for c in all_url_citations:
-                                    if c["url"] == url and not c.get("source_id"):
-                                        c["source_id"] = source_id
-                                        break
+                                aliases = c.setdefault("source_ids", [])
+                                if source_id not in aliases:
+                                    aliases.append(source_id)
                             return
                         title = payload.get("title") or url
                         snippet = payload.get("snippet") or payload.get("quote") or ""
@@ -3078,7 +3094,7 @@ class ExternalProviderClient:
                                 "url": url,
                                 "title": title,
                                 "snippet": snippet,
-                                "source_id": source_id,
+                                "source_ids": [source_id] if source_id else [],
                             }
                         )
 

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3134,17 +3134,17 @@ class ExternalProviderClient:
                         out: list[str] = []
                         while pending_citation_segments:
                             seg = pending_citation_segments[0]
-                            rewritten, unresolved = (
-                                _rewrite_citation_markers_partial(
-                                    seg, all_url_citations,
-                                )
+                            rewritten, unresolved = _rewrite_citation_markers_partial(
+                                seg,
+                                all_url_citations,
                             )
                             if unresolved and not force:
                                 pending_citation_segments[0] = rewritten
                                 break
                             if unresolved and force:
                                 rewritten = _replace_openai_citation_markers(
-                                    rewritten, all_url_citations,
+                                    rewritten,
+                                    all_url_citations,
                                 )
                             pending_citation_segments.pop(0)
                             if rewritten:
@@ -3410,7 +3410,8 @@ class ExternalProviderClient:
                                             yield _chunk_with_text(flushed)
                                         head_rewritten, has_unresolved = (
                                             _rewrite_citation_markers_partial(
-                                                head, all_url_citations,
+                                                head,
+                                                all_url_citations,
                                             )
                                         )
                                         if has_unresolved or pending_citation_segments:

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -188,13 +188,20 @@ def _rewrite_citation_markers_partial(
         nonlocal has_unresolved
         tokens = [t for t in match.group(1).split(_OPENAI_CITE_DELIM) if t]
         rendered: list[str] = []
+        any_unresolved = False
         for tok in tokens:
             hit = by_source.get(tok)
             if hit is None:
+                any_unresolved = True
                 continue
             idx, url = hit
             rendered.append(f"[[{idx}]]({url})")
-        if not rendered:
+        # If even one token in a multi-source marker is unresolved,
+        # leave the whole marker verbatim so the caller buffers the
+        # segment and re-runs once the late annotation lands. Emitting
+        # just the resolved tokens would discard the unresolved ids
+        # for good when the caller no longer retains the source text.
+        if any_unresolved:
             has_unresolved = True
             return match.group(0)
         return "".join(rendered)

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3154,33 +3154,48 @@ class ExternalProviderClient:
                     def _flush_pending_marker_tail(tail: str) -> str:
                         """Render any leftover citation tail for emission.
 
-                        Runs the held-over text through the rewriter
-                        one more time (in case a late annotation
-                        resolved it), then strips any leftover private-
-                        use codepoints so a never-closed marker
-                        (truncated stream, upstream error, annotation
-                        never arrived) never leaks garbled glyphs into
-                        the rendered prose. The sources panel is
-                        unaffected -- url_citations are aggregated
-                        separately and applied to the last web_search
-                        call's tool_end.
+                        ``pending_marker_tail`` starts at an unclosed
+                        opener by construction -- the split helper only
+                        buffers the suffix that lacks a closing stop
+                        byte. If the closing byte still has not arrived
+                        by end-of-stream the tail is meaningless
+                        without the annotation it would have referenced,
+                        so drop it. The user-visible prose before the
+                        opener was already emitted as ``head`` on the
+                        originating delta; only the marker fragment is
+                        held back. On the off chance the close arrives
+                        concatenated onto the tail (the stream finishes
+                        with a complete marker still in the buffer),
+                        run the rewriter against it one more time, then
+                        strip any leftover private-use bytes plus the
+                        literal ``cite``-prefixed source id so the
+                        renderer never sees raw markup. The sources
+                        panel is unaffected -- url_citations are
+                        aggregated separately and applied to the last
+                        web_search call's tool_end.
                         """
                         if not tail:
+                            return ""
+                        if _OPENAI_CITE_STOP not in tail:
+                            # Truly unterminated: drop it. The
+                            # codepoints AND the residual "cite" +
+                            # source id would otherwise leak as plain
+                            # text once we stripped the private-use
+                            # bytes.
                             return ""
                         rendered = _replace_openai_citation_markers(
                             tail, all_url_citations
                         )
-                        # Strip every cite open/stop/delim codepoint
-                        # so partial junk like "citetu" doesn't
-                        # render as garbled "E200E202tu" glyphs.
+                        # Belt-and-braces: scrub any residual
+                        # private-use bytes the rewriter chose not to
+                        # touch (e.g. a leading partial opener).
                         for ch in ("", "", ""):
                             rendered = rendered.replace(ch, "")
-                        # If the tail was a pure unterminated marker
-                        # with no surrounding text, the literal "cite"
-                        # prefix leaks through after we strip the
-                        # private-use bytes. Suppress that exact case.
-                        if rendered == "cite":
-                            return ""
+                        # Drop any orphan ``cite<sid>`` literal at the
+                        # head of the buffer -- without its closing
+                        # byte and matching url_citation it is
+                        # meaningless to the user.
+                        rendered = re.sub(r"^cite\S*", "", rendered)
                         return rendered
 
                     def _emit_tool_event(payload: dict[str, Any]) -> str:

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -71,35 +71,35 @@ _OPENAI_REASONING_SUMMARY_UNSUPPORTED = re.compile(r"^o3(?:[-.]|$)")
 # OpenAI's Responses stream emits inline citation markers shaped like
 # `citeSOURCE_ID` (private-use codepoints, see
 # https://developers.openai.com/api/docs/guides/citation-formatting).
-# Most fonts render the codepoints as garbled "E202" glyphs or empty
-# boxes, and markdown layers tend to strip them, leaving run-on text
-# like "citeturn1view0turn1view1...". We rewrite each marker into a
-# markdown link `[N](URL)` when the matching url_citation has arrived
-# on this stream, or drop it silently when the source_id is unknown.
-# Group 1 is the source id; an optional `<locator>` suffix is
-# discarded (we link the whole source rather than per-line locators).
-_OPENAI_CITATION_MARKER = re.compile("cite([^]+)(?:[^]*)?")
+# Multi-source markers reuse the same delimiter: `citeid1id2`.
+# An optional `<locator>` suffix (e.g. `L8-L13` or a page number)
+# may follow the source id list. Most fonts render the codepoints
+# as garbled "E202" glyphs or empty boxes, and markdown layers
+# tend to strip them, leaving run-on text like
+# "citeturn1view0turn1view1...". We rewrite each marker into a
+# markdown link `[[N]](URL)` per resolvable source id, or drop the
+# marker silently when none of its ids are known. Group 1 captures
+# everything between the cite-open and stop bytes; we then split
+# on the delimiter and try every token against the annotation
+# table. Tokens that don't resolve (locators, unknown ids) are
+# dropped silently so no garbled glyph ever reaches the renderer.
+_OPENAI_CITE_OPEN = "cite"
+_OPENAI_CITE_STOP = ""
+_OPENAI_CITE_DELIM = ""
+_OPENAI_CITATION_MARKER = re.compile(
+    f"{_OPENAI_CITE_OPEN}([^{_OPENAI_CITE_STOP}]+){_OPENAI_CITE_STOP}"
+)
 
 
-def _replace_openai_citation_markers(
-    text: str,
+def _build_citation_lookup(
     url_citations: list[dict[str, Any]],
-) -> str:
-    """Rewrite `\\ue200cite\\ue202SOURCE_ID\\ue201` markers in ``text``.
+) -> dict[str, tuple[int, str]]:
+    """Map every known ``source_id`` alias to ``(citation_index, url)``.
 
-    For each marker, look up the source_id against the running
-    ``url_citations`` list and replace with `[[N]](URL)` where N is the
-    1-based index of that citation. Unknown source_ids strip the marker
-    silently so garbled glyphs never reach the renderer. Idempotent on
-    text that contains no private-use codepoints.
+    Accepts both the singular ``source_id`` and plural ``source_ids``
+    citation shapes. First-seen wins on alias collision so an earlier
+    citation keeps its number.
     """
-    if not text or "" not in text:
-        return text
-    # Each citation may carry several source_id aliases (the upstream
-    # stream emits multiple inline markers for the same URL when the
-    # model cites different spans/locators). Accept both the singular
-    # ``source_id`` and plural ``source_ids`` shapes. First-seen wins
-    # on collision so an earlier citation keeps its number.
     by_source: dict[str, tuple[int, str]] = {}
     for idx, cit in enumerate(url_citations, start = 1):
         url = cit.get("url")
@@ -114,16 +114,79 @@ def _replace_openai_citation_markers(
             aliases.extend(s for s in sids if isinstance(s, str) and s)
         for alias in aliases:
             by_source.setdefault(alias, (idx, url))
+    return by_source
+
+
+def _replace_openai_citation_markers(
+    text: str,
+    url_citations: list[dict[str, Any]],
+) -> str:
+    """Rewrite `\\ue200cite\\ue202SOURCE_ID[\\ue202LOCATOR]\\ue201` markers.
+
+    For each marker, look up the source_id against the running
+    ``url_citations`` list and replace with `[[N]](URL)` where N is
+    the 1-based index of that citation. Multi-source markers expand
+    into one `[[N]](URL)` per resolvable id. Unknown source_ids and
+    locator suffixes are dropped silently so garbled glyphs never
+    reach the renderer. Idempotent on text that contains no private-
+    use codepoints.
+    """
+    if not text or _OPENAI_CITE_STOP not in text:
+        return text
+    by_source = _build_citation_lookup(url_citations)
 
     def _sub(match: re.Match[str]) -> str:
-        sid = match.group(1)
-        hit = by_source.get(sid)
-        if hit is None:
-            return ""
-        idx, url = hit
-        return f"[[{idx}]]({url})"
+        # The capture group contains either a single source id, a
+        # delim-separated list of source ids (multi-source markers),
+        # or a source id followed by a locator. We try every
+        # delim-split token against the lookup; unresolved tokens
+        # are dropped silently. That handles multi-source (every
+        # token resolves, every token expands) AND source+locator
+        # (only the first token resolves, the locator is dropped).
+        # When no tokens resolve, the whole marker is stripped so
+        # the user-facing text stays clean.
+        rendered: list[str] = []
+        for tok in match.group(1).split(_OPENAI_CITE_DELIM):
+            if not tok:
+                continue
+            hit = by_source.get(tok)
+            if hit is None:
+                continue
+            idx, url = hit
+            rendered.append(f"[[{idx}]]({url})")
+        return "".join(rendered)
 
     return _OPENAI_CITATION_MARKER.sub(_sub, text)
+
+
+def _split_pending_citation_tail(text: str) -> tuple[str, str]:
+    """Split ``text`` into ``(head, pending_tail)`` for streamed deltas.
+
+    OpenAI's Responses stream chunks text on byte-buffer boundaries
+    that have no awareness of the inline citation marker grammar,
+    so a marker can straddle two ``response.output_text.delta``
+    events (e.g. delta-1 ends with ``\\ue200citetu`` and delta-2
+    starts with ``rn0view0\\ue201``). Processing each delta in
+    isolation would leak the half-marker to the user. We hold the
+    unterminated tail and prepend it onto the next delta so the
+    rewriter sees a complete marker.
+
+    ``pending_tail`` is the longest suffix that begins with
+    ``\\ue200`` and contains NO stop byte ``\\ue201``. ``head`` is
+    the part that's safe to emit immediately. When ``text`` ends
+    with a fully closed marker (or no marker at all) the tail is
+    empty.
+    """
+    if not text:
+        return text, ""
+    last_open = text.rfind("")
+    if last_open == -1:
+        return text, ""
+    # If a stop byte appears after the last open byte, the marker
+    # closed inside this delta and nothing needs to be buffered.
+    if _OPENAI_CITE_STOP in text[last_open:]:
+        return text, ""
+    return text[:last_open], text[last_open:]
 
 
 class _AnthropicThinkingSpec(NamedTuple):
@@ -3000,6 +3063,46 @@ class ExternalProviderClient:
                     # see.
                     latched_container_id: Optional[str] = None
                     container_id_emitted = False
+                    # Buffer for an unterminated citation marker that
+                    # straddles two ``response.output_text.delta``
+                    # events. See ``_split_pending_citation_tail`` for
+                    # why this is necessary. Always concatenated onto
+                    # the front of the next delta so the rewriter sees
+                    # a complete ``cite...`` marker
+                    # rather than half of one.
+                    pending_marker_tail: str = ""
+
+                    def _flush_pending_marker_tail(tail: str) -> str:
+                        """Render any leftover citation tail for emission.
+
+                        Runs the held-over text through the rewriter
+                        one more time (in case a late annotation
+                        resolved it), then strips any leftover private-
+                        use codepoints so a never-closed marker
+                        (truncated stream, upstream error, annotation
+                        never arrived) never leaks garbled glyphs into
+                        the rendered prose. The sources panel is
+                        unaffected -- url_citations are aggregated
+                        separately and applied to the last web_search
+                        call's tool_end.
+                        """
+                        if not tail:
+                            return ""
+                        rendered = _replace_openai_citation_markers(
+                            tail, all_url_citations
+                        )
+                        # Strip every cite open/stop/delim codepoint
+                        # so partial junk like "citetu" doesn't
+                        # render as garbled "E200E202tu" glyphs.
+                        for ch in ("", "", ""):
+                            rendered = rendered.replace(ch, "")
+                        # If the tail was a pure unterminated marker
+                        # with no surrounding text, the literal "cite"
+                        # prefix leaks through after we strip the
+                        # private-use bytes. Suppress that exact case.
+                        if rendered == "cite":
+                            return ""
+                        return rendered
 
                     def _emit_tool_event(payload: dict[str, Any]) -> str:
                         chunk = {
@@ -3151,6 +3254,21 @@ class ExternalProviderClient:
                             if not data_str:
                                 continue
                             if data_str == "[DONE]":
+                                # Flush any held-over partial citation
+                                # marker that never got its closing
+                                # `` -- strip the private-use
+                                # bytes so garbled glyphs don't reach
+                                # the renderer.
+                                if pending_marker_tail:
+                                    flushed = _flush_pending_marker_tail(
+                                        pending_marker_tail
+                                    )
+                                    pending_marker_tail = ""
+                                    if flushed:
+                                        if reasoning_open:
+                                            yield _chunk_with_text("</think>")
+                                            reasoning_open = False
+                                        yield _chunk_with_text(flushed)
                                 if not done_emitted:
                                     yield "data: [DONE]"
                                     done_emitted = True
@@ -3176,15 +3294,24 @@ class ExternalProviderClient:
                                 for ann in event.get("annotations") or []:
                                     if isinstance(ann, dict):
                                         _record_url_citation(ann)
-                                if delta_text:
-                                    if reasoning_open:
-                                        yield _chunk_with_text("</think>")
-                                        reasoning_open = False
-                                    delta_text = _replace_openai_citation_markers(
-                                        delta_text, all_url_citations
+                                if delta_text or pending_marker_tail:
+                                    # Concatenate any unterminated marker
+                                    # tail held over from the previous
+                                    # delta so a marker that straddles
+                                    # two SSE events resolves cleanly.
+                                    combined = pending_marker_tail + delta_text
+                                    head, pending_marker_tail = (
+                                        _split_pending_citation_tail(combined)
                                     )
-                                    if delta_text:
-                                        yield _chunk_with_text(delta_text)
+                                    if head:
+                                        if reasoning_open:
+                                            yield _chunk_with_text("</think>")
+                                            reasoning_open = False
+                                        head = _replace_openai_citation_markers(
+                                            head, all_url_citations
+                                        )
+                                        if head:
+                                            yield _chunk_with_text(head)
 
                             elif event_type == "response.output_text.annotation.added":
                                 ann = event.get("annotation")
@@ -3428,6 +3555,24 @@ class ExternalProviderClient:
                                 )
                                 if isinstance(completed_usage, dict):
                                     last_usage = completed_usage
+                                # Flush any unterminated citation tail
+                                # held over from the last delta. By
+                                # the time we get here every annotation
+                                # has been recorded so a late-arriving
+                                # source_id may resolve cleanly; if it
+                                # still doesn't, the helper strips the
+                                # private-use bytes so no garbled
+                                # glyph reaches the user.
+                                if pending_marker_tail:
+                                    flushed = _flush_pending_marker_tail(
+                                        pending_marker_tail
+                                    )
+                                    pending_marker_tail = ""
+                                    if flushed:
+                                        if reasoning_open:
+                                            yield _chunk_with_text("</think>")
+                                            reasoning_open = False
+                                        yield _chunk_with_text(flushed)
                                 if reasoning_open:
                                     yield _chunk_with_text("</think>")
                                     reasoning_open = False
@@ -3520,6 +3665,19 @@ class ExternalProviderClient:
                                 )
                                 if isinstance(incomplete_usage, dict):
                                     last_usage = incomplete_usage
+                                # Same flush as response.completed --
+                                # truncated streams can leave a half-
+                                # marker in the buffer.
+                                if pending_marker_tail:
+                                    flushed = _flush_pending_marker_tail(
+                                        pending_marker_tail
+                                    )
+                                    pending_marker_tail = ""
+                                    if flushed:
+                                        if reasoning_open:
+                                            yield _chunk_with_text("</think>")
+                                            reasoning_open = False
+                                        yield _chunk_with_text(flushed)
                                 if reasoning_open:
                                     yield _chunk_with_text("</think>")
                                     reasoning_open = False

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -68,6 +68,52 @@ _ANTHROPIC_4_7_SAMPLING_REMOVED = re.compile(
 )
 _OPENAI_REASONING_SUMMARY_UNSUPPORTED = re.compile(r"^o3(?:[-.]|$)")
 
+# OpenAI's Responses stream emits inline citation markers shaped like
+# `citeSOURCE_ID` (private-use codepoints, see
+# https://developers.openai.com/api/docs/guides/citation-formatting).
+# Most fonts render the codepoints as garbled "E202" glyphs or empty
+# boxes, and markdown layers tend to strip them, leaving run-on text
+# like "citeturn1view0turn1view1...". We rewrite each marker into a
+# markdown link `[N](URL)` when the matching url_citation has arrived
+# on this stream, or drop it silently when the source_id is unknown.
+# Group 1 is the source id; an optional `<locator>` suffix is
+# discarded (we link the whole source rather than per-line locators).
+_OPENAI_CITATION_MARKER = re.compile(
+    "cite([^]+)(?:[^]*)?"
+)
+
+
+def _replace_openai_citation_markers(
+    text: str,
+    url_citations: list[dict[str, Any]],
+) -> str:
+    """Rewrite `\\ue200cite\\ue202SOURCE_ID\\ue201` markers in ``text``.
+
+    For each marker, look up the source_id against the running
+    ``url_citations`` list and replace with `[[N]](URL)` where N is the
+    1-based index of that citation. Unknown source_ids strip the marker
+    silently so garbled glyphs never reach the renderer. Idempotent on
+    text that contains no private-use codepoints.
+    """
+    if not text or "" not in text:
+        return text
+    by_source: dict[str, tuple[int, str]] = {}
+    for idx, cit in enumerate(url_citations, start = 1):
+        sid = cit.get("source_id")
+        url = cit.get("url")
+        if isinstance(sid, str) and sid and isinstance(url, str) and url:
+            by_source.setdefault(sid, (idx, url))
+
+    def _sub(match: re.Match[str]) -> str:
+        sid = match.group(1)
+        hit = by_source.get(sid)
+        if hit is None:
+            return ""
+        idx, url = hit
+        return f"[[{idx}]]({url})"
+
+    return _OPENAI_CITATION_MARKER.sub(_sub, text)
+
 
 class _AnthropicThinkingSpec(NamedTuple):
     prefixes: tuple[str, ...]
@@ -3000,16 +3046,32 @@ class ExternalProviderClient:
 
                     def _record_url_citation(payload: dict[str, Any]) -> None:
                         """Append a url_citation onto the shared all_url_citations
-                        list. Dedup by URL — the same source can be cited multiple
-                        times across deltas. We do NOT try to attribute citations
-                        to individual web_search_call invocations because OpenAI's
-                        annotation events don't carry that linkage."""
+                        list. Dedup by URL. We also capture the ``source_id``
+                        the upstream stream uses inside its inline
+                        ``\\ue200cite\\ue202SOURCE_ID\\ue201`` markers so the
+                        delta-text rewriter can resolve markers to
+                        ``[N](URL)`` links. The id may live under
+                        ``source_id``, ``id``, or ``locator`` across the
+                        Responses API revisions."""
                         if payload.get("type") != "url_citation":
                             return
                         url = payload.get("url", "")
                         if not url:
                             return
+                        source_id = (
+                            payload.get("source_id")
+                            or payload.get("id")
+                            or payload.get("locator")
+                            or ""
+                        )
                         if any(c["url"] == url for c in all_url_citations):
+                            # Backfill source_id on the existing entry if
+                            # the first annotation event omitted it.
+                            if source_id:
+                                for c in all_url_citations:
+                                    if c["url"] == url and not c.get("source_id"):
+                                        c["source_id"] = source_id
+                                        break
                             return
                         title = payload.get("title") or url
                         snippet = payload.get("snippet") or payload.get("quote") or ""
@@ -3018,6 +3080,7 @@ class ExternalProviderClient:
                                 "url": url,
                                 "title": title,
                                 "snippet": snippet,
+                                "source_id": source_id,
                             }
                         )
 
@@ -3088,17 +3151,26 @@ class ExternalProviderClient:
 
                             if event_type == "response.output_text.delta":
                                 delta_text = event.get("delta", "")
+                                # Process inline annotations FIRST so that
+                                # any source_ids referenced by markers in
+                                # the same delta are already in the lookup
+                                # table when the rewriter runs below. Some
+                                # API versions inline url citations on the
+                                # delta event itself rather than as a
+                                # separate response.output_text.annotation
+                                # .added event.
+                                for ann in event.get("annotations") or []:
+                                    if isinstance(ann, dict):
+                                        _record_url_citation(ann)
                                 if delta_text:
                                     if reasoning_open:
                                         yield _chunk_with_text("</think>")
                                         reasoning_open = False
-                                    yield _chunk_with_text(delta_text)
-                                # Some API versions inline url citations on the
-                                # delta event itself rather than as a separate
-                                # response.output_text.annotation.added event.
-                                for ann in event.get("annotations") or []:
-                                    if isinstance(ann, dict):
-                                        _record_url_citation(ann)
+                                    delta_text = _replace_openai_citation_markers(
+                                        delta_text, all_url_citations
+                                    )
+                                    if delta_text:
+                                        yield _chunk_with_text(delta_text)
 
                             elif event_type == "response.output_text.annotation.added":
                                 ann = event.get("annotation")

--- a/studio/backend/tests/test_openai_citation_markers.py
+++ b/studio/backend/tests/test_openai_citation_markers.py
@@ -137,3 +137,44 @@ def test_citation_without_source_id_does_not_crash(citation):
     # No mapping, marker stripped. Crash-free is the contract.
     assert not _has_marker_codepoints(out)
     assert "turnXviewY" not in out
+
+
+def test_multiple_source_id_aliases_resolve_to_same_url():
+    """When the upstream stream emits several inline markers for the
+    same URL (one per span/locator), every alias must resolve back to
+    that URL rather than getting silently dropped after the first one.
+    Regression for the Codex P1 on the original PR."""
+    a = _marker("turn0view0")
+    b = _marker("turn0view0_span_1")
+    c = _marker("turn0view0_span_2")
+    text = f"Triple {a}{b}{c} cite."
+    citations = [
+        {
+            "source_ids": ["turn0view0", "turn0view0_span_1", "turn0view0_span_2"],
+            "url": "https://example.com/paris",
+            "title": "Paris",
+        },
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    # All three aliases collapse onto citation [1] -- the URL is the
+    # same so it would be misleading to show three different numbers.
+    assert out.count("[[1]](https://example.com/paris)") == 3
+    assert not _has_marker_codepoints(out)
+
+
+def test_source_ids_list_and_legacy_source_id_both_resolve():
+    """Mixed-shape citation: legacy ``source_id`` plus newer
+    ``source_ids`` aliases both resolve."""
+    legacy = _marker("legacy_id")
+    alias = _marker("alias_id")
+    text = f"Both {legacy} and {alias} work."
+    citations = [
+        {
+            "source_id": "legacy_id",
+            "source_ids": ["alias_id"],
+            "url": "https://example.com/doc",
+        },
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert out.count("[[1]](https://example.com/doc)") == 2
+    assert not _has_marker_codepoints(out)

--- a/studio/backend/tests/test_openai_citation_markers.py
+++ b/studio/backend/tests/test_openai_citation_markers.py
@@ -3,14 +3,9 @@
 
 """Tests for the OpenAI Responses-API citation marker rewriter.
 
-The Responses stream interleaves text deltas with citation markers
-shaped like ``\\ue200cite\\ue202SOURCE_ID\\ue201``. The private-use
-code points either render as garbled "E202" glyphs in most fonts or
-get stripped by the markdown layer, leaving run-on text like
-"citeturn1view0turn1view1...". The rewriter translates each marker
-into a markdown link `[N](URL)` when the matching annotation has
-arrived, and drops the marker silently otherwise so the prose stays
-clean. The full URL list still flows through to the Sources panel via
+The stream interleaves text deltas with ``\\ue200cite\\ue202SOURCE_ID\\ue201``
+markers. The rewriter resolves each to `[N](URL)` when the annotation has
+arrived and drops it otherwise; the URL list still flows to Sources via
 `_record_url_citation`.
 
 Reference: https://developers.openai.com/api/docs/guides/citation-formatting
@@ -119,9 +114,7 @@ def test_empty_text_returns_verbatim():
 
 
 def test_idempotent_on_pre_stripped_text():
-    """If something upstream already stripped the private-use codepoints
-    (leaving readable run-on text like "citeturn1view0"), don't try to
-    parse them again -- return verbatim."""
+    """Pre-stripped text (no private-use codepoints) returns verbatim."""
     text = "citeturn1view0 plain"
     assert _replace_openai_citation_markers(text, []) == text
 
@@ -143,9 +136,7 @@ def test_citation_without_source_id_does_not_crash(citation):
 
 
 def test_multiple_source_id_aliases_resolve_to_same_url():
-    """When the upstream stream emits several inline markers for the
-    same URL (one per span/locator), every alias must resolve back to
-    that URL rather than getting silently dropped after the first one.
+    """Every alias for the same URL must resolve, not just the first.
     Regression for the Codex P1 on the original PR."""
     a = _marker("turn0view0")
     b = _marker("turn0view0_span_1")
@@ -184,13 +175,9 @@ def test_source_ids_list_and_legacy_source_id_both_resolve():
 
 
 # ---------------------------------------------------------------------------
-# _rewrite_citation_markers_partial: deferred-annotation tests. OpenAI
-# emits the url_citation annotation on a subsequent SSE event rather
-# than alongside the delta that contains the inline marker. The
-# stateless rewriter cannot tell pending-annotation apart from
-# bogus-source so it drops the marker; this helper instead reports
-# `has_unresolved` so the streaming loop can defer emission until the
-# annotation arrives. See PR #5713 audit.
+# _rewrite_citation_markers_partial: deferred-annotation tests. OpenAI emits
+# url_citation annotations on a subsequent SSE event; this helper reports
+# `has_unresolved` so the stream loop defers emission. See PR #5713 audit.
 # ---------------------------------------------------------------------------
 
 
@@ -215,8 +202,7 @@ def test_partial_unknown_marker_preserves_verbatim_and_flags():
 
 
 def test_partial_resolves_after_late_annotation():
-    """Two-pass scenario: first call sees no citations, second call
-    receives the annotation and resolves the same buffered text."""
+    """Two-pass: first call sees no citations, second resolves after annotation."""
     text = f"See {_marker('s1')} for details."
     out1, unresolved1 = _rewrite_citation_markers_partial(text, [])
     assert unresolved1 is True
@@ -228,13 +214,9 @@ def test_partial_resolves_after_late_annotation():
 
 
 def test_partial_multi_source_partial_resolution_keeps_marker_pending():
-    """When any token in a multi-source marker is unresolved, the
-    whole marker is left verbatim and ``unresolved`` is True. Emitting
-    just the resolved token would discard the unresolved id once the
-    caller drops the segment, so we defer until either every id
-    resolves (a follow-up partial pass) or end-of-stream forces a
-    flush (the non-partial helper drops unresolved tokens then).
-    """
+    """Any unresolved token in a multi-source marker leaves the whole marker
+    verbatim with ``unresolved`` True; defer until every id resolves or
+    end-of-stream forces a flush (dropping unresolved tokens then)."""
     cite = f"{CITE_START}cite{CITE_DELIM}known{CITE_DELIM}locator{CITE_STOP}"
     text = f"Pre {cite} post."
     citations = [{"source_id": "known", "url": "https://example.com/y"}]

--- a/studio/backend/tests/test_openai_citation_markers.py
+++ b/studio/backend/tests/test_openai_citation_markers.py
@@ -18,7 +18,10 @@ Reference: https://developers.openai.com/api/docs/guides/citation-formatting
 
 import pytest
 
-from core.inference.external_provider import _replace_openai_citation_markers
+from core.inference.external_provider import (
+    _replace_openai_citation_markers,
+    _rewrite_citation_markers_partial,
+)
 
 
 # Citation marker control codepoints (private-use area):
@@ -178,3 +181,81 @@ def test_source_ids_list_and_legacy_source_id_both_resolve():
     out = _replace_openai_citation_markers(text, citations)
     assert out.count("[[1]](https://example.com/doc)") == 2
     assert not _has_marker_codepoints(out)
+
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_citation_markers_partial: deferred-annotation tests. OpenAI
+# emits the url_citation annotation on a subsequent SSE event rather
+# than alongside the delta that contains the inline marker. The
+# stateless rewriter cannot tell pending-annotation apart from
+# bogus-source so it drops the marker; this helper instead reports
+# `has_unresolved` so the streaming loop can defer emission until the
+# annotation arrives. See PR #5713 audit.
+# ---------------------------------------------------------------------------
+
+
+def test_partial_known_marker_resolves_and_clears_unresolved():
+    text = f"Foo {_marker('s1')} bar."
+    out, unresolved = _rewrite_citation_markers_partial(
+        text, [{"source_id": "s1", "url": "https://example.com/a"}],
+    )
+    assert "[[1]](https://example.com/a)" in out
+    assert unresolved is False
+    assert not _has_marker_codepoints(out)
+
+
+def test_partial_unknown_marker_preserves_verbatim_and_flags():
+    text = f"Foo {_marker('s1')} bar."
+    out, unresolved = _rewrite_citation_markers_partial(text, [])
+    assert unresolved is True
+    # Codepoints must remain so a follow-up pass can re-parse.
+    assert _has_marker_codepoints(out)
+    assert "Foo" in out and "bar." in out
+
+
+def test_partial_resolves_after_late_annotation():
+    """Two-pass scenario: first call sees no citations, second call
+    receives the annotation and resolves the same buffered text."""
+    text = f"See {_marker('s1')} for details."
+    out1, unresolved1 = _rewrite_citation_markers_partial(text, [])
+    assert unresolved1 is True
+    citations = [{"source_id": "s1", "url": "https://example.com/x"}]
+    out2, unresolved2 = _rewrite_citation_markers_partial(out1, citations)
+    assert unresolved2 is False
+    assert "[[1]](https://example.com/x)" in out2
+    assert not _has_marker_codepoints(out2)
+
+
+def test_partial_multi_source_partial_resolution_treats_as_resolved():
+    """When at least one token in a multi-source marker resolves, the
+    marker is considered resolved -- unknown tokens are dropped (they
+    are typically locators rather than missing annotations)."""
+    cite = f"{CITE_START}cite{CITE_DELIM}known{CITE_DELIM}locator{CITE_STOP}"
+    text = f"Pre {cite} post."
+    citations = [{"source_id": "known", "url": "https://example.com/y"}]
+    out, unresolved = _rewrite_citation_markers_partial(text, citations)
+    assert unresolved is False
+    assert "[[1]](https://example.com/y)" in out
+    assert "locator" not in out
+    assert not _has_marker_codepoints(out)
+
+
+def test_partial_idempotent_on_marker_free_text():
+    text = "Plain text."
+    out, unresolved = _rewrite_citation_markers_partial(text, [])
+    assert out == text
+    assert unresolved is False
+
+
+def test_partial_mixed_known_and_pending_markers_flags_unresolved():
+    known = _marker("known")
+    pending = _marker("pending")
+    text = f"{known} {pending}"
+    citations = [{"source_id": "known", "url": "https://example.com/k"}]
+    out, unresolved = _rewrite_citation_markers_partial(text, citations)
+    assert unresolved is True  # the pending marker drives the flag
+    assert "[[1]](https://example.com/k)" in out
+    # The pending marker stays verbatim for the next pass.
+    assert CITE_START in out and "pending" in out
+

--- a/studio/backend/tests/test_openai_citation_markers.py
+++ b/studio/backend/tests/test_openai_citation_markers.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for the OpenAI Responses-API citation marker rewriter.
+
+The Responses stream interleaves text deltas with citation markers
+shaped like ``\\ue200cite\\ue202SOURCE_ID\\ue201``. The private-use
+code points either render as garbled "E202" glyphs in most fonts or
+get stripped by the markdown layer, leaving run-on text like
+"citeturn1view0turn1view1...". The rewriter translates each marker
+into a markdown link `[N](URL)` when the matching annotation has
+arrived, and drops the marker silently otherwise so the prose stays
+clean. The full URL list still flows through to the Sources panel via
+`_record_url_citation`.
+
+Reference: https://developers.openai.com/api/docs/guides/citation-formatting
+"""
+
+import pytest
+
+from core.inference.external_provider import _replace_openai_citation_markers
+
+
+# Citation marker control codepoints (private-use area):
+CITE_START = ""
+CITE_STOP = ""
+CITE_DELIM = ""
+
+
+def _marker(source_id: str, locator: str | None = None) -> str:
+    payload = f"{CITE_START}cite{CITE_DELIM}{source_id}"
+    if locator:
+        payload = f"{payload}{CITE_DELIM}{locator}"
+    return f"{payload}{CITE_STOP}"
+
+
+def _has_marker_codepoints(text: str) -> bool:
+    return any(c in text for c in (CITE_START, CITE_STOP, CITE_DELIM))
+
+
+def test_passthrough_when_no_marker_present():
+    text = "Plain text with no citation markers."
+    assert _replace_openai_citation_markers(text, []) == text
+
+
+def test_marker_rewritten_to_link_when_annotation_known():
+    text = f"The capital is Paris {_marker('turn0view0')}."
+    citations = [
+        {"source_id": "turn0view0", "url": "https://example.com/paris", "title": "Paris"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert not _has_marker_codepoints(out)
+    assert "[[1]](https://example.com/paris)" in out
+
+
+def test_unknown_source_marker_dropped_silently():
+    text = f"Foo {_marker('turn9view9')} bar."
+    out = _replace_openai_citation_markers(text, [])
+    # Marker stripped, no garbled "E202" glyph leaks through, and the
+    # surrounding text stays intact.
+    assert not _has_marker_codepoints(out)
+    assert "E202" not in out
+    assert "turn9view9" not in out
+    assert "Foo" in out and "bar" in out
+
+
+def test_multiple_concatenated_markers_resolved_in_order():
+    """Real-world wire shape: a string of markers butted up against each other
+    after a sentence, as in the user-reported bug."""
+    markers = "".join(
+        _marker(f"turn{i}view{j}") for i, j in [(1, 0), (1, 1), (3, 0)]
+    )
+    text = f"All animals ranked. {markers}"
+    citations = [
+        {"source_id": "turn1view0", "url": "https://a.example/dog", "title": "Dog"},
+        {"source_id": "turn1view1", "url": "https://a.example/cat", "title": "Cat"},
+        {"source_id": "turn3view0", "url": "https://a.example/tiger", "title": "Tiger"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert "[[1]](https://a.example/dog)" in out
+    assert "[[2]](https://a.example/cat)" in out
+    assert "[[3]](https://a.example/tiger)" in out
+    assert not _has_marker_codepoints(out)
+
+
+def test_marker_with_locator_resolves():
+    text = f"See {_marker('turn2file0', 'L8-L13')}."
+    citations = [
+        {"source_id": "turn2file0", "url": "https://example.com/doc.txt"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert "[[1]](https://example.com/doc.txt)" in out
+    assert "L8-L13" not in out  # locator detail dropped; we just link.
+    assert not _has_marker_codepoints(out)
+
+
+def test_mixed_known_and_unknown_markers():
+    known = _marker("turn0view0")
+    unknown = _marker("turn0view99")
+    text = f"Known {known} and unknown {unknown}."
+    citations = [
+        {"source_id": "turn0view0", "url": "https://example.com/known"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert "[[1]](https://example.com/known)" in out
+    # Unknown markers leave no trace, but surrounding prose stays.
+    assert "Known" in out and "unknown" in out
+    assert not _has_marker_codepoints(out)
+    assert "E202" not in out
+
+
+def test_empty_text_returns_verbatim():
+    assert _replace_openai_citation_markers("", []) == ""
+
+
+def test_idempotent_on_pre_stripped_text():
+    """If something upstream already stripped the private-use codepoints
+    (leaving readable run-on text like "citeturn1view0"), don't try to
+    parse them again -- return verbatim."""
+    text = "citeturn1view0 plain"
+    assert _replace_openai_citation_markers(text, []) == text
+
+
+@pytest.mark.parametrize(
+    "citation",
+    [
+        {"url": "https://example.com/a"},  # no source_id at all
+        {"source_id": None, "url": "https://example.com/b"},
+        {"source_id": "", "url": "https://example.com/c"},
+    ],
+)
+def test_citation_without_source_id_does_not_crash(citation):
+    text = f"X {_marker('turnXviewY')} Y"
+    out = _replace_openai_citation_markers(text, [citation])
+    # No mapping, marker stripped. Crash-free is the contract.
+    assert not _has_marker_codepoints(out)
+    assert "turnXviewY" not in out

--- a/studio/backend/tests/test_openai_citation_markers.py
+++ b/studio/backend/tests/test_openai_citation_markers.py
@@ -227,18 +227,27 @@ def test_partial_resolves_after_late_annotation():
     assert not _has_marker_codepoints(out2)
 
 
-def test_partial_multi_source_partial_resolution_treats_as_resolved():
-    """When at least one token in a multi-source marker resolves, the
-    marker is considered resolved -- unknown tokens are dropped (they
-    are typically locators rather than missing annotations)."""
+def test_partial_multi_source_partial_resolution_keeps_marker_pending():
+    """When any token in a multi-source marker is unresolved, the
+    whole marker is left verbatim and ``unresolved`` is True. Emitting
+    just the resolved token would discard the unresolved id once the
+    caller drops the segment, so we defer until either every id
+    resolves (a follow-up partial pass) or end-of-stream forces a
+    flush (the non-partial helper drops unresolved tokens then).
+    """
     cite = f"{CITE_START}cite{CITE_DELIM}known{CITE_DELIM}locator{CITE_STOP}"
     text = f"Pre {cite} post."
     citations = [{"source_id": "known", "url": "https://example.com/y"}]
     out, unresolved = _rewrite_citation_markers_partial(text, citations)
-    assert unresolved is False
-    assert "[[1]](https://example.com/y)" in out
-    assert "locator" not in out
-    assert not _has_marker_codepoints(out)
+    assert unresolved is True
+    assert cite in out
+    # End-of-stream force flush: drop the unresolved token, keep the
+    # resolved link. The streamer routes pending segments through
+    # `_replace_openai_citation_markers` at force=True for this.
+    forced = _replace_openai_citation_markers(out, citations)
+    assert "[[1]](https://example.com/y)" in forced
+    assert "locator" not in forced
+    assert not _has_marker_codepoints(forced)
 
 
 def test_partial_idempotent_on_marker_free_text():

--- a/studio/backend/tests/test_openai_citation_markers.py
+++ b/studio/backend/tests/test_openai_citation_markers.py
@@ -183,7 +183,6 @@ def test_source_ids_list_and_legacy_source_id_both_resolve():
     assert not _has_marker_codepoints(out)
 
 
-
 # ---------------------------------------------------------------------------
 # _rewrite_citation_markers_partial: deferred-annotation tests. OpenAI
 # emits the url_citation annotation on a subsequent SSE event rather
@@ -198,7 +197,8 @@ def test_source_ids_list_and_legacy_source_id_both_resolve():
 def test_partial_known_marker_resolves_and_clears_unresolved():
     text = f"Foo {_marker('s1')} bar."
     out, unresolved = _rewrite_citation_markers_partial(
-        text, [{"source_id": "s1", "url": "https://example.com/a"}],
+        text,
+        [{"source_id": "s1", "url": "https://example.com/a"}],
     )
     assert "[[1]](https://example.com/a)" in out
     assert unresolved is False
@@ -258,4 +258,3 @@ def test_partial_mixed_known_and_pending_markers_flags_unresolved():
     assert "[[1]](https://example.com/k)" in out
     # The pending marker stays verbatim for the next pass.
     assert CITE_START in out and "pending" in out
-

--- a/studio/backend/tests/test_openai_citation_markers.py
+++ b/studio/backend/tests/test_openai_citation_markers.py
@@ -46,7 +46,11 @@ def test_passthrough_when_no_marker_present():
 def test_marker_rewritten_to_link_when_annotation_known():
     text = f"The capital is Paris {_marker('turn0view0')}."
     citations = [
-        {"source_id": "turn0view0", "url": "https://example.com/paris", "title": "Paris"},
+        {
+            "source_id": "turn0view0",
+            "url": "https://example.com/paris",
+            "title": "Paris",
+        },
     ]
     out = _replace_openai_citation_markers(text, citations)
     assert not _has_marker_codepoints(out)
@@ -67,9 +71,7 @@ def test_unknown_source_marker_dropped_silently():
 def test_multiple_concatenated_markers_resolved_in_order():
     """Real-world wire shape: a string of markers butted up against each other
     after a sentence, as in the user-reported bug."""
-    markers = "".join(
-        _marker(f"turn{i}view{j}") for i, j in [(1, 0), (1, 1), (3, 0)]
-    )
+    markers = "".join(_marker(f"turn{i}view{j}") for i, j in [(1, 0), (1, 1), (3, 0)])
     text = f"All animals ranked. {markers}"
     citations = [
         {"source_id": "turn1view0", "url": "https://a.example/dog", "title": "Dog"},

--- a/studio/backend/tests/test_openai_citation_markers_edge.py
+++ b/studio/backend/tests/test_openai_citation_markers_edge.py
@@ -134,7 +134,7 @@ def test_multi_source_marker_partial_resolution():
 
 
 def test_marker_with_numeric_locator():
-    text = f"See {_marker('tu0', locator='42')}."
+    text = f"See {_marker('tu0', locator = '42')}."
     citations = [{"source_id": "tu0", "url": "https://example.com/doc"}]
     out = _replace_openai_citation_markers(text, citations)
     assert "[[1]](https://example.com/doc)" in out
@@ -143,7 +143,7 @@ def test_marker_with_numeric_locator():
 
 
 def test_marker_with_range_locator():
-    text = f"See {_marker('tu0', locator='L8-L13')}."
+    text = f"See {_marker('tu0', locator = 'L8-L13')}."
     citations = [{"source_id": "tu0", "url": "https://example.com/code"}]
     out = _replace_openai_citation_markers(text, citations)
     assert "[[1]](https://example.com/code)" in out

--- a/studio/backend/tests/test_openai_citation_markers_edge.py
+++ b/studio/backend/tests/test_openai_citation_markers_edge.py
@@ -89,6 +89,7 @@ def _simulate_delta_stream(
             for ch in (CITE_START, CITE_STOP, CITE_DELIM):
                 rendered = rendered.replace(ch, "")
             import re as _re
+
             rendered = _re.sub(r"^cite\S*", "", rendered)
         if rendered:
             emitted.append(rendered)
@@ -409,7 +410,6 @@ def test_unknown_marker_does_not_perturb_citation_indexing():
     assert _no_private_use(out)
 
 
-
 # ---------------------------------------------------------------------------
 # Regression: unterminated marker tail must NOT leak the residual
 # ``cite``-prefixed source id as plain text. PR #5713 audit P1.
@@ -471,4 +471,3 @@ def test_closing_byte_arrives_after_pending_buffered_split():
     assert "a " in out and "b" in out
     assert _no_private_use(out)
     assert "citesid" not in out
-

--- a/studio/backend/tests/test_openai_citation_markers_edge.py
+++ b/studio/backend/tests/test_openai_citation_markers_edge.py
@@ -3,28 +3,9 @@
 
 """Edge-case tests for the OpenAI Responses citation marker rewriter.
 
-These cover:
-
-  * Multi-source markers (one ``cite`` element referencing several
-    ``source_id`` aliases at once -- per the OpenAI doc, the wire shape
-    is ``\\ue200cite\\ue202id1\\ue202id2\\ue201``).
-  * Source id + locator markers (``\\ue200cite\\ue202sid\\ue202L8-L13
-    \\ue201`` -- the locator is dropped, the link still resolves).
-  * Marker SPLIT across two streaming ``response.output_text.delta``
-    events. OpenAI's stream chunks text on byte-buffer boundaries
-    that have no awareness of the marker grammar, so a marker can be
-    cut anywhere. The rewriter must buffer the unterminated tail and
-    prepend it onto the next delta so the user never sees
-    ``\\ue200citetu`` followed by ``rn0view0\\ue201`` (i.e. a garbled
-    glyph then a stray "rn0view0" word).
-  * Unterminated marker at the end of a stream (truncation): the
-    held-over tail is stripped of private-use bytes on flush so no
-    glyph leaks.
-  * Multiple unrelated markers within a single delta still resolve.
-  * Annotation-before-marker ordering (the annotation arrives on the
-    same delta as the marker -- the rewriter must see it in the
-    lookup table).
-  * Idempotency: running the rewriter twice produces the same output.
+Covers multi-source markers, source+locator, marker SPLIT across SSE deltas,
+unterminated tails at end-of-stream, multiple markers per delta, late
+annotation ordering, and idempotency.
 
 Reference: https://developers.openai.com/api/docs/guides/citation-formatting
 """
@@ -32,9 +13,8 @@ Reference: https://developers.openai.com/api/docs/guides/citation-formatting
 import importlib
 
 
-# Import the module-level helpers under test. The streaming integration
-# is exercised by ``_simulate_delta_stream`` further down which mirrors
-# the head/buffer/flush dance from ``_stream_openai_responses``.
+# Streaming integration is exercised by ``_simulate_delta_stream`` further
+# down, mirroring the head/buffer/flush dance from ``_stream_openai_responses``.
 _module = importlib.import_module("core.inference.external_provider")
 _replace_openai_citation_markers = _module._replace_openai_citation_markers
 _split_pending_citation_tail = _module._split_pending_citation_tail
@@ -47,9 +27,7 @@ CITE_DELIM = ""
 
 def _marker(*source_ids: str, locator: str | None = None) -> str:
     """Build a ``\\ue200cite\\ue202<sid>[\\ue202<sid>...][\\ue202<loc>]\\ue201``
-    marker. ``source_ids`` may contain one entry (single-source) or
-    several (multi-source). ``locator`` adds a trailing locator token
-    after all source ids."""
+    marker. Accepts one or many ``source_ids`` plus an optional ``locator``."""
     payload = f"{CITE_START}cite{CITE_DELIM}" + CITE_DELIM.join(source_ids)
     if locator:
         payload = f"{payload}{CITE_DELIM}{locator}"
@@ -60,9 +38,8 @@ def _no_private_use(text: str) -> bool:
     return all(c not in text for c in (CITE_START, CITE_STOP, CITE_DELIM))
 
 
-# A tiny harness that mirrors the head / pending-tail / flush dance
-# that lives in `_stream_openai_responses`. Used by the streaming
-# tests below so we don't have to spin up an httpx mock per case.
+# Harness mirroring the head/pending-tail/flush dance in
+# `_stream_openai_responses`, so streaming tests skip the httpx mock.
 def _simulate_delta_stream(
     deltas: list[str],
     citations: list[dict],
@@ -79,9 +56,8 @@ def _simulate_delta_stream(
             if head:
                 emitted.append(head)
     if flush and pending:
-        # Mirror the FIXED `_flush_pending_marker_tail`: drop the tail
-        # outright if no closing stop byte ever arrived (otherwise the
-        # literal ``cite`` + source id residue leaks as plain text).
+        # Mirror `_flush_pending_marker_tail`: drop the tail entirely if no
+        # closing stop byte arrived; the literal ``cite<sid>`` would leak otherwise.
         if CITE_STOP not in pending:
             rendered = ""
         else:
@@ -102,9 +78,8 @@ def _simulate_delta_stream(
 
 
 def test_multi_source_marker_all_resolve():
-    """\\ue200cite\\ue202id1\\ue202id2\\ue202id3\\ue201 expands to three
-    bracket links when every source id is known. The previous regex
-    captured only the first source id and silently dropped id2/id3."""
+    """\\ue200cite\\ue202id1\\ue202id2\\ue202id3\\ue201 expands to three links
+    when every id is known. Earlier regex captured only id1 and dropped id2/id3."""
     text = f"All three: {_marker('id1', 'id2', 'id3')}"
     citations = [
         {"source_id": "id1", "url": "https://example.com/1"},
@@ -119,8 +94,7 @@ def test_multi_source_marker_all_resolve():
 
 
 def test_multi_source_marker_partial_resolution():
-    """Some ids known, some not. Known ids render; unknown ids drop
-    silently. No garbled glyph leaks."""
+    """Known ids render, unknown ids drop silently, no glyph leaks."""
     text = f"Mixed: {_marker('known', 'unknown', 'also_known')}"
     citations = [
         {"source_id": "known", "url": "https://k.example"},
@@ -162,12 +136,9 @@ def test_marker_with_range_locator():
 
 
 def test_marker_split_in_source_id():
-    """Delta-1 ends mid-source-id (``\\ue200cite\\ue202tu``); delta-2
-    starts with the rest (``rn0view0\\ue201``). WITHOUT the buffer,
-    the rewriter sees each delta in isolation, leaks
-    ``\\ue200cite\\ue202tu`` to the user, then leaks ``rn0view0`` and
-    the stray ``\\ue201``. WITH the buffer the two halves are
-    stitched back together and resolve to one link."""
+    """Delta-1 ends mid-source-id (``\\ue200cite\\ue202tu``), delta-2 starts
+    with the rest (``rn0view0\\ue201``). The buffer stitches the halves
+    back together so they resolve to one link instead of leaking."""
     full = f"See {_marker('turn0view0')} now."
     # Cut right after the second delim + "tu" inside the source id.
     cut = full.index("tu", full.index(CITE_START)) + len("tu")
@@ -182,9 +153,8 @@ def test_marker_split_in_source_id():
 
 
 def test_marker_split_at_start_byte():
-    """The split is exactly at the opening ``\\ue200`` byte -- the
-    next delta starts a fresh marker. The buffer must hold the lone
-    open byte until the rest arrives."""
+    """Split exactly after the opening ``\\ue200`` byte; the buffer must
+    hold the lone open byte until the rest arrives."""
     full = f"Text {_marker('sid')} done"
     cut = full.index(CITE_START) + 1  # right AFTER the open byte
     d1, d2 = full[:cut], full[cut:]
@@ -195,9 +165,7 @@ def test_marker_split_at_start_byte():
 
 
 def test_marker_split_across_three_deltas():
-    """Worst-case split: the marker is chopped into three pieces and
-    arrives over three separate deltas with arbitrary text in
-    between."""
+    """Worst case: marker chopped into three pieces across three deltas."""
     full = f"A {_marker('threesplit')} B"
     # cut at two points inside the marker
     open_pos = full.index(CITE_START)
@@ -212,8 +180,7 @@ def test_marker_split_across_three_deltas():
 
 
 def test_marker_split_with_trailing_text_after_close():
-    """The second delta closes the marker AND carries more prose
-    after the close byte. Both pieces must emit cleanly."""
+    """Delta-2 closes the marker AND carries trailing prose; both emit cleanly."""
     full = f"X {_marker('sid')} after"
     cut = full.index("cite") + len("ci")
     d1, d2 = full[:cut], full[cut:]
@@ -224,8 +191,7 @@ def test_marker_split_with_trailing_text_after_close():
 
 
 def test_split_marker_unknown_source_is_dropped_cleanly():
-    """Split marker for an unknown source -- the whole marker drops
-    silently on flush, no garbled glyph leaks."""
+    """Split marker for an unknown source drops silently on flush."""
     full = f"Pre {_marker('never_seen')} post"
     cut = full.index(CITE_START) + 3
     d1, d2 = full[:cut], full[cut:]
@@ -240,25 +206,21 @@ def test_split_marker_unknown_source_is_dropped_cleanly():
 
 
 def test_unterminated_marker_at_stream_end_dropped_on_flush():
-    """Stream ends mid-marker (e.g. response.incomplete). The pending
-    tail is flushed: private-use bytes are stripped so no garbled
-    glyph or `E202` text leaks."""
+    """Stream ends mid-marker (e.g. response.incomplete); the tail is
+    flushed with private-use bytes stripped, no `E202` text leaks."""
     deltas = ["Some text ", f"{CITE_START}citetu", "rn0view0"]  # no STOP ever
     out = _simulate_delta_stream(deltas, [], flush = True)
     assert _no_private_use(out)
     assert "E200" not in out and "E202" not in out
-    # Surrounding prose stays. We don't make hard claims on the exact
-    # remainder of the unterminated marker -- only that no glyph leaks.
+    # Surrounding prose stays; we don't assert exact marker remainder.
     assert "Some text " in out
 
 
 def test_flush_resolves_marker_when_late_annotation_arrives():
-    """The marker arrives in a delta, but the matching annotation
-    only arrives later (e.g. on response.output_text.annotation.added
-    after the final delta). Today, the rewriter looks at
-    ``all_url_citations`` LIVE at flush time, so a late annotation
-    still resolves a buffered marker -- the SAME annotation_first
-    re-order applies on flush."""
+    """Marker in a delta, matching annotation arrives later (on
+    response.output_text.annotation.added after the final delta). The
+    rewriter reads ``all_url_citations`` LIVE at flush, so the buffered
+    marker still resolves."""
     deltas = ["Look ", f"{CITE_START}cite{CITE_DELIM}late_sid"]
     pending = ""
     citations: list[dict] = []
@@ -307,8 +269,7 @@ def test_three_markers_in_one_delta_resolve_independently():
 
 
 def test_rewriter_idempotent_on_already_rewritten_text():
-    """Running the rewriter twice doesn't double-link or corrupt the
-    markdown brackets it just emitted."""
+    """Running the rewriter twice does not double-link or corrupt brackets."""
     text = f"alpha {_marker('a')} omega"
     citations = [{"source_id": "a", "url": "https://example.com/a"}]
     once = _replace_openai_citation_markers(text, citations)
@@ -330,9 +291,8 @@ def test_rewriter_idempotent_on_marker_free_text():
 
 
 def test_only_marker_no_surrounding_text():
-    """A delta that is JUST a marker (no surrounding prose) must
-    still render correctly. Without the empty-string short-circuit
-    in _split_pending_citation_tail this used to leak."""
+    """A delta that is JUST a marker (no prose) still renders correctly;
+    used to leak without the empty-string short-circuit in the split helper."""
     text = _marker("solo")
     citations = [{"source_id": "solo", "url": "https://solo.example"}]
     out = _replace_openai_citation_markers(text, citations)
@@ -340,8 +300,7 @@ def test_only_marker_no_surrounding_text():
 
 
 def test_back_to_back_markers_with_no_separator():
-    """Two markers butted up against each other resolve to two
-    bracket links concatenated, no joining whitespace."""
+    """Adjacent markers resolve to concatenated links, no joining whitespace."""
     text = f"{_marker('x')}{_marker('y')}"
     citations = [
         {"source_id": "x", "url": "https://x.example"},
@@ -352,9 +311,8 @@ def test_back_to_back_markers_with_no_separator():
 
 
 def test_split_helper_buffers_only_after_last_open_byte():
-    """If a delta contains a complete marker followed by an
-    unterminated marker, the head must include the complete marker
-    and the buffer must hold only the trailing partial."""
+    """A complete marker followed by an unterminated one: head includes
+    the complete marker, buffer holds only the trailing partial."""
     complete = _marker("done")
     partial = f"{CITE_START}cite{CITE_DELIM}half"  # no STOP
     text = f"pre {complete} mid {partial}"
@@ -379,32 +337,27 @@ def test_split_helper_no_open_byte():
 
 
 def test_split_helper_complete_marker_only():
-    """A delta that ends with a complete (closed) marker should NOT
-    leave anything in the buffer."""
+    """A delta ending with a closed marker leaves the buffer empty."""
     text = f"alpha {_marker('a')}"
     head, tail = _split_pending_citation_tail(text)
     assert head == text and tail == ""
 
 
 # ---------------------------------------------------------------------------
-# 8. Sources-panel behaviour: marker drop must not affect citation
-# aggregation. We re-derive the citation index list from the same
-# url_citations list the rewriter consumes.
+# 8. Sources-panel: marker drop must not affect citation aggregation.
+# Indices come from the url_citations list, not the marker stream.
 # ---------------------------------------------------------------------------
 
 
 def test_unknown_marker_does_not_perturb_citation_indexing():
-    """An unknown source_id marker is dropped, but the OTHER citations
-    in the list keep their original 1-based numbering."""
+    """Unknown source_id markers drop without consuming an index slot."""
     text = f"A {_marker('unknown')} B {_marker('real_a')} C {_marker('real_b')}"
     citations = [
         {"source_id": "real_a", "url": "https://example.com/a"},
         {"source_id": "real_b", "url": "https://example.com/b"},
     ]
     out = _replace_openai_citation_markers(text, citations)
-    # real_a is index 1 (NOT 0 -- the unknown marker doesn't take a
-    # slot, because indices come from the citation list, not the
-    # marker stream).
+    # real_a is index 1; unknown does not take a slot.
     assert "[[1]](https://example.com/a)" in out
     assert "[[2]](https://example.com/b)" in out
     assert _no_private_use(out)
@@ -413,51 +366,38 @@ def test_unknown_marker_does_not_perturb_citation_indexing():
 # ---------------------------------------------------------------------------
 # Regression: unterminated marker tail must NOT leak the residual
 # ``cite``-prefixed source id as plain text. PR #5713 audit P1.
-# Symptom before the fix: a stream ending mid-marker had its codepoints
-# stripped, but the literal "cite" + source id ("citeturn0view0") was
-# emitted to the user as garbage trailing text.
 # ---------------------------------------------------------------------------
 
 
 def test_unterminated_marker_does_not_leak_cite_residue():
-    """Stream ends mid-marker: the entire tail must be dropped, NOT
-    have its codepoints stripped while leaving 'cite<sid>' behind."""
-    # Build a delta that includes user-visible prose followed by an
-    # opener and only HALF a source id -- no closing byte ever
-    # arrives.
+    """Stream ends mid-marker: drop the whole tail rather than strip
+    codepoints and leave ``cite<sid>`` behind."""
     half = f"Hi there {CITE_START}cite{CITE_DELIM}turn0view0"
     out = _simulate_delta_stream([half], [], flush = True)
-    # Prose before the marker stays.
+    # Prose before the marker stays; no private-use bytes or cite residue.
     assert "Hi there" in out
-    # No private-use bytes leak.
     assert _no_private_use(out)
-    # Crucially: the literal "cite" + source id does NOT leak.
     assert "citeturn0view0" not in out
-    # ``cite`` standalone (without the marker codepoints) is also
-    # meaningless here -- shouldn't appear.
     assert "cite" not in out.split("Hi there", 1)[1]
 
 
 def test_unterminated_marker_only_no_prefix_drops_entirely():
-    """A delta that is purely an unterminated marker (no surrounding
-    prose) flushes to the empty string."""
+    """A delta that is purely an unterminated marker flushes to ""."""
     half = f"{CITE_START}cite{CITE_DELIM}turn0view0"
     out = _simulate_delta_stream([half], [], flush = True)
     assert out == ""
 
 
 def test_unterminated_marker_with_prefix_emits_only_prefix():
-    """A delta with prose then an unterminated marker emits the prose
-    and drops the marker remnant."""
+    """Prose then unterminated marker: prose emits, marker remnant drops."""
     half = f"prefix prose {CITE_START}cite{CITE_DELIM}abc"
     out = _simulate_delta_stream([half], [], flush = True)
     assert out == "prefix prose "
 
 
 def test_closing_byte_arrives_after_pending_buffered_split():
-    """The marker's closing byte arrives in a later delta after the
-    opener and source id were buffered. The link should resolve and
-    no residue leaks."""
+    """Closing byte arrives in a later delta after opener + source id were
+    buffered; link resolves with no residue."""
     cuts = [
         f"a {CITE_START}cite{CITE_DELIM}",
         f"sid{CITE_STOP} b",

--- a/studio/backend/tests/test_openai_citation_markers_edge.py
+++ b/studio/backend/tests/test_openai_citation_markers_edge.py
@@ -79,13 +79,17 @@ def _simulate_delta_stream(
             if head:
                 emitted.append(head)
     if flush and pending:
-        # Mirror `_flush_pending_marker_tail`: try once more in case a
-        # late annotation resolved it, then strip private-use bytes.
-        rendered = _replace_openai_citation_markers(pending, citations)
-        for ch in (CITE_START, CITE_STOP, CITE_DELIM):
-            rendered = rendered.replace(ch, "")
-        if rendered == "cite":
+        # Mirror the FIXED `_flush_pending_marker_tail`: drop the tail
+        # outright if no closing stop byte ever arrived (otherwise the
+        # literal ``cite`` + source id residue leaks as plain text).
+        if CITE_STOP not in pending:
             rendered = ""
+        else:
+            rendered = _replace_openai_citation_markers(pending, citations)
+            for ch in (CITE_START, CITE_STOP, CITE_DELIM):
+                rendered = rendered.replace(ch, "")
+            import re as _re
+            rendered = _re.sub(r"^cite\S*", "", rendered)
         if rendered:
             emitted.append(rendered)
     return "".join(emitted)
@@ -403,3 +407,68 @@ def test_unknown_marker_does_not_perturb_citation_indexing():
     assert "[[1]](https://example.com/a)" in out
     assert "[[2]](https://example.com/b)" in out
     assert _no_private_use(out)
+
+
+
+# ---------------------------------------------------------------------------
+# Regression: unterminated marker tail must NOT leak the residual
+# ``cite``-prefixed source id as plain text. PR #5713 audit P1.
+# Symptom before the fix: a stream ending mid-marker had its codepoints
+# stripped, but the literal "cite" + source id ("citeturn0view0") was
+# emitted to the user as garbage trailing text.
+# ---------------------------------------------------------------------------
+
+
+def test_unterminated_marker_does_not_leak_cite_residue():
+    """Stream ends mid-marker: the entire tail must be dropped, NOT
+    have its codepoints stripped while leaving 'cite<sid>' behind."""
+    # Build a delta that includes user-visible prose followed by an
+    # opener and only HALF a source id -- no closing byte ever
+    # arrives.
+    half = f"Hi there {CITE_START}cite{CITE_DELIM}turn0view0"
+    out = _simulate_delta_stream([half], [], flush = True)
+    # Prose before the marker stays.
+    assert "Hi there" in out
+    # No private-use bytes leak.
+    assert _no_private_use(out)
+    # Crucially: the literal "cite" + source id does NOT leak.
+    assert "citeturn0view0" not in out
+    # ``cite`` standalone (without the marker codepoints) is also
+    # meaningless here -- shouldn't appear.
+    assert "cite" not in out.split("Hi there", 1)[1]
+
+
+def test_unterminated_marker_only_no_prefix_drops_entirely():
+    """A delta that is purely an unterminated marker (no surrounding
+    prose) flushes to the empty string."""
+    half = f"{CITE_START}cite{CITE_DELIM}turn0view0"
+    out = _simulate_delta_stream([half], [], flush = True)
+    assert out == ""
+
+
+def test_unterminated_marker_with_prefix_emits_only_prefix():
+    """A delta with prose then an unterminated marker emits the prose
+    and drops the marker remnant."""
+    half = f"prefix prose {CITE_START}cite{CITE_DELIM}abc"
+    out = _simulate_delta_stream([half], [], flush = True)
+    assert out == "prefix prose "
+
+
+def test_closing_byte_arrives_after_pending_buffered_split():
+    """The marker's closing byte arrives in a later delta after the
+    opener and source id were buffered. The link should resolve and
+    no residue leaks."""
+    cuts = [
+        f"a {CITE_START}cite{CITE_DELIM}",
+        f"sid{CITE_STOP} b",
+    ]
+    out = _simulate_delta_stream(
+        cuts,
+        [{"source_id": "sid", "url": "https://example.com/x"}],
+        flush = True,
+    )
+    assert "[[1]](https://example.com/x)" in out
+    assert "a " in out and "b" in out
+    assert _no_private_use(out)
+    assert "citesid" not in out
+

--- a/studio/backend/tests/test_openai_citation_markers_edge.py
+++ b/studio/backend/tests/test_openai_citation_markers_edge.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Edge-case tests for the OpenAI Responses citation marker rewriter.
+
+These cover:
+
+  * Multi-source markers (one ``cite`` element referencing several
+    ``source_id`` aliases at once -- per the OpenAI doc, the wire shape
+    is ``\\ue200cite\\ue202id1\\ue202id2\\ue201``).
+  * Source id + locator markers (``\\ue200cite\\ue202sid\\ue202L8-L13
+    \\ue201`` -- the locator is dropped, the link still resolves).
+  * Marker SPLIT across two streaming ``response.output_text.delta``
+    events. OpenAI's stream chunks text on byte-buffer boundaries
+    that have no awareness of the marker grammar, so a marker can be
+    cut anywhere. The rewriter must buffer the unterminated tail and
+    prepend it onto the next delta so the user never sees
+    ``\\ue200citetu`` followed by ``rn0view0\\ue201`` (i.e. a garbled
+    glyph then a stray "rn0view0" word).
+  * Unterminated marker at the end of a stream (truncation): the
+    held-over tail is stripped of private-use bytes on flush so no
+    glyph leaks.
+  * Multiple unrelated markers within a single delta still resolve.
+  * Annotation-before-marker ordering (the annotation arrives on the
+    same delta as the marker -- the rewriter must see it in the
+    lookup table).
+  * Idempotency: running the rewriter twice produces the same output.
+
+Reference: https://developers.openai.com/api/docs/guides/citation-formatting
+"""
+
+import importlib
+
+
+# Import the module-level helpers under test. The streaming integration
+# is exercised by ``_simulate_delta_stream`` further down which mirrors
+# the head/buffer/flush dance from ``_stream_openai_responses``.
+_module = importlib.import_module("core.inference.external_provider")
+_replace_openai_citation_markers = _module._replace_openai_citation_markers
+_split_pending_citation_tail = _module._split_pending_citation_tail
+
+
+CITE_START = ""
+CITE_STOP = ""
+CITE_DELIM = ""
+
+
+def _marker(*source_ids: str, locator: str | None = None) -> str:
+    """Build a ``\\ue200cite\\ue202<sid>[\\ue202<sid>...][\\ue202<loc>]\\ue201``
+    marker. ``source_ids`` may contain one entry (single-source) or
+    several (multi-source). ``locator`` adds a trailing locator token
+    after all source ids."""
+    payload = f"{CITE_START}cite{CITE_DELIM}" + CITE_DELIM.join(source_ids)
+    if locator:
+        payload = f"{payload}{CITE_DELIM}{locator}"
+    return f"{payload}{CITE_STOP}"
+
+
+def _no_private_use(text: str) -> bool:
+    return all(c not in text for c in (CITE_START, CITE_STOP, CITE_DELIM))
+
+
+# A tiny harness that mirrors the head / pending-tail / flush dance
+# that lives in `_stream_openai_responses`. Used by the streaming
+# tests below so we don't have to spin up an httpx mock per case.
+def _simulate_delta_stream(
+    deltas: list[str],
+    citations: list[dict],
+    *,
+    flush: bool = True,
+) -> str:
+    pending = ""
+    emitted: list[str] = []
+    for delta in deltas:
+        combined = pending + delta
+        head, pending = _split_pending_citation_tail(combined)
+        if head:
+            head = _replace_openai_citation_markers(head, citations)
+            if head:
+                emitted.append(head)
+    if flush and pending:
+        # Mirror `_flush_pending_marker_tail`: try once more in case a
+        # late annotation resolved it, then strip private-use bytes.
+        rendered = _replace_openai_citation_markers(pending, citations)
+        for ch in (CITE_START, CITE_STOP, CITE_DELIM):
+            rendered = rendered.replace(ch, "")
+        if rendered == "cite":
+            rendered = ""
+        if rendered:
+            emitted.append(rendered)
+    return "".join(emitted)
+
+
+# ---------------------------------------------------------------------------
+# 1. Multi-source markers per the OpenAI docs.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_source_marker_all_resolve():
+    """\\ue200cite\\ue202id1\\ue202id2\\ue202id3\\ue201 expands to three
+    bracket links when every source id is known. The previous regex
+    captured only the first source id and silently dropped id2/id3."""
+    text = f"All three: {_marker('id1', 'id2', 'id3')}"
+    citations = [
+        {"source_id": "id1", "url": "https://example.com/1"},
+        {"source_id": "id2", "url": "https://example.com/2"},
+        {"source_id": "id3", "url": "https://example.com/3"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert "[[1]](https://example.com/1)" in out
+    assert "[[2]](https://example.com/2)" in out
+    assert "[[3]](https://example.com/3)" in out
+    assert _no_private_use(out)
+
+
+def test_multi_source_marker_partial_resolution():
+    """Some ids known, some not. Known ids render; unknown ids drop
+    silently. No garbled glyph leaks."""
+    text = f"Mixed: {_marker('known', 'unknown', 'also_known')}"
+    citations = [
+        {"source_id": "known", "url": "https://k.example"},
+        {"source_id": "also_known", "url": "https://ak.example"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert "[[1]](https://k.example)" in out
+    assert "[[2]](https://ak.example)" in out
+    assert "unknown" not in out
+    assert _no_private_use(out)
+
+
+# ---------------------------------------------------------------------------
+# 2. Source + locator: locator is dropped, link still resolves.
+# ---------------------------------------------------------------------------
+
+
+def test_marker_with_numeric_locator():
+    text = f"See {_marker('tu0', locator='42')}."
+    citations = [{"source_id": "tu0", "url": "https://example.com/doc"}]
+    out = _replace_openai_citation_markers(text, citations)
+    assert "[[1]](https://example.com/doc)" in out
+    assert "42" not in out
+    assert _no_private_use(out)
+
+
+def test_marker_with_range_locator():
+    text = f"See {_marker('tu0', locator='L8-L13')}."
+    citations = [{"source_id": "tu0", "url": "https://example.com/code"}]
+    out = _replace_openai_citation_markers(text, citations)
+    assert "[[1]](https://example.com/code)" in out
+    assert "L8-L13" not in out
+    assert _no_private_use(out)
+
+
+# ---------------------------------------------------------------------------
+# 3. Marker SPLIT across two SSE deltas -- the codex-flagged P1.
+# ---------------------------------------------------------------------------
+
+
+def test_marker_split_in_source_id():
+    """Delta-1 ends mid-source-id (``\\ue200cite\\ue202tu``); delta-2
+    starts with the rest (``rn0view0\\ue201``). WITHOUT the buffer,
+    the rewriter sees each delta in isolation, leaks
+    ``\\ue200cite\\ue202tu`` to the user, then leaks ``rn0view0`` and
+    the stray ``\\ue201``. WITH the buffer the two halves are
+    stitched back together and resolve to one link."""
+    full = f"See {_marker('turn0view0')} now."
+    # Cut right after the second delim + "tu" inside the source id.
+    cut = full.index("tu", full.index(CITE_START)) + len("tu")
+    d1, d2 = full[:cut], full[cut:]
+    # Sanity check: delta-1 actually contains a partial marker.
+    assert CITE_START in d1 and CITE_STOP not in d1
+    assert CITE_STOP in d2
+    citations = [{"source_id": "turn0view0", "url": "https://x"}]
+    out = _simulate_delta_stream([d1, d2], citations)
+    assert out == "See [[1]](https://x) now."
+    assert _no_private_use(out)
+
+
+def test_marker_split_at_start_byte():
+    """The split is exactly at the opening ``\\ue200`` byte -- the
+    next delta starts a fresh marker. The buffer must hold the lone
+    open byte until the rest arrives."""
+    full = f"Text {_marker('sid')} done"
+    cut = full.index(CITE_START) + 1  # right AFTER the open byte
+    d1, d2 = full[:cut], full[cut:]
+    citations = [{"source_id": "sid", "url": "https://y"}]
+    out = _simulate_delta_stream([d1, d2], citations)
+    assert out == "Text [[1]](https://y) done"
+    assert _no_private_use(out)
+
+
+def test_marker_split_across_three_deltas():
+    """Worst-case split: the marker is chopped into three pieces and
+    arrives over three separate deltas with arbitrary text in
+    between."""
+    full = f"A {_marker('threesplit')} B"
+    # cut at two points inside the marker
+    open_pos = full.index(CITE_START)
+    stop_pos = full.index(CITE_STOP)
+    cut1 = open_pos + 4
+    cut2 = stop_pos - 2
+    parts = [full[:cut1], full[cut1:cut2], full[cut2:]]
+    citations = [{"source_id": "threesplit", "url": "https://z"}]
+    out = _simulate_delta_stream(parts, citations)
+    assert out == "A [[1]](https://z) B"
+    assert _no_private_use(out)
+
+
+def test_marker_split_with_trailing_text_after_close():
+    """The second delta closes the marker AND carries more prose
+    after the close byte. Both pieces must emit cleanly."""
+    full = f"X {_marker('sid')} after"
+    cut = full.index("cite") + len("ci")
+    d1, d2 = full[:cut], full[cut:]
+    citations = [{"source_id": "sid", "url": "https://a"}]
+    out = _simulate_delta_stream([d1, d2], citations)
+    assert out == "X [[1]](https://a) after"
+    assert _no_private_use(out)
+
+
+def test_split_marker_unknown_source_is_dropped_cleanly():
+    """Split marker for an unknown source -- the whole marker drops
+    silently on flush, no garbled glyph leaks."""
+    full = f"Pre {_marker('never_seen')} post"
+    cut = full.index(CITE_START) + 3
+    d1, d2 = full[:cut], full[cut:]
+    out = _simulate_delta_stream([d1, d2], [])
+    assert out == "Pre  post"
+    assert _no_private_use(out)
+
+
+# ---------------------------------------------------------------------------
+# 4. Unterminated marker at end-of-stream -- truncation safety.
+# ---------------------------------------------------------------------------
+
+
+def test_unterminated_marker_at_stream_end_dropped_on_flush():
+    """Stream ends mid-marker (e.g. response.incomplete). The pending
+    tail is flushed: private-use bytes are stripped so no garbled
+    glyph or `E202` text leaks."""
+    deltas = ["Some text ", f"{CITE_START}citetu", "rn0view0"]  # no STOP ever
+    out = _simulate_delta_stream(deltas, [], flush = True)
+    assert _no_private_use(out)
+    assert "E200" not in out and "E202" not in out
+    # Surrounding prose stays. We don't make hard claims on the exact
+    # remainder of the unterminated marker -- only that no glyph leaks.
+    assert "Some text " in out
+
+
+def test_flush_resolves_marker_when_late_annotation_arrives():
+    """The marker arrives in a delta, but the matching annotation
+    only arrives later (e.g. on response.output_text.annotation.added
+    after the final delta). Today, the rewriter looks at
+    ``all_url_citations`` LIVE at flush time, so a late annotation
+    still resolves a buffered marker -- the SAME annotation_first
+    re-order applies on flush."""
+    deltas = ["Look ", f"{CITE_START}cite{CITE_DELIM}late_sid"]
+    pending = ""
+    citations: list[dict] = []
+    emitted: list[str] = []
+    for d in deltas:
+        combined = pending + d
+        head, pending = _split_pending_citation_tail(combined)
+        if head:
+            emitted.append(_replace_openai_citation_markers(head, citations))
+    # Annotation arrives AFTER all deltas but BEFORE flush.
+    citations.append({"source_id": "late_sid", "url": "https://late.example"})
+    # Append the STOP byte that closed the marker in a later delta.
+    pending = pending + CITE_STOP
+    flushed = _replace_openai_citation_markers(pending, citations)
+    for ch in (CITE_START, CITE_STOP, CITE_DELIM):
+        flushed = flushed.replace(ch, "")
+    emitted.append(flushed)
+    out = "".join(emitted)
+    assert "[[1]](https://late.example)" in out
+    assert _no_private_use(out)
+
+
+# ---------------------------------------------------------------------------
+# 5. Multiple unrelated markers in a single delta.
+# ---------------------------------------------------------------------------
+
+
+def test_three_markers_in_one_delta_resolve_independently():
+    text = f"alpha {_marker('a')} beta {_marker('b')} gamma {_marker('c')} end"
+    citations = [
+        {"source_id": "a", "url": "https://example.com/a"},
+        {"source_id": "b", "url": "https://example.com/b"},
+        {"source_id": "c", "url": "https://example.com/c"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert out == (
+        "alpha [[1]](https://example.com/a) beta "
+        "[[2]](https://example.com/b) gamma "
+        "[[3]](https://example.com/c) end"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Idempotency.
+# ---------------------------------------------------------------------------
+
+
+def test_rewriter_idempotent_on_already_rewritten_text():
+    """Running the rewriter twice doesn't double-link or corrupt the
+    markdown brackets it just emitted."""
+    text = f"alpha {_marker('a')} omega"
+    citations = [{"source_id": "a", "url": "https://example.com/a"}]
+    once = _replace_openai_citation_markers(text, citations)
+    twice = _replace_openai_citation_markers(once, citations)
+    assert once == twice
+    assert _no_private_use(once)
+
+
+def test_rewriter_idempotent_on_marker_free_text():
+    """No-op when there is nothing to rewrite."""
+    text = "Plain prose with no citations and no private-use bytes."
+    out = _replace_openai_citation_markers(text, [])
+    assert out is text or out == text
+
+
+# ---------------------------------------------------------------------------
+# 7. Edge / robustness.
+# ---------------------------------------------------------------------------
+
+
+def test_only_marker_no_surrounding_text():
+    """A delta that is JUST a marker (no surrounding prose) must
+    still render correctly. Without the empty-string short-circuit
+    in _split_pending_citation_tail this used to leak."""
+    text = _marker("solo")
+    citations = [{"source_id": "solo", "url": "https://solo.example"}]
+    out = _replace_openai_citation_markers(text, citations)
+    assert out == "[[1]](https://solo.example)"
+
+
+def test_back_to_back_markers_with_no_separator():
+    """Two markers butted up against each other resolve to two
+    bracket links concatenated, no joining whitespace."""
+    text = f"{_marker('x')}{_marker('y')}"
+    citations = [
+        {"source_id": "x", "url": "https://x.example"},
+        {"source_id": "y", "url": "https://y.example"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    assert out == "[[1]](https://x.example)[[2]](https://y.example)"
+
+
+def test_split_helper_buffers_only_after_last_open_byte():
+    """If a delta contains a complete marker followed by an
+    unterminated marker, the head must include the complete marker
+    and the buffer must hold only the trailing partial."""
+    complete = _marker("done")
+    partial = f"{CITE_START}cite{CITE_DELIM}half"  # no STOP
+    text = f"pre {complete} mid {partial}"
+    head, tail = _split_pending_citation_tail(text)
+    assert head == f"pre {complete} mid "
+    assert tail == partial
+    # And the head, once rewritten, drops every private-use byte.
+    rewritten = _replace_openai_citation_markers(
+        head, [{"source_id": "done", "url": "https://d"}]
+    )
+    assert rewritten == "pre [[1]](https://d) mid "
+
+
+def test_split_helper_empty_input():
+    head, tail = _split_pending_citation_tail("")
+    assert head == "" and tail == ""
+
+
+def test_split_helper_no_open_byte():
+    head, tail = _split_pending_citation_tail("nothing to see here")
+    assert head == "nothing to see here" and tail == ""
+
+
+def test_split_helper_complete_marker_only():
+    """A delta that ends with a complete (closed) marker should NOT
+    leave anything in the buffer."""
+    text = f"alpha {_marker('a')}"
+    head, tail = _split_pending_citation_tail(text)
+    assert head == text and tail == ""
+
+
+# ---------------------------------------------------------------------------
+# 8. Sources-panel behaviour: marker drop must not affect citation
+# aggregation. We re-derive the citation index list from the same
+# url_citations list the rewriter consumes.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_marker_does_not_perturb_citation_indexing():
+    """An unknown source_id marker is dropped, but the OTHER citations
+    in the list keep their original 1-based numbering."""
+    text = f"A {_marker('unknown')} B {_marker('real_a')} C {_marker('real_b')}"
+    citations = [
+        {"source_id": "real_a", "url": "https://example.com/a"},
+        {"source_id": "real_b", "url": "https://example.com/b"},
+    ]
+    out = _replace_openai_citation_markers(text, citations)
+    # real_a is index 1 (NOT 0 -- the unknown marker doesn't take a
+    # slot, because indices come from the citation list, not the
+    # marker stream).
+    assert "[[1]](https://example.com/a)" in out
+    assert "[[2]](https://example.com/b)" in out
+    assert _no_private_use(out)


### PR DESCRIPTION
## Summary

OpenAI's `/v1/responses` stream interleaves text deltas with inline citation markers built from private-use codepoints (U+E200 / U+E201 / U+E202) shaped like `citeSOURCE_ID`. Most fonts render the codepoints as garbled "E202" glyphs or empty boxes, and the markdown layer further strips them, leaving run-on text like `citeturn1view0turn1view1turn3view0turn3view1turn4view0...` smeared across the assistant message. The Sources panel still received the URLs (via `url_citation` annotations) but the inline hand-off into the prose was unreadable.

This PR rewrites each marker into a clickable `[N](URL)` markdown link when the matching `url_citation` annotation has already been recorded on this stream, and drops the marker silently otherwise. The lookup uses a new `source_id` field captured on `_record_url_citation` (accepts `source_id` / `id` / `locator` across Responses API revisions). Annotations are now processed BEFORE the delta text is rewritten so that markers and their resolving annotation arriving in the same SSE event still resolve.

Reference: https://developers.openai.com/api/docs/guides/citation-formatting

## Repro before this PR

1. Connect an OpenAI cloud provider.
2. Pick a `gpt-5.x` Responses-family model and enable web_search.
3. Ask something that pulls multiple sources, e.g. "Find what's the highest grossing film in the last month".
4. The streamed reply contains `citeturn1view0turn1view1turn3view0...` instead of citations.

## Behavior after this PR

The same query renders inline citations as `[[1]](https://...) [[2]](https://...)` links resolving to the same URLs the Sources panel already showed.

## Test plan

- [x] `cd studio && python -m pytest backend/tests/test_openai_citation_markers.py -v` (11 new tests, all passing)
- [x] `cd studio && python -m pytest backend/tests/test_openai_responses_translation.py -v` (no regression)
- [x] Idempotency: text containing no private-use codepoints is returned verbatim, so accidental double-rewriting is safe.
- [x] Unknown source_ids: marker is silently stripped, surrounding prose preserved, no `E202` glyph ever leaks through.