### PR TITLE
studio/frontend: pad Python tool code block to fix corner clipping

### DIFF
--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -78,7 +78,7 @@ function HighlightedCode({ code: source, language }: { code: string; language: s
     [source, language],
   );
   return (
-    <div className="max-h-48 overflow-auto text-xs [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:!text-xs [&_[data-streamdown=code-block]]:!my-0 [&_[data-streamdown=code-block]]:!p-0 [&_[data-streamdown=code-block]]:!border-0">
+    <div className="max-h-48 overflow-auto text-xs [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:!text-xs [&_[data-streamdown=code-block]]:!my-0 [&_[data-streamdown=code-block]]:!p-3 [&_[data-streamdown=code-block]]:!border-0">
       <Streamdown
         mode="static"
         plugins={{ code: codePlugin }}


### PR DESCRIPTION
Python code inside code blocks inside tool call blocks previously looked clipped like this:

<img width="829" height="396" alt="before" src="https://github.com/user-attachments/assets/454f77e8-f946-4591-ac3c-7bb8cc2a9574" />

This PR fixes that by just increasing the inner padding. Result:

<img width="821" height="445" alt="after" src="https://github.com/user-attachments/assets/e716d031-b76a-4d34-9970-9b0a271453da" />
