### PR TITLE
Fix MLX Studio base model export save method

### DIFF
--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -475,6 +475,7 @@ class ExportBackend:
                     self.current_model.save_pretrained_merged(
                         save_directory,
                         self.current_tokenizer,
+                        save_method = "merged_16bit",
                     )
                 else:
                     self.current_model.save_pretrained(save_directory)
@@ -510,6 +511,7 @@ class ExportBackend:
                             self.current_model.save_pretrained_merged(
                                 tmp_dir,
                                 self.current_tokenizer,
+                                save_method = "merged_16bit",
                             )
                             self.current_model.push_to_hub_merged(
                                 repo_id,


### PR DESCRIPTION
## Summary

Fix MLX Studio base model export by explicitly saving full 16-bit model artifacts.

- pass `save_method="merged_16bit"` when exporting MLX base models locally
- pass the same save method for the temporary MLX save used before Hub upload
- leave the CUDA base export path unchanged

## Why

The MLX `save_pretrained_merged()` helper defaults to `save_method="lora"`, which is adapter-only. Studio base export is supposed to write a full HF-compatible model, so non-LoRA / full-finetuned MLX exports could fail with:

```text
save_method='lora' but the model has no LoRA layers
```