### PR TITLE
fix(studio): make the reset-password hint work on Windows, macOS, and Linux

### DIFF
--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -9,6 +9,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 import ipaddress
 import os
+import shlex
+import sys
 import threading
 import time
 from collections import deque
@@ -36,6 +38,36 @@ from auth.authentication import (
 )
 
 router = APIRouter()
+
+
+def _reset_password_command() -> str:
+    """Shell command shown in the 'incorrect password' hint.
+
+    Prefer the ABSOLUTE path to this install's ``unsloth`` launcher (a sibling
+    of the running interpreter) so the hint works even when the launcher's
+    directory is not on PATH -- e.g. a terminal opened before install, a stale
+    Windows PATH, or ``~/.local/bin`` not on PATH (the default on macOS) -- and
+    regardless of the current working directory.
+
+    On POSIX the path is shell-quoted so spaces are handled. On Windows we only
+    use the bare absolute path when it has no spaces, because a quoted path needs
+    different syntax in cmd (``"..."``) vs PowerShell (``& "..."``); when it has
+    a space we fall back to the PATH-based form to stay unambiguous across
+    shells. If the launcher can't be located we fall back to the PATH form too.
+    """
+    try:
+        bin_dir = os.path.dirname(os.path.abspath(sys.executable))
+        if os.name == "nt":
+            exe = os.path.join(bin_dir, "unsloth.exe")
+            if os.path.isfile(exe) and " " not in exe:
+                return f"{exe} studio reset-password"
+        else:
+            exe = os.path.join(bin_dir, "unsloth")
+            if os.path.isfile(exe):
+                return f"{shlex.quote(exe)} studio reset-password"
+    except Exception:
+        pass
+    return "unsloth studio reset-password"
 
 
 # Per-(ip, username) bucket + per-IP aggregate. Account bucket stops one user's
@@ -228,7 +260,7 @@ async def login(payload: AuthLoginRequest, request: Request) -> Token:
         _record_login_failure(unknown_key)
         raise HTTPException(
             status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Incorrect password. Run 'unsloth studio reset-password' in your terminal to reset it.",
+            detail = f"Incorrect password. Run '{_reset_password_command()}' in your terminal to reset it.",
         )
 
     salt, pwd_hash, _jwt_secret, must_change_password = record
@@ -236,7 +268,7 @@ async def login(payload: AuthLoginRequest, request: Request) -> Token:
         _record_login_failure(key)
         raise HTTPException(
             status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = "Incorrect password. Run 'unsloth studio reset-password' in your terminal to reset it.",
+            detail = f"Incorrect password. Run '{_reset_password_command()}' in your terminal to reset it.",
         )
 
     _clear_login_bucket(key)

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -10,7 +10,6 @@ import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ReactElement } from "react";
 import type { SyntheticEvent } from "react";
-import { usePlatformStore } from "@/config/env";
 import { refreshSession } from "../api";
 
 // Bootstrap credentials injected into index.html by the backend
@@ -294,13 +293,13 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
       storeAuthTokens(token.access_token, token.refresh_token);
       navigate({ to: getPostAuthRoute() });
     } catch (err: unknown) {
-      let msg = err instanceof Error ? err.message : "Auth failed.";
-      if (msg.includes("unsloth studio reset-password") && usePlatformStore.getState().deviceType === "windows") {
-        msg = msg.replace(
-          "unsloth studio reset-password",
-          ".\\unsloth_studio\\Scripts\\unsloth.exe studio reset-password",
-        );
-      }
+      // The backend already returns the correct, PATH-based command
+      // ("unsloth studio reset-password"), which the installer puts on PATH on
+      // every platform. Do NOT rewrite it to a relative Windows path like
+      // ".\unsloth_studio\Scripts\unsloth.exe ..." -- that only resolves when the
+      // terminal happens to be inside the Studio home dir, so it fails with
+      // CommandNotFoundException everywhere else. Show the backend message as-is.
+      const msg = err instanceof Error ? err.message : "Auth failed.";
       setError(msg);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Problem

On the Studio login screen, an incorrect password tells the user to run a command to reset it. On **Windows** that command was broken, and on **all platforms** it relied on the launcher being on `PATH`.

### 1. Windows: broken relative path (hard failure)

The hint showed:

> Run `.\unsloth_studio\Scripts\unsloth.exe studio reset-password` …

a **relative** path that only resolves when the terminal is already inside the Studio home dir (`~\.unsloth\studio`). From any normal directory (e.g. `C:\Users\<you>`) it fails:

```
.\unsloth_studio\Scripts\unsloth.exe : The term ... is not recognized ...
    + FullyQualifiedErrorId : CommandNotFoundException
```

Root cause: the backend returns the correct `unsloth studio reset-password`, but `auth-form.tsx` rewrote it **on Windows only** into that relative path.

### 2. All platforms: PATH reliance (soft failure)

Even the correct `unsloth studio reset-password` only works once the launcher dir is on `PATH`. The installer adds it, but it isn't active when a terminal was opened before install (stale `PATH`), or when `~/.local/bin` isn't on `PATH` (the default on **macOS**), etc.

## Fix

- **Frontend (`auth-form.tsx`):** remove the Windows-only rewrite (and its now-unused `usePlatformStore` import); show the backend's command as-is.
- **Backend (`routes/auth.py`):** emit the **absolute path** to this install's own `unsloth` launcher (a sibling of `sys.executable`), so the command works regardless of `PATH` or current directory on Windows, macOS, and Linux. POSIX paths are shell-quoted; on Windows the bare absolute path is used when it has no spaces (works in both cmd and PowerShell), otherwise it falls back to the `PATH` form to avoid cmd-vs-PowerShell quoting differences. Falls back to `unsloth studio reset-password` if the launcher can't be located.

The CLI command name is unchanged, so CI smoke steps that call `unsloth studio reset-password` directly are unaffected.

## Verification

- **Windows:** emitted hint is `C:\Users\<you>\.unsloth\studio\unsloth_studio\Scripts\unsloth.exe studio reset-password`; the bare absolute path runs in PowerShell and resolves `reset-password`. The old relative form throws `CommandNotFoundException` from `C:\Users\<you>`.
- **Linux (WSL):** emitted hint is `/…/.unsloth/studio/unsloth_studio/bin/unsloth studio reset-password`; the absolute path runs and resolves `reset-password`.
- `studio/frontend` `npm run typecheck` passes for the change (the one remaining `tsc` error, `@tauri-apps/plugin-window-state` in `provider.tsx`, is a pre-existing desktop-only module-resolution issue unrelated to this PR). `auth.py` passes `py_compile`. No backend tests assert the message string.
