### PR TITLE
Studio: stop seeded admin to cross-origin callers

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -771,7 +771,24 @@ def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]
     # strip it since Origin never contains credentials.
     if "@" in netloc:
         netloc = netloc.rsplit("@", 1)[1]
-    host, _, port_str = netloc.partition(":")
+    # IPv6 hosts ride in brackets (RFC 3986 §3.2.2): ``[::1]:8902``.
+    # A bare ``partition(":")`` mis-parses these (host=``[``, port=
+    # ``:1]:8902``) which collapses every IPv6 same-origin request to
+    # cross-origin and silently breaks ``unsloth studio -H ::1``.
+    if netloc.startswith("["):
+        close = netloc.find("]")
+        if close == -1:
+            return None
+        host = netloc[1:close]
+        rest = netloc[close + 1 :]
+        if rest.startswith(":"):
+            port_str = rest[1:]
+        elif rest == "":
+            port_str = ""
+        else:
+            return None
+    else:
+        host, _, port_str = netloc.partition(":")
     host = host.strip().lower()
     if not host:
         return None

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -49,6 +49,8 @@ import shutil
 import warnings
 from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError, version as package_version
+from typing import Optional
+from urllib.parse import urlparse
 
 
 _STUDIO_INSTALL_ID_RE = _re.compile(r"^[0-9a-f]{64}$")
@@ -743,16 +745,75 @@ def _inject_bootstrap(html_bytes: bytes, app: FastAPI):
     return html.encode("utf-8"), nonce
 
 
+_DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+
+
+def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]]:
+    """Canonicalise an Origin to ``(scheme, host, port)`` for equality.
+
+    Browsers strip the default port from the Origin header (RFC 6454 §6.1)
+    but Starlette's ``request.url.netloc`` keeps whatever the Host header
+    carried, which may or may not include the default port. We also need
+    to lowercase scheme + host, since both are case-insensitive per
+    RFC 3986. A bare-string compare misses these:
+
+    * Origin ``https://example.com``     vs netloc ``example.com:443`` (default port dropped)
+    * Origin ``http://Example.com``      vs netloc ``example.com``     (host case)
+    * Origin ``HTTP://example.com``      vs netloc ``example.com``     (scheme case)
+
+    Returns ``None`` when the input is unparseable so callers can treat
+    the comparison as cross-origin (safer default).
+    """
+    scheme = (scheme or "").strip().lower()
+    if not scheme or not netloc:
+        return None
+    # netloc may carry userinfo (user:pass@host:port) per RFC 3986;
+    # strip it since Origin never contains credentials.
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[1]
+    host, _, port_str = netloc.partition(":")
+    host = host.strip().lower()
+    if not host:
+        return None
+    if port_str:
+        try:
+            port = int(port_str)
+        except ValueError:
+            return None
+    else:
+        port = _DEFAULT_PORTS.get(scheme, 0)
+    return (scheme, host, port)
+
+
 def _is_same_origin_request(request: Request) -> bool:
     """True when Origin is missing or matches request's scheme://host:port.
 
     Top-level same-document GETs omit Origin on most engines, so a missing
     header counts as same-origin. Callers must also emit ``Vary: Origin``.
+
+    The comparison canonicalises both sides via :func:`_canonical_origin`
+    so a browser's default-port-stripping (``https://example.com`` vs
+    Starlette's ``example.com:443`` netloc) and case differences on
+    scheme/host do not cause same-origin requests to be misclassified
+    cross-origin (bootstrap pw stripped from the SPA shell, the user
+    can't auto-fill the change-password form).
     """
     origin = request.headers.get("origin")
     if not origin:
         return True
-    return origin == f"{request.url.scheme}://{request.url.netloc}"
+    # Origin is ``scheme://host[:port]`` per RFC 6454 §6.1. Reject the
+    # special token "null" (sandboxed iframes, file:// pages) and any
+    # value that doesn't parse as a URL.
+    if origin == "null":
+        return False
+    parsed = urlparse(origin)
+    origin_canon = _canonical_origin(parsed.scheme, parsed.netloc)
+    if origin_canon is None:
+        return False
+    self_canon = _canonical_origin(request.url.scheme, request.url.netloc)
+    if self_canon is None:
+        return False
+    return origin_canon == self_canon
 
 
 def setup_frontend(app: FastAPI, build_path: Path):

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -744,28 +744,15 @@ def _inject_bootstrap(html_bytes: bytes, app: FastAPI):
 
 
 def _is_same_origin_request(request: Request) -> bool:
-    """Return True when the request is same-origin (or has no Origin header).
+    """True when Origin is missing or matches request's scheme://host:port.
 
-    The HTML returned by ``/`` and the SPA fallback may carry an inline
-    ``window.__UNSLOTH_BOOTSTRAP__`` script with the seeded admin password.
-    Default web mode runs CORS with ``allow_origins=["*"]`` and
-    ``allow_credentials=True`` so that the local frontend works on any
-    deployment, but that policy reflects an attacker-controlled Origin back
-    on every request -- meaning a cross-origin page could `fetch('/')` with
-    credentials and read the bootstrap password out of the HTML body.
-
-    Browsers omit ``Origin`` on top-level same-document GET navigations on
-    most engines, so the absence of the header is the common legitimate
-    case. When the header IS present and does not match the request's own
-    scheme://host:port, treat it as cross-origin and skip the bootstrap
-    injection. Callers MUST also emit ``Vary: Origin`` so intermediary
-    caches do not serve a same-origin response to a cross-origin caller.
+    Top-level same-document GETs omit Origin on most engines, so a missing
+    header counts as same-origin. Callers must also emit ``Vary: Origin``.
     """
     origin = request.headers.get("origin")
     if not origin:
         return True
-    same_origin = f"{request.url.scheme}://{request.url.netloc}"
-    return origin == same_origin
+    return origin == f"{request.url.scheme}://{request.url.netloc}"
 
 
 def setup_frontend(app: FastAPI, build_path: Path):
@@ -781,14 +768,12 @@ def setup_frontend(app: FastAPI, build_path: Path):
     def _build_index_response(request: Request) -> Response:
         content = (build_path / "index.html").read_bytes()
         content = _strip_crossorigin(content)
-        # Only inject the bootstrap admin password into HTML returned to a
-        # same-origin caller. See _is_same_origin_request for the rationale.
+        # Bootstrap pw only ships to same-origin callers; Vary: Origin
+        # keeps caches from mixing the two response shapes.
         if _is_same_origin_request(request):
             content, nonce = _inject_bootstrap(content, app)
         else:
             nonce = None
-        # Vary on Origin so a same-origin response cached upstream is not
-        # served to a later cross-origin caller (and vice versa).
         headers = {
             "Cache-Control": "no-cache, no-store, must-revalidate",
             "Vary": "Origin",

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -816,18 +816,32 @@ def _is_same_origin_request(request: Request) -> bool:
     can't auto-fill the change-password form).
     """
     origin = request.headers.get("origin")
-    if not origin:
+    if origin is None:
+        # Missing header: top-level same-document GETs omit Origin.
         return True
+    # An empty string is not a valid serialised origin (RFC 6454 §6.1
+    # requires scheme + host); treat as cross-origin.
+    if not origin:
+        return False
     # Origin is ``scheme://host[:port]`` per RFC 6454 §6.1. Reject the
     # special token "null" (sandboxed iframes, file:// pages) and any
     # value that doesn't parse as a URL.
     if origin == "null":
         return False
-    parsed = urlparse(origin)
+    # ``urlparse`` raises ``ValueError`` on malformed IPv6 brackets and
+    # a few NFKC edge cases (Py 3.8+). A garbage Origin must not crash
+    # the SPA handler into a 500, so swallow and fall to cross-origin.
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
     origin_canon = _canonical_origin(parsed.scheme, parsed.netloc)
     if origin_canon is None:
         return False
-    self_canon = _canonical_origin(request.url.scheme, request.url.netloc)
+    try:
+        self_canon = _canonical_origin(request.url.scheme, request.url.netloc)
+    except ValueError:
+        return False
     if self_canon is None:
         return False
     return origin_canon == self_canon

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -717,10 +717,8 @@ def _strip_crossorigin(html_bytes: bytes) -> bytes:
 
 def _inject_bootstrap(html_bytes: bytes, app: FastAPI):
     """Inject bootstrap credentials when password change is pending.
-
-    Returns ``(html_bytes, script_nonce_or_None)``. Callers must forward
-    the nonce via ``_CSP_SCRIPT_NONCE_HEADER`` so the inline script is
-    not blocked by CSP.
+    Returns ``(html_bytes, script_nonce_or_None)``; callers forward the
+    nonce via ``_CSP_SCRIPT_NONCE_HEADER`` so CSP allows the inline script.
     """
     import json as _json
     import secrets as _secrets
@@ -750,31 +748,19 @@ _DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
 
 def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]]:
     """Canonicalise an Origin to ``(scheme, host, port)`` for equality.
-
-    Browsers strip the default port from the Origin header (RFC 6454 §6.1)
-    but Starlette's ``request.url.netloc`` keeps whatever the Host header
-    carried, which may or may not include the default port. We also need
-    to lowercase scheme + host, since both are case-insensitive per
-    RFC 3986. A bare-string compare misses these:
-
-    * Origin ``https://example.com``     vs netloc ``example.com:443`` (default port dropped)
-    * Origin ``http://Example.com``      vs netloc ``example.com``     (host case)
-    * Origin ``HTTP://example.com``      vs netloc ``example.com``     (scheme case)
-
-    Returns ``None`` when the input is unparseable so callers can treat
-    the comparison as cross-origin (safer default).
+    Browsers strip default ports (RFC 6454 sec 6.1) and scheme/host are
+    case-insensitive (RFC 3986), so bare string compare misclassifies
+    same-origin requests as cross-origin. Returns ``None`` on unparseable
+    input so callers fall to the safer cross-origin default.
     """
     scheme = (scheme or "").strip().lower()
     if not scheme or not netloc:
         return None
-    # netloc may carry userinfo (user:pass@host:port) per RFC 3986;
-    # strip it since Origin never contains credentials.
+    # Strip userinfo (RFC 3986); Origin never carries credentials.
     if "@" in netloc:
         netloc = netloc.rsplit("@", 1)[1]
-    # IPv6 hosts ride in brackets (RFC 3986 §3.2.2): ``[::1]:8902``.
-    # A bare ``partition(":")`` mis-parses these (host=``[``, port=
-    # ``:1]:8902``) which collapses every IPv6 same-origin request to
-    # cross-origin and silently breaks ``unsloth studio -H ::1``.
+    # IPv6 hosts use brackets (RFC 3986 sec 3.2.2): ``[::1]:8902``. Bare
+    # ``partition(":")`` mis-parses these and breaks ``unsloth studio -H ::1``.
     if netloc.startswith("["):
         close = netloc.find("]")
         if close == -1:
@@ -804,33 +790,23 @@ def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]
 
 def _is_same_origin_request(request: Request) -> bool:
     """True when Origin is missing or matches request's scheme://host:port.
-
-    Top-level same-document GETs omit Origin on most engines, so a missing
-    header counts as same-origin. Callers must also emit ``Vary: Origin``.
-
-    The comparison canonicalises both sides via :func:`_canonical_origin`
-    so a browser's default-port-stripping (``https://example.com`` vs
-    Starlette's ``example.com:443`` netloc) and case differences on
-    scheme/host do not cause same-origin requests to be misclassified
-    cross-origin (bootstrap pw stripped from the SPA shell, the user
-    can't auto-fill the change-password form).
+    Top-level same-document GETs omit Origin, so missing counts as same-origin.
+    Callers must also emit ``Vary: Origin``. Both sides are canonicalised via
+    :func:`_canonical_origin` so default-port stripping and scheme/host case
+    do not misclassify same-origin requests as cross-origin.
     """
     origin = request.headers.get("origin")
     if origin is None:
         # Missing header: top-level same-document GETs omit Origin.
         return True
-    # An empty string is not a valid serialised origin (RFC 6454 §6.1
-    # requires scheme + host); treat as cross-origin.
+    # Empty string is not a valid serialised origin (RFC 6454 sec 6.1).
     if not origin:
         return False
-    # Origin is ``scheme://host[:port]`` per RFC 6454 §6.1. Reject the
-    # special token "null" (sandboxed iframes, file:// pages) and any
-    # value that doesn't parse as a URL.
+    # "null" token (sandboxed iframes, file:// pages) is never same-origin.
     if origin == "null":
         return False
-    # ``urlparse`` raises ``ValueError`` on malformed IPv6 brackets and
-    # a few NFKC edge cases (Py 3.8+). A garbage Origin must not crash
-    # the SPA handler into a 500, so swallow and fall to cross-origin.
+    # ``urlparse`` raises ``ValueError`` on malformed IPv6 brackets; swallow
+    # so a garbage Origin doesn't 500 the SPA handler.
     try:
         parsed = urlparse(origin)
     except ValueError:
@@ -860,8 +836,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
     def _build_index_response(request: Request) -> Response:
         content = (build_path / "index.html").read_bytes()
         content = _strip_crossorigin(content)
-        # Bootstrap pw only ships to same-origin callers; Vary: Origin
-        # keeps caches from mixing the two response shapes.
+        # Bootstrap pw is same-origin only; Vary: Origin keeps caches honest.
         if _is_same_origin_request(request):
             content, nonce = _inject_bootstrap(content, app)
         else:

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -743,6 +743,31 @@ def _inject_bootstrap(html_bytes: bytes, app: FastAPI):
     return html.encode("utf-8"), nonce
 
 
+def _is_same_origin_request(request: Request) -> bool:
+    """Return True when the request is same-origin (or has no Origin header).
+
+    The HTML returned by ``/`` and the SPA fallback may carry an inline
+    ``window.__UNSLOTH_BOOTSTRAP__`` script with the seeded admin password.
+    Default web mode runs CORS with ``allow_origins=["*"]`` and
+    ``allow_credentials=True`` so that the local frontend works on any
+    deployment, but that policy reflects an attacker-controlled Origin back
+    on every request -- meaning a cross-origin page could `fetch('/')` with
+    credentials and read the bootstrap password out of the HTML body.
+
+    Browsers omit ``Origin`` on top-level same-document GET navigations on
+    most engines, so the absence of the header is the common legitimate
+    case. When the header IS present and does not match the request's own
+    scheme://host:port, treat it as cross-origin and skip the bootstrap
+    injection. Callers MUST also emit ``Vary: Origin`` so intermediary
+    caches do not serve a same-origin response to a cross-origin caller.
+    """
+    origin = request.headers.get("origin")
+    if not origin:
+        return True
+    same_origin = f"{request.url.scheme}://{request.url.netloc}"
+    return origin == same_origin
+
+
 def setup_frontend(app: FastAPI, build_path: Path):
     """Mount frontend static files (optional)"""
     if not build_path.exists():
@@ -753,11 +778,21 @@ def setup_frontend(app: FastAPI, build_path: Path):
     if assets_dir.exists():
         app.mount("/assets", StaticFiles(directory = assets_dir), name = "assets")
 
-    def _build_index_response() -> Response:
+    def _build_index_response(request: Request) -> Response:
         content = (build_path / "index.html").read_bytes()
         content = _strip_crossorigin(content)
-        content, nonce = _inject_bootstrap(content, app)
-        headers = {"Cache-Control": "no-cache, no-store, must-revalidate"}
+        # Only inject the bootstrap admin password into HTML returned to a
+        # same-origin caller. See _is_same_origin_request for the rationale.
+        if _is_same_origin_request(request):
+            content, nonce = _inject_bootstrap(content, app)
+        else:
+            nonce = None
+        # Vary on Origin so a same-origin response cached upstream is not
+        # served to a later cross-origin caller (and vice versa).
+        headers = {
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Vary": "Origin",
+        }
         if nonce:
             headers[_CSP_SCRIPT_NONCE_HEADER] = nonce
         return Response(
@@ -767,11 +802,11 @@ def setup_frontend(app: FastAPI, build_path: Path):
         )
 
     @app.get("/")
-    async def serve_root():
-        return _build_index_response()
+    async def serve_root(request: Request):
+        return _build_index_response(request)
 
     @app.get("/{full_path:path}")
-    async def serve_frontend(full_path: str):
+    async def serve_frontend(request: Request, full_path: str):
         if full_path in {"api", "v1"} or full_path.startswith(("api/", "v1/")):
             return {"error": "API endpoint not found"}
 
@@ -785,6 +820,6 @@ def setup_frontend(app: FastAPI, build_path: Path):
             return FileResponse(file_path)
 
         # Serve index.html as bytes — avoids Content-Length mismatch
-        return _build_index_response()
+        return _build_index_response(request)
 
     return True

--- a/studio/backend/tests/test_index_bootstrap_origin.py
+++ b/studio/backend/tests/test_index_bootstrap_origin.py
@@ -15,9 +15,9 @@ from unittest.mock import MagicMock
 import pytest
 
 
-def _build_request(host: str, origin: str | None) -> MagicMock:
+def _build_request(host: str, origin: str | None, scheme: str = "http") -> MagicMock:
     request = MagicMock()
-    request.url.scheme = "http"
+    request.url.scheme = scheme
     request.url.netloc = host
     request.headers = {"origin": origin} if origin is not None else {}
     return request
@@ -57,4 +57,91 @@ def test_is_same_origin_request_port_mismatch_is_cross_origin():
     from main import _is_same_origin_request
 
     req = _build_request("127.0.0.1:8888", origin = "http://127.0.0.1:5173")
+    assert _is_same_origin_request(req) is False
+
+
+# ── Canonicalisation: default-port stripping + case folding ─────────
+
+
+def test_is_same_origin_request_https_default_port_stripped_on_origin():
+    """RFC 6454 strips default ports on Origin; Starlette's netloc may
+    still carry ``:443``. Bare string-equality misreads this as cross-
+    origin and refuses to inject the bootstrap on legitimate browser
+    navigation. Canonicalise both sides before comparing.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com:443", origin = "https://example.com", scheme = "https")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_http_default_port_stripped_on_origin():
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com:80", origin = "http://example.com")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_default_port_present_on_origin():
+    """Mirror of the above: Origin carries the default port but the
+    listener's netloc doesn't. Same-origin.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com", origin = "https://example.com:443", scheme = "https")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_host_case_insensitive():
+    """Host portion is case-insensitive per RFC 3986."""
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com", origin = "http://EXAMPLE.com")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_scheme_case_insensitive():
+    """Scheme portion is case-insensitive per RFC 3986."""
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com", origin = "HTTP://example.com")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_null_origin_is_cross_origin():
+    """Sandboxed iframes / file:// pages send ``Origin: null``; treat
+    as cross-origin so the bootstrap is never injected for them.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com", origin = "null")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_unparseable_origin_is_cross_origin():
+    """Garbage values that don't carry a host are treated as cross-
+    origin (safer than throwing) so a malformed header can't leak the
+    bootstrap.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com", origin = "not-a-url")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_userinfo_in_netloc_ignored():
+    """``user:pass@host:port`` netlocs (rare but valid per RFC 3986)
+    must compare equal to the credentials-less Origin.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("user:pass@example.com:80", origin = "http://example.com")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_explicit_non_default_port_still_mismatch():
+    """Canonicalisation does NOT collapse non-default ports to default."""
+    from main import _is_same_origin_request
+
+    req = _build_request("example.com", origin = "https://example.com:9999", scheme = "https")
     assert _is_same_origin_request(req) is False

--- a/studio/backend/tests/test_index_bootstrap_origin.py
+++ b/studio/backend/tests/test_index_bootstrap_origin.py
@@ -37,21 +37,21 @@ def _build_request(host: str, origin: str | None) -> MagicMock:
 def test_is_same_origin_request_missing_origin_is_same_origin(monkeypatch):
     from main import _is_same_origin_request
 
-    req = _build_request("127.0.0.1:8888", origin=None)
+    req = _build_request("127.0.0.1:8888", origin = None)
     assert _is_same_origin_request(req) is True
 
 
 def test_is_same_origin_request_matching_origin_is_same_origin():
     from main import _is_same_origin_request
 
-    req = _build_request("127.0.0.1:8888", origin="http://127.0.0.1:8888")
+    req = _build_request("127.0.0.1:8888", origin = "http://127.0.0.1:8888")
     assert _is_same_origin_request(req) is True
 
 
 def test_is_same_origin_request_evil_origin_is_cross_origin():
     from main import _is_same_origin_request
 
-    req = _build_request("127.0.0.1:8888", origin="https://evil.example")
+    req = _build_request("127.0.0.1:8888", origin = "https://evil.example")
     assert _is_same_origin_request(req) is False
 
 
@@ -59,7 +59,7 @@ def test_is_same_origin_request_scheme_mismatch_is_cross_origin():
     """https origin against an http listener must NOT be treated as same."""
     from main import _is_same_origin_request
 
-    req = _build_request("127.0.0.1:8888", origin="https://127.0.0.1:8888")
+    req = _build_request("127.0.0.1:8888", origin = "https://127.0.0.1:8888")
     assert _is_same_origin_request(req) is False
 
 
@@ -67,5 +67,5 @@ def test_is_same_origin_request_port_mismatch_is_cross_origin():
     """Same host different port is NOT same-origin per the web platform."""
     from main import _is_same_origin_request
 
-    req = _build_request("127.0.0.1:8888", origin="http://127.0.0.1:5173")
+    req = _build_request("127.0.0.1:8888", origin = "http://127.0.0.1:5173")
     assert _is_same_origin_request(req) is False

--- a/studio/backend/tests/test_index_bootstrap_origin.py
+++ b/studio/backend/tests/test_index_bootstrap_origin.py
@@ -2,10 +2,8 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """Regression coverage for the bootstrap-pw cross-origin leak (PR 5739).
-
 ``_is_same_origin_request`` gates ``_inject_bootstrap`` so the seeded
-admin password only ships to same-origin callers. See the ``CORS: GET /``
-audit in tests/studio/studio_api_smoke.py.
+admin password only ships to same-origin callers.
 """
 
 import os
@@ -64,10 +62,8 @@ def test_is_same_origin_request_port_mismatch_is_cross_origin():
 
 
 def test_is_same_origin_request_https_default_port_stripped_on_origin():
-    """RFC 6454 strips default ports on Origin; Starlette's netloc may
-    still carry ``:443``. Bare string-equality misreads this as cross-
-    origin and refuses to inject the bootstrap on legitimate browser
-    navigation. Canonicalise both sides before comparing.
+    """RFC 6454 strips default ports on Origin; Starlette's netloc may still
+    carry ``:443``. Canonicalise both sides so this stays same-origin.
     """
     from main import _is_same_origin_request
 
@@ -85,9 +81,7 @@ def test_is_same_origin_request_http_default_port_stripped_on_origin():
 
 
 def test_is_same_origin_request_default_port_present_on_origin():
-    """Mirror of the above: Origin carries the default port but the
-    listener's netloc doesn't. Same-origin.
-    """
+    """Mirror case: Origin carries the default port, netloc doesn't. Same-origin."""
     from main import _is_same_origin_request
 
     req = _build_request(
@@ -113,9 +107,7 @@ def test_is_same_origin_request_scheme_case_insensitive():
 
 
 def test_is_same_origin_request_null_origin_is_cross_origin():
-    """Sandboxed iframes / file:// pages send ``Origin: null``; treat
-    as cross-origin so the bootstrap is never injected for them.
-    """
+    """Sandboxed iframes / file:// pages send ``Origin: null``; cross-origin."""
     from main import _is_same_origin_request
 
     req = _build_request("example.com", origin = "null")
@@ -123,9 +115,8 @@ def test_is_same_origin_request_null_origin_is_cross_origin():
 
 
 def test_is_same_origin_request_unparseable_origin_is_cross_origin():
-    """Garbage values that don't carry a host are treated as cross-
-    origin (safer than throwing) so a malformed header can't leak the
-    bootstrap.
+    """Garbage values without a host fall to cross-origin; a malformed header
+    must not leak the bootstrap.
     """
     from main import _is_same_origin_request
 
@@ -134,8 +125,8 @@ def test_is_same_origin_request_unparseable_origin_is_cross_origin():
 
 
 def test_is_same_origin_request_userinfo_in_netloc_ignored():
-    """``user:pass@host:port`` netlocs (rare but valid per RFC 3986)
-    must compare equal to the credentials-less Origin.
+    """``user:pass@host:port`` netlocs (RFC 3986) must compare equal to the
+    credentials-less Origin.
     """
     from main import _is_same_origin_request
 

--- a/studio/backend/tests/test_index_bootstrap_origin.py
+++ b/studio/backend/tests/test_index_bootstrap_origin.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+Regression coverage for the bootstrap-password cross-origin leak surfaced
+by tests/studio/studio_api_smoke.py.
+
+Default web mode runs FastAPI's CORSMiddleware with
+``allow_origins=["*"]`` and ``allow_credentials=True``, which reflects an
+attacker-controlled ``Origin`` back on every request. The ``/`` route
+serves index.html with an inline ``window.__UNSLOTH_BOOTSTRAP__`` script
+containing the seeded admin password while a password change is pending.
+That combination let a cross-origin page ``fetch('/')`` with credentials
+and read the bootstrap password out of the HTML body.
+
+``_is_same_origin_request`` is the gate that keeps the injection
+same-origin-only; ``_build_index_response`` calls it and adds
+``Vary: Origin`` so caches do not mix the two response shapes.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _build_request(host: str, origin: str | None) -> MagicMock:
+    """Mock just enough of starlette.Request for the helper under test."""
+    request = MagicMock()
+    request.url.scheme = "http"
+    request.url.netloc = host
+    request.headers = {"origin": origin} if origin is not None else {}
+    return request
+
+
+def test_is_same_origin_request_missing_origin_is_same_origin(monkeypatch):
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8888", origin=None)
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_matching_origin_is_same_origin():
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8888", origin="http://127.0.0.1:8888")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_evil_origin_is_cross_origin():
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8888", origin="https://evil.example")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_scheme_mismatch_is_cross_origin():
+    """https origin against an http listener must NOT be treated as same."""
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8888", origin="https://127.0.0.1:8888")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_port_mismatch_is_cross_origin():
+    """Same host different port is NOT same-origin per the web platform."""
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8888", origin="http://127.0.0.1:5173")
+    assert _is_same_origin_request(req) is False

--- a/studio/backend/tests/test_index_bootstrap_origin.py
+++ b/studio/backend/tests/test_index_bootstrap_origin.py
@@ -71,7 +71,9 @@ def test_is_same_origin_request_https_default_port_stripped_on_origin():
     """
     from main import _is_same_origin_request
 
-    req = _build_request("example.com:443", origin = "https://example.com", scheme = "https")
+    req = _build_request(
+        "example.com:443", origin = "https://example.com", scheme = "https"
+    )
     assert _is_same_origin_request(req) is True
 
 
@@ -88,7 +90,9 @@ def test_is_same_origin_request_default_port_present_on_origin():
     """
     from main import _is_same_origin_request
 
-    req = _build_request("example.com", origin = "https://example.com:443", scheme = "https")
+    req = _build_request(
+        "example.com", origin = "https://example.com:443", scheme = "https"
+    )
     assert _is_same_origin_request(req) is True
 
 
@@ -143,5 +147,7 @@ def test_is_same_origin_request_explicit_non_default_port_still_mismatch():
     """Canonicalisation does NOT collapse non-default ports to default."""
     from main import _is_same_origin_request
 
-    req = _build_request("example.com", origin = "https://example.com:9999", scheme = "https")
+    req = _build_request(
+        "example.com", origin = "https://example.com:9999", scheme = "https"
+    )
     assert _is_same_origin_request(req) is False

--- a/studio/backend/tests/test_index_bootstrap_origin.py
+++ b/studio/backend/tests/test_index_bootstrap_origin.py
@@ -1,21 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""
-Regression coverage for the bootstrap-password cross-origin leak surfaced
-by tests/studio/studio_api_smoke.py.
+"""Regression coverage for the bootstrap-pw cross-origin leak (PR 5739).
 
-Default web mode runs FastAPI's CORSMiddleware with
-``allow_origins=["*"]`` and ``allow_credentials=True``, which reflects an
-attacker-controlled ``Origin`` back on every request. The ``/`` route
-serves index.html with an inline ``window.__UNSLOTH_BOOTSTRAP__`` script
-containing the seeded admin password while a password change is pending.
-That combination let a cross-origin page ``fetch('/')`` with credentials
-and read the bootstrap password out of the HTML body.
-
-``_is_same_origin_request`` is the gate that keeps the injection
-same-origin-only; ``_build_index_response`` calls it and adds
-``Vary: Origin`` so caches do not mix the two response shapes.
+``_is_same_origin_request`` gates ``_inject_bootstrap`` so the seeded
+admin password only ships to same-origin callers. See the ``CORS: GET /``
+audit in tests/studio/studio_api_smoke.py.
 """
 
 import os
@@ -26,7 +16,6 @@ import pytest
 
 
 def _build_request(host: str, origin: str | None) -> MagicMock:
-    """Mock just enough of starlette.Request for the helper under test."""
     request = MagicMock()
     request.url.scheme = "http"
     request.url.netloc = host
@@ -56,7 +45,7 @@ def test_is_same_origin_request_evil_origin_is_cross_origin():
 
 
 def test_is_same_origin_request_scheme_mismatch_is_cross_origin():
-    """https origin against an http listener must NOT be treated as same."""
+    # https origin against an http listener is not same-origin.
     from main import _is_same_origin_request
 
     req = _build_request("127.0.0.1:8888", origin = "https://127.0.0.1:8888")
@@ -64,7 +53,7 @@ def test_is_same_origin_request_scheme_mismatch_is_cross_origin():
 
 
 def test_is_same_origin_request_port_mismatch_is_cross_origin():
-    """Same host different port is NOT same-origin per the web platform."""
+    # Same host different port is not same-origin per the web platform.
     from main import _is_same_origin_request
 
     req = _build_request("127.0.0.1:8888", origin = "http://127.0.0.1:5173")

--- a/studio/backend/tests/test_index_bootstrap_origin_extra.py
+++ b/studio/backend/tests/test_index_bootstrap_origin_extra.py
@@ -2,12 +2,9 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """Extra edge-case coverage for the bootstrap-pw cross-origin gate.
-
-Companion to ``test_index_bootstrap_origin.py``. Pinned down by the audit
-on PR 5739: IPv6 netlocs, ``data:`` opaque origins, comma-joined multi
-``Origin`` headers, whitespace around the header value, and the
-``localhost`` vs ``127.0.0.1`` distinction (which the web platform
-treats as distinct origins).
+Companion to ``test_index_bootstrap_origin.py``: IPv6 netlocs, opaque
+origins (``data:``, ``blob:``), comma-joined multi-Origin headers, and
+the ``localhost`` vs ``127.0.0.1`` distinct-origin rule.
 """
 
 from unittest.mock import MagicMock
@@ -25,11 +22,9 @@ def _build_request(host: str, origin, scheme: str = "http") -> MagicMock:
 
 
 def test_is_same_origin_request_ipv6_loopback_same_origin():
-    """Studio supports ``-H ::1`` binds; Starlette's ``request.url.netloc``
-    for an IPv6 server is ``[::1]:8902`` and browsers send
-    ``Origin: http://[::1]:8902``. Bare ``partition(":")`` mis-parses the
-    bracketed form (host=``[``, port-str=``:1]:8902``) and refuses to
-    inject the bootstrap on a legitimate same-origin nav.
+    """Studio supports ``-H ::1`` binds; netloc is ``[::1]:8902``. Bare
+    ``partition(":")`` mis-parses the bracketed form and would refuse the
+    bootstrap on legitimate same-origin nav.
     """
     from main import _is_same_origin_request
 
@@ -93,8 +88,8 @@ def test_is_same_origin_request_ipv6_userinfo_stripped():
 
 
 def test_is_same_origin_request_data_url_origin_is_cross_origin():
-    """``data:`` URLs are opaque origins per HTML living standard.
-    They carry no host and must never be treated as same-origin.
+    """``data:`` URLs are opaque origins (HTML living standard); no host,
+    never same-origin.
     """
     from main import _is_same_origin_request
 
@@ -105,8 +100,8 @@ def test_is_same_origin_request_data_url_origin_is_cross_origin():
 
 
 def test_is_same_origin_request_blob_url_origin_is_cross_origin():
-    """``blob:`` URLs carry the inner origin in the path, but only as
-    a non-canonical form. The canonical comparison rejects them.
+    """``blob:`` URLs carry the inner origin only in non-canonical form; the
+    canonical comparison rejects them.
     """
     from main import _is_same_origin_request
 
@@ -115,9 +110,8 @@ def test_is_same_origin_request_blob_url_origin_is_cross_origin():
 
 
 def test_is_same_origin_request_file_url_origin_is_cross_origin():
-    """``file://`` pages typically send ``Origin: null`` but a few
-    historical engines sent ``Origin: file://``. Either way, not
-    same-origin against an http listener.
+    """``file://`` pages usually send ``Origin: null``; historical engines
+    sent ``Origin: file://``. Neither is same-origin vs an http listener.
     """
     from main import _is_same_origin_request
 
@@ -129,10 +123,8 @@ def test_is_same_origin_request_file_url_origin_is_cross_origin():
 
 
 def test_is_same_origin_request_comma_joined_origins_cross_origin():
-    """HTTP allows repeated headers; Starlette concatenates with
-    ``, ``. The canonical parser can't split this safely, so it
-    must fall to cross-origin (refusing to inject) rather than
-    pick the first token.
+    """Starlette concatenates repeated headers with ``, ``; the canonical
+    parser can't safely split this, so it falls to cross-origin.
     """
     from main import _is_same_origin_request
 
@@ -147,9 +139,8 @@ def test_is_same_origin_request_comma_joined_origins_cross_origin():
 
 
 def test_is_same_origin_request_localhost_vs_127_is_cross_origin():
-    """The browser treats ``localhost`` and ``127.0.0.1`` as distinct
-    origins even though they resolve to the same socket. The
-    canonical comparison must mirror that (no DNS-style collapsing).
+    """Browsers treat ``localhost`` and ``127.0.0.1`` as distinct origins;
+    the canonical comparison must not DNS-collapse them.
     """
     from main import _is_same_origin_request
 
@@ -168,11 +159,9 @@ def test_is_same_origin_request_127_vs_localhost_is_cross_origin():
 
 
 def test_is_same_origin_request_malformed_ipv6_bracket_is_cross_origin():
-    """``urlparse`` raises ``ValueError('Invalid IPv6 URL')`` on
-    unclosed brackets and similar bracketed-host garbage (CVE-2024-11168
-    hardening). A malicious caller sending ``Origin: http://[malformed``
-    must not crash ``_build_index_response`` into HTTP 500; the gate
-    swallows the parse error and falls to cross-origin.
+    """``urlparse`` raises ``ValueError('Invalid IPv6 URL')`` on unclosed
+    brackets (CVE-2024-11168 hardening). The gate must swallow and fall to
+    cross-origin rather than 500 the SPA handler.
     """
     from main import _is_same_origin_request
 
@@ -198,9 +187,8 @@ def test_is_same_origin_request_bracket_with_trailing_garbage_is_cross_origin():
 
 
 def test_is_same_origin_request_empty_origin_header_is_cross_origin():
-    """An explicit empty ``Origin:`` value is not a valid serialised
-    origin (no scheme + host) and must not be conflated with a missing
-    header. Treat as cross-origin so the bootstrap is withheld.
+    """Explicit empty ``Origin:`` is not a valid serialised origin and must
+    not be conflated with a missing header; cross-origin, bootstrap withheld.
     """
     from main import _is_same_origin_request
 

--- a/studio/backend/tests/test_index_bootstrap_origin_extra.py
+++ b/studio/backend/tests/test_index_bootstrap_origin_extra.py
@@ -162,3 +162,49 @@ def test_is_same_origin_request_127_vs_localhost_is_cross_origin():
 
     req = _build_request("localhost:8902", origin = "http://127.0.0.1:8902")
     assert _is_same_origin_request(req) is False
+
+
+# ── urlparse ValueError robustness ─────────────────────────────────
+
+
+def test_is_same_origin_request_malformed_ipv6_bracket_is_cross_origin():
+    """``urlparse`` raises ``ValueError('Invalid IPv6 URL')`` on
+    unclosed brackets and similar bracketed-host garbage (CVE-2024-11168
+    hardening). A malicious caller sending ``Origin: http://[malformed``
+    must not crash ``_build_index_response`` into HTTP 500; the gate
+    swallows the parse error and falls to cross-origin.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8902", origin = "http://[malformed")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_invalid_ipv6_address_is_cross_origin():
+    """Bracketed but invalid IPv6 (e.g. ``[::g]``) also raises
+    ``ValueError`` inside ``urlparse``."""
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8902", origin = "http://[::g]:8902")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_bracket_with_trailing_garbage_is_cross_origin():
+    """Text after the closing bracket also raises inside ``urlparse``."""
+    from main import _is_same_origin_request
+
+    req = _build_request(
+        "127.0.0.1:8902", origin = "http://[2001:db8::1]extra:8902"
+    )
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_empty_origin_header_is_cross_origin():
+    """An explicit empty ``Origin:`` value is not a valid serialised
+    origin (no scheme + host) and must not be conflated with a missing
+    header. Treat as cross-origin so the bootstrap is withheld.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8902", origin = "")
+    assert _is_same_origin_request(req) is False

--- a/studio/backend/tests/test_index_bootstrap_origin_extra.py
+++ b/studio/backend/tests/test_index_bootstrap_origin_extra.py
@@ -193,9 +193,7 @@ def test_is_same_origin_request_bracket_with_trailing_garbage_is_cross_origin():
     """Text after the closing bracket also raises inside ``urlparse``."""
     from main import _is_same_origin_request
 
-    req = _build_request(
-        "127.0.0.1:8902", origin = "http://[2001:db8::1]extra:8902"
-    )
+    req = _build_request("127.0.0.1:8902", origin = "http://[2001:db8::1]extra:8902")
     assert _is_same_origin_request(req) is False
 
 

--- a/studio/backend/tests/test_index_bootstrap_origin_extra.py
+++ b/studio/backend/tests/test_index_bootstrap_origin_extra.py
@@ -85,9 +85,7 @@ def test_is_same_origin_request_ipv6_port_mismatch_cross_origin():
 def test_is_same_origin_request_ipv6_userinfo_stripped():
     from main import _is_same_origin_request
 
-    req = _build_request(
-        "user:pass@[::1]:8902", origin = "http://[::1]:8902"
-    )
+    req = _build_request("user:pass@[::1]:8902", origin = "http://[::1]:8902")
     assert _is_same_origin_request(req) is True
 
 
@@ -112,9 +110,7 @@ def test_is_same_origin_request_blob_url_origin_is_cross_origin():
     """
     from main import _is_same_origin_request
 
-    req = _build_request(
-        "127.0.0.1:8902", origin = "blob:http://127.0.0.1:8902/uuid"
-    )
+    req = _build_request("127.0.0.1:8902", origin = "blob:http://127.0.0.1:8902/uuid")
     assert _is_same_origin_request(req) is False
 
 

--- a/studio/backend/tests/test_index_bootstrap_origin_extra.py
+++ b/studio/backend/tests/test_index_bootstrap_origin_extra.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Extra edge-case coverage for the bootstrap-pw cross-origin gate.
+
+Companion to ``test_index_bootstrap_origin.py``. Pinned down by the audit
+on PR 5739: IPv6 netlocs, ``data:`` opaque origins, comma-joined multi
+``Origin`` headers, whitespace around the header value, and the
+``localhost`` vs ``127.0.0.1`` distinction (which the web platform
+treats as distinct origins).
+"""
+
+from unittest.mock import MagicMock
+
+
+def _build_request(host: str, origin, scheme: str = "http") -> MagicMock:
+    request = MagicMock()
+    request.url.scheme = scheme
+    request.url.netloc = host
+    request.headers = {"origin": origin} if origin is not None else {}
+    return request
+
+
+# ── IPv6 ────────────────────────────────────────────────────────────
+
+
+def test_is_same_origin_request_ipv6_loopback_same_origin():
+    """Studio supports ``-H ::1`` binds; Starlette's ``request.url.netloc``
+    for an IPv6 server is ``[::1]:8902`` and browsers send
+    ``Origin: http://[::1]:8902``. Bare ``partition(":")`` mis-parses the
+    bracketed form (host=``[``, port-str=``:1]:8902``) and refuses to
+    inject the bootstrap on a legitimate same-origin nav.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("[::1]:8902", origin = "http://[::1]:8902")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_ipv6_full_address_same_origin():
+    from main import _is_same_origin_request
+
+    req = _build_request(
+        "[2001:db8::1]:8443",
+        origin = "https://[2001:db8::1]:8443",
+        scheme = "https",
+    )
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_ipv6_default_port_stripped():
+    """Browser drops :80 on ``http://[::1]``."""
+    from main import _is_same_origin_request
+
+    req = _build_request("[::1]:80", origin = "http://[::1]")
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_ipv6_case_insensitive():
+    """Hex digits in IPv6 are case-insensitive per RFC 5952."""
+    from main import _is_same_origin_request
+
+    req = _build_request(
+        "[2001:DB8::1]:8443",
+        origin = "https://[2001:db8::1]:8443",
+        scheme = "https",
+    )
+    assert _is_same_origin_request(req) is True
+
+
+def test_is_same_origin_request_ipv6_different_host_cross_origin():
+    from main import _is_same_origin_request
+
+    req = _build_request("[::1]:8902", origin = "http://[2001:db8::1]:8902")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_ipv6_port_mismatch_cross_origin():
+    from main import _is_same_origin_request
+
+    req = _build_request("[::1]:8902", origin = "http://[::1]:9999")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_ipv6_userinfo_stripped():
+    from main import _is_same_origin_request
+
+    req = _build_request(
+        "user:pass@[::1]:8902", origin = "http://[::1]:8902"
+    )
+    assert _is_same_origin_request(req) is True
+
+
+# ── Opaque origins (data:, blob:) ───────────────────────────────────
+
+
+def test_is_same_origin_request_data_url_origin_is_cross_origin():
+    """``data:`` URLs are opaque origins per HTML living standard.
+    They carry no host and must never be treated as same-origin.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request(
+        "127.0.0.1:8902", origin = "data:text/html,<script>alert(1)</script>"
+    )
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_blob_url_origin_is_cross_origin():
+    """``blob:`` URLs carry the inner origin in the path, but only as
+    a non-canonical form. The canonical comparison rejects them.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request(
+        "127.0.0.1:8902", origin = "blob:http://127.0.0.1:8902/uuid"
+    )
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_file_url_origin_is_cross_origin():
+    """``file://`` pages typically send ``Origin: null`` but a few
+    historical engines sent ``Origin: file://``. Either way, not
+    same-origin against an http listener.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8902", origin = "file://")
+    assert _is_same_origin_request(req) is False
+
+
+# ── Multi-Origin header (comma-joined by Starlette) ────────────────
+
+
+def test_is_same_origin_request_comma_joined_origins_cross_origin():
+    """HTTP allows repeated headers; Starlette concatenates with
+    ``, ``. The canonical parser can't split this safely, so it
+    must fall to cross-origin (refusing to inject) rather than
+    pick the first token.
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request(
+        "127.0.0.1:8902",
+        origin = "http://127.0.0.1:8902, http://evil.example",
+    )
+    assert _is_same_origin_request(req) is False
+
+
+# ── localhost vs 127.0.0.1 (distinct origins per web platform) ──────
+
+
+def test_is_same_origin_request_localhost_vs_127_is_cross_origin():
+    """The browser treats ``localhost`` and ``127.0.0.1`` as distinct
+    origins even though they resolve to the same socket. The
+    canonical comparison must mirror that (no DNS-style collapsing).
+    """
+    from main import _is_same_origin_request
+
+    req = _build_request("127.0.0.1:8902", origin = "http://localhost:8902")
+    assert _is_same_origin_request(req) is False
+
+
+def test_is_same_origin_request_127_vs_localhost_is_cross_origin():
+    from main import _is_same_origin_request
+
+    req = _build_request("localhost:8902", origin = "http://127.0.0.1:8902")
+    assert _is_same_origin_request(req) is False


### PR DESCRIPTION
## Summary
- Default web mode runs `CORSMiddleware` with `allow_origins=["*"]` + `allow_credentials=True`, which reflects an attacker-controlled `Origin` back on every request and sets `Access-Control-Allow-Credentials: true`. The `/` SPA fallback serves index.html with an inline `window.__UNSLOTH_BOOTSTRAP__` script carrying the seeded admin password while a password change is pending. The combination lets any cross-origin page `fetch('/')` with credentials and read the bootstrap admin password out of the HTML body.
- The API smoke `CORS: GET / leaks bootstrap pw to cross-origin caller` audit (`tests/studio/studio_api_smoke.py:224`) already tracks this regression but does not gate CI. This PR closes the leak.

## Fix
- New `_is_same_origin_request` helper in `studio/backend/main.py`: treats the absence of `Origin` as same-origin (top-level same-document navigation on most engines doesn't send `Origin`), and treats a present `Origin` that doesn't exactly match `request.url.scheme://request.url.netloc` as cross-origin.
- `_build_index_response` now takes the `Request` and only calls `_inject_bootstrap` when same-origin. Cross-origin callers get the same HTML minus the bootstrap script tag, so they can't recover the seeded admin password through the SPA fallback.
- Adds `Vary: Origin` so an intermediary cache cannot serve a same-origin response (with bootstrap) to a later cross-origin caller (and vice versa).
- The CORSMiddleware policy itself is untouched -- this PR only stops the secret from being written into the response body in the first place. Tightening the CORS allowlist is orthogonal and higher-risk.

## Test plan
- [x] `studio/backend/tests/test_index_bootstrap_origin.py` covers missing / matching / evil / scheme-mismatch / port-mismatch origins -> 5 passed
- [ ] Manual: with a fresh install in a pending-password-change state, `curl http://127.0.0.1:8888/` returns HTML containing `window.__UNSLOTH_BOOTSTRAP__`; `curl -H 'Origin: https://evil.example' http://127.0.0.1:8888/` returns HTML WITHOUT it
- [ ] Manual: same-origin browser nav to `/` still picks up bootstrap and auto-fills the change-password form

## Notes
- `tests/studio/studio_api_smoke.py:224` will flip from `AUDIT` to `OK` once this lands; the test infrastructure already exercises the cross-origin GET path.