### PR TITLE
studio: upgrade MiniMax defaults to M3 (default), keep M2.7, drop earlier models

### DIFF
--- a/studio/backend/assets/configs/inference_defaults.json
+++ b/studio/backend/assets/configs/inference_defaults.json
@@ -277,14 +277,14 @@
       "min_p": 0.01,
       "repetition_penalty": 1.0
     },
-    "minimax-m2.5": {
+    "minimax-m3": {
       "temperature": 1.0,
       "top_p": 0.95,
       "top_k": 40,
       "min_p": 0.01,
       "repetition_penalty": 1.0
     },
-    "minimax": {
+    "minimax-m2.7": {
       "temperature": 1.0,
       "top_p": 0.95,
       "top_k": 40,
@@ -390,7 +390,7 @@
     "deepseek-r1", "deepseek-v3", "deepseek-ocr",
     "glm-5", "glm-4",
     "nemotron",
-    "minimax-m2.5", "minimax",
+    "minimax-m2.7", "minimax-m3",
     "gpt-oss", "granite-4",
     "kimi-k2", "kimi",
     "lfm2", "smollm", "olmo", "falcon", "ernie", "seed", "grok", "mimo"


### PR DESCRIPTION
## Summary

MiniMax released **M3** (524K context window, 128K max output) as the new flagship model. Refresh `studio/backend/assets/configs/inference_defaults.json` so Studio's family-based defaults pick up M3 GGUFs as the new default, keep M2.7 explicit, and drop M2.5 plus the generic catch-all so older MiniMax models (M2.5 / M2 / M1) no longer match the Studio preset table.

### Changes (single file: `inference_defaults.json`)

- Add `minimax-m3` family entry as the new default (`temperature=1.0`, `top_p=0.95`, `top_k=40`, `min_p=0.01`, `repetition_penalty=1.0`).
- Add `minimax-m2.7` family entry so M2.7 GGUFs continue to receive sensible defaults via an explicit family match (not via the generic catch-all).
- Drop `minimax-m2.5` and the bare `minimax` catch-all — earlier MiniMax models (M2.5, M2, M1) no longer match the Studio preset table; they fall back to `default.yaml`.
- Update the patterns list to `minimax-m2.7, minimax-m3` so it stays longest-match-first within the MiniMax section.

Only one file is touched; no other Studio components are affected. Merge order with #4277 is irrelevant — this PR is self-contained.