### PR TITLE
studio(ui): use the --primary brand token for the avatar fallback color

### DIFF
--- a/studio/frontend/src/features/profile/utils/avatar-initials.ts
+++ b/studio/frontend/src/features/profile/utils/avatar-initials.ts
@@ -10,12 +10,16 @@ export function initialsFromName(name: string): string {
 /**
  * Default Unsloth-brand background for the avatar fallback (readable white text).
  *
- * Uses the shared `--primary` design token (#17b88b) instead of a one-off
- * hardcoded shade, so the avatar always matches the app's general brand green
- * (send button, primary buttons, etc.). It previously hardcoded a slightly
- * different `#14b789`, which looked inconsistent next to primary-colored UI
- * such as the artifact preview/code panel.
+ * Uses the shared `--primary` design token instead of a one-off hardcoded
+ * shade, so the avatar always matches the app's general brand green (send
+ * button, primary buttons, etc.). It previously hardcoded a slightly different
+ * `#14b789`, which looked inconsistent next to primary-colored UI such as the
+ * artifact preview/code panel.
+ *
+ * The literal fallback (the current `--primary` value) only applies if this
+ * reusable avatar is ever rendered outside the theme root, where `--primary`
+ * is undefined -- it keeps the avatar branded instead of transparent.
  */
 export function avatarBgStyle(): { backgroundColor: string } {
-  return { backgroundColor: "var(--primary)" };
+  return { backgroundColor: "var(--primary, #17b88b)" };
 }

--- a/studio/frontend/src/features/profile/utils/avatar-initials.ts
+++ b/studio/frontend/src/features/profile/utils/avatar-initials.ts
@@ -7,7 +7,15 @@ export function initialsFromName(name: string): string {
   return trimmed[0]!.toUpperCase();
 }
 
-/** Default Unsloth-green background for avatar fallback (readable white text). */
+/**
+ * Default Unsloth-brand background for the avatar fallback (readable white text).
+ *
+ * Uses the shared `--primary` design token (#17b88b) instead of a one-off
+ * hardcoded shade, so the avatar always matches the app's general brand green
+ * (send button, primary buttons, etc.). It previously hardcoded a slightly
+ * different `#14b789`, which looked inconsistent next to primary-colored UI
+ * such as the artifact preview/code panel.
+ */
 export function avatarBgStyle(): { backgroundColor: string } {
-  return { backgroundColor: "#14b789" };
+  return { backgroundColor: "var(--primary)" };
 }


### PR DESCRIPTION
## Problem
The fallback profile avatar (the “U” chip in the sidebar footer) hardcoded `#14b789` — a slightly different green from the app’s general brand color `--primary` (`#17b88b`), which the send button and every other primary-colored control already use. Next to primary-colored UI — e.g. the artifact **preview/code** panel — the avatar’s off-brand shade looked inconsistent (“changes color weirdly”).

## Fix
Point `avatarBgStyle()` at `var(--primary)` so the avatar always renders the **general** brand green and follows the theme token.

This is the only hardcoded brand-green left in the frontend — every other brand-green element already uses `--primary` / `bg-primary` (audited: `#14b789` had a single occurrence).

## Verification
Confirmed live in Studio: the avatar computed to `rgb(20,183,137)` (`#14b789`) while `--primary` resolves to `rgb(23,184,139)` (`#17b88b`); the change unifies them. White text stays readable on `#17b88b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)