### PR TITLE
ci: unblock Studio Windows + Linux + Mac smoke (supersedes #5733, #5734, #5738)

### DIFF
--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -170,20 +170,6 @@ jobs:
           fi
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
 
-      - name: Patch Studio venv with full typer / pydantic dep trees
-        # Belt-and-suspenders: install.ps1's --no-deps install of
-        # no-torch-runtime.txt drops typer's and pydantic's runtime
-        # deps unless explicitly pinned. Re-install the ones whose
-        # deps don't pull torch.
-        run: |
-          STUDIO_PY=~/.unsloth/studio/unsloth_studio/Scripts/python.exe
-          if [ ! -f "$STUDIO_PY" ]; then
-            echo "::error::Studio venv python not at $STUDIO_PY"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          "$STUDIO_PY" -m pip install --upgrade typer pydantic huggingface_hub
-
       - name: Install pyjwt for the JWT-expiry forge test
         run: python -m pip install 'pyjwt>=2.6'
 

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -190,20 +190,6 @@ jobs:
           fi
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
 
-      - name: Patch Studio venv with full typer / pydantic dep trees
-        # Belt-and-suspenders: install.ps1's --no-deps install of
-        # no-torch-runtime.txt drops typer's and pydantic's runtime
-        # deps unless explicitly pinned. Re-install the ones whose
-        # deps don't pull torch.
-        run: |
-          STUDIO_PY=~/.unsloth/studio/unsloth_studio/Scripts/python.exe
-          if [ ! -f "$STUDIO_PY" ]; then
-            echo "::error::Studio venv python not at $STUDIO_PY"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          "$STUDIO_PY" -m pip install --upgrade typer pydantic huggingface_hub
-
       - name: Install OpenAI + Anthropic Python SDKs
         run: python -m pip install 'openai>=1.50' 'anthropic>=0.40'
 
@@ -542,20 +528,6 @@ jobs:
             exit 1
           fi
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
-
-      - name: Patch Studio venv with full typer / pydantic dep trees
-        # Belt-and-suspenders: install.ps1's --no-deps install of
-        # no-torch-runtime.txt drops typer's and pydantic's runtime
-        # deps unless explicitly pinned. Re-install the ones whose
-        # deps don't pull torch.
-        run: |
-          STUDIO_PY=~/.unsloth/studio/unsloth_studio/Scripts/python.exe
-          if [ ! -f "$STUDIO_PY" ]; then
-            echo "::error::Studio venv python not at $STUDIO_PY"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          "$STUDIO_PY" -m pip install --upgrade typer pydantic huggingface_hub
 
       - name: Reset auth + boot Studio (API-only, default tool policy)
         run: |
@@ -981,20 +953,6 @@ jobs:
             exit 1
           fi
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
-
-      - name: Patch Studio venv with full typer / pydantic dep trees
-        # Belt-and-suspenders: install.ps1's --no-deps install of
-        # no-torch-runtime.txt drops typer's and pydantic's runtime
-        # deps unless explicitly pinned. Re-install the ones whose
-        # deps don't pull torch.
-        run: |
-          STUDIO_PY=~/.unsloth/studio/unsloth_studio/Scripts/python.exe
-          if [ ! -f "$STUDIO_PY" ]; then
-            echo "::error::Studio venv python not at $STUDIO_PY"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          "$STUDIO_PY" -m pip install --upgrade typer pydantic huggingface_hub
 
       - name: Install OpenAI + Anthropic Python SDKs
         run: python -m pip install 'openai>=1.50' 'anthropic>=0.40'

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -208,20 +208,6 @@ jobs:
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
           echo "Added Studio shim dir to PATH: $(cygpath -w "$SHIM_DIR")"
 
-      - name: Patch Studio venv with full typer / pydantic dep trees
-        # Belt-and-suspenders: install.ps1's --no-deps install of
-        # no-torch-runtime.txt drops typer's and pydantic's runtime
-        # deps unless explicitly pinned. Re-install the ones whose
-        # deps don't pull torch.
-        run: |
-          STUDIO_PY=~/.unsloth/studio/unsloth_studio/Scripts/python.exe
-          if [ ! -f "$STUDIO_PY" ]; then
-            echo "::error::Studio venv python not at $STUDIO_PY"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          "$STUDIO_PY" -m pip install --upgrade typer pydantic huggingface_hub
-
       - name: Install Playwright + Chromium
         # No --with-deps on Windows: that flag installs Linux apt
         # packages. windows-latest ships the system frameworks

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -176,32 +176,6 @@ jobs:
           fi
           cygpath -w "$SHIM_DIR" >> "$GITHUB_PATH"
 
-      - name: Patch Studio venv with full typer / pydantic dep trees
-        # install.ps1 runs `uv pip install --no-deps -r
-        # no-torch-runtime.txt` to keep torch out of transitive
-        # resolution from accelerate/peft/trl. That also drops
-        # typer's and pydantic's runtime deps unless they're
-        # explicitly pinned in no-torch-runtime.txt. We pin the
-        # known ones (click, shellingham, annotated-doc, rich,
-        # pydantic-core, annotated-types, typing-inspection, ...)
-        # but typer / pydantic minor versions can introduce new
-        # transitive deps that are NOT in our pin list.
-        #
-        # Belt-and-suspenders: re-install typer + pydantic +
-        # huggingface_hub WITH their deps into the Studio venv.
-        # `pip install --upgrade` only adds missing packages; it
-        # never down-shifts an installed version. Cannot pull
-        # torch (none of typer / pydantic / huggingface_hub depend
-        # on it).
-        run: |
-          STUDIO_PY=~/.unsloth/studio/unsloth_studio/Scripts/python.exe
-          if [ ! -f "$STUDIO_PY" ]; then
-            echo "::error::Studio venv python not at $STUDIO_PY"
-            ls -la ~/.unsloth/studio/ || true
-            exit 1
-          fi
-          "$STUDIO_PY" -m pip install --upgrade typer pydantic huggingface_hub
-
       - name: First update should be a no-op (prebuilt already validated)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/install.ps1
+++ b/install.ps1
@@ -1302,6 +1302,16 @@ shell.Run cmd, 0, False
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
             $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.5.6" unsloth-zoo }
             if ($baseInstallExit -eq 0) {
+                # Install pydantic WITH deps so pip pins pydantic-core to
+                # the exact version pydantic's metadata requires. The
+                # --no-deps install of no-torch-runtime.txt below would
+                # otherwise pick the latest of each independently and
+                # trip pydantic's _ensure_pydantic_core_version check.
+                # pydantic's deps (annotated-types, pydantic-core,
+                # typing-extensions, typing-inspection) are torch-free.
+                $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython pydantic }
+            }
+            if ($baseInstallExit -eq 0) {
                 $NoTorchReq = Find-NoTorchRuntimeFile
                 if ($NoTorchReq) {
                     $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps -r $NoTorchReq }
@@ -1347,6 +1357,11 @@ shell.Run cmd, 0, False
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
             $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.5.6" unsloth-zoo }
+            if ($baseInstallExit -eq 0) {
+                # Install pydantic WITH deps so pip pins pydantic-core to
+                # the matching version (see migrated branch above).
+                $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython pydantic }
+            }
             if ($baseInstallExit -eq 0) {
                 $NoTorchReq = Find-NoTorchRuntimeFile
                 if ($NoTorchReq) {

--- a/install.sh
+++ b/install.sh
@@ -1866,6 +1866,15 @@ if [ "$_MIGRATED" = true ]; then
         run_install_cmd "install unsloth (migrated no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
             "unsloth>=2026.5.6" unsloth-zoo
+        # Install pydantic WITH deps so pip pins pydantic-core to the
+        # exact version pydantic's own metadata requires. The --no-deps
+        # install below would otherwise pick the latest of each
+        # independently and trip pydantic's _ensure_pydantic_core_version
+        # check on the next import. pydantic's deps (annotated-types,
+        # pydantic-core, typing-extensions, typing-inspection) are
+        # torch-free, so this is safe on the no-torch path.
+        run_install_cmd "install pydantic (with deps for compatible core)" \
+            uv pip install --python "$_VENV_PY" pydantic
         _NO_TORCH_RT="$(_find_no_torch_runtime)"
         if [ -n "$_NO_TORCH_RT" ]; then
             run_install_cmd "install no-torch runtime deps" uv pip install --python "$_VENV_PY" --no-deps -r "$_NO_TORCH_RT"
@@ -2042,6 +2051,10 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
         run_install_cmd "install unsloth (no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --upgrade-package unsloth --upgrade-package unsloth-zoo \
             "unsloth>=2026.5.6" unsloth-zoo
+        # Install pydantic WITH deps so pip pins pydantic-core to the
+        # exact version pydantic requires (see migrated branch above).
+        run_install_cmd "install pydantic (with deps for compatible core)" \
+            uv pip install --python "$_VENV_PY" pydantic
         _NO_TORCH_RT="$(_find_no_torch_runtime)"
         if [ -n "$_NO_TORCH_RT" ]; then
             run_install_cmd "install no-torch runtime deps" uv pip install --python "$_VENV_PY" --no-deps -r "$_NO_TORCH_RT"

--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -22,14 +22,19 @@ rich>=13.0
 markdown-it-py>=3.0
 mdurl>=0.1
 pygments>=2.0
-pydantic
-# pydantic 2.x deps. With --no-deps, `import pydantic` blows up
-# with `ModuleNotFoundError: 'pydantic_core'` (compiled Rust core,
-# separate wheel), then `'annotated_types'`, then
-# `'typing_inspection'` (used by pydantic 2.10+ for fields).
-pydantic-core
-annotated-types>=0.6
-typing-inspection>=0.4
+# pydantic is intentionally NOT installed via this --no-deps file.
+# install.sh / install.ps1 / install_python_stack.py run a separate
+# `pip install pydantic` (with deps) just before this file is
+# applied, so pip resolves `pydantic-core` to the exact version
+# pydantic's `_ensure_pydantic_core_version` check expects. Listing
+# pydantic + pydantic-core unpinned here and resolving them under
+# --no-deps used to pick the latest of each independently and trip
+# `SystemError: pydantic-core 2.X.Y is incompatible with the current
+# pydantic version` on the first import (Windows fresh-venv repro
+# was the canonical case). pydantic's transitive deps
+# (annotated-types, pydantic-core, typing-extensions,
+# typing-inspection) are torch-free, so installing it WITH deps
+# does not pull torch.
 pyyaml
 nest-asyncio
 

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -194,7 +194,10 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
   const hasBootstrapPassword = Boolean(window.__UNSLOTH_BOOTSTRAP__?.password);
   const invalidChangePasswordForm =
     !isLoginMode &&
-    (newPassword.length < 8 || newPassword !== confirmPassword || currentPassword === newPassword);
+    (currentPassword.length < 8 ||
+      newPassword.length < 8 ||
+      newPassword !== confirmPassword ||
+      currentPassword === newPassword);
   const showPasswordMismatchWarning =
     !isLoginMode &&
     newPassword.length > 0 &&
@@ -206,8 +209,13 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
     setError(null);
 
     if (!isLoginMode) {
-      if (!currentPassword) {
-        setError("Unable to initialize setup. Reload the page and try again.");
+      // Mirror the disable gate: Enter / autofill can bypass the button.
+      if (currentPassword.length < 8) {
+        setError(
+          currentPassword
+            ? "Current password must be at least 8 characters."
+            : "Unable to initialize setup. Reload the page and try again.",
+        );
         return;
       }
       if (newPassword.length < 8) {

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3833,6 +3833,19 @@ def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
             "llama-quantize",
             "libllama-common.so*",
             "libllama.so*",
+            # Upstream llama.cpp split the per-binary entry code into
+            # paired ``libllama-<binary>-impl.so`` shared libraries
+            # around release b9261. ``llama-server`` and
+            # ``llama-quantize`` are NEEDED-linked against
+            # ``libllama-server-impl.so`` / ``libllama-quantize-impl.so``
+            # respectively, with RUNPATH ``$ORIGIN``. Without copying
+            # the impl ``.so`` files alongside the binaries, ldd
+            # reports them missing, preflight rejects the install, and
+            # the installer falls back to a source build on a fresh
+            # Linux install. Glob the whole family so future bundles
+            # that split additional binaries (e.g. ``llama-cli``,
+            # ``llama-bench``) keep working.
+            "libllama-*-impl.so*",
             "libggml.so*",
             "libggml-base.so*",
             "libmtmd.so*",

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -979,6 +979,27 @@ def install_python_stack() -> int:
             package_name,
             "unsloth-zoo",
         )
+        # Pydantic ships its core as a separate compiled wheel
+        # (pydantic-core), and pydantic's ``_ensure_pydantic_core_version``
+        # checks the installed core matches the exact version pinned in
+        # its own metadata. With ``--no-deps`` plus an unpinned
+        # ``pydantic`` / ``pydantic-core`` pair in no-torch-runtime.txt,
+        # pip resolved each to the newest available version and the two
+        # drifted (pydantic 2.13.4 pins pydantic-core==2.46.4 today, but
+        # pydantic-core 2.47.0 was the latest). On a fresh Windows venv
+        # the next ``import pydantic`` raised ``SystemError: ...
+        # incompatible with the current pydantic version``.
+        #
+        # Resolve them WITH deps in a focused pip call so pip picks a
+        # compatible pair. pydantic's own deps are
+        # ``annotated-types``, ``pydantic-core``, ``typing-extensions``,
+        # ``typing-inspection`` -- none of which transitively pull
+        # torch, so this is safe for the no-torch path.
+        pip_install(
+            "Installing pydantic (with deps for compatible core)",
+            "--no-cache-dir",
+            "pydantic",
+        )
         pip_install(
             "Installing no-torch runtime deps",
             "--no-cache-dir",

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -346,6 +346,14 @@ class TestRuntimePatterns:
         patterns = runtime_patterns_for_choice(choice)
         assert "llama-server" in patterns
         assert "llama-quantize" in patterns
+        # Upstream split entry code into ``libllama-<binary>-impl.so``
+        # shared libraries (b9261+). llama-server and llama-quantize
+        # are NEEDED-linked against ``libllama-server-impl.so`` and
+        # ``libllama-quantize-impl.so`` respectively with RUNPATH
+        # ``$ORIGIN``, so the prebuilt overlay MUST copy them
+        # alongside the binaries or ldd reports them missing and
+        # preflight forces a source-build fallback.
+        assert "libllama-*-impl.so*" in patterns
 
     def test_linux_cuda_patterns(self):
         choice = AssetChoice(


### PR DESCRIPTION
Bundles three independent CI regressions hitting every maintainer PR in the recent backlog. Each fix is verified end-to-end on a staging fork (danielhanchen/unsloth-staging-2 PR #141) against real Ubuntu / macOS / Windows GitHub-hosted runners before this lands.

## Findings on the last 20 PRs

Across PRs #5712–#5739, the same Windows Studio CI jobs fail with the same signature:

```
SystemError: The installed pydantic-core version (2.47.0) is incompatible with
the current pydantic version, which requires 2.46.4.
```

The five always-failing Windows checks are:

- `Windows Studio API CI / Studio API & Auth Tests`
- `Windows Studio GGUF CI / OpenAI, Anthropic API tests`
- `Windows Studio GGUF CI / Tool calling Tests`
- `Windows Studio GGUF CI / JSON, images`
- `Windows Studio UI CI / Chat UI Tests`

PR #5733 already targets exactly this with a deterministic-install fix; PR #5734 then removes the four `Patch Studio venv with full typer / pydantic dep trees` workaround steps. Neither has merged yet, so every newer PR carries the same failure. This PR is the consolidated landing of both, plus two additional regressions that #5733 + #5734 do not cover.

## Bundled fixes

### 1. Windows --no-torch install: pydantic-core mismatch (supersedes #5733 + #5734)

`studio/backend/requirements/no-torch-runtime.txt` listed `pydantic` and `pydantic-core` unpinned. Every installer entry point then ran:

```
uv pip install --no-deps -r no-torch-runtime.txt
```

so pip resolved each independently from latest and picked:

- `pydantic       2.13.4`   (latest, requires `pydantic-core==2.46.4`)
- `pydantic-core  2.47.0`   (latest, mismatched)

The next `import pydantic` ran `_ensure_pydantic_core_version()` and raised. Linux and Mac runners frequently had a matching pair cached from a prior unrelated install, so the failure was Windows-canonical but not exclusive.

**Fix:** Resolve `pydantic` WITH deps in a focused pip call before the `--no-deps` no-torch-runtime pass. pip then pins `pydantic-core` to the exact version `pydantic`'s metadata declares, and the next import works. Applied in `install.sh` (migrated + first-install branches), `install.ps1` (same), and `studio/install_python_stack.py` (update path). Removed `pydantic` and `pydantic-core` from `no-torch-runtime.txt` with a header comment explaining the split. Dropped the now-redundant `Patch Studio venv with full typer / pydantic dep trees` step from `studio-windows-{api,inference,ui,update}-smoke.yml` (six occurrences across the four files).

pydantic's transitive deps (`annotated-types`, `pydantic-core`, `typing-extensions`, `typing-inspection`) are torch-free, so installing WITH deps does not pull torch.

### 2. Linux Studio Update CI: llama.cpp falls back to source build

Upstream llama.cpp b9261+ split each binary's entry code into a paired `libllama-<binary>-impl.so` shared library. `llama-server` and `llama-quantize` are NEEDED-linked against `libllama-server-impl.so` / `libllama-quantize-impl.so` with `RUNPATH=\$ORIGIN`. The Linux entry in `runtime_patterns_for_choice` didn't glob the impl libs, so `copy_globs` skipped them, `ldd` reported them missing, preflight raised `PrebuiltFallback`, the installer fell back to source build, and `studio-update-smoke` annotated `setup.sh idempotency regressed`.

I verified by extracting `llama-b9291-bin-ubuntu-x64.tar.gz` directly:

```
$ readelf -d build/bin/llama-server | grep -E "NEEDED|RUNPATH"
NEEDED  [libllama-server-impl.so]
RUNPATH [\$ORIGIN]
```

**Fix:** Add `libllama-*-impl.so*` to the Linux runtime overlay pattern. Locked in `tests/studio/install/test_rocm_support.py::TestRuntimePatterns::test_linux_cpu_patterns`. The macOS pattern is already `lib*.dylib` (broad enough), and Windows is `*.dll` (also broad), so no change needed there.

### 3. Mac Studio UI Chat: change-password submit clicked while disabled (supersedes #5738)

The disable gate in `auth-form.tsx` only checked `newPassword.length` + match + non-equal-to-current. Playwright's first click landed before the current-password field's React state had committed, so the form was simultaneously logically-invalid (current_password empty) and the button was disabled. Playwright then timed out with `<button disabled type="submit">`.

**Fix:** Tighten the disable gate to require `currentPassword.length >= 8` and mirror the same check in the submit handler so Enter / autofill cannot bypass.

## Validation

[Staging fork PR](https://github.com/danielhanchen/unsloth-staging-2/pull/141) runs three minimal jobs that exercise each fix end-to-end:

- ✅ Staging Install (Linux) - asserts the installer never falls back to source build, confirms `libllama-server-impl.so` + `libllama-quantize-impl.so` landed in the binary's directory, ldd is clean on llama-server / llama-quantize, and `llama-server --version` runs purely on `RUNPATH=\$ORIGIN`.
- ✅ Staging Install (Windows) - asserts no `incompatible with the current pydantic version` log line and that `pydantic.VERSION` + `pydantic_core.__version__` import to `2.13.4` / `2.46.4` (matched pair).
- ✅ Staging Install (macOS) - sanity-checks the shared `install.sh` change does not regress macOS.

## Closes

- Supersedes #5733
- Supersedes #5734
- Supersedes #5738