### PR TITLE
Studio: strip orphan tool_call XML leaking into visible content

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -429,7 +429,7 @@ _TOOL_ACTION_NUDGE = (
 
 # Regex for stripping leaked tool-call XML from assistant messages/stream.
 #
-# Three leak shapes are handled, all caused by the speculative-buffer
+# Four leak shapes are handled, all caused by the speculative-buffer
 # state machine in `core/inference/llama_cpp.py` boundary-slicing the
 # tool_call XML between content_accum (visible) and the silent
 # DRAINING buffer:
@@ -442,11 +442,22 @@ _TOOL_ACTION_NUDGE = (
 # 3. Orphan close (`...</function>\n</tool_call>`) -- the opening was
 #    DRAINED and only the trailing close leaked; matched by the bare
 #    `</tool_call>` / `</function>` alternatives.
+# 4. Tail-only `</parameter>` orphan (gdpval sweep, 7/192 trials) --
+#    `<tool_call><function=...><parameter=...>...content...</parameter>`
+#    where the OUTER `</function>\n</tool_call>` was truncated by EOS
+#    and the INNER `<parameter=...>` open got DRAINED, leaving just
+#    `</parameter>\n\n` at end-of-buffer. We strip ONLY when anchored
+#    to end-of-string (`\s*\Z`) so legitimate mid-text uses of
+#    `<parameter>...</parameter>` in user code samples survive.
 _TOOL_XML_RE = _re.compile(
-    r"<tool_call>.*?(?:</tool_call>|\Z)"
-    r"|<function=\w+>.*?(?:</function>|\Z)"
-    r"|</tool_call>"
-    r"|</function>",
+    # opening + body + close-or-EOF; close tag may be tool_call OR function
+    # (well-formed pairs nest; non-greedy stops at the inner one and the
+    # outer dangling close gets picked up by the next alternative).
+    r"<(?:tool_call|function=\w+)>.*?(?:</(?:tool_call|function)>|\Z)"
+    # bare orphan closes (opening was DRAINED, close leaked alone)
+    r"|</(?:tool_call|function)>"
+    # tail-only </parameter> (anchored to EOF; mid-text uses preserved)
+    r"|</parameter>\s*\Z",
     _re.DOTALL,
 )
 logger = get_logger(__name__)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -427,36 +427,16 @@ _TOOL_ACTION_NUDGE = (
     " Do NOT output code blocks -- use the python tool instead."
 )
 
-# Regex for stripping leaked tool-call XML from assistant messages/stream.
-#
-# Four leak shapes are handled, all caused by the speculative-buffer
-# state machine in `core/inference/llama_cpp.py` boundary-slicing the
-# tool_call XML between content_accum (visible) and the silent
-# DRAINING buffer:
-#
-# 1. Well-formed `<tool_call>...</tool_call>` (or `<function=...></function>`)
-#    -- both opening and close ended up in content.
-# 2. Orphan opening (`<tool_call>...EOF`) -- the close was DRAINED so
-#    only the opening leaks; `(?:</tool_call>|\Z)` consumes from the
-#    opening to end-of-string when no close is found.
-# 3. Orphan close (`...</function>\n</tool_call>`) -- the opening was
-#    DRAINED and only the trailing close leaked; matched by the bare
-#    `</tool_call>` / `</function>` alternatives.
-# 4. Tail-only `</parameter>` orphan (gdpval sweep, 7/192 trials) --
-#    `<tool_call><function=...><parameter=...>...content...</parameter>`
-#    where the OUTER `</function>\n</tool_call>` was truncated by EOS
-#    and the INNER `<parameter=...>` open got DRAINED, leaving just
-#    `</parameter>\n\n` at end-of-buffer. We strip ONLY when anchored
-#    to end-of-string (`\s*\Z`) so legitimate mid-text uses of
-#    `<parameter>...</parameter>` in user code samples survive.
+# Strip tool-call XML the speculative buffer in core/inference/llama_cpp.py
+# split across the visible/DRAIN boundary. Four leak shapes:
+#   1. well-formed `<tool_call>...</tool_call>` / `<function=...>...</function>`
+#   2. orphan opening to EOF (close was DRAINED)
+#   3. bare orphan close (open was DRAINED)
+#   4. tail-only `</parameter>` (outer close truncated by EOS); anchored to
+#      `\Z` so mid-text `<parameter>` in user code samples survives.
 _TOOL_XML_RE = _re.compile(
-    # opening + body + close-or-EOF; close tag may be tool_call OR function
-    # (well-formed pairs nest; non-greedy stops at the inner one and the
-    # outer dangling close gets picked up by the next alternative).
     r"<(?:tool_call|function=\w+)>.*?(?:</(?:tool_call|function)>|\Z)"
-    # bare orphan closes (opening was DRAINED, close leaked alone)
     r"|</(?:tool_call|function)>"
-    # tail-only </parameter> (anchored to EOF; mid-text uses preserved)
     r"|</parameter>\s*\Z",
     _re.DOTALL,
 )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -427,9 +427,26 @@ _TOOL_ACTION_NUDGE = (
     " Do NOT output code blocks -- use the python tool instead."
 )
 
-# Regex for stripping leaked tool-call XML from assistant messages/stream
+# Regex for stripping leaked tool-call XML from assistant messages/stream.
+#
+# Three leak shapes are handled, all caused by the speculative-buffer
+# state machine in `core/inference/llama_cpp.py` boundary-slicing the
+# tool_call XML between content_accum (visible) and the silent
+# DRAINING buffer:
+#
+# 1. Well-formed `<tool_call>...</tool_call>` (or `<function=...></function>`)
+#    -- both opening and close ended up in content.
+# 2. Orphan opening (`<tool_call>...EOF`) -- the close was DRAINED so
+#    only the opening leaks; `(?:</tool_call>|\Z)` consumes from the
+#    opening to end-of-string when no close is found.
+# 3. Orphan close (`...</function>\n</tool_call>`) -- the opening was
+#    DRAINED and only the trailing close leaked; matched by the bare
+#    `</tool_call>` / `</function>` alternatives.
 _TOOL_XML_RE = _re.compile(
-    r"<tool_call>.*?</tool_call>|<function=\w+>.*?</function>",
+    r"<tool_call>.*?(?:</tool_call>|\Z)"
+    r"|<function=\w+>.*?(?:</function>|\Z)"
+    r"|</tool_call>"
+    r"|</function>",
     _re.DOTALL,
 )
 logger = get_logger(__name__)

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -142,9 +142,61 @@ def test_strips_orphan_closing_tag():
     cleaned = _TOOL_XML_RE.sub("", text)
     assert "</tool_call>" not in cleaned
     assert "</function>" not in cleaned
-    # </parameter> is NOT stripped (it's a separator inside tool_call XML
-    # but harmless on its own; stripping it could accidentally remove
-    # user-supplied XML samples in code blocks).
+    # Mid-string </parameter> is intentionally NOT stripped here -- a user
+    # could legitimately have <parameter>...</parameter> XML in a code
+    # sample. Only the end-of-buffer orphan (test below) is stripped.
+
+
+# ── Tail-only </parameter> orphan (gdpval sweep, 7/192 trials) ────
+
+
+def test_strips_tail_only_parameter_orphan():
+    """`</parameter>\\n\\n` at end-of-buffer with no enclosing tags.
+
+    Real example from the 2026-05-22 gdpval sweep on
+    Qwen3.5-27B Q8 / worldbank seed00 -- the OUTER `</function>\\n</tool_call>`
+    was truncated by EOS (max_tokens=4096) and the INNER `<parameter=...>`
+    open got DRAINED, leaving just `</parameter>\\n\\n` as the visible tail.
+    """
+    text = "and the text is not readable.\n</parameter>\n\n"
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "</parameter>" not in cleaned, "tail orphan </parameter> must be stripped"
+    assert "and the text is not readable." in cleaned
+
+
+def test_strips_tail_only_parameter_orphan_single_newline():
+    text = "Global Economic Prospects\n</parameter>\n"
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "</parameter>" not in cleaned
+    assert "Global Economic Prospects" in cleaned
+
+
+def test_strips_tail_only_parameter_orphan_no_trailing_ws():
+    text = "Final answer.</parameter>"
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "</parameter>" not in cleaned
+    assert "Final answer." in cleaned
+
+
+def test_preserves_mid_string_parameter_in_code_sample():
+    """A user-supplied XML code sample with </parameter> mid-text must survive.
+
+    Stripping every </parameter> would corrupt documentation pages, model
+    chat-template examples, or any prose discussing tool-call XML shapes.
+    """
+    text = (
+        "Here is the Qwen tool-call format:\n"
+        "```xml\n"
+        "<tool_call><function=foo><parameter=arg>value</parameter></function></tool_call>\n"
+        "```\n"
+        "Note the closing </parameter> sits inside <function>."
+    )
+    cleaned = _TOOL_XML_RE.sub("", text)
+    # The fenced sample DOES get its <tool_call>...</tool_call> stripped
+    # (legacy behaviour, well-formed pattern). What we need is the
+    # SECOND `</parameter>` (in prose, mid-text, NOT end-of-buffer) to
+    # survive.
+    assert "Note the closing </parameter> sits inside" in cleaned
 
 
 def test_strips_well_formed_then_orphan():
@@ -213,3 +265,79 @@ def test_real_world_sweep_leaks_get_stripped(leak):
     cleaned = _TOOL_XML_RE.sub("", leak)
     assert "<tool_call>" not in cleaned, f"leak survived: {cleaned!r}"
     assert "<function=" not in cleaned, f"leak survived: {cleaned!r}"
+
+
+# ── Real-world tail-only </parameter> orphans (gdpval sweep) ──────
+
+
+# All 7 of these are end-anchored: `</parameter>` followed only by
+# whitespace to end-of-buffer. The opening `<tool_call><function=...>
+# <parameter=...>` was DRAINED but `</parameter>...EOS` truncation
+# left a bare close visible.
+GDPVAL_PARAMETER_LEAKS = [
+    # Qwen3.5-27B Q8_0 / worldbank seed00
+    "the page contains image data and the text is not readable.\n</parameter>\n\n",
+    # Qwen3.5-27B Q8_0 / worldbank seed42 (preceded by mojibake)
+    "...some mojibake content here...\n</parameter>\n\n",
+    # Qwen3.5-27B UD-Q4_K_XL / coppa seed07
+    "blocked, while others may still be in effect. The law is currently under further review by the Ninth Circuit.\n</parameter>\n\n",
+    # Qwen3.5-27B UD-Q4_K_XL / police_training seed00
+    "comprehensive training report\n</parameter>\n\n",
+    # Qwen3.5-27B UD-Q4_K_XL / worldbank seed00
+    "Global Economic Prospects\nJune 2025\nGlobal Economic Prospects\n</parameter>\n",
+    # Qwen3.6-27B Q8_0 / overpass seed07
+    "Let me create a comprehensive query and instructions document.\n</parameter>\n\n",
+]
+
+
+@pytest.mark.parametrize(
+    "leak",
+    GDPVAL_PARAMETER_LEAKS,
+    ids = [f"gdpval_param_orphan_{i}" for i in range(len(GDPVAL_PARAMETER_LEAKS))],
+)
+def test_gdpval_parameter_orphans_get_stripped(leak):
+    """The 6 distinct tail-only </parameter> orphans from the
+    2026-05-22 gdpval sweep (7 trial hits across 6 patterns).
+
+    Pre-fix these leaked `</parameter>\\n\\n` visible to the user.
+    """
+    cleaned = _TOOL_XML_RE.sub("", leak)
+    assert "</parameter>" not in cleaned, f"leak survived: {cleaned!r}"
+
+
+# ── Performance regression guards ────────────────────────────────
+
+
+def test_no_catastrophic_backtracking_on_open_bracket_spam():
+    """A long run of '<' chars with no close tag must not blow up.
+
+    Each '<' could conceivably start a `<tool_call>` or `<function=...>`
+    match attempt; we need the engine to fail fast (literal mismatch on
+    char 2) rather than backtracking.
+    """
+    import time
+
+    adv = "<" * (1024 * 256) + "X"  # 256 KB of '<'
+    t0 = time.perf_counter()
+    _TOOL_XML_RE.sub("", adv)
+    elapsed = time.perf_counter() - t0
+    # generous bound: 256KB should complete in well under 100ms on any
+    # reasonable hardware. Real numbers seen: ~5ms.
+    assert elapsed < 0.5, f"regex took {elapsed*1000:.0f}ms on 256KB '<' spam"
+
+
+def test_no_catastrophic_backtracking_on_orphan_opening_spam():
+    """1000 unclosed `<tool_call>X` openings -- non-greedy could regress here.
+
+    Each opening matches via the `\\Z` branch, but only one (the last
+    one before EOF). The engine should not retry every prior opening.
+    """
+    import time
+
+    adv = "<tool_call>X" * 1000
+    t0 = time.perf_counter()
+    cleaned = _TOOL_XML_RE.sub("", adv)
+    elapsed = time.perf_counter() - t0
+    assert elapsed < 0.1, f"regex took {elapsed*1000:.0f}ms on 1000x orphan opens"
+    # All openings must be stripped (greedy first alt consumes them all).
+    assert "<tool_call>" not in cleaned

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -1,32 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Tests for the leaked-tool-call-XML stripper at routes/inference.py.
-
-The model's chat template instructs it to emit tool calls in an XML
-shape like ::
-
-    <tool_call>
-    <function=web_search>
-    <parameter=query>
-    "Billboard Hot 100" "2015" peak 3
-    </parameter>
-    </function>
-    </tool_call>
-
-The speculative-buffer state machine in `core/inference/llama_cpp.py`
-detects this and routes the bytes to `tool_calls_acc` instead of
-visible content. But the detection only fires once 32 chars have been
-buffered, so for models that hop straight into `<tool_call>` mid-stream
-after the BUFFERING -> STREAMING transition, the OPENING tags can leak
-into `content_accum` before DRAINING engages. The closing `</tool_call>`
-then disappears into the silent buffer, leaving an UNTERMINATED
-fragment in the user-visible content.
-
-`_TOOL_XML_RE` is the post-stream cleaner that strips this. The original
-pattern only matched well-formed `<tool_call>...</tool_call>` pairs;
-this test suite pins the relaxed pattern that also strips orphan
-openings.
+"""Tests for `_TOOL_XML_RE` (routes/inference.py) -- strips tool-call
+XML that leaks past the speculative buffer in core/inference/llama_cpp.py
+when the open/close pair is split across the visible/DRAIN boundary.
 """
 
 from __future__ import annotations
@@ -41,8 +18,7 @@ _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
-# Studio's routes module needs a lot of stubbing to import in isolation;
-# pull the regex out directly via the source so this test is hermetic.
+# Extract the regex from source (routes module needs heavy stubbing to import).
 import re as _re
 
 _src = (Path(_BACKEND_DIR) / "routes" / "inference.py").read_text()
@@ -53,7 +29,7 @@ exec(f"_TOOL_XML_RE = _re.compile({_m.group(1)})", _ns)
 _TOOL_XML_RE = _ns["_TOOL_XML_RE"]
 
 
-# ── Well-formed tool_call XML is stripped (no regression) ─────────
+# ── Well-formed pairs ─────────────────────────────────────────────
 
 
 def test_strips_well_formed_tool_call():
@@ -83,11 +59,10 @@ def test_strips_function_only_well_formed():
     assert "Done." in cleaned
 
 
-# ── Orphan / unterminated openings (THIS PR) ──────────────────────
+# ── Orphan openings ───────────────────────────────────────────────
 
 
 def test_strips_orphan_tool_call_no_close():
-    """Pre-fix this would survive the strip (regex required close tag)."""
     text = (
         "Reasoning.\n</think>"
         "<tool_call>\n"
@@ -96,30 +71,25 @@ def test_strips_orphan_tool_call_no_close():
         "</function"
     )
     cleaned = _TOOL_XML_RE.sub("", text)
-    assert "<tool_call>" not in cleaned, "orphan <tool_call> must be stripped"
+    assert "<tool_call>" not in cleaned
     assert "<function=" not in cleaned
-    assert "Reasoning." in cleaned, "leading prose must survive"
+    assert "Reasoning." in cleaned
 
 
 def test_strips_orphan_function_no_close():
-    text = (
-        "I'll call python:\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>"
-    )
+    text = "I'll call python:\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>"
     cleaned = _TOOL_XML_RE.sub("", text)
     assert "<function=" not in cleaned
     assert "I'll call python:" in cleaned
 
 
 def test_strips_orphan_only_opening_tag():
-    """Just `<tool_call>` with nothing after it."""
-    text = "Search starting.\n<tool_call>"
-    cleaned = _TOOL_XML_RE.sub("", text)
+    cleaned = _TOOL_XML_RE.sub("", "Search starting.\n<tool_call>")
     assert "<tool_call>" not in cleaned
     assert "Search starting." in cleaned
 
 
 def test_strips_multiple_orphans():
-    """Two orphan openings in the same content."""
     text = (
         "First call:\n<tool_call>\n<function=python>\n<parameter=code>\nx=1\n"
         "Second call:\n<function=web_search>\n<parameter=query>\nhi\n"
@@ -129,61 +99,42 @@ def test_strips_multiple_orphans():
     assert "<function=" not in cleaned
 
 
-# ── Mixed: well-formed first, orphan second ───────────────────────
+# ── Orphan closes ─────────────────────────────────────────────────
 
 
 def test_strips_orphan_closing_tag():
-    """The opposite case: opening got DRAINED, only the close leaked.
-
-    Real example from the 2026-05-22 sweep on Qwen3.6-27B Q8:
-    `...the table rows directly.\\n</parameter>\\n</function>\\n</tool_call><think>...`
-    """
+    # Real shape from Qwen3.6-27B Q8 sweep (open got DRAINED, close leaked).
     text = "...the table rows directly.\n</parameter>\n</function>\n</tool_call><think>Continuing</think>"
     cleaned = _TOOL_XML_RE.sub("", text)
     assert "</tool_call>" not in cleaned
     assert "</function>" not in cleaned
-    # Mid-string </parameter> is intentionally NOT stripped here -- a user
-    # could legitimately have <parameter>...</parameter> XML in a code
-    # sample. Only the end-of-buffer orphan (test below) is stripped.
+    # Mid-string </parameter> intentionally preserved (see preserve test).
 
 
-# ── Tail-only </parameter> orphan (gdpval sweep, 7/192 trials) ────
+# ── Tail-only </parameter> (PR #5735 follow-up) ───────────────────
 
 
 def test_strips_tail_only_parameter_orphan():
-    """`</parameter>\\n\\n` at end-of-buffer with no enclosing tags.
-
-    Real example from the 2026-05-22 gdpval sweep on
-    Qwen3.5-27B Q8 / worldbank seed00 -- the OUTER `</function>\\n</tool_call>`
-    was truncated by EOS (max_tokens=4096) and the INNER `<parameter=...>`
-    open got DRAINED, leaving just `</parameter>\\n\\n` as the visible tail.
-    """
-    text = "and the text is not readable.\n</parameter>\n\n"
-    cleaned = _TOOL_XML_RE.sub("", text)
-    assert "</parameter>" not in cleaned, "tail orphan </parameter> must be stripped"
+    # Outer </function></tool_call> truncated by EOS, inner <parameter=...> DRAINED.
+    cleaned = _TOOL_XML_RE.sub("", "and the text is not readable.\n</parameter>\n\n")
+    assert "</parameter>" not in cleaned
     assert "and the text is not readable." in cleaned
 
 
 def test_strips_tail_only_parameter_orphan_single_newline():
-    text = "Global Economic Prospects\n</parameter>\n"
-    cleaned = _TOOL_XML_RE.sub("", text)
+    cleaned = _TOOL_XML_RE.sub("", "Global Economic Prospects\n</parameter>\n")
     assert "</parameter>" not in cleaned
     assert "Global Economic Prospects" in cleaned
 
 
 def test_strips_tail_only_parameter_orphan_no_trailing_ws():
-    text = "Final answer.</parameter>"
-    cleaned = _TOOL_XML_RE.sub("", text)
+    cleaned = _TOOL_XML_RE.sub("", "Final answer.</parameter>")
     assert "</parameter>" not in cleaned
     assert "Final answer." in cleaned
 
 
 def test_preserves_mid_string_parameter_in_code_sample():
-    """A user-supplied XML code sample with </parameter> mid-text must survive.
-
-    Stripping every </parameter> would corrupt documentation pages, model
-    chat-template examples, or any prose discussing tool-call XML shapes.
-    """
+    # Tail-anchor on `</parameter>` is required so doc/example prose survives.
     text = (
         "Here is the Qwen tool-call format:\n"
         "```xml\n"
@@ -192,10 +143,6 @@ def test_preserves_mid_string_parameter_in_code_sample():
         "Note the closing </parameter> sits inside <function>."
     )
     cleaned = _TOOL_XML_RE.sub("", text)
-    # The fenced sample DOES get its <tool_call>...</tool_call> stripped
-    # (legacy behaviour, well-formed pattern). What we need is the
-    # SECOND `</parameter>` (in prose, mid-text, NOT end-of-buffer) to
-    # survive.
     assert "Note the closing </parameter> sits inside" in cleaned
 
 
@@ -213,40 +160,37 @@ def test_strips_well_formed_then_orphan():
     assert "Now round two:" in cleaned
 
 
-# ── No regression on plain text ──────────────────────────────────
+# ── Preservation (no false positives) ────────────────────────────
 
 
 def test_preserves_plain_text():
-    """Text without XML must be unchanged."""
     text = "1. Animals — Maroon 5\n2. Take Me to Church — Hozier"
     assert _TOOL_XML_RE.sub("", text) == text
 
 
 def test_preserves_code_fences():
-    """Code fences are not tool_call XML and must be untouched."""
     text = "```python\nimport sys\nprint(sys.version)\n```"
     assert _TOOL_XML_RE.sub("", text) == text
 
 
 def test_preserves_html_in_prose():
-    """Inline HTML mentions (not <tool_call> / <function=) survive."""
     text = "Use the <html> tag for documents."
     assert _TOOL_XML_RE.sub("", text) == text
 
 
-# ── Real-world leak samples from the 2026-05-22 sweep ─────────────
+# ── Real-world leak samples from the 2026-05-22 sweep ────────────
 
 
 REAL_LEAKS = [
-    # Qwen3.5-35B-A3B UD-Q4_K_XL billboard seed 22 -- orphan opening
+    # Qwen3.5-35B-A3B UD-Q4_K_XL billboard s22 -- orphan open
     'rectly.\n\nLet me try searching for Wikipedia pages that might have weekly chart data for 2015.\n</think><tool_call>\n<function=web_search>\n<parameter=query>\n"Billboard Hot 100" "2015" "weekly" "chart" "position" "3"\n</parameter>\n</function',
-    # Qwen3.6-27B UD-Q2_K_XL billboard seed 14 -- orphan opening
+    # Qwen3.6-27B UD-Q2_K_XL billboard s14 -- orphan open
     'arch `site:wikipedia.org "peaked at number 3" "2015" Billboard`\nI\'ll do a quick web search.\n</think><tool_call>\n<function=web_search>\n<parameter=query>\n"peaked at number 3" Billboard Hot 100 2015 list\n</parameter>\n</function',
-    # Qwen3.6-27B UD-Q2_K_XL billboard seed 15 -- orphan opening
+    # Qwen3.6-27B UD-Q2_K_XL billboard s15 -- orphan open
     'rd Hot 100 top-ten singles in 2015".\nI\'ll use web_search to find this exact Wikipedia page.\n</think><tool_call>\n<function=web_search>\n<parameter=query>\n"List of Billboard Hot 100 top-ten singles in 2015" wikipedia\n</parameter>\n</function',
-    # Qwen3.6-27B Q8_0 billboard seed 02 -- orphan close
+    # Qwen3.6-27B Q8_0 billboard s02 -- orphan close
     "the table rows directly.\n</parameter>\n</function>\n</tool_call><think>The user wants me to list and categorize all songs that charted #3 on the Billboard Hot 100 in 2015. I have been trying to get this data",
-    # Qwen3.6-35B-A3B Q8_0 billboard seed 21 -- orphan close
+    # Qwen3.6-35B-A3B Q8_0 billboard s21 -- orphan close
     "parse it more carefully.\n</parameter>\n</function>\n</tool_call><think>The user wants a list of songs that charted #3 on the Billboard Hot 100 in 2015, categorized.",
 ]
 
@@ -255,37 +199,28 @@ REAL_LEAKS = [
     "leak", REAL_LEAKS, ids = [f"sweep_sample_{i}" for i in range(len(REAL_LEAKS))]
 )
 def test_real_world_sweep_leaks_get_stripped(leak):
-    """Each of these triggered the XML-leak bug in the 2026-05-22 sweep.
-
-    Pre-fix `_TOOL_XML_RE` left `<tool_call>` / `<function=` in the output
-    because the closing `</tool_call>` was lost to the speculative-buffer
-    DRAINING path. Post-fix the regex strips from the opening tag all
-    the way to end-of-string when no close tag is found.
-    """
     cleaned = _TOOL_XML_RE.sub("", leak)
     assert "<tool_call>" not in cleaned, f"leak survived: {cleaned!r}"
     assert "<function=" not in cleaned, f"leak survived: {cleaned!r}"
 
 
-# ── Real-world tail-only </parameter> orphans (gdpval sweep) ──────
+# ── Real-world tail-only </parameter> from gdpval sweep ──────────
 
 
-# All 7 of these are end-anchored: `</parameter>` followed only by
-# whitespace to end-of-buffer. The opening `<tool_call><function=...>
-# <parameter=...>` was DRAINED but `</parameter>...EOS` truncation
-# left a bare close visible.
+# All end-anchored: outer </function></tool_call> truncated by EOS,
+# inner <parameter=...> open DRAINED, leaving bare </parameter> tail.
 GDPVAL_PARAMETER_LEAKS = [
-    # Qwen3.5-27B Q8_0 / worldbank seed00
+    # Qwen3.5-27B Q8_0 / worldbank s00
     "the page contains image data and the text is not readable.\n</parameter>\n\n",
-    # Qwen3.5-27B Q8_0 / worldbank seed42 (preceded by mojibake)
+    # Qwen3.5-27B Q8_0 / worldbank s42 (preceded by mojibake)
     "...some mojibake content here...\n</parameter>\n\n",
-    # Qwen3.5-27B UD-Q4_K_XL / coppa seed07
+    # Qwen3.5-27B UD-Q4_K_XL / coppa s07
     "blocked, while others may still be in effect. The law is currently under further review by the Ninth Circuit.\n</parameter>\n\n",
-    # Qwen3.5-27B UD-Q4_K_XL / police_training seed00
+    # Qwen3.5-27B UD-Q4_K_XL / police_training s00
     "comprehensive training report\n</parameter>\n\n",
-    # Qwen3.5-27B UD-Q4_K_XL / worldbank seed00
+    # Qwen3.5-27B UD-Q4_K_XL / worldbank s00
     "Global Economic Prospects\nJune 2025\nGlobal Economic Prospects\n</parameter>\n",
-    # Qwen3.6-27B Q8_0 / overpass seed07
+    # Qwen3.6-27B Q8_0 / overpass s07
     "Let me create a comprehensive query and instructions document.\n</parameter>\n\n",
 ]
 
@@ -296,48 +231,29 @@ GDPVAL_PARAMETER_LEAKS = [
     ids = [f"gdpval_param_orphan_{i}" for i in range(len(GDPVAL_PARAMETER_LEAKS))],
 )
 def test_gdpval_parameter_orphans_get_stripped(leak):
-    """The 6 distinct tail-only </parameter> orphans from the
-    2026-05-22 gdpval sweep (7 trial hits across 6 patterns).
-
-    Pre-fix these leaked `</parameter>\\n\\n` visible to the user.
-    """
     cleaned = _TOOL_XML_RE.sub("", leak)
     assert "</parameter>" not in cleaned, f"leak survived: {cleaned!r}"
 
 
-# ── Performance regression guards ────────────────────────────────
+# ── Backtracking guards ──────────────────────────────────────────
 
 
 def test_no_catastrophic_backtracking_on_open_bracket_spam():
-    """A long run of '<' chars with no close tag must not blow up.
-
-    Each '<' could conceivably start a `<tool_call>` or `<function=...>`
-    match attempt; we need the engine to fail fast (literal mismatch on
-    char 2) rather than backtracking.
-    """
+    # 256KB of '<' must fail fast (literal mismatch char 2), not backtrack.
     import time
-
-    adv = "<" * (1024 * 256) + "X"  # 256 KB of '<'
+    adv = "<" * (1024 * 256) + "X"
     t0 = time.perf_counter()
     _TOOL_XML_RE.sub("", adv)
     elapsed = time.perf_counter() - t0
-    # generous bound: 256KB should complete in well under 100ms on any
-    # reasonable hardware. Real numbers seen: ~5ms.
     assert elapsed < 0.5, f"regex took {elapsed*1000:.0f}ms on 256KB '<' spam"
 
 
 def test_no_catastrophic_backtracking_on_orphan_opening_spam():
-    """1000 unclosed `<tool_call>X` openings -- non-greedy could regress here.
-
-    Each opening matches via the `\\Z` branch, but only one (the last
-    one before EOF). The engine should not retry every prior opening.
-    """
+    # 1000 unclosed openings: first alt must consume them all greedily.
     import time
-
     adv = "<tool_call>X" * 1000
     t0 = time.perf_counter()
     cleaned = _TOOL_XML_RE.sub("", adv)
     elapsed = time.perf_counter() - t0
     assert elapsed < 0.1, f"regex took {elapsed*1000:.0f}ms on 1000x orphan opens"
-    # All openings must be stripped (greedy first alt consumes them all).
     assert "<tool_call>" not in cleaned

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -102,7 +102,9 @@ def test_strips_orphan_tool_call_no_close():
 
 
 def test_strips_orphan_function_no_close():
-    text = "I'll call python:\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>"
+    text = (
+        "I'll call python:\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>"
+    )
     cleaned = _TOOL_XML_RE.sub("", text)
     assert "<function=" not in cleaned
     assert "I'll call python:" in cleaned
@@ -197,7 +199,9 @@ REAL_LEAKS = [
 ]
 
 
-@pytest.mark.parametrize("leak", REAL_LEAKS, ids=[f"sweep_sample_{i}" for i in range(len(REAL_LEAKS))])
+@pytest.mark.parametrize(
+    "leak", REAL_LEAKS, ids = [f"sweep_sample_{i}" for i in range(len(REAL_LEAKS))]
+)
 def test_real_world_sweep_leaks_get_stripped(leak):
     """Each of these triggered the XML-leak bug in the 2026-05-22 sweep.
 

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -77,7 +77,9 @@ def test_strips_orphan_tool_call_no_close():
 
 
 def test_strips_orphan_function_no_close():
-    text = "I'll call python:\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>"
+    text = (
+        "I'll call python:\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>"
+    )
     cleaned = _TOOL_XML_RE.sub("", text)
     assert "<function=" not in cleaned
     assert "I'll call python:" in cleaned
@@ -241,6 +243,7 @@ def test_gdpval_parameter_orphans_get_stripped(leak):
 def test_no_catastrophic_backtracking_on_open_bracket_spam():
     # 256KB of '<' must fail fast (literal mismatch char 2), not backtrack.
     import time
+
     adv = "<" * (1024 * 256) + "X"
     t0 = time.perf_counter()
     _TOOL_XML_RE.sub("", adv)
@@ -251,6 +254,7 @@ def test_no_catastrophic_backtracking_on_open_bracket_spam():
 def test_no_catastrophic_backtracking_on_orphan_opening_spam():
     # 1000 unclosed openings: first alt must consume them all greedily.
     import time
+
     adv = "<tool_call>X" * 1000
     t0 = time.perf_counter()
     cleaned = _TOOL_XML_RE.sub("", adv)

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for the leaked-tool-call-XML stripper at routes/inference.py.
+
+The model's chat template instructs it to emit tool calls in an XML
+shape like ::
+
+    <tool_call>
+    <function=web_search>
+    <parameter=query>
+    "Billboard Hot 100" "2015" peak 3
+    </parameter>
+    </function>
+    </tool_call>
+
+The speculative-buffer state machine in `core/inference/llama_cpp.py`
+detects this and routes the bytes to `tool_calls_acc` instead of
+visible content. But the detection only fires once 32 chars have been
+buffered, so for models that hop straight into `<tool_call>` mid-stream
+after the BUFFERING -> STREAMING transition, the OPENING tags can leak
+into `content_accum` before DRAINING engages. The closing `</tool_call>`
+then disappears into the silent buffer, leaving an UNTERMINATED
+fragment in the user-visible content.
+
+`_TOOL_XML_RE` is the post-stream cleaner that strips this. The original
+pattern only matched well-formed `<tool_call>...</tool_call>` pairs;
+this test suite pins the relaxed pattern that also strips orphan
+openings.
+"""
+
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Studio's routes module needs a lot of stubbing to import in isolation;
+# pull the regex out directly via the source so this test is hermetic.
+import re as _re
+
+_src = (Path(_BACKEND_DIR) / "routes" / "inference.py").read_text()
+_m = _re.search(r"_TOOL_XML_RE = _re\.compile\((.*?)\n\)", _src, _re.DOTALL)
+assert _m, "could not extract _TOOL_XML_RE source"
+_ns = {"_re": _re}
+exec(f"_TOOL_XML_RE = _re.compile({_m.group(1)})", _ns)
+_TOOL_XML_RE = _ns["_TOOL_XML_RE"]
+
+
+# ── Well-formed tool_call XML is stripped (no regression) ─────────
+
+
+def test_strips_well_formed_tool_call():
+    text = (
+        "Let me search.\n"
+        "<tool_call>\n"
+        "<function=web_search>\n"
+        "<parameter=query>\nBillboard 2015\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>\n"
+        "Here are the songs:"
+    )
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "<tool_call>" not in cleaned
+    assert "<function=" not in cleaned
+    assert "</tool_call>" not in cleaned
+    assert "</function>" not in cleaned
+    assert "Here are the songs:" in cleaned, "non-XML content must survive"
+    assert "Let me search." in cleaned
+
+
+def test_strips_function_only_well_formed():
+    text = "Setup.\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>\n</function>\nDone."
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "<function=" not in cleaned
+    assert "Setup." in cleaned
+    assert "Done." in cleaned
+
+
+# ── Orphan / unterminated openings (THIS PR) ──────────────────────
+
+
+def test_strips_orphan_tool_call_no_close():
+    """Pre-fix this would survive the strip (regex required close tag)."""
+    text = (
+        "Reasoning.\n</think>"
+        "<tool_call>\n"
+        "<function=web_search>\n"
+        "<parameter=query>\nBillboard 2015\n</parameter>\n"
+        "</function"
+    )
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "<tool_call>" not in cleaned, "orphan <tool_call> must be stripped"
+    assert "<function=" not in cleaned
+    assert "Reasoning." in cleaned, "leading prose must survive"
+
+
+def test_strips_orphan_function_no_close():
+    text = "I'll call python:\n<function=python>\n<parameter=code>\nprint(1)\n</parameter>"
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "<function=" not in cleaned
+    assert "I'll call python:" in cleaned
+
+
+def test_strips_orphan_only_opening_tag():
+    """Just `<tool_call>` with nothing after it."""
+    text = "Search starting.\n<tool_call>"
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "<tool_call>" not in cleaned
+    assert "Search starting." in cleaned
+
+
+def test_strips_multiple_orphans():
+    """Two orphan openings in the same content."""
+    text = (
+        "First call:\n<tool_call>\n<function=python>\n<parameter=code>\nx=1\n"
+        "Second call:\n<function=web_search>\n<parameter=query>\nhi\n"
+    )
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "<tool_call>" not in cleaned
+    assert "<function=" not in cleaned
+
+
+# ── Mixed: well-formed first, orphan second ───────────────────────
+
+
+def test_strips_orphan_closing_tag():
+    """The opposite case: opening got DRAINED, only the close leaked.
+
+    Real example from the 2026-05-22 sweep on Qwen3.6-27B Q8:
+    `...the table rows directly.\\n</parameter>\\n</function>\\n</tool_call><think>...`
+    """
+    text = "...the table rows directly.\n</parameter>\n</function>\n</tool_call><think>Continuing</think>"
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "</tool_call>" not in cleaned
+    assert "</function>" not in cleaned
+    # </parameter> is NOT stripped (it's a separator inside tool_call XML
+    # but harmless on its own; stripping it could accidentally remove
+    # user-supplied XML samples in code blocks).
+
+
+def test_strips_well_formed_then_orphan():
+    text = (
+        "Round one:\n<tool_call>\n<function=python>\n<parameter=code>\n1\n"
+        "</parameter>\n</function>\n</tool_call>\n"
+        "Now round two:\n<tool_call>\n<function=web_search>\n<parameter=query>\n"
+        "what is X\n</parameter>\n</function"
+    )
+    cleaned = _TOOL_XML_RE.sub("", text)
+    assert "<tool_call>" not in cleaned
+    assert "<function=" not in cleaned
+    assert "Round one:" in cleaned
+    assert "Now round two:" in cleaned
+
+
+# ── No regression on plain text ──────────────────────────────────
+
+
+def test_preserves_plain_text():
+    """Text without XML must be unchanged."""
+    text = "1. Animals — Maroon 5\n2. Take Me to Church — Hozier"
+    assert _TOOL_XML_RE.sub("", text) == text
+
+
+def test_preserves_code_fences():
+    """Code fences are not tool_call XML and must be untouched."""
+    text = "```python\nimport sys\nprint(sys.version)\n```"
+    assert _TOOL_XML_RE.sub("", text) == text
+
+
+def test_preserves_html_in_prose():
+    """Inline HTML mentions (not <tool_call> / <function=) survive."""
+    text = "Use the <html> tag for documents."
+    assert _TOOL_XML_RE.sub("", text) == text
+
+
+# ── Real-world leak samples from the 2026-05-22 sweep ─────────────
+
+
+REAL_LEAKS = [
+    # Qwen3.5-35B-A3B UD-Q4_K_XL billboard seed 22 -- orphan opening
+    'rectly.\n\nLet me try searching for Wikipedia pages that might have weekly chart data for 2015.\n</think><tool_call>\n<function=web_search>\n<parameter=query>\n"Billboard Hot 100" "2015" "weekly" "chart" "position" "3"\n</parameter>\n</function',
+    # Qwen3.6-27B UD-Q2_K_XL billboard seed 14 -- orphan opening
+    'arch `site:wikipedia.org "peaked at number 3" "2015" Billboard`\nI\'ll do a quick web search.\n</think><tool_call>\n<function=web_search>\n<parameter=query>\n"peaked at number 3" Billboard Hot 100 2015 list\n</parameter>\n</function',
+    # Qwen3.6-27B UD-Q2_K_XL billboard seed 15 -- orphan opening
+    'rd Hot 100 top-ten singles in 2015".\nI\'ll use web_search to find this exact Wikipedia page.\n</think><tool_call>\n<function=web_search>\n<parameter=query>\n"List of Billboard Hot 100 top-ten singles in 2015" wikipedia\n</parameter>\n</function',
+    # Qwen3.6-27B Q8_0 billboard seed 02 -- orphan close
+    "the table rows directly.\n</parameter>\n</function>\n</tool_call><think>The user wants me to list and categorize all songs that charted #3 on the Billboard Hot 100 in 2015. I have been trying to get this data",
+    # Qwen3.6-35B-A3B Q8_0 billboard seed 21 -- orphan close
+    "parse it more carefully.\n</parameter>\n</function>\n</tool_call><think>The user wants a list of songs that charted #3 on the Billboard Hot 100 in 2015, categorized.",
+]
+
+
+@pytest.mark.parametrize("leak", REAL_LEAKS, ids=[f"sweep_sample_{i}" for i in range(len(REAL_LEAKS))])
+def test_real_world_sweep_leaks_get_stripped(leak):
+    """Each of these triggered the XML-leak bug in the 2026-05-22 sweep.
+
+    Pre-fix `_TOOL_XML_RE` left `<tool_call>` / `<function=` in the output
+    because the closing `</tool_call>` was lost to the speculative-buffer
+    DRAINING path. Post-fix the regex strips from the opening tag all
+    the way to end-of-string when no close tag is found.
+    """
+    cleaned = _TOOL_XML_RE.sub("", leak)
+    assert "<tool_call>" not in cleaned, f"leak survived: {cleaned!r}"
+    assert "<function=" not in cleaned, f"leak survived: {cleaned!r}"


### PR DESCRIPTION
## Summary

The speculative-buffer state machine in `studio/backend/core/inference/llama_cpp.py` slices a tool_call XML block between the silent DRAINING path and visible `content_accum`, depending on when in the model's emission the BUFFERING -> STREAMING -> DRAINING transitions fire. Three leak shapes were observed in a 900-run sweep of Qwen3.5 / Qwen3.6 GGUFs:

1. Well-formed pair (both opening and close in content).
2. Orphan opening (close was DRAINED, only `<tool_call><function=...><parameter=...>...</parameter></function` ended up visible).
3. Orphan close (opening was DRAINED, only `...</parameter></function></tool_call>` ended up visible).

The existing `_TOOL_XML_RE` only matched well-formed pairs, so shapes 2 and 3 survived the strip and the user saw raw `<tool_call>` / `</tool_call>` fragments in the chat output.

## Sweep evidence (2026-05-22, 900 runs across 15 configs)

XML leak rate per config:

| Config | leaks/60 | % |
|---|---|---|
| Qwen3.6-35B-A3B Q8_0 | 4/60 | 6.7% |
| Qwen3.6-35B-A3B-MTP UD-Q4_K_XL | 4/60 | 6.7% |
| Qwen3.5-35B-A3B Q8_0 | 3/60 | 5.0% |
| Qwen3.6-27B Q8_0 | 3/60 | 5.0% |
| Qwen3.6-27B UD-Q2_K_XL | 2/60 | 3.3% |
| (4 more configs) | 1/60 | 1.7% |
| all UD-Q4_K_XL dense configs | 0/60 | 0% |
| **Total** | 20/900 | **2.22%** |

## Fix

```python
_TOOL_XML_RE = _re.compile(
    r"<tool_call>.*?(?:</tool_call>|\Z)"
    r"|<function=\w+>.*?(?:</function>|\Z)"
    r"|</tool_call>"
    r"|</function>",
    _re.DOTALL,
)
```

- `(?:</tool_call>|\Z)` and `(?:</function>|\Z)` extend the opening-match to end-of-string when no close is found (shape 2).
- Bare `</tool_call>` / `</function>` alternatives strip orphan closes (shape 3).

## Verification

Replayed the strip on all 900 stored sweep outputs:

```
Pre-fix leaks:  20/900 (2.22%)
Post-fix leaks: 0/900  (0.00%)
Reduction:      100% of detected XML leaks fixed
```

16 unit tests in `studio/backend/tests/test_tool_xml_strip.py` pin all three leak shapes, the no-regression on plain text / code fences / inline HTML, and parametrised checks on 5 actual real-world leak samples from the sweep data.

## Test plan

- [x] 16 new unit tests pass
- [x] Replay on 900 stored sweep records: 20 -> 0 leaks
- [ ] CI green