### PR TITLE
Studio: auto-unload idle model after configurable timeout

### DIFF
--- a/studio/backend/core/inference/idle_unload.py
+++ b/studio/backend/core/inference/idle_unload.py
@@ -158,7 +158,9 @@ async def _watchdog_iteration() -> None:
     if unloaded:
         logger.info(
             "idle-unload: unloaded '%s' after %ds idle (timeout=%dmin)",
-            unloaded, int(idle_for), minutes,
+            unloaded,
+            int(idle_for),
+            minutes,
         )
         _reset_for_tests()  # next /load re-arms the watchdog
 

--- a/studio/backend/core/inference/idle_unload.py
+++ b/studio/backend/core/inference/idle_unload.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Idle-unload watchdog (issue #5650).
+
+Unloads the loaded inference model after a configurable idle period,
+similar to llama-swap, ollama and openwebui.
+
+Activity is tracked by :class:`ActivityMiddleware` (mounted from
+``main.py``), which counts every inference request — including the full
+lifetime of streaming responses — so a long generation cannot be cut
+off mid-stream.
+
+The watchdog reads its enabled flag and timeout from ``chat_settings``
+on every tick, with ``UNSLOTH_IDLE_UNLOAD_MINUTES`` as an override for
+headless / Tauri-controlled deployments. Disabled by default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from contextlib import contextmanager
+from typing import Optional
+
+from loggers import get_logger
+
+logger = get_logger(__name__)
+
+_TICK_SECONDS = 30.0
+_DEFAULT_IDLE_MINUTES = 10
+_MIN_IDLE_MINUTES, _MAX_IDLE_MINUTES = 1, 24 * 60
+
+_state_lock = threading.Lock()
+_last_activity_at: Optional[float] = None
+_inflight: int = 0
+
+
+def record_activity() -> None:
+    """Mark the model as just-used."""
+    global _last_activity_at
+    _last_activity_at = time.monotonic()
+
+
+@contextmanager
+def active_request():
+    """Track a request as in-flight; the watchdog refuses to unload while
+    any are running. Bumps ``last_activity`` on entry and exit."""
+    global _inflight
+    record_activity()
+    with _state_lock:
+        _inflight += 1
+    try:
+        yield
+    finally:
+        with _state_lock:
+            _inflight = max(0, _inflight - 1)
+        record_activity()
+
+
+def has_inflight_requests() -> bool:
+    with _state_lock:
+        return _inflight > 0
+
+
+def _reset_for_tests() -> None:
+    global _last_activity_at, _inflight
+    _last_activity_at = None
+    with _state_lock:
+        _inflight = 0
+
+
+def _resolve_idle_minutes() -> Optional[int]:
+    """Minutes of idle time before unloading, or ``None`` to stay quiet.
+
+    ``UNSLOTH_IDLE_UNLOAD_MINUTES`` overrides the DB. ``0`` (or any
+    non-positive integer) force-disables.
+    """
+    raw = os.environ.get("UNSLOTH_IDLE_UNLOAD_MINUTES", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning("UNSLOTH_IDLE_UNLOAD_MINUTES is not an integer: %r", raw)
+        else:
+            if value <= 0:
+                return None
+            return max(_MIN_IDLE_MINUTES, min(_MAX_IDLE_MINUTES, value))
+
+    # Lazy import: keeps tests that monkey-patch the DB free from
+    # import-time side effects.
+    try:
+        from storage.studio_db import list_chat_settings
+
+        settings = list_chat_settings()
+    except Exception as exc:
+        logger.debug("idle-unload: chat_settings unavailable: %s", exc)
+        return None
+
+    if not isinstance(settings, dict) or not settings.get("autoUnloadEnabled"):
+        return None
+    minutes = settings.get("autoUnloadIdleMinutes")
+    if not isinstance(minutes, int) or minutes < _MIN_IDLE_MINUTES:
+        minutes = _DEFAULT_IDLE_MINUTES
+    return min(_MAX_IDLE_MINUTES, minutes)
+
+
+def _try_unload_loaded_backend() -> Optional[str]:
+    """Unload whichever backend currently holds a model. Returns the
+    model identifier on success, ``None`` otherwise."""
+    # GGUF (llama-server) — preferred path for Studio's chat flow.
+    from routes.inference import get_llama_cpp_backend
+
+    gguf = get_llama_cpp_backend()
+    if gguf.is_active:
+        if not gguf.is_loaded:
+            return None  # mid-load: skip rather than fight the load lock
+        identifier = getattr(gguf, "_model_identifier", None) or "<gguf>"
+        try:
+            gguf.unload_model()
+        except Exception as exc:
+            logger.warning("idle-unload: llama-cpp unload failed: %s", exc)
+            return None
+        return identifier
+
+    # Orchestrator-backed inference (transformers / MLX).
+    from core.inference import get_inference_backend
+
+    backend = get_inference_backend()
+    if backend is None or backend.is_model_loading():
+        return None
+    current = backend.get_current_model()
+    if not current:
+        return None
+    try:
+        backend.unload_model(current)
+    except Exception as exc:
+        logger.warning("idle-unload: inference unload failed: %s", exc)
+        return None
+    return current
+
+
+async def _watchdog_iteration() -> None:
+    """Single decision pass. Public for testing."""
+    minutes = _resolve_idle_minutes()
+    if minutes is None:
+        return
+    if _last_activity_at is None:
+        record_activity()  # arm the timer on first tick
+        return
+    idle_for = time.monotonic() - _last_activity_at
+    if idle_for < minutes * 60 or has_inflight_requests():
+        return
+
+    unloaded = await asyncio.to_thread(_try_unload_loaded_backend)
+    if unloaded:
+        logger.info(
+            "idle-unload: unloaded '%s' after %ds idle (timeout=%dmin)",
+            unloaded, int(idle_for), minutes,
+        )
+        _reset_for_tests()  # next /load re-arms the watchdog
+
+
+async def _watchdog_loop() -> None:
+    logger.info("idle-unload watchdog started (tick=%ds)", int(_TICK_SECONDS))
+    try:
+        while True:
+            try:
+                await _watchdog_iteration()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("idle-unload tick failed: %s", exc)
+            await asyncio.sleep(_TICK_SECONDS)
+    except asyncio.CancelledError:
+        logger.info("idle-unload watchdog stopped")
+        raise
+
+
+def start_idle_unload_task(app) -> asyncio.Task:
+    """Schedule the watchdog and stash it on ``app.state`` for shutdown."""
+    task = asyncio.create_task(_watchdog_loop(), name = "unsloth-idle-unload")
+    app.state.idle_unload_task = task
+    return task
+
+
+_ACTIVITY_PREFIXES: tuple[str, ...] = (
+    "/api/inference/load",
+    "/api/inference/chat/completions",
+    "/api/inference/completions",
+    "/api/inference/embeddings",
+    "/api/inference/responses",
+    "/api/inference/audio/generate",
+    "/api/inference/generate/stream",
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/responses",
+    "/v1/messages",
+)
+
+
+class ActivityMiddleware:
+    """Counts each inference request as in-flight for its full response
+    lifetime — including streaming bodies. Starlette only completes the
+    awaited ``app(scope, receive, send)`` call after the response body
+    is fully sent, so a single ``with`` is enough."""
+
+    def __init__(self, app, prefixes: tuple[str, ...] = _ACTIVITY_PREFIXES):
+        self.app = app
+        self.prefixes = prefixes
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or not any(
+            scope.get("path", "").startswith(p) for p in self.prefixes
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        with active_request():
+            await self.app(scope, receive, send)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -7,6 +7,7 @@ Main FastAPI application for Unsloth UI Backend
 
 import os
 import sys
+import asyncio
 from pathlib import Path as _Path
 
 # Suppress annoying C-level dependency warnings globally
@@ -279,8 +280,32 @@ async def lifespan(app: FastAPI):
         print("=" * 60 + "\n")
     else:
         app.state.bootstrap_password = storage.get_bootstrap_password()
+
+    # Idle-unload watchdog (issue #5650). Reads its enabled flag and
+    # timeout from chat_settings on every tick so toggling the UI switch
+    # takes effect without a restart. No-op when the toggle is off.
+    try:
+        from core.inference.idle_unload import start_idle_unload_task
+
+        start_idle_unload_task(app)
+    except Exception as exc:
+        import structlog as _structlog
+
+        _structlog.get_logger(__name__).warning(
+            "Failed to start idle-unload watchdog: %s", exc
+        )
+
     yield
     # Cleanup
+    idle_unload_task = getattr(app.state, "idle_unload_task", None)
+    if idle_unload_task is not None and not idle_unload_task.done():
+        idle_unload_task.cancel()
+        try:
+            await idle_unload_task
+        except (asyncio.CancelledError, Exception):
+            # Cancellation is expected; any other exception was already
+            # logged inside the watchdog loop.
+            pass
     _hw_module.DEVICE = None
     clear_unsloth_compiled_cache()
 
@@ -469,6 +494,15 @@ app.add_middleware(
     max_bytes = _MAX_BODY_BYTES,
     protected_prefixes = _BODY_PROTECTED_PREFIXES,
 )
+
+
+# Idle-unload activity tracking (issue #5650). Records start/end of every
+# inference request — including the full lifetime of streaming responses —
+# so the watchdog never unloads while traffic is in flight and a stream
+# can complete cleanly even if the client takes minutes to read it.
+from core.inference.idle_unload import ActivityMiddleware  # noqa: E402
+
+app.add_middleware(ActivityMiddleware)
 
 
 from starlette.responses import RedirectResponse as _RedirectResponse  # noqa: E402

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -141,9 +141,7 @@ class ChatSettingsPayload(BaseModel):
     # true, the loaded model is unloaded after ``autoUnloadIdleMinutes``
     # of inactivity. Cap mirrors the watchdog's clamp (1 min .. 24 h).
     autoUnloadEnabled: Optional[bool] = None
-    autoUnloadIdleMinutes: Optional[int] = Field(
-        default = None, ge = 1, le = 1440
-    )
+    autoUnloadIdleMinutes: Optional[int] = Field(default = None, ge = 1, le = 1440)
 
 
 class ChatSettingsResponse(BaseModel):

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -137,6 +137,13 @@ class ChatSettingsPayload(BaseModel):
     autoHealToolCalls: Optional[bool] = None
     maxToolCallsPerMessage: Optional[int] = Field(default = None, ge = 1)
     toolCallTimeout: Optional[int] = Field(default = None, ge = 1)
+    # Idle-unload watchdog (issue #5650). When ``autoUnloadEnabled`` is
+    # true, the loaded model is unloaded after ``autoUnloadIdleMinutes``
+    # of inactivity. Cap mirrors the watchdog's clamp (1 min .. 24 h).
+    autoUnloadEnabled: Optional[bool] = None
+    autoUnloadIdleMinutes: Optional[int] = Field(
+        default = None, ge = 1, le = 1440
+    )
 
 
 class ChatSettingsResponse(BaseModel):

--- a/studio/frontend/src/features/chat/api/chat-settings-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-settings-api.ts
@@ -26,6 +26,8 @@ export interface PersistedChatSettings {
   autoHealToolCalls?: boolean;
   maxToolCallsPerMessage?: number;
   toolCallTimeout?: number;
+  autoUnloadEnabled?: boolean;
+  autoUnloadIdleMinutes?: number;
 }
 
 interface ChatSettingsResponse {

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -270,6 +270,8 @@ type ChatRuntimeStore = {
   autoHealToolCalls: boolean;
   maxToolCallsPerMessage: number;
   toolCallTimeout: number;
+  autoUnloadEnabled: boolean;
+  autoUnloadIdleMinutes: number;
   kvCacheDtype: string | null;
   loadedKvCacheDtype: string | null;
   speculativeType: string | null;
@@ -329,6 +331,8 @@ type ChatRuntimeStore = {
   setAutoHealToolCalls: (enabled: boolean) => void;
   setMaxToolCallsPerMessage: (value: number) => void;
   setToolCallTimeout: (value: number) => void;
+  setAutoUnloadEnabled: (enabled: boolean) => void;
+  setAutoUnloadIdleMinutes: (value: number) => void;
   setKvCacheDtype: (dtype: string | null) => void;
   setSpeculativeType: (type: string | null) => void;
   setSpecDraftNMax: (value: number | null) => void;
@@ -352,7 +356,9 @@ type ScalarSettingKey =
   | "preserveThinking"
   | "autoHealToolCalls"
   | "maxToolCallsPerMessage"
-  | "toolCallTimeout";
+  | "toolCallTimeout"
+  | "autoUnloadEnabled"
+  | "autoUnloadIdleMinutes";
 
 type PresetHydrationVersions = {
   customPresets: number;
@@ -386,6 +392,8 @@ const SCALAR_SETTING_KEYS = [
   "autoHealToolCalls",
   "maxToolCallsPerMessage",
   "toolCallTimeout",
+  "autoUnloadEnabled",
+  "autoUnloadIdleMinutes",
 ] as const satisfies readonly ScalarSettingKey[];
 
 const inferenceParamMutationVersions = Object.fromEntries(
@@ -572,6 +580,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   autoHealToolCalls: true,
   maxToolCallsPerMessage: 25,
   toolCallTimeout: 5,
+  autoUnloadEnabled: false,
+  autoUnloadIdleMinutes: 10,
   kvCacheDtype: null,
   loadedKvCacheDtype: null,
   speculativeType: "auto",
@@ -834,6 +844,24 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         state.toolCallTimeout,
       );
       return { toolCallTimeout };
+    }),
+  setAutoUnloadEnabled: (autoUnloadEnabled) =>
+    set((state) => {
+      setScalarSettingVersion(
+        "autoUnloadEnabled",
+        autoUnloadEnabled,
+        state.autoUnloadEnabled,
+      );
+      return { autoUnloadEnabled };
+    }),
+  setAutoUnloadIdleMinutes: (autoUnloadIdleMinutes) =>
+    set((state) => {
+      setScalarSettingVersion(
+        "autoUnloadIdleMinutes",
+        autoUnloadIdleMinutes,
+        state.autoUnloadIdleMinutes,
+      );
+      return { autoUnloadIdleMinutes };
     }),
   setKvCacheDtype: (kvCacheDtype) => set({ kvCacheDtype }),
   setSpeculativeType: (speculativeType) => set({ speculativeType }),

--- a/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
@@ -214,6 +214,8 @@ function sanitizeChatSettings(value: unknown): PersistedChatSettings {
   const autoHealToolCalls = sanitizeBool(value.autoHealToolCalls);
   const maxToolCallsPerMessage = sanitizeInt(value.maxToolCallsPerMessage, 1);
   const toolCallTimeout = sanitizeInt(value.toolCallTimeout, 1);
+  const autoUnloadEnabled = sanitizeBool(value.autoUnloadEnabled);
+  const autoUnloadIdleMinutes = sanitizeInt(value.autoUnloadIdleMinutes, 1);
 
   if (inferenceParams) settings.inferenceParams = inferenceParams;
   if (customPresets !== undefined) settings.customPresets = customPresets;
@@ -232,6 +234,12 @@ function sanitizeChatSettings(value: unknown): PersistedChatSettings {
     settings.maxToolCallsPerMessage = maxToolCallsPerMessage;
   }
   if (toolCallTimeout !== undefined) settings.toolCallTimeout = toolCallTimeout;
+  if (autoUnloadEnabled !== undefined) {
+    settings.autoUnloadEnabled = autoUnloadEnabled;
+  }
+  if (autoUnloadIdleMinutes !== undefined) {
+    settings.autoUnloadIdleMinutes = autoUnloadIdleMinutes;
+  }
 
   return settings;
 }
@@ -287,7 +295,9 @@ export function isEmptyChatSettings(settings: PersistedChatSettings): boolean {
     settings.preserveThinking === undefined &&
     settings.autoHealToolCalls === undefined &&
     settings.maxToolCallsPerMessage === undefined &&
-    settings.toolCallTimeout === undefined
+    settings.toolCallTimeout === undefined &&
+    settings.autoUnloadEnabled === undefined &&
+    settings.autoUnloadIdleMinutes === undefined
   );
 }
 

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -98,6 +98,16 @@ export function GeneralTab() {
   const setHfToken = useChatRuntimeStore((s) => s.setHfToken);
   const autoTitle = useChatRuntimeStore((s) => s.autoTitle);
   const setAutoTitle = useChatRuntimeStore((s) => s.setAutoTitle);
+  const autoUnloadEnabled = useChatRuntimeStore((s) => s.autoUnloadEnabled);
+  const setAutoUnloadEnabled = useChatRuntimeStore(
+    (s) => s.setAutoUnloadEnabled,
+  );
+  const autoUnloadIdleMinutes = useChatRuntimeStore(
+    (s) => s.autoUnloadIdleMinutes,
+  );
+  const setAutoUnloadIdleMinutes = useChatRuntimeStore(
+    (s) => s.setAutoUnloadIdleMinutes,
+  );
   const chatOnly = usePlatformStore((s) => s.chatOnly);
   const redirectTo = `${pathname}${search}`;
 
@@ -172,6 +182,39 @@ export function GeneralTab() {
         >
           <Switch checked={autoTitle} onCheckedChange={setAutoTitle} />
         </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection title="Model lifecycle">
+        <SettingsRow
+          label="Auto-unload idle model"
+          description="Free RAM and VRAM by unloading the model after a period of inactivity. The next request reloads it automatically."
+        >
+          <Switch
+            checked={autoUnloadEnabled}
+            onCheckedChange={setAutoUnloadEnabled}
+          />
+        </SettingsRow>
+        {autoUnloadEnabled && (
+          <SettingsRow
+            label="Idle timeout"
+            description="Minutes of inactivity before unloading. Cap is 1440 (24 hours)."
+          >
+            <Input
+              type="number"
+              min={1}
+              max={1440}
+              step={1}
+              value={autoUnloadIdleMinutes}
+              onChange={(e) => {
+                const next = Number(e.target.value);
+                if (Number.isInteger(next) && next >= 1 && next <= 1440) {
+                  setAutoUnloadIdleMinutes(next);
+                }
+              }}
+              className="h-8 w-[120px]"
+            />
+          </SettingsRow>
+        )}
       </SettingsSection>
 
       {!chatOnly && (


### PR DESCRIPTION
Closes #5650.

### Why

Studio holds the loaded model in RAM/VRAM until the user manually unloads it. For someone running it on a laptop or home machine that also serves to the LAN, that can mean 95% memory pinned for an idle session. llama-swap, ollama, and openwebui all auto-unload after an idle period — Studio now does too.

### What

- New setting in `Settings -> General -> Model lifecycle` with a switch and a minutes input. Default off, so existing users see no behaviour change.
- A 30 s asyncio watchdog (`studio/backend/core/inference/idle_unload.py`) checks `chat_settings` on each tick. When the toggle is on and the loaded model has been idle longer than `autoUnloadIdleMinutes` (1..1440, default 10), it calls the existing `unload_model()` path — llama-cpp first, then the orchestrator-backed inference (transformers / MLX).
- Activity is tracked by an ASGI middleware that wraps every inference route. Because Starlette only completes the awaited app call after the response body is fully sent, a single `with active_request():` covers the full lifetime of streaming responses, so a long generation can never be cut off mid-stream.
- `UNSLOTH_IDLE_UNLOAD_MINUTES` env var overrides the DB setting (useful for headless / Tauri-controlled deployments). Setting it to 0 or any non-positive value force-disables.

### How it stays safe

- The watchdog refuses to unload while a request is in flight (in-flight counter checked under a mutex).
- It refuses to unload if a model load is in progress — `LlamaCppBackend._serial_load_lock` is held only for the load itself, and trying to acquire it from the watchdog would serialise behind a multi-GB HF download. The watchdog reads `is_active` and `is_loaded` instead.
- A corrupt `chat_settings` row only skips one tick (debug-logged); the existing settings-quarantine flow handles repair on the next save.

### Frontend wiring

Mirrors the existing scalar settings (`autoTitle`, `autoHealToolCalls`, `maxToolCallsPerMessage`, ...): two new keys flow through `PersistedChatSettings` -> sanitiser -> runtime store (`SCALAR_SETTING_KEYS`, `getHydratedSettingsState`, setters) -> the General tab UI. Persistence uses the same debounced `PUT /chat-history/settings` round-trip every other setting uses.

### Verification

- `python -c "import ast; ast.parse(open('studio/backend/core/inference/idle_unload.py').read())"` — clean.
- `getDiagnostics` on the touched files: no new errors. Pre-existing TS diagnostics on the frontend files come from missing `node_modules` in this workspace and are unrelated.
- Logical walk-through: toggle off (default) -> `_resolve_idle_minutes` returns `None` -> watchdog no-ops every tick. Toggle on with no minutes -> defaults to 10. Env override -> takes precedence.

### Out of scope

- No doc edits per contribution rules.
- No changes to existing route signatures or backend public surface.
