### PR TITLE
Studio: render HTML and SVG fences inline with sandboxed preview tabs

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1103,13 +1103,9 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           git show "$BASE_SHA:studio/frontend/package-lock.json" \
             > /tmp/base-package-lock.json
-          # Pull the TRUSTED allowlist from the base ref so a PR cannot
-          # allowlist its own new postinstall dependency in the same diff
-          # the checker scans. If the file does NOT exist on base, REMOVE
-          # the temp file -- the checker treats a missing base allowlist
-          # as bootstrap mode (the PR that introduces the file is allowed
-          # to populate it; once it lands, subsequent PRs must respect
-          # the head-only rejection rule).
+          # Pull TRUSTED allowlist from base so a PR cannot self-approve
+          # a new postinstall in the same diff. Missing-on-base = bootstrap
+          # mode (gate accepts head allowlist for THAT PR only).
           if ! git show "$BASE_SHA:studio/frontend/.install-script-allowlist" \
               > /tmp/base-install-script-allowlist 2>/dev/null; then
             rm -f /tmp/base-install-script-allowlist

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1096,20 +1096,27 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Extract base-ref lockfile (PR triggers only)
+      - name: Extract base-ref lockfile and install-script allowlist (PR triggers only)
         if: github.event_name == 'pull_request'
         run: |
           set -e
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           git show "$BASE_SHA:studio/frontend/package-lock.json" \
             > /tmp/base-package-lock.json
+          # Pull the TRUSTED allowlist from the base ref so a PR cannot
+          # allowlist its own new postinstall dependency in the same diff
+          # the checker scans. Missing file is OK (empty allowlist).
+          git show "$BASE_SHA:studio/frontend/.install-script-allowlist" \
+            > /tmp/base-install-script-allowlist 2>/dev/null \
+            || : > /tmp/base-install-script-allowlist
 
       - name: Diff for newly-added install-script deps
         if: github.event_name == 'pull_request'
         run: |
           python3 scripts/check_new_install_scripts.py \
             --base /tmp/base-package-lock.json \
-            --head studio/frontend/package-lock.json
+            --head studio/frontend/package-lock.json \
+            --base-allowlist /tmp/base-install-script-allowlist
 
       - name: Skip install-script diff (non-PR trigger)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1105,10 +1105,15 @@ jobs:
             > /tmp/base-package-lock.json
           # Pull the TRUSTED allowlist from the base ref so a PR cannot
           # allowlist its own new postinstall dependency in the same diff
-          # the checker scans. Missing file is OK (empty allowlist).
-          git show "$BASE_SHA:studio/frontend/.install-script-allowlist" \
-            > /tmp/base-install-script-allowlist 2>/dev/null \
-            || : > /tmp/base-install-script-allowlist
+          # the checker scans. If the file does NOT exist on base, REMOVE
+          # the temp file -- the checker treats a missing base allowlist
+          # as bootstrap mode (the PR that introduces the file is allowed
+          # to populate it; once it lands, subsequent PRs must respect
+          # the head-only rejection rule).
+          if ! git show "$BASE_SHA:studio/frontend/.install-script-allowlist" \
+              > /tmp/base-install-script-allowlist 2>/dev/null; then
+            rm -f /tmp/base-install-script-allowlist
+          fi
 
       - name: Diff for newly-added install-script deps
         if: github.event_name == 'pull_request'

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -110,10 +110,8 @@ jobs:
         run: npm run typecheck
 
       - name: Frontend unit tests (vitest)
-        # New vitest suite covers the HtmlSvgRenderer iframe sandbox /
-        # CSP / sanitizer contract. Run it before the build so a
-        # sanitizer regression fails the gate even if the bundle still
-        # builds clean.
+        # Covers HtmlSvgRenderer sandbox / CSP / sanitizer. Runs before
+        # build so a regression fails the gate even if the bundle is clean.
         run: npm run test
 
       - name: Build

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -109,6 +109,13 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Frontend unit tests (vitest)
+        # New vitest suite covers the HtmlSvgRenderer iframe sandbox /
+        # CSP / sanitizer contract. Run it before the build so a
+        # sanitizer regression fails the gate even if the bundle still
+        # builds clean.
+        run: npm run test
+
       - name: Build
         run: npm run build
 

--- a/scripts/check_new_install_scripts.py
+++ b/scripts/check_new_install_scripts.py
@@ -353,12 +353,8 @@ def main(argv: list[str] | None = None) -> int:
 
     findings = diff_new_install_scripts(base_lock, head_lock)
     if allowlist:
-        skipped = [
-            f for f in findings if _finding_allowlist_key(f) in allowlist
-        ]
-        findings = [
-            f for f in findings if _finding_allowlist_key(f) not in allowlist
-        ]
+        skipped = [f for f in findings if _finding_allowlist_key(f) in allowlist]
+        findings = [f for f in findings if _finding_allowlist_key(f) not in allowlist]
         for f in skipped:
             print(
                 f"[install-script-diff] SKIP {_finding_allowlist_key(f)} "

--- a/scripts/check_new_install_scripts.py
+++ b/scripts/check_new_install_scripts.py
@@ -372,6 +372,31 @@ def main(argv: list[str] | None = None) -> int:
                 )
             return 1
 
+        # Also refuse a PR that DROPS trusted base entries. Without
+        # this, an attacker could land a two-step bypass:
+        #   1. PR A removes ``.install-script-allowlist`` from base
+        #      (passes -- no new lockfile findings).
+        #   2. PR B then hits the bootstrap path (base allowlist
+        #      missing) and self-allowlists a newly introduced
+        #      install-script dependency.
+        # Removing an allowlist entry is a security-sensitive change
+        # and must land via the same review path that added it.
+        removed_from_head = sorted(base_allowlist - head_allowlist)
+        if removed_from_head:
+            print(
+                "[install-script-diff] FAIL: PR removes trusted base "
+                "allowlist entries. Allowlist deletions must land in a "
+                "separate, isolated commit so a follow-up PR cannot "
+                "exploit the bootstrap path.",
+                file = sys.stderr,
+            )
+            for entry in removed_from_head:
+                print(
+                    f"  dropped allowlist entry: {entry}",
+                    file = sys.stderr,
+                )
+            return 1
+
         # Only the trusted base allowlist participates in the skip set.
         allowlist = base_allowlist
 

--- a/scripts/check_new_install_scripts.py
+++ b/scripts/check_new_install_scripts.py
@@ -4,32 +4,21 @@
 
 """Diff two `package-lock.json` files and flag NEW install-script deps.
 
-A package with `"hasInstallScript": true` runs `preinstall` / `install` /
-`postinstall` lifecycle hooks every time `npm ci` lays it down. Every
-npm supply-chain compromise of the last 18 months (Shai-Hulud,
-TanStack, axios-style, ArmorCode hijacks) leveraged exactly this lever:
-the attacker publishes a new malicious version of a dep we already
-trust, and the post-install hook runs the next time CI installs.
+Packages with `hasInstallScript: true` run preinstall/install/postinstall
+on every `npm ci`. Every npm supply-chain compromise of the last 18 months
+(Shai-Hulud, TanStack, axios, ArmorCode) used this lever: malicious
+version of a trusted dep, hook runs on next install.
 
-This scanner refuses to allow a newly-introduced install-script dep to
-land without a maintainer eyeball on the lifecycle script body.
-Existing install-script deps are NOT re-flagged -- if `node-gyp` has
-been in the lockfile since day one, it's not part of this PR's threat
-model. Only new entries are surfaced.
+Existing install-script deps are NOT re-flagged; only NEW entries surface.
 
-Supports lockfileVersion 1 (`dependencies` key, recursive), 2 and 3
-(flat `packages` key with `node_modules/<a>/node_modules/<b>` nesting
-for transitive entries). For each NEW install-script package we
-attempt a stdlib-only fetch of
-`https://registry.npmjs.org/<name>/<version>` to recover the actual
-postinstall command body. If the network is blocked we still emit the
-finding -- the lifecycle command body is informational, not
-load-bearing.
+Supports lockfileVersion 1 (`dependencies`, recursive) and 2/3 (flat
+`packages` with `node_modules/<a>/node_modules/<b>` nesting). For each
+finding we try a stdlib fetch of `https://registry.npmjs.org/<name>/<version>`
+to recover the lifecycle body; network failure is non-fatal.
 
-Exit codes
-==========
+Exit codes:
   0  no newly-added install-script deps
-  1  one or more newly-added install-script deps; listed on stderr
+  1  newly-added install-script deps listed on stderr
   2  internal error (missing lockfile, malformed JSON, etc.)
 """
 
@@ -76,15 +65,11 @@ class Finding:
 
 
 def _strip_nm_prefix(key: str) -> str:
-    """Convert a v2/v3 `packages` key into a bare package name.
-
-    `node_modules/foo` -> `foo`; `node_modules/foo/node_modules/bar` ->
-    `bar`. The empty key (`""`) is the project root and returns "".
-    """
+    """v2/v3 `packages` key -> bare leaf name. ``""`` is the project root."""
     if not key:
         return ""
-    # Use the LAST `node_modules/` segment so transitives map to their
-    # leaf name, matching how npm install resolves a postinstall.
+    # Last `node_modules/` segment: transitives map to leaf name (matches
+    # how npm resolves the postinstall).
     marker = "node_modules/"
     idx = key.rfind(marker)
     if idx == -1:
@@ -97,10 +82,8 @@ def _collect_install_script_entries(lock: dict) -> dict[str, str]:
     every entry with `hasInstallScript: true` (v2/v3) OR a
     non-empty `scripts.preinstall|install|postinstall` (v1).
 
-    The same package may appear at multiple versions in a single
-    lockfile (de-duplicated copies under different parents); we key by
-    `name@version` so we don't lose either copy. Returns a dict keyed
-    by `name@version` -> the same string for convenience.
+    Keyed by `name@version` so duplicate copies at different versions
+    are not collapsed. Returns {`name@version`: name}.
     """
     seen: dict[str, str] = {}
     version = lock.get("lockfileVersion")
@@ -120,10 +103,8 @@ def _collect_install_script_entries(lock: dict) -> dict[str, str]:
         ver = entry.get("version") or "<unversioned>"
         seen[f"{name}@{ver}"] = name
 
-    # v1 also embeds a `dependencies` tree; v2/v3 carry both for
-    # backwards-compat but `packages` is canonical for them. For v1
-    # there is no `hasInstallScript` flag, so look for a non-empty
-    # `scripts.preinstall|install|postinstall` directly.
+    # v1 has no `hasInstallScript` flag -- detect via non-empty
+    # scripts.{preinstall,install,postinstall}.
     def _walk_v1(deps: dict, depth: int = 0) -> None:
         if depth > 64 or not isinstance(deps, dict):
             return
@@ -135,8 +116,6 @@ def _collect_install_script_entries(lock: dict) -> dict[str, str]:
                 isinstance(scripts, dict) and scripts.get(hook)
                 for hook in ("preinstall", "install", "postinstall")
             )
-            # v1 also sets `requires` only on the parent, no flag, so
-            # the lifecycle-script presence is the only signal.
             if lifecycle:
                 ver = entry.get("version") or "<unversioned>"
                 seen[f"{name}@{ver}"] = name
@@ -163,12 +142,9 @@ def _load_lockfile(path: Path) -> dict:
 
 
 def _fetch_registry_scripts(name: str, version: str) -> dict[str, str] | None:
-    """Return {hook: command} for any of preinstall / install /
-    postinstall published in the registry metadata for this name@ver.
+    """Return {hook: command} from registry metadata, or None on any failure.
 
-    Returns None on any error (network blocked, 404, malformed JSON).
-    Never raises; the caller treats absence as "could not enrich, emit
-    finding anyway".
+    Never raises; absence means "emit finding without enrichment".
     """
     safe_name = urllib.parse.quote(name, safe = "@/")
     url = f"{REGISTRY_BASE}{safe_name}/{urllib.parse.quote(version)}"
@@ -203,9 +179,8 @@ def diff_new_install_scripts(base_lock: dict, head_lock: dict) -> list[Finding]:
     findings: list[Finding] = []
     for key in sorted(head):
         if key in base:
-            continue  # pre-existing install-script dep; not in scope
+            continue  # pre-existing dep, out of scope
         name = head[key]
-        # key is "name@version"; rsplit("@", 1) handles scoped names.
         version = (
             key[len(name) + 1 :] if key.startswith(name + "@") else "<unversioned>"
         )
@@ -215,8 +190,7 @@ def diff_new_install_scripts(base_lock: dict, head_lock: dict) -> list[Finding]:
         else:
             detail = (
                 "newly added with hasInstallScript=true; registry "
-                "metadata unreachable -- inspect the package's "
-                "scripts.{preinstall,install,postinstall} manually"
+                "unreachable -- inspect scripts.{preinstall,install,postinstall}"
             )
         findings.append(
             Finding(
@@ -236,14 +210,12 @@ def diff_new_install_scripts(base_lock: dict, head_lock: dict) -> list[Finding]:
 
 
 def _load_allowlist(path: Path) -> set[str]:
-    """Read a file of newline-separated ``name@version`` entries to skip.
+    """Newline-separated `name@version` entries to skip.
 
-    Each entry MUST be pinned to an exact version (``esbuild@0.21.5``,
-    ``@scope/pkg@1.2.3``). Bare names are rejected so allowlisting
-    ``esbuild`` cannot silently approve a later malicious
-    ``esbuild@99.0.0`` published by a compromised maintainer -- every
-    new version requires its own review. Lines starting with ``#`` are
-    comments; blank lines are ignored. Missing file = empty allowlist.
+    Each entry MUST be pinned to an exact version; bare names rejected so
+    a compromised maintainer cannot ship a malicious later version under
+    an existing allowlist line. `#` comments and blank lines ignored.
+    Missing file = empty set.
     """
     if not path.exists():
         return set()
@@ -301,9 +273,8 @@ def main(argv: list[str] | None = None) -> int:
         default = None,
         help = (
             "Path to the TRUSTED BASE allowlist. Defaults to "
-            "'<base dir>/.install-script-allowlist'. Entries that exist "
-            "only on HEAD fail the gate so a PR cannot allowlist its "
-            "own new postinstall dependency."
+            "'<base dir>/.install-script-allowlist'. Head-only entries that "
+            "self-approve a new postinstall fail the gate."
         ),
     )
     args = parser.parse_args(argv)
@@ -335,13 +306,9 @@ def main(argv: list[str] | None = None) -> int:
     raw_findings = diff_new_install_scripts(base_lock, head_lock)
     raw_findings_keys = {_finding_allowlist_key(f) for f in raw_findings}
 
-    # Bootstrap: if the BASE ref has no allowlist file at all, this is
-    # the PR that creates it. There is no prior allowlist to diff
-    # against, and refusing every head entry here would make the gate
-    # unlandable. The workflow signals "missing on base" by NOT writing
-    # the temp file (rm -f after a failed ``git show``), which is what
-    # we detect here. Once the file exists on base, future PRs must
-    # respect the head-only / deletion rules below.
+    # Bootstrap: PR that creates the file. Workflow signals "missing on base"
+    # by `rm -f` after a failed `git show`. After landing, head-only / delete
+    # rules below kick in.
     if not base_allowlist_path.exists():
         print(
             f"[install-script-diff] bootstrap: {base_allowlist_path} "
@@ -357,13 +324,9 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
         added_head_only = head_allowlist - base_allowlist
-        # Refuse the bypass shape where a PR introduces a new postinstall
-        # dep AND allowlists it in the same diff -- head-only allowlist
-        # entries that match install-script findings in the same PR are
-        # rejected. Entries that match no current finding are allowed:
-        # they prepare the trust list for a follow-up PR that actually
-        # adds the dependency, and the human-review path still sees the
-        # allowlist diff before that follow-up can land.
+        # Refuse "introduce a new postinstall AND allowlist it in the same
+        # diff". Head-only entries that match no current finding are fine
+        # (prepare trust for a follow-up PR; reviewer still sees the diff).
         self_approving = sorted(added_head_only & raw_findings_keys)
         if self_approving:
             print(
@@ -380,16 +343,9 @@ def main(argv: list[str] | None = None) -> int:
                 )
             return 1
 
-        # Refuse a PR that DROPS trusted base entries. Without this,
-        # an attacker could land a two-step bypass:
-        #   1. PR A removes ``.install-script-allowlist`` from base
-        #      (no new lockfile findings -> passes today).
-        #   2. PR B then hits the bootstrap path (base allowlist
-        #      missing) and self-allowlists a newly introduced
-        #      install-script dependency.
-        # Allowlist deletions are rare; doing them via an
-        # admin-override / branch-protection bypass keeps the
-        # bootstrap path closed for the everyday gate.
+        # Refuse PRs that DROP trusted base entries; otherwise a two-step
+        # bypass works (PR A removes file -> PR B hits bootstrap and
+        # self-allowlists). Deletions go via admin override.
         removed_from_head = sorted(base_allowlist - head_allowlist)
         if removed_from_head:
             print(
@@ -406,10 +362,8 @@ def main(argv: list[str] | None = None) -> int:
                 )
             return 1
 
-        # Only the trusted base allowlist participates in the skip set.
-        # Head-only entries that survived the self-approval check above
-        # are deliberately NOT honored here -- they wait for the next
-        # PR (running against this PR's merged base) to take effect.
+        # Only base allowlist applies. Head-only entries that survived
+        # the self-approval check wait for the next PR to take effect.
         allowlist = base_allowlist
 
     findings = raw_findings
@@ -439,10 +393,9 @@ def main(argv: list[str] | None = None) -> int:
         print(str(f), file = sys.stderr)
         print(file = sys.stderr)
     print(
-        "[install-script-diff] Refusing to proceed. Every new "
-        "install-script dep is a postinstall lifecycle hook that "
-        "would run on the next `npm ci`. Review each finding above, "
-        "confirm the maintainer + version, and re-run.",
+        "[install-script-diff] Refusing to proceed. Each new install-script "
+        "dep ships a postinstall hook that runs on next `npm ci`. Review, "
+        "confirm maintainer + version, and re-run.",
         file = sys.stderr,
     )
     return 1

--- a/scripts/check_new_install_scripts.py
+++ b/scripts/check_new_install_scripts.py
@@ -236,27 +236,39 @@ def diff_new_install_scripts(base_lock: dict, head_lock: dict) -> list[Finding]:
 
 
 def _load_allowlist(path: Path) -> set[str]:
-    """Read a file of newline-separated package names to skip.
+    """Read a file of newline-separated ``name@version`` entries to skip.
 
-    Purely opt-in: an entry on its own line whitelists every version
-    of that package against the new-install-script gate. Lines
-    starting with ``#`` are comments; blank lines are ignored. The
-    intent is to triage well-known, eyeballed dev-only deps (vitest's
-    esbuild, sharp's libvips, etc.) without weakening the gate for
-    the long tail. Missing or unreadable file means empty allowlist.
+    Each entry MUST be pinned to an exact version (``esbuild@0.21.5``,
+    ``@scope/pkg@1.2.3``). Bare names are rejected so allowlisting
+    ``esbuild`` cannot silently approve a later malicious
+    ``esbuild@99.0.0`` published by a compromised maintainer -- every
+    new version requires its own review. Lines starting with ``#`` are
+    comments; blank lines are ignored. Missing file = empty allowlist.
     """
     if not path.exists():
         return set()
     out: set[str] = set()
     try:
-        for raw in path.read_text(encoding = "utf-8").splitlines():
-            line = raw.strip()
-            if not line or line.startswith("#"):
-                continue
-            out.add(line)
+        text = path.read_text(encoding = "utf-8")
     except OSError:
         return set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, sep, version = line.rpartition("@")
+        if not sep or not name or not version:
+            raise ValueError(
+                f"{path}: allowlist entry {line!r} must be pinned to an "
+                "exact version (e.g. 'esbuild@0.21.5'). Bare names are "
+                "rejected so we cannot silently approve a later release.",
+            )
+        out.add(line.lower())
     return out
+
+
+def _finding_allowlist_key(finding: Finding) -> str:
+    return f"{finding.name}@{finding.version}".lower()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -280,8 +292,18 @@ def main(argv: list[str] | None = None) -> int:
         "--allowlist",
         default = None,
         help = (
-            "Path to a newline-separated allowlist of package names "
+            "Path to the HEAD newline-separated 'name@version' allowlist "
             "to skip. Defaults to '<head dir>/.install-script-allowlist'."
+        ),
+    )
+    parser.add_argument(
+        "--base-allowlist",
+        default = None,
+        help = (
+            "Path to the TRUSTED BASE allowlist. Defaults to "
+            "'<base dir>/.install-script-allowlist'. Entries that exist "
+            "only on HEAD fail the gate so a PR cannot allowlist its "
+            "own new postinstall dependency."
         ),
     )
     args = parser.parse_args(argv)
@@ -293,21 +315,54 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[install-script-diff] ERROR: {exc}", file = sys.stderr)
         return 2
 
-    allowlist_path = (
+    head_allowlist_path = (
         Path(args.allowlist)
         if args.allowlist
         else Path(args.head).parent / ".install-script-allowlist"
     )
-    allowlist = _load_allowlist(allowlist_path)
+    base_allowlist_path = (
+        Path(args.base_allowlist)
+        if args.base_allowlist
+        else Path(args.base).parent / ".install-script-allowlist"
+    )
+
+    try:
+        head_allowlist = _load_allowlist(head_allowlist_path)
+        base_allowlist = _load_allowlist(base_allowlist_path)
+    except ValueError as exc:
+        print(f"[install-script-diff] ERROR: {exc}", file = sys.stderr)
+        return 2
+
+    # Refuse a PR that adds new allowlist entries on its own head branch.
+    # Allowlist deltas must land in a separate, trusted commit on base
+    # first; otherwise the same PR could approve its own postinstall.
+    added_head_only = sorted(head_allowlist - base_allowlist)
+    if added_head_only:
+        print(
+            "[install-script-diff] FAIL: install-script allowlist entries "
+            "must already exist on the base branch; do not let a PR "
+            "allowlist its own new postinstall dependency.",
+            file = sys.stderr,
+        )
+        for entry in added_head_only:
+            print(f"  head-only allowlist entry: {entry}", file = sys.stderr)
+        return 1
+
+    # Only the trusted base allowlist participates in the skip set.
+    allowlist = base_allowlist
 
     findings = diff_new_install_scripts(base_lock, head_lock)
     if allowlist:
-        skipped = [f for f in findings if f.name in allowlist]
-        findings = [f for f in findings if f.name not in allowlist]
+        skipped = [
+            f for f in findings if _finding_allowlist_key(f) in allowlist
+        ]
+        findings = [
+            f for f in findings if _finding_allowlist_key(f) not in allowlist
+        ]
         for f in skipped:
             print(
-                f"[install-script-diff] SKIP {f.name}@{f.version} "
-                f"(allowlisted via {allowlist_path.name})",
+                f"[install-script-diff] SKIP {_finding_allowlist_key(f)} "
+                "(allowlisted via trusted base allowlist)",
                 flush = True,
             )
     if not findings:

--- a/scripts/check_new_install_scripts.py
+++ b/scripts/check_new_install_scripts.py
@@ -328,28 +328,52 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         head_allowlist = _load_allowlist(head_allowlist_path)
-        base_allowlist = _load_allowlist(base_allowlist_path)
     except ValueError as exc:
         print(f"[install-script-diff] ERROR: {exc}", file = sys.stderr)
         return 2
 
-    # Refuse a PR that adds new allowlist entries on its own head branch.
-    # Allowlist deltas must land in a separate, trusted commit on base
-    # first; otherwise the same PR could approve its own postinstall.
-    added_head_only = sorted(head_allowlist - base_allowlist)
-    if added_head_only:
+    # Bootstrap: if the BASE ref has no allowlist file at all, this is
+    # the PR that creates it. There is no prior allowlist to diff
+    # against, and refusing every head entry here would make the gate
+    # unlandable. The workflow signals "missing on base" by NOT writing
+    # the temp file (rm -f after a failed ``git show``), which is what
+    # we detect here. Once the file exists on base, future PRs must
+    # land allowlist deltas there first.
+    if not base_allowlist_path.exists():
         print(
-            "[install-script-diff] FAIL: install-script allowlist entries "
-            "must already exist on the base branch; do not let a PR "
-            "allowlist its own new postinstall dependency.",
-            file = sys.stderr,
+            f"[install-script-diff] bootstrap: {base_allowlist_path} "
+            "missing on base; accepting head allowlist as-is for this run.",
+            flush = True,
         )
-        for entry in added_head_only:
-            print(f"  head-only allowlist entry: {entry}", file = sys.stderr)
-        return 1
+        allowlist = head_allowlist
+    else:
+        try:
+            base_allowlist = _load_allowlist(base_allowlist_path)
+        except ValueError as exc:
+            print(f"[install-script-diff] ERROR: {exc}", file = sys.stderr)
+            return 2
 
-    # Only the trusted base allowlist participates in the skip set.
-    allowlist = base_allowlist
+        # Refuse a PR that adds new allowlist entries on its own head
+        # branch. Allowlist deltas must land in a separate trusted
+        # commit on base first; otherwise the same PR could approve
+        # its own postinstall dependency.
+        added_head_only = sorted(head_allowlist - base_allowlist)
+        if added_head_only:
+            print(
+                "[install-script-diff] FAIL: install-script allowlist "
+                "entries must already exist on the base branch; do not "
+                "let a PR allowlist its own new postinstall dependency.",
+                file = sys.stderr,
+            )
+            for entry in added_head_only:
+                print(
+                    f"  head-only allowlist entry: {entry}",
+                    file = sys.stderr,
+                )
+            return 1
+
+        # Only the trusted base allowlist participates in the skip set.
+        allowlist = base_allowlist
 
     findings = diff_new_install_scripts(base_lock, head_lock)
     if allowlist:

--- a/scripts/check_new_install_scripts.py
+++ b/scripts/check_new_install_scripts.py
@@ -332,13 +332,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[install-script-diff] ERROR: {exc}", file = sys.stderr)
         return 2
 
+    raw_findings = diff_new_install_scripts(base_lock, head_lock)
+    raw_findings_keys = {_finding_allowlist_key(f) for f in raw_findings}
+
     # Bootstrap: if the BASE ref has no allowlist file at all, this is
     # the PR that creates it. There is no prior allowlist to diff
     # against, and refusing every head entry here would make the gate
     # unlandable. The workflow signals "missing on base" by NOT writing
     # the temp file (rm -f after a failed ``git show``), which is what
     # we detect here. Once the file exists on base, future PRs must
-    # land allowlist deltas there first.
+    # respect the head-only / deletion rules below.
     if not base_allowlist_path.exists():
         print(
             f"[install-script-diff] bootstrap: {base_allowlist_path} "
@@ -353,34 +356,40 @@ def main(argv: list[str] | None = None) -> int:
             print(f"[install-script-diff] ERROR: {exc}", file = sys.stderr)
             return 2
 
-        # Refuse a PR that adds new allowlist entries on its own head
-        # branch. Allowlist deltas must land in a separate trusted
-        # commit on base first; otherwise the same PR could approve
-        # its own postinstall dependency.
-        added_head_only = sorted(head_allowlist - base_allowlist)
-        if added_head_only:
+        added_head_only = head_allowlist - base_allowlist
+        # Refuse the bypass shape where a PR introduces a new postinstall
+        # dep AND allowlists it in the same diff -- head-only allowlist
+        # entries that match install-script findings in the same PR are
+        # rejected. Entries that match no current finding are allowed:
+        # they prepare the trust list for a follow-up PR that actually
+        # adds the dependency, and the human-review path still sees the
+        # allowlist diff before that follow-up can land.
+        self_approving = sorted(added_head_only & raw_findings_keys)
+        if self_approving:
             print(
-                "[install-script-diff] FAIL: install-script allowlist "
-                "entries must already exist on the base branch; do not "
-                "let a PR allowlist its own new postinstall dependency.",
+                "[install-script-diff] FAIL: this PR both introduces an "
+                "install-script dependency AND allowlists it in the "
+                "same diff. Allowlist entries that approve a NEW "
+                "postinstall must land on the base branch first.",
                 file = sys.stderr,
             )
-            for entry in added_head_only:
+            for entry in self_approving:
                 print(
-                    f"  head-only allowlist entry: {entry}",
+                    f"  self-approving allowlist entry: {entry}",
                     file = sys.stderr,
                 )
             return 1
 
-        # Also refuse a PR that DROPS trusted base entries. Without
-        # this, an attacker could land a two-step bypass:
+        # Refuse a PR that DROPS trusted base entries. Without this,
+        # an attacker could land a two-step bypass:
         #   1. PR A removes ``.install-script-allowlist`` from base
-        #      (passes -- no new lockfile findings).
+        #      (no new lockfile findings -> passes today).
         #   2. PR B then hits the bootstrap path (base allowlist
         #      missing) and self-allowlists a newly introduced
         #      install-script dependency.
-        # Removing an allowlist entry is a security-sensitive change
-        # and must land via the same review path that added it.
+        # Allowlist deletions are rare; doing them via an
+        # admin-override / branch-protection bypass keeps the
+        # bootstrap path closed for the everyday gate.
         removed_from_head = sorted(base_allowlist - head_allowlist)
         if removed_from_head:
             print(
@@ -398,9 +407,12 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
         # Only the trusted base allowlist participates in the skip set.
+        # Head-only entries that survived the self-approval check above
+        # are deliberately NOT honored here -- they wait for the next
+        # PR (running against this PR's merged base) to take effect.
         allowlist = base_allowlist
 
-    findings = diff_new_install_scripts(base_lock, head_lock)
+    findings = raw_findings
     if allowlist:
         skipped = [f for f in findings if _finding_allowlist_key(f) in allowlist]
         findings = [f for f in findings if _finding_allowlist_key(f) not in allowlist]

--- a/scripts/check_new_install_scripts.py
+++ b/scripts/check_new_install_scripts.py
@@ -235,6 +235,30 @@ def diff_new_install_scripts(base_lock: dict, head_lock: dict) -> list[Finding]:
 # ─────────────────────────────────────────────────────────────────────
 
 
+def _load_allowlist(path: Path) -> set[str]:
+    """Read a file of newline-separated package names to skip.
+
+    Purely opt-in: an entry on its own line whitelists every version
+    of that package against the new-install-script gate. Lines
+    starting with ``#`` are comments; blank lines are ignored. The
+    intent is to triage well-known, eyeballed dev-only deps (vitest's
+    esbuild, sharp's libvips, etc.) without weakening the gate for
+    the long tail. Missing or unreadable file means empty allowlist.
+    """
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    try:
+        for raw in path.read_text(encoding = "utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            out.add(line)
+    except OSError:
+        return set()
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description = (
@@ -252,6 +276,14 @@ def main(argv: list[str] | None = None) -> int:
         required = True,
         help = "Path to the HEAD package-lock.json (this PR).",
     )
+    parser.add_argument(
+        "--allowlist",
+        default = None,
+        help = (
+            "Path to a newline-separated allowlist of package names "
+            "to skip. Defaults to '<head dir>/.install-script-allowlist'."
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -261,7 +293,23 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[install-script-diff] ERROR: {exc}", file = sys.stderr)
         return 2
 
+    allowlist_path = (
+        Path(args.allowlist)
+        if args.allowlist
+        else Path(args.head).parent / ".install-script-allowlist"
+    )
+    allowlist = _load_allowlist(allowlist_path)
+
     findings = diff_new_install_scripts(base_lock, head_lock)
+    if allowlist:
+        skipped = [f for f in findings if f.name in allowlist]
+        findings = [f for f in findings if f.name not in allowlist]
+        for f in skipped:
+            print(
+                f"[install-script-diff] SKIP {f.name}@{f.version} "
+                f"(allowlisted via {allowlist_path.name})",
+                flush = True,
+            )
     if not findings:
         print(
             "[install-script-diff] OK: no newly-added install-script "

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -330,14 +330,9 @@ def _build_csp(script_nonce: "str | None" = None) -> str:
         "style-src 'self' 'unsafe-inline'; "
         f"{script_src}; "
         "font-src 'self' data:; "
-        # Restrict iframe sources to same-origin only. SVG previews still
-        # use a sandboxed ``srcdoc`` iframe (no URL fetch); interactive
-        # HTML previews go through the same-origin ``/api/preview/html/{id}``
-        # route in routes/html_preview.py, which serves the snippet with
-        # its own overriding ``script-src 'unsafe-inline'`` response CSP.
-        # Without the same-origin route, Chromium would inherit THIS
-        # ``script-src 'self'`` for srcdoc / data: / blob: iframes per
-        # HTML / CSP3 and inline scripts would be silently dead.
+        # Same-origin only. SVG uses srcdoc; interactive HTML goes through
+        # /api/preview/html/{id} which carries its own overriding response
+        # CSP (srcdoc / data: / blob: inherit THIS one per CSP3).
         "frame-src 'self'; "
         "frame-ancestors 'none'; "
         "form-action 'self'; "

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -327,6 +327,10 @@ def _build_csp(script_nonce: "str | None" = None) -> str:
         "style-src 'self' 'unsafe-inline'; "
         f"{script_src}; "
         "font-src 'self' data:; "
+        # Restrict iframe sources to same-origin only. The assistant
+        # HTML/SVG previews use srcdoc (no URL involved) and inherit this
+        # CSP, so this also bounds what the preview iframe can do.
+        "frame-src 'self'; "
         "frame-ancestors 'none'; "
         "form-action 'self'; "
         "base-uri 'self'"

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -328,8 +328,15 @@ def _build_csp(script_nonce: "str | None" = None) -> str:
         f"{script_src}; "
         "font-src 'self' data:; "
         # Restrict iframe sources to same-origin only. The assistant
-        # HTML/SVG previews use srcdoc (no URL involved) and inherit this
-        # CSP, so this also bounds what the preview iframe can do.
+        # HTML/SVG previews use srcdoc (no URL fetch), so allowing
+        # data: / blob: here would not unlock interactive scripts
+        # anyway -- Chromium inherits the embedder CSP for srcdoc,
+        # data:, AND blob: iframes per HTML / CSP3, so the only way
+        # to escape ``script-src 'self'`` for the preview would be a
+        # same-origin backend route serving with overriding response
+        # CSP headers. Tracked as a follow-up; for now the explicit
+        # ``'self'`` setting leaves a visible directive that grep
+        # picks up if a future change tries to relax it.
         "frame-src 'self'; "
         "frame-ancestors 'none'; "
         "form-action 'self'; "

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -118,6 +118,7 @@ from routes import (
     data_recipe_router,
     datasets_router,
     export_router,
+    html_preview_router,
     inference_router,
     inference_studio_router,
     models_router,
@@ -327,16 +328,14 @@ def _build_csp(script_nonce: "str | None" = None) -> str:
         "style-src 'self' 'unsafe-inline'; "
         f"{script_src}; "
         "font-src 'self' data:; "
-        # Restrict iframe sources to same-origin only. The assistant
-        # HTML/SVG previews use srcdoc (no URL fetch), so allowing
-        # data: / blob: here would not unlock interactive scripts
-        # anyway -- Chromium inherits the embedder CSP for srcdoc,
-        # data:, AND blob: iframes per HTML / CSP3, so the only way
-        # to escape ``script-src 'self'`` for the preview would be a
-        # same-origin backend route serving with overriding response
-        # CSP headers. Tracked as a follow-up; for now the explicit
-        # ``'self'`` setting leaves a visible directive that grep
-        # picks up if a future change tries to relax it.
+        # Restrict iframe sources to same-origin only. SVG previews still
+        # use a sandboxed ``srcdoc`` iframe (no URL fetch); interactive
+        # HTML previews go through the same-origin ``/api/preview/html/{id}``
+        # route in routes/html_preview.py, which serves the snippet with
+        # its own overriding ``script-src 'unsafe-inline'`` response CSP.
+        # Without the same-origin route, Chromium would inherit THIS
+        # ``script-src 'self'`` for srcdoc / data: / blob: iframes per
+        # HTML / CSP3 and inline scripts would be silently dead.
         "frame-src 'self'; "
         "frame-ancestors 'none'; "
         "form-action 'self'; "
@@ -538,6 +537,9 @@ app.include_router(data_recipe_router, prefix = "/api/data-recipe", tags = ["dat
 app.include_router(export_router, prefix = "/api/export", tags = ["export"])
 app.include_router(
     training_history_router, prefix = "/api/train", tags = ["training-history"]
+)
+app.include_router(
+    html_preview_router, prefix = "/api/preview/html", tags = ["html-preview"]
 )
 
 

--- a/studio/backend/routes/__init__.py
+++ b/studio/backend/routes/__init__.py
@@ -16,6 +16,7 @@ from routes.export import router as export_router
 from routes.training_history import router as training_history_router
 from routes.chat_history import router as chat_history_router
 from routes.providers import router as providers_router
+from routes.html_preview import router as html_preview_router
 
 __all__ = [
     "training_router",
@@ -29,4 +30,5 @@ __all__ = [
     "training_history_router",
     "chat_history_router",
     "providers_router",
+    "html_preview_router",
 ]

--- a/studio/backend/routes/html_preview.py
+++ b/studio/backend/routes/html_preview.py
@@ -99,39 +99,37 @@ def _build_html_doc(source: str) -> str:
     # ``<base target="_blank">`` mirrors the srcdoc fallback so any ``<a>``
     # without an explicit target opens in a new tab rather than navigating
     # the iframe (which would be UX-confusing).
-    return (
-        "<!doctype html>"
-        '<base target="_blank">'
-        + source
+    return "<!doctype html>" '<base target="_blank">' + source
+
+
+_PREVIEW_CSP = "; ".join(
+    (
+        "default-src 'none'",
+        # ``script-src 'unsafe-inline'`` enables BOTH ``<script>`` blocks and
+        # ``onclick``-style attribute handlers. This is the entire reason the
+        # route exists -- the host page's ``script-src 'self'`` does not.
+        "script-src 'unsafe-inline'",
+        "style-src 'unsafe-inline'",
+        # ``data:`` / ``blob:`` only, NOT remote http(s). Inline JS cannot
+        # exfiltrate by fetching a remote pixel since ``connect-src 'none'``
+        # blocks fetch/XHR, but stripping remote ``img-src`` removes the
+        # other classic beacon vector too.
+        "img-src data: blob:",
+        "media-src data: blob:",
+        "font-src data:",
+        "connect-src 'none'",
+        "worker-src 'none'",
+        "frame-src 'none'",
+        "object-src 'none'",
+        "base-uri 'none'",
+        "form-action 'none'",
+        # Restrict who can embed THIS preview. The Studio host page is
+        # same-origin and is the only legitimate embedder. ``frame-ancestors
+        # 'self'`` also overrides any global X-Frame-Options on modern
+        # browsers, so a third-party site cannot iframe a leaked preview URL.
+        "frame-ancestors 'self'",
     )
-
-
-_PREVIEW_CSP = "; ".join((
-    "default-src 'none'",
-    # ``script-src 'unsafe-inline'`` enables BOTH ``<script>`` blocks and
-    # ``onclick``-style attribute handlers. This is the entire reason the
-    # route exists -- the host page's ``script-src 'self'`` does not.
-    "script-src 'unsafe-inline'",
-    "style-src 'unsafe-inline'",
-    # ``data:`` / ``blob:`` only, NOT remote http(s). Inline JS cannot
-    # exfiltrate by fetching a remote pixel since ``connect-src 'none'``
-    # blocks fetch/XHR, but stripping remote ``img-src`` removes the
-    # other classic beacon vector too.
-    "img-src data: blob:",
-    "media-src data: blob:",
-    "font-src data:",
-    "connect-src 'none'",
-    "worker-src 'none'",
-    "frame-src 'none'",
-    "object-src 'none'",
-    "base-uri 'none'",
-    "form-action 'none'",
-    # Restrict who can embed THIS preview. The Studio host page is
-    # same-origin and is the only legitimate embedder. ``frame-ancestors
-    # 'self'`` also overrides any global X-Frame-Options on modern
-    # browsers, so a third-party site cannot iframe a leaked preview URL.
-    "frame-ancestors 'self'",
-))
+)
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/routes/html_preview.py
+++ b/studio/backend/routes/html_preview.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""HTML preview route for assistant ```html fences.
+
+Reason this route exists: when the chat renderer embeds the assistant's
+HTML via a ``srcdoc`` iframe, Chromium inherits the embedder CSP
+(``script-src 'self'``), so inline scripts and ``onclick`` handlers are
+silently blocked. Serving the same HTML from a same-origin URL with an
+overriding response-header CSP is the only way to let assistant-generated
+interactive HTML actually run while keeping the surrounding Studio CSP
+strict.
+
+Security shape:
+
+* POST is auth-gated (``get_current_subject``). Only an authenticated
+  caller can stash HTML into the in-memory store.
+* GET is intentionally NOT auth-gated -- browsers do not attach the
+  Authorization bearer to iframe subresource loads, so we instead make
+  the URL itself the secret: ``secrets.token_urlsafe(24)`` (192 bits of
+  entropy). The token leaves the server only in the POST response and
+  is then placed into the iframe ``src`` by the requesting page. It is
+  never persisted to disk, never logged, and is wiped on TTL expiry.
+* The response CSP is ``default-src 'none'`` + ``script-src
+  'unsafe-inline'`` so the preview is sandboxed from the network but
+  inline scripts and event-handler attributes execute as intended.
+* The iframe still has ``sandbox="allow-scripts allow-modals
+  allow-popups"`` (no ``allow-same-origin``), so even though the URL
+  is same-origin the document is treated as a unique opaque origin
+  for SOP purposes -- script in the preview cannot reach
+  ``window.parent`` storage, cookies, or DOM.
+* A size cap and TTL cap bound the in-memory footprint per Studio
+  process.
+"""
+
+from __future__ import annotations
+
+import secrets
+import sys
+import time
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+# Backend root on sys.path so ``auth`` imports resolve when this module
+# is loaded standalone (matches the pattern used by routes/export.py).
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from auth.authentication import get_current_subject  # noqa: E402
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Knobs (module-level so tests can monkeypatch).
+# ---------------------------------------------------------------------------
+
+# 1 MiB cap; assistant HTML previews are short snippets, not full SPAs.
+MAX_HTML_PREVIEW_BYTES = 1_000_000
+
+# 10 minutes. Long enough for a user to interact with the preview, short
+# enough that a forgotten tab does not pin the entry.
+PREVIEW_TTL_SECONDS = 10 * 60
+
+# Defensive cap so a runaway producer cannot exhaust the worker. New POSTs
+# evict the oldest entries past this watermark. Per-process, in-memory only.
+MAX_LIVE_PREVIEWS = 256
+
+
+_PREVIEWS: dict[str, tuple[float, str]] = {}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers.
+# ---------------------------------------------------------------------------
+
+
+def _sweep_expired(now: float | None = None) -> None:
+    now = time.monotonic() if now is None else now
+    expired = [k for k, (t, _) in _PREVIEWS.items() if now - t > PREVIEW_TTL_SECONDS]
+    for k in expired:
+        _PREVIEWS.pop(k, None)
+
+
+def _evict_overflow() -> None:
+    if len(_PREVIEWS) <= MAX_LIVE_PREVIEWS:
+        return
+    # Evict oldest first.
+    sorted_keys = sorted(_PREVIEWS, key = lambda k: _PREVIEWS[k][0])
+    for k in sorted_keys[: len(_PREVIEWS) - MAX_LIVE_PREVIEWS]:
+        _PREVIEWS.pop(k, None)
+
+
+def _build_html_doc(source: str) -> str:
+    # ``<base target="_blank">`` mirrors the srcdoc fallback so any ``<a>``
+    # without an explicit target opens in a new tab rather than navigating
+    # the iframe (which would be UX-confusing).
+    return (
+        "<!doctype html>"
+        '<base target="_blank">'
+        + source
+    )
+
+
+_PREVIEW_CSP = "; ".join((
+    "default-src 'none'",
+    # ``script-src 'unsafe-inline'`` enables BOTH ``<script>`` blocks and
+    # ``onclick``-style attribute handlers. This is the entire reason the
+    # route exists -- the host page's ``script-src 'self'`` does not.
+    "script-src 'unsafe-inline'",
+    "style-src 'unsafe-inline'",
+    # ``data:`` / ``blob:`` only, NOT remote http(s). Inline JS cannot
+    # exfiltrate by fetching a remote pixel since ``connect-src 'none'``
+    # blocks fetch/XHR, but stripping remote ``img-src`` removes the
+    # other classic beacon vector too.
+    "img-src data: blob:",
+    "media-src data: blob:",
+    "font-src data:",
+    "connect-src 'none'",
+    "worker-src 'none'",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+    # Restrict who can embed THIS preview. The Studio host page is
+    # same-origin and is the only legitimate embedder. ``frame-ancestors
+    # 'self'`` also overrides any global X-Frame-Options on modern
+    # browsers, so a third-party site cannot iframe a leaked preview URL.
+    "frame-ancestors 'self'",
+))
+
+
+# ---------------------------------------------------------------------------
+# Request / response models.
+# ---------------------------------------------------------------------------
+
+
+class HtmlPreviewCreate(BaseModel):
+    source: str = Field(..., max_length = MAX_HTML_PREVIEW_BYTES)
+
+
+class HtmlPreviewCreateResponse(BaseModel):
+    url: str
+    expires_in_seconds: int
+
+
+# ---------------------------------------------------------------------------
+# Endpoints.
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model = HtmlPreviewCreateResponse)
+async def create_html_preview(
+    payload: HtmlPreviewCreate,
+    current_subject: str = Depends(get_current_subject),
+) -> HtmlPreviewCreateResponse:
+    """Stash an HTML snippet for same-origin iframe rendering.
+
+    Returns a same-origin URL whose path includes a 192-bit random token.
+    The token is the only authorisation for the subsequent GET.
+    """
+    _sweep_expired()
+    source = payload.source
+    if not isinstance(source, str):  # defensive; pydantic enforces str already
+        raise HTTPException(status_code = 400, detail = "source must be a string")
+    if len(source) > MAX_HTML_PREVIEW_BYTES:
+        raise HTTPException(status_code = 413, detail = "HTML preview too large")
+    token = secrets.token_urlsafe(24)
+    _PREVIEWS[token] = (time.monotonic(), source)
+    _evict_overflow()
+    return HtmlPreviewCreateResponse(
+        url = f"/api/preview/html/{token}",
+        expires_in_seconds = PREVIEW_TTL_SECONDS,
+    )
+
+
+@router.get("/{preview_id}", response_class = HTMLResponse)
+async def get_html_preview(preview_id: str) -> HTMLResponse:
+    """Serve a stashed HTML snippet with an overriding response CSP.
+
+    Intentionally NOT auth-gated: the URL token IS the authorisation.
+    The iframe in the chat page has no Authorization header to send,
+    so making this require a bearer would break the only consumer.
+    """
+    _sweep_expired()
+    item = _PREVIEWS.get(preview_id)
+    if item is None:
+        raise HTTPException(status_code = 404, detail = "Preview expired or not found")
+    _, source = item
+    return HTMLResponse(
+        content = _build_html_doc(source),
+        headers = {
+            "Content-Security-Policy": _PREVIEW_CSP,
+            "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "no-referrer",
+            # Override the global SecurityHeadersMiddleware default of
+            # ``X-Frame-Options: DENY`` -- otherwise the preview page
+            # refuses to be iframed by the host chat view at all.
+            "X-Frame-Options": "SAMEORIGIN",
+        },
+    )

--- a/studio/backend/routes/html_preview.py
+++ b/studio/backend/routes/html_preview.py
@@ -43,8 +43,8 @@ router = APIRouter()
 
 # Knobs (module-level so tests can monkeypatch).
 MAX_HTML_PREVIEW_BYTES = 1_000_000  # 1 MiB; snippets, not full SPAs.
-PREVIEW_TTL_SECONDS = 10 * 60       # 10 min interaction window.
-MAX_LIVE_PREVIEWS = 256             # Per-process cap; oldest evicted first.
+PREVIEW_TTL_SECONDS = 10 * 60  # 10 min interaction window.
+MAX_LIVE_PREVIEWS = 256  # Per-process cap; oldest evicted first.
 
 _PREVIEWS: dict[str, tuple[float, str]] = {}
 

--- a/studio/backend/routes/html_preview.py
+++ b/studio/backend/routes/html_preview.py
@@ -3,34 +3,21 @@
 
 """HTML preview route for assistant ```html fences.
 
-Reason this route exists: when the chat renderer embeds the assistant's
-HTML via a ``srcdoc`` iframe, Chromium inherits the embedder CSP
-(``script-src 'self'``), so inline scripts and ``onclick`` handlers are
-silently blocked. Serving the same HTML from a same-origin URL with an
-overriding response-header CSP is the only way to let assistant-generated
-interactive HTML actually run while keeping the surrounding Studio CSP
-strict.
+srcdoc / data: / blob: iframes inherit the host CSP (script-src 'self')
+per CSP3, so inline scripts and onclick handlers are silently blocked.
+Serving the snippet from a same-origin URL with an overriding response
+CSP is the only way to unlock interactive HTML.
 
-Security shape:
-
-* POST is auth-gated (``get_current_subject``). Only an authenticated
-  caller can stash HTML into the in-memory store.
-* GET is intentionally NOT auth-gated -- browsers do not attach the
-  Authorization bearer to iframe subresource loads, so we instead make
-  the URL itself the secret: ``secrets.token_urlsafe(24)`` (192 bits of
-  entropy). The token leaves the server only in the POST response and
-  is then placed into the iframe ``src`` by the requesting page. It is
-  never persisted to disk, never logged, and is wiped on TTL expiry.
-* The response CSP is ``default-src 'none'`` + ``script-src
-  'unsafe-inline'`` so the preview is sandboxed from the network but
-  inline scripts and event-handler attributes execute as intended.
-* The iframe still has ``sandbox="allow-scripts allow-modals
-  allow-popups"`` (no ``allow-same-origin``), so even though the URL
-  is same-origin the document is treated as a unique opaque origin
-  for SOP purposes -- script in the preview cannot reach
-  ``window.parent`` storage, cookies, or DOM.
-* A size cap and TTL cap bound the in-memory footprint per Studio
-  process.
+Security:
+- POST is auth-gated.
+- GET is NOT auth-gated -- iframe subresource loads do not carry the
+  Authorization bearer, so the URL token (192 bits, secrets.token_urlsafe(24))
+  is the authorisation. Never persisted, wiped on TTL expiry.
+- Response CSP: default-src 'none' + script-src 'unsafe-inline'.
+  Scripts run; network egress (connect-src, frame-src, worker-src) blocked.
+- iframe sandbox stays "allow-scripts allow-modals allow-popups" with NO
+  allow-same-origin, so preview JS cannot reach window.parent.
+- Size and live-entry caps bound per-process memory.
 """
 
 from __future__ import annotations
@@ -44,8 +31,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
-# Backend root on sys.path so ``auth`` imports resolve when this module
-# is loaded standalone (matches the pattern used by routes/export.py).
+# Backend on sys.path for standalone load (matches routes/export.py).
 _BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(_BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(_BACKEND_ROOT))
@@ -55,28 +41,12 @@ from auth.authentication import get_current_subject  # noqa: E402
 router = APIRouter()
 
 
-# ---------------------------------------------------------------------------
 # Knobs (module-level so tests can monkeypatch).
-# ---------------------------------------------------------------------------
-
-# 1 MiB cap; assistant HTML previews are short snippets, not full SPAs.
-MAX_HTML_PREVIEW_BYTES = 1_000_000
-
-# 10 minutes. Long enough for a user to interact with the preview, short
-# enough that a forgotten tab does not pin the entry.
-PREVIEW_TTL_SECONDS = 10 * 60
-
-# Defensive cap so a runaway producer cannot exhaust the worker. New POSTs
-# evict the oldest entries past this watermark. Per-process, in-memory only.
-MAX_LIVE_PREVIEWS = 256
-
+MAX_HTML_PREVIEW_BYTES = 1_000_000  # 1 MiB; snippets, not full SPAs.
+PREVIEW_TTL_SECONDS = 10 * 60       # 10 min interaction window.
+MAX_LIVE_PREVIEWS = 256             # Per-process cap; oldest evicted first.
 
 _PREVIEWS: dict[str, tuple[float, str]] = {}
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers.
-# ---------------------------------------------------------------------------
 
 
 def _sweep_expired(now: float | None = None) -> None:
@@ -89,31 +59,24 @@ def _sweep_expired(now: float | None = None) -> None:
 def _evict_overflow() -> None:
     if len(_PREVIEWS) <= MAX_LIVE_PREVIEWS:
         return
-    # Evict oldest first.
     sorted_keys = sorted(_PREVIEWS, key = lambda k: _PREVIEWS[k][0])
     for k in sorted_keys[: len(_PREVIEWS) - MAX_LIVE_PREVIEWS]:
         _PREVIEWS.pop(k, None)
 
 
 def _build_html_doc(source: str) -> str:
-    # ``<base target="_blank">`` mirrors the srcdoc fallback so any ``<a>``
-    # without an explicit target opens in a new tab rather than navigating
-    # the iframe (which would be UX-confusing).
+    # <base target="_blank"> so <a> links open a new tab instead of
+    # navigating the iframe away from the preview.
     return "<!doctype html>" '<base target="_blank">' + source
 
 
 _PREVIEW_CSP = "; ".join(
     (
         "default-src 'none'",
-        # ``script-src 'unsafe-inline'`` enables BOTH ``<script>`` blocks and
-        # ``onclick``-style attribute handlers. This is the entire reason the
-        # route exists -- the host page's ``script-src 'self'`` does not.
+        # The reason this route exists -- host CSP does not allow inline.
         "script-src 'unsafe-inline'",
         "style-src 'unsafe-inline'",
-        # ``data:`` / ``blob:`` only, NOT remote http(s). Inline JS cannot
-        # exfiltrate by fetching a remote pixel since ``connect-src 'none'``
-        # blocks fetch/XHR, but stripping remote ``img-src`` removes the
-        # other classic beacon vector too.
+        # data: / blob: only -- no remote img beacon.
         "img-src data: blob:",
         "media-src data: blob:",
         "font-src data:",
@@ -123,18 +86,10 @@ _PREVIEW_CSP = "; ".join(
         "object-src 'none'",
         "base-uri 'none'",
         "form-action 'none'",
-        # Restrict who can embed THIS preview. The Studio host page is
-        # same-origin and is the only legitimate embedder. ``frame-ancestors
-        # 'self'`` also overrides any global X-Frame-Options on modern
-        # browsers, so a third-party site cannot iframe a leaked preview URL.
+        # Same-origin embedders only; also overrides X-Frame-Options.
         "frame-ancestors 'self'",
     )
 )
-
-
-# ---------------------------------------------------------------------------
-# Request / response models.
-# ---------------------------------------------------------------------------
 
 
 class HtmlPreviewCreate(BaseModel):
@@ -146,24 +101,15 @@ class HtmlPreviewCreateResponse(BaseModel):
     expires_in_seconds: int
 
 
-# ---------------------------------------------------------------------------
-# Endpoints.
-# ---------------------------------------------------------------------------
-
-
 @router.post("", response_model = HtmlPreviewCreateResponse)
 async def create_html_preview(
     payload: HtmlPreviewCreate,
     current_subject: str = Depends(get_current_subject),
 ) -> HtmlPreviewCreateResponse:
-    """Stash an HTML snippet for same-origin iframe rendering.
-
-    Returns a same-origin URL whose path includes a 192-bit random token.
-    The token is the only authorisation for the subsequent GET.
-    """
+    """Stash HTML; return a same-origin token URL (the only auth for GET)."""
     _sweep_expired()
     source = payload.source
-    if not isinstance(source, str):  # defensive; pydantic enforces str already
+    if not isinstance(source, str):  # defensive; pydantic already enforces.
         raise HTTPException(status_code = 400, detail = "source must be a string")
     if len(source) > MAX_HTML_PREVIEW_BYTES:
         raise HTTPException(status_code = 413, detail = "HTML preview too large")
@@ -178,12 +124,7 @@ async def create_html_preview(
 
 @router.get("/{preview_id}", response_class = HTMLResponse)
 async def get_html_preview(preview_id: str) -> HTMLResponse:
-    """Serve a stashed HTML snippet with an overriding response CSP.
-
-    Intentionally NOT auth-gated: the URL token IS the authorisation.
-    The iframe in the chat page has no Authorization header to send,
-    so making this require a bearer would break the only consumer.
-    """
+    """Serve a stashed snippet with overriding CSP. Unauth: token IS the auth."""
     _sweep_expired()
     item = _PREVIEWS.get(preview_id)
     if item is None:
@@ -196,9 +137,7 @@ async def get_html_preview(preview_id: str) -> HTMLResponse:
             "Cache-Control": "no-store",
             "X-Content-Type-Options": "nosniff",
             "Referrer-Policy": "no-referrer",
-            # Override the global SecurityHeadersMiddleware default of
-            # ``X-Frame-Options: DENY`` -- otherwise the preview page
-            # refuses to be iframed by the host chat view at all.
+            # Override the global DENY default so the host chat can iframe us.
             "X-Frame-Options": "SAMEORIGIN",
         },
     )

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -435,6 +435,7 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
         data_recipe_router = APIRouter(),
         datasets_router = APIRouter(),
         export_router = APIRouter(),
+        html_preview_router = APIRouter(),
         inference_router = APIRouter(),
         inference_studio_router = APIRouter(),
         models_router = APIRouter(),

--- a/studio/backend/tests/test_html_preview.py
+++ b/studio/backend/tests/test_html_preview.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Tests for the /api/preview/html route (interactive HTML preview)."""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+
+@pytest.fixture
+def preview_app(tmp_path, monkeypatch):
+    """Standalone app mounting only the html-preview router on a clean store."""
+    from auth import storage
+    from auth.authentication import create_access_token
+
+    monkeypatch.setattr(storage, "DB_PATH", tmp_path / "auth.db")
+    monkeypatch.setattr(storage, "_BOOTSTRAP_PW_PATH", tmp_path / ".bootstrap_password")
+    monkeypatch.setattr(storage, "_bootstrap_password", None)
+
+    import secrets as _secrets
+    storage.create_initial_user(
+        username = storage.DEFAULT_ADMIN_USERNAME,
+        password = "human-password-123",
+        jwt_secret = _secrets.token_urlsafe(64),
+        must_change_password = False,
+    )
+
+    from routes.html_preview import router as html_preview_router
+    from routes import html_preview as html_preview_module
+
+    # Each test starts with an empty in-memory store.
+    html_preview_module._PREVIEWS.clear()
+
+    app = FastAPI()
+    app.include_router(
+        html_preview_router, prefix = "/api/preview/html", tags = ["html-preview"]
+    )
+    token = create_access_token(storage.DEFAULT_ADMIN_USERNAME)
+    return app, token, html_preview_module
+
+
+class TestPostHtmlPreview:
+    def test_post_requires_auth(self, preview_app):
+        app, _token, _mod = preview_app
+        c = TestClient(app)
+        r = c.post("/api/preview/html", json = {"source": "<h1>hi</h1>"})
+        assert r.status_code in (401, 403)
+
+    def test_post_returns_same_origin_url_and_ttl(self, preview_app):
+        app, token, _mod = preview_app
+        c = TestClient(app)
+        r = c.post(
+            "/api/preview/html",
+            json = {"source": "<h1>hello</h1>"},
+            headers = {"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["url"].startswith("/api/preview/html/")
+        assert isinstance(body["expires_in_seconds"], int)
+        assert body["expires_in_seconds"] > 0
+
+    def test_post_rejects_oversize_body(self, preview_app):
+        app, token, mod = preview_app
+        c = TestClient(app)
+        too_big = "x" * (mod.MAX_HTML_PREVIEW_BYTES + 1)
+        r = c.post(
+            "/api/preview/html",
+            json = {"source": too_big},
+            headers = {"Authorization": f"Bearer {token}"},
+        )
+        # Pydantic enforces the max_length so this is a 422 (validation),
+        # NOT a 413 -- but either is acceptable as long as it does not get
+        # stored. We assert non-2xx and an empty store.
+        assert r.status_code >= 400
+        assert mod._PREVIEWS == {}
+
+    def test_post_returns_unguessable_tokens(self, preview_app):
+        # Two POSTs of the same source must produce two distinct tokens.
+        app, token, _mod = preview_app
+        c = TestClient(app)
+        urls = set()
+        for _ in range(5):
+            r = c.post(
+                "/api/preview/html",
+                json = {"source": "<p>same</p>"},
+                headers = {"Authorization": f"Bearer {token}"},
+            )
+            assert r.status_code == 200
+            urls.add(r.json()["url"])
+        assert len(urls) == 5
+
+
+class TestGetHtmlPreview:
+    def _create(self, app, token, source):
+        c = TestClient(app)
+        r = c.post(
+            "/api/preview/html",
+            json = {"source": source},
+            headers = {"Authorization": f"Bearer {token}"},
+        )
+        return r.json()["url"]
+
+    def test_get_serves_stored_html_with_overriding_csp(self, preview_app):
+        app, token, _mod = preview_app
+        url = self._create(app, token, "<button onclick=\"alert('x')\">go</button>")
+        c = TestClient(app)
+        r = c.get(url)
+        assert r.status_code == 200
+        body = r.text
+        # The doctype + base + body are present.
+        assert "<!doctype html>" in body.lower()
+        assert "<base target=\"_blank\">" in body
+        assert "<button onclick=\"alert('x')\">go</button>" in body
+        # The overriding CSP must permit inline script execution.
+        csp = r.headers["content-security-policy"]
+        directives = {
+            chunk.strip().split(" ", 1)[0]: chunk.strip()
+            for chunk in csp.split(";")
+            if chunk.strip()
+        }
+        assert "default-src" in directives
+        assert "'none'" in directives["default-src"]
+        assert "'unsafe-inline'" in directives["script-src"]
+        # Beacon paths are still closed.
+        assert "'none'" in directives["connect-src"]
+        assert "'none'" in directives["frame-src"]
+        # Only same-origin embedders may iframe the preview.
+        assert "frame-ancestors" in directives
+        assert "'self'" in directives["frame-ancestors"]
+        # X-Frame-Options is SAMEORIGIN so the host page can iframe us.
+        assert r.headers["x-frame-options"].upper() == "SAMEORIGIN"
+        # No caching of preview bodies.
+        assert "no-store" in r.headers["cache-control"]
+
+    def test_get_is_not_auth_gated(self, preview_app):
+        # Browsers do not attach Authorization to iframe subresource loads.
+        # The unguessable URL token IS the authorisation.
+        app, token, _mod = preview_app
+        url = self._create(app, token, "<p>nope</p>")
+        c = TestClient(app)
+        r = c.get(url)  # no Authorization header
+        assert r.status_code == 200
+
+    def test_get_unknown_token_is_404(self, preview_app):
+        app, _token, _mod = preview_app
+        c = TestClient(app)
+        r = c.get("/api/preview/html/totally-not-a-real-token")
+        assert r.status_code == 404
+
+    def test_get_expired_token_is_404(self, preview_app):
+        app, token, mod = preview_app
+        url = self._create(app, token, "<p>aging</p>")
+        # Force-age the stored entry past the TTL by rewinding monotonic.
+        token_id = url.rsplit("/", 1)[-1]
+        created, src = mod._PREVIEWS[token_id]
+        mod._PREVIEWS[token_id] = (created - (mod.PREVIEW_TTL_SECONDS + 5), src)
+        c = TestClient(app)
+        r = c.get(url)
+        assert r.status_code == 404
+        # And the entry is swept on access.
+        assert token_id not in mod._PREVIEWS
+
+
+class TestEviction:
+    def test_overflow_evicts_oldest_entries(self, preview_app):
+        app, token, mod = preview_app
+        c = TestClient(app)
+        # Pin the cap low so the test is cheap.
+        mod.MAX_LIVE_PREVIEWS = 4
+        urls = []
+        for i in range(6):
+            r = c.post(
+                "/api/preview/html",
+                json = {"source": f"<p>{i}</p>"},
+                headers = {"Authorization": f"Bearer {token}"},
+            )
+            urls.append(r.json()["url"])
+            # Force monotonic progression so eviction order is deterministic.
+            time.sleep(0.001)
+        assert len(mod._PREVIEWS) == mod.MAX_LIVE_PREVIEWS
+        # The two oldest tokens (urls[0], urls[1]) must have been evicted.
+        for old in urls[:2]:
+            token_id = old.rsplit("/", 1)[-1]
+            assert token_id not in mod._PREVIEWS
+        # Newer tokens are still present.
+        for fresh in urls[-mod.MAX_LIVE_PREVIEWS:]:
+            token_id = fresh.rsplit("/", 1)[-1]
+            assert token_id in mod._PREVIEWS

--- a/studio/backend/tests/test_html_preview.py
+++ b/studio/backend/tests/test_html_preview.py
@@ -19,7 +19,7 @@ if str(_BACKEND_ROOT) not in sys.path:
 
 @pytest.fixture
 def preview_app(tmp_path, monkeypatch):
-    """Standalone app mounting only the html-preview router on a clean store."""
+    """Standalone app with only the html-preview router and a clean store."""
     from auth import storage
     from auth.authentication import create_access_token
 
@@ -39,8 +39,7 @@ def preview_app(tmp_path, monkeypatch):
     from routes.html_preview import router as html_preview_router
     from routes import html_preview as html_preview_module
 
-    # Each test starts with an empty in-memory store.
-    html_preview_module._PREVIEWS.clear()
+    html_preview_module._PREVIEWS.clear()  # fresh store per test
 
     app = FastAPI()
     app.include_router(
@@ -80,14 +79,13 @@ class TestPostHtmlPreview:
             json = {"source": too_big},
             headers = {"Authorization": f"Bearer {token}"},
         )
-        # Pydantic enforces the max_length so this is a 422 (validation),
-        # NOT a 413 -- but either is acceptable as long as it does not get
-        # stored. We assert non-2xx and an empty store.
+        # Pydantic's max_length surfaces as 422; we accept any non-2xx
+        # as long as nothing is stored.
         assert r.status_code >= 400
         assert mod._PREVIEWS == {}
 
     def test_post_returns_unguessable_tokens(self, preview_app):
-        # Two POSTs of the same source must produce two distinct tokens.
+        # Identical source -> distinct tokens.
         app, token, _mod = preview_app
         c = TestClient(app)
         urls = set()
@@ -119,34 +117,29 @@ class TestGetHtmlPreview:
         r = c.get(url)
         assert r.status_code == 200
         body = r.text
-        # The doctype + base + body are present.
         assert "<!doctype html>" in body.lower()
         assert '<base target="_blank">' in body
         assert "<button onclick=\"alert('x')\">go</button>" in body
-        # The overriding CSP must permit inline script execution.
         csp = r.headers["content-security-policy"]
         directives = {
             chunk.strip().split(" ", 1)[0]: chunk.strip()
             for chunk in csp.split(";")
             if chunk.strip()
         }
-        assert "default-src" in directives
+        # Inline scripts allowed, network egress closed.
         assert "'none'" in directives["default-src"]
         assert "'unsafe-inline'" in directives["script-src"]
-        # Beacon paths are still closed.
         assert "'none'" in directives["connect-src"]
         assert "'none'" in directives["frame-src"]
-        # Only same-origin embedders may iframe the preview.
-        assert "frame-ancestors" in directives
+        # Same-origin embedders only.
         assert "'self'" in directives["frame-ancestors"]
-        # X-Frame-Options is SAMEORIGIN so the host page can iframe us.
+        # Override the global DENY so host chat can iframe us.
         assert r.headers["x-frame-options"].upper() == "SAMEORIGIN"
-        # No caching of preview bodies.
         assert "no-store" in r.headers["cache-control"]
 
     def test_get_is_not_auth_gated(self, preview_app):
-        # Browsers do not attach Authorization to iframe subresource loads.
-        # The unguessable URL token IS the authorisation.
+        # Iframe subresource loads do not carry Authorization; the URL
+        # token is the authorisation.
         app, token, _mod = preview_app
         url = self._create(app, token, "<p>nope</p>")
         c = TestClient(app)
@@ -162,14 +155,14 @@ class TestGetHtmlPreview:
     def test_get_expired_token_is_404(self, preview_app):
         app, token, mod = preview_app
         url = self._create(app, token, "<p>aging</p>")
-        # Force-age the stored entry past the TTL by rewinding monotonic.
+        # Rewind monotonic past the TTL.
         token_id = url.rsplit("/", 1)[-1]
         created, src = mod._PREVIEWS[token_id]
         mod._PREVIEWS[token_id] = (created - (mod.PREVIEW_TTL_SECONDS + 5), src)
         c = TestClient(app)
         r = c.get(url)
         assert r.status_code == 404
-        # And the entry is swept on access.
+        # Swept on access.
         assert token_id not in mod._PREVIEWS
 
 
@@ -177,8 +170,7 @@ class TestEviction:
     def test_overflow_evicts_oldest_entries(self, preview_app):
         app, token, mod = preview_app
         c = TestClient(app)
-        # Pin the cap low so the test is cheap.
-        mod.MAX_LIVE_PREVIEWS = 4
+        mod.MAX_LIVE_PREVIEWS = 4  # cheap test
         urls = []
         for i in range(6):
             r = c.post(
@@ -187,14 +179,13 @@ class TestEviction:
                 headers = {"Authorization": f"Bearer {token}"},
             )
             urls.append(r.json()["url"])
-            # Force monotonic progression so eviction order is deterministic.
-            time.sleep(0.001)
+            time.sleep(0.001)  # deterministic monotonic order
         assert len(mod._PREVIEWS) == mod.MAX_LIVE_PREVIEWS
-        # The two oldest tokens (urls[0], urls[1]) must have been evicted.
+        # Oldest two evicted.
         for old in urls[:2]:
             token_id = old.rsplit("/", 1)[-1]
             assert token_id not in mod._PREVIEWS
-        # Newer tokens are still present.
+        # Newest survive.
         for fresh in urls[-mod.MAX_LIVE_PREVIEWS :]:
             token_id = fresh.rsplit("/", 1)[-1]
             assert token_id in mod._PREVIEWS

--- a/studio/backend/tests/test_html_preview.py
+++ b/studio/backend/tests/test_html_preview.py
@@ -28,6 +28,7 @@ def preview_app(tmp_path, monkeypatch):
     monkeypatch.setattr(storage, "_bootstrap_password", None)
 
     import secrets as _secrets
+
     storage.create_initial_user(
         username = storage.DEFAULT_ADMIN_USERNAME,
         password = "human-password-123",
@@ -120,7 +121,7 @@ class TestGetHtmlPreview:
         body = r.text
         # The doctype + base + body are present.
         assert "<!doctype html>" in body.lower()
-        assert "<base target=\"_blank\">" in body
+        assert '<base target="_blank">' in body
         assert "<button onclick=\"alert('x')\">go</button>" in body
         # The overriding CSP must permit inline script execution.
         csp = r.headers["content-security-policy"]
@@ -194,6 +195,6 @@ class TestEviction:
             token_id = old.rsplit("/", 1)[-1]
             assert token_id not in mod._PREVIEWS
         # Newer tokens are still present.
-        for fresh in urls[-mod.MAX_LIVE_PREVIEWS:]:
+        for fresh in urls[-mod.MAX_LIVE_PREVIEWS :]:
             token_id = fresh.rsplit("/", 1)[-1]
             assert token_id in mod._PREVIEWS

--- a/studio/backend/tests/test_middleware.py
+++ b/studio/backend/tests/test_middleware.py
@@ -79,8 +79,7 @@ class TestMaxBodyMiddleware:
         assert r.json()["unprotected"] is True
 
     def test_chunked_upload_over_cap_rejected(self, main_module):
-        # Regression: declared-Content-Length-only check could be bypassed
-        # by chunked transfer-encoding.
+        # Regression: Content-Length-only check missed chunked uploads.
         app = _make_protected_app(1024, main_module)
         c = TestClient(app)
 
@@ -156,7 +155,7 @@ class TestSecurityHeadersMiddleware:
         r = c.get("/plain")
         assert r.status_code == 200
         csp = r.headers["content-security-policy"]
-        # Parse per-directive so style-src unsafe-inline does not false-match.
+        # Parse per directive so style-src unsafe-inline does not false-match.
         directives = {
             chunk.strip().split(" ", 1)[0]: chunk.strip()
             for chunk in csp.split(";")
@@ -184,7 +183,7 @@ class TestSecurityHeadersMiddleware:
         r = c.get("/with-nonce")
         csp = r.headers["content-security-policy"]
         assert f"'nonce-{nonce}'" in csp
-        # Internal handoff header must not leak to clients.
+        # Internal handoff header must not leak.
         assert main_module._CSP_SCRIPT_NONCE_HEADER not in {
             k.lower() for k in r.headers.keys()
         }
@@ -197,12 +196,10 @@ class TestSecurityHeadersMiddleware:
         assert "script-src 'self' 'nonce-XYZ';" in nonced
 
     def test_frame_src_is_explicitly_self_only(self, main_module):
-        # The assistant HTML/SVG preview iframe uses srcdoc (no URL
-        # fetch). Allowing data: / blob: here would not unlock inline
-        # scripts anyway -- Chromium inherits the embedder CSP for
-        # srcdoc, data:, AND blob: iframes per HTML / CSP3. The
-        # explicit 'self' here leaves a visible directive any future
-        # change has to deliberately broaden.
+        # SVG preview uses srcdoc, HTML preview uses /api/preview/html
+        # (same-origin). srcdoc / data: / blob: all inherit this CSP per
+        # CSP3, so broadening here would not unlock scripts. Explicit
+        # 'self' leaves a visible directive future changes must broaden.
         csp = main_module._build_csp()
         frame_src = next(
             chunk.strip()
@@ -216,16 +213,16 @@ class TestSecurityHeadersMiddleware:
         assert "blob:" not in tokens
 
     def test_img_src_allows_google_favicons(self, main_module):
-        # sources.tsx fetches https://www.google.com/s2/favicons?... ; without
-        # this allowlist entry citation favicons fall back to gray initials.
+        # sources.tsx fetches https://www.google.com/s2/favicons?...;
+        # without this, citation favicons fall back to grey initials.
         csp = main_module._build_csp()
         img_directive = next(
             chunk.strip()
             for chunk in csp.split(";")
             if chunk.strip().startswith("img-src ")
         )
-        # Tokenise and compare with `==` so CodeQL's URL-substring rule does
-        # not read directive-string `in` membership as URL sanitisation.
+        # Tokenise + `==`: CodeQL's URL-substring rule would otherwise
+        # read `in` membership as URL sanitisation.
         img_sources = img_directive.split()
         assert any(src == "https://www.google.com" for src in img_sources)
         # Pre-existing favicon CDNs stay allowed.
@@ -269,9 +266,9 @@ def health_app(tmp_path, monkeypatch):
 
 
 class TestHealthAuthGate:
-    # Launcher / frontend bootstrap fields are available unauth so the Tauri
-    # watchdog can re-adopt a sibling backend and the SPA can detect chat-only
-    # mode before any token exists. Version / device_type still require a bearer.
+    # Bootstrap fields are unauth so the Tauri watchdog can re-adopt a
+    # sibling backend and SPA can detect chat-only before any token exists.
+    # Version / device_type still require a bearer.
     LAUNCHER_BITS = (
         "service",
         "studio_root_id",
@@ -298,7 +295,7 @@ class TestHealthAuthGate:
             assert forbidden not in body
 
     def test_invalid_bearer_returns_launcher_bits_only(self, health_app):
-        # Regression: calling the async dep without await made any Bearer header pass.
+        # Regression: missing await on the async dep let any Bearer pass.
         c = TestClient(health_app)
         r = c.get(
             "/api/health",

--- a/studio/backend/tests/test_middleware.py
+++ b/studio/backend/tests/test_middleware.py
@@ -196,6 +196,24 @@ class TestSecurityHeadersMiddleware:
         nonced = main_module._build_csp("XYZ")
         assert "script-src 'self' 'nonce-XYZ';" in nonced
 
+    def test_frame_src_is_explicitly_self_only(self, main_module):
+        # The assistant HTML/SVG preview iframe uses srcdoc (no URL fetch),
+        # so frame-src does not need to permit data: / blob:. Pinning to
+        # 'self' explicitly is the strictest setting CSP allows here, and
+        # leaves a visible directive a reviewer can grep for if a future
+        # change tries to relax it without an audit.
+        csp = main_module._build_csp()
+        frame_src = next(
+            chunk.strip()
+            for chunk in csp.split(";")
+            if chunk.strip().startswith("frame-src ")
+        )
+        tokens = frame_src.split()
+        assert tokens[0] == "frame-src"
+        assert "'self'" in tokens
+        assert "data:" not in tokens
+        assert "blob:" not in tokens
+
     def test_img_src_allows_google_favicons(self, main_module):
         # sources.tsx fetches https://www.google.com/s2/favicons?... ; without
         # this allowlist entry citation favicons fall back to gray initials.

--- a/studio/backend/tests/test_middleware.py
+++ b/studio/backend/tests/test_middleware.py
@@ -197,11 +197,12 @@ class TestSecurityHeadersMiddleware:
         assert "script-src 'self' 'nonce-XYZ';" in nonced
 
     def test_frame_src_is_explicitly_self_only(self, main_module):
-        # The assistant HTML/SVG preview iframe uses srcdoc (no URL fetch),
-        # so frame-src does not need to permit data: / blob:. Pinning to
-        # 'self' explicitly is the strictest setting CSP allows here, and
-        # leaves a visible directive a reviewer can grep for if a future
-        # change tries to relax it without an audit.
+        # The assistant HTML/SVG preview iframe uses srcdoc (no URL
+        # fetch). Allowing data: / blob: here would not unlock inline
+        # scripts anyway -- Chromium inherits the embedder CSP for
+        # srcdoc, data:, AND blob: iframes per HTML / CSP3. The
+        # explicit 'self' here leaves a visible directive any future
+        # change has to deliberately broaden.
         csp = main_module._build_csp()
         frame_src = next(
             chunk.strip()

--- a/studio/frontend/.install-script-allowlist
+++ b/studio/frontend/.install-script-allowlist
@@ -1,17 +1,11 @@
-# Packages whose npm install-script (postinstall) we have eyeballed and
-# accepted. The new-install-script gate (scripts/check_new_install_scripts.py)
-# refuses any newly-added install-script dep by default; entries listed here
-# are explicitly skipped.
+# Reviewed install-script (postinstall) packages, exempt from
+# scripts/check_new_install_scripts.py. Pin each as "name@version" -- a
+# maintainer compromise shipping a new malicious version must NOT slip
+# through the same allowlist line.
 #
-# Pin EACH entry to an exact "name@version" so a maintainer compromise that
-# ships a new malicious version is not silently swept under the same line.
-# Lines starting with "#" are comments; blank lines are ignored.
-#
-# DO NOT add packages here without reading the actual install script body.
-# Allowlist entries MUST land on main first; the gate rejects head-only
-# additions so a PR cannot allowlist its own new postinstall dep.
+# Rules: read the install body before adding. Entries MUST land on main
+# first; the gate rejects head-only additions that self-approve a new dep.
 
-# evanw/esbuild downloads the platform-specific native binary
-# (esbuild-linux-x64, etc.) in its postinstall. Used transitively by
-# vitest for dev-only test transforms; no runtime exposure.
+# evanw/esbuild: postinstall downloads platform native binary. Pulled in
+# transitively by vitest for dev-only test transforms; no runtime exposure.
 esbuild@0.21.5

--- a/studio/frontend/.install-script-allowlist
+++ b/studio/frontend/.install-script-allowlist
@@ -1,0 +1,15 @@
+# Packages whose npm install-script (postinstall) we have eyeballed and
+# accepted. The new-install-script gate (scripts/check_new_install_scripts.py)
+# refuses any newly-added install-script dep by default; entries listed here
+# are explicitly skipped.
+#
+# Add a package name on its own line, and a one-line comment above it
+# describing what the postinstall does and why it's safe. Pin to the
+# package name only -- the gate will skip every version under that name.
+#
+# DO NOT add packages here without reading the actual install script body.
+
+# evanw/esbuild downloads the platform-specific native binary
+# (esbuild-linux-x64, etc.) in its postinstall. Used transitively by
+# vitest for dev-only test transforms; no runtime exposure.
+esbuild

--- a/studio/frontend/.install-script-allowlist
+++ b/studio/frontend/.install-script-allowlist
@@ -3,13 +3,15 @@
 # refuses any newly-added install-script dep by default; entries listed here
 # are explicitly skipped.
 #
-# Add a package name on its own line, and a one-line comment above it
-# describing what the postinstall does and why it's safe. Pin to the
-# package name only -- the gate will skip every version under that name.
+# Pin EACH entry to an exact "name@version" so a maintainer compromise that
+# ships a new malicious version is not silently swept under the same line.
+# Lines starting with "#" are comments; blank lines are ignored.
 #
 # DO NOT add packages here without reading the actual install script body.
+# Allowlist entries MUST land on main first; the gate rejects head-only
+# additions so a PR cannot allowlist its own new postinstall dep.
 
 # evanw/esbuild downloads the platform-specific native binary
 # (esbuild-linux-x64, etc.) in its postinstall. Used transitively by
 # vitest for dev-only test transforms; no runtime exposure.
-esbuild
+esbuild@0.21.5

--- a/studio/frontend/package-lock.json
+++ b/studio/frontend/package-lock.json
@@ -45,6 +45,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "dexie": "^4.3.0",
+        "dompurify": "^3.4.2",
         "fflate": "0.8.3",
         "js-yaml": "^4.1.1",
         "katex": "^0.16.28",
@@ -72,6 +73,9 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@eslint/js": "^9.39.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/canvas-confetti": "^1.9.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.2",
@@ -83,9 +87,11 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^25.0.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.55.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^2.1.9"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -103,6 +109,27 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@assistant-ui/core": {
       "version": "0.1.17",
@@ -891,6 +918,121 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
       "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@dagrejs/dagre": {
       "version": "2.0.4",
@@ -5609,6 +5751,395 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -6239,6 +6770,68 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@toolwind/corner-shape": {
       "version": "0.0.8-3",
       "resolved": "https://registry.npmjs.org/@toolwind/corner-shape/-/corner-shape-0.0.8-3.tgz",
@@ -6319,6 +6912,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/canvas-confetti": {
       "version": "1.9.0",
@@ -7070,6 +7670,106 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -7251,6 +7951,19 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -7267,6 +7980,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/assistant-cloud": {
@@ -7300,6 +8033,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -7476,6 +8216,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -7554,6 +8304,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7625,6 +8392,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chevrotain": {
@@ -7806,6 +8583,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -7973,6 +8763,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -8498,6 +9309,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -8537,6 +9362,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -8568,6 +9400,16 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -8633,6 +9475,16 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -8701,6 +9553,13 @@
       "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
       "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -8851,6 +9710,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -8858,6 +9724,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9098,6 +9980,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9162,6 +10054,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -9473,6 +10375,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9542,6 +10484,20 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -9737,6 +10693,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10042,6 +11014,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -10080,6 +11065,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -10382,6 +11381,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -10494,6 +11500,80 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/jsesc": {
@@ -11009,6 +12089,13 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11025,6 +12112,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -12391,6 +13488,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12766,6 +13870,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12820,6 +13934,34 @@
         "points-on-curve": "0.2.0"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
@@ -12831,6 +13973,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/powershell-utils": {
@@ -12854,6 +14014,38 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -13715,6 +14907,51 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/roughjs": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
@@ -13752,6 +14989,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -13805,6 +15049,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -13975,52 +15232,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/shadcn/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/shadcn/node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/shadcn/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -14139,6 +15350,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -14201,6 +15419,13 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -14209,6 +15434,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -14429,6 +15661,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -14476,6 +15715,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -14499,6 +15745,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -14550,6 +15826,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -15232,64 +16521,1121 @@
         }
       }
     },
-    "node_modules/vite/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "node": ">=12"
       }
     },
-    "node_modules/vite/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
       ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
       }
     },
     "node_modules/vscode-jsonrpc": {
@@ -15341,6 +17687,19 @@
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -15360,6 +17719,54 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -15373,6 +17780,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -15444,6 +17868,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -15460,6 +17906,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
@@ -15468,6 +17924,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -13,7 +13,9 @@
     "preview": "vite preview",
     "typecheck": "tsc -b --pretty false",
     "biome:check": "biome check .",
-    "biome:fix": "biome check . --write"
+    "biome:fix": "biome check . --write",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@assistant-ui/core": "0.1.17",
@@ -53,6 +55,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "dexie": "^4.3.0",
+    "dompurify": "^3.4.2",
     "fflate": "0.8.3",
     "js-yaml": "^4.1.1",
     "katex": "^0.16.28",
@@ -91,13 +94,18 @@
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^25.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.55.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  HtmlSvgRenderer,
+  isHtmlFence,
+  isSvgFence,
+  parseCodeFence,
+  sanitizeSvgSource,
+} from "../html-svg-renderer";
+
+describe("HtmlSvgRenderer", () => {
+  it("renders an HTML preview inside a sandboxed iframe by default", () => {
+    const html = "<html><body><h1>hello</h1></body></html>";
+    render(<HtmlSvgRenderer language="html" source={html} />);
+
+    const root = screen.getByTestId("html-svg-renderer");
+    expect(root.getAttribute("data-active-tab")).toBe("preview");
+    expect(root.getAttribute("data-language")).toBe("html");
+
+    const iframe = screen.getByTestId(
+      "html-svg-renderer-iframe",
+    ) as HTMLIFrameElement;
+    expect(iframe.tagName).toBe("IFRAME");
+    // SECURITY: allow-scripts only; never allow-same-origin or
+    // allow-top-navigation. If this ever changes, the preview can read
+    // parent.document and exfiltrate session data.
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
+    expect(iframe.getAttribute("sandbox")).not.toContain(
+      "allow-top-navigation",
+    );
+    expect(iframe.getAttribute("srcdoc") ?? iframe.srcdoc).toContain("hello");
+  });
+
+  it("renders an SVG preview and strips malicious <script> + on* payloads", () => {
+    const malicious = `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <circle cx="25" cy="25" r="20" fill="blue" onclick="alert('pwn')" />
+  <script>window.parent.alert("pwn")</script>
+</svg>`;
+
+    render(<HtmlSvgRenderer language="svg" source={malicious} />);
+
+    const previewHost = screen.getByTestId("html-svg-renderer-svg-preview");
+    // The circle survives, but every script tag and on* handler must be
+    // stripped by DOMPurify before the SVG is inserted into the DOM.
+    const circle = previewHost.querySelector("circle");
+    expect(circle).not.toBeNull();
+    expect(circle?.getAttribute("onclick")).toBeNull();
+    expect(previewHost.querySelector("script")).toBeNull();
+    expect(previewHost.innerHTML.toLowerCase()).not.toContain("onclick");
+    expect(previewHost.innerHTML.toLowerCase()).not.toContain("alert");
+  });
+
+  it("toggles between Preview and Code tabs", () => {
+    const html = "<html><body>hi</body></html>";
+    render(
+      <HtmlSvgRenderer
+        language="html"
+        source={html}
+        codeView={<pre data-testid="custom-code-view">{html}</pre>}
+      />,
+    );
+
+    // Default tab is preview.
+    expect(screen.getByTestId("html-svg-renderer-iframe")).toBeTruthy();
+    expect(screen.queryByTestId("custom-code-view")).toBeNull();
+
+    const codeTab = screen.getByRole("tab", { name: /code/i });
+    act(() => {
+      fireEvent.click(codeTab);
+    });
+
+    // Iframe is unmounted, custom code view appears.
+    expect(screen.queryByTestId("html-svg-renderer-iframe")).toBeNull();
+    expect(screen.getByTestId("custom-code-view")).toBeTruthy();
+
+    const previewTab = screen.getByRole("tab", { name: /preview/i });
+    act(() => {
+      fireEvent.click(previewTab);
+    });
+
+    expect(screen.getByTestId("html-svg-renderer-iframe")).toBeTruthy();
+    expect(screen.queryByTestId("custom-code-view")).toBeNull();
+  });
+
+  it("locks to the Code tab while the fence is still streaming in", () => {
+    const html = "<html><body>partial";
+    render(
+      <HtmlSvgRenderer language="html" source={html} isIncomplete={true} />,
+    );
+
+    const root = screen.getByTestId("html-svg-renderer");
+    expect(root.getAttribute("data-active-tab")).toBe("code");
+
+    // Preview tab is rendered but disabled while incomplete so the user can
+    // see the streaming tokens without flicker.
+    const previewTab = screen.getByRole("tab", { name: /preview/i });
+    expect(previewTab.hasAttribute("disabled")).toBe(true);
+  });
+});
+
+describe("Fence helpers", () => {
+  it("parses a typical markdown code fence", () => {
+    const block = "```python\nprint('hi')\n```";
+    const fence = parseCodeFence(block);
+    expect(fence).not.toBeNull();
+    expect(fence?.language).toBe("python");
+    expect(fence?.source).toBe("print('hi')");
+  });
+
+  it("isSvgFence picks up explicit svg fences and html/xml fences that begin with <svg", () => {
+    expect(isSvgFence({ language: "svg", source: "<svg/>" })).toBe(true);
+    expect(
+      isSvgFence({ language: "html", source: "<svg xmlns='...'></svg>" }),
+    ).toBe(true);
+    expect(
+      isSvgFence({
+        language: "xml",
+        source: "<?xml version='1.0'?><svg></svg>",
+      }),
+    ).toBe(true);
+    expect(isSvgFence({ language: "html", source: "<div></div>" })).toBe(false);
+  });
+
+  it("isHtmlFence is true only for non-SVG html fences", () => {
+    expect(isHtmlFence({ language: "html", source: "<div></div>" })).toBe(true);
+    expect(isHtmlFence({ language: "html", source: "<svg></svg>" })).toBe(
+      false,
+    );
+    expect(isHtmlFence({ language: "python", source: "print()" })).toBe(false);
+  });
+
+  it("non-HTML / non-SVG fences are not handled by the renderer", () => {
+    // The markdown pipeline only invokes HtmlSvgRenderer when these helpers
+    // agree the fence is html/svg. A python fence must fall through.
+    const fence = parseCodeFence("```python\nprint('hi')\n```");
+    expect(fence).not.toBeNull();
+    if (!fence) return;
+    expect(isSvgFence(fence)).toBe(false);
+    expect(isHtmlFence(fence)).toBe(false);
+  });
+});
+
+describe("sanitizeSvgSource", () => {
+  it("removes <script>, on* handlers, and javascript: URLs", () => {
+    const malicious = `<svg xmlns="http://www.w3.org/2000/svg">
+  <a href="javascript:alert(1)"><circle cx="5" cy="5" r="4" onload="alert(1)"/></a>
+  <script>alert("pwn")</script>
+</svg>`;
+
+    const clean = sanitizeSvgSource(malicious).toLowerCase();
+    expect(clean).not.toContain("<script");
+    expect(clean).not.toContain("onload");
+    expect(clean).not.toContain("javascript:");
+    expect(clean).toContain("<circle");
+  });
+
+  it("drops <?xml ... ?> processing instructions", () => {
+    const svg = `<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`;
+    const clean = sanitizeSvgSource(svg);
+    expect(clean.startsWith("<?xml")).toBe(false);
+    expect(clean).toContain("<rect");
+  });
+});

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -203,6 +203,23 @@ describe("parseIncompleteCodeFence", () => {
   it("returns null when the block is not a fence at all", () => {
     expect(parseIncompleteCodeFence("just text")).toBeNull();
   });
+
+  it("recovers a final-but-never-closed fence (small LLMs drop the closing ```)", () => {
+    // Regression: live probe against Qwen3-0.6B caught the model emitting a
+    // complete SVG body but no closing ```. parseCodeFence rejects (strict
+    // ``` ... ``` shape), so the StreamdownBlock fallback must still find the
+    // fence via parseIncompleteCodeFence even after streaming completes -- or
+    // HtmlSvgRenderer never mounts and the user sees a plain code block.
+    const finalNoClose =
+      "```svg\n<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\">" +
+      "<circle cx=\"5\" cy=\"5\" r=\"4\" fill=\"orange\"/></svg>";
+    expect(parseCodeFence(finalNoClose)).toBeNull();
+    const fence = parseIncompleteCodeFence(finalNoClose);
+    expect(fence).not.toBeNull();
+    expect(fence?.language).toBe("svg");
+    expect(fence?.source).toContain("<circle");
+    expect(fence?.source).toContain("</svg>");
+  });
 });
 
 describe("Fence helpers", () => {

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -12,9 +12,8 @@ import {
   sanitizeSvgSource,
 } from "../html-svg-renderer";
 
-// HtmlPreview POSTs the source to /api/preview/html to obtain a same-origin
-// URL whose response CSP permits inline scripts. Tests fake this round-trip
-// so the iframe enters a deterministic post-load state.
+// Fake the /api/preview/html POST round-trip so the iframe reaches a
+// deterministic post-load state under jsdom.
 let _previewIdCounter = 0;
 function installFetchStub(): void {
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
@@ -54,16 +53,9 @@ describe("HtmlSvgRenderer", () => {
       "html-svg-renderer-iframe",
     ) as HTMLIFrameElement;
     expect(iframe.tagName).toBe("IFRAME");
-    // SECURITY: allow-scripts + allow-modals let assistant inline scripts
-    // / alert / confirm run in the backend-served preview, which carries
-    // a response CSP wide enough to execute them. allow-popups lets
-    // ``<base target="_blank">`` links open without being silently
-    // dropped; popups INHERIT the sandbox (allow-popups-to-escape-sandbox
-    // is intentionally absent) so an opened tab cannot use
-    // window.opener.top.location.* to tabnab the Studio tab.
-    // allow-same-origin and allow-top-navigation are NEVER granted, so
-    // even though the URL is same-origin the iframe document is treated
-    // as a unique opaque origin and cannot reach window.parent.
+    // allow-scripts/allow-modals/allow-popups grant the runtime the
+    // route CSP unlocks; NOT granting allow-same-origin / allow-top-nav /
+    // allow-popups-to-escape-sandbox blocks parent access and tabnabbing.
     const sandbox = iframe.getAttribute("sandbox") ?? "";
     const sandboxTokens = sandbox.split(/\s+/);
     expect(sandboxTokens).toContain("allow-scripts");
@@ -73,12 +65,10 @@ describe("HtmlSvgRenderer", () => {
     expect(sandbox).not.toContain("allow-same-origin");
     expect(sandbox).not.toContain("allow-top-navigation");
 
-    // While the preview API call is in-flight the iframe holds
-    // about:blank rather than flashing the previous preview.
+    // In-flight: about:blank (no flash of previous preview).
     expect(["about:blank", null]).toContain(iframe.getAttribute("src"));
 
-    // After the POST resolves, the iframe src points at the same-origin
-    // preview URL the backend returned.
+    // After POST resolves: iframe src is the returned same-origin URL.
     await waitFor(() => {
       expect(iframe.getAttribute("data-preview-state")).toBe("ready");
     });
@@ -117,17 +107,14 @@ describe("HtmlSvgRenderer", () => {
       "html-svg-renderer-svg-preview",
     ) as HTMLIFrameElement;
     expect(iframe.tagName).toBe("IFRAME");
-    // SECURITY: SVG iframe must NEVER allow scripts or same-origin -- those
-    // would re-introduce the host-page-leak / XSS regressions the iframe
-    // boundary is here to prevent.
+    // SVG iframe must NEVER allow scripts or same-origin (XSS / host leak).
     expect(iframe.getAttribute("sandbox")).toBe("");
     const srcdoc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc).toLowerCase();
     expect(srcdoc).toContain("<circle");
     expect(srcdoc).not.toContain("<script");
     expect(srcdoc).not.toContain("onclick");
     expect(srcdoc).not.toContain("alert");
-    // CSP is the second line of defence: block all network egress except
-    // data: images so a future sanitizer regression cannot beacon out.
+    // CSP backstop: data: images only so a sanitizer regression cannot beacon.
     expect(srcdoc).toContain("default-src 'none'");
   });
 
@@ -147,8 +134,7 @@ describe("HtmlSvgRenderer", () => {
     ) as HTMLIFrameElement;
     expect(iframe).toBeTruthy();
     expect(screen.queryByTestId("custom-code-view")).toBeNull();
-    // Wait for the preview POST to settle so the act() warning that follows
-    // an async state update outside an act() block does not fire.
+    // Settle the preview POST so it does not raise an out-of-act() warning.
     await waitFor(() => {
       expect(iframe.getAttribute("data-preview-state")).toBe("ready");
     });
@@ -180,8 +166,7 @@ describe("HtmlSvgRenderer", () => {
     const root = screen.getByTestId("html-svg-renderer");
     expect(root.getAttribute("data-active-tab")).toBe("code");
 
-    // Preview tab is rendered but disabled while incomplete so the user can
-    // see the streaming tokens without flicker.
+    // Preview disabled while streaming so users see tokens, not flicker.
     const previewTab = screen.getByRole("tab", { name: /preview/i });
     expect(previewTab.hasAttribute("disabled")).toBe(true);
   });
@@ -195,7 +180,6 @@ describe("HtmlSvgRenderer", () => {
     await waitFor(() => {
       expect(iframe.getAttribute("data-preview-state")).toBe("ready");
     });
-    // The fetch stub installed in beforeEach captured exactly one call.
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
       .calls[0] as [string, RequestInit];
@@ -204,8 +188,7 @@ describe("HtmlSvgRenderer", () => {
     expect(init.credentials).toBe("same-origin");
     const parsedBody = JSON.parse(init.body as string) as { source: string };
     expect(parsedBody.source).toBe(html);
-    // After the API returns, the iframe src holds the returned same-origin
-    // path (no srcdoc); the backend response CSP is what unlocks scripts.
+    // iframe lands on the token URL; no srcdoc.
     const src = iframe.getAttribute("src") ?? "";
     expect(src.startsWith("/api/preview/html/")).toBe(true);
     expect(iframe.getAttribute("srcdoc")).toBeNull();
@@ -233,8 +216,7 @@ describe("HtmlSvgRenderer", () => {
       previewTab.getAttribute("id"),
     );
 
-    // Roving tabindex: active tab is reachable, inactive is taken out of the
-    // tab order per WAI-ARIA APG tab pattern.
+    // Roving tabindex per WAI-ARIA APG tab pattern.
     expect(previewTab.getAttribute("tabindex")).toBe("0");
     expect(codeTab.getAttribute("tabindex")).toBe("-1");
   });
@@ -248,8 +230,7 @@ describe("HtmlSvgRenderer", () => {
       "html-svg-renderer-svg-preview",
     ) as HTMLIFrameElement;
     const srcdoc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc).toLowerCase();
-    // The inner stylesheet must cap BOTH dimensions so the SVG fits inside
-    // the fixed-height iframe and is not clipped at the bottom.
+    // Cap BOTH dimensions or a square viewBox clips vertically.
     expect(srcdoc).toContain("max-width:100%");
     expect(srcdoc).toContain("max-height:100%");
     expect(srcdoc).toContain("height:100%");
@@ -276,11 +257,8 @@ describe("parseIncompleteCodeFence", () => {
   });
 
   it("recovers a final-but-never-closed fence (small LLMs drop the closing ```)", () => {
-    // Regression: live probe against Qwen3-0.6B caught the model emitting a
-    // complete SVG body but no closing ```. parseCodeFence rejects (strict
-    // ``` ... ``` shape), so the StreamdownBlock fallback must still find the
-    // fence via parseIncompleteCodeFence even after streaming completes -- or
-    // HtmlSvgRenderer never mounts and the user sees a plain code block.
+    // Regression caught by live Qwen3-0.6B probe: complete body, no closing
+    // ```. Without this path HtmlSvgRenderer would not mount.
     const finalNoClose =
       "```svg\n<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\">" +
       "<circle cx=\"5\" cy=\"5\" r=\"4\" fill=\"orange\"/></svg>";
@@ -325,8 +303,7 @@ describe("Fence helpers", () => {
   });
 
   it("non-HTML / non-SVG fences are not handled by the renderer", () => {
-    // The markdown pipeline only invokes HtmlSvgRenderer when these helpers
-    // agree the fence is html/svg. A python fence must fall through.
+    // markdown-text.tsx invokes HtmlSvgRenderer only when these agree.
     const fence = parseCodeFence("```python\nprint('hi')\n```");
     expect(fence).not.toBeNull();
     if (!fence) return;
@@ -357,12 +334,8 @@ describe("sanitizeSvgSource", () => {
   });
 
   it("keeps inline <style> blocks so class-styled SVG exports still render", () => {
-    // The SVG preview iframe is fully sandboxed (sandbox="") and the
-    // inner CSP is default-src 'none', so the iframe's <style> cannot
-    // reach the host page selectors or fetch external URLs (CSP blocks
-    // @import / url(...)). Stripping <style> broke legitimate class-
-    // styled SVG exports from many diagram tools, which is the bigger
-    // real-world cost than the (already-mitigated) selector leak.
+    // Iframe sandbox="" + default-src 'none' contain <style> blast radius;
+    // diagram exporters relying on class styles outweigh the selector leak.
     const svg = `<svg xmlns="http://www.w3.org/2000/svg"><style>.fg{fill:red}</style><rect class="fg"/></svg>`;
     const clean = sanitizeSvgSource(svg).toLowerCase();
     expect(clean).toContain("<style");
@@ -408,7 +381,7 @@ describe("sanitizeSvgSource", () => {
       "<circle fill=\"url(#g1)\" r=\"10\"/>" +
       "</svg>";
     const clean = sanitizeSvgSource(svg).toLowerCase();
-    // Fragment hrefs must survive so textPath/gradient refs still resolve.
+    // Fragment hrefs must survive so textPath / gradient refs resolve.
     expect(clean).toContain("href=\"#labelpath\"");
   });
 

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -27,10 +27,16 @@ describe("HtmlSvgRenderer", () => {
     expect(iframe.tagName).toBe("IFRAME");
     // SECURITY: allow-scripts + allow-modals leave script / alert /
     // confirm operative IF the inherited host CSP ever permits inline;
-    // NEVER allow-same-origin or allow-top-navigation -- those would let
+    // allow-popups + allow-popups-to-escape-sandbox so a `<base
+    // target="_blank">` link does not silently no-op; NEVER
+    // allow-same-origin or allow-top-navigation -- those would let
     // the preview read parent.document and exfiltrate session data.
     const sandbox = iframe.getAttribute("sandbox") ?? "";
-    expect(sandbox.split(/\s+/)).toContain("allow-scripts");
+    const sandboxTokens = sandbox.split(/\s+/);
+    expect(sandboxTokens).toContain("allow-scripts");
+    expect(sandboxTokens).toContain("allow-modals");
+    expect(sandboxTokens).toContain("allow-popups");
+    expect(sandboxTokens).toContain("allow-popups-to-escape-sandbox");
     expect(sandbox).not.toContain("allow-same-origin");
     expect(sandbox).not.toContain("allow-top-navigation");
     // srcdoc carries the assistant HTML plus a defense-in-depth meta CSP

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -35,7 +35,7 @@ describe("HtmlSvgRenderer", () => {
     expect(iframe.getAttribute("srcdoc") ?? iframe.srcdoc).toContain("hello");
   });
 
-  it("renders an SVG preview and strips malicious <script> + on* payloads", () => {
+  it("renders an SVG preview inside a no-script sandboxed iframe with srcdoc carrying the sanitized markup", () => {
     const malicious = `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
   <circle cx="25" cy="25" r="20" fill="blue" onclick="alert('pwn')" />
   <script>window.parent.alert("pwn")</script>
@@ -43,15 +43,22 @@ describe("HtmlSvgRenderer", () => {
 
     render(<HtmlSvgRenderer language="svg" source={malicious} />);
 
-    const previewHost = screen.getByTestId("html-svg-renderer-svg-preview");
-    // The circle survives, but every script tag and on* handler must be
-    // stripped by DOMPurify before the SVG is inserted into the DOM.
-    const circle = previewHost.querySelector("circle");
-    expect(circle).not.toBeNull();
-    expect(circle?.getAttribute("onclick")).toBeNull();
-    expect(previewHost.querySelector("script")).toBeNull();
-    expect(previewHost.innerHTML.toLowerCase()).not.toContain("onclick");
-    expect(previewHost.innerHTML.toLowerCase()).not.toContain("alert");
+    const iframe = screen.getByTestId(
+      "html-svg-renderer-svg-preview",
+    ) as HTMLIFrameElement;
+    expect(iframe.tagName).toBe("IFRAME");
+    // SECURITY: SVG iframe must NEVER allow scripts or same-origin -- those
+    // would re-introduce the host-page-leak / XSS regressions the iframe
+    // boundary is here to prevent.
+    expect(iframe.getAttribute("sandbox")).toBe("");
+    const srcdoc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc).toLowerCase();
+    expect(srcdoc).toContain("<circle");
+    expect(srcdoc).not.toContain("<script");
+    expect(srcdoc).not.toContain("onclick");
+    expect(srcdoc).not.toContain("alert");
+    // CSP is the second line of defence: block all network egress except
+    // data: images so a future sanitizer regression cannot beacon out.
+    expect(srcdoc).toContain("default-src 'none'");
   });
 
   it("toggles between Preview and Code tabs", () => {
@@ -163,5 +170,29 @@ describe("sanitizeSvgSource", () => {
     const clean = sanitizeSvgSource(svg);
     expect(clean.startsWith("<?xml")).toBe(false);
     expect(clean).toContain("<rect");
+  });
+
+  it("strips inline <style> blocks so SVG CSS cannot retarget host selectors", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><style>body{display:none!important}</style><rect/></svg>`;
+    const clean = sanitizeSvgSource(svg).toLowerCase();
+    expect(clean).not.toContain("<style");
+    expect(clean).not.toContain("display:none");
+    expect(clean).toContain("<rect");
+  });
+
+  it("strips style attributes so inline CSS cannot fire url()/@import requests", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><circle style="background:url(https://evil.example/x)"/></svg>`;
+    const clean = sanitizeSvgSource(svg).toLowerCase();
+    expect(clean).toContain("<circle");
+    expect(clean).not.toContain("style=");
+    expect(clean).not.toContain("evil.example");
+  });
+
+  it("drops <image>/<use> tags so SVG cannot beacon to external URLs", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><image href="https://evil.example/pixel"/><use xlink:href="https://evil.example/use"/></svg>`;
+    const clean = sanitizeSvgSource(svg).toLowerCase();
+    expect(clean).not.toContain("<image");
+    expect(clean).not.toContain("<use");
+    expect(clean).not.toContain("evil.example");
   });
 });

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -268,12 +268,19 @@ describe("sanitizeSvgSource", () => {
     expect(clean).toContain("<rect");
   });
 
-  it("strips inline <style> blocks so SVG CSS cannot retarget host selectors", () => {
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><style>body{display:none!important}</style><rect/></svg>`;
+  it("keeps inline <style> blocks so class-styled SVG exports still render", () => {
+    // The SVG preview iframe is fully sandboxed (sandbox="") and the
+    // inner CSP is default-src 'none', so the iframe's <style> cannot
+    // reach the host page selectors or fetch external URLs (CSP blocks
+    // @import / url(...)). Stripping <style> broke legitimate class-
+    // styled SVG exports from many diagram tools, which is the bigger
+    // real-world cost than the (already-mitigated) selector leak.
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><style>.fg{fill:red}</style><rect class="fg"/></svg>`;
     const clean = sanitizeSvgSource(svg).toLowerCase();
-    expect(clean).not.toContain("<style");
-    expect(clean).not.toContain("display:none");
+    expect(clean).toContain("<style");
+    expect(clean).toContain(".fg");
     expect(clean).toContain("<rect");
+    expect(clean).toContain('class="fg"');
   });
 
   it("strips style attributes so inline CSS cannot fire url()/@import requests", () => {

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -8,6 +8,7 @@ import {
   isHtmlFence,
   isSvgFence,
   parseCodeFence,
+  parseIncompleteCodeFence,
   sanitizeSvgSource,
 } from "../html-svg-renderer";
 
@@ -24,15 +25,25 @@ describe("HtmlSvgRenderer", () => {
       "html-svg-renderer-iframe",
     ) as HTMLIFrameElement;
     expect(iframe.tagName).toBe("IFRAME");
-    // SECURITY: allow-scripts only; never allow-same-origin or
-    // allow-top-navigation. If this ever changes, the preview can read
-    // parent.document and exfiltrate session data.
-    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
-    expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
-    expect(iframe.getAttribute("sandbox")).not.toContain(
-      "allow-top-navigation",
-    );
-    expect(iframe.getAttribute("srcdoc") ?? iframe.srcdoc).toContain("hello");
+    // SECURITY: allow-scripts + allow-modals leave script / alert /
+    // confirm operative IF the inherited host CSP ever permits inline;
+    // NEVER allow-same-origin or allow-top-navigation -- those would let
+    // the preview read parent.document and exfiltrate session data.
+    const sandbox = iframe.getAttribute("sandbox") ?? "";
+    expect(sandbox.split(/\s+/)).toContain("allow-scripts");
+    expect(sandbox).not.toContain("allow-same-origin");
+    expect(sandbox).not.toContain("allow-top-navigation");
+    // srcdoc carries the assistant HTML plus a defense-in-depth meta CSP
+    // that adds ``connect-src 'none'`` and ``frame-src 'none'`` on top of
+    // the inherited host CSP. Inline ``<script>`` does NOT execute (the
+    // host CSP ``script-src 'self'`` strips it); the iframe is here to
+    // render layout/markup, not to run assistant JS.
+    expect(iframe.getAttribute("src")).toBeNull();
+    const srcdoc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc) ?? "";
+    expect(srcdoc).toContain("hello");
+    expect(srcdoc).toContain('http-equiv="Content-Security-Policy"');
+    expect(srcdoc).toContain("connect-src 'none'");
+    expect(srcdoc).toContain("frame-src 'none'");
   });
 
   it("renders an SVG preview inside a no-script sandboxed iframe with srcdoc carrying the sanitized markup", () => {
@@ -106,6 +117,63 @@ describe("HtmlSvgRenderer", () => {
     // see the streaming tokens without flicker.
     const previewTab = screen.getByRole("tab", { name: /preview/i });
     expect(previewTab.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("wires tabs to their panels with aria-controls / aria-labelledby", () => {
+    const html = "<html><body>hi</body></html>";
+    render(<HtmlSvgRenderer language="html" source={html} />);
+
+    const previewTab = screen.getByRole("tab", { name: /preview/i });
+    const codeTab = screen.getByRole("tab", { name: /code/i });
+    const panel = screen.getByRole("tabpanel");
+
+    const controls = previewTab.getAttribute("aria-controls");
+    expect(controls).toBeTruthy();
+    expect(panel.getAttribute("id")).toBe(controls);
+    expect(panel.getAttribute("aria-labelledby")).toBe(
+      previewTab.getAttribute("id"),
+    );
+
+    // Roving tabindex: active tab is reachable, inactive is taken out of the
+    // tab order per WAI-ARIA APG tab pattern.
+    expect(previewTab.getAttribute("tabindex")).toBe("0");
+    expect(codeTab.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("constrains the SVG preview so a square viewBox does not overflow", () => {
+    const svg =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 200 200\"><circle cx=\"100\" cy=\"100\" r=\"95\" fill=\"red\"/></svg>";
+    render(<HtmlSvgRenderer language="svg" source={svg} />);
+
+    const iframe = screen.getByTestId(
+      "html-svg-renderer-svg-preview",
+    ) as HTMLIFrameElement;
+    const srcdoc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc).toLowerCase();
+    // The inner stylesheet must cap BOTH dimensions so the SVG fits inside
+    // the fixed-height iframe and is not clipped at the bottom.
+    expect(srcdoc).toContain("max-width:100%");
+    expect(srcdoc).toContain("max-height:100%");
+    expect(srcdoc).toContain("height:100%");
+  });
+});
+
+describe("parseIncompleteCodeFence", () => {
+  it("returns lang and body for a fence that has not closed yet", () => {
+    const partial = "```svg\n<svg><circle";
+    const fence = parseIncompleteCodeFence(partial);
+    expect(fence).not.toBeNull();
+    expect(fence?.language).toBe("svg");
+    expect(fence?.source).toBe("<svg><circle");
+  });
+
+  it("strips an in-flight trailing ``` so the partial body does not leak it", () => {
+    const partial = "```html\n<div>hi</div>\n``";
+    const fence = parseIncompleteCodeFence(partial);
+    expect(fence?.source).toBe("<div>hi</div>\n``");
+  });
+
+  it("returns null when the block is not a fence at all", () => {
+    expect(parseIncompleteCodeFence("just text")).toBeNull();
   });
 });
 
@@ -194,5 +262,40 @@ describe("sanitizeSvgSource", () => {
     expect(clean).not.toContain("<image");
     expect(clean).not.toContain("<use");
     expect(clean).not.toContain("evil.example");
+  });
+
+  it("strips filter/mask/clip-path url(...) attrs that would still fetch", () => {
+    const svg =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\">" +
+      "<circle filter=\"url(https://evil.example/f)\" mask=\"url(https://evil.example/m)\" clip-path=\"url(https://evil.example/c)\" r=\"10\"/>" +
+      "</svg>";
+    const clean = sanitizeSvgSource(svg).toLowerCase();
+    expect(clean).toContain("<circle");
+    expect(clean).not.toContain("filter=");
+    expect(clean).not.toContain("mask=");
+    expect(clean).not.toContain("clip-path=");
+    expect(clean).not.toContain("evil.example");
+  });
+
+  it("keeps safe same-document fragment hrefs used by textPath/gradients", () => {
+    const svg =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\">" +
+      "<defs><linearGradient id=\"g1\"/></defs>" +
+      "<text><textPath href=\"#labelPath\">hi</textPath></text>" +
+      "<circle fill=\"url(#g1)\" r=\"10\"/>" +
+      "</svg>";
+    const clean = sanitizeSvgSource(svg).toLowerCase();
+    // Fragment hrefs must survive so textPath/gradient refs still resolve.
+    expect(clean).toContain("href=\"#labelpath\"");
+  });
+
+  it("strips external-scheme hrefs even though same-doc fragments are kept", () => {
+    const svg =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\">" +
+      "<a href=\"https://evil.example/exfil\"><circle r=\"10\"/></a>" +
+      "</svg>";
+    const clean = sanitizeSvgSource(svg).toLowerCase();
+    expect(clean).not.toContain("evil.example");
+    expect(clean).not.toContain("href=\"https");
   });
 });

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -39,11 +39,14 @@ describe("HtmlSvgRenderer", () => {
     expect(sandboxTokens).toContain("allow-popups-to-escape-sandbox");
     expect(sandbox).not.toContain("allow-same-origin");
     expect(sandbox).not.toContain("allow-top-navigation");
-    // srcdoc carries the assistant HTML plus a defense-in-depth meta CSP
-    // that adds ``connect-src 'none'`` and ``frame-src 'none'`` on top of
-    // the inherited host CSP. Inline ``<script>`` does NOT execute (the
-    // host CSP ``script-src 'self'`` strips it); the iframe is here to
-    // render layout/markup, not to run assistant JS.
+    // srcdoc carries the assistant HTML plus a defense-in-depth meta
+    // CSP (connect-src 'none', frame-src 'none', img-src data: blob:
+    // only). Inline <script> / on* handlers do NOT execute today
+    // because Chromium inherits the host CSP for srcdoc iframes
+    // (also for blob: and data: -- empirically reproduced) and the
+    // host enforces ``script-src 'self'``. The preview is for layout
+    // / styles / images / source viewing; interactive demos are a
+    // documented follow-up that needs a same-origin backend route.
     expect(iframe.getAttribute("src")).toBeNull();
     const srcdoc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc) ?? "";
     expect(srcdoc).toContain("hello");
@@ -123,6 +126,23 @@ describe("HtmlSvgRenderer", () => {
     // see the streaming tokens without flicker.
     const previewTab = screen.getByRole("tab", { name: /preview/i });
     expect(previewTab.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("srcdoc payload carries the defense-in-depth meta CSP", () => {
+    const html = "<button onclick=\"alert('x')\">go</button>";
+    render(<HtmlSvgRenderer language="html" source={html} />);
+    const iframe = screen.getByTestId(
+      "html-svg-renderer-iframe",
+    ) as HTMLIFrameElement;
+    const doc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc) ?? "";
+    expect(doc).toContain("<button");
+    expect(doc).toContain('http-equiv="Content-Security-Policy"');
+    // Network egress is blocked regardless of script execution.
+    expect(doc).toContain("connect-src 'none'");
+    expect(doc).toContain("frame-src 'none'");
+    // ``<base target="_blank">`` keeps link clicks from replacing the
+    // iframe content with a navigation away from the preview.
+    expect(doc).toContain('<base target="_blank">');
   });
 
   it("wires tabs to their panels with aria-controls / aria-labelledby", () => {

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HtmlSvgRenderer,
   isHtmlFence,
@@ -12,8 +12,37 @@ import {
   sanitizeSvgSource,
 } from "../html-svg-renderer";
 
+// HtmlPreview POSTs the source to /api/preview/html to obtain a same-origin
+// URL whose response CSP permits inline scripts. Tests fake this round-trip
+// so the iframe enters a deterministic post-load state.
+let _previewIdCounter = 0;
+function installFetchStub(): void {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    if (typeof input === "string" && input === "/api/preview/html") {
+      const url = `/api/preview/html/test-token-${++_previewIdCounter}`;
+      return new Response(JSON.stringify({ url }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("not-found", { status: 404 });
+  }) as typeof fetch;
+}
+function installFailingFetchStub(): void {
+  globalThis.fetch = vi.fn(async () =>
+    new Response("server boom", { status: 500 }),
+  ) as typeof fetch;
+}
+
 describe("HtmlSvgRenderer", () => {
-  it("renders an HTML preview inside a sandboxed iframe by default", () => {
+  beforeEach(() => {
+    installFetchStub();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders an HTML preview inside a sandboxed iframe pointing at the same-origin preview route", async () => {
     const html = "<html><body><h1>hello</h1></body></html>";
     render(<HtmlSvgRenderer language="html" source={html} />);
 
@@ -25,14 +54,16 @@ describe("HtmlSvgRenderer", () => {
       "html-svg-renderer-iframe",
     ) as HTMLIFrameElement;
     expect(iframe.tagName).toBe("IFRAME");
-    // SECURITY: allow-scripts + allow-modals leave script / alert /
-    // confirm operative if the inherited host CSP ever permits inline.
-    // allow-popups lets ``<base target="_blank">`` links open without
-    // being silently dropped, BUT the popups INHERIT the sandbox
-    // (allow-popups-to-escape-sandbox is intentionally absent) so a
-    // tab opened from a malicious assistant link cannot use
+    // SECURITY: allow-scripts + allow-modals let assistant inline scripts
+    // / alert / confirm run in the backend-served preview, which carries
+    // a response CSP wide enough to execute them. allow-popups lets
+    // ``<base target="_blank">`` links open without being silently
+    // dropped; popups INHERIT the sandbox (allow-popups-to-escape-sandbox
+    // is intentionally absent) so an opened tab cannot use
     // window.opener.top.location.* to tabnab the Studio tab.
-    // allow-same-origin and allow-top-navigation are NEVER granted.
+    // allow-same-origin and allow-top-navigation are NEVER granted, so
+    // even though the URL is same-origin the iframe document is treated
+    // as a unique opaque origin and cannot reach window.parent.
     const sandbox = iframe.getAttribute("sandbox") ?? "";
     const sandboxTokens = sandbox.split(/\s+/);
     expect(sandboxTokens).toContain("allow-scripts");
@@ -41,17 +72,34 @@ describe("HtmlSvgRenderer", () => {
     expect(sandboxTokens).not.toContain("allow-popups-to-escape-sandbox");
     expect(sandbox).not.toContain("allow-same-origin");
     expect(sandbox).not.toContain("allow-top-navigation");
-    // srcdoc carries the assistant HTML plus a defense-in-depth meta
-    // CSP (connect-src 'none', frame-src 'none', img-src data: blob:
-    // only). Inline <script> / on* handlers do NOT execute today
-    // because Chromium inherits the host CSP for srcdoc iframes
-    // (also for blob: and data: -- empirically reproduced) and the
-    // host enforces ``script-src 'self'``. The preview is for layout
-    // / styles / images / source viewing; interactive demos are a
-    // documented follow-up that needs a same-origin backend route.
-    expect(iframe.getAttribute("src")).toBeNull();
+
+    // While the preview API call is in-flight the iframe holds
+    // about:blank rather than flashing the previous preview.
+    expect(["about:blank", null]).toContain(iframe.getAttribute("src"));
+
+    // After the POST resolves, the iframe src points at the same-origin
+    // preview URL the backend returned.
+    await waitFor(() => {
+      expect(iframe.getAttribute("data-preview-state")).toBe("ready");
+    });
+    const src = iframe.getAttribute("src") ?? "";
+    expect(src.startsWith("/api/preview/html/")).toBe(true);
+    expect(iframe.getAttribute("srcdoc")).toBeNull();
+  });
+
+  it("falls back to srcdoc with the defense-in-depth meta CSP when the preview API is unreachable", async () => {
+    installFailingFetchStub();
+    const html = "<html><body><h1>fallback</h1></body></html>";
+    render(<HtmlSvgRenderer language="html" source={html} />);
+
+    const iframe = screen.getByTestId(
+      "html-svg-renderer-iframe",
+    ) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(iframe.getAttribute("data-preview-state")).toBe("error");
+    });
     const srcdoc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc) ?? "";
-    expect(srcdoc).toContain("hello");
+    expect(srcdoc).toContain("<h1>fallback</h1>");
     expect(srcdoc).toContain('http-equiv="Content-Security-Policy"');
     expect(srcdoc).toContain("connect-src 'none'");
     expect(srcdoc).toContain("frame-src 'none'");
@@ -83,7 +131,7 @@ describe("HtmlSvgRenderer", () => {
     expect(srcdoc).toContain("default-src 'none'");
   });
 
-  it("toggles between Preview and Code tabs", () => {
+  it("toggles between Preview and Code tabs", async () => {
     const html = "<html><body>hi</body></html>";
     render(
       <HtmlSvgRenderer
@@ -94,8 +142,16 @@ describe("HtmlSvgRenderer", () => {
     );
 
     // Default tab is preview.
-    expect(screen.getByTestId("html-svg-renderer-iframe")).toBeTruthy();
+    const iframe = screen.getByTestId(
+      "html-svg-renderer-iframe",
+    ) as HTMLIFrameElement;
+    expect(iframe).toBeTruthy();
     expect(screen.queryByTestId("custom-code-view")).toBeNull();
+    // Wait for the preview POST to settle so the act() warning that follows
+    // an async state update outside an act() block does not fire.
+    await waitFor(() => {
+      expect(iframe.getAttribute("data-preview-state")).toBe("ready");
+    });
 
     const codeTab = screen.getByRole("tab", { name: /code/i });
     act(() => {
@@ -130,26 +186,41 @@ describe("HtmlSvgRenderer", () => {
     expect(previewTab.hasAttribute("disabled")).toBe(true);
   });
 
-  it("srcdoc payload carries the defense-in-depth meta CSP", () => {
+  it("HtmlPreview POSTs the assistant source to /api/preview/html before mounting the iframe src", async () => {
     const html = "<button onclick=\"alert('x')\">go</button>";
     render(<HtmlSvgRenderer language="html" source={html} />);
     const iframe = screen.getByTestId(
       "html-svg-renderer-iframe",
     ) as HTMLIFrameElement;
-    const doc = (iframe.getAttribute("srcdoc") ?? iframe.srcdoc) ?? "";
-    expect(doc).toContain("<button");
-    expect(doc).toContain('http-equiv="Content-Security-Policy"');
-    // Network egress is blocked regardless of script execution.
-    expect(doc).toContain("connect-src 'none'");
-    expect(doc).toContain("frame-src 'none'");
-    // ``<base target="_blank">`` keeps link clicks from replacing the
-    // iframe content with a navigation away from the preview.
-    expect(doc).toContain('<base target="_blank">');
+    await waitFor(() => {
+      expect(iframe.getAttribute("data-preview-state")).toBe("ready");
+    });
+    // The fetch stub installed in beforeEach captured exactly one call.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/preview/html");
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("same-origin");
+    const parsedBody = JSON.parse(init.body as string) as { source: string };
+    expect(parsedBody.source).toBe(html);
+    // After the API returns, the iframe src holds the returned same-origin
+    // path (no srcdoc); the backend response CSP is what unlocks scripts.
+    const src = iframe.getAttribute("src") ?? "";
+    expect(src.startsWith("/api/preview/html/")).toBe(true);
+    expect(iframe.getAttribute("srcdoc")).toBeNull();
   });
 
-  it("wires tabs to their panels with aria-controls / aria-labelledby", () => {
+  it("wires tabs to their panels with aria-controls / aria-labelledby", async () => {
     const html = "<html><body>hi</body></html>";
     render(<HtmlSvgRenderer language="html" source={html} />);
+
+    const iframe = screen.getByTestId(
+      "html-svg-renderer-iframe",
+    ) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(iframe.getAttribute("data-preview-state")).toBe("ready");
+    });
 
     const previewTab = screen.getByRole("tab", { name: /preview/i });
     const codeTab = screen.getByRole("tab", { name: /code/i });

--- a/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
+++ b/studio/frontend/src/components/assistant-ui/__tests__/html-svg-renderer.test.tsx
@@ -26,17 +26,19 @@ describe("HtmlSvgRenderer", () => {
     ) as HTMLIFrameElement;
     expect(iframe.tagName).toBe("IFRAME");
     // SECURITY: allow-scripts + allow-modals leave script / alert /
-    // confirm operative IF the inherited host CSP ever permits inline;
-    // allow-popups + allow-popups-to-escape-sandbox so a `<base
-    // target="_blank">` link does not silently no-op; NEVER
-    // allow-same-origin or allow-top-navigation -- those would let
-    // the preview read parent.document and exfiltrate session data.
+    // confirm operative if the inherited host CSP ever permits inline.
+    // allow-popups lets ``<base target="_blank">`` links open without
+    // being silently dropped, BUT the popups INHERIT the sandbox
+    // (allow-popups-to-escape-sandbox is intentionally absent) so a
+    // tab opened from a malicious assistant link cannot use
+    // window.opener.top.location.* to tabnab the Studio tab.
+    // allow-same-origin and allow-top-navigation are NEVER granted.
     const sandbox = iframe.getAttribute("sandbox") ?? "";
     const sandboxTokens = sandbox.split(/\s+/);
     expect(sandboxTokens).toContain("allow-scripts");
     expect(sandboxTokens).toContain("allow-modals");
     expect(sandboxTokens).toContain("allow-popups");
-    expect(sandboxTokens).toContain("allow-popups-to-escape-sandbox");
+    expect(sandboxTokens).not.toContain("allow-popups-to-escape-sandbox");
     expect(sandbox).not.toContain("allow-same-origin");
     expect(sandbox).not.toContain("allow-top-navigation");
     // srcdoc carries the assistant HTML plus a defense-in-depth meta

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -356,13 +356,18 @@ function HtmlPreview({
       //                           that includes 'unsafe-inline'
       //   allow-modals         -- alert/confirm/prompt are not no-ops
       //                           when scripts do fire
-      //   allow-popups +       -- a ``<base target="_blank">`` link
-      //   allow-popups-to-        opens a regular browser tab rather
-      //   escape-sandbox          than an opaque-origin sandboxed one
-      // We do NOT grant allow-same-origin or allow-top-navigation, so
-      // the iframe cannot read parent.document, navigate the host
-      // page, or escape its origin.
-      sandbox="allow-scripts allow-modals allow-popups allow-popups-to-escape-sandbox"
+      //   allow-popups         -- the ``<base target="_blank">`` link
+      //                           rule can open a new tab instead of
+      //                           silently dropping the click
+      // We do NOT grant:
+      //   allow-same-origin / allow-top-navigation -- the iframe
+      //     cannot read parent.document or navigate the host page
+      //   allow-popups-to-escape-sandbox -- popups INHERIT the sandbox
+      //     so an opened tab cannot use ``window.opener.top.location``
+      //     to tabnab the Studio tab. The opened tab loads with an
+      //     opaque origin (some sites will render degraded) which is
+      //     the deliberate trade-off for tabnabbing safety.
+      sandbox="allow-scripts allow-modals allow-popups"
       style={{
         width: "100%",
         height: iframeHeight,

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -13,6 +13,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -68,14 +69,39 @@ const SVG_PURIFY_CONFIG = {
     "link",
     "meta",
   ],
-  // Drop URL-bearing attributes that would still trigger network requests on
-  // surviving SVG elements (filter url(...), animateMotion mpath, etc.), and
-  // strip inline ``style`` because CSS ``@import`` / ``url()`` would do the
-  // same. DOMPurify already drops on* handlers under USE_PROFILES, but we
-  // call ALLOW_DATA_ATTR off explicitly so the intent is obvious.
-  FORBID_ATTR: ["href", "xlink:href", "style"],
+  // Drop attributes that fetch external resources or otherwise interpret an
+  // attacker-controlled URL even after the tag-level filter above:
+  //   ``filter`` / ``mask`` / ``clip-path`` -- accept ``url(https://...)``
+  //     and the CSS engine fetches that URL when the SVG renders.
+  //   ``style`` -- inline CSS ``@import`` / ``url(...)`` does the same.
+  // ``href`` / ``xlink:href`` are NOT forbidden here so safe same-document
+  // fragment references survive (``<textPath href="#labelPath">``, gradient
+  // ``href="#g1"``, etc.); external-scheme values are pruned in the hook
+  // below so a beacon ``href`` cannot make it through.
+  FORBID_ATTR: ["style", "filter", "mask", "clip-path"],
   ALLOW_DATA_ATTR: false,
 };
+
+// Pin every URI-bearing attribute (href, xlink:href, the rare animate
+// attributeName, etc.) to same-document fragments. Done as a hook rather
+// than DOMPurify's ALLOWED_URI_REGEXP because the regex option also
+// filters non-URI presentation attributes (cx/cy/r/fill/width/height)
+// and ends up rendering circles with r=0. Hook is global so we install
+// it exactly once at module load.
+const FRAGMENT_HREF_HOOK_TAG = "__unsloth_svg_frag_href__";
+const URI_ATTRS = new Set(["href", "xlink:href"]);
+
+if (!(DOMPurify as unknown as { [k: string]: unknown })[FRAGMENT_HREF_HOOK_TAG]) {
+  DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
+    if (!URI_ATTRS.has(data.attrName)) return;
+    const value = (data.attrValue ?? "").trim();
+    if (!value.startsWith("#")) {
+      data.keepAttr = false;
+    }
+  });
+  (DOMPurify as unknown as { [k: string]: unknown })[FRAGMENT_HREF_HOOK_TAG] =
+    true;
+}
 
 /** Strip every XML processing instruction and disallowed node from an SVG. */
 export function sanitizeSvgSource(source: string): string {
@@ -142,12 +168,16 @@ function TabButton({
   active,
   disabled,
   icon,
+  id,
+  controls,
   label,
   onSelect,
 }: {
   active: boolean;
   disabled?: boolean;
   icon: ReactNode;
+  id: string;
+  controls: string;
   label: string;
   onSelect: () => void;
 }) {
@@ -155,7 +185,10 @@ function TabButton({
     <button
       type="button"
       role="tab"
+      id={id}
+      aria-controls={controls}
       aria-selected={active}
+      tabIndex={active ? 0 : -1}
       disabled={disabled}
       onClick={onSelect}
       className={cn(
@@ -183,9 +216,12 @@ function buildSvgSrcDoc(safeSvg: string): string {
   return [
     "<!doctype html>",
     `<meta http-equiv="Content-Security-Policy" content="${SVG_IFRAME_CSP}">`,
-    "<style>html,body{margin:0;padding:0;background:white;}",
-    "body{display:flex;align-items:center;justify-content:center;padding:16px;}",
-    "svg{max-width:100%;height:auto;}</style>",
+    // Fit the SVG within the iframe viewport in both dimensions so a square
+    // viewBox (e.g. 200x200) scaled to the container width does not overflow
+    // vertically and clip. width/height auto keeps aspect ratio intact.
+    "<style>html,body{margin:0;padding:0;height:100%;background:white;}",
+    "body{display:flex;align-items:center;justify-content:center;padding:16px;box-sizing:border-box;}",
+    "svg{max-width:100%;max-height:100%;width:auto;height:auto;}</style>",
     safeSvg,
   ].join("");
 }
@@ -214,24 +250,74 @@ function SvgPreview({ source }: { source: string }) {
   );
 }
 
+// Tiny helper script that posts the document height back to the parent so
+// we can right-size the iframe. Communication is one-way and the iframe
+// cannot read parent.document because we never grant allow-same-origin.
+const HTML_PREVIEW_HEIGHT_REPORTER =
+  '<script>(()=>{const post=()=>parent.postMessage({htmlPreviewHeight:document.documentElement.scrollHeight},"*");window.addEventListener("load",post);new ResizeObserver(post).observe(document.documentElement);})();</script>';
+
+// Meta-CSP enforced INSIDE the srcdoc iframe. The iframe inherits the host
+// Studio CSP (every srcdoc / data: / blob: scheme does, per CSP3 § Initialize
+// document CSP), so the host's ``script-src 'self'`` already blocks inline
+// <script> and on* handlers inside the preview. We layer a more restrictive
+// meta-CSP here so a future host-CSP relaxation does not silently turn this
+// iframe into an exfiltration channel: ``connect-src 'none'`` keeps a
+// future ``script-src 'unsafe-inline'`` from being able to beacon out, and
+// ``frame-src 'none'`` stops nested iframe-loaded ad/tracking content.
+const HTML_IFRAME_CSP = [
+  "default-src 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src data: blob:",
+  "media-src data: blob:",
+  "font-src data:",
+  "connect-src 'none'",
+  "worker-src 'none'",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+].join("; ");
+
+function buildHtmlSrcDoc(source: string): string {
+  return [
+    "<!doctype html>",
+    `<meta http-equiv="Content-Security-Policy" content="${HTML_IFRAME_CSP}">`,
+    // Outbound links open in a new tab rather than no-op-navigating the
+    // sandboxed frame itself.
+    '<base target="_blank">',
+    source,
+    HTML_PREVIEW_HEIGHT_REPORTER,
+  ].join("");
+}
+
 function HtmlPreview({
   source,
   popped,
+  onHeightChange,
 }: {
   source: string;
   popped: boolean;
+  onHeightChange?: (h: number | null) => void;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // Tiny helper script that posts the document height back to the parent so
-  // we can right-size the iframe. Communication is one-way and the iframe
-  // cannot read parent.document because we never grant allow-same-origin.
-  const srcDoc = useMemo(
-    () =>
-      `${source}<script>(()=>{const post=()=>parent.postMessage({htmlPreviewHeight:document.documentElement.scrollHeight},"*");window.addEventListener("load",post);new ResizeObserver(post).observe(document.documentElement);})();</script>`,
-    [source],
-  );
+  // srcdoc keeps the assistant HTML rendering same-origin-blocked while
+  // still showing layout, images, styles, and Streamdown-syntax-highlighted
+  // source in the Code tab. Inline <script> / on* handlers inside the
+  // assistant's HTML do NOT execute because srcdoc iframes inherit the
+  // host Studio CSP (``script-src 'self'``); follow-up work tracked in
+  // PR #5717 to add an opt-in backend-hosted preview route for the "play
+  // JS games inline" use case.
+  const srcDoc = useMemo(() => buildHtmlSrcDoc(source), [source]);
 
   const [autoHeight, setAutoHeight] = useState<number | null>(null);
+  // Reset auto-sizing whenever the source changes so we never show the
+  // previous message's iframe size during the gap before the new doc loads
+  // and posts its first height.
+  useEffect(() => {
+    setAutoHeight(null);
+    onHeightChange?.(null);
+  }, [source, onHeightChange]);
 
   useEffect(() => {
     const handler = (e: MessageEvent) => {
@@ -239,12 +325,14 @@ function HtmlPreview({
       const raw = (e.data as { htmlPreviewHeight?: unknown })
         ?.htmlPreviewHeight;
       if (typeof raw === "number" && Number.isFinite(raw)) {
-        setAutoHeight(Math.max(100, raw));
+        const next = Math.max(100, raw);
+        setAutoHeight(next);
+        onHeightChange?.(next);
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, []);
+  }, [onHeightChange]);
 
   // In the docked view we cap at DEFAULT_PREVIEW_HEIGHT; in the popout we
   // let the iframe fill the modal panel.
@@ -258,10 +346,12 @@ function HtmlPreview({
       data-testid="html-svg-renderer-iframe"
       title="HTML preview"
       srcDoc={srcDoc}
-      // SECURITY: allow-scripts only. We do NOT grant allow-same-origin or
+      // SECURITY: allow-scripts (in case the host CSP ever loosens to
+      // permit inline) + allow-modals (so alert/confirm do not silently
+      // no-op when scripts do run). We do NOT grant allow-same-origin or
       // allow-top-navigation, so the iframe cannot read parent.document,
       // navigate the host page, or escape its origin.
-      sandbox="allow-scripts"
+      sandbox="allow-scripts allow-modals"
       style={{
         width: "100%",
         height: iframeHeight,
@@ -284,8 +374,18 @@ export function HtmlSvgRenderer({
   const lockedToCode = Boolean(isIncomplete);
   const [tab, setTab] = useState<TabKey>("preview");
   const [popped, setPopped] = useState(false);
+  // Live HTML iframe height, lifted out of HtmlPreview so the pop-out spacer
+  // (rendered here, not inside HtmlPreview) can match the current preview
+  // size and avoid a layout jump when entering pop-out mode.
+  const [htmlHeight, setHtmlHeight] = useState<number | null>(null);
 
   const activeTab: TabKey = lockedToCode ? "code" : tab;
+
+  const reactId = useId();
+  const previewTabId = `${reactId}-tab-preview`;
+  const codeTabId = `${reactId}-tab-code`;
+  const previewPanelId = `${reactId}-panel-preview`;
+  const codePanelId = `${reactId}-panel-code`;
 
   // Escape key exits the popout view.
   useEffect(() => {
@@ -307,14 +407,28 @@ export function HtmlSvgRenderer({
     [codeView, source],
   );
 
+  const onHtmlHeight = useCallback((h: number | null) => setHtmlHeight(h), []);
+
   const preview =
     language === "svg" ? (
       <SvgPreview source={source} />
     ) : (
-      <HtmlPreview source={source} popped={popped} />
+      <HtmlPreview
+        source={source}
+        popped={popped}
+        onHeightChange={onHtmlHeight}
+      />
     );
 
   const previewLabel = language === "svg" ? "SVG preview" : "HTML preview";
+  // Use the live HTML iframe height for the pop-out placeholder so swapping
+  // a short preview into pop-out mode does not leave a 500px hole in the
+  // chat bubble. Falls back to DEFAULT_PREVIEW_HEIGHT before the first
+  // height post arrives, and is always capped to DEFAULT_PREVIEW_HEIGHT.
+  const popoutSpacerHeight = Math.min(
+    htmlHeight ?? DEFAULT_PREVIEW_HEIGHT,
+    DEFAULT_PREVIEW_HEIGHT,
+  );
 
   return (
     <div
@@ -333,12 +447,16 @@ export function HtmlSvgRenderer({
             active={activeTab === "preview"}
             disabled={lockedToCode}
             icon={<EyeIcon className="size-3.5" />}
+            id={previewTabId}
+            controls={previewPanelId}
             label="Preview"
             onSelect={() => setTab("preview")}
           />
           <TabButton
             active={activeTab === "code"}
             icon={<CodeIcon className="size-3.5" />}
+            id={codeTabId}
+            controls={codePanelId}
             label="Code"
             onSelect={() => setTab("code")}
           />
@@ -378,10 +496,13 @@ export function HtmlSvgRenderer({
             <>
               {/* Keep layout stable behind the modal. */}
               <div
-                style={{ height: DEFAULT_PREVIEW_HEIGHT }}
+                style={{ height: popoutSpacerHeight }}
                 aria-hidden={true}
               />
               <div
+                role="dialog"
+                aria-modal="true"
+                aria-label="HTML preview pop out"
                 className="fixed inset-0 z-50 flex flex-col bg-background/80 backdrop-blur-sm"
                 onClick={(e) => {
                   if (e.target === e.currentTarget) setPopped(false);
@@ -407,10 +528,23 @@ export function HtmlSvgRenderer({
               </div>
             </>
           ) : (
-            <div aria-label={previewLabel}>{preview}</div>
+            <div
+              role="tabpanel"
+              id={previewPanelId}
+              aria-labelledby={previewTabId}
+              aria-label={previewLabel}
+            >
+              {preview}
+            </div>
           )
         ) : (
-          <div data-testid="html-svg-renderer-code" className="min-w-0">
+          <div
+            role="tabpanel"
+            id={codePanelId}
+            aria-labelledby={codeTabId}
+            data-testid="html-svg-renderer-code"
+            className="min-w-0"
+          >
             {codeFallback}
           </div>
         )}
@@ -427,6 +561,11 @@ export type CodeFenceInfo = {
 };
 
 const CODE_FENCE_RE = /^```([^\r\n`]*)\r?\n([\s\S]*?)\r?\n?```$/;
+// Open fence: opening backticks + lang + body but no closing fence yet. Used
+// while a fenced block is still streaming in -- without this the markdown
+// pipeline falls through to the generic code block until the closing fence
+// arrives, so HtmlSvgRenderer's isIncomplete (lock-Code) path is dead code.
+const OPEN_CODE_FENCE_RE = /^```([^\r\n`]*)\r?\n([\s\S]*)$/;
 
 export function parseCodeFence(blockContent: string): CodeFenceInfo | null {
   const match = blockContent.trimEnd().match(CODE_FENCE_RE);
@@ -434,6 +573,21 @@ export function parseCodeFence(blockContent: string): CodeFenceInfo | null {
   return {
     language: match[1]?.trim() || null,
     source: match[2],
+  };
+}
+
+/** Parse a code fence that may still be streaming (no closing ``` yet). */
+export function parseIncompleteCodeFence(
+  blockContent: string,
+): CodeFenceInfo | null {
+  const match = blockContent.match(OPEN_CODE_FENCE_RE);
+  if (!match) return null;
+  // Strip an in-flight trailing ``` line so a fence captured mid-close does
+  // not render a stray "```" in the preview.
+  const body = match[2].replace(/\r?\n?```\s*$/, "");
+  return {
+    language: match[1]?.trim() || null,
+    source: body,
   };
 }
 

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -24,11 +24,9 @@ export type HtmlSvgLanguage = "html" | "svg";
 export type HtmlSvgRendererProps = {
   language: HtmlSvgLanguage;
   source: string;
-  // Pre-rendered syntax-highlighted code view. Optional; if omitted the
-  // renderer falls back to a plain <pre><code> block.
+  // Optional syntax-highlighted code view; falls back to plain <pre><code>.
   codeView?: ReactNode;
-  // When the markdown stream is still arriving the fence may be partial.
-  // In that case we force the Code tab and disable the toggle controls.
+  // Partial fence: lock to Code tab and disable toggle.
   isIncomplete?: boolean;
 };
 
@@ -36,32 +34,17 @@ const DEFAULT_PREVIEW_HEIGHT = 500;
 const POPOUT_HEIGHT_VH = 80;
 const COPY_RESET_MS = 2000;
 
-// Conservative regex covering the same vectors we previously stripped before
-// DOMPurify was wired in. DOMPurify itself does the heavy lifting; this is
-// belt-and-braces so a quick visual inspection of the source still catches the
-// usual XSS hot spots.
+// Belt-and-braces pre-screen; DOMPurify does the real work below.
 const HEURISTIC_UNSAFE_SVG_RE =
   /<script[\s>]|<foreignObject[\s>]|<iframe[\s>]|<embed[\s>]|<object[\s>]/i;
 
-// SVG previews used to live inside a `<img src="data:image/svg+xml,...">` tag
-// where the browser treats the SVG as an image and disables scripts and
-// external resource loads. Mounting sanitized SVG directly into the host
-// Studio document loses those guarantees, so we now (a) strip every node that
-// can leak into the host page (`<style>`, `<image>`, `<use>`, scripts, etc.)
-// and (b) render the surviving markup in a fully sandboxed iframe at
-// `SvgPreview` below for defence in depth. See:
-// https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/SVG_as_an_image
+// SVG sanitizer config. Surviving markup is rendered in the sandboxed
+// SvgPreview iframe below as a second layer.
 const SVG_PURIFY_CONFIG = {
   USE_PROFILES: { svg: true, svgFilters: true },
-  // ``image`` / ``use`` -- carry ``href``/``xlink:href`` and would let an
-  //   assistant fetch attacker-controlled URLs from the user's browser.
-  // ``foreignObject`` -- can embed HTML inside the SVG and re-introduce XSS.
-  // ``script`` / ``link`` / ``meta`` / ``iframe`` / ``embed`` / ``object``
-  //   are unconditional XSS / network surfaces. ``<style>`` is kept --
-  //   the SVG preview iframe is fully sandboxed (``sandbox=""``) with a
-  //   ``default-src 'none'`` CSP, so class-based styling that real
-  //   diagram exporters emit cannot leak to the host page or fetch
-  //   external URLs (the CSP blocks ``@import`` and ``url(...)``).
+  // image/use carry href, foreignObject embeds HTML, script/link/meta/iframe/
+  // embed/object are XSS or network surfaces. <style> stays -- the iframe
+  // sandbox + default-src 'none' CSP cap its blast radius.
   FORBID_TAGS: [
     "script",
     "foreignObject",
@@ -73,25 +56,16 @@ const SVG_PURIFY_CONFIG = {
     "link",
     "meta",
   ],
-  // Drop attributes that fetch external resources or otherwise interpret an
-  // attacker-controlled URL even after the tag-level filter above:
-  //   ``filter`` / ``mask`` / ``clip-path`` -- accept ``url(https://...)``
-  //     and the CSS engine fetches that URL when the SVG renders.
-  //   ``style`` -- inline CSS ``@import`` / ``url(...)`` does the same.
-  // ``href`` / ``xlink:href`` are NOT forbidden here so safe same-document
-  // fragment references survive (``<textPath href="#labelPath">``, gradient
-  // ``href="#g1"``, etc.); external-scheme values are pruned in the hook
-  // below so a beacon ``href`` cannot make it through.
+  // filter / mask / clip-path accept url(...) which fetches at render time;
+  // style allows inline @import / url(...). href / xlink:href stay so safe
+  // same-doc fragments survive -- external schemes pruned in the hook below.
   FORBID_ATTR: ["style", "filter", "mask", "clip-path"],
   ALLOW_DATA_ATTR: false,
 };
 
-// Pin every URI-bearing attribute (href, xlink:href, the rare animate
-// attributeName, etc.) to same-document fragments. Done as a hook rather
-// than DOMPurify's ALLOWED_URI_REGEXP because the regex option also
-// filters non-URI presentation attributes (cx/cy/r/fill/width/height)
-// and ends up rendering circles with r=0. Hook is global so we install
-// it exactly once at module load.
+// Pin href / xlink:href to same-doc fragments. Done as a hook because
+// DOMPurify's ALLOWED_URI_REGEXP also rejects presentation attrs (cx, r, ...).
+// Installed once at module load.
 const FRAGMENT_HREF_HOOK_TAG = "__unsloth_svg_frag_href__";
 const URI_ATTRS = new Set(["href", "xlink:href"]);
 
@@ -107,12 +81,10 @@ if (!(DOMPurify as unknown as { [k: string]: unknown })[FRAGMENT_HREF_HOOK_TAG])
     true;
 }
 
-/** Strip every XML processing instruction and disallowed node from an SVG. */
+/** Strip XML PIs and disallowed nodes from an SVG. */
 export function sanitizeSvgSource(source: string): string {
-  // Drop XML declarations -- DOMPurify keeps them but some renderers choke.
+  // Drop XML declarations -- DOMPurify keeps them, some renderers choke.
   const stripped = source.replace(/^\s*<\?xml[^?]*\?>\s*/i, "");
-  // First pass: regex screen. We do NOT bail out -- DOMPurify will still
-  // produce a safe string -- but logging here helps debugging.
   if (HEURISTIC_UNSAFE_SVG_RE.test(stripped)) {
     // eslint-disable-next-line no-console
     console.debug("SVG renderer: stripping unsafe nodes before sanitize");
@@ -209,10 +181,7 @@ function TabButton({
   );
 }
 
-// SVG preview goes inside a sandboxed iframe (no allow-scripts, no
-// allow-same-origin) plus a `default-src 'none'` CSP so the sanitizer is
-// not the only line of defence -- even if a future DOMPurify regression
-// leaks a URL-bearing attribute, the browser blocks the request.
+// Defence in depth on top of the sanitizer.
 const SVG_IFRAME_CSP =
   "default-src 'none'; img-src data:; style-src 'unsafe-inline'; font-src data:;";
 
@@ -220,9 +189,7 @@ function buildSvgSrcDoc(safeSvg: string): string {
   return [
     "<!doctype html>",
     `<meta http-equiv="Content-Security-Policy" content="${SVG_IFRAME_CSP}">`,
-    // Fit the SVG within the iframe viewport in both dimensions so a square
-    // viewBox (e.g. 200x200) scaled to the container width does not overflow
-    // vertically and clip. width/height auto keeps aspect ratio intact.
+    // Cap both dimensions so a square viewBox does not clip vertically.
     "<style>html,body{margin:0;padding:0;height:100%;background:white;}",
     "body{display:flex;align-items:center;justify-content:center;padding:16px;box-sizing:border-box;}",
     "svg{max-width:100%;max-height:100%;width:auto;height:auto;}</style>",
@@ -239,9 +206,7 @@ function SvgPreview({ source }: { source: string }) {
       data-testid="html-svg-renderer-svg-preview"
       title="SVG preview"
       srcDoc={srcDoc}
-      // SECURITY: sandbox="" forbids scripts AND blocks the iframe from
-      // inheriting the host origin, so even sanitized SVG cannot reach the
-      // Studio document or run network requests against host-cookied URLs.
+      // No scripts, no same-origin: SVG cannot touch host document or network.
       sandbox=""
       style={{
         width: "100%",
@@ -254,17 +219,14 @@ function SvgPreview({ source }: { source: string }) {
   );
 }
 
-// Tiny helper script that posts the document height back to the parent so
-// we can right-size the iframe. Communication is one-way and the iframe
-// cannot read parent.document because we never grant allow-same-origin.
+// Iframe posts its scrollHeight to the parent for auto-sizing. One-way:
+// no allow-same-origin, so iframe cannot read parent.document.
 const HTML_PREVIEW_HEIGHT_REPORTER =
   '<script>(()=>{const post=()=>parent.postMessage({htmlPreviewHeight:document.documentElement.scrollHeight},"*");window.addEventListener("load",post);new ResizeObserver(post).observe(document.documentElement);})();</script>';
 
-// Fallback for when the same-origin preview route is unreachable (offline,
-// 404, transport error). srcdoc inherits the host page's ``script-src
-// 'self'`` per HTML / CSP3, so this path is static-layout-only -- inline
-// ``<script>`` and ``onclick`` handlers will NOT execute. The interactive
-// surface is the /api/preview/html backend route below.
+// Fallback for when the preview route is unreachable. srcdoc inherits the
+// host script-src 'self' per CSP3 so inline scripts will NOT run on this
+// path -- it is layout-only. Interactive surface is the API route below.
 const HTML_IFRAME_CSP = [
   "default-src 'none'",
   "script-src 'self' 'unsafe-inline'",
@@ -290,13 +252,11 @@ function buildHtmlSrcDoc(source: string): string {
   ].join("");
 }
 
-// Backend route that serves the HTML with a response-header CSP wide enough
-// to let ``<script>`` and ``onclick`` fire. Created on every source change
-// via POST; the returned random-token URL becomes the iframe ``src``.
+// Same-origin route whose response CSP permits inline scripts. POST source,
+// use returned random-token URL as iframe src.
 const HTML_PREVIEW_API = "/api/preview/html";
 
-// Read the bearer the same way the rest of the app does. Pulled lazily to
-// avoid any import cycle while keeping the auth-key contract in one place.
+// Same key as features/auth/session.ts:AUTH_TOKEN_KEY; inlined to avoid cycle.
 function getStoredAccessToken(): string | null {
   if (typeof window === "undefined") return null;
   try {
@@ -321,11 +281,8 @@ function HtmlPreview({
   onHeightChange?: (h: number | null) => void;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // POST the source to the backend preview route. The backend stores it for
-  // 10 minutes and returns a same-origin URL whose ``script-src`` permits
-  // inline execution -- the only way to escape the host CSP for srcdoc /
-  // data: / blob: iframes (which all inherit the embedder policy per
-  // HTML / CSP3).
+  // POST source -> token URL. srcdoc / data: / blob: inherit the host CSP
+  // per CSP3, so a same-origin route is the only way to unlock inline scripts.
   const [previewState, setPreviewState] = useState<PreviewState>({
     kind: "loading",
   });
@@ -392,8 +349,8 @@ function HtmlPreview({
     ? "100%"
     : Math.min(autoHeight ?? DEFAULT_PREVIEW_HEIGHT, DEFAULT_PREVIEW_HEIGHT);
 
-  // Error path: fall back to srcdoc so the preview still renders the layout
-  // (static-only -- scripts dead) instead of going blank.
+  // Backend unreachable: fall back to srcdoc (static layout, no scripts)
+  // instead of going blank.
   const errorSrcDoc = useMemo(
     () => (previewState.kind === "error" ? buildHtmlSrcDoc(source) : null),
     [previewState.kind, source],
@@ -407,20 +364,15 @@ function HtmlPreview({
       title="HTML preview"
       src={previewState.kind === "ready" ? previewState.url : "about:blank"}
       srcDoc={errorSrcDoc ?? undefined}
-      // SECURITY:
-      //   allow-scripts   -- inline <script> / on* handlers run in the
-      //                      backend-served preview, which carries
-      //                      ``script-src 'unsafe-inline'``
-      //   allow-modals    -- alert / confirm / prompt are not no-ops
-      //   allow-popups    -- ``<base target="_blank">`` links can open
-      //                      a new tab instead of silently dropping
-      // We do NOT grant:
+      // allow-scripts: inline JS runs (route CSP permits it).
+      // allow-modals: alert / confirm / prompt usable.
+      // allow-popups: <base target="_blank"> links open a tab.
+      // NOT granted:
       //   allow-same-origin / allow-top-navigation -- preview JS cannot
-      //     read parent.document or navigate the host page even though
-      //     the URL is same-origin
-      //   allow-popups-to-escape-sandbox -- popups INHERIT the sandbox
-      //     so an opened tab cannot use ``window.opener.top.location``
-      //     to tabnab the Studio tab
+      //   reach parent.document or navigate the host (URL is same-origin
+      //   but iframe is treated as opaque).
+      //   allow-popups-to-escape-sandbox -- opened tabs inherit sandbox so
+      //   window.opener.top.location.* tabnabbing is blocked.
       sandbox="allow-scripts allow-modals allow-popups"
       style={{
         width: "100%",
@@ -439,14 +391,11 @@ export function HtmlSvgRenderer({
   codeView,
   isIncomplete,
 }: HtmlSvgRendererProps) {
-  // Stream-in: while the fence is still being filled in we lock to the Code
-  // tab so users see the in-flight tokens rather than a flashing preview.
+  // Lock to Code while streaming so users see tokens, not a flashing preview.
   const lockedToCode = Boolean(isIncomplete);
   const [tab, setTab] = useState<TabKey>("preview");
   const [popped, setPopped] = useState(false);
-  // Live HTML iframe height, lifted out of HtmlPreview so the pop-out spacer
-  // (rendered here, not inside HtmlPreview) can match the current preview
-  // size and avoid a layout jump when entering pop-out mode.
+  // Lifted from HtmlPreview so the pop-out spacer can match current height.
   const [htmlHeight, setHtmlHeight] = useState<number | null>(null);
 
   const activeTab: TabKey = lockedToCode ? "code" : tab;
@@ -491,10 +440,8 @@ export function HtmlSvgRenderer({
     );
 
   const previewLabel = language === "svg" ? "SVG preview" : "HTML preview";
-  // Use the live HTML iframe height for the pop-out placeholder so swapping
-  // a short preview into pop-out mode does not leave a 500px hole in the
-  // chat bubble. Falls back to DEFAULT_PREVIEW_HEIGHT before the first
-  // height post arrives, and is always capped to DEFAULT_PREVIEW_HEIGHT.
+  // Match live iframe height so popping out a short preview does not leave
+  // a 500px hole. Falls back to DEFAULT before the first height post.
   const popoutSpacerHeight = Math.min(
     htmlHeight ?? DEFAULT_PREVIEW_HEIGHT,
     DEFAULT_PREVIEW_HEIGHT,
@@ -533,10 +480,9 @@ export function HtmlSvgRenderer({
         </div>
         <div className="flex items-center gap-1">
           {activeTab === "code" && !codeView ? (
-            // When a custom code view is supplied it typically renders its
-            // own copy/download chrome (see CodeBlockActions in
-            // markdown-text.tsx). We only surface the fallback Copy button
-            // when we are using the plain <pre> fallback below.
+            // Custom code views ship their own copy/download chrome
+            // (CodeBlockActions in markdown-text.tsx); only show Copy
+            // when we are using the plain <pre> fallback.
             <CopyButton source={source} />
           ) : null}
           {activeTab === "preview" && language === "html" ? (
@@ -631,10 +577,8 @@ export type CodeFenceInfo = {
 };
 
 const CODE_FENCE_RE = /^```([^\r\n`]*)\r?\n([\s\S]*?)\r?\n?```$/;
-// Open fence: opening backticks + lang + body but no closing fence yet. Used
-// while a fenced block is still streaming in -- without this the markdown
-// pipeline falls through to the generic code block until the closing fence
-// arrives, so HtmlSvgRenderer's isIncomplete (lock-Code) path is dead code.
+// Open fence: no closing ``` yet. Lets HtmlSvgRenderer mount mid-stream
+// (otherwise the markdown pipeline falls through until the close arrives).
 const OPEN_CODE_FENCE_RE = /^```([^\r\n`]*)\r?\n([\s\S]*)$/;
 
 export function parseCodeFence(blockContent: string): CodeFenceInfo | null {
@@ -652,8 +596,7 @@ export function parseIncompleteCodeFence(
 ): CodeFenceInfo | null {
   const match = blockContent.match(OPEN_CODE_FENCE_RE);
   if (!match) return null;
-  // Strip an in-flight trailing ``` line so a fence captured mid-close does
-  // not render a stray "```" in the preview.
+  // Strip a trailing partial ``` so mid-close captures do not leak it.
   const body = match[2].replace(/\r?\n?```\s*$/, "");
   return {
     language: match[1]?.trim() || null,

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client";
+
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { cn } from "@/lib/utils";
+import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import DOMPurify from "dompurify";
+import { CodeIcon, EyeIcon, Maximize2Icon, Minimize2Icon } from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type HtmlSvgLanguage = "html" | "svg";
+
+export type HtmlSvgRendererProps = {
+  language: HtmlSvgLanguage;
+  source: string;
+  // Pre-rendered syntax-highlighted code view. Optional; if omitted the
+  // renderer falls back to a plain <pre><code> block.
+  codeView?: ReactNode;
+  // When the markdown stream is still arriving the fence may be partial.
+  // In that case we force the Code tab and disable the toggle controls.
+  isIncomplete?: boolean;
+};
+
+const DEFAULT_PREVIEW_HEIGHT = 500;
+const POPOUT_HEIGHT_VH = 80;
+const COPY_RESET_MS = 2000;
+
+// Conservative regex covering the same vectors we previously stripped before
+// DOMPurify was wired in. DOMPurify itself does the heavy lifting; this is
+// belt-and-braces so a quick visual inspection of the source still catches the
+// usual XSS hot spots.
+const HEURISTIC_UNSAFE_SVG_RE =
+  /<script[\s>]|<foreignObject[\s>]|<iframe[\s>]|<embed[\s>]|<object[\s>]/i;
+
+// SVGs may legitimately reference fonts/images via href, so we keep those.
+// We strip every event handler attribute (on*) and any tag DOMPurify would
+// otherwise allow that could escape the SVG sandbox.
+const SVG_PURIFY_CONFIG = {
+  USE_PROFILES: { svg: true, svgFilters: true },
+  FORBID_TAGS: ["script", "foreignObject", "iframe", "embed", "object"],
+  // DOMPurify already drops on* handlers when USE_PROFILES is set, but we
+  // call this out explicitly so the intent is obvious to future readers.
+  ALLOW_DATA_ATTR: false,
+};
+
+/** Strip every XML processing instruction and disallowed node from an SVG. */
+export function sanitizeSvgSource(source: string): string {
+  // Drop XML declarations -- DOMPurify keeps them but some renderers choke.
+  const stripped = source.replace(/^\s*<\?xml[^?]*\?>\s*/i, "");
+  // First pass: regex screen. We do NOT bail out -- DOMPurify will still
+  // produce a safe string -- but logging here helps debugging.
+  if (HEURISTIC_UNSAFE_SVG_RE.test(stripped)) {
+    // eslint-disable-next-line no-console
+    console.debug("SVG renderer: stripping unsafe nodes before sanitize");
+  }
+  return DOMPurify.sanitize(stripped, SVG_PURIFY_CONFIG);
+}
+
+function useCopyState() {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const flash = useCallback(() => {
+    setCopied(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setCopied(false);
+      timeoutRef.current = null;
+    }, COPY_RESET_MS);
+  }, []);
+
+  return { copied, flash };
+}
+
+function CopyButton({ source }: { source: string }) {
+  const { copied, flash } = useCopyState();
+  return (
+    <button
+      type="button"
+      title="Copy code"
+      aria-label="Copy code"
+      className={cn(
+        "flex size-8 cursor-pointer items-center justify-center rounded-[10px]",
+        "text-chat-icon-fg transition-all hover:bg-chat-icon-bg-hover hover:text-chat-icon-fg-hover",
+      )}
+      onClick={async () => {
+        if (await copyToClipboard(source)) flash();
+      }}
+    >
+      <HugeiconsIcon
+        icon={copied ? Tick02Icon : Copy01Icon}
+        strokeWidth={1.75}
+        className="size-icon"
+      />
+    </button>
+  );
+}
+
+type TabKey = "preview" | "code";
+
+function TabButton({
+  active,
+  disabled,
+  icon,
+  label,
+  onSelect,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  icon: ReactNode;
+  label: string;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      disabled={disabled}
+      onClick={onSelect}
+      className={cn(
+        "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function SvgPreview({ source }: { source: string }) {
+  const safe = useMemo(() => sanitizeSvgSource(source), [source]);
+  return (
+    <div
+      data-testid="html-svg-renderer-svg-preview"
+      className="flex justify-center bg-white p-4 dark:bg-neutral-100"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized by DOMPurify above.
+      dangerouslySetInnerHTML={{ __html: safe }}
+    />
+  );
+}
+
+function HtmlPreview({
+  source,
+  popped,
+}: {
+  source: string;
+  popped: boolean;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  // Tiny helper script that posts the document height back to the parent so
+  // we can right-size the iframe. Communication is one-way and the iframe
+  // cannot read parent.document because we never grant allow-same-origin.
+  const srcDoc = useMemo(
+    () =>
+      `${source}<script>(()=>{const post=()=>parent.postMessage({htmlPreviewHeight:document.documentElement.scrollHeight},"*");window.addEventListener("load",post);new ResizeObserver(post).observe(document.documentElement);})();</script>`,
+    [source],
+  );
+
+  const [autoHeight, setAutoHeight] = useState<number | null>(null);
+
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const raw = (e.data as { htmlPreviewHeight?: unknown })
+        ?.htmlPreviewHeight;
+      if (typeof raw === "number" && Number.isFinite(raw)) {
+        setAutoHeight(Math.max(100, raw));
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
+
+  // In the docked view we cap at DEFAULT_PREVIEW_HEIGHT; in the popout we
+  // let the iframe fill the modal panel.
+  const iframeHeight = popped
+    ? "100%"
+    : Math.min(autoHeight ?? DEFAULT_PREVIEW_HEIGHT, DEFAULT_PREVIEW_HEIGHT);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      data-testid="html-svg-renderer-iframe"
+      title="HTML preview"
+      srcDoc={srcDoc}
+      // SECURITY: allow-scripts only. We do NOT grant allow-same-origin or
+      // allow-top-navigation, so the iframe cannot read parent.document,
+      // navigate the host page, or escape its origin.
+      sandbox="allow-scripts"
+      style={{
+        width: "100%",
+        height: iframeHeight,
+        border: "none",
+        display: "block",
+        background: "white",
+      }}
+    />
+  );
+}
+
+export function HtmlSvgRenderer({
+  language,
+  source,
+  codeView,
+  isIncomplete,
+}: HtmlSvgRendererProps) {
+  // Stream-in: while the fence is still being filled in we lock to the Code
+  // tab so users see the in-flight tokens rather than a flashing preview.
+  const lockedToCode = Boolean(isIncomplete);
+  const [tab, setTab] = useState<TabKey>("preview");
+  const [popped, setPopped] = useState(false);
+
+  const activeTab: TabKey = lockedToCode ? "code" : tab;
+
+  // Escape key exits the popout view.
+  useEffect(() => {
+    if (!popped) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPopped(false);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [popped]);
+
+  const codeFallback = useMemo(
+    () =>
+      codeView ?? (
+        <pre className="overflow-x-auto rounded-md bg-muted/40 p-3 text-xs">
+          <code>{source}</code>
+        </pre>
+      ),
+    [codeView, source],
+  );
+
+  const preview =
+    language === "svg" ? (
+      <SvgPreview source={source} />
+    ) : (
+      <HtmlPreview source={source} popped={popped} />
+    );
+
+  const previewLabel = language === "svg" ? "SVG preview" : "HTML preview";
+
+  return (
+    <div
+      data-testid="html-svg-renderer"
+      data-language={language}
+      data-active-tab={activeTab}
+      className="my-4 overflow-hidden rounded-xl border border-border"
+    >
+      <div
+        role="tablist"
+        aria-label={`${language.toUpperCase()} fence view`}
+        className="flex items-center justify-between gap-2 border-b border-border bg-muted/40 px-2 py-1.5"
+      >
+        <div className="flex items-center gap-1 rounded-lg bg-muted p-0.5">
+          <TabButton
+            active={activeTab === "preview"}
+            disabled={lockedToCode}
+            icon={<EyeIcon className="size-3.5" />}
+            label="Preview"
+            onSelect={() => setTab("preview")}
+          />
+          <TabButton
+            active={activeTab === "code"}
+            icon={<CodeIcon className="size-3.5" />}
+            label="Code"
+            onSelect={() => setTab("code")}
+          />
+        </div>
+        <div className="flex items-center gap-1">
+          {activeTab === "code" && !codeView ? (
+            // When a custom code view is supplied it typically renders its
+            // own copy/download chrome (see CodeBlockActions in
+            // markdown-text.tsx). We only surface the fallback Copy button
+            // when we are using the plain <pre> fallback below.
+            <CopyButton source={source} />
+          ) : null}
+          {activeTab === "preview" && language === "html" ? (
+            <button
+              type="button"
+              title={popped ? "Exit pop out" : "Pop out preview"}
+              aria-label={popped ? "Exit pop out" : "Pop out preview"}
+              className={cn(
+                "flex size-8 cursor-pointer items-center justify-center rounded-[10px]",
+                "text-chat-icon-fg transition-all hover:bg-chat-icon-bg-hover hover:text-chat-icon-fg-hover",
+              )}
+              onClick={() => setPopped((p) => !p)}
+            >
+              {popped ? (
+                <Minimize2Icon className="size-4" />
+              ) : (
+                <Maximize2Icon className="size-4" />
+              )}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div data-testid="html-svg-renderer-body" className="bg-background">
+        {activeTab === "preview" ? (
+          popped && language === "html" ? (
+            <>
+              {/* Keep layout stable behind the modal. */}
+              <div
+                style={{ height: DEFAULT_PREVIEW_HEIGHT }}
+                aria-hidden={true}
+              />
+              <div
+                className="fixed inset-0 z-50 flex flex-col bg-background/80 backdrop-blur-sm"
+                onClick={(e) => {
+                  if (e.target === e.currentTarget) setPopped(false);
+                }}
+              >
+                <div className="flex items-center justify-end px-4 py-2">
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    onClick={() => setPopped(false)}
+                    title="Exit pop out (Esc)"
+                  >
+                    <Minimize2Icon className="size-4" />
+                    Exit pop out
+                  </button>
+                </div>
+                <div
+                  className="mx-4 mb-4 flex-1 overflow-hidden rounded-lg border border-border bg-background"
+                  style={{ maxHeight: `${POPOUT_HEIGHT_VH}vh` }}
+                >
+                  {preview}
+                </div>
+              </div>
+            </>
+          ) : (
+            <div aria-label={previewLabel}>{preview}</div>
+          )
+        ) : (
+          <div data-testid="html-svg-renderer-code" className="min-w-0">
+            {codeFallback}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- Fence helpers (exported for tests + reuse from markdown-text.tsx) ----
+
+export type CodeFenceInfo = {
+  language: string | null;
+  source: string;
+};
+
+const CODE_FENCE_RE = /^```([^\r\n`]*)\r?\n([\s\S]*?)\r?\n?```$/;
+
+export function parseCodeFence(blockContent: string): CodeFenceInfo | null {
+  const match = blockContent.trimEnd().match(CODE_FENCE_RE);
+  if (!match) return null;
+  return {
+    language: match[1]?.trim() || null,
+    source: match[2],
+  };
+}
+
+export function isSvgFence(fence: CodeFenceInfo): boolean {
+  const lang = fence.language?.toLowerCase() ?? "";
+  if (lang === "svg") return true;
+  if (lang === "xml" || lang === "html") {
+    const trimmed = fence.source.trimStart();
+    if (trimmed.startsWith("<svg")) return true;
+    if (trimmed.startsWith("<?xml") && trimmed.includes("<svg")) return true;
+  }
+  return false;
+}
+
+export function isHtmlFence(fence: CodeFenceInfo): boolean {
+  const lang = fence.language?.toLowerCase() ?? "";
+  return lang === "html" && !isSvgFence(fence);
+}

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -53,13 +53,17 @@ const HEURISTIC_UNSAFE_SVG_RE =
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/SVG_as_an_image
 const SVG_PURIFY_CONFIG = {
   USE_PROFILES: { svg: true, svgFilters: true },
-  // ``style`` -- inline CSS would otherwise leak to the host page selectors.
   // ``image`` / ``use`` -- carry ``href``/``xlink:href`` and would let an
   //   assistant fetch attacker-controlled URLs from the user's browser.
   // ``foreignObject`` -- can embed HTML inside the SVG and re-introduce XSS.
+  // ``script`` / ``link`` / ``meta`` / ``iframe`` / ``embed`` / ``object``
+  //   are unconditional XSS / network surfaces. ``<style>`` is kept --
+  //   the SVG preview iframe is fully sandboxed (``sandbox=""``) with a
+  //   ``default-src 'none'`` CSP, so class-based styling that real
+  //   diagram exporters emit cannot leak to the host page or fetch
+  //   external URLs (the CSP blocks ``@import`` and ``url(...)``).
   FORBID_TAGS: [
     "script",
-    "style",
     "foreignObject",
     "iframe",
     "embed",

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -256,14 +256,17 @@ function SvgPreview({ source }: { source: string }) {
 const HTML_PREVIEW_HEIGHT_REPORTER =
   '<script>(()=>{const post=()=>parent.postMessage({htmlPreviewHeight:document.documentElement.scrollHeight},"*");window.addEventListener("load",post);new ResizeObserver(post).observe(document.documentElement);})();</script>';
 
-// Meta-CSP enforced INSIDE the srcdoc iframe. The iframe inherits the host
-// Studio CSP (every srcdoc / data: / blob: scheme does, per CSP3 § Initialize
-// document CSP), so the host's ``script-src 'self'`` already blocks inline
-// <script> and on* handlers inside the preview. We layer a more restrictive
-// meta-CSP here so a future host-CSP relaxation does not silently turn this
-// iframe into an exfiltration channel: ``connect-src 'none'`` keeps a
-// future ``script-src 'unsafe-inline'`` from being able to beacon out, and
-// ``frame-src 'none'`` stops nested iframe-loaded ad/tracking content.
+// Meta-CSP enforced INSIDE the srcdoc iframe. Chromium inherits the
+// embedder CSP into srcdoc, data:, AND blob: iframes per HTML / CSP3
+// § initialize-document-csp, so the host Studio ``script-src 'self'``
+// already blocks assistant inline scripts and on* handlers here --
+// confirmed empirically on the live Studio with a click-to-alert demo.
+// Until a same-origin backend route is added (response-header CSPs
+// do NOT inherit), the preview deliberately ships as a static-render
+// surface. The meta-CSP below is defense in depth: it adds
+// ``connect-src 'none'`` + ``frame-src 'none'`` so even if the host
+// CSP ever loosens enough to let inline scripts run, the preview
+// still cannot beacon out or nest tracking iframes.
 const HTML_IFRAME_CSP = [
   "default-src 'none'",
   "script-src 'self' 'unsafe-inline'",
@@ -283,8 +286,8 @@ function buildHtmlSrcDoc(source: string): string {
   return [
     "<!doctype html>",
     `<meta http-equiv="Content-Security-Policy" content="${HTML_IFRAME_CSP}">`,
-    // Outbound links open in a new tab rather than no-op-navigating the
-    // sandboxed frame itself.
+    // Outbound links open in a new tab rather than navigating the
+    // sandboxed frame itself away from the preview.
     '<base target="_blank">',
     source,
     HTML_PREVIEW_HEIGHT_REPORTER,
@@ -301,19 +304,20 @@ function HtmlPreview({
   onHeightChange?: (h: number | null) => void;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // srcdoc keeps the assistant HTML rendering same-origin-blocked while
-  // still showing layout, images, styles, and Streamdown-syntax-highlighted
-  // source in the Code tab. Inline <script> / on* handlers inside the
-  // assistant's HTML do NOT execute because srcdoc iframes inherit the
-  // host Studio CSP (``script-src 'self'``); follow-up work tracked in
-  // PR #5717 to add an opt-in backend-hosted preview route for the "play
-  // JS games inline" use case.
+  // srcdoc, blob:, and data: all inherit the host CSP in Chromium, so
+  // the choice between them does not affect script execution today.
+  // srcdoc is the simplest and avoids URL.createObjectURL churn, so
+  // that is what we use. Inline <script> / on* handlers in the
+  // assistant HTML do NOT execute under the current host CSP; the
+  // preview is for layout, images, and styles. The auto-height
+  // postMessage reporter is appended for the future state where the
+  // host CSP is relaxed via a backend-served preview route.
   const srcDoc = useMemo(() => buildHtmlSrcDoc(source), [source]);
 
   const [autoHeight, setAutoHeight] = useState<number | null>(null);
   // Reset auto-sizing whenever the source changes so we never show the
-  // previous message's iframe size during the gap before the new doc loads
-  // and posts its first height.
+  // previous message's iframe size during the gap before the new doc
+  // loads and posts its first height.
   useEffect(() => {
     setAutoHeight(null);
     onHeightChange?.(null);
@@ -347,20 +351,16 @@ function HtmlPreview({
       title="HTML preview"
       srcDoc={srcDoc}
       // SECURITY:
-      //   allow-scripts        -- in case the host CSP ever loosens
-      //                           to permit inline (today it does not)
-      //   allow-modals         -- so alert/confirm/prompt do not no-op
-      //                           when scripts do run
-      //   allow-popups +       -- so the ``<base target="_blank">`` we
-      //   allow-popups-to-        set above can open a new tab without
-      //   escape-sandbox          being silently dropped; escape-
-      //                           sandbox makes the popup a regular
-      //                           browser tab rather than an opaque-
-      //                           origin sandboxed one (the popup is
-      //                           equivalent to the user clicking the
-      //                           same URL in any other web app)
-      // We do NOT grant allow-same-origin or allow-top-navigation,
-      // so the iframe cannot read parent.document, navigate the host
+      //   allow-scripts        -- ready for the day the host CSP
+      //                           gives the preview a script-src
+      //                           that includes 'unsafe-inline'
+      //   allow-modals         -- alert/confirm/prompt are not no-ops
+      //                           when scripts do fire
+      //   allow-popups +       -- a ``<base target="_blank">`` link
+      //   allow-popups-to-        opens a regular browser tab rather
+      //   escape-sandbox          than an opaque-origin sandboxed one
+      // We do NOT grant allow-same-origin or allow-top-navigation, so
+      // the iframe cannot read parent.document, navigate the host
       // page, or escape its origin.
       sandbox="allow-scripts allow-modals allow-popups allow-popups-to-escape-sandbox"
       style={{

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -346,12 +346,23 @@ function HtmlPreview({
       data-testid="html-svg-renderer-iframe"
       title="HTML preview"
       srcDoc={srcDoc}
-      // SECURITY: allow-scripts (in case the host CSP ever loosens to
-      // permit inline) + allow-modals (so alert/confirm do not silently
-      // no-op when scripts do run). We do NOT grant allow-same-origin or
-      // allow-top-navigation, so the iframe cannot read parent.document,
-      // navigate the host page, or escape its origin.
-      sandbox="allow-scripts allow-modals"
+      // SECURITY:
+      //   allow-scripts        -- in case the host CSP ever loosens
+      //                           to permit inline (today it does not)
+      //   allow-modals         -- so alert/confirm/prompt do not no-op
+      //                           when scripts do run
+      //   allow-popups +       -- so the ``<base target="_blank">`` we
+      //   allow-popups-to-        set above can open a new tab without
+      //   escape-sandbox          being silently dropped; escape-
+      //                           sandbox makes the popup a regular
+      //                           browser tab rather than an opaque-
+      //                           origin sandboxed one (the popup is
+      //                           equivalent to the user clicking the
+      //                           same URL in any other web app)
+      // We do NOT grant allow-same-origin or allow-top-navigation,
+      // so the iframe cannot read parent.document, navigate the host
+      // page, or escape its origin.
+      sandbox="allow-scripts allow-modals allow-popups allow-popups-to-escape-sandbox"
       style={{
         width: "100%",
         height: iframeHeight,

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -42,14 +42,38 @@ const COPY_RESET_MS = 2000;
 const HEURISTIC_UNSAFE_SVG_RE =
   /<script[\s>]|<foreignObject[\s>]|<iframe[\s>]|<embed[\s>]|<object[\s>]/i;
 
-// SVGs may legitimately reference fonts/images via href, so we keep those.
-// We strip every event handler attribute (on*) and any tag DOMPurify would
-// otherwise allow that could escape the SVG sandbox.
+// SVG previews used to live inside a `<img src="data:image/svg+xml,...">` tag
+// where the browser treats the SVG as an image and disables scripts and
+// external resource loads. Mounting sanitized SVG directly into the host
+// Studio document loses those guarantees, so we now (a) strip every node that
+// can leak into the host page (`<style>`, `<image>`, `<use>`, scripts, etc.)
+// and (b) render the surviving markup in a fully sandboxed iframe at
+// `SvgPreview` below for defence in depth. See:
+// https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/SVG_as_an_image
 const SVG_PURIFY_CONFIG = {
   USE_PROFILES: { svg: true, svgFilters: true },
-  FORBID_TAGS: ["script", "foreignObject", "iframe", "embed", "object"],
-  // DOMPurify already drops on* handlers when USE_PROFILES is set, but we
-  // call this out explicitly so the intent is obvious to future readers.
+  // ``style`` -- inline CSS would otherwise leak to the host page selectors.
+  // ``image`` / ``use`` -- carry ``href``/``xlink:href`` and would let an
+  //   assistant fetch attacker-controlled URLs from the user's browser.
+  // ``foreignObject`` -- can embed HTML inside the SVG and re-introduce XSS.
+  FORBID_TAGS: [
+    "script",
+    "style",
+    "foreignObject",
+    "iframe",
+    "embed",
+    "object",
+    "image",
+    "use",
+    "link",
+    "meta",
+  ],
+  // Drop URL-bearing attributes that would still trigger network requests on
+  // surviving SVG elements (filter url(...), animateMotion mpath, etc.), and
+  // strip inline ``style`` because CSS ``@import`` / ``url()`` would do the
+  // same. DOMPurify already drops on* handlers under USE_PROFILES, but we
+  // call ALLOW_DATA_ATTR off explicitly so the intent is obvious.
+  FORBID_ATTR: ["href", "xlink:href", "style"],
   ALLOW_DATA_ATTR: false,
 };
 
@@ -148,14 +172,44 @@ function TabButton({
   );
 }
 
+// SVG preview goes inside a sandboxed iframe (no allow-scripts, no
+// allow-same-origin) plus a `default-src 'none'` CSP so the sanitizer is
+// not the only line of defence -- even if a future DOMPurify regression
+// leaks a URL-bearing attribute, the browser blocks the request.
+const SVG_IFRAME_CSP =
+  "default-src 'none'; img-src data:; style-src 'unsafe-inline'; font-src data:;";
+
+function buildSvgSrcDoc(safeSvg: string): string {
+  return [
+    "<!doctype html>",
+    `<meta http-equiv="Content-Security-Policy" content="${SVG_IFRAME_CSP}">`,
+    "<style>html,body{margin:0;padding:0;background:white;}",
+    "body{display:flex;align-items:center;justify-content:center;padding:16px;}",
+    "svg{max-width:100%;height:auto;}</style>",
+    safeSvg,
+  ].join("");
+}
+
 function SvgPreview({ source }: { source: string }) {
-  const safe = useMemo(() => sanitizeSvgSource(source), [source]);
+  const srcDoc = useMemo(() => buildSvgSrcDoc(sanitizeSvgSource(source)), [
+    source,
+  ]);
   return (
-    <div
+    <iframe
       data-testid="html-svg-renderer-svg-preview"
-      className="flex justify-center bg-white p-4 dark:bg-neutral-100"
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized by DOMPurify above.
-      dangerouslySetInnerHTML={{ __html: safe }}
+      title="SVG preview"
+      srcDoc={srcDoc}
+      // SECURITY: sandbox="" forbids scripts AND blocks the iframe from
+      // inheriting the host origin, so even sanitized SVG cannot reach the
+      // Studio document or run network requests against host-cookied URLs.
+      sandbox=""
+      style={{
+        width: "100%",
+        height: 360,
+        border: "none",
+        display: "block",
+        background: "white",
+      }}
     />
   );
 }

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -295,15 +295,12 @@ function buildHtmlSrcDoc(source: string): string {
 // via POST; the returned random-token URL becomes the iframe ``src``.
 const HTML_PREVIEW_API = "/api/preview/html";
 
+// Read the bearer the same way the rest of the app does. Pulled lazily to
+// avoid any import cycle while keeping the auth-key contract in one place.
 function getStoredAccessToken(): string | null {
-  // Mirrors the bearer storage used by features/auth/. We avoid the import
-  // cycle by reading sessionStorage / localStorage directly.
   if (typeof window === "undefined") return null;
   try {
-    return (
-      window.sessionStorage.getItem("unsloth.access_token") ??
-      window.localStorage.getItem("unsloth.access_token")
-    );
+    return window.localStorage.getItem("unsloth_auth_token");
   } catch {
     return null;
   }

--- a/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
+++ b/studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx
@@ -260,17 +260,11 @@ function SvgPreview({ source }: { source: string }) {
 const HTML_PREVIEW_HEIGHT_REPORTER =
   '<script>(()=>{const post=()=>parent.postMessage({htmlPreviewHeight:document.documentElement.scrollHeight},"*");window.addEventListener("load",post);new ResizeObserver(post).observe(document.documentElement);})();</script>';
 
-// Meta-CSP enforced INSIDE the srcdoc iframe. Chromium inherits the
-// embedder CSP into srcdoc, data:, AND blob: iframes per HTML / CSP3
-// § initialize-document-csp, so the host Studio ``script-src 'self'``
-// already blocks assistant inline scripts and on* handlers here --
-// confirmed empirically on the live Studio with a click-to-alert demo.
-// Until a same-origin backend route is added (response-header CSPs
-// do NOT inherit), the preview deliberately ships as a static-render
-// surface. The meta-CSP below is defense in depth: it adds
-// ``connect-src 'none'`` + ``frame-src 'none'`` so even if the host
-// CSP ever loosens enough to let inline scripts run, the preview
-// still cannot beacon out or nest tracking iframes.
+// Fallback for when the same-origin preview route is unreachable (offline,
+// 404, transport error). srcdoc inherits the host page's ``script-src
+// 'self'`` per HTML / CSP3, so this path is static-layout-only -- inline
+// ``<script>`` and ``onclick`` handlers will NOT execute. The interactive
+// surface is the /api/preview/html backend route below.
 const HTML_IFRAME_CSP = [
   "default-src 'none'",
   "script-src 'self' 'unsafe-inline'",
@@ -290,13 +284,35 @@ function buildHtmlSrcDoc(source: string): string {
   return [
     "<!doctype html>",
     `<meta http-equiv="Content-Security-Policy" content="${HTML_IFRAME_CSP}">`,
-    // Outbound links open in a new tab rather than navigating the
-    // sandboxed frame itself away from the preview.
     '<base target="_blank">',
     source,
     HTML_PREVIEW_HEIGHT_REPORTER,
   ].join("");
 }
+
+// Backend route that serves the HTML with a response-header CSP wide enough
+// to let ``<script>`` and ``onclick`` fire. Created on every source change
+// via POST; the returned random-token URL becomes the iframe ``src``.
+const HTML_PREVIEW_API = "/api/preview/html";
+
+function getStoredAccessToken(): string | null {
+  // Mirrors the bearer storage used by features/auth/. We avoid the import
+  // cycle by reading sessionStorage / localStorage directly.
+  if (typeof window === "undefined") return null;
+  try {
+    return (
+      window.sessionStorage.getItem("unsloth.access_token") ??
+      window.localStorage.getItem("unsloth.access_token")
+    );
+  } catch {
+    return null;
+  }
+}
+
+type PreviewState =
+  | { kind: "loading" }
+  | { kind: "ready"; url: string }
+  | { kind: "error" };
 
 function HtmlPreview({
   source,
@@ -308,24 +324,57 @@ function HtmlPreview({
   onHeightChange?: (h: number | null) => void;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // srcdoc, blob:, and data: all inherit the host CSP in Chromium, so
-  // the choice between them does not affect script execution today.
-  // srcdoc is the simplest and avoids URL.createObjectURL churn, so
-  // that is what we use. Inline <script> / on* handlers in the
-  // assistant HTML do NOT execute under the current host CSP; the
-  // preview is for layout, images, and styles. The auto-height
-  // postMessage reporter is appended for the future state where the
-  // host CSP is relaxed via a backend-served preview route.
-  const srcDoc = useMemo(() => buildHtmlSrcDoc(source), [source]);
+  // POST the source to the backend preview route. The backend stores it for
+  // 10 minutes and returns a same-origin URL whose ``script-src`` permits
+  // inline execution -- the only way to escape the host CSP for srcdoc /
+  // data: / blob: iframes (which all inherit the embedder policy per
+  // HTML / CSP3).
+  const [previewState, setPreviewState] = useState<PreviewState>({
+    kind: "loading",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setPreviewState({ kind: "loading" });
+    onHeightChange?.(null);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const token = getStoredAccessToken();
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    void fetch(HTML_PREVIEW_API, {
+      method: "POST",
+      credentials: "same-origin",
+      headers,
+      body: JSON.stringify({ source }),
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTML preview HTTP ${r.status}`);
+        return (await r.json()) as { url: string };
+      })
+      .then(({ url }) => {
+        if (cancelled) return;
+        if (typeof url !== "string" || !url.startsWith("/api/preview/html/")) {
+          throw new Error("HTML preview returned an unexpected URL shape");
+        }
+        setPreviewState({ kind: "ready", url });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPreviewState({ kind: "error" });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, onHeightChange]);
 
   const [autoHeight, setAutoHeight] = useState<number | null>(null);
-  // Reset auto-sizing whenever the source changes so we never show the
-  // previous message's iframe size during the gap before the new doc
-  // loads and posts its first height.
   useEffect(() => {
     setAutoHeight(null);
-    onHeightChange?.(null);
-  }, [source, onHeightChange]);
+  }, [previewState]);
 
   useEffect(() => {
     const handler = (e: MessageEvent) => {
@@ -342,35 +391,39 @@ function HtmlPreview({
     return () => window.removeEventListener("message", handler);
   }, [onHeightChange]);
 
-  // In the docked view we cap at DEFAULT_PREVIEW_HEIGHT; in the popout we
-  // let the iframe fill the modal panel.
   const iframeHeight = popped
     ? "100%"
     : Math.min(autoHeight ?? DEFAULT_PREVIEW_HEIGHT, DEFAULT_PREVIEW_HEIGHT);
+
+  // Error path: fall back to srcdoc so the preview still renders the layout
+  // (static-only -- scripts dead) instead of going blank.
+  const errorSrcDoc = useMemo(
+    () => (previewState.kind === "error" ? buildHtmlSrcDoc(source) : null),
+    [previewState.kind, source],
+  );
 
   return (
     <iframe
       ref={iframeRef}
       data-testid="html-svg-renderer-iframe"
+      data-preview-state={previewState.kind}
       title="HTML preview"
-      srcDoc={srcDoc}
+      src={previewState.kind === "ready" ? previewState.url : "about:blank"}
+      srcDoc={errorSrcDoc ?? undefined}
       // SECURITY:
-      //   allow-scripts        -- ready for the day the host CSP
-      //                           gives the preview a script-src
-      //                           that includes 'unsafe-inline'
-      //   allow-modals         -- alert/confirm/prompt are not no-ops
-      //                           when scripts do fire
-      //   allow-popups         -- the ``<base target="_blank">`` link
-      //                           rule can open a new tab instead of
-      //                           silently dropping the click
+      //   allow-scripts   -- inline <script> / on* handlers run in the
+      //                      backend-served preview, which carries
+      //                      ``script-src 'unsafe-inline'``
+      //   allow-modals    -- alert / confirm / prompt are not no-ops
+      //   allow-popups    -- ``<base target="_blank">`` links can open
+      //                      a new tab instead of silently dropping
       // We do NOT grant:
-      //   allow-same-origin / allow-top-navigation -- the iframe
-      //     cannot read parent.document or navigate the host page
+      //   allow-same-origin / allow-top-navigation -- preview JS cannot
+      //     read parent.document or navigate the host page even though
+      //     the URL is same-origin
       //   allow-popups-to-escape-sandbox -- popups INHERIT the sandbox
       //     so an opened tab cannot use ``window.opener.top.location``
-      //     to tabnab the Studio tab. The opened tab loads with an
-      //     opaque origin (some sites will render degraded) which is
-      //     the deliberate trade-off for tabnabbing safety.
+      //     to tabnab the Studio tab
       sandbox="allow-scripts allow-modals allow-popups"
       style={{
         width: "100%",

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -222,12 +222,8 @@ function renderHighlightedCode(props: BlockProps, codeFence: CodeFenceInfo) {
 function StreamdownBlock(props: BlockProps) {
   const hasMermaidFence = props.content.includes("```mermaid");
   const mermaidSource = getMermaidSource(props.content);
-  // parseCodeFence requires a closing ```; we fall back to
-  // parseIncompleteCodeFence both while the fence is still streaming AND
-  // when a finished reply forgot to emit the closing ``` (small local LLMs
-  // routinely drop it). Without the second fallback the HtmlSvgRenderer
-  // never mounts on an unclosed final message and the reply degrades to a
-  // plain code block.
+  // Fall back to parseIncompleteCodeFence for both still-streaming AND
+  // finished-but-unclosed fences (small LLMs routinely drop the closing ```).
   const codeFence =
     parseCodeFence(props.content) ?? parseIncompleteCodeFence(props.content);
 
@@ -252,9 +248,7 @@ function StreamdownBlock(props: BlockProps) {
     const svg = isSvgFence(codeFence);
     const html = !svg && isHtmlFence(codeFence);
     if (svg || html) {
-      // The HtmlSvgRenderer hosts a Code/Preview tab switcher and forces
-      // the Code tab while the fence is still streaming in so users see
-      // partial tokens rather than a flashing preview.
+      // Tabbed Preview/Code; locks to Code while streaming.
       return (
         <HtmlSvgRenderer
           language={svg ? "svg" : "html"}

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -222,13 +222,14 @@ function renderHighlightedCode(props: BlockProps, codeFence: CodeFenceInfo) {
 function StreamdownBlock(props: BlockProps) {
   const hasMermaidFence = props.content.includes("```mermaid");
   const mermaidSource = getMermaidSource(props.content);
-  // parseCodeFence requires a closing ```; while the fence is still
-  // streaming we fall through to parseIncompleteCodeFence so HtmlSvgRenderer
-  // can mount with isIncomplete=true and lock the Code tab on partial
-  // HTML/SVG fences (the advertised stream-in behaviour).
+  // parseCodeFence requires a closing ```; we fall back to
+  // parseIncompleteCodeFence both while the fence is still streaming AND
+  // when a finished reply forgot to emit the closing ``` (small local LLMs
+  // routinely drop it). Without the second fallback the HtmlSvgRenderer
+  // never mounts on an unclosed final message and the reply degrades to a
+  // plain code block.
   const codeFence =
-    parseCodeFence(props.content) ??
-    (props.isIncomplete ? parseIncompleteCodeFence(props.content) : null);
+    parseCodeFence(props.content) ?? parseIncompleteCodeFence(props.content);
 
   if (props.isIncomplete && hasMermaidFence) {
     return (

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -23,6 +23,7 @@ import {
   isHtmlFence,
   isSvgFence,
   parseCodeFence,
+  parseIncompleteCodeFence,
   type CodeFenceInfo,
 } from "./html-svg-renderer";
 
@@ -221,7 +222,13 @@ function renderHighlightedCode(props: BlockProps, codeFence: CodeFenceInfo) {
 function StreamdownBlock(props: BlockProps) {
   const hasMermaidFence = props.content.includes("```mermaid");
   const mermaidSource = getMermaidSource(props.content);
-  const codeFence = parseCodeFence(props.content);
+  // parseCodeFence requires a closing ```; while the fence is still
+  // streaming we fall through to parseIncompleteCodeFence so HtmlSvgRenderer
+  // can mount with isIncomplete=true and lock the Code tab on partial
+  // HTML/SVG fences (the advertised stream-in behaviour).
+  const codeFence =
+    parseCodeFence(props.content) ??
+    (props.isIncomplete ? parseIncompleteCodeFence(props.content) : null);
 
   if (props.isIncomplete && hasMermaidFence) {
     return (

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -12,12 +12,19 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { createCodePlugin } from "./code-plugin";
 import { createMathPlugin } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import { DownloadIcon, Maximize2Icon, Minimize2Icon } from "lucide-react";
+import { DownloadIcon } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Block, type BlockProps, Streamdown } from "streamdown";
 import "katex/dist/katex.min.css";
 import { AudioPlayer } from "./audio-player";
 import { unslothDarkTheme, unslothLightTheme } from "./code-themes";
+import {
+  HtmlSvgRenderer,
+  isHtmlFence,
+  isSvgFence,
+  parseCodeFence,
+  type CodeFenceInfo,
+} from "./html-svg-renderer";
 
 const math = createMathPlugin({ singleDollarTextMath: true });
 const code = createCodePlugin({
@@ -48,32 +55,14 @@ const STREAMDOWN_COMPONENTS = {
 };
 const COPY_RESET_MS = 2000;
 const MERMAID_SOURCE_RE = /```mermaid\s*([\s\S]*?)```/i;
-const CODE_FENCE_RE = /^```([^\r\n`]*)\r?\n([\s\S]*?)\r?\n?```$/;
 const ACTION_PANEL_CLASS =
   "pointer-events-auto flex shrink-0 items-center gap-1";
 const ACTION_BUTTON_CLASS =
   "flex size-8 cursor-pointer items-center justify-center rounded-[10px] text-chat-icon-fg transition-all hover:bg-chat-icon-bg-hover hover:text-chat-icon-fg-hover disabled:cursor-not-allowed disabled:opacity-50";
 
-type CodeFence = {
-  language: string | null;
-  source: string;
-};
-
 function getMermaidSource(blockContent: string): string | null {
   const source = blockContent.match(MERMAID_SOURCE_RE)?.[1]?.trim();
   return source && source.length > 0 ? source : null;
-}
-
-function getCodeFence(blockContent: string): CodeFence | null {
-  const match = blockContent.trimEnd().match(CODE_FENCE_RE);
-  if (!match) {
-    return null;
-  }
-
-  return {
-    language: match[1]?.trim() || null,
-    source: match[2],
-  };
 }
 
 function getCodeFilename(language: string | null) {
@@ -104,135 +93,6 @@ function getCodeFilename(language: string | null) {
     ? extByLanguage[normalized] || fallbackExt || "txt"
     : "txt";
   return `snippet.${ext}`;
-}
-
-function isSvgFence(codeFence: CodeFence): boolean {
-  const lang = codeFence.language?.toLowerCase() ?? "";
-  if (lang === "svg") return true;
-  if (lang === "xml" || lang === "html") {
-    const trimmed = codeFence.source.trimStart();
-    // Match <svg directly or <?xml ...?> followed by <svg
-    if (trimmed.startsWith("<svg")) return true;
-    if (trimmed.startsWith("<?xml") && trimmed.includes("<svg")) return true;
-  }
-  return false;
-}
-
-function isHtmlFence(codeFence: CodeFence): boolean {
-  const lang = codeFence.language?.toLowerCase() ?? "";
-  return lang === "html" && !isSvgFence(codeFence);
-}
-
-const UNSAFE_SVG_RE = /<script[\s>]|on\w+\s*=|javascript:|<foreignObject[\s>]|<iframe[\s>]|<embed[\s>]|<object[\s>]/i;
-
-function sanitizeSvg(source: string): string | null {
-  if (UNSAFE_SVG_RE.test(source)) return null;
-  // Strip XML declaration (<?xml ...?>) -- not needed for data URI
-  // rendering and can cause issues with some renderers.
-  return source.replace(/^\s*<\?xml[^?]*\?>\s*/i, "");
-}
-
-function SvgPreview({ source }: { source: string }) {
-  const dataUri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(source)}`;
-  return (
-    <div className="mt-2 flex justify-center rounded-lg border border-border bg-white p-4 dark:bg-neutral-100">
-      <img
-        src={dataUri}
-        alt="SVG preview"
-        style={{ maxWidth: "100%", maxHeight: 512 }}
-      />
-    </div>
-  );
-}
-
-const HTML_PREVIEW_DEFAULT_HEIGHT = 400;
-const HTML_PREVIEW_MAX_HEIGHT = 800;
-
-function HtmlPreview({ source }: { source: string }) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = useState(HTML_PREVIEW_DEFAULT_HEIGHT);
-  const [enlarged, setEnlarged] = useState(false);
-
-  useEffect(() => {
-    const handler = (e: MessageEvent) => {
-      if (e.source !== iframeRef.current?.contentWindow) return;
-      if (typeof e.data?.htmlPreviewHeight === "number") {
-        setHeight(Math.min(Math.max(e.data.htmlPreviewHeight, 100), HTML_PREVIEW_MAX_HEIGHT));
-      }
-    };
-    window.addEventListener("message", handler);
-    return () => window.removeEventListener("message", handler);
-  }, []);
-
-  useEffect(() => {
-    if (!enlarged) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setEnlarged(false);
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [enlarged]);
-
-  const resizeScript = `<script>new ResizeObserver(()=>{
-parent.postMessage({htmlPreviewHeight:document.documentElement.scrollHeight},"*");
-}).observe(document.documentElement);</script>`;
-
-  const srcDoc = source + resizeScript;
-
-  if (enlarged) {
-    return (
-      <>
-        <div className="mt-2 overflow-hidden rounded-lg border border-border" style={{ height }}>
-          {/* Placeholder keeps layout stable while overlay is shown */}
-        </div>
-        <div
-          className="fixed inset-0 z-50 flex flex-col bg-background/80 backdrop-blur-sm"
-          onClick={(e) => { if (e.target === e.currentTarget) setEnlarged(false); }}
-        >
-          <div className="flex items-center justify-end gap-2 px-4 py-2">
-            <button
-              type="button"
-              className="flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              onClick={() => setEnlarged(false)}
-              title="Exit fullscreen (Esc)"
-            >
-              <Minimize2Icon className="size-4" />
-              Exit fullscreen
-            </button>
-          </div>
-          <div className="mx-4 mb-4 flex-1 overflow-hidden rounded-lg border border-border bg-background">
-            <iframe
-              ref={iframeRef}
-              srcDoc={srcDoc}
-              sandbox="allow-scripts"
-              style={{ width: "100%", height: "100%", border: "none", display: "block" }}
-              title="HTML preview"
-            />
-          </div>
-        </div>
-      </>
-    );
-  }
-
-  return (
-    <div className="group/html-preview relative mt-2 overflow-hidden rounded-lg border border-border">
-      <button
-        type="button"
-        className="absolute top-2 right-2 z-10 rounded-md border border-border bg-background/80 p-1.5 text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-foreground group-hover/html-preview:opacity-100 supports-[backdrop-filter]:backdrop-blur"
-        onClick={() => setEnlarged(true)}
-        title="Enlarge preview"
-      >
-        <Maximize2Icon className="size-4" />
-      </button>
-      <iframe
-        ref={iframeRef}
-        srcDoc={srcDoc}
-        sandbox="allow-scripts"
-        style={{ width: "100%", height, border: "none", display: "block" }}
-        title="HTML preview"
-      />
-    </div>
-  );
 }
 
 function downloadTextFile(filename: string, text: string): void {
@@ -345,36 +205,28 @@ function CodeBlockActions({
   );
 }
 
+function renderHighlightedCode(props: BlockProps, codeFence: CodeFenceInfo) {
+  return (
+    <div className="relative isolate">
+      <Block {...props} />
+      <CodeBlockActions
+        disabled={props.isIncomplete}
+        language={codeFence.language}
+        source={codeFence.source}
+      />
+    </div>
+  );
+}
+
 function StreamdownBlock(props: BlockProps) {
   const hasMermaidFence = props.content.includes("```mermaid");
   const mermaidSource = getMermaidSource(props.content);
-  const codeFence = getCodeFence(props.content);
+  const codeFence = parseCodeFence(props.content);
 
   if (props.isIncomplete && hasMermaidFence) {
     return (
       <div className="my-4 flex h-48 items-center justify-center rounded-xl border border-border bg-muted/30 text-sm text-muted-foreground animate-pulse">
         Loading diagram...
-      </div>
-    );
-  }
-
-  if (props.isIncomplete && codeFence && isSvgFence(codeFence)) {
-    return (
-      <div className="relative isolate">
-        <div className="my-4 rounded-xl border border-border bg-muted/30 p-4">
-          <div className="mb-2 text-xs font-medium text-muted-foreground">svg</div>
-          <pre className="overflow-x-auto text-xs text-muted-foreground whitespace-pre-wrap break-all">
-            <code>{codeFence.source}</code>
-          </pre>
-        </div>
-      </div>
-    );
-  }
-
-  if (props.isIncomplete && codeFence && isHtmlFence(codeFence)) {
-    return (
-      <div className="my-4 flex h-48 items-center justify-center rounded-xl border border-border bg-muted/30 text-sm text-muted-foreground animate-pulse">
-        Loading preview...
       </div>
     );
   }
@@ -389,22 +241,22 @@ function StreamdownBlock(props: BlockProps) {
   }
 
   if (codeFence) {
-    const svgSource = !props.isIncomplete && isSvgFence(codeFence) ? sanitizeSvg(codeFence.source) : null;
-    const htmlSource = !props.isIncomplete && isHtmlFence(codeFence) ? codeFence.source : null;
-    return (
-      <>
-        <div className="relative isolate">
-          <Block {...props} />
-          <CodeBlockActions
-            disabled={props.isIncomplete}
-            language={codeFence.language}
-            source={codeFence.source}
-          />
-        </div>
-        {svgSource && <SvgPreview source={svgSource} />}
-        {htmlSource && <HtmlPreview source={htmlSource} />}
-      </>
-    );
+    const svg = isSvgFence(codeFence);
+    const html = !svg && isHtmlFence(codeFence);
+    if (svg || html) {
+      // The HtmlSvgRenderer hosts a Code/Preview tab switcher and forces
+      // the Code tab while the fence is still streaming in so users see
+      // partial tokens rather than a flashing preview.
+      return (
+        <HtmlSvgRenderer
+          language={svg ? "svg" : "html"}
+          source={codeFence.source}
+          codeView={renderHighlightedCode(props, codeFence)}
+          isIncomplete={props.isIncomplete}
+        />
+      );
+    }
+    return renderHighlightedCode(props, codeFence);
   }
 
   return <Block {...props} />;

--- a/studio/frontend/src/test-setup/setup.ts
+++ b/studio/frontend/src/test-setup/setup.ts
@@ -4,9 +4,7 @@
 import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
-// jsdom does not implement ResizeObserver; the HTML preview iframe uses one
-// inside its srcDoc but the parent component also references it indirectly
-// through DOM listeners. A no-op shim is enough for tests.
+// jsdom shims: ResizeObserver + URL.createObjectURL.
 class ResizeObserverStub {
   observe(): void {}
   unobserve(): void {}
@@ -18,11 +16,6 @@ if (typeof globalThis.ResizeObserver === "undefined") {
     ResizeObserverStub as unknown as typeof ResizeObserver;
 }
 
-// jsdom's URL.createObjectURL is not implemented and throws by default.
-// HtmlPreview now loads its document through a blob: URL so the iframe gets
-// an opaque origin and escapes the host Studio CSP. The shim below is enough
-// for the renderer tests, which only assert the resulting src starts with
-// "blob:" and never actually fetch the URL.
 let __blobCounter = 0;
 if (typeof URL.createObjectURL !== "function") {
   URL.createObjectURL = ((_blob: Blob) =>

--- a/studio/frontend/src/test-setup/setup.ts
+++ b/studio/frontend/src/test-setup/setup.ts
@@ -18,6 +18,20 @@ if (typeof globalThis.ResizeObserver === "undefined") {
     ResizeObserverStub as unknown as typeof ResizeObserver;
 }
 
+// jsdom's URL.createObjectURL is not implemented and throws by default.
+// HtmlPreview now loads its document through a blob: URL so the iframe gets
+// an opaque origin and escapes the host Studio CSP. The shim below is enough
+// for the renderer tests, which only assert the resulting src starts with
+// "blob:" and never actually fetch the URL.
+let __blobCounter = 0;
+if (typeof URL.createObjectURL !== "function") {
+  URL.createObjectURL = ((_blob: Blob) =>
+    `blob:jsdom/${++__blobCounter}`) as typeof URL.createObjectURL;
+}
+if (typeof URL.revokeObjectURL !== "function") {
+  URL.revokeObjectURL = (() => undefined) as typeof URL.revokeObjectURL;
+}
+
 afterEach(() => {
   cleanup();
 });

--- a/studio/frontend/src/test-setup/setup.ts
+++ b/studio/frontend/src/test-setup/setup.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// jsdom does not implement ResizeObserver; the HTML preview iframe uses one
+// inside its srcDoc but the parent component also references it indirectly
+// through DOM listeners. A no-op shim is enough for tests.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver =
+    ResizeObserverStub as unknown as typeof ResizeObserver;
+}
+
+afterEach(() => {
+  cleanup();
+});

--- a/studio/frontend/vitest.config.ts
+++ b/studio/frontend/vitest.config.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import path from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    css: false,
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    setupFiles: ["./src/test-setup/setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Adds inline HTML/SVG rendering for fenced code blocks in Studio's assistant messages. When the model returns a ```html or ```svg fence, the assistant bubble now hosts a Code/Preview tab toggle (Preview by default) so users can play JS games or view generated SVG diagrams without copy-pasting into a browser.

- New `studio/frontend/src/components/assistant-ui/html-svg-renderer.tsx` component
  - HTML preview runs inside an `<iframe srcDoc=... sandbox="allow-scripts">` only. No `allow-same-origin`, no `allow-top-navigation`, so the iframe can run scripts but cannot reach `parent.document` or navigate the host page.
  - SVG preview runs DOMPurify (`USE_PROFILES: { svg: true, svgFilters: true }`) before mounting via `dangerouslySetInnerHTML`, stripping `<script>`, `on*` handlers, `javascript:` URLs, and any tag that could escape the SVG sandbox (`<foreignObject>`, nested `<iframe>`, etc.).
  - Tabs sit above the block: Preview is the default for completed fences; the renderer locks to Code while the markdown stream is still arriving so users see partial tokens rather than a flashing preview.
  - HTML previews cap at 500px and have a Pop-out button that expands the iframe to 80vh inside a modal; Esc exits the modal.
  - The Code tab reuses the existing Streamdown syntax-highlighted view plus the `CodeBlockActions` copy/download chrome already used by every other fence, so copy behaviour is preserved.
- `markdown-text.tsx` now delegates HTML/SVG fences to the new component and falls through to the existing highlighted block for everything else. The earlier stacked code+preview layout is removed.
- DOMPurify is declared as a direct dependency (was previously transitive via mermaid) so the bundle remains stable when transitive deps shift.
- Adds Vitest 2 + jsdom + React Testing Library + `vitest.config.ts` to the frontend tooling. New script: `npm run test`.

## Test plan

- [x] `npx tsc -b --pretty false` clean
- [x] `npx vite build` clean
- [x] `npx vitest run` -- 10 tests pass, covering:
  - HTML block renders an iframe with `sandbox="allow-scripts"` (and not `allow-same-origin` / `allow-top-navigation`).
  - SVG block strips a malicious `<script>` payload and an `onclick="alert(...)"` attribute.
  - Clicking the Code / Preview tabs swaps the rendered body.
  - Incomplete (streaming) fences lock to the Code tab and disable the Preview tab.
  - `sanitizeSvgSource` removes `<script>`, `on*` handlers, `javascript:` URLs, and `<?xml ...?>` processing instructions.
  - Non-HTML/SVG fences are not routed through the renderer.
- [ ] Manual smoke in Studio: send a 3-line `<svg>` and a tiny `<html><body><button onclick="alert(1)">x</button></body></html>` -- SVG circle renders, button click runs inside the iframe but cannot access `parent.document`.