### PR TITLE
Studio: cover B300 (sm_103) with the Linux prebuilt bundles

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -176,6 +176,10 @@ _PINNED_MACOS_FALLBACK_TAG = "b9415"
 _PINNED_MACOS_LATEST_FLOOR = (26, 0)
 FORCE_COMPILE_DEFAULT_REF = os.environ.get("UNSLOTH_LLAMA_FORCE_COMPILE_REF", "master")
 
+# sm_103 (B300 / GB300 Blackwell Ultra) is not built natively but runs on the
+# bundled base compute_100 PTX, which the driver JIT-compiles forward to sm_103.
+# It is listed in every bundle that ships the sm_100 build (the "newer" and
+# "portable" classes) so those hosts get a prebuilt instead of a source compile.
 DIRECT_LINUX_BUNDLE_PROFILES: dict[str, dict[str, Any]] = {
     "cuda12-older": {
         "runtime_line": "cuda12",
@@ -188,7 +192,7 @@ DIRECT_LINUX_BUNDLE_PROFILES: dict[str, dict[str, Any]] = {
     "cuda12-newer": {
         "runtime_line": "cuda12",
         "coverage_class": "newer",
-        "supported_sms": ["86", "89", "90", "100", "120"],
+        "supported_sms": ["86", "89", "90", "100", "103", "120"],
         "min_sm": 86,
         "max_sm": 120,
         "rank": 20,
@@ -196,7 +200,7 @@ DIRECT_LINUX_BUNDLE_PROFILES: dict[str, dict[str, Any]] = {
     "cuda12-portable": {
         "runtime_line": "cuda12",
         "coverage_class": "portable",
-        "supported_sms": ["70", "75", "80", "86", "89", "90", "100", "120"],
+        "supported_sms": ["70", "75", "80", "86", "89", "90", "100", "103", "120"],
         "min_sm": 70,
         "max_sm": 120,
         "rank": 30,
@@ -212,7 +216,7 @@ DIRECT_LINUX_BUNDLE_PROFILES: dict[str, dict[str, Any]] = {
     "cuda13-newer": {
         "runtime_line": "cuda13",
         "coverage_class": "newer",
-        "supported_sms": ["86", "89", "90", "100", "120"],
+        "supported_sms": ["86", "89", "90", "100", "103", "120"],
         "min_sm": 86,
         "max_sm": 120,
         "rank": 50,
@@ -220,7 +224,7 @@ DIRECT_LINUX_BUNDLE_PROFILES: dict[str, dict[str, Any]] = {
     "cuda13-portable": {
         "runtime_line": "cuda13",
         "coverage_class": "portable",
-        "supported_sms": ["75", "80", "86", "89", "90", "100", "120"],
+        "supported_sms": ["75", "80", "86", "89", "90", "100", "103", "120"],
         "min_sm": 75,
         "max_sm": 120,
         "rank": 60,

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1252,6 +1252,76 @@ class TestLinuxCudaChoiceFromRelease:
         assert result is None
 
 
+def make_profile_artifact(asset_name, profile_name, **overrides):
+    profile = INSTALL_LLAMA_PREBUILT.DIRECT_LINUX_BUNDLE_PROFILES[profile_name]
+    defaults = dict(
+        runtime_line = profile["runtime_line"],
+        coverage_class = profile["coverage_class"],
+        supported_sms = [str(value) for value in profile["supported_sms"]],
+        min_sm = int(profile["min_sm"]),
+        max_sm = int(profile["max_sm"]),
+        bundle_profile = profile_name,
+        rank = int(profile["rank"]),
+    )
+    defaults.update(overrides)
+    return make_artifact(asset_name, **defaults)
+
+
+class TestBlackwellUltraSm103Coverage:
+    """sm_103 (B300 / GB300) runs on the bundled base compute_100 PTX via JIT."""
+
+    def test_profiles_list_sm103_wherever_sm100_is_shipped(self):
+        for name, profile in INSTALL_LLAMA_PREBUILT.DIRECT_LINUX_BUNDLE_PROFILES.items():
+            sms = {str(value) for value in profile["supported_sms"]}
+            if "100" in sms:
+                assert "103" in sms, name
+            else:
+                assert "103" not in sms, name
+
+    def test_b300_selects_cuda13_newer_prebuilt(self, monkeypatch):
+        mock_linux_runtime(monkeypatch, ["cuda13"])
+        host = make_host(compute_caps = ["103"], driver_cuda_version = (13, 0))
+        art = make_profile_artifact("cuda13-newer.tar.gz", "cuda13-newer")
+        release = make_release([art])
+        result = linux_cuda_choice_from_release(host, release)
+        assert result is not None
+        assert result.primary.name == "cuda13-newer.tar.gz"
+
+    def test_b300_selects_cuda12_newer_prebuilt(self, monkeypatch):
+        mock_linux_runtime(monkeypatch, ["cuda12"])
+        host = make_host(compute_caps = ["103"], driver_cuda_version = (12, 8))
+        art = make_profile_artifact("cuda12-newer.tar.gz", "cuda12-newer")
+        release = make_release([art])
+        result = linux_cuda_choice_from_release(host, release)
+        assert result is not None
+        assert result.primary.name == "cuda12-newer.tar.gz"
+
+    def test_b300_reported_as_decimal_normalizes_and_matches(self, monkeypatch):
+        mock_linux_runtime(monkeypatch, ["cuda13"])
+        host = make_host(compute_caps = ["10.3"], driver_cuda_version = (13, 0))
+        art = make_profile_artifact("cuda13-portable.tar.gz", "cuda13-portable")
+        release = make_release([art])
+        result = linux_cuda_choice_from_release(host, release)
+        assert result is not None
+
+    def test_b300_falls_back_to_portable_when_only_portable_present(self, monkeypatch):
+        mock_linux_runtime(monkeypatch, ["cuda13"])
+        host = make_host(compute_caps = ["103"], driver_cuda_version = (13, 0))
+        art = make_profile_artifact("cuda13-portable.tar.gz", "cuda13-portable")
+        release = make_release([art])
+        result = linux_cuda_choice_from_release(host, release)
+        assert result is not None
+        assert result.primary.name == "cuda13-portable.tar.gz"
+
+    def test_older_bundle_still_rejects_b300(self, monkeypatch):
+        mock_linux_runtime(monkeypatch, ["cuda13"])
+        host = make_host(compute_caps = ["103"], driver_cuda_version = (13, 0))
+        art = make_profile_artifact("cuda13-older.tar.gz", "cuda13-older")
+        release = make_release([art])
+        result = linux_cuda_choice_from_release(host, release)
+        assert result is None
+
+
 # ===========================================================================
 # L. resolve_install_attempts
 # ===========================================================================

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1271,7 +1271,10 @@ class TestBlackwellUltraSm103Coverage:
     """sm_103 (B300 / GB300) runs on the bundled base compute_100 PTX via JIT."""
 
     def test_profiles_list_sm103_wherever_sm100_is_shipped(self):
-        for name, profile in INSTALL_LLAMA_PREBUILT.DIRECT_LINUX_BUNDLE_PROFILES.items():
+        for (
+            name,
+            profile,
+        ) in INSTALL_LLAMA_PREBUILT.DIRECT_LINUX_BUNDLE_PROFILES.items():
             sms = {str(value) for value in profile["supported_sms"]}
             if "100" in sms:
                 assert "103" in sms, name


### PR DESCRIPTION
### Problem

A B300 / GB300 (Blackwell Ultra, compute capability `sm_103`) on Linux x86_64 was not listed in any prebuilt bundle's `supported_sms` in `DIRECT_LINUX_BUNDLE_PROFILES`, which topped out at `sm_120`. The selector rejected every prebuilt for that host and fell through to a full llama.cpp source compile. That works, but it is slow and needs a local CUDA toolkit, which is exactly what the prebuilt path exists to avoid.

### Why the prebuilt already runs on B300

The `newer` and `portable` bundles ship a base, unsuffixed `compute_100` PTX image. Base PTX is forward compatible: the driver JIT-compiles it up to any higher compute capability in the same major family, including `sm_103`. I confirmed this directly against the published bundles:

```
cuobjdump --list-ptx libggml-cuda.so   # cuda13-newer and cuda12-newer
PTX:  sm_100  sm_120a  sm_86  sm_89  sm_90
```

The `sm_100` entry is base `compute_100` PTX (only `sm_120a` is arch specific). A B300 loads that `compute_100` PTX and JITs it to `sm_103`, so the existing bundle already runs on the GPU. The selector simply never offered it because `103` was absent from the table.

### Change

Add `"103"` to `supported_sms` for the four bundles that ship the `sm_100` build: `cuda12-newer`, `cuda12-portable`, `cuda13-newer`, `cuda13-portable`. `sm_103` is already inside each bundle's `[min_sm, max_sm]`, so no bound changes are needed. The `older` bundles do not ship `sm_100` and are left untouched. The source-build fallback still compiles native `sm_103` when a host is genuinely off the prebuilt path.

### Tests

`tests/studio/install/test_selection_logic.py`, new `TestBlackwellUltraSm103Coverage`:

- The real profile table lists `103` wherever it ships `100`, and never on the `older` bundles.
- A `sm_103` host selects the `cuda13-newer` and `cuda12-newer` prebuilts.
- A driver that reports the capability as `10.3` normalizes to `103` and matches.
- Portable-only releases still cover B300; `older` bundles still reject it.

Full suite: `617 passed, 1 skipped`.
