### PR TITLE
Studio: surface Anthropic document citations inline + in Sources panel

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2548,9 +2548,7 @@ class ExternalProviderClient:
                             if document_citations:
                                 clean_cits = []
                                 for c in document_citations:
-                                    entry = {
-                                        k: v for k, v in c.items() if k != "_key"
-                                    }
+                                    entry = {k: v for k, v in c.items() if k != "_key"}
                                     cited = entry.get("cited_text")
                                     if (
                                         isinstance(cited, str)

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -177,6 +177,13 @@ def _anthropic_supports_compaction(model: str) -> bool:
     return model.startswith(_ANTHROPIC_COMPACTION_PREFIXES)
 
 
+# Server-side cap on ``cited_text`` forwarded inside the synthetic
+# ``document_citations`` tool_event. The frontend Sources panel trims
+# to 240 chars anyway; truncating here keeps SSE bytes bounded when
+# a long RAG / search-result block returns a multi-KB cited span.
+_CITED_TEXT_MAX_LEN = 512
+
+
 def _anthropic_citation_key(citation: dict[str, Any]) -> tuple:
     """Stable dedup key for an Anthropic ``citations_delta.citation``.
 
@@ -2534,11 +2541,25 @@ class ExternalProviderClient:
                             # Sources panel can render the footnotes the
                             # inline [N] markers point at. No-op when
                             # the stream carried no citations_delta.
+                            # ``cited_text`` is truncated server-side
+                            # (frontend trims to 240 chars in the
+                            # Sources panel anyway) so SSE bytes stay
+                            # bounded on long RAG / search-result spans.
                             if document_citations:
-                                clean_cits = [
-                                    {k: v for k, v in c.items() if k != "_key"}
-                                    for c in document_citations
-                                ]
+                                clean_cits = []
+                                for c in document_citations:
+                                    entry = {
+                                        k: v for k, v in c.items() if k != "_key"
+                                    }
+                                    cited = entry.get("cited_text")
+                                    if (
+                                        isinstance(cited, str)
+                                        and len(cited) > _CITED_TEXT_MAX_LEN
+                                    ):
+                                        entry["cited_text"] = (
+                                            cited[:_CITED_TEXT_MAX_LEN] + "…"
+                                        )
+                                    clean_cits.append(entry)
                                 yield _emit_tool_event(
                                     {
                                         "type": "document_citations",

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -177,6 +177,42 @@ def _anthropic_supports_compaction(model: str) -> bool:
     return model.startswith(_ANTHROPIC_COMPACTION_PREFIXES)
 
 
+def _anthropic_citation_key(citation: dict[str, Any]) -> tuple:
+    """Stable dedup key for an Anthropic ``citations_delta.citation``.
+
+    Shape varies per document type per
+    https://platform.claude.com/docs/en/build-with-claude/citations
+    and https://platform.claude.com/docs/en/build-with-claude/search-results :
+
+    * ``char_location``: ``document_index`` + ``start_char_index``
+    * ``page_location``: ``document_index`` + ``start_page_number``
+    * ``content_block_location``: ``document_index`` + ``start_block_index``
+    * ``search_result_location``: ``document_index`` + ``source`` +
+      ``start_block_index``
+
+    Anything unrecognised falls back to a stringified copy so a future
+    shape still dedupes (worst case: more entries, never collisions).
+    """
+    ctype = citation.get("type")
+    doc = citation.get("document_index")
+    title = citation.get("document_title") or ""
+    if ctype == "char_location":
+        return (ctype, doc, title, citation.get("start_char_index"))
+    if ctype == "page_location":
+        return (ctype, doc, title, citation.get("start_page_number"))
+    if ctype == "content_block_location":
+        return (ctype, doc, title, citation.get("start_block_index"))
+    if ctype == "search_result_location":
+        return (
+            ctype,
+            doc,
+            title,
+            citation.get("source"),
+            citation.get("start_block_index"),
+        )
+    return (ctype, _json.dumps(citation, sort_keys = True))
+
+
 class _MistralThinkingSpec(NamedTuple):
     models: tuple[str, ...]
     style: Literal["prompt_mode", "reasoning_effort", "disabled"]
@@ -1767,6 +1803,19 @@ class ExternalProviderClient:
                 # the next turn.
                 current_compaction: Optional[dict[str, Any]] = None
                 compaction_blocks_seen = 0
+                # Document citations accumulator. Anthropic streams
+                # ``citations_delta`` events on content_block_delta when
+                # the user enabled ``citations: {enabled: true}`` on a
+                # document block. Each event carries one citation; we
+                # dedupe by the type-specific anchor key, assign a
+                # 1-based number, and inject ``[N]`` inline right after
+                # the cited run so the reader sees footnote markers.
+                # The full list is forwarded as a synthetic tool_end
+                # on message_stop so the Sources panel can render them
+                # next to web_search / web_fetch citations. See
+                #   https://platform.claude.com/docs/en/build-with-claude/citations
+                #   https://platform.claude.com/docs/en/build-with-claude/search-results
+                document_citations: list[dict[str, Any]] = []
                 # Counts surfaced in the final log line so reports of
                 # "Code execution did nothing" can be triaged at a
                 # glance. generated_files_count is interesting for the
@@ -2118,10 +2167,30 @@ class ExternalProviderClient:
                                         thinking_open = False
                                     if text:
                                         yield _content_chunk(text)
-                                    # Citations on text deltas are attached
-                                    # per-call by Anthropic via the
-                                    # `web_search_tool_result` block; we don't
-                                    # need to scrape them off the text events.
+                                    # web_search citations: web_search_tool_result.
+                                    # User-doc citations: citations_delta below.
+                            elif delta_type == "citations_delta":
+                                # https://platform.claude.com/docs/en/build-with-claude/citations
+                                # Each citations_delta carries one citation.
+                                # Collapse onto a numbered footnote list
+                                # and inject [N] inline so the prose has
+                                # reader-visible references.
+                                cit = delta.get("citation")
+                                if isinstance(cit, dict):
+                                    key = _anthropic_citation_key(cit)
+                                    idx_for_marker: Optional[int] = None
+                                    for idx, existing in enumerate(
+                                        document_citations, start = 1
+                                    ):
+                                        if existing.get("_key") == key:
+                                            idx_for_marker = idx
+                                            break
+                                    if idx_for_marker is None:
+                                        document_citations.append(
+                                            {**cit, "_key": key}
+                                        )
+                                        idx_for_marker = len(document_citations)
+                                    yield _content_chunk(f"[{idx_for_marker}]")
                             elif delta_type == "input_json_delta":
                                 # Streamed partial_json carrying tool inputs
                                 # — the search query for web_search, or the
@@ -2428,6 +2497,21 @@ class ExternalProviderClient:
                             if thinking_open:
                                 yield _content_chunk("</think>")
                                 thinking_open = False
+                            # Forward accumulated document_citations so the
+                            # Sources panel can render the footnotes the
+                            # inline [N] markers point at. No-op when
+                            # the stream carried no citations_delta.
+                            if document_citations:
+                                clean_cits = [
+                                    {k: v for k, v in c.items() if k != "_key"}
+                                    for c in document_citations
+                                ]
+                                yield _emit_tool_event(
+                                    {
+                                        "type": "document_citations",
+                                        "citations": clean_cits,
+                                    }
+                                )
                             # Final include_usage-style chunk so callers can
                             # see cache_creation / cache_read without
                             # scraping the server log.

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -184,14 +184,18 @@ def _anthropic_citation_key(citation: dict[str, Any]) -> tuple:
     https://platform.claude.com/docs/en/build-with-claude/citations
     and https://platform.claude.com/docs/en/build-with-claude/search-results :
 
-    * ``char_location``: ``document_index`` + ``start_char_index``
-    * ``page_location``: ``document_index`` + ``start_page_number``
-    * ``content_block_location``: ``document_index`` + ``start_block_index``
+    * ``char_location``: ``document_index`` + start/end char index
+    * ``page_location``: ``document_index`` + start/end page number
+    * ``content_block_location``: ``document_index`` + start/end block index
     * ``search_result_location``: ``search_result_index`` + ``source`` +
-      ``title`` + ``start_block_index`` + ``end_block_index``
+      ``title`` + start/end block index
       (search-result citations do NOT carry document_index /
       document_title -- using those would collapse distinct results
       with the same source into one footnote.)
+
+    The end anchor is part of the key for every variant: Anthropic
+    citation ranges are defined by start AND exclusive end indices,
+    so a same-start / different-end pair is two distinct citations.
 
     Anything unrecognised falls back to a stringified copy so a future
     shape still dedupes (worst case: more entries, never collisions).
@@ -200,11 +204,29 @@ def _anthropic_citation_key(citation: dict[str, Any]) -> tuple:
     doc = citation.get("document_index")
     title = citation.get("document_title") or ""
     if ctype == "char_location":
-        return (ctype, doc, title, citation.get("start_char_index"))
+        return (
+            ctype,
+            doc,
+            title,
+            citation.get("start_char_index"),
+            citation.get("end_char_index"),
+        )
     if ctype == "page_location":
-        return (ctype, doc, title, citation.get("start_page_number"))
+        return (
+            ctype,
+            doc,
+            title,
+            citation.get("start_page_number"),
+            citation.get("end_page_number"),
+        )
     if ctype == "content_block_location":
-        return (ctype, doc, title, citation.get("start_block_index"))
+        return (
+            ctype,
+            doc,
+            title,
+            citation.get("start_block_index"),
+            citation.get("end_block_index"),
+        )
     if ctype == "search_result_location":
         return (
             ctype,

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -187,8 +187,11 @@ def _anthropic_citation_key(citation: dict[str, Any]) -> tuple:
     * ``char_location``: ``document_index`` + ``start_char_index``
     * ``page_location``: ``document_index`` + ``start_page_number``
     * ``content_block_location``: ``document_index`` + ``start_block_index``
-    * ``search_result_location``: ``document_index`` + ``source`` +
-      ``start_block_index``
+    * ``search_result_location``: ``search_result_index`` + ``source`` +
+      ``title`` + ``start_block_index`` + ``end_block_index``
+      (search-result citations do NOT carry document_index /
+      document_title -- using those would collapse distinct results
+      with the same source into one footnote.)
 
     Anything unrecognised falls back to a stringified copy so a future
     shape still dedupes (worst case: more entries, never collisions).
@@ -205,10 +208,11 @@ def _anthropic_citation_key(citation: dict[str, Any]) -> tuple:
     if ctype == "search_result_location":
         return (
             ctype,
-            doc,
-            title,
+            citation.get("search_result_index"),
             citation.get("source"),
+            citation.get("title") or "",
             citation.get("start_block_index"),
+            citation.get("end_block_index"),
         )
     return (ctype, _json.dumps(citation, sort_keys = True))
 

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1367,6 +1367,14 @@ class ExternalProviderClient:
                                     "media_type": media_type,
                                     "data": b64data,
                                 },
+                                # Opt the document block into Anthropic's
+                                # natural-citation pipeline. Without this,
+                                # the model never emits citations_delta
+                                # events and the inline [N] + Sources
+                                # panel plumbing in the stream handler
+                                # is a no-op for real user uploads. See
+                                # https://platform.claude.com/docs/en/build-with-claude/citations
+                                "citations": {"enabled": True},
                             }
                             if title:
                                 doc_block["title"] = title
@@ -1378,6 +1386,7 @@ class ExternalProviderClient:
                                     "type": "url",
                                     "url": url,
                                 },
+                                "citations": {"enabled": True},
                             }
                             if title:
                                 doc_block["title"] = title

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2186,9 +2186,7 @@ class ExternalProviderClient:
                                             idx_for_marker = idx
                                             break
                                     if idx_for_marker is None:
-                                        document_citations.append(
-                                            {**cit, "_key": key}
-                                        )
+                                        document_citations.append({**cit, "_key": key})
                                         idx_for_marker = len(document_citations)
                                     yield _content_chunk(f"[{idx_for_marker}]")
                             elif delta_type == "input_json_delta":

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -177,35 +177,25 @@ def _anthropic_supports_compaction(model: str) -> bool:
     return model.startswith(_ANTHROPIC_COMPACTION_PREFIXES)
 
 
-# Server-side cap on ``cited_text`` forwarded inside the synthetic
-# ``document_citations`` tool_event. The frontend Sources panel trims
-# to 240 chars anyway; truncating here keeps SSE bytes bounded when
-# a long RAG / search-result block returns a multi-KB cited span.
+# Cap on ``cited_text`` forwarded in document_citations tool_events;
+# keeps SSE bytes bounded on multi-KB cited spans (frontend trims to
+# 240 chars anyway).
 _CITED_TEXT_MAX_LEN = 512
 
 
 def _anthropic_citation_key(citation: dict[str, Any]) -> tuple:
     """Stable dedup key for an Anthropic ``citations_delta.citation``.
 
-    Shape varies per document type per
+    Anchor fields vary per type (char_location, page_location,
+    content_block_location, search_result_location); both start AND
+    exclusive end indices are part of the key so same-start /
+    different-end pairs stay distinct. search_result_location keys on
+    ``search_result_index`` + ``source`` instead of document_index so
+    distinct results with the same source don't collapse. Unknown
+    shapes fall back to a stringified copy (more entries, never
+    collisions). See
     https://platform.claude.com/docs/en/build-with-claude/citations
-    and https://platform.claude.com/docs/en/build-with-claude/search-results :
-
-    * ``char_location``: ``document_index`` + start/end char index
-    * ``page_location``: ``document_index`` + start/end page number
-    * ``content_block_location``: ``document_index`` + start/end block index
-    * ``search_result_location``: ``search_result_index`` + ``source`` +
-      ``title`` + start/end block index
-      (search-result citations do NOT carry document_index /
-      document_title -- using those would collapse distinct results
-      with the same source into one footnote.)
-
-    The end anchor is part of the key for every variant: Anthropic
-    citation ranges are defined by start AND exclusive end indices,
-    so a same-start / different-end pair is two distinct citations.
-
-    Anything unrecognised falls back to a stringified copy so a future
-    shape still dedupes (worst case: more entries, never collisions).
+    and https://platform.claude.com/docs/en/build-with-claude/search-results.
     """
     ctype = citation.get("type")
     doc = citation.get("document_index")
@@ -1374,12 +1364,9 @@ class ExternalProviderClient:
                                     "media_type": media_type,
                                     "data": b64data,
                                 },
-                                # Opt the document block into Anthropic's
-                                # natural-citation pipeline. Without this,
-                                # the model never emits citations_delta
-                                # events and the inline [N] + Sources
-                                # panel plumbing in the stream handler
-                                # is a no-op for real user uploads. See
+                                # Opt into Anthropic's natural-citation
+                                # pipeline; without this no citations_delta
+                                # events fire. See
                                 # https://platform.claude.com/docs/en/build-with-claude/citations
                                 "citations": {"enabled": True},
                             }
@@ -1845,18 +1832,11 @@ class ExternalProviderClient:
                 # the next turn.
                 current_compaction: Optional[dict[str, Any]] = None
                 compaction_blocks_seen = 0
-                # Document citations accumulator. Anthropic streams
-                # ``citations_delta`` events on content_block_delta when
-                # the user enabled ``citations: {enabled: true}`` on a
-                # document block. Each event carries one citation; we
-                # dedupe by the type-specific anchor key, assign a
-                # 1-based number, and inject ``[N]`` inline right after
-                # the cited run so the reader sees footnote markers.
-                # The full list is forwarded as a synthetic tool_end
-                # on message_stop so the Sources panel can render them
-                # next to web_search / web_fetch citations. See
-                #   https://platform.claude.com/docs/en/build-with-claude/citations
-                #   https://platform.claude.com/docs/en/build-with-claude/search-results
+                # Document citations from ``citations_delta`` events.
+                # Deduped by type-specific anchor key; inline [N] is
+                # injected after each cited run, and the full list is
+                # forwarded as a synthetic document_citations tool_event
+                # on message_stop for the Sources panel.
                 document_citations: list[dict[str, Any]] = []
                 # Counts surfaced in the final log line so reports of
                 # "Code execution did nothing" can be triaged at a
@@ -2212,11 +2192,10 @@ class ExternalProviderClient:
                                     # web_search citations: web_search_tool_result.
                                     # User-doc citations: citations_delta below.
                             elif delta_type == "citations_delta":
+                                # One citation per event; collapse onto a
+                                # numbered footnote list and inject [N]
+                                # inline. See
                                 # https://platform.claude.com/docs/en/build-with-claude/citations
-                                # Each citations_delta carries one citation.
-                                # Collapse onto a numbered footnote list
-                                # and inject [N] inline so the prose has
-                                # reader-visible references.
                                 cit = delta.get("citation")
                                 if isinstance(cit, dict):
                                     key = _anthropic_citation_key(cit)
@@ -2537,14 +2516,10 @@ class ExternalProviderClient:
                             if thinking_open:
                                 yield _content_chunk("</think>")
                                 thinking_open = False
-                            # Forward accumulated document_citations so the
-                            # Sources panel can render the footnotes the
-                            # inline [N] markers point at. No-op when
-                            # the stream carried no citations_delta.
-                            # ``cited_text`` is truncated server-side
-                            # (frontend trims to 240 chars in the
-                            # Sources panel anyway) so SSE bytes stay
-                            # bounded on long RAG / search-result spans.
+                            # Forward document_citations so the Sources
+                            # panel can render the inline [N] footnotes.
+                            # ``cited_text`` is truncated server-side to
+                            # keep SSE bytes bounded on long spans.
                             if document_citations:
                                 clean_cits = []
                                 for c in document_citations:

--- a/studio/backend/tests/test_anthropic_citations.py
+++ b/studio/backend/tests/test_anthropic_citations.py
@@ -285,6 +285,46 @@ def test_search_result_location_supported(monkeypatch):
     assert "example.com/doc.html" in body
 
 
+def test_same_start_different_end_offsets_get_distinct_numbers(monkeypatch):
+    """char_location citations sharing start_char_index but with
+    different end_char_index are distinct spans (Anthropic ranges
+    are defined by start AND exclusive end) and must get distinct
+    footnote numbers."""
+    cit_a = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 100,
+        "end_char_index": 150,
+        "cited_text": "first half",
+    }
+    cit_b = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 100,
+        "end_char_index": 250,
+        "cited_text": "wider span",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("A "),
+            _citations_delta(cit_a),
+            _text_delta(" and B "),
+            _citations_delta(cit_b),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body, body
+    assert "[2]" in body, body
+
+
 def test_search_result_location_different_indices_get_distinct_numbers(monkeypatch):
     """Two search_result_location citations with the same source but
     different ``search_result_index`` must dedupe as distinct footnotes,

--- a/studio/backend/tests/test_anthropic_citations.py
+++ b/studio/backend/tests/test_anthropic_citations.py
@@ -3,22 +3,12 @@
 
 """Tests for Anthropic ``citations_delta`` handling in the streaming proxy.
 
-When a user enables ``citations: {enabled: true}`` on a document block in
-the request, Anthropic emits ``content_block_delta`` events whose ``delta``
-is shaped as ``{"type": "citations_delta", "citation": {...}}``. Each
-event carries one citation pointing at a source document and the
-citations interleave with ``text_delta`` events on the same content
-block. See https://platform.claude.com/docs/en/build-with-claude/citations
-
-The proxy must:
-  * inject a numbered footnote marker ``[N]`` inline right after the
-    text run the citation refers to;
-  * dedupe by the type-specific anchor so re-cites of the same span
-    collapse onto a single footnote;
-  * forward the full list as a synthetic ``document_citations``
-    tool_event at ``message_stop`` so the Sources panel can render the
-    footnotes next to existing web_search / web_fetch citations;
-  * stay invariant for streams that never emit ``citations_delta``.
+Verifies the proxy injects inline ``[N]`` markers after cited text,
+dedupes by type-specific anchor (char_location, page_location,
+content_block_location, search_result_location), forwards a synthetic
+``document_citations`` tool_event at message_stop, and stays inert when
+no citations_delta events fire. See
+https://platform.claude.com/docs/en/build-with-claude/citations
 """
 
 import asyncio
@@ -137,8 +127,8 @@ def _joined(lines: list[str]) -> str:
 
 
 def test_no_citations_stream_unchanged(monkeypatch):
-    """A plain text stream without citations_delta passes through with no
-    inline markers and no document_citations tool_event."""
+    """Plain text streams pass through with no inline markers and no
+    document_citations tool_event."""
     lines = _capture(
         monkeypatch,
         [
@@ -286,10 +276,8 @@ def test_search_result_location_supported(monkeypatch):
 
 
 def test_same_start_different_end_offsets_get_distinct_numbers(monkeypatch):
-    """char_location citations sharing start_char_index but with
-    different end_char_index are distinct spans (Anthropic ranges
-    are defined by start AND exclusive end) and must get distinct
-    footnote numbers."""
+    """Same start_char_index + different end_char_index = distinct spans,
+    so they must get distinct footnote numbers (ranges use exclusive end)."""
     cit_a = {
         "type": "char_location",
         "document_index": 0,
@@ -326,9 +314,8 @@ def test_same_start_different_end_offsets_get_distinct_numbers(monkeypatch):
 
 
 def test_search_result_location_different_indices_get_distinct_numbers(monkeypatch):
-    """Two search_result_location citations with the same source but
-    different ``search_result_index`` must dedupe as distinct footnotes,
-    matching the Anthropic search-result citation contract."""
+    """Same source + different search_result_index = distinct footnotes
+    (matches the Anthropic search-result citation contract)."""
     cit_a = {
         "type": "search_result_location",
         "search_result_index": 0,

--- a/studio/backend/tests/test_anthropic_citations.py
+++ b/studio/backend/tests/test_anthropic_citations.py
@@ -283,3 +283,44 @@ def test_search_result_location_supported(monkeypatch):
     assert "[1]" in body
     assert "search_result_location" in body
     assert "example.com/doc.html" in body
+
+
+def test_search_result_location_different_indices_get_distinct_numbers(monkeypatch):
+    """Two search_result_location citations with the same source but
+    different ``search_result_index`` must dedupe as distinct footnotes,
+    matching the Anthropic search-result citation contract."""
+    cit_a = {
+        "type": "search_result_location",
+        "search_result_index": 0,
+        "source": "https://example.com/result.html",
+        "title": "Result",
+        "start_block_index": 0,
+        "end_block_index": 1,
+        "cited_text": "first",
+    }
+    cit_b = {
+        "type": "search_result_location",
+        "search_result_index": 1,
+        "source": "https://example.com/result.html",
+        "title": "Result",
+        "start_block_index": 0,
+        "end_block_index": 1,
+        "cited_text": "second",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("A "),
+            _citations_delta(cit_a),
+            _text_delta(" and B "),
+            _citations_delta(cit_b),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body, body
+    assert "[2]" in body, body

--- a/studio/backend/tests/test_anthropic_citations.py
+++ b/studio/backend/tests/test_anthropic_citations.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for Anthropic ``citations_delta`` handling in the streaming proxy.
+
+When a user enables ``citations: {enabled: true}`` on a document block in
+the request, Anthropic emits ``content_block_delta`` events whose ``delta``
+is shaped as ``{"type": "citations_delta", "citation": {...}}``. Each
+event carries one citation pointing at a source document and the
+citations interleave with ``text_delta`` events on the same content
+block. See https://platform.claude.com/docs/en/build-with-claude/citations
+
+The proxy must:
+  * inject a numbered footnote marker ``[N]`` inline right after the
+    text run the citation refers to;
+  * dedupe by the type-specific anchor so re-cites of the same span
+    collapse onto a single footnote;
+  * forward the full list as a synthetic ``document_citations``
+    tool_event at ``message_stop`` so the Sources panel can render the
+    footnotes next to existing web_search / web_fetch citations;
+  * stay invariant for streams that never emit ``citations_delta``.
+"""
+
+import asyncio
+import json
+
+import httpx
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_client() -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = "anthropic",
+        base_url = "https://api.anthropic.com/v1",
+        api_key = "sk-ant-test",
+    )
+
+
+def _sse(events: list[dict]) -> bytes:
+    out = []
+    for e in events:
+        ev = e.get("type", "message")
+        out.append(f"event: {ev}\ndata: {json.dumps(e)}\n\n")
+    return "".join(out).encode("utf-8")
+
+
+def _capture(monkeypatch, events: list[dict]) -> list[str]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = _sse(events),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+    )
+
+    lines: list[str] = []
+
+    async def run():
+        client = _make_client()
+        try:
+            async for line in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "what color is grass?"}],
+                model = "claude-opus-4-7",
+                max_tokens = 64,
+            ):
+                lines.append(line)
+        finally:
+            await client.close()
+
+    _drive(run())
+    return lines
+
+
+def _message_start() -> dict:
+    return {
+        "type": "message_start",
+        "message": {
+            "id": "m1",
+            "content": [],
+            "model": "claude-opus-4-7",
+            "role": "assistant",
+            "stop_reason": None,
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+        },
+    }
+
+
+def _content_block_start_text() -> dict:
+    return {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    }
+
+
+def _text_delta(text: str, index: int = 0) -> dict:
+    return {
+        "type": "content_block_delta",
+        "index": index,
+        "delta": {"type": "text_delta", "text": text},
+    }
+
+
+def _citations_delta(citation: dict, index: int = 0) -> dict:
+    return {
+        "type": "content_block_delta",
+        "index": index,
+        "delta": {"type": "citations_delta", "citation": citation},
+    }
+
+
+def _content_block_stop(index: int = 0) -> dict:
+    return {"type": "content_block_stop", "index": index}
+
+
+def _message_delta_end() -> dict:
+    return {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}
+
+
+def _message_stop() -> dict:
+    return {"type": "message_stop"}
+
+
+def _joined(lines: list[str]) -> str:
+    return "\n".join(lines)
+
+
+def test_no_citations_stream_unchanged(monkeypatch):
+    """A plain text stream without citations_delta passes through with no
+    inline markers and no document_citations tool_event."""
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Grass is green."),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "Grass is green." in body
+    assert "document_citations" not in body
+    assert "[1]" not in body
+
+
+def test_single_char_location_emits_inline_marker(monkeypatch):
+    cit = {
+        "type": "char_location",
+        "cited_text": "The grass is green.",
+        "document_index": 0,
+        "document_title": "Example",
+        "start_char_index": 0,
+        "end_char_index": 20,
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Grass is green."),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "Grass is green." in body
+    assert "[1]" in body, body
+    assert "document_citations" in body, body
+    assert '"document_index": 0' in body, body
+    assert "_key" not in body, body
+
+
+def test_duplicate_citation_dedupes_to_same_number(monkeypatch):
+    cit = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Example",
+        "start_char_index": 0,
+        "end_char_index": 20,
+        "cited_text": "The grass is green.",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Grass."),
+            _citations_delta(cit),
+            _text_delta(" Still green."),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert body.count("[1]") == 2, body
+    citation_blob = body[body.index("document_citations") :]
+    assert citation_blob.count('"start_char_index"') == 1, citation_blob
+
+
+def test_distinct_sources_get_distinct_numbers(monkeypatch):
+    cit1 = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc A",
+        "start_char_index": 0,
+        "end_char_index": 5,
+    }
+    cit2 = {
+        "type": "page_location",
+        "document_index": 1,
+        "document_title": "Doc B",
+        "start_page_number": 3,
+        "end_page_number": 4,
+    }
+    cit3 = {
+        "type": "content_block_location",
+        "document_index": 2,
+        "document_title": "Doc C",
+        "start_block_index": 0,
+        "end_block_index": 1,
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("First"),
+            _citations_delta(cit1),
+            _text_delta(" Second"),
+            _citations_delta(cit2),
+            _text_delta(" Third"),
+            _citations_delta(cit3),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body and "[2]" in body and "[3]" in body, body
+    assert body.index("[1]") < body.index("[2]") < body.index("[3]")
+
+
+def test_search_result_location_supported(monkeypatch):
+    cit = {
+        "type": "search_result_location",
+        "document_index": 0,
+        "document_title": "Anthropic Search Results",
+        "source": "https://example.com/doc.html",
+        "start_block_index": 0,
+        "end_block_index": 1,
+        "cited_text": "blah",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Some sourced fact."),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body
+    assert "search_result_location" in body
+    assert "example.com/doc.html" in body

--- a/studio/backend/tests/test_anthropic_citations_edge.py
+++ b/studio/backend/tests/test_anthropic_citations_edge.py
@@ -662,3 +662,46 @@ def test_input_document_translation_enables_citations(monkeypatch):
     doc_block = next(p for p in user_msg["content"] if p.get("type") == "document")
     assert doc_block["source"]["type"] == "url", doc_block
     assert doc_block.get("citations") == {"enabled": True}, doc_block
+
+
+# ── cited_text truncation + safe-url citation conversion ────────
+
+
+def test_cited_text_truncated_in_synthetic_event(monkeypatch):
+    """``cited_text`` is bounded server-side so a multi-KB span does
+    not balloon the SSE payload. The frontend trims to 240 chars
+    anyway; truncating at the source keeps bytes bounded.
+    """
+    from core.inference.external_provider import _CITED_TEXT_MAX_LEN
+
+    long_quote = "x" * (_CITED_TEXT_MAX_LEN + 4000)
+    events = [
+        {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 1, "output_tokens": 0}}},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "claim "}},
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "citations_delta",
+                "citation": {
+                    "type": "char_location",
+                    "document_index": 0,
+                    "document_title": "doc",
+                    "start_char_index": 0,
+                    "end_char_index": 5,
+                    "cited_text": long_quote,
+                },
+            },
+        },
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 1}},
+        {"type": "message_stop"},
+    ]
+    chunks = _capture(monkeypatch, events)
+    tool_events = [c for c in chunks if "_toolEvent" in c and "document_citations" in c]
+    assert tool_events, "no document_citations tool event"
+    payload = json.loads(tool_events[0].split("data: ", 1)[1])
+    cited = payload["_toolEvent"]["citations"][0]["cited_text"]
+    assert len(cited) <= _CITED_TEXT_MAX_LEN + 1, len(cited)
+    assert cited.endswith("…")

--- a/studio/backend/tests/test_anthropic_citations_edge.py
+++ b/studio/backend/tests/test_anthropic_citations_edge.py
@@ -676,9 +676,23 @@ def test_cited_text_truncated_in_synthetic_event(monkeypatch):
 
     long_quote = "x" * (_CITED_TEXT_MAX_LEN + 4000)
     events = [
-        {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 1, "output_tokens": 0}}},
-        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
-        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "claim "}},
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "claim "},
+        },
         {
             "type": "content_block_delta",
             "index": 0,
@@ -695,7 +709,11 @@ def test_cited_text_truncated_in_synthetic_event(monkeypatch):
             },
         },
         {"type": "content_block_stop", "index": 0},
-        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 1}},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 1},
+        },
         {"type": "message_stop"},
     ]
     chunks = _capture(monkeypatch, events)

--- a/studio/backend/tests/test_anthropic_citations_edge.py
+++ b/studio/backend/tests/test_anthropic_citations_edge.py
@@ -59,6 +59,7 @@ def _capture(
     Anthropic shape (e.g. that ``citations: {enabled: true}`` made it
     onto the document block).
     """
+
     def handler(request: httpx.Request) -> httpx.Response:
         if captured_body is not None:
             try:
@@ -83,9 +84,8 @@ def _capture(
         client = _make_client()
         try:
             async for line in client.stream_chat_completion(
-                messages = messages or [
-                    {"role": "user", "content": "what color is grass?"}
-                ],
+                messages = messages
+                or [{"role": "user", "content": "what color is grass?"}],
                 model = "claude-opus-4-7",
                 max_tokens = 64,
             ):
@@ -163,11 +163,14 @@ def _citation_payload(body: str) -> dict:
         if not line.startswith("data: "):
             continue
         try:
-            payload = json.loads(line[len("data: "):])
+            payload = json.loads(line[len("data: ") :])
         except json.JSONDecodeError:
             continue
         tool_event = payload.get("_toolEvent") if isinstance(payload, dict) else None
-        if isinstance(tool_event, dict) and tool_event.get("type") == "document_citations":
+        if (
+            isinstance(tool_event, dict)
+            and tool_event.get("type") == "document_citations"
+        ):
             return tool_event
     raise AssertionError("document_citations event not parsed out of SSE body")
 
@@ -625,9 +628,7 @@ def test_input_document_translation_enables_citations(monkeypatch):
         captured_body = captured_b64,
     )
     user_msg = captured_b64["messages"][0]
-    doc_block = next(
-        p for p in user_msg["content"] if p.get("type") == "document"
-    )
+    doc_block = next(p for p in user_msg["content"] if p.get("type") == "document")
     assert doc_block["source"]["type"] == "base64", doc_block
     assert doc_block.get("citations") == {"enabled": True}, doc_block
 
@@ -658,8 +659,6 @@ def test_input_document_translation_enables_citations(monkeypatch):
         captured_body = captured_url,
     )
     user_msg = captured_url["messages"][0]
-    doc_block = next(
-        p for p in user_msg["content"] if p.get("type") == "document"
-    )
+    doc_block = next(p for p in user_msg["content"] if p.get("type") == "document")
     assert doc_block["source"]["type"] == "url", doc_block
     assert doc_block.get("citations") == {"enabled": True}, doc_block

--- a/studio/backend/tests/test_anthropic_citations_edge.py
+++ b/studio/backend/tests/test_anthropic_citations_edge.py
@@ -4,12 +4,11 @@
 """Edge-case tests for Anthropic ``citations_delta`` handling.
 
 Complements ``test_anthropic_citations.py``. Covers malformed payloads,
-unusual orderings, mixed citation types, and the ``citations: {enabled:
-true}`` opt-in we now attach to translated ``input_document`` blocks.
-
-References:
-  * https://platform.claude.com/docs/en/build-with-claude/citations
-  * https://platform.claude.com/docs/en/build-with-claude/search-results
+unusual orderings, mixed citation types, and the ``citations:
+{enabled: true}`` opt-in attached to translated ``input_document``
+blocks. See
+https://platform.claude.com/docs/en/build-with-claude/citations and
+https://platform.claude.com/docs/en/build-with-claude/search-results.
 """
 
 import asyncio
@@ -52,12 +51,9 @@ def _capture(
     captured_body: dict | None = None,
 ) -> list[str]:
     """Drive ``stream_chat_completion`` against a mocked Anthropic
-    response and return the SSE lines we'd send back to the browser.
-
-    Pass ``captured_body`` (a dict) to also capture the request body
-    we sent upstream -- the test can then assert on the translated
-    Anthropic shape (e.g. that ``citations: {enabled: true}`` made it
-    onto the document block).
+    response and return the SSE lines. Pass ``captured_body`` to also
+    capture the outgoing request body for assertions on the translated
+    Anthropic shape.
     """
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -152,12 +148,8 @@ def _joined(lines: list[str]) -> str:
 
 
 def _citation_payload(body: str) -> dict:
-    """Pull the ``document_citations`` synthetic tool_event out of the
-    streamed SSE body and return its decoded payload.
-
-    Raises if no such event was emitted -- helper is for the tests that
-    expect the event to be present.
-    """
+    """Pull the ``document_citations`` synthetic tool_event from the
+    SSE body and return its payload. Raises if absent."""
     assert "document_citations" in body, body
     for line in body.splitlines():
         if not line.startswith("data: "):
@@ -179,10 +171,8 @@ def _citation_payload(body: str) -> dict:
 
 
 def test_citation_with_no_preceding_text_still_emits_marker(monkeypatch):
-    """A citations_delta arriving before any text_delta on a fresh
-    content block must not crash -- the marker just lands at the
-    beginning of the block. (Anthropic in practice emits text first,
-    but the proxy must not assume it.)"""
+    """citations_delta before any text_delta must not crash; marker
+    lands at the start of the block."""
     cit = {
         "type": "char_location",
         "document_index": 0,
@@ -209,9 +199,8 @@ def test_citation_with_no_preceding_text_still_emits_marker(monkeypatch):
 
 
 def test_citations_delta_with_non_dict_citation_is_ignored(monkeypatch):
-    """A malformed event where ``delta.citation`` is not a dict (e.g.
-    a future-proof string sentinel) must not crash, must not emit a
-    marker, and must not poison the document_citations list."""
+    """Non-dict ``delta.citation`` must not crash, emit a marker, or
+    poison the document_citations list."""
     lines = _capture(
         monkeypatch,
         [
@@ -235,8 +224,8 @@ def test_citations_delta_with_non_dict_citation_is_ignored(monkeypatch):
 
 
 def test_citations_delta_with_missing_citation_field_is_ignored(monkeypatch):
-    """citations_delta with no ``citation`` field is treated the same as
-    a non-dict citation -- skip without crashing."""
+    """Missing ``citation`` field is treated like a non-dict citation:
+    skip without crashing."""
     lines = _capture(
         monkeypatch,
         [
@@ -260,10 +249,8 @@ def test_citations_delta_with_missing_citation_field_is_ignored(monkeypatch):
 
 
 def test_char_location_with_reversed_indices_does_not_crash(monkeypatch):
-    """A malformed char_location where ``start_char_index >
-    end_char_index`` must not crash the stream -- the dedup key
-    accepts any int pair, and we still surface a footnote for the
-    caller to inspect."""
+    """Malformed char_location with reversed indices must not crash;
+    the dedup key accepts any int pair and still surfaces a footnote."""
     cit = {
         "type": "char_location",
         "document_index": 0,
@@ -292,9 +279,8 @@ def test_char_location_with_reversed_indices_does_not_crash(monkeypatch):
 
 
 def test_page_location_missing_document_index_does_not_crash(monkeypatch):
-    """page_location with no ``document_index`` (e.g. when Anthropic
-    only sends ``document_title``) must still produce a footnote.
-    The dedup key falls back to ``None`` for the missing field."""
+    """page_location missing ``document_index`` still produces a
+    footnote; dedup key falls back to ``None`` for the missing field."""
     cit = {
         "type": "page_location",
         "document_title": "Untitled PDF",
@@ -321,9 +307,8 @@ def test_page_location_missing_document_index_does_not_crash(monkeypatch):
 
 
 def test_content_block_location_with_non_int_block_index_does_not_crash(monkeypatch):
-    """content_block_location whose block indices are unexpectedly
-    strings (future shape / provider bug) must not crash. The dedup
-    key tolerates non-int values."""
+    """content_block_location with string block indices must not crash;
+    dedup key tolerates non-int values."""
     cit = {
         "type": "content_block_location",
         "document_index": 0,
@@ -351,9 +336,8 @@ def test_content_block_location_with_non_int_block_index_does_not_crash(monkeypa
 
 
 def test_unknown_citation_type_falls_back_to_stringified_key(monkeypatch):
-    """An unrecognised citation ``type`` (forward-compat) must still
-    dedupe: identical unknown citations collapse to one footnote;
-    citations that differ in any field get distinct numbers."""
+    """Unknown citation ``type`` (forward-compat) still dedupes:
+    identical ones collapse, differing ones get distinct numbers."""
     cit_a = {
         "type": "future_shape_location",
         "anchor": "abc",
@@ -389,10 +373,8 @@ def test_unknown_citation_type_falls_back_to_stringified_key(monkeypatch):
 
 
 def test_mixed_citation_types_same_document_get_distinct_keys(monkeypatch):
-    """A char_location and a page_location for the same
-    ``document_index`` are different citation shapes and must be
-    treated as distinct footnotes -- the dedup key carries the
-    citation type as its first slot."""
+    """char_location and page_location on the same document_index are
+    distinct shapes; dedup key uses citation type as its first slot."""
     cit_char = {
         "type": "char_location",
         "document_index": 0,
@@ -428,13 +410,9 @@ def test_mixed_citation_types_same_document_get_distinct_keys(monkeypatch):
 
 
 def test_cited_text_is_preserved_in_synthetic_event(monkeypatch):
-    """The ``cited_text`` field on a citation must survive into the
-    synthetic ``document_citations`` tool_event so the Sources panel
-    can render the cited snippet as a tooltip / description.
-
-    Per the Anthropic docs, ``cited_text`` is the verbatim cited
-    span and is not counted towards output tokens, so dropping it
-    here would lose user-visible context for free."""
+    """``cited_text`` must survive into the synthetic event so the
+    Sources panel can render it as a tooltip. Anthropic does not bill
+    cited_text against output tokens, so preserving it is free."""
     cit = {
         "type": "char_location",
         "document_index": 0,
@@ -461,10 +439,8 @@ def test_cited_text_is_preserved_in_synthetic_event(monkeypatch):
 
 
 def test_internal_key_field_never_leaks_to_client(monkeypatch):
-    """The ``_key`` sentinel we attach to each citation for in-process
-    dedup must be stripped before the synthetic event is forwarded
-    -- it's internal accounting state, not a documented Anthropic
-    field, and surfacing it would confuse downstream consumers."""
+    """The internal ``_key`` dedup sentinel must be stripped before
+    the synthetic event is forwarded; it is not an Anthropic field."""
     cit = {
         "type": "char_location",
         "document_index": 0,
@@ -493,10 +469,8 @@ def test_internal_key_field_never_leaks_to_client(monkeypatch):
 
 
 def test_citation_across_multiple_content_blocks_numbers_continue(monkeypatch):
-    """Footnote numbering must be per-message, not per-content-block.
-    A citation on block index 0 followed by one on block index 2
-    (split across a tool-use block, say) must come out as [1] then
-    [2], not [1] then [1]."""
+    """Footnote numbering is per-message, not per-content-block:
+    citations across separate blocks emit [1] then [2]."""
     cit_a = {
         "type": "char_location",
         "document_index": 0,
@@ -539,10 +513,9 @@ def test_citation_across_multiple_content_blocks_numbers_continue(monkeypatch):
 
 
 def test_inline_marker_lands_after_text_run(monkeypatch):
-    """The inline ``[N]`` marker must come AFTER the text run it
-    annotates, not before -- Anthropic streams the text first and
-    the citation second, and the proxy preserves that order so the
-    footnote reads ``"...grass is green.[1]"``, not ``"[1]...grass``."""
+    """Inline ``[N]`` must land AFTER the cited text run: Anthropic
+    streams text then citation, so the proxy emits ``"...green.[1]"``
+    not ``"[1]green"``."""
     cit = {
         "type": "char_location",
         "document_index": 0,
@@ -572,10 +545,8 @@ def test_inline_marker_lands_after_text_run(monkeypatch):
 
 
 def test_no_synthetic_event_when_only_text_deltas(monkeypatch):
-    """A stream that carries text_delta events but no citations_delta
-    must NOT emit a synthetic ``document_citations`` event -- the
-    Sources panel relies on absence of the event to know there are
-    no document footnotes to render."""
+    """No citations_delta means no synthetic ``document_citations``
+    event; Sources panel relies on absence to suppress the section."""
     lines = _capture(
         monkeypatch,
         [
@@ -594,13 +565,9 @@ def test_no_synthetic_event_when_only_text_deltas(monkeypatch):
 
 
 def test_input_document_translation_enables_citations(monkeypatch):
-    """Studio's normalised ``input_document`` content part must
-    translate to an Anthropic ``document`` block carrying ``citations:
-    {enabled: true}`` so the upstream actually emits citations_delta
-    events. Without this opt-in the rest of the citation plumbing is
-    a no-op for real user requests.
-
-    Covers both the base64 and the url ``source`` branches."""
+    """``input_document`` must translate to an Anthropic ``document``
+    block carrying ``citations: {enabled: true}`` (both base64 and url
+    source branches) so upstream emits citations_delta."""
     captured_b64: dict = {}
     _capture(
         monkeypatch,
@@ -668,10 +635,8 @@ def test_input_document_translation_enables_citations(monkeypatch):
 
 
 def test_cited_text_truncated_in_synthetic_event(monkeypatch):
-    """``cited_text`` is bounded server-side so a multi-KB span does
-    not balloon the SSE payload. The frontend trims to 240 chars
-    anyway; truncating at the source keeps bytes bounded.
-    """
+    """``cited_text`` is capped server-side so multi-KB spans do not
+    balloon the SSE payload."""
     from core.inference.external_provider import _CITED_TEXT_MAX_LEN
 
     long_quote = "x" * (_CITED_TEXT_MAX_LEN + 4000)

--- a/studio/backend/tests/test_anthropic_citations_edge.py
+++ b/studio/backend/tests/test_anthropic_citations_edge.py
@@ -1,0 +1,665 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Edge-case tests for Anthropic ``citations_delta`` handling.
+
+Complements ``test_anthropic_citations.py``. Covers malformed payloads,
+unusual orderings, mixed citation types, and the ``citations: {enabled:
+true}`` opt-in we now attach to translated ``input_document`` blocks.
+
+References:
+  * https://platform.claude.com/docs/en/build-with-claude/citations
+  * https://platform.claude.com/docs/en/build-with-claude/search-results
+"""
+
+import asyncio
+import json
+
+import httpx
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+
+
+# ── shared SSE harness ───────────────────────────────────────
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_client() -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = "anthropic",
+        base_url = "https://api.anthropic.com/v1",
+        api_key = "sk-ant-test",
+    )
+
+
+def _sse(events: list[dict]) -> bytes:
+    out = []
+    for e in events:
+        ev = e.get("type", "message")
+        out.append(f"event: {ev}\ndata: {json.dumps(e)}\n\n")
+    return "".join(out).encode("utf-8")
+
+
+def _capture(
+    monkeypatch,
+    events: list[dict],
+    *,
+    messages: list[dict] | None = None,
+    captured_body: dict | None = None,
+) -> list[str]:
+    """Drive ``stream_chat_completion`` against a mocked Anthropic
+    response and return the SSE lines we'd send back to the browser.
+
+    Pass ``captured_body`` (a dict) to also capture the request body
+    we sent upstream -- the test can then assert on the translated
+    Anthropic shape (e.g. that ``citations: {enabled: true}`` made it
+    onto the document block).
+    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        if captured_body is not None:
+            try:
+                captured_body.update(json.loads(request.content.decode("utf-8")))
+            except Exception:  # pragma: no cover -- diagnostic only
+                pass
+        return httpx.Response(
+            200,
+            content = _sse(events),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+    )
+
+    lines: list[str] = []
+
+    async def run():
+        client = _make_client()
+        try:
+            async for line in client.stream_chat_completion(
+                messages = messages or [
+                    {"role": "user", "content": "what color is grass?"}
+                ],
+                model = "claude-opus-4-7",
+                max_tokens = 64,
+            ):
+                lines.append(line)
+        finally:
+            await client.close()
+
+    _drive(run())
+    return lines
+
+
+def _message_start() -> dict:
+    return {
+        "type": "message_start",
+        "message": {
+            "id": "m1",
+            "content": [],
+            "model": "claude-opus-4-7",
+            "role": "assistant",
+            "stop_reason": None,
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+        },
+    }
+
+
+def _content_block_start_text() -> dict:
+    return {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    }
+
+
+def _text_delta(text: str, index: int = 0) -> dict:
+    return {
+        "type": "content_block_delta",
+        "index": index,
+        "delta": {"type": "text_delta", "text": text},
+    }
+
+
+def _citations_delta(citation: dict, index: int = 0) -> dict:
+    return {
+        "type": "content_block_delta",
+        "index": index,
+        "delta": {"type": "citations_delta", "citation": citation},
+    }
+
+
+def _content_block_stop(index: int = 0) -> dict:
+    return {"type": "content_block_stop", "index": index}
+
+
+def _message_delta_end() -> dict:
+    return {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}
+
+
+def _message_stop() -> dict:
+    return {"type": "message_stop"}
+
+
+def _joined(lines: list[str]) -> str:
+    return "\n".join(lines)
+
+
+def _citation_payload(body: str) -> dict:
+    """Pull the ``document_citations`` synthetic tool_event out of the
+    streamed SSE body and return its decoded payload.
+
+    Raises if no such event was emitted -- helper is for the tests that
+    expect the event to be present.
+    """
+    assert "document_citations" in body, body
+    for line in body.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            payload = json.loads(line[len("data: "):])
+        except json.JSONDecodeError:
+            continue
+        tool_event = payload.get("_toolEvent") if isinstance(payload, dict) else None
+        if isinstance(tool_event, dict) and tool_event.get("type") == "document_citations":
+            return tool_event
+    raise AssertionError("document_citations event not parsed out of SSE body")
+
+
+# ── edge cases ───────────────────────────────────────────────
+
+
+def test_citation_with_no_preceding_text_still_emits_marker(monkeypatch):
+    """A citations_delta arriving before any text_delta on a fresh
+    content block must not crash -- the marker just lands at the
+    beginning of the block. (Anthropic in practice emits text first,
+    but the proxy must not assume it.)"""
+    cit = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "X",
+        "start_char_index": 0,
+        "end_char_index": 5,
+        "cited_text": "x",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _citations_delta(cit),
+            _text_delta("hello"),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body, body
+    assert "document_citations" in body, body
+
+
+def test_citations_delta_with_non_dict_citation_is_ignored(monkeypatch):
+    """A malformed event where ``delta.citation`` is not a dict (e.g.
+    a future-proof string sentinel) must not crash, must not emit a
+    marker, and must not poison the document_citations list."""
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Hello."),
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "citations_delta", "citation": "not-a-dict"},
+            },
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "Hello." in body
+    assert "[1]" not in body
+    assert "document_citations" not in body
+
+
+def test_citations_delta_with_missing_citation_field_is_ignored(monkeypatch):
+    """citations_delta with no ``citation`` field is treated the same as
+    a non-dict citation -- skip without crashing."""
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Hello."),
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "citations_delta"},
+            },
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "Hello." in body
+    assert "[1]" not in body
+    assert "document_citations" not in body
+
+
+def test_char_location_with_reversed_indices_does_not_crash(monkeypatch):
+    """A malformed char_location where ``start_char_index >
+    end_char_index`` must not crash the stream -- the dedup key
+    accepts any int pair, and we still surface a footnote for the
+    caller to inspect."""
+    cit = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 300,
+        "end_char_index": 50,
+        "cited_text": "?",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Weird."),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body, body
+    payload = _citation_payload(body)
+    assert payload["citations"][0]["start_char_index"] == 300
+    assert payload["citations"][0]["end_char_index"] == 50
+
+
+def test_page_location_missing_document_index_does_not_crash(monkeypatch):
+    """page_location with no ``document_index`` (e.g. when Anthropic
+    only sends ``document_title``) must still produce a footnote.
+    The dedup key falls back to ``None`` for the missing field."""
+    cit = {
+        "type": "page_location",
+        "document_title": "Untitled PDF",
+        "start_page_number": 1,
+        "end_page_number": 2,
+        "cited_text": "p1",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("From the PDF:"),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body, body
+    payload = _citation_payload(body)
+    assert payload["citations"][0].get("document_index") is None
+
+
+def test_content_block_location_with_non_int_block_index_does_not_crash(monkeypatch):
+    """content_block_location whose block indices are unexpectedly
+    strings (future shape / provider bug) must not crash. The dedup
+    key tolerates non-int values."""
+    cit = {
+        "type": "content_block_location",
+        "document_index": 0,
+        "document_title": "Custom",
+        "start_block_index": "0",
+        "end_block_index": "1",
+        "cited_text": "anything",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Cite."),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body, body
+    payload = _citation_payload(body)
+    assert payload["citations"][0]["start_block_index"] == "0"
+
+
+def test_unknown_citation_type_falls_back_to_stringified_key(monkeypatch):
+    """An unrecognised citation ``type`` (forward-compat) must still
+    dedupe: identical unknown citations collapse to one footnote;
+    citations that differ in any field get distinct numbers."""
+    cit_a = {
+        "type": "future_shape_location",
+        "anchor": "abc",
+        "cited_text": "blah",
+    }
+    cit_b = {
+        "type": "future_shape_location",
+        "anchor": "xyz",
+        "cited_text": "blah",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("A"),
+            _citations_delta(cit_a),
+            _text_delta(" again"),
+            _citations_delta(cit_a),
+            _text_delta(" B"),
+            _citations_delta(cit_b),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    # cit_a dedupes onto [1], cit_b gets [2].
+    assert body.count("[1]") == 2, body
+    assert body.count("[2]") == 1, body
+    payload = _citation_payload(body)
+    assert len(payload["citations"]) == 2
+
+
+def test_mixed_citation_types_same_document_get_distinct_keys(monkeypatch):
+    """A char_location and a page_location for the same
+    ``document_index`` are different citation shapes and must be
+    treated as distinct footnotes -- the dedup key carries the
+    citation type as its first slot."""
+    cit_char = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 0,
+        "end_char_index": 10,
+    }
+    cit_page = {
+        "type": "page_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_page_number": 1,
+        "end_page_number": 2,
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("char-cite"),
+            _citations_delta(cit_char),
+            _text_delta(" page-cite"),
+            _citations_delta(cit_page),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body and "[2]" in body, body
+    payload = _citation_payload(body)
+    assert len(payload["citations"]) == 2
+
+
+def test_cited_text_is_preserved_in_synthetic_event(monkeypatch):
+    """The ``cited_text`` field on a citation must survive into the
+    synthetic ``document_citations`` tool_event so the Sources panel
+    can render the cited snippet as a tooltip / description.
+
+    Per the Anthropic docs, ``cited_text`` is the verbatim cited
+    span and is not counted towards output tokens, so dropping it
+    here would lose user-visible context for free."""
+    cit = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Trustworthy Doc",
+        "start_char_index": 0,
+        "end_char_index": 20,
+        "cited_text": "The grass is green.",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Grass is green."),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    payload = _citation_payload(body)
+    assert payload["citations"][0]["cited_text"] == "The grass is green."
+
+
+def test_internal_key_field_never_leaks_to_client(monkeypatch):
+    """The ``_key`` sentinel we attach to each citation for in-process
+    dedup must be stripped before the synthetic event is forwarded
+    -- it's internal accounting state, not a documented Anthropic
+    field, and surfacing it would confuse downstream consumers."""
+    cit = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 0,
+        "end_char_index": 5,
+        "cited_text": "..",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("hi"),
+            _citations_delta(cit),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    payload = _citation_payload(body)
+    assert payload["citations"], payload
+    for c in payload["citations"]:
+        assert "_key" not in c, c
+
+
+def test_citation_across_multiple_content_blocks_numbers_continue(monkeypatch):
+    """Footnote numbering must be per-message, not per-content-block.
+    A citation on block index 0 followed by one on block index 2
+    (split across a tool-use block, say) must come out as [1] then
+    [2], not [1] then [1]."""
+    cit_a = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 0,
+        "end_char_index": 5,
+    }
+    cit_b = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 100,
+        "end_char_index": 105,
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("first"),
+            _citations_delta(cit_a, index = 0),
+            _content_block_stop(0),
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text", "text": ""},
+            },
+            _text_delta(" second", index = 1),
+            _citations_delta(cit_b, index = 1),
+            _content_block_stop(1),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "[1]" in body and "[2]" in body, body
+    assert body.index("[1]") < body.index("[2]")
+    payload = _citation_payload(body)
+    assert len(payload["citations"]) == 2
+
+
+def test_inline_marker_lands_after_text_run(monkeypatch):
+    """The inline ``[N]`` marker must come AFTER the text run it
+    annotates, not before -- Anthropic streams the text first and
+    the citation second, and the proxy preserves that order so the
+    footnote reads ``"...grass is green.[1]"``, not ``"[1]...grass``."""
+    cit = {
+        "type": "char_location",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_char_index": 0,
+        "end_char_index": 20,
+        "cited_text": "grass",
+    }
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Grass is green."),
+            _citations_delta(cit),
+            _text_delta(" Sky is blue."),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    grass = body.index("Grass is green.")
+    marker = body.index("[1]")
+    sky = body.index("Sky is blue.")
+    assert grass < marker < sky, body
+
+
+def test_no_synthetic_event_when_only_text_deltas(monkeypatch):
+    """A stream that carries text_delta events but no citations_delta
+    must NOT emit a synthetic ``document_citations`` event -- the
+    Sources panel relies on absence of the event to know there are
+    no document footnotes to render."""
+    lines = _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("Just some prose. "),
+            _text_delta("More prose."),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+    )
+    body = _joined(lines)
+    assert "document_citations" not in body
+    assert "[1]" not in body
+
+
+def test_input_document_translation_enables_citations(monkeypatch):
+    """Studio's normalised ``input_document`` content part must
+    translate to an Anthropic ``document`` block carrying ``citations:
+    {enabled: true}`` so the upstream actually emits citations_delta
+    events. Without this opt-in the rest of the citation plumbing is
+    a no-op for real user requests.
+
+    Covers both the base64 and the url ``source`` branches."""
+    captured_b64: dict = {}
+    _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("ok"),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_document",
+                        "file_data": "data:application/pdf;base64,QUJD",
+                        "filename": "spec.pdf",
+                    },
+                    {"type": "text", "text": "summarise"},
+                ],
+            }
+        ],
+        captured_body = captured_b64,
+    )
+    user_msg = captured_b64["messages"][0]
+    doc_block = next(
+        p for p in user_msg["content"] if p.get("type") == "document"
+    )
+    assert doc_block["source"]["type"] == "base64", doc_block
+    assert doc_block.get("citations") == {"enabled": True}, doc_block
+
+    captured_url: dict = {}
+    _capture(
+        monkeypatch,
+        [
+            _message_start(),
+            _content_block_start_text(),
+            _text_delta("ok"),
+            _content_block_stop(),
+            _message_delta_end(),
+            _message_stop(),
+        ],
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_document",
+                        "file_url": "https://example.com/doc.pdf",
+                        "filename": "doc.pdf",
+                    },
+                    {"type": "text", "text": "summarise"},
+                ],
+            }
+        ],
+        captured_body = captured_url,
+    )
+    user_msg = captured_url["messages"][0]
+    doc_block = next(
+        p for p in user_msg["content"] if p.get("type") == "document"
+    )
+    assert doc_block["source"]["type"] == "url", doc_block
+    assert doc_block.get("citations") == {"enabled": True}, doc_block

--- a/studio/backend/tests/test_multimodal_document.py
+++ b/studio/backend/tests/test_multimodal_document.py
@@ -117,6 +117,10 @@ def test_anthropic_base64_pdf_becomes_document_block(monkeypatch):
     types = [p.get("type") for p in parts]
     assert "document" in types, parts
     doc = _strip_cache(next(p for p in parts if p.get("type") == "document"))
+    # citations: {enabled: true} opts the document into Anthropic's
+    # natural-citation pipeline so the streaming proxy can render
+    # inline [N] markers + a Sources panel entry. Without it the
+    # citations_delta handler in external_provider.py is a no-op.
     assert doc == {
         "type": "document",
         "source": {
@@ -124,6 +128,7 @@ def test_anthropic_base64_pdf_becomes_document_block(monkeypatch):
             "media_type": "application/pdf",
             "data": _TINY_PDF_B64,
         },
+        "citations": {"enabled": True},
         "title": "paper.pdf",
     }
 
@@ -151,6 +156,7 @@ def test_anthropic_url_pdf_becomes_document_block(monkeypatch):
     assert doc == {
         "type": "document",
         "source": {"type": "url", "url": "https://example.com/doc.pdf"},
+        "citations": {"enabled": True},
     }
 
 
@@ -255,6 +261,7 @@ def test_anthropic_empty_data_uri_falls_back_to_file_url(monkeypatch):
     assert doc == {
         "type": "document",
         "source": {"type": "url", "url": "https://example.com/doc.pdf"},
+        "citations": {"enabled": True},
         "title": "doc.pdf",
     }
 
@@ -283,6 +290,7 @@ def test_anthropic_whitespace_only_data_uri_falls_back_to_file_url(monkeypatch):
     assert doc == {
         "type": "document",
         "source": {"type": "url", "url": "https://example.com/doc.pdf"},
+        "citations": {"enabled": True},
     }
 
 

--- a/studio/backend/tests/test_multimodal_document.py
+++ b/studio/backend/tests/test_multimodal_document.py
@@ -117,10 +117,8 @@ def test_anthropic_base64_pdf_becomes_document_block(monkeypatch):
     types = [p.get("type") for p in parts]
     assert "document" in types, parts
     doc = _strip_cache(next(p for p in parts if p.get("type") == "document"))
-    # citations: {enabled: true} opts the document into Anthropic's
-    # natural-citation pipeline so the streaming proxy can render
-    # inline [N] markers + a Sources panel entry. Without it the
-    # citations_delta handler in external_provider.py is a no-op.
+    # citations: {enabled: true} opts into Anthropic's natural-citation
+    # pipeline; without it the citations_delta handler is a no-op.
     assert doc == {
         "type": "document",
         "source": {

--- a/studio/frontend/src/components/assistant-ui/sources.tsx
+++ b/studio/frontend/src/components/assistant-ui/sources.tsx
@@ -127,6 +127,13 @@ function Source({
 // ── Source badge with hover card ─────────────────────────────
 
 interface SourceData {
+  /**
+   * Stable per-citation key. Multiple SourceData entries can intentionally
+   * share the same ``url`` (e.g., two Anthropic document citations into
+   * different spans of the same source), so React lists key on ``id``
+   * rather than ``url`` to keep each footnote distinct.
+   */
+  id: string;
   url: string;
   title: string;
   description?: string;
@@ -190,8 +197,14 @@ const SourcesGroup: FC = () => {
         "url" in part &&
         part.url
       ) {
+        const url = part.url as string;
+        const partId =
+          typeof (part as { id?: unknown }).id === "string"
+            ? ((part as { id: string }).id)
+            : url;
         sources.push({
-          url: part.url as string,
+          id: partId,
+          url,
           title: (part as { title?: string }).title || "",
           description: (part as { metadata?: { description?: string } })
             .metadata?.description,
@@ -258,7 +271,7 @@ const SourcesGroup: FC = () => {
         className="flex w-full flex-wrap gap-1 invisible absolute pointer-events-none"
       >
         {sources.map((source) => (
-          <span key={source.url} className="inline-block">
+          <span key={source.id} className="inline-block">
             <Source href={source.url}>
               <SourceIcon url={source.url} />
               <SourceTitle>{source.title || extractDomain(source.url)}</SourceTitle>
@@ -270,7 +283,7 @@ const SourcesGroup: FC = () => {
       {/* Visible container */}
       <div className="flex flex-wrap gap-1">
         {displayedSources.map((source) => (
-          <SourceBadge key={source.url} source={source} />
+          <SourceBadge key={source.id} source={source} />
         ))}
         {shouldCollapse && !expanded && (
           <button

--- a/studio/frontend/src/components/assistant-ui/sources.tsx
+++ b/studio/frontend/src/components/assistant-ui/sources.tsx
@@ -128,10 +128,9 @@ function Source({
 
 interface SourceData {
   /**
-   * Stable per-citation key. Multiple SourceData entries can intentionally
-   * share the same ``url`` (e.g., two Anthropic document citations into
-   * different spans of the same source), so React lists key on ``id``
-   * rather than ``url`` to keep each footnote distinct.
+   * Stable per-citation key. Two Anthropic document citations into
+   * different spans of the same source share a ``url``, so React keys
+   * on ``id`` to keep each footnote distinct.
    */
   id: string;
   url: string;

--- a/studio/frontend/src/components/assistant-ui/tool-ui-web-search.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-web-search.tsx
@@ -26,9 +26,8 @@ const RE_SNIPPET = /Snippet:\s*(.+)/s;
 
 /**
  * Reject anything that is not a real http(s) URL. Web-search / web-fetch
- * tool output is provider-controlled, so a hostile ``URL: javascript:...``
- * or ``URL: data:...`` line would otherwise be rendered as a clickable
- * <a href> via the shared Source badge.
+ * output is provider-controlled, so hostile ``javascript:`` / ``data:``
+ * lines must not reach the Source badge's <a href>.
  */
 function isSafeHttpUrl(raw: string): boolean {
   const value = raw.trim();

--- a/studio/frontend/src/components/assistant-ui/tool-ui-web-search.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-web-search.tsx
@@ -24,6 +24,23 @@ const RE_TITLE = /Title:\s*(.+)/;
 const RE_URL = /URL:\s*(.+)/;
 const RE_SNIPPET = /Snippet:\s*(.+)/s;
 
+/**
+ * Reject anything that is not a real http(s) URL. Web-search / web-fetch
+ * tool output is provider-controlled, so a hostile ``URL: javascript:...``
+ * or ``URL: data:...`` line would otherwise be rendered as a clickable
+ * <a href> via the shared Source badge.
+ */
+function isSafeHttpUrl(raw: string): boolean {
+  const value = raw.trim();
+  if (!value || /[\r\n]/.test(value)) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /** Parse the backend's "Title: ...\nURL: ...\nSnippet: ...\n---" format into structured sources. */
 function parseSearchResults(raw: string): ParsedSource[] {
   if (!raw) {
@@ -35,13 +52,14 @@ function parseSearchResults(raw: string): ParsedSource[] {
     const titleMatch = block.match(RE_TITLE);
     const urlMatch = block.match(RE_URL);
     const snippetMatch = block.match(RE_SNIPPET);
-    if (titleMatch && urlMatch) {
-      sources.push({
-        title: titleMatch[1].trim(),
-        url: urlMatch[1].trim(),
-        snippet: snippetMatch?.[1]?.trim() ?? "",
-      });
-    }
+    if (!titleMatch || !urlMatch) continue;
+    const url = urlMatch[1].trim();
+    if (!isSafeHttpUrl(url)) continue;
+    sources.push({
+      title: titleMatch[1].trim(),
+      url,
+      snippet: snippetMatch?.[1]?.trim() ?? "",
+    });
   }
   return sources;
 }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -164,19 +164,37 @@ function documentCitationToSource(
   const docIndex =
     typeof cit.document_index === "number" ? cit.document_index : undefined;
   // Use the search-result source URL when present; otherwise fall back
-  // to a stable doc anchor so the panel can still dedupe by id.
-  const url =
-    source || `#anthropic-doc-${docIndex ?? fallbackIdx}`;
+  // to a stable doc anchor.
+  const url = source || `#anthropic-doc-${docIndex ?? fallbackIdx}`;
   const title = docTitle || source || `Document ${fallbackIdx + 1}`;
   const cited =
     typeof cit.cited_text === "string" ? cit.cited_text.trim() : "";
   // Trim the cited snippet so the Sources panel stays scannable.
   const description =
     cited.length > 240 ? `${cited.slice(0, 240)}...` : cited;
+  // Anthropic numbers each inline [N] marker by citation, not by
+  // source URL: two distinct citations from the same document (or
+  // two search_result_locations with the same source but different
+  // search_result_index) must keep distinct entries. Fold the
+  // position-bearing fields into the id so the Sources panel
+  // preserves the 1:1 mapping with the inline footnotes.
+  const positionParts = [
+    cit.search_result_index,
+    cit.start_char_index,
+    cit.end_char_index,
+    cit.start_page_number,
+    cit.end_page_number,
+    cit.start_block_index,
+    cit.end_block_index,
+  ]
+    .filter((v) => typeof v === "number")
+    .map((v) => String(v))
+    .join(":");
+  const id = positionParts ? `${url}#${positionParts}` : `${url}#${fallbackIdx}`;
   return {
     type: "source" as const,
     sourceType: "url" as const,
-    id: url,
+    id,
     url,
     title,
     ...(description ? { metadata: { description } } : {}),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -145,10 +145,9 @@ async function updateStoredChatThreadEventually(
 
 /**
  * Return ``raw`` when it is a safe-to-navigate http(s) URL, or "" otherwise.
- * Rejects non-string input, CR/LF (header-injection / link-smuggling), and
- * any non-http(s) scheme so provider/tool-controlled strings such as
- * ``javascript:`` / ``data:`` / ``vbscript:`` cannot land in an
- * ``<a href>`` rendered by the Sources panel.
+ * Rejects non-string input, CR/LF (header injection), and non-http(s)
+ * schemes (``javascript:`` / ``data:`` / ``vbscript:``) so provider /
+ * tool-controlled strings cannot land in an <a href>.
  */
 function isSafeNavigableSourceUrl(raw: unknown): string {
   if (typeof raw !== "string") return "";
@@ -185,12 +184,10 @@ function documentCitationToSource(
     "";
   const docIndex =
     typeof cit.document_index === "number" ? cit.document_index : undefined;
-  // Only treat ``source`` as a navigable URL when it is a real
-  // http(s) address. Anthropic search_result_location ``source`` can
-  // be a free-form identifier (e.g. ``kb-doc-42``); a hostile model
-  // can also return ``javascript:`` / ``data:`` / ``vbscript:``
-  // strings that would execute when rendered as an <a href>. Fall
-  // back to a stable doc anchor for anything else.
+  // Only treat ``source`` as a navigable URL when it is real http(s);
+  // search_result_location can carry a free-form id (e.g. ``kb-doc-42``)
+  // or a hostile ``javascript:`` / ``data:`` / ``vbscript:`` string.
+  // Fall back to a stable doc anchor otherwise.
   const url =
     isSafeNavigableSourceUrl(source) || `#anthropic-doc-${docIndex ?? fallbackIdx}`;
   const title = docTitle || source || `Document ${fallbackIdx + 1}`;
@@ -199,14 +196,10 @@ function documentCitationToSource(
   // Trim the cited snippet so the Sources panel stays scannable.
   const description =
     cited.length > 240 ? `${cited.slice(0, 240)}...` : cited;
-  // Anthropic numbers each inline [N] marker by citation, not by
-  // source URL: two distinct citations from the same document (or
-  // two search_result_locations with the same source but different
-  // search_result_index) must keep distinct entries. Fold the
-  // citation type plus position-bearing fields into the id so the
-  // Sources panel preserves the 1:1 mapping with the inline
-  // footnotes (otherwise char_location(0,5) and page_location(0,5)
-  // for the same source would collapse).
+  // Anthropic numbers inline [N] per citation, not per source URL.
+  // Fold citation type + position-bearing fields into the id so two
+  // distinct citations on the same source (or two search_result_locations
+  // with different search_result_index) keep separate Sources entries.
   const citationType =
     typeof cit.type === "string" ? String(cit.type) : "";
   const positionParts = [
@@ -259,10 +252,9 @@ function parseSourcesFromResult(raw: string): {
     const urlMatch = block.match(/URL:\s*(.+)/);
     const snippetMatch = block.match(/Snippet:\s*(.+)/);
     if (titleMatch && urlMatch) {
-      // Drop blocks whose ``URL:`` is not a safe-to-navigate http(s) link.
-      // Provider/tool output is attacker-controllable, so a hostile
-      // ``URL: javascript:...`` / ``URL: data:...`` line would otherwise
-      // be rendered as a clickable <a href> in the Sources panel.
+      // Drop blocks whose ``URL:`` is not safe http(s); provider/tool
+      // output is attacker-controllable so a hostile ``javascript:`` /
+      // ``data:`` line must not reach the Sources panel <a href>.
       const url = isSafeNavigableSourceUrl(urlMatch[1]);
       if (!url) continue;
       const snippet = snippetMatch?.[1]?.trim();
@@ -1233,10 +1225,9 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // Tool call content parts — accumulated and yielded cumulatively.
       // result is set directly on the tool-call part when tool_end arrives.
       const toolCallParts: ToolCallMessagePart[] = [];
-      // Anthropic document citations collected from
-      // `_toolEvent.type === "document_citations"` (emitted on
-      // message_stop). Converted into Sources-panel source parts at
-      // end-of-stream so the inline [N] markers have matching entries.
+      // Anthropic document_citations tool_event payload, converted to
+      // Sources-panel source parts at end-of-stream so the inline [N]
+      // markers have matching entries.
       const documentCitationParts: Array<{
         type: "source";
         sourceType: "url";
@@ -1693,9 +1684,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                   continue;
                 }
                 if (toolEvent.type === "document_citations") {
-                  // Anthropic citations_delta footnotes. Convert into
-                  // Sources-panel entries so the inline [N] markers
-                  // emitted by the backend have matching links.
+                  // Convert Anthropic citations_delta footnotes into
+                  // Sources-panel entries matching the inline [N] markers.
                   const cits = toolEvent.citations;
                   if (Array.isArray(cits)) {
                     cits.forEach((entry, idx) => {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -163,9 +163,17 @@ function documentCitationToSource(
     "";
   const docIndex =
     typeof cit.document_index === "number" ? cit.document_index : undefined;
-  // Use the search-result source URL when present; otherwise fall back
-  // to a stable doc anchor.
-  const url = source || `#anthropic-doc-${docIndex ?? fallbackIdx}`;
+  // Only treat ``source`` as a navigable URL when it is a real
+  // http(s) address. Anthropic search_result_location ``source`` can
+  // be a free-form identifier (e.g. ``kb-doc-42``); a hostile model
+  // can also return ``javascript:`` / ``data:`` / ``vbscript:``
+  // strings that would execute when rendered as an <a href>. Fall
+  // back to a stable doc anchor for anything else.
+  const isNavigable =
+    /^https?:\/\//i.test(source) && !/[\r\n]/.test(source);
+  const url = isNavigable
+    ? source
+    : `#anthropic-doc-${docIndex ?? fallbackIdx}`;
   const title = docTitle || source || `Document ${fallbackIdx + 1}`;
   const cited =
     typeof cit.cited_text === "string" ? cit.cited_text.trim() : "";
@@ -176,8 +184,12 @@ function documentCitationToSource(
   // source URL: two distinct citations from the same document (or
   // two search_result_locations with the same source but different
   // search_result_index) must keep distinct entries. Fold the
-  // position-bearing fields into the id so the Sources panel
-  // preserves the 1:1 mapping with the inline footnotes.
+  // citation type plus position-bearing fields into the id so the
+  // Sources panel preserves the 1:1 mapping with the inline
+  // footnotes (otherwise char_location(0,5) and page_location(0,5)
+  // for the same source would collapse).
+  const citationType =
+    typeof cit.type === "string" ? String(cit.type) : "";
   const positionParts = [
     cit.search_result_index,
     cit.start_char_index,
@@ -190,7 +202,10 @@ function documentCitationToSource(
     .filter((v) => typeof v === "number")
     .map((v) => String(v))
     .join(":");
-  const id = positionParts ? `${url}#${positionParts}` : `${url}#${fallbackIdx}`;
+  const idAnchor = positionParts
+    ? `${citationType}:${positionParts}`
+    : `${citationType}:${fallbackIdx}`;
+  const id = `${url}#${idAnchor}`;
   return {
     type: "source" as const,
     sourceType: "url" as const,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -143,6 +143,28 @@ async function updateStoredChatThreadEventually(
   }
 }
 
+/**
+ * Return ``raw`` when it is a safe-to-navigate http(s) URL, or "" otherwise.
+ * Rejects non-string input, CR/LF (header-injection / link-smuggling), and
+ * any non-http(s) scheme so provider/tool-controlled strings such as
+ * ``javascript:`` / ``data:`` / ``vbscript:`` cannot land in an
+ * ``<a href>`` rendered by the Sources panel.
+ */
+function isSafeNavigableSourceUrl(raw: unknown): string {
+  if (typeof raw !== "string") return "";
+  const value = raw.trim();
+  if (!value || /[\r\n]/.test(value)) return "";
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return value;
+    }
+  } catch {
+    // Fall through.
+  }
+  return "";
+}
+
 /** Convert an Anthropic document citation dict into a Sources-panel source. */
 function documentCitationToSource(
   cit: Record<string, unknown>,
@@ -169,11 +191,8 @@ function documentCitationToSource(
   // can also return ``javascript:`` / ``data:`` / ``vbscript:``
   // strings that would execute when rendered as an <a href>. Fall
   // back to a stable doc anchor for anything else.
-  const isNavigable =
-    /^https?:\/\//i.test(source) && !/[\r\n]/.test(source);
-  const url = isNavigable
-    ? source
-    : `#anthropic-doc-${docIndex ?? fallbackIdx}`;
+  const url =
+    isSafeNavigableSourceUrl(source) || `#anthropic-doc-${docIndex ?? fallbackIdx}`;
   const title = docTitle || source || `Document ${fallbackIdx + 1}`;
   const cited =
     typeof cit.cited_text === "string" ? cit.cited_text.trim() : "";
@@ -240,7 +259,12 @@ function parseSourcesFromResult(raw: string): {
     const urlMatch = block.match(/URL:\s*(.+)/);
     const snippetMatch = block.match(/Snippet:\s*(.+)/);
     if (titleMatch && urlMatch) {
-      const url = urlMatch[1].trim();
+      // Drop blocks whose ``URL:`` is not a safe-to-navigate http(s) link.
+      // Provider/tool output is attacker-controllable, so a hostile
+      // ``URL: javascript:...`` / ``URL: data:...`` line would otherwise
+      // be rendered as a clickable <a href> in the Sources panel.
+      const url = isSafeNavigableSourceUrl(urlMatch[1]);
+      if (!url) continue;
       const snippet = snippetMatch?.[1]?.trim();
       sources.push({
         type: "source" as const,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -143,6 +143,46 @@ async function updateStoredChatThreadEventually(
   }
 }
 
+/** Convert an Anthropic document citation dict into a Sources-panel source. */
+function documentCitationToSource(
+  cit: Record<string, unknown>,
+  fallbackIdx: number,
+): {
+  type: "source";
+  sourceType: "url";
+  id: string;
+  url: string;
+  title: string;
+  metadata?: { description: string };
+} | null {
+  const source =
+    typeof cit.source === "string" && cit.source ? cit.source : "";
+  const docTitle =
+    (typeof cit.document_title === "string" && cit.document_title) ||
+    (typeof cit.title === "string" && cit.title) ||
+    "";
+  const docIndex =
+    typeof cit.document_index === "number" ? cit.document_index : undefined;
+  // Use the search-result source URL when present; otherwise fall back
+  // to a stable doc anchor so the panel can still dedupe by id.
+  const url =
+    source || `#anthropic-doc-${docIndex ?? fallbackIdx}`;
+  const title = docTitle || source || `Document ${fallbackIdx + 1}`;
+  const cited =
+    typeof cit.cited_text === "string" ? cit.cited_text.trim() : "";
+  // Trim the cited snippet so the Sources panel stays scannable.
+  const description =
+    cited.length > 240 ? `${cited.slice(0, 240)}...` : cited;
+  return {
+    type: "source" as const,
+    sourceType: "url" as const,
+    id: url,
+    url,
+    title,
+    ...(description ? { metadata: { description } } : {}),
+  };
+}
+
 /** Parse "Title: ...\nURL: ...\nSnippet: ..." blocks into source content parts. */
 function parseSourcesFromResult(raw: string): {
   type: "source";
@@ -1136,6 +1176,18 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // Tool call content parts — accumulated and yielded cumulatively.
       // result is set directly on the tool-call part when tool_end arrives.
       const toolCallParts: ToolCallMessagePart[] = [];
+      // Anthropic document citations collected from
+      // `_toolEvent.type === "document_citations"` (emitted on
+      // message_stop). Converted into Sources-panel source parts at
+      // end-of-stream so the inline [N] markers have matching entries.
+      const documentCitationParts: Array<{
+        type: "source";
+        sourceType: "url";
+        id: string;
+        url: string;
+        title: string;
+        metadata?: { description: string };
+      }> = [];
       let serverMetadata: {
         usage?: ServerUsage;
         timings?: ServerTimings;
@@ -1583,6 +1635,28 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                   }
                   continue;
                 }
+                if (toolEvent.type === "document_citations") {
+                  // Anthropic citations_delta footnotes. Convert into
+                  // Sources-panel entries so the inline [N] markers
+                  // emitted by the backend have matching links.
+                  const cits = toolEvent.citations;
+                  if (Array.isArray(cits)) {
+                    cits.forEach((entry, idx) => {
+                      if (!entry || typeof entry !== "object") return;
+                      const part = documentCitationToSource(
+                        entry as Record<string, unknown>,
+                        idx,
+                      );
+                      if (
+                        part &&
+                        !documentCitationParts.some((p) => p.id === part.id)
+                      ) {
+                        documentCitationParts.push(part);
+                      }
+                    });
+                  }
+                  continue;
+                }
                 if (toolEvent.type === "container_invalidated") {
                   if (resolvedThreadId) {
                     const field =
@@ -1911,6 +1985,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             ...toolCallParts,
             ...parseAssistantContent(cumulativeText),
             ...sourceParts,
+            ...documentCitationParts,
           ],
           metadata: {
             timing: finalTiming,


### PR DESCRIPTION
## Summary

Anthropic streams ``citations_delta`` events on ``content_block_delta`` when the request enables ``citations: {enabled: true}`` on a document block (https://platform.claude.com/docs/en/build-with-claude/citations). Previously the proxy silently dropped them, so reader-visible references never reached the chat UI even when the model was citing properly. This PR threads the citation events end-to-end.

- Dedupe by the type-specific anchor (``char_location`` / ``page_location`` / ``content_block_location`` / ``search_result_location``) so re-cites of the same span collapse onto one footnote.
- Inject ``[N]`` inline right after the matching text run.
- Forward the full list as a synthetic ``document_citations`` tool_event at ``message_stop`` so the Sources panel can render per-document footnotes next to web_search / web_fetch citations.

Streams that never emit ``citations_delta`` stay byte-identical, so this is opt-in via the existing document-block path users already use for PDFs / plain text. ``search_result_location`` from the newer search-results content block (https://platform.claude.com/docs/en/build-with-claude/search-results) is also covered.

## Test plan

- [x] ``cd studio && python -m pytest backend/tests/test_anthropic_citations.py -v`` (5 passing): passthrough, single ``char_location``, dedup of repeat citations, distinct sources get distinct numbers, ``search_result_location`` supported.
- [x] Full Anthropic test suite still green (1 pre-existing E2E fixture error, unrelated).
- [ ] Frontend rendering of the ``document_citations`` tool_event in the Sources panel: follow-up PR.