### PR TITLE
Normalize shell scripts to LF in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Normalize Python files to LF line endings
 *.py text eol=lf
+
+# Always check out shell scripts with LF endings. Without this rule a Windows
+# clone (core.autocrlf=true) rewrites them to CRLF, and the trailing \r breaks
+# them when run in WSL/Linux (e.g. `set -e` -> "set: Illegal option -").
+*.sh text eol=lf


### PR DESCRIPTION
## Problem

`.gitattributes` only normalizes `*.py`, so shell scripts have no end-of-line rule. They are stored as LF in git, but on a Windows clone with `core.autocrlf=true` (the common default) git rewrites them to **CRLF on checkout**. The trailing `\r` then breaks them when the same checkout is run in WSL/Linux:

```
$ scripts/uninstall.sh
scripts/uninstall.sh: 13: set: Illegal option -
```

(`set -e` becomes `set -e\r`, which `dash`/`sh` rejects.)

This does **not** affect normal users — the `curl … | sh` one-liner and the installer-generated launch scripts are already LF. It bites **developers who clone on Windows and run the repo's `*.sh` directly inside WSL**, which is increasingly common now that the project supports AMD Strix Halo ROCm-on-WSL.

## Fix

Add a single rule so every shell script always checks out with LF, regardless of the contributor's platform or `core.autocrlf` setting:

```gitattributes
*.sh text eol=lf
```

## Scope / decisions

- All 18 tracked `*.sh` files use Unix shebangs (`#!/bin/sh`, `#!/bin/bash`, `#!/usr/bin/env …`); none are Windows-targeted, so none legitimately need CRLF.
- There are no extensionless shell scripts (only `CODEOWNERS`/`COPYING`/`LICENSE`) and no committed shell launcher templates, so the `*.sh` glob is sufficient.
- `*.ps1` / `*.bat` are intentionally left alone — PowerShell/cmd tolerate LF and are unaffected by this bug. Keeping the change minimal.
- The committed `*.sh` blobs are already LF, so this only changes checkout behaviour; there is no content change to any script.

## Verification

`git ls-files --eol` after a fresh checkout on Windows (`core.autocrlf=true`) — every shell script now resolves to LF in both the index and the working tree:

```
i/lf    w/lf    attr/text eol=lf      install.sh
i/lf    w/lf    attr/text eol=lf      scripts/uninstall.sh
i/lf    w/lf    attr/text eol=lf      studio/setup.sh
…   (all 18 *.sh)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
