### PR TITLE
Fix chat text cutoff at composer dock and speed up plus icon spin

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -380,9 +380,10 @@ const ThreadComposerDock: FC<{
         overlay ? "z-40" : "z-20",
       )}
     >
+      {/* Fade the top edge so scrolling text is not cut off by a hard line. */}
       <div
         aria-hidden={true}
-        className="absolute inset-x-0 bottom-0 top-[10px] bg-background"
+        className="absolute inset-x-0 bottom-0 top-[10px] bg-gradient-to-t from-background from-[calc(100%_-_28px)] to-transparent"
       />
       <div className="relative px-5 pb-2">
         <div className="pointer-events-auto mx-auto w-full max-w-(--thread-max-width)">

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1140,7 +1140,7 @@
 	/* Open menu rotates the plus 45deg into an x. Ease-in-out for a smooth
 	   spin; keep it at 45deg so it never passes back through a "+". */
 	.unsloth-composer-plus svg {
-		transition: transform 300ms cubic-bezier(0.65, 0, 0.35, 1);
+		transition: transform 250ms cubic-bezier(0.65, 0, 0.35, 1);
 		will-change: transform;
 	}
 
@@ -2009,6 +2009,6 @@
 	/* Keep the plus/x morph animating under reduced motion (small rotation,
 	   like the spinners above). */
 	.unsloth-composer-plus svg {
-		transition-duration: 300ms !important;
+		transition-duration: 250ms !important;
 	}
 }


### PR DESCRIPTION
## What this fixes

Two small Studio chat polish items:

1. **Chat text was cut off by a white block at the composer.** The backdrop behind the chat input is a solid `bg-background` block with a hard top edge, so any message text scrolling underneath it gets sharply clipped at that edge. This is most visible next to the rounded corners of the input, where a line of text just stops mid-character against a flat block.

2. **The plus to x rotation on the composer menu felt a touch slow.** When the tools menu opens, the plus icon rotates 45 degrees into an x over 300ms.

## Changes

- `thread.tsx`: the `ThreadComposerDock` backdrop now fades its top 28px to transparent via `bg-gradient-to-t from-background from-[calc(100%_-_28px)] to-transparent`, so text fades out smoothly behind the composer instead of hitting a hard line. Everything below the fade band stays fully opaque, same as before.
- `index.css`: the plus icon rotation is now 250ms (was 300ms), with the same easing curve. The reduced motion override is updated to match so both paths stay in sync.

## Before / after

Before: text scrolling under the composer is clipped by a hard edge.

After: text fades out over the top 28px of the backdrop, and the plus to x spin is slightly snappier.

Tested locally in Studio chat in both light and dark mode with long conversations scrolled mid-message under the composer.