### PR TITLE
fix(studio): don't double-quote the reset-password hint for paths with spaces

### DIFF
--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -260,7 +260,7 @@ async def login(payload: AuthLoginRequest, request: Request) -> Token:
         _record_login_failure(unknown_key)
         raise HTTPException(
             status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = f"Incorrect password. Run '{_reset_password_command()}' in your terminal to reset it.",
+            detail = f"Incorrect password. To reset it, run this in your terminal: {_reset_password_command()}",
         )
 
     salt, pwd_hash, _jwt_secret, must_change_password = record
@@ -268,7 +268,7 @@ async def login(payload: AuthLoginRequest, request: Request) -> Token:
         _record_login_failure(key)
         raise HTTPException(
             status_code = status.HTTP_401_UNAUTHORIZED,
-            detail = f"Incorrect password. Run '{_reset_password_command()}' in your terminal to reset it.",
+            detail = f"Incorrect password. To reset it, run this in your terminal: {_reset_password_command()}",
         )
 
     _clear_login_bucket(key)


### PR DESCRIPTION
## Problem

Follow-up to #5971 (already merged). The "incorrect password" hint wraps the reset command in single quotes:

```python
detail = f"Incorrect password. Run '{_reset_password_command()}' in your terminal to reset it."
```

But `_reset_password_command()` already shell-quotes the launcher path on POSIX (`shlex.quote`). When the installed `unsloth` path contains a space (custom `UNSLOTH_STUDIO_HOME`, or a home dir with a space), the result is **double-quoted**:

```
Incorrect password. Run ''/tmp/Unsloth Studio/unsloth_studio/bin/unsloth' studio reset-password' in your terminal to reset it.
```

A shell parses `''/tmp/.../unsloth'` as the empty string concatenated with the path, breaking the recovery command. Both the unknown-user and wrong-password branches are affected. (Flagged by chatgpt-codex on #5971 after it had already merged.)

## Fix

Drop the outer quotes and put the command at the **end** of the message, so it's unambiguous and copy-pasteable in every case (the helper's own quoting is the only quoting):

```python
detail = f"Incorrect password. To reset it, run this in your terminal: {_reset_password_command()}"
```

Resulting hints:
- default install: `… run this in your terminal: unsloth studio reset-password`
- Windows abs path: `… run this in your terminal: C:\Users\you\.unsloth\studio\unsloth_studio\Scripts\unsloth.exe studio reset-password`
- spaced POSIX path: `… run this in your terminal: '/tmp/Unsloth Studio/unsloth_studio/bin/unsloth' studio reset-password`

## Notes

- 2-line change; `auth.py` passes `py_compile`. No test asserts the message string. The frontend displays the backend `detail` as-is (the Windows-only rewrite was removed in #5971), so no frontend change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
