### PR TITLE
Studio: defer the Windows CUDA Toolkit check so prebuilt users are not blocked

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2605,7 +2605,8 @@ if ($NeedLlamaSourceBuild) {
 # We build:
 #   - llama-server:   for GGUF model inference (with HTTPS if OpenSSL available)
 #   - llama-quantize: for GGUF export quantization
-# Prerequisites (git, cmake, VS Build Tools, CUDA Toolkit) already installed in Phase 1.
+# Prerequisites git, cmake, VS Build Tools were installed in Phase 1; the CUDA
+# Toolkit is resolved lazily just below via Resolve-CudaToolkit (source build only).
 $OriginalLlamaCppDir = $LlamaCppDir
 $BuildDir = Join-Path $LlamaCppDir "build"
 $LlamaServerBin = Join-Path $BuildDir "bin\Release\llama-server.exe"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -50,6 +50,12 @@ if ($script:UnslothVerbose) {
     $env:UNSLOTH_VERBOSE = '1'
 }
 $script:LlamaCppDegraded = $false
+# CUDA toolkit state, published by Resolve-CudaToolkit. Only the Phase 4 source
+# build consumes these; the prebuilt path leaves them at these defaults.
+$script:CudaToolkitReady = $false
+$script:NvccPath = $null
+$script:CudaToolkitRoot = $null
+$script:CudaArch = $null
 
 # Detect if running from pip install (no frontend/ dir in studio)
 $FrontendDir = Join-Path $ScriptDir "frontend"
@@ -1050,7 +1056,12 @@ if ($vsResult) {
 # ============================================
 # 1e. CUDA Toolkit (nvcc for llama.cpp build + env vars)
 # ============================================
-if ($HasNvidiaSmi) {
+# Defined here but invoked lazily right before a Phase 4 source build; the
+# prebuilt llama.cpp path needs no local toolkit. With -RequireOrExit a source
+# build is committed, so hard-fail if no driver-compatible toolkit can be found
+# or installed. Without it, detection is best-effort and only sets the flag.
+function Resolve-CudaToolkit {
+    param([switch]$RequireOrExit)
 # IMPORTANT: The CUDA Toolkit version must be <= the max CUDA version the
 # NVIDIA driver supports.  nvidia-smi reports this as "CUDA Version: X.Y".
 # If we install a toolkit newer than the driver supports, llama-server will
@@ -1146,6 +1157,11 @@ if ($DriverMaxCuda) {
 
 # -- If incompatible toolkit is blocking, tell user to uninstall it --
 if (-not $NvccPath -and $IncompatibleToolkit) {
+    if (-not $RequireOrExit) {
+        substep "CUDA Toolkit $IncompatibleToolkit exceeds driver max $DriverMaxCuda -- skipping; prebuilt llama.cpp needs no local toolkit" "Yellow"
+        $script:CudaToolkitReady = $false
+        return
+    }
     Write-Host "" -ForegroundColor Red
     Write-Host "========================================================================" -ForegroundColor Red
     Write-Host "[ERROR] CUDA Toolkit $IncompatibleToolkit is installed but INCOMPATIBLE" -ForegroundColor Red
@@ -1163,8 +1179,8 @@ if (-not $NvccPath -and $IncompatibleToolkit) {
     exit 1
 }
 
-# -- No toolkit at all: install via winget --
-if (-not $NvccPath) {
+# -- No toolkit at all: install via winget (only when a source build needs it) --
+if (-not $NvccPath -and $RequireOrExit) {
     Write-Host "CUDA toolkit (nvcc) not found -- installing via winget..." -ForegroundColor Yellow
     $HasWinget = $null -ne (Get-Command winget -ErrorAction SilentlyContinue)
     if ($HasWinget) {
@@ -1223,6 +1239,11 @@ if (-not $NvccPath) {
 }
 
 if (-not $NvccPath) {
+    if (-not $RequireOrExit) {
+        substep "no driver-compatible CUDA Toolkit found -- skipping; prebuilt llama.cpp needs no local toolkit" "Yellow"
+        $script:CudaToolkitReady = $false
+        return
+    }
     Write-Host "[ERROR] CUDA Toolkit (nvcc) is required but could not be found or installed." -ForegroundColor Red
     if ($DriverMaxCuda) {
         Write-Host "        Install CUDA Toolkit $DriverMaxCuda from https://developer.nvidia.com/cuda-toolkit-archive" -ForegroundColor Yellow
@@ -1313,8 +1334,11 @@ substep "CudaToolkitDir = $CudaToolkitRoot\"
 if (-not $CudaArch) {
     substep "could not detect compute capability -- cmake will use defaults" "Yellow"
 }
-} else {
-    step "cuda" "skipped (no NVIDIA GPU detected)" "Yellow"
+# Publish the resolved toolkit to script scope for the Phase 4 build.
+$script:NvccPath = $NvccPath
+$script:CudaToolkitRoot = $CudaToolkitRoot
+$script:CudaArch = $CudaArch
+$script:CudaToolkitReady = $true
 }
 
 if ($HasROCm) {
@@ -2627,6 +2651,10 @@ if (-not $NeedLlamaSourceBuild) {
     substep "Install CMake from https://cmake.org/download/ and re-run setup." "Yellow"
     $script:LlamaCppDegraded = $true
 } else {
+    # A source build is committed here. The CUDA toolkit is only needed now, so
+    # resolve (and winget-install if needed) it lazily, failing fast if no
+    # driver-compatible toolkit exists. The prebuilt path never reaches this.
+    if ($HasNvidiaSmi) { Resolve-CudaToolkit -RequireOrExit }
     Write-Host ""
     if ($HasNvidiaSmi) {
         substep "building llama.cpp with CUDA support..."

--- a/tests/studio/test_resolve_cuda_toolkit.ps1
+++ b/tests/studio/test_resolve_cuda_toolkit.ps1
@@ -1,0 +1,121 @@
+#!/usr/bin/env pwsh
+# Unit test for Resolve-CudaToolkit in studio/setup.ps1. No GPU required: the
+# detection helpers (nvidia-smi, nvcc, Find-Nvcc, ...) are stubbed so the real
+# function logic runs against a spoofed Blackwell sm_120 / driver 13.2 host.
+#
+# The function is extracted via AST and run in a child pwsh per scenario, because
+# the -RequireOrExit path calls `exit` (which would otherwise kill this harness).
+#
+# Run: pwsh -NoProfile -File tests/studio/test_resolve_cuda_toolkit.ps1
+
+$ErrorActionPreference = "Stop"
+$setupPath = [System.IO.Path]::Combine($PSScriptRoot, "..", "..", "studio", "setup.ps1")
+$setupPath = (Resolve-Path $setupPath).Path
+
+# --- Extract the function source (not the whole installer) ---
+$tokens = $null; $errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+if ($errors) { $errors | ForEach-Object { $_.ToString() }; throw "setup.ps1 has parse errors" }
+$fn = $ast.FindAll({ param($n)
+    $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq "Resolve-CudaToolkit"
+}, $true)
+if ($fn.Count -ne 1) { throw "expected exactly one Resolve-CudaToolkit, found $($fn.Count)" }
+$fnText = $fn[0].Extent.Text
+
+# --- Spoof executables: nvidia-smi reports driver max CUDA 13.2; nvcc 13.3 ---
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("rct_" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $work | Out-Null
+$smiFake  = Join-Path $work "nvidia-smi.ps1"
+$nvccFake = Join-Path $work "nvcc.ps1"
+Set-Content -LiteralPath $smiFake  -Value "'CUDA Version: 13.2'"
+Set-Content -LiteralPath $nvccFake -Value "'Cuda compilation tools, release 13.3, V13.3.0'"
+
+$failures = 0
+function Check($name, $cond) {
+    if ($cond) { Write-Host "  PASS  $name" }
+    else { Write-Host "  FAIL  $name" -ForegroundColor Red; $script:failures++ }
+}
+
+# Build + run one scenario in a child pwsh; returns @{ Exit; Out }.
+function Run-Case {
+    param([string]$FindMode, [bool]$Require)
+    $requireLit = if ($Require) { '$true' } else { '$false' }
+    $child = @"
+`$ErrorActionPreference = 'Continue'
+[Environment]::SetEnvironmentVariable('CUDA_PATH', `$null, 'Process')
+`$FindNvccMode = '$FindMode'
+`$NvccFake = '$nvccFake'
+function substep { param(`$m, `$c) Write-Host "  `$m" }
+function step    { param(`$l, `$v, `$c) Write-Host "[`$l] `$v" }
+function Add-ToUserPath { param(`$Directory, `$Position) `$true }
+function Refresh-Environment { }
+function Get-CudaComputeCapability { '120' }
+function Test-NvccArchSupport { param(`$NvccExe, `$Arch) `$true }
+function Get-NvccMaxArch { param(`$NvccExe) '120' }
+`$script:WingetCalled = `$false
+function winget { `$script:WingetCalled = `$true; 'no matching versions' }
+function Find-Nvcc {
+    param([string]`$MaxVersion = '')
+    switch (`$FindNvccMode) {
+        'compatible'   { return `$NvccFake }
+        'incompatible' { if (`$MaxVersion) { return `$null } else { return `$NvccFake } }
+        default        { return `$null }
+    }
+}
+`$NvidiaSmiExe  = '$smiFake'
+`$VsInstallPath = `$null
+`$HasNvidiaSmi  = `$true
+`$script:CudaToolkitReady = `$false
+`$script:NvccPath = `$null; `$script:CudaToolkitRoot = `$null; `$script:CudaArch = `$null
+
+$fnText
+
+if ($requireLit) { Resolve-CudaToolkit -RequireOrExit } else { Resolve-CudaToolkit }
+Write-Host ("RESULT ready={0} nvcc={1} winget={2}" -f `$script:CudaToolkitReady, `$script:NvccPath, `$script:WingetCalled)
+"@
+    $childFile = Join-Path $work ("case_" + [guid]::NewGuid().ToString("N") + ".ps1")
+    Set-Content -LiteralPath $childFile -Value $child
+    $out = & pwsh -NoProfile -File $childFile 2>&1 | Out-String
+    return @{ Exit = $LASTEXITCODE; Out = $out }
+}
+
+try {
+    Write-Host "Scenario 1: prebuilt path, too-new toolkit (no -RequireOrExit) -> defers, no exit"
+    $r = Run-Case -FindMode "incompatible" -Require $false
+    Check "exits 0 (not blocked)"        ($r.Exit -eq 0)
+    Check "CudaToolkitReady = false"     ($r.Out -match "ready=False")
+    Check "winget NOT called"            ($r.Out -match "winget=False")
+    Check "no INCOMPATIBLE error text"   (-not ($r.Out -match "INCOMPATIBLE"))
+
+    Write-Host "Scenario 2: forced source build, too-new toolkit (-RequireOrExit) -> hard exit"
+    $r = Run-Case -FindMode "incompatible" -Require $true
+    Check "exits non-zero"               ($r.Exit -ne 0)
+    Check "preserved INCOMPATIBLE error" ($r.Out -match "is installed but INCOMPATIBLE")
+
+    Write-Host "Scenario 3: compatible toolkit (-RequireOrExit) -> resolves, env set"
+    $r = Run-Case -FindMode "compatible" -Require $true
+    Check "exits 0"                      ($r.Exit -eq 0)
+    Check "CudaToolkitReady = true"      ($r.Out -match "ready=True")
+    Check "NvccPath published"           ($r.Out -match "nvcc=.*nvcc")
+
+    Write-Host "Scenario 4: no toolkit, prebuilt path (no -RequireOrExit) -> defers, no winget"
+    $r = Run-Case -FindMode "none" -Require $false
+    Check "exits 0"                      ($r.Exit -eq 0)
+    Check "CudaToolkitReady = false"     ($r.Out -match "ready=False")
+    Check "winget NOT called"            ($r.Out -match "winget=False")
+
+    Write-Host "Scenario 5: no toolkit, forced (-RequireOrExit) -> winget attempted then exit"
+    # The function exits before the RESULT line here, so assert on the winget-block
+    # marker in output rather than the flag.
+    $r = Run-Case -FindMode "none" -Require $true
+    Check "winget attempted"             ($r.Out -match "installing via winget")
+    Check "exits non-zero"               ($r.Exit -ne 0)
+    Check "preserved nvcc-required error" ($r.Out -match "CUDA Toolkit \(nvcc\) is required")
+}
+finally {
+    Remove-Item -Recurse -Force -LiteralPath $work -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+if ($failures -gt 0) { Write-Host "$failures check(s) FAILED" -ForegroundColor Red; exit 1 }
+Write-Host "All checks passed" -ForegroundColor Green


### PR DESCRIPTION
## Summary

A Blackwell user hit this on Windows setup:

```
GPU Compute Capability = 12.0 (sm_120)
driver supports up to CUDA 13.2
CUDA_PATH (...CUDA\v13.3) has CUDA 13.3 which exceeds driver max 13.2
[ERROR] CUDA Toolkit 13.3 is installed but INCOMPATIBLE ... exit code 1
```

`studio/setup.ps1` section "1e. CUDA Toolkit" validates the installed toolkit against the driver in Phase 1 and hard `exit 1`s when the toolkit is newer than the driver supports and no compatible toolkit is found. That runs before Phase 3.4, which installs a self-contained prebuilt llama.cpp bundle that needs no local CUDA toolkit. So this host is blocked entirely, even though the prebuilt selector would hand it a working GPU build (driver 13.2 can run the pinned `b9360` `cuda-13.1` build, sm_120 covered).

nvcc / `CUDA_PATH` are only consumed by the Phase 4 source build. This moves section 1e into a `Resolve-CudaToolkit` function and calls it lazily only when a source compile is actually about to run.

## What changed

- `studio/setup.ps1`: section 1e becomes `function Resolve-CudaToolkit { param([switch]$RequireOrExit) ... }`, invoked at the source-compile branch as `if ($HasNvidiaSmi) { Resolve-CudaToolkit -RequireOrExit }`.
  - Prebuilt path: never calls the function, so a too-new or missing toolkit no longer blocks install.
  - Source build: `-RequireOrExit` keeps the identical behavior - the same driver check, winget auto-install, and the byte-for-byte error text - and still fails fast before compiling.
  - The function publishes `$script:NvccPath` / `$script:CudaToolkitRoot` / `$script:CudaArch` for the build (the build reads the bare names, which resolve to script scope).
- `tests/studio/test_resolve_cuda_toolkit.ps1`: extracts the real function via AST and runs it against a spoofed Blackwell sm_120 / driver 13.2 / toolkit 13.3 host (no GPU needed). Covers: prebuilt path with a too-new toolkit defers and never calls winget; a forced build with the same toolkit still hard-exits with the preserved error; a compatible toolkit resolves and sets the env; winget runs only for a committed source build. Run with `pwsh -File tests/studio/test_resolve_cuda_toolkit.ps1` on Windows or Linux.

## Behavior

| Host | Before | After |
| --- | --- | --- |
| Blackwell, driver 13.2, toolkit 13.3, prebuilt path | exit 1 at the toolkit check | installs the prebuilt (no toolkit needed) |
| `UNSLOTH_LLAMA_FORCE_COMPILE=1`, too-new toolkit | exit 1 with the incompatible error | exit 1 with the same error (just lazily) |
| Compatible toolkit, source build | resolves, sets CUDA env | identical |
| No GPU | unchanged | unchanged (function never called) |

## Validation

- `pwsh` AST parse of `setup.ps1`: no errors.
- `pwsh -File tests/studio/test_resolve_cuda_toolkit.ps1`: all checks pass.
- The existing Windows GGUF smoke jobs run on this PR (they path-trigger on `studio/**`) and cover the real-Windows, no-GPU prebuilt path. Since the function is only called when a GPU is present, those runs confirm the non-GPU path is unchanged.

Note: a true GPU end-to-end spoof is not a green-able CI target on the free runners (no real CUDA device for `validate_server` to offload to), so the spoofed Blackwell validation runs at the function level via the pwsh test above.

Refs #5879.
