### PR TITLE
Studio: match the Linux llama.cpp prebuilt to the runtime cudart major

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -1402,7 +1402,16 @@ def direct_linux_release_plan(
 
     attempts: list[AssetChoice] = []
     if host.has_usable_nvidia:
-        selection = linux_cuda_choice_from_release(host, bundle)
+        # Prefer the cudart major Studio loads at runtime (torch's bundled
+        # libcudart), not the newest detected on disk. Without this a stray
+        # cuda13 runtime outranks the torch cuda12 the binary links against.
+        torch_preference = detect_torch_cuda_runtime_preference(host)
+        selection = linux_cuda_choice_from_release(
+            host,
+            bundle,
+            preferred_runtime_line = torch_preference.runtime_line,
+            selection_preamble = torch_preference.selection_log,
+        )
         if selection is not None:
             attempts.extend(selection.attempts)
     if host.has_rocm and not host.has_usable_nvidia:

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -468,7 +468,9 @@ def test_simple_linux_direct_release_honors_torch_cudart_preference(
             ["cuda13", "cuda12"],
             {
                 "cuda13": ["/usr/local/lib/python3.13/site-packages/nvidia/cu13/lib"],
-                "cuda12": ["/venv/lib/python3.13/site-packages/nvidia/cuda_runtime/lib"],
+                "cuda12": [
+                    "/venv/lib/python3.13/site-packages/nvidia/cuda_runtime/lib"
+                ],
             },
         ),
     )
@@ -507,9 +509,7 @@ def test_simple_linux_direct_release_honors_torch_cudart_preference(
     assert primary.runtime_line == "cuda12"
 
     # torch unavailable -> unchanged newest-major fallback (documents the residual).
-    assert (
-        first_asset_for_torch(None).name == "app-b9334-linux-x64-cuda13-newer.tar.gz"
-    )
+    assert first_asset_for_torch(None).name == "app-b9334-linux-x64-cuda13-newer.tar.gz"
 
 
 @pytest.mark.parametrize(

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -438,6 +438,80 @@ def test_simple_linux_direct_release_uses_published_source_checksums_for_branch(
     assert exact_source is True
 
 
+def test_simple_linux_direct_release_honors_torch_cudart_preference(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Regression: a Blackwell host (sm_120, driver 13.0) with BOTH cudart majors
+    # visible -- a stray cuda13 wheel plus torch's cuda12 -- must install the
+    # cuda12 build that matches the runtime torch, not the newest-major cuda13
+    # build (which loads no GPU and silently falls back to CPU).
+    release = {
+        "tag_name": "b9334",
+        "assets": [
+            {
+                "name": f"app-b9334-linux-x64-{profile}.tar.gz",
+                "browser_download_url": f"https://example.test/app-b9334-linux-x64-{profile}.tar.gz",
+            }
+            for profile in (
+                "cuda12-newer",
+                "cuda12-portable",
+                "cuda13-newer",
+                "cuda13-portable",
+            )
+        ],
+    }
+    # cuda13 detected first (newest-major order); both compatible with driver 13.0.
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "detected_linux_runtime_lines",
+        lambda: (
+            ["cuda13", "cuda12"],
+            {
+                "cuda13": ["/usr/local/lib/python3.13/site-packages/nvidia/cu13/lib"],
+                "cuda12": ["/venv/lib/python3.13/site-packages/nvidia/cuda_runtime/lib"],
+            },
+        ),
+    )
+    host = HostInfo(
+        system = "Linux",
+        machine = "x86_64",
+        is_windows = False,
+        is_linux = True,
+        is_macos = False,
+        is_x86_64 = True,
+        is_arm64 = False,
+        nvidia_smi = "nvidia-smi",
+        driver_cuda_version = (13, 0),
+        compute_caps = ["120"],
+        visible_cuda_devices = None,
+        has_physical_nvidia = True,
+        has_usable_nvidia = True,
+    )
+
+    def first_asset_for_torch(line):
+        monkeypatch.setattr(
+            INSTALL_LLAMA_PREBUILT,
+            "detect_torch_cuda_runtime_preference",
+            lambda h: INSTALL_LLAMA_PREBUILT.CudaRuntimePreference(
+                runtime_line = line, selection_log = []
+            ),
+        )
+        plan = INSTALL_LLAMA_PREBUILT.direct_linux_release_plan(
+            release, host, "unslothai/llama.cpp", "latest"
+        )
+        return plan.attempts[0]
+
+    # torch reports cuda12 (the cu128 runtime) -> install the cuda12 build.
+    primary = first_asset_for_torch("cuda12")
+    assert primary.name == "app-b9334-linux-x64-cuda12-newer.tar.gz"
+    assert primary.runtime_line == "cuda12"
+
+    # torch unavailable -> unchanged newest-major fallback (documents the residual).
+    assert (
+        first_asset_for_torch(None).name == "app-b9334-linux-x64-cuda13-newer.tar.gz"
+    )
+
+
 @pytest.mark.parametrize(
     "mutate, expected_match",
     [


### PR DESCRIPTION
## Summary

On Linux, Studio installs the prebuilt llama.cpp via the `--simple-policy` path (`setup.sh` -> `resolve_simple_install_release_plans` -> `direct_linux_release_plan`). That path called `linux_cuda_choice_from_release(host, bundle)` without the torch cudart preference, so it ranked candidates newest-CUDA-major-first. When a host has more than one cudart major visible on disk, it installs the newest one regardless of what Studio actually loads at runtime.

A user on an RTX PRO 6000 Blackwell (sm_120, driver CUDA 13.0) hit this. Their machine had two cudart majors visible:

- `libcudart.so.13` from a stray `nvidia-cu13` wheel in system site-packages
- `libcudart.so.12` from torch `2.10.0+cu128` in the Studio venv (what llama-server actually loads)

So the installer picked `app-b9334-linux-x64-cuda13-newer.tar.gz` (`runtime_line: cuda13`). At runtime Studio sets `LD_LIBRARY_PATH` from the backend venv's `nvidia/cu*/lib` (cuda12 only), so the cuda13 binary found no usable CUDA, logged `no usable GPU found`, ignored `-ngl -1`, and ran fully on CPU.

The other selection path (`resolve_linux_cuda_choice`, used by the manifest policy) already passes the torch preference. This brings the simple-policy path in line with it.

## What changed

`direct_linux_release_plan` now resolves the torch cudart runtime preference and passes it to `linux_cuda_choice_from_release`, mirroring `resolve_linux_cuda_choice`:

```python
torch_preference = detect_torch_cuda_runtime_preference(host)
selection = linux_cuda_choice_from_release(
    host, bundle,
    preferred_runtime_line = torch_preference.runtime_line,
    selection_preamble = torch_preference.selection_log,
)
```

When torch reports cuda12, the selector now installs `cuda12-newer` (which covers sm_120, built with CUDA 12.8+, and loads on a 13.0 driver against the cuda12 runtime). When torch reports cuda13, cuda13 is still chosen. Behavior is unchanged on single-major hosts.

## Validation

- New regression test `test_simple_linux_direct_release_honors_torch_cudart_preference`: a Blackwell host (sm_120, driver 13.0) with both cudart majors detected (cuda13 first) installs `cuda12-newer` when torch reports cuda12, and is unchanged otherwise.
- Full install suite: 590 passed, 1 skipped (was 589; only the new test added, no regressions).

## Note on scope

This corrects the selection when the installer process can import torch (the common case, since Studio installs torch into the env it runs the installer from). If the installer runs in an interpreter with no torch at all, the preference is unavailable and the newest-major fallback still applies; making that case robust is a separate follow-up about ensuring the installer resolves the runtime torch.
