### PR TITLE
fix(studio): resolve UAC path isolation and enforce VS C++ workload

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -57,15 +57,12 @@ $script:NvccPath = $null
 $script:CudaToolkitRoot = $null
 $script:CudaArch = $null
 
-# ─────────────────────────────────────────────
-# Guard: LOCALAPPDATA must not point to systemprofile
-# ─────────────────────────────────────────────
-# When setup.ps1 runs under a SYSTEM/service token (a scheduled task as
-# SYSTEM, psexec -s, an MDM/SCCM deploy) the process inherits that token's
-# LOCALAPPDATA (C:\Windows\system32\config\systemprofile) instead of the
-# real user path. Every code path below (prebuilt installs, CMake probe,
-# source builds) relies on a writable LOCALAPPDATA, so we fix it once here
-# at the top.
+# Guard: LOCALAPPDATA must not point to systemprofile.
+# Under a SYSTEM/service token (a scheduled task as SYSTEM, psexec -s, an
+# MDM/SCCM deploy) the process inherits that token's LOCALAPPDATA
+# (C:\Windows\system32\config\systemprofile), which isn't writable. Every
+# code path below (prebuilt installs, CMake probe, source builds) needs a
+# writable LOCALAPPDATA, so we fix it once here at the top.
 if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
     $env:LOCALAPPDATA = [Environment]::GetFolderPath('LocalApplicationData')
     if (([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") -and -not [string]::IsNullOrEmpty($env:USERPROFILE)) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -60,18 +60,19 @@ $script:CudaArch = $null
 # ─────────────────────────────────────────────
 # Guard: LOCALAPPDATA must not point to systemprofile
 # ─────────────────────────────────────────────
-# When setup.ps1 is elevated via UAC the child process can inherit the
-# SYSTEM token's LOCALAPPDATA (C:\Windows\system32\config\systemprofile)
-# instead of the real user path. Every code path below — prebuilt installs,
-# CMake probe, source builds — relies on a writable LOCALAPPDATA, so we
-# fix it once here at the top.
+# When setup.ps1 runs under a SYSTEM/service token (a scheduled task as
+# SYSTEM, psexec -s, an MDM/SCCM deploy) the process inherits that token's
+# LOCALAPPDATA (C:\Windows\system32\config\systemprofile) instead of the
+# real user path. Every code path below (prebuilt installs, CMake probe,
+# source builds) relies on a writable LOCALAPPDATA, so we fix it once here
+# at the top.
 if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
     $env:LOCALAPPDATA = [Environment]::GetFolderPath('LocalApplicationData')
-    if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
+    if (([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") -and -not [string]::IsNullOrEmpty($env:USERPROFILE)) {
         $env:LOCALAPPDATA = "$env:USERPROFILE\AppData\Local"
     }
 }
-if ($env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
+if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
     Write-Host "ERROR: Could not resolve a valid LOCALAPPDATA path." -ForegroundColor Red
     Write-Host "       Current value: $env:LOCALAPPDATA" -ForegroundColor Red
     Write-Host "       This usually means the script is running under a SYSTEM or" -ForegroundColor Red
@@ -2524,7 +2525,6 @@ if ($env:UNSLOTH_LLAMA_FORCE_COMPILE -eq "1") {
             $PSNativeCommandUseErrorActionPreference = $false
             $restoreNativeErrorPreference = $true
         }
-
         try {
             if ($script:UnslothVerbose) {
                 # Show live output in verbose mode while still capturing for error log

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -395,11 +395,6 @@ function Find-VsBuildTools {
             if ($n) {
                 return @{ Generator = "Visual Studio $n $y"; InstallPath = $path.Trim(); Source = 'vswhere' }
             }
-        } else {
-            Write-Host ""
-            Write-Host "[ERROR] Visual Studio detected, but the C++ compiler is missing." -ForegroundColor Red
-            Write-Host "You must install the 'Desktop development with C++' workload via the Visual Studio Installer to build Unsloth." -ForegroundColor Yellow
-            exit 1
         }
     }
     # --- Scan filesystem (handles broken vswhere registration after winget cycles) ---
@@ -2507,7 +2502,12 @@ if ($env:UNSLOTH_LLAMA_FORCE_COMPILE -eq "1") {
             $PSNativeCommandUseErrorActionPreference = $false
             $restoreNativeErrorPreference = $true
         }
-        $env:LOCALAPPDATA = "$env:USERPROFILE\AppData\Local"
+        if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "*systemprofile*") {
+            $env:LOCALAPPDATA = [Environment]::GetFolderPath('LocalApplicationData')
+            if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "*systemprofile*") {
+                $env:LOCALAPPDATA = "$env:USERPROFILE\AppData\Local"
+            }
+        }
         try {
             if ($script:UnslothVerbose) {
                 # Show live output in verbose mode while still capturing for error log

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -388,15 +388,20 @@ function Find-VsBuildTools {
     if (Test-Path $vsw) {
         $info = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion 2>$null
         $path = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+        
         if ($info -and $path) {
             $y = $info.Trim()
             $n = $map[$y]
             if ($n) {
                 return @{ Generator = "Visual Studio $n $y"; InstallPath = $path.Trim(); Source = 'vswhere' }
             }
+        } else {
+            Write-Host ""
+            Write-Host "[ERROR] Visual Studio detected, but the C++ compiler is missing." -ForegroundColor Red
+            Write-Host "You must install the 'Desktop development with C++' workload via the Visual Studio Installer to build Unsloth." -ForegroundColor Yellow
+            exit 1
         }
     }
-
     # --- Scan filesystem (handles broken vswhere registration after winget cycles) ---
     $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)})
     $editions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
@@ -2502,6 +2507,7 @@ if ($env:UNSLOTH_LLAMA_FORCE_COMPILE -eq "1") {
             $PSNativeCommandUseErrorActionPreference = $false
             $restoreNativeErrorPreference = $true
         }
+        $env:LOCALAPPDATA = "$env:USERPROFILE\AppData\Local"
         try {
             if ($script:UnslothVerbose) {
                 # Show live output in verbose mode while still capturing for error log

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -57,6 +57,28 @@ $script:NvccPath = $null
 $script:CudaToolkitRoot = $null
 $script:CudaArch = $null
 
+# ─────────────────────────────────────────────
+# Guard: LOCALAPPDATA must not point to systemprofile
+# ─────────────────────────────────────────────
+# When setup.ps1 is elevated via UAC the child process can inherit the
+# SYSTEM token's LOCALAPPDATA (C:\Windows\system32\config\systemprofile)
+# instead of the real user path. Every code path below — prebuilt installs,
+# CMake probe, source builds — relies on a writable LOCALAPPDATA, so we
+# fix it once here at the top.
+if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
+    $env:LOCALAPPDATA = [Environment]::GetFolderPath('LocalApplicationData')
+    if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
+        $env:LOCALAPPDATA = "$env:USERPROFILE\AppData\Local"
+    }
+}
+if ($env:LOCALAPPDATA -like "C:\Windows\*\config\systemprofile*") {
+    Write-Host "ERROR: Could not resolve a valid LOCALAPPDATA path." -ForegroundColor Red
+    Write-Host "       Current value: $env:LOCALAPPDATA" -ForegroundColor Red
+    Write-Host "       This usually means the script is running under a SYSTEM or" -ForegroundColor Red
+    Write-Host "       service account. Please run from a normal user PowerShell session." -ForegroundColor Red
+    exit 1
+}
+
 # Detect if running from pip install (no frontend/ dir in studio)
 $FrontendDir = Join-Path $ScriptDir "frontend"
 $OxcValidatorDir = Join-Path $ScriptDir "backend\core\data_recipe\oxc-validator"
@@ -388,7 +410,6 @@ function Find-VsBuildTools {
     if (Test-Path $vsw) {
         $info = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion 2>$null
         $path = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
-        
         if ($info -and $path) {
             $y = $info.Trim()
             $n = $map[$y]
@@ -397,6 +418,7 @@ function Find-VsBuildTools {
             }
         }
     }
+
     # --- Scan filesystem (handles broken vswhere registration after winget cycles) ---
     $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)})
     $editions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
@@ -2502,12 +2524,7 @@ if ($env:UNSLOTH_LLAMA_FORCE_COMPILE -eq "1") {
             $PSNativeCommandUseErrorActionPreference = $false
             $restoreNativeErrorPreference = $true
         }
-        if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "*systemprofile*") {
-            $env:LOCALAPPDATA = [Environment]::GetFolderPath('LocalApplicationData')
-            if ([string]::IsNullOrEmpty($env:LOCALAPPDATA) -or $env:LOCALAPPDATA -like "*systemprofile*") {
-                $env:LOCALAPPDATA = "$env:USERPROFILE\AppData\Local"
-            }
-        }
+
         try {
             if ($script:UnslothVerbose) {
                 # Show live output in verbose mode while still capturing for error log


### PR DESCRIPTION
fix(studio): fix LOCALAPPDATA resolving to systemprofile on UAC elevation

When setup.ps1 gets elevated via UAC, $env:LOCALAPPDATA can end up pointing at C:\Windows\system32\config\systemprofile instead of the actual user path, which causes WinError 5 (Access is denied) during prebuilt lookups.

What changed:

moved the LOCALAPPDATA guard to the top of the script so it covers all code paths (was previously only in the prebuilt-install branch, missed by -SkipPrebuiltInstall and UNSLOTH_LLAMA_FORCE_COMPILE=1)
anchored the pattern to C:\Windows*\config\systemprofile* instead of just systemprofile to avoid false-matching usernames
added exit 1 with a clear message if all fallbacks still resolve to systemprofile (SYSTEM/service account edge case)