### PR TITLE
ci: broaden Linux + narrow Windows llama.cpp runtime patterns + trim #5741 comments

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1302,13 +1302,9 @@ shell.Run cmd, 0, False
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
             $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.5.6" unsloth-zoo }
             if ($baseInstallExit -eq 0) {
-                # Install pydantic WITH deps so pip pins pydantic-core to
-                # the exact version pydantic's metadata requires. The
-                # --no-deps install of no-torch-runtime.txt below would
-                # otherwise pick the latest of each independently and
-                # trip pydantic's _ensure_pydantic_core_version check.
-                # pydantic's deps (annotated-types, pydantic-core,
-                # typing-extensions, typing-inspection) are torch-free.
+                # Resolve pydantic WITH deps so pip pins pydantic-core
+                # to the matching version (no-torch-runtime.txt below
+                # is --no-deps). All transitive deps are torch-free.
                 $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython pydantic }
             }
             if ($baseInstallExit -eq 0) {
@@ -1358,8 +1354,7 @@ shell.Run cmd, 0, False
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
             $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.5.6" unsloth-zoo }
             if ($baseInstallExit -eq 0) {
-                # Install pydantic WITH deps so pip pins pydantic-core to
-                # the matching version (see migrated branch above).
+                # Same pydantic-with-deps trick as the migrated branch.
                 $baseInstallExit = Invoke-InstallCommand { uv pip install --python $VenvPython pydantic }
             }
             if ($baseInstallExit -eq 0) {

--- a/install.sh
+++ b/install.sh
@@ -1866,13 +1866,9 @@ if [ "$_MIGRATED" = true ]; then
         run_install_cmd "install unsloth (migrated no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
             "unsloth>=2026.5.6" unsloth-zoo
-        # Install pydantic WITH deps so pip pins pydantic-core to the
-        # exact version pydantic's own metadata requires. The --no-deps
-        # install below would otherwise pick the latest of each
-        # independently and trip pydantic's _ensure_pydantic_core_version
-        # check on the next import. pydantic's deps (annotated-types,
-        # pydantic-core, typing-extensions, typing-inspection) are
-        # torch-free, so this is safe on the no-torch path.
+        # Resolve pydantic WITH deps so pip pins pydantic-core to the
+        # matching version (no-torch-runtime.txt below is --no-deps).
+        # All transitive deps are torch-free.
         run_install_cmd "install pydantic (with deps for compatible core)" \
             uv pip install --python "$_VENV_PY" pydantic
         _NO_TORCH_RT="$(_find_no_torch_runtime)"
@@ -2051,8 +2047,7 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
         run_install_cmd "install unsloth (no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --upgrade-package unsloth --upgrade-package unsloth-zoo \
             "unsloth>=2026.5.6" unsloth-zoo
-        # Install pydantic WITH deps so pip pins pydantic-core to the
-        # exact version pydantic requires (see migrated branch above).
+        # Same pydantic-with-deps trick as the migrated branch.
         run_install_cmd "install pydantic (with deps for compatible core)" \
             uv pip install --python "$_VENV_PY" pydantic
         _NO_TORCH_RT="$(_find_no_torch_runtime)"

--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -22,19 +22,11 @@ rich>=13.0
 markdown-it-py>=3.0
 mdurl>=0.1
 pygments>=2.0
-# pydantic is intentionally NOT installed via this --no-deps file.
-# install.sh / install.ps1 / install_python_stack.py run a separate
-# `pip install pydantic` (with deps) just before this file is
-# applied, so pip resolves `pydantic-core` to the exact version
-# pydantic's `_ensure_pydantic_core_version` check expects. Listing
-# pydantic + pydantic-core unpinned here and resolving them under
-# --no-deps used to pick the latest of each independently and trip
-# `SystemError: pydantic-core 2.X.Y is incompatible with the current
-# pydantic version` on the first import (Windows fresh-venv repro
-# was the canonical case). pydantic's transitive deps
-# (annotated-types, pydantic-core, typing-extensions,
-# typing-inspection) are torch-free, so installing it WITH deps
-# does not pull torch.
+# pydantic is intentionally NOT pinned here. install.sh / install.ps1
+# / install_python_stack.py run `pip install pydantic` WITH deps just
+# before this --no-deps file is applied, so pip resolves pydantic-core
+# to the exact version pydantic's _ensure_pydantic_core_version check
+# expects. Pinning both under --no-deps used to drift them apart.
 pyyaml
 nest-asyncio
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3831,13 +3831,14 @@ def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
     # repackage the SO/DLL set (e.g. ggml-org/llama.cpp#23462 split the
     # per-binary entry code into paired ``lib<binary>-impl.so`` shared
     # libraries between b9279 and b9283) without us re-enumerating
-    # every new file. Mac and Windows already used this style.
+    # every new file. Studio only invokes llama-server and llama-quantize;
+    # other CLIs upstream ships (llama-cli, llama-bench, ...) are skipped.
     if choice.install_kind in {"linux-cpu", "linux-cuda", "linux-rocm"}:
         return ["llama-server", "llama-quantize", "lib*.so*"]
     if choice.install_kind in {"macos-arm64", "macos-x64"}:
         return ["llama-server", "llama-quantize", "lib*.dylib"]
     if choice.install_kind in {"windows-cpu", "windows-cuda", "windows-hip"}:
-        return ["*.exe", "*.dll"]
+        return ["llama-server.exe", "llama-quantize.exe", "*.dll"]
     raise PrebuiltFallback(
         f"unsupported install kind for runtime overlay: {choice.install_kind}"
     )

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3827,33 +3827,13 @@ def paired_runtime_dll_patterns(choice: AssetChoice) -> list[str]:
 
 
 def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
+    # Broad shared-library glob + explicit binary names. Lets upstream
+    # repackage the SO/DLL set (e.g. ggml-org/llama.cpp#23462 split the
+    # per-binary entry code into paired ``lib<binary>-impl.so`` shared
+    # libraries between b9279 and b9283) without us re-enumerating
+    # every new file. Mac and Windows already used this style.
     if choice.install_kind in {"linux-cpu", "linux-cuda", "linux-rocm"}:
-        return [
-            "llama-server",
-            "llama-quantize",
-            "libllama-common.so*",
-            "libllama.so*",
-            # Upstream llama.cpp split the per-binary entry code into
-            # paired ``libllama-<binary>-impl.so`` shared libraries
-            # around release b9261. ``llama-server`` and
-            # ``llama-quantize`` are NEEDED-linked against
-            # ``libllama-server-impl.so`` / ``libllama-quantize-impl.so``
-            # respectively, with RUNPATH ``$ORIGIN``. Without copying
-            # the impl ``.so`` files alongside the binaries, ldd
-            # reports them missing, preflight rejects the install, and
-            # the installer falls back to a source build on a fresh
-            # Linux install. Glob the whole family so future bundles
-            # that split additional binaries (e.g. ``llama-cli``,
-            # ``llama-bench``) keep working.
-            "libllama-*-impl.so*",
-            "libggml.so*",
-            "libggml-base.so*",
-            "libmtmd.so*",
-            "libggml-cpu-*.so*",
-            "libggml-cuda.so*",
-            "libggml-hip.so*",
-            "libggml-rpc.so*",
-        ]
+        return ["llama-server", "llama-quantize", "lib*.so*"]
     if choice.install_kind in {"macos-arm64", "macos-x64"}:
         return ["llama-server", "llama-quantize", "lib*.dylib"]
     if choice.install_kind in {"windows-cpu", "windows-cuda", "windows-hip"}:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -979,22 +979,11 @@ def install_python_stack() -> int:
             package_name,
             "unsloth-zoo",
         )
-        # Pydantic ships its core as a separate compiled wheel
-        # (pydantic-core), and pydantic's ``_ensure_pydantic_core_version``
-        # checks the installed core matches the exact version pinned in
-        # its own metadata. With ``--no-deps`` plus an unpinned
-        # ``pydantic`` / ``pydantic-core`` pair in no-torch-runtime.txt,
-        # pip resolved each to the newest available version and the two
-        # drifted (pydantic 2.13.4 pins pydantic-core==2.46.4 today, but
-        # pydantic-core 2.47.0 was the latest). On a fresh Windows venv
-        # the next ``import pydantic`` raised ``SystemError: ...
-        # incompatible with the current pydantic version``.
-        #
-        # Resolve them WITH deps in a focused pip call so pip picks a
-        # compatible pair. pydantic's own deps are
-        # ``annotated-types``, ``pydantic-core``, ``typing-extensions``,
-        # ``typing-inspection`` -- none of which transitively pull
-        # torch, so this is safe for the no-torch path.
+        # Resolve pydantic WITH deps so pip pins pydantic-core to the
+        # exact version pydantic's metadata declares. Under --no-deps
+        # alone pip picks the latest of each and trips pydantic's
+        # _ensure_pydantic_core_version check. Transitive deps are
+        # torch-free.
         pip_install(
             "Installing pydantic (with deps for compatible core)",
             "--no-cache-dir",

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -378,7 +378,10 @@ class TestRuntimePatterns:
             install_kind = "windows-hip",
         )
         patterns = runtime_patterns_for_choice(choice)
-        assert "*.exe" in patterns
+        # Narrowed from "*.exe" to the two binaries Studio actually
+        # invokes, mirroring the Linux/macOS pattern style.
+        assert "llama-server.exe" in patterns
+        assert "llama-quantize.exe" in patterns
         assert "*.dll" in patterns
 
     def test_macos_patterns(self):

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -346,28 +346,26 @@ class TestRuntimePatterns:
         patterns = runtime_patterns_for_choice(choice)
         assert "llama-server" in patterns
         assert "llama-quantize" in patterns
-        # Upstream split entry code into ``libllama-<binary>-impl.so``
-        # shared libraries (b9261+). llama-server and llama-quantize
-        # are NEEDED-linked against ``libllama-server-impl.so`` and
-        # ``libllama-quantize-impl.so`` respectively with RUNPATH
-        # ``$ORIGIN``, so the prebuilt overlay MUST copy them
-        # alongside the binaries or ldd reports them missing and
-        # preflight forces a source-build fallback.
-        assert "libllama-*-impl.so*" in patterns
+        # Broad lib*.so* covers libllama, libggml, libmtmd, libggml-cpu-*,
+        # plus the libllama-<binary>-impl.so split that ggml-org/llama.cpp
+        # #23462 introduced between b9279 and b9283.
+        assert "lib*.so*" in patterns
 
     def test_linux_cuda_patterns(self):
         choice = AssetChoice(
             repo = "", tag = "", name = "", url = "", source_label = "", install_kind = "linux-cuda"
         )
         patterns = runtime_patterns_for_choice(choice)
-        assert "libggml-cuda.so*" in patterns
+        # libggml-cuda.so is matched by lib*.so* now.
+        assert "lib*.so*" in patterns
 
     def test_linux_rocm_patterns(self):
         choice = AssetChoice(
             repo = "", tag = "", name = "", url = "", source_label = "", install_kind = "linux-rocm"
         )
         patterns = runtime_patterns_for_choice(choice)
-        assert "libggml-hip.so*" in patterns
+        # libggml-hip.so is matched by lib*.so* now.
+        assert "lib*.so*" in patterns
         assert "llama-server" in patterns
 
     def test_windows_hip_patterns(self):


### PR DESCRIPTION
Follow-up to #5741. Three cleanups bundled together.

## 1. Broaden Linux llama.cpp runtime pattern to `lib*.so*`

#5741 patched the explicit Linux pattern list to add `libllama-*-impl.so*` after `ggml-org/llama.cpp#23462` (commit `bb28c1fe`, landed between b9279 and b9283) split each binary's entry code into a paired `lib<binary>-impl.so` shared library. Same class of upstream repackaging will hit us again whenever a new shared lib is added.

Cross-platform audit of b9296 (Linux x64/arm64/ROCm, macOS arm64/x64, Windows CPU/CUDA/HIP/ARM64):

- **Linux** used an explicit per-lib list — fragile, drifted, needed the #5741 patch.
- **macOS** uses `["llama-server", "llama-quantize", "lib*.dylib"]` — broad glob caught the new `libllama-*-impl.dylib` automatically with no change.
- **Windows** uses `*.dll` — broad glob caught the new `llama-*-impl.dll` automatically.

Mirror macOS on Linux:

```python
if linux:
    return ["llama-server", "llama-quantize", "lib*.so*"]
```

Drops the per-lib entries (`libggml.so*`, `libggml-base.so*`, `libmtmd.so*`, `libggml-cpu-*.so*`, `libggml-cuda.so*`, `libggml-hip.so*`, `libggml-rpc.so*`, `libllama-common.so*`, `libllama.so*`, `libllama-*-impl.so*`) — all subsumed by `lib*.so*`.

### Reasoning the original explicit list
1. **Defense against unwanted files.** Still holds — `lib*.so*` rejects every CLI binary in the bundle (they don't start with `lib`).
2. **Self-documentation.** Moved to `runtime_payload_health_groups` (line 5189), the post-install spec of minimum-required libs per variant. Left intact.
3. **Per-variant filtering of `libggml-cuda.so*` / `libggml-hip.so*`.** Never worked — `copy_globs` (line 3614) unions patterns rather than intersecting them.
4. **Historical accretion.** Exactly the problem we just hit.
5. **`copy_globs` ambiguity errors.** Linux bundles are flat; not a concern.

### Verification
Dry-run of the new pattern against `llama-b9296-bin-ubuntu-x64.tar.gz`:
- **40 files copied** — all `ggml`, `llama`, `mtmd`, impl variants, plus the two binaries.
- **22 files skipped** — `LICENSE`, `llama`, `llama-batched-bench`, `llama-bench`, `llama-cli`, `llama-completion`, `llama-debug-template-parser`, `llama-fit-params`, `llama-gemma3-cli`, `llama-gguf-split`, `llama-imatrix`, `llama-llava-cli`, `llama-minicpmv-cli`, `llama-mtmd-cli`, `llama-mtmd-debug`, `llama-perplexity`, `llama-qwen2vl-cli`, `llama-results`, `llama-template-analysis`, `llama-tokenize`, `llama-tts`, `rpc-server`.

Functionally identical to the post-#5741 set. Resilient to the next upstream repackaging.

### Upstream bisection

| range | impl libs in bundle |
|-------|---------------------|
| b8955 → b9279 (May 22 01:51 UTC) | 0 |
| b9283 (May 22 13:43 UTC) → b9297 | 8 |

ggml-org/llama.cpp commits in that window: `bb28c1fe` "cmake: remove STATIC from impl libraries" (#23462) and `bbce619a` "cmake: add install() for impl libraries" (#23511).

Note: `unslothai/llama.cpp` fork's latest release is `b9267` — pre-split. The Linux installer's default `unslothai/llama.cpp` source stays on the pre-split layout. When the fork rebases past b9283 it picks up the new layout cleanly.

## 2. Narrow Windows runtime pattern

Studio only invokes `llama-server` and `llama-quantize`. Mac and Linux already filter to those two binaries; Windows was the odd one out with `*.exe` copying every CLI upstream ships (`llama-cli.exe`, `llama-bench.exe`, `llama-mtmd-cli.exe`, ...).

```python
if windows:
    return ["llama-server.exe", "llama-quantize.exe", "*.dll"]
```

Dry-run on b9296 (win cpu-x64, cpu-arm64, cuda-13.1, hip-radeon): **20 unused EXEs skipped per variant**, all DLLs (incl. the new `llama-*-impl.dll` family) still copied via `*.dll`. `existing_install_matches_choice` already checks `llama-server.exe` exists explicitly (line 5297), so the post-install health gate is unchanged.

## 3. Trim #5741 comments

The comments #5741 added across `install.ps1`, `install.sh`, `studio/install_python_stack.py`, `studio/backend/requirements/no-torch-runtime.txt`, and `tests/studio/install/test_rocm_support.py` re-explained the original bug in full at each site. Trimmed to one short paragraph per site. Full reasoning lives in #5741's PR description. No behavior change.

## What's deliberately NOT in this PR

**Adding `libllama-*-impl.so*` to `runtime_payload_health_groups`.** Considered it as defense-in-depth so an install missing impl libs would fail the post-install gate. Dropped because `runtime_payload_is_healthy` (line 5253) is what `existing_install_matches_choice` uses to decide "should I re-install" — and the default Linux source is `unslothai/llama.cpp` whose latest release is `b9267` (pre-split, no impl libs). Adding impl libs to health groups would force every user on the default source into an infinite re-install loop until the fork rebases past b9283. The preflight `ldd` check on fresh install already catches missing impl libs without this risk.