### PR TITLE
studio/frontend: show "1 second" instead of "1 seconds" in thinking blocks

### DIFF
--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -134,7 +134,7 @@ function ReasoningTrigger({
         {active ? (
           <span className="text-sm">Thinking...</span>
         ) : (
-          <span>Thought for {duration ?? 0} second{duration === 1 ? "" : "s"}</span>
+          <span>Thought for {duration ?? 0} {duration === 1 ? "second" : "seconds"}</span>
         )}
       </span>
       <ChevronDownIcon

--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -134,7 +134,7 @@ function ReasoningTrigger({
         {active ? (
           <span className="text-sm">Thinking...</span>
         ) : (
-          <span>Thought for {duration ?? 0} seconds</span>
+          <span>Thought for {duration ?? 0} second{duration === 1 ? "" : "s"}</span>
         )}
       </span>
       <ChevronDownIcon


### PR DESCRIPTION
The reasoning trigger always read "Thought for N seconds", so a one-second thinking block showed "Thought for 1 seconds".

**Fix:** drop the trailing "s" when the duration is exactly 1, so it reads "1 second". Other values (including 0) keep "seconds".
