### PR TITLE
Studio: expose image size setting in training UI

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3125,9 +3125,13 @@ class UnslothTrainer:
                 FastVisionModel.for_training(self.model)
                 vision_image_size = training_args.get("vision_image_size")
                 if vision_image_size is None:
-                    data_collator = UnslothVisionDataCollator(self.model, self.tokenizer)
+                    data_collator = UnslothVisionDataCollator(
+                        self.model, self.tokenizer
+                    )
                 else:
-                    logger.info(f"Vision image resize: {vision_image_size} (max dimension)\n")
+                    logger.info(
+                        f"Vision image resize: {vision_image_size} (max dimension)\n"
+                    )
                     data_collator = UnslothVisionDataCollator(
                         self.model,
                         self.tokenizer,

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3062,8 +3062,7 @@ class UnslothTrainer:
                     # large documents still works.
                     vision_image_size = training_args.get("vision_image_size")
                     deepseek_image_size = (
-                        640 if vision_image_size is None
-                        else int(vision_image_size)
+                        640 if vision_image_size is None else int(vision_image_size)
                     )
                     if vision_image_size is not None:
                         logger.info(

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3057,10 +3057,23 @@ class UnslothTrainer:
 
                     logger.info("Configuring DeepSeek OCR data collator...\n")
                     FastVisionModel.for_training(self.model)
+                    # Honor user-selected Image Size. Keep base_size + crop_mode
+                    # at the Gundam preset (1024 / True) so dynamic cropping of
+                    # large documents still works.
+                    vision_image_size = training_args.get("vision_image_size")
+                    deepseek_image_size = (
+                        640 if vision_image_size is None
+                        else int(vision_image_size)
+                    )
+                    if vision_image_size is not None:
+                        logger.info(
+                            f"DeepSeek OCR image resize: "
+                            f"{deepseek_image_size} (per-crop tile size)\n"
+                        )
                     data_collator = DeepSeekOCRDataCollator(
                         tokenizer = self.tokenizer,
                         model = self.model,
-                        image_size = 640,
+                        image_size = deepseek_image_size,
                         base_size = 1024,
                         crop_mode = True,
                         train_on_responses_only = training_args.get(

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3057,15 +3057,9 @@ class UnslothTrainer:
 
                     logger.info("Configuring DeepSeek OCR data collator...\n")
                     FastVisionModel.for_training(self.model)
-                    # DeepSeek OCR's (image_size, base_size, crop_mode) tuple
-                    # is a single preset (Tiny / Small / Base / Large / Gundam).
-                    # Changing image_size in isolation desynchronizes the per-
-                    # crop pixel grid from num_queries downstream, so the
-                    # user-selected vision_image_size is intentionally ignored
-                    # here. Default to the Gundam preset, which is the
-                    # recommended training configuration. Threading the Image
-                    # Size knob through DeepSeek OCR requires patching
-                    # dynamic_preprocess first.
+                    # DeepSeek OCR's (image_size, base_size, crop_mode) is a
+                    # coupled preset; changing image_size alone desyncs the
+                    # per-crop pixel grid from num_queries. Use Gundam.
                     if training_args.get("vision_image_size") is not None:
                         logger.info(
                             "Vision image resize ignored for DeepSeek OCR "

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3057,22 +3057,24 @@ class UnslothTrainer:
 
                     logger.info("Configuring DeepSeek OCR data collator...\n")
                     FastVisionModel.for_training(self.model)
-                    # Honor user-selected Image Size. Keep base_size + crop_mode
-                    # at the Gundam preset (1024 / True) so dynamic cropping of
-                    # large documents still works.
-                    vision_image_size = training_args.get("vision_image_size")
-                    deepseek_image_size = (
-                        640 if vision_image_size is None else int(vision_image_size)
-                    )
-                    if vision_image_size is not None:
+                    # DeepSeek OCR's (image_size, base_size, crop_mode) tuple
+                    # is a single preset (Tiny / Small / Base / Large / Gundam).
+                    # Changing image_size in isolation desynchronizes the per-
+                    # crop pixel grid from num_queries downstream, so the
+                    # user-selected vision_image_size is intentionally ignored
+                    # here. Default to the Gundam preset, which is the
+                    # recommended training configuration. Threading the Image
+                    # Size knob through DeepSeek OCR requires patching
+                    # dynamic_preprocess first.
+                    if training_args.get("vision_image_size") is not None:
                         logger.info(
-                            f"DeepSeek OCR image resize: "
-                            f"{deepseek_image_size} (per-crop tile size)\n"
+                            "Vision image resize ignored for DeepSeek OCR "
+                            "(uses fixed Gundam preset).\n"
                         )
                     data_collator = DeepSeekOCRDataCollator(
                         tokenizer = self.tokenizer,
                         model = self.model,
-                        image_size = deepseek_image_size,
+                        image_size = 640,
                         base_size = 1024,
                         crop_mode = True,
                         train_on_responses_only = training_args.get(

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3123,7 +3123,17 @@ class UnslothTrainer:
                 from unsloth.trainer import UnslothVisionDataCollator
 
                 FastVisionModel.for_training(self.model)
-                data_collator = UnslothVisionDataCollator(self.model, self.tokenizer)
+                vision_image_size = training_args.get("vision_image_size")
+                if vision_image_size is None:
+                    data_collator = UnslothVisionDataCollator(self.model, self.tokenizer)
+                else:
+                    logger.info(f"Vision image resize: {vision_image_size} (max dimension)\n")
+                    data_collator = UnslothVisionDataCollator(
+                        self.model,
+                        self.tokenizer,
+                        resize = vision_image_size,
+                        resize_dimension = "max",
+                    )
                 logger.info("Vision data collator configured\n")
 
             # ========== TRAINING CONFIGURATION ==========

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -193,6 +193,7 @@ class TrainingBackend:
             "hf_token": kwargs.get("hf_token", ""),
             "load_in_4bit": kwargs.get("load_in_4bit", True),
             "max_seq_length": kwargs.get("max_seq_length", 2048),
+            "vision_image_size": kwargs.get("vision_image_size"),
             "hf_dataset": kwargs.get("hf_dataset", ""),
             "local_datasets": kwargs.get("local_datasets"),
             "local_eval_datasets": kwargs.get("local_eval_datasets"),

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -984,9 +984,10 @@ def _resize_mlx_vlm_image(image, resize):
     if new_size != image.size:
         resampling = getattr(Image, "Resampling", Image).LANCZOS
         image = image.resize(new_size, resampling)
-    # mlx-vlm's internal collator square-resizes PIL images. Return an ndarray
-    # so Studio's max-dimension resize is the final resize, like trainer.py.
-    return np.asarray(image)
+    # mlx-vlm's internal collator square-resizes PIL images. Return a writable
+    # ndarray so Studio's max-dimension resize is the final one (like
+    # trainer.py) and HF processors don't warn on non-writable views.
+    return np.array(image, copy = True)
 
 
 def _resize_mlx_vlm_images(value, resize):

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -987,8 +987,9 @@ def _resize_mlx_vlm_image(image, resize):
     if new_size != image.size:
         resampling = getattr(Image, "Resampling", Image).LANCZOS
         image = image.resize(new_size, resampling)
-    # Return a writable ndarray so mlx-vlm skips its PIL-path square-resize
-    # and HF processors don't warn on non-writable views.
+    # When a resize is requested, hand mlx-vlm a writable RGB ndarray so its
+    # PIL-path square-resize is skipped and HF processors don't warn on
+    # non-writable views. resize=None (Default) above keeps the original PIL.
     return np.array(image, copy = True)
 
 

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -965,8 +965,13 @@ def _mlx_vlm_max_resized_size(width: int, height: int, target: int) -> tuple[int
     largest_side = max(width, height)
     if largest_side <= target:
         return width, height
-    scale = float(target) / float(largest_side)
-    return max(1, int(round(width * scale))), max(1, int(round(height * scale)))
+    # Mirror UnslothVisionDataCollator's integer formula at
+    # unsloth_zoo/vision_utils.py so MLX and Torch produce the same pixels.
+    # Python's round() uses banker's rounding which can disagree by 1px on
+    # half-pixel cases (e.g. 333x1000 with target 500).
+    new_w = max(1, (width * target + largest_side // 2) // largest_side)
+    new_h = max(1, (height * target + largest_side // 2) // largest_side)
+    return new_w, new_h
 
 
 def _resize_mlx_vlm_image(image, resize):

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -965,10 +965,8 @@ def _mlx_vlm_max_resized_size(width: int, height: int, target: int) -> tuple[int
     largest_side = max(width, height)
     if largest_side <= target:
         return width, height
-    # Mirror UnslothVisionDataCollator's integer formula at
-    # unsloth_zoo/vision_utils.py so MLX and Torch produce the same pixels.
-    # Python's round() uses banker's rounding which can disagree by 1px on
-    # half-pixel cases (e.g. 333x1000 with target 500).
+    # Integer formula matches unsloth_zoo's collator (Python round() differs
+    # by 1px on half-pixel cases). max(1, _) avoids zero-side degenerate output.
     new_w = max(1, (width * target + largest_side // 2) // largest_side)
     new_h = max(1, (height * target + largest_side // 2) // largest_side)
     return new_w, new_h
@@ -989,9 +987,8 @@ def _resize_mlx_vlm_image(image, resize):
     if new_size != image.size:
         resampling = getattr(Image, "Resampling", Image).LANCZOS
         image = image.resize(new_size, resampling)
-    # mlx-vlm's internal collator square-resizes PIL images. Return a writable
-    # ndarray so Studio's max-dimension resize is the final one (like
-    # trainer.py) and HF processors don't warn on non-writable views.
+    # Return a writable ndarray so mlx-vlm skips its PIL-path square-resize
+    # and HF processors don't warn on non-writable views.
     return np.array(image, copy = True)
 
 
@@ -1211,9 +1208,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
     is_vlm = bool(is_dataset_image and getattr(model, "_is_vlm_model", False))
     model._is_vlm_model = is_vlm
     vision_image_size = config.get("vision_image_size")
-    # Mirror the Torch trainer.py exclusion: DeepSeek OCR's preset is a tuple
-    # (image_size, base_size, crop_mode), so resizing dataset images outside
-    # that preset desyncs the token grid. Skip the resize on MLX too.
+    # DeepSeek OCR uses a coupled preset tuple; skip resize like the Torch path.
     _model_name_lower = str(config.get("model_name", "")).lower()
     _is_deepseek_ocr = "deepseek" in _model_name_lower and "ocr" in _model_name_lower
     if is_vlm and vision_image_size is not None and _is_deepseek_ocr:

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1211,7 +1211,23 @@ def _run_mlx_training(event_queue, stop_queue, config):
     is_vlm = bool(is_dataset_image and getattr(model, "_is_vlm_model", False))
     model._is_vlm_model = is_vlm
     vision_image_size = config.get("vision_image_size")
-    if is_vlm and vision_image_size is not None:
+    # Mirror the Torch trainer.py exclusion: DeepSeek OCR's preset is a tuple
+    # (image_size, base_size, crop_mode), so resizing dataset images outside
+    # that preset desyncs the token grid. Skip the resize on MLX too.
+    _model_name_lower = str(config.get("model_name", "")).lower()
+    _is_deepseek_ocr = (
+        "deepseek" in _model_name_lower and "ocr" in _model_name_lower
+    )
+    if is_vlm and vision_image_size is not None and _is_deepseek_ocr:
+        _send(
+            "status",
+            status_message = (
+                "MLX vision image resize ignored for DeepSeek OCR "
+                "(uses fixed Gundam preset)."
+            ),
+        )
+        vision_image_size = None
+    elif is_vlm and vision_image_size is not None:
         vision_image_size = int(vision_image_size)
         _send(
             "status",

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -959,7 +959,43 @@ def _activate_transformers_version(model_name: str) -> None:
     activate_transformers_for_subprocess(model_name)
 
 
-def _adapt_for_mlx_vlm(items):
+def _mlx_vlm_max_resized_size(width: int, height: int, target: int) -> tuple[int, int]:
+    if width <= 0 or height <= 0 or target <= 0:
+        return width, height
+    largest_side = max(width, height)
+    if largest_side <= target:
+        return width, height
+    scale = float(target) / float(largest_side)
+    return max(1, int(round(width * scale))), max(1, int(round(height * scale)))
+
+
+def _resize_mlx_vlm_image(image, resize):
+    if resize is None:
+        return image
+    try:
+        from PIL import Image
+        import numpy as np
+    except ImportError:
+        return image
+    if not isinstance(image, Image.Image):
+        return image
+    image = image.convert("RGB")
+    new_size = _mlx_vlm_max_resized_size(*image.size, int(resize))
+    if new_size != image.size:
+        resampling = getattr(Image, "Resampling", Image).LANCZOS
+        image = image.resize(new_size, resampling)
+    # mlx-vlm's internal collator square-resizes PIL images. Return an ndarray
+    # so Studio's max-dimension resize is the final resize, like trainer.py.
+    return np.asarray(image)
+
+
+def _resize_mlx_vlm_images(value, resize):
+    if isinstance(value, list):
+        return [_resize_mlx_vlm_image(image, resize) for image in value]
+    return _resize_mlx_vlm_image(value, resize)
+
+
+def _adapt_for_mlx_vlm(items, resize = None):
     """Adapt GPU-path VLM dataset output for mlx-vlm consumption.
 
     The GPU path embeds PIL images inside messages content as
@@ -979,7 +1015,7 @@ def _adapt_for_mlx_vlm(items):
                     if isinstance(part, dict) and part.get("type") == "image":
                         img = part.get("image")
                         if img is not None:
-                            images.append(img)
+                            images.append(_resize_mlx_vlm_image(img, resize))
                         new_content.append({"type": "image"})
                     else:
                         new_content.append(part)
@@ -990,9 +1026,9 @@ def _adapt_for_mlx_vlm(items):
         if images:
             out["image"] = images[0] if len(images) == 1 else images
         elif "image" in item:
-            out["image"] = item["image"]
+            out["image"] = _resize_mlx_vlm_images(item["image"], resize)
         elif "images" in item:
-            out["images"] = item["images"]
+            out["images"] = _resize_mlx_vlm_images(item["images"], resize)
         adapted.append(out)
     return adapted
 
@@ -1168,6 +1204,13 @@ def _run_mlx_training(event_queue, stop_queue, config):
 
     is_vlm = bool(is_dataset_image and getattr(model, "_is_vlm_model", False))
     model._is_vlm_model = is_vlm
+    vision_image_size = config.get("vision_image_size")
+    if is_vlm and vision_image_size is not None:
+        vision_image_size = int(vision_image_size)
+        _send(
+            "status",
+            status_message = f"MLX vision image resize: {vision_image_size} (max dimension)",
+        )
 
     # ── 2. Apply LoRA / full FT ──
     # Pass gradient_checkpointing as string ("mlx"/"unsloth"/"none"/etc.)
@@ -1302,7 +1345,10 @@ def _run_mlx_training(event_queue, stop_queue, config):
                 progress_callback = _fmt_progress,
             )
             if vlm_info.get("success"):
-                dataset = _adapt_for_mlx_vlm(vlm_info["dataset"])
+                dataset = _adapt_for_mlx_vlm(
+                    vlm_info["dataset"],
+                    resize = vision_image_size,
+                )
             else:
                 errors = vlm_info.get("errors", [])
                 raise ValueError(
@@ -1317,7 +1363,10 @@ def _run_mlx_training(event_queue, stop_queue, config):
                     dataset_name = hf_dataset or "local",
                 )
                 if ev_info.get("success"):
-                    eval_dataset = _adapt_for_mlx_vlm(ev_info["dataset"])
+                    eval_dataset = _adapt_for_mlx_vlm(
+                        ev_info["dataset"],
+                        resize = vision_image_size,
+                    )
 
         elif format_type:
             _send("status", status_message = f"Formatting dataset ({format_type})...")
@@ -2248,6 +2297,7 @@ def run_training_process(
             eval_dataset = eval_dataset,
             eval_steps = eval_steps,
             max_seq_length = config.get("max_seq_length", 2048),
+            vision_image_size = config.get("vision_image_size"),
             optim = config.get("optim", "adamw_8bit"),
             lr_scheduler_type = config.get("lr_scheduler_type", "linear"),
             is_cpt = is_cpt,

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1215,9 +1215,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
     # (image_size, base_size, crop_mode), so resizing dataset images outside
     # that preset desyncs the token grid. Skip the resize on MLX too.
     _model_name_lower = str(config.get("model_name", "")).lower()
-    _is_deepseek_ocr = (
-        "deepseek" in _model_name_lower and "ocr" in _model_name_lower
-    )
+    _is_deepseek_ocr = "deepseek" in _model_name_lower and "ocr" in _model_name_lower
     if is_vlm and vision_image_size is not None and _is_deepseek_ocr:
         _send(
             "status",

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -18,6 +18,9 @@ _MAX_SEQ_LENGTH = 2_000_000
 _MAX_LR_VALUE = 1.0
 _MAX_LORA_R = 16_384
 _MAX_LORA_ALPHA = 32_768
+_MIN_VISION_IMAGE_SIZE = 256
+# 2048 was the most I could get most llms to work at without getting unstable
+_MAX_VISION_IMAGE_SIZE = 2048
 
 
 def _parse_lr(v: Any) -> float:
@@ -58,6 +61,10 @@ class TrainingStartRequest(BaseModel):
     hf_token: Optional[str] = Field(None, description = "HuggingFace token")
     load_in_4bit: bool = Field(True, description = "Load model in 4-bit quantization")
     max_seq_length: int = Field(2048, description = "Maximum sequence length")
+    vision_image_size: Optional[int] = Field(
+        None,
+        description = "Optional maximum image side length for VLM training. Null uses model default.",
+    )
     trust_remote_code: bool = Field(
         False,
         description = "Allow loading models with custom code (e.g. NVIDIA Nemotron). Only enable for repos you trust.",
@@ -156,6 +163,20 @@ class TrainingStartRequest(BaseModel):
         if v is None or v < 1 or v > _MAX_SEQ_LENGTH:
             raise ValueError(
                 f"max_seq_length must be in [1, {_MAX_SEQ_LENGTH}] (got {v!r})"
+            )
+        return v
+
+    @field_validator("vision_image_size")
+    @classmethod
+    def _check_vision_image_size(cls, v: Optional[int]) -> Optional[int]:
+        if v is None:
+            return v
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise ValueError("vision_image_size must be an integer or null")
+        if v < _MIN_VISION_IMAGE_SIZE or v > _MAX_VISION_IMAGE_SIZE:
+            raise ValueError(
+                f"vision_image_size must be in [{_MIN_VISION_IMAGE_SIZE}, "
+                f"{_MAX_VISION_IMAGE_SIZE}] (got {v!r})"
             )
         return v
 

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -185,6 +185,7 @@ class TrainingStartRequest(BaseModel):
             # numpy ints and other Integral subclasses (no hard numpy import).
             try:
                 import numbers
+
                 if isinstance(v, numbers.Integral):
                     coerced = int(v)
                 elif isinstance(v, numbers.Real) and float(v).is_integer():
@@ -192,9 +193,7 @@ class TrainingStartRequest(BaseModel):
                 else:
                     raise TypeError
             except Exception:
-                raise ValueError(
-                    "vision_image_size must be an integer or null"
-                )
+                raise ValueError("vision_image_size must be an integer or null")
         if coerced < _MIN_VISION_IMAGE_SIZE or coerced > _MAX_VISION_IMAGE_SIZE:
             raise ValueError(
                 f"vision_image_size must be in [{_MIN_VISION_IMAGE_SIZE}, "

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -169,8 +169,7 @@ class TrainingStartRequest(BaseModel):
     @field_validator("vision_image_size", mode = "before")
     @classmethod
     def _check_vision_image_size(cls, v: Any) -> Optional[int]:
-        # mode="before" runs ahead of Pydantic's int coercion so True/False
-        # surface as bool (not 1/0) and we can give a precise error.
+        # mode="before" sees True/False as bool (not 1/0) for a precise error.
         if v is None:
             return v
         if isinstance(v, bool):
@@ -182,7 +181,7 @@ class TrainingStartRequest(BaseModel):
         elif isinstance(v, float) and v.is_integer():
             coerced = int(v)
         else:
-            # numpy ints and other Integral subclasses (no hard numpy import).
+            # numpy ints / Integral subclasses, without a hard numpy import.
             try:
                 import numbers
 

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -166,19 +166,41 @@ class TrainingStartRequest(BaseModel):
             )
         return v
 
-    @field_validator("vision_image_size")
+    @field_validator("vision_image_size", mode = "before")
     @classmethod
-    def _check_vision_image_size(cls, v: Optional[int]) -> Optional[int]:
+    def _check_vision_image_size(cls, v: Any) -> Optional[int]:
+        # mode="before" runs ahead of Pydantic's int coercion so True/False
+        # surface as bool (not 1/0) and we can give a precise error.
         if v is None:
             return v
-        if isinstance(v, bool) or not isinstance(v, int):
+        if isinstance(v, bool):
             raise ValueError("vision_image_size must be an integer or null")
-        if v < _MIN_VISION_IMAGE_SIZE or v > _MAX_VISION_IMAGE_SIZE:
+        if isinstance(v, int):
+            coerced = v
+        elif isinstance(v, str) and v.strip().lstrip("+-").isdigit():
+            coerced = int(v)
+        elif isinstance(v, float) and v.is_integer():
+            coerced = int(v)
+        else:
+            # numpy ints and other Integral subclasses (no hard numpy import).
+            try:
+                import numbers
+                if isinstance(v, numbers.Integral):
+                    coerced = int(v)
+                elif isinstance(v, numbers.Real) and float(v).is_integer():
+                    coerced = int(v)
+                else:
+                    raise TypeError
+            except Exception:
+                raise ValueError(
+                    "vision_image_size must be an integer or null"
+                )
+        if coerced < _MIN_VISION_IMAGE_SIZE or coerced > _MAX_VISION_IMAGE_SIZE:
             raise ValueError(
                 f"vision_image_size must be in [{_MIN_VISION_IMAGE_SIZE}, "
-                f"{_MAX_VISION_IMAGE_SIZE}] (got {v!r})"
+                f"{_MAX_VISION_IMAGE_SIZE}] (got {coerced!r})"
             )
-        return v
+        return coerced
 
     @field_validator("warmup_steps")
     @classmethod

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -5,8 +5,15 @@
 Pydantic schemas for Training API
 """
 
+import re
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing import Any, Optional, List, Dict, Literal
+
+
+# ASCII integer with an optional single sign. Used by _check_vision_image_size
+# to reject "++512", "--256", and Unicode-digit strings ("５１２", "٥١٢") that
+# would otherwise slip through str.isdigit() + int().
+_INT_RE = re.compile(r"[+-]?[0-9]+")
 
 
 _MAX_BATCH_SIZE = 4096
@@ -176,8 +183,8 @@ class TrainingStartRequest(BaseModel):
             raise ValueError("vision_image_size must be an integer or null")
         if isinstance(v, int):
             coerced = v
-        elif isinstance(v, str) and v.strip().lstrip("+-").isdigit():
-            coerced = int(v)
+        elif isinstance(v, str) and _INT_RE.fullmatch(v.strip()):
+            coerced = int(v.strip())
         elif isinstance(v, float) and v.is_integer():
             coerced = int(v)
         else:

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -194,6 +194,7 @@ async def start_training(
             "hf_token": request.hf_token or "",
             "load_in_4bit": request.load_in_4bit,
             "max_seq_length": request.max_seq_length,
+            "vision_image_size": request.vision_image_size,
             "hf_dataset": request.hf_dataset or "",
             "local_datasets": request.local_datasets,
             "local_eval_datasets": request.local_eval_datasets,

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -91,8 +91,6 @@ def test_mlx_vlm_resize_uses_max_dimension_like_torch_trainer():
     assert _mlx_vlm_max_resized_size(1000, 1000, 512) == (512, 512)
     assert _mlx_vlm_max_resized_size(256, 128, 1536) == (256, 128)
     assert _mlx_vlm_max_resized_size(512, 256, 512) == (512, 256)
-    # Half-pixel cases must match the Torch collator's integer formula
-    # (w * size + size_func // 2) // size_func, not Python round() which
-    # uses banker's rounding.
+    # Half-pixel cases must match the Torch collator (not banker's round).
     assert _mlx_vlm_max_resized_size(333, 1000, 500) == (167, 500)
     assert _mlx_vlm_max_resized_size(1000, 333, 500) == (500, 167)

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -66,6 +66,7 @@ def _load_worker_module():
 _worker = _load_worker_module()
 _normalize_mlx_studio_optimizer = _worker._normalize_mlx_studio_optimizer
 _normalize_mlx_studio_scheduler = _worker._normalize_mlx_studio_scheduler
+_mlx_vlm_max_resized_size = _worker._mlx_vlm_max_resized_size
 
 
 def test_mlx_studio_optimizer_aliases_are_explicit():
@@ -82,3 +83,11 @@ def test_mlx_studio_rejects_unknown_optimizer():
 def test_mlx_studio_rejects_unknown_scheduler():
     with pytest.raises(ValueError, match = "Unsupported LR scheduler for MLX training"):
         _normalize_mlx_studio_scheduler("linear_typo")
+
+
+def test_mlx_vlm_resize_uses_max_dimension_like_torch_trainer():
+    assert _mlx_vlm_max_resized_size(1000, 500, 512) == (512, 256)
+    assert _mlx_vlm_max_resized_size(500, 1000, 512) == (256, 512)
+    assert _mlx_vlm_max_resized_size(1000, 1000, 512) == (512, 512)
+    assert _mlx_vlm_max_resized_size(256, 128, 1536) == (256, 128)
+    assert _mlx_vlm_max_resized_size(512, 256, 512) == (512, 256)

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -91,3 +91,8 @@ def test_mlx_vlm_resize_uses_max_dimension_like_torch_trainer():
     assert _mlx_vlm_max_resized_size(1000, 1000, 512) == (512, 512)
     assert _mlx_vlm_max_resized_size(256, 128, 1536) == (256, 128)
     assert _mlx_vlm_max_resized_size(512, 256, 512) == (512, 256)
+    # Half-pixel cases must match the Torch collator's integer formula
+    # (w * size + size_func // 2) // size_func, not Python round() which
+    # uses banker's rounding.
+    assert _mlx_vlm_max_resized_size(333, 1000, 500) == (167, 500)
+    assert _mlx_vlm_max_resized_size(1000, 333, 500) == (500, 167)

--- a/studio/backend/tests/test_studio_train_validation.py
+++ b/studio/backend/tests/test_studio_train_validation.py
@@ -85,6 +85,14 @@ class TestVisionImageSizeCap:
         with pytest.raises(ValidationError):
             _check_field("vision_image_size", value)
 
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_error_says_integer_not_range(self, value):
+        # Regression guard: pre-fix the bool was coerced to 1/0 and the
+        # message read "must be in [256, 2048] (got 1)", which was confusing.
+        with pytest.raises(ValidationError) as exc:
+            _check_field("vision_image_size", value)
+        assert "integer or null" in str(exc.value)
+
 
 class TestLoraRCap:
     def test_at_cap_accepts(self):

--- a/studio/backend/tests/test_studio_train_validation.py
+++ b/studio/backend/tests/test_studio_train_validation.py
@@ -92,6 +92,23 @@ class TestVisionImageSizeCap:
             _check_field("vision_image_size", value)
         assert "integer or null" in str(exc.value)
 
+    @pytest.mark.parametrize("value", ["++512", "--256", "+-+512", "+", "-"])
+    def test_multi_sign_string_says_integer_not_raw(self, value):
+        # Regression guard: multi-sign strings must not leak int()'s raw
+        # "invalid literal" message; precise contract is "integer or null".
+        with pytest.raises(ValidationError) as exc:
+            _check_field("vision_image_size", value)
+        assert "integer or null" in str(exc.value)
+        assert "invalid literal" not in str(exc.value)
+
+    @pytest.mark.parametrize("value", ["５１２", "٥١٢", "१०२४"])
+    def test_unicode_digit_string_rejected(self, value):
+        # Full-width / Arabic-Indic / Devanagari digits must be rejected so the
+        # value reaching the backend equals the ASCII the user typed.
+        with pytest.raises(ValidationError) as exc:
+            _check_field("vision_image_size", value)
+        assert "integer or null" in str(exc.value)
+
 
 class TestLoraRCap:
     def test_at_cap_accepts(self):

--- a/studio/backend/tests/test_studio_train_validation.py
+++ b/studio/backend/tests/test_studio_train_validation.py
@@ -18,6 +18,8 @@ from models.training import (
     _MAX_LORA_ALPHA,
     _MAX_LORA_R,
     _MAX_SEQ_LENGTH,
+    _MAX_VISION_IMAGE_SIZE,
+    _MIN_VISION_IMAGE_SIZE,
 )
 
 
@@ -60,6 +62,28 @@ class TestBatchSizeCap:
     def test_below_min_rejects(self):
         with pytest.raises(ValidationError):
             _check_field("batch_size", 0)
+
+
+class TestVisionImageSizeCap:
+    def test_none_accepts_model_default(self):
+        _check_field("vision_image_size", None)
+
+    @pytest.mark.parametrize(
+        "value",
+        [_MIN_VISION_IMAGE_SIZE, 640, 1000, _MAX_VISION_IMAGE_SIZE],
+    )
+    def test_in_range_accepts(self, value):
+        _check_field("vision_image_size", value)
+        assert _MIN_VISION_IMAGE_SIZE == 256
+        assert _MAX_VISION_IMAGE_SIZE == 2048
+
+    @pytest.mark.parametrize(
+        "value",
+        [_MIN_VISION_IMAGE_SIZE - 1, _MAX_VISION_IMAGE_SIZE + 1, 640.5, True],
+    )
+    def test_invalid_rejects(self, value):
+        with pytest.raises(ValidationError):
+            _check_field("vision_image_size", value)
 
 
 class TestLoraRCap:

--- a/studio/backend/tests/test_studio_train_validation.py
+++ b/studio/backend/tests/test_studio_train_validation.py
@@ -87,8 +87,7 @@ class TestVisionImageSizeCap:
 
     @pytest.mark.parametrize("value", [True, False])
     def test_bool_error_says_integer_not_range(self, value):
-        # Regression guard: pre-fix the bool was coerced to 1/0 and the
-        # message read "must be in [256, 2048] (got 1)", which was confusing.
+        # Regression guard: bools must say "integer or null", not "in [256, 2048]".
         with pytest.raises(ValidationError) as exc:
             _check_field("vision_image_size", value)
         assert "integer or null" in str(exc.value)

--- a/studio/frontend/src/config/training.ts
+++ b/studio/frontend/src/config/training.ts
@@ -108,6 +108,7 @@ export const LR_DEFAULT_CPT = 5e-5;
 export const DEFAULT_HYPERPARAMS = {
   epochs: 3,
   contextLength: 2048,
+  visionImageSize: null as number | null,
   learningRate: LR_DEFAULT_LORA,
   // null = let backend auto-compute (lr/10 per Unsloth CPT recipe). Only used by CPT.
   embeddingLearningRate: null as number | null,

--- a/studio/frontend/src/features/studio/sections/params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/params-section.tsx
@@ -139,6 +139,7 @@ export function ParamsSection(): ReactElement {
   const [ctxInput, setCtxInput] = useState(String(store.contextLength));
   const ctxAnchorRef = useRef<HTMLDivElement>(null);
   const ctxItems = CONTEXT_LENGTHS.map(String);
+  const visionImageSizePresets = [384, 512, 768, 1024, 1536, 2048];
 
   // Keep input in sync when the store value changes externally
   // (e.g. model defaults being applied after model selection).
@@ -915,6 +916,52 @@ export function ParamsSection(): ReactElement {
                 </TabsContent>
 
                 <TabsContent value="memory" className="mt-3 flex flex-col gap-3">
+                  {showVisionLora && (
+                    <Row
+                      label="Image Size"
+                      tooltip={
+                        <>
+                          Resize images by maximum side length. Default uses the
+                          model image size. Larger images use up more context. Does not upscale or change aspect ratio.{" "}
+                          <a
+                            href="https://unsloth.ai/docs/basics/vision-fine-tuning"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary underline"
+                          >
+                            Read more
+                          </a>
+                        </>
+                      }
+                    >
+                      <Select
+                        value={
+                          store.visionImageSize == null
+                            ? "default"
+                            : String(store.visionImageSize)
+                        }
+                        onValueChange={(value) => {
+                          if (value === "default") {
+                            store.setVisionImageSize(null);
+                            return;
+                          }
+                          store.setVisionImageSize(Number(value));
+                        }}
+                      >
+                        <SelectTrigger className="w-32">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="default">Default</SelectItem>
+                          {visionImageSizePresets.map((size) => (
+                            <SelectItem key={size} value={String(size)}>
+                              {size}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </Row>
+                  )}
                   <Row
                     label="Grad Checkpoint"
                     tooltip={

--- a/studio/frontend/src/features/studio/sections/params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/params-section.tsx
@@ -139,7 +139,8 @@ export function ParamsSection(): ReactElement {
   const [ctxInput, setCtxInput] = useState(String(store.contextLength));
   const ctxAnchorRef = useRef<HTMLDivElement>(null);
   const ctxItems = CONTEXT_LENGTHS.map(String);
-  const visionImageSizePresets = [384, 512, 768, 1024, 1536, 2048];
+  // Backend validator allows [256, 2048]; offer the full span.
+  const visionImageSizePresets = [256, 384, 512, 768, 1024, 1536, 2048];
 
   // Keep input in sync when the store value changes externally
   // (e.g. model defaults being applied after model selection).
@@ -953,6 +954,16 @@ export function ParamsSection(): ReactElement {
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="default">Default</SelectItem>
+                          {store.visionImageSize != null &&
+                            !visionImageSizePresets.includes(
+                              store.visionImageSize,
+                            ) && (
+                              <SelectItem
+                                value={String(store.visionImageSize)}
+                              >
+                                {store.visionImageSize}
+                              </SelectItem>
+                            )}
                           {visionImageSizePresets.map((size) => (
                             <SelectItem key={size} value={String(size)}>
                               {size}

--- a/studio/frontend/src/features/studio/sections/params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/params-section.tsx
@@ -133,6 +133,14 @@ export function ParamsSection(): ReactElement {
   const isCpt = store.trainingMethod === "cpt";
   const isRawText = isRawTextDatasetFormat(store.datasetFormat);
   const showVisionLora = store.isVisionModel && store.isDatasetImage === true;
+  // DeepSeek OCR's preset is a coupled tuple, so the backend ignores any
+  // user-selected image size for it. Hide the control rather than offer a
+  // setting that silently has no effect.
+  const _selectedModelLower = (store.selectedModel ?? "").toLowerCase();
+  const isDeepseekOcr =
+    _selectedModelLower.includes("deepseek") &&
+    _selectedModelLower.includes("ocr");
+  const showVisionImageSize = showVisionLora && !isDeepseekOcr;
   const [loraOpen, setLoraOpen] = useState(false);
   const [hyperOpen, setHyperOpen] = useState(false);
   const needsExpandedHeight = isCpt || (isLora && loraOpen) || hyperOpen;
@@ -917,7 +925,7 @@ export function ParamsSection(): ReactElement {
                 </TabsContent>
 
                 <TabsContent value="memory" className="mt-3 flex flex-col gap-3">
-                  {showVisionLora && (
+                  {showVisionImageSize && (
                     <Row
                       label="Image Size"
                       tooltip={

--- a/studio/frontend/src/features/studio/sections/params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/params-section.tsx
@@ -133,9 +133,7 @@ export function ParamsSection(): ReactElement {
   const isCpt = store.trainingMethod === "cpt";
   const isRawText = isRawTextDatasetFormat(store.datasetFormat);
   const showVisionLora = store.isVisionModel && store.isDatasetImage === true;
-  // DeepSeek OCR's preset is a coupled tuple, so the backend ignores any
-  // user-selected image size for it. Hide the control rather than offer a
-  // setting that silently has no effect.
+  // DeepSeek OCR uses a coupled preset; backend ignores user image size.
   const _selectedModelLower = (store.selectedModel ?? "").toLowerCase();
   const isDeepseekOcr =
     _selectedModelLower.includes("deepseek") &&

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -80,8 +80,11 @@ export function TrainingSection() {
   };
 
   const handleSaveConfig = () => {
-    // isDatasetImage is null during dataset checks; treat that as "save it"
-    // so an in-flight check doesn't silently drop the user's choice.
+    // isDatasetImage is null in three windows: before a dataset check
+    // completes, after dataset edits, and on import. Treat all three as
+    // "save it" so the user's choice is never silently dropped while we
+    // wait to confirm the dataset type. Only a confirmed text-only dataset
+    // (=== false) suppresses the vision fields.
     const includeVisionFields =
       store.isVisionModel && store.isDatasetImage !== false;
     // DeepSeek OCR ignores vision_image_size; don't emit it to YAML either,

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -80,10 +80,13 @@ export function TrainingSection() {
   };
 
   const handleSaveConfig = () => {
-    // Match the API mapper gate so exported YAML never carries
-    // vision_image_size for non-image datasets.
+    // Save vision fields for any vision-capable model unless we have positive
+    // confirmation the dataset is text-only. isDatasetImage is undetermined
+    // (null) before a dataset check completes, after dataset edits, and on
+    // import; treating that as "don't save" would silently drop the user's
+    // vision_image_size choice in those windows.
     const includeVisionFields =
-      store.isVisionModel && store.isDatasetImage === true;
+      store.isVisionModel && store.isDatasetImage !== false;
     const yamlStr = serializeConfigToYaml(store, includeVisionFields);
     const blob = new Blob([yamlStr], { type: "text/yaml" });
     const url = URL.createObjectURL(blob);

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -80,7 +80,11 @@ export function TrainingSection() {
   };
 
   const handleSaveConfig = () => {
-    const yamlStr = serializeConfigToYaml(store, store.isVisionModel);
+    // Match the API mapper gate so exported YAML never carries
+    // vision_image_size for non-image datasets.
+    const includeVisionFields =
+      store.isVisionModel && store.isDatasetImage === true;
+    const yamlStr = serializeConfigToYaml(store, includeVisionFields);
     const blob = new Blob([yamlStr], { type: "text/yaml" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -87,7 +87,18 @@ export function TrainingSection() {
     // vision_image_size choice in those windows.
     const includeVisionFields =
       store.isVisionModel && store.isDatasetImage !== false;
-    const yamlStr = serializeConfigToYaml(store, includeVisionFields);
+    // DeepSeek OCR ignores vision_image_size at training time (mappers.ts
+    // sends null), so do not emit it to YAML either; otherwise a stale
+    // value could later apply to a non-DeepSeek vision model.
+    const selectedModelLower = (store.selectedModel ?? "").toLowerCase();
+    const isDeepseekOcr =
+      selectedModelLower.includes("deepseek") &&
+      selectedModelLower.includes("ocr");
+    const yamlStr = serializeConfigToYaml(
+      store,
+      includeVisionFields,
+      includeVisionFields && !isDeepseekOcr,
+    );
     const blob = new Blob([yamlStr], { type: "text/yaml" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -80,16 +80,12 @@ export function TrainingSection() {
   };
 
   const handleSaveConfig = () => {
-    // Save vision fields for any vision-capable model unless we have positive
-    // confirmation the dataset is text-only. isDatasetImage is undetermined
-    // (null) before a dataset check completes, after dataset edits, and on
-    // import; treating that as "don't save" would silently drop the user's
-    // vision_image_size choice in those windows.
+    // isDatasetImage is null during dataset checks; treat that as "save it"
+    // so an in-flight check doesn't silently drop the user's choice.
     const includeVisionFields =
       store.isVisionModel && store.isDatasetImage !== false;
-    // DeepSeek OCR ignores vision_image_size at training time (mappers.ts
-    // sends null), so do not emit it to YAML either; otherwise a stale
-    // value could later apply to a non-DeepSeek vision model.
+    // DeepSeek OCR ignores vision_image_size; don't emit it to YAML either,
+    // or a later import on a non-DeepSeek model would activate the stale value.
     const selectedModelLower = (store.selectedModel ?? "").toLowerCase();
     const isDeepseekOcr =
       selectedModelLower.includes("deepseek") &&

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -55,6 +55,10 @@ export function buildTrainingStartPayload(
     hf_token: config.hfToken.trim() || null,
     load_in_4bit: (adapterMethod && isQloraMethod) || (isCpt && isFourBitModel),
     max_seq_length: config.contextLength,
+    vision_image_size:
+      config.isVisionModel && config.isDatasetImage === true
+        ? config.visionImageSize
+        : null,
     trust_remote_code: config.trustRemoteCode ?? false,
     hf_dataset: hfDataset,
     subset: hfDataset ? config.datasetSubset : null,

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -23,7 +23,12 @@ export function buildTrainingStartPayload(
   const isCpt = config.trainingMethod === "cpt";
   const adapterMethod = config.trainingMethod !== "full";
   const isQloraMethod = config.trainingMethod === "qlora";
-  const isFourBitModel = (config.selectedModel ?? "").toLowerCase().includes("4bit");
+  const _selectedModelLower = (config.selectedModel ?? "").toLowerCase();
+  const isFourBitModel = _selectedModelLower.includes("4bit");
+  // DeepSeek OCR ignores user-selected image size; do not send it.
+  const isDeepseekOcr =
+    _selectedModelLower.includes("deepseek") &&
+    _selectedModelLower.includes("ocr");
   const isEmbedding = config.isEmbeddingModel;
   const isRawText = isRawTextDatasetFormat(config.datasetFormat);
   const hfDataset = config.datasetSource === "huggingface" ? config.dataset : null;
@@ -56,7 +61,7 @@ export function buildTrainingStartPayload(
     load_in_4bit: (adapterMethod && isQloraMethod) || (isCpt && isFourBitModel),
     max_seq_length: config.contextLength,
     vision_image_size:
-      config.isVisionModel && config.isDatasetImage === true
+      config.isVisionModel && config.isDatasetImage === true && !isDeepseekOcr
         ? config.visionImageSize
         : null,
     trust_remote_code: config.trustRemoteCode ?? false,

--- a/studio/frontend/src/features/training/api/models-api.ts
+++ b/studio/frontend/src/features/training/api/models-api.ts
@@ -27,6 +27,7 @@ interface BackendTrainingDefaults {
   eval_steps?: number;
   weight_decay?: number;
   random_seed?: number;
+  vision_image_size?: number | string | null;
   packing?: boolean;
   train_on_completions?: boolean;
   gradient_checkpointing?: "none" | "true" | "unsloth";

--- a/studio/frontend/src/features/training/lib/model-defaults.ts
+++ b/studio/frontend/src/features/training/lib/model-defaults.ts
@@ -137,7 +137,9 @@ export function mapBackendModelConfigToTrainingPatch(
     if (raw == null) {
       patch.visionImageSize = null;
     } else {
-      // Drop anything the backend validator would reject.
+      // Mirror studio/backend/models/training.py:_check_vision_image_size:
+      // drop anything outside [_MIN_VISION_IMAGE_SIZE, _MAX_VISION_IMAGE_SIZE]
+      // so the store/UI never show a value the backend would reject.
       const n = toNumber(raw);
       if (n !== undefined && Number.isInteger(n) && n >= 256 && n <= 2048) {
         patch.visionImageSize = n;

--- a/studio/frontend/src/features/training/lib/model-defaults.ts
+++ b/studio/frontend/src/features/training/lib/model-defaults.ts
@@ -28,6 +28,7 @@ type ModelDefaultsPatch = Partial<
     | "trainOnCompletions"
     | "gradientCheckpointing"
     | "randomSeed"
+    | "visionImageSize"
     | "enableWandb"
     | "wandbProject"
     | "enableTensorboard"
@@ -128,6 +129,13 @@ export function mapBackendModelConfigToTrainingPatch(
 
   const randomSeed = toNumber(training?.random_seed);
   if (randomSeed !== undefined) patch.randomSeed = randomSeed;
+
+  if (Object.hasOwn(training ?? {}, "vision_image_size")) {
+    const visionImageSize = training?.vision_image_size == null
+      ? null
+      : toNumber(training.vision_image_size);
+    if (visionImageSize !== undefined) patch.visionImageSize = visionImageSize;
+  }
 
   const packing = toBoolean(training?.packing);
   if (packing !== undefined) patch.packing = packing;

--- a/studio/frontend/src/features/training/lib/model-defaults.ts
+++ b/studio/frontend/src/features/training/lib/model-defaults.ts
@@ -131,10 +131,18 @@ export function mapBackendModelConfigToTrainingPatch(
   if (randomSeed !== undefined) patch.randomSeed = randomSeed;
 
   if (Object.hasOwn(training ?? {}, "vision_image_size")) {
-    const visionImageSize = training?.vision_image_size == null
-      ? null
-      : toNumber(training.vision_image_size);
-    if (visionImageSize !== undefined) patch.visionImageSize = visionImageSize;
+    const raw = training?.vision_image_size;
+    if (raw == null) {
+      patch.visionImageSize = null;
+    } else {
+      // Mirror the backend validator at studio/backend/models/training.py:169.
+      // Anything not an integer in [256, 2048] is dropped so the store and UI
+      // never show a value the backend would reject.
+      const n = toNumber(raw);
+      if (n !== undefined && Number.isInteger(n) && n >= 256 && n <= 2048) {
+        patch.visionImageSize = n;
+      }
+    }
   }
 
   const packing = toBoolean(training?.packing);

--- a/studio/frontend/src/features/training/lib/model-defaults.ts
+++ b/studio/frontend/src/features/training/lib/model-defaults.ts
@@ -130,6 +130,11 @@ export function mapBackendModelConfigToTrainingPatch(
   const randomSeed = toNumber(training?.random_seed);
   if (randomSeed !== undefined) patch.randomSeed = randomSeed;
 
+  // Switching models must reset image size to the model default. Sibling
+  // training fields would also be reset by their respective branches above,
+  // but vision_image_size is special: model-default YAMLs in-tree currently
+  // omit the key, so without an explicit reset a stale 2048 from a previous
+  // model would silently apply to the new one.
   if (Object.hasOwn(training ?? {}, "vision_image_size")) {
     const raw = training?.vision_image_size;
     if (raw == null) {
@@ -141,8 +146,12 @@ export function mapBackendModelConfigToTrainingPatch(
       const n = toNumber(raw);
       if (n !== undefined && Number.isInteger(n) && n >= 256 && n <= 2048) {
         patch.visionImageSize = n;
+      } else {
+        patch.visionImageSize = null;
       }
     }
+  } else {
+    patch.visionImageSize = null;
   }
 
   const packing = toBoolean(training?.packing);

--- a/studio/frontend/src/features/training/lib/model-defaults.ts
+++ b/studio/frontend/src/features/training/lib/model-defaults.ts
@@ -130,11 +130,10 @@ export function mapBackendModelConfigToTrainingPatch(
   const randomSeed = toNumber(training?.random_seed);
   if (randomSeed !== undefined) patch.randomSeed = randomSeed;
 
-  // Switching models must reset image size to the model default. Sibling
-  // training fields would also be reset by their respective branches above,
-  // but vision_image_size is special: model-default YAMLs in-tree currently
-  // omit the key, so without an explicit reset a stale 2048 from a previous
-  // model would silently apply to the new one.
+  // Only patch visionImageSize when the model config explicitly carries it.
+  // Resetting a stale value on model SWITCH happens in
+  // training-config-store.ts setSelectedModel, not here, so that same-model
+  // defaults reloads do not wipe a value the user just selected.
   if (Object.hasOwn(training ?? {}, "vision_image_size")) {
     const raw = training?.vision_image_size;
     if (raw == null) {
@@ -150,8 +149,6 @@ export function mapBackendModelConfigToTrainingPatch(
         patch.visionImageSize = null;
       }
     }
-  } else {
-    patch.visionImageSize = null;
   }
 
   const packing = toBoolean(training?.packing);

--- a/studio/frontend/src/features/training/lib/model-defaults.ts
+++ b/studio/frontend/src/features/training/lib/model-defaults.ts
@@ -130,18 +130,14 @@ export function mapBackendModelConfigToTrainingPatch(
   const randomSeed = toNumber(training?.random_seed);
   if (randomSeed !== undefined) patch.randomSeed = randomSeed;
 
-  // Only patch visionImageSize when the model config explicitly carries it.
-  // Resetting a stale value on model SWITCH happens in
-  // training-config-store.ts setSelectedModel, not here, so that same-model
-  // defaults reloads do not wipe a value the user just selected.
+  // Only patch when the config carries the key; model-switch reset lives in
+  // setSelectedModel so same-model reloads don't wipe a user's choice.
   if (Object.hasOwn(training ?? {}, "vision_image_size")) {
     const raw = training?.vision_image_size;
     if (raw == null) {
       patch.visionImageSize = null;
     } else {
-      // Mirror the backend validator at studio/backend/models/training.py:169.
-      // Anything not an integer in [256, 2048] is dropped so the store and UI
-      // never show a value the backend would reject.
+      // Drop anything the backend validator would reject.
       const n = toNumber(raw);
       if (n !== undefined && Number.isInteger(n) && n >= 256 && n <= 2048) {
         patch.visionImageSize = n;

--- a/studio/frontend/src/features/training/lib/yaml-config.ts
+++ b/studio/frontend/src/features/training/lib/yaml-config.ts
@@ -32,23 +32,23 @@ export function parseYamlConfig(text: string): BackendModelConfig {
   // preserve a stale one. Same-model defaults reloads (which also flow
   // through the model-config mapper) skip the reset via Object.hasOwn
   // in model-defaults.ts; here we forge the key so import always wins.
-  // This also covers configs with no training section at all (lora-only
-  // exports), which otherwise would not trigger the mapper's vision
-  // patch and would leak the previously selected image size.
-  let trainingObj: unknown =
-    raw.training != null &&
-    typeof raw.training === "object" &&
-    !Array.isArray(raw.training)
-      ? { ...(raw.training as Record<string, unknown>) }
-      : raw.training;
-  if (trainingObj == null) {
+  // This also covers configs where the training section is missing,
+  // null, an array, or any non-mapping scalar - in all such cases the
+  // mapper would otherwise emit no vision patch and the previously
+  // selected image size would silently persist.
+  const rawTraining = raw.training;
+  const isPlainTrainingObject =
+    rawTraining != null &&
+    typeof rawTraining === "object" &&
+    !Array.isArray(rawTraining);
+  let trainingObj: Record<string, unknown>;
+  if (!isPlainTrainingObject) {
     trainingObj = { vision_image_size: null };
-  } else if (
-    typeof trainingObj === "object" &&
-    !Array.isArray(trainingObj) &&
-    !Object.hasOwn(trainingObj, "vision_image_size")
-  ) {
-    (trainingObj as Record<string, unknown>).vision_image_size = null;
+  } else {
+    trainingObj = { ...(rawTraining as Record<string, unknown>) };
+    if (!Object.hasOwn(trainingObj, "vision_image_size")) {
+      trainingObj.vision_image_size = null;
+    }
   }
 
   return {

--- a/studio/frontend/src/features/training/lib/yaml-config.ts
+++ b/studio/frontend/src/features/training/lib/yaml-config.ts
@@ -27,15 +27,10 @@ export function parseYamlConfig(text: string): BackendModelConfig {
     console.warn("Ignored unknown YAML keys:", unknownKeys.join(", "));
   }
 
-  // YAML import means "use this config as authoritative". An absent
-  // vision_image_size should reset the in-memory value to Default, not
-  // preserve a stale one. Same-model defaults reloads (which also flow
-  // through the model-config mapper) skip the reset via Object.hasOwn
-  // in model-defaults.ts; here we forge the key so import always wins.
-  // This also covers configs where the training section is missing,
-  // null, an array, or any non-mapping scalar - in all such cases the
-  // mapper would otherwise emit no vision patch and the previously
-  // selected image size would silently persist.
+  // File import is authoritative: forge vision_image_size = null when the
+  // training section is missing, malformed, or missing the key, so a stale
+  // store value cannot survive an import. (Same-model defaults reloads
+  // preserve user choice via Object.hasOwn in model-defaults.ts.)
   const rawTraining = raw.training;
   const isPlainTrainingObject =
     rawTraining != null &&

--- a/studio/frontend/src/features/training/lib/yaml-config.ts
+++ b/studio/frontend/src/features/training/lib/yaml-config.ts
@@ -32,14 +32,18 @@ export function parseYamlConfig(text: string): BackendModelConfig {
   // preserve a stale one. Same-model defaults reloads (which also flow
   // through the model-config mapper) skip the reset via Object.hasOwn
   // in model-defaults.ts; here we forge the key so import always wins.
-  const trainingObj =
+  // This also covers configs with no training section at all (lora-only
+  // exports), which otherwise would not trigger the mapper's vision
+  // patch and would leak the previously selected image size.
+  let trainingObj: unknown =
     raw.training != null &&
     typeof raw.training === "object" &&
     !Array.isArray(raw.training)
       ? { ...(raw.training as Record<string, unknown>) }
       : raw.training;
-  if (
-    trainingObj != null &&
+  if (trainingObj == null) {
+    trainingObj = { vision_image_size: null };
+  } else if (
     typeof trainingObj === "object" &&
     !Array.isArray(trainingObj) &&
     !Object.hasOwn(trainingObj, "vision_image_size")

--- a/studio/frontend/src/features/training/lib/yaml-config.ts
+++ b/studio/frontend/src/features/training/lib/yaml-config.ts
@@ -58,25 +58,31 @@ export function serializeConfigToYaml(
     lora.finetune_mlp_modules = state.finetuneMLPModules;
   }
 
+  const training: Record<string, unknown> = {
+    max_seq_length: state.contextLength,
+    num_epochs: state.epochs,
+    learning_rate: state.learningRate,
+    batch_size: state.batchSize,
+    gradient_accumulation_steps: state.gradientAccumulation,
+    warmup_steps: state.warmupSteps,
+    max_steps: state.maxSteps,
+    save_steps: state.saveSteps,
+    eval_steps: state.evalSteps,
+    weight_decay: state.weightDecay,
+    random_seed: state.randomSeed,
+    packing: state.packing,
+    train_on_completions: state.trainOnCompletions,
+    gradient_checkpointing: state.gradientCheckpointing,
+    optim: state.optimizerType,
+    lr_scheduler_type: state.lrSchedulerType,
+  };
+
+  if (includeVisionFields) {
+    training.vision_image_size = state.visionImageSize;
+  }
+
   const config = {
-    training: {
-      max_seq_length: state.contextLength,
-      num_epochs: state.epochs,
-      learning_rate: state.learningRate,
-      batch_size: state.batchSize,
-      gradient_accumulation_steps: state.gradientAccumulation,
-      warmup_steps: state.warmupSteps,
-      max_steps: state.maxSteps,
-      save_steps: state.saveSteps,
-      eval_steps: state.evalSteps,
-      weight_decay: state.weightDecay,
-      random_seed: state.randomSeed,
-      packing: state.packing,
-      train_on_completions: state.trainOnCompletions,
-      gradient_checkpointing: state.gradientCheckpointing,
-      optim: state.optimizerType,
-      lr_scheduler_type: state.lrSchedulerType,
-    },
+    training,
     lora,
   };
 

--- a/studio/frontend/src/features/training/lib/yaml-config.ts
+++ b/studio/frontend/src/features/training/lib/yaml-config.ts
@@ -27,8 +27,28 @@ export function parseYamlConfig(text: string): BackendModelConfig {
     console.warn("Ignored unknown YAML keys:", unknownKeys.join(", "));
   }
 
+  // YAML import means "use this config as authoritative". An absent
+  // vision_image_size should reset the in-memory value to Default, not
+  // preserve a stale one. Same-model defaults reloads (which also flow
+  // through the model-config mapper) skip the reset via Object.hasOwn
+  // in model-defaults.ts; here we forge the key so import always wins.
+  const trainingObj =
+    raw.training != null &&
+    typeof raw.training === "object" &&
+    !Array.isArray(raw.training)
+      ? { ...(raw.training as Record<string, unknown>) }
+      : raw.training;
+  if (
+    trainingObj != null &&
+    typeof trainingObj === "object" &&
+    !Array.isArray(trainingObj) &&
+    !Object.hasOwn(trainingObj, "vision_image_size")
+  ) {
+    (trainingObj as Record<string, unknown>).vision_image_size = null;
+  }
+
   return {
-    training: (raw.training ?? undefined) as BackendModelConfig["training"],
+    training: trainingObj as BackendModelConfig["training"],
     lora: (raw.lora ?? undefined) as BackendModelConfig["lora"],
     logging: (raw.logging ?? undefined) as BackendModelConfig["logging"],
   };
@@ -41,6 +61,7 @@ export function parseYamlConfig(text: string): BackendModelConfig {
 export function serializeConfigToYaml(
   state: TrainingConfigState,
   includeVisionFields: boolean,
+  includeVisionImageSize: boolean = includeVisionFields,
 ): string {
   const lora: Record<string, unknown> = {
     lora_r: state.loraRank,
@@ -77,7 +98,7 @@ export function serializeConfigToYaml(
     lr_scheduler_type: state.lrSchedulerType,
   };
 
-  if (includeVisionFields) {
+  if (includeVisionImageSize) {
     training.vision_image_size = state.visionImageSize;
   }
 

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -502,7 +502,18 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         },
         setSelectedModel: (selectedModel) => {
           const previousModel = get().selectedModel;
-          set({ selectedModel, modelDefaultsError: null });
+          // True model switch resets the image size sentinel so a stale
+          // value from a previous model does not silently apply to the new
+          // one. We do this here (not in mapBackendModelConfigToTrainingPatch)
+          // so same-model defaults reloads do not wipe the user's choice.
+          const patch: { selectedModel: string | null; modelDefaultsError: null; visionImageSize?: number | null } = {
+            selectedModel,
+            modelDefaultsError: null,
+          };
+          if (selectedModel !== previousModel) {
+            patch.visionImageSize = DEFAULT_HYPERPARAMS.visionImageSize;
+          }
+          set(patch);
 
           if (!selectedModel) {
             _modelConfigController?.abort();

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -701,6 +701,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         }),
         setEpochs: (epochs) => set({ epochs }),
         setContextLength: (contextLength) => set({ contextLength }),
+        setVisionImageSize: (visionImageSize) => set({ visionImageSize }),
         setLearningRate: (learningRate) => {
           _learningRateManuallySet = true;
           set({ learningRate });
@@ -755,7 +756,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         resetToModelDefaults: () => {
           const { selectedModel } = get();
           if (!selectedModel) return;
-          set({ modelDefaultsAppliedFor: null });
+          set({
+            modelDefaultsAppliedFor: null,
+            visionImageSize: DEFAULT_HYPERPARAMS.visionImageSize,
+          });
           loadAndApplyModelDefaults(selectedModel);
         },
         applyConfigPatch: (config: BackendModelConfig) => {

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -390,6 +390,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
                 error instanceof Error
                   ? error.message
                   : "Failed to load model defaults",
+              // Defaults load failed, so we cannot map the new model's
+              // vision_image_size. Reset to the global default so a stale
+              // value from a prior model never silently applies.
+              visionImageSize: DEFAULT_HYPERPARAMS.visionImageSize,
             });
 
             // Fallback vision check if config endpoint fails.

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -390,9 +390,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
                 error instanceof Error
                   ? error.message
                   : "Failed to load model defaults",
-              // Defaults load failed, so we cannot map the new model's
-              // vision_image_size. Reset to the global default so a stale
-              // value from a prior model never silently applies.
+              // Defaults load failed; reset so no prior model's value lingers.
               visionImageSize: DEFAULT_HYPERPARAMS.visionImageSize,
             });
 
@@ -502,10 +500,8 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         },
         setSelectedModel: (selectedModel) => {
           const previousModel = get().selectedModel;
-          // True model switch resets the image size sentinel so a stale
-          // value from a previous model does not silently apply to the new
-          // one. We do this here (not in mapBackendModelConfigToTrainingPatch)
-          // so same-model defaults reloads do not wipe the user's choice.
+          // Reset vision_image_size on a true switch only; same-model reloads
+          // go through the mapper, which preserves the user's choice.
           const patch: { selectedModel: string | null; modelDefaultsError: null; visionImageSize?: number | null } = {
             selectedModel,
             modelDefaultsError: null,

--- a/studio/frontend/src/features/training/types/api.ts
+++ b/studio/frontend/src/features/training/types/api.ts
@@ -7,6 +7,7 @@ export interface TrainingStartRequest {
   hf_token: string | null;
   load_in_4bit: boolean;
   max_seq_length: number;
+  vision_image_size?: number | null;
   /** Allow loading models with custom code. Only enable for repos you trust. */
   trust_remote_code?: boolean;
   hf_dataset: string | null;

--- a/studio/frontend/src/features/training/types/config.ts
+++ b/studio/frontend/src/features/training/types/config.ts
@@ -82,6 +82,7 @@ export interface TrainingConfigState {
   finetuneMLPModules: boolean;
   targetModules: string[];
   maxPositionEmbeddings: number | null;
+  visionImageSize: number | null;
 }
 
 export interface TrainingConfigActions {
@@ -115,6 +116,7 @@ export interface TrainingConfigActions {
   setUploadedEvalFile: (file: string | null) => void;
   setEpochs: (epochs: number) => void;
   setContextLength: (length: number) => void;
+  setVisionImageSize: (size: number | null) => void;
   setLearningRate: (rate: number) => void;
   setEmbeddingLearningRate: (rate: number | null) => void;
   setOptimizerType: (value: string) => void;


### PR DESCRIPTION
One thing that has always bothered me was not being able to **change/override the downscalling of images** when training for image specific tasks to traide quality for speed or the other way around.. Now this is possible thanks to a new exposed "Image Size" option under the Memory tab in the Parameters page.

<img width="524" height="745" alt="image" src="https://github.com/user-attachments/assets/c36bc0f4-b2d4-4692-b0b1-dd6e620169ff" />

It has the following settings in the dropdown:

<img width="490" height="360" alt="image" src="https://github.com/user-attachments/assets/4296735e-546b-4400-91a7-01f6cd7c9d88" />

When Default is selected, nothing changes when compared to before this PR. Higher resolutions require more context, if not enough context is pressent, this Error message will appear upon starting training:

<img width="900" height="193" alt="image" src="https://github.com/user-attachments/assets/5b33ee40-e86f-4e19-bcc3-aea394d816b8" />

The setting is saved in the YAML training config. I have added tests. 
I ran multiple training runs on my NVIDIA GPU to test its robustness using qwen3.5 and gemma4 models using LoRA, QLoRA and Full Finetune. I tested MLX but I did not do a full training run with it. I tested the changes in WSL (Ubuntu).
A custom implementation for MLX was required as I did not find any relevant documentation on any backend features already implementing this. :)