### PR TITLE
Studio: pricing follow-up to #5690 (longest-prefix match + chat-style usage keys)

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3939,6 +3939,12 @@ def _build_usage_chunk(
             "cache_creation_input_tokens": cache_creation,
             "cache_read_input_tokens": cache_read,
         }
+        # Forward the 5m / 1h cache-write breakdown so downstream cost
+        # calculation can apply the 2x 1h premium instead of silently
+        # falling back to 5m default pricing on chat-style envelopes.
+        cc_breakdown = last_usage.get("cache_creation")
+        if isinstance(cc_breakdown, dict) and cc_breakdown:
+            usage_block["cache_creation"] = cc_breakdown
     else:
         prompt_tokens = last_usage.get("input_tokens") or 0
         cached = 0

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3939,9 +3939,8 @@ def _build_usage_chunk(
             "cache_creation_input_tokens": cache_creation,
             "cache_read_input_tokens": cache_read,
         }
-        # Forward the 5m / 1h cache-write breakdown so downstream cost
-        # calculation can apply the 2x 1h premium instead of silently
-        # falling back to 5m default pricing on chat-style envelopes.
+        # Forward 5m/1h cache-write breakdown so cost calc applies the
+        # 2x 1h premium instead of defaulting to 5m on chat-style.
         cc_breakdown = last_usage.get("cache_creation")
         if isinstance(cc_breakdown, dict) and cc_breakdown:
             usage_block["cache_creation"] = cc_breakdown

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -221,9 +221,14 @@ def calculate_cost(
             input_tokens = max(0, prompt_tokens - cache_creation - cache_read)
         else:
             input_tokens = prompt_tokens
-    output_tokens = int(
-        usage.get("output_tokens") or usage.get("completion_tokens") or 0
-    )
+    # Prefer the raw upstream key when present, even when its value is
+    # explicitly 0 -- the ``or`` fallback would mistakenly pick a stale
+    # ``completion_tokens`` for an empty completion. Mirrors the
+    # has_input_tokens precedence above.
+    if "output_tokens" in usage and usage.get("output_tokens") is not None:
+        output_tokens = int(usage.get("output_tokens") or 0)
+    else:
+        output_tokens = int(usage.get("completion_tokens") or 0)
     if provider == "openai":
         details = usage.get("input_tokens_details") or {}
         if isinstance(details, dict):

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -197,20 +197,33 @@ def calculate_cost(
 
     # Accept both shapes: raw Anthropic / OpenAI Responses usage
     # carries ``input_tokens`` / ``output_tokens``; the OpenAI-Chat-
-    # style usage chunk Studio re-emits (``_build_usage_chunk``) uses
-    # ``prompt_tokens`` / ``completion_tokens``. Either is fine here
-    # so a caller can hand whichever envelope landed first.
-    input_tokens = int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0)
+    # style envelope Studio re-emits (``_build_usage_chunk``) uses
+    # ``prompt_tokens`` / ``completion_tokens``. Normalise to a single
+    # ``uncached_input`` view because the two envelopes treat the
+    # cache buckets differently:
+    #
+    #   raw Anthropic:    input_tokens EXCLUDES cache_creation + cache_read
+    #   raw OpenAI:       input_tokens INCLUDES cache_read (no cache_create)
+    #   Studio Anthropic: prompt_tokens INCLUDES cache_creation + cache_read
+    #   Studio OpenAI:    prompt_tokens == raw input_tokens (includes cache_read)
+    cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
+    cache_read = int(usage.get("cache_read_input_tokens") or 0)
+    has_input_tokens = "input_tokens" in usage and usage.get("input_tokens") is not None
+    if has_input_tokens:
+        # Raw upstream envelope.
+        input_tokens = int(usage.get("input_tokens") or 0)
+    else:
+        # Studio chat-style envelope: prompt_tokens already folds the
+        # cache buckets for Anthropic, so peel them off to recover the
+        # raw uncached prompt count and keep downstream math symmetric.
+        prompt_tokens = int(usage.get("prompt_tokens") or 0)
+        if provider == "anthropic":
+            input_tokens = max(0, prompt_tokens - cache_creation - cache_read)
+        else:
+            input_tokens = prompt_tokens
     output_tokens = int(
         usage.get("output_tokens") or usage.get("completion_tokens") or 0
     )
-    cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
-    cache_read = int(usage.get("cache_read_input_tokens") or 0)
-    # OpenAI Responses reports cached tokens under input_tokens_details
-    # but ALSO folds them into the top-level input_tokens, so we don't
-    # add cache_read into the billable total again below (Anthropic
-    # excludes cache buckets from input_tokens, OpenAI includes them --
-    # the two providers differ here and the calculator must match).
     if provider == "openai":
         details = usage.get("input_tokens_details") or {}
         if isinstance(details, dict):
@@ -218,7 +231,8 @@ def calculate_cost(
         # OpenAI: cache_read already counted inside input_tokens.
         out["billable_input_tokens"] = input_tokens + cache_creation
     else:
-        # Anthropic: input_tokens excludes cache_* buckets, add them all.
+        # Anthropic: input_tokens (post-normalisation) excludes cache
+        # buckets, so add them all back.
         out["billable_input_tokens"] = input_tokens + cache_creation + cache_read
     out["billable_output_tokens"] = output_tokens
 

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -220,6 +220,18 @@ def calculate_cost(
     # session total tooltip.
     cache_creation = max(0, int(usage.get("cache_creation_input_tokens") or 0))
     cache_read = max(0, int(usage.get("cache_read_input_tokens") or 0))
+    # Defense in depth for Anthropic: a chat-style envelope arriving
+    # without the native ``cache_read_input_tokens`` key (e.g. via a
+    # proxy that only emits the mirrored ``prompt_tokens_details``
+    # block) would otherwise be billed as uncached input. Pull the
+    # cache-read count from the mirrored field when the native one is
+    # missing or zero. Studio's own ``_build_usage_chunk`` emits both
+    # so this never fires on canonical traffic; it just hardens the
+    # path against off-spec callers.
+    if cache_read == 0:
+        details = usage.get("prompt_tokens_details") or {}
+        if isinstance(details, dict):
+            cache_read = max(0, int(details.get("cached_tokens") or 0))
     has_input_tokens = "input_tokens" in usage and usage.get("input_tokens") is not None
     if has_input_tokens:
         # Raw upstream envelope.

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -1,50 +1,24 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Static per-MTok pricing tables for external providers, plus a
-``calculate_cost`` helper that turns an upstream ``usage`` block into
-a USD figure for surfacing in the chat UI.
+"""Static per-MTok pricing tables and ``calculate_cost`` helper for
+turning an upstream ``usage`` block into a USD figure.
 
-Neither the Anthropic Messages API nor the OpenAI Responses API
-reports a ``cost`` field on the response. Both expose detailed token
-counts (input, output, cache hits, server-tool invocations); pricing
-multipliers live in the provider docs. We fold the docs into a static
-table here, multiply by the usage block, and emit a per-turn cost +
-running session total client-side.
-
-Sources (verified live 2026-05-22):
-- Anthropic models overview:
-    https://platform.claude.com/docs/en/about-claude/models/overview
-- Anthropic prompt-caching multipliers (5m write 1.25x, 1h write 2x,
-  read 0.1x):
-    https://platform.claude.com/docs/en/build-with-claude/prompt-caching
-- Anthropic web search ($10 / 1000 searches, code execution
-  free-with-paid when paired with the newer web tools):
-    https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool
-    https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool
-- OpenAI pricing page (input / output per MTok per model family):
-    https://platform.openai.com/docs/pricing
+Sources: Anthropic prompt-caching docs (5m write 1.25x, 1h write 2x,
+read 0.1x), web search ($10/1000), code execution; OpenAI pricing page.
 """
 
 from __future__ import annotations
 
 from typing import Any, Optional
 
-# Per-million-token base pricing. `cache_5m_write_mult`, `cache_1h_write_mult`,
-# `cache_read_mult` are multipliers ON `input_per_mtok` -- not absolute prices --
-# matching how Anthropic publishes them (5m write = 1.25x base, etc.).
-#
-# `input_per_mtok` and `output_per_mtok` are USD per 1,000,000 tokens.
+# Per-MTok base pricing in USD. Cache multipliers are applied ON
+# `input_per_mtok` (not absolute prices), matching Anthropic's docs.
 ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
     "claude-opus-4-7": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
     "claude-opus-4-6": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
-    # Canonical 4.5 ids are referenced from backend defaults (e.g.
-    # PROVIDER_REGISTRY['anthropic'].default_models) without the date
-    # suffix. The dated ids ARE the canonical names per Anthropic's
-    # models overview, but lookups for the bare id ("claude-opus-4-5")
-    # don't prefix-match the dated key the other way around, so we
-    # alias both forms here. Otherwise calculate_cost returns
-    # priced=False + zero cost for the common ids.
+    # Alias both the bare id and dated id: backend defaults reference
+    # the bare form, which won't prefix-match the dated key.
     "claude-opus-4-5": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
     "claude-opus-4-5-20251101": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
     "claude-opus-4-1": {"input_per_mtok": 15.0, "output_per_mtok": 75.0},
@@ -59,19 +33,9 @@ ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
 }
 
 OPENAI_PRICING: dict[str, dict[str, float]] = {
-    # All values verified against developers.openai.com/api/docs/pricing
-    # 2026-05-22. Update against the live pricing page on every model launch.
-    # Initial commit underbilled every gpt-5.x family 2-6x -- fixed here
-    # after PR review caught it via doc cross-check.
-    #
-    # `long_context_input_per_mtok` / `long_context_output_per_mtok` /
-    # `long_context_threshold` are populated when OpenAI publishes a
-    # second pricing tier for prompts above N input tokens. gpt-5.5 and
-    # gpt-5.4 cross over at 272k input tokens; the long-context rates
-    # are double the headline input price (and ~1.5x on output). Other
-    # families currently ship with a single rate (no `long_context_*`
-    # keys = no tier crossover). Reference:
-    #   https://developers.openai.com/api/docs/pricing
+    # Verified against developers.openai.com/api/docs/pricing.
+    # `long_context_*` keys apply once input exceeds the threshold
+    # (gpt-5.5/5.4: 272k); families without these keys ship a single rate.
     "gpt-5.5": {
         "input_per_mtok": 5.0,
         "output_per_mtok": 30.0,
@@ -91,14 +55,11 @@ OPENAI_PRICING: dict[str, dict[str, float]] = {
     "gpt-5.4-mini": {"input_per_mtok": 0.75, "output_per_mtok": 4.5},
     "gpt-5.4-nano": {"input_per_mtok": 0.20, "output_per_mtok": 1.25},
     "gpt-5.3-codex": {"input_per_mtok": 1.75, "output_per_mtok": 14.0},
-    # chat-latest / gpt-5.3-chat-latest is an alias for the current
-    # ChatGPT model; same price as gpt-5.5.
+    # chat-latest aliases gpt-5.5.
     "gpt-5.3-chat-latest": {"input_per_mtok": 5.0, "output_per_mtok": 30.0},
     "chat-latest": {"input_per_mtok": 5.0, "output_per_mtok": 30.0},
-    # o-series and gpt-4.5: NOT currently listed on the pricing page.
-    # Removed to avoid silent-underbilling drift. Returning priced=False
-    # is honest; the UI can still render token counts. Restore with
-    # verified per-MTok rates if/when the page lists them again.
+    # o-series and gpt-4.5 are no longer on the pricing page; omit them
+    # so calculate_cost returns priced=False rather than silently $0.
 }
 
 # Shared multipliers (same across every Anthropic model).
@@ -106,28 +67,18 @@ ANTHROPIC_CACHE_5M_WRITE_MULT = 1.25
 ANTHROPIC_CACHE_1H_WRITE_MULT = 2.0
 ANTHROPIC_CACHE_READ_MULT = 0.1
 
-# OpenAI: cache reads are 0.1x base input, cache writes are not billed
-# separately (the first prefix-write request just pays normal input).
+# OpenAI: cache reads 0.1x; cache writes pay normal input price.
 OPENAI_CACHE_READ_MULT = 0.1
 
-# Server-tool surcharges.
-# Anthropic: $10 / 1000 web searches; code_execution is $0.05/hr after
-# 50 free hours/day per org (no per-org visibility here, so the
-# calculator reports the marginal rate).
+# Server-tool surcharges. Anthropic code_exec is $0.05/hr marginal
+# (50 free hours/day per org, not visible here).
 ANTHROPIC_WEB_SEARCH_USD_PER_1K = 10.0
 ANTHROPIC_CODE_EXEC_USD_PER_HOUR = 0.05
 
-# OpenAI: web_search is billed at $10/1000 calls plus the model's
-# token rate for the returned search content (already captured under
-# input/output_tokens). The hosted shell tool bills per 20-minute
-# session per container memory tier (1g/4g/16g/64g at
-# $0.03/$0.12/$0.48/$1.92). Since Studio doesn't surface the memory
-# tier in the cost ledger and most users land on the default 1g, we
-# bill the 1g rate ($0.09/hour) and let the user inspect the OpenAI
-# dashboard for the exact figure on heavier configs.
-# Source: developers.openai.com/api/docs/pricing 2026-05-22.
+# OpenAI container bills per memory tier; we report the 1g default
+# ($0.09/hour) since the tier isn't surfaced to the cost ledger.
 OPENAI_WEB_SEARCH_USD_PER_1K = 10.0
-OPENAI_CONTAINER_USD_PER_HOUR = 0.09  # 1g default tier; 3 x $0.03 / 60min
+OPENAI_CONTAINER_USD_PER_HOUR = 0.09  # 1g default tier
 
 
 def _lookup(provider: str, model: str) -> Optional[dict[str, float]]:
@@ -142,19 +93,10 @@ def _lookup(provider: str, model: str) -> Optional[dict[str, float]]:
         return None
     if model in table:
         return table[model]
-    # Fall back to a longest-prefix match so dated snapshots
-    # ("gpt-5.5-2026-04-23") inherit the canonical-id prices AND ids
-    # like "gpt-5.4-mini-2026-..." match "gpt-5.4-mini" before they
-    # collide with the shorter "gpt-5.4" entry. Sorting keys by
-    # length descending picks the most specific table row first.
-    #
-    # The match has to land on a token boundary -- otherwise a future
-    # "claude-opus-4-15" would falsely inherit "claude-opus-4-1" prices,
-    # and a hypothetical "gpt-5.5-prod" would silently bill as
-    # "gpt-5.5-pro" (5x overcharge). We require the next character after
-    # the prefix to be "-" so we only match on dash-separated
-    # date / variant suffixes, never on a longer numeric or alpha
-    # continuation of the same component.
+    # Longest-prefix match on a dash boundary: lets dated snapshots
+    # inherit canonical prices while preventing "claude-opus-4-15"
+    # from matching "claude-opus-4-1" or "gpt-5.5-prod" from matching
+    # "gpt-5.5-pro". Sort longest-first to pick the most specific row.
     for key in sorted(table, key = len, reverse = True):
         if model.startswith(key) and (len(model) == len(key) or model[len(key)] == "-"):
             return table[key]
@@ -166,28 +108,11 @@ def calculate_cost(
     model: str,
     usage: dict[str, Any],
 ) -> dict[str, float]:
-    """Return a per-turn USD cost breakdown.
-
-    Returns a dict with the per-bucket cost AND the totals so the
-    frontend can render either a single number or a "where did the
-    money go" tooltip without re-doing the math:
-
-        {
-          "input_usd": 0.0042,
-          "output_usd": 0.012,
-          "cache_write_usd": 0.0001,
-          "cache_read_usd": 0.0008,
-          "server_tools_usd": 0.01,
-          "total_usd": 0.0271,
-          "billable_input_tokens": 5023,    # input + cache_create + cache_read
-          "billable_output_tokens": 480,
-          "model_priced": "claude-opus-4-7",
-          "priced": true,
-        }
-
-    When the model isn't in the static table (new family, custom base
-    URL), `priced` is False and every USD field is 0.0; the frontend
-    can still show the token counts.
+    """Return a per-turn USD cost breakdown with per-bucket + total
+    fields so the frontend can render either a single number or a
+    tooltip without re-doing the math. When the model isn't in the
+    static table, ``priced`` is False and USD fields are 0.0 (token
+    counts still report).
     """
     prices = _lookup(provider, model)
     out: dict[str, float] = {
@@ -203,91 +128,64 @@ def calculate_cost(
         "priced": bool(prices),
     }
 
-    # Accept both shapes: raw Anthropic / OpenAI Responses usage
-    # carries ``input_tokens`` / ``output_tokens``; the OpenAI-Chat-
-    # style envelope Studio re-emits (``_build_usage_chunk``) uses
-    # ``prompt_tokens`` / ``completion_tokens``. Normalise to a single
-    # ``uncached_input`` view because the two envelopes treat the
-    # cache buckets differently:
-    #
-    #   raw Anthropic:    input_tokens EXCLUDES cache_creation + cache_read
-    #   raw OpenAI:       input_tokens INCLUDES cache_read (no cache_create)
+    # Accept raw (input_tokens/output_tokens) and Studio chat-style
+    # (prompt_tokens/completion_tokens) envelopes. Cache buckets
+    # behave differently per envelope:
+    #   raw Anthropic:    input_tokens EXCLUDES cache buckets
+    #   raw OpenAI:       input_tokens INCLUDES cache_read
     #   Studio Anthropic: prompt_tokens INCLUDES cache_creation + cache_read
-    #   Studio OpenAI:    prompt_tokens == raw input_tokens (includes cache_read)
-    # Defense in depth: clamp every token count to >=0 so a corrupted
-    # upstream payload (negative cached count, off-by-one in a fixture)
-    # can never produce a NEGATIVE bill that masks real spend in the
-    # session total tooltip.
+    #   Studio OpenAI:    prompt_tokens == raw input_tokens
+    # Clamp tokens >=0 so corrupted payloads can't produce a negative bill.
     cache_creation = max(0, int(usage.get("cache_creation_input_tokens") or 0))
     cache_read_native_present = (
         "cache_read_input_tokens" in usage
         and usage.get("cache_read_input_tokens") is not None
     )
     cache_read = max(0, int(usage.get("cache_read_input_tokens") or 0))
-    # Defense in depth for Anthropic: a chat-style envelope arriving
-    # without the native ``cache_read_input_tokens`` key (e.g. via a
-    # proxy that only emits the mirrored ``prompt_tokens_details``
-    # block) would otherwise be billed as uncached input. Pull the
-    # cache-read count from the mirrored field only when the native
-    # key is absent -- an explicit ``cache_read_input_tokens: 0`` from
-    # the upstream is authoritative, so a stale ``prompt_tokens_details``
-    # (e.g. a proxy forwarding a previous turn's details block) can
-    # never inflate cache_read past the native count. Studio's own
-    # ``_build_usage_chunk`` emits both so canonical traffic is
-    # unaffected; this just hardens the path against off-spec callers.
+    # Fallback to mirrored prompt_tokens_details only when the native
+    # cache_read_input_tokens key is absent. An explicit native 0 is
+    # authoritative, so a stale mirrored block from a proxy can never
+    # inflate cache_read past the native count.
     if not cache_read_native_present:
         details = usage.get("prompt_tokens_details") or {}
         if isinstance(details, dict):
             cache_read = max(0, int(details.get("cached_tokens") or 0))
     has_input_tokens = "input_tokens" in usage and usage.get("input_tokens") is not None
     if has_input_tokens:
-        # Raw upstream envelope.
         input_tokens = max(0, int(usage.get("input_tokens") or 0))
     else:
-        # Studio chat-style envelope: prompt_tokens already folds the
-        # cache buckets for Anthropic, so peel them off to recover the
-        # raw uncached prompt count and keep downstream math symmetric.
+        # Chat-style: peel cache buckets back out for Anthropic to
+        # recover the raw uncached prompt count.
         prompt_tokens = max(0, int(usage.get("prompt_tokens") or 0))
         if provider == "anthropic":
             input_tokens = max(0, prompt_tokens - cache_creation - cache_read)
         else:
             input_tokens = prompt_tokens
-    # Prefer the raw upstream key when present, even when its value is
-    # explicitly 0 -- the ``or`` fallback would mistakenly pick a stale
-    # ``completion_tokens`` for an empty completion. Mirrors the
-    # has_input_tokens precedence above.
+    # Prefer raw output_tokens even when 0 (an `or` fallback would
+    # silently pick a stale completion_tokens).
     if "output_tokens" in usage and usage.get("output_tokens") is not None:
         output_tokens = max(0, int(usage.get("output_tokens") or 0))
     else:
         output_tokens = max(0, int(usage.get("completion_tokens") or 0))
     if provider == "openai":
-        # Cached prompt tokens live on different sub-objects depending on
-        # which envelope landed here. Raw OpenAI Responses usage uses
-        # ``input_tokens_details.cached_tokens``; the OpenAI Chat
-        # Completions envelope Studio re-emits via ``_build_usage_chunk``
-        # uses ``prompt_tokens_details.cached_tokens``. Check both so
-        # cache-heavy chat-style turns get the 0.1x cache_read_mult
-        # discount instead of full input pricing.
+        # Cached tokens land on either input_tokens_details (raw
+        # Responses) or prompt_tokens_details (Studio chat-style).
         for key in ("input_tokens_details", "prompt_tokens_details"):
             details = usage.get(key) or {}
             if isinstance(details, dict):
                 cache_read = max(cache_read, int(details.get("cached_tokens") or 0))
-        # OpenAI: cache_read already counted inside input_tokens.
+        # OpenAI input_tokens already counts cache_read.
         out["billable_input_tokens"] = input_tokens + cache_creation
     else:
-        # Anthropic: input_tokens (post-normalisation) excludes cache
-        # buckets, so add them all back.
+        # Anthropic input_tokens excludes cache buckets; add them back.
         out["billable_input_tokens"] = input_tokens + cache_creation + cache_read
     out["billable_output_tokens"] = output_tokens
 
     if not prices:
         return out
 
-    # Long-context tier crossover (gpt-5.5 / gpt-5.4 today). OpenAI
-    # bills the whole turn at the long-context rate once the prompt
-    # crosses the threshold, NOT a per-token blend, so we pick a
-    # single (base, out_per) pair for this turn based on
-    # billable_input_tokens.
+    # Long-context tier: whole-turn flip (not per-token blend) once
+    # billable_input_tokens crosses the threshold.
     lc_thresh = prices.get("long_context_threshold")
     in_long_context_tier = (
         lc_thresh is not None
@@ -307,16 +205,14 @@ def calculate_cost(
     out["output_usd"] = (output_tokens / 1_000_000.0) * out_per
 
     if provider == "anthropic":
-        # Split cache_creation across 5m / 1h buckets when the
-        # response surfaces the breakdown. Tolerate a non-dict value
-        # (some upstream proxies fold the field down to an int total)
-        # so we don't crash the cost calculation on a malformed payload.
+        # Split cache_creation into 5m / 1h buckets when surfaced.
+        # Tolerate non-dict (some proxies fold to an int total).
         cc_raw = usage.get("cache_creation")
         cc_breakdown = cc_raw if isinstance(cc_raw, dict) else {}
         cc_5m = max(0, int(cc_breakdown.get("ephemeral_5m_input_tokens") or 0))
         cc_1h = max(0, int(cc_breakdown.get("ephemeral_1h_input_tokens") or 0))
         if cc_5m + cc_1h == 0 and cache_creation > 0:
-            # Fall back: assume default 5m pool when no breakdown is given.
+            # No breakdown -- assume default 5m pool.
             cc_5m = cache_creation
         out["cache_write_usd"] = (
             cc_5m / 1_000_000.0
@@ -336,24 +232,17 @@ def calculate_cost(
                 + code_exec_hours * ANTHROPIC_CODE_EXEC_USD_PER_HOUR
             )
     else:
-        # OpenAI: cache writes share the base input price (no premium).
-        # Only cache reads get the 0.1x multiplier; subtract those from
-        # the input_usd we already counted so we don't double-bill.
-        # Anthropic excludes cache buckets from input_tokens, but
-        # OpenAI folds them in, so the math differs.
+        # OpenAI: cache writes pay base input; only cache reads get
+        # 0.1x. Subtract cached from already-counted input_usd to
+        # avoid double-billing (OpenAI folds cache into input_tokens).
         if cache_read > 0:
             non_cached_input = max(0, input_tokens - cache_read)
             out["input_usd"] = (non_cached_input / 1_000_000.0) * base
             out["cache_read_usd"] = (
                 (cache_read / 1_000_000.0) * base * OPENAI_CACHE_READ_MULT
             )
-        # Server-tool surcharges. OpenAI doesn't include these on its
-        # `usage` object directly -- web_search invocations are counted
-        # from `ResponseFunctionWebSearch` items in the output array,
-        # and container hours come from the SSE translator's shell-tool
-        # accounting. Studio surfaces both under a normalised
-        # `openai_tool_use` key on the usage dict the SSE finaliser
-        # hands to this calculator.
+        # OpenAI server-tool surcharges arrive under `openai_tool_use`
+        # (normalised by the SSE finaliser from output array items).
         srv = usage.get("openai_tool_use") or {}
         if isinstance(srv, dict):
             web_searches = int(srv.get("web_search_requests") or 0)
@@ -375,11 +264,7 @@ def calculate_cost(
 
 
 def pricing_snapshot() -> dict[str, Any]:
-    """Whole pricing table, for the /api/providers/pricing endpoint.
-
-    Returns a flat structure the frontend can hand to its cost
-    formatter without re-implementing the multipliers.
-    """
+    """Whole pricing table for the /api/providers/pricing endpoint."""
     return {
         "anthropic": {
             "models": dict(ANTHROPIC_PRICING),

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -156,9 +156,7 @@ def _lookup(provider: str, model: str) -> Optional[dict[str, float]]:
     # date / variant suffixes, never on a longer numeric or alpha
     # continuation of the same component.
     for key in sorted(table, key = len, reverse = True):
-        if model.startswith(key) and (
-            len(model) == len(key) or model[len(key)] == "-"
-        ):
+        if model.startswith(key) and (len(model) == len(key) or model[len(key)] == "-"):
             return table[key]
     return None
 

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -240,9 +240,7 @@ def calculate_cost(
         for key in ("input_tokens_details", "prompt_tokens_details"):
             details = usage.get(key) or {}
             if isinstance(details, dict):
-                cache_read = max(
-                    cache_read, int(details.get("cached_tokens") or 0)
-                )
+                cache_read = max(cache_read, int(details.get("cached_tokens") or 0))
         # OpenAI: cache_read already counted inside input_tokens.
         out["billable_input_tokens"] = input_tokens + cache_creation
     else:

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -106,15 +106,6 @@ ANTHROPIC_CACHE_5M_WRITE_MULT = 1.25
 ANTHROPIC_CACHE_1H_WRITE_MULT = 2.0
 ANTHROPIC_CACHE_READ_MULT = 0.1
 
-# Anthropic fast_mode (Opus 4.6/4.7 only) bills BOTH input AND output
-# at 6x standard rates per
-# https://platform.claude.com/docs/en/build-with-claude/fast-mode
-# (Opus 4.7 standard: $5/$25 per MTok; fast: $30/$150 per MTok).
-# Cache multipliers stack on top of the fast premium. Exposed via
-# pricing_snapshot so the frontend cost panel can apply it when
-# inferenceParams.fastMode was set on the request (see #5715).
-ANTHROPIC_FAST_MODE_MULT = 6.0
-
 # OpenAI: cache reads are 0.1x base input, cache writes are not billed
 # separately (the first prefix-write request just pays normal input).
 OPENAI_CACHE_READ_MULT = 0.1
@@ -174,8 +165,6 @@ def calculate_cost(
     provider: str,
     model: str,
     usage: dict[str, Any],
-    *,
-    fast_mode: bool = False,
 ) -> dict[str, float]:
     """Return a per-turn USD cost breakdown.
 
@@ -314,21 +303,6 @@ def calculate_cost(
         base = prices["input_per_mtok"]
         out_per = prices["output_per_mtok"]
 
-    # Anthropic fast_mode bills BOTH input AND output at 6x; the
-    # premium stacks on top of the cache multipliers (Anthropic docs:
-    # "Prompt caching multipliers apply on top of fast mode pricing").
-    # Restricted to claude-opus-4-6 / 4-7 -- silently no-op on every
-    # other model so a stray ``fast_mode=True`` on a Sonnet can't
-    # over-charge the user.
-    if (
-        fast_mode
-        and provider == "anthropic"
-        and (model.startswith("claude-opus-4-6") or model.startswith("claude-opus-4-7"))
-    ):
-        base = base * ANTHROPIC_FAST_MODE_MULT
-        out_per = out_per * ANTHROPIC_FAST_MODE_MULT
-        out["model_priced"] = f"{out['model_priced'] or model} (fast)"
-
     out["input_usd"] = (input_tokens / 1_000_000.0) * base
     out["output_usd"] = (output_tokens / 1_000_000.0) * out_per
 
@@ -412,7 +386,6 @@ def pricing_snapshot() -> dict[str, Any]:
             "cache_5m_write_mult": ANTHROPIC_CACHE_5M_WRITE_MULT,
             "cache_1h_write_mult": ANTHROPIC_CACHE_1H_WRITE_MULT,
             "cache_read_mult": ANTHROPIC_CACHE_READ_MULT,
-            "fast_mode_mult": ANTHROPIC_FAST_MODE_MULT,
             "web_search_usd_per_1k": ANTHROPIC_WEB_SEARCH_USD_PER_1K,
             "code_execution_usd_per_hour": ANTHROPIC_CODE_EXEC_USD_PER_HOUR,
         },

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -200,9 +200,7 @@ def calculate_cost(
     # style usage chunk Studio re-emits (``_build_usage_chunk``) uses
     # ``prompt_tokens`` / ``completion_tokens``. Either is fine here
     # so a caller can hand whichever envelope landed first.
-    input_tokens = int(
-        usage.get("input_tokens") or usage.get("prompt_tokens") or 0
-    )
+    input_tokens = int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0)
     output_tokens = int(
         usage.get("output_tokens") or usage.get("completion_tokens") or 0
     )

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -320,9 +320,7 @@ def calculate_cost(
     ):
         base = base * ANTHROPIC_FAST_MODE_MULT
         out_per = out_per * ANTHROPIC_FAST_MODE_MULT
-        out["model_priced"] = (
-            f"{out['model_priced'] or model} (fast)"
-        )
+        out["model_priced"] = f"{out['model_priced'] or model} (fast)"
 
     out["input_usd"] = (input_tokens / 1_000_000.0) * base
     out["output_usd"] = (output_tokens / 1_000_000.0) * out_per

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -142,11 +142,14 @@ def _lookup(provider: str, model: str) -> Optional[dict[str, float]]:
         return None
     if model in table:
         return table[model]
-    # Fall back to a prefix match so date-suffixed snapshots
-    # ("gpt-5.5-2026-04-23") inherit the canonical-id prices.
-    for key, val in table.items():
+    # Fall back to a longest-prefix match so dated snapshots
+    # ("gpt-5.5-2026-04-23") inherit the canonical-id prices AND ids
+    # like "gpt-5.4-mini-2026-..." match "gpt-5.4-mini" before they
+    # collide with the shorter "gpt-5.4" entry. Sorting keys by
+    # length descending picks the most specific table row first.
+    for key in sorted(table, key = len, reverse = True):
         if model.startswith(key):
-            return val
+            return table[key]
     return None
 
 
@@ -192,8 +195,17 @@ def calculate_cost(
         "priced": bool(prices),
     }
 
-    input_tokens = int(usage.get("input_tokens") or 0)
-    output_tokens = int(usage.get("output_tokens") or 0)
+    # Accept both shapes: raw Anthropic / OpenAI Responses usage
+    # carries ``input_tokens`` / ``output_tokens``; the OpenAI-Chat-
+    # style usage chunk Studio re-emits (``_build_usage_chunk``) uses
+    # ``prompt_tokens`` / ``completion_tokens``. Either is fine here
+    # so a caller can hand whichever envelope landed first.
+    input_tokens = int(
+        usage.get("input_tokens") or usage.get("prompt_tokens") or 0
+    )
+    output_tokens = int(
+        usage.get("output_tokens") or usage.get("completion_tokens") or 0
+    )
     cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
     cache_read = int(usage.get("cache_read_input_tokens") or 0)
     # OpenAI Responses reports cached tokens under input_tokens_details

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -230,16 +230,23 @@ def calculate_cost(
     # can never produce a NEGATIVE bill that masks real spend in the
     # session total tooltip.
     cache_creation = max(0, int(usage.get("cache_creation_input_tokens") or 0))
+    cache_read_native_present = (
+        "cache_read_input_tokens" in usage
+        and usage.get("cache_read_input_tokens") is not None
+    )
     cache_read = max(0, int(usage.get("cache_read_input_tokens") or 0))
     # Defense in depth for Anthropic: a chat-style envelope arriving
     # without the native ``cache_read_input_tokens`` key (e.g. via a
     # proxy that only emits the mirrored ``prompt_tokens_details``
     # block) would otherwise be billed as uncached input. Pull the
-    # cache-read count from the mirrored field when the native one is
-    # missing or zero. Studio's own ``_build_usage_chunk`` emits both
-    # so this never fires on canonical traffic; it just hardens the
-    # path against off-spec callers.
-    if cache_read == 0:
+    # cache-read count from the mirrored field only when the native
+    # key is absent -- an explicit ``cache_read_input_tokens: 0`` from
+    # the upstream is authoritative, so a stale ``prompt_tokens_details``
+    # (e.g. a proxy forwarding a previous turn's details block) can
+    # never inflate cache_read past the native count. Studio's own
+    # ``_build_usage_chunk`` emits both so canonical traffic is
+    # unaffected; this just hardens the path against off-spec callers.
+    if not cache_read_native_present:
         details = usage.get("prompt_tokens_details") or {}
         if isinstance(details, dict):
             cache_read = max(0, int(details.get("cached_tokens") or 0))

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -230,9 +230,19 @@ def calculate_cost(
     else:
         output_tokens = int(usage.get("completion_tokens") or 0)
     if provider == "openai":
-        details = usage.get("input_tokens_details") or {}
-        if isinstance(details, dict):
-            cache_read = max(cache_read, int(details.get("cached_tokens") or 0))
+        # Cached prompt tokens live on different sub-objects depending on
+        # which envelope landed here. Raw OpenAI Responses usage uses
+        # ``input_tokens_details.cached_tokens``; the OpenAI Chat
+        # Completions envelope Studio re-emits via ``_build_usage_chunk``
+        # uses ``prompt_tokens_details.cached_tokens``. Check both so
+        # cache-heavy chat-style turns get the 0.1x cache_read_mult
+        # discount instead of full input pricing.
+        for key in ("input_tokens_details", "prompt_tokens_details"):
+            details = usage.get(key) or {}
+            if isinstance(details, dict):
+                cache_read = max(
+                    cache_read, int(details.get("cached_tokens") or 0)
+                )
         # OpenAI: cache_read already counted inside input_tokens.
         out["billable_input_tokens"] = input_tokens + cache_creation
     else:

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -147,8 +147,18 @@ def _lookup(provider: str, model: str) -> Optional[dict[str, float]]:
     # like "gpt-5.4-mini-2026-..." match "gpt-5.4-mini" before they
     # collide with the shorter "gpt-5.4" entry. Sorting keys by
     # length descending picks the most specific table row first.
+    #
+    # The match has to land on a token boundary -- otherwise a future
+    # "claude-opus-4-15" would falsely inherit "claude-opus-4-1" prices,
+    # and a hypothetical "gpt-5.5-prod" would silently bill as
+    # "gpt-5.5-pro" (5x overcharge). We require the next character after
+    # the prefix to be "-" so we only match on dash-separated
+    # date / variant suffixes, never on a longer numeric or alpha
+    # continuation of the same component.
     for key in sorted(table, key = len, reverse = True):
-        if model.startswith(key):
+        if model.startswith(key) and (
+            len(model) == len(key) or model[len(key)] == "-"
+        ):
             return table[key]
     return None
 
@@ -206,17 +216,21 @@ def calculate_cost(
     #   raw OpenAI:       input_tokens INCLUDES cache_read (no cache_create)
     #   Studio Anthropic: prompt_tokens INCLUDES cache_creation + cache_read
     #   Studio OpenAI:    prompt_tokens == raw input_tokens (includes cache_read)
-    cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
-    cache_read = int(usage.get("cache_read_input_tokens") or 0)
+    # Defense in depth: clamp every token count to >=0 so a corrupted
+    # upstream payload (negative cached count, off-by-one in a fixture)
+    # can never produce a NEGATIVE bill that masks real spend in the
+    # session total tooltip.
+    cache_creation = max(0, int(usage.get("cache_creation_input_tokens") or 0))
+    cache_read = max(0, int(usage.get("cache_read_input_tokens") or 0))
     has_input_tokens = "input_tokens" in usage and usage.get("input_tokens") is not None
     if has_input_tokens:
         # Raw upstream envelope.
-        input_tokens = int(usage.get("input_tokens") or 0)
+        input_tokens = max(0, int(usage.get("input_tokens") or 0))
     else:
         # Studio chat-style envelope: prompt_tokens already folds the
         # cache buckets for Anthropic, so peel them off to recover the
         # raw uncached prompt count and keep downstream math symmetric.
-        prompt_tokens = int(usage.get("prompt_tokens") or 0)
+        prompt_tokens = max(0, int(usage.get("prompt_tokens") or 0))
         if provider == "anthropic":
             input_tokens = max(0, prompt_tokens - cache_creation - cache_read)
         else:
@@ -226,9 +240,9 @@ def calculate_cost(
     # ``completion_tokens`` for an empty completion. Mirrors the
     # has_input_tokens precedence above.
     if "output_tokens" in usage and usage.get("output_tokens") is not None:
-        output_tokens = int(usage.get("output_tokens") or 0)
+        output_tokens = max(0, int(usage.get("output_tokens") or 0))
     else:
-        output_tokens = int(usage.get("completion_tokens") or 0)
+        output_tokens = max(0, int(usage.get("completion_tokens") or 0))
     if provider == "openai":
         # Cached prompt tokens live on different sub-objects depending on
         # which envelope landed here. Raw OpenAI Responses usage uses
@@ -277,10 +291,13 @@ def calculate_cost(
 
     if provider == "anthropic":
         # Split cache_creation across 5m / 1h buckets when the
-        # response surfaces the breakdown.
-        cc_breakdown = usage.get("cache_creation") or {}
-        cc_5m = int(cc_breakdown.get("ephemeral_5m_input_tokens") or 0)
-        cc_1h = int(cc_breakdown.get("ephemeral_1h_input_tokens") or 0)
+        # response surfaces the breakdown. Tolerate a non-dict value
+        # (some upstream proxies fold the field down to an int total)
+        # so we don't crash the cost calculation on a malformed payload.
+        cc_raw = usage.get("cache_creation")
+        cc_breakdown = cc_raw if isinstance(cc_raw, dict) else {}
+        cc_5m = max(0, int(cc_breakdown.get("ephemeral_5m_input_tokens") or 0))
+        cc_1h = max(0, int(cc_breakdown.get("ephemeral_1h_input_tokens") or 0))
         if cc_5m + cc_1h == 0 and cache_creation > 0:
             # Fall back: assume default 5m pool when no breakdown is given.
             cc_5m = cache_creation

--- a/studio/backend/core/inference/pricing.py
+++ b/studio/backend/core/inference/pricing.py
@@ -106,6 +106,15 @@ ANTHROPIC_CACHE_5M_WRITE_MULT = 1.25
 ANTHROPIC_CACHE_1H_WRITE_MULT = 2.0
 ANTHROPIC_CACHE_READ_MULT = 0.1
 
+# Anthropic fast_mode (Opus 4.6/4.7 only) bills BOTH input AND output
+# at 6x standard rates per
+# https://platform.claude.com/docs/en/build-with-claude/fast-mode
+# (Opus 4.7 standard: $5/$25 per MTok; fast: $30/$150 per MTok).
+# Cache multipliers stack on top of the fast premium. Exposed via
+# pricing_snapshot so the frontend cost panel can apply it when
+# inferenceParams.fastMode was set on the request (see #5715).
+ANTHROPIC_FAST_MODE_MULT = 6.0
+
 # OpenAI: cache reads are 0.1x base input, cache writes are not billed
 # separately (the first prefix-write request just pays normal input).
 OPENAI_CACHE_READ_MULT = 0.1
@@ -165,6 +174,8 @@ def calculate_cost(
     provider: str,
     model: str,
     usage: dict[str, Any],
+    *,
+    fast_mode: bool = False,
 ) -> dict[str, float]:
     """Return a per-turn USD cost breakdown.
 
@@ -296,6 +307,23 @@ def calculate_cost(
         base = prices["input_per_mtok"]
         out_per = prices["output_per_mtok"]
 
+    # Anthropic fast_mode bills BOTH input AND output at 6x; the
+    # premium stacks on top of the cache multipliers (Anthropic docs:
+    # "Prompt caching multipliers apply on top of fast mode pricing").
+    # Restricted to claude-opus-4-6 / 4-7 -- silently no-op on every
+    # other model so a stray ``fast_mode=True`` on a Sonnet can't
+    # over-charge the user.
+    if (
+        fast_mode
+        and provider == "anthropic"
+        and (model.startswith("claude-opus-4-6") or model.startswith("claude-opus-4-7"))
+    ):
+        base = base * ANTHROPIC_FAST_MODE_MULT
+        out_per = out_per * ANTHROPIC_FAST_MODE_MULT
+        out["model_priced"] = (
+            f"{out['model_priced'] or model} (fast)"
+        )
+
     out["input_usd"] = (input_tokens / 1_000_000.0) * base
     out["output_usd"] = (output_tokens / 1_000_000.0) * out_per
 
@@ -379,6 +407,7 @@ def pricing_snapshot() -> dict[str, Any]:
             "cache_5m_write_mult": ANTHROPIC_CACHE_5M_WRITE_MULT,
             "cache_1h_write_mult": ANTHROPIC_CACHE_1H_WRITE_MULT,
             "cache_read_mult": ANTHROPIC_CACHE_READ_MULT,
+            "fast_mode_mult": ANTHROPIC_FAST_MODE_MULT,
             "web_search_usd_per_1k": ANTHROPIC_WEB_SEARCH_USD_PER_1K,
             "code_execution_usd_per_hour": ANTHROPIC_CODE_EXEC_USD_PER_HOUR,
         },

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -493,3 +493,64 @@ def test_input_tokens_preferred_when_both_keys_present():
     )
     # input_tokens=2M wins -> 2 * 0.75 = 1.50.
     assert _isclose(out["input_usd"], 1.50), out
+
+
+def test_anthropic_chat_style_prompt_tokens_dedupes_cache_buckets():
+    """Anthropic prompt_tokens (Studio's chat-style envelope) already
+    folds cache_creation + cache_read into the total. The calculator
+    must NOT add them again or it double-counts billable input.
+    Regression for the Codex P1 on the pricing follow-up PR."""
+    # 1M uncached + 200K cache_creation + 500K cache_read.
+    # Studio envelope: prompt_tokens = 1.7M (everything folded).
+    raw = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "input_tokens": 1_000_000,
+            "cache_creation_input_tokens": 200_000,
+            "cache_read_input_tokens": 500_000,
+            "output_tokens": 0,
+        },
+    )
+    chat = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "prompt_tokens": 1_700_000,
+            "cache_creation_input_tokens": 200_000,
+            "cache_read_input_tokens": 500_000,
+            "completion_tokens": 0,
+        },
+    )
+    # Both envelopes must price the same -- no double-count.
+    assert _isclose(chat["input_usd"], raw["input_usd"]), (chat, raw)
+    assert _isclose(chat["cache_write_usd"], raw["cache_write_usd"]), (chat, raw)
+    assert _isclose(chat["cache_read_usd"], raw["cache_read_usd"]), (chat, raw)
+    assert _isclose(chat["total_usd"], raw["total_usd"]), (chat, raw)
+    assert (
+        chat["billable_input_tokens"] == raw["billable_input_tokens"]
+    ), (chat, raw)
+
+
+def test_openai_chat_style_prompt_tokens_keeps_cache_read_semantics():
+    """For OpenAI, prompt_tokens already includes cache_read just like
+    raw input_tokens, so both envelopes should price identically."""
+    raw = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "input_tokens": 1_000_000,
+            "input_tokens_details": {"cached_tokens": 200_000},
+            "output_tokens": 100_000,
+        },
+    )
+    chat = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "prompt_tokens": 1_000_000,
+            "cache_read_input_tokens": 200_000,
+            "completion_tokens": 100_000,
+        },
+    )
+    assert _isclose(chat["total_usd"], raw["total_usd"]), (chat, raw)

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -552,3 +552,25 @@ def test_openai_chat_style_prompt_tokens_keeps_cache_read_semantics():
         },
     )
     assert _isclose(chat["total_usd"], raw["total_usd"]), (chat, raw)
+
+
+def test_explicit_zero_output_tokens_wins_over_stale_completion_tokens():
+    """``output_tokens: 0`` must beat a stale ``completion_tokens: 50``.
+
+    The previous ``or`` fallback treated 0 as missing and silently
+    re-priced the response against the stale chat-style count. The
+    raw upstream key now takes precedence even when its value is 0.
+    """
+    out = calculate_cost(
+        "openai",
+        "gpt-4o-mini",
+        {
+            "input_tokens": 100,
+            "output_tokens": 0,
+            # Mixed envelope: stale chat-style completion_tokens that
+            # the caller forgot to clear. We must NOT bill against it.
+            "completion_tokens": 50,
+        },
+    )
+    assert out["billable_output_tokens"] == 0, out
+    assert out["output_usd"] == 0.0, out

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -425,3 +425,71 @@ def test_snapshot_contains_provider_buckets_and_multipliers():
     assert gpt55["long_context_threshold"] == 272_000
     assert gpt55["long_context_input_per_mtok"] == 10.0
     assert gpt55["long_context_output_per_mtok"] == 45.0
+
+
+# ── longest-prefix match: dated mini variant must not collide with the
+#    shorter family prefix (regression for PR 5690 review feedback). ──
+
+
+def test_longest_prefix_match_wins_for_dated_mini_snapshot():
+    """A `gpt-5.4-mini-2026-...` snapshot must inherit the `mini` rate,
+    not the (much higher) shorter `gpt-5.4` rate it would naively
+    match if `_lookup` returned the first prefix hit instead of the
+    longest one."""
+    out = calculate_cost(
+        "openai",
+        "gpt-5.4-mini-2026-04-23",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert out["priced"] is True
+    # gpt-5.4-mini = 0.75 / MTok input. gpt-5.4 = 2.5 / MTok input.
+    # Exact match on the longer key gives 0.75; collision on the
+    # shorter one would give 2.5 (>3x overcharge).
+    assert _isclose(out["input_usd"], 0.75), out
+
+
+def test_longest_prefix_match_wins_for_dated_pro_snapshot():
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5-pro-2026-04-23",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert out["priced"] is True
+    # gpt-5.5-pro = 30 / MTok. gpt-5.5 = 5 / MTok. Longest wins.
+    assert _isclose(out["input_usd"], 30.0), out
+
+
+# ── accept both prompt_tokens (chat-style) and input_tokens (Responses)
+#    so callers can hand either envelope shape. Regression for the
+#    Gemini review on PR 5690. ──
+
+
+def test_openai_chat_style_usage_keys_priced_correctly():
+    """A caller handing in `prompt_tokens` / `completion_tokens` (the
+    OpenAI-Chat-style envelope Studio re-emits) must still produce a
+    non-zero cost. Previously the calculator only read `input_tokens`
+    / `output_tokens` and silently zeroed the bill."""
+    out = calculate_cost(
+        "openai",
+        "gpt-5.4-mini",
+        {"prompt_tokens": 1_000_000, "completion_tokens": 1_000_000},
+    )
+    # gpt-5.4-mini: 0.75 input + 4.5 output per MTok.
+    assert _isclose(out["input_usd"], 0.75), out
+    assert _isclose(out["output_usd"], 4.5), out
+
+
+def test_input_tokens_preferred_when_both_keys_present():
+    """If a caller hands in both shapes, the raw key wins so the test
+    fixtures that mirror the upstream wire stay deterministic."""
+    out = calculate_cost(
+        "openai",
+        "gpt-5.4-mini",
+        {
+            "input_tokens": 2_000_000,
+            "prompt_tokens": 5_000_000,
+            "output_tokens": 0,
+        },
+    )
+    # input_tokens=2M wins -> 2 * 0.75 = 1.50.
+    assert _isclose(out["input_usd"], 1.50), out

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -554,6 +554,43 @@ def test_openai_chat_style_prompt_tokens_keeps_cache_read_semantics():
     assert _isclose(chat["total_usd"], raw["total_usd"]), (chat, raw)
 
 
+def test_openai_chat_style_envelope_reads_cache_from_prompt_tokens_details():
+    """``_build_usage_chunk`` emits cached tokens under
+    ``prompt_tokens_details.cached_tokens`` (chat-style), not
+    ``input_tokens_details``. The cost calculator must honour
+    both so cache-heavy chat-style turns get the discounted rate."""
+    base = OPENAI_PRICING["gpt-5.5"]["input_per_mtok"]
+    raw = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "input_tokens": 100_000,
+            "input_tokens_details": {"cached_tokens": 80_000},
+            "output_tokens": 0,
+        },
+    )
+    chat_style = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "prompt_tokens": 100_000,
+            "prompt_tokens_details": {"cached_tokens": 80_000},
+            "completion_tokens": 0,
+        },
+    )
+    # Both envelopes must price identically.
+    assert _isclose(chat_style["input_usd"], raw["input_usd"]), (chat_style, raw)
+    assert _isclose(chat_style["cache_read_usd"], raw["cache_read_usd"]), (
+        chat_style,
+        raw,
+    )
+    # And the discount is real: 80k charged at 0.1x base, 20k at full.
+    assert _isclose(
+        chat_style["cache_read_usd"],
+        80_000 / 1_000_000.0 * base * OPENAI_CACHE_READ_MULT,
+    )
+
+
 def test_explicit_zero_output_tokens_wins_over_stale_completion_tokens():
     """``output_tokens: 0`` must beat a stale ``completion_tokens: 50``.
 

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -527,9 +527,7 @@ def test_anthropic_chat_style_prompt_tokens_dedupes_cache_buckets():
     assert _isclose(chat["cache_write_usd"], raw["cache_write_usd"]), (chat, raw)
     assert _isclose(chat["cache_read_usd"], raw["cache_read_usd"]), (chat, raw)
     assert _isclose(chat["total_usd"], raw["total_usd"]), (chat, raw)
-    assert (
-        chat["billable_input_tokens"] == raw["billable_input_tokens"]
-    ), (chat, raw)
+    assert chat["billable_input_tokens"] == raw["billable_input_tokens"], (chat, raw)
 
 
 def test_openai_chat_style_prompt_tokens_keeps_cache_read_semantics():

--- a/studio/backend/tests/test_pricing.py
+++ b/studio/backend/tests/test_pricing.py
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Unit tests for the per-session cost calculator.
-
-Pricing inputs are baked into ``core/inference/pricing.py``; this
-test verifies the math (with multipliers from the prompt-caching
-docs) and that unknown models / empty usage degrade gracefully.
-"""
+"""Unit tests for the per-session cost calculator. Verifies math
+against ``core/inference/pricing.py`` and graceful degradation."""
 
 import math
 
@@ -102,8 +98,7 @@ def test_anthropic_cache_1h_write_uses_2x_multiplier():
 
 
 def test_anthropic_cache_5m_default_when_no_breakdown():
-    # When the docs/response doesn't surface the 5m/1h split, treat
-    # the full cache_creation bucket as 5m (the upstream default pool).
+    # No 5m/1h split surfaced -> assume the default 5m pool.
     base = ANTHROPIC_PRICING["claude-opus-4-7"]["input_per_mtok"]
     out = calculate_cost(
         "anthropic",
@@ -148,8 +143,7 @@ def test_anthropic_code_exec_charged_per_hour():
 
 
 def test_anthropic_dated_id_falls_back_to_canonical_prefix():
-    # Hypothetical dated snapshot of claude-opus-4-7 should still
-    # inherit the canonical-id pricing via the prefix-match fallback.
+    # Dated snapshot inherits canonical pricing via prefix-match.
     out = calculate_cost(
         "anthropic",
         "claude-opus-4-7-20260712",
@@ -163,8 +157,7 @@ def test_anthropic_dated_id_falls_back_to_canonical_prefix():
 
 
 def test_openai_gpt55_input_output_math():
-    # Sub-272k input keeps us in the short-context tier ($5/$30).
-    # The dedicated long-context tests below exercise the crossover.
+    # Sub-272k stays in short-context tier ($5/$30).
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -176,11 +169,7 @@ def test_openai_gpt55_input_output_math():
 
 
 def test_openai_cache_read_subtracted_from_input_at_discount():
-    # OpenAI folds cached tokens into input_tokens, unlike Anthropic.
-    # The calculator must subtract cached_tokens from the "full price"
-    # bucket and re-bill them at 0.1x. Use a sub-272k total so the
-    # short-context tier applies (long-context crossover is exercised
-    # in its own test below).
+    # OpenAI folds cached into input_tokens; subtract and re-bill at 0.1x.
     base = OPENAI_PRICING["gpt-5.5"]["input_per_mtok"]
     out = calculate_cost(
         "openai",
@@ -199,9 +188,7 @@ def test_openai_cache_read_subtracted_from_input_at_discount():
 
 
 def test_openai_billable_input_tokens_does_not_double_count_cache_read():
-    # OpenAI's input_tokens already includes cached_tokens, so the
-    # billable counter must NOT add cache_read on top -- otherwise the
-    # tooltip says 180k input when the bill is for 100k.
+    # input_tokens already includes cached; don't double-count.
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -215,9 +202,7 @@ def test_openai_billable_input_tokens_does_not_double_count_cache_read():
 
 
 def test_openai_dated_snapshot_inherits_canonical_pricing():
-    # Sub-272k stays in the short-context tier; the prefix-match
-    # fallback is what proves the dated snapshot inherits gpt-5.5
-    # pricing.
+    # Dated snapshot inherits gpt-5.5 pricing via prefix-match.
     out = calculate_cost(
         "openai",
         "gpt-5.5-2026-04-23",
@@ -228,10 +213,7 @@ def test_openai_dated_snapshot_inherits_canonical_pricing():
 
 
 def test_openai_gpt54_family_uses_verified_prices():
-    # Spot-check the lower-tier rows that previously underbilled.
-    # gpt-5.4 has a long-context tier so the input has to stay
-    # below 272k; the mini/nano/codex rows have no crossover so
-    # 1M tokens is fine.
+    # Spot-check lower-tier rows that previously underbilled.
     cases = {
         # (input_tokens, expected_input_usd, expected_output_usd)
         "gpt-5.4": (200_000, 200_000 / 1_000_000.0 * 2.5, 200_000 / 1_000_000.0 * 15.0),
@@ -251,8 +233,7 @@ def test_openai_gpt54_family_uses_verified_prices():
 
 
 def test_openai_unlisted_model_priced_false_not_zero_default():
-    # o-series / gpt-4.5 are no longer on the pricing page, so we
-    # intentionally drop them rather than silently underbill at $0.
+    # o-series / gpt-4.5 are off the pricing page; drop rather than $0.
     for model in ("o3", "o4-mini", "gpt-4.5", "gpt-4.5-preview"):
         out = calculate_cost(
             "openai",
@@ -270,9 +251,7 @@ def test_openai_unlisted_model_priced_false_not_zero_default():
 
 
 def test_anthropic_canonical_4_5_ids_are_priced():
-    # Codex P1: claude-opus-4-5 (no date) is the canonical id used
-    # in backend defaults but was missing from the table, so the
-    # calculator returned priced=False + zero cost. Pin the aliases.
+    # Pin the bare-id aliases (backend defaults reference these).
     cases = {
         "claude-opus-4-5": (5.0, 25.0),
         "claude-sonnet-4-5": (3.0, 15.0),
@@ -307,8 +286,7 @@ def test_openai_gpt55_short_context_under_272k_uses_base_rates():
 
 
 def test_openai_gpt55_long_context_crossover_uses_higher_rates():
-    # 300k billable input > 272k threshold -> long-context tier
-    # applies to the WHOLE turn, not a per-token blend.
+    # >272k billable -> long-context tier on the whole turn.
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -330,8 +308,7 @@ def test_openai_gpt54_long_context_crossover():
 
 
 def test_openai_gpt54_mini_has_no_long_context_tier():
-    # Mini/nano/codex don't publish a long-context price; the base
-    # rate must keep applying even at very large prompts.
+    # Mini/nano/codex have no long-context tier; base rate always applies.
     out = calculate_cost(
         "openai",
         "gpt-5.4-mini",
@@ -374,8 +351,7 @@ def test_openai_container_hours_charged():
 
 
 def test_openai_tool_surcharges_added_to_total():
-    # End-to-end: input + output + web_search + container in one
-    # turn. Total must sum all four buckets.
+    # End-to-end: total must sum input + output + web_search + container.
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -416,8 +392,7 @@ def test_snapshot_contains_provider_buckets_and_multipliers():
     assert "code_execution_usd_per_hour" in a
     assert "models" in o and "gpt-5.5" in o["models"]
     assert o["cache_read_mult"] == OPENAI_CACHE_READ_MULT
-    # OpenAI tool surcharge constants are also exposed so the frontend
-    # tooltip can render the per-call rate.
+    # OpenAI tool surcharge constants are exposed for the frontend.
     assert o["web_search_usd_per_1k"] == OPENAI_WEB_SEARCH_USD_PER_1K
     assert o["container_usd_per_hour"] == OPENAI_CONTAINER_USD_PER_HOUR
     # Long-context tier metadata travels with the model row.
@@ -428,23 +403,19 @@ def test_snapshot_contains_provider_buckets_and_multipliers():
 
 
 # ── longest-prefix match: dated mini variant must not collide with the
-#    shorter family prefix (regression for PR 5690 review feedback). ──
+#    shorter family prefix. ──
 
 
 def test_longest_prefix_match_wins_for_dated_mini_snapshot():
-    """A `gpt-5.4-mini-2026-...` snapshot must inherit the `mini` rate,
-    not the (much higher) shorter `gpt-5.4` rate it would naively
-    match if `_lookup` returned the first prefix hit instead of the
-    longest one."""
+    """`gpt-5.4-mini-2026-...` must inherit the mini rate, not the
+    shorter `gpt-5.4` rate (longest prefix wins)."""
     out = calculate_cost(
         "openai",
         "gpt-5.4-mini-2026-04-23",
         {"input_tokens": 1_000_000, "output_tokens": 0},
     )
     assert out["priced"] is True
-    # gpt-5.4-mini = 0.75 / MTok input. gpt-5.4 = 2.5 / MTok input.
-    # Exact match on the longer key gives 0.75; collision on the
-    # shorter one would give 2.5 (>3x overcharge).
+    # mini = 0.75/MTok, shorter gpt-5.4 = 2.5/MTok (>3x overcharge).
     assert _isclose(out["input_usd"], 0.75), out
 
 
@@ -455,20 +426,16 @@ def test_longest_prefix_match_wins_for_dated_pro_snapshot():
         {"input_tokens": 1_000_000, "output_tokens": 0},
     )
     assert out["priced"] is True
-    # gpt-5.5-pro = 30 / MTok. gpt-5.5 = 5 / MTok. Longest wins.
+    # gpt-5.5-pro = 30/MTok vs gpt-5.5 = 5/MTok; longest wins.
     assert _isclose(out["input_usd"], 30.0), out
 
 
-# ── accept both prompt_tokens (chat-style) and input_tokens (Responses)
-#    so callers can hand either envelope shape. Regression for the
-#    Gemini review on PR 5690. ──
+# ── accept both chat-style and Responses envelope shapes. ──
 
 
 def test_openai_chat_style_usage_keys_priced_correctly():
-    """A caller handing in `prompt_tokens` / `completion_tokens` (the
-    OpenAI-Chat-style envelope Studio re-emits) must still produce a
-    non-zero cost. Previously the calculator only read `input_tokens`
-    / `output_tokens` and silently zeroed the bill."""
+    """Chat-style envelope (`prompt_tokens` / `completion_tokens`) must
+    produce a non-zero cost (previously silently zeroed)."""
     out = calculate_cost(
         "openai",
         "gpt-5.4-mini",
@@ -480,8 +447,7 @@ def test_openai_chat_style_usage_keys_priced_correctly():
 
 
 def test_input_tokens_preferred_when_both_keys_present():
-    """If a caller hands in both shapes, the raw key wins so the test
-    fixtures that mirror the upstream wire stay deterministic."""
+    """Raw key wins when both envelope shapes are present."""
     out = calculate_cost(
         "openai",
         "gpt-5.4-mini",
@@ -496,12 +462,9 @@ def test_input_tokens_preferred_when_both_keys_present():
 
 
 def test_anthropic_chat_style_prompt_tokens_dedupes_cache_buckets():
-    """Anthropic prompt_tokens (Studio's chat-style envelope) already
-    folds cache_creation + cache_read into the total. The calculator
-    must NOT add them again or it double-counts billable input.
-    Regression for the Codex P1 on the pricing follow-up PR."""
-    # 1M uncached + 200K cache_creation + 500K cache_read.
-    # Studio envelope: prompt_tokens = 1.7M (everything folded).
+    """Anthropic chat-style prompt_tokens already folds cache buckets;
+    don't double-count billable input."""
+    # 1M uncached + 200K cache_creation + 500K cache_read -> 1.7M folded.
     raw = calculate_cost(
         "anthropic",
         "claude-opus-4-7",
@@ -522,7 +485,7 @@ def test_anthropic_chat_style_prompt_tokens_dedupes_cache_buckets():
             "completion_tokens": 0,
         },
     )
-    # Both envelopes must price the same -- no double-count.
+    # Both envelopes must price the same.
     assert _isclose(chat["input_usd"], raw["input_usd"]), (chat, raw)
     assert _isclose(chat["cache_write_usd"], raw["cache_write_usd"]), (chat, raw)
     assert _isclose(chat["cache_read_usd"], raw["cache_read_usd"]), (chat, raw)
@@ -531,8 +494,7 @@ def test_anthropic_chat_style_prompt_tokens_dedupes_cache_buckets():
 
 
 def test_openai_chat_style_prompt_tokens_keeps_cache_read_semantics():
-    """For OpenAI, prompt_tokens already includes cache_read just like
-    raw input_tokens, so both envelopes should price identically."""
+    """OpenAI prompt_tokens includes cache_read like raw input_tokens."""
     raw = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -555,10 +517,8 @@ def test_openai_chat_style_prompt_tokens_keeps_cache_read_semantics():
 
 
 def test_openai_chat_style_envelope_reads_cache_from_prompt_tokens_details():
-    """``_build_usage_chunk`` emits cached tokens under
-    ``prompt_tokens_details.cached_tokens`` (chat-style), not
-    ``input_tokens_details``. The cost calculator must honour
-    both so cache-heavy chat-style turns get the discounted rate."""
+    """Chat-style envelope ships cached under prompt_tokens_details;
+    calculator must honour both this and input_tokens_details."""
     base = OPENAI_PRICING["gpt-5.5"]["input_per_mtok"]
     raw = calculate_cost(
         "openai",
@@ -584,7 +544,7 @@ def test_openai_chat_style_envelope_reads_cache_from_prompt_tokens_details():
         chat_style,
         raw,
     )
-    # And the discount is real: 80k charged at 0.1x base, 20k at full.
+    # 80k at 0.1x base, 20k at full.
     assert _isclose(
         chat_style["cache_read_usd"],
         80_000 / 1_000_000.0 * base * OPENAI_CACHE_READ_MULT,
@@ -592,20 +552,15 @@ def test_openai_chat_style_envelope_reads_cache_from_prompt_tokens_details():
 
 
 def test_explicit_zero_output_tokens_wins_over_stale_completion_tokens():
-    """``output_tokens: 0`` must beat a stale ``completion_tokens: 50``.
-
-    The previous ``or`` fallback treated 0 as missing and silently
-    re-priced the response against the stale chat-style count. The
-    raw upstream key now takes precedence even when its value is 0.
-    """
+    """Explicit ``output_tokens: 0`` beats a stale ``completion_tokens``;
+    the previous `or` fallback treated 0 as missing."""
     out = calculate_cost(
         "openai",
         "gpt-4o-mini",
         {
             "input_tokens": 100,
             "output_tokens": 0,
-            # Mixed envelope: stale chat-style completion_tokens that
-            # the caller forgot to clear. We must NOT bill against it.
+            # Stale chat-style mirror; must not bill against it.
             "completion_tokens": 50,
         },
     )

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -530,5 +530,3 @@ def test_calculate_cost_uses_forwarded_cache_creation_for_1h_premium():
     # 1M tokens at 1h-premium (2x of $5 = $10/M = $10). 5m baseline
     # would be 1.25x ($6.25). 2x means cache_write_usd ~= $10.
     assert math.isclose(r["cache_write_usd"], 10.0, rel_tol = 1e-2), r
-
-

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -395,3 +395,108 @@ def test_empty_usage_dict_zero_bill():
     assert out["priced"] is True  # model is in the table
     assert out["billable_input_tokens"] == 0
     assert out["total_usd"] == 0.0
+
+
+# ── Defense-in-depth: Anthropic prompt_tokens_details.cached_tokens ──
+
+
+def test_anthropic_prompt_tokens_details_fallback_when_native_key_missing():
+    """A chat-style envelope without ``cache_read_input_tokens`` but
+    with the mirrored ``prompt_tokens_details.cached_tokens`` should
+    still apply the cache_read discount instead of billing as full
+    uncached input.
+    """
+    r = calculate_cost(
+        provider = "anthropic",
+        model = "claude-opus-4-7",
+        usage = {
+            "prompt_tokens": 1_000_000,
+            "completion_tokens": 0,
+            # No cache_read_input_tokens; only the mirrored shape.
+            "prompt_tokens_details": {"cached_tokens": 1_000_000},
+            "cache_creation_input_tokens": 0,
+        },
+    )
+    assert r["billable_input_tokens"] == 1_000_000, r
+    # 1M cached tokens at 0.1x of $5 (opus 4.7 input rate) = $0.50
+    assert math.isclose(r["cache_read_usd"], 0.5, rel_tol = 1e-3), r
+
+
+def test_anthropic_native_key_takes_precedence_over_mirrored():
+    """When both ``cache_read_input_tokens`` and
+    ``prompt_tokens_details.cached_tokens`` are present, the native
+    Anthropic field wins (the mirror is only a fallback). Studio's
+    canonical envelope always sets both to the same value, so there is
+    no observable difference in production; the precedence rule just
+    keeps the math deterministic on off-spec inputs.
+    """
+    r = calculate_cost(
+        provider = "anthropic",
+        model = "claude-opus-4-7",
+        usage = {
+            "prompt_tokens": 1_000_000,
+            "cache_read_input_tokens": 800_000,
+            "prompt_tokens_details": {"cached_tokens": 1_000_000},
+            "cache_creation_input_tokens": 0,
+        },
+    )
+    # billable_input_tokens = uncached_input + cache_creation + cache_read
+    # uncached_input = prompt_tokens - cache_creation - cache_read
+    #               = 1_000_000 - 0 - 800_000 = 200_000
+    # billable = 200_000 + 0 + 800_000 = 1_000_000
+    assert r["billable_input_tokens"] == 1_000_000, r
+    # cache_read_usd uses 800_000 not 1_000_000 (native wins).
+    assert math.isclose(r["cache_read_usd"], 0.4, rel_tol = 1e-3), r
+
+
+# ── _build_usage_chunk preserves cache_creation breakdown ──
+
+
+def test_build_usage_chunk_forwards_anthropic_cache_creation_breakdown():
+    """Studio chat-style envelope must carry the 5m / 1h cache-write
+    breakdown so downstream cost calc can apply the 2x 1h premium.
+    """
+    import json
+    from core.inference.external_provider import _build_usage_chunk
+
+    chunk = _build_usage_chunk(
+        completion_id = "cmpl-x",
+        provider = "anthropic",
+        last_usage = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_creation_input_tokens": 1_000_000,
+            "cache_read_input_tokens": 0,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 250_000,
+                "ephemeral_1h_input_tokens": 750_000,
+            },
+        },
+    )
+    assert chunk is not None
+    payload = json.loads(chunk.split("data: ", 1)[1])
+    cc = payload["usage"]["cache_creation"]
+    assert cc["ephemeral_1h_input_tokens"] == 750_000, cc
+    assert cc["ephemeral_5m_input_tokens"] == 250_000, cc
+
+
+def test_calculate_cost_uses_forwarded_cache_creation_for_1h_premium():
+    """Re-emitted chat envelope must price 1h cache writes at 2x base.
+    """
+    r = calculate_cost(
+        provider = "anthropic",
+        model = "claude-opus-4-7",
+        usage = {
+            "prompt_tokens": 1_000_010,
+            "completion_tokens": 0,
+            "cache_creation_input_tokens": 1_000_000,
+            "cache_read_input_tokens": 0,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 1_000_000,
+            },
+        },
+    )
+    # 1M tokens at 1h-premium (2x of $5 = $10/M = $10). 5m baseline
+    # would be 1.25x ($6.25). 2x means cache_write_usd ~= $10.
+    assert math.isclose(r["cache_write_usd"], 10.0, rel_tol = 1e-2), r

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -32,11 +32,13 @@ import math
 from core.inference.pricing import (
     ANTHROPIC_CACHE_5M_WRITE_MULT,
     ANTHROPIC_CACHE_READ_MULT,
+    ANTHROPIC_FAST_MODE_MULT,
     ANTHROPIC_PRICING,
     OPENAI_CACHE_READ_MULT,
     OPENAI_PRICING,
     _lookup,
     calculate_cost,
+    pricing_snapshot,
 )
 
 
@@ -499,3 +501,82 @@ def test_calculate_cost_uses_forwarded_cache_creation_for_1h_premium():
     # 1M tokens at 1h-premium (2x of $5 = $10/M = $10). 5m baseline
     # would be 1.25x ($6.25). 2x means cache_write_usd ~= $10.
     assert math.isclose(r["cache_write_usd"], 10.0, rel_tol = 1e-2), r
+
+
+# ── Anthropic fast_mode pricing ───────────────────────────────────
+
+
+def test_fast_mode_bills_input_and_output_at_6x_on_opus_47():
+    """Opus 4.7 standard: $5/$25; fast: $30/$150."""
+    standard = calculate_cost(
+        "anthropic", "claude-opus-4-7",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    fast = calculate_cost(
+        "anthropic", "claude-opus-4-7",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        fast_mode = True,
+    )
+    assert math.isclose(standard["input_usd"], 5.0)
+    assert math.isclose(standard["output_usd"], 25.0)
+    assert math.isclose(fast["input_usd"], 30.0)
+    assert math.isclose(fast["output_usd"], 150.0)
+    assert "fast" in fast["model_priced"]
+
+
+def test_fast_mode_applies_to_opus_46_too():
+    fast = calculate_cost(
+        "anthropic", "claude-opus-4-6",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+        fast_mode = True,
+    )
+    assert math.isclose(fast["input_usd"], 30.0), fast
+
+
+def test_fast_mode_silently_dropped_on_non_opus_46_47():
+    """Stray fast_mode=True on Sonnet/Haiku must not over-charge."""
+    for model in ("claude-sonnet-4-5", "claude-sonnet-4-6", "claude-haiku-4-5"):
+        std = calculate_cost(
+            "anthropic", model,
+            {"input_tokens": 1_000_000, "output_tokens": 0},
+        )
+        fast = calculate_cost(
+            "anthropic", model,
+            {"input_tokens": 1_000_000, "output_tokens": 0},
+            fast_mode = True,
+        )
+        assert math.isclose(std["input_usd"], fast["input_usd"]), (model, std, fast)
+
+
+def test_fast_mode_ignored_on_openai():
+    """Provider gate: fast_mode is Anthropic-only."""
+    std = calculate_cost(
+        "openai", "gpt-5.4",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    fast = calculate_cost(
+        "openai", "gpt-5.4",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+        fast_mode = True,
+    )
+    assert math.isclose(std["input_usd"], fast["input_usd"]), (std, fast)
+
+
+def test_fast_mode_stacks_with_cache_read_discount():
+    """Cache reads stay at 0.1x base * fast_mult per Anthropic docs."""
+    r = calculate_cost(
+        "anthropic", "claude-opus-4-7",
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 1_000_000,
+        },
+        fast_mode = True,
+    )
+    # 1M cache_read at 0.1x base (where base = $5 * 6 = $30) = $3.
+    assert math.isclose(r["cache_read_usd"], 3.0, rel_tol = 1e-3), r
+
+
+def test_pricing_snapshot_exposes_fast_mode_mult():
+    snap = pricing_snapshot()
+    assert snap["anthropic"]["fast_mode_mult"] == 6.0

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -451,6 +451,37 @@ def test_anthropic_native_key_takes_precedence_over_mirrored():
     assert math.isclose(r["cache_read_usd"], 0.4, rel_tol = 1e-3), r
 
 
+def test_anthropic_native_zero_takes_precedence_over_mirrored():
+    """An explicit ``cache_read_input_tokens: 0`` from the upstream is
+    authoritative -- the mirrored ``prompt_tokens_details.cached_tokens``
+    is a fallback for the *missing-key* case, not an override. A stale
+    proxy that forwards a previous turn's details block must not be
+    able to inflate cache_read past the native zero count, which would
+    overbill the turn (false cache-read line) AND inflate
+    ``billable_input_tokens``.
+    """
+    r = calculate_cost(
+        provider = "anthropic",
+        model = "claude-opus-4-7",
+        usage = {
+            "input_tokens": 1_000_000,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 0,
+            # Stale / off-spec mirror from a proxy. Must be ignored
+            # because the native key is present (== 0).
+            "prompt_tokens_details": {"cached_tokens": 1_000_000},
+        },
+    )
+    # Native says 0, so cache_read stays 0; no cache_read_usd bill.
+    assert r["cache_read_usd"] == 0.0, r
+    # billable_input_tokens = input_tokens + cache_creation + cache_read
+    #                      = 1_000_000 + 0 + 0 = 1_000_000
+    assert r["billable_input_tokens"] == 1_000_000, r
+    # 1M uncached input tokens at $5/M = $5.00 (no cache discount).
+    assert math.isclose(r["input_usd"], 5.0, rel_tol = 1e-3), r
+    assert math.isclose(r["total_usd"], 5.0, rel_tol = 1e-3), r
+
+
 # ── _build_usage_chunk preserves cache_creation breakdown ──
 
 

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -509,11 +509,13 @@ def test_calculate_cost_uses_forwarded_cache_creation_for_1h_premium():
 def test_fast_mode_bills_input_and_output_at_6x_on_opus_47():
     """Opus 4.7 standard: $5/$25; fast: $30/$150."""
     standard = calculate_cost(
-        "anthropic", "claude-opus-4-7",
+        "anthropic",
+        "claude-opus-4-7",
         {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
     )
     fast = calculate_cost(
-        "anthropic", "claude-opus-4-7",
+        "anthropic",
+        "claude-opus-4-7",
         {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
         fast_mode = True,
     )
@@ -526,7 +528,8 @@ def test_fast_mode_bills_input_and_output_at_6x_on_opus_47():
 
 def test_fast_mode_applies_to_opus_46_too():
     fast = calculate_cost(
-        "anthropic", "claude-opus-4-6",
+        "anthropic",
+        "claude-opus-4-6",
         {"input_tokens": 1_000_000, "output_tokens": 0},
         fast_mode = True,
     )
@@ -537,11 +540,13 @@ def test_fast_mode_silently_dropped_on_non_opus_46_47():
     """Stray fast_mode=True on Sonnet/Haiku must not over-charge."""
     for model in ("claude-sonnet-4-5", "claude-sonnet-4-6", "claude-haiku-4-5"):
         std = calculate_cost(
-            "anthropic", model,
+            "anthropic",
+            model,
             {"input_tokens": 1_000_000, "output_tokens": 0},
         )
         fast = calculate_cost(
-            "anthropic", model,
+            "anthropic",
+            model,
             {"input_tokens": 1_000_000, "output_tokens": 0},
             fast_mode = True,
         )
@@ -551,11 +556,13 @@ def test_fast_mode_silently_dropped_on_non_opus_46_47():
 def test_fast_mode_ignored_on_openai():
     """Provider gate: fast_mode is Anthropic-only."""
     std = calculate_cost(
-        "openai", "gpt-5.4",
+        "openai",
+        "gpt-5.4",
         {"input_tokens": 1_000_000, "output_tokens": 0},
     )
     fast = calculate_cost(
-        "openai", "gpt-5.4",
+        "openai",
+        "gpt-5.4",
         {"input_tokens": 1_000_000, "output_tokens": 0},
         fast_mode = True,
     )
@@ -565,7 +572,8 @@ def test_fast_mode_ignored_on_openai():
 def test_fast_mode_stacks_with_cache_read_discount():
     """Cache reads stay at 0.1x base * fast_mult per Anthropic docs."""
     r = calculate_cost(
-        "anthropic", "claude-opus-4-7",
+        "anthropic",
+        "claude-opus-4-7",
         {
             "input_tokens": 0,
             "output_tokens": 0,

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -85,9 +85,9 @@ def test_prefix_match_requires_dash_boundary_pro_lookalike():
     # lands on the canonical ``gpt-5.5`` row instead.
     prices = _lookup("openai", "gpt-5.5-prod")
     assert prices is not None
-    assert prices["input_per_mtok"] == OPENAI_PRICING["gpt-5.5"]["input_per_mtok"], (
-        "expected fallback to gpt-5.5 base ($5), not gpt-5.5-pro ($30)"
-    )
+    assert (
+        prices["input_per_mtok"] == OPENAI_PRICING["gpt-5.5"]["input_per_mtok"]
+    ), "expected fallback to gpt-5.5 base ($5), not gpt-5.5-pro ($30)"
     out = calculate_cost(
         "openai",
         "gpt-5.5-prod",
@@ -324,7 +324,8 @@ def test_cache_creation_as_int_does_not_crash():
     )
     # Falls back to the 5m default for the whole cache_creation bucket.
     assert _isclose(
-        out["cache_write_usd"], 1_000_000 / 1_000_000.0 * base * ANTHROPIC_CACHE_5M_WRITE_MULT
+        out["cache_write_usd"],
+        1_000_000 / 1_000_000.0 * base * ANTHROPIC_CACHE_5M_WRITE_MULT,
     )
 
 

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -481,8 +481,7 @@ def test_build_usage_chunk_forwards_anthropic_cache_creation_breakdown():
 
 
 def test_calculate_cost_uses_forwarded_cache_creation_for_1h_premium():
-    """Re-emitted chat envelope must price 1h cache writes at 2x base.
-    """
+    """Re-emitted chat envelope must price 1h cache writes at 2x base."""
     r = calculate_cost(
         provider = "anthropic",
         model = "claude-opus-4-7",

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -1,31 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Adversarial edge cases for ``calculate_cost`` / ``_lookup``.
-
-The companion ``test_pricing.py`` module pins the happy-path math.
-This module pins the corner cases reviewers asked about on the
-pricing follow-up:
-
-- prefix matching must land on a token boundary so a future
-  ``claude-opus-4-15`` can't silently inherit ``claude-opus-4-1``
-  pricing, and a hypothetical ``gpt-5.5-prod`` can't bill as the
-  much more expensive ``gpt-5.5-pro``;
-- negative / non-int token values from a corrupted upstream payload
-  must never produce a negative bill that masks real spend in the
-  running session total;
-- chat-style and raw envelopes must produce identical totals on the
-  cache-heavy boundary cases (zero cache_read, cache_read > prompt,
-  cache_creation > prompt) so the cost ledger doesn't flip per
-  envelope choice;
-- the long-context tier crossover has to fire on the ``billable``
-  input count (which folds cache_creation for OpenAI), not the raw
-  ``input_tokens`` only, otherwise cache-heavy turns dodge the
-  long-context premium they should pay;
-- malformed sub-objects (cache_creation as int, server_tool_use as
-  str) must not raise -- the calculator surfaces zero cost for the
-  malformed bucket and keeps pricing the rest of the turn.
-"""
+"""Adversarial edge cases for ``calculate_cost`` / ``_lookup``: prefix
+boundary, negative tokens, chat vs raw parity, long-context crossover
+on billable count, and malformed sub-objects."""
 
 import math
 
@@ -48,9 +26,8 @@ def _isclose(a, b, tol = 1e-6):
 
 
 def test_prefix_match_requires_dash_boundary_opus_variant():
-    # Hypothetical future ``claude-opus-4-15`` must NOT inherit the
-    # ``claude-opus-4-1`` ($15 / $75) row by way of a naive substring
-    # ``startswith`` -- the next char has to be ``-`` or end-of-string.
+    # `claude-opus-4-15` must not inherit `claude-opus-4-1` pricing;
+    # next char must be `-` or end-of-string.
     assert _lookup("anthropic", "claude-opus-4-15") is None
     out = calculate_cost(
         "anthropic",
@@ -62,9 +39,7 @@ def test_prefix_match_requires_dash_boundary_opus_variant():
 
 
 def test_prefix_match_requires_dash_boundary_gpt_variant():
-    # ``gpt-5.55`` is hypothetical but defends the same invariant:
-    # a different model in the same family tree can't piggy-back on the
-    # ``gpt-5.5`` row just because the canonical id is a string prefix.
+    # Same dash-boundary invariant for OpenAI ids.
     assert _lookup("openai", "gpt-5.55") is None
     assert _lookup("openai", "gpt-5.55-2026-04-23") is None
     out = calculate_cost(
@@ -76,13 +51,8 @@ def test_prefix_match_requires_dash_boundary_gpt_variant():
 
 
 def test_prefix_match_requires_dash_boundary_pro_lookalike():
-    # ``gpt-5.5-pro`` and ``gpt-5.5-prod`` share an undelimited "prod"
-    # / "pro" component. A naive prefix match would land
-    # ``gpt-5.5-prod`` on the ``gpt-5.5-pro`` row ($30 / MTok) -- a 6x
-    # overcharge against the canonical ``gpt-5.5`` row ($5 / MTok). The
-    # dash-boundary check forces the longest matching key to end on
-    # ``-``, so ``gpt-5.5-prod`` falls through ``gpt-5.5-pro`` and
-    # lands on the canonical ``gpt-5.5`` row instead.
+    # `gpt-5.5-prod` must fall through `gpt-5.5-pro` (6x overcharge)
+    # and land on the canonical `gpt-5.5` row.
     prices = _lookup("openai", "gpt-5.5-prod")
     assert prices is not None
     assert (
@@ -98,8 +68,7 @@ def test_prefix_match_requires_dash_boundary_pro_lookalike():
 
 
 def test_prefix_match_still_resolves_legit_dated_snapshots():
-    # The boundary fix must NOT regress the real win the PR is for.
-    # gpt-5.4-mini-2026-04-23 inherits the mini row, NOT gpt-5.4's.
+    # Boundary fix must not regress legit dated snapshots.
     out = calculate_cost(
         "openai",
         "gpt-5.4-mini-2026-04-23",
@@ -108,7 +77,7 @@ def test_prefix_match_still_resolves_legit_dated_snapshots():
     assert out["priced"] is True
     assert _isclose(out["input_usd"], 0.75)
 
-    # And an Anthropic dated snapshot still resolves to its canonical row.
+    # And Anthropic dated snapshot still resolves to canonical row.
     out = calculate_cost(
         "anthropic",
         "claude-opus-4-7-20260414",
@@ -122,9 +91,7 @@ def test_prefix_match_still_resolves_legit_dated_snapshots():
 
 
 def test_explicit_zero_input_tokens_wins_over_stale_prompt_tokens():
-    # Mirror of ``test_explicit_zero_output_tokens_wins_over_stale_completion_tokens``
-    # for the input side -- a turn that genuinely consumed zero prompt
-    # tokens must not silently bill against the chat-style mirror.
+    # Input-side mirror of the output zero precedence test.
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -139,8 +106,7 @@ def test_explicit_zero_input_tokens_wins_over_stale_prompt_tokens():
 
 
 def test_none_input_tokens_falls_through_to_prompt_tokens():
-    # ``None`` is the "key present but unset" case -- treated as
-    # missing so the chat-style mirror still wins.
+    # `None` is "key present but unset"; chat-style mirror wins.
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -206,9 +172,8 @@ def test_negative_prompt_tokens_chat_style_clamp():
 
 
 def test_anthropic_chat_cache_read_exceeds_prompt_no_negative_billable():
-    # If cache_read claims more tokens than prompt_tokens reports,
-    # the uncached_input should clamp at 0 -- but the billable counter
-    # still reflects the cache buckets (we charge for what we got).
+    # cache_read > prompt_tokens clamps uncached_input at 0; billable
+    # still reflects cache buckets (we charge for what we got).
     out = calculate_cost(
         "anthropic",
         "claude-opus-4-7",
@@ -229,8 +194,7 @@ def test_anthropic_chat_cache_read_exceeds_prompt_no_negative_billable():
 
 
 def test_openai_raw_cached_tokens_exceeds_input_clamp_non_cached():
-    # OpenAI variant of the same defense: cached > input shouldn't
-    # produce a negative "non_cached_input" or a negative input_usd.
+    # OpenAI variant: cached > input must not produce negative input_usd.
     base = OPENAI_PRICING["gpt-5.5"]["input_per_mtok"]
     out = calculate_cost(
         "openai",
@@ -252,9 +216,8 @@ def test_openai_raw_cached_tokens_exceeds_input_clamp_non_cached():
 
 
 def test_openai_long_context_triggers_on_cache_creation_inflated_billable():
-    # 250k raw input + 50k cache_creation pushes billable to 300k, which
-    # crosses the 272k threshold. The whole turn should price at the
-    # long-context tier so we don't undercount.
+    # cache_creation pushes billable past 272k -> long-context tier
+    # must fire to avoid undercounting.
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -271,7 +234,7 @@ def test_openai_long_context_triggers_on_cache_creation_inflated_billable():
 
 
 def test_openai_long_context_threshold_boundary_inclusive():
-    # 272_000 exactly should land in the long-context tier (>=).
+    # Threshold is inclusive (>=).
     out = calculate_cost(
         "openai",
         "gpt-5.5",
@@ -309,8 +272,8 @@ def test_openai_chat_envelope_long_context_parity_with_raw():
 
 
 def test_cache_creation_as_int_does_not_crash():
-    # Some upstream proxies fold cache_creation down to a single int.
-    # The calculator must tolerate that and fall back to the 5m default.
+    # Proxies sometimes fold cache_creation to an int; tolerate it
+    # and fall back to the 5m default.
     base = ANTHROPIC_PRICING["claude-opus-4-7"]["input_per_mtok"]
     out = calculate_cost(
         "anthropic",
@@ -322,7 +285,7 @@ def test_cache_creation_as_int_does_not_crash():
             "cache_creation": 12345,  # malformed; must not raise
         },
     )
-    # Falls back to the 5m default for the whole cache_creation bucket.
+    # Falls back to 5m default for the whole bucket.
     assert _isclose(
         out["cache_write_usd"],
         1_000_000 / 1_000_000.0 * base * ANTHROPIC_CACHE_5M_WRITE_MULT,
@@ -356,7 +319,7 @@ def test_non_dict_input_tokens_details_is_ignored():
             "prompt_tokens_details": [1, 2, 3],
         },
     )
-    # No cached_tokens recovered, so no cache_read_usd discount.
+    # No cached_tokens recovered -> no discount.
     assert out["cache_read_usd"] == 0.0
 
 
@@ -371,14 +334,13 @@ def test_unknown_provider_priced_false_zero_bill():
     )
     assert out["priced"] is False
     assert out["total_usd"] == 0.0
-    # Tokens still report for the UI counter.
+    # Tokens still report for the UI.
     assert out["billable_input_tokens"] == 1_000_000
     assert out["billable_output_tokens"] == 1_000_000
 
 
 def test_anthropic_provider_with_openai_model_priced_false():
-    # Provider routing mistake: handing an OpenAI id to the Anthropic
-    # table must not falsely match a similar-looking Anthropic key.
+    # OpenAI id against Anthropic table must not falsely match.
     out = calculate_cost(
         "anthropic",
         "gpt-5.5",
@@ -401,35 +363,28 @@ def test_empty_usage_dict_zero_bill():
 
 
 def test_anthropic_prompt_tokens_details_fallback_when_native_key_missing():
-    """A chat-style envelope without ``cache_read_input_tokens`` but
-    with the mirrored ``prompt_tokens_details.cached_tokens`` should
-    still apply the cache_read discount instead of billing as full
-    uncached input.
-    """
+    """Chat-style envelope without `cache_read_input_tokens` but with
+    mirrored `prompt_tokens_details.cached_tokens` should still apply
+    the cache_read discount."""
     r = calculate_cost(
         provider = "anthropic",
         model = "claude-opus-4-7",
         usage = {
             "prompt_tokens": 1_000_000,
             "completion_tokens": 0,
-            # No cache_read_input_tokens; only the mirrored shape.
+            # Only the mirrored shape (no native key).
             "prompt_tokens_details": {"cached_tokens": 1_000_000},
             "cache_creation_input_tokens": 0,
         },
     )
     assert r["billable_input_tokens"] == 1_000_000, r
-    # 1M cached tokens at 0.1x of $5 (opus 4.7 input rate) = $0.50
+    # 1M cached at 0.1x of $5 (opus 4.7) = $0.50
     assert math.isclose(r["cache_read_usd"], 0.5, rel_tol = 1e-3), r
 
 
 def test_anthropic_native_key_takes_precedence_over_mirrored():
-    """When both ``cache_read_input_tokens`` and
-    ``prompt_tokens_details.cached_tokens`` are present, the native
-    Anthropic field wins (the mirror is only a fallback). Studio's
-    canonical envelope always sets both to the same value, so there is
-    no observable difference in production; the precedence rule just
-    keeps the math deterministic on off-spec inputs.
-    """
+    """When both native and mirrored cache-read fields are present,
+    the native Anthropic field wins (mirror is fallback-only)."""
     r = calculate_cost(
         provider = "anthropic",
         model = "claude-opus-4-7",
@@ -440,24 +395,16 @@ def test_anthropic_native_key_takes_precedence_over_mirrored():
             "cache_creation_input_tokens": 0,
         },
     )
-    # billable_input_tokens = uncached_input + cache_creation + cache_read
-    # uncached_input = prompt_tokens - cache_creation - cache_read
-    #               = 1_000_000 - 0 - 800_000 = 200_000
-    # billable = 200_000 + 0 + 800_000 = 1_000_000
+    # billable = uncached_input + cache_creation + cache_read
+    #         = (1M - 0 - 800k) + 0 + 800k = 1M
     assert r["billable_input_tokens"] == 1_000_000, r
-    # cache_read_usd uses 800_000 not 1_000_000 (native wins).
+    # cache_read uses 800k (native), not 1M (mirrored).
     assert math.isclose(r["cache_read_usd"], 0.4, rel_tol = 1e-3), r
 
 
 def test_anthropic_native_zero_takes_precedence_over_mirrored():
-    """An explicit ``cache_read_input_tokens: 0`` from the upstream is
-    authoritative -- the mirrored ``prompt_tokens_details.cached_tokens``
-    is a fallback for the *missing-key* case, not an override. A stale
-    proxy that forwards a previous turn's details block must not be
-    able to inflate cache_read past the native zero count, which would
-    overbill the turn (false cache-read line) AND inflate
-    ``billable_input_tokens``.
-    """
+    """Explicit `cache_read_input_tokens: 0` is authoritative; a stale
+    mirrored block from a proxy must not inflate cache_read past it."""
     r = calculate_cost(
         provider = "anthropic",
         model = "claude-opus-4-7",
@@ -465,17 +412,15 @@ def test_anthropic_native_zero_takes_precedence_over_mirrored():
             "input_tokens": 1_000_000,
             "output_tokens": 0,
             "cache_read_input_tokens": 0,
-            # Stale / off-spec mirror from a proxy. Must be ignored
-            # because the native key is present (== 0).
+            # Stale mirror from a proxy; must be ignored (native present).
             "prompt_tokens_details": {"cached_tokens": 1_000_000},
         },
     )
-    # Native says 0, so cache_read stays 0; no cache_read_usd bill.
+    # Native is 0 -> cache_read stays 0.
     assert r["cache_read_usd"] == 0.0, r
-    # billable_input_tokens = input_tokens + cache_creation + cache_read
-    #                      = 1_000_000 + 0 + 0 = 1_000_000
+    # billable = input + cache_creation + cache_read = 1M + 0 + 0
     assert r["billable_input_tokens"] == 1_000_000, r
-    # 1M uncached input tokens at $5/M = $5.00 (no cache discount).
+    # 1M uncached at $5/M (no discount).
     assert math.isclose(r["input_usd"], 5.0, rel_tol = 1e-3), r
     assert math.isclose(r["total_usd"], 5.0, rel_tol = 1e-3), r
 
@@ -484,9 +429,8 @@ def test_anthropic_native_zero_takes_precedence_over_mirrored():
 
 
 def test_build_usage_chunk_forwards_anthropic_cache_creation_breakdown():
-    """Studio chat-style envelope must carry the 5m / 1h cache-write
-    breakdown so downstream cost calc can apply the 2x 1h premium.
-    """
+    """Chat-style envelope must carry the 5m/1h cache-write breakdown
+    so downstream cost calc applies the 2x 1h premium."""
     import json
     from core.inference.external_provider import _build_usage_chunk
 
@@ -527,6 +471,5 @@ def test_calculate_cost_uses_forwarded_cache_creation_for_1h_premium():
             },
         },
     )
-    # 1M tokens at 1h-premium (2x of $5 = $10/M = $10). 5m baseline
-    # would be 1.25x ($6.25). 2x means cache_write_usd ~= $10.
+    # 1M at 1h-premium (2x of $5 = $10); 5m baseline would be $6.25.
     assert math.isclose(r["cache_write_usd"], 10.0, rel_tol = 1e-2), r

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Adversarial edge cases for ``calculate_cost`` / ``_lookup``.
+
+The companion ``test_pricing.py`` module pins the happy-path math.
+This module pins the corner cases reviewers asked about on the
+pricing follow-up:
+
+- prefix matching must land on a token boundary so a future
+  ``claude-opus-4-15`` can't silently inherit ``claude-opus-4-1``
+  pricing, and a hypothetical ``gpt-5.5-prod`` can't bill as the
+  much more expensive ``gpt-5.5-pro``;
+- negative / non-int token values from a corrupted upstream payload
+  must never produce a negative bill that masks real spend in the
+  running session total;
+- chat-style and raw envelopes must produce identical totals on the
+  cache-heavy boundary cases (zero cache_read, cache_read > prompt,
+  cache_creation > prompt) so the cost ledger doesn't flip per
+  envelope choice;
+- the long-context tier crossover has to fire on the ``billable``
+  input count (which folds cache_creation for OpenAI), not the raw
+  ``input_tokens`` only, otherwise cache-heavy turns dodge the
+  long-context premium they should pay;
+- malformed sub-objects (cache_creation as int, server_tool_use as
+  str) must not raise -- the calculator surfaces zero cost for the
+  malformed bucket and keeps pricing the rest of the turn.
+"""
+
+import math
+
+from core.inference.pricing import (
+    ANTHROPIC_CACHE_5M_WRITE_MULT,
+    ANTHROPIC_CACHE_READ_MULT,
+    ANTHROPIC_PRICING,
+    OPENAI_CACHE_READ_MULT,
+    OPENAI_PRICING,
+    _lookup,
+    calculate_cost,
+)
+
+
+def _isclose(a, b, tol = 1e-6):
+    return math.isclose(a, b, rel_tol = tol, abs_tol = tol)
+
+
+# ── prefix-match boundary checks ────────────────────────────────────
+
+
+def test_prefix_match_requires_dash_boundary_opus_variant():
+    # Hypothetical future ``claude-opus-4-15`` must NOT inherit the
+    # ``claude-opus-4-1`` ($15 / $75) row by way of a naive substring
+    # ``startswith`` -- the next char has to be ``-`` or end-of-string.
+    assert _lookup("anthropic", "claude-opus-4-15") is None
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-15",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert out["priced"] is False
+    assert out["total_usd"] == 0.0
+
+
+def test_prefix_match_requires_dash_boundary_gpt_variant():
+    # ``gpt-5.55`` is hypothetical but defends the same invariant:
+    # a different model in the same family tree can't piggy-back on the
+    # ``gpt-5.5`` row just because the canonical id is a string prefix.
+    assert _lookup("openai", "gpt-5.55") is None
+    assert _lookup("openai", "gpt-5.55-2026-04-23") is None
+    out = calculate_cost(
+        "openai",
+        "gpt-5.55-2026-04-23",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert out["priced"] is False
+
+
+def test_prefix_match_requires_dash_boundary_pro_lookalike():
+    # ``gpt-5.5-pro`` and ``gpt-5.5-prod`` share an undelimited "prod"
+    # / "pro" component. A naive prefix match would land
+    # ``gpt-5.5-prod`` on the ``gpt-5.5-pro`` row ($30 / MTok) -- a 6x
+    # overcharge against the canonical ``gpt-5.5`` row ($5 / MTok). The
+    # dash-boundary check forces the longest matching key to end on
+    # ``-``, so ``gpt-5.5-prod`` falls through ``gpt-5.5-pro`` and
+    # lands on the canonical ``gpt-5.5`` row instead.
+    prices = _lookup("openai", "gpt-5.5-prod")
+    assert prices is not None
+    assert prices["input_per_mtok"] == OPENAI_PRICING["gpt-5.5"]["input_per_mtok"], (
+        "expected fallback to gpt-5.5 base ($5), not gpt-5.5-pro ($30)"
+    )
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5-prod",
+        {"input_tokens": 100_000, "output_tokens": 0},
+    )
+    assert out["priced"] is True
+    assert _isclose(out["input_usd"], 100_000 / 1_000_000.0 * 5.0)
+
+
+def test_prefix_match_still_resolves_legit_dated_snapshots():
+    # The boundary fix must NOT regress the real win the PR is for.
+    # gpt-5.4-mini-2026-04-23 inherits the mini row, NOT gpt-5.4's.
+    out = calculate_cost(
+        "openai",
+        "gpt-5.4-mini-2026-04-23",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert out["priced"] is True
+    assert _isclose(out["input_usd"], 0.75)
+
+    # And an Anthropic dated snapshot still resolves to its canonical row.
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7-20260414",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert out["priced"] is True
+    assert _isclose(out["input_usd"], 5.0)
+
+
+# ── precedence: input_tokens wins over prompt_tokens (and 0 is real) ──
+
+
+def test_explicit_zero_input_tokens_wins_over_stale_prompt_tokens():
+    # Mirror of ``test_explicit_zero_output_tokens_wins_over_stale_completion_tokens``
+    # for the input side -- a turn that genuinely consumed zero prompt
+    # tokens must not silently bill against the chat-style mirror.
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "input_tokens": 0,
+            "prompt_tokens": 1_000_000,  # stale chat-style mirror
+            "output_tokens": 100,
+        },
+    )
+    assert out["billable_input_tokens"] == 0
+    assert out["input_usd"] == 0.0
+
+
+def test_none_input_tokens_falls_through_to_prompt_tokens():
+    # ``None`` is the "key present but unset" case -- treated as
+    # missing so the chat-style mirror still wins.
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "input_tokens": None,
+            "prompt_tokens": 200_000,
+            "output_tokens": None,
+            "completion_tokens": 5_000,
+        },
+    )
+    assert out["billable_input_tokens"] == 200_000
+    assert out["billable_output_tokens"] == 5_000
+    assert _isclose(out["input_usd"], 200_000 / 1_000_000.0 * 5.0)
+    assert _isclose(out["output_usd"], 5_000 / 1_000_000.0 * 30.0)
+
+
+# ── negative / corrupted upstream values clamp to zero ──────────────
+
+
+def test_negative_tokens_clamp_to_zero_no_negative_bill():
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {"input_tokens": -100, "output_tokens": -50},
+    )
+    assert out["billable_input_tokens"] == 0
+    assert out["billable_output_tokens"] == 0
+    assert out["input_usd"] == 0.0
+    assert out["output_usd"] == 0.0
+    assert out["total_usd"] == 0.0
+
+
+def test_negative_cache_buckets_clamp_to_zero():
+    # Negative cache_read on Anthropic would otherwise refund the bill.
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "input_tokens": 1_000,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": -500,
+            "cache_read_input_tokens": -1_000,
+        },
+    )
+    assert out["cache_write_usd"] == 0.0
+    assert out["cache_read_usd"] == 0.0
+    assert out["billable_input_tokens"] == 1_000
+    assert out["total_usd"] >= 0.0
+
+
+def test_negative_prompt_tokens_chat_style_clamp():
+    out = calculate_cost(
+        "openai",
+        "gpt-5.4-mini",
+        {"prompt_tokens": -100, "completion_tokens": -50},
+    )
+    assert out["billable_input_tokens"] == 0
+    assert out["billable_output_tokens"] == 0
+    assert out["total_usd"] == 0.0
+
+
+# ── cache_read > prompt_tokens corruption: no negative billable ─────
+
+
+def test_anthropic_chat_cache_read_exceeds_prompt_no_negative_billable():
+    # If cache_read claims more tokens than prompt_tokens reports,
+    # the uncached_input should clamp at 0 -- but the billable counter
+    # still reflects the cache buckets (we charge for what we got).
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "prompt_tokens": 100,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 500,
+            "completion_tokens": 0,
+        },
+    )
+    assert out["input_usd"] == 0.0  # uncached clamped to 0
+    assert out["billable_input_tokens"] == 500  # 0 uncached + 500 cache_read
+    # cache_read still priced at the discount rate.
+    base = ANTHROPIC_PRICING["claude-opus-4-7"]["input_per_mtok"]
+    assert _isclose(
+        out["cache_read_usd"], 500 / 1_000_000.0 * base * ANTHROPIC_CACHE_READ_MULT
+    )
+
+
+def test_openai_raw_cached_tokens_exceeds_input_clamp_non_cached():
+    # OpenAI variant of the same defense: cached > input shouldn't
+    # produce a negative "non_cached_input" or a negative input_usd.
+    base = OPENAI_PRICING["gpt-5.5"]["input_per_mtok"]
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "input_tokens": 100,
+            "output_tokens": 0,
+            "input_tokens_details": {"cached_tokens": 500},
+        },
+    )
+    assert out["input_usd"] == 0.0
+    # Cache read still priced (the 0.1x bucket).
+    assert _isclose(
+        out["cache_read_usd"], 500 / 1_000_000.0 * base * OPENAI_CACHE_READ_MULT
+    )
+
+
+# ── long-context tier crosses on billable, including cache_creation ──
+
+
+def test_openai_long_context_triggers_on_cache_creation_inflated_billable():
+    # 250k raw input + 50k cache_creation pushes billable to 300k, which
+    # crosses the 272k threshold. The whole turn should price at the
+    # long-context tier so we don't undercount.
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "input_tokens": 250_000,
+            "cache_creation_input_tokens": 50_000,
+            "output_tokens": 1_000,
+        },
+    )
+    assert out["billable_input_tokens"] == 300_000
+    assert "long-context" in out["model_priced"]
+    assert _isclose(out["input_usd"], 250_000 / 1_000_000.0 * 10.0)
+    assert _isclose(out["output_usd"], 1_000 / 1_000_000.0 * 45.0)
+
+
+def test_openai_long_context_threshold_boundary_inclusive():
+    # 272_000 exactly should land in the long-context tier (>=).
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {"input_tokens": 272_000, "output_tokens": 1_000},
+    )
+    assert "long-context" in out["model_priced"]
+    out_lo = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {"input_tokens": 271_999, "output_tokens": 1_000},
+    )
+    assert "long-context" not in out_lo["model_priced"]
+
+
+# ── chat-style vs raw envelope parity at OpenAI long-context tier ──
+
+
+def test_openai_chat_envelope_long_context_parity_with_raw():
+    raw = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {"input_tokens": 300_000, "output_tokens": 10_000},
+    )
+    chat = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {"prompt_tokens": 300_000, "completion_tokens": 10_000},
+    )
+    assert _isclose(chat["total_usd"], raw["total_usd"])
+    assert "long-context" in chat["model_priced"]
+    assert "long-context" in raw["model_priced"]
+
+
+# ── malformed sub-objects: no crash, no false bill ──────────────────
+
+
+def test_cache_creation_as_int_does_not_crash():
+    # Some upstream proxies fold cache_creation down to a single int.
+    # The calculator must tolerate that and fall back to the 5m default.
+    base = ANTHROPIC_PRICING["claude-opus-4-7"]["input_per_mtok"]
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 1_000_000,
+            "cache_creation": 12345,  # malformed; must not raise
+        },
+    )
+    # Falls back to the 5m default for the whole cache_creation bucket.
+    assert _isclose(
+        out["cache_write_usd"], 1_000_000 / 1_000_000.0 * base * ANTHROPIC_CACHE_5M_WRITE_MULT
+    )
+
+
+def test_non_dict_server_tool_use_is_ignored():
+    out = calculate_cost(
+        "anthropic",
+        "claude-opus-4-7",
+        {"input_tokens": 100, "output_tokens": 100, "server_tool_use": "garbage"},
+    )
+    assert out["server_tools_usd"] == 0.0
+
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {"input_tokens": 100, "output_tokens": 100, "openai_tool_use": [1, 2, 3]},
+    )
+    assert out["server_tools_usd"] == 0.0
+
+
+def test_non_dict_input_tokens_details_is_ignored():
+    out = calculate_cost(
+        "openai",
+        "gpt-5.5",
+        {
+            "input_tokens": 100,
+            "output_tokens": 0,
+            "input_tokens_details": "nope",
+            "prompt_tokens_details": [1, 2, 3],
+        },
+    )
+    # No cached_tokens recovered, so no cache_read_usd discount.
+    assert out["cache_read_usd"] == 0.0
+
+
+# ── unknown provider degrades gracefully ────────────────────────────
+
+
+def test_unknown_provider_priced_false_zero_bill():
+    out = calculate_cost(
+        "gemini",
+        "gemini-pro",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    assert out["priced"] is False
+    assert out["total_usd"] == 0.0
+    # Tokens still report for the UI counter.
+    assert out["billable_input_tokens"] == 1_000_000
+    assert out["billable_output_tokens"] == 1_000_000
+
+
+def test_anthropic_provider_with_openai_model_priced_false():
+    # Provider routing mistake: handing an OpenAI id to the Anthropic
+    # table must not falsely match a similar-looking Anthropic key.
+    out = calculate_cost(
+        "anthropic",
+        "gpt-5.5",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert out["priced"] is False
+
+
+# ── all-zero / empty usage stays at zero ────────────────────────────
+
+
+def test_empty_usage_dict_zero_bill():
+    out = calculate_cost("openai", "gpt-5.5", {})
+    assert out["priced"] is True  # model is in the table
+    assert out["billable_input_tokens"] == 0
+    assert out["total_usd"] == 0.0

--- a/studio/backend/tests/test_pricing_edge.py
+++ b/studio/backend/tests/test_pricing_edge.py
@@ -32,13 +32,11 @@ import math
 from core.inference.pricing import (
     ANTHROPIC_CACHE_5M_WRITE_MULT,
     ANTHROPIC_CACHE_READ_MULT,
-    ANTHROPIC_FAST_MODE_MULT,
     ANTHROPIC_PRICING,
     OPENAI_CACHE_READ_MULT,
     OPENAI_PRICING,
     _lookup,
     calculate_cost,
-    pricing_snapshot,
 )
 
 
@@ -534,88 +532,3 @@ def test_calculate_cost_uses_forwarded_cache_creation_for_1h_premium():
     assert math.isclose(r["cache_write_usd"], 10.0, rel_tol = 1e-2), r
 
 
-# ── Anthropic fast_mode pricing ───────────────────────────────────
-
-
-def test_fast_mode_bills_input_and_output_at_6x_on_opus_47():
-    """Opus 4.7 standard: $5/$25; fast: $30/$150."""
-    standard = calculate_cost(
-        "anthropic",
-        "claude-opus-4-7",
-        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
-    )
-    fast = calculate_cost(
-        "anthropic",
-        "claude-opus-4-7",
-        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
-        fast_mode = True,
-    )
-    assert math.isclose(standard["input_usd"], 5.0)
-    assert math.isclose(standard["output_usd"], 25.0)
-    assert math.isclose(fast["input_usd"], 30.0)
-    assert math.isclose(fast["output_usd"], 150.0)
-    assert "fast" in fast["model_priced"]
-
-
-def test_fast_mode_applies_to_opus_46_too():
-    fast = calculate_cost(
-        "anthropic",
-        "claude-opus-4-6",
-        {"input_tokens": 1_000_000, "output_tokens": 0},
-        fast_mode = True,
-    )
-    assert math.isclose(fast["input_usd"], 30.0), fast
-
-
-def test_fast_mode_silently_dropped_on_non_opus_46_47():
-    """Stray fast_mode=True on Sonnet/Haiku must not over-charge."""
-    for model in ("claude-sonnet-4-5", "claude-sonnet-4-6", "claude-haiku-4-5"):
-        std = calculate_cost(
-            "anthropic",
-            model,
-            {"input_tokens": 1_000_000, "output_tokens": 0},
-        )
-        fast = calculate_cost(
-            "anthropic",
-            model,
-            {"input_tokens": 1_000_000, "output_tokens": 0},
-            fast_mode = True,
-        )
-        assert math.isclose(std["input_usd"], fast["input_usd"]), (model, std, fast)
-
-
-def test_fast_mode_ignored_on_openai():
-    """Provider gate: fast_mode is Anthropic-only."""
-    std = calculate_cost(
-        "openai",
-        "gpt-5.4",
-        {"input_tokens": 1_000_000, "output_tokens": 0},
-    )
-    fast = calculate_cost(
-        "openai",
-        "gpt-5.4",
-        {"input_tokens": 1_000_000, "output_tokens": 0},
-        fast_mode = True,
-    )
-    assert math.isclose(std["input_usd"], fast["input_usd"]), (std, fast)
-
-
-def test_fast_mode_stacks_with_cache_read_discount():
-    """Cache reads stay at 0.1x base * fast_mult per Anthropic docs."""
-    r = calculate_cost(
-        "anthropic",
-        "claude-opus-4-7",
-        {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_input_tokens": 1_000_000,
-        },
-        fast_mode = True,
-    )
-    # 1M cache_read at 0.1x base (where base = $5 * 6 = $30) = $3.
-    assert math.isclose(r["cache_read_usd"], 3.0, rel_tol = 1e-3), r
-
-
-def test_pricing_snapshot_exposes_fast_mode_mult():
-    snap = pricing_snapshot()
-    assert snap["anthropic"]["fast_mode_mult"] == 6.0


### PR DESCRIPTION
## Summary

Two P1 / High follow-ups from review on the merged #5690 pricing module.

1. **Longest-prefix pricing match.** Looking up a dated snapshot like `gpt-5.4-mini-2026-04-23` returned the first matching prefix, which was the shorter `gpt-5.4` entry. That overbilled by 3x+ on the mini family. Sort table keys longest-first so the most specific entry wins.
2. **Accept OpenAI-Chat-style usage keys.** `calculate_cost` only read `input_tokens` / `output_tokens`, but Studio's OpenAI-Chat-style usage envelope re-emits `prompt_tokens` / `completion_tokens` (the Chat Completions vocabulary). Callers handing in the chat-style shape silently got a zeroed bill. Accept either pair so the calculator works against both raw upstream usage and the Studio-translated envelope.

Reported by Codex + Gemini bots on #5690.

## Test plan

- [x] `cd studio && python -m pytest backend/tests/test_pricing.py -v` (27 passing, 4 new):
  - `test_longest_prefix_match_wins_for_dated_mini_snapshot`
  - `test_longest_prefix_match_wins_for_dated_pro_snapshot`
  - `test_openai_chat_style_usage_keys_priced_correctly`
  - `test_input_tokens_preferred_when_both_keys_present`
- [x] All 23 prior pricing tests still green.