### PR TITLE
Studio install: deterministic pydantic install on no-torch path

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1302,6 +1302,16 @@ shell.Run cmd, 0, False
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
             $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.5.6" unsloth-zoo }
             if ($baseInstallExit -eq 0) {
+                # Install pydantic WITH deps so pip pins pydantic-core to
+                # the exact version pydantic's metadata requires. The
+                # --no-deps install of no-torch-runtime.txt below would
+                # otherwise pick the latest of each independently and
+                # trip pydantic's _ensure_pydantic_core_version check.
+                # pydantic's deps (annotated-types, pydantic-core,
+                # typing-extensions, typing-inspection) are torch-free.
+                $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython pydantic }
+            }
+            if ($baseInstallExit -eq 0) {
                 $NoTorchReq = Find-NoTorchRuntimeFile
                 if ($NoTorchReq) {
                     $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps -r $NoTorchReq }
@@ -1347,6 +1357,11 @@ shell.Run cmd, 0, False
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
             $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.5.6" unsloth-zoo }
+            if ($baseInstallExit -eq 0) {
+                # Install pydantic WITH deps so pip pins pydantic-core to
+                # the matching version (see migrated branch above).
+                $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython pydantic }
+            }
             if ($baseInstallExit -eq 0) {
                 $NoTorchReq = Find-NoTorchRuntimeFile
                 if ($NoTorchReq) {

--- a/install.sh
+++ b/install.sh
@@ -1866,6 +1866,15 @@ if [ "$_MIGRATED" = true ]; then
         run_install_cmd "install unsloth (migrated no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
             "unsloth>=2026.5.6" unsloth-zoo
+        # Install pydantic WITH deps so pip pins pydantic-core to the
+        # exact version pydantic's own metadata requires. The --no-deps
+        # install below would otherwise pick the latest of each
+        # independently and trip pydantic's _ensure_pydantic_core_version
+        # check on the next import. pydantic's deps (annotated-types,
+        # pydantic-core, typing-extensions, typing-inspection) are
+        # torch-free, so this is safe on the no-torch path.
+        run_install_cmd "install pydantic (with deps for compatible core)" \
+            uv pip install --python "$_VENV_PY" pydantic
         _NO_TORCH_RT="$(_find_no_torch_runtime)"
         if [ -n "$_NO_TORCH_RT" ]; then
             run_install_cmd "install no-torch runtime deps" uv pip install --python "$_VENV_PY" --no-deps -r "$_NO_TORCH_RT"
@@ -2042,6 +2051,10 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
         run_install_cmd "install unsloth (no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --upgrade-package unsloth --upgrade-package unsloth-zoo \
             "unsloth>=2026.5.6" unsloth-zoo
+        # Install pydantic WITH deps so pip pins pydantic-core to the
+        # exact version pydantic requires (see migrated branch above).
+        run_install_cmd "install pydantic (with deps for compatible core)" \
+            uv pip install --python "$_VENV_PY" pydantic
         _NO_TORCH_RT="$(_find_no_torch_runtime)"
         if [ -n "$_NO_TORCH_RT" ]; then
             run_install_cmd "install no-torch runtime deps" uv pip install --python "$_VENV_PY" --no-deps -r "$_NO_TORCH_RT"

--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -22,14 +22,19 @@ rich>=13.0
 markdown-it-py>=3.0
 mdurl>=0.1
 pygments>=2.0
-pydantic
-# pydantic 2.x deps. With --no-deps, `import pydantic` blows up
-# with `ModuleNotFoundError: 'pydantic_core'` (compiled Rust core,
-# separate wheel), then `'annotated_types'`, then
-# `'typing_inspection'` (used by pydantic 2.10+ for fields).
-pydantic-core
-annotated-types>=0.6
-typing-inspection>=0.4
+# pydantic is intentionally NOT installed via this --no-deps file.
+# install.sh / install.ps1 / install_python_stack.py run a separate
+# `pip install pydantic` (with deps) just before this file is
+# applied, so pip resolves `pydantic-core` to the exact version
+# pydantic's `_ensure_pydantic_core_version` check expects. Listing
+# pydantic + pydantic-core unpinned here and resolving them under
+# --no-deps used to pick the latest of each independently and trip
+# `SystemError: pydantic-core 2.X.Y is incompatible with the current
+# pydantic version` on the first import (Windows fresh-venv repro
+# was the canonical case). pydantic's transitive deps
+# (annotated-types, pydantic-core, typing-extensions,
+# typing-inspection) are torch-free, so installing it WITH deps
+# does not pull torch.
 pyyaml
 nest-asyncio
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -979,6 +979,27 @@ def install_python_stack() -> int:
             package_name,
             "unsloth-zoo",
         )
+        # Pydantic ships its core as a separate compiled wheel
+        # (pydantic-core), and pydantic's ``_ensure_pydantic_core_version``
+        # checks the installed core matches the exact version pinned in
+        # its own metadata. With ``--no-deps`` plus an unpinned
+        # ``pydantic`` / ``pydantic-core`` pair in no-torch-runtime.txt,
+        # pip resolved each to the newest available version and the two
+        # drifted (pydantic 2.13.4 pins pydantic-core==2.46.4 today, but
+        # pydantic-core 2.47.0 was the latest). On a fresh Windows venv
+        # the next ``import pydantic`` raised ``SystemError: ...
+        # incompatible with the current pydantic version``.
+        #
+        # Resolve them WITH deps in a focused pip call so pip picks a
+        # compatible pair. pydantic's own deps are
+        # ``annotated-types``, ``pydantic-core``, ``typing-extensions``,
+        # ``typing-inspection`` -- none of which transitively pull
+        # torch, so this is safe for the no-torch path.
+        pip_install(
+            "Installing pydantic (with deps for compatible core)",
+            "--no-cache-dir",
+            "pydantic",
+        )
         pip_install(
             "Installing no-torch runtime deps",
             "--no-cache-dir",


### PR DESCRIPTION
## Summary

Real Windows CI failure across every authored PR, not a flake. Every Studio Windows smoke job (Studio API + Auth, OpenAI Anthropic API, Chat UI, Tool calling, JSON images) fails at `unsloth studio setup` time with

```
SystemError: The installed pydantic-core version (2.47.0) is incompatible with
the current pydantic version, which requires 2.46.4.
```

## Root cause

`studio/backend/requirements/no-torch-runtime.txt` lists `pydantic` and `pydantic-core` unpinned. Every installer entry point (install.sh, install.ps1, install_python_stack.py update path) then runs

```
uv pip install --no-deps -r no-torch-runtime.txt
```

so pip resolves each independently and picks

* `pydantic       2.13.4`   (latest, requires `pydantic-core==2.46.4`)
* `pydantic-core  2.47.0`   (latest, mismatched)

pydantic's `_ensure_pydantic_core_version` check then fails on the next import. Linux and Mac runners frequently have a matching pair cached from a prior unrelated install, so the trip only fires reliably on a fresh Windows venv.

## Fix

Install `pydantic` WITH deps before the `--no-deps` no-torch runtime install in every no-torch entry point (two paths each in install.sh and install.ps1, plus the update path in install_python_stack.py). pip then pins `pydantic-core` to the exact version `pydantic` declares, and the next import works. pydantic's transitive deps (`annotated-types`, `pydantic-core`, `typing-extensions`, `typing-inspection`) are all torch-free so the no-torch contract still holds.

Dropped the now-redundant `pydantic` / `pydantic-core` / `annotated-types` / `typing-inspection` entries from `no-torch-runtime.txt` with a header comment explaining the split.

## Test plan

- [ ] Watch the Windows Studio smoke jobs on this PR pass without the SystemError
- [ ] Linux Studio backend tests stay green
- [ ] Confirm the existing `Patch Studio venv with full typer / pydantic dep trees` workaround step in studio-windows-*-smoke.yml is now redundant (followup, needs workflow scope)