### PR TITLE
Lower default RL weight_decay from 0.01 to 0.001 for LoRA

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1312,7 +1312,9 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
         "logging_nan_inf_filter": False,
         "per_device_train_batch_size": 4,
         "gradient_accumulation_steps": 2,
-        "weight_decay": 0.01,
+        # LoRA decays A and B toward 0 so effective W = W_init + (alpha/r) * B @ A is pulled toward W_init, not 0 as in full FT.
+        # 0.001 keeps a small Frobenius prior |A|_F^2 + |B|_F^2 without measurably dragging the merged adapter back to base.
+        "weight_decay": 0.001,
         "seed": 3407,
         "optim": "adamw_8bit",
         "learning_rate": 5e-05,


### PR DESCRIPTION
## Summary

Lowers the default `weight_decay` in the patched RL config (`unsloth/models/rl.py`) from `0.01` to `0.001`, aligned with the new default across all unsloth notebook templates.

## Why

In full fine-tuning, AdamW weight decay shrinks the parameter directly,

$$W \leftarrow W - \eta\, g_L - \eta\lambda W$$

so the implicit prior is $W \to 0$.

In LoRA the trained parameters are $A, B$ but the effective weight is

$$W_\text{eff} = W_\text{init} + \tfrac{\alpha}{r}\, B A$$

Standard AdamW decays $A$ and $B$ separately,

$$A \leftarrow A - \eta\, g_A - \eta\lambda A, \qquad B \leftarrow B - \eta\, g_B - \eta\lambda B$$

so the implicit prior shifts: $BA \to 0$, hence $W_\text{eff} \to W_\text{init}$, not $0$. The composed adapter is being pulled back toward the frozen base instead of being regularised in magnitude. See [LoRA and Weight Decay](https://irhum.github.io/blog/lorawd/#the-interaction) for the full derivation.

At the previous default $\lambda = 0.01$ with $\eta = 5 \times 10^{-5}$, the pure-decay shrinkage per step is $\eta\lambda \approx 5 \times 10^{-7}$, which compounds over a few thousand steps into a measurable drag on the adapter delta. Dropping to $\lambda = 0.001$ keeps a small Frobenius-norm prior `|A|_F^2 + |B|_F^2` for numerical stability without meaningfully biasing the merged weight toward init.

## Change

- `unsloth/models/rl.py`: RL config default `weight_decay` `0.01` -> `0.001`, with a 2-line math comment inline above the `"weight_decay"` key explaining the asymmetry.

## Test plan

- [ ] Run an existing GRPO recipe with the new default and confirm reward curves are unchanged or slightly improved on a small dataset.
- [ ] Confirm the new default flows through to the generated RL config in the patched trainer.
- [ ] Companion notebook PR: https://github.com/unslothai/notebooks/pull/270