### PR TITLE
Fix macOS Apple Silicon installs resolving torch against x86_64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1529,7 +1529,17 @@ fi
 if [ ! -x "$VENV_DIR/bin/python" ]; then
     step "venv" "creating Python ${PYTHON_VERSION} virtual environment"
     substep "$VENV_DIR"
-    run_install_cmd "create venv" uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
+    if [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ] && [ -z "$_USER_PYTHON" ]; then
+        # Apple Silicon: request an arch-explicit arm64 CPython so uv cannot
+        # reuse a cached x86_64 (Rosetta) build. torch ships no macOS x86_64
+        # wheels since 2.2.2, so an x86_64 venv makes the torch install
+        # unresolvable. The arm64 guard below is kept as a backstop for
+        # migrated / pre-existing venvs.
+        run_install_cmd "create venv" uv venv "$VENV_DIR" \
+            --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
+    else
+        run_install_cmd "create venv" uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
+    fi
 fi
 
 # Mark the freshly-created venv as Studio-owned so a partial install can be
@@ -1561,6 +1571,18 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
     _info=$(_inspect_venv)
     _VENV_ARCH=${_info%% *}
     _PY_VER=${_info##* }
+    # If the interpreter could not be executed (an x86_64 venv python on a Mac
+    # without Rosetta installed), the probe above yields an empty arch. Fall
+    # back to reading the binary's Mach-O arch statically so the x86_64
+    # recreate below still triggers instead of letting uv fail later.
+    if [ -z "$_VENV_ARCH" ] && [ -x "$VENV_DIR/bin/python" ]; then
+        _archs=$(lipo -archs "$VENV_DIR/bin/python" 2>/dev/null \
+            || file "$VENV_DIR/bin/python" 2>/dev/null)
+        case "$_archs" in
+            *arm64*)  _VENV_ARCH=arm64 ;;
+            *x86_64*) _VENV_ARCH=x86_64 ;;
+        esac
+    fi
 
     if [ "$_VENV_ARCH" = "x86_64" ]; then
         echo "  WARNING: venv was created with an x86_64 (Rosetta) Python on Apple Silicon."

--- a/install.sh
+++ b/install.sh
@@ -1576,8 +1576,11 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
     # back to reading the binary's Mach-O arch statically so the x86_64
     # recreate below still triggers instead of letting uv fail later.
     if [ -z "$_VENV_ARCH" ] && [ -x "$VENV_DIR/bin/python" ]; then
+        # uv symlinks bin/python to the base interpreter, so dereference with
+        # file -L (lipo already follows the link). Trailing || true keeps the
+        # installer alive under set -e when neither tool is present.
         _archs=$(lipo -archs "$VENV_DIR/bin/python" 2>/dev/null \
-            || file "$VENV_DIR/bin/python" 2>/dev/null)
+            || file -L "$VENV_DIR/bin/python" 2>/dev/null || true)
         case "$_archs" in
             *arm64*)  _VENV_ARCH=arm64 ;;
             *x86_64*) _VENV_ARCH=x86_64 ;;


### PR DESCRIPTION
## Problem

On Apple Silicon Macs the Studio installer can fail at the PyTorch step with:

```
× No solution found when resolving dependencies:
  ╰─▶ ... torch>=2.6.0,<=2.10.0+cpu has no wheels with a matching
      platform tag (e.g., macosx_26_0_x86_64) ...
And because you require torch>=2.6,<2.11.0, ... your requirements are unsatisfiable.
hint: Wheels are available for torch (v2.10.0+cpu) on the following platforms:
manylinux_2_28_aarch64, manylinux_2_28_x86_64, ..., win_amd64, ...
```

The shell is native arm64 (the `torch>=2.6,<2.11.0` constraint is only set on the macOS arm64 + Python 3.13 branch), but the resolver targets `macosx_*_x86_64`. That means the venv interpreter is x86_64: `uv venv --python 3.13` reused a cached x86_64 (Rosetta) CPython, often because uv itself is an x86_64 build. PyTorch has shipped no macOS x86_64 wheels since 2.2.2, so no `torch>=2.6` wheel exists for that platform on any index and resolution is unsatisfiable.

Note the `download.pytorch.org/whl/cpu` index is not at fault: it does carry macOS arm64 wheels (e.g. `torch-2.10.0-cp313-none-macosx_11_0_arm64.whl`). A correctly-arm64 venv resolves fine. The bug is purely the venv interpreter arch.

The existing x86_64 guard did not catch it: it detects the arch by executing the venv python (`platform.machine()`). When that python is x86_64 and Rosetta is absent, the probe fails silently, the arch comes back empty, the recreate is skipped, and uv then resolves statically against x86_64 and fails.

## Fix

Both changes are scoped to macOS arm64 and additive. No other install path (Linux CUDA/ROCm/CPU, WSL, Intel Mac, `--python` override, migrated env) changes behavior.

1. Create the venv with an arch-explicit `cpython-${PYTHON_VERSION}-macos-aarch64-none` request on Apple Silicon (when no `--python` is given), so uv cannot reuse a cached x86_64 interpreter. This matches the string already used by the recreate paths below it.
2. Harden the x86_64 guard: when the venv python cannot be executed, fall back to reading the binary's Mach-O arch via `lipo`/`file` so migrated or pre-existing x86_64 venvs are still recreated as arm64. Safe no-op if both tools are unavailable.

## Verification

- `bash -n` and `sh -n` pass.
- shellcheck (sh dialect): no new findings introduced; edited regions clean.
- Branch-selection simulation over every variable combination confirms only macOS arm64 (without `--python`) takes the new path; Linux x86_64/aarch64, WSL, Intel Mac, and the arm64 `--python` override all use the original command verbatim.