### PR TITLE
Studio: forward --has-rocm from setup.sh when gfx resolution fails

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -862,6 +862,10 @@ else
     # name-inferred arch). Implies --has-rocm on the installer side.
     if [ -n "${_setup_gfx:-}" ]; then
         _PREBUILT_CMD+=(--rocm-gfx "$_setup_gfx")
+    elif [ "$_setup_amd_detected" = true ]; then
+        # AMD was detected but gfx resolution failed; tell the installer ROCm is
+        # present so it can still attempt a prebuilt. Mirrors setup.ps1 behaviour.
+        _PREBUILT_CMD+=(--has-rocm)
     fi
     _PREBUILT_LOG="$(mktemp)"
     set +e

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2682,6 +2682,13 @@ class TestRocmGfxForwarding:
         assert "--rocm-gfx" in source
         assert '"$_setup_gfx"' in source
 
+    def test_setup_sh_forwards_has_rocm(self):
+        # When AMD is detected but gfx resolution fails, setup.sh must still
+        # forward --has-rocm so the installer knows ROCm is present.
+        source = _SETUP_SH_PATH.read_text(encoding = "utf-8")
+        assert "--has-rocm" in source
+        assert "_setup_amd_detected" in source
+
     def test_setup_ps1_forwards_rocm_gfx(self):
         source = _SETUP_PS1_PATH.read_text(encoding = "utf-8")
         assert "--rocm-gfx" in source


### PR DESCRIPTION
setup.ps1 already forwards --has-rocm whenever AMD is detected regardless of whether gfx resolved. setup.sh only forwarded --rocm-gfx, so a Linux host where AMD was detected but gfx resolution failed would forward nothing, leaving the installer with has_rocm=False and falling back to a source build.

Add the elif branch to forward --has-rocm when _setup_amd_detected is true but _setup_gfx is empty, matching setup.ps1 parity. Add a source-level test to verify both flags are present in setup.sh.