### PR TITLE
Studio: omit --threads when unset so llama.cpp picks physical cores

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4267,6 +4267,11 @@ class LlamaCppBackend:
 
                 # Library paths so llama-server finds its shared libs and CUDA DLLs.
                 env = self._llama_server_env_for_binary(binary)
+                # Omitting --threads relies on llama.cpp's physical-core default, so
+                # drop an inherited LLAMA_ARG_THREADS that would otherwise feed the
+                # arg handler and silently force hardware_concurrency(). #5692
+                if "--threads" not in cmd:
+                    env.pop("LLAMA_ARG_THREADS", None)
 
                 # Windows + full offload: PASSIVE OMP + 2 threads stop
                 # spin-wait burning CPU. CPU/partial offload keeps default

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4073,19 +4073,21 @@ class LlamaCppBackend:
                 threads_overridden = _extra_args_set_any_flag(extra_args, _THREAD_OVERRIDE_FLAGS)
                 full_offload_tuning_active = fully_gpu_offloaded and not offload_overridden
 
-                # Pass --threads explicitly so we do not inherit llama-server
-                # defaults. Windows + full offload caps at 2 to stop OpenMP
-                # spin-wait burning CPU during GPU decode. User pass-through
-                # offload/thread flags keep last-wins semantics. #5692.
+                # Thread count: an unset --threads makes llama.cpp pick physical
+                # cores (common_cpu_get_num_math), but an explicit --threads -1
+                # resolves to hardware_concurrency() (every hyperthread), which
+                # contends on the memory bus and slows CPU / hybrid decode. So
+                # omit the flag when unset and only pin it for an explicit
+                # override or the Windows full-offload OpenMP cap. Pass-through
+                # thread flags in extra_args still win (appended last). #5692
                 if (
                     sys.platform == "win32"
                     and full_offload_tuning_active
                     and not threads_overridden
                 ):
-                    threads_arg = 2
-                else:
-                    threads_arg = n_threads if n_threads is not None else -1
-                cmd.extend(["--threads", str(threads_arg)])
+                    cmd.extend(["--threads", "2"])
+                elif n_threads is not None and n_threads > 0:
+                    cmd.extend(["--threads", str(n_threads)])
 
                 # Enable Jinja chat template rendering
                 cmd.extend(["--jinja"])


### PR DESCRIPTION
## Summary

Studio launched `llama-server` with `--threads -1` whenever the user had not set a thread count. The intent (per the old comment) was "use physical cores", but `--threads -1` does not do that.

As @oobabooga pointed out (https://github.com/unslothai/unsloth/pull/5894#issuecomment-4589307757), the distinction is where the value gets resolved:

- Passing `--threads -1` explicitly goes through llama.cpp's arg parser, which for any value `<= 0` calls `std::thread::hardware_concurrency()`, that is every logical core including hyperthreads.
- Leaving `--threads` unset keeps `n_threads` at its internal default of `-1`, which llama.cpp later resolves to physical cores via `common_cpu_get_num_math()`.

Token generation is memory-bandwidth bound, so one worker per hyperthread mostly contends for the same memory bus and adds scheduling overhead. The slowdown shows up once any layers run on CPU (CPU offload, partial GPU offload, MoE experts on host), where a user reported throughput dropping from about 60-75 tok/s to about 20-30 tok/s.

## Fix

Instead of computing physical cores in Python, defer to llama.cpp's own (correct) default:

- Explicit `n_threads > 0`: pass `--threads <n>` unchanged.
- Windows full-offload OpenMP cap: still pin `--threads 2` (#5692).
- Otherwise: omit `--threads` entirely, so llama.cpp resolves to physical cores via `common_cpu_get_num_math()`.

This drops the psutil-based physical-core computation from the earlier revision (which can miscount under cgroup or container CPU limits) and is correct cross-platform. A pass-through `--threads` in `extra_args` still wins, since it is appended last.

Since the child inherits `os.environ` and llama.cpp also reads `--threads` from `LLAMA_ARG_THREADS` (routed through the same arg handler, so a value `<= 0` becomes `hardware_concurrency()`), an ambient `LLAMA_ARG_THREADS` would silently override the physical-core default. We scrub it from the child env only when we omit the flag, so the default stays deterministic.

## Files

- `studio/backend/core/inference/llama_cpp.py`

Thanks @oobabooga for the precise arg.cpp vs common.cpp diagnosis.
