### PR TITLE
Studio CI: tolerate transient runner crashes in the llama-server log collection step

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -372,6 +372,9 @@ jobs:
 
       - name: Collect llama-server logs
         if: always()
+        # A transient Windows DLL-init crash (0xC0000142) in this diagnostic
+        # copy must not fail an otherwise-green job.
+        continue-on-error: true
         shell: bash
         # Copy llama-server's own stdout/stderr (teed by Studio under
         # ~/.unsloth/studio/logs/llama-server/) into the workspace so
@@ -802,6 +805,9 @@ jobs:
 
       - name: Collect llama-server logs
         if: always()
+        # A transient Windows DLL-init crash (0xC0000142) in this diagnostic
+        # copy must not fail an otherwise-green job.
+        continue-on-error: true
         shell: bash
         # Copy llama-server's own stdout/stderr (teed by Studio under
         # ~/.unsloth/studio/logs/llama-server/) into the workspace so
@@ -1202,6 +1208,9 @@ jobs:
 
       - name: Collect llama-server logs
         if: always()
+        # A transient Windows DLL-init crash (0xC0000142) in this diagnostic
+        # copy must not fail an otherwise-green job.
+        continue-on-error: true
         shell: bash
         # Copy llama-server's own stdout/stderr (teed by Studio under
         # ~/.unsloth/studio/logs/llama-server/) into the workspace so


### PR DESCRIPTION
## Summary

The `Tool calling Tests` job (and its siblings) in the Windows GGUF CI intermittently fails at the `Collect llama-server logs` step with exit code `-1073741502` (`0xC0000142`, `STATUS_DLL_INIT_FAILED`). That is a Windows runner crash spawning the copy process, not a test failure, and it turns an otherwise-green job red after the tests have already run.

This was failing on `main` as well, unrelated to any feature change.

## Fix

`Collect llama-server logs` is a diagnostic-only step (`if: always()`, copies llama-server stdout into the workspace for debugging). Mark it `continue-on-error: true` in all three jobs (`openai-anthropic`, `tool-calling`, `json-images`), the same treatment #5913 gave the artifact-upload diagnostic steps. A transient crash in log collection no longer fails the job.

The actual test steps are unchanged and still gate the job.

Refs #5913.
