### PR TITLE
Fix UnicodeEncodeError when printing emoji on legacy Windows consoles

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -27,6 +27,7 @@ os.environ["UNSLOTH_IS_PRESENT"] = "1"
 # errors="replace" guarantees we can never crash on an unencodable glyph.
 if platform.system() == "Windows":
     import sys as _sys
+
     for _name in ("stdout", "stderr"):
         _s = getattr(_sys, _name, None)
         try:

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -16,6 +16,26 @@ import os, importlib.util, platform
 
 os.environ["UNSLOTH_IS_PRESENT"] = "1"
 
+# ── Windows console UTF-8 safety ─────────────────────────────────────────────
+# Legacy Windows consoles use a non-UTF-8 code page (e.g. cp1252) that cannot
+# encode the emoji / box-drawing glyphs Unsloth prints, so a bare
+# print("\U0001f9a5 ...") raises UnicodeEncodeError and aborts (observed at
+# SFTTrainer init, unsloth/trainer.py). Reconfigure stdout/stderr to UTF-8 ONLY
+# on Windows and ONLY when they are not already UTF-8 -- this is a no-op when
+# PYTHONUTF8 / PYTHONIOENCODING is set (Unsloth Studio worker, modern terminals)
+# and is never touched on Linux/macOS, so it cannot change their behaviour.
+# errors="replace" guarantees we can never crash on an unencodable glyph.
+if platform.system() == "Windows":
+    import sys as _sys
+    for _name in ("stdout", "stderr"):
+        _s = getattr(_sys, _name, None)
+        try:
+            _enc = (getattr(_s, "encoding", None) or "").lower()
+            if _s is not None and hasattr(_s, "reconfigure") and "utf" not in _enc:
+                _s.reconfigure(encoding = "utf-8", errors = "replace")
+        except Exception:
+            pass
+
 
 def _is_mlx_available():
     # Transitional import barrier: while the paired unsloth-zoo MLX runtime


### PR DESCRIPTION
## Problem
On Windows, stdout often uses a legacy code page (e.g. **cp1252**) that cannot encode the emoji / box-drawing glyphs Unsloth prints. A direct finetune then dies with:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f9a5' in position 0: character maps to <undefined>
```

Repro: a direct `unsloth/gemma-3-270m-it` LoRA finetune on a default Windows console crashes at **SFTTrainer init** (`unsloth/trainer.py`, the "Padding-free auto-enabled" print) — before training starts. (Unsloth Studio is unaffected because its worker already runs with UTF-8 stdout.)

## Fix
At unsloth import, **on Windows only**, reconfigure `sys.stdout`/`sys.stderr` to UTF-8 — but **only when they are not already UTF-8**:
- no-op on Linux/macOS (`platform.system() == "Windows"` guard),
- no-op when `PYTHONUTF8`/`PYTHONIOENCODING` is already set (Studio worker, modern terminals — encoding already contains `utf`),
- guarded with `hasattr(stream, "reconfigure")` + `try/except`, `errors="replace"` so it can never itself raise.

One reconfigure at import covers **every** emoji print across unsloth + unsloth-zoo (shared process stdout), so no per-call-site edits are needed. Independent of transformers / TRL / vLLM versions.

## No regressions
- Linux/macOS: code path skipped entirely.
- Windows where stdout is already UTF-8 (Studio, `PYTHONUTF8`): no-op (guard skips).
- Applies to all Windows GPU types (NVIDIA/AMD/Intel/CPU) — it only ever *fixes* the same crash, never changes already-working output.

## Verification
Direct `gemma-3-270m-it` LoRA finetune on a cp1252 Windows console: previously crashed at SFTTrainer init; with this change it prints fine and trains to completion (torch.compile path included).
