### PR TITLE
Studio: fix phantom scroll area below messages with many sources

### DIFF
--- a/studio/frontend/src/components/assistant-ui/sources.tsx
+++ b/studio/frontend/src/components/assistant-ui/sources.tsx
@@ -263,20 +263,34 @@ const SourcesGroup: FC = () => {
 
   return (
     <div className="relative mt-2 mb-3">
-      {/* Hidden measurement container — renders all badges to measure row positions */}
+      {/* Hidden measurement container. Renders all badges off-screen so we
+          can read each child's offsetTop and decide how many fit in two
+          rows. Wrapped in an absolute, h-0, overflow-hidden box so the
+          measurement pills do NOT contribute to the viewport's scrollable
+          overflow region. Without this clip, every hidden source row
+          adds ~30px to scrollHeight, producing a phantom empty scroll
+          area below the message: visible to users as unbounded blank
+          space below the assistant action bar. The inner div still
+          flex-wraps its children for measurement; offsetTop reads
+          correctly because the wrapper is positioned (absolute) and the
+          children's offsetTop is measured relative to it. */}
       <div
-        ref={containerRef}
         aria-hidden
-        className="flex w-full flex-wrap gap-1 invisible absolute pointer-events-none"
+        className="absolute pointer-events-none overflow-hidden h-0 w-full left-0 top-0"
       >
-        {sources.map((source) => (
-          <span key={source.id} className="inline-block">
-            <Source href={source.url}>
-              <SourceIcon url={source.url} />
-              <SourceTitle>{source.title || extractDomain(source.url)}</SourceTitle>
-            </Source>
-          </span>
-        ))}
+        <div
+          ref={containerRef}
+          className="flex w-full flex-wrap gap-1 invisible"
+        >
+          {sources.map((source) => (
+            <span key={source.id} className="inline-block">
+              <Source href={source.url}>
+                <SourceIcon url={source.url} />
+                <SourceTitle>{source.title || extractDomain(source.url)}</SourceTitle>
+              </Source>
+            </span>
+          ))}
+        </div>
       </div>
 
       {/* Visible container */}


### PR DESCRIPTION
## Summary
- The chat source-badge measurement container renders every citation off-screen with `invisible absolute`, but absolute descendants still contribute to the parent's scrollable overflow region. On messages with long source lists this added hundreds of pixels of empty scroll space below the assistant message.
- Wrap the measurement container in an absolute, `h-0`, `overflow-hidden` box so the off-screen badges are clipped out of the scrollable overflow region. Measurement still works because `offsetTop` is read relative to the positioned wrapper.

## Test plan
- [ ] Open a chat thread with a long sources list and confirm there is no phantom empty scroll area below the action bar.
- [ ] Confirm the "+N more" / "Show less" toggle still measures the right cutoff (no regression in which badges are hidden by default).