### PR TITLE
fix(chat_templates): check find() return value before slicing on placeholders

### DIFF
--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -20,6 +20,7 @@ from unsloth.chat_templates import construct_chat_template
 class _FakeTokenizer:
     """Minimum surface construct_chat_template touches before the
     validation guards fire."""
+
     name_or_path = "fake/tokenizer"
     eos_token = "</s>"
 
@@ -30,17 +31,17 @@ class _FakeTokenizer:
 @pytest.mark.parametrize(
     "template, expected_in_message",
     [
-        ("only {INPUT} here, no output marker",                "{OUTPUT}"),
-        ("only {OUTPUT} here, no input marker",                "{INPUT}"),
-        ("neither sentinel here, just literal text",           "{INPUT}"),
-        ("neither sentinel here, just literal text",           "{OUTPUT}"),
+        ("only {INPUT} here, no output marker", "{OUTPUT}"),
+        ("only {OUTPUT} here, no input marker", "{INPUT}"),
+        ("neither sentinel here, just literal text", "{INPUT}"),
+        ("neither sentinel here, just literal text", "{OUTPUT}"),
     ],
 )
 def test_missing_placeholder_in_chat_template_raises(template, expected_in_message):
     with pytest.raises(RuntimeError) as exc_info:
         construct_chat_template(
-            tokenizer        = _FakeTokenizer(),
-            chat_template    = template,
+            tokenizer = _FakeTokenizer(),
+            chat_template = template,
             extra_eos_tokens = ["</s>"],
         )
     assert expected_in_message in str(exc_info.value)
@@ -53,8 +54,8 @@ def test_single_pair_template_raises_clear_error_not_attribute_error():
     template = "user: {INPUT}\nassistant: {OUTPUT}\n"
     with pytest.raises(RuntimeError):
         construct_chat_template(
-            tokenizer        = _FakeTokenizer(),
-            chat_template    = template,
+            tokenizer = _FakeTokenizer(),
+            chat_template = template,
             extra_eos_tokens = ["</s>"],
         )
 
@@ -65,8 +66,8 @@ def test_error_message_excerpt_is_bounded():
     huge = ("garbage " * 5000) + "{INPUT}"  # ~40 KB, missing {OUTPUT}
     with pytest.raises(RuntimeError) as exc_info:
         construct_chat_template(
-            tokenizer        = _FakeTokenizer(),
-            chat_template    = huge,
+            tokenizer = _FakeTokenizer(),
+            chat_template = huge,
             extra_eos_tokens = ["</s>"],
         )
     msg = str(exc_info.value)

--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -1,0 +1,76 @@
+"""Negative-path validation tests for unsloth.chat_templates.construct_chat_template.
+
+Regression coverage for the str.find() / regex no-match guards added in
+PR #5763 follow-up: missing placeholders or unrecoverable two-example
+structures must raise RuntimeError with a clear message, not IndexError
+or AttributeError, and must never silently drop the last character via
+s[:-1].
+
+Uses a minimal fake tokenizer so the cases run on CPU-only CI without
+HF_TOKEN and without downloading a gated model. The validation paths
+exercised here fail before construct_chat_template reaches any heavy
+tokenizer interaction, so the stub stays small.
+"""
+
+import pytest
+
+from unsloth.chat_templates import construct_chat_template
+
+
+class _FakeTokenizer:
+    """Minimum surface construct_chat_template touches before the
+    validation guards fire."""
+    name_or_path = "fake/tokenizer"
+    eos_token = "</s>"
+
+    def get_vocab(self):
+        return {"</s>": 0}
+
+
+@pytest.mark.parametrize(
+    "template, expected_in_message",
+    [
+        ("only {INPUT} here, no output marker",                "{OUTPUT}"),
+        ("only {OUTPUT} here, no input marker",                "{INPUT}"),
+        ("neither sentinel here, just literal text",           "{INPUT}"),
+        ("neither sentinel here, just literal text",           "{OUTPUT}"),
+    ],
+)
+def test_missing_placeholder_in_chat_template_raises(template, expected_in_message):
+    with pytest.raises(RuntimeError) as exc_info:
+        construct_chat_template(
+            tokenizer        = _FakeTokenizer(),
+            chat_template    = template,
+            extra_eos_tokens = ["</s>"],
+        )
+    assert expected_in_message in str(exc_info.value)
+
+
+def test_single_pair_template_raises_clear_error_not_attribute_error():
+    """One {INPUT}/{OUTPUT} pair (rather than the required two) used to
+    crash with AttributeError on `found.group(1)` after the for-loop
+    broke without setting `found`. Must raise RuntimeError now."""
+    template = "user: {INPUT}\nassistant: {OUTPUT}\n"
+    with pytest.raises(RuntimeError):
+        construct_chat_template(
+            tokenizer        = _FakeTokenizer(),
+            chat_template    = template,
+            extra_eos_tokens = ["</s>"],
+        )
+
+
+def test_error_message_excerpt_is_bounded():
+    """Error messages must include a bounded excerpt of the offending
+    template, not dump arbitrarily large content into the traceback."""
+    huge = ("garbage " * 5000) + "{INPUT}"  # ~40 KB, missing {OUTPUT}
+    with pytest.raises(RuntimeError) as exc_info:
+        construct_chat_template(
+            tokenizer        = _FakeTokenizer(),
+            chat_template    = huge,
+            extra_eos_tokens = ["</s>"],
+        )
+    msg = str(exc_info.value)
+    # Excerpt is repr-quoted and capped; total message should stay well
+    # under the template length.
+    assert len(msg) < 1000
+    assert "{OUTPUT}" in msg

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2462,21 +2462,39 @@ extra_eos_tokens = None,
             )
     except:
         output_pos = chat_template.find("{OUTPUT}")
-        if output_pos == -1:
+        input_pos  = chat_template.find("{INPUT}")
+        if output_pos == -1 or input_pos == -1:
+            missing = []
+            if input_pos  == -1: missing.append("{INPUT}")
+            if output_pos == -1: missing.append("{OUTPUT}")
             raise RuntimeError(
-                "Unsloth: chat_template must contain a '{OUTPUT}' placeholder."
+                f"Unsloth: chat_template must contain {' and '.join(missing)} "
+                f"placeholder(s). Got: {chat_template[:200]!r}"
             )
         ending = chat_template[output_pos + len("{OUTPUT}"):]
 
         ending = re.escape(ending)
         find_text = "{INPUT}" + ending + "(.+?{OUTPUT}" + ending + ")"
         response_part = re.findall(find_text, chat_template, flags = re.DOTALL | re.MULTILINE)
+        if len(response_part) == 0:
+            raise RuntimeError(
+                "Unsloth: Could not recover a two-example structure from chat_template. "
+                "Provide exactly two {INPUT}/{OUTPUT} pairs (and optionally {SYSTEM}). "
+                f"Got: {chat_template[:200]!r}"
+            )
         response_part = response_part[0]
 
+        found = None
         for j in range(1, len(response_part)):
             try_find = re.escape(response_part[:j])
             try: found = next(re.finditer("(" + try_find + ").+?\\{INPUT\\}", chat_template, flags = re.DOTALL | re.MULTILINE))
             except: break
+        if found is None:
+            raise RuntimeError(
+                "Unsloth: Could not locate a separator between examples in chat_template. "
+                "Provide exactly two {INPUT}/{OUTPUT} pairs (and optionally {SYSTEM}). "
+                f"Got: {chat_template[:200]!r}"
+            )
         separator = found.group(1)
 
         response_start = chat_template.find(response_part)
@@ -2616,11 +2634,13 @@ extra_eos_tokens = None,
     output_idx = output_part.find("{OUTPUT}")
     if input_idx == -1:
         raise RuntimeError(
-            "Unsloth: input_part must contain '{INPUT}' placeholder."
+            f"Unsloth: The instruction section of the template must contain the "
+            f"'{{INPUT}}' placeholder. Section: {input_part[:200]!r}"
         )
     if output_idx == -1:
         raise RuntimeError(
-            "Unsloth: output_part must contain '{OUTPUT}' placeholder."
+            f"Unsloth: The response section of the template must contain the "
+            f"'{{OUTPUT}}' placeholder. Section: {output_part[:200]!r}"
         )
     input_part  = input_part [:input_idx ]
     output_part = output_part[:output_idx]

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2461,7 +2461,12 @@ extra_eos_tokens = None,
                 f"{left_changed}"
             )
     except:
-        ending = chat_template[chat_template.find("{OUTPUT}") + len("{OUTPUT}"):]
+        output_pos = chat_template.find("{OUTPUT}")
+        if output_pos == -1:
+            raise RuntimeError(
+                "Unsloth: chat_template must contain a '{OUTPUT}' placeholder."
+            )
+        ending = chat_template[output_pos + len("{OUTPUT}"):]
 
         ending = re.escape(ending)
         find_text = "{INPUT}" + ending + "(.+?{OUTPUT}" + ending + ")"
@@ -2607,8 +2612,18 @@ extra_eos_tokens = None,
             jinja_template = "{{ bos_token }}" + jinja_template
 
     # Get instruction and output parts for train_on_inputs = False
-    input_part  = input_part [:input_part .find("{INPUT}")]
-    output_part = output_part[:output_part.find("{OUTPUT}")]
+    input_idx  = input_part .find("{INPUT}")
+    output_idx = output_part.find("{OUTPUT}")
+    if input_idx == -1:
+        raise RuntimeError(
+            "Unsloth: input_part must contain '{INPUT}' placeholder."
+        )
+    if output_idx == -1:
+        raise RuntimeError(
+            "Unsloth: output_part must contain '{OUTPUT}' placeholder."
+        )
+    input_part  = input_part [:input_idx ]
+    output_part = output_part[:output_idx]
     return modelfile, jinja_template, input_part, output_part
 
 


### PR DESCRIPTION
## Summary

Two places in `construct_chat_template()` use `str.find()` for sentinel placeholders (`{INPUT}` / `{OUTPUT}`) without checking the `-1` return. Same shape as the `try_fix_tokenizer` fix that landed in #4923.

## Bug 1 — except-block fallback (around line 2464)

```python
except:
    ending = chat_template[chat_template.find("{OUTPUT}") + len("{OUTPUT}"):]
```

If `chat_template` has no `{OUTPUT}` marker, `find()` returns `-1`, the slice starts at offset `7` (`-1 + len("{OUTPUT}")`), and `ending` becomes garbage from the start of the template. That garbage is then `re.escape`-d and fed back into the template-recovery regex on the next line, which finds nothing — so the user sees a confusing `IndexError` on `response_part = response_part[0]` instead of the actual problem (missing placeholder).

## Bug 2 — final trim before return (around line 2610-2611)

```python
input_part  = input_part [:input_part .find("{INPUT}")]
output_part = output_part[:output_part.find("{OUTPUT}")]
return modelfile, jinja_template, input_part, output_part
```

If either placeholder is missing, `find()` returns `-1`, and `s[:-1]` silently drops the last character. The function returns a corrupted template prefix to the caller, who then trains on subtly wrong tokens.

## Fix

Split each `find()` from its arithmetic / slice, then raise a clear `RuntimeError` naming the missing placeholder when the result is `-1`. Mirrors the guard pattern from #4923.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('unsloth/chat_templates.py').read())"` — parses cleanly
- [ ] Existing `test_construct_chat_template()` should still pass (it uses a well-formed template with both placeholders)
- [ ] Manually: a template missing `{OUTPUT}` now raises `RuntimeError("...must contain '{OUTPUT}' placeholder.")` instead of `IndexError: list index out of range`

🤖 Generated with [Claude Code](https://claude.com/claude-code)