### PR TITLE
studio/frontend: fix MCP dialog overflow on long URLs

### DIFF
--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -415,7 +415,7 @@ export function ChatMcpServersDialog({
             </div>
           </div>
         ) : (
-          <div className="flex flex-col gap-3">
+          <div className="flex min-w-0 flex-col gap-3">
             <div className="flex justify-end">
               <Button size="sm" onClick={startCreate}>
                 <HugeiconsIcon icon={PlusSignIcon} size={14} />


### PR DESCRIPTION
Just a small UI fix to the MCP dialog.

Before:

<img width="579" height="322" alt="before" src="https://github.com/user-attachments/assets/c61b8ad3-03ff-425e-853e-b8e137416bd9" />

After:

<img width="529" height="342" alt="after" src="https://github.com/user-attachments/assets/2c483b92-bd64-485c-9933-fa74a1760861" />
