### PR TITLE
fix(studio): disable mlx gc for none

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1362,7 +1362,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
     gc_setting = config.get("gradient_checkpointing", "mlx")
     if isinstance(gc_setting, str):
         use_grad_checkpoint = (
-            gc_setting if gc_setting.lower() not in ("false", "") else False
+            gc_setting if gc_setting.lower() not in ("false", "none", "") else False
         )
     else:
         use_grad_checkpoint = gc_setting


### PR DESCRIPTION
set `Grad Checkpoint` to `None` in Studio does not disable gradient checkpointing


https://github.com/unslothai/unsloth/blob/ae6c2594a21a6714cf0005fa11d7858a7b67d8b8/studio/backend/core/training/worker.py#L1239-L1248


https://github.com/unslothai/unsloth-zoo/blob/4f70b5f1d7e0a0e323cdcc889439e8addf303fd2/unsloth_zoo/mlx/trainer.py#L1057-L1060