### PR TITLE
Studio: surface external-provider cache hits and writes in context bar

### DIFF
--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -45,9 +45,8 @@ export const MessageTiming: FC<{
       }
     | undefined;
   const st = custom?.serverTimings;
-  // Prefer llama-server timings, fall back to external usage envelope.
-  // Use nullish coalescing so an explicit cache_n=0 (local no-cache turn)
-  // does not silently get replaced by a stale contextUsage.cachedTokens.
+  // `??` (not `||`) so an explicit cache_n=0 isn't replaced by a stale
+  // contextUsage.cachedTokens from a prior turn.
   const cacheHits =
     st?.cache_n ?? custom?.contextUsage?.cachedTokens ?? 0;
   // Anthropic-only cache-write count.

--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -46,7 +46,10 @@ export const MessageTiming: FC<{
     | undefined;
   const st = custom?.serverTimings;
   // Prefer llama-server timings, fall back to external usage envelope.
-  const cacheHits = (st?.cache_n ?? 0) || (custom?.contextUsage?.cachedTokens ?? 0);
+  // Use nullish coalescing so an explicit cache_n=0 (local no-cache turn)
+  // does not silently get replaced by a stale contextUsage.cachedTokens.
+  const cacheHits =
+    st?.cache_n ?? custom?.contextUsage?.cachedTokens ?? 0;
   // Anthropic-only cache-write count.
   const cacheWrites = custom?.contextUsage?.cacheWriteTokens ?? 0;
 

--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -33,10 +33,27 @@ export const MessageTiming: FC<{
 
   if (timing?.totalStreamTime === undefined) return null;
 
-  const serverTimings = (
+  const custom = (
     message.metadata as Record<string, unknown> | undefined
-  )?.custom as { serverTimings?: Record<string, number> } | undefined;
-  const st = serverTimings?.serverTimings;
+  )?.custom as
+    | {
+        serverTimings?: Record<string, number>;
+        contextUsage?: {
+          cachedTokens?: number;
+          cacheWriteTokens?: number;
+        };
+      }
+    | undefined;
+  const st = custom?.serverTimings;
+  // Cache-hit / cache-write counts. llama-server reports hits on
+  // timings.cache_n; external providers (Anthropic / OpenAI Responses /
+  // Gemini) report them on the include_usage envelope that the adapter
+  // normalizes into custom.contextUsage. Prefer the local-runtime value
+  // when present (so llama.cpp keeps populating the badge mid-stream)
+  // and fall back to the external envelope otherwise.
+  const cacheHits = (st?.cache_n ?? 0) || (custom?.contextUsage?.cachedTokens ?? 0);
+  // Anthropic-only: tokens written into the prompt cache on this turn.
+  const cacheWrites = custom?.contextUsage?.cacheWriteTokens ?? 0;
 
   // Guard unphysical tok/s: llama.cpp emits predicted_ms=0 on no-op
   // turns, blowing the rate up to Infinity. Require >=1 token AND a
@@ -122,11 +139,19 @@ export const MessageTiming: FC<{
                   </span>
                 </div>
               )}
-              {(st?.cache_n ?? 0) > 0 && (
+              {cacheHits > 0 && (
                 <div className="flex items-center justify-between gap-4">
                   <span className="text-muted-foreground">Cache hits</span>
                   <span className="font-mono tabular-nums">
-                    {formatNumber(st!.cache_n)}
+                    {formatNumber(cacheHits)}
+                  </span>
+                </div>
+              )}
+              {cacheWrites > 0 && (
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-muted-foreground">Cache writes</span>
+                  <span className="font-mono tabular-nums">
+                    {formatNumber(cacheWrites)}
                   </span>
                 </div>
               )}
@@ -146,12 +171,28 @@ export const MessageTiming: FC<{
             </>
           ) : (
             <>
-              {/* Client-side metrics (safetensors fallback) */}
+              {/* Client-side metrics (safetensors + external provider fallback) */}
               {timing.firstTokenTime !== undefined && (
                 <div className="flex items-center justify-between gap-4">
                   <span className="text-muted-foreground">First token</span>
                   <span className="font-mono tabular-nums">
                     {formatTimingMs(timing.firstTokenTime)}
+                  </span>
+                </div>
+              )}
+              {cacheHits > 0 && (
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-muted-foreground">Cache hits</span>
+                  <span className="font-mono tabular-nums">
+                    {formatNumber(cacheHits)}
+                  </span>
+                </div>
+              )}
+              {cacheWrites > 0 && (
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-muted-foreground">Cache writes</span>
+                  <span className="font-mono tabular-nums">
+                    {formatNumber(cacheWrites)}
                   </span>
                 </div>
               )}

--- a/studio/frontend/src/components/assistant-ui/message-timing.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-timing.tsx
@@ -45,14 +45,9 @@ export const MessageTiming: FC<{
       }
     | undefined;
   const st = custom?.serverTimings;
-  // Cache-hit / cache-write counts. llama-server reports hits on
-  // timings.cache_n; external providers (Anthropic / OpenAI Responses /
-  // Gemini) report them on the include_usage envelope that the adapter
-  // normalizes into custom.contextUsage. Prefer the local-runtime value
-  // when present (so llama.cpp keeps populating the badge mid-stream)
-  // and fall back to the external envelope otherwise.
+  // Prefer llama-server timings, fall back to external usage envelope.
   const cacheHits = (st?.cache_n ?? 0) || (custom?.contextUsage?.cachedTokens ?? 0);
-  // Anthropic-only: tokens written into the prompt cache on this turn.
+  // Anthropic-only cache-write count.
   const cacheWrites = custom?.contextUsage?.cacheWriteTokens ?? 0;
 
   // Guard unphysical tok/s: llama.cpp emits predicted_ms=0 on no-op

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1899,12 +1899,16 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         // Anthropic-only cache-write count (billed at the write premium).
         const cacheWriteTokens = meta?.usage?.cache_creation_input_tokens ?? 0;
 
-        // Update context usage in store if we got valid server data
+        // Update context usage in store if we got valid server data.
+        // Gate on the captured checkpoint still being active so a late
+        // completion from provider A does not populate the context bar
+        // after the user switched to provider B mid-stream.
         if (
           meta?.usage &&
           typeof meta.usage.prompt_tokens === "number" &&
           typeof meta.usage.completion_tokens === "number" &&
-          typeof meta.usage.total_tokens === "number"
+          typeof meta.usage.total_tokens === "number" &&
+          useChatRuntimeStore.getState().params.checkpoint === params.checkpoint
         ) {
           useChatRuntimeStore.getState().setContextUsage({
             promptTokens: meta.usage.prompt_tokens,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -70,6 +70,21 @@ interface ServerUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  /**
+   * External providers (Anthropic / OpenAI Responses / Gemini) surface
+   * prompt-cache accounting on the same `usage` envelope via
+   * `_build_usage_chunk` in `studio/backend/core/inference/external_provider.py`.
+   * `prompt_tokens_details.cached_tokens` is the normalised cache-read count
+   * present for every provider that supports it; `cache_creation_input_tokens`
+   * / `cache_read_input_tokens` are the Anthropic-native keys (cache_read
+   * mirrors `prompt_tokens_details.cached_tokens`; cache_creation is
+   * Anthropic-only and billed at the cache-write premium).
+   */
+  prompt_tokens_details?: {
+    cached_tokens?: number;
+  };
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
 }
 
 /** Server-side timing data from llama-server's timings object. */
@@ -1881,6 +1896,26 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const finalTokPerSec = meta?.timings?.predicted_per_second;
         const serverPromptEvalTime = meta?.timings?.prompt_ms;
 
+        // Cache-hit count. llama-server reports it on `timings.cache_n`;
+        // external providers (Anthropic, OpenAI Responses, Gemini) report
+        // it on `usage.prompt_tokens_details.cached_tokens` -- see the
+        // `_build_usage_chunk` helper in
+        // studio/backend/core/inference/external_provider.py. Prefer the
+        // local-runtime value when it is present (so llama.cpp keeps
+        // populating the bar mid-stream) and fall back to the external
+        // usage envelope otherwise. cache_read_input_tokens is Anthropic's
+        // native key for the same value; read it as a last resort for
+        // providers that only emit the Anthropic shape.
+        const cachedTokens =
+          meta?.timings?.cache_n ??
+          meta?.usage?.prompt_tokens_details?.cached_tokens ??
+          meta?.usage?.cache_read_input_tokens ??
+          0;
+        // Anthropic-only: tokens written into the prompt cache on this
+        // turn, billed at the cache-write premium. Surfaced separately so
+        // users can tell a cache miss from a cache hit.
+        const cacheWriteTokens = meta?.usage?.cache_creation_input_tokens ?? 0;
+
         // Update context usage in store if we got valid server data
         if (
           meta?.usage &&
@@ -1892,7 +1927,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
             promptTokens: meta.usage.prompt_tokens,
             completionTokens: meta.usage.completion_tokens,
             totalTokens: meta.usage.total_tokens,
-            cachedTokens: meta.timings?.cache_n ?? 0,
+            cachedTokens,
+            cacheWriteTokens,
           });
         }
 
@@ -1922,7 +1958,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                     promptTokens: meta.usage.prompt_tokens,
                     completionTokens: meta.usage.completion_tokens,
                     totalTokens: meta.usage.total_tokens,
-                    cachedTokens: meta.timings?.cache_n ?? 0,
+                    cachedTokens,
+                    cacheWriteTokens,
                     modelId: params.checkpoint,
                   }
                 : undefined,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -70,9 +70,8 @@ interface ServerUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
-  // External prompt-cache fields from `_build_usage_chunk` in
-  // studio/backend/core/inference/external_provider.py. cache_read mirrors
-  // prompt_tokens_details.cached_tokens; cache_creation is Anthropic-only.
+  // External prompt-cache fields (see _build_usage_chunk in
+  // external_provider.py). cache_creation is Anthropic-only.
   prompt_tokens_details?: {
     cached_tokens?: number;
   };
@@ -1889,20 +1888,18 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const finalTokPerSec = meta?.timings?.predicted_per_second;
         const serverPromptEvalTime = meta?.timings?.prompt_ms;
 
-        // Cache-hit count: prefer llama-server timings, fall back to the
-        // external-provider usage envelope (Anthropic-native key last).
+        // Prefer llama-server timings; fall back to provider usage envelope.
         const cachedTokens =
           meta?.timings?.cache_n ??
           meta?.usage?.prompt_tokens_details?.cached_tokens ??
           meta?.usage?.cache_read_input_tokens ??
           0;
-        // Anthropic-only cache-write count (billed at the write premium).
+        // Anthropic-only (billed at the write premium).
         const cacheWriteTokens = meta?.usage?.cache_creation_input_tokens ?? 0;
 
-        // Update context usage in store if we got valid server data.
         // Gate on the captured checkpoint still being active so a late
-        // completion from provider A does not populate the context bar
-        // after the user switched to provider B mid-stream.
+        // completion from provider A doesn't populate the bar after the
+        // user switched to provider B mid-stream.
         if (
           meta?.usage &&
           typeof meta.usage.prompt_tokens === "number" &&

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -70,16 +70,9 @@ interface ServerUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
-  /**
-   * External providers (Anthropic / OpenAI Responses / Gemini) surface
-   * prompt-cache accounting on the same `usage` envelope via
-   * `_build_usage_chunk` in `studio/backend/core/inference/external_provider.py`.
-   * `prompt_tokens_details.cached_tokens` is the normalised cache-read count
-   * present for every provider that supports it; `cache_creation_input_tokens`
-   * / `cache_read_input_tokens` are the Anthropic-native keys (cache_read
-   * mirrors `prompt_tokens_details.cached_tokens`; cache_creation is
-   * Anthropic-only and billed at the cache-write premium).
-   */
+  // External prompt-cache fields from `_build_usage_chunk` in
+  // studio/backend/core/inference/external_provider.py. cache_read mirrors
+  // prompt_tokens_details.cached_tokens; cache_creation is Anthropic-only.
   prompt_tokens_details?: {
     cached_tokens?: number;
   };
@@ -1896,24 +1889,14 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const finalTokPerSec = meta?.timings?.predicted_per_second;
         const serverPromptEvalTime = meta?.timings?.prompt_ms;
 
-        // Cache-hit count. llama-server reports it on `timings.cache_n`;
-        // external providers (Anthropic, OpenAI Responses, Gemini) report
-        // it on `usage.prompt_tokens_details.cached_tokens` -- see the
-        // `_build_usage_chunk` helper in
-        // studio/backend/core/inference/external_provider.py. Prefer the
-        // local-runtime value when it is present (so llama.cpp keeps
-        // populating the bar mid-stream) and fall back to the external
-        // usage envelope otherwise. cache_read_input_tokens is Anthropic's
-        // native key for the same value; read it as a last resort for
-        // providers that only emit the Anthropic shape.
+        // Cache-hit count: prefer llama-server timings, fall back to the
+        // external-provider usage envelope (Anthropic-native key last).
         const cachedTokens =
           meta?.timings?.cache_n ??
           meta?.usage?.prompt_tokens_details?.cached_tokens ??
           meta?.usage?.cache_read_input_tokens ??
           0;
-        // Anthropic-only: tokens written into the prompt cache on this
-        // turn, billed at the cache-write premium. Surfaced separately so
-        // users can tell a cache miss from a cache hit.
+        // Anthropic-only cache-write count (billed at the write premium).
         const cacheWriteTokens = meta?.usage?.cache_creation_input_tokens ?? 0;
 
         // Update context usage in store if we got valid server data

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1491,9 +1491,15 @@ export function ChatPage(): ReactElement {
             ) : null}
           </div>
           <div className="ml-auto flex items-center gap-2">
-            {view.mode === "single" && ggufContextLength && contextUsage ? (
+            {view.mode === "single" && contextUsage ? (
               <ContextUsageBar
                 used={contextUsage.totalTokens}
+                // ggufContextLength is the local llama-server's KV-cache size;
+                // external providers (Anthropic / OpenAI Responses / Gemini)
+                // don't expose a stable per-model context window through the
+                // picker, so it is null in that mode. Pass it as-is -- the bar
+                // drops the "/ total" ratio + percentage when total is absent
+                // and still renders the per-turn counters + cache stats.
                 total={ggufContextLength}
                 cached={contextUsage.cachedTokens}
                 cacheWrites={contextUsage.cacheWriteTokens}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1191,13 +1191,12 @@ export function ChatPage(): ReactElement {
             (usage as { modelId?: unknown }).modelId;
           // Scope by modelId when the saved usage carries one (the
           // chat-adapter stamps it on every external + local turn).
-          if (
-            typeof usageModelId === "string" &&
-            usageModelId &&
-            activeCheckpoint &&
-            usageModelId !== activeCheckpoint
-          ) {
-            return;
+          // Reject when there is no active checkpoint at all -- model-
+          // scoped usage cannot be safely attributed to "nothing".
+          if (typeof usageModelId === "string" && usageModelId) {
+            if (!activeCheckpoint || usageModelId !== activeCheckpoint) {
+              return;
+            }
           }
           // For local llama-server turns, also require that the
           // restored prompt count fits inside the active context

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1037,10 +1037,9 @@ export function ChatPage(): ReactElement {
           ggufMaxContextLength: null,
           ggufNativeContextLength: null,
           activeNativePathToken: null,
-          // External selection arrives mid-session: also clear any
-          // pre-existing per-turn usage from the previous model so the
-          // relaxed external-provider render gate does not show stale
-          // counts until the next completion overwrites them.
+          // Clear previous-model counters; the relaxed external-provider
+          // render gate would otherwise show stale stats until the next
+          // completion overwrites them.
           contextUsage: null,
           supportsReasoning: reasoningCaps.supportsReasoning,
           reasoningAlwaysOn: reasoningCaps.reasoningAlwaysOn,
@@ -1166,11 +1165,9 @@ export function ChatPage(): ReactElement {
     if (!saved) return;
     viewBeforeCompareRef.current = null;
     navigate({ to: "/chat", search: saved });
-    // Restore context usage from the active thread's last assistant
-    // message, but only if it was produced by the SAME checkpoint the
-    // user is now sitting on. Without this guard the relaxed render
-    // gate would show stale token / cache stats from a different
-    // provider or a local turn that exceeds the active GGUF window.
+    // Restore usage from the last assistant message, but only if it
+    // matches the currently active checkpoint. Without this guard the
+    // relaxed render gate would show stale stats from another model.
     const threadId =
       saved.thread ?? useChatRuntimeStore.getState().activeThreadId;
     if (threadId) {
@@ -1189,20 +1186,15 @@ export function ChatPage(): ReactElement {
           const activeCheckpoint = store.params.checkpoint;
           const usageModelId =
             (usage as { modelId?: unknown }).modelId;
-          // Scope by modelId when the saved usage carries one (the
-          // chat-adapter stamps it on every external + local turn).
-          // Reject when there is no active checkpoint at all -- model-
-          // scoped usage cannot be safely attributed to "nothing".
+          // Scope by modelId when present; reject if no active checkpoint
+          // (model-scoped usage cannot be attributed to "nothing").
           if (typeof usageModelId === "string" && usageModelId) {
             if (!activeCheckpoint || usageModelId !== activeCheckpoint) {
               return;
             }
           }
-          // For local llama-server turns, also require that the
-          // restored prompt count fits inside the active context
-          // window. Skip the check when the window is unknown (e.g.
-          // external provider, no ggufContextLength) so the existing
-          // external-provider rendering path stays intact.
+          // For local turns, also require the restored count to fit in
+          // the active window. Skip when unknown (external provider).
           const limit = store.ggufContextLength;
           if (
             typeof limit === "number" &&

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1496,6 +1496,7 @@ export function ChatPage(): ReactElement {
                 used={contextUsage.totalTokens}
                 total={ggufContextLength}
                 cached={contextUsage.cachedTokens}
+                cacheWrites={contextUsage.cacheWriteTokens}
                 promptTokens={contextUsage.promptTokens}
                 completionTokens={contextUsage.completionTokens}
                 className="h-[34px]"

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1494,12 +1494,7 @@ export function ChatPage(): ReactElement {
             {view.mode === "single" && contextUsage ? (
               <ContextUsageBar
                 used={contextUsage.totalTokens}
-                // ggufContextLength is the local llama-server's KV-cache size;
-                // external providers (Anthropic / OpenAI Responses / Gemini)
-                // don't expose a stable per-model context window through the
-                // picker, so it is null in that mode. Pass it as-is -- the bar
-                // drops the "/ total" ratio + percentage when total is absent
-                // and still renders the per-turn counters + cache stats.
+                // null on external providers; the bar handles that.
                 total={ggufContextLength}
                 cached={contextUsage.cachedTokens}
                 cacheWrites={contextUsage.cacheWriteTokens}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1037,6 +1037,11 @@ export function ChatPage(): ReactElement {
           ggufMaxContextLength: null,
           ggufNativeContextLength: null,
           activeNativePathToken: null,
+          // External selection arrives mid-session: also clear any
+          // pre-existing per-turn usage from the previous model so the
+          // relaxed external-provider render gate does not show stale
+          // counts until the next completion overwrites them.
+          contextUsage: null,
           supportsReasoning: reasoningCaps.supportsReasoning,
           reasoningAlwaysOn: reasoningCaps.reasoningAlwaysOn,
           reasoningStyle: reasoningCaps.reasoningStyle,
@@ -1161,7 +1166,11 @@ export function ChatPage(): ReactElement {
     if (!saved) return;
     viewBeforeCompareRef.current = null;
     navigate({ to: "/chat", search: saved });
-    // Restore context usage from the active thread's last assistant message.
+    // Restore context usage from the active thread's last assistant
+    // message, but only if it was produced by the SAME checkpoint the
+    // user is now sitting on. Without this guard the relaxed render
+    // gate would show stale token / cache stats from a different
+    // provider or a local turn that exceeds the active GGUF window.
     const threadId =
       saved.thread ?? useChatRuntimeStore.getState().activeThreadId;
     if (threadId) {
@@ -1175,7 +1184,35 @@ export function ChatPage(): ReactElement {
           const usage = metadata?.contextUsage as ReturnType<
             typeof useChatRuntimeStore.getState
           >["contextUsage"];
-          if (usage) useChatRuntimeStore.getState().setContextUsage(usage);
+          if (!usage) return;
+          const store = useChatRuntimeStore.getState();
+          const activeCheckpoint = store.params.checkpoint;
+          const usageModelId =
+            (usage as { modelId?: unknown }).modelId;
+          // Scope by modelId when the saved usage carries one (the
+          // chat-adapter stamps it on every external + local turn).
+          if (
+            typeof usageModelId === "string" &&
+            usageModelId &&
+            activeCheckpoint &&
+            usageModelId !== activeCheckpoint
+          ) {
+            return;
+          }
+          // For local llama-server turns, also require that the
+          // restored prompt count fits inside the active context
+          // window. Skip the check when the window is unknown (e.g.
+          // external provider, no ggufContextLength) so the existing
+          // external-provider rendering path stays intact.
+          const limit = store.ggufContextLength;
+          if (
+            typeof limit === "number" &&
+            limit > 0 &&
+            (usage.totalTokens ?? 0) > limit
+          ) {
+            return;
+          }
+          store.setContextUsage(usage);
         })
         .catch((error) => {
           if (!isExpectedBackgroundChatStorageError(error)) {

--- a/studio/frontend/src/features/chat/components/context-usage-bar.tsx
+++ b/studio/frontend/src/features/chat/components/context-usage-bar.tsx
@@ -28,11 +28,10 @@ function getSeverityColor(percent: number): {
 
 export const ContextUsageBar: FC<{
   used: number;
-  // Optional: only local llama-server knows the context window. When absent
-  // the bar shows token counts without the "/ total" ratio.
+  // null on external providers (no known window); bar then hides the ratio.
   total?: number | null;
   cached?: number;
-  // Anthropic-only cache-write count (billed at the write premium).
+  // Anthropic-only (billed at the write premium).
   cacheWrites?: number;
   promptTokens?: number;
   completionTokens?: number;

--- a/studio/frontend/src/features/chat/components/context-usage-bar.tsx
+++ b/studio/frontend/src/features/chat/components/context-usage-bar.tsx
@@ -28,7 +28,15 @@ function getSeverityColor(percent: number): {
 
 export const ContextUsageBar: FC<{
   used: number;
-  total: number;
+  /**
+   * Context window size. Optional because external providers don't expose a
+   * stable per-model limit through the chat picker -- the local llama-server
+   * path is the only one that populates ggufContextLength. When omitted, the
+   * bar drops the "/ total" ratio + percentage bar and just shows the token
+   * counts (so cache hits / writes from Anthropic / OpenAI Responses still
+   * land in the tooltip).
+   */
+  total?: number | null;
   cached?: number;
   /**
    * Anthropic-only cache-write count (tokens written into the prompt cache
@@ -48,31 +56,49 @@ export const ContextUsageBar: FC<{
   completionTokens,
   className,
 }) => {
-  if (total <= 0) return null;
+  const hasKnownLimit = typeof total === "number" && total > 0;
+  const hasUsageDetails =
+    promptTokens !== undefined ||
+    completionTokens !== undefined ||
+    (cached !== undefined && cached > 0) ||
+    (cacheWrites !== undefined && cacheWrites > 0);
 
-  const percent = Math.min((used / total) * 100, 100);
-  const severity = getSeverityColor(percent);
+  // Nothing to show: no limit and no per-turn counters.
+  if (!hasKnownLimit && used <= 0 && !hasUsageDetails) return null;
+
+  const percent = hasKnownLimit
+    ? Math.min((used / (total as number)) * 100, 100)
+    : null;
+  const severity = getSeverityColor(percent ?? 0);
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <button
           type="button"
-          aria-label={`Context usage: ${formatTokenCount(used)} of ${formatTokenCount(total)} tokens`}
+          aria-label={
+            hasKnownLimit
+              ? `Context usage: ${formatTokenCount(used)} of ${formatTokenCount(total as number)} tokens`
+              : `Token usage: ${formatTokenCount(used)} tokens`
+          }
           className={cn(
             "flex items-center gap-2 rounded-[10px] px-2.5 py-1 font-mono text-chat-icon-fg text-[13px] tabular-nums transition-colors hover:bg-chat-icon-bg-hover hover:text-chat-icon-fg-hover",
             className,
           )}
         >
           <span>
-            {formatTokenCount(used)} / {formatTokenCount(total)}
+            {hasKnownLimit
+              ? `${formatTokenCount(used)} / ${formatTokenCount(total as number)}`
+              : `${formatTokenCount(used)} tokens`}
           </span>
-          <div className="h-1.5 w-16 rounded-full bg-black/10 dark:bg-white/15 overflow-hidden">
-            <div
-              className={cn("h-full rounded-full transition-all", severity.bar)}
-              style={{ width: `${percent}%` }}
-            />
-          </div>
+          {hasKnownLimit && percent !== null ? (
+            <div className="h-1.5 w-16 rounded-full bg-black/10 dark:bg-white/15 overflow-hidden">
+              <div
+                className={cn("h-full rounded-full transition-all", severity.bar)}
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          ) : null}
         </button>
       </TooltipTrigger>
       <TooltipContent
@@ -82,12 +108,14 @@ export const ContextUsageBar: FC<{
         className="[&_span>svg]:hidden!"
       >
         <div className="grid min-w-44 gap-1.5 text-xs">
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-muted-foreground">Context usage</span>
-            <span className={cn("font-mono tabular-nums font-medium", severity.text)}>
-              {percent.toFixed(1)}%
-            </span>
-          </div>
+          {hasKnownLimit && percent !== null ? (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Context usage</span>
+              <span className={cn("font-mono tabular-nums font-medium", severity.text)}>
+                {percent.toFixed(1)}%
+              </span>
+            </div>
+          ) : null}
           {promptTokens !== undefined && (
             <div className="flex items-center justify-between gap-4">
               <span className="text-muted-foreground">Prompt tokens</span>
@@ -122,18 +150,22 @@ export const ContextUsageBar: FC<{
           )}
           <div className="my-0.5 border-t border-border/40" />
           <div className="flex items-center justify-between gap-4">
-            <span className="text-muted-foreground">Total</span>
+            <span className="text-muted-foreground">
+              {hasKnownLimit ? "Total" : "Total tokens"}
+            </span>
             <span className="font-mono tabular-nums">
-              {formatTokenCountFull(used)} / {formatTokenCountFull(total)}
+              {hasKnownLimit
+                ? `${formatTokenCountFull(used)} / ${formatTokenCountFull(total as number)}`
+                : formatTokenCountFull(used)}
             </span>
           </div>
-          {percent > 85 && (
+          {hasKnownLimit && percent !== null && percent > 85 ? (
             <div className="mt-1 max-w-64 text-[11px] leading-snug text-muted-foreground/90">
               Close to the context limit. Generation will stop at 100%.
               Increase <span className="font-medium">Context Length</span> in
               the chat Settings panel to keep going.
             </div>
-          )}
+          ) : null}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/studio/frontend/src/features/chat/components/context-usage-bar.tsx
+++ b/studio/frontend/src/features/chat/components/context-usage-bar.tsx
@@ -30,10 +30,24 @@ export const ContextUsageBar: FC<{
   used: number;
   total: number;
   cached?: number;
+  /**
+   * Anthropic-only cache-write count (tokens written into the prompt cache
+   * on this turn, billed at the cache-write premium). Shown as a separate
+   * tooltip line so users can tell a cache miss from a cache hit.
+   */
+  cacheWrites?: number;
   promptTokens?: number;
   completionTokens?: number;
   className?: string;
-}> = ({ used, total, cached, promptTokens, completionTokens, className }) => {
+}> = ({
+  used,
+  total,
+  cached,
+  cacheWrites,
+  promptTokens,
+  completionTokens,
+  className,
+}) => {
   if (total <= 0) return null;
 
   const percent = Math.min((used / total) * 100, 100);
@@ -95,6 +109,14 @@ export const ContextUsageBar: FC<{
               <span className="text-muted-foreground">Cache hits</span>
               <span className="font-mono tabular-nums">
                 {formatTokenCountFull(cached)}
+              </span>
+            </div>
+          )}
+          {cacheWrites !== undefined && cacheWrites > 0 && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Cache writes</span>
+              <span className="font-mono tabular-nums">
+                {formatTokenCountFull(cacheWrites)}
               </span>
             </div>
           )}

--- a/studio/frontend/src/features/chat/components/context-usage-bar.tsx
+++ b/studio/frontend/src/features/chat/components/context-usage-bar.tsx
@@ -28,21 +28,11 @@ function getSeverityColor(percent: number): {
 
 export const ContextUsageBar: FC<{
   used: number;
-  /**
-   * Context window size. Optional because external providers don't expose a
-   * stable per-model limit through the chat picker -- the local llama-server
-   * path is the only one that populates ggufContextLength. When omitted, the
-   * bar drops the "/ total" ratio + percentage bar and just shows the token
-   * counts (so cache hits / writes from Anthropic / OpenAI Responses still
-   * land in the tooltip).
-   */
+  // Optional: only local llama-server knows the context window. When absent
+  // the bar shows token counts without the "/ total" ratio.
   total?: number | null;
   cached?: number;
-  /**
-   * Anthropic-only cache-write count (tokens written into the prompt cache
-   * on this turn, billed at the cache-write premium). Shown as a separate
-   * tooltip line so users can tell a cache miss from a cache hit.
-   */
+  // Anthropic-only cache-write count (billed at the write premium).
   cacheWrites?: number;
   promptTokens?: number;
   completionTokens?: number;

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -831,11 +831,8 @@ function useStudioRuntimeAdapters(): StudioRuntimeAdapters {
             }
           | undefined;
         const store = useChatRuntimeStore.getState();
-        // External-provider threads have ggufContextLength === null because
-        // external picker selections don't carry a context-window number.
-        // Restore the persisted usage as long as it belongs to the active
-        // checkpoint; when a local GGUF context window IS known, also keep
-        // the original sanity check that the saved total fits inside it.
+        // Only enforce the fits-in-window check when a local GGUF window
+        // is known; external providers have ggufContextLength === null.
         const withinLocalLimit =
           !store.ggufContextLength ||
           (savedUsage?.totalTokens ?? 0) <= store.ggufContextLength;

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -836,12 +836,15 @@ function useStudioRuntimeAdapters(): StudioRuntimeAdapters {
         const withinLocalLimit =
           !store.ggufContextLength ||
           (savedUsage?.totalTokens ?? 0) <= store.ggufContextLength;
-        if (
-          savedUsage &&
-          withinLocalLimit &&
-          (!savedUsage.modelId ||
-            savedUsage.modelId === store.params.checkpoint)
-        ) {
+        // Legacy unscoped usage (no modelId) predates the chat-adapter's
+        // model stamp. Only trust it when a known local window also
+        // bounds the totals; otherwise we cannot rule out attributing
+        // an old local turn to a newly-selected external provider.
+        const modelMatches = savedUsage?.modelId
+          ? savedUsage.modelId === store.params.checkpoint
+          : typeof store.ggufContextLength === "number" &&
+            store.ggufContextLength > 0;
+        if (savedUsage && withinLocalLimit && modelMatches) {
           store.setContextUsage(savedUsage);
         }
 

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -826,6 +826,7 @@ function useStudioRuntimeAdapters(): StudioRuntimeAdapters {
               completionTokens: number;
               totalTokens: number;
               cachedTokens: number;
+              cacheWriteTokens?: number;
               modelId?: string;
             }
           | undefined;

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -831,14 +831,13 @@ function useStudioRuntimeAdapters(): StudioRuntimeAdapters {
             }
           | undefined;
         const store = useChatRuntimeStore.getState();
-        // Only enforce the fits-in-window check when a local GGUF window
-        // is known; external providers have ggufContextLength === null.
+        // Window check applies only when a local GGUF window is known;
+        // external providers have ggufContextLength === null.
         const withinLocalLimit =
           !store.ggufContextLength ||
           (savedUsage?.totalTokens ?? 0) <= store.ggufContextLength;
-        // Legacy unscoped usage (no modelId) predates the chat-adapter's
-        // model stamp. Only trust it when a known local window also
-        // bounds the totals; otherwise we cannot rule out attributing
+        // Legacy unscoped usage (no modelId) is only trusted when a
+        // known local window bounds the totals, so we can't misattribute
         // an old local turn to a newly-selected external provider.
         const modelMatches = savedUsage?.modelId
           ? savedUsage.modelId === store.params.checkpoint

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -831,10 +831,17 @@ function useStudioRuntimeAdapters(): StudioRuntimeAdapters {
             }
           | undefined;
         const store = useChatRuntimeStore.getState();
+        // External-provider threads have ggufContextLength === null because
+        // external picker selections don't carry a context-window number.
+        // Restore the persisted usage as long as it belongs to the active
+        // checkpoint; when a local GGUF context window IS known, also keep
+        // the original sanity check that the saved total fits inside it.
+        const withinLocalLimit =
+          !store.ggufContextLength ||
+          (savedUsage?.totalTokens ?? 0) <= store.ggufContextLength;
         if (
           savedUsage &&
-          store.ggufContextLength &&
-          savedUsage.totalTokens <= store.ggufContextLength &&
+          withinLocalLimit &&
           (!savedUsage.modelId ||
             savedUsage.modelId === store.params.checkpoint)
         ) {

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -642,11 +642,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       if (state.settingsHydrated && hasKeys(changedParams)) {
         saveSettingsPatch({ inferenceParams: changedParams });
       }
-      // Mirror setCheckpoint: the local model load path mutates
-      // params.checkpoint via setParams(mergeBackendRecommendedInference(...))
-      // before refresh() eventually calls setCheckpoint, leaving a window
-      // where the relaxed context-bar render gate would show the previous
-      // model's per-turn counters under the new checkpoint.
+      // Mirror setCheckpoint: the local model load path can mutate
+      // params.checkpoint via setParams() before setCheckpoint runs,
+      // leaving stale per-turn counters under the new checkpoint.
       const checkpointChanged = state.params.checkpoint !== params.checkpoint;
       return {
         params,
@@ -715,14 +713,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // mount, and a stale persisted local id would race against the
       // freshly-loaded model. See LAST_EXTERNAL_CHECKPOINT_KEY notes.
       saveLastExternalCheckpoint(isExternalModelId(modelId) ? modelId : null);
-      // Clear any stale per-turn usage when the active model changes.
-      // The context bar render gate was relaxed for external providers
-      // (no longer requires ggufContextLength), so leaving a previous
-      // turn's counters around would visibly show old token / cache
-      // stats from a different model until the next completion
-      // overwrites them. setActiveThreadId / clearCheckpoint already
-      // do this; keep the invariant on the most-traveled transition
-      // path too.
+      // Clear stale per-turn usage when the model changes; the relaxed
+      // external-provider render gate would otherwise show old counters
+      // until the next completion overwrites them.
       const checkpointChanged = state.params.checkpoint !== modelId;
       return {
         params: {

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -291,6 +291,10 @@ type ChatRuntimeStore = {
     completionTokens: number;
     totalTokens: number;
     cachedTokens: number;
+    // Anthropic-only cache-write count from
+    // `usage.cache_creation_input_tokens`. Optional so older persisted
+    // entries from llama-server / pre-cache-stats builds keep loading.
+    cacheWriteTokens?: number;
   } | null;
   modelLoading: boolean;
   activeNativePathToken: string | null;

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -706,12 +706,22 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // mount, and a stale persisted local id would race against the
       // freshly-loaded model. See LAST_EXTERNAL_CHECKPOINT_KEY notes.
       saveLastExternalCheckpoint(isExternalModelId(modelId) ? modelId : null);
+      // Clear any stale per-turn usage when the active model changes.
+      // The context bar render gate was relaxed for external providers
+      // (no longer requires ggufContextLength), so leaving a previous
+      // turn's counters around would visibly show old token / cache
+      // stats from a different model until the next completion
+      // overwrites them. setActiveThreadId / clearCheckpoint already
+      // do this; keep the invariant on the most-traveled transition
+      // path too.
+      const checkpointChanged = state.params.checkpoint !== modelId;
       return {
         params: {
           ...state.params,
           checkpoint: modelId,
         },
         activeGgufVariant: ggufVariant ?? null,
+        ...(checkpointChanged ? { contextUsage: null } : {}),
       };
     }),
   setActiveThreadId: (activeThreadId) =>

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -291,9 +291,7 @@ type ChatRuntimeStore = {
     completionTokens: number;
     totalTokens: number;
     cachedTokens: number;
-    // Anthropic-only cache-write count from
-    // `usage.cache_creation_input_tokens`. Optional so older persisted
-    // entries from llama-server / pre-cache-stats builds keep loading.
+    // Anthropic-only; optional so pre-cache-stats persisted entries load.
     cacheWriteTokens?: number;
   } | null;
   modelLoading: boolean;

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -642,7 +642,16 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       if (state.settingsHydrated && hasKeys(changedParams)) {
         saveSettingsPatch({ inferenceParams: changedParams });
       }
-      return { params };
+      // Mirror setCheckpoint: the local model load path mutates
+      // params.checkpoint via setParams(mergeBackendRecommendedInference(...))
+      // before refresh() eventually calls setCheckpoint, leaving a window
+      // where the relaxed context-bar render gate would show the previous
+      // model's per-turn counters under the new checkpoint.
+      const checkpointChanged = state.params.checkpoint !== params.checkpoint;
+      return {
+        params,
+        ...(checkpointChanged ? { contextUsage: null } : {}),
+      };
     }),
   setCustomPresets: (customPresets) =>
     set(() => {


### PR DESCRIPTION
## Summary
- The Anthropic / OpenAI Responses streaming paths already emit an OpenAI `include_usage`-style chunk carrying `prompt_tokens_details.cached_tokens` and `cache_creation_input_tokens` / `cache_read_input_tokens` (built by `_build_usage_chunk` in `studio/backend/core/inference/external_provider.py`), but the chat-adapter only read llama-server's `timings.cache_n`. The context-usage tooltip therefore never showed cache activity for external providers, even though the backend already had the numbers.
- Read the external usage envelope as a fallback for `cachedTokens` when `timings.cache_n` is absent. Surface Anthropic `cache_creation_input_tokens` separately as a new "Cache writes" line in the tooltip so a cache miss (writes-only) is visually distinguishable from a cache hit (reads).

## Changes
- `studio/frontend/src/features/chat/api/chat-adapter.ts`: `ServerUsage` gains optional `prompt_tokens_details.cached_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`. Extract `cachedTokens` from `timings.cache_n` -> `prompt_tokens_details.cached_tokens` -> `cache_read_input_tokens` (in that order). Extract `cacheWriteTokens` from `cache_creation_input_tokens`. Both flow into the runtime store and the persisted metadata payload.
- `studio/frontend/src/features/chat/stores/chat-runtime-store.ts`: `contextUsage` gains optional `cacheWriteTokens`.
- `studio/frontend/src/features/chat/runtime-provider.tsx`: stored-message rehydration accepts `cacheWriteTokens`.
- `studio/frontend/src/features/chat/components/context-usage-bar.tsx`: new optional `cacheWrites` prop, rendered as a separate tooltip line when > 0.
- `studio/frontend/src/features/chat/chat-page.tsx`: forwards `contextUsage.cacheWriteTokens` into `<ContextUsageBar />`.

## Test plan
- [ ] `cd studio/frontend && npm run typecheck` clean
- [ ] Open chat with Anthropic (or any cached-prompt provider), send a turn long enough to cache, verify tooltip shows non-zero "Cache hits" on the second turn and non-zero "Cache writes" on the first turn
- [ ] Local llama-server chat still surfaces `timings.cache_n` as "Cache hits" with no "Cache writes" line