### PR TITLE
Studio: fix mobile composer action overflow

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -42,6 +42,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { sentAudioNames } from "@/features/chat/api/chat-adapter";
+import { ComposerMobileActionsMenu } from "@/features/chat/composer-mobile-actions-menu";
 import { parseExternalModelId } from "@/features/chat/external-providers";
 import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
@@ -1182,13 +1183,22 @@ const ComposerAction: FC<{
   return (
     <div className="aui-composer-action-wrapper composer-action-wrapper">
       <div className="flex items-center gap-0.5">
-        <ComposerAddAttachment />
+        <ComposerMobileActionsMenu />
+        <div className="hidden sm:contents">
+          <ComposerAddAttachment />
+        </div>
         <ComposerAudioUpload />
         <ReasoningToggle />
-        <PreserveThinkingToggle />
-        <WebSearchToggle />
-        <CodeToolsToggle />
-        <ImagesToggle />
+        <div className="hidden sm:contents">
+          <PreserveThinkingToggle />
+        </div>
+        <div className="hidden sm:contents">
+          <WebSearchToggle />
+        </div>
+        <div className="hidden sm:contents">
+          <CodeToolsToggle />
+          <ImagesToggle />
+        </div>
       </div>
       <div className="flex items-center gap-1">
         <ComposerPrimitive.If dictation={false}>

--- a/studio/frontend/src/features/chat/composer-mobile-actions-menu.tsx
+++ b/studio/frontend/src/features/chat/composer-mobile-actions-menu.tsx
@@ -78,10 +78,24 @@ export function ComposerMobileActionsMenu({
       ? externalProvidersAll.find((p) => p.id === externalSelection.providerId)
       : undefined;
   const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
+  const isExternalGemini = selectedExternalProvider?.providerType === "gemini";
 
-  const searchDisabled = !modelLoaded || !(supportsTools || supportsBuiltinWebSearch);
-  const codeDisabled = !modelLoaded || !(supportsTools || supportsBuiltinCodeExecution);
-  const imageDisabled = !modelLoaded;
+  const imageDisabled = !modelLoaded || !supportsBuiltinImageGeneration;
+  const imageModeDisablesCode =
+    isExternalGemini && imageToolsEnabled && !imageDisabled;
+  const isGeminiImageTier =
+    isExternalGemini && supportsBuiltinImageGeneration;
+  const searchDisabled =
+    !modelLoaded ||
+    (isGeminiImageTier
+      ? !supportsBuiltinWebSearch
+      : !(supportsTools || supportsBuiltinWebSearch));
+  const codeDisabled =
+    !modelLoaded ||
+    (isGeminiImageTier
+      ? true
+      : !(supportsTools || supportsBuiltinCodeExecution)) ||
+    imageModeDisablesCode;
   const webFetchDisabled = !modelLoaded || !supportsBuiltinWebFetch;
 
   const addAttachmentItem = (
@@ -117,7 +131,7 @@ export function ComposerMobileActionsMenu({
             const next = Boolean(checked);
             setToolsEnabled(next);
             if (isKimiExternal) {
-              setReasoningEnabled(!next);
+              setReasoningEnabled(!next, { persist: false });
               applyQwenThinkingParams(!next);
             }
           }}

--- a/studio/frontend/src/features/chat/composer-mobile-actions-menu.tsx
+++ b/studio/frontend/src/features/chat/composer-mobile-actions-menu.tsx
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { CodeToggleIcon } from "@/components/assistant-ui/code-toggle-icon";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ComposerPrimitive } from "@assistant-ui/react";
+import { Image03Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  DownloadIcon,
+  GlobeIcon,
+  LightbulbIcon,
+  LightbulbOffIcon,
+  PlusIcon,
+} from "lucide-react";
+import { applyQwenThinkingParams } from "./utils/qwen-params";
+import { parseExternalModelId } from "./external-providers";
+import { useExternalProvidersStore } from "./stores/external-providers-store";
+import { useChatRuntimeStore } from "./stores/chat-runtime-store";
+
+type ComposerMobileActionsMenuProps = {
+  onAddAttachment?: () => void;
+};
+
+export function ComposerMobileActionsMenu({
+  onAddAttachment,
+}: ComposerMobileActionsMenuProps) {
+  const checkpoint = useChatRuntimeStore((s) => s.params.checkpoint);
+  const modelLoaded = useChatRuntimeStore(
+    (s) => !!s.params.checkpoint && !s.modelLoading,
+  );
+  const supportsTools = useChatRuntimeStore((s) => s.supportsTools);
+  const supportsBuiltinWebSearch = useChatRuntimeStore(
+    (s) => s.supportsBuiltinWebSearch,
+  );
+  const toolsEnabled = useChatRuntimeStore((s) => s.toolsEnabled);
+  const setToolsEnabled = useChatRuntimeStore((s) => s.setToolsEnabled);
+  const setReasoningEnabled = useChatRuntimeStore((s) => s.setReasoningEnabled);
+  const supportsPreserveThinking = useChatRuntimeStore(
+    (s) => s.supportsPreserveThinking,
+  );
+  const preserveThinking = useChatRuntimeStore((s) => s.preserveThinking);
+  const setPreserveThinking = useChatRuntimeStore((s) => s.setPreserveThinking);
+  const supportsBuiltinCodeExecution = useChatRuntimeStore(
+    (s) => s.supportsBuiltinCodeExecution,
+  );
+  const codeToolsEnabled = useChatRuntimeStore((s) => s.codeToolsEnabled);
+  const setCodeToolsEnabled = useChatRuntimeStore((s) => s.setCodeToolsEnabled);
+  const supportsBuiltinImageGeneration = useChatRuntimeStore(
+    (s) => s.supportsBuiltinImageGeneration,
+  );
+  const imageToolsEnabled = useChatRuntimeStore((s) => s.imageToolsEnabled);
+  const setImageToolsEnabled = useChatRuntimeStore(
+    (s) => s.setImageToolsEnabled,
+  );
+  const supportsBuiltinWebFetch = useChatRuntimeStore(
+    (s) => s.supportsBuiltinWebFetch,
+  );
+  const webFetchToolsEnabled = useChatRuntimeStore(
+    (s) => s.webFetchToolsEnabled,
+  );
+  const setWebFetchToolsEnabled = useChatRuntimeStore(
+    (s) => s.setWebFetchToolsEnabled,
+  );
+  const connectionsEnabled = useExternalProvidersStore(
+    (s) => s.connectionsEnabled,
+  );
+  const externalProvidersAll = useExternalProvidersStore((s) => s.providers);
+  const externalSelection = parseExternalModelId(checkpoint);
+  const selectedExternalProvider =
+    externalSelection != null && connectionsEnabled
+      ? externalProvidersAll.find((p) => p.id === externalSelection.providerId)
+      : undefined;
+  const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
+
+  const searchDisabled = !modelLoaded || !(supportsTools || supportsBuiltinWebSearch);
+  const codeDisabled = !modelLoaded || !(supportsTools || supportsBuiltinCodeExecution);
+  const imageDisabled = !modelLoaded;
+  const webFetchDisabled = !modelLoaded || !supportsBuiltinWebFetch;
+
+  const addAttachmentItem = (
+    <DropdownMenuItem onSelect={onAddAttachment}>
+      <PlusIcon className="size-4" />
+      Add attachment
+    </DropdownMenuItem>
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild={true}>
+        <button
+          type="button"
+          className="flex size-8.5 items-center justify-center rounded-full p-1 font-semibold text-xs hover:bg-muted-foreground/15 sm:hidden dark:hover:bg-muted-foreground/30"
+          aria-label="Composer actions"
+        >
+          <PlusIcon className="size-5 stroke-[1.5px]" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" side="top" className="w-56">
+        {onAddAttachment ? (
+          addAttachmentItem
+        ) : (
+          <ComposerPrimitive.AddAttachment asChild={true}>
+            {addAttachmentItem}
+          </ComposerPrimitive.AddAttachment>
+        )}
+        <DropdownMenuCheckboxItem
+          checked={toolsEnabled && !searchDisabled}
+          disabled={searchDisabled}
+          onCheckedChange={(checked) => {
+            const next = Boolean(checked);
+            setToolsEnabled(next);
+            if (isKimiExternal) {
+              setReasoningEnabled(!next);
+              applyQwenThinkingParams(!next);
+            }
+          }}
+        >
+          <GlobeIcon className="size-4" />
+          Search
+        </DropdownMenuCheckboxItem>
+        {supportsPreserveThinking && (
+          <DropdownMenuCheckboxItem
+            checked={preserveThinking && modelLoaded}
+            disabled={!modelLoaded}
+            onCheckedChange={(checked) => setPreserveThinking(Boolean(checked))}
+          >
+            {preserveThinking && modelLoaded ? (
+              <LightbulbIcon className="size-4" />
+            ) : (
+              <LightbulbOffIcon className="size-4" />
+            )}
+            Preserve Think
+          </DropdownMenuCheckboxItem>
+        )}
+        <DropdownMenuCheckboxItem
+          checked={codeToolsEnabled && !codeDisabled}
+          disabled={codeDisabled}
+          onCheckedChange={(checked) => setCodeToolsEnabled(Boolean(checked))}
+        >
+          <CodeToggleIcon className="size-4" />
+          Code
+        </DropdownMenuCheckboxItem>
+        {supportsBuiltinImageGeneration && (
+          <DropdownMenuCheckboxItem
+            checked={imageToolsEnabled && !imageDisabled}
+            disabled={imageDisabled}
+            onCheckedChange={(checked) => setImageToolsEnabled(Boolean(checked))}
+          >
+            <HugeiconsIcon icon={Image03Icon} className="size-4" strokeWidth={2} />
+            Images
+          </DropdownMenuCheckboxItem>
+        )}
+        {supportsBuiltinWebFetch && (
+          <DropdownMenuCheckboxItem
+            checked={webFetchToolsEnabled && !webFetchDisabled}
+            disabled={webFetchDisabled}
+            onCheckedChange={(checked) => setWebFetchToolsEnabled(Boolean(checked))}
+          >
+            <DownloadIcon className="size-4" />
+            Fetch
+          </DropdownMenuCheckboxItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ComposerMobileActionsMenu } from "./composer-mobile-actions-menu";
 import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
 import { AUDIO_ACCEPT, MAX_AUDIO_SIZE, fileToBase64 } from "@/lib/audio-utils";
 import { isTauri } from "@/lib/api-base";
@@ -909,12 +910,15 @@ export function SharedComposer({
               e.target.value = "";
             }}
           />
+          <ComposerMobileActionsMenu
+            onAddAttachment={() => fileInputRef.current?.click()}
+          />
           <TooltipIconButton
             tooltip="Add Attachment"
             side="bottom"
             variant="ghost"
             size="icon"
-            className="size-8.5 rounded-full p-1 font-semibold text-xs hover:bg-muted-foreground/15 dark:hover:bg-muted-foreground/30"
+            className="hidden size-8.5 rounded-full p-1 font-semibold text-xs hover:bg-muted-foreground/15 sm:inline-flex dark:hover:bg-muted-foreground/30"
             onClick={() => {
               // The picker accepts both image and audio. Don't gate the
               // button on image-availability — addFiles still filters
@@ -1085,7 +1089,7 @@ export function SharedComposer({
               disabled={!modelLoaded}
               onClick={() => setPreserveThinking(!preserveThinking)}
               className={cn(
-                "flex items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors",
+                "hidden items-center gap-1.5 rounded-full px-1.5 py-1.5 text-[13px] font-medium text-muted-foreground/70 transition-colors sm:flex",
                 !modelLoaded
                   ? "cursor-not-allowed opacity-40"
                   : preserveThinking
@@ -1120,7 +1124,7 @@ export function SharedComposer({
                 applyQwenThinkingParams(!next);
               }
             }}
-            className="composer-pill-btn"
+            className="composer-pill-btn hidden sm:flex"
             data-active={toolsEnabled && !searchDisabled ? "true" : "false"}
             aria-label={toolsEnabled ? "Disable web search" : "Enable web search"}
           >
@@ -1131,7 +1135,7 @@ export function SharedComposer({
             type="button"
             disabled={codeDisabled}
             onClick={() => setCodeToolsEnabled(!codeToolsEnabled)}
-            className="composer-pill-btn"
+            className="composer-pill-btn hidden sm:flex"
             data-active={codeToolsEnabled && !codeDisabled ? "true" : "false"}
             aria-label={codeToolsEnabled ? "Disable code execution" : "Enable code execution"}
           >
@@ -1143,7 +1147,7 @@ export function SharedComposer({
               type="button"
               disabled={imageDisabled}
               onClick={() => setImageToolsEnabled(!imageToolsEnabled)}
-              className="composer-pill-btn"
+              className="composer-pill-btn hidden sm:flex"
               data-active={imageToolsEnabled && !imageDisabled ? "true" : "false"}
               aria-label={
                 imageToolsEnabled ? "Disable image generation" : "Enable image generation"
@@ -1162,7 +1166,7 @@ export function SharedComposer({
               type="button"
               disabled={webFetchDisabled}
               onClick={() => setWebFetchToolsEnabled(!webFetchToolsEnabled)}
-              className="composer-pill-btn"
+              className="composer-pill-btn hidden sm:flex"
               data-active={
                 webFetchToolsEnabled && !webFetchDisabled ? "true" : "false"
               }


### PR DESCRIPTION
## Summary

 #5800

Fixes mobile composer action overflow when extra controls like Preserve Think are available.

On mobile:
- Keeps the primary composer row compact
- Moves secondary actions into the `+` menu
- Preserves desktop composer layout
- Applies to both the main thread composer and shared/compare composer

Old:
<img width="588" height="1150" alt="image" src="https://github.com/user-attachments/assets/df0a5573-f7d9-4122-8f32-34edc99fc79f" />

 
New:
<img width="738" height="1227" alt="image" src="https://github.com/user-attachments/assets/5885e473-8c4a-442c-a373-9fd7951404ec" />
<img width="530" height="438" alt="image" src="https://github.com/user-attachments/assets/bd7e4a29-3607-4f97-8f1a-66e27c942e35" />
