### PR TITLE
fix: resolve dtype mismatch in LoRA kernels under torch.autocast

### DIFF
--- a/unsloth/kernels/fast_lora.py
+++ b/unsloth/kernels/fast_lora.py
@@ -14,6 +14,7 @@
 
 import torch
 from .utils import (
+    _get_compute_dtype,
     _maybe_fake_quantize_activations,
     fast_dequantize,
     QUANT_STATE,
@@ -133,7 +134,8 @@ class LoRA_MLP(torch.autograd.Function):
         X = X.view(-1, X.shape[-1])
         e = e.view(-1, e.shape[-1])
         g = g.view(-1, g.shape[-1])
-        dtype = X.dtype
+        dtype = _get_compute_dtype(X)
+        X = X.to(dtype)
 
         gateA, gateB, upA, upB, downA, downB = (
             gateA.to(dtype),
@@ -438,7 +440,8 @@ class LoRA_QKV(torch.autograd.Function):
         dK = dK.reshape(-1, dK.shape[-1])  # view doesn't work on K.T
         dV = dV.view(-1, dV.shape[-1])
         X = X.view(-1, X.shape[-1])
-        dtype = X.dtype
+        dtype = _get_compute_dtype(X)
+        X = X.to(dtype)
 
         QA, QB, KA, KB, VA, VB = (
             QA.to(dtype),
@@ -609,7 +612,8 @@ class LoRA_W(torch.autograd.Function):
         batch, seq_len, hd = X.shape
         dY = dY.reshape(-1, dY.shape[-1])  # Must be reshape
         X = X.reshape(-1, X.shape[-1])  # Must be reshape
-        dtype = X.dtype
+        dtype = _get_compute_dtype(X)
+        X = X.to(dtype)
 
         A, B = A.to(dtype), B.to(dtype)
 

--- a/unsloth/kernels/fast_lora.py
+++ b/unsloth/kernels/fast_lora.py
@@ -135,7 +135,7 @@ class LoRA_MLP(torch.autograd.Function):
         e = e.view(-1, e.shape[-1])
         g = g.view(-1, g.shape[-1])
         dtype = _get_compute_dtype(X)
-        X = X.to(dtype)
+        X, dY = X.to(dtype), dY.to(dtype)
 
         gateA, gateB, upA, upB, downA, downB = (
             gateA.to(dtype),
@@ -441,7 +441,7 @@ class LoRA_QKV(torch.autograd.Function):
         dV = dV.view(-1, dV.shape[-1])
         X = X.view(-1, X.shape[-1])
         dtype = _get_compute_dtype(X)
-        X = X.to(dtype)
+        X, dQ, dK, dV = X.to(dtype), dQ.to(dtype), dK.to(dtype), dV.to(dtype)
 
         QA, QB, KA, KB, VA, VB = (
             QA.to(dtype),
@@ -613,7 +613,7 @@ class LoRA_W(torch.autograd.Function):
         dY = dY.reshape(-1, dY.shape[-1])  # Must be reshape
         X = X.reshape(-1, X.shape[-1])  # Must be reshape
         dtype = _get_compute_dtype(X)
-        X = X.to(dtype)
+        X, dY = X.to(dtype), dY.to(dtype)
 
         A, B = A.to(dtype), B.to(dtype)
 

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -1014,6 +1014,7 @@ else:
 # (XPU support in unsloth already requires torch >= 2.6, so the legacy path is
 # effectively cuda-only.) Branch at module load to avoid try/except in hot paths.
 if Version(torch.__version__) >= Version("2.4.0"):
+
     def _get_compute_dtype(X: "torch.Tensor") -> "torch.dtype":
         """
         Return the effective compute dtype for LoRA weight casts.
@@ -1033,6 +1034,7 @@ if Version(torch.__version__) >= Version("2.4.0"):
             return torch.get_autocast_dtype(DEVICE_TYPE_TORCH)
         return X.dtype
 else:
+
     def _get_compute_dtype(X: "torch.Tensor") -> "torch.dtype":
         """torch < 2.4 fallback - cuda-only (xpu requires torch >= 2.6)."""
         if torch.is_autocast_enabled():

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -1009,6 +1009,37 @@ else:
     pass
 
 
+# torch.is_autocast_enabled(device_type) / torch.get_autocast_dtype(device_type)
+# were added in torch 2.4. On older torch, use the legacy CUDA-only API.
+# (XPU support in unsloth already requires torch >= 2.6, so the legacy path is
+# effectively cuda-only.) Branch at module load to avoid try/except in hot paths.
+if Version(torch.__version__) >= Version("2.4.0"):
+    def _get_compute_dtype(X: "torch.Tensor") -> "torch.dtype":
+        """
+        Return the effective compute dtype for LoRA weight casts.
+
+        When torch.autocast is active, eligible matmul ops produce outputs in the
+        autocast dtype (e.g. bfloat16/float16), NOT in X.dtype. In-place ops like
+        addmm_ do not go through autocast, so LoRA operands must be cast to the
+        same dtype as those matmul outputs.
+
+        torch.amp.custom_fwd(cast_inputs=None) - used here - does not cast inputs,
+        so callers must resolve the compute dtype themselves.
+
+        DEVICE_TYPE_TORCH handles the hip -> cuda mapping for AMD devices.
+        """
+        global DEVICE_TYPE_TORCH
+        if torch.is_autocast_enabled(DEVICE_TYPE_TORCH):
+            return torch.get_autocast_dtype(DEVICE_TYPE_TORCH)
+        return X.dtype
+else:
+    def _get_compute_dtype(X: "torch.Tensor") -> "torch.dtype":
+        """torch < 2.4 fallback - cuda-only (xpu requires torch >= 2.6)."""
+        if torch.is_autocast_enabled():
+            return torch.get_autocast_gpu_dtype()
+        return X.dtype
+
+
 def fast_linear_forward(proj, X, temp_lora = None, out = None):
     W, W_quant, lora_A, lora_B, lora_S, bias = get_lora_parameters_bias(proj)
     bsz, q_len, in_dim = X.shape
@@ -1028,9 +1059,9 @@ def fast_linear_forward(proj, X, temp_lora = None, out = None):
     # Add in LoRA weights
     if lora_A is not None:
         out_dim = out.shape[2]
-        dtype = X.dtype
+        dtype = _get_compute_dtype(X)
 
-        if not hasattr(lora_A, "_fast_lora"):
+        if not hasattr(lora_A, "_fast_lora") or lora_A._fast_lora.dtype != dtype:
             lora_A._fast_lora = lora_A.to(dtype)
             lora_B._fast_lora = lora_B.to(dtype)
 
@@ -1053,7 +1084,7 @@ def fast_linear_forward(proj, X, temp_lora = None, out = None):
 
 
 def matmul_lora(X, W, W_quant, A, B, s, out = None):
-    dtype = X.dtype
+    dtype = _get_compute_dtype(X)
 
     if X.dim() == 3:
         batch, seq_len, d = X.shape


### PR DESCRIPTION
Under torch.autocast, torch.matmul outputs are in the autocast dtype (bfloat16/float16), but the subsequent in-place addmm_ calls in matmul_lora, fast_linear_forward, and the backward methods of LoRA_W, LoRA_QKV, and LoRA_MLP used dtype = X.dtype, which returns float32 when the input activation is a float32 tensor. This caused addmm_ to crash with a dtype mismatch.

Add a _get_compute_dtype(X) helper that queries the autocast state via the unified torch.is_autocast_enabled(device_type) / torch.get_autocast_dtype(device_type) API on torch >= 2.4, with a legacy fallback (is_autocast_enabled() / get_autocast_gpu_dtype()) for torch < 2.4. The branch is resolved at module load (matching the existing torch_amp_custom_fwd pattern) so the hot path has no try/except cost on older torch. Uses DEVICE_TYPE_TORCH so the helper works on CUDA, HIP (maps to cuda), and XPU. Replace all five dtype = X.dtype call sites with this helper, and add X = X.to(dtype) in the three backward methods so that the saved float32 activation is cast to the compute dtype before the addmm_ calls.

Also fix a cache poisoning bug in fast_linear_forward: the _fast_lora cache is now invalidated when the compute dtype changes between calls (e.g. inference outside autocast followed by bf16 training).

Tested on RTX 4060, CUDA 12.8, torch 2.11.0+cu128:
- Tier 1 kernel unit tests: 4/4 pass (before fix: 1/4) Includes a real fast_linear_forward q_len=1 cache test using a PEFT-shaped Proj that verifies the cache flips fp16 -> bf16 across the autocast boundary.
- Tier 2 backward smoke tests: 3/3 pass (before fix: 0/3)
- Tier 3 GRPO end-to-end: 10 steps, no dtype crash (Qwen2.5-1.5B-4bit, bf16 autocast)

The helper itself emits no DeprecationWarning on torch >= 2.4. The torch < 2.4 fallback is verified by extracting the legacy branch via AST and exec'ing it against a shimmed torch namespace.