### PR TITLE
Setup: add Visual Studio Build Tools 2026 detection support

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -381,7 +381,7 @@ function Get-PytorchCudaTag {
 # Strategy: (1) vswhere, (2) scan filesystem (handles broken vswhere registration).
 # Returns @{ Generator = "Visual Studio 17 2022"; InstallPath = "C:\..."; Source = "..." } or $null.
 function Find-VsBuildTools {
-    $map = @{ '2022' = '17'; '2019' = '16'; '2017' = '15' }
+    $map = @{ '2026' = '18'; '2022' = '17'; '2019' = '16'; '2017' = '15' }
 
     # --- Try vswhere first (works when VS is properly registered) ---
     $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -400,7 +400,7 @@ function Find-VsBuildTools {
     # --- Scan filesystem (handles broken vswhere registration after winget cycles) ---
     $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)})
     $editions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
-    $years = @('2022', '2019', '2017')
+    $years = @('2026', '2022', '2019', '2017')
 
     foreach ($y in $years) {
         foreach ($r in $roots) {


### PR DESCRIPTION
## Summary
Add support for detecting Visual Studio Build Tools 2026 in the Windows setup script.

## Problem
The setup script only detected VS Build Tools 2022/2019/2017. Users with VS 2026 installed saw "Visual Studio Build Tools not found" and the installer downloaded VS 2022 unnecessarily.

## Solution
- Add VS 2026 (version 18) to the version map
- Add 2026 to the filesystem scan years (first position to prefer newer versions)
- Both vswhere and filesystem detection now recognize VS 2026

## Changes
```powershell
# Before
$map = @{ '2022' = '17'; '2019' = '16'; '2017' = '15' }
$years = @('2022', '2019', '2017')

# After  
$map = @{ '2026' = '18'; '2022' = '17'; '2019' = '16'; '2017' = '15' }
$years = @('2026', '2022', '2019', '2017')
```

## Test plan
- [ ] Test on Windows with VS Build Tools 2026 installed
- [ ] Verify detection via vswhere works for VS 2026
- [ ] Verify filesystem scan finds VS 2026 in standard paths
- [ ] Confirm fallback to 2022 still works when 2026 not present

Fixes #5859

🤖 Generated with [Claude Code](https://claude.com/claude-code)