### PR TITLE
studio: make NVIDIA prebuilt selection track CUDA version bumps (Windows + Linux)

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3359,6 +3359,44 @@ def _pinned_windows_cuda_fallback(
     )
 
 
+def _augment_checksums_with_pin(
+    checksums: ApprovedReleaseChecksums, pin: AssetChoice
+) -> ApprovedReleaseChecksums:
+    """Add the pin's own verified hashes to a copy of the approved checksums so
+    apply_approved_hashes keeps it on the published path (b9360 is not in the
+    release manifest)."""
+    artifacts = dict(checksums.artifacts)
+    if pin.expected_sha256:
+        artifacts[pin.name] = ApprovedArtifactHash(
+            asset_name = pin.name,
+            sha256 = pin.expected_sha256,
+            repo = pin.repo,
+            kind = "prebuilt",
+        )
+    if pin.runtime_name and pin.runtime_sha256:
+        artifacts[pin.runtime_name] = ApprovedArtifactHash(
+            asset_name = pin.runtime_name,
+            sha256 = pin.runtime_sha256,
+            repo = pin.repo,
+            kind = "prebuilt",
+        )
+    return dataclasses_replace(checksums, artifacts = artifacts)
+
+
+def _with_pinned_windows_cuda_fallback(
+    host: HostInfo,
+    attempts: list[AssetChoice],
+    checksums: ApprovedReleaseChecksums,
+) -> tuple[list[AssetChoice], ApprovedReleaseChecksums]:
+    """Insert the Blackwell pin ahead of the Windows CUDA attempts and keep it
+    through apply_approved_hashes, or return the inputs unchanged when dormant.
+    Gives the published install path the same GPU fallback as the simple path."""
+    pin = _pinned_windows_cuda_fallback(host, attempts)
+    if pin is None:
+        return attempts, checksums
+    return [pin, *attempts], _augment_checksums_with_pin(checksums, pin)
+
+
 def published_windows_cuda_attempts(
     host: HostInfo,
     release: PublishedReleaseBundle,
@@ -3980,18 +4018,23 @@ def resolve_release_asset_choice(
             torch_preference.selection_log,
         )
         if published_attempts:
+            pin_attempts, pin_checksums = _with_pinned_windows_cuda_fallback(
+                host, published_attempts, checksums
+            )
             try:
-                return apply_approved_hashes(published_attempts, checksums)
+                return apply_approved_hashes(pin_attempts, pin_checksums)
             except PrebuiltFallback as exc:
                 log(
                     "published Windows CUDA assets ignored for install planning: "
                     f"{release.repo}@{release.release_tag} ({exc})"
                 )
         upstream_assets = github_release_assets(UPSTREAM_REPO, llama_tag)
-        return apply_approved_hashes(
+        upstream_attempts, upstream_checksums = _with_pinned_windows_cuda_fallback(
+            host,
             resolve_windows_cuda_choices(host, llama_tag, upstream_assets),
             checksums,
         )
+        return apply_approved_hashes(upstream_attempts, upstream_checksums)
 
     published_choice: AssetChoice | None = None
     if host.is_windows and host.is_x86_64:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -220,6 +220,24 @@ DIRECT_LINUX_BUNDLE_PROFILES: dict[str, dict[str, Any]] = {
 _MIN_CUDA_MAJOR = 12
 _MAX_PROBE_CUDA_MAJOR = 19
 
+# Last ggml-org release whose Windows win-cuda-13 build is still sub-13.3
+# (cuda-13.1, b9360, 2026-05-27). Upstream bumped win-cuda-13 to 13.3 at b9365
+# and now ships only cuda-12.4 + cuda-13.3. cuda-12.4 predates Blackwell (ggml
+# compiles sm_120 only at toolkit >= 12.8), so a Blackwell host on a 13.1/13.2
+# driver is gated off 13.3 and would drop to a CPU-only 12.4 build. b9360 is
+# immutable, so we pin its cuda-13.1 build (plus paired cudart) as a GPU
+# fallback for exactly those hosts. See unslothai/unsloth#5887.
+_PINNED_BLACKWELL_FALLBACK_TAG = "b9360"
+_PINNED_BLACKWELL_FALLBACK_RUNTIME = "13.1"
+_PINNED_BLACKWELL_DRIVER_FLOOR = (13, 1)
+_BLACKWELL_MIN_SM = 120
+_PINNED_BLACKWELL_LLAMA_SHA256 = (
+    "31ddb8b42d7ab4a47cab8c48c397519f580ca502df7e73f3ab396eacc16c8e8d"
+)
+_PINNED_BLACKWELL_CUDART_SHA256 = (
+    "f96935e7e385e3b2d0189239077c10fe8fd7e95690fea4afec455b1b6c7e3f18"
+)
+
 
 def _cuda_runtime_lines_for_major(major: int) -> list[str]:
     """Runtime lines a driver of this CUDA major can use, newest major first
@@ -1451,6 +1469,11 @@ def direct_upstream_release_plan(
                     torch_preference.selection_log,
                 )
             )
+            # Blackwell on a 13.1/13.2 driver: prefer the pinned cuda-13.1 GPU
+            # build over the CPU-only cuda-12.4 the in-release gating leaves.
+            pinned = _pinned_windows_cuda_fallback(host, attempts)
+            if pinned is not None:
+                attempts.insert(0, pinned)
         elif host.has_rocm:
             lemonade_choice = resolve_lemonade_rocm_choice(
                 host, "windows", "windows-hip", llama_tag = requested_tag
@@ -3268,6 +3291,53 @@ def windows_cuda_attempts(
             )
         )
     return attempts
+
+
+def _pinned_windows_cuda_fallback(
+    host: HostInfo, existing_cuda_attempts: list[AssetChoice]
+) -> AssetChoice | None:
+    """Pinned GPU fallback for a Blackwell host the in-release cuda13 build gates
+    off. Upstream stopped publishing a sub-13.3 Windows cuda13 build after b9360,
+    and cuda-12.4 cannot offload sm_120, so a 13.1/13.2 driver would land on CPU.
+    b9360's cuda-13.1 build is immutable and runs on those drivers. Returns None
+    (dormant) whenever a runnable in-release cuda13 build is already present, so
+    it self-disables once upstream ships a driver-runnable build again."""
+    if not (host.is_windows and host.is_x86_64 and host.has_usable_nvidia):
+        return None
+    driver = host.driver_cuda_version
+    if driver is None or driver < _PINNED_BLACKWELL_DRIVER_FLOOR:
+        return None
+    caps = normalize_compute_caps(host.compute_caps)
+    if not caps or int(caps[-1]) < _BLACKWELL_MIN_SM:
+        return None
+    if any(attempt.runtime_line == "cuda13" for attempt in existing_cuda_attempts):
+        return None
+    tag = _PINNED_BLACKWELL_FALLBACK_TAG
+    runtime = _PINNED_BLACKWELL_FALLBACK_RUNTIME
+    base = (
+        f"https://github.com/{UPSTREAM_REPO}/releases/download/"
+        f"{urllib.parse.quote(tag, safe = '')}"
+    )
+    name = f"llama-{tag}-bin-win-cuda-{runtime}-x64.zip"
+    cudart_name = f"cudart-llama-bin-win-cuda-{runtime}-x64.zip"
+    return AssetChoice(
+        repo = UPSTREAM_REPO,
+        tag = tag,
+        name = name,
+        url = f"{base}/{name}",
+        source_label = "upstream",
+        install_kind = "windows-cuda",
+        runtime_line = "cuda13",
+        runtime_name = cudart_name,
+        runtime_url = f"{base}/{cudart_name}",
+        expected_sha256 = _PINNED_BLACKWELL_LLAMA_SHA256,
+        runtime_sha256 = _PINNED_BLACKWELL_CUDART_SHA256,
+        selection_log = [
+            f"windows_cuda_selection: pinned {tag} cuda-{runtime} Blackwell GPU "
+            f"fallback (in-release cuda13 gated off by driver "
+            f"{driver[0]}.{driver[1]})"
+        ],
+    )
 
 
 def published_windows_cuda_attempts(

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3312,11 +3312,20 @@ def published_windows_cuda_attempts(
             asset_url = release.assets.get(artifact.asset_name)
             if not asset_url:
                 continue
-            # See windows_cuda_attempts: pair the cudart bundle.
+            am = re.search(r"-bin-win-cuda-(\d+)\.(\d+)-x64\.zip$", artifact.asset_name)
+            # Gate the real published minor against the driver, so a published
+            # windows-cuda artifact can never bypass the driver-version gate.
+            if (
+                am is not None
+                and host.driver_cuda_version is not None
+                and (int(am.group(1)), int(am.group(2))) > host.driver_cuda_version
+            ):
+                continue
+            # See windows_cuda_attempts: pair the cudart bundle for the real minor.
             runtime_archive_name: str | None = None
             runtime_archive_url: str | None = None
-            if artifact.asset_name.startswith("llama-"):
-                runtime = runtime_by_line[runtime_line]
+            if am is not None and artifact.asset_name.startswith("llama-"):
+                runtime = f"{am.group(1)}.{am.group(2)}"
                 cudart_name = f"cudart-llama-bin-win-cuda-{runtime}-x64.zip"
                 cudart_url = release.assets.get(cudart_name)
                 if cudart_url and cudart_url != asset_url:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3303,7 +3303,9 @@ def _windows_cuda_attempt_covers_blackwell(attempt: AssetChoice) -> bool:
     if attempt.install_kind != "windows-cuda":
         return False
     m = re.search(r"-bin-win-cuda-(\d+)\.(\d+)-x64\.zip$", attempt.name)
-    return m is not None and (int(m.group(1)), int(m.group(2))) >= _BLACKWELL_MIN_TOOLKIT
+    return (
+        m is not None and (int(m.group(1)), int(m.group(2))) >= _BLACKWELL_MIN_TOOLKIT
+    )
 
 
 def _pinned_windows_cuda_fallback(

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -757,6 +757,22 @@ def windows_cuda_asset_aliases(
     return aliases
 
 
+def _published_windows_cuda_runtime(
+    upstream_assets: dict[str, str], major: int
+) -> str | None:
+    """Highest cuda-<major>.<minor> minor actually published upstream, so the
+    Windows selector follows ggml-org when they bump the minor (13.1 -> 13.3)
+    rather than requesting a now-missing asset name. None if nothing matches."""
+    best: int | None = None
+    for name in upstream_assets:
+        m = re.search(r"-bin-win-cuda-(\d+)\.(\d+)-x64\.zip$", name)
+        if m and int(m.group(1)) == major:
+            minor = int(m.group(2))
+            if best is None or minor > best:
+                best = minor
+    return f"{major}.{best}" if best is not None else None
+
+
 def format_byte_count(num_bytes: float) -> str:
     units = ["B", "KiB", "MiB", "GiB", "TiB"]
     value = float(num_bytes)
@@ -3135,7 +3151,13 @@ def windows_cuda_attempts(
 
     attempts: list[AssetChoice] = []
     for runtime_line in runtime_order:
-        runtime = runtime_by_line[runtime_line]
+        major = 13 if runtime_line == "cuda13" else 12
+        # Use the minor ggml-org actually ships (13.1 -> 13.3); the hardcoded
+        # default is only a fallback when upstream has no matching asset.
+        runtime = (
+            _published_windows_cuda_runtime(upstream_assets, major)
+            or runtime_by_line[runtime_line]
+        )
         selected_name = None
         asset_url = None
         for candidate_name in windows_cuda_upstream_asset_names(llama_tag, runtime):

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -213,6 +213,44 @@ DIRECT_LINUX_BUNDLE_PROFILES: dict[str, dict[str, Any]] = {
     },
 }
 
+# Lowest CUDA major we ship prebuilts for, and the highest major we probe for
+# installed runtime libraries. Detection and runtime-line derivation are
+# generated per major so a new toolkit (cuda14, ...) needs no code change while
+# llama.cpp keeps the cudart64_<major>.dll / libcudart.so.<major> naming.
+_MIN_CUDA_MAJOR = 12
+_MAX_PROBE_CUDA_MAJOR = 19
+
+
+def _cuda_runtime_lines_for_major(major: int) -> list[str]:
+    """Runtime lines a driver of this CUDA major can use, newest major first
+    down to the minimum we ship. A driver runs its own major and any older one
+    (backward compatibility)."""
+    return [f"cuda{m}" for m in range(major, _MIN_CUDA_MAJOR - 1, -1)]
+
+
+def _resolve_linux_bundle_profile(bundle_profile: str) -> "dict[str, Any] | None":
+    """Profile (runtime line + sm coverage) for a linux-x64-cuda<major>-<class>
+    bundle. Known majors use their published coverage; an unknown future major
+    reuses the newest known major's coverage for the same class as a forward
+    default, with the post-build GPU smoke test as the backstop."""
+    known = DIRECT_LINUX_BUNDLE_PROFILES.get(bundle_profile)
+    if known is not None:
+        return known
+    m = re.fullmatch(r"cuda(?P<major>\d+)-(?P<klass>older|newer|portable)", bundle_profile)
+    if not m:
+        return None
+    base_key = max(
+        (k for k, v in DIRECT_LINUX_BUNDLE_PROFILES.items()
+         if v["coverage_class"] == m.group("klass")),
+        key = lambda k: int(re.match(r"cuda(\d+)-", k).group(1)),
+        default = None,
+    )
+    if base_key is None:
+        return None
+    profile = dict(DIRECT_LINUX_BUNDLE_PROFILES[base_key])
+    profile["runtime_line"] = f"cuda{m.group('major')}"
+    return profile
+
 
 @dataclass
 class HostInfo:
@@ -1229,7 +1267,7 @@ def parse_direct_linux_release_bundle(
     inferred_labels: list[str] = []
 
     linux_asset_re = re.compile(
-        r"^app-(?P<label>.+)-(?P<target>linux-x64(?:-cpu)?|linux-x64-(?:cuda12|cuda13)-(?:older|newer|portable))\.tar\.gz$"
+        r"^app-(?P<label>.+)-(?P<target>linux-x64(?:-cpu)?|linux-x64-cuda\d+-(?:older|newer|portable))\.tar\.gz$"
     )
     for asset_name in sorted(assets):
         match = linux_asset_re.fullmatch(asset_name)
@@ -1254,7 +1292,7 @@ def parse_direct_linux_release_bundle(
             continue
 
         bundle_profile = target.removeprefix("linux-x64-")
-        profile = DIRECT_LINUX_BUNDLE_PROFILES.get(bundle_profile)
+        profile = _resolve_linux_bundle_profile(bundle_profile)
         if profile is None:
             continue
         artifacts.append(
@@ -1763,8 +1801,8 @@ def linux_runtime_dirs_for_required_libraries(
 
 def detected_linux_runtime_lines() -> tuple[list[str], dict[str, list[str]]]:
     line_requirements = {
-        "cuda13": ["libcudart.so.13", "libcublas.so.13"],
-        "cuda12": ["libcudart.so.12", "libcublas.so.12"],
+        f"cuda{m}": [f"libcudart.so.{m}", f"libcublas.so.{m}"]
+        for m in range(_MAX_PROBE_CUDA_MAJOR, _MIN_CUDA_MAJOR - 1, -1)
     }
     detected: list[str] = []
     runtime_dirs: dict[str, list[str]] = {}
@@ -2959,17 +2997,21 @@ def compatible_linux_runtime_lines(host: HostInfo) -> list[str]:
     if not host.driver_cuda_version:
         return []
     major, _minor = host.driver_cuda_version
-    if major >= 13:
-        return ["cuda13", "cuda12"]
-    if major >= 12:
-        return ["cuda12"]
-    return []
+    if major < _MIN_CUDA_MAJOR:
+        return []
+    return _cuda_runtime_lines_for_major(major)
 
 
 def windows_runtime_line_info() -> dict[str, tuple[str, ...]]:
+    # Generated per CUDA major (newest first) so a new toolkit is detected
+    # without a code change while the cudart64_<major>.dll naming holds.
     return {
-        "cuda13": ("cudart64_13*.dll", "cublas64_13*.dll", "cublasLt64_13*.dll"),
-        "cuda12": ("cudart64_12*.dll", "cublas64_12*.dll", "cublasLt64_12*.dll"),
+        f"cuda{m}": (
+            f"cudart64_{m}*.dll",
+            f"cublas64_{m}*.dll",
+            f"cublasLt64_{m}*.dll",
+        )
+        for m in range(_MAX_PROBE_CUDA_MAJOR, _MIN_CUDA_MAJOR - 1, -1)
     }
 
 
@@ -2986,12 +3028,13 @@ def detected_windows_runtime_lines() -> tuple[list[str], dict[str, list[str]]]:
 
 
 def compatible_windows_runtime_lines(host: HostInfo) -> list[str]:
-    driver_runtime = pick_windows_cuda_runtime(host)
-    if driver_runtime == "13.1":
-        return ["cuda13", "cuda12"]
-    if driver_runtime == "12.4":
-        return ["cuda12"]
-    return []
+    if not host.driver_cuda_version:
+        return []
+    major, minor = host.driver_cuda_version
+    # cuda12 prebuilts need a 12.4+ driver; cuda13+ any minor of the major.
+    if major < _MIN_CUDA_MAJOR or (major == _MIN_CUDA_MAJOR and minor < 4):
+        return []
+    return _cuda_runtime_lines_for_major(major)
 
 
 def runtime_line_from_cuda_version(cuda_version: str | None) -> str | None:
@@ -3068,7 +3111,6 @@ def windows_cuda_attempts(
     selection_preamble: Iterable[str] = (),
 ) -> list[AssetChoice]:
     selection_log = list(selection_preamble)
-    runtime_by_line = {"cuda12": "12.4", "cuda13": "13.1"}
     driver_runtime = pick_windows_cuda_runtime(host)
     detected_runtime_lines, runtime_dirs = detected_windows_runtime_lines()
     compatible_runtime_lines = compatible_windows_runtime_lines(host)
@@ -3111,12 +3153,7 @@ def windows_cuda_attempts(
             selection_log.append(
                 "windows_cuda_selection: detected CUDA runtime DLLs were incompatible with the reported driver"
             )
-        fallback_runtime_lines = (
-            ["cuda13", "cuda12"]
-            if driver_runtime == "13.1"
-            else (["cuda12"] if driver_runtime == "12.4" else [])
-        )
-        normal_runtime_lines = fallback_runtime_lines
+        normal_runtime_lines = compatible_runtime_lines
 
     runtime_order: list[str] = []
     if preferred_runtime_line and preferred_runtime_line in normal_runtime_lines:
@@ -3151,13 +3188,16 @@ def windows_cuda_attempts(
 
     attempts: list[AssetChoice] = []
     for runtime_line in runtime_order:
-        major = 13 if runtime_line == "cuda13" else 12
-        # Use the minor ggml-org actually ships (13.1 -> 13.3); the hardcoded
-        # default is only a fallback when upstream has no matching asset.
-        runtime = (
-            _published_windows_cuda_runtime(upstream_assets, major)
-            or runtime_by_line[runtime_line]
-        )
+        major = int(runtime_line.removeprefix("cuda"))
+        # Track whatever minor llama.cpp actually ships for this major
+        # (cuda13 -> 13.1, 13.3, ...). Skip the line when the release has no
+        # matching asset instead of guessing a now-missing name.
+        runtime = _published_windows_cuda_runtime(upstream_assets, major)
+        if runtime is None:
+            selection_log.append(
+                f"windows_cuda_selection: no upstream asset for {runtime_line}"
+            )
+            continue
         selected_name = None
         asset_url = None
         for candidate_name in windows_cuda_upstream_asset_names(llama_tag, runtime):

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3317,7 +3317,11 @@ def _pinned_windows_cuda_fallback(
     b9360's cuda-13.1 build is immutable and runs on those drivers. Returns None
     (dormant) whenever the in-release selection already offers a Blackwell-capable
     build (toolkit >= 12.8, e.g. a runnable cuda13/cuda14), so it self-disables
-    once upstream ships a driver-runnable build again."""
+    once upstream ships a driver-runnable build again.
+
+    The b9360 binary reuses the current release's source tree and convert scripts
+    and is recorded via binary_release_tag, the same binary/source split used for
+    the lemonade prebuilt."""
     if not (host.is_windows and host.is_x86_64 and host.has_usable_nvidia):
         return None
     driver = host.driver_cuda_version

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -801,17 +801,21 @@ def windows_cuda_asset_aliases(
 
 
 def _published_windows_cuda_runtime(
-    upstream_assets: dict[str, str], major: int
+    upstream_assets: dict[str, str], major: int, driver: tuple[int, int] | None
 ) -> str | None:
-    """Highest cuda-<major>.<minor> minor actually published upstream, so the
-    Windows selector follows ggml-org when they bump the minor (13.1 -> 13.3)
-    rather than requesting a now-missing asset name. None if nothing matches."""
+    """Highest cuda-<major>.<minor> published upstream that `driver` can run by
+    default CUDA compatibility, i.e. (major, minor) <= driver. None if nothing
+    qualifies. Gating on the driver (not just the major) keeps a 13.3 build off
+    a driver that only advertises 13.1, where it would otherwise rely on the
+    unguaranteed minor-version-compatibility path."""
+    if driver is None:
+        return None
     best: int | None = None
     for name in upstream_assets:
         m = re.search(r"-bin-win-cuda-(\d+)\.(\d+)-x64\.zip$", name)
         if m and int(m.group(1)) == major:
             minor = int(m.group(2))
-            if best is None or minor > best:
+            if (major, minor) <= driver and (best is None or minor > best):
                 best = minor
     return f"{major}.{best}" if best is not None else None
 
@@ -3182,6 +3186,13 @@ def windows_cuda_attempts(
         for runtime_line in normal_runtime_lines
         if runtime_line not in runtime_order
     )
+    # Keep every driver-compatible line reachable as a fallback, so a line gated
+    # out by the driver version still drops to an older major (cuda13 -> cuda12).
+    runtime_order.extend(
+        runtime_line
+        for runtime_line in compatible_runtime_lines
+        if runtime_line not in runtime_order
+    )
     selection_log.append(
         "windows_cuda_selection: normal_runtime_order="
         + (",".join(normal_runtime_lines) if normal_runtime_lines else "none")
@@ -3197,10 +3208,12 @@ def windows_cuda_attempts(
         # Track whatever minor llama.cpp actually ships for this major
         # (cuda13 -> 13.1, 13.3, ...). Skip the line when the release has no
         # matching asset instead of guessing a now-missing name.
-        runtime = _published_windows_cuda_runtime(upstream_assets, major)
+        runtime = _published_windows_cuda_runtime(
+            upstream_assets, major, host.driver_cuda_version
+        )
         if runtime is None:
             selection_log.append(
-                f"windows_cuda_selection: no upstream asset for {runtime_line}"
+                f"windows_cuda_selection: no driver-supported asset for {runtime_line}"
             )
             continue
         selected_name = None

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -3347,13 +3347,26 @@ def published_windows_cuda_attempts(
     selection_preamble: Iterable[str] = (),
 ) -> list[AssetChoice]:
     selection_log = list(release.selection_log) + list(selection_preamble)
-    runtime_by_line = {"cuda12": "12.4", "cuda13": "13.1"}
+    # Seed the runtime-line ordering from the real published windows-cuda minors
+    # (their names encode the minor), so a future CUDA major published here is
+    # ordered too instead of a hardcoded cuda12/cuda13 pair. Keys mirror the
+    # upstream naming so windows_cuda_attempts can match them; fall back to the
+    # long-standing default when the release lists no windows-cuda asset.
+    published_minors: list[str] = []
+    for artifact in release.artifacts:
+        if artifact.install_kind != "windows-cuda":
+            continue
+        m = re.search(r"-bin-win-cuda-(\d+\.\d+)-x64\.zip$", artifact.asset_name)
+        if m:
+            published_minors.append(m.group(1))
+    if not published_minors:
+        published_minors = ["12.4", "13.1"]
     runtime_order = windows_cuda_attempts(
         host,
         release.upstream_tag,
         {
-            f"llama-{release.upstream_tag}-bin-win-cuda-{runtime}-x64.zip": "published"
-            for runtime in runtime_by_line.values()
+            f"llama-{release.upstream_tag}-bin-win-cuda-{minor}-x64.zip": "published"
+            for minor in published_minors
         },
         preferred_runtime_line,
         selection_log,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -236,12 +236,17 @@ def _resolve_linux_bundle_profile(bundle_profile: str) -> "dict[str, Any] | None
     known = DIRECT_LINUX_BUNDLE_PROFILES.get(bundle_profile)
     if known is not None:
         return known
-    m = re.fullmatch(r"cuda(?P<major>\d+)-(?P<klass>older|newer|portable)", bundle_profile)
+    m = re.fullmatch(
+        r"cuda(?P<major>\d+)-(?P<klass>older|newer|portable)", bundle_profile
+    )
     if not m:
         return None
     base_key = max(
-        (k for k, v in DIRECT_LINUX_BUNDLE_PROFILES.items()
-         if v["coverage_class"] == m.group("klass")),
+        (
+            k
+            for k, v in DIRECT_LINUX_BUNDLE_PROFILES.items()
+            if v["coverage_class"] == m.group("klass")
+        ),
         key = lambda k: int(re.match(r"cuda(\d+)-", k).group(1)),
         default = None,
     )

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -231,6 +231,10 @@ _PINNED_BLACKWELL_FALLBACK_TAG = "b9360"
 _PINNED_BLACKWELL_FALLBACK_RUNTIME = "13.1"
 _PINNED_BLACKWELL_DRIVER_FLOOR = (13, 1)
 _BLACKWELL_MIN_SM = 120
+# ggml compiles Blackwell sm_120 only at toolkit >= 12.8, so an in-release
+# windows-cuda build at or above this already covers Blackwell and makes the
+# older pinned 13.1 fallback unnecessary (cuda-12.4 is below it).
+_BLACKWELL_MIN_TOOLKIT = (12, 8)
 _PINNED_BLACKWELL_LLAMA_SHA256 = (
     "31ddb8b42d7ab4a47cab8c48c397519f580ca502df7e73f3ab396eacc16c8e8d"
 )
@@ -3293,15 +3297,25 @@ def windows_cuda_attempts(
     return attempts
 
 
+def _windows_cuda_attempt_covers_blackwell(attempt: AssetChoice) -> bool:
+    """True if an in-release windows-cuda attempt is built with a toolkit that
+    covers Blackwell sm_120 (>= 12.8), read from its asset name's CUDA minor."""
+    if attempt.install_kind != "windows-cuda":
+        return False
+    m = re.search(r"-bin-win-cuda-(\d+)\.(\d+)-x64\.zip$", attempt.name)
+    return m is not None and (int(m.group(1)), int(m.group(2))) >= _BLACKWELL_MIN_TOOLKIT
+
+
 def _pinned_windows_cuda_fallback(
     host: HostInfo, existing_cuda_attempts: list[AssetChoice]
 ) -> AssetChoice | None:
-    """Pinned GPU fallback for a Blackwell host the in-release cuda13 build gates
-    off. Upstream stopped publishing a sub-13.3 Windows cuda13 build after b9360,
-    and cuda-12.4 cannot offload sm_120, so a 13.1/13.2 driver would land on CPU.
+    """Pinned GPU fallback for a Blackwell host the in-release build gates off.
+    Upstream stopped publishing a sub-13.3 Windows cuda13 build after b9360, and
+    cuda-12.4 cannot offload sm_120, so a 13.1/13.2 driver would land on CPU.
     b9360's cuda-13.1 build is immutable and runs on those drivers. Returns None
-    (dormant) whenever a runnable in-release cuda13 build is already present, so
-    it self-disables once upstream ships a driver-runnable build again."""
+    (dormant) whenever the in-release selection already offers a Blackwell-capable
+    build (toolkit >= 12.8, e.g. a runnable cuda13/cuda14), so it self-disables
+    once upstream ships a driver-runnable build again."""
     if not (host.is_windows and host.is_x86_64 and host.has_usable_nvidia):
         return None
     driver = host.driver_cuda_version
@@ -3310,7 +3324,10 @@ def _pinned_windows_cuda_fallback(
     caps = normalize_compute_caps(host.compute_caps)
     if not caps or int(caps[-1]) < _BLACKWELL_MIN_SM:
         return None
-    if any(attempt.runtime_line == "cuda13" for attempt in existing_cuda_attempts):
+    if any(
+        _windows_cuda_attempt_covers_blackwell(attempt)
+        for attempt in existing_cuda_attempts
+    ):
         return None
     tag = _PINNED_BLACKWELL_FALLBACK_TAG
     runtime = _PINNED_BLACKWELL_FALLBACK_RUNTIME

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -80,6 +80,7 @@ env_int = INSTALL_LLAMA_PREBUILT.env_int
 direct_upstream_release_plan = INSTALL_LLAMA_PREBUILT.direct_upstream_release_plan
 _pinned_windows_cuda_fallback = INSTALL_LLAMA_PREBUILT._pinned_windows_cuda_fallback
 CudaRuntimePreference = INSTALL_LLAMA_PREBUILT.CudaRuntimePreference
+published_windows_cuda_attempts = INSTALL_LLAMA_PREBUILT.published_windows_cuda_attempts
 
 
 # ---------------------------------------------------------------------------
@@ -2172,6 +2173,70 @@ class TestDirectUpstreamBlackwellPin:
         assert plan.attempts[0].tag == self.TAG
         assert plan.attempts[0].runtime_line == "cuda13"
         assert plan.attempts[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+
+
+# ===========================================================================
+# N.1d. published_windows_cuda_attempts -- version-dynamic ordering seed
+# ===========================================================================
+
+
+class TestPublishedWindowsCudaAttemptsDynamicMajor:
+    """The published-path ordering seed is derived from the release's real
+    published minors, so a future CUDA major published here is selectable
+    instead of being hidden by a hardcoded cuda12/cuda13 seed."""
+
+    TAG = "b8508"
+
+    def _win_cuda_artifact(self, minor, runtime_line):
+        return make_artifact(
+            f"llama-{self.TAG}-bin-win-cuda-{minor}-x64.zip",
+            install_kind = "windows-cuda",
+            runtime_line = runtime_line,
+            max_sm = 120,
+        )
+
+    def _release(self, minors_lines):
+        artifacts = [self._win_cuda_artifact(m, line) for m, line in minors_lines]
+        return make_release(artifacts, upstream_tag = self.TAG)
+
+    def test_future_cuda14_published_is_selected(self, monkeypatch):
+        # With the dynamic seed a 14.x driver reaches a published cuda14 build;
+        # the old hardcoded cuda12/cuda13 seed would never order it (the cuda14
+        # line would be skipped for want of a 14.x asset in the seed).
+        mock_windows_runtime(monkeypatch, ["cuda14", "cuda13", "cuda12"])
+        release = self._release(
+            [("14.0", "cuda14"), ("13.3", "cuda13"), ("12.4", "cuda12")]
+        )
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (14, 0), compute_caps = ["120"],
+        )
+        result = published_windows_cuda_attempts(host, release, None)
+        assert result[0].runtime_line == "cuda14"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-14.0-x64.zip"
+
+    def test_cuda13_minor_selected_for_13_3_driver(self, monkeypatch):
+        # Existing behavior unchanged: a 13.3 driver gets the real 13.3 build.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (13, 3), compute_caps = ["120"],
+        )
+        result = published_windows_cuda_attempts(host, release, None)
+        assert result[0].runtime_line == "cuda13"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+
+    def test_below_minor_driver_gated_to_cuda12(self, monkeypatch):
+        # A 13.1 driver is gated off a published 13.3 and falls to cuda12.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (13, 1), compute_caps = ["120"],
+        )
+        result = published_windows_cuda_attempts(host, release, None)
+        assert result[0].runtime_line == "cuda12"
 
 
 # ===========================================================================

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -81,6 +81,9 @@ direct_upstream_release_plan = INSTALL_LLAMA_PREBUILT.direct_upstream_release_pl
 _pinned_windows_cuda_fallback = INSTALL_LLAMA_PREBUILT._pinned_windows_cuda_fallback
 CudaRuntimePreference = INSTALL_LLAMA_PREBUILT.CudaRuntimePreference
 published_windows_cuda_attempts = INSTALL_LLAMA_PREBUILT.published_windows_cuda_attempts
+_windows_cuda_attempt_covers_blackwell = (
+    INSTALL_LLAMA_PREBUILT._windows_cuda_attempt_covers_blackwell
+)
 
 
 # ---------------------------------------------------------------------------
@@ -2098,6 +2101,59 @@ class TestPinnedBlackwellCudaFallback:
         existing = windows_cuda_attempts(host, self.TAG, assets, None)
         assert any(a.runtime_line == "cuda13" for a in existing)
         assert _pinned_windows_cuda_fallback(host, existing) is None
+
+    def _win_cuda_attempt(self, minor):
+        major = minor.split(".")[0]
+        return AssetChoice(
+            repo = UPSTREAM_REPO,
+            tag = self.TAG,
+            name = f"llama-{self.TAG}-bin-win-cuda-{minor}-x64.zip",
+            url = "https://example.com/x",
+            source_label = "upstream",
+            install_kind = "windows-cuda",
+            runtime_line = f"cuda{major}",
+        )
+
+    def test_pin_dormant_when_runnable_cuda14_present(self, monkeypatch):
+        # A future Blackwell host with an in-release cuda14 build (no cuda13)
+        # must not get the older b9360 13.1 pin ahead of the runnable cuda14.
+        mock_windows_runtime(monkeypatch, ["cuda14", "cuda12"])
+        host = self._win_host((14, 0), ["120"])
+        assets = {
+            f"llama-{self.TAG}-bin-win-cuda-14.0-x64.zip": "https://example.com/14.0",
+            f"llama-{self.TAG}-bin-win-cuda-12.4-x64.zip": "https://example.com/12.4",
+        }
+        existing = windows_cuda_attempts(host, self.TAG, assets, None)
+        assert any(a.runtime_line == "cuda14" for a in existing)
+        assert _pinned_windows_cuda_fallback(host, existing) is None
+
+    def test_pin_dormant_when_runnable_cuda12_8_present(self):
+        # A cuda-12.8 build also covers Blackwell, so the pin defers to it.
+        host = self._win_host((13, 1), ["120"])
+        existing = [self._win_cuda_attempt("12.8")]
+        assert _pinned_windows_cuda_fallback(host, existing) is None
+
+    def test_pin_fires_when_only_cuda12_4_present(self):
+        # cuda-12.4 does not cover Blackwell, so the pin still fires.
+        host = self._win_host((13, 1), ["120"])
+        existing = [self._win_cuda_attempt("12.4")]
+        assert _pinned_windows_cuda_fallback(host, existing) is not None
+
+    @pytest.mark.parametrize(
+        "minor, covers",
+        [("12.4", False), ("12.8", True), ("13.1", True), ("13.3", True), ("14.0", True)],
+    )
+    def test_attempt_covers_blackwell(self, minor, covers):
+        assert _windows_cuda_attempt_covers_blackwell(self._win_cuda_attempt(minor)) is covers
+
+    def test_attempt_covers_blackwell_ignores_non_cuda_kind(self):
+        cpu = AssetChoice(
+            repo = UPSTREAM_REPO, tag = self.TAG,
+            name = f"llama-{self.TAG}-bin-win-cpu-x64.zip",
+            url = "https://example.com/x", source_label = "upstream",
+            install_kind = "windows-cpu",
+        )
+        assert _windows_cuda_attempt_covers_blackwell(cpu) is False
 
 
 # ===========================================================================

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -2141,16 +2141,27 @@ class TestPinnedBlackwellCudaFallback:
 
     @pytest.mark.parametrize(
         "minor, covers",
-        [("12.4", False), ("12.8", True), ("13.1", True), ("13.3", True), ("14.0", True)],
+        [
+            ("12.4", False),
+            ("12.8", True),
+            ("13.1", True),
+            ("13.3", True),
+            ("14.0", True),
+        ],
     )
     def test_attempt_covers_blackwell(self, minor, covers):
-        assert _windows_cuda_attempt_covers_blackwell(self._win_cuda_attempt(minor)) is covers
+        assert (
+            _windows_cuda_attempt_covers_blackwell(self._win_cuda_attempt(minor))
+            is covers
+        )
 
     def test_attempt_covers_blackwell_ignores_non_cuda_kind(self):
         cpu = AssetChoice(
-            repo = UPSTREAM_REPO, tag = self.TAG,
+            repo = UPSTREAM_REPO,
+            tag = self.TAG,
             name = f"llama-{self.TAG}-bin-win-cpu-x64.zip",
-            url = "https://example.com/x", source_label = "upstream",
+            url = "https://example.com/x",
+            source_label = "upstream",
             install_kind = "windows-cpu",
         )
         assert _windows_cuda_attempt_covers_blackwell(cpu) is False

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -77,6 +77,9 @@ windows_cuda_upstream_asset_names = (
     INSTALL_LLAMA_PREBUILT.windows_cuda_upstream_asset_names
 )
 env_int = INSTALL_LLAMA_PREBUILT.env_int
+direct_upstream_release_plan = INSTALL_LLAMA_PREBUILT.direct_upstream_release_plan
+_pinned_windows_cuda_fallback = INSTALL_LLAMA_PREBUILT._pinned_windows_cuda_fallback
+CudaRuntimePreference = INSTALL_LLAMA_PREBUILT.CudaRuntimePreference
 
 
 # ---------------------------------------------------------------------------
@@ -2001,6 +2004,152 @@ class TestWindowsCudaAttempts:
         assets = self._upstream("13.3", "12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+
+
+# ===========================================================================
+# N.1b. _pinned_windows_cuda_fallback -- pinned b9360 cuda-13.1 Blackwell fallback
+# ===========================================================================
+
+
+class TestPinnedBlackwellCudaFallback:
+    """A Blackwell host on a 13.1/13.2 driver, gated off the in-release 13.3
+    build, gets the pinned immutable b9360 cuda-13.1 GPU build instead of the
+    CPU-only cuda-12.4 drop. The pin is dormant for everyone else."""
+
+    TAG = "b8508"
+
+    def _win_host(self, driver, caps):
+        return make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = driver, compute_caps = caps,
+        )
+
+    def test_pin_offered_for_driver_13_1_blackwell(self):
+        pin = _pinned_windows_cuda_fallback(self._win_host((13, 1), ["120"]), [])
+        assert pin is not None
+        assert pin.tag == "b9360"
+        assert pin.runtime_line == "cuda13"
+        assert pin.name == "llama-b9360-bin-win-cuda-13.1-x64.zip"
+        assert pin.runtime_name == "cudart-llama-bin-win-cuda-13.1-x64.zip"
+        assert pin.url.endswith("/b9360/llama-b9360-bin-win-cuda-13.1-x64.zip")
+        assert pin.runtime_url.endswith("/b9360/cudart-llama-bin-win-cuda-13.1-x64.zip")
+        assert pin.install_kind == "windows-cuda"
+        assert pin.expected_sha256 and len(pin.expected_sha256) == 64
+        assert pin.runtime_sha256 and len(pin.runtime_sha256) == 64
+
+    def test_pin_offered_for_driver_13_2(self):
+        assert _pinned_windows_cuda_fallback(self._win_host((13, 2), ["120"]), []) is not None
+
+    def test_pin_offered_for_sm121_variant(self):
+        # sm_121 is Blackwell-family and also needs toolkit >= 12.8.
+        assert _pinned_windows_cuda_fallback(self._win_host((13, 1), ["121"]), []) is not None
+
+    def test_pin_uses_max_of_multi_gpu_caps(self):
+        assert (
+            _pinned_windows_cuda_fallback(self._win_host((13, 1), ["86", "120"]), [])
+            is not None
+        )
+
+    @pytest.mark.parametrize("sm", ["89", "90", "100"])
+    def test_pin_not_offered_to_non_blackwell(self, sm):
+        # Ada/Hopper run the cuda-12.4 build fine; the pin must not fire.
+        assert _pinned_windows_cuda_fallback(self._win_host((13, 1), [sm]), []) is None
+
+    def test_pin_not_offered_to_driver_13_0(self):
+        # 13.0 cannot run the 13.1 build (forward minor); residual CPU gap.
+        assert _pinned_windows_cuda_fallback(self._win_host((13, 0), ["120"]), []) is None
+
+    def test_pin_not_offered_below_floor(self):
+        assert _pinned_windows_cuda_fallback(self._win_host((12, 8), ["120"]), []) is None
+
+    def test_pin_not_offered_without_driver(self):
+        assert _pinned_windows_cuda_fallback(self._win_host(None, ["120"]), []) is None
+
+    def test_pin_not_offered_on_linux(self):
+        host = make_host(
+            system = "Linux", machine = "x86_64",
+            driver_cuda_version = (13, 1), compute_caps = ["120"],
+        )
+        assert _pinned_windows_cuda_fallback(host, []) is None
+
+    def test_pin_dormant_when_cuda13_attempt_present(self, monkeypatch):
+        # A runnable in-release cuda13 build makes the pin unnecessary.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = self._win_host((13, 1), ["120"])
+        assets = {
+            f"llama-{self.TAG}-bin-win-cuda-13.1-x64.zip": "https://example.com/13.1",
+            f"llama-{self.TAG}-bin-win-cuda-12.4-x64.zip": "https://example.com/12.4",
+        }
+        existing = windows_cuda_attempts(host, self.TAG, assets, None)
+        assert any(a.runtime_line == "cuda13" for a in existing)
+        assert _pinned_windows_cuda_fallback(host, existing) is None
+
+
+# ===========================================================================
+# N.1c. direct_upstream_release_plan -- pinned Blackwell fallback ordering
+# ===========================================================================
+
+
+class TestDirectUpstreamBlackwellPin:
+    """End to end: the pin lands ahead of cuda-12.4 on the simple/upstream path
+    a Blackwell Windows host actually uses, and stays absent once a runnable
+    in-release cuda13 build exists."""
+
+    TAG = "b9365"
+
+    def _release(self):
+        names = [
+            f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip",
+            "cudart-llama-bin-win-cuda-13.3-x64.zip",
+            f"llama-{self.TAG}-bin-win-cuda-12.4-x64.zip",
+            "cudart-llama-bin-win-cuda-12.4-x64.zip",
+            f"llama-{self.TAG}-bin-win-cpu-x64.zip",
+        ]
+        return {
+            "tag_name": self.TAG,
+            "assets": [
+                {"name": n, "browser_download_url": f"https://example.com/{n}"}
+                for n in names
+            ],
+        }
+
+    def _no_torch(self, monkeypatch):
+        monkeypatch.setattr(
+            INSTALL_LLAMA_PREBUILT,
+            "detect_torch_cuda_runtime_preference",
+            lambda host: CudaRuntimePreference(runtime_line = None, selection_log = []),
+        )
+
+    def test_blackwell_13_1_prepends_pin(self, monkeypatch):
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        self._no_torch(monkeypatch)
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (13, 1), compute_caps = ["120"],
+        )
+        plan = direct_upstream_release_plan(self._release(), host, UPSTREAM_REPO, "latest")
+        order = [(a.tag, a.runtime_line or a.install_kind) for a in plan.attempts]
+        assert order == [
+            ("b9360", "cuda13"),
+            (self.TAG, "cuda12"),
+            (self.TAG, "windows-cpu"),
+        ]
+        assert plan.attempts[0].name == "llama-b9360-bin-win-cuda-13.1-x64.zip"
+        # Direct/upstream path stays unverified-by-manifest (no approved hashes).
+        assert plan.approved_checksums.artifacts == {}
+
+    def test_blackwell_13_3_no_pin(self, monkeypatch):
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        self._no_torch(monkeypatch)
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (13, 3), compute_caps = ["120"],
+        )
+        plan = direct_upstream_release_plan(self._release(), host, UPSTREAM_REPO, "latest")
+        assert "b9360" not in [a.tag for a in plan.attempts]
+        assert plan.attempts[0].tag == self.TAG
+        assert plan.attempts[0].runtime_line == "cuda13"
+        assert plan.attempts[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
 
 
 # ===========================================================================

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -84,6 +84,7 @@ published_windows_cuda_attempts = INSTALL_LLAMA_PREBUILT.published_windows_cuda_
 _windows_cuda_attempt_covers_blackwell = (
     INSTALL_LLAMA_PREBUILT._windows_cuda_attempt_covers_blackwell
 )
+resolve_release_asset_choice = INSTALL_LLAMA_PREBUILT.resolve_release_asset_choice
 
 
 # ---------------------------------------------------------------------------
@@ -2310,6 +2311,95 @@ class TestPublishedWindowsCudaAttemptsDynamicMajor:
         )
         result = published_windows_cuda_attempts(host, release, None)
         assert result[0].runtime_line == "cuda12"
+
+
+# ===========================================================================
+# N.1e. resolve_release_asset_choice -- pin on the published install path
+# ===========================================================================
+
+
+class TestResolveReleaseAssetChoicePin:
+    """The published (non --simple-policy) install path reaches the same b9360
+    Blackwell pin as the simple path, with its verified hash threaded."""
+
+    TAG = "b8508"
+
+    def _release(self, minors_lines):
+        artifacts = [
+            make_artifact(
+                f"llama-{self.TAG}-bin-win-cuda-{minor}-x64.zip",
+                install_kind = "windows-cuda",
+                runtime_line = line,
+                max_sm = 120,
+            )
+            for minor, line in minors_lines
+        ]
+        assets = {}
+        for minor, _line in minors_lines:
+            assets[f"llama-{self.TAG}-bin-win-cuda-{minor}-x64.zip"] = (
+                f"https://example.com/llama-{minor}"
+            )
+            assets[f"cudart-llama-bin-win-cuda-{minor}-x64.zip"] = (
+                f"https://example.com/cudart-{minor}"
+            )
+        return make_release(artifacts, upstream_tag = self.TAG, assets = assets)
+
+    def _checksums(self, minors):
+        names = []
+        for minor in minors:
+            names.append(f"llama-{self.TAG}-bin-win-cuda-{minor}-x64.zip")
+            names.append(f"cudart-llama-bin-win-cuda-{minor}-x64.zip")
+        return make_checksums(names)
+
+    def _no_torch(self, monkeypatch):
+        monkeypatch.setattr(
+            INSTALL_LLAMA_PREBUILT,
+            "detect_torch_cuda_runtime_preference",
+            lambda host: CudaRuntimePreference(runtime_line = None, selection_log = []),
+        )
+
+    def test_pin_applied_on_published_path_for_13_1(self, monkeypatch):
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        self._no_torch(monkeypatch)
+        release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
+        checksums = self._checksums(["12.4"])  # 13.3 gated off for a 13.1 driver
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (13, 1), compute_caps = ["120"],
+        )
+        result = resolve_release_asset_choice(host, self.TAG, release, checksums)
+        assert result[0].tag == "b9360"
+        assert result[0].name == "llama-b9360-bin-win-cuda-13.1-x64.zip"
+        # apply_approved_hashes threaded the pin's verified hash from the
+        # augmented checksums (the pin survives the approved-hash gate).
+        assert result[0].expected_sha256 and len(result[0].expected_sha256) == 64
+        assert result[0].runtime_sha256 and len(result[0].runtime_sha256) == 64
+        assert any(a.runtime_line == "cuda12" for a in result)
+
+    def test_pin_dormant_on_published_path_for_13_3(self, monkeypatch):
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        self._no_torch(monkeypatch)
+        release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
+        checksums = self._checksums(["13.3", "12.4"])
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (13, 3), compute_caps = ["120"],
+        )
+        result = resolve_release_asset_choice(host, self.TAG, release, checksums)
+        assert "b9360" not in [a.tag for a in result]
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+
+    def test_pin_not_applied_for_non_blackwell(self, monkeypatch):
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        self._no_torch(monkeypatch)
+        release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
+        checksums = self._checksums(["12.4"])
+        host = make_host(
+            system = "Windows", machine = "AMD64",
+            driver_cuda_version = (13, 1), compute_caps = ["89"],
+        )
+        result = resolve_release_asset_choice(host, self.TAG, release, checksums)
+        assert "b9360" not in [a.tag for a in result]
 
 
 # ===========================================================================

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1885,6 +1885,40 @@ class TestWindowsCudaAttempts:
             assert attempt.runtime_url is None
             assert attempt.runtime_name is None
 
+    def test_tracks_upstream_cuda13_minor_bump(self, monkeypatch):
+        # ggml-org bumped the published Windows cuda13 build 13.1 -> 13.3; the
+        # selector must follow it instead of the old hardcoded 13.1 (#5861).
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 3))
+        assets = self._upstream("13.3", "12.4")
+        result = windows_cuda_attempts(host, self.TAG, assets, None)
+        assert result[0].runtime_line == "cuda13"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+
+    def test_cuda13_minor_bump_pairs_matching_cudart(self, monkeypatch):
+        # The paired cudart bundle must track the same bumped minor.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 3))
+        assets = {
+            f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip": "https://example.com/llama-13.3",
+            "cudart-llama-bin-win-cuda-13.3-x64.zip": "https://example.com/cudart-13.3",
+            f"llama-{self.TAG}-bin-win-cuda-12.4-x64.zip": "https://example.com/llama-12.4",
+            "cudart-llama-bin-win-cuda-12.4-x64.zip": "https://example.com/cudart-12.4",
+        }
+        result = windows_cuda_attempts(host, self.TAG, assets, None)
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+        assert result[0].runtime_name == "cudart-llama-bin-win-cuda-13.3-x64.zip"
+
+    def test_cuda13_build_offered_across_same_major_driver(self, monkeypatch):
+        # Any 13.x driver gets the published cuda13 build (minor-version compat
+        # within the major), matching the existing 13.0 -> 13.1 behavior.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 1))
+        assets = self._upstream("13.3", "12.4")
+        result = windows_cuda_attempts(host, self.TAG, assets, None)
+        assert result[0].runtime_line == "cuda13"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+
 
 # ===========================================================================
 # N.1. apply_approved_hashes -- runtime archive checksum threading

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -2020,8 +2020,10 @@ class TestPinnedBlackwellCudaFallback:
 
     def _win_host(self, driver, caps):
         return make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = driver, compute_caps = caps,
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = driver,
+            compute_caps = caps,
         )
 
     def test_pin_offered_for_driver_13_1_blackwell(self):
@@ -2038,11 +2040,17 @@ class TestPinnedBlackwellCudaFallback:
         assert pin.runtime_sha256 and len(pin.runtime_sha256) == 64
 
     def test_pin_offered_for_driver_13_2(self):
-        assert _pinned_windows_cuda_fallback(self._win_host((13, 2), ["120"]), []) is not None
+        assert (
+            _pinned_windows_cuda_fallback(self._win_host((13, 2), ["120"]), [])
+            is not None
+        )
 
     def test_pin_offered_for_sm121_variant(self):
         # sm_121 is Blackwell-family and also needs toolkit >= 12.8.
-        assert _pinned_windows_cuda_fallback(self._win_host((13, 1), ["121"]), []) is not None
+        assert (
+            _pinned_windows_cuda_fallback(self._win_host((13, 1), ["121"]), [])
+            is not None
+        )
 
     def test_pin_uses_max_of_multi_gpu_caps(self):
         assert (
@@ -2057,18 +2065,24 @@ class TestPinnedBlackwellCudaFallback:
 
     def test_pin_not_offered_to_driver_13_0(self):
         # 13.0 cannot run the 13.1 build (forward minor); residual CPU gap.
-        assert _pinned_windows_cuda_fallback(self._win_host((13, 0), ["120"]), []) is None
+        assert (
+            _pinned_windows_cuda_fallback(self._win_host((13, 0), ["120"]), []) is None
+        )
 
     def test_pin_not_offered_below_floor(self):
-        assert _pinned_windows_cuda_fallback(self._win_host((12, 8), ["120"]), []) is None
+        assert (
+            _pinned_windows_cuda_fallback(self._win_host((12, 8), ["120"]), []) is None
+        )
 
     def test_pin_not_offered_without_driver(self):
         assert _pinned_windows_cuda_fallback(self._win_host(None, ["120"]), []) is None
 
     def test_pin_not_offered_on_linux(self):
         host = make_host(
-            system = "Linux", machine = "x86_64",
-            driver_cuda_version = (13, 1), compute_caps = ["120"],
+            system = "Linux",
+            machine = "x86_64",
+            driver_cuda_version = (13, 1),
+            compute_caps = ["120"],
         )
         assert _pinned_windows_cuda_fallback(host, []) is None
 
@@ -2124,10 +2138,14 @@ class TestDirectUpstreamBlackwellPin:
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
         self._no_torch(monkeypatch)
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (13, 1), compute_caps = ["120"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (13, 1),
+            compute_caps = ["120"],
         )
-        plan = direct_upstream_release_plan(self._release(), host, UPSTREAM_REPO, "latest")
+        plan = direct_upstream_release_plan(
+            self._release(), host, UPSTREAM_REPO, "latest"
+        )
         order = [(a.tag, a.runtime_line or a.install_kind) for a in plan.attempts]
         assert order == [
             ("b9360", "cuda13"),
@@ -2142,10 +2160,14 @@ class TestDirectUpstreamBlackwellPin:
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
         self._no_torch(monkeypatch)
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (13, 3), compute_caps = ["120"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (13, 3),
+            compute_caps = ["120"],
         )
-        plan = direct_upstream_release_plan(self._release(), host, UPSTREAM_REPO, "latest")
+        plan = direct_upstream_release_plan(
+            self._release(), host, UPSTREAM_REPO, "latest"
+        )
         assert "b9360" not in [a.tag for a in plan.attempts]
         assert plan.attempts[0].tag == self.TAG
         assert plan.attempts[0].runtime_line == "cuda13"

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -2208,8 +2208,10 @@ class TestPublishedWindowsCudaAttemptsDynamicMajor:
             [("14.0", "cuda14"), ("13.3", "cuda13"), ("12.4", "cuda12")]
         )
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (14, 0), compute_caps = ["120"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (14, 0),
+            compute_caps = ["120"],
         )
         result = published_windows_cuda_attempts(host, release, None)
         assert result[0].runtime_line == "cuda14"
@@ -2220,8 +2222,10 @@ class TestPublishedWindowsCudaAttemptsDynamicMajor:
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
         release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (13, 3), compute_caps = ["120"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (13, 3),
+            compute_caps = ["120"],
         )
         result = published_windows_cuda_attempts(host, release, None)
         assert result[0].runtime_line == "cuda13"
@@ -2232,8 +2236,10 @@ class TestPublishedWindowsCudaAttemptsDynamicMajor:
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
         release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (13, 1), compute_caps = ["120"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (13, 1),
+            compute_caps = ["120"],
         )
         result = published_windows_cuda_attempts(host, release, None)
         assert result[0].runtime_line == "cuda12"

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -52,7 +52,9 @@ compatible_windows_runtime_lines = (
 runtime_line_from_cuda_version = INSTALL_LLAMA_PREBUILT.runtime_line_from_cuda_version
 apply_approved_hashes = INSTALL_LLAMA_PREBUILT.apply_approved_hashes
 linux_cuda_choice_from_release = INSTALL_LLAMA_PREBUILT.linux_cuda_choice_from_release
-parse_direct_linux_release_bundle = INSTALL_LLAMA_PREBUILT.parse_direct_linux_release_bundle
+parse_direct_linux_release_bundle = (
+    INSTALL_LLAMA_PREBUILT.parse_direct_linux_release_bundle
+)
 windows_cuda_attempts = INSTALL_LLAMA_PREBUILT.windows_cuda_attempts
 resolve_upstream_asset_choice = INSTALL_LLAMA_PREBUILT.resolve_upstream_asset_choice
 resolve_requested_install_tag = INSTALL_LLAMA_PREBUILT.resolve_requested_install_tag

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -2364,8 +2364,10 @@ class TestResolveReleaseAssetChoicePin:
         release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
         checksums = self._checksums(["12.4"])  # 13.3 gated off for a 13.1 driver
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (13, 1), compute_caps = ["120"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (13, 1),
+            compute_caps = ["120"],
         )
         result = resolve_release_asset_choice(host, self.TAG, release, checksums)
         assert result[0].tag == "b9360"
@@ -2382,8 +2384,10 @@ class TestResolveReleaseAssetChoicePin:
         release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
         checksums = self._checksums(["13.3", "12.4"])
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (13, 3), compute_caps = ["120"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (13, 3),
+            compute_caps = ["120"],
         )
         result = resolve_release_asset_choice(host, self.TAG, release, checksums)
         assert "b9360" not in [a.tag for a in result]
@@ -2395,8 +2399,10 @@ class TestResolveReleaseAssetChoicePin:
         release = self._release([("13.3", "cuda13"), ("12.4", "cuda12")])
         checksums = self._checksums(["12.4"])
         host = make_host(
-            system = "Windows", machine = "AMD64",
-            driver_cuda_version = (13, 1), compute_caps = ["89"],
+            system = "Windows",
+            machine = "AMD64",
+            driver_cuda_version = (13, 1),
+            compute_caps = ["89"],
         )
         result = resolve_release_asset_choice(host, self.TAG, release, checksums)
         assert "b9360" not in [a.tag for a in result]

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1822,12 +1822,23 @@ class TestWindowsCudaAttempts:
         assert result[0].runtime_line == "cuda13"
         assert result[1].runtime_line == "cuda12"
 
-    def test_driver_13_0_cuda13_dlls_selects_cuda13_asset(self, monkeypatch):
+    def test_driver_below_published_minor_is_gated_to_cuda12(self, monkeypatch):
+        # A 13.0 driver cannot run a 13.1 build (forward minor), so it is gated
+        # out of cuda13 and falls back to the cuda12 build it can run, even when
+        # only the cuda13 runtime libs are detected.
         mock_windows_runtime(monkeypatch, ["cuda13"])
         host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 0))
         assets = self._upstream("13.1", "12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
-        assert len(result) == 1
+        assert result[0].runtime_line == "cuda12"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-12.4-x64.zip"
+
+    def test_driver_at_published_minor_selects_cuda13(self, monkeypatch):
+        # A 13.1 driver matches the published 13.1 build exactly.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 1))
+        assets = self._upstream("13.1", "12.4")
+        result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert result[0].runtime_line == "cuda13"
         assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.1-x64.zip"
 
@@ -1954,15 +1965,16 @@ class TestWindowsCudaAttempts:
         assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
         assert result[0].runtime_name == "cudart-llama-bin-win-cuda-13.3-x64.zip"
 
-    def test_cuda13_build_offered_across_same_major_driver(self, monkeypatch):
-        # Any 13.x driver gets the published cuda13 build (minor-version compat
-        # within the major), matching the existing 13.0 -> 13.1 behavior.
+    def test_driver_below_published_minor_does_not_get_newer_build(self, monkeypatch):
+        # ggml-org ships only cuda-13.3; a 13.1 driver cannot run it (forward
+        # minor), so it is gated to the cuda-12.4 build instead of an
+        # unguaranteed 13.3. A 13.3 driver still gets 13.3 (see other tests).
         mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
         host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 1))
         assets = self._upstream("13.3", "12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
-        assert result[0].runtime_line == "cuda13"
-        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+        assert result[0].runtime_line == "cuda12"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-12.4-x64.zip"
 
     def test_tracks_future_cuda13_minor(self, monkeypatch):
         # A later within-major bump (13.4) is tracked the same as 13.3.

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -52,6 +52,7 @@ compatible_windows_runtime_lines = (
 runtime_line_from_cuda_version = INSTALL_LLAMA_PREBUILT.runtime_line_from_cuda_version
 apply_approved_hashes = INSTALL_LLAMA_PREBUILT.apply_approved_hashes
 linux_cuda_choice_from_release = INSTALL_LLAMA_PREBUILT.linux_cuda_choice_from_release
+parse_direct_linux_release_bundle = INSTALL_LLAMA_PREBUILT.parse_direct_linux_release_bundle
 windows_cuda_attempts = INSTALL_LLAMA_PREBUILT.windows_cuda_attempts
 resolve_upstream_asset_choice = INSTALL_LLAMA_PREBUILT.resolve_upstream_asset_choice
 resolve_requested_install_tag = INSTALL_LLAMA_PREBUILT.resolve_requested_install_tag
@@ -397,6 +398,44 @@ class TestCompatibleLinuxRuntimeLines:
         host = make_host(driver_cuda_version = (13, 0))
         assert compatible_linux_runtime_lines(host) == ["cuda13", "cuda12"]
 
+    def test_future_major_derives_lines(self):
+        # A future major (14.x) offers cuda14 first, then older majors.
+        host = make_host(driver_cuda_version = (14, 0))
+        assert compatible_linux_runtime_lines(host) == ["cuda14", "cuda13", "cuda12"]
+
+
+class TestParseDirectLinuxReleaseBundle:
+    def _release(self, *targets):
+        names = [f"app-bTEST-linux-x64-{t}.tar.gz" for t in targets]
+        return {
+            "tag_name": "bTEST",
+            "assets": [
+                {"name": n, "browser_download_url": "https://x/" + n} for n in names
+            ],
+        }
+
+    def _cuda_artifact(self, bundle):
+        return [a for a in bundle.artifacts if a.install_kind == "linux-cuda"][0]
+
+    def test_parses_known_cuda13_bundle(self):
+        bundle = parse_direct_linux_release_bundle(
+            "unslothai/llama.cpp", self._release("cuda13-newer")
+        )
+        assert bundle is not None
+        assert self._cuda_artifact(bundle).runtime_line == "cuda13"
+
+    def test_parses_future_cuda_major_with_forward_profile(self):
+        # A future major name parses and inherits the newest known major's
+        # coverage for the same class as a forward default.
+        bundle = parse_direct_linux_release_bundle(
+            "unslothai/llama.cpp", self._release("cuda14-newer")
+        )
+        assert bundle is not None
+        art = self._cuda_artifact(bundle)
+        assert art.runtime_line == "cuda14"
+        assert art.coverage_class == "newer"
+        assert art.max_sm == 120  # inherited from cuda13-newer
+
 
 # ===========================================================================
 # G. pick_windows_cuda_runtime + compatible_windows_runtime_lines
@@ -441,6 +480,10 @@ class TestCompatibleWindowsRuntimeLines:
     def test_driver_13_0_uses_cuda13_line(self):
         host = make_host(driver_cuda_version = (13, 0))
         assert compatible_windows_runtime_lines(host) == ["cuda13", "cuda12"]
+
+    def test_future_major_derives_lines(self):
+        host = make_host(driver_cuda_version = (14, 0))
+        assert compatible_windows_runtime_lines(host) == ["cuda14", "cuda13", "cuda12"]
 
 
 # ===========================================================================
@@ -1917,6 +1960,32 @@ class TestWindowsCudaAttempts:
         assets = self._upstream("13.3", "12.4")
         result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert result[0].runtime_line == "cuda13"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
+
+    def test_tracks_future_cuda13_minor(self, monkeypatch):
+        # A later within-major bump (13.4) is tracked the same as 13.3.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (13, 4))
+        assets = self._upstream("13.4", "12.4")
+        result = windows_cuda_attempts(host, self.TAG, assets, None)
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.4-x64.zip"
+
+    def test_new_cuda_major_selected_when_published(self, monkeypatch):
+        # A new CUDA major (14.x) driver picks the published cuda14 build.
+        mock_windows_runtime(monkeypatch, ["cuda14", "cuda13", "cuda12"])
+        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (14, 0))
+        assets = self._upstream("14.0", "13.3", "12.4")
+        result = windows_cuda_attempts(host, self.TAG, assets, None)
+        assert result[0].runtime_line == "cuda14"
+        assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-14.0-x64.zip"
+
+    def test_new_cuda_major_degrades_to_published_cuda13(self, monkeypatch):
+        # A 14.x driver with no cuda14 build runs the newest published cuda13
+        # build via backward compatibility.
+        mock_windows_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(system = "Windows", machine = "AMD64", driver_cuda_version = (14, 0))
+        assets = self._upstream("13.3", "12.4")
+        result = windows_cuda_attempts(host, self.TAG, assets, None)
         assert result[0].name == f"llama-{self.TAG}-bin-win-cuda-13.3-x64.zip"
 
 


### PR DESCRIPTION
## Summary

The Windows prebuilt selector hardcoded the cuda13 minor as `13.1`. ggml-org bumped their published Windows CUDA 13 build to `13.3` (b9365 and later; current releases ship `cuda-12.4` and `cuda-13.3` only), so the selector requested a `cuda-13.1` asset that no longer exists, missed, and silently fell back to `cuda-12.4`. The native cuda13 prebuilt was unreachable.

Rather than swap one hardcoded minor for another, this makes the NVIDIA prebuilt selection version-dynamic and driver-gated on both the Windows (ggml-org) and Linux (unslothai/llama.cpp) paths, so future CUDA bumps are handled with no code change while staying safe across driver versions. It then pins one immutable older asset to keep Blackwell on a sub-13.3 driver on the GPU.

## What this changes

- Candidate CUDA runtime lines are derived from the driver major (newest major down to `cuda12`) instead of a hardcoded `cuda13`/`cuda12` pair. A driver runs its own major and any older major (backward compatibility).
- The minor for each major is the highest one published upstream that the driver can actually run by default CUDA compatibility, i.e. `(major, minor) <= driver`. So the selector follows ggml-org's minor bumps (`13.1` -> `13.3` -> ...) but does not hand a `13.3` build to a driver that only advertises `13.1` (that would rely on the unguaranteed minor-version-compatibility path; CUDA 13.3 wants a 610+ driver, 13.1 ships 590). A gated line falls through to the next older major, which the driver can run.
- Runtime-library detection is generated per major (`cudart64_<major>.dll` on Windows, `libcudart.so.<major>` on Linux), so a new toolkit is detected without a code change.
- The Linux bundle name parser accepts `cuda<major>` generically; an unknown future major inherits the newest known major's sm coverage for the same class as a forward default, with the post-build GPU smoke test as the backstop.
- The published-bundle path seeds its runtime-line ordering from the release's real published windows-cuda minors instead of a hardcoded `cuda12`/`cuda13` pair, so a future published `cuda14` asset is ordered with no code change.

## Blackwell GPU fallback (b9360 cuda-13.1 pin)

ggml-org compiles Blackwell `sm_120` (`120a-real`) only when the CUDA toolkit is `>= 12.8`, so their `cuda-12.4` Windows build never offloads on Blackwell. With the gating above, a Blackwell (sm_120/sm_121) host on a `13.1` or `13.2` driver is correctly kept off the `13.3` build, but the only sub-13.3 Windows asset is `cuda-12.4`, so it would run CPU-only.

`b9360` is the last release whose Windows `cuda-13` build is sub-13.3 (`13.1`), and release assets are immutable. So on the upstream install path, when a Blackwell host is gated off the in-release cuda13 build but its driver can run `13.1`, the selector inserts the `b9360` `cuda-13.1` build (with its paired cudart and verified sha256 for both archives) ahead of `cuda-12.4`. If that download or validation ever fails it degrades to `cuda-12.4` then CPU, exactly as before.

The pin is dormant for non-Blackwell hosts, sub-`13.1` or non-NVIDIA drivers, and any release that publishes a driver-runnable cuda13 build (the `no existing cuda13 attempt` guard), so it self-disables the moment upstream resumes a sub-13.3 build. Linux is unaffected: it uses unslothai/llama.cpp `cuda12-newer`, built with toolkit 12.8, which already covers Blackwell.

## Behavior (verified by spoofing the driver version, no GPU)

Windows (ggml-org ships `12.4` + `13.3`):

| Driver (nvidia-smi) | GPU | Before | After |
| --- | --- | --- | --- |
| 13.3 | any | cuda-12.4 (bug) | cuda-13.3 |
| 13.1 / 13.2 | Blackwell sm_120+ | cuda-12.4 (CPU) | pinned b9360 cuda-13.1, then cuda-12.4 |
| 13.1 / 13.2 | Ada / Hopper | cuda-12.4 | cuda-12.4 (gated, runs on GPU) |
| 13.0 / 12.x | Blackwell | cuda-12.4 (CPU) | cuda-12.4 (CPU, residual; needs a driver update) |
| 14.x | any | cuda-12.4 (bug) | cuda-13.3 (backward compat) |

When ggml-org publishes a `cuda-14.0` or resumes a sub-13.3 build, the dynamic selection picks it automatically and the pin stays dormant.

Linux / WSL (unslothai/llama.cpp major-named bundles): a 13.x driver selects the cuda13 bundle, a 14.x driver selects a published cuda14 bundle when present (else cuda13 via backward compatibility), and a 12.x driver selects cuda12. Unaffected by the Windows minor rename because these bundles are named by major.

## Tests

`tests/studio/install/test_selection_logic.py`:
- Version-dynamic + gating: cuda13 minor bump (13.3) and matching cudart pairing, a 13.0 driver gated off a 13.1 build and a 13.1 driver gated off a 13.3 build (both falling to cuda12), exact-minor match, a later minor bump (13.4), new-major selection (14.0) and degrade to cuda13, plus Linux driver-derived lines for a future major and a `cuda14` bundle parse.
- Blackwell pin: pin offered for 13.1 / 13.2 drivers on sm_120 / sm_121 (and multi-GPU max-of-caps), dormant for non-Blackwell sm, sub-13.1 / missing driver, Linux, and when a runnable in-release cuda13 build is present; end to end through `direct_upstream_release_plan` the order is `[b9360 cuda-13.1, cuda-12.4, windows-cpu]` for a 13.1 driver and unchanged for a 13.3 driver.

## Validation

- `python -m pytest tests/studio/install/` green (532 passed, 1 skipped), no regression.
- End to end on real hardware (RTX PRO 6000 Blackwell, driver 13.0, sm_120): the installer selected `cuda12-newer`, downloaded and sha256-verified the bundle, the `validate_server` GPU smoke passed, and the activated `llama-server` offloads to the GPU (CUDA0 in use, coherent output). A Blackwell host gets a working CUDA prebuilt on Linux, not CPU.
- The two pinned `b9360` URLs resolve (HTTP 200) and their sizes match the GitHub asset digests embedded as the verified sha256.
- Offline + cross-OS simulation of the selector against the live ggml-org and unslothai/llama.cpp release feeds.

## Notes

Scope is the prebuilt asset selector. #5826 (source-build `-allow-unsupported-compiler` + CUDA to CPU fallback) and #5817 (UMD version detection) are separate code paths. The Blackwell pin resolves the `13.1`/`13.2`-driver case of #5887; the `13.0`/`12.x`-driver Blackwell sliver remains a driver-update matter (or is closed when ggml-org ships a sub-13.3 Windows build). Refs #5861, #5817, #5807, #5858, #5854, #5826, #5887.