### PR TITLE
Studio CI: run the Resolve-CudaToolkit unit test in the Windows GGUF job

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -65,6 +65,18 @@ jobs:
         with:
           persist-credentials: false
 
+      # Fast GPU-free gate: parse setup.ps1 and run the Resolve-CudaToolkit unit
+      # test (deferred Windows CUDA Toolkit check) before the heavy GGUF smoke.
+      - name: setup.ps1 unit test (Resolve-CudaToolkit)
+        shell: pwsh
+        run: |
+          $errs = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path studio/setup.ps1).Path, [ref]$null, [ref]$errs)
+          if ($errs) { $errs | ForEach-Object { $_.ToString() }; exit 1 }
+          Write-Host "setup.ps1 parsed with no errors"
+          pwsh -NoProfile -File tests/studio/test_resolve_cuda_toolkit.ps1
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '22'


### PR DESCRIPTION
## Summary

#5912 moved the Windows CUDA Toolkit check off the prebuilt path into `Resolve-CudaToolkit` and added a pwsh unit test (`tests/studio/test_resolve_cuda_toolkit.ps1`), but nothing ran that test. This wires it into CI without adding a new workflow.

Instead of a standalone workflow, the test is folded into the existing `Windows Studio GGUF CI` job as a fast, GPU-free gate that runs right after checkout, before the heavy GGUF smoke, on the runner that is already spun up. A `setup.ps1` regression now fails fast.

## What it does

In `studio-windows-inference-smoke.yml`, the `openai-anthropic` job gains one early step that:

1. Parses `setup.ps1` for syntax errors (catches brace and scope mistakes the refactor is prone to).
2. Runs `test_resolve_cuda_toolkit.ps1`, which AST-extracts the real `Resolve-CudaToolkit` and asserts:
   - prebuilt path with a too-new toolkit defers (no exit, no winget),
   - a forced source build still fails fast with the preserved error text,
   - a compatible toolkit resolves and publishes the env vars.

No new workflow file; the step reuses the existing `windows-latest` runner.

## Validation

Ran the test locally with pwsh 7.6: all 5 scenarios pass, exit 0.

Refs #5912.
