### PR TITLE
fix: warn when localhost resolves to ::1 but Studio is bound only to 127.0.0.1

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -158,10 +158,13 @@ def _working_local_url(port: int) -> "str | None":
 
 
 def _localhost_ipv6_mismatch_url(bind_host: str, port: int) -> "str | None":
-    """Return the IPv4 loopback URL when localhost resolves only to ::1.
+    """Return the IPv4 loopback URL when localhost will not reach 127.0.0.1.
 
     Local Studio intentionally binds to 127.0.0.1. On hosts where localhost
-    resolves to IPv6 only, browsers can fail even though 127.0.0.1 works.
+    resolves to IPv6 only (::1), a browser pointed at http://localhost:<port>
+    fails -- or worse, reaches a different process listening on ::1 -- even
+    though http://127.0.0.1:<port> works. Return the IPv4 URL so the caller can
+    tell the user which address to open.
     """
     import socket
 
@@ -169,11 +172,12 @@ def _localhost_ipv6_mismatch_url(bind_host: str, port: int) -> "str | None":
         return None
 
     ipv4_url = f"http://127.0.0.1:{port}"
+
+    # Only warn once Studio is confirmed answering on the IPv4 loopback.
+    if _working_local_url(port) != ipv4_url:
+        return None
+
     try:
-        if _working_local_url(port) != ipv4_url:
-            return None
-        if _local_port_open("::1", port, timeout = 0.25):
-            return None
         addr_info = socket.getaddrinfo(
             "localhost", port, socket.AF_UNSPEC, socket.SOCK_STREAM
         )
@@ -193,9 +197,26 @@ def _localhost_ipv6_mismatch_url(bind_host: str, port: int) -> "str | None":
             if host == "::1":
                 has_ipv6_loopback = True
 
+    # A successful connection to ::1 is NOT evidence that Studio is reachable
+    # there: Studio binds 127.0.0.1 only, so anything answering on ::1 is a
+    # different process -- which is exactly when the user must be steered to
+    # 127.0.0.1. Dual-stack localhost is fine (browsers fall back to 127.0.0.1
+    # when ::1 refuses), so only the IPv6-only case strands the user.
     if has_ipv6_loopback and not has_ipv4_loopback:
         return ipv4_url
     return None
+
+
+def _stdout_color_ok() -> bool:
+    """Whether to emit ANSI color codes on stdout. Mirrors startup_banner."""
+    if os.environ.get("NO_COLOR", "").strip():
+        return False
+    if os.environ.get("FORCE_COLOR", "").strip():
+        return True
+    try:
+        return sys.stdout.isatty()
+    except (AttributeError, OSError, ValueError):
+        return False
 
 
 def _print_localhost_ipv6_mismatch_warning(local_url: str, port: int) -> None:
@@ -210,18 +231,6 @@ def _print_localhost_ipv6_mismatch_warning(local_url: str, port: int) -> None:
         f"http://localhost:{port}.{reset}",
         flush = True,
     )
-
-
-def _stdout_color_ok() -> bool:
-    """Whether to emit ANSI color codes on stdout. Mirrors startup_banner."""
-    if os.environ.get("NO_COLOR", "").strip():
-        return False
-    if os.environ.get("FORCE_COLOR", "").strip():
-        return True
-    try:
-        return sys.stdout.isatty()
-    except (AttributeError, OSError, ValueError):
-        return False
 
 
 def _verify_global_reachability(display_host: str, port: int) -> None:
@@ -387,6 +396,33 @@ def _verify_global_reachability(display_host: str, port: int) -> None:
         pass
     except Exception:
         pass
+
+
+def _emit_startup_output(host: str, port: int, display_host: str) -> None:
+    """Print the access banner plus any post-startup warnings.
+
+    Extracted from ``_run`` so the banner/warning wiring is unit-testable. The
+    ``localhost``-to-::1 mismatch warning and the wildcard reachability check
+    are mutually exclusive (the mismatch helper returns None for any non
+    127.0.0.1 bind, and wildcard binds are never 127.0.0.1), so the trailing
+    stop hint is emitted exactly once.
+    """
+    wildcard_bind = host in ("0.0.0.0", "::")
+    localhost_mismatch_url = _localhost_ipv6_mismatch_url(host, port)
+    # For wildcard binds, run the reachability check between the URL section
+    # and the stop hint so the stop hint stays last on screen.
+    print_studio_access_banner(
+        port = port,
+        bind_host = host,
+        display_host = display_host,
+        include_stop_hint = not wildcard_bind and not localhost_mismatch_url,
+    )
+    if localhost_mismatch_url:
+        _print_localhost_ipv6_mismatch_warning(localhost_mismatch_url, port)
+        print_studio_stop_hint()
+    elif wildcard_bind:
+        _verify_global_reachability(display_host, port)
+        print_studio_stop_hint()
 
 
 def _get_pid_on_port(port: int) -> "tuple[int, str] | None":
@@ -878,22 +914,7 @@ def run_server(
         print(f"TAURI_PORT={port}", flush = True)
 
     if not silent:
-        wildcard_bind = host in ("0.0.0.0", "::")
-        localhost_mismatch_url = _localhost_ipv6_mismatch_url(host, port)
-        # For wildcard binds, run the reachability check between the URL
-        # section and the stop hint so the stop hint stays last on screen.
-        print_studio_access_banner(
-            port = port,
-            bind_host = host,
-            display_host = display_host,
-            include_stop_hint = not wildcard_bind and not localhost_mismatch_url,
-        )
-        if localhost_mismatch_url:
-            _print_localhost_ipv6_mismatch_warning(localhost_mismatch_url, port)
-            print_studio_stop_hint()
-        if wildcard_bind:
-            _verify_global_reachability(display_host, port)
-            print_studio_stop_hint()
+        _emit_startup_output(host, port, display_host)
 
     return app
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -157,6 +157,61 @@ def _working_local_url(port: int) -> "str | None":
     return None
 
 
+def _localhost_ipv6_mismatch_url(bind_host: str, port: int) -> "str | None":
+    """Return the IPv4 loopback URL when localhost resolves only to ::1.
+
+    Local Studio intentionally binds to 127.0.0.1. On hosts where localhost
+    resolves to IPv6 only, browsers can fail even though 127.0.0.1 works.
+    """
+    import socket
+
+    if bind_host != "127.0.0.1" or not port or port <= 0:
+        return None
+
+    ipv4_url = f"http://127.0.0.1:{port}"
+    try:
+        if _working_local_url(port) != ipv4_url:
+            return None
+        if _local_port_open("::1", port, timeout = 0.25):
+            return None
+        addr_info = socket.getaddrinfo(
+            "localhost", port, socket.AF_UNSPEC, socket.SOCK_STREAM
+        )
+    except Exception:
+        return None
+
+    if not addr_info:
+        return None
+
+    has_ipv4_loopback = False
+    has_ipv6_loopback = False
+    for family, _, _, _, sockaddr in addr_info:
+        if family == socket.AF_INET and sockaddr and sockaddr[0] == "127.0.0.1":
+            has_ipv4_loopback = True
+        elif family == socket.AF_INET6 and sockaddr:
+            host = sockaddr[0].split("%", 1)[0]
+            if host == "::1":
+                has_ipv6_loopback = True
+
+    if has_ipv6_loopback and not has_ipv4_loopback:
+        return ipv4_url
+    return None
+
+
+def _print_localhost_ipv6_mismatch_warning(local_url: str, port: int) -> None:
+    """Warn that localhost points at ::1 while Studio is bound to 127.0.0.1."""
+    use_color = _stdout_color_ok()
+    warn_c = "\033[38;5;215;1m" if use_color else ""
+    reset = "\033[0m" if use_color else ""
+
+    print(
+        f"{warn_c}  Warning: localhost resolves to IPv6 (::1), but Unsloth "
+        f"Studio is listening on 127.0.0.1 only. Open {local_url} instead of "
+        f"http://localhost:{port}.{reset}",
+        flush = True,
+    )
+
+
 def _stdout_color_ok() -> bool:
     """Whether to emit ANSI color codes on stdout. Mirrors startup_banner."""
     if os.environ.get("NO_COLOR", "").strip():
@@ -824,14 +879,18 @@ def run_server(
 
     if not silent:
         wildcard_bind = host in ("0.0.0.0", "::")
+        localhost_mismatch_url = _localhost_ipv6_mismatch_url(host, port)
         # For wildcard binds, run the reachability check between the URL
         # section and the stop hint so the stop hint stays last on screen.
         print_studio_access_banner(
             port = port,
             bind_host = host,
             display_host = display_host,
-            include_stop_hint = not wildcard_bind,
+            include_stop_hint = not wildcard_bind and not localhost_mismatch_url,
         )
+        if localhost_mismatch_url:
+            _print_localhost_ipv6_mismatch_warning(localhost_mismatch_url, port)
+            print_studio_stop_hint()
         if wildcard_bind:
             _verify_global_reachability(display_host, port)
             print_studio_stop_hint()

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -11,7 +11,9 @@ No GPU, no network, no torch required -- all I/O is monkeypatched.
 """
 
 import importlib.util
+import socket
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -19,6 +21,7 @@ import pytest
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[3]
 MODULE_PATH = PACKAGE_ROOT / "studio" / "install_llama_prebuilt.py"
+RUN_MODULE_PATH = PACKAGE_ROOT / "studio" / "backend" / "run.py"
 SPEC = importlib.util.spec_from_file_location(
     "studio_install_llama_prebuilt", MODULE_PATH
 )
@@ -89,6 +92,39 @@ pinned_macos_release_tag = INSTALL_LLAMA_PREBUILT.pinned_macos_release_tag
 resolve_simple_install_release_plans = (
     INSTALL_LLAMA_PREBUILT.resolve_simple_install_release_plans
 )
+
+
+def load_studio_run_module(monkeypatch):
+    logger = types.SimpleNamespace(
+        debug = lambda *a, **k: None,
+        info = lambda *a, **k: None,
+        warning = lambda *a, **k: None,
+    )
+    loggers = types.ModuleType("loggers")
+    loggers.get_logger = lambda name: logger
+    monkeypatch.setitem(sys.modules, "loggers", loggers)
+
+    startup_banner = types.ModuleType("startup_banner")
+    startup_banner.print_studio_access_banner = lambda **k: None
+    startup_banner.print_studio_stop_hint = lambda: None
+    monkeypatch.setitem(sys.modules, "startup_banner", startup_banner)
+
+    paths = types.ModuleType("utils.paths")
+    paths.__path__ = []
+    storage_roots = types.ModuleType("utils.paths.storage_roots")
+    storage_roots.studio_root = lambda: PACKAGE_ROOT / ".studio-test-root"
+    paths.storage_roots = storage_roots
+    monkeypatch.setitem(sys.modules, "utils.paths", paths)
+    monkeypatch.setitem(sys.modules, "utils.paths.storage_roots", storage_roots)
+    monkeypatch.syspath_prepend(str(RUN_MODULE_PATH.parent))
+
+    spec = importlib.util.spec_from_file_location(
+        "studio_backend_run_warning_test", RUN_MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +289,107 @@ def mock_windows_runtime(monkeypatch, lines):
         "detected_windows_runtime_lines",
         lambda: (list(lines), dict(dirs)),
     )
+
+
+# ===========================================================================
+# Studio run.py localhost warning
+# ===========================================================================
+
+
+class TestStudioLocalhostIpv6Warning:
+    def _prepare_loopback(self, run_module, monkeypatch, *, ipv6_open = False):
+        monkeypatch.setattr(
+            run_module,
+            "_working_local_url",
+            lambda port: f"http://127.0.0.1:{port}",
+        )
+        monkeypatch.setattr(
+            run_module,
+            "_local_port_open",
+            lambda host, port, timeout = 1.0: ipv6_open if host == "::1" else True,
+        )
+
+    def test_ipv4_localhost_does_not_warn(self, monkeypatch):
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch)
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **k: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 8888))
+            ],
+        )
+
+        assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
+
+    def test_ipv6_only_localhost_warns_with_ipv4_url(self, monkeypatch, capsys):
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch)
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **k: [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 8888, 0, 0))
+            ],
+        )
+        monkeypatch.setattr(run_module, "_stdout_color_ok", lambda: False)
+
+        local_url = run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888)
+        assert local_url == "http://127.0.0.1:8888"
+
+        run_module._print_localhost_ipv6_mismatch_warning(local_url, 8888)
+        captured = capsys.readouterr()
+        assert "localhost resolves to IPv6 (::1)" in captured.out
+        assert "http://127.0.0.1:8888" in captured.out
+        assert "http://localhost:8888" in captured.out
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
+    def test_network_bind_suppresses_warning(self, monkeypatch, host):
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch)
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **k: [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 8888, 0, 0))
+            ],
+        )
+
+        assert run_module._localhost_ipv6_mismatch_url(host, 8888) is None
+
+    def test_ipv6_listener_suppresses_warning(self, monkeypatch):
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch, ipv6_open = True)
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **k: [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 8888, 0, 0))
+            ],
+        )
+
+        assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
+
+    @pytest.mark.parametrize("addr_info", [[], None])
+    def test_empty_or_unusable_resolver_result_suppresses_warning(
+        self, monkeypatch, addr_info
+    ):
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch)
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: addr_info)
+
+        assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
+
+    def test_resolver_error_suppresses_warning(self, monkeypatch):
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch)
+
+        def _raise(*_a, **_k):
+            raise socket.gaierror("resolver unavailable")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _raise)
+
+        assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
 
 
 # ===========================================================================

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -468,9 +468,7 @@ class TestStudioLocalhostIpv6Warning:
         assert calls["reachability"] == []
 
     @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
-    def test_emit_startup_output_wildcard_runs_reachability(
-        self, monkeypatch, host
-    ):
+    def test_emit_startup_output_wildcard_runs_reachability(self, monkeypatch, host):
         run_module = load_studio_run_module(monkeypatch)
         calls = self._wire_recorders(run_module, monkeypatch)
         monkeypatch.setattr(

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -297,41 +297,47 @@ def mock_windows_runtime(monkeypatch, lines):
 
 
 class TestStudioLocalhostIpv6Warning:
-    def _prepare_loopback(self, run_module, monkeypatch, *, ipv6_open = False):
+    def _prepare_loopback(self, run_module, monkeypatch):
+        # Studio is confirmed answering on the IPv4 loopback.
         monkeypatch.setattr(
             run_module,
             "_working_local_url",
             lambda port: f"http://127.0.0.1:{port}",
         )
-        monkeypatch.setattr(
-            run_module,
-            "_local_port_open",
-            lambda host, port, timeout = 1.0: ipv6_open if host == "::1" else True,
-        )
+
+    def _set_getaddrinfo(self, monkeypatch, entries):
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: entries)
+
+    @staticmethod
+    def _ipv4(port = 8888):
+        return (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port))
+
+    @staticmethod
+    def _ipv6(port = 8888):
+        return (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", port, 0, 0))
+
+    # -- _localhost_ipv6_mismatch_url ------------------------------------
 
     def test_ipv4_localhost_does_not_warn(self, monkeypatch):
         run_module = load_studio_run_module(monkeypatch)
         self._prepare_loopback(run_module, monkeypatch)
-        monkeypatch.setattr(
-            socket,
-            "getaddrinfo",
-            lambda *a, **k: [
-                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 8888))
-            ],
-        )
+        self._set_getaddrinfo(monkeypatch, [self._ipv4()])
 
         assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
 
-    def test_ipv6_only_localhost_warns_with_ipv4_url(self, monkeypatch, capsys):
+    def test_dual_stack_localhost_does_not_warn(self, monkeypatch):
+        # localhost -> both ::1 and 127.0.0.1: browsers fall back to IPv4 when
+        # ::1 refuses, so the URL is reachable and no warning is needed.
         run_module = load_studio_run_module(monkeypatch)
         self._prepare_loopback(run_module, monkeypatch)
-        monkeypatch.setattr(
-            socket,
-            "getaddrinfo",
-            lambda *a, **k: [
-                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 8888, 0, 0))
-            ],
-        )
+        self._set_getaddrinfo(monkeypatch, [self._ipv6(), self._ipv4()])
+
+        assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
+
+    def test_ipv6_only_localhost_returns_ipv4_url(self, monkeypatch, capsys):
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch)
+        self._set_getaddrinfo(monkeypatch, [self._ipv6()])
         monkeypatch.setattr(run_module, "_stdout_color_ok", lambda: False)
 
         local_url = run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888)
@@ -343,40 +349,52 @@ class TestStudioLocalhostIpv6Warning:
         assert "http://127.0.0.1:8888" in captured.out
         assert "http://localhost:8888" in captured.out
 
+    def test_ipv6_listener_does_not_suppress_warning(self, monkeypatch):
+        # Regression for the Codex review: a process answering on ::1 is NOT
+        # Studio (Studio binds 127.0.0.1 only), so the warning must still fire
+        # -- that is exactly when http://localhost would open the wrong service.
+        run_module = load_studio_run_module(monkeypatch)
+        self._prepare_loopback(run_module, monkeypatch)
+        self._set_getaddrinfo(monkeypatch, [self._ipv6()])
+        # Even with something listening on ::1, the result is unchanged.
+        monkeypatch.setattr(
+            run_module,
+            "_local_port_open",
+            lambda host, port, timeout = 1.0: True,
+        )
+
+        assert (
+            run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888)
+            == "http://127.0.0.1:8888"
+        )
+
     @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
     def test_network_bind_suppresses_warning(self, monkeypatch, host):
         run_module = load_studio_run_module(monkeypatch)
         self._prepare_loopback(run_module, monkeypatch)
-        monkeypatch.setattr(
-            socket,
-            "getaddrinfo",
-            lambda *a, **k: [
-                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 8888, 0, 0))
-            ],
-        )
+        self._set_getaddrinfo(monkeypatch, [self._ipv6()])
 
         assert run_module._localhost_ipv6_mismatch_url(host, 8888) is None
 
-    def test_ipv6_listener_suppresses_warning(self, monkeypatch):
+    @pytest.mark.parametrize("port", [0, -1])
+    def test_non_positive_port_returns_none(self, monkeypatch, port):
         run_module = load_studio_run_module(monkeypatch)
-        self._prepare_loopback(run_module, monkeypatch, ipv6_open = True)
-        monkeypatch.setattr(
-            socket,
-            "getaddrinfo",
-            lambda *a, **k: [
-                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 8888, 0, 0))
-            ],
-        )
+        self._prepare_loopback(run_module, monkeypatch)
+
+        assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", port) is None
+
+    def test_ipv4_not_answering_suppresses_warning(self, monkeypatch):
+        # Studio not confirmed on 127.0.0.1 -> do not warn.
+        run_module = load_studio_run_module(monkeypatch)
+        monkeypatch.setattr(run_module, "_working_local_url", lambda port: None)
+        self._set_getaddrinfo(monkeypatch, [self._ipv6()])
 
         assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
 
-    @pytest.mark.parametrize("addr_info", [[], None])
-    def test_empty_or_unusable_resolver_result_suppresses_warning(
-        self, monkeypatch, addr_info
-    ):
+    def test_empty_resolver_result_suppresses_warning(self, monkeypatch):
         run_module = load_studio_run_module(monkeypatch)
         self._prepare_loopback(run_module, monkeypatch)
-        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: addr_info)
+        self._set_getaddrinfo(monkeypatch, [])
 
         assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
 
@@ -390,6 +408,81 @@ class TestStudioLocalhostIpv6Warning:
         monkeypatch.setattr(socket, "getaddrinfo", _raise)
 
         assert run_module._localhost_ipv6_mismatch_url("127.0.0.1", 8888) is None
+
+    # -- _emit_startup_output (banner / warning wiring) ------------------
+
+    def _wire_recorders(self, run_module, monkeypatch):
+        calls = {"banner": [], "warning": [], "stop_hint": 0, "reachability": []}
+        monkeypatch.setattr(
+            run_module,
+            "print_studio_access_banner",
+            lambda **kwargs: calls["banner"].append(kwargs),
+        )
+        monkeypatch.setattr(
+            run_module,
+            "_print_localhost_ipv6_mismatch_warning",
+            lambda local_url, port: calls["warning"].append((local_url, port)),
+        )
+        monkeypatch.setattr(
+            run_module,
+            "print_studio_stop_hint",
+            lambda: calls.__setitem__("stop_hint", calls["stop_hint"] + 1),
+        )
+        monkeypatch.setattr(
+            run_module,
+            "_verify_global_reachability",
+            lambda display_host, port: calls["reachability"].append(
+                (display_host, port)
+            ),
+        )
+        return calls
+
+    def test_emit_startup_output_wires_mismatch_warning(self, monkeypatch):
+        run_module = load_studio_run_module(monkeypatch)
+        calls = self._wire_recorders(run_module, monkeypatch)
+        monkeypatch.setattr(
+            run_module,
+            "_localhost_ipv6_mismatch_url",
+            lambda host, port: "http://127.0.0.1:8888",
+        )
+
+        run_module._emit_startup_output("127.0.0.1", 8888, "127.0.0.1")
+
+        assert calls["banner"][0]["include_stop_hint"] is False
+        assert calls["warning"] == [("http://127.0.0.1:8888", 8888)]
+        assert calls["stop_hint"] == 1
+        assert calls["reachability"] == []
+
+    def test_emit_startup_output_plain_localhost(self, monkeypatch):
+        run_module = load_studio_run_module(monkeypatch)
+        calls = self._wire_recorders(run_module, monkeypatch)
+        monkeypatch.setattr(
+            run_module, "_localhost_ipv6_mismatch_url", lambda host, port: None
+        )
+
+        run_module._emit_startup_output("127.0.0.1", 8888, "127.0.0.1")
+
+        assert calls["banner"][0]["include_stop_hint"] is True
+        assert calls["warning"] == []
+        assert calls["stop_hint"] == 0
+        assert calls["reachability"] == []
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
+    def test_emit_startup_output_wildcard_runs_reachability(
+        self, monkeypatch, host
+    ):
+        run_module = load_studio_run_module(monkeypatch)
+        calls = self._wire_recorders(run_module, monkeypatch)
+        monkeypatch.setattr(
+            run_module, "_localhost_ipv6_mismatch_url", lambda h, port: None
+        )
+
+        run_module._emit_startup_output(host, 8888, "203.0.113.5")
+
+        assert calls["banner"][0]["include_stop_hint"] is False
+        assert calls["warning"] == []
+        assert calls["reachability"] == [("203.0.113.5", 8888)]
+        assert calls["stop_hint"] == 1
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

On hosts where `localhost` resolves to IPv6 (`::1`) but Studio is bound only to `127.0.0.1`, a browser pointed at `http://localhost:<port>` fails to connect even though the server is up at `http://127.0.0.1:<port>`. `studio/backend/run.py` now detects that mismatch at startup and prints a single non-fatal warning telling the user to open the `127.0.0.1` URL. The default `127.0.0.1`-only bind is unchanged.

## Why this matters

Issue #5965 reported that on Windows hosts where Docker Desktop comments out the default `127.0.0.1 localhost` / `::1 localhost` entries, the OS resolves `localhost` to `::1`, so the Studio URL appears dead. The maintainer (rolandtannous) confirmed the `127.0.0.1`-only bind is intentional for security and rejected the `0.0.0.0` change in PR #5966 because it exposes the machine to the LAN, asking instead for a startup warning that points users to `http://127.0.0.1:<port>`. The new `_localhost_ipv6_mismatch_url` helper reuses `_working_local_url` / `_local_port_open` plus `socket.getaddrinfo("localhost", port)` to confirm the IPv6-only resolution before warning via `_print_localhost_ipv6_mismatch_warning`.

## Testing

Covered by the new cases in `tests/studio/install/test_selection_logic.py`: `localhost` to `127.0.0.1` (no warning), `::1`-only with a `127.0.0.1` bind (warning with the correct URL), `0.0.0.0`/`::` network bind (suppressed), and a `getaddrinfo` failure (swallowed, no warning, startup never blocked). Full suite runs in CI.

Fixes #5965
