### PR TITLE
Studio: stop the model from replying twice when it refuses

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -60,7 +60,9 @@ _INTENT_SIGNAL = re.compile(
     # Handles both straight and curly apostrophes.
     # Excludes "I can", "I should", "I want to", "let's" which
     # appear frequently in direct answers / explanations.
-    r"\b(i['\u2019](ll|m going to|m gonna)|i am (going to|gonna)|i will|i shall|let me|allow me)\b"
+    # Negative lookahead drops negated forms ("I will not", "I'll never")
+    # so a refusal doesn't trigger a re-prompt.
+    r"\b(i['\u2019](ll|m going to|m gonna)|i am (going to|gonna)|i will|i shall|let me|allow me)\b(?!\s+(?:not|never)\b)"
     r"|"
     # Step/plan framing: "First ...", "Step 1:", "Here's my plan"
     r"\b(?:first\b|step \d+:?|here['\u2019]?s (?:my |the |a )?(?:plan|approach))"


### PR DESCRIPTION
When a GGUF model in Studio refuses a request, it can reply twice in one turn: e.g. "I will not respond to that." then "I cannot fulfill this request.", each with its own thinking block.

**Cause:** the agentic loop re-prompts the model when it announces a plan ("I'll...", "Let me...") without calling a tool, detected by the `_INTENT_SIGNAL` regex. Its `i will` pattern also matches refusals like "I will not...", so a refusal is misread as a plan and triggers a second generation.

**Fix:** a negative lookahead so negated forms ("I will not", "I'll never") no longer match. Genuine plans like "I will search" still re-prompt.

Only fires with tools enabled. Related: #5714, #5549, #5706 rework the same path for other cases; none cover refusals.

### Reproduction

1. Load a GGUF model in Studio (e.g. `gemma-4-E2B-it-GGUF`) and turn on tools ("Think, Search, Code").
2. Send a request the model refuses with a reply starting "I will not...".
3. It replies twice in one turn, each with its own thinking block.
