### PR TITLE
Studio CI: tolerate transient artifact-upload flakes on diagnostic log steps

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -296,6 +296,8 @@ jobs:
       - name: Upload logs
         # Always upload so green runs are still reviewable.
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: openai-anthropic-log
@@ -771,6 +773,8 @@ jobs:
       - name: Upload logs
         # Always upload so green runs are still reviewable.
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: tool-calling-log
@@ -1043,6 +1047,8 @@ jobs:
       - name: Upload logs
         # Always upload so green runs are still reviewable.
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: json-images-log

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -289,6 +289,8 @@ jobs:
       - name: Upload logs
         # Always upload so green runs are still reviewable.
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: openai-anthropic-log
@@ -649,6 +651,8 @@ jobs:
       - name: Upload logs
         # Always upload so green runs are still reviewable.
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: tool-calling-log
@@ -1025,6 +1029,8 @@ jobs:
       - name: Upload logs
         # Always upload so green runs are still reviewable.
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: json-images-log

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -373,6 +373,8 @@ jobs:
 
       - name: Upload logs
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: windows-openai-anthropic-log
@@ -801,6 +803,8 @@ jobs:
 
       - name: Upload logs
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: windows-tool-calling-log
@@ -1199,6 +1203,8 @@ jobs:
 
       - name: Upload logs
         if: always()
+        # Diagnostic only: a transient artifact-service drop must not fail a green job.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: windows-json-images-log


### PR DESCRIPTION
## Summary

The Studio inference-smoke jobs occasionally go red on a transient `actions/upload-artifact` failure in the final "Upload logs" step, even when every real assertion (install, prebuilt check, boot, tool calling, thinking) passed. Example: PR #5912's "Tool calling Tests" failed only on log upload (the upload validated "3 files uploaded / Artifact name is valid" then the service dropped the POST); the same branch passed the identical workflow minutes earlier, and a plain retrigger went green.

These "Upload logs" steps run `if: always()` but had no `continue-on-error`, so a flaky artifact service reds an otherwise-green job.

## What changed

Add `continue-on-error: true` to the diagnostic "Upload logs" step in the three inference-smoke workflows (9 steps total), for Linux/Mac/Windows parity:

- `studio-inference-smoke.yml` (Linux, 3 jobs)
- `studio-mac-inference-smoke.yml` (Mac, 3 jobs)
- `studio-windows-inference-smoke.yml` (Windows, 3 jobs)

## Why this is safe

`continue-on-error` only neutralizes the log-upload step. Every assertion step stays a hard failure that reds the job, so real regressions still fail. The logs are debugging aids; if the artifact service is down we still want a passing test to pass. This matches the lighter Studio smoke jobs.

## Validation

- `yaml.safe_load` on all three files parses clean; each "Upload logs" step now carries `continue-on-error: true` (3/3/3).
- Diff is 18 insertions only (9 steps, each a one-line comment plus the flag); no other lines touched.
