### PR TITLE
Studio: extend the pinned Blackwell GPU fallback to CUDA 13.0 drivers

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -237,13 +237,16 @@ _MAX_PROBE_CUDA_MAJOR = 19
 # Last ggml-org release whose Windows win-cuda-13 build is still sub-13.3
 # (cuda-13.1, b9360, 2026-05-27). Upstream bumped win-cuda-13 to 13.3 at b9365
 # and now ships only cuda-12.4 + cuda-13.3. cuda-12.4 predates Blackwell (ggml
-# compiles sm_120 only at toolkit >= 12.8), so a Blackwell host on a 13.1/13.2
+# compiles sm_120 only at toolkit >= 12.8), so a Blackwell host on a 13.0/13.1/13.2
 # driver is gated off 13.3 and would drop to a CPU-only 12.4 build. b9360 is
 # immutable, so we pin its cuda-13.1 build (plus paired cudart) as a GPU
 # fallback for exactly those hosts. See unslothai/unsloth#5887.
 _PINNED_BLACKWELL_FALLBACK_TAG = "b9360"
 _PINNED_BLACKWELL_FALLBACK_RUNTIME = "13.1"
-_PINNED_BLACKWELL_DRIVER_FLOOR = (13, 1)
+# Floor at 13.0: b9360 ships native sm_120a SASS (no PTX/JIT) and a bundled
+# cuda-13.1 cudart, both of which run on a CUDA 13.0 r580+ driver via CUDA
+# minor-version compatibility, so the mainstream 13.0 Blackwell branch is covered.
+_PINNED_BLACKWELL_DRIVER_FLOOR = (13, 0)
 _BLACKWELL_MIN_SM = 120
 # ggml compiles Blackwell sm_120 only at toolkit >= 12.8, so an in-release
 # windows-cuda build at or above this already covers Blackwell and makes the

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -2021,7 +2021,7 @@ class TestWindowsCudaAttempts:
 
 
 class TestPinnedBlackwellCudaFallback:
-    """A Blackwell host on a 13.1/13.2 driver, gated off the in-release 13.3
+    """A Blackwell host on a 13.0/13.1/13.2 driver, gated off the in-release 13.3
     build, gets the pinned immutable b9360 cuda-13.1 GPU build instead of the
     CPU-only cuda-12.4 drop. The pin is dormant for everyone else."""
 
@@ -2072,15 +2072,19 @@ class TestPinnedBlackwellCudaFallback:
         # Ada/Hopper run the cuda-12.4 build fine; the pin must not fire.
         assert _pinned_windows_cuda_fallback(self._win_host((13, 1), [sm]), []) is None
 
-    def test_pin_not_offered_to_driver_13_0(self):
-        # 13.0 cannot run the 13.1 build (forward minor); residual CPU gap.
+    def test_pin_offered_for_driver_13_0(self):
+        # b9360 is native sm_120a SASS (no JIT) and ships a cuda-13.1 cudart,
+        # both of which run on a 13.0 r580+ driver via CUDA minor-version
+        # compatibility. 13.0 is the mainstream Blackwell branch, so it must fire.
         assert (
-            _pinned_windows_cuda_fallback(self._win_host((13, 0), ["120"]), []) is None
+            _pinned_windows_cuda_fallback(self._win_host((13, 0), ["120"]), [])
+            is not None
         )
 
     def test_pin_not_offered_below_floor(self):
+        # 12.x predates Blackwell entirely; the pin stays dormant below 13.0.
         assert (
-            _pinned_windows_cuda_fallback(self._win_host((12, 8), ["120"]), []) is None
+            _pinned_windows_cuda_fallback(self._win_host((12, 9), ["120"]), []) is None
         )
 
     def test_pin_not_offered_without_driver(self):


### PR DESCRIPTION
## Summary

A Blackwell host (sm_120) on the mainstream r580 driver, which reports CUDA 13.0, installed Studio's prebuilt llama.cpp on CPU instead of the GPU. The pinned `b9360` cuda-13.1 GPU fallback that exists for exactly this situation only fired when the driver advertised CUDA `>= 13.1`, so the 13.0 branch fell through it, was gated off the in-release 13.3 build, and dropped to the CPU-only cuda-12.4 build.

## Root cause

`_PINNED_BLACKWELL_DRIVER_FLOOR` was `(13, 1)`. `_pinned_windows_cuda_fallback()` returns `None` when `driver < floor`, so a host reporting `(13, 0)` got no pin.

Upstream stopped publishing a sub-13.3 Windows cuda13 build after b9360, and cuda-12.4 predates Blackwell (ggml compiles sm_120 only at toolkit `>= 12.8`), so on a 13.0 driver the only remaining GPU-capable option was the pin, which was switched off.

## Fix

Lower `_PINNED_BLACKWELL_DRIVER_FLOOR` to `(13, 0)`.

This is safe because the pin is a specific, hash-pinned, immutable artifact we can reason about:

- `b9360`'s binary is native `sm_120a` SASS (no PTX), so it needs no JIT and no newer toolkit at runtime.
- Its bundled runtime is cuda-13.1 cudart.
- Both run on a CUDA 13.0 r580+ driver under NVIDIA's CUDA minor-version compatibility.

The generic published-runtime gate is deliberately left untouched: an arbitrary, unverified in-release 13.1 build is still gated off a 13.0 driver. Only the specific SASS-verified b9360 pin is extended to 13.0.

## Tests

- Updated `tests/studio/install/test_selection_logic.py`: `test_pin_offered_for_driver_13_0` now asserts the pin fires on a 13.0 Blackwell host (was asserting `None`); the below-floor case moved to 12.9.
- Full install suite: 590 passed, 1 skipped.

Refs #5887.
