### PR TITLE
fix: skip vision tower when FastLanguageModel loads VLM checkpoints

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -358,6 +358,7 @@ class FastLanguageModel(FastLlamaModel):
                 qat_scheme = qat_scheme,
                 load_in_fp8 = load_in_fp8,
                 unsloth_tiled_mlp = unsloth_tiled_mlp,
+                is_text_only = True,
                 *args,
                 **kwargs,
             )
@@ -708,6 +709,7 @@ class FastLanguageModel(FastLlamaModel):
                 qat_scheme = qat_scheme,
                 load_in_fp8 = load_in_fp8,
                 unsloth_tiled_mlp = unsloth_tiled_mlp,
+                is_text_only = True,
                 *args,
                 **kwargs,
             )
@@ -892,6 +894,7 @@ class FastModel(FastBaseModel):
         load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
         unsloth_tiled_mlp = False,
         target_parameters = None,  # For MoE expert parameters
+        is_text_only = False,  # When True, skip vision tower for VLM checkpoints
         *args,
         **kwargs,
     ):
@@ -1471,7 +1474,13 @@ class FastModel(FastBaseModel):
                 # in their auto_map, not AutoModelForImageTextToText/AutoModelForVision2Seq.
                 _auto_map = getattr(model_config, "auto_map", {}) or {}
                 _vlm_class_name = AutoModelForVision2Seq.__name__
-                if (
+                if is_text_only and hasattr(model_config, "text_config"):
+                    # User called FastLanguageModel on a VLM checkpoint: use the
+                    # text-only CausalLM class so the vision tower is never
+                    # instantiated (e.g. Gemma3ForCausalLM instead of
+                    # Gemma3ForConditionalGeneration).
+                    auto_model = AutoModelForCausalLM
+                elif (
                     "AutoModelForCausalLM" in _auto_map
                     and _vlm_class_name not in _auto_map
                 ):


### PR DESCRIPTION
## Summary

When `FastLanguageModel.from_pretrained()` is used with a VLM checkpoint (e.g. `google/gemma-3-27b-it`) for **text-only** fine-tuning, the loader incorrectly routes through `AutoModelForVision2Seq`, which instantiates the SiglipVisionModel and crashes with a `flex_attention` error.

## Root Cause

`FastLanguageModel.from_pretrained` and `FastVisionModel.from_pretrained` both ultimately call `FastModel.from_pretrained`, which dispatches into `FastBaseModel.from_pretrained` — the user's intent ("I want text-only") is lost in that hand-off. When the auto-class selection runs, Gemma 3 27B is detected as a VLM (`Gemma3ForConditionalGeneration` + has `vision_config`), so it loads via `AutoModelForVision2Seq`, which instantiates the SigLIP vision tower and crashes.

## Fix

Thread an explicit `is_text_only` flag through the dispatch chain:

1. `FastLanguageModel.from_pretrained` passes `is_text_only=True` when delegating to `FastModel.from_pretrained`
2. `FastModel.from_pretrained` accepts the new parameter (default `False`)
3. The VLM detection block checks: if `is_text_only=True` and the model has a `text_config`, use `AutoModelForCausalLM` instead of `AutoModelForVision2Seq` — skipping the vision tower entirely

The `hasattr(model_config, "text_config")` guard ensures we only redirect for VLMs that have a text-only sub-config (Gemma 3, Qwen2.5-VL, LLaVA, etc.); pure vision models without one still go through the VLM path.

Fixes #5793