### PR TITLE
tests: unblock three stale assertions broken on main (MLX CI + Backend CI)

### DIFF
--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -484,11 +484,14 @@ from typer.testing import CliRunner
 studio_home = Path(sys.argv[1])
 real_import = builtins.__import__
 
-def guarded_import(name, *args, **kwargs):
+def guarded_import(name, globals = None, locals = None, fromlist = (), level = 0):
+    # Only gate absolute imports; relative `from .utils import x` inside
+    # third-party packages (e.g. typer._click.decorators) hits level > 0
+    # with name="utils" and must pass through.
     blocked = ("auth", "fastapi", "structlog", "utils")
-    if name in blocked or name.startswith(("auth.", "utils.")):
+    if level == 0 and (name in blocked or name.startswith(("auth.", "utils."))):
         raise ModuleNotFoundError(name)
-    return real_import(name, *args, **kwargs)
+    return real_import(name, globals, locals, fromlist, level)
 
 builtins.__import__ = guarded_import
 from unsloth_cli.commands import studio as studio_cli

--- a/tests/studio/run_real_mlx_smoke.py
+++ b/tests/studio/run_real_mlx_smoke.py
@@ -390,7 +390,11 @@ def cmd_train(args) -> int:
         )
         if k in train_result
     }
-    assert len(losses_per_step) == 7, f"expected 7 logged steps, got {losses_per_step}"
+    # logging_steps=1 + max_steps=N -> N callbacks; track config so the
+    # gate auto-follows if max_steps is bumped again.
+    assert len(losses_per_step) == config.max_steps, (
+        f"expected {config.max_steps} logged steps, got {losses_per_step}"
+    )
     for i, l in enumerate(losses_per_step):
         # Allow exact 0.0: fp16 per-step loss underflows to 0.0 after
         # the LoRA reaches loss=0 around step ~10 with this fixture +

--- a/tests/studio/run_real_mlx_smoke.py
+++ b/tests/studio/run_real_mlx_smoke.py
@@ -392,9 +392,9 @@ def cmd_train(args) -> int:
     }
     # logging_steps=1 + max_steps=N -> N callbacks; track config so the
     # gate auto-follows if max_steps is bumped again.
-    assert len(losses_per_step) == config.max_steps, (
-        f"expected {config.max_steps} logged steps, got {losses_per_step}"
-    )
+    assert (
+        len(losses_per_step) == config.max_steps
+    ), f"expected {config.max_steps} logged steps, got {losses_per_step}"
     for i, l in enumerate(losses_per_step):
         # Allow exact 0.0: fp16 per-step loss underflows to 0.0 after
         # the LoRA reaches loss=0 around step ~10 with this fixture +


### PR DESCRIPTION
## Summary

`MLX CI on Mac M1` and `Backend CI` have been red on every push to `main` for days. The underlying code is fine. Three test files have stale anchors / assertions left behind by recently-landed PRs.

This PR fixes all three so PR-time CI on every open PR (including #5743) goes back to green without rebasing past these regressions.

### 1. MLX CI — `tests/studio/run_real_mlx_smoke.py:393`

PR #5537 bumped `max_steps` from 7 to 30 to make the convergence gate seed-robust but left the assertion at `== 7`. With `logging_steps = 1`, the callback fires once per step, so 30 entries, not 7. Failure since 2026-05-18:

```
AssertionError: expected 7 logged steps, got
  [10.5475, 5.4663, 3.1851, 1.6394, ..., 0.0]   (30 entries)
```

Fix: track `config.max_steps` so the gate auto-follows future bumps.

### 2. Backend CI / Repo tests (CPU) — `tests/studio/test_composer_rtl_bidi_attribute.py:29`

PR #5775 changed `studio/frontend/src/components/assistant-ui/thread.tsx:537` from the literal

```tsx
aria-label="Message input"
```

to a JSX ternary

```tsx
aria-label={overlay ? "Image edit instructions" : "Message input"}
```

but the test still anchors on the old literal form, so `src.find(...)` returns `-1`:

```
AssertionError: anchor 'aria-label="Message input"' not found
assert -1 != -1
```

Fix: anchor on the inner string literal `"Message input"`.

### 3. Backend CI / Python 3.10-3.13 — `studio/backend/tests/test_desktop_auth.py:487`

`test_provision_desktop_auth_writes_secret_and_creates_db_without_backend_deps` installs a `builtins.__import__` guard that blocks `("auth", "fastapi", "structlog", "utils")` to prove the CLI does not pull in Studio backend deps. The guard is too broad: it matches the relative `from .utils import echo` inside `typer._click.decorators` (typer 0.25+), which calls `__import__("utils", ..., level=1)`:

```
File ".../typer/_click/decorators.py", line 5, in <module>
File "<string>", line 13, in guarded_import
ModuleNotFoundError: utils
```

Fix: gate the block on `level == 0` so only absolute imports of `auth` / `fastapi` / `structlog` / `utils` get rejected; relative imports inside third-party packages pass through. This preserves the test's intent (no Studio backend deps) without misclassifying every `from .utils import x` everywhere on `sys.path`.

## Verification

```
$ pytest tests/studio/test_composer_rtl_bidi_attribute.py -v
12 passed in 0.03s

$ pytest studio/backend/tests/test_desktop_auth.py::test_provision_desktop_auth_writes_secret_and_creates_db_without_backend_deps -v
1 passed in 0.69s
```

The MLX one cannot be exercised on Linux but the change is mechanical (`7` -> `config.max_steps`); it will be validated by `MLX CI on Mac M1` on this PR.

## Test plan

- [ ] `MLX CI on Mac M1` goes green on this PR
- [ ] `Backend CI` (Repo tests CPU + all Python matrix variants) goes green
- [ ] No new regressions in any other workflow