### PR TITLE
Use remove-circle icon for eject model button

### DIFF
--- a/studio/frontend/src/components/assistant-ui/model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector.tsx
@@ -17,7 +17,7 @@ import {
   CloudIcon,
   DashboardSquare01Icon,
   FolderSearchIcon,
-  Logout01Icon,
+  RemoveCircleIcon,
   Search01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -326,7 +326,7 @@ function ModelSelectorContent({
             className="flex w-full items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs text-destructive transition-colors hover:bg-destructive/10"
             title="Eject model"
           >
-            <HugeiconsIcon icon={Logout01Icon} className="size-3.5" />
+            <HugeiconsIcon icon={RemoveCircleIcon} className="size-3.5" />
             Eject loaded model
           </button>
         </div>


### PR DESCRIPTION
Swaps the eject model button in the chat model selector from the logout icon to the remove-circle icon, which reads more clearly as removing/unloading the active model.

Changes `studio/frontend/src/components/assistant-ui/model-selector.tsx` to import `RemoveCircleIcon` from `@hugeicons/core-free-icons` in place of `Logout01Icon`.