### PR TITLE
Update Studio sidebar logout icon to logout-05

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -49,7 +49,7 @@ import {
   Edit03Icon,
   Globe02Icon,
   HelpCircleIcon,
-  Logout01Icon,
+  Logout05Icon,
   Search01Icon,
   PowerIcon,
   PencilEdit02Icon,
@@ -796,7 +796,7 @@ export function AppSidebar() {
                     void navigate({ to: "/login" });
                   }}
                 >
-                  <HugeiconsIcon icon={Logout01Icon} strokeWidth={1.75} className="size-icon" />
+                  <HugeiconsIcon icon={Logout05Icon} strokeWidth={1.75} className="size-icon" />
                   <span>{t("shell.navigation.logOut")}</span>
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setShutdownOpen(true)}>


### PR DESCRIPTION
Swaps the Log Out icon in the Studio sidebar user menu from `Logout01Icon` to `Logout05Icon`.

The new logout-05 glyph (door on the left with the arrow exiting to the right) reads more clearly as a sign out action. Both icons already ship in `@hugeicons/core-free-icons`, so this is just an import swap with no new dependency.

## Changes
- `studio/frontend/src/components/app-sidebar.tsx`: update the import and the icon used in the Log Out menu item.

## Testing
- Rebuilt the frontend and confirmed the logout-05 path is in the served bundle, then verified the icon in the sidebar user dropdown.