### PR TITLE
Keep generated image loading dots animated

### DIFF
--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1244,11 +1244,11 @@
  * end state. Hover colour changes become instant rather than fading, which is
  * the documented WCAG outcome (motion is "minimised, not removed").
  *
- * .animate-spin is the exception: loading spinners are essential progress
+ * .animate-spin and generated image loading dots are the exceptions: loading
  * indicators across Studio (tool execution loaders, sonner toasts, Tauri
- * startup / update screens, the <Spinner /> primitive). Freezing them
- * removes the only visual signal that work is in flight, so they keep
- * animating but at a slower, less aggressive 1.5s cadence.
+ * startup / update screens, the <Spinner /> primitive, and image generation
+ * cards). Freezing them removes the only visual signal that work is in flight,
+ * so they keep animating.
  */
 @media (prefers-reduced-motion: reduce) {
 	*,
@@ -1262,6 +1262,11 @@
 
 	.animate-spin {
 		animation-duration: 1.5s !important;
+		animation-iteration-count: infinite !important;
+	}
+
+	.generated-image-loading-dot {
+		animation-duration: 1850ms !important;
 		animation-iteration-count: infinite !important;
 	}
 }


### PR DESCRIPTION
## Summary
- Keep generated image loading dots animated during reduced motion.
- Preserve reduced motion behavior for the rest of Studio.

## Testing
- cd studio/frontend && npm run build