### PR TITLE
Studio: unblock install on Linux ARM64 + Windows ARM64 + Intel Mac

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -887,12 +887,19 @@ shell.Run cmd, 0, False
     }
 
     # ── Check winget ──
+    # winget is only needed to install Python or uv. If both are
+    # already on PATH (Windows ARM64 GitHub-hosted runners, manual
+    # python.org + Astral uv installs, corporate locked-down hosts
+    # without the Store, etc.) the script can proceed without it.
+    # We defer the hard failure to the Python / uv install branches
+    # below, where winget is actually invoked.
     Write-TauriLog "STEP" "Checking system dependencies"
-    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-        step "winget" "not available" "Red"
-        substep "Install it from https://aka.ms/getwinget" "Yellow"
-        substep "or install Python $PythonVersion and uv manually, then re-run." "Yellow"
-        return (Exit-InstallFailure "winget is not available")
+    $script:WingetAvailable = [bool](Get-Command winget -ErrorAction SilentlyContinue)
+    if ($script:WingetAvailable) {
+        step "winget" "available"
+    } else {
+        step "winget" "not available -- will require Python + uv to be already installed" "Yellow"
+        substep "Get it from https://aka.ms/getwinget if Python / uv are not already on PATH." "Yellow"
     }
 
     # ── Helper: detect a working Python 3.11-3.13 on the system ──
@@ -973,6 +980,12 @@ shell.Run cmd, 0, False
         step "python" "Python $($DetectedPython.Version) already installed"
     }
     if (-not $DetectedPython) {
+        if (-not $script:WingetAvailable) {
+            Write-Host "[ERROR] No compatible Python (3.11-3.13) found and winget is unavailable on this host." -ForegroundColor Red
+            Write-Host "        Install Python $PythonVersion from https://www.python.org/downloads/" -ForegroundColor Yellow
+            Write-Host "        and re-run this installer (make sure 'Add Python to PATH' is checked)." -ForegroundColor Yellow
+            return (Exit-InstallFailure "winget required to install Python on this host")
+        }
         substep "installing Python ${PythonVersion}..."
         $pythonPackageId = "Python.Python.$PythonVersion"
         # Temporarily lower ErrorActionPreference so that winget stderr
@@ -1024,14 +1037,19 @@ shell.Run cmd, 0, False
     Write-TauriLog "STEP" "Installing uv package manager"
     if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
         substep "installing uv package manager..."
-        $prevEAP = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        try { winget install --id=astral-sh.uv -e --accept-package-agreements --accept-source-agreements } catch {}
-        $ErrorActionPreference = $prevEAP
-        Refresh-SessionPath
-        # Fallback: if winget didn't put uv on PATH, try the PowerShell installer
+        if ($script:WingetAvailable) {
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            try { winget install --id=astral-sh.uv -e --accept-package-agreements --accept-source-agreements } catch {}
+            $ErrorActionPreference = $prevEAP
+            Refresh-SessionPath
+        }
+        # Fallback: if winget is unavailable or didn't put uv on PATH,
+        # use Astral's official PowerShell installer. This is the only
+        # supported path on hosts without winget (Windows ARM64 runners,
+        # corporate machines without the Store, etc.).
         if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-            substep "trying alternative uv installer..." "Yellow"
+            substep "installing uv via https://astral.sh/uv/install.ps1..." "Yellow"
             Invoke-Expression (Invoke-RestMethod -Uri "https://astral.sh/uv/install.ps1")
             Refresh-SessionPath
         }

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -1349,6 +1349,24 @@ def direct_upstream_release_plan(
                     install_kind = "windows-cpu",
                 )
             )
+    elif host.is_windows and host.is_arm64:
+        # Upstream ggml-org/llama.cpp ships llama-bNNNN-bin-win-cpu-arm64.zip
+        # (visible in the b9334 release manifest). Without this branch the
+        # selector returned 0 attempts and the installer fell back to a
+        # source build on every Windows ARM64 host.
+        cpu_asset = f"llama-{release_tag}-bin-win-cpu-arm64.zip"
+        cpu_url = assets.get(cpu_asset)
+        if cpu_url:
+            attempts.append(
+                AssetChoice(
+                    repo = repo,
+                    tag = release_tag,
+                    name = cpu_asset,
+                    url = cpu_url,
+                    source_label = "upstream",
+                    install_kind = "windows-arm64",
+                )
+            )
     elif host.is_macos and host.is_arm64:
         asset_name = f"llama-{release_tag}-bin-macos-arm64.tar.gz"
         asset_url = assets.get(asset_name)
@@ -1389,6 +1407,25 @@ def direct_upstream_release_plan(
                     url = asset_url,
                     source_label = "upstream",
                     install_kind = "linux-cpu",
+                )
+            )
+    elif host.is_linux and host.is_arm64 and not host.has_usable_nvidia:
+        # Upstream ggml-org/llama.cpp ships llama-bNNNN-bin-ubuntu-arm64.tar.gz
+        # (visible in the b9334 release manifest). Without this branch the
+        # selector returned 0 attempts and the installer fell back to a
+        # source build on every Linux ARM64 host (DGX Spark, Ampere
+        # Altra, GitHub-hosted ubuntu-24.04-arm runners, etc.).
+        asset_name = f"llama-{release_tag}-bin-ubuntu-arm64.tar.gz"
+        asset_url = assets.get(asset_name)
+        if asset_url:
+            attempts.append(
+                AssetChoice(
+                    repo = repo,
+                    tag = release_tag,
+                    name = asset_name,
+                    url = asset_url,
+                    source_label = "upstream",
+                    install_kind = "linux-arm64",
                 )
             )
     if not attempts:
@@ -3833,11 +3870,11 @@ def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
     # libraries between b9279 and b9283) without us re-enumerating
     # every new file. Studio only invokes llama-server and llama-quantize;
     # other CLIs upstream ships (llama-cli, llama-bench, ...) are skipped.
-    if choice.install_kind in {"linux-cpu", "linux-cuda", "linux-rocm"}:
+    if choice.install_kind in {"linux-cpu", "linux-cuda", "linux-rocm", "linux-arm64"}:
         return ["llama-server", "llama-quantize", "lib*.so*"]
     if choice.install_kind in {"macos-arm64", "macos-x64"}:
         return ["llama-server", "llama-quantize", "lib*.dylib"]
-    if choice.install_kind in {"windows-cpu", "windows-cuda", "windows-hip"}:
+    if choice.install_kind in {"windows-cpu", "windows-cuda", "windows-hip", "windows-arm64"}:
         return ["llama-server.exe", "llama-quantize.exe", "*.dll"]
     raise PrebuiltFallback(
         f"unsupported install kind for runtime overlay: {choice.install_kind}"
@@ -5188,7 +5225,7 @@ def load_prebuilt_metadata(install_dir: Path) -> dict[str, Any] | None:
 
 
 def runtime_payload_health_groups(choice: AssetChoice) -> list[list[str]]:
-    if choice.install_kind == "linux-cpu":
+    if choice.install_kind in {"linux-cpu", "linux-arm64"}:
         return [
             ["libllama-common.so*"],
             ["libllama.so*"],
@@ -5223,7 +5260,7 @@ def runtime_payload_health_groups(choice: AssetChoice) -> list[list[str]]:
             ["libmtmd.so*"],
             ["libggml-hip.so*"],
         ]
-    if choice.install_kind == "windows-cpu":
+    if choice.install_kind in {"windows-cpu", "windows-arm64"}:
         return [["llama.dll"]]
     if choice.install_kind == "windows-cuda":
         groups = [["llama.dll"], ["ggml-cuda.dll"]]

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3874,7 +3874,12 @@ def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
         return ["llama-server", "llama-quantize", "lib*.so*"]
     if choice.install_kind in {"macos-arm64", "macos-x64"}:
         return ["llama-server", "llama-quantize", "lib*.dylib"]
-    if choice.install_kind in {"windows-cpu", "windows-cuda", "windows-hip", "windows-arm64"}:
+    if choice.install_kind in {
+        "windows-cpu",
+        "windows-cuda",
+        "windows-hip",
+        "windows-arm64",
+    }:
         return ["llama-server.exe", "llama-quantize.exe", "*.dll"]
     raise PrebuiltFallback(
         f"unsupported install kind for runtime overlay: {choice.install_kind}"

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -616,7 +616,14 @@ WINDOWS_SKIP_PACKAGES = {"open_spiel", "triton_kernels"}
 # Packages to skip when torch is unavailable (Intel Mac GGUF-only mode).
 # These packages either *are* torch extensions or have unconditional
 # ``Requires-Dist: torch`` in their published metadata, so installing
-# them would pull torch back into the environment.
+# them would pull torch back into the environment. ``librosa`` also
+# lives in this set even though it does not itself require torch:
+# upstream ``llvmlite`` dropped its macOS x86_64 wheel between 0.42.0
+# and 0.46.0+ (see https://pypi.org/project/llvmlite/0.47.0/#files --
+# only macosx_arm64 / manylinux / win_amd64 remain), so on Intel Mac
+# the librosa -> numba -> llvmlite chain triggers a from-source build
+# that fails inside CI and on the host without LLVM 14/15 headers.
+# Tracked separately in unslothai/unsloth#5046.
 NO_TORCH_SKIP_PACKAGES = {
     "torch-stoi",
     "timm",
@@ -624,6 +631,7 @@ NO_TORCH_SKIP_PACKAGES = {
     "torch-c-dlpack-ext",
     "openai-whisper",
     "transformers-cfg",
+    "librosa",
 }
 
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -38,6 +38,18 @@ IS_WINDOWS = sys.platform == "win32"
 IS_MACOS = sys.platform == "darwin"
 IS_MAC_INTEL = IS_MACOS and platform.machine() == "x86_64"
 IS_MAC_ARM = IS_MACOS and platform.machine() == "arm64"
+IS_LINUX = sys.platform.startswith("linux")
+# torchcodec ships wheels only for manylinux_2_28_x86_64,
+# macosx_12_0_arm64, and win_amd64 (visible in the 0.10.0 PyPI page).
+# Trying to install it on any other host fails the whole
+# extras-no-deps step. `unsloth studio update` does not have a
+# --no-torch flag, so on these hosts the audio extras must be
+# filtered out independent of the NO_TORCH env var.
+PLATFORM_LACKS_TORCHCODEC_WHEEL = (
+    (IS_LINUX and platform.machine() in {"aarch64", "arm64"})
+    or (IS_WINDOWS and platform.machine().lower() in {"arm64", "aarch64"})
+    or IS_MAC_INTEL
+)
 
 # ── ROCm / AMD GPU support ─────────────────────────────────────────────────────
 # Mapping from detected ROCm (major, minor) to the best PyTorch wheel tag on
@@ -838,6 +850,14 @@ def pip_install(
         temp_reqs.append(actual_req)
     if actual_req is not None and NO_TORCH and NO_TORCH_SKIP_PACKAGES:
         actual_req = _filter_requirements(actual_req, NO_TORCH_SKIP_PACKAGES)
+        temp_reqs.append(actual_req)
+    if actual_req is not None and PLATFORM_LACKS_TORCHCODEC_WHEEL:
+        # Linux aarch64 / Windows ARM64 / Intel Mac have no torchcodec
+        # wheel. `unsloth studio update --local` does not pass
+        # --no-torch, so the NO_TORCH filter above does not fire; do
+        # the targeted skip independently so the audio extras step
+        # does not take down the whole update.
+        actual_req = _filter_requirements(actual_req, {"torchcodec"})
         temp_reqs.append(actual_req)
     req_args_pip: list[str] = []
     req_args_uv: list[str] = []

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -671,6 +671,16 @@ elif [ "$_HOST_SYSTEM" = "Linux" ] \
         && [ "$_HOST_MACHINE" = "x86_64" ] \
         && [ "$_LINUX_HAS_GPU" = false ]; then
     _HELPER_RELEASE_REPO="ggml-org/llama.cpp"
+elif [ "$_HOST_SYSTEM" = "Linux" ] \
+        && { [ "$_HOST_MACHINE" = "aarch64" ] || [ "$_HOST_MACHINE" = "arm64" ]; } \
+        && [ "$_LINUX_HAS_GPU" = false ]; then
+    # Linux ARM64 (Ampere Altra, Raspberry Pi 5, GitHub `ubuntu-24.04-arm`,
+    # CPU-only Jetson rescue mode, ...). unslothai/llama.cpp only ships
+    # the Linux CUDA bundles, so without this branch the prebuilt
+    # resolver returns 0 attempts on every release and the installer
+    # falls all the way back to a source build. Upstream ggml-org ships
+    # llama-bNNNN-bin-ubuntu-arm64.tar.gz from at least b9072 onward.
+    _HELPER_RELEASE_REPO="ggml-org/llama.cpp"
 else
     _HELPER_RELEASE_REPO="unslothai/llama.cpp"
 fi

--- a/tests/studio/_playwright_robust.py
+++ b/tests/studio/_playwright_robust.py
@@ -436,6 +436,8 @@ def evaluate_fetch(
     headers: dict[str, str] | None = None,
     body: Any = None,
     timeout_ms: int = 20_000,
+    transport_retries: int = 2,
+    transport_backoff_ms: int = 250,
 ) -> dict[str, Any]:
     """Run `fetch(url, opts)` inside the page with an AbortSignal deadline.
 
@@ -482,16 +484,47 @@ def evaluate_fetch(
             }
         }
     """
-    return page.evaluate(
-        js,
-        {
-            "url": url,
-            "method": method,
-            "headers": headers or {},
-            "body": body_arg,
-            "timeoutMs": int(timeout_ms),
-        },
-    )
+    payload = {
+        "url": url,
+        "method": method,
+        "headers": headers or {},
+        "body": body_arg,
+        "timeoutMs": int(timeout_ms),
+    }
+    # Bounded retry on transport failures only.
+    #   status != 0  -> real HTTP response (incl. 4xx/5xx); propagate.
+    #   AbortError   -> caller's deadline; propagate.
+    #   else (==0)   -> stale-keepalive / "TypeError: Failed to fetch"
+    #                   on macos-14 right after auth rotations close
+    #                   existing sessions. Retry after backoff so the
+    #                   browser pool evicts the dead socket.
+    last: dict[str, Any] | None = None
+    attempts = max(1, int(transport_retries) + 1)
+    for attempt in range(attempts):
+        result = page.evaluate(js, payload)
+        last = result
+        try:
+            status = int(result.get("status") or 0)
+        except (TypeError, ValueError):
+            status = 0
+        if status != 0:
+            return result
+        err = str(result.get("error") or "")
+        if "AbortError" in err:
+            return result
+        if attempt < attempts - 1:
+            wait_ms = transport_backoff_ms * (2**attempt)
+            try:
+                sys.stderr.write(
+                    f"[evaluate_fetch] {method} {url}: transport failure "
+                    f"({attempt + 1}/{attempts}, err={err!r}); "
+                    f"retrying in {wait_ms}ms\n"
+                )
+                sys.stderr.flush()
+            except Exception:
+                pass
+            time.sleep(wait_ms / 1000.0)
+    return last or {"status": 0, "body": None, "error": "no attempt made"}
 
 
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four bugs that together prevent `install.sh` / `install.ps1` from completing on the ARM machines GitHub Actions now ships (`ubuntu-24.04-arm`, `windows-11-arm`) and on `macos-15-intel`. End-to-end-verified on the staging-2 cross-OS smoke suite (`danielhanchen/unsloth-staging-2#154`) -- five per-OS workflows pinned to `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-14`, `macos-15-intel`, `windows-11-arm`. With this PR overlaid each one installs Studio, asserts the right per-host upstream prebuilt is picked, boots Studio, runs `unsloth studio update --local`, and re-asserts `/api/health`.

### 1. `studio/install_llama_prebuilt.py` -- missing ARM64 branches in `resolve_simple_install_release_plans`

Branches existed for `windows+x86_64`, `macos+arm64`, `macos+x86_64`, and `linux+x86_64` only. Upstream `ggml-org/llama.cpp` ships `llama-bNNNN-bin-ubuntu-arm64.tar.gz` and `llama-bNNNN-bin-win-cpu-arm64.zip` (visible in the [b9334 release manifest](https://github.com/ggml-org/llama.cpp/releases/tag/b9334)); the missing `elif` branches force every Linux ARM64 and Windows ARM64 host into a source build even when a perfectly good upstream prebuilt is one HTTP GET away.

Adds two branches mirroring the existing CPU variants. `runtime_patterns_for_choice` and `runtime_payload_health_groups` gain `linux-arm64` (.so layout) and `windows-arm64` (.dll layout) so the runtime health pass-through matches the asset shape.

### 2. `studio/setup.sh` -- helper-release-repo selector ignored Linux ARM64

The selector that picks between `unslothai/llama.cpp` and `ggml-org/llama.cpp` routed any non-x86_64 Linux to `unslothai/llama.cpp`, which only publishes the Linux CUDA bundle set. On Linux ARM64 the result was a guaranteed `direct_linux_release_plan` raise of `no compatible Linux prebuilt asset was found` on every release in the scan, then a source-build fallback. Routes Linux ARM64 (CPU-only) to `ggml-org/llama.cpp` so the new branch in (1) can see the upstream asset. `setup.ps1` already hardcodes `ggml-org/llama.cpp`, so Windows ARM64 picks up (1) without an additional change.

### 3. `install.ps1` -- winget hard-gate before Python/uv detection

`windows-11-arm` runners and many corporate Windows hosts ship without winget but already have a usable Python plus the Astral uv PowerShell installer reachable. install.ps1's winget pre-check hard-failed before Python or uv detection. Demotes the winget check to a soft warning, defers the hard failure to the Python install branch (the only path that genuinely needs winget), and lets the uv install fall through to `https://astral.sh/uv/install.ps1` when winget is absent. The uv PowerShell installer was already the existing fallback for the "winget present but uv install failed" case; this just makes it the primary path on hosts without winget.

### 4. `studio/install_python_stack.py` -- torchcodec + librosa wheel gaps

Two related skips needed during `unsloth studio update --local`, which has no `--no-torch` flag and so does not inherit the auto-skip path of the install-time `MAC_INTEL` branch:

- `torchcodec==0.10.0` ships wheels only for `manylinux_2_28_x86_64`, `macosx_12_0_arm64`, `win_amd64`. On Linux aarch64 / Windows ARM64 / Intel Mac the resolver fails with `No matching distribution found for torchcodec==0.10.0`. Adds a `PLATFORM_LACKS_TORCHCODEC_WHEEL` predicate and applies a targeted skip independent of NO_TORCH.

- `librosa` lives in `extras.txt` and pulls `numba -> llvmlite`. Upstream `llvmlite` dropped its macOS x86_64 wheel between 0.42.0 and 0.46.0+ (see https://pypi.org/project/llvmlite/0.47.0/#files -- only `macosx_arm64` / `manylinux` / `win_amd64` remain), so on Intel Mac pip falls back to a from-source FFI build that needs LLVM 14/15 headers + libs, which Xcode CLT does not supply. Adds `librosa` to `NO_TORCH_SKIP_PACKAGES` so Intel Mac (which auto-sets NO_TORCH=true) and `--no-torch` hosts skip it transparently. Closes the install gap tracked in #5046.

## Reproduction (against `main` HEAD, no overlay)

| runner | result on main | failure mode |
|---|---|---|
| `ubuntu-latest` | green | control |
| `macos-14` (Apple Silicon) | green | control |
| `ubuntu-24.04-arm` | red | `[llama-prebuilt] no compatible Linux prebuilt asset was found` on every release, then source-build fallback; `unsloth studio update --local` fails on `torchcodec==0.10.0` (no aarch64 wheel) |
| `windows-11-arm` | red | `winget not available` exit 1 before Python/uv detection |
| `macos-15-intel` | red | `Failed building wheel for llvmlite` (librosa -> numba -> llvmlite, dropped macosx_x86_64 wheel upstream) -- #5046 |

## Verification (with this PR overlaid into the staging tree)

| runner | install reaches `/api/health` | prebuilt asset | `update --local` is a no-op | post-update `/api/health` |
|---|---|---|---|---|
| `ubuntu-latest` | yes | `bin-ubuntu-x64.tar.gz` | yes | yes |
| `macos-14` | yes | `bin-macos-arm64.tar.gz` | yes | yes |
| `ubuntu-24.04-arm` | yes | `bin-ubuntu-arm64.tar.gz` | yes | yes |
| `windows-11-arm` | yes | `bin-win-cpu-arm64.zip` | yes | yes |
| `macos-15-intel` | yes (with librosa skip) | `bin-macos-x64.tar.gz` | yes | yes |

Each smoke run uploads `logs/install.log`, `logs/studio.log`, `logs/update.log`, `logs/studio_post_update.log` (retention 7 days).

## Test plan

- [x] Linux x86_64 control still green
- [x] Apple Silicon control still green
- [x] Linux ARM64 reaches `/api/health`, `UNSLOTH_PREBUILT_INFO.json.asset` ends in `bin-ubuntu-arm64.tar.gz`, update is a no-op
- [x] Windows ARM64 reaches `/api/health` (no winget gate), `UNSLOTH_PREBUILT_INFO.json.asset` ends in `bin-win-cpu-arm64.zip`, update is a no-op
- [x] macOS Intel install reaches `/api/health` via the auto-skip-torch path with the librosa skip; closes #5046