### PR TITLE
Update Install Scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -6,6 +6,7 @@
 # irm | iex cannot forward arguments, so web installs take options as env vars set
 # before the pipe (flags still work via .\install.ps1):
 #   $env:UNSLOTH_NO_TORCH=1; irm https://unsloth.ai/install.ps1 | iex       # skip PyTorch (GGUF-only)
+#   $env:UNSLOTH_PYTHON='3.12'; irm https://unsloth.ai/install.ps1 | iex    # pin Python version
 #   $env:UNSLOTH_STUDIO_HOME='C:\path'; irm https://unsloth.ai/install.ps1 | iex
 #   .\install.ps1 --no-torch                                                # equivalent flag
 # Or pass flags to a scriptblock: & ([scriptblock]::Create((irm https://unsloth.ai/install.ps1))) --no-torch
@@ -141,7 +142,8 @@ function Install-UnslothStudio {
         return (Exit-InstallFailure "--package name contains invalid characters")
     }
 
-    $PythonVersion = "3.13"
+    # UNSLOTH_PYTHON pins the version (mirrors install.sh --python); default 3.13.
+    $PythonVersion = if ($env:UNSLOTH_PYTHON) { $env:UNSLOTH_PYTHON } else { "3.13" }
 
     # Resolve install destinations. Priority: UNSLOTH_STUDIO_HOME, then
     # STUDIO_HOME alias, then USERPROFILE-redirect, then default.
@@ -944,7 +946,9 @@ shell.Run cmd, 0, False
         # py.exe resolves to the standard CPython install, not conda.
         $pyLauncher = Get-Command py -CommandType Application -ErrorAction SilentlyContinue
         if ($pyLauncher -and $pyLauncher.Source -notmatch $script:CondaSkipPattern) {
-            foreach ($minor in @("3.13", "3.12", "3.11")) {
+            # Prefer the requested $PythonVersion, then newest-first fallback.
+            $minors = @($PythonVersion) + (@("3.13", "3.12", "3.11") | Where-Object { $_ -ne $PythonVersion })
+            foreach ($minor in $minors) {
                 try {
                     $out = & $pyLauncher.Source "-$minor" --version 2>&1 | Out-String
                     if ($out -match "Python (3\.1[1-3])\.\d+") {

--- a/install.ps1
+++ b/install.ps1
@@ -1,14 +1,19 @@
 # Unsloth Studio Installer for Windows PowerShell
-# Usage:  irm https://raw.githubusercontent.com/unslothai/unsloth/main/install.ps1 | iex
-# Local:  Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; .\install.ps1 --local
-# NoTorch: .\install.ps1 --no-torch  (skip PyTorch, GGUF-only mode)
-# Test:   .\install.ps1 --package roland-sloth
 #
-# Env vars (priority: UNSLOTH_STUDIO_HOME > STUDIO_HOME > USERPROFILE-redirect > default):
-#   UNSLOTH_STUDIO_HOME / STUDIO_HOME = path -> install under that path
-#   (DataDir nests inside; user PATH not modified persistently).
-# Default ($USERPROFILE\.unsloth\studio) is preserved when no env var is set.
-
+# Usage:  irm https://unsloth.ai/install.ps1 | iex
+#         Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; .\install.ps1 --local
+#
+# irm | iex cannot forward arguments, so web installs take options as env vars set
+# before the pipe (flags still work via .\install.ps1):
+#   $env:UNSLOTH_NO_TORCH=1; irm https://unsloth.ai/install.ps1 | iex       # skip PyTorch (GGUF-only)
+#   $env:UNSLOTH_STUDIO_HOME='C:\path'; irm https://unsloth.ai/install.ps1 | iex
+#   .\install.ps1 --no-torch                                                # equivalent flag
+# Or pass flags to a scriptblock: & ([scriptblock]::Create((irm https://unsloth.ai/install.ps1))) --no-torch
+#
+# Install dir priority: UNSLOTH_STUDIO_HOME > STUDIO_HOME (alias) > $USERPROFILE\.unsloth\studio
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 function Install-UnslothStudio {
     $ErrorActionPreference = "Stop"
     $script:UnslothVerbose = ($env:UNSLOTH_VERBOSE -eq "1")
@@ -112,6 +117,10 @@ function Install-UnslothStudio {
             }
         }
     }
+
+    # Env-var equivalent for web installs; an explicit flag still wins.
+    if ($env:UNSLOTH_NO_TORCH -in @('1', 'true', 'yes', 'on')) { $SkipTorch = $true }
+
     # Propagate to child processes so they also respect verbose mode.
     # Process-scoped -- does not persist.
     if ($script:UnslothVerbose) {

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
-# Unsloth Studio Installer
-# Usage (curl):  curl -fsSL https://unsloth.ai/install.sh | sh
-# Usage (wget):  wget -qO- https://unsloth.ai/install.sh | sh
-# Usage (local): ./install.sh --local   (install from local repo instead of PyPI)
-# Usage (no-torch): ./install.sh --no-torch  (skip PyTorch, GGUF-only mode)
-# Usage (test):  ./install.sh --package roland-sloth  (install a different package name)
-# Usage (py):    ./install.sh --python 3.12  (override auto-detected Python version)
 #
-# Env vars (priority: UNSLOTH_STUDIO_HOME > STUDIO_HOME > HOME-redirect > default):
-#   UNSLOTH_STUDIO_HOME=/abs/path  -> install under that path
-#   STUDIO_HOME=/abs/path          -> alias, same effect (UNSLOTH_STUDIO_HOME wins)
-#   (DATA_DIR + unsloth CLI shim nest inside; no shell rc-file append.)
-# Default ($HOME/.unsloth/studio) is preserved when no env var is set.
+# Unsloth Studio Installer
+#
+# Usage:  curl -fsSL https://unsloth.ai/install.sh | sh
+#         wget  -qO- https://unsloth.ai/install.sh | sh
+#         ./install.sh --local   (install from a cloned repo instead of PyPI)
+#
+# Piped installs take options as env vars after the pipe (a bare `| sh --no-torch`
+# makes sh reject --no-torch as its own option). Flags still work via ./install.sh:
+#   curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_NO_TORCH=1 sh    # skip PyTorch (GGUF-only)
+#   curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_PYTHON=3.12 sh   # pin Python version
+#   curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_STUDIO_HOME=/abs/path sh
+# Equivalent flags: ./install.sh --no-torch --python 3.12  (or pipe them: sh -s -- --no-torch)
+#
+# Install dir priority: UNSLOTH_STUDIO_HOME > STUDIO_HOME (alias) > $HOME/.unsloth/studio
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 set -e
 
 # ── Output style (aligned with studio/setup.sh) ──
@@ -69,6 +74,10 @@ for arg in "$@"; do
         --shortcuts-only) _SHORTCUTS_ONLY=true ;;
     esac
 done
+
+# Env-var equivalents for piped installs; an explicit flag still wins.
+case "${UNSLOTH_NO_TORCH:-}" in 1|true|TRUE|yes|YES|on|ON) _NO_TORCH_FLAG=true ;; esac
+[ -z "$_USER_PYTHON" ] && [ -n "${UNSLOTH_PYTHON:-}" ] && _USER_PYTHON="$UNSLOTH_PYTHON"
 
 if [ "$_VERBOSE" = true ]; then
     export UNSLOTH_VERBOSE=1

--- a/scripts/install_gemma4_mlx.sh
+++ b/scripts/install_gemma4_mlx.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 set -euo pipefail
 
 # ============================================================

--- a/scripts/install_qwen3_6_mlx.sh
+++ b/scripts/install_qwen3_6_mlx.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 set -euo pipefail
 
 # ============================================================

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+#
 # Unsloth Studio uninstaller for Windows PowerShell.
 # Stops running servers and removes install dir, launcher data, CLI shim,
 # desktop and Start Menu shortcuts, the user PATH entry, and the PathBackup

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+#
 # Unsloth Studio uninstaller (macOS / Linux / WSL).
 # Stops running servers and removes install dir, launcher data,
 # CLI shim, desktop shortcut, .app bundle, and Launch Services entry.

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -1406,7 +1406,7 @@ def install_python_stack() -> int:
     # When called from "unsloth studio update", it is NOT set so base packages
     # (unsloth + unsloth-zoo) are always reinstalled to pick up new versions.
     skip_base = os.environ.get("SKIP_STUDIO_BASE", "0") == "1"
-    # When --package is used, install a different package name (e.g. roland-sloth for testing)
+    # When --package is used, install a different package name (for testing)
     package_name = os.environ.get("STUDIO_PACKAGE_NAME", "unsloth")
     # When --local is used, overlay a local repo checkout after updating deps
     local_repo = os.environ.get("STUDIO_LOCAL_REPO", "")
@@ -1565,7 +1565,7 @@ def install_python_stack() -> int:
             constrain = False,
         )
     elif package_name != "unsloth":
-        # Custom package name (e.g. roland-sloth for testing) — install directly
+        # Custom package name (for testing), install directly
         _progress("base packages")
         pip_install(
             f"Installing {package_name}",

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2016,7 +2016,7 @@ if ($env:SKIP_STUDIO_BASE -ne "1" -and $env:STUDIO_LOCAL_INSTALL -ne "1") {
 #     # the fresh .venv. Install it so run_install() can find its modules
 #     # and bundled requirements files.
 #     Write-Host "   Installing package into venv..." -ForegroundColor Cyan
-#     pip install unsloth-roland-test 2>&1 | Out-Null
+#     pip install unsloth 2>&1 | Out-Null
 # }
 
 if (-not $SkipPythonDeps) {


### PR DESCRIPTION
## Summary

Tidies up the installer scripts and makes the piped web installs configurable without awkward argument passing.

## Changes

- **Environment variable options for piped installs.** `curl ... | sh` and `irm ... | iex` cannot take positional flags cleanly, so `install.sh` and `install.ps1` now also read the common toggles from the environment:
  - `UNSLOTH_NO_TORCH=1` skips PyTorch (GGUF only).
  - `UNSLOTH_PYTHON=3.12` pins the Python version (`install.sh`).
  - Positional flags (`./install.sh --no-torch`, `.\install.ps1 --no-torch`) and the pipe forms (`sh -s -- --no-torch`, the PowerShell scriptblock) still work. An explicit flag wins over the env var.
- **Fix the `UNSLOTH_STUDIO_HOME` example.** Placed before `curl` the variable attaches to curl, not `sh`, so the custom install dir was never picked up. It now sits after the pipe: `curl ... | UNSLOTH_STUDIO_HOME=/abs/path sh`.
- **SPDX headers.** Added `SPDX-License-Identifier: AGPL-3.0-only` plus the copyright line to `install.sh`, `install.ps1`, `scripts/uninstall.sh`, `scripts/uninstall.ps1`, `scripts/install_gemma4_mlx.sh`, and `scripts/install_qwen3_6_mlx.sh`, matching `studio/setup.sh`.
- **Comment cleanup.** Removed the internal test package names from the `studio/install_python_stack.py` and `studio/setup.ps1` comments and tightened the installer header comments.

## Usage

Linux, macOS, WSL:

```sh
curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_NO_TORCH=1 sh
```

Windows:

```powershell
$env:UNSLOTH_NO_TORCH=1; irm https://unsloth.ai/install.ps1 | iex
```

## Testing

- PowerShell AST (`Parser::ParseFile`): 0 errors on `install.ps1`, `scripts/uninstall.ps1`, `studio/setup.ps1`.
- Python AST (`ast.parse`): clean on `studio/install_python_stack.py`.
- Shell syntax (`sh -n` / `bash -n`): clean on all shell scripts.
- Confirmed the env vars resolve and that flags still override them on dash, bash, and zsh, and that the PowerShell condition matches `1`, `true`, `yes`, `on` case-insensitively.
