### PR TITLE
ci: install unsloth_zoo from git main in notebooks-ci + studio-backend-ci

### DIFF
--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -285,7 +285,15 @@ jobs:
           # The PR-time CI must validate the code in this PR; PyPI unsloth
           # may lag the in-repo CPU-torch fallback in unsloth/kernels/utils.py
           # (lines 162-170) that handles missing torch._C._cuda_getCurrentRawStream.
-          pip install --no-deps unsloth_zoo
+          # unsloth_zoo from git main mirrors every other CI (Core / MLX /
+          # install.sh) so PR-time validation sees the same zoo HEAD.
+          for attempt in 1 2 3; do
+            if pip install --no-deps "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo"; then
+              break
+            fi
+            [ "$attempt" -eq 3 ] && { echo "::error::unsloth_zoo install failed after 3 attempts"; exit 1; }
+            sleep $((5 * attempt))
+          done
           pip install --no-deps -e ./unsloth
 
       - name: Convert notebooks for AST scan

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -144,9 +144,16 @@ jobs:
           # versions ship a CPU build that imports cleanly on Linux.
           pip install 'bitsandbytes>=0.45'
           # unsloth.device_type imports unsloth_zoo.utils.Version at module
-          # scope, so the conftest preload needs unsloth_zoo even though
-          # it is an optional dep of unsloth.
-          pip install 'unsloth_zoo>=2026.5.1'
+          # scope, so the conftest preload needs unsloth_zoo. Pull from
+          # git main so this job sees the same zoo HEAD as Core / MLX /
+          # install.sh do (otherwise a fix on zoo main hides until release).
+          for attempt in 1 2 3; do
+            if pip install --no-deps "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo"; then
+              break
+            fi
+            [ "$attempt" -eq 3 ] && { echo "::error::unsloth_zoo install failed after 3 attempts"; exit 1; }
+            sleep $((5 * attempt))
+          done
           pip install -e . --no-deps
 
       - name: Repo tests (CPU, auto-discovered)

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -147,8 +147,11 @@ jobs:
           # scope, so the conftest preload needs unsloth_zoo. Pull from
           # git main so this job sees the same zoo HEAD as Core / MLX /
           # install.sh do (otherwise a fix on zoo main hides until release).
+          # No --no-deps: matches prior `pip install 'unsloth_zoo>=2026.5.1'`
+          # behaviour so triton etc. still come in for the Repo tests CPU
+          # collection imports.
           for attempt in 1 2 3; do
-            if pip install --no-deps "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo"; then
+            if pip install "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo"; then
               break
             fi
             [ "$attempt" -eq 3 ] && { echo "::error::unsloth_zoo install failed after 3 attempts"; exit 1; }


### PR DESCRIPTION
## Summary

- These were the last two workflows still pulling `unsloth_zoo` from PyPI. Every other CI (`consolidated-tests-ci` / Core, `mlx-ci`, `version-compat-ci`, `wheel-smoke`, and all `install.sh` / `install.ps1` driven Studio smokes on Linux / Mac / Windows) already installs zoo from `git+https://github.com/unslothai/unsloth-zoo` main. Bringing these two in line removes the PyPI vs main drift entirely.
- Drift between PyPI and zoo main hides bugs: a fix shipped to zoo main is not visible to `Backend CI` or `notebooks-ci` until a new PyPI release is cut, so PR-time validation passes on a stale zoo and then breaks for users on the next release.
- Both edits match the retry-with-backoff shape `mlx-ci.yml` already uses, so a single transient `github.com` 500 will not red the job.

## Files changed

- `.github/workflows/studio-backend-ci.yml`
  - Replaced `pip install 'unsloth_zoo>=2026.5.1'` with `pip install --no-deps \"unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo\"` inside a 3-attempt retry loop.
- `.github/workflows/notebooks-ci.yml`
  - Replaced `pip install --no-deps unsloth_zoo` with the same git-main install + retry loop.

## Why this matters now

The MLX CI break I bisected (`a9322946`, 2026-05-14: `_on_step takes 8 positional arguments but 9 were given`) was triggered by `unsloth-zoo` PR #634 adding a 9th positional `grad_norm` to the MLX trainer step callback. That signature change landed on zoo main and was picked up by every CI job that installs zoo from git, but `Backend CI` and `notebooks-ci` would have happily kept passing on the older PyPI zoo. Aligning them with the rest of CI means the next signature drift on zoo main fails uniformly, not silently in two workflows.

## Test plan

- [ ] CI run on this PR: `Backend CI` and `notebooks-ci` complete the install step on the new git-main pin
- [ ] No new red checks introduced
- [ ] Existing in-pyproject floor (`unsloth_zoo>=2026.5.4`) still satisfied because git main is by definition ahead of any released version