### PR TITLE
studio/frontend: add space above the scroll-to-bottom arrow in chat

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -175,7 +175,8 @@ export const Thread: FC<{
               <ThreadPrimitive.ViewportFooter
                 className={cn(
                   "aui-thread-viewport-footer pointer-events-none sticky z-20 flex w-full justify-center bg-transparent",
-                  hideComposer ? "bottom-3" : "bottom-[140px]",
+                  // 150px (was 140px) to add a small gap above the composer
+                  hideComposer ? "bottom-3" : "bottom-[150px]",
                 )}
               >
                 <ThreadScrollToBottom />


### PR DESCRIPTION
The "scroll to bottom" arrow in the chat sat flush against the composer with no space between them.

**Fix:** bump the arrow's sticky offset from `bottom-[140px]` to `bottom-[150px]` so it clears the ~142px composer and floats with a small gap above it.

-----

Before:

<img width="924" height="280" alt="image" src="https://github.com/user-attachments/assets/0ee44be0-7914-4c32-ba6c-06c9cda4c099" />

After:

<img width="912" height="272" alt="image" src="https://github.com/user-attachments/assets/c21fe36c-9377-49b1-a90c-4cf44605dcb4" />
