### PR TITLE
Studio: per-card web_search result + shell_call output fallback (OpenAI)

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3873,14 +3873,20 @@ class ExternalProviderClient:
                                             ),
                                         }
                                     )
+                                    # Seed result with the call's own query so
+                                    # each card shows "Searching: <query>"
+                                    # instead of an empty panel. The last call
+                                    # is still overwritten at response.completed
+                                    # with the aggregated citation list (used
+                                    # by the source-pill extractor).
+                                    per_call_result = (
+                                        f"Searching: {query}" if query else ""
+                                    )
                                     yield _emit_tool_event(
                                         {
                                             "type": "tool_end",
                                             "tool_call_id": item_id,
-                                            # Empty result — the last call gets
-                                            # overwritten with citations at
-                                            # response.completed.
-                                            "result": "",
+                                            "result": per_call_result,
                                         }
                                     )
                                 elif item.get("type") == "shell_call":
@@ -3908,7 +3914,11 @@ class ExternalProviderClient:
                                     )
                                     shell_calls.setdefault(
                                         item_id,
-                                        {"commands": [], "output": None},
+                                        {
+                                            "commands": [],
+                                            "output": None,
+                                            "tool_end_emitted": False,
+                                        },
                                     )
                                     shell_calls[item_id]["commands"] = (
                                         list(commands)
@@ -3926,6 +3936,27 @@ class ExternalProviderClient:
                                             },
                                         }
                                     )
+                                    # Fallback: some Responses streams ship the
+                                    # output bundled on the shell_call item's
+                                    # done event instead of as a separate
+                                    # shell_call_output. If so, emit tool_end
+                                    # now so the card never stays in "running".
+                                    embedded_output = item.get("output")
+                                    if (
+                                        isinstance(embedded_output, list)
+                                        and embedded_output
+                                    ):
+                                        shell_calls[item_id]["output"] = embedded_output
+                                        shell_calls[item_id]["tool_end_emitted"] = True
+                                        yield _emit_tool_event(
+                                            {
+                                                "type": "tool_end",
+                                                "tool_call_id": item_id,
+                                                "result": _format_shell_output(
+                                                    embedded_output
+                                                ),
+                                            }
+                                        )
                                 elif item.get("type") == "shell_call_output":
                                     # `call_id` links back to the shell_call's
                                     # `id`, which is what we used as the
@@ -3936,8 +3967,16 @@ class ExternalProviderClient:
                                         item.get("call_id") or item.get("id") or ""
                                     )
                                     output = item.get("output") or []
+                                    # Skip if the fallback above already emitted
+                                    # tool_end for this call from the bundled
+                                    # output, so the card is not re-completed.
+                                    if shell_calls.get(call_id, {}).get(
+                                        "tool_end_emitted"
+                                    ):
+                                        continue
                                     if call_id in shell_calls:
                                         shell_calls[call_id]["output"] = output
+                                        shell_calls[call_id]["tool_end_emitted"] = True
                                     result_text = _format_shell_output(output)
                                     yield _emit_tool_event(
                                         {
@@ -4099,9 +4138,10 @@ class ExternalProviderClient:
                                 # parseSourcesFromResult flatMaps every
                                 # web_search tool-call result, so a single
                                 # non-empty result is enough to surface the
-                                # whole source-pill set at the message tail —
-                                # no need to fan out across every card (which
-                                # would just duplicate the same pills).
+                                # whole source-pill set at the message tail.
+                                # Earlier per-call results carry their own
+                                # "Searching: <query>" text so the cards are
+                                # never empty.
                                 if web_search_calls and all_url_citations:
                                     last_id = list(web_search_calls.keys())[-1]
                                     blocks: list[str] = []
@@ -4119,6 +4159,25 @@ class ExternalProviderClient:
                                             "result": "\n---\n".join(blocks),
                                         }
                                     )
+                                # Final flush: any shell_call that never got
+                                # an output event needs a tool_end so the card
+                                # transitions out of "running". Emit with the
+                                # accumulated output (may be empty) so the
+                                # frontend renders "(no output)" rather than
+                                # spinning indefinitely.
+                                for sc_id, sc_state in shell_calls.items():
+                                    if sc_state.get("tool_end_emitted"):
+                                        continue
+                                    yield _emit_tool_event(
+                                        {
+                                            "type": "tool_end",
+                                            "tool_call_id": sc_id,
+                                            "result": _format_shell_output(
+                                                sc_state.get("output") or []
+                                            ),
+                                        }
+                                    )
+                                    sc_state["tool_end_emitted"] = True
                                 chunk = {
                                     "id": completion_id,
                                     "object": "chat.completion.chunk",

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3873,12 +3873,8 @@ class ExternalProviderClient:
                                             ),
                                         }
                                     )
-                                    # Seed result with the call's own query so
-                                    # each card shows "Searching: <query>"
-                                    # instead of an empty panel. The last call
-                                    # is still overwritten at response.completed
-                                    # with the aggregated citation list (used
-                                    # by the source-pill extractor).
+                                    # Per-card text; last call gets overwritten
+                                    # with citations at response.completed.
                                     per_call_result = (
                                         f"Searching: {query}" if query else ""
                                     )
@@ -3936,11 +3932,8 @@ class ExternalProviderClient:
                                             },
                                         }
                                     )
-                                    # Fallback: some Responses streams ship the
-                                    # output bundled on the shell_call item's
-                                    # done event instead of as a separate
-                                    # shell_call_output. If so, emit tool_end
-                                    # now so the card never stays in "running".
+                                    # Fallback: output may be bundled on the
+                                    # shell_call done event itself.
                                     embedded_output = item.get("output")
                                     if (
                                         isinstance(embedded_output, list)
@@ -3967,9 +3960,8 @@ class ExternalProviderClient:
                                         item.get("call_id") or item.get("id") or ""
                                     )
                                     output = item.get("output") or []
-                                    # Skip if the fallback above already emitted
-                                    # tool_end for this call from the bundled
-                                    # output, so the card is not re-completed.
+                                    # Skip if bundled-output path already
+                                    # finalised this card.
                                     if shell_calls.get(call_id, {}).get(
                                         "tool_end_emitted"
                                     ):
@@ -4132,16 +4124,10 @@ class ExternalProviderClient:
                                         }
                                     )
                                     container_id_emitted = True
-                                # Apply the aggregated citation list onto the
-                                # *last* web_search call by overwriting its
-                                # tool_end result. The frontend's
-                                # parseSourcesFromResult flatMaps every
-                                # web_search tool-call result, so a single
-                                # non-empty result is enough to surface the
-                                # whole source-pill set at the message tail.
-                                # Earlier per-call results carry their own
-                                # "Searching: <query>" text so the cards are
-                                # never empty.
+                                # Overwrite the last web_search call with the
+                                # citation list; the source-pill extractor
+                                # flatMaps across cards. Earlier cards keep
+                                # their per-call "Searching:" text.
                                 if web_search_calls and all_url_citations:
                                     last_id = list(web_search_calls.keys())[-1]
                                     blocks: list[str] = []
@@ -4159,12 +4145,8 @@ class ExternalProviderClient:
                                             "result": "\n---\n".join(blocks),
                                         }
                                     )
-                                # Final flush: any shell_call that never got
-                                # an output event needs a tool_end so the card
-                                # transitions out of "running". Emit with the
-                                # accumulated output (may be empty) so the
-                                # frontend renders "(no output)" rather than
-                                # spinning indefinitely.
+                                # Final flush: finalise any orphan shell_call
+                                # so the card stops spinning.
                                 for sc_id, sc_state in shell_calls.items():
                                     if sc_state.get("tool_end_emitted"):
                                         continue
@@ -4256,11 +4238,9 @@ class ExternalProviderClient:
                                             "result": "\n---\n".join(blocks),
                                         }
                                     )
-                                # Same orphan-shell_call flush as
-                                # response.completed: a truncated stream
-                                # (max_tokens hit) leaves any in-flight
-                                # shell_call stuck on "running" unless we
-                                # emit a final tool_end here too.
+                                # Mirror the response.completed flush so
+                                # truncated streams also finalise orphan
+                                # shell_calls.
                                 for sc_id, sc_state in shell_calls.items():
                                     if sc_state.get("tool_end_emitted"):
                                         continue

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -4256,6 +4256,24 @@ class ExternalProviderClient:
                                             "result": "\n---\n".join(blocks),
                                         }
                                     )
+                                # Same orphan-shell_call flush as
+                                # response.completed: a truncated stream
+                                # (max_tokens hit) leaves any in-flight
+                                # shell_call stuck on "running" unless we
+                                # emit a final tool_end here too.
+                                for sc_id, sc_state in shell_calls.items():
+                                    if sc_state.get("tool_end_emitted"):
+                                        continue
+                                    yield _emit_tool_event(
+                                        {
+                                            "type": "tool_end",
+                                            "tool_call_id": sc_id,
+                                            "result": _format_shell_output(
+                                                sc_state.get("output") or []
+                                            ),
+                                        }
+                                    )
+                                    sc_state["tool_end_emitted"] = True
                                 chunk = {
                                     "id": completion_id,
                                     "object": "chat.completion.chunk",

--- a/studio/backend/tests/test_openai_tool_result_fallbacks.py
+++ b/studio/backend/tests/test_openai_tool_result_fallbacks.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for OpenAI Responses tool-result rendering.
+
+Two bug classes covered:
+
+1. web_search: every call's tool_end carried `result: ""`, leaving every
+   card except the last one empty in the chat thread. Now each call seeds
+   its own `Searching: <query>` text so the cards always render content;
+   the last call is still overwritten at response.completed with the
+   aggregated citation list (consumed by the source-pill extractor).
+
+2. shell_call (code_execution): when OpenAI bundles the output on the
+   shell_call item's `response.output_item.done` event instead of as a
+   separate `shell_call_output`, the previous handler never emitted
+   tool_end and the card stayed in "running" with no output. The fallback
+   now emits tool_end from the bundled output. A final flush at
+   response.completed catches shell_call ids that received neither.
+"""
+
+import asyncio
+import json
+
+import httpx
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+async def _collect(agen):
+    out = []
+    async for line in agen:
+        out.append(line)
+    return out
+
+
+def _mock_http_client(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(ep_mod, "_http_client", httpx.AsyncClient(transport = transport))
+
+
+def _make_client(base_url: str = "https://api.openai.com/v1") -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = "openai",
+        base_url = base_url,
+        api_key = "sk-test",
+    )
+
+
+def _openai_sse(events: list[dict]) -> bytes:
+    chunks: list[str] = []
+    for event in events:
+        chunks.append(f"event: {event['type']}")
+        chunks.append(f"data: {json.dumps(event)}")
+        chunks.append("")
+    return ("\n".join(chunks) + "\n").encode("utf-8")
+
+
+def _tool_events(lines: list[str]) -> list[dict]:
+    out: list[dict] = []
+    for line in lines:
+        if not line.startswith("data:"):
+            continue
+        raw = line[len("data:") :].strip()
+        if not raw or raw == "[DONE]":
+            continue
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and "_toolEvent" in parsed:
+            out.append(parsed["_toolEvent"])
+    return out
+
+
+def _drive_stream(sse_events, enabled_tools, monkeypatch):
+    def handler(request):
+        return httpx.Response(
+            200,
+            content = _openai_sse(sse_events),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        return await _collect(
+            client._stream_openai_responses(
+                messages = [{"role": "user", "content": "x"}],
+                model = "gpt-5.5",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 4096,
+                enable_thinking = None,
+                reasoning_effort = None,
+                enabled_tools = enabled_tools,
+            )
+        )
+
+    return _drive(run())
+
+
+# ── web_search per-card result ─────────────────────────────────────────
+
+
+def test_web_search_each_call_carries_its_own_query_as_result(monkeypatch):
+    """Three search calls, no citations. Each card must render with its
+    own `Searching: <query>` text; none should be empty."""
+    sse_events = [
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "action": {"query": "popular animals 2026"},
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "web_search_call",
+                "id": "ws_2",
+                "action": {"query": "most loved animals poll"},
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "web_search_call",
+                "id": "ws_3",
+                "action": {"query": "tiger ranking"},
+            },
+        },
+        {"type": "response.completed", "response": {}},
+    ]
+    lines = _drive_stream(sse_events, ["web_search"], monkeypatch)
+    events = _tool_events(lines)
+    ends = [e for e in events if e["type"] == "tool_end"]
+    by_id = {e["tool_call_id"]: e for e in ends}
+    assert by_id["ws_1"]["result"] == "Searching: popular animals 2026"
+    assert by_id["ws_2"]["result"] == "Searching: most loved animals poll"
+    assert by_id["ws_3"]["result"] == "Searching: tiger ranking"
+
+
+def test_web_search_last_call_overwritten_with_citations(monkeypatch):
+    """Pin the existing behaviour: the last call still gets the
+    aggregated citation list (the source-pill extractor depends on this).
+    Earlier calls keep their per-call `Searching:` text."""
+    sse_events = [
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "action": {"query": "first query"},
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "web_search_call",
+                "id": "ws_2",
+                "action": {"query": "second query"},
+            },
+        },
+        {
+            "type": "response.output_text.annotation.added",
+            "annotation": {
+                "type": "url_citation",
+                "url": "https://example.com/a",
+                "title": "Example A",
+            },
+        },
+        {"type": "response.completed", "response": {}},
+    ]
+    lines = _drive_stream(sse_events, ["web_search"], monkeypatch)
+    events = _tool_events(lines)
+    ends = [e for e in events if e["type"] == "tool_end"]
+    by_id: dict = {}
+    # Keep the LAST tool_end per id (the citation overwrite for ws_2).
+    for e in ends:
+        by_id[e["tool_call_id"]] = e
+    # First call keeps its own query.
+    assert by_id["ws_1"]["result"] == "Searching: first query"
+    # Last call gets overwritten with the citation block.
+    assert "Title: Example A" in by_id["ws_2"]["result"]
+    assert "URL: https://example.com/a" in by_id["ws_2"]["result"]
+
+
+def test_web_search_empty_query_falls_back_to_empty_result(monkeypatch):
+    """Defensive: if the action carries no query, do not write a junk
+    `Searching:` placeholder; leave the result empty so the existing
+    last-call overwrite path is unchanged."""
+    sse_events = [
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "web_search_call",
+                "id": "ws_only",
+                "action": {},
+            },
+        },
+        {"type": "response.completed", "response": {}},
+    ]
+    lines = _drive_stream(sse_events, ["web_search"], monkeypatch)
+    events = _tool_events(lines)
+    ends = [e for e in events if e["type"] == "tool_end"]
+    assert len(ends) == 1
+    assert ends[0]["result"] == ""
+
+
+# ── shell_call output fallbacks ────────────────────────────────────────
+
+
+def test_shell_call_emits_tool_end_when_output_bundled_on_done(monkeypatch):
+    """Some Responses streams ship the output array embedded on the
+    shell_call item's done event instead of as a separate
+    shell_call_output. The fallback must emit tool_end from that bundled
+    output so the card never stays in "running"."""
+    sse_events = [
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "shell_call",
+                "id": "scall_bundled",
+                "action": {"commands": ["echo hi"]},
+                "output": [
+                    {
+                        "stdout": "hi\n",
+                        "stderr": "",
+                        "outcome": {"type": "exit", "exit_code": 0},
+                    }
+                ],
+            },
+        },
+        {"type": "response.completed", "response": {}},
+    ]
+    lines = _drive_stream(sse_events, ["code_execution"], monkeypatch)
+    events = _tool_events(lines)
+    starts = [e for e in events if e["type"] == "tool_start"]
+    ends = [e for e in events if e["type"] == "tool_end"]
+    assert len(starts) == 1
+    assert starts[0]["tool_call_id"] == "scall_bundled"
+    assert len(ends) == 1
+    assert ends[0]["tool_call_id"] == "scall_bundled"
+    assert "hi" in ends[0]["result"]
+
+
+def test_shell_call_bundled_then_separate_output_does_not_double_emit(monkeypatch):
+    """If the bundled output ALREADY emitted tool_end and a separate
+    shell_call_output event arrives afterwards (some streams do both),
+    the second one is skipped so the card is not re-completed."""
+    sse_events = [
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "shell_call",
+                "id": "scall_both",
+                "action": {"commands": ["echo bundle"]},
+                "output": [
+                    {
+                        "stdout": "bundle\n",
+                        "stderr": "",
+                        "outcome": {"type": "exit", "exit_code": 0},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "shell_call_output",
+                "id": "scout_both",
+                "call_id": "scall_both",
+                "output": [
+                    {
+                        "stdout": "should not double-emit\n",
+                        "stderr": "",
+                        "outcome": {"type": "exit", "exit_code": 0},
+                    }
+                ],
+            },
+        },
+        {"type": "response.completed", "response": {}},
+    ]
+    lines = _drive_stream(sse_events, ["code_execution"], monkeypatch)
+    events = _tool_events(lines)
+    ends = [e for e in events if e["type"] == "tool_end"]
+    assert len(ends) == 1
+    assert ends[0]["tool_call_id"] == "scall_both"
+    assert "bundle" in ends[0]["result"]
+    assert "should not double-emit" not in ends[0]["result"]
+
+
+def test_shell_call_final_flush_on_completed_when_no_output_event(monkeypatch):
+    """shell_call gets tool_start but no shell_call_output arrives and
+    the done event has no bundled output either. The final flush at
+    response.completed must emit tool_end so the card finalises."""
+    sse_events = [
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "shell_call",
+                "id": "scall_orphan",
+                "action": {"commands": ["true"]},
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "shell_call",
+                "id": "scall_orphan",
+                "action": {"commands": ["true"]},
+                "status": "completed",
+            },
+        },
+        {"type": "response.completed", "response": {}},
+    ]
+    lines = _drive_stream(sse_events, ["code_execution"], monkeypatch)
+    events = _tool_events(lines)
+    ends = [e for e in events if e["type"] == "tool_end"]
+    assert any(e["tool_call_id"] == "scall_orphan" for e in ends)

--- a/studio/backend/tests/test_openai_tool_result_fallbacks.py
+++ b/studio/backend/tests/test_openai_tool_result_fallbacks.py
@@ -326,3 +326,73 @@ def test_shell_call_final_flush_on_completed_when_no_output_event(monkeypatch):
     events = _tool_events(lines)
     ends = [e for e in events if e["type"] == "tool_end"]
     assert any(e["tool_call_id"] == "scall_orphan" for e in ends)
+
+
+def test_shell_call_flushed_on_response_incomplete_truncation(monkeypatch):
+    """Truncated streams (max_tokens hit) end with response.incomplete
+    instead of response.completed. The orphan-shell_call flush must fire
+    here too, otherwise the card spins indefinitely in the UI."""
+    sse_events = [
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "shell_call",
+                "id": "scall_truncated",
+                "action": {"commands": ["long_running"]},
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "shell_call",
+                "id": "scall_truncated",
+                "action": {"commands": ["long_running"]},
+                "status": "in_progress",
+            },
+        },
+        {
+            "type": "response.incomplete",
+            "response": {
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        },
+    ]
+    lines = _drive_stream(sse_events, ["code_execution"], monkeypatch)
+    events = _tool_events(lines)
+    ends = [e for e in events if e["type"] == "tool_end"]
+    assert any(e["tool_call_id"] == "scall_truncated" for e in ends)
+
+
+def test_shell_call_incomplete_does_not_double_emit(monkeypatch):
+    """If a shell_call already finalised via bundled output on its done
+    event, the response.incomplete flush must skip it rather than emit
+    a second tool_end and re-complete the card."""
+    sse_events = [
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "shell_call",
+                "id": "scall_done",
+                "action": {"commands": ["echo done"]},
+                "output": [
+                    {
+                        "stdout": "done\n",
+                        "stderr": "",
+                        "outcome": {"type": "exit", "exit_code": 0},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "response.incomplete",
+            "response": {
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        },
+    ]
+    lines = _drive_stream(sse_events, ["code_execution"], monkeypatch)
+    events = _tool_events(lines)
+    ends = [e for e in events if e["type"] == "tool_end"]
+    assert len(ends) == 1
+    assert ends[0]["tool_call_id"] == "scall_done"
+    assert "done" in ends[0]["result"]

--- a/studio/backend/tests/test_openai_tool_result_fallbacks.py
+++ b/studio/backend/tests/test_openai_tool_result_fallbacks.py
@@ -3,20 +3,9 @@
 
 """Regression tests for OpenAI Responses tool-result rendering.
 
-Two bug classes covered:
-
-1. web_search: every call's tool_end carried `result: ""`, leaving every
-   card except the last one empty in the chat thread. Now each call seeds
-   its own `Searching: <query>` text so the cards always render content;
-   the last call is still overwritten at response.completed with the
-   aggregated citation list (consumed by the source-pill extractor).
-
-2. shell_call (code_execution): when OpenAI bundles the output on the
-   shell_call item's `response.output_item.done` event instead of as a
-   separate `shell_call_output`, the previous handler never emitted
-   tool_end and the card stayed in "running" with no output. The fallback
-   now emits tool_end from the bundled output. A final flush at
-   response.completed catches shell_call ids that received neither.
+Covers two bug classes: empty web_search cards (per-card result seeded
+with "Searching: <query>") and orphan shell_call cards (bundled-output
+fallback + final flush at response.completed / response.incomplete).
 """
 
 import asyncio
@@ -110,8 +99,7 @@ def _drive_stream(sse_events, enabled_tools, monkeypatch):
 
 
 def test_web_search_each_call_carries_its_own_query_as_result(monkeypatch):
-    """Three search calls, no citations. Each card must render with its
-    own `Searching: <query>` text; none should be empty."""
+    """Each card carries its own `Searching: <query>` text; no empties."""
     sse_events = [
         {
             "type": "response.output_item.done",
@@ -149,9 +137,8 @@ def test_web_search_each_call_carries_its_own_query_as_result(monkeypatch):
 
 
 def test_web_search_last_call_overwritten_with_citations(monkeypatch):
-    """Pin the existing behaviour: the last call still gets the
-    aggregated citation list (the source-pill extractor depends on this).
-    Earlier calls keep their per-call `Searching:` text."""
+    """Last call still gets the aggregated citation list; earlier calls
+    keep their per-call `Searching:` text."""
     sse_events = [
         {
             "type": "response.output_item.done",
@@ -194,9 +181,7 @@ def test_web_search_last_call_overwritten_with_citations(monkeypatch):
 
 
 def test_web_search_empty_query_falls_back_to_empty_result(monkeypatch):
-    """Defensive: if the action carries no query, do not write a junk
-    `Searching:` placeholder; leave the result empty so the existing
-    last-call overwrite path is unchanged."""
+    """No query -> empty result (no `Searching:` placeholder)."""
     sse_events = [
         {
             "type": "response.output_item.done",
@@ -219,10 +204,7 @@ def test_web_search_empty_query_falls_back_to_empty_result(monkeypatch):
 
 
 def test_shell_call_emits_tool_end_when_output_bundled_on_done(monkeypatch):
-    """Some Responses streams ship the output array embedded on the
-    shell_call item's done event instead of as a separate
-    shell_call_output. The fallback must emit tool_end from that bundled
-    output so the card never stays in "running"."""
+    """Output bundled on the shell_call done event emits tool_end."""
     sse_events = [
         {
             "type": "response.output_item.done",
@@ -253,9 +235,7 @@ def test_shell_call_emits_tool_end_when_output_bundled_on_done(monkeypatch):
 
 
 def test_shell_call_bundled_then_separate_output_does_not_double_emit(monkeypatch):
-    """If the bundled output ALREADY emitted tool_end and a separate
-    shell_call_output event arrives afterwards (some streams do both),
-    the second one is skipped so the card is not re-completed."""
+    """Separate shell_call_output after bundled-output is a no-op."""
     sse_events = [
         {
             "type": "response.output_item.done",
@@ -299,9 +279,7 @@ def test_shell_call_bundled_then_separate_output_does_not_double_emit(monkeypatc
 
 
 def test_shell_call_final_flush_on_completed_when_no_output_event(monkeypatch):
-    """shell_call gets tool_start but no shell_call_output arrives and
-    the done event has no bundled output either. The final flush at
-    response.completed must emit tool_end so the card finalises."""
+    """Orphan shell_call finalises via the response.completed flush."""
     sse_events = [
         {
             "type": "response.output_item.added",
@@ -329,9 +307,7 @@ def test_shell_call_final_flush_on_completed_when_no_output_event(monkeypatch):
 
 
 def test_shell_call_flushed_on_response_incomplete_truncation(monkeypatch):
-    """Truncated streams (max_tokens hit) end with response.incomplete
-    instead of response.completed. The orphan-shell_call flush must fire
-    here too, otherwise the card spins indefinitely in the UI."""
+    """Truncated streams (response.incomplete) also flush orphan calls."""
     sse_events = [
         {
             "type": "response.output_item.added",
@@ -364,9 +340,7 @@ def test_shell_call_flushed_on_response_incomplete_truncation(monkeypatch):
 
 
 def test_shell_call_incomplete_does_not_double_emit(monkeypatch):
-    """If a shell_call already finalised via bundled output on its done
-    event, the response.incomplete flush must skip it rather than emit
-    a second tool_end and re-complete the card."""
+    """response.incomplete is idempotent against already-finalised calls."""
     sse_events = [
         {
             "type": "response.output_item.done",

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -21,6 +21,7 @@ import { pickFriendlyContainerName } from "../lib/friendly-names";
 import {
   EXTERNAL_MAX_OUTPUT_TOKENS,
   clampReasoningEffortToLevels,
+  getExternalMaxOutputTokens,
   getExternalMinOutputTokens,
   getExternalReasoningCapabilities,
   getProviderCapabilities,
@@ -1692,18 +1693,21 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               ...(externalCapabilities?.topP !== false
                 ? { top_p: params.topP }
                 : {}),
-              // Clamp to the cross-provider output cap so a maxTokens value
+              // Clamp to the per-model output cap so a maxTokens value
               // carried over from a local-model session does not blow past
               // provider limits (e.g. Claude Opus 400s on >128k). Also
-              // floor to the provider's documented minimum — Kimi's
-              // thinking models need >=16k or the response truncates
-              // before the answer fits alongside reasoning_content.
+              // floor to the provider's documented minimum (Kimi thinking
+              // needs >=16k or the response truncates before the answer
+              // fits alongside reasoning_content).
               max_tokens: Math.min(
                 Math.max(
                   params.maxTokens,
                   getExternalMinOutputTokens(externalProvider?.providerType),
                 ),
-                EXTERNAL_MAX_OUTPUT_TOKENS,
+                getExternalMaxOutputTokens(
+                  externalProvider?.providerType,
+                  externalSelection?.modelId,
+                ),
               ),
               // Only forward sampling knobs the provider actually accepts; the
               // backend's external-provider proxy is param-permissive and would

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1693,12 +1693,8 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
               ...(externalCapabilities?.topP !== false
                 ? { top_p: params.topP }
                 : {}),
-              // Clamp to the per-model output cap so a maxTokens value
-              // carried over from a local-model session does not blow past
-              // provider limits (e.g. Claude Opus 400s on >128k). Also
-              // floor to the provider's documented minimum (Kimi thinking
-              // needs >=16k or the response truncates before the answer
-              // fits alongside reasoning_content).
+              // Floor at the provider's documented min (Kimi thinking
+              // needs >=16k); clamp at the per-model max.
               max_tokens: Math.min(
                 Math.max(
                   params.maxTokens,

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -85,6 +85,7 @@ import {
 import {
   EXTERNAL_MAX_OUTPUT_TOKENS,
   type ProviderCapabilities,
+  getExternalMaxOutputTokens,
   getExternalMinOutputTokens,
   providerSupportsBuiltinCodeExecution,
   providerSupportsFastMode,
@@ -1309,7 +1310,10 @@ export function ChatSettingsPanel({
               }
               max={
                 isExternalModel
-                  ? EXTERNAL_MAX_OUTPUT_TOKENS
+                  ? getExternalMaxOutputTokens(
+                      externalProviderType,
+                      externalSelection?.modelId,
+                    )
                   : isGguf && ggufContextLength
                     ? ggufContextLength
                     : 32768

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -71,17 +71,111 @@ export function clampReasoningEffortToLevels(
 }
 
 /**
- * Output-token cap for any external provider request. Picked to stay below the
- * tightest declared limit across the providers we ship (Anthropic Claude Opus
- * tops out at 128k, GPT-5.x ~128k, Gemini 2.5 ~65k, DeepSeek 8k) while staying
- * well above what a typical chat reply needs. The local-model path is not
- * subject to this — local backends honour whatever the loaded context allows.
- *
- * If a user's stored maxTokens (e.g. carried over from a prior local-model
- * session with a 128k+ context) exceeds this, chat-adapter clamps the
- * outbound request so the provider does not 400 on it.
+ * Conservative cross-provider output cap, used as a final clamp and as the
+ * fallback for providers/models we don't have a documented limit for.
+ * Prefer `getExternalMaxOutputTokens(providerType, modelId)` for the real
+ * per-model cap (gpt-5.5 / claude-opus-4-7 both ship 128k max output, much
+ * higher than this conservative floor).
  */
 export const EXTERNAL_MAX_OUTPUT_TOKENS = 32768;
+
+/**
+ * Per-model max-output cap, sourced from each provider's docs. Used by the
+ * settings-slider max and by chat-adapter's send-time clamp so the slider
+ * never reports a value above what the provider will accept.
+ *
+ * Patterns are ordered most-specific-first so `gpt-5.5-pro` doesn't match
+ * the `gpt-5.5` row, etc. Look-up runs longest-prefix-first via
+ * `_pickByPrefix` below.
+ *
+ * Sources:
+ * - OpenAI: https://developers.openai.com/api/docs/models/gpt-5.5
+ *   (gpt-5.5: 128k max output; gpt-5.4: 64k; gpt-5.3: 16k)
+ * - Anthropic: https://platform.claude.com/docs/en/about-claude/models/
+ *   (Opus 4.7: 128k max output; 4.6 / 4.5 family: 64k)
+ * - Google Gemini 3.x: 65535 max output tokens
+ * - DeepSeek: 8192 max output tokens
+ *
+ * The local-model path is not subject to this; local backends honour
+ * whatever the loaded context allows.
+ */
+const EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL: Array<{
+  providerType: string;
+  prefixes: readonly string[];
+  cap: number;
+}> = [
+  // OpenAI
+  { providerType: "openai", prefixes: ["gpt-5.5-pro", "gpt-5.5"], cap: 128000 },
+  { providerType: "openai", prefixes: ["gpt-5.4-pro", "gpt-5.4"], cap: 65536 },
+  { providerType: "openai", prefixes: ["gpt-5.3"], cap: 16384 },
+  // Anthropic
+  {
+    providerType: "anthropic",
+    prefixes: ["claude-opus-4-7"],
+    cap: 128000,
+  },
+  {
+    providerType: "anthropic",
+    prefixes: [
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "claude-opus-4-5",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+    ],
+    cap: 64000,
+  },
+  // Gemini
+  { providerType: "gemini", prefixes: ["gemini-3", "gemini-pro", "gemini-flash"], cap: 65535 },
+  // DeepSeek
+  { providerType: "deepseek", prefixes: ["deepseek"], cap: 8192 },
+];
+
+/**
+ * Return the documented max-output-tokens cap for a given external
+ * provider + model. Falls back to `EXTERNAL_MAX_OUTPUT_TOKENS` (32k) for
+ * provider/model combinations we don't have a published number for, so
+ * unknown ids never regress to a higher-than-supported value.
+ *
+ * OpenRouter normalises to `provider/model`; strip the `provider/`
+ * prefix before matching so `openai/gpt-5.5` resolves the same as
+ * `gpt-5.5`.
+ */
+export function getExternalMaxOutputTokens(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): number {
+  if (!providerType || !modelId) return EXTERNAL_MAX_OUTPUT_TOKENS;
+  const normalized = modelId.trim().toLowerCase();
+  if (!normalized) return EXTERNAL_MAX_OUTPUT_TOKENS;
+  const stripped =
+    providerType === "openrouter" && normalized.includes("/")
+      ? normalized.split("/").slice(-1)[0]
+      : normalized;
+  const effectiveProvider =
+    providerType === "openrouter"
+      ? _inferProviderFromOpenrouterId(normalized) ?? providerType
+      : providerType;
+  for (const entry of EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL) {
+    if (entry.providerType !== effectiveProvider) continue;
+    if (entry.prefixes.some((prefix) => stripped.startsWith(prefix))) {
+      return entry.cap;
+    }
+  }
+  return EXTERNAL_MAX_OUTPUT_TOKENS;
+}
+
+function _inferProviderFromOpenrouterId(
+  normalizedId: string,
+): string | null {
+  // OpenRouter ids are `provider/model`. Map the prefix back to one of
+  // our internal providerType keys so the per-model cap table applies.
+  if (normalizedId.startsWith("openai/")) return "openai";
+  if (normalizedId.startsWith("anthropic/")) return "anthropic";
+  if (normalizedId.startsWith("google/")) return "gemini";
+  if (normalizedId.startsWith("deepseek/")) return "deepseek";
+  return null;
+}
 
 /**
  * Whether the external provider offers a built-in web-search tool that the

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -71,35 +71,18 @@ export function clampReasoningEffortToLevels(
 }
 
 /**
- * Conservative cross-provider output cap, used as a final clamp and as the
- * fallback for providers/models we don't have a documented limit for.
- * Prefer `getExternalMaxOutputTokens(providerType, modelId)` for the real
- * per-model cap (gpt-5.5 / claude-opus-4-7 both ship 128k max output, much
- * higher than this conservative floor).
+ * Fallback cap for unknown providers / models. Prefer
+ * `getExternalMaxOutputTokens(providerType, modelId)` for the real cap.
  */
 export const EXTERNAL_MAX_OUTPUT_TOKENS = 32768;
 
 /**
- * Per-model max-output cap, sourced from each provider's docs. Used by the
- * settings-slider max and by chat-adapter's send-time clamp so the slider
- * never reports a value above what the provider will accept.
- *
- * Patterns are ordered most-specific-first so `gpt-5.5-pro` doesn't match
- * the `gpt-5.5` row, etc. Look-up runs longest-prefix-first via
- * `_pickByPrefix` below.
- *
- * Sources:
- * - OpenAI: https://developers.openai.com/api/docs/models/gpt-5.5
- *   (gpt-5.5: 128k max output; gpt-5.4: 64k; gpt-5.3: 16k)
- * - Anthropic: https://platform.claude.com/docs/en/about-claude/models/
- *   (Opus 4.7: 128k max output; 4.6 / 4.5 family: 64k)
- * - Google Gemini 3.x: 65536 max output tokens
- *   (https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview)
- * - DeepSeek V4 (deepseek-chat / deepseek-reasoner aliases): 384000 max
- *   output tokens (https://api-docs.deepseek.com/quick_start/pricing)
- *
- * The local-model path is not subject to this; local backends honour
- * whatever the loaded context allows.
+ * Per-model max-output caps from each provider's docs:
+ *   OpenAI:    developers.openai.com/api/docs/models/gpt-5.5
+ *   Anthropic: platform.claude.com/docs/en/about-claude/models
+ *   Gemini:    ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
+ *   DeepSeek:  api-docs.deepseek.com/quick_start/pricing (V4 family)
+ * Local-model path is unaffected.
  */
 const EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL: Array<{
   providerType: string;
@@ -133,20 +116,14 @@ const EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL: Array<{
     prefixes: ["gemini-3", "gemini-pro", "gemini-flash"],
     cap: 65536,
   },
-  // DeepSeek (V4 family; deepseek-chat / deepseek-reasoner alias the
-  // non-thinking and thinking modes of deepseek-v4-flash respectively).
+  // DeepSeek (V4: deepseek-chat / deepseek-reasoner alias V4-flash).
   { providerType: "deepseek", prefixes: ["deepseek"], cap: 384000 },
 ];
 
 /**
- * Return the documented max-output-tokens cap for a given external
- * provider + model. Falls back to `EXTERNAL_MAX_OUTPUT_TOKENS` (32k) for
- * provider/model combinations we don't have a published number for, so
- * unknown ids never regress to a higher-than-supported value.
- *
- * OpenRouter normalises to `provider/model`; strip the `provider/`
- * prefix before matching so `openai/gpt-5.5` resolves the same as
- * `gpt-5.5`.
+ * Documented per-model output cap; unknown ids fall back to
+ * `EXTERNAL_MAX_OUTPUT_TOKENS` (32k). OpenRouter ids are
+ * `provider/model`; the prefix is stripped before matching.
  */
 export function getExternalMaxOutputTokens(
   providerType: string | null | undefined,
@@ -175,8 +152,7 @@ export function getExternalMaxOutputTokens(
 function _inferProviderFromOpenrouterId(
   normalizedId: string,
 ): string | null {
-  // OpenRouter ids are `provider/model`. Map the prefix back to one of
-  // our internal providerType keys so the per-model cap table applies.
+  // Map OpenRouter `provider/model` prefix to our internal providerType.
   if (normalizedId.startsWith("openai/")) return "openai";
   if (normalizedId.startsWith("anthropic/")) return "anthropic";
   if (normalizedId.startsWith("google/")) return "gemini";

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -93,8 +93,10 @@ export const EXTERNAL_MAX_OUTPUT_TOKENS = 32768;
  *   (gpt-5.5: 128k max output; gpt-5.4: 64k; gpt-5.3: 16k)
  * - Anthropic: https://platform.claude.com/docs/en/about-claude/models/
  *   (Opus 4.7: 128k max output; 4.6 / 4.5 family: 64k)
- * - Google Gemini 3.x: 65535 max output tokens
- * - DeepSeek: 8192 max output tokens
+ * - Google Gemini 3.x: 65536 max output tokens
+ *   (https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview)
+ * - DeepSeek V4 (deepseek-chat / deepseek-reasoner aliases): 384000 max
+ *   output tokens (https://api-docs.deepseek.com/quick_start/pricing)
  *
  * The local-model path is not subject to this; local backends honour
  * whatever the loaded context allows.
@@ -126,9 +128,14 @@ const EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL: Array<{
     cap: 64000,
   },
   // Gemini
-  { providerType: "gemini", prefixes: ["gemini-3", "gemini-pro", "gemini-flash"], cap: 65535 },
-  // DeepSeek
-  { providerType: "deepseek", prefixes: ["deepseek"], cap: 8192 },
+  {
+    providerType: "gemini",
+    prefixes: ["gemini-3", "gemini-pro", "gemini-flash"],
+    cap: 65536,
+  },
+  // DeepSeek (V4 family; deepseek-chat / deepseek-reasoner alias the
+  // non-thinking and thinking modes of deepseek-v4-flash respectively).
+  { providerType: "deepseek", prefixes: ["deepseek"], cap: 384000 },
 ];
 
 /**

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -749,12 +749,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // external-provider render gate would otherwise show old counters
       // until the next completion overwrites them.
       const checkpointChanged = state.params.checkpoint !== modelId;
-      // Clamp maxTokens to the new model's cap when switching INTO an
-      // external model. Otherwise a value carried over from a prior
-      // local-model session (e.g. Gemma's 262144 context) would render
-      // in the slider above the external cap, even though the wire-side
-      // clamp would still bring it down at send time. Keeps the
-      // displayed value honest.
+      // Clamp maxTokens to the new model's cap on switch into an
+      // external model so a value carried over from a prior local
+      // session does not render above the slider's max.
       let nextMaxTokens = state.params.maxTokens;
       if (checkpointChanged && isExternalModelId(modelId)) {
         const parsed = parseExternalModelId(modelId);

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -14,7 +14,9 @@ import {
   DEFAULT_INFERENCE_PARAMS,
   type InferenceParams,
 } from "../types/runtime";
-import { isExternalModelId } from "../external-providers";
+import { isExternalModelId, parseExternalModelId } from "../external-providers";
+import { getExternalMaxOutputTokens } from "../provider-capabilities";
+import { useExternalProvidersStore } from "./external-providers-store";
 import {
   loadChatSettingsWithLegacyImport,
   savePersistedChatSettingsPatch,
@@ -747,10 +749,33 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // external-provider render gate would otherwise show old counters
       // until the next completion overwrites them.
       const checkpointChanged = state.params.checkpoint !== modelId;
+      // Clamp maxTokens to the new model's cap when switching INTO an
+      // external model. Otherwise a value carried over from a prior
+      // local-model session (e.g. Gemma's 262144 context) would render
+      // in the slider above the external cap, even though the wire-side
+      // clamp would still bring it down at send time. Keeps the
+      // displayed value honest.
+      let nextMaxTokens = state.params.maxTokens;
+      if (checkpointChanged && isExternalModelId(modelId)) {
+        const parsed = parseExternalModelId(modelId);
+        const provider = parsed
+          ? useExternalProvidersStore
+              .getState()
+              .providers.find((p) => p.id === parsed.providerId)
+          : null;
+        const cap = getExternalMaxOutputTokens(
+          provider?.providerType,
+          parsed?.modelId,
+        );
+        if (nextMaxTokens > cap) {
+          nextMaxTokens = cap;
+        }
+      }
       return {
         params: {
           ...state.params,
           checkpoint: modelId,
+          maxTokens: nextMaxTokens,
         },
         activeGgufVariant: ggufVariant ?? null,
         ...(checkpointChanged ? { contextUsage: null } : {}),


### PR DESCRIPTION
## Summary

Two empty-output bugs in the OpenAI Responses tool-result rendering. They show up clearly when a single prompt invokes many tool calls in one turn (the reproducing prompt asked for 9 web_search + 4 code_execution + 1 image_generation in one assistant turn). The SQLite-stored chat history shape:

- 8 of 9 `web_search` tool-call records had `result == ""` (every card except the last rendered empty in the chat thread)
- 4 of 4 `code_execution` (`shell_call`) records were missing the `result` key entirely (NoneType), so the command card showed the command but no output panel at all
- `image_generation` worked, as did the very last `web_search` of the run

Both root causes live in `studio/backend/core/inference/external_provider.py`. The Anthropic native Messages-API path and the local llama-server path are untouched, so local-model behaviour cannot regress.

## Bug 1: web_search cards rendered empty

`web_search_call`'s `tool_end` emitted `result: ""` by design, with the intent of overwriting only the LAST call at `response.completed` with the full citation list. The frontend's `parseSourcesFromResult` flatMaps across every `web_search` result, so a single non-empty result was enough for the trailing source pills. The side effect is that every intermediate card in the thread renders empty.

Fix: seed each call's own `tool_end` result with `Searching: <query>` so the per-card text is never empty, then keep the last-call overwrite path so the source-pill extractor still works. Falls back to empty when the model emits an action with no query, so the existing last-call path stays unchanged for that edge.

## Bug 2: code_execution result missing entirely

`shell_call`'s `tool_start` was emitted from `response.output_item.done` for the call item, but `tool_end` lived in the separate `response.output_item.done` handler for `shell_call_output`. When OpenAI's Responses stream bundles the output array onto the `shell_call` item's own `done` event (no separate `shell_call_output` item), the previous handler emitted `tool_start` with no following `tool_end`. The card spun on running indefinitely and stored as `NoneType` in the thread DB.

Fix:
- When the `shell_call`'s `done` event carries an embedded `output` list, emit `tool_end` immediately from that.
- Track `tool_end_emitted` on the `shell_calls` map so a subsequent `shell_call_output` event (some streams ship both) is skipped instead of double-completing the card.
- A final flush at `response.completed` emits `tool_end` for any orphan `shell_call` that received neither bundled output nor a separate output event, so cards always finalise.

## Tests

`studio/backend/tests/test_openai_tool_result_fallbacks.py` (6 new):

- `test_web_search_each_call_carries_its_own_query_as_result` -- three calls, each card's result is its own `Searching: <query>` text, no empties
- `test_web_search_last_call_overwritten_with_citations` -- last call still receives the aggregated citation block when `url_citation` annotations arrive (pins the overwrite path)
- `test_web_search_empty_query_falls_back_to_empty_result` -- empty `action.query` falls back to `result == ""`, no junk `Searching:` placeholder
- `test_shell_call_emits_tool_end_when_output_bundled_on_done` -- bundled output on `done` emits a single `tool_end` with that output as the result text
- `test_shell_call_bundled_then_separate_output_does_not_double_emit` -- a subsequent `shell_call_output` event is skipped after the bundled-output path has already completed the card
- `test_shell_call_final_flush_on_completed_when_no_output_event` -- orphan call with neither bundled nor separate output finalises at `response.completed`

15/15 tests green when combined with the existing 9 in `test_openai_code_execution.py`. Pre-commit + ruff format clean.

## Scope

OpenAI Responses-API code path only. Confirmed:
- `_stream_anthropic` and the Anthropic `code_execution_20250825` / `web_search_20250305` paths: untouched
- Local llama-server streaming: untouched
- Chat-completions OpenAI path: untouched (the edited handler is only entered when `_stream_openai_responses` is the active streaming method, which is gated on Responses-API models like gpt-5.x)

## Test plan

- [x] `pytest studio/backend/tests/test_openai_tool_result_fallbacks.py studio/backend/tests/test_openai_code_execution.py` (15 passing)
- [x] `pre-commit run --files` on the touched files (ruff legacy + format clean)
- [ ] End-to-end smoke against api.openai.com with the same animal-popularity prompt that triggered the original bug. Will land in a follow-up commit alongside the per-model `max_tokens` fixes that the same investigation surfaced.