### PR TITLE
Document install env vars in README advanced launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,33 @@ unsloth studio -p 8888
 ```
 
 #### Advanced launch options
-Cap Studio's native CPU thread pools on high-core hosts: `UNSLOTH_CPU_THREADS=8 unsloth studio -p 8888`. Explicit `OMP_NUM_THREADS` / `MKL_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `NUMEXPR_NUM_THREADS` still take precedence.
+Installer options can be passed as environment variables. On macOS, Linux and WSL place the variable after the pipe so the shell passes it to `sh`; on Windows set it with `$env:` before piping to `iex`.
+
+Skip PyTorch (GGUF-only mode):
+```bash
+curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_NO_TORCH=1 sh
+```
+```powershell
+$env:UNSLOTH_NO_TORCH=1; irm https://unsloth.ai/install.ps1 | iex
+```
+
+Pin the Python version:
+```bash
+curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_PYTHON=3.12 sh
+```
+```powershell
+$env:UNSLOTH_PYTHON='3.12'; irm https://unsloth.ai/install.ps1 | iex
+```
+
+Install to a custom location with `UNSLOTH_STUDIO_HOME`:
+```bash
+curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_STUDIO_HOME=/abs/path sh
+```
+```powershell
+$env:UNSLOTH_STUDIO_HOME='C:\path'; irm https://unsloth.ai/install.ps1 | iex
+```
+
+Cap Studio's native CPU thread pools on high-core hosts: `UNSLOTH_CPU_THREADS=8 unsloth studio -p 8888`.
 
 #### Uninstall
 The recommended way to fully remove Unsloth Studio is the matching uninstall script for your OS. It stops any running servers, removes the install dir, the launcher data dir, the desktop shortcut, and any platform-specific entries (macOS `.app` bundle + Launch Services on Mac; Start Menu, `HKCU\Software\Unsloth` registry key and user `PATH` entries on Windows):


### PR DESCRIPTION
## Summary

Expands the README "Advanced launch options" section so the installer environment variables are documented with copyable examples.

## Changes

- Adds per-platform, single-cell examples for the three installer environment variables:
  - `UNSLOTH_NO_TORCH=1` (skip PyTorch, GGUF-only mode)
  - `UNSLOTH_PYTHON=3.12` (pin the Python version)
  - `UNSLOTH_STUDIO_HOME` (install to a custom location)
- Each command is its own fenced code block so it copies as one cell. macOS, Linux and WSL place the variable after the pipe (`curl ... | UNSLOTH_NO_TORCH=1 sh`); Windows sets `$env:` before piping to `iex`.
- Simplifies the `UNSLOTH_CPU_THREADS` note (drops the `OMP_NUM_THREADS` / `MKL_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `NUMEXPR_NUM_THREADS` precedence sentence) and moves it to the end of the section.

Documentation only; no code changes.
