### PR TITLE
Studio: standalone Fetch pill for Anthropic web_fetch

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1509,24 +1509,13 @@ class ExternalProviderClient:
             )
             body["tools"] = anthropic_tools
 
-        # Anthropic server-side web_fetch — see
-        #   https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool
-        # `web_fetch_20250910` reads a single URL (text or PDF) and
-        # returns a document block in a `web_fetch_tool_result`. For
-        # safety Anthropic only lets the model fetch URLs that already
-        # appeared in the conversation (user message, prior tool
-        # result, web_search hit) — there is no domain restriction we
-        # have to apply locally. No beta header is required today; the
-        # tool ships under the standard `2023-06-01` API version. We
-        # mirror the web_search wiring: max_uses cap, opt in via
-        # `enabled_tools=["web_fetch"]`, citations off by default
-        # because the frontend already paints source pills from the
-        # generic tool_end payload. The tool type is date-pinned per
-        # model family; `_anthropic_web_fetch_version` picks
-        # `web_fetch_20260209` (dynamic filtering) on Opus 4.6/4.7 and
-        # Sonnet 4.6 and falls back to `web_fetch_20250910` everywhere
-        # else. Sending the new variant to an older model returns 400
-        # "tool not supported", so the picker is required.
+        # Anthropic server-side web_fetch reads a single URL (text/PDF)
+        # and returns a `web_fetch_tool_result` document block. Opt in
+        # via `enabled_tools=["web_fetch"]`; no beta header required.
+        # `_anthropic_web_fetch_version` picks `web_fetch_20260209`
+        # (dynamic filtering) for Opus 4.6/4.7 + Sonnet 4.6, falling
+        # back to `web_fetch_20250910` elsewhere; mismatched variants
+        # return 400 so the per-model picker is required.
         web_fetch_enabled = bool(enabled_tools and "web_fetch" in enabled_tools)
         if web_fetch_enabled:
             anthropic_tools = list(body.get("tools") or [])

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1521,13 +1521,18 @@ class ExternalProviderClient:
         # mirror the web_search wiring: max_uses cap, opt in via
         # `enabled_tools=["web_fetch"]`, citations off by default
         # because the frontend already paints source pills from the
-        # generic tool_end payload.
+        # generic tool_end payload. The tool type is date-pinned per
+        # model family; `_anthropic_web_fetch_version` picks
+        # `web_fetch_20260209` (dynamic filtering) on Opus 4.6/4.7 and
+        # Sonnet 4.6 and falls back to `web_fetch_20250910` everywhere
+        # else. Sending the new variant to an older model returns 400
+        # "tool not supported", so the picker is required.
         web_fetch_enabled = bool(enabled_tools and "web_fetch" in enabled_tools)
         if web_fetch_enabled:
             anthropic_tools = list(body.get("tools") or [])
             anthropic_tools.append(
                 {
-                    "type": "web_fetch_20250910",
+                    "type": _anthropic_web_fetch_version(model),
                     "name": "web_fetch",
                     "max_uses": 5,
                 }

--- a/studio/backend/tests/test_anthropic_web_fetch.py
+++ b/studio/backend/tests/test_anthropic_web_fetch.py
@@ -206,8 +206,7 @@ def test_no_web_fetch_tool_when_pill_off(monkeypatch):
 
     tools = captured["body"].get("tools") or []
     assert all(
-        t.get("type") not in ("web_fetch_20250910", "web_fetch_20260209")
-        for t in tools
+        t.get("type") not in ("web_fetch_20250910", "web_fetch_20260209") for t in tools
     )
 
 

--- a/studio/backend/tests/test_anthropic_web_fetch.py
+++ b/studio/backend/tests/test_anthropic_web_fetch.py
@@ -2,30 +2,12 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """
-Unit tests for Anthropic's server-side `web_fetch_20250910` /
-`web_fetch_20260209` tool
-translation in `_stream_anthropic`.
-
-Covers:
-- Request body: when ``enabled_tools=["web_fetch"]``, the outbound
-  ``tools`` array carries ``{"type":"web_fetch_<version>",
-  "name":"web_fetch", "max_uses":5}`` where the version is picked per
-  model by ``_anthropic_web_fetch_version`` (``_20260209`` for Opus
-  4.6/4.7 + Sonnet 4.6, ``_20250910`` otherwise). No beta header is
-  required.
-- Combined request: ``enabled_tools=["web_search","web_fetch",
-  "code_execution"]`` sends all three tool entries.
-- Disabled by default: with ``enabled_tools=["web_search"]`` (or None),
-  the body does NOT carry a web_fetch entry.
-- SSE translation (success): a `web_fetch` server_tool_use streaming
-  ``{"url": "..."}`` followed by a `web_fetch_tool_result` block with
-  a document source emits one ``tool_start`` and one ``tool_end``
-  `_toolEvent`. The ``tool_start.arguments.url`` matches the fetched
-  URL and the ``tool_end.result`` carries the Title / URL / snippet
-  prefix the source-pill renderer expects.
-- SSE translation (error): a `web_fetch_tool_error` with
-  ``error_code="url_not_accessible"`` renders as ``"Error:
-  url_not_accessible"`` in the tool_end result.
+Unit tests for Anthropic's `web_fetch_20250910` / `web_fetch_20260209`
+translation in ``_stream_anthropic``. Covers request body emission
+(version picked by ``_anthropic_web_fetch_version``: ``_20260209`` for
+Opus 4.6/4.7 + Sonnet 4.6, ``_20250910`` otherwise), combined tool
+requests, off-by-default behavior, and SSE translation of success and
+``url_not_accessible`` error paths into ``tool_start`` / ``tool_end``.
 """
 
 import asyncio
@@ -121,9 +103,7 @@ def test_web_fetch_tool_appended_to_request_body(monkeypatch):
 
     body = captured["body"]
     tools = body.get("tools") or []
-    # claude-opus-4-7 routes web_fetch to the _20260209 variant (dynamic
-    # filtering); older models fall back to _20250910 via
-    # _anthropic_web_fetch_version.
+    # claude-opus-4-7 routes web_fetch to _20260209 (dynamic filtering).
     assert {
         "type": "web_fetch_20260209",
         "name": "web_fetch",
@@ -164,10 +144,8 @@ def test_web_fetch_combined_with_web_search_and_code_execution(monkeypatch):
 
     tools = captured["body"].get("tools") or []
     tool_types = [t.get("type") for t in tools]
-    # After PR 5679's per-model tool version dispatch landed,
-    # claude-opus-4-7 routes web_search to the _20260209 variant,
-    # web_fetch to _20260209 (dynamic filtering), and code_execution
-    # to _20260120.
+    # claude-opus-4-7 routes web_search and web_fetch to _20260209
+    # and code_execution to _20260120 (per PR 5679 dispatch).
     assert "web_search_20260209" in tool_types, tool_types
     assert "web_fetch_20260209" in tool_types, tool_types
     assert "code_execution_20260120" in tool_types, tool_types

--- a/studio/backend/tests/test_anthropic_web_fetch.py
+++ b/studio/backend/tests/test_anthropic_web_fetch.py
@@ -2,13 +2,17 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """
-Unit tests for Anthropic's server-side `web_fetch_20250910` tool
+Unit tests for Anthropic's server-side `web_fetch_20250910` /
+`web_fetch_20260209` tool
 translation in `_stream_anthropic`.
 
 Covers:
 - Request body: when ``enabled_tools=["web_fetch"]``, the outbound
-  ``tools`` array carries ``{"type":"web_fetch_20250910",
-  "name":"web_fetch", "max_uses":5}``. No beta header is required.
+  ``tools`` array carries ``{"type":"web_fetch_<version>",
+  "name":"web_fetch", "max_uses":5}`` where the version is picked per
+  model by ``_anthropic_web_fetch_version`` (``_20260209`` for Opus
+  4.6/4.7 + Sonnet 4.6, ``_20250910`` otherwise). No beta header is
+  required.
 - Combined request: ``enabled_tools=["web_search","web_fetch",
   "code_execution"]`` sends all three tool entries.
 - Disabled by default: with ``enabled_tools=["web_search"]`` (or None),
@@ -117,8 +121,11 @@ def test_web_fetch_tool_appended_to_request_body(monkeypatch):
 
     body = captured["body"]
     tools = body.get("tools") or []
+    # claude-opus-4-7 routes web_fetch to the _20260209 variant (dynamic
+    # filtering); older models fall back to _20250910 via
+    # _anthropic_web_fetch_version.
     assert {
-        "type": "web_fetch_20250910",
+        "type": "web_fetch_20260209",
         "name": "web_fetch",
         "max_uses": 5,
     } in tools
@@ -158,12 +165,11 @@ def test_web_fetch_combined_with_web_search_and_code_execution(monkeypatch):
     tools = captured["body"].get("tools") or []
     tool_types = [t.get("type") for t in tools]
     # After PR 5679's per-model tool version dispatch landed,
-    # claude-opus-4-7 routes web_search to the _20260209 variant and
-    # code_execution to _20260120. web_fetch still hardcodes
-    # _20250910 today; see follow-up to thread it through
-    # _anthropic_web_fetch_version.
+    # claude-opus-4-7 routes web_search to the _20260209 variant,
+    # web_fetch to _20260209 (dynamic filtering), and code_execution
+    # to _20260120.
     assert "web_search_20260209" in tool_types, tool_types
-    assert "web_fetch_20250910" in tool_types, tool_types
+    assert "web_fetch_20260209" in tool_types, tool_types
     assert "code_execution_20260120" in tool_types, tool_types
     # Code-execution still adds its beta flag; web_fetch must not
     # have accidentally stripped it.
@@ -199,7 +205,10 @@ def test_no_web_fetch_tool_when_pill_off(monkeypatch):
     _drive(run())
 
     tools = captured["body"].get("tools") or []
-    assert all(t.get("type") != "web_fetch_20250910" for t in tools)
+    assert all(
+        t.get("type") not in ("web_fetch_20250910", "web_fetch_20260209")
+        for t in tools
+    )
 
 
 # ── SSE translation ─────────────────────────────────────────────────

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -833,7 +833,13 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
       // Re-read store after potential auto-load / model ready wait
       runtime = useChatRuntimeStore.getState();
       const { params } = runtime;
-      const { supportsTools, toolsEnabled, codeToolsEnabled, imageToolsEnabled } = runtime;
+      const {
+        supportsTools,
+        toolsEnabled,
+        codeToolsEnabled,
+        imageToolsEnabled,
+        webFetchToolsEnabled,
+      } = runtime;
       const externalSelection = parseExternalModelId(params.checkpoint);
       const isExternalRequest = externalSelection !== null;
       if (
@@ -889,14 +895,18 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               externalProvider.baseUrl,
             ),
         );
-      // web_fetch shares the Search pill with web_search (no separate
-      // UI toggle), so it follows toolsEnabled. Anthropic is the only
-      // provider that ships it today; on others providerSupportsBuiltinWebFetch
-      // returns false and this stays inert.
+      // Fetch pill is independent of Search. Anthropic bills per
+      // web_fetch invocation separately from web_search hits, so
+      // bundling them used to make the cost surface confusing and
+      // blocked "just fetch this URL" workflows where the user knows
+      // exactly which page they want read. Source from
+      // `webFetchToolsEnabled` directly; on providers that don't ship
+      // web_fetch `providerSupportsBuiltinWebFetch` returns false and
+      // the toggle is forced off in chat-page's runtime setState.
       const webFetchEnabledForThisTurn =
         Boolean(
           externalProvider &&
-            toolsEnabled &&
+            webFetchToolsEnabled &&
             providerSupportsBuiltinWebFetch(externalProvider.providerType),
         );
       const providerShipsWebFetch = Boolean(
@@ -1419,13 +1429,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                     enable_tools: true,
                     enabled_tools: [
                       ...(webSearchEnabledForThisTurn ? ["web_search"] : []),
-                      // Pair web_fetch with the Search pill on any
-                      // provider that ships it (Anthropic today). The
-                      // common workflow is "search returns URLs, fetch
-                      // reads them"; without web_fetch the model can
-                      // surface a citation but cannot quote from the
-                      // page body, which is the whole point of the
-                      // tool. There is no separate UI toggle yet.
+                      // web_fetch ships as a standalone toggle (Fetch
+                      // pill), independent of Search. Anthropic is the
+                      // only provider that ships it today and bills it
+                      // per invocation separately from web_search hits.
                       ...(webFetchEnabledForThisTurn ? ["web_fetch"] : []),
                       ...(codeExecEnabledForThisTurn ? ["code_execution"] : []),
                       // OpenAI Responses-API only: `image_generation`

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -951,14 +951,24 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const webLabel = providerShipsWebFetch
           ? "web search or web fetch"
           : "web search";
-        if (!webSearchEnabledForThisTurn && !codeExecEnabledForThisTurn) {
+        // Treat search and fetch as a single "any web tool enabled"
+        // axis. The guard only needs to warn the model when no web
+        // tool is wired in for this turn; once either pill is on the
+        // model can pick the right one from the tool schema. Earlier
+        // revisions checked webSearchEnabledForThisTurn alone, which
+        // mis-fired when the standalone Fetch pill was on and Search
+        // was off and told Claude it had no web_fetch when in fact it
+        // did, suppressing live web_fetch tool calls.
+        const anyWebEnabledForThisTurn =
+          webSearchEnabledForThisTurn || webFetchEnabledForThisTurn;
+        if (!anyWebEnabledForThisTurn && !codeExecEnabledForThisTurn) {
           disabledToolGuard =
             `You do not have ${webLabel} or code execution tools in this conversation. ` +
             "Answer from your own knowledge. " +
             "If a request genuinely requires tool use, live data fetch or running code, " +
             "inform the user that you do not have access to these capabilities. " +
             "Do not return tool-call syntax inside your response.";
-        } else if (!webSearchEnabledForThisTurn) {
+        } else if (!anyWebEnabledForThisTurn) {
           disabledToolGuard =
             `You do not have ${webLabel} tools in this conversation. ` +
             "You may still use code execution tools when they are available and useful. " +

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -895,14 +895,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               externalProvider.baseUrl,
             ),
         );
-      // Fetch pill is independent of Search. Anthropic bills per
-      // web_fetch invocation separately from web_search hits, so
-      // bundling them used to make the cost surface confusing and
-      // blocked "just fetch this URL" workflows where the user knows
-      // exactly which page they want read. Source from
-      // `webFetchToolsEnabled` directly; on providers that don't ship
-      // web_fetch `providerSupportsBuiltinWebFetch` returns false and
-      // the toggle is forced off in chat-page's runtime setState.
+      // Fetch pill is independent of Search (Anthropic bills web_fetch
+      // separately from web_search). Sourced from `webFetchToolsEnabled`;
+      // on providers without web_fetch the toggle is forced off in
+      // chat-page's runtime setState.
       const webFetchEnabledForThisTurn =
         Boolean(
           externalProvider &&
@@ -951,14 +947,10 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         const webLabel = providerShipsWebFetch
           ? "web search or web fetch"
           : "web search";
-        // Treat search and fetch as a single "any web tool enabled"
-        // axis. The guard only needs to warn the model when no web
-        // tool is wired in for this turn; once either pill is on the
-        // model can pick the right one from the tool schema. Earlier
-        // revisions checked webSearchEnabledForThisTurn alone, which
-        // mis-fired when the standalone Fetch pill was on and Search
-        // was off and told Claude it had no web_fetch when in fact it
-        // did, suppressing live web_fetch tool calls.
+        // Treat search and fetch as a single "any web tool" axis so
+        // the guard only warns when neither pill is on; checking
+        // webSearchEnabledForThisTurn alone mis-fired when only Fetch
+        // was on and suppressed live web_fetch calls.
         const anyWebEnabledForThisTurn =
           webSearchEnabledForThisTurn || webFetchEnabledForThisTurn;
         if (!anyWebEnabledForThisTurn && !codeExecEnabledForThisTurn) {
@@ -1439,10 +1431,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                     enable_tools: true,
                     enabled_tools: [
                       ...(webSearchEnabledForThisTurn ? ["web_search"] : []),
-                      // web_fetch ships as a standalone toggle (Fetch
-                      // pill), independent of Search. Anthropic is the
-                      // only provider that ships it today and bills it
-                      // per invocation separately from web_search hits.
+                      // web_fetch has its own Fetch pill, independent
+                      // of Search. Anthropic-only today.
                       ...(webFetchEnabledForThisTurn ? ["web_fetch"] : []),
                       ...(codeExecEnabledForThisTurn ? ["code_execution"] : []),
                       // OpenAI Responses-API only: `image_generation`

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -57,6 +57,7 @@ import {
   getProviderCapabilities,
   providerSupportsBuiltinCodeExecution,
   providerSupportsBuiltinImageGeneration,
+  providerSupportsBuiltinWebFetch,
   providerSupportsBuiltinWebSearch,
 } from "./provider-capabilities";
 import { ChatRuntimeProvider } from "./runtime-provider";
@@ -71,6 +72,7 @@ import {
   CHAT_CODE_TOOLS_ENABLED_KEY,
   CHAT_IMAGE_TOOLS_ENABLED_KEY,
   CHAT_TOOLS_ENABLED_KEY,
+  CHAT_WEB_FETCH_TOOLS_ENABLED_KEY,
   loadOptionalBool,
   useChatRuntimeStore,
 } from "./stores/chat-runtime-store";
@@ -779,6 +781,9 @@ export function ChatPage(): ReactElement {
         selection.modelId,
         provider?.baseUrl,
       );
+    const supportsBuiltinWebFetch = providerSupportsBuiltinWebFetch(
+      provider?.providerType,
+    );
     // Kimi's k2.6/k2.5 default to thinking enabled on the server side
     // (per https://platform.kimi.ai/docs/models). Mirror that default
     // in the UI so the Think pill comes up clicked when the user picks
@@ -800,6 +805,9 @@ export function ChatPage(): ReactElement {
     const storedCodeToolsEnabled = loadOptionalBool(CHAT_CODE_TOOLS_ENABLED_KEY);
     const storedImageToolsEnabled = loadOptionalBool(
       CHAT_IMAGE_TOOLS_ENABLED_KEY,
+    );
+    const storedWebFetchToolsEnabled = loadOptionalBool(
+      CHAT_WEB_FETCH_TOOLS_ENABLED_KEY,
     );
     const nextToolsEnabled = supportsBuiltinWebSearch
       ? isKimi
@@ -834,12 +842,19 @@ export function ChatPage(): ReactElement {
       supportsBuiltinWebSearch,
       supportsBuiltinCodeExecution,
       supportsBuiltinImageGeneration,
+      supportsBuiltinWebFetch,
       toolsEnabled: nextToolsEnabled,
       codeToolsEnabled: supportsBuiltinCodeExecution
         ? (storedCodeToolsEnabled ?? false)
         : false,
       imageToolsEnabled: supportsBuiltinImageGeneration
         ? (storedImageToolsEnabled ?? false)
+        : false,
+      // Default Fetch off when the user has not chosen one yet. Anthropic
+      // bills per fetch; surfacing the toggle visible but inactive keeps
+      // it a deliberate opt-in rather than an implicit cost.
+      webFetchToolsEnabled: supportsBuiltinWebFetch
+        ? (storedWebFetchToolsEnabled ?? false)
         : false,
     });
   }, [externalProvidersForChat, inferenceParams.checkpoint]);
@@ -1008,6 +1023,9 @@ export function ChatPage(): ReactElement {
             selectedExternal?.modelId,
             selectedProvider?.baseUrl,
           );
+        const supportsBuiltinWebFetch = providerSupportsBuiltinWebFetch(
+          selectedProvider?.providerType,
+        );
         // See sibling useEffect above: Kimi's k2.x default to thinking
         // enabled, so the Think pill comes up clicked. Search pill stays
         // off by default; mutual exclusion flips them via the composer.
@@ -1025,6 +1043,9 @@ export function ChatPage(): ReactElement {
         );
         const storedImageToolsEnabled = loadOptionalBool(
           CHAT_IMAGE_TOOLS_ENABLED_KEY,
+        );
+        const storedWebFetchToolsEnabled = loadOptionalBool(
+          CHAT_WEB_FETCH_TOOLS_ENABLED_KEY,
         );
         const nextToolsEnabled = supportsBuiltinWebSearch
           ? isKimi
@@ -1063,12 +1084,16 @@ export function ChatPage(): ReactElement {
           supportsBuiltinWebSearch,
           supportsBuiltinCodeExecution,
           supportsBuiltinImageGeneration,
+          supportsBuiltinWebFetch,
           toolsEnabled: nextToolsEnabled,
           codeToolsEnabled: supportsBuiltinCodeExecution
             ? (storedCodeToolsEnabled ?? false)
             : false,
           imageToolsEnabled: supportsBuiltinImageGeneration
             ? (storedImageToolsEnabled ?? false)
+            : false,
+          webFetchToolsEnabled: supportsBuiltinWebFetch
+            ? (storedWebFetchToolsEnabled ?? false)
             : false,
           ...(stillOnOpenRouterFree ? {} : { lastOpenRouterChosenModel: null }),
         });

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -850,9 +850,7 @@ export function ChatPage(): ReactElement {
       imageToolsEnabled: supportsBuiltinImageGeneration
         ? (storedImageToolsEnabled ?? false)
         : false,
-      // Default Fetch off when the user has not chosen one yet. Anthropic
-      // bills per fetch; surfacing the toggle visible but inactive keeps
-      // it a deliberate opt-in rather than an implicit cost.
+      // Default Fetch off (Anthropic bills per fetch); deliberate opt-in.
       webFetchToolsEnabled: supportsBuiltinWebFetch
         ? (storedWebFetchToolsEnabled ?? false)
         : false,

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -123,13 +123,9 @@ export function providerSupportsBuiltinWebSearch(
 
 /**
  * Whether the external provider exposes a server-side web_fetch tool
- * that retrieves a single URL (text or PDF) and emits a document block.
- * Only Anthropic ships one today (`web_fetch_20250910` /
- * `web_fetch_20260209`). Gates the chat composer's standalone Fetch
- * pill so users can read a specific URL or PDF without also turning
- * on web_search. Earlier revisions bundled web_fetch with the Search
- * pill, but Anthropic bills each fetch separately from search hits
- * and the bundled toggle blocked "just fetch this one URL" workflows.
+ * (single URL, text or PDF) emitting a document block. Anthropic-only
+ * today (`web_fetch_20250910` / `web_fetch_20260209`). Gates the
+ * composer's standalone Fetch pill, independent of Search.
  */
 export function providerSupportsBuiltinWebFetch(
   providerType: string | null | undefined,

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -124,10 +124,12 @@ export function providerSupportsBuiltinWebSearch(
 /**
  * Whether the external provider exposes a server-side web_fetch tool
  * that retrieves a single URL (text or PDF) and emits a document block.
- * Only Anthropic ships one today (`web_fetch_20250910`); the chat
- * composer pairs it with the Search pill because the typical workflow
- * is "search returns URLs, fetch reads them" and the UI doesn't (yet)
- * expose web_fetch as an independent toggle.
+ * Only Anthropic ships one today (`web_fetch_20250910` /
+ * `web_fetch_20260209`). Gates the chat composer's standalone Fetch
+ * pill so users can read a specific URL or PDF without also turning
+ * on web_search. Earlier revisions bundled web_fetch with the Search
+ * pill, but Anthropic bills each fetch separately from search hits
+ * and the bundled toggle blocked "just fetch this one URL" workflows.
  */
 export function providerSupportsBuiltinWebFetch(
   providerType: string | null | undefined,

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -21,7 +21,7 @@ import { isTauri } from "@/lib/api-base";
 import { isMultimodalResponse } from "./types/api";
 import { getImageInputUnavailableReason } from "./utils/image-input-support";
 import { useAui } from "@assistant-ui/react";
-import { ArrowUpIcon, GlobeIcon, HeadphonesIcon, ImageIcon, LightbulbIcon, LightbulbOffIcon, MicIcon, PlusIcon, SquareIcon, XIcon } from "lucide-react";
+import { ArrowUpIcon, DownloadIcon, GlobeIcon, HeadphonesIcon, ImageIcon, LightbulbIcon, LightbulbOffIcon, MicIcon, PlusIcon, SquareIcon, XIcon } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { loadModel, validateModel } from "./api/chat-api";
 import { parseExternalModelId, providerTypeSupportsVision } from "./external-providers";
@@ -34,6 +34,7 @@ import {
   getExternalReasoningCapabilities,
   providerSupportsBuiltinCodeExecution,
   providerSupportsBuiltinImageGeneration,
+  providerSupportsBuiltinWebFetch,
 } from "./provider-capabilities";
 import {
   type CompositionEvent,
@@ -336,6 +337,12 @@ export function SharedComposer({
   const setImageToolsEnabled = useChatRuntimeStore(
     (s) => s.setImageToolsEnabled,
   );
+  const webFetchToolsEnabled = useChatRuntimeStore(
+    (s) => s.webFetchToolsEnabled,
+  );
+  const setWebFetchToolsEnabled = useChatRuntimeStore(
+    (s) => s.setWebFetchToolsEnabled,
+  );
   const lastOpenRouterChosenModel = useChatRuntimeStore(
     (s) => s.lastOpenRouterChosenModel,
   );
@@ -426,6 +433,9 @@ export function SharedComposer({
     effectiveExternalModelId,
     selectedExternalProvider?.baseUrl,
   );
+  const supportsBuiltinWebFetch = providerSupportsBuiltinWebFetch(
+    selectedExternalProvider?.providerType,
+  );
   const searchDisabled =
     !modelLoaded || !(supportsTools || supportsBuiltinWebSearch);
   const codeDisabled =
@@ -437,6 +447,11 @@ export function SharedComposer({
   // the pill row stays compact for providers without the capability.
   const imageDisabled = !modelLoaded || !supportsBuiltinImageGeneration;
   const showImagePill = supportsBuiltinImageGeneration;
+  // Fetch pill is Anthropic-only today (web_fetch_20250910 /
+  // web_fetch_20260209). Hidden on providers that don't ship it so the
+  // pill row stays clean.
+  const webFetchDisabled = !modelLoaded || !supportsBuiltinWebFetch;
+  const showWebFetchPill = supportsBuiltinWebFetch;
   // Backwards-compatible alias for any other call site that may still
   // reference `toolsDisabled` (rare; both pills used it before).
   const toolsDisabled = codeDisabled;
@@ -1104,6 +1119,23 @@ export function SharedComposer({
             >
               <ImageIcon className="size-3.5" />
               <span>Images</span>
+            </button>
+          )}
+          {showWebFetchPill && (
+            <button
+              type="button"
+              disabled={webFetchDisabled}
+              onClick={() => setWebFetchToolsEnabled(!webFetchToolsEnabled)}
+              className="composer-pill-btn"
+              data-active={
+                webFetchToolsEnabled && !webFetchDisabled ? "true" : "false"
+              }
+              aria-label={
+                webFetchToolsEnabled ? "Disable URL fetch" : "Enable URL fetch"
+              }
+            >
+              <DownloadIcon className="size-3.5" />
+              <span>Fetch</span>
             </button>
           )}
         </div>

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -447,9 +447,7 @@ export function SharedComposer({
   // the pill row stays compact for providers without the capability.
   const imageDisabled = !modelLoaded || !supportsBuiltinImageGeneration;
   const showImagePill = supportsBuiltinImageGeneration;
-  // Fetch pill is Anthropic-only today (web_fetch_20250910 /
-  // web_fetch_20260209). Hidden on providers that don't ship it so the
-  // pill row stays clean.
+  // Fetch pill: Anthropic-only (web_fetch_20250910 / web_fetch_20260209).
   const webFetchDisabled = !modelLoaded || !supportsBuiltinWebFetch;
   const showWebFetchPill = supportsBuiltinWebFetch;
   // Backwards-compatible alias for any other call site that may still

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -267,22 +267,16 @@ type ChatRuntimeStore = {
   /**
    * Whether the active external provider exposes a server-side
    * web_fetch tool (Anthropic's `web_fetch_20250910` /
-   * `web_fetch_20260209`). Gates the chat composer's Fetch pill so
-   * users can read a URL or PDF without also turning on web_search.
-   * Web fetch used to be implicitly bundled with the Search pill
-   * because the typical workflow is "search returns URLs, fetch
-   * reads them", but enabling them together prevented "just fetch
-   * this one URL" workflows and made the cost surface confusing
-   * (each fetch is metered separately from search hits).
+   * `web_fetch_20260209`). Gates the composer's Fetch pill,
+   * independent of Search.
    */
   supportsBuiltinWebFetch: boolean;
   toolsEnabled: boolean;
   codeToolsEnabled: boolean;
   imageToolsEnabled: boolean;
   /**
-   * Standalone Fetch pill state for the chat composer. Independent
-   * of `toolsEnabled` (Search pill) and only consulted when the
-   * active provider returns true from `providerSupportsBuiltinWebFetch`.
+   * Fetch pill state, independent of `toolsEnabled` (Search). Only
+   * consulted when `providerSupportsBuiltinWebFetch` is true.
    */
   webFetchToolsEnabled: boolean;
   toolStatus: string | null;

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -25,6 +25,8 @@ export const CHAT_REASONING_ENABLED_KEY = "unsloth_chat_reasoning_enabled";
 export const CHAT_TOOLS_ENABLED_KEY = "unsloth_chat_tools_enabled";
 export const CHAT_CODE_TOOLS_ENABLED_KEY = "unsloth_chat_code_tools_enabled";
 export const CHAT_IMAGE_TOOLS_ENABLED_KEY = "unsloth_chat_image_tools_enabled";
+export const CHAT_WEB_FETCH_TOOLS_ENABLED_KEY =
+  "unsloth_chat_web_fetch_tools_enabled";
 
 // External provider selection is encoded into `params.checkpoint` as
 // `external::<providerId>::<modelId>`. PersistedChatSettings deliberately
@@ -262,9 +264,27 @@ type ChatRuntimeStore = {
    * receive the tool because their runtime cannot dispatch it.
    */
   supportsBuiltinImageGeneration: boolean;
+  /**
+   * Whether the active external provider exposes a server-side
+   * web_fetch tool (Anthropic's `web_fetch_20250910` /
+   * `web_fetch_20260209`). Gates the chat composer's Fetch pill so
+   * users can read a URL or PDF without also turning on web_search.
+   * Web fetch used to be implicitly bundled with the Search pill
+   * because the typical workflow is "search returns URLs, fetch
+   * reads them", but enabling them together prevented "just fetch
+   * this one URL" workflows and made the cost surface confusing
+   * (each fetch is metered separately from search hits).
+   */
+  supportsBuiltinWebFetch: boolean;
   toolsEnabled: boolean;
   codeToolsEnabled: boolean;
   imageToolsEnabled: boolean;
+  /**
+   * Standalone Fetch pill state for the chat composer. Independent
+   * of `toolsEnabled` (Search pill) and only consulted when the
+   * active provider returns true from `providerSupportsBuiltinWebFetch`.
+   */
+  webFetchToolsEnabled: boolean;
   toolStatus: string | null;
   generatingStatus: string | null;
   autoHealToolCalls: boolean;
@@ -324,6 +344,7 @@ type ChatRuntimeStore = {
   setToolsEnabled: (enabled: boolean, options?: { persist?: boolean }) => void;
   setCodeToolsEnabled: (enabled: boolean) => void;
   setImageToolsEnabled: (enabled: boolean) => void;
+  setWebFetchToolsEnabled: (enabled: boolean) => void;
   setToolStatus: (status: string | null) => void;
   setGeneratingStatus: (status: string | null) => void;
   setAutoHealToolCalls: (enabled: boolean) => void;
@@ -564,9 +585,11 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   supportsBuiltinWebSearch: false,
   supportsBuiltinCodeExecution: false,
   supportsBuiltinImageGeneration: false,
+  supportsBuiltinWebFetch: false,
   toolsEnabled: loadBool(CHAT_TOOLS_ENABLED_KEY, false),
   codeToolsEnabled: loadBool(CHAT_CODE_TOOLS_ENABLED_KEY, false),
   imageToolsEnabled: loadBool(CHAT_IMAGE_TOOLS_ENABLED_KEY, false),
+  webFetchToolsEnabled: loadBool(CHAT_WEB_FETCH_TOOLS_ENABLED_KEY, false),
   toolStatus: null,
   generatingStatus: null,
   autoHealToolCalls: true,
@@ -744,9 +767,11 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       supportsBuiltinWebSearch: false,
       supportsBuiltinCodeExecution: false,
       supportsBuiltinImageGeneration: false,
+      supportsBuiltinWebFetch: false,
       toolsEnabled: false,
       codeToolsEnabled: false,
       imageToolsEnabled: false,
+      webFetchToolsEnabled: false,
       toolStatus: null,
       kvCacheDtype: null,
       loadedKvCacheDtype: null,
@@ -805,6 +830,11 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     set(() => {
       saveBool(CHAT_IMAGE_TOOLS_ENABLED_KEY, imageToolsEnabled);
       return { imageToolsEnabled };
+    }),
+  setWebFetchToolsEnabled: (webFetchToolsEnabled) =>
+    set(() => {
+      saveBool(CHAT_WEB_FETCH_TOOLS_ENABLED_KEY, webFetchToolsEnabled);
+      return { webFetchToolsEnabled };
     }),
   setToolStatus: (toolStatus) => set({ toolStatus }),
   setGeneratingStatus: (generatingStatus) => set({ generatingStatus }),


### PR DESCRIPTION
## Summary

- Decouples Anthropic's server-side `web_fetch_20250910` / `web_fetch_20260209` from the Search pill so users can read a single URL or PDF without also turning on web_search.
- Adds a Fetch pill to the chat composer with its own persisted toggle (`webFetchToolsEnabled` / `unsloth_chat_web_fetch_tools_enabled` in localStorage). The pill is hidden on providers that don't ship web_fetch.
- Defaults Fetch off so per-fetch billing is always a deliberate opt-in.

## Why

web_fetch used to be silently bundled with the Search pill on the assumption that "search returns URLs, fetch reads them" is the typical workflow. Two problems with that:

- Anthropic bills each `web_fetch` invocation separately from `web_search` hits, so combining them made the per-message cost surface ambiguous.
- It blocked "just fetch this one URL" workflows where the user already knows the page they want read and does not want a search round-trip.

## Implementation

- `chat-runtime-store.ts`: new `webFetchToolsEnabled` boolean (persisted via `loadBool` / `saveBool` on `CHAT_WEB_FETCH_TOOLS_ENABLED_KEY`), matching `supportsBuiltinWebFetch` capability, `setWebFetchToolsEnabled` setter, plus reset entries in `resetExternalModelState`.
- `chat-page.tsx`: both runtime-bootstrap sites compute `supportsBuiltinWebFetch` from `providerSupportsBuiltinWebFetch` and hydrate `webFetchToolsEnabled` from stored localStorage (default off).
- `chat-adapter.ts`: `webFetchEnabledForThisTurn` now sources from `webFetchToolsEnabled` instead of `toolsEnabled`.
- `shared-composer.tsx`: Fetch pill rendered next to Images, only when `supportsBuiltinWebFetch`. Disabled when no model is loaded.
- `provider-capabilities.ts`: comment updated to reflect the standalone pill.

Backend translation is unchanged: when `enabled_tools` already contains `\"web_fetch\"`, `_stream_anthropic` appends the `web_fetch_20250910` / `web_fetch_20260209` tool exactly as before. Coverage already pinned in `studio/backend/tests/test_anthropic_web_fetch.py` at `test_web_fetch_tool_appended_to_request_body` (standalone-only) and `test_web_fetch_combined_with_web_search_and_code_execution` (combined).

## Test plan

- [x] `npx tsc --noEmit` in `studio/frontend/` (clean).
- [ ] Manual chat with Anthropic Claude 4.7: Fetch pill alone forwards `enabled_tools=[\"web_fetch\"]` and the model can read a URL without web_search being enabled.
- [ ] Manual chat: Fetch + Search both on forwards `[\"web_search\", \"web_fetch\"]` and behaves identically to the pre-change combined path.
- [ ] Manual: Fetch pill is hidden on OpenAI / Gemini / OpenRouter / Kimi / DeepSeek / Mistral.
- [ ] Refresh chat: Fetch toggle survives reload (localStorage round-trip).