### PR TITLE
Studio: gate change-password submit on current_password length

### DIFF
--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -209,11 +209,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
     setError(null);
 
     if (!isLoginMode) {
-      // Mirror the disable gate's length check on the submit path. The
-      // button is normally kept disabled in this state, but native form
-      // submission (Enter on a focused input, browser autofill replaying
-      // a form post) can bypass the disabled attribute and reach the
-      // handler with a short / missing current_password.
+      // Mirror the disable gate: Enter / autofill can bypass the button.
       if (currentPassword.length < 8) {
         setError(
           currentPassword

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -209,8 +209,17 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
     setError(null);
 
     if (!isLoginMode) {
-      if (!currentPassword) {
-        setError("Unable to initialize setup. Reload the page and try again.");
+      // Mirror the disable gate's length check on the submit path. The
+      // button is normally kept disabled in this state, but native form
+      // submission (Enter on a focused input, browser autofill replaying
+      // a form post) can bypass the disabled attribute and reach the
+      // handler with a short / missing current_password.
+      if (currentPassword.length < 8) {
+        setError(
+          currentPassword
+            ? "Current password must be at least 8 characters."
+            : "Unable to initialize setup. Reload the page and try again.",
+        );
         return;
       }
       if (newPassword.length < 8) {

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -194,7 +194,10 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
   const hasBootstrapPassword = Boolean(window.__UNSLOTH_BOOTSTRAP__?.password);
   const invalidChangePasswordForm =
     !isLoginMode &&
-    (newPassword.length < 8 || newPassword !== confirmPassword || currentPassword === newPassword);
+    (currentPassword.length < 8 ||
+      newPassword.length < 8 ||
+      newPassword !== confirmPassword ||
+      currentPassword === newPassword);
   const showPasswordMismatchWarning =
     !isLoginMode &&
     newPassword.length > 0 &&


### PR DESCRIPTION
## Summary
- The change-password form's submit disable gate checks new password length, confirm equality, and current != new, but skipped a current_password length check. When `__UNSLOTH_BOOTSTRAP__` is injected this is harmless (currentPassword falls back to a 16+ char bootstrap value), but on the admin-forced `must_change_password` path no bootstrap is published, the "Current password" input is rendered, and the gate let users submit with an empty current_password.
- The submit handler then rejected it with "Unable to initialize setup. Reload the page and try again." -- a misleading error that hints at a backend bootstrap problem when the real cause is just an empty input. Surfaced while running the autonomous Playwright probe against an isolated `UNSLOTH_STUDIO_HOME` build.

## Fix
- Add `currentPassword.length < 8` to `invalidChangePasswordForm` in `studio/frontend/src/features/auth/components/auth-form.tsx`. The new gate is a strict superset of the submit handler's own validation, so the noisy reload-error path becomes unreachable.
- Common bootstrap-injection flow unchanged: bootstrap pws are 16+ chars, so `currentPassword.length < 8` is always false there.

## Test plan
- [ ] `cd studio/frontend && npm run typecheck` clean
- [ ] On a fresh install (bootstrap injected): change-password form behaves identically -- type new + confirm (>= 8 chars), button enables, submit succeeds
- [ ] On an admin-forced `must_change_password=true` reset (no bootstrap): "Current password" input rendered, button stays disabled until that field has 8+ chars, no more "Unable to initialize setup" error