### PR TITLE
fix: set HAS_FLEX_ATTENTION=True after successful import (closes #3650)

### DIFF
--- a/unsloth/kernels/flex_attention.py
+++ b/unsloth/kernels/flex_attention.py
@@ -35,7 +35,7 @@ try:
     _flex_attention = torch.compile(
         _flex_attention, dynamic = True, options = torch_compile_options
     )
-    HAS_FLEX_ATTENTION = False
+    HAS_FLEX_ATTENTION = True
 except:
     HAS_FLEX_ATTENTION = False
 


### PR DESCRIPTION
## What
In `unsloth/kernels/flex_attention.py`, `HAS_FLEX_ATTENTION` is incorrectly set to `False` even after successfully importing `flex_attention` from `torch.nn.attention.flex_attention`. This causes the flex attention code path to never be used, always falling back to the slow attention path, which can cause maximum recursion depth errors with models like Gemma 3n.

## Fix
Change `HAS_FLEX_ATTENTION = False` to `HAS_FLEX_ATTENTION = True` inside the `try` block after successfully importing and compiling flex attention.

Closes #3650