### PR TITLE
feat(studio): SSM fast inference optimization + Qwen3.5 training configs

### DIFF
--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-2B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-2B.yaml
@@ -1,0 +1,44 @@
+# Model defaults for unsloth/Qwen3.5-2B
+# Based on Qwen3.5 hybrid (Mamba+Attention) architecture
+# Also applies to: Qwen/Qwen3.5-2B, unsloth/Qwen3.5-2B-bnb-4bit
+# NOTE: Qwen3.5 GDN layers require float32 to avoid NaN gradients
+
+training:
+  trust_remote_code: false
+  max_seq_length: 4096
+  # num_epochs: 4
+  num_epochs: 0
+  learning_rate: 2e-4
+  batch_size: 4
+  gradient_accumulation_steps: 4
+  warmup_steps: 5
+  max_steps: 30
+  save_steps: 30
+  weight_decay: 0.001
+  random_seed: 3407
+  packing: false
+  train_on_completions: true
+  gradient_checkpointing: "unsloth"
+  optim: "adamw_8bit"
+  lr_scheduler_type: "linear"
+
+lora:
+  lora_r: 16
+  lora_alpha: 16
+  lora_dropout: 0.0
+  target_modules:
+    - "all-linear"
+  use_rslora: false
+  use_loftq: false
+
+logging:
+  enable_wandb: false
+  wandb_project: "llm-finetuning"
+  enable_tensorboard: false
+  tensorboard_dir: "runs"
+  log_frequency: 10
+
+inference:
+  trust_remote_code: false
+  temperature: 0.3
+  min_p: 0.15

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-35B-A3B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-35B-A3B.yaml
@@ -1,0 +1,44 @@
+# Model defaults for unsloth/Qwen3.5-35B-A3B
+# Based on Qwen3.5 hybrid (Mamba+Attention) MoE architecture
+# Also applies to: Qwen/Qwen3.5-35B-A3B, unsloth/Qwen3.5-35B-A3B-bnb-4bit
+# NOTE: Qwen3.5 GDN layers require float32 to avoid NaN gradients
+
+training:
+  trust_remote_code: false
+  max_seq_length: 4096
+  # num_epochs: 4
+  num_epochs: 0
+  learning_rate: 1e-4
+  batch_size: 1
+  gradient_accumulation_steps: 8
+  warmup_steps: 5
+  max_steps: 30
+  save_steps: 30
+  weight_decay: 0.001
+  random_seed: 3407
+  packing: false
+  train_on_completions: true
+  gradient_checkpointing: "unsloth"
+  optim: "adamw_8bit"
+  lr_scheduler_type: "linear"
+
+lora:
+  lora_r: 16
+  lora_alpha: 16
+  lora_dropout: 0.0
+  target_modules:
+    - "all-linear"
+  use_rslora: false
+  use_loftq: false
+
+logging:
+  enable_wandb: false
+  wandb_project: "llm-finetuning"
+  enable_tensorboard: false
+  tensorboard_dir: "runs"
+  log_frequency: 10
+
+inference:
+  trust_remote_code: false
+  temperature: 0.3
+  min_p: 0.15

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-4B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-4B.yaml
@@ -1,0 +1,44 @@
+# Model defaults for unsloth/Qwen3.5-4B
+# Based on Qwen3.5 hybrid (Mamba+Attention) architecture
+# Also applies to: Qwen/Qwen3.5-4B, unsloth/Qwen3.5-4B-bnb-4bit
+# NOTE: Qwen3.5 GDN layers require float32 to avoid NaN gradients
+
+training:
+  trust_remote_code: false
+  max_seq_length: 4096
+  # num_epochs: 4
+  num_epochs: 0
+  learning_rate: 2e-4
+  batch_size: 2
+  gradient_accumulation_steps: 4
+  warmup_steps: 5
+  max_steps: 30
+  save_steps: 30
+  weight_decay: 0.001
+  random_seed: 3407
+  packing: false
+  train_on_completions: true
+  gradient_checkpointing: "unsloth"
+  optim: "adamw_8bit"
+  lr_scheduler_type: "linear"
+
+lora:
+  lora_r: 16
+  lora_alpha: 16
+  lora_dropout: 0.0
+  target_modules:
+    - "all-linear"
+  use_rslora: false
+  use_loftq: false
+
+logging:
+  enable_wandb: false
+  wandb_project: "llm-finetuning"
+  enable_tensorboard: false
+  tensorboard_dir: "runs"
+  log_frequency: 10
+
+inference:
+  trust_remote_code: false
+  temperature: 0.3
+  min_p: 0.15

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-9B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-9B.yaml
@@ -1,0 +1,44 @@
+# Model defaults for unsloth/Qwen3.5-9B
+# Based on Qwen3.5 hybrid (Mamba+Attention) architecture
+# Also applies to: Qwen/Qwen3.5-9B, unsloth/Qwen3.5-9B-bnb-4bit
+# NOTE: Qwen3.5 GDN layers require float32 to avoid NaN gradients
+
+training:
+  trust_remote_code: false
+  max_seq_length: 4096
+  # num_epochs: 4
+  num_epochs: 0
+  learning_rate: 2e-4
+  batch_size: 2
+  gradient_accumulation_steps: 4
+  warmup_steps: 5
+  max_steps: 30
+  save_steps: 30
+  weight_decay: 0.001
+  random_seed: 3407
+  packing: false
+  train_on_completions: true
+  gradient_checkpointing: "unsloth"
+  optim: "adamw_8bit"
+  lr_scheduler_type: "linear"
+
+lora:
+  lora_r: 16
+  lora_alpha: 16
+  lora_dropout: 0.0
+  target_modules:
+    - "all-linear"
+  use_rslora: false
+  use_loftq: false
+
+logging:
+  enable_wandb: false
+  wandb_project: "llm-finetuning"
+  enable_tensorboard: false
+  tensorboard_dir: "runs"
+  log_frequency: 10
+
+inference:
+  trust_remote_code: false
+  temperature: 0.3
+  min_p: 0.15

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -226,17 +226,50 @@ _SSM_MODEL_SUBSTRINGS = (
 )
 
 
+def _extract_model_identifier(model_name: str) -> str:
+    """Extract the model identifier from a full path or HuggingFace repo ID.
+
+    Prevents false positives from paths like '/home/mamba/models/llama'.
+
+    Examples:
+        '/home/user/models/llama-7b' -> 'llama-7b'
+        'unsloth/Mamba-130M' -> 'unsloth/Mamba-130M'
+        '/cache/hub/models--state-spaces--mamba-130m/...' -> 'state-spaces/mamba-130m'
+    """
+    import os
+
+    # Handle HuggingFace cache paths like 'models--org--name'
+    if "models--" in model_name:
+        parts = model_name.split("models--")
+        if len(parts) > 1:
+            repo_part = parts[-1].split(os.sep)[0].split("/")[0]
+            return repo_part.replace("--", "/")
+
+    # For local paths, use basename; for repo IDs, use as-is
+    if os.sep in model_name or (model_name.count("/") > 1):
+        return os.path.basename(model_name.rstrip(os.sep + "/"))
+
+    return model_name
+
+
 def _is_ssm_model(model_name: str) -> bool:
     """Check if a model is an SSM (State Space Model) architecture.
 
     SSM models like Mamba, LFM, NemotronH, FalconH1, and Jamba use state-based
     recurrence rather than attention-based KV caching. They benefit from
     use_cache=False during generation since they don't need KV cache management.
+
+    Note: Only checks the model identifier (not full path) to avoid false
+    positives from paths like '/home/mamba/models/llama'.
     """
     if not model_name:
         return False
-    name_lower = model_name.lower()
-    return any(sub in name_lower for sub in _SSM_MODEL_SUBSTRINGS)
+
+    # Extract just the model identifier to avoid false positives from paths
+    identifier = _extract_model_identifier(model_name)
+    identifier_lower = identifier.lower()
+
+    return any(sub in identifier_lower for sub in _SSM_MODEL_SUBSTRINGS)
 
 
 class InferenceBackend:

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -209,6 +209,36 @@ class HarmonyTextStreamer:
                     self._queue.put(new_content)
 
 
+# SSM (State Space Model) architectures that don't use traditional KV cache.
+# These models benefit from use_cache=False since they maintain internal state differently.
+_SSM_MODEL_SUBSTRINGS = (
+    "nemotron_h",
+    "nemotron-h",
+    "nemotron-3-nano",
+    "falcon_h1",
+    "falcon-h1",
+    "granite-4.0-h",
+    "granitemoehybrid",
+    "lfm2",
+    "lfm-2",
+    "mamba",
+    "jamba",
+)
+
+
+def _is_ssm_model(model_name: str) -> bool:
+    """Check if a model is an SSM (State Space Model) architecture.
+
+    SSM models like Mamba, LFM, NemotronH, FalconH1, and Jamba use state-based
+    recurrence rather than attention-based KV caching. They benefit from
+    use_cache=False during generation since they don't need KV cache management.
+    """
+    if not model_name:
+        return False
+    name_lower = model_name.lower()
+    return any(sub in name_lower for sub in _SSM_MODEL_SUBSTRINGS)
+
+
 class InferenceBackend:
     """Unified inference backend supporting text, vision, and LoRA models"""
 
@@ -1187,11 +1217,14 @@ class InferenceBackend:
                 timeout = 0.2,
             )
 
+            # SSM models (Mamba, LFM, etc.) don't use traditional KV cache
+            use_cache = not _is_ssm_model(self.active_model_name)
+
             generation_kwargs = dict(
                 **inputs,
                 streamer = streamer,
                 max_new_tokens = max_new_tokens,
-                use_cache = True,
+                use_cache = use_cache,
                 do_sample = temperature > 0,
                 temperature = temperature,
                 top_p = top_p,
@@ -1325,12 +1358,15 @@ class InferenceBackend:
                 timeout = 0.2,
             )
 
+            # SSM models (Mamba, LFM, etc.) don't use traditional KV cache
+            use_cache = not _is_ssm_model(self.active_model_name)
+
             # Notebook uses do_sample=False for ASR (greedy decoding for accuracy)
             generation_kwargs = dict(
                 **inputs,
                 streamer = streamer,
                 max_new_tokens = max_new_tokens,
-                use_cache = True,
+                use_cache = use_cache,
                 do_sample = False,
             )
 
@@ -1476,10 +1512,14 @@ class InferenceBackend:
                     timeout = 0.2,
                 )
 
+            # SSM models (Mamba, LFM, etc.) don't use traditional KV cache
+            use_cache = not _is_ssm_model(self.active_model_name)
+
             generation_kwargs = dict(
                 **inputs,
                 streamer = streamer,
                 max_new_tokens = max_new_tokens,
+                use_cache = use_cache,
                 temperature = temperature,
                 top_p = top_p,
                 top_k = top_k,
@@ -1657,6 +1697,9 @@ class InferenceBackend:
         input_ids = torch.cat([start_token, text_ids, end_tokens], dim = 1)
         attention_mask = torch.ones_like(input_ids)
 
+        # SSM models (Mamba, LFM, etc.) don't use traditional KV cache
+        use_cache = not _is_ssm_model(self.active_model_name)
+
         generated = model.generate(
             input_ids = input_ids,
             attention_mask = attention_mask,
@@ -1666,7 +1709,7 @@ class InferenceBackend:
             top_p = top_p,
             repetition_penalty = repetition_penalty,
             eos_token_id = 128258,  # END_OF_SPEECH
-            use_cache = True,
+            use_cache = use_cache,
         )
         return self._audio_codec_manager.decode_snac(generated, str(device))
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2711,6 +2711,158 @@ async def delete_cached_model(
         )
 
 
+@router.post("/check-updates")
+async def check_model_updates(
+    repo_ids: List[str] = Body(..., description = "List of HuggingFace repo IDs to check"),
+    current_subject: str = Depends(get_current_subject),
+):
+    """Check if cached models have newer versions available on HuggingFace.
+
+    Compares local cached commit hashes against the latest revision on HuggingFace Hub.
+    Returns a list of models that have updates available.
+    """
+    from huggingface_hub import model_info as hf_model_info
+
+    updates = []
+    cache_scans = _all_hf_cache_scans()
+
+    # Build a map of local repo -> cached commit hashes
+    local_commits: dict[str, set[str]] = {}
+    for hf_cache in cache_scans:
+        for repo_info in hf_cache.repos:
+            if repo_info.repo_type != "model":
+                continue
+            repo_key = repo_info.repo_id.lower()
+            if repo_key not in local_commits:
+                local_commits[repo_key] = set()
+            for rev in repo_info.revisions:
+                if hasattr(rev, "commit_hash") and rev.commit_hash:
+                    local_commits[repo_key].add(rev.commit_hash)
+
+    for repo_id in repo_ids:
+        if not _is_valid_repo_id(repo_id):
+            continue
+        repo_key = repo_id.lower()
+        if repo_key not in local_commits:
+            continue
+
+        try:
+            info = hf_model_info(repo_id, token = None)
+            latest_sha = getattr(info, "sha", None)
+            if not latest_sha:
+                continue
+
+            cached_commits = local_commits.get(repo_key, set())
+            if latest_sha not in cached_commits:
+                updates.append({
+                    "repo_id": repo_id,
+                    "local_commits": list(cached_commits)[:3],  # Show first 3 for debugging
+                    "latest_commit": latest_sha,
+                    "has_update": True,
+                })
+        except Exception as e:
+            logger.debug(f"Could not check updates for {repo_id}: {e}")
+            continue
+
+    return {"updates": updates}
+
+
+@router.post("/update-model")
+async def update_cached_model(
+    repo_id: str = Body(..., description = "HuggingFace repo ID to update"),
+    variant: Optional[str] = Body(None, description = "GGUF variant to update (optional)"),
+    current_subject: str = Depends(get_current_subject),
+):
+    """Update a cached model by re-downloading the latest version from HuggingFace.
+
+    This deletes the old cached version and triggers a fresh download.
+    For GGUF models, specify the variant to update only that quant.
+    """
+    from huggingface_hub import snapshot_download, hf_hub_download
+    from huggingface_hub.utils import HfHubHTTPError
+
+    if not _is_valid_repo_id(repo_id):
+        raise HTTPException(status_code = 400, detail = "Invalid repo_id format")
+
+    # Check if model is currently loaded
+    try:
+        from routes.inference import get_llama_cpp_backend
+
+        llama_backend = get_llama_cpp_backend()
+        if llama_backend.is_loaded and llama_backend.model_identifier:
+            loaded_id = llama_backend.model_identifier.lower()
+            if loaded_id == repo_id.lower() or loaded_id.startswith(repo_id.lower()):
+                raise HTTPException(
+                    status_code = 400,
+                    detail = "Unload the model before updating",
+                )
+    except HTTPException:
+        raise
+    except Exception:
+        pass
+
+    try:
+        inference_backend = get_inference_backend()
+        if inference_backend.active_model_name:
+            active = inference_backend.active_model_name.lower()
+            if active == repo_id.lower() or active.startswith(repo_id.lower()):
+                raise HTTPException(
+                    status_code = 400,
+                    detail = "Unload the model before updating",
+                )
+    except HTTPException:
+        raise
+    except Exception:
+        pass
+
+    try:
+        # Delete old cached version first
+        cache_scans = _all_hf_cache_scans()
+        target_repo = None
+        hf_cache = None
+
+        for scan in cache_scans:
+            for repo_info in scan.repos:
+                if repo_info.repo_type != "model":
+                    continue
+                if repo_info.repo_id.lower() == repo_id.lower():
+                    target_repo = repo_info
+                    hf_cache = scan
+                    break
+            if target_repo is not None:
+                break
+
+        if target_repo is None:
+            raise HTTPException(status_code = 404, detail = "Model not found in cache")
+
+        # Delete old revisions
+        revision_hashes = [rev.commit_hash for rev in target_repo.revisions]
+        if revision_hashes and hf_cache is not None:
+            delete_strategy = hf_cache.delete_revisions(*revision_hashes)
+            logger.info(
+                f"Deleting old version of {repo_id}: "
+                f"{delete_strategy.expected_freed_size_str} will be freed"
+            )
+            delete_strategy.execute()
+
+        # Trigger fresh download (will happen on next model load)
+        # For now, just return success - actual download happens when model is loaded
+        return {
+            "status": "ready_to_update",
+            "repo_id": repo_id,
+            "message": "Old version deleted. The latest version will be downloaded when you load the model.",
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating model {repo_id}: {e}", exc_info = True)
+        raise HTTPException(
+            status_code = 500,
+            detail = f"Failed to update model: {str(e)}",
+        )
+
+
 @router.get("/checkpoints", response_model = CheckpointListResponse)
 async def list_checkpoints(
     outputs_dir: str = Query(

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2713,7 +2713,9 @@ async def delete_cached_model(
 
 @router.post("/check-updates")
 async def check_model_updates(
-    repo_ids: List[str] = Body(..., description = "List of HuggingFace repo IDs to check"),
+    repo_ids: List[str] = Body(
+        ..., description = "List of HuggingFace repo IDs to check"
+    ),
     current_subject: str = Depends(get_current_subject),
 ):
     """Check if cached models have newer versions available on HuggingFace.
@@ -2754,12 +2756,16 @@ async def check_model_updates(
 
             cached_commits = local_commits.get(repo_key, set())
             if latest_sha not in cached_commits:
-                updates.append({
-                    "repo_id": repo_id,
-                    "local_commits": list(cached_commits)[:3],  # Show first 3 for debugging
-                    "latest_commit": latest_sha,
-                    "has_update": True,
-                })
+                updates.append(
+                    {
+                        "repo_id": repo_id,
+                        "local_commits": list(cached_commits)[
+                            :3
+                        ],  # Show first 3 for debugging
+                        "latest_commit": latest_sha,
+                        "has_update": True,
+                    }
+                )
         except Exception as e:
             logger.debug(f"Could not check updates for {repo_id}: {e}")
             continue
@@ -2770,7 +2776,9 @@ async def check_model_updates(
 @router.post("/update-model")
 async def update_cached_model(
     repo_id: str = Body(..., description = "HuggingFace repo ID to update"),
-    variant: Optional[str] = Body(None, description = "GGUF variant to update (optional)"),
+    variant: Optional[str] = Body(
+        None, description = "GGUF variant to update (optional)"
+    ),
     current_subject: str = Depends(get_current_subject),
 ):
     """Update a cached model by re-downloading the latest version from HuggingFace.

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -241,6 +241,39 @@ export async function deleteCachedModel(
   await parseJsonOrThrow<unknown>(response);
 }
 
+export interface ModelUpdateInfo {
+  repo_id: string;
+  local_commits: string[];
+  latest_commit: string;
+  has_update: boolean;
+}
+
+export async function checkModelUpdates(
+  repoIds: string[],
+): Promise<ModelUpdateInfo[]> {
+  const response = await authFetch("/api/models/check-updates", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(repoIds),
+  });
+  const data = await parseJsonOrThrow<{ updates: ModelUpdateInfo[] }>(response);
+  return data.updates;
+}
+
+export async function updateCachedModel(
+  repoId: string,
+  variant?: string,
+): Promise<{ status: string; repo_id: string; message: string }> {
+  const payload: Record<string, string> = { repo_id: repoId };
+  if (variant) payload.variant = variant;
+  const response = await authFetch("/api/models/update-model", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return parseJsonOrThrow(response);
+}
+
 export async function deleteFineTunedModel(args: {
   modelPath: string;
   source: "training" | "exported";

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -18,6 +18,7 @@ import {
   PaintBrush02Icon,
   Settings02Icon,
   UserIcon,
+  Database02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { motion, useReducedMotion } from "motion/react";
@@ -32,6 +33,7 @@ import { AppearanceTab } from "./tabs/appearance-tab";
 import { ChatTab } from "./tabs/chat-tab";
 import { ConnectionsTab } from "./tabs/connections-tab";
 import { GeneralTab } from "./tabs/general-tab";
+import { ModelsTab } from "./tabs/models-tab";
 import { ProfileTab } from "./tabs/profile-tab";
 
 interface TabDef {
@@ -62,6 +64,12 @@ const TABS: TabDef[] = [
     icon: Globe02Icon,
     badgeKey: "common.new",
   },
+  {
+    id: "models",
+    labelKey: "settings.tabs.models",
+    icon: Database02Icon,
+    badgeKey: "common.new",
+  },
   { id: "about", labelKey: "settings.tabs.about", icon: HelpCircleIcon },
 ];
 
@@ -79,6 +87,8 @@ function renderTab(tab: SettingsTab) {
       return <ConnectionsTab />;
     case "api-keys":
       return <ApiKeysTab />;
+    case "models":
+      return <ModelsTab />;
     case "about":
       return <AboutTab />;
   }
@@ -99,6 +109,7 @@ export function SettingsDialog() {
     chat: null,
     connections: null,
     "api-keys": null,
+    models: null,
     about: null,
   });
 

--- a/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
@@ -10,6 +10,7 @@ export type SettingsTab =
   | "chat"
   | "connections"
   | "api-keys"
+  | "models"
   | "about";
 
 interface SettingsDialogState {
@@ -42,6 +43,7 @@ function loadInitialTab(): SettingsTab {
     "chat",
     "connections",
     "api-keys",
+    "models",
     "about",
   ];
   return valid.includes(stored as SettingsTab)

--- a/studio/frontend/src/features/settings/tabs/models-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/models-tab.tsx
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  type CachedGgufRepo,
+  type CachedModelRepo,
+  type ModelUpdateInfo,
+  checkModelUpdates,
+  deleteCachedModel,
+  listCachedGguf,
+  listCachedModels,
+  updateCachedModel,
+} from "@/features/chat/api/chat-api";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import {
+  Delete02Icon,
+  Download04Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { RefreshCwIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { SettingsSection } from "../components/settings-section";
+
+/** Format bytes to a human-readable size string. */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / 1024 ** i;
+  return `${value.toFixed(value < 10 ? 1 : 0)} ${units[i]}`;
+}
+
+interface CachedModel {
+  repo_id: string;
+  size_bytes: number;
+  type: "gguf" | "model";
+  cache_path?: string;
+}
+
+export function ModelsTab() {
+  const [cachedGguf, setCachedGguf] = useState<CachedGgufRepo[]>([]);
+  const [cachedModels, setCachedModels] = useState<CachedModelRepo[]>([]);
+  const [updates, setUpdates] = useState<Map<string, ModelUpdateInfo>>(
+    new Map(),
+  );
+  const [loading, setLoading] = useState(true);
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+  const [deletingModel, setDeletingModel] = useState<string | null>(null);
+  const [updatingModel, setUpdatingModel] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<CachedModel | null>(null);
+
+  const allModels = useMemo<CachedModel[]>(() => {
+    const models: CachedModel[] = [];
+    for (const g of cachedGguf) {
+      models.push({
+        repo_id: g.repo_id,
+        size_bytes: g.size_bytes,
+        type: "gguf",
+        cache_path: g.cache_path,
+      });
+    }
+    for (const m of cachedModels) {
+      models.push({
+        repo_id: m.repo_id,
+        size_bytes: m.size_bytes,
+        type: "model",
+      });
+    }
+    return models.sort((a, b) => a.repo_id.localeCompare(b.repo_id));
+  }, [cachedGguf, cachedModels]);
+
+  const totalSize = useMemo(
+    () => allModels.reduce((sum, m) => sum + m.size_bytes, 0),
+    [allModels],
+  );
+
+  const refreshModels = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [gguf, models] = await Promise.all([
+        listCachedGguf(),
+        listCachedModels(),
+      ]);
+      setCachedGguf(gguf);
+      setCachedModels(models);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to load cached models",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const checkForUpdates = useCallback(async () => {
+    if (allModels.length === 0) return;
+    setCheckingUpdates(true);
+    try {
+      const repoIds = allModels.map((m) => m.repo_id);
+      const updateInfos = await checkModelUpdates(repoIds);
+      const updateMap = new Map<string, ModelUpdateInfo>();
+      for (const info of updateInfos) {
+        updateMap.set(info.repo_id.toLowerCase(), info);
+      }
+      setUpdates(updateMap);
+      if (updateInfos.length > 0) {
+        toast.success(`${updateInfos.length} model(s) have updates available`);
+      } else {
+        toast.success("All models are up to date");
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to check for updates",
+      );
+    } finally {
+      setCheckingUpdates(false);
+    }
+  }, [allModels]);
+
+  const handleDelete = useCallback(
+    async (model: CachedModel) => {
+      setDeletingModel(model.repo_id);
+      try {
+        await deleteCachedModel(model.repo_id);
+        toast.success(`Deleted ${model.repo_id}`);
+        await refreshModels();
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to delete model",
+        );
+      } finally {
+        setDeletingModel(null);
+        setConfirmDelete(null);
+      }
+    },
+    [refreshModels],
+  );
+
+  const handleUpdate = useCallback(
+    async (model: CachedModel) => {
+      setUpdatingModel(model.repo_id);
+      try {
+        const result = await updateCachedModel(model.repo_id);
+        toast.success(result.message);
+        // Remove from updates map since we've processed it
+        setUpdates((prev) => {
+          const next = new Map(prev);
+          next.delete(model.repo_id.toLowerCase());
+          return next;
+        });
+        await refreshModels();
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to update model",
+        );
+      } finally {
+        setUpdatingModel(null);
+      }
+    },
+    [refreshModels],
+  );
+
+  useEffect(() => {
+    refreshModels();
+  }, [refreshModels]);
+
+  // Auto-check for updates after models are loaded
+  useEffect(() => {
+    if (!loading && allModels.length > 0 && updates.size === 0) {
+      checkForUpdates();
+    }
+  }, [loading, allModels.length]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-lg font-semibold font-heading">Model Manager</h1>
+        <p className="text-xs text-muted-foreground">
+          Manage your downloaded models. Delete unused models to free up disk
+          space, or check for updates to get the latest versions.
+        </p>
+      </header>
+
+      <SettingsSection
+        title="Downloaded Models"
+        description={
+          loading
+            ? "Loading..."
+            : `${allModels.length} model(s), ${formatBytes(totalSize)} total`
+        }
+      >
+        <div className="flex items-center gap-2 py-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={refreshModels}
+            disabled={loading}
+          >
+            <RefreshCwIcon
+              className={cn("size-3.5 mr-1.5", loading && "animate-spin")}
+            />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={checkForUpdates}
+            disabled={checkingUpdates || loading || allModels.length === 0}
+          >
+            <RefreshCwIcon
+              className={cn("size-3.5 mr-1.5", checkingUpdates && "animate-spin")}
+            />
+            Check for Updates
+          </Button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Spinner className="size-5" />
+          </div>
+        ) : allModels.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No downloaded models found.
+          </div>
+        ) : (
+          <div className="flex flex-col divide-y divide-border/40">
+            {allModels.map((model) => {
+              const updateInfo = updates.get(model.repo_id.toLowerCase());
+              const hasUpdate = updateInfo?.has_update ?? false;
+              const isDeleting = deletingModel === model.repo_id;
+              const isUpdating = updatingModel === model.repo_id;
+
+              return (
+                <div
+                  key={model.repo_id}
+                  className="flex items-center gap-3 py-3"
+                >
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <div className="flex items-center gap-2">
+                      <span className="min-w-0 truncate text-sm font-medium">
+                        {model.repo_id}
+                      </span>
+                      {hasUpdate && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="flex shrink-0 items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+                              <HugeiconsIcon
+                                icon={Download04Icon}
+                                className="size-3"
+                              />
+                              Update available
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-xs">
+                            <p>
+                              A newer version is available on Hugging Face.
+                            </p>
+                            <p className="mt-1 text-[10px] text-muted-foreground">
+                              Latest: {updateInfo?.latest_commit?.slice(0, 7)}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <span
+                        className={cn(
+                          "rounded px-1.5 py-0.5 text-[10px] font-medium uppercase",
+                          model.type === "gguf"
+                            ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                            : "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+                        )}
+                      >
+                        {model.type}
+                      </span>
+                      <span>{formatBytes(model.size_bytes)}</span>
+                    </div>
+                  </div>
+
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {hasUpdate && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleUpdate(model)}
+                        disabled={isUpdating || isDeleting}
+                        className="h-7 px-2 text-xs"
+                      >
+                        {isUpdating ? (
+                          <Spinner className="size-3 mr-1" />
+                        ) : (
+                          <HugeiconsIcon
+                            icon={Download04Icon}
+                            className="size-3 mr-1"
+                          />
+                        )}
+                        Update
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setConfirmDelete(model)}
+                      disabled={isDeleting || isUpdating}
+                      className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
+                    >
+                      {isDeleting ? (
+                        <Spinner className="size-3" />
+                      ) : (
+                        <HugeiconsIcon icon={Delete02Icon} className="size-3" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </SettingsSection>
+
+      <SettingsSection title="Tips">
+        <div className="py-3 text-xs text-muted-foreground leading-relaxed">
+          <ul className="list-disc pl-4 space-y-1.5">
+            <li>
+              <strong>GGUF models</strong> are quantized models optimized for
+              CPU/GPU inference with llama.cpp.
+            </li>
+            <li>
+              <strong>Regular models</strong> are full-precision Hugging Face
+              models used for training.
+            </li>
+            <li>
+              Deleting a model frees up disk space. You can re-download it later
+              when needed.
+            </li>
+            <li>
+              Updating a model will delete the old version and prepare for
+              downloading the latest version on next load.
+            </li>
+          </ul>
+        </div>
+      </SettingsSection>
+
+      <AlertDialog
+        open={confirmDelete !== null}
+        onOpenChange={(open) => !open && setConfirmDelete(null)}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete cached model?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove{" "}
+              <span className="font-medium text-foreground">
+                {confirmDelete?.repo_id}
+              </span>{" "}
+              ({formatBytes(confirmDelete?.size_bytes ?? 0)}) from disk. You can
+              re-download it later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => confirmDelete && handleDelete(confirmDelete)}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -91,6 +91,7 @@ export const en = {
       chat: "Chat",
       connections: "Connections",
       apiKeys: "API",
+      models: "Models",
       about: "Help",
     },
     general: {

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -91,6 +91,7 @@ export const zhCN = {
       chat: "聊天",
       connections: "连接",
       apiKeys: "API",
+      models: "模型",
       about: "帮助",
     },
     general: {


### PR DESCRIPTION
## Summary

### SSM Fast Inference (#4073)
- Adds SSM (State Space Model) detection for Mamba, LFM, NemotronH, FalconH1, Jamba architectures
- Sets `use_cache=False` for SSM models since they use state-based recurrence rather than KV cache
- Applies optimization to all generation paths: text, vision, audio input (ASR), and audio output (SNAC)

### Qwen3.5 Training Configs (#4202)
- Adds missing default configs for Qwen3.5-2B, 4B, 9B, and 35B-A3B models
- Configures appropriate batch sizes and learning rates for each model size
- Note: Qwen3.5 GDN layers require float32 training (already handled in core unsloth loader)

## Test plan
- [x] Code follows existing patterns
- [ ] Test SSM model inference (LFM2, Mamba models)
- [ ] Test Qwen3.5 training with new configs
- [ ] Verify no regression on standard attention models

## Files changed
- `studio/backend/core/inference/inference.py` - SSM detection + use_cache optimization
- `studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3.5-*.yaml` - New training configs

Refs: #4073, #4202