### PR TITLE
Remove dead top-level bitsandbytes import from models/_utils.py

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1216,8 +1216,6 @@ if is_openai_available():
 
 # =============================================
 # Get Flash Attention v2 if Ampere (RTX 30xx, A100)
-import bitsandbytes as bnb
-
 from transformers import AutoTokenizer
 from transformers.utils.import_utils import _is_package_available
 


### PR DESCRIPTION
The top-level `import bitsandbytes as bnb` at line 1219 of unsloth/models/_utils.py is dead: the resulting `bnb` name is never used anywhere in the file (the only `bnb` token in the module is the qualified `peft.tuners.lora.bnb` attribute path on line 2548, which is unrelated, and `bnb` is not in `__all__`). The unguarded import breaks `import unsloth` for users without bitsandbytes installed, contradicting the warning in _gpu_init.py:252-258 that "16bit and full finetuning works" without bitsandbytes.

This PR removes the dead import and adds a pure-AST regression test in the same style as test_callback_signature_drift.py and test_import_fixes_drift.py, pinning both directions (no top-level bitsandbytes import, no bare `bnb` name used). If a real use of bitsandbytes is added later, the import should come back guarded with try/except (matching _gpu_init.py:252-258), not unconditionally.

Note: `import unsloth` as a package still requires bitsandbytes because of other unguarded imports in kernels/utils.py (heavy real use), models/granite.py and save.py (isinstance checks). Making the whole package optionally importable without bitsandbytes is a deeper, separately-scoped change; this PR just removes the dead one.