### PR TITLE
Guard model-load success path against mid-refresh cancellation

### DIFF
--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -245,7 +245,8 @@ export function useChatModelRuntime() {
     [],
   );
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (options?: { signal?: AbortSignal }) => {
+    const signal = options?.signal;
     setModelsError(null);
     try {
       const [listRes, statusRes, lorasRes] = await Promise.all([
@@ -253,6 +254,11 @@ export function useChatModelRuntime() {
         getInferenceStatus(),
         listLoras(),
       ]);
+
+      // Cancellation can land while the requests above are in flight (e.g. the
+      // user cancels a load during this refresh). Bail before writing any
+      // backend state back into the store -- cancelLoading already cleared it.
+      if (signal?.aborted) return;
 
       setModels(listRes.models.map(toChatModelSummary));
       setLoras(lorasRes.loras.map(toLoraSummary));
@@ -395,6 +401,7 @@ export function useChatModelRuntime() {
         });
       }
     } catch (error) {
+      if (signal?.aborted) return;
       const message =
         error instanceof Error ? error.message : "Failed to load models";
       setModelsError(message);
@@ -750,7 +757,7 @@ export function useChatModelRuntime() {
                 store.setParams({ ...store.params, ...p });
               }
             }
-            await refresh();
+            await refresh({ signal: abortCtrl.signal });
           } catch (error) {
             // Skip rollback if user cancelled -- model is already being unloaded.
             if (abortCtrl.signal.aborted) throw error;

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -1053,6 +1053,8 @@ export function useChatModelRuntime() {
 
         try {
           await performLoad();
+          // User cancelled mid-refresh; cancelLoading handles teardown.
+          if (abortCtrl.signal.aborted) return;
           if (loadToastDismissedRef.current) {
             toast.success(`${displayName} loaded`);
           } else {


### PR DESCRIPTION
## Summary

Fixes a latent cancellation race in the Studio chat model-loading flow. When the user clicks **Cancel** during the final `await refresh()` window of a load, two stale outcomes could occur even though `cancelLoading` had simultaneously fired `unloadModel` to tear the model down:

1. A success toast (`"X loaded"`) and, on the Tauri desktop build, an OS-level "Model ready" notification.
2. `refresh` writing the just-loaded model's `active_model` (checkpoint) and capability flags back into the store — re-populating state that `cancelLoading` had already cleared.

The user got a "ready" signal, and the UI kept showing the model as selected/active, for a model that was being unloaded.

## Root cause

`performLoad`'s last abort check is right after `loadModel` (`use-chat-model-runtime.ts:631`). After that it runs `setParams`, a large `setState`, and finally `await refresh()` with no further abort re-check. Two gaps followed:

- The success path in `selectModel` (after `performLoad` resolves) showed the toast + fired `notifyNative` unconditionally.
- `refresh` itself dispatches `Promise.all([listModels, getInferenceStatus, listLoras])` and then writes the results into the store. A cancel landing while those requests are in flight still let `getInferenceStatus` return the (about-to-be-unloaded) model as `active_model`, which `refresh` then wrote back via `setCheckpoint(...)` + `setState(...)` — overwriting the `clearCheckpoint()` that `cancelLoading` had just performed.

Every *other* completion branch already gated on `abortCtrl.signal.aborted` (rollback catch `:756`, error-toast catch `:1072`, outermost catch `:1097`); these two paths were the gaps.

## Changes

**1. Guard the success path** (`selectModel`, after `await performLoad()`):

```ts
await performLoad();
// User cancelled mid-refresh; cancelLoading handles teardown.
if (abortCtrl.signal.aborted) return;
```

The `return` exits through the existing inner `finally` (clears the progress interval + `resetLoadingUi()`) and doesn't throw, so the outer catch is untouched. Identical to the pre-existing guard at `:1097`.

**2. Make `refresh` cancellation-aware** so it cannot write stale backend state into the store:

```ts
const refresh = useCallback(async (options?: { signal?: AbortSignal }) => {
  const signal = options?.signal;
  ...
  const [listRes, statusRes, lorasRes] = await Promise.all([...]);
  if (signal?.aborted) return;        // bail before any store writes
  ...
} catch (error) {
  if (signal?.aborted) return;        // no spurious "Failed to refresh" toast
  ...
});
```

The abort check is placed **after** the in-flight `Promise.all` — that's exactly where a mid-load cancel lands. The signal is optional, so the other `refresh()` call sites (mount, unload paths, rollback) are unaffected; only the load-path call passes it:

```ts
await refresh({ signal: abortCtrl.signal });
```

Both guards are needed: #1 covers the toast/native notification (which live in `selectModel`, after `refresh`), #2 covers the stale state writes (which happen inside `refresh`, before `selectModel`'s guard runs).

## Scope / notes

- Pre-existing bug — the same gaps existed when Cancel was a React `<Button>` on `main`; correctly out of scope of the recent styling PR that touched the toast UI.
- Severity: low (narrow race, partially self-corrects via the unload) but cheap and correct.
- Does **not** touch the `loadToastDismissedRef` / dismissed flag — that flag is a symptom, not the root cause.

## Testing

- `npm run typecheck` — passes (exit 0).
- `biome check` on the file — zero new diagnostics (counts identical before/after both commits; remaining ones are pre-existing).
- No automated test added: `studio/frontend` has no test runner (no `vitest`/`jest`, no `test` script) and zero `*.test.ts*` files; standing up that infra for these control-flow guards is out of scope.
- Manual repro: start a model load, click Cancel during the post-`loadModel` refresh window. Expected after the fix — no `"X loaded"` toast, no "Model ready" native notification, the model is not left selected/active, and the `"Stopped loading model"` info toast still shows.
