### PR TITLE
CI: track deepseek_ocr2 compile timeout in known-broken list

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -990,6 +990,7 @@ jobs:
               # First seen on transformers >=5,<6; each represents a slow
               # or recursive source-rewriter path the zoo can address.
               "beit":            "TimeoutError: compile exceeds per-model budget",
+              "deepseek_ocr2":   "TimeoutError: compile exceeds per-model budget",
               "sam":             "TimeoutError: compile exceeds per-model budget",
               "sam_hq":          "TimeoutError: compile exceeds per-model budget",
           }


### PR DESCRIPTION
## Summary

The Core (HF=latest + TRL=latest) job runs the full transformers.models.* compile sweep in `consolidated-tests-ci.yml`. transformers main now ships `deepseek_ocr2`, which exceeds the 60s per-model compile budget on the runner and trips the new-failure guard:

```
unsloth_compile_transformers introduced new failures on 1 model_types not in the known-broken list: ['deepseek_ocr2']
assert not [('deepseek_ocr2', 'TimeoutError: compile exceeded per-model budget')]
```

This adds `deepseek_ocr2` to the Category F (per-model budget timeout) entries in `KNOWN_BROKEN_COMPILE`, alongside the existing `beit`, `sam` and `sam_hq` entries, so the sweep tracks it as a known follow-up rather than a hard failure.

## Notes

- Only touches the known-broken tracking dict in the sweep shim. No runtime code changes.
- YAML parses and the embedded shim AST-parses cleanly with the new entry.
- Reproduces identically on main (run 26901317158), so this is upstream transformers drift, not specific to any open PR.