### PR TITLE
Studio: bump openssl, rand, rustls-webpki, tar in src-tauri for security advisories

### DIFF
--- a/studio/src-tauri/Cargo.lock
+++ b/studio/src-tauri/Cargo.lock
@@ -2731,15 +2731,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2763,9 +2762,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2978,7 +2977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2988,7 +2987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3361,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3382,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3765,9 +3764,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4450,9 +4449,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5380,7 +5379,7 @@ dependencies = [
  "log",
  "open",
  "process-wrap",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.12.28",
  "serde",


### PR DESCRIPTION
## Summary

Bumps four advisory-flagged Rust crates in the Studio Tauri shell (`studio/src-tauri/Cargo.lock`) to their fixed releases. Every bump stays inside the existing semver requirement, so this is a lockfile-only change with no `Cargo.toml` edits and no API surface change.

| Crate | Old | New | Advisory |
|-------|-----|-----|----------|
| openssl | 0.10.76 | 0.10.80 | CVE-2026-41676 (GHSA-pqf5-4pqq-29f5) + related, fixed 0.10.78 |
| openssl-sys | 0.9.112 | 0.9.116 | (pulled by openssl 0.10.80) |
| rand | 0.8.5 | 0.8.6 | RUSTSEC-2026-0097 (GHSA-cq8v-f236-94qc), fixed 0.8.6 |
| rand | 0.10.0 | 0.10.1 | RUSTSEC-2026-0097, fixed 0.10.1 |
| rustls-webpki | 0.103.10 | 0.103.13 | RUSTSEC-2026-0098 / -0099 / -0104, fixed 0.103.13 |
| tar | 0.4.45 | 0.4.46 | GHSA-3pv8-6f4r-ffg2 (PAX header desync), fixed 0.4.46 |

This supersedes #5866, which bumps only openssl; that PR can be closed in favor of this one.

## Validation

- Generated with `cargo update --precise` so the lockfile matches what Cargo resolves; the diff is limited to dependency versions, checksums, and the affected dependency references.
- `cargo build --locked` of `studio/src-tauri` builds the full Tauri Linux debug binary cleanly (the same path `studio-tauri-smoke.yml` exercises), confirming the bumps do not break Studio.
- `scripts/lockfile_supply_chain_audit.py` reports 0 findings.
- An OSV cross-ecosystem scan of the lockfile confirms the openssl, rustls-webpki, tar, and the fixable rand lines (0.8.x, 0.10.x) advisories are resolved.

## Notes

- `rand 0.7.3` remains in the tree transitively and is not fixed here: its only fix is 0.8.6, which is outside the `0.7` range, so it cannot be addressed by a lockfile bump.
- The remaining cargo audit baseline is the unmaintained GTK3-era transitive stack (`gtk` / `atk` / `gdk` / `glib` / `gtk3-macros`, `unic-*`, `proc-macro-error`, `fxhash`). Those are locked by Tauri's Linux webview stack and require a framework-level upgrade, not a lockfile change. Unchanged from `main`.
- The Tauri advisory CVE-2026-42184 (fixed in 2.11.1) is intentionally left out. It is a semver-minor framework bump that can affect IPC, plugins, generated bindings, and platform behavior, so it should be handled in a dedicated PR with a full runtime smoke test rather than bundled into this patch-level set.
