### PR TITLE
Studio: Anthropic fast_mode toggle and streaming refusal handling

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2466,11 +2466,20 @@ class ExternalProviderClient:
                                         "Anthropic refusal stop_reason (model=%s)",
                                         model,
                                     )
+                                    # Trailing HTML comment is a stable
+                                    # sentinel the chat-adapter matches
+                                    # to drop this assistant turn from
+                                    # the next request's outbound
+                                    # history. Anthropic's docs say
+                                    # the refused turn must be removed
+                                    # or updated before continuing or
+                                    # the next call will keep refusing.
                                     yield _content_chunk(
                                         "\n\n_The response was stopped by "
                                         "Anthropic's safety classifier. Edit "
                                         "or remove the previous turn and try "
                                         "again._"
+                                        "\n<!--studio:anthropic-refusal-->"
                                     )
                                 if mapped is not None:
                                     chunk = {

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -173,8 +173,25 @@ _ANTHROPIC_COMPACTION_TYPE = "compact_20260112"
 _ANTHROPIC_COMPACTION_MIN = 50_000
 
 
+# Anthropic fast-mode beta. Only Claude Opus 4.6 / 4.7 are listed in the
+# docs (https://platform.claude.com/docs/en/build-with-claude/fast-mode).
+# Sending `speed: "fast"` against any other model 400s upstream so we
+# silently drop the flag for unsupported models rather than letting the
+# user hit a confusing error in the chat. Mutually exclusive with the
+# Priority service tier (also per the upstream docs).
+_ANTHROPIC_FAST_MODE_BETA = "fast-mode-2026-02-01"
+_ANTHROPIC_FAST_MODE_PREFIXES = (
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+)
+
+
 def _anthropic_supports_compaction(model: str) -> bool:
     return model.startswith(_ANTHROPIC_COMPACTION_PREFIXES)
+
+
+def _anthropic_supports_fast_mode(model: str) -> bool:
+    return model.startswith(_ANTHROPIC_FAST_MODE_PREFIXES)
 
 
 class _MistralThinkingSpec(NamedTuple):
@@ -348,6 +365,7 @@ class ExternalProviderClient:
         anthropic_code_exec_container_id: Optional[str] = None,
         prompt_cache_ttl: Optional[str] = None,
         compaction_threshold: Optional[int] = None,
+        fast_mode: Optional[bool] = None,
         stream: bool = True,
     ) -> AsyncGenerator[str, None]:
         """
@@ -360,6 +378,10 @@ class ExternalProviderClient:
         supplies a value the provider accepts — the frontend's
         provider-capability map already filters these per provider, so we
         treat them as opt-in here.
+
+        ``fast_mode`` only applies to Anthropic Opus 4.6 / 4.7 (silently
+        dropped elsewhere); the helper adds the beta header and the
+        top-level ``speed: "fast"`` field per the upstream docs.
         """
         if not self._is_openai_compatible():
             async for line in self._stream_anthropic(
@@ -376,6 +398,7 @@ class ExternalProviderClient:
                 anthropic_code_exec_container_id,
                 prompt_cache_ttl,
                 compaction_threshold,
+                fast_mode = fast_mode,
             ):
                 yield line
             return
@@ -1186,6 +1209,8 @@ class ExternalProviderClient:
         anthropic_code_exec_container_id: Optional[str] = None,
         prompt_cache_ttl: Optional[str] = None,
         compaction_threshold: Optional[int] = None,
+        *,
+        fast_mode: Optional[bool] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Call the Anthropic Messages API and translate its SSE to OpenAI format.
@@ -1611,6 +1636,18 @@ class ExternalProviderClient:
                 ]
             }
 
+        # Anthropic fast_mode — only emit ``speed: "fast"`` for Opus
+        # 4.6/4.7. Sending it on Sonnet / Haiku / older Opus 400s
+        # upstream, so silently drop for unsupported models per our
+        # standard provider-knob policy. Note the upstream docs flag
+        # fast_mode as incompatible with the Priority service_tier;
+        # the frontend capability gate already keeps users from
+        # picking both at once, and the backend lets Anthropic 400
+        # the request if they do reach the API together.
+        fast_mode_active = bool(fast_mode) and _anthropic_supports_fast_mode(model)
+        if fast_mode_active:
+            body["speed"] = "fast"
+
         url = f"{self.base_url}/messages"
         completion_id = f"chatcmpl-anthropic-{model.replace('/', '-')}"
 
@@ -1669,6 +1706,8 @@ class ExternalProviderClient:
             beta_parts.append(_ANTHROPIC_CODE_EXECUTION_BETA)
         if compaction_active and _ANTHROPIC_COMPACTION_BETA not in beta_parts:
             beta_parts.append(_ANTHROPIC_COMPACTION_BETA)
+        if fast_mode_active and _ANTHROPIC_FAST_MODE_BETA not in beta_parts:
+            beta_parts.append(_ANTHROPIC_FAST_MODE_BETA)
         if beta_parts:
             request_headers["anthropic-beta"] = ",".join(beta_parts)
 
@@ -2410,6 +2449,29 @@ class ExternalProviderClient:
                                 # finish_reason="stop" chunk that would
                                 # truncate the rendered message in the UI.
                                 mapped = _finish_reason_map.get(stop_reason, "stop")
+                                # Streaming refusal: surface a user-facing
+                                # marker so the chat bubble isn't silently
+                                # empty when Anthropic's safety classifier
+                                # truncates the response. The mapped
+                                # finish_reason is "content_filter" which
+                                # the OpenAI spec already documents; this
+                                # extra content delta is purely cosmetic.
+                                # Per the upstream docs the conversation
+                                # must be reset before continuing, so we
+                                # also log so a future client-side reset
+                                # path can be wired without ambiguity.
+                                # https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals
+                                if stop_reason == "refusal":
+                                    logger.warning(
+                                        "Anthropic refusal stop_reason (model=%s)",
+                                        model,
+                                    )
+                                    yield _content_chunk(
+                                        "\n\n_The response was stopped by "
+                                        "Anthropic's safety classifier. Edit "
+                                        "or remove the previous turn and try "
+                                        "again._"
+                                    )
                                 if mapped is not None:
                                     chunk = {
                                         "id": completion_id,

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -197,8 +197,7 @@ def _anthropic_supports_fast_mode(model: str) -> bool:
     # "claude-opus-4-70" / "claude-opus-4-7b" that merely share a
     # prefix with the supported families.
     return any(
-        model == p or model.startswith(f"{p}-")
-        for p in _ANTHROPIC_FAST_MODE_PREFIXES
+        model == p or model.startswith(f"{p}-") for p in _ANTHROPIC_FAST_MODE_PREFIXES
     )
 
 

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -173,12 +173,9 @@ _ANTHROPIC_COMPACTION_TYPE = "compact_20260112"
 _ANTHROPIC_COMPACTION_MIN = 50_000
 
 
-# Anthropic fast-mode beta. Only Claude Opus 4.6 / 4.7 are listed in the
-# docs (https://platform.claude.com/docs/en/build-with-claude/fast-mode).
-# Sending `speed: "fast"` against any other model 400s upstream so we
-# silently drop the flag for unsupported models rather than letting the
-# user hit a confusing error in the chat. Mutually exclusive with the
-# Priority service tier (also per the upstream docs).
+# Anthropic fast-mode beta (Opus 4.6 / 4.7 only, per
+# https://platform.claude.com/docs/en/build-with-claude/fast-mode).
+# Mutually exclusive with the Priority service tier.
 _ANTHROPIC_FAST_MODE_BETA = "fast-mode-2026-02-01"
 _ANTHROPIC_FAST_MODE_PREFIXES = (
     "claude-opus-4-7",
@@ -191,11 +188,8 @@ def _anthropic_supports_compaction(model: str) -> bool:
 
 
 def _anthropic_supports_fast_mode(model: str) -> bool:
-    # Require the prefix to terminate at a family boundary (end of
-    # string or a "-" separator before the date snapshot) so the
-    # check does not light up on hypothetical IDs like
-    # "claude-opus-4-70" / "claude-opus-4-7b" that merely share a
-    # prefix with the supported families.
+    # Require a family boundary ("" or "-") after the prefix so IDs like
+    # "claude-opus-4-70" / "claude-opus-4-7b" do not match.
     return any(
         model == p or model.startswith(f"{p}-") for p in _ANTHROPIC_FAST_MODE_PREFIXES
     )
@@ -387,8 +381,7 @@ class ExternalProviderClient:
         treat them as opt-in here.
 
         ``fast_mode`` only applies to Anthropic Opus 4.6 / 4.7 (silently
-        dropped elsewhere); the helper adds the beta header and the
-        top-level ``speed: "fast"`` field per the upstream docs.
+        dropped elsewhere); adds the beta header and ``speed: "fast"``.
         """
         if not self._is_openai_compatible():
             async for line in self._stream_anthropic(
@@ -1643,14 +1636,9 @@ class ExternalProviderClient:
                 ]
             }
 
-        # Anthropic fast_mode — only emit ``speed: "fast"`` for Opus
-        # 4.6/4.7. Sending it on Sonnet / Haiku / older Opus 400s
-        # upstream, so silently drop for unsupported models per our
-        # standard provider-knob policy. Note the upstream docs flag
-        # fast_mode as incompatible with the Priority service_tier;
-        # the frontend capability gate already keeps users from
-        # picking both at once, and the backend lets Anthropic 400
-        # the request if they do reach the API together.
+        # fast_mode is Opus 4.6/4.7 only; silently drop elsewhere.
+        # Incompatible with the Priority service_tier (frontend gate
+        # prevents both at once; backend lets Anthropic 400 if combined).
         fast_mode_active = bool(fast_mode) and _anthropic_supports_fast_mode(model)
         if fast_mode_active:
             body["speed"] = "fast"
@@ -2456,36 +2444,20 @@ class ExternalProviderClient:
                                 # finish_reason="stop" chunk that would
                                 # truncate the rendered message in the UI.
                                 mapped = _finish_reason_map.get(stop_reason, "stop")
-                                # Streaming refusal: surface a user-facing
-                                # marker so the chat bubble isn't silently
-                                # empty when Anthropic's safety classifier
-                                # truncates the response. The mapped
-                                # finish_reason is "content_filter" which
-                                # the OpenAI spec already documents; this
-                                # extra content delta is purely cosmetic.
-                                # Per the upstream docs the conversation
-                                # must be reset before continuing, so we
-                                # also log so a future client-side reset
-                                # path can be wired without ambiguity.
+                                # Streaming refusal: emit a visible notice
+                                # plus an out-of-band _toolEvent so the
+                                # frontend can prune the refused turn.
+                                # The mapped finish_reason is
+                                # "content_filter" per OpenAI spec.
                                 # https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals
                                 if stop_reason == "refusal":
                                     logger.warning(
                                         "Anthropic refusal stop_reason (model=%s)",
                                         model,
                                     )
-                                    # User-facing notice so the chat bubble
-                                    # is not silently empty after the
-                                    # safety classifier truncates the
-                                    # response. The out-of-band drop
-                                    # signal rides a separate _toolEvent
-                                    # below so assistant text can never
-                                    # spoof a context reset by including
-                                    # a literal marker. Anthropic's docs
-                                    # say the refused turn must be
-                                    # removed or updated before
-                                    # continuing or the next call will
-                                    # keep refusing.
-                                    # https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals
+                                    # Drop signal rides _toolEvent (not
+                                    # text) so assistant content cannot
+                                    # spoof a context reset.
                                     yield _content_chunk(
                                         "\n\n_The response was stopped by "
                                         "Anthropic's safety classifier. Edit "
@@ -4024,12 +3996,9 @@ def _build_usage_chunk(
             "cache_creation_input_tokens": cache_creation,
             "cache_read_input_tokens": cache_read,
         }
-        # Anthropic fast-mode responses include `usage.speed` so callers
-        # can verify whether a premium fast-mode request actually ran
-        # fast (the API silently falls back to "standard" when the
-        # beta is unsupported or rate-limited). Surface it on the
-        # OpenAI-style chunk so the pricing/cost ledger can apply the
-        # 6x multiplier without re-derivation.
+        # Propagate fast-mode `usage.speed` so the cost ledger can apply
+        # the 6x multiplier without re-derivation (Anthropic falls back
+        # to "standard" when fast-mode is unsupported or rate-limited).
         speed = last_usage.get("speed")
         if speed in ("fast", "standard"):
             usage_block["speed"] = speed

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -191,7 +191,15 @@ def _anthropic_supports_compaction(model: str) -> bool:
 
 
 def _anthropic_supports_fast_mode(model: str) -> bool:
-    return model.startswith(_ANTHROPIC_FAST_MODE_PREFIXES)
+    # Require the prefix to terminate at a family boundary (end of
+    # string or a "-" separator before the date snapshot) so the
+    # check does not light up on hypothetical IDs like
+    # "claude-opus-4-70" / "claude-opus-4-7b" that merely share a
+    # prefix with the supported families.
+    return any(
+        model == p or model.startswith(f"{p}-")
+        for p in _ANTHROPIC_FAST_MODE_PREFIXES
+    )
 
 
 class _MistralThinkingSpec(NamedTuple):
@@ -2466,20 +2474,27 @@ class ExternalProviderClient:
                                         "Anthropic refusal stop_reason (model=%s)",
                                         model,
                                     )
-                                    # Trailing HTML comment is a stable
-                                    # sentinel the chat-adapter matches
-                                    # to drop this assistant turn from
-                                    # the next request's outbound
-                                    # history. Anthropic's docs say
-                                    # the refused turn must be removed
-                                    # or updated before continuing or
-                                    # the next call will keep refusing.
+                                    # User-facing notice so the chat bubble
+                                    # is not silently empty after the
+                                    # safety classifier truncates the
+                                    # response. The out-of-band drop
+                                    # signal rides a separate _toolEvent
+                                    # below so assistant text can never
+                                    # spoof a context reset by including
+                                    # a literal marker. Anthropic's docs
+                                    # say the refused turn must be
+                                    # removed or updated before
+                                    # continuing or the next call will
+                                    # keep refusing.
+                                    # https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals
                                     yield _content_chunk(
                                         "\n\n_The response was stopped by "
                                         "Anthropic's safety classifier. Edit "
                                         "or remove the previous turn and try "
                                         "again._"
-                                        "\n<!--studio:anthropic-refusal-->"
+                                    )
+                                    yield _emit_tool_event(
+                                        {"type": "anthropic_refusal"}
                                     )
                                 if mapped is not None:
                                     chunk = {
@@ -4010,6 +4025,15 @@ def _build_usage_chunk(
             "cache_creation_input_tokens": cache_creation,
             "cache_read_input_tokens": cache_read,
         }
+        # Anthropic fast-mode responses include `usage.speed` so callers
+        # can verify whether a premium fast-mode request actually ran
+        # fast (the API silently falls back to "standard" when the
+        # beta is unsupported or rate-limited). Surface it on the
+        # OpenAI-style chunk so the pricing/cost ledger can apply the
+        # 6x multiplier without re-derivation.
+        speed = last_usage.get("speed")
+        if speed in ("fast", "standard"):
+            usage_block["speed"] = speed
     else:
         prompt_tokens = last_usage.get("input_tokens") or 0
         cached = 0

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -105,6 +105,10 @@ OPENAI_PRICING: dict[str, dict[str, float]] = {
 ANTHROPIC_CACHE_5M_WRITE_MULT = 1.25
 ANTHROPIC_CACHE_1H_WRITE_MULT = 2.0
 ANTHROPIC_CACHE_READ_MULT = 0.1
+# Anthropic fast-mode beta (Opus 4.6 / 4.7 only): 6x standard rates on
+# both input and output across the full context window.
+# https://platform.claude.com/docs/en/build-with-claude/fast-mode#pricing
+ANTHROPIC_FAST_MODE_MULT = 6.0
 
 # OpenAI: cache reads are 0.1x base input, cache writes are not billed
 # separately (the first prefix-write request just pays normal input).
@@ -235,6 +239,17 @@ def calculate_cost(
         base = prices["input_per_mtok"]
         out_per = prices["output_per_mtok"]
 
+    # Anthropic fast-mode beta: 6x standard on both input + output across
+    # the full context window. Prompt-cache multipliers stack on top of
+    # the fast-mode base per the docs, so applying the multiplier once
+    # to (base, out_per) propagates correctly into the cache_*_usd
+    # buckets computed below.
+    if provider == "anthropic" and usage.get("speed") == "fast":
+        base *= ANTHROPIC_FAST_MODE_MULT
+        out_per *= ANTHROPIC_FAST_MODE_MULT
+        if out["model_priced"]:
+            out["model_priced"] = f"{out['model_priced']} (fast)"
+
     out["input_usd"] = (input_tokens / 1_000_000.0) * base
     out["output_usd"] = (output_tokens / 1_000_000.0) * out_per
 
@@ -315,6 +330,7 @@ def pricing_snapshot() -> dict[str, Any]:
             "cache_5m_write_mult": ANTHROPIC_CACHE_5M_WRITE_MULT,
             "cache_1h_write_mult": ANTHROPIC_CACHE_1H_WRITE_MULT,
             "cache_read_mult": ANTHROPIC_CACHE_READ_MULT,
+            "fast_mode_mult": ANTHROPIC_FAST_MODE_MULT,
             "web_search_usd_per_1k": ANTHROPIC_WEB_SEARCH_USD_PER_1K,
             "code_execution_usd_per_hour": ANTHROPIC_CODE_EXEC_USD_PER_HOUR,
         },

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -105,8 +105,7 @@ OPENAI_PRICING: dict[str, dict[str, float]] = {
 ANTHROPIC_CACHE_5M_WRITE_MULT = 1.25
 ANTHROPIC_CACHE_1H_WRITE_MULT = 2.0
 ANTHROPIC_CACHE_READ_MULT = 0.1
-# Anthropic fast-mode beta (Opus 4.6 / 4.7 only): 6x standard rates on
-# both input and output across the full context window.
+# Anthropic fast-mode (Opus 4.6 / 4.7 only): 6x standard on input + output.
 # https://platform.claude.com/docs/en/build-with-claude/fast-mode#pricing
 ANTHROPIC_FAST_MODE_MULT = 6.0
 
@@ -239,11 +238,9 @@ def calculate_cost(
         base = prices["input_per_mtok"]
         out_per = prices["output_per_mtok"]
 
-    # Anthropic fast-mode beta: 6x standard on both input + output across
-    # the full context window. Prompt-cache multipliers stack on top of
-    # the fast-mode base per the docs, so applying the multiplier once
-    # to (base, out_per) propagates correctly into the cache_*_usd
-    # buckets computed below.
+    # Anthropic fast-mode: 6x on input + output. Cache multipliers stack
+    # on top of fast-mode, so applying once to (base, out_per) propagates
+    # into the cache_*_usd buckets computed below.
     if provider == "anthropic" and usage.get("speed") == "fast":
         base *= ANTHROPIC_FAST_MODE_MULT
         out_per *= ANTHROPIC_FAST_MODE_MULT

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -786,6 +786,19 @@ class ChatCompletionRequest(BaseModel):
             "to auto-create."
         ),
     )
+    fast_mode: Optional[bool] = Field(
+        None,
+        description = (
+            "[x-unsloth] Anthropic fast-mode toggle. When True and the "
+            "selected model is Claude Opus 4.6 or 4.7, the backend adds "
+            "the `fast-mode-2026-02-01` beta header and sends "
+            "`speed: 'fast'` on /v1/messages for up to 2.5x faster output "
+            "tokens per second at premium pricing. Silently ignored on "
+            "every other model and provider so a stale frontend cannot "
+            "make Anthropic 400 the request. See "
+            "https://platform.claude.com/docs/en/build-with-claude/fast-mode"
+        ),
+    )
 
     @model_validator(mode = "after")
     def _resolve_missing_tool_call_ids(self) -> "ChatCompletionRequest":

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -789,13 +789,10 @@ class ChatCompletionRequest(BaseModel):
     fast_mode: Optional[bool] = Field(
         None,
         description = (
-            "[x-unsloth] Anthropic fast-mode toggle. When True and the "
-            "selected model is Claude Opus 4.6 or 4.7, the backend adds "
-            "the `fast-mode-2026-02-01` beta header and sends "
-            "`speed: 'fast'` on /v1/messages for up to 2.5x faster output "
-            "tokens per second at premium pricing. Silently ignored on "
-            "every other model and provider so a stale frontend cannot "
-            "make Anthropic 400 the request. See "
+            "[x-unsloth] Anthropic fast-mode toggle. On Claude Opus 4.6 / "
+            "4.7 adds the `fast-mode-2026-02-01` beta header and sends "
+            "`speed: 'fast'` for higher OTPS at premium pricing. Silently "
+            "ignored on every other model + provider. See "
             "https://platform.claude.com/docs/en/build-with-claude/fast-mode"
         ),
     )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1868,6 +1868,7 @@ async def _proxy_to_external_provider(
             anthropic_code_exec_container_id = payload.anthropic_code_exec_container_id,
             prompt_cache_ttl = payload.prompt_cache_ttl,
             compaction_threshold = payload.compaction_threshold,
+            fast_mode = payload.fast_mode,
             stream = payload.stream,
         )
         try:

--- a/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for Anthropic fast-mode wiring and streaming refusal handling.
+
+``fast_mode=True`` on Claude Opus 4.6/4.7 must:
+  * attach the ``fast-mode-2026-02-01`` beta header to the outbound
+    /v1/messages call (alongside any other beta headers the request
+    already needed); and
+  * set the top-level ``speed: "fast"`` field on the body.
+
+Any unsupported model (Sonnet, Haiku, older Opus, non-Anthropic) silently
+drops the flag so a stale frontend cannot make the request 400.
+
+A streaming ``message_delta`` event carrying ``stop_reason: "refusal"``
+must surface a user-facing notice in the assistant message before the
+translated OpenAI chunk emits ``finish_reason="content_filter"``, so the
+chat bubble doesn't render empty. See
+https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals
+"""
+
+import asyncio
+import json
+
+import httpx
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_client() -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = "anthropic",
+        base_url = "https://api.anthropic.com/v1",
+        api_key = "sk-ant-test",
+    )
+
+
+def _empty_message_sse() -> bytes:
+    return (
+        b'event: message_start\ndata: {"type":"message_start","message":'
+        b'{"id":"m1","content":[],"model":"claude-opus-4-7","role":"assistant",'
+        b'"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n'
+        b'event: message_delta\ndata: {"type":"message_delta",'
+        b'"delta":{"stop_reason":"end_turn"}}\n\n'
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+    )
+
+
+def _refusal_sse() -> bytes:
+    return (
+        b'event: message_start\ndata: {"type":"message_start","message":'
+        b'{"id":"m1","content":[],"model":"claude-opus-4-7","role":"assistant",'
+        b'"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n'
+        b'event: content_block_start\ndata: {"type":"content_block_start",'
+        b'"index":0,"content_block":{"type":"text","text":""}}\n\n'
+        b'event: content_block_delta\ndata: {"type":"content_block_delta",'
+        b'"index":0,"delta":{"type":"text_delta","text":"Hello."}}\n\n'
+        b'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n'
+        b'event: message_delta\ndata: {"type":"message_delta",'
+        b'"delta":{"stop_reason":"refusal"}}\n\n'
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+    )
+
+
+def _capture(monkeypatch, sse: bytes = b"", **kwargs) -> tuple[dict, list[str]]:
+    """Install a MockTransport, drive one streamed call, return body+lines."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            content = sse or _empty_message_sse(),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+    )
+
+    out_lines: list[str] = []
+
+    async def run():
+        client = _make_client()
+        try:
+            async for line in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = kwargs.get("model", "claude-opus-4-7"),
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 32,
+                fast_mode = kwargs.get("fast_mode"),
+            ):
+                out_lines.append(line)
+        finally:
+            await client.close()
+
+    _drive(run())
+    return captured, out_lines
+
+
+def test_fast_mode_attaches_beta_header_and_speed_on_opus_4_7(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7")
+    assert cap["body"].get("speed") == "fast", cap["body"]
+    beta = cap["headers"].get("anthropic-beta", "")
+    assert "fast-mode-2026-02-01" in beta, beta
+
+
+def test_fast_mode_attaches_beta_header_and_speed_on_opus_4_6(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-6")
+    assert cap["body"].get("speed") == "fast", cap["body"]
+    assert "fast-mode-2026-02-01" in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_dropped_on_sonnet(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-sonnet-4-6")
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_dropped_on_haiku(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-haiku-4-5")
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_dropped_on_older_opus(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-5")
+    assert "speed" not in cap["body"], cap["body"]
+
+
+def test_fast_mode_false_does_not_attach_header_or_field(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = False)
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_none_does_not_attach_header_or_field(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = None)
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_refusal_emits_user_facing_notice_and_content_filter_finish(monkeypatch):
+    _, lines = _capture(monkeypatch, sse = _refusal_sse())
+    body = "\n".join(lines)
+    # User-visible refusal notice.
+    assert "stopped by Anthropic's safety classifier" in body, body
+    # OpenAI-spec finish_reason mapping.
+    assert '"finish_reason": "content_filter"' in body, body
+    # Original deltas preserved before the refusal supplement.
+    assert "Hello." in body, body

--- a/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
@@ -158,3 +158,16 @@ def test_refusal_emits_user_facing_notice_and_content_filter_finish(monkeypatch)
     assert '"finish_reason": "content_filter"' in body, body
     # Original deltas preserved before the refusal supplement.
     assert "Hello." in body, body
+
+
+def test_refusal_emits_hidden_sentinel_for_chat_adapter_drop(monkeypatch):
+    """Refused turns embed a hidden sentinel the chat-adapter matches on.
+
+    The frontend drops any assistant message containing this sentinel
+    from the next request's outbound history, per Anthropic's docs:
+    leaving the refused output in context causes the next call to keep
+    refusing.
+    """
+    _, lines = _capture(monkeypatch, sse = _refusal_sse())
+    body = "\n".join(lines)
+    assert "studio:anthropic-refusal" in body, body

--- a/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
@@ -160,14 +160,20 @@ def test_refusal_emits_user_facing_notice_and_content_filter_finish(monkeypatch)
     assert "Hello." in body, body
 
 
-def test_refusal_emits_hidden_sentinel_for_chat_adapter_drop(monkeypatch):
-    """Refused turns embed a hidden sentinel the chat-adapter matches on.
+def test_refusal_emits_tool_event_for_chat_adapter_drop(monkeypatch):
+    """Refused turns emit an out-of-band `_toolEvent` the chat-adapter
+    latches into assistant `metadata.custom.anthropicRefusal`.
 
-    The frontend drops any assistant message containing this sentinel
+    The frontend drops any assistant message with that metadata flag
     from the next request's outbound history, per Anthropic's docs:
     leaving the refused output in context causes the next call to keep
-    refusing.
+    refusing. Using a tool event (not a text sentinel) means assistant
+    content can never spoof a context reset.
     """
     _, lines = _capture(monkeypatch, sse = _refusal_sse())
     body = "\n".join(lines)
-    assert "studio:anthropic-refusal" in body, body
+    assert '"_toolEvent": {"type": "anthropic_refusal"}' in body, body
+    # The visible refusal notice must NOT carry a text sentinel: an
+    # assistant message that echoes that string would otherwise spoof
+    # a context reset on the next request.
+    assert "studio:anthropic-refusal" not in body, body

--- a/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_and_refusal.py
@@ -3,19 +3,10 @@
 
 """Tests for Anthropic fast-mode wiring and streaming refusal handling.
 
-``fast_mode=True`` on Claude Opus 4.6/4.7 must:
-  * attach the ``fast-mode-2026-02-01`` beta header to the outbound
-    /v1/messages call (alongside any other beta headers the request
-    already needed); and
-  * set the top-level ``speed: "fast"`` field on the body.
-
-Any unsupported model (Sonnet, Haiku, older Opus, non-Anthropic) silently
-drops the flag so a stale frontend cannot make the request 400.
-
-A streaming ``message_delta`` event carrying ``stop_reason: "refusal"``
-must surface a user-facing notice in the assistant message before the
-translated OpenAI chunk emits ``finish_reason="content_filter"``, so the
-chat bubble doesn't render empty. See
+fast_mode=True on Opus 4.6/4.7 attaches the ``fast-mode-2026-02-01``
+beta header and sets ``speed: "fast"``; unsupported models drop both.
+Streaming ``stop_reason: "refusal"`` surfaces a user notice before the
+``content_filter`` finish chunk.
 https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals
 """
 
@@ -161,19 +152,13 @@ def test_refusal_emits_user_facing_notice_and_content_filter_finish(monkeypatch)
 
 
 def test_refusal_emits_tool_event_for_chat_adapter_drop(monkeypatch):
-    """Refused turns emit an out-of-band `_toolEvent` the chat-adapter
-    latches into assistant `metadata.custom.anthropicRefusal`.
-
-    The frontend drops any assistant message with that metadata flag
-    from the next request's outbound history, per Anthropic's docs:
-    leaving the refused output in context causes the next call to keep
-    refusing. Using a tool event (not a text sentinel) means assistant
-    content can never spoof a context reset.
+    """Refused turns emit an out-of-band `_toolEvent` that the chat-adapter
+    latches into assistant `metadata.custom.anthropicRefusal`, driving
+    the next-request prune. Tool event (not text) prevents spoofing.
     """
     _, lines = _capture(monkeypatch, sse = _refusal_sse())
     body = "\n".join(lines)
     assert '"_toolEvent": {"type": "anthropic_refusal"}' in body, body
-    # The visible refusal notice must NOT carry a text sentinel: an
-    # assistant message that echoes that string would otherwise spoof
-    # a context reset on the next request.
+    # Visible refusal text must not embed a sentinel that could spoof
+    # a context reset if echoed by another assistant message.
     assert "studio:anthropic-refusal" not in body, body

--- a/studio/backend/tests/test_anthropic_fast_mode_edge.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_edge.py
@@ -498,9 +498,7 @@ def test_usage_speed_propagates_to_final_usage_chunk_fast(monkeypatch):
     can apply the 6x multiplier and clients can verify a fast-mode
     request actually ran fast."""
     _, lines = _capture(monkeypatch, sse = _fast_speed_sse(speed = "fast"))
-    usage_lines = [
-        l for l in lines if l.startswith("data: ") and '"usage"' in l
-    ]
+    usage_lines = [l for l in lines if l.startswith("data: ") and '"usage"' in l]
     assert usage_lines, lines
     parsed = [json.loads(l[len("data: ") :]) for l in usage_lines]
     speeds = [p["usage"].get("speed") for p in parsed if "usage" in p]

--- a/studio/backend/tests/test_anthropic_fast_mode_edge.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_edge.py
@@ -3,40 +3,10 @@
 
 """Edge-case coverage for the Anthropic fast-mode + refusal wiring.
 
-The base ``test_anthropic_fast_mode_and_refusal.py`` pins the happy path
-(beta header + body field on Opus 4.6/4.7, silent drop on Sonnet / Haiku
-/ older Opus / None / False, refusal notice + content_filter mapping).
-This file fills in the remaining behaviour cliffs:
-
-* Dated-snapshot Opus 4.6 / 4.7 (``claude-opus-4-7-2026-02-01``) still
-  matches the prefix gate.
-* Strict opt-in semantics: a future ``claude-opus-4-8`` / ``claude-opus-5``
-  does NOT auto-enable fast mode -- if a new family ever ships we must
-  bump ``_ANTHROPIC_FAST_MODE_PREFIXES`` explicitly. This codifies the
-  conservative stance.
-* Beta-header merge: the existing ``anthropic-beta`` value (from the
-  provider registry or a previously-set entry) must keep its values and
-  receive ``fast-mode-2026-02-01`` appended as a comma-separated extra,
-  not overwritten.
-* Multi-beta interaction with the code-execution and compaction betas:
-  all three must coexist in one comma-separated header with no
-  duplicates and no truncation.
-* Idempotence: setting ``fast_mode=True`` twice via the same body still
-  results in one beta-header entry.
-* Streaming refusal signal: a single out-of-band ``_toolEvent`` carrying
-  ``{"type": "anthropic_refusal"}`` rides alongside the visible refusal
-  notice. The frontend latches the tool event into assistant
-  metadata.custom.anthropicRefusal; assistant text never controls the
-  pruner. The notice always precedes the finish_reason chunk so a UI
-  reading the SSE in order paints text before flipping to
-  ``content_filter``.
-* Refusal on a non-Opus model: refusal handling is provider-side, not
-  model-gated, so a refusal mid-stream on Sonnet must still surface the
-  notice + tool event.
-* Non-destruction: when ``fast_mode`` is ``None``, the outbound body
-  and headers must be byte-identical to the version that omits the
-  argument entirely. This guarantees the upgrade path is non-breaking
-  on existing Anthropic streams.
+Complements ``test_anthropic_fast_mode_and_refusal.py`` (happy path)
+with dated snapshots, strict opt-in (future Opus families do not
+auto-enable), multi-beta header merging, refusal stream ordering, and
+the non-destruction guarantee for unset/None fast_mode.
 """
 
 import asyncio
@@ -140,13 +110,7 @@ def _capture(monkeypatch, sse: bytes = b"", **kwargs) -> tuple[dict, list[str]]:
 
 # ──────────────────────────── dated snapshot prefix ────────────────────────────
 def test_fast_mode_attaches_on_dated_opus_4_7_snapshot(monkeypatch):
-    """Dated snapshot ``claude-opus-4-7-2026-02-01`` must match the prefix.
-
-    Anthropic's /v1/models surfaces both the canonical alias and a
-    dated snapshot for each family. The fast-mode gate uses
-    ``str.startswith`` against the tuple of family aliases, so a dated
-    snapshot of an opted-in family is implicitly included.
-    """
+    """Dated snapshot ``claude-opus-4-7-2026-02-01`` must match the prefix."""
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7-2026-02-01")
     assert cap["body"].get("speed") == "fast", cap["body"]
     assert "fast-mode-2026-02-01" in cap["headers"].get("anthropic-beta", "")
@@ -160,12 +124,7 @@ def test_fast_mode_attaches_on_dated_opus_4_6_snapshot(monkeypatch):
 
 # ──────────────────────────── strict opt-in semantics ────────────────────────────
 def test_fast_mode_does_not_auto_enable_on_future_opus_4_8(monkeypatch):
-    """A hypothetical ``claude-opus-4-8`` is NOT in the prefix tuple, so
-    fast_mode must be silently dropped until the list is updated.
-
-    This codifies the conservative stance documented on
-    ``_ANTHROPIC_FAST_MODE_PREFIXES``: opt-in per model family.
-    """
+    """Future ``claude-opus-4-8`` must not auto-enable; opt-in per family."""
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-8")
     assert "speed" not in cap["body"], cap["body"]
     assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
@@ -178,9 +137,7 @@ def test_fast_mode_does_not_auto_enable_on_future_opus_5(monkeypatch):
 
 
 def test_fast_mode_does_not_auto_enable_on_sonnet_dated_snapshot(monkeypatch):
-    """``claude-sonnet-4-6-2026-...`` shares the family prefix tuple with
-    compaction but NOT with fast_mode -- the gate must keep them
-    separate."""
+    """Sonnet snapshots share the compaction prefix but not fast_mode."""
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-sonnet-4-6-2026-02-01")
     assert "speed" not in cap["body"], cap["body"]
     assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
@@ -193,8 +150,7 @@ def _beta_parts(headers: dict) -> list[str]:
 
 
 def test_fast_mode_merges_with_code_execution_beta(monkeypatch):
-    """fast_mode + enabled_tools=['code_execution'] -> two comma-separated
-    beta entries, no overwrite."""
+    """fast_mode + code_execution -> two comma-separated betas, no overwrite."""
     cap, _ = _capture(
         monkeypatch,
         fast_mode = True,
@@ -209,7 +165,7 @@ def test_fast_mode_merges_with_code_execution_beta(monkeypatch):
 
 
 def test_fast_mode_merges_with_compaction_beta(monkeypatch):
-    """fast_mode + compaction_threshold>=50K -> both betas."""
+    """fast_mode + compaction_threshold >= 50K -> both betas present."""
     cap, _ = _capture(
         monkeypatch,
         fast_mode = True,
@@ -222,8 +178,7 @@ def test_fast_mode_merges_with_compaction_beta(monkeypatch):
 
 
 def test_fast_mode_merges_with_code_execution_and_compaction(monkeypatch):
-    """Three betas active simultaneously must all land in a single
-    comma-separated header value, with no duplicates."""
+    """Three betas coexist in one comma-separated header, no duplicates."""
     cap, _ = _capture(
         monkeypatch,
         fast_mode = True,
@@ -240,12 +195,7 @@ def test_fast_mode_merges_with_code_execution_and_compaction(monkeypatch):
 
 
 def test_fast_mode_beta_value_is_pinned(monkeypatch):
-    """Belt-and-braces: the exact beta tag matches the docs token.
-
-    Anthropic's docs spell it ``fast-mode-2026-02-01`` -- if someone
-    fat-fingers it the API would 400 in production. Pin it here so a
-    rename is caught in CI.
-    """
+    """Pin the exact beta tag ``fast-mode-2026-02-01`` from the docs."""
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7")
     parts = _beta_parts(cap["headers"])
     assert "fast-mode-2026-02-01" in parts, parts
@@ -256,11 +206,7 @@ def test_fast_mode_beta_value_is_pinned(monkeypatch):
 
 # ──────────────────────────── non-destruction guarantee ────────────────────────────
 def test_fast_mode_unset_is_byte_identical_to_omitted(monkeypatch):
-    """Passing ``fast_mode=None`` must produce the same outbound body and
-    headers as omitting the argument entirely.
-
-    The upgrade path for existing Anthropic streams must be non-breaking.
-    """
+    """``fast_mode=None`` must produce the same body/headers as omission."""
     cap_none, _ = _capture(monkeypatch, fast_mode = None, model = "claude-opus-4-7")
 
     # Re-run without passing fast_mode at all.
@@ -309,9 +255,7 @@ def test_fast_mode_unset_is_byte_identical_to_omitted(monkeypatch):
 
 
 def test_fast_mode_false_on_opus_4_7_byte_identical_to_unset(monkeypatch):
-    """``fast_mode=False`` is the explicit opt-out -- it must produce the
-    same outbound shape as the unset case so we don't accidentally start
-    sending ``speed: 'standard'`` or similar."""
+    """``fast_mode=False`` produces the same outbound shape as unset."""
     cap_false, _ = _capture(monkeypatch, fast_mode = False, model = "claude-opus-4-7")
     assert "speed" not in cap_false["body"], cap_false["body"]
     assert "fast-mode-2026-02-01" not in cap_false["headers"].get("anthropic-beta", "")
@@ -319,9 +263,7 @@ def test_fast_mode_false_on_opus_4_7_byte_identical_to_unset(monkeypatch):
 
 # ──────────────────────────── refusal stream ordering ────────────────────────────
 def test_refusal_notice_appears_before_content_filter_chunk(monkeypatch):
-    """The user-visible notice must be emitted as a content delta BEFORE
-    the finish_reason chunk so a streaming UI paints the text first,
-    then flips state to ``content_filter``."""
+    """The notice content delta must precede the finish_reason chunk."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
     notice_idx = next(i for i, l in enumerate(lines) if "stopped by Anthropic" in l)
     filter_idx = next(
@@ -331,13 +273,7 @@ def test_refusal_notice_appears_before_content_filter_chunk(monkeypatch):
 
 
 def test_refusal_tool_event_emitted_exactly_once(monkeypatch):
-    """A single refusal must emit the chat-adapter drop signal one time.
-
-    The frontend latches the tool event into assistant metadata and
-    uses it to drop the refused pair from the next request. Emitting
-    twice would still be metadata-idempotent but indicates a backend
-    bug, so pin the count.
-    """
+    """A single refusal emits the chat-adapter drop signal exactly once."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse())
     body = "\n".join(lines)
     count = body.count('"_toolEvent": {"type": "anthropic_refusal"}')
@@ -345,20 +281,15 @@ def test_refusal_tool_event_emitted_exactly_once(monkeypatch):
 
 
 def test_refusal_text_carries_no_html_sentinel(monkeypatch):
-    """Belt-and-braces: ensure the assistant-visible refusal text does
-    not embed any ``studio:anthropic-refusal`` marker. The drop signal
-    must ride the out-of-band ``_toolEvent`` channel only -- otherwise
-    an assistant message that echoes the literal marker would spoof a
-    context reset on the next request."""
+    """Visible refusal text must not embed a ``studio:anthropic-refusal``
+    sentinel; the drop signal rides _toolEvent only."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse())
     body = "\n".join(lines)
     assert "studio:anthropic-refusal" not in body, body
 
 
 def test_refusal_handling_works_on_sonnet_model(monkeypatch):
-    """Refusal handling is provider-side, not gated on a fast-mode-capable
-    model. If Anthropic's classifier refuses a Sonnet stream it must
-    surface the same notice + tool event + content_filter mapping."""
+    """Refusal handling is provider-side; Sonnet refusals must also surface."""
     _, lines = _capture(
         monkeypatch, sse = _refusal_sse("claude-sonnet-4-6"), model = "claude-sonnet-4-6"
     )
@@ -369,9 +300,7 @@ def test_refusal_handling_works_on_sonnet_model(monkeypatch):
 
 
 def test_refusal_preserves_partial_assistant_text(monkeypatch):
-    """The classifier may stop mid-completion. The partial deltas already
-    streamed must still reach the client BEFORE the refusal notice is
-    appended -- otherwise users lose context for why the bubble ended."""
+    """Partial deltas already streamed must precede the refusal notice."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
     body = "\n".join(lines)
     hello_idx = body.index("Hello.")
@@ -380,10 +309,8 @@ def test_refusal_preserves_partial_assistant_text(monkeypatch):
 
 
 def test_refusal_chunk_is_proper_openai_delta_shape(monkeypatch):
-    """The notice rides a normal ``choices[0].delta.content`` chunk, not
-    a finish_reason chunk, so OpenAI-spec clients (Aurora, OpenAI SDK)
-    treat it as ordinary streamed text. The drop signal arrives on a
-    separate `_toolEvent` chunk (verified below)."""
+    """The notice rides ``choices[0].delta.content`` (not a finish chunk);
+    OpenAI-spec clients treat it as ordinary streamed text."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
     # Find the chunk that carries the refusal text.
     notice_chunk = None
@@ -402,11 +329,9 @@ def test_refusal_chunk_is_proper_openai_delta_shape(monkeypatch):
 
 
 def test_refusal_tool_event_chunk_shape(monkeypatch):
-    """The out-of-band drop signal rides a separate chunk shaped like a
-    Studio `_toolEvent` envelope (choices=[{index:0, delta:{},
-    finish_reason:null}] + `_toolEvent`). The frontend latches on
-    `_toolEvent.type == "anthropic_refusal"` and stamps the assistant
-    message metadata; assistant text never controls the prune."""
+    """Drop signal rides a Studio `_toolEvent` envelope (delta={},
+    finish_reason=null); the frontend latches on
+    `_toolEvent.type == "anthropic_refusal"`."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
     refusal_chunk = None
     for line in lines:
@@ -422,11 +347,8 @@ def test_refusal_tool_event_chunk_shape(monkeypatch):
 
 # ──────────────────────────── future-proofing ────────────────────────────
 def test_fast_mode_prefix_tuple_matches_capability_doc(monkeypatch):
-    """If a maintainer extends ``_ANTHROPIC_FAST_MODE_PREFIXES`` they
-    should also extend this test. Today the tuple is exactly the two
-    families called out on
-    https://platform.claude.com/docs/en/build-with-claude/fast-mode.
-    """
+    """Tuple must exactly match the two families in the upstream docs:
+    https://platform.claude.com/docs/en/build-with-claude/fast-mode."""
     from core.inference.external_provider import _ANTHROPIC_FAST_MODE_PREFIXES
 
     assert set(_ANTHROPIC_FAST_MODE_PREFIXES) == {
@@ -436,26 +358,20 @@ def test_fast_mode_prefix_tuple_matches_capability_doc(monkeypatch):
 
 
 def test_fast_mode_speed_field_value_is_literal_fast(monkeypatch):
-    """The spec value is the string ``"fast"`` -- not ``True``, not
-    ``"fast-mode"``, not a tier name. Pin so a refactor cannot silently
-    flip the wire shape."""
+    """Pin the wire value to the literal string ``"fast"``."""
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7")
     assert cap["body"]["speed"] == "fast", cap["body"]
 
 
 def test_fast_mode_dropped_on_opus_4_5_dated_snapshot(monkeypatch):
-    """``claude-opus-4-5-2025-...`` is the previous-family snapshot
-    pattern; must NOT match the fast-mode prefix."""
+    """Previous-family snapshots like ``claude-opus-4-5-2025-...`` must not match."""
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-5-2025-08-01")
     assert "speed" not in cap["body"], cap["body"]
     assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
 
 
 def test_fast_mode_rejects_prefix_collision_4_70(monkeypatch):
-    """The family gate must require a "-" boundary after the supported
-    prefix so hypothetical IDs like ``claude-opus-4-70`` or
-    ``claude-opus-4-7b`` do not get fast-mode on a naive
-    ``startswith`` match."""
+    """IDs like ``claude-opus-4-70`` / ``-4-7b`` must not match the prefix."""
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-70")
     assert "speed" not in cap["body"], cap["body"]
     assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
@@ -493,10 +409,7 @@ def _fast_speed_sse(model: str = "claude-opus-4-7", speed: str = "fast") -> byte
 
 
 def test_usage_speed_propagates_to_final_usage_chunk_fast(monkeypatch):
-    """When Anthropic returns ``usage.speed == "fast"`` the Studio
-    OpenAI-style usage chunk must carry that field so the cost ledger
-    can apply the 6x multiplier and clients can verify a fast-mode
-    request actually ran fast."""
+    """``usage.speed == "fast"`` from upstream must reach the Studio usage chunk."""
     _, lines = _capture(monkeypatch, sse = _fast_speed_sse(speed = "fast"))
     usage_lines = [l for l in lines if l.startswith("data: ") and '"usage"' in l]
     assert usage_lines, lines
@@ -517,9 +430,7 @@ def test_usage_speed_propagates_to_final_usage_chunk_standard(monkeypatch):
 
 
 def test_usage_speed_absent_when_anthropic_does_not_report(monkeypatch):
-    """When the upstream stream omits ``usage.speed`` (pre-fast-mode
-    models / older snapshots), the Studio usage chunk must not invent
-    a value."""
+    """Studio must not invent ``usage.speed`` when upstream omits it."""
     _, lines = _capture(monkeypatch)
     parsed = [
         json.loads(l[len("data: ") :])

--- a/studio/backend/tests/test_anthropic_fast_mode_edge.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_edge.py
@@ -145,17 +145,13 @@ def test_fast_mode_attaches_on_dated_opus_4_7_snapshot(monkeypatch):
     ``str.startswith`` against the tuple of family aliases, so a dated
     snapshot of an opted-in family is implicitly included.
     """
-    cap, _ = _capture(
-        monkeypatch, fast_mode = True, model = "claude-opus-4-7-2026-02-01"
-    )
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7-2026-02-01")
     assert cap["body"].get("speed") == "fast", cap["body"]
     assert "fast-mode-2026-02-01" in cap["headers"].get("anthropic-beta", "")
 
 
 def test_fast_mode_attaches_on_dated_opus_4_6_snapshot(monkeypatch):
-    cap, _ = _capture(
-        monkeypatch, fast_mode = True, model = "claude-opus-4-6-2026-02-01"
-    )
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-6-2026-02-01")
     assert cap["body"].get("speed") == "fast", cap["body"]
     assert "fast-mode-2026-02-01" in cap["headers"].get("anthropic-beta", "")
 
@@ -183,9 +179,7 @@ def test_fast_mode_does_not_auto_enable_on_sonnet_dated_snapshot(monkeypatch):
     """``claude-sonnet-4-6-2026-...`` shares the family prefix tuple with
     compaction but NOT with fast_mode -- the gate must keep them
     separate."""
-    cap, _ = _capture(
-        monkeypatch, fast_mode = True, model = "claude-sonnet-4-6-2026-02-01"
-    )
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-sonnet-4-6-2026-02-01")
     assert "speed" not in cap["body"], cap["body"]
     assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
 
@@ -327,9 +321,7 @@ def test_refusal_notice_appears_before_content_filter_chunk(monkeypatch):
     the finish_reason chunk so a streaming UI paints the text first,
     then flips state to ``content_filter``."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
-    notice_idx = next(
-        i for i, l in enumerate(lines) if "stopped by Anthropic" in l
-    )
+    notice_idx = next(i for i, l in enumerate(lines) if "stopped by Anthropic" in l)
     filter_idx = next(
         i for i, l in enumerate(lines) if '"finish_reason": "content_filter"' in l
     )
@@ -420,8 +412,6 @@ def test_fast_mode_speed_field_value_is_literal_fast(monkeypatch):
 def test_fast_mode_dropped_on_opus_4_5_dated_snapshot(monkeypatch):
     """``claude-opus-4-5-2025-...`` is the previous-family snapshot
     pattern; must NOT match the fast-mode prefix."""
-    cap, _ = _capture(
-        monkeypatch, fast_mode = True, model = "claude-opus-4-5-2025-08-01"
-    )
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-5-2025-08-01")
     assert "speed" not in cap["body"], cap["body"]
     assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")

--- a/studio/backend/tests/test_anthropic_fast_mode_edge.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_edge.py
@@ -23,14 +23,16 @@ This file fills in the remaining behaviour cliffs:
   duplicates and no truncation.
 * Idempotence: setting ``fast_mode=True`` twice via the same body still
   results in one beta-header entry.
-* Streaming refusal sentinel: emitted exactly once, with the exact
-  ``<!--studio:anthropic-refusal-->`` token the frontend matches on,
-  and the notice always precedes the finish_reason chunk so a UI
+* Streaming refusal signal: a single out-of-band ``_toolEvent`` carrying
+  ``{"type": "anthropic_refusal"}`` rides alongside the visible refusal
+  notice. The frontend latches the tool event into assistant
+  metadata.custom.anthropicRefusal; assistant text never controls the
+  pruner. The notice always precedes the finish_reason chunk so a UI
   reading the SSE in order paints text before flipping to
   ``content_filter``.
 * Refusal on a non-Opus model: refusal handling is provider-side, not
   model-gated, so a refusal mid-stream on Sonnet must still surface the
-  notice + sentinel.
+  notice + tool event.
 * Non-destruction: when ``fast_mode`` is ``None``, the outbound body
   and headers must be byte-identical to the version that omits the
   argument entirely. This guarantees the upgrade path is non-breaking
@@ -328,30 +330,41 @@ def test_refusal_notice_appears_before_content_filter_chunk(monkeypatch):
     assert notice_idx < filter_idx, (notice_idx, filter_idx, lines)
 
 
-def test_refusal_sentinel_emitted_exactly_once(monkeypatch):
-    """A single refusal must emit the chat-adapter drop sentinel one time.
+def test_refusal_tool_event_emitted_exactly_once(monkeypatch):
+    """A single refusal must emit the chat-adapter drop signal one time.
 
-    The frontend's ``toOpenAIMessage`` uses ``includes`` for the match,
-    so duplicates wouldn't cause false drops -- but emitting it twice
-    would still inflate the bubble and break the UX guarantee that the
-    sentinel is an invisible HTML comment.
+    The frontend latches the tool event into assistant metadata and
+    uses it to drop the refused pair from the next request. Emitting
+    twice would still be metadata-idempotent but indicates a backend
+    bug, so pin the count.
     """
     _, lines = _capture(monkeypatch, sse = _refusal_sse())
     body = "\n".join(lines)
-    count = body.count("<!--studio:anthropic-refusal-->")
+    count = body.count('"_toolEvent": {"type": "anthropic_refusal"}')
     assert count == 1, (count, body)
+
+
+def test_refusal_text_carries_no_html_sentinel(monkeypatch):
+    """Belt-and-braces: ensure the assistant-visible refusal text does
+    not embed any ``studio:anthropic-refusal`` marker. The drop signal
+    must ride the out-of-band ``_toolEvent`` channel only -- otherwise
+    an assistant message that echoes the literal marker would spoof a
+    context reset on the next request."""
+    _, lines = _capture(monkeypatch, sse = _refusal_sse())
+    body = "\n".join(lines)
+    assert "studio:anthropic-refusal" not in body, body
 
 
 def test_refusal_handling_works_on_sonnet_model(monkeypatch):
     """Refusal handling is provider-side, not gated on a fast-mode-capable
     model. If Anthropic's classifier refuses a Sonnet stream it must
-    surface the same notice + sentinel + content_filter mapping."""
+    surface the same notice + tool event + content_filter mapping."""
     _, lines = _capture(
         monkeypatch, sse = _refusal_sse("claude-sonnet-4-6"), model = "claude-sonnet-4-6"
     )
     body = "\n".join(lines)
     assert "stopped by Anthropic's safety classifier" in body, body
-    assert "<!--studio:anthropic-refusal-->" in body, body
+    assert '"_toolEvent": {"type": "anthropic_refusal"}' in body, body
     assert '"finish_reason": "content_filter"' in body, body
 
 
@@ -369,7 +382,8 @@ def test_refusal_preserves_partial_assistant_text(monkeypatch):
 def test_refusal_chunk_is_proper_openai_delta_shape(monkeypatch):
     """The notice rides a normal ``choices[0].delta.content`` chunk, not
     a finish_reason chunk, so OpenAI-spec clients (Aurora, OpenAI SDK)
-    treat it as ordinary streamed text."""
+    treat it as ordinary streamed text. The drop signal arrives on a
+    separate `_toolEvent` chunk (verified below)."""
     _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
     # Find the chunk that carries the refusal text.
     notice_chunk = None
@@ -383,7 +397,27 @@ def test_refusal_chunk_is_proper_openai_delta_shape(monkeypatch):
     # Must NOT carry a finish_reason itself -- that comes on the next
     # chunk.
     assert choice.get("finish_reason") in (None,), notice_chunk
-    assert "<!--studio:anthropic-refusal-->" in choice["delta"]["content"]
+    # Refusal text is plain-spoken; no embedded sentinel.
+    assert "studio:anthropic-refusal" not in choice["delta"]["content"]
+
+
+def test_refusal_tool_event_chunk_shape(monkeypatch):
+    """The out-of-band drop signal rides a separate chunk shaped like a
+    Studio `_toolEvent` envelope (choices=[{index:0, delta:{},
+    finish_reason:null}] + `_toolEvent`). The frontend latches on
+    `_toolEvent.type == "anthropic_refusal"` and stamps the assistant
+    message metadata; assistant text never controls the prune."""
+    _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
+    refusal_chunk = None
+    for line in lines:
+        if line.startswith("data: ") and "anthropic_refusal" in line:
+            refusal_chunk = json.loads(line[len("data: ") :])
+            break
+    assert refusal_chunk is not None, lines
+    assert refusal_chunk["_toolEvent"] == {"type": "anthropic_refusal"}, refusal_chunk
+    choice = refusal_chunk["choices"][0]
+    assert choice["delta"] == {}, refusal_chunk
+    assert choice["finish_reason"] is None, refusal_chunk
 
 
 # ──────────────────────────── future-proofing ────────────────────────────
@@ -415,3 +449,85 @@ def test_fast_mode_dropped_on_opus_4_5_dated_snapshot(monkeypatch):
     cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-5-2025-08-01")
     assert "speed" not in cap["body"], cap["body"]
     assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_rejects_prefix_collision_4_70(monkeypatch):
+    """The family gate must require a "-" boundary after the supported
+    prefix so hypothetical IDs like ``claude-opus-4-70`` or
+    ``claude-opus-4-7b`` do not get fast-mode on a naive
+    ``startswith`` match."""
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-70")
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_rejects_prefix_collision_4_7b(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7b")
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_rejects_prefix_collision_4_6_extra(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-60")
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+# ──────────────────────────── usage.speed propagation ────────────────────────────
+def _fast_speed_sse(model: str = "claude-opus-4-7", speed: str = "fast") -> bytes:
+    return (
+        b'event: message_start\ndata: {"type":"message_start","message":'
+        b'{"id":"m1","content":[],"model":"' + model.encode() + b'",'
+        b'"role":"assistant","stop_reason":null,"usage":'
+        b'{"input_tokens":4,"output_tokens":1}}}\n\n'
+        b'event: content_block_start\ndata: {"type":"content_block_start",'
+        b'"index":0,"content_block":{"type":"text","text":""}}\n\n'
+        b'event: content_block_delta\ndata: {"type":"content_block_delta",'
+        b'"index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n'
+        b'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n'
+        b'event: message_delta\ndata: {"type":"message_delta",'
+        b'"delta":{"stop_reason":"end_turn"},'
+        b'"usage":{"output_tokens":5,"speed":"' + speed.encode() + b'"}}\n\n'
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+    )
+
+
+def test_usage_speed_propagates_to_final_usage_chunk_fast(monkeypatch):
+    """When Anthropic returns ``usage.speed == "fast"`` the Studio
+    OpenAI-style usage chunk must carry that field so the cost ledger
+    can apply the 6x multiplier and clients can verify a fast-mode
+    request actually ran fast."""
+    _, lines = _capture(monkeypatch, sse = _fast_speed_sse(speed = "fast"))
+    usage_lines = [
+        l for l in lines if l.startswith("data: ") and '"usage"' in l
+    ]
+    assert usage_lines, lines
+    parsed = [json.loads(l[len("data: ") :]) for l in usage_lines]
+    speeds = [p["usage"].get("speed") for p in parsed if "usage" in p]
+    assert "fast" in speeds, parsed
+
+
+def test_usage_speed_propagates_to_final_usage_chunk_standard(monkeypatch):
+    _, lines = _capture(monkeypatch, sse = _fast_speed_sse(speed = "standard"))
+    parsed = [
+        json.loads(l[len("data: ") :])
+        for l in lines
+        if l.startswith("data: ") and '"usage"' in l
+    ]
+    speeds = [p["usage"].get("speed") for p in parsed if "usage" in p]
+    assert "standard" in speeds, parsed
+
+
+def test_usage_speed_absent_when_anthropic_does_not_report(monkeypatch):
+    """When the upstream stream omits ``usage.speed`` (pre-fast-mode
+    models / older snapshots), the Studio usage chunk must not invent
+    a value."""
+    _, lines = _capture(monkeypatch)
+    parsed = [
+        json.loads(l[len("data: ") :])
+        for l in lines
+        if l.startswith("data: ") and '"usage"' in l
+    ]
+    for p in parsed:
+        usage = p.get("usage") or {}
+        assert "speed" not in usage, p

--- a/studio/backend/tests/test_anthropic_fast_mode_edge.py
+++ b/studio/backend/tests/test_anthropic_fast_mode_edge.py
@@ -1,0 +1,427 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Edge-case coverage for the Anthropic fast-mode + refusal wiring.
+
+The base ``test_anthropic_fast_mode_and_refusal.py`` pins the happy path
+(beta header + body field on Opus 4.6/4.7, silent drop on Sonnet / Haiku
+/ older Opus / None / False, refusal notice + content_filter mapping).
+This file fills in the remaining behaviour cliffs:
+
+* Dated-snapshot Opus 4.6 / 4.7 (``claude-opus-4-7-2026-02-01``) still
+  matches the prefix gate.
+* Strict opt-in semantics: a future ``claude-opus-4-8`` / ``claude-opus-5``
+  does NOT auto-enable fast mode -- if a new family ever ships we must
+  bump ``_ANTHROPIC_FAST_MODE_PREFIXES`` explicitly. This codifies the
+  conservative stance.
+* Beta-header merge: the existing ``anthropic-beta`` value (from the
+  provider registry or a previously-set entry) must keep its values and
+  receive ``fast-mode-2026-02-01`` appended as a comma-separated extra,
+  not overwritten.
+* Multi-beta interaction with the code-execution and compaction betas:
+  all three must coexist in one comma-separated header with no
+  duplicates and no truncation.
+* Idempotence: setting ``fast_mode=True`` twice via the same body still
+  results in one beta-header entry.
+* Streaming refusal sentinel: emitted exactly once, with the exact
+  ``<!--studio:anthropic-refusal-->`` token the frontend matches on,
+  and the notice always precedes the finish_reason chunk so a UI
+  reading the SSE in order paints text before flipping to
+  ``content_filter``.
+* Refusal on a non-Opus model: refusal handling is provider-side, not
+  model-gated, so a refusal mid-stream on Sonnet must still surface the
+  notice + sentinel.
+* Non-destruction: when ``fast_mode`` is ``None``, the outbound body
+  and headers must be byte-identical to the version that omits the
+  argument entirely. This guarantees the upgrade path is non-breaking
+  on existing Anthropic streams.
+"""
+
+import asyncio
+import json
+import re
+
+import httpx
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_client() -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = "anthropic",
+        base_url = "https://api.anthropic.com/v1",
+        api_key = "sk-ant-test",
+    )
+
+
+def _empty_message_sse(model: str = "claude-opus-4-7") -> bytes:
+    return (
+        b'event: message_start\ndata: {"type":"message_start","message":'
+        b'{"id":"m1","content":[],"model":"' + model.encode() + b'",'
+        b'"role":"assistant","stop_reason":null,"usage":'
+        b'{"input_tokens":1,"output_tokens":1}}}\n\n'
+        b'event: message_delta\ndata: {"type":"message_delta",'
+        b'"delta":{"stop_reason":"end_turn"}}\n\n'
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+    )
+
+
+def _refusal_sse(model: str = "claude-opus-4-7") -> bytes:
+    return (
+        b'event: message_start\ndata: {"type":"message_start","message":'
+        b'{"id":"m1","content":[],"model":"' + model.encode() + b'",'
+        b'"role":"assistant","stop_reason":null,"usage":'
+        b'{"input_tokens":1,"output_tokens":1}}}\n\n'
+        b'event: content_block_start\ndata: {"type":"content_block_start",'
+        b'"index":0,"content_block":{"type":"text","text":""}}\n\n'
+        b'event: content_block_delta\ndata: {"type":"content_block_delta",'
+        b'"index":0,"delta":{"type":"text_delta","text":"Hello."}}\n\n'
+        b'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n'
+        b'event: message_delta\ndata: {"type":"message_delta",'
+        b'"delta":{"stop_reason":"refusal"}}\n\n'
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+    )
+
+
+def _capture(monkeypatch, sse: bytes = b"", **kwargs) -> tuple[dict, list[str]]:
+    """Install a MockTransport, drive one streamed call, return body+lines."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            content = sse or _empty_message_sse(kwargs.get("model", "claude-opus-4-7")),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+    )
+
+    out_lines: list[str] = []
+
+    async def run():
+        client = _make_client()
+        try:
+            extra = {}
+            for key in (
+                "enabled_tools",
+                "compaction_threshold",
+                "fast_mode",
+            ):
+                if key in kwargs:
+                    extra[key] = kwargs[key]
+            async for line in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = kwargs.get("model", "claude-opus-4-7"),
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 32,
+                **extra,
+            ):
+                out_lines.append(line)
+        finally:
+            await client.close()
+
+    _drive(run())
+    return captured, out_lines
+
+
+# ──────────────────────────── dated snapshot prefix ────────────────────────────
+def test_fast_mode_attaches_on_dated_opus_4_7_snapshot(monkeypatch):
+    """Dated snapshot ``claude-opus-4-7-2026-02-01`` must match the prefix.
+
+    Anthropic's /v1/models surfaces both the canonical alias and a
+    dated snapshot for each family. The fast-mode gate uses
+    ``str.startswith`` against the tuple of family aliases, so a dated
+    snapshot of an opted-in family is implicitly included.
+    """
+    cap, _ = _capture(
+        monkeypatch, fast_mode = True, model = "claude-opus-4-7-2026-02-01"
+    )
+    assert cap["body"].get("speed") == "fast", cap["body"]
+    assert "fast-mode-2026-02-01" in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_attaches_on_dated_opus_4_6_snapshot(monkeypatch):
+    cap, _ = _capture(
+        monkeypatch, fast_mode = True, model = "claude-opus-4-6-2026-02-01"
+    )
+    assert cap["body"].get("speed") == "fast", cap["body"]
+    assert "fast-mode-2026-02-01" in cap["headers"].get("anthropic-beta", "")
+
+
+# ──────────────────────────── strict opt-in semantics ────────────────────────────
+def test_fast_mode_does_not_auto_enable_on_future_opus_4_8(monkeypatch):
+    """A hypothetical ``claude-opus-4-8`` is NOT in the prefix tuple, so
+    fast_mode must be silently dropped until the list is updated.
+
+    This codifies the conservative stance documented on
+    ``_ANTHROPIC_FAST_MODE_PREFIXES``: opt-in per model family.
+    """
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-8")
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_does_not_auto_enable_on_future_opus_5(monkeypatch):
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-5")
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+def test_fast_mode_does_not_auto_enable_on_sonnet_dated_snapshot(monkeypatch):
+    """``claude-sonnet-4-6-2026-...`` shares the family prefix tuple with
+    compaction but NOT with fast_mode -- the gate must keep them
+    separate."""
+    cap, _ = _capture(
+        monkeypatch, fast_mode = True, model = "claude-sonnet-4-6-2026-02-01"
+    )
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")
+
+
+# ──────────────────────────── beta header merge ────────────────────────────
+def _beta_parts(headers: dict) -> list[str]:
+    raw = headers.get("anthropic-beta", "")
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def test_fast_mode_merges_with_code_execution_beta(monkeypatch):
+    """fast_mode + enabled_tools=['code_execution'] -> two comma-separated
+    beta entries, no overwrite."""
+    cap, _ = _capture(
+        monkeypatch,
+        fast_mode = True,
+        model = "claude-opus-4-7",
+        enabled_tools = ["code_execution"],
+    )
+    parts = _beta_parts(cap["headers"])
+    assert "fast-mode-2026-02-01" in parts, cap["headers"]
+    assert any(p.startswith("code-execution-") for p in parts), cap["headers"]
+    # No duplicates.
+    assert len(parts) == len(set(parts)), parts
+
+
+def test_fast_mode_merges_with_compaction_beta(monkeypatch):
+    """fast_mode + compaction_threshold>=50K -> both betas."""
+    cap, _ = _capture(
+        monkeypatch,
+        fast_mode = True,
+        model = "claude-opus-4-7",
+        compaction_threshold = 100_000,
+    )
+    parts = _beta_parts(cap["headers"])
+    assert "fast-mode-2026-02-01" in parts, cap["headers"]
+    assert "compact-2026-01-12" in parts, cap["headers"]
+
+
+def test_fast_mode_merges_with_code_execution_and_compaction(monkeypatch):
+    """Three betas active simultaneously must all land in a single
+    comma-separated header value, with no duplicates."""
+    cap, _ = _capture(
+        monkeypatch,
+        fast_mode = True,
+        model = "claude-opus-4-7",
+        enabled_tools = ["code_execution"],
+        compaction_threshold = 100_000,
+    )
+    parts = _beta_parts(cap["headers"])
+    assert "fast-mode-2026-02-01" in parts
+    assert "compact-2026-01-12" in parts
+    assert any(p.startswith("code-execution-") for p in parts), parts
+    assert len(parts) >= 3
+    assert len(parts) == len(set(parts)), parts
+
+
+def test_fast_mode_beta_value_is_pinned(monkeypatch):
+    """Belt-and-braces: the exact beta tag matches the docs token.
+
+    Anthropic's docs spell it ``fast-mode-2026-02-01`` -- if someone
+    fat-fingers it the API would 400 in production. Pin it here so a
+    rename is caught in CI.
+    """
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7")
+    parts = _beta_parts(cap["headers"])
+    assert "fast-mode-2026-02-01" in parts, parts
+    # Reject obvious typos.
+    assert not any(p.startswith("fastmode-") for p in parts), parts
+    assert not any("fast_mode" in p for p in parts), parts
+
+
+# ──────────────────────────── non-destruction guarantee ────────────────────────────
+def test_fast_mode_unset_is_byte_identical_to_omitted(monkeypatch):
+    """Passing ``fast_mode=None`` must produce the same outbound body and
+    headers as omitting the argument entirely.
+
+    The upgrade path for existing Anthropic streams must be non-breaking.
+    """
+    cap_none, _ = _capture(monkeypatch, fast_mode = None, model = "claude-opus-4-7")
+
+    # Re-run without passing fast_mode at all.
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            content = _empty_message_sse(),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+    )
+
+    async def run():
+        client = _make_client()
+        try:
+            async for _ in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "claude-opus-4-7",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 32,
+            ):
+                pass
+        finally:
+            await client.close()
+
+    _drive(run())
+
+    assert cap_none["body"] == captured["body"], (cap_none["body"], captured["body"])
+    # Headers can vary by httpx-injected fields (host, connection); compare
+    # the load-bearing ones.
+    for key in ("anthropic-version", "x-api-key", "content-type"):
+        assert cap_none["headers"].get(key) == captured["headers"].get(key), key
+    assert "anthropic-beta" not in cap_none["headers"]
+    assert "anthropic-beta" not in captured["headers"]
+    assert "speed" not in cap_none["body"]
+    assert "speed" not in captured["body"]
+
+
+def test_fast_mode_false_on_opus_4_7_byte_identical_to_unset(monkeypatch):
+    """``fast_mode=False`` is the explicit opt-out -- it must produce the
+    same outbound shape as the unset case so we don't accidentally start
+    sending ``speed: 'standard'`` or similar."""
+    cap_false, _ = _capture(monkeypatch, fast_mode = False, model = "claude-opus-4-7")
+    assert "speed" not in cap_false["body"], cap_false["body"]
+    assert "fast-mode-2026-02-01" not in cap_false["headers"].get("anthropic-beta", "")
+
+
+# ──────────────────────────── refusal stream ordering ────────────────────────────
+def test_refusal_notice_appears_before_content_filter_chunk(monkeypatch):
+    """The user-visible notice must be emitted as a content delta BEFORE
+    the finish_reason chunk so a streaming UI paints the text first,
+    then flips state to ``content_filter``."""
+    _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
+    notice_idx = next(
+        i for i, l in enumerate(lines) if "stopped by Anthropic" in l
+    )
+    filter_idx = next(
+        i for i, l in enumerate(lines) if '"finish_reason": "content_filter"' in l
+    )
+    assert notice_idx < filter_idx, (notice_idx, filter_idx, lines)
+
+
+def test_refusal_sentinel_emitted_exactly_once(monkeypatch):
+    """A single refusal must emit the chat-adapter drop sentinel one time.
+
+    The frontend's ``toOpenAIMessage`` uses ``includes`` for the match,
+    so duplicates wouldn't cause false drops -- but emitting it twice
+    would still inflate the bubble and break the UX guarantee that the
+    sentinel is an invisible HTML comment.
+    """
+    _, lines = _capture(monkeypatch, sse = _refusal_sse())
+    body = "\n".join(lines)
+    count = body.count("<!--studio:anthropic-refusal-->")
+    assert count == 1, (count, body)
+
+
+def test_refusal_handling_works_on_sonnet_model(monkeypatch):
+    """Refusal handling is provider-side, not gated on a fast-mode-capable
+    model. If Anthropic's classifier refuses a Sonnet stream it must
+    surface the same notice + sentinel + content_filter mapping."""
+    _, lines = _capture(
+        monkeypatch, sse = _refusal_sse("claude-sonnet-4-6"), model = "claude-sonnet-4-6"
+    )
+    body = "\n".join(lines)
+    assert "stopped by Anthropic's safety classifier" in body, body
+    assert "<!--studio:anthropic-refusal-->" in body, body
+    assert '"finish_reason": "content_filter"' in body, body
+
+
+def test_refusal_preserves_partial_assistant_text(monkeypatch):
+    """The classifier may stop mid-completion. The partial deltas already
+    streamed must still reach the client BEFORE the refusal notice is
+    appended -- otherwise users lose context for why the bubble ended."""
+    _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
+    body = "\n".join(lines)
+    hello_idx = body.index("Hello.")
+    notice_idx = body.index("stopped by Anthropic")
+    assert hello_idx < notice_idx, (hello_idx, notice_idx)
+
+
+def test_refusal_chunk_is_proper_openai_delta_shape(monkeypatch):
+    """The notice rides a normal ``choices[0].delta.content`` chunk, not
+    a finish_reason chunk, so OpenAI-spec clients (Aurora, OpenAI SDK)
+    treat it as ordinary streamed text."""
+    _, lines = _capture(monkeypatch, sse = _refusal_sse(), model = "claude-opus-4-7")
+    # Find the chunk that carries the refusal text.
+    notice_chunk = None
+    for line in lines:
+        if line.startswith("data: ") and "stopped by Anthropic" in line:
+            notice_chunk = json.loads(line[len("data: ") :])
+            break
+    assert notice_chunk is not None, lines
+    choice = notice_chunk["choices"][0]
+    assert "delta" in choice and "content" in choice["delta"], notice_chunk
+    # Must NOT carry a finish_reason itself -- that comes on the next
+    # chunk.
+    assert choice.get("finish_reason") in (None,), notice_chunk
+    assert "<!--studio:anthropic-refusal-->" in choice["delta"]["content"]
+
+
+# ──────────────────────────── future-proofing ────────────────────────────
+def test_fast_mode_prefix_tuple_matches_capability_doc(monkeypatch):
+    """If a maintainer extends ``_ANTHROPIC_FAST_MODE_PREFIXES`` they
+    should also extend this test. Today the tuple is exactly the two
+    families called out on
+    https://platform.claude.com/docs/en/build-with-claude/fast-mode.
+    """
+    from core.inference.external_provider import _ANTHROPIC_FAST_MODE_PREFIXES
+
+    assert set(_ANTHROPIC_FAST_MODE_PREFIXES) == {
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+    }, _ANTHROPIC_FAST_MODE_PREFIXES
+
+
+def test_fast_mode_speed_field_value_is_literal_fast(monkeypatch):
+    """The spec value is the string ``"fast"`` -- not ``True``, not
+    ``"fast-mode"``, not a tier name. Pin so a refactor cannot silently
+    flip the wire shape."""
+    cap, _ = _capture(monkeypatch, fast_mode = True, model = "claude-opus-4-7")
+    assert cap["body"]["speed"] == "fast", cap["body"]
+
+
+def test_fast_mode_dropped_on_opus_4_5_dated_snapshot(monkeypatch):
+    """``claude-opus-4-5-2025-...`` is the previous-family snapshot
+    pattern; must NOT match the fast-mode prefix."""
+    cap, _ = _capture(
+        monkeypatch, fast_mode = True, model = "claude-opus-4-5-2025-08-01"
+    )
+    assert "speed" not in cap["body"], cap["body"]
+    assert "fast-mode-2026-02-01" not in cap["headers"].get("anthropic-beta", "")

--- a/studio/backend/tests/test_anthropic_web_fetch.py
+++ b/studio/backend/tests/test_anthropic_web_fetch.py
@@ -365,15 +365,9 @@ def test_web_fetch_error_renders_error_code(monkeypatch):
 
 
 def _finish_reasons(lines: list[str]) -> list:
-    """Return the non-null finish_reason fields from every
-    chat.completion.chunk.
-
-    Content delta chunks carry ``finish_reason: None`` -- those are
-    not finish reasons, they are mid-stream deltas. We only care about
-    the chunks that actually announce the end of the assistant turn
-    (the post-PR refusal path emits a user-visible content notice
-    before the mapped content_filter chunk, which is exactly the
-    case this helper used to ignore on the older streams)."""
+    """Return non-null finish_reason fields from each chat.completion.chunk.
+    Mid-stream content deltas carry ``finish_reason: None`` and are skipped
+    (the refusal path emits a notice delta before the content_filter chunk)."""
     out: list = []
     for line in lines:
         if not line.startswith("data:"):

--- a/studio/backend/tests/test_anthropic_web_fetch.py
+++ b/studio/backend/tests/test_anthropic_web_fetch.py
@@ -365,7 +365,15 @@ def test_web_fetch_error_renders_error_code(monkeypatch):
 
 
 def _finish_reasons(lines: list[str]) -> list:
-    """Return the finish_reason fields from every chat.completion.chunk."""
+    """Return the non-null finish_reason fields from every
+    chat.completion.chunk.
+
+    Content delta chunks carry ``finish_reason: None`` -- those are
+    not finish reasons, they are mid-stream deltas. We only care about
+    the chunks that actually announce the end of the assistant turn
+    (the post-PR refusal path emits a user-visible content notice
+    before the mapped content_filter chunk, which is exactly the
+    case this helper used to ignore on the older streams)."""
     out: list = []
     for line in lines:
         if not line.startswith("data:"):
@@ -380,8 +388,9 @@ def _finish_reasons(lines: list[str]) -> list:
         if parsed.get("object") != "chat.completion.chunk":
             continue
         for choice in parsed.get("choices") or []:
-            if "finish_reason" in choice:
-                out.append(choice["finish_reason"])
+            reason = choice.get("finish_reason")
+            if reason is not None:
+                out.append(reason)
     return out
 
 

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -14,6 +14,7 @@ from core.inference.pricing import (
     ANTHROPIC_CACHE_5M_WRITE_MULT,
     ANTHROPIC_CACHE_1H_WRITE_MULT,
     ANTHROPIC_CACHE_READ_MULT,
+    ANTHROPIC_FAST_MODE_MULT,
     ANTHROPIC_PRICING,
     OPENAI_CACHE_READ_MULT,
     OPENAI_CONTAINER_USD_PER_HOUR,
@@ -55,6 +56,65 @@ def test_anthropic_opus_4_7_input_and_output_math():
     assert _isclose(out["input_usd"], 5.0)
     assert _isclose(out["output_usd"], 25.0)
     assert _isclose(out["total_usd"], 30.0)
+
+
+# ── Anthropic fast-mode 6x multiplier (Opus 4.6 / 4.7 only) ─────────
+
+
+def test_anthropic_fast_mode_charges_6x_standard_opus():
+    """Per https://platform.claude.com/docs/en/build-with-claude/fast-mode
+    fast-mode requests are billed at 6x the standard Opus rates across
+    the full context window. ``usage.speed == "fast"`` is the trigger."""
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+            "speed": "fast",
+        },
+    )
+    assert _isclose(out["input_usd"], 5.0 * ANTHROPIC_FAST_MODE_MULT)
+    assert _isclose(out["output_usd"], 25.0 * ANTHROPIC_FAST_MODE_MULT)
+    assert _isclose(out["total_usd"], 30.0 * ANTHROPIC_FAST_MODE_MULT)
+    assert "(fast)" in out["model_priced"], out["model_priced"]
+
+
+def test_anthropic_fast_mode_does_not_affect_standard_speed():
+    """``speed: "standard"`` (or missing) keeps the base rates."""
+    out_standard = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+            "speed": "standard",
+        },
+    )
+    out_missing = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    assert _isclose(out_standard["total_usd"], out_missing["total_usd"])
+    assert _isclose(out_standard["total_usd"], 30.0)
+
+
+def test_anthropic_fast_mode_stacks_with_cache_read_multiplier():
+    """Cache multipliers apply on top of fast-mode (per docs)."""
+    base = ANTHROPIC_PRICING["claude-opus-4-7"]["input_per_mtok"]
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 1_000_000,
+            "speed": "fast",
+        },
+    )
+    expected = base * ANTHROPIC_FAST_MODE_MULT * ANTHROPIC_CACHE_READ_MULT
+    assert _isclose(out["cache_read_usd"], expected)
 
 
 # ── Anthropic cache write 5m + read multipliers ──────────────────────
@@ -412,6 +472,7 @@ def test_snapshot_contains_provider_buckets_and_multipliers():
     assert a["cache_5m_write_mult"] == ANTHROPIC_CACHE_5M_WRITE_MULT
     assert a["cache_1h_write_mult"] == ANTHROPIC_CACHE_1H_WRITE_MULT
     assert a["cache_read_mult"] == ANTHROPIC_CACHE_READ_MULT
+    assert a["fast_mode_mult"] == ANTHROPIC_FAST_MODE_MULT
     assert "web_search_usd_per_1k" in a
     assert "code_execution_usd_per_hour" in a
     assert "models" in o and "gpt-5.5" in o["models"]

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -62,9 +62,8 @@ def test_anthropic_opus_4_7_input_and_output_math():
 
 
 def test_anthropic_fast_mode_charges_6x_standard_opus():
-    """Per https://platform.claude.com/docs/en/build-with-claude/fast-mode
-    fast-mode requests are billed at 6x the standard Opus rates across
-    the full context window. ``usage.speed == "fast"`` is the trigger."""
+    """6x on input + output when ``usage.speed == "fast"``.
+    https://platform.claude.com/docs/en/build-with-claude/fast-mode"""
     out = calculate_cost(
         "anthropic",
         "claude-opus-4-7",

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -933,7 +933,29 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           ),
       );
 
-      const outboundMessages = messages
+      // Two-pass build so a refused assistant turn drops the user
+      // message that triggered it as well. Anthropic's refusal-handling
+      // guidance is explicit that leaving the offending user prompt in
+      // context causes the next request to re-trigger the classifier;
+      // returning null on just the assistant side was not enough.
+      const survivingMessages: RunMessage[] = [];
+      for (const message of messages) {
+        if (
+          message.role === "assistant" &&
+          collectTextParts(message)
+            .join("\n")
+            .includes(ANTHROPIC_REFUSAL_SENTINEL)
+        ) {
+          const last = survivingMessages.at(-1);
+          if (last && last.role === "user") {
+            survivingMessages.pop();
+          }
+          continue;
+        }
+        survivingMessages.push(message);
+      }
+
+      const outboundMessages = survivingMessages
         .map(toOpenAIMessage)
         .filter((message): message is NonNullable<typeof message> =>
           Boolean(message),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -341,12 +341,19 @@ function collectImageParts(
   return parts;
 }
 
-// Sentinel emitted by the backend at the end of an assistant turn that
-// Anthropic ended with stop_reason="refusal". We drop the entire turn
-// from the next request body because Anthropic's guidance says leaving
-// the refused output in context causes the next call to keep refusing.
-// Keep in sync with studio/backend/core/inference/external_provider.py.
-const ANTHROPIC_REFUSAL_SENTINEL = "<!--studio:anthropic-refusal-->";
+// Out-of-band refusal flag stamped onto assistant message metadata by the
+// adapter when the backend emits an `anthropic_refusal` _toolEvent. We
+// drop the entire turn from the next request body because Anthropic's
+// guidance says leaving the refused output in context causes the next
+// call to keep refusing. Using metadata (not text) means assistant
+// content can never spoof a context reset.
+function isAnthropicRefusalMessage(message: RunMessage): boolean {
+  if (message.role !== "assistant") return false;
+  const metadata = (message as { metadata?: unknown }).metadata as
+    | { custom?: Record<string, unknown> }
+    | undefined;
+  return metadata?.custom?.anthropicRefusal === true;
+}
 
 function toOpenAIMessage(message: RunMessage): {
   role: "system" | "user" | "assistant";
@@ -368,7 +375,7 @@ function toOpenAIMessage(message: RunMessage): {
       /data:audio\/[a-z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g,
       "[audio]",
     );
-    if (textContent.includes(ANTHROPIC_REFUSAL_SENTINEL)) {
+    if (isAnthropicRefusalMessage(message)) {
       // Drop refused assistant turns entirely so the next request does
       // not re-trigger the same safety classifier. The user-visible
       // notice stays in the rendered transcript; only the outbound
@@ -938,14 +945,12 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // guidance is explicit that leaving the offending user prompt in
       // context causes the next request to re-trigger the classifier;
       // returning null on just the assistant side was not enough.
+      // The refusal flag rides assistant metadata.custom.anthropicRefusal
+      // (set out-of-band from the backend _toolEvent) so assistant text
+      // can never spoof a context reset.
       const survivingMessages: RunMessage[] = [];
       for (const message of messages) {
-        if (
-          message.role === "assistant" &&
-          collectTextParts(message)
-            .join("\n")
-            .includes(ANTHROPIC_REFUSAL_SENTINEL)
-        ) {
+        if (isAnthropicRefusalMessage(message)) {
           const last = survivingMessages.at(-1);
           if (last && last.role === "user") {
             survivingMessages.pop();
@@ -1025,8 +1030,12 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           });
         }
       }
-      const imageBase64 = findLatestUserImageBase64(messages);
-      const audioBase64 = findLatestUserAudioBase64(messages);
+      // Scan the post-prune history so a refused user turn with an
+      // image/audio attachment does not gate / mis-attribute the next
+      // non-refused turn (the refused pair is pruned from the request
+      // body above).
+      const imageBase64 = findLatestUserImageBase64(survivingMessages);
+      const audioBase64 = findLatestUserAudioBase64(survivingMessages);
 
       // Block when ANY image is in the outbound payload (current or
       // prior turns) and the loaded model can't process images. Keeps
@@ -1062,7 +1071,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       if (audioBase64) {
         const audioName = runtime.pendingAudioName;
         if (audioName) {
-          const lastUserMsg = [...messages]
+          const lastUserMsg = [...survivingMessages]
             .reverse()
             .find((m) => m.role === "user");
           if (lastUserMsg) sentAudioNames.set(lastUserMsg.id, audioName);
@@ -1173,6 +1182,12 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // Tool call content parts — accumulated and yielded cumulatively.
       // result is set directly on the tool-call part when tool_end arrives.
       const toolCallParts: ToolCallMessagePart[] = [];
+      // Latched when the backend emits an `anthropic_refusal` tool event
+      // on Anthropic stop_reason="refusal". Stamped onto the final
+      // assistant message metadata as `custom.anthropicRefusal` so the
+      // history-prune logic above can drop the refused pair on the next
+      // request without relying on text-content sentinels.
+      let anthropicRefusalSeen = false;
       let serverMetadata: {
         usage?: ServerUsage;
         timings?: ServerTimings;
@@ -1645,6 +1660,14 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                   }
                   continue;
                 }
+                if (toolEvent.type === "anthropic_refusal") {
+                  // Backend signalled stop_reason="refusal" out-of-band.
+                  // Latch and stamp onto the final message metadata so
+                  // the two-pass history pruner can drop the refused
+                  // pair on the next request.
+                  anthropicRefusalSeen = true;
+                  continue;
+                }
                 if (toolEvent.type === "tool_start") {
                   const id =
                     (toolEvent.tool_call_id as string) ||
@@ -1965,6 +1988,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             timing: finalTiming,
             custom: {
               reasoningDuration,
+              // Persisted refusal flag; drives the two-pass history
+              // pruner that drops the refused assistant + user pair
+              // on the next request.
+              anthropicRefusal: anthropicRefusalSeen || undefined,
               serverTimings: meta?.timings ?? undefined,
               contextUsage: meta?.usage
                 ? {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -341,12 +341,10 @@ function collectImageParts(
   return parts;
 }
 
-// Out-of-band refusal flag stamped onto assistant message metadata by the
-// adapter when the backend emits an `anthropic_refusal` _toolEvent. We
-// drop the entire turn from the next request body because Anthropic's
-// guidance says leaving the refused output in context causes the next
-// call to keep refusing. Using metadata (not text) means assistant
-// content can never spoof a context reset.
+// Refusal flag stamped on assistant metadata when the backend emits the
+// `anthropic_refusal` _toolEvent. We drop the refused pair from the next
+// request body (Anthropic guidance: leaving refusals in context keeps
+// refusing). Metadata (not text) prevents content from spoofing a reset.
 function isAnthropicRefusalMessage(message: RunMessage): boolean {
   if (message.role !== "assistant") return false;
   const metadata = (message as { metadata?: unknown }).metadata as
@@ -376,10 +374,8 @@ function toOpenAIMessage(message: RunMessage): {
       "[audio]",
     );
     if (isAnthropicRefusalMessage(message)) {
-      // Drop refused assistant turns entirely so the next request does
-      // not re-trigger the same safety classifier. The user-visible
-      // notice stays in the rendered transcript; only the outbound
-      // history is pruned.
+      // Prune refused assistant turn from outbound history; the
+      // rendered transcript still shows the user-visible notice.
       return null;
     }
   }
@@ -940,14 +936,11 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           ),
       );
 
-      // Two-pass build so a refused assistant turn drops the user
-      // message that triggered it as well. Anthropic's refusal-handling
-      // guidance is explicit that leaving the offending user prompt in
-      // context causes the next request to re-trigger the classifier;
-      // returning null on just the assistant side was not enough.
-      // The refusal flag rides assistant metadata.custom.anthropicRefusal
-      // (set out-of-band from the backend _toolEvent) so assistant text
-      // can never spoof a context reset.
+      // Two-pass build: a refused assistant turn also drops the user
+      // prompt that triggered it (leaving it in context re-triggers
+      // the classifier). Refusal flag rides assistant
+      // metadata.custom.anthropicRefusal, set out-of-band from the
+      // backend _toolEvent.
       const survivingMessages: RunMessage[] = [];
       for (const message of messages) {
         if (isAnthropicRefusalMessage(message)) {
@@ -1030,10 +1023,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           });
         }
       }
-      // Scan the post-prune history so a refused user turn with an
-      // image/audio attachment does not gate / mis-attribute the next
-      // non-refused turn (the refused pair is pruned from the request
-      // body above).
+      // Scan post-prune history so a refused user turn's image/audio
+      // doesn't gate or mis-attribute the next non-refused turn.
       const imageBase64 = findLatestUserImageBase64(survivingMessages);
       const audioBase64 = findLatestUserAudioBase64(survivingMessages);
 
@@ -1182,11 +1173,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // Tool call content parts — accumulated and yielded cumulatively.
       // result is set directly on the tool-call part when tool_end arrives.
       const toolCallParts: ToolCallMessagePart[] = [];
-      // Latched when the backend emits an `anthropic_refusal` tool event
-      // on Anthropic stop_reason="refusal". Stamped onto the final
-      // assistant message metadata as `custom.anthropicRefusal` so the
-      // history-prune logic above can drop the refused pair on the next
-      // request without relying on text-content sentinels.
+      // Latched on the `anthropic_refusal` tool event; stamped onto the
+      // final assistant metadata as `custom.anthropicRefusal` to drive
+      // the history-prune above.
       let anthropicRefusalSeen = false;
       let serverMetadata: {
         usage?: ServerUsage;
@@ -1530,11 +1519,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               isPromptCacheTtl(externalProvider.promptCacheTtl)
                 ? { prompt_cache_ttl: externalProvider.promptCacheTtl }
                 : {}),
-              // Anthropic-only fast mode (Opus 4.6 / 4.7 only). The
-              // capability gate hides the toggle on other models so
-              // this branch only fires when the field is meaningful.
-              // Backend silently drops on unsupported models as a
-              // second line of defence.
+              // Anthropic fast mode (Opus 4.6 / 4.7 only); backend
+              // silently drops on unsupported models as a second
+              // line of defence.
               ...(params.fastMode &&
               providerSupportsFastMode(
                 externalProvider.providerType,
@@ -1661,10 +1648,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                   continue;
                 }
                 if (toolEvent.type === "anthropic_refusal") {
-                  // Backend signalled stop_reason="refusal" out-of-band.
-                  // Latch and stamp onto the final message metadata so
-                  // the two-pass history pruner can drop the refused
-                  // pair on the next request.
+                  // Latch the backend refusal signal so the final
+                  // message metadata can drive the prune.
                   anthropicRefusalSeen = true;
                   continue;
                 }
@@ -1988,9 +1973,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             timing: finalTiming,
             custom: {
               reasoningDuration,
-              // Persisted refusal flag; drives the two-pass history
-              // pruner that drops the refused assistant + user pair
-              // on the next request.
+              // Persisted refusal flag driving the two-pass prune.
               anthropicRefusal: anthropicRefusalSeen || undefined,
               serverTimings: meta?.timings ?? undefined,
               contextUsage: meta?.usage

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -28,6 +28,7 @@ import {
   providerSupportsBuiltinImageGeneration,
   providerSupportsBuiltinWebFetch,
   providerSupportsBuiltinWebSearch,
+  providerSupportsFastMode,
 } from "../provider-capabilities";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { useExternalProvidersStore } from "../stores/external-providers-store";
@@ -1477,6 +1478,18 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               (externalProvider.enablePromptCaching ?? true) &&
               isPromptCacheTtl(externalProvider.promptCacheTtl)
                 ? { prompt_cache_ttl: externalProvider.promptCacheTtl }
+                : {}),
+              // Anthropic-only fast mode (Opus 4.6 / 4.7 only). The
+              // capability gate hides the toggle on other models so
+              // this branch only fires when the field is meaningful.
+              // Backend silently drops on unsupported models as a
+              // second line of defence.
+              ...(params.fastMode &&
+              providerSupportsFastMode(
+                externalProvider.providerType,
+                externalSelection.modelId,
+              )
+                ? { fast_mode: true }
                 : {}),
               ...(externalReasoningCaps.supportsReasoning
                 ? externalReasoningCaps.reasoningStyle === "reasoning_effort"

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -341,6 +341,13 @@ function collectImageParts(
   return parts;
 }
 
+// Sentinel emitted by the backend at the end of an assistant turn that
+// Anthropic ended with stop_reason="refusal". We drop the entire turn
+// from the next request body because Anthropic's guidance says leaving
+// the refused output in context causes the next call to keep refusing.
+// Keep in sync with studio/backend/core/inference/external_provider.py.
+const ANTHROPIC_REFUSAL_SENTINEL = "<!--studio:anthropic-refusal-->";
+
 function toOpenAIMessage(message: RunMessage): {
   role: "system" | "user" | "assistant";
   content: OpenAIMessageContent;
@@ -361,6 +368,13 @@ function toOpenAIMessage(message: RunMessage): {
       /data:audio\/[a-z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g,
       "[audio]",
     );
+    if (textContent.includes(ANTHROPIC_REFUSAL_SENTINEL)) {
+      // Drop refused assistant turns entirely so the next request does
+      // not re-trigger the same safety classifier. The user-visible
+      // notice stays in the rendered transcript; only the outbound
+      // history is pruned.
+      return null;
+    }
   }
 
   const imageParts = collectImageParts(message);

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -87,6 +87,7 @@ import {
   type ProviderCapabilities,
   getExternalMinOutputTokens,
   providerSupportsBuiltinCodeExecution,
+  providerSupportsFastMode,
 } from "./provider-capabilities";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import type { InferenceParams } from "./types/runtime";
@@ -552,6 +553,12 @@ export function ChatSettingsPanel({
       activeExternalProvider.baseUrl,
     ) &&
     activeExternalProvider.providerType === "openai";
+  const showFastModeControl =
+    activeExternalProvider != null &&
+    providerSupportsFastMode(
+      activeExternalProvider.providerType,
+      externalSelection?.modelId,
+    );
   const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const openAiApiKeyForSection = activeExternalProvider
     ? getExternalProviderApiKey(activeExternalProvider.id) || null
@@ -1150,6 +1157,28 @@ export function ChatSettingsPanel({
                     <SelectItem value="1h">1 hour</SelectItem>
                   </SelectContent>
                 </Select>
+              </div>
+            ) : null}
+            {showFastModeControl ? (
+              <div className="flex items-center justify-between gap-3 pt-3">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="min-w-0 text-[13px] font-medium leading-[1.25] tracking-nav text-nav-fg">
+                    Fast mode
+                  </span>
+                  <InfoHint>
+                    Beta. Up to 2.5x higher output tokens per second on
+                    Claude Opus 4.6 and 4.7 at 6x standard Opus pricing.
+                    Switching between fast and standard invalidates the
+                    prompt cache and is incompatible with the Priority
+                    service tier.
+                  </InfoHint>
+                </div>
+                <Switch
+                  className="panel-switch shrink-0"
+                  checked={Boolean(params.fastMode)}
+                  onCheckedChange={set("fastMode")}
+                  aria-label="Fast mode"
+                />
               </div>
             ) : null}
           </CollapsibleSection>

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -155,8 +155,12 @@ export function providerSupportsFastMode(
 ): boolean {
   if (providerType !== "anthropic") return false;
   if (!modelId) return false;
-  return ANTHROPIC_FAST_MODE_MODEL_PREFIXES.some((prefix) =>
-    modelId.startsWith(prefix),
+  // Require the prefix to terminate at a family boundary (end of
+  // string or "-" before a dated snapshot) so the check does not
+  // match unsupported IDs that merely share a prefix, e.g.
+  // "claude-opus-4-70" / "claude-opus-4-7b".
+  return ANTHROPIC_FAST_MODE_MODEL_PREFIXES.some(
+    (prefix) => modelId === prefix || modelId.startsWith(`${prefix}-`),
   );
 }
 

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -136,13 +136,10 @@ export function providerSupportsBuiltinWebFetch(
 }
 
 /**
- * Whether the active provider + model combination supports Anthropic's
- * fast-mode beta (`speed: "fast"` + `fast-mode-2026-02-01` header).
- * Per https://platform.claude.com/docs/en/build-with-claude/fast-mode
- * the docs only list Claude Opus 4.6 and 4.7. Sonnet / Haiku / older
- * Opus would 400 on the body so the picker hides the toggle entirely.
- * The backend silently drops the flag on unsupported models as a
- * second line of defence, so a stale frontend cannot regress.
+ * Whether the active provider + model supports Anthropic fast-mode
+ * (`speed: "fast"` + `fast-mode-2026-02-01` header). Opus 4.6 / 4.7
+ * only per https://platform.claude.com/docs/en/build-with-claude/fast-mode.
+ * Backend silently drops on unsupported models as a second defence.
  */
 const ANTHROPIC_FAST_MODE_MODEL_PREFIXES = [
   "claude-opus-4-7",
@@ -155,10 +152,8 @@ export function providerSupportsFastMode(
 ): boolean {
   if (providerType !== "anthropic") return false;
   if (!modelId) return false;
-  // Require the prefix to terminate at a family boundary (end of
-  // string or "-" before a dated snapshot) so the check does not
-  // match unsupported IDs that merely share a prefix, e.g.
-  // "claude-opus-4-70" / "claude-opus-4-7b".
+  // Family boundary ("" or "-") required so IDs like "claude-opus-4-70"
+  // / "claude-opus-4-7b" do not match.
   return ANTHROPIC_FAST_MODE_MODEL_PREFIXES.some(
     (prefix) => modelId === prefix || modelId.startsWith(`${prefix}-`),
   );

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -136,6 +136,31 @@ export function providerSupportsBuiltinWebFetch(
 }
 
 /**
+ * Whether the active provider + model combination supports Anthropic's
+ * fast-mode beta (`speed: "fast"` + `fast-mode-2026-02-01` header).
+ * Per https://platform.claude.com/docs/en/build-with-claude/fast-mode
+ * the docs only list Claude Opus 4.6 and 4.7. Sonnet / Haiku / older
+ * Opus would 400 on the body so the picker hides the toggle entirely.
+ * The backend silently drops the flag on unsupported models as a
+ * second line of defence, so a stale frontend cannot regress.
+ */
+const ANTHROPIC_FAST_MODE_MODEL_PREFIXES = [
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+] as const;
+
+export function providerSupportsFastMode(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): boolean {
+  if (providerType !== "anthropic") return false;
+  if (!modelId) return false;
+  return ANTHROPIC_FAST_MODE_MODEL_PREFIXES.some((prefix) =>
+    modelId.startsWith(prefix),
+  );
+}
+
+/**
  * Whether the selected external provider/model exposes a server-side
  * code-execution tool. Two providers ship one today:
  *

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -377,6 +377,7 @@ const PERSISTED_INFERENCE_PARAM_KEYS = [
   "maxTokens",
   "systemPrompt",
   "trustRemoteCode",
+  "fastMode",
 ] as const satisfies readonly PersistedInferenceParamKey[];
 
 const SCALAR_SETTING_KEYS = [

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -263,9 +263,8 @@ export interface OpenAIChatCompletionsRequest {
    */
   anthropic_code_exec_container_id?: string | null;
   /**
-   * Anthropic fast-mode toggle. Only Claude Opus 4.6 and 4.7 accept
-   * the `speed: "fast"` field upstream; on any other model + provider
-   * the backend drops the flag silently rather than 400ing. See
+   * Anthropic fast-mode toggle. Opus 4.6 / 4.7 only; backend drops
+   * silently on every other model + provider. See
    * https://platform.claude.com/docs/en/build-with-claude/fast-mode
    */
   fast_mode?: boolean | null;

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -262,6 +262,13 @@ export interface OpenAIChatCompletionsRequest {
    * the Anthropic provider with `code_execution` in `enabled_tools`.
    */
   anthropic_code_exec_container_id?: string | null;
+  /**
+   * Anthropic fast-mode toggle. Only Claude Opus 4.6 and 4.7 accept
+   * the `speed: "fast"` field upstream; on any other model + provider
+   * the backend drops the flag silently rather than 400ing. See
+   * https://platform.claude.com/docs/en/build-with-claude/fast-mode
+   */
+  fast_mode?: boolean | null;
 }
 
 export interface OpenAIChatDelta {

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -14,6 +14,14 @@ export interface InferenceParams {
   checkpoint: string;
   /** Allow loading models with custom code (e.g. NVIDIA Nemotron). Only enable for repos you trust. */
   trustRemoteCode?: boolean;
+  /**
+   * Anthropic fast-mode toggle. Only active on Claude Opus 4.6 and 4.7;
+   * silently dropped on every other model + provider. Higher OTPS at
+   * premium pricing -- see
+   * https://platform.claude.com/docs/en/build-with-claude/fast-mode
+   * Default false because pricing is 6x standard Opus.
+   */
+  fastMode?: boolean;
 }
 
 export const DEFAULT_INFERENCE_PARAMS: InferenceParams = {
@@ -28,6 +36,7 @@ export const DEFAULT_INFERENCE_PARAMS: InferenceParams = {
   systemPrompt: "",
   checkpoint: "",
   trustRemoteCode: false,
+  fastMode: false,
 };
 
 export interface ChatModelSummary {

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -15,11 +15,9 @@ export interface InferenceParams {
   /** Allow loading models with custom code (e.g. NVIDIA Nemotron). Only enable for repos you trust. */
   trustRemoteCode?: boolean;
   /**
-   * Anthropic fast-mode toggle. Only active on Claude Opus 4.6 and 4.7;
-   * silently dropped on every other model + provider. Higher OTPS at
-   * premium pricing -- see
+   * Anthropic fast-mode toggle. Opus 4.6 / 4.7 only; higher OTPS at
+   * 6x standard Opus pricing. Default false.
    * https://platform.claude.com/docs/en/build-with-claude/fast-mode
-   * Default false because pricing is 6x standard Opus.
    */
   fastMode?: boolean;
 }

--- a/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
@@ -140,10 +140,7 @@ function sanitizeInferenceParams(
   if (typeof value.trustRemoteCode === "boolean") {
     params.trustRemoteCode = value.trustRemoteCode;
   }
-  // fastMode is in PERSISTED_INFERENCE_PARAM_KEYS but used to be
-  // stripped here because the sanitizer only kept numeric fields plus
-  // the two explicit string/bool fields above. Save the toggle the
-  // same way trustRemoteCode is saved so the value survives reload
+  // Mirror trustRemoteCode handling so the toggle survives reload
   // and the /api/chat/settings round-trip.
   if (typeof value.fastMode === "boolean") {
     params.fastMode = value.fastMode;

--- a/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
@@ -140,6 +140,14 @@ function sanitizeInferenceParams(
   if (typeof value.trustRemoteCode === "boolean") {
     params.trustRemoteCode = value.trustRemoteCode;
   }
+  // fastMode is in PERSISTED_INFERENCE_PARAM_KEYS but used to be
+  // stripped here because the sanitizer only kept numeric fields plus
+  // the two explicit string/bool fields above. Save the toggle the
+  // same way trustRemoteCode is saved so the value survives reload
+  // and the /api/chat/settings round-trip.
+  if (typeof value.fastMode === "boolean") {
+    params.fastMode = value.fastMode;
+  }
   return hasKeys(params) ? params : undefined;
 }
 


### PR DESCRIPTION
## Summary

- **Fast mode (beta).** Adds a Configuration toggle that flips on `speed: \"fast\"` and the `fast-mode-2026-02-01` beta header for Claude Opus 4.6 / 4.7. Up to 2.5x higher output tokens per second at 6x standard Opus pricing per the upstream docs. Hidden on every other model + provider so the picker never offers a knob the upstream API would 400 on; backend silently drops the flag as a second line of defence.
- **Streaming refusal notice.** When Anthropic's safety classifier truncates a stream with `message_delta.delta.stop_reason = \"refusal\"` on Claude 4 models, the assistant message now ends with a short notice explaining what happened, followed by the existing OpenAI-spec `finish_reason = \"content_filter\"`. Previously the chat bubble truncated silently with nothing to tell the user why the response stopped.

References:
- https://platform.claude.com/docs/en/build-with-claude/fast-mode
- https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals

## Test plan

- [x] `cd studio && python -m pytest backend/tests/test_anthropic_fast_mode_and_refusal.py -v` -- 8 new tests, all passing.
  - `fast_mode` pass-through on Opus 4.6 + 4.7 (body field + beta header).
  - silent drop on Sonnet 4.6, Haiku 4.5, older Opus, False, None.
  - refusal stream emits the user-facing notice plus `content_filter` finish reason while preserving the partial assistant text.
- [x] `cd studio/frontend && npx tsc -b --pretty false` clean.
- [x] Confirmed the toggle is hidden when an OpenAI / OpenRouter / Kimi / local model is selected (capability gate keyed on Anthropic + Opus 4.6/4.7 model prefixes).
- [ ] Manual smoke test against `claude-opus-4-7` with fast mode on -- defer to QA once Anthropic surfaces the per-key fast-mode rate limit (waitlist gate).