### PR TITLE
Studio: enable GGUF tools with vision inputs

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4855,13 +4855,14 @@ def _normalize_anthropic_openai_images(
 
 
 def _set_or_prepend_system_message(
-    messages: list[dict], system_prompt: str
+    messages: Optional[list[dict]], system_prompt: str
 ) -> list[dict]:
     """Return messages with a system prompt without dropping multimodal parts."""
+    safe_messages = messages or []
     if not system_prompt:
-        return messages
+        return safe_messages
 
-    updated = [dict(msg) for msg in messages]
+    updated = [dict(msg) for msg in safe_messages]
     if updated and updated[0].get("role") == "system":
         updated[0]["content"] = system_prompt
         return updated

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2804,10 +2804,7 @@ async def openai_chat_completions(
         _cli_policy = _get_tool_policy_g()
         _tools_on = _effective_enable_tools(payload)
         _mcp_allowed = bool(payload.mcp_enabled) and _cli_policy is not False
-        use_tools = (
-            (_tools_on or _mcp_allowed)
-            and llama_backend.supports_tools
-        )
+        use_tools = (_tools_on or _mcp_allowed) and llama_backend.supports_tools
 
         if use_tools:
             from core.inference.tools import ALL_TOOLS, get_enabled_mcp_tools

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2780,7 +2780,7 @@ async def openai_chat_completions(
                 detail = "Audio input is not supported for GGUF chat models yet.",
             )
 
-        gguf_messages, has_gguf_image = _openai_messages_for_gguf_chat(
+        gguf_messages, _ = _openai_messages_for_gguf_chat(
             payload,
             llama_backend.is_vision,
         )
@@ -4857,17 +4857,15 @@ def _normalize_anthropic_openai_images(
 def _set_or_prepend_system_message(
     messages: Optional[list[dict]], system_prompt: str
 ) -> list[dict]:
-    """Return messages with a system prompt without dropping multimodal parts."""
+    """Return messages with a single leading system prompt, preserving multimodal parts."""
     safe_messages = messages or []
     if not system_prompt:
         return safe_messages
 
-    updated = [dict(msg) for msg in safe_messages]
-    if updated and updated[0].get("role") == "system":
-        updated[0]["content"] = system_prompt
-        return updated
-
-    return [{"role": "system", "content": system_prompt}, *updated]
+    # Drop existing system turns so the backend never sees duplicate or
+    # conflicting system instructions, then prepend the resolved prompt.
+    others = [dict(msg) for msg in safe_messages if msg.get("role") != "system"]
+    return [{"role": "system", "content": system_prompt}, *others]
 
 
 @router.post("/messages")

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2807,7 +2807,6 @@ async def openai_chat_completions(
         use_tools = (
             (_tools_on or _mcp_allowed)
             and llama_backend.supports_tools
-            and not has_gguf_image
         )
 
         if use_tools:
@@ -2897,11 +2896,9 @@ async def openai_chat_completions(
                     system_prompt = system_prompt.rstrip() + "\n\n" + _nudge
                 else:
                     system_prompt = _nudge
-                # Rebuild gguf_messages with updated system prompt
-                gguf_messages = []
-                if system_prompt:
-                    gguf_messages.append({"role": "system", "content": system_prompt})
-                gguf_messages.extend(chat_messages)
+                gguf_messages = _set_or_prepend_system_message(
+                    gguf_messages, system_prompt
+                )
 
             # ── Strip stale tool-call XML from conversation history ─
             for _msg in gguf_messages:
@@ -4858,6 +4855,21 @@ def _normalize_anthropic_openai_images(
             part["image_url"] = {"url": f"data:image/png;base64,{png_b64}"}
 
     return has_image
+
+
+def _set_or_prepend_system_message(
+    messages: list[dict], system_prompt: str
+) -> list[dict]:
+    """Return messages with a system prompt without dropping multimodal parts."""
+    if not system_prompt:
+        return messages
+
+    updated = [dict(msg) for msg in messages]
+    if updated and updated[0].get("role") == "system":
+        updated[0]["content"] = system_prompt
+        return updated
+
+    return [{"role": "system", "content": system_prompt}, *updated]
 
 
 @router.post("/messages")

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -768,6 +768,20 @@ class TestGgufVisionMessages:
             {"role": "system", "content": "Use tools."}
         ]
 
+    def test_tool_nudge_system_update_dedupes_non_leading_system(self):
+        messages = [
+            {"role": "user", "content": "earlier"},
+            {"role": "system", "content": "Mid instructions."},
+            {"role": "user", "content": "now"},
+        ]
+
+        updated = _set_or_prepend_system_message(
+            messages, "Mid instructions.\n\nUse tools."
+        )
+
+        assert [m["role"] for m in updated] == ["system", "user", "user"]
+        assert updated[0]["content"] == "Mid instructions.\n\nUse tools."
+
 
 class TestGgufVisionToolRouting:
     class _Request:

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -20,6 +20,8 @@ No running server or GPU required.
 
 import os
 import sys
+import asyncio
+from types import SimpleNamespace
 
 _backend = os.path.join(os.path.dirname(__file__), "..")
 sys.path.insert(0, _backend)
@@ -36,7 +38,13 @@ from models.inference import (
 from core.inference.anthropic_compat import (
     anthropic_tool_choice_to_openai,
 )
-from routes.inference import _build_passthrough_payload, _friendly_error
+from routes.inference import (
+    _build_passthrough_payload,
+    _friendly_error,
+    _set_or_prepend_system_message,
+    openai_chat_completions,
+)
+from state.tool_policy import reset_tool_policy
 
 
 # =====================================================================
@@ -725,3 +733,117 @@ class TestGgufVisionMessages:
         with pytest.raises(HTTPException) as exc_info:
             _openai_messages_for_gguf_chat(req, is_vision = False)
         assert "does not support vision" in str(exc_info.value)
+
+    def test_tool_nudge_system_update_preserves_image_parts(self):
+        messages = [
+            {"role": "system", "content": "Base instructions."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:image/png;base64,{self._PNG_B64}",
+                        },
+                    },
+                ],
+            },
+        ]
+
+        updated = _set_or_prepend_system_message(
+            messages, "Base instructions.\n\nUse tools when appropriate."
+        )
+
+        assert updated[0] == {
+            "role": "system",
+            "content": "Base instructions.\n\nUse tools when appropriate.",
+        }
+        assert updated[1]["content"][1]["type"] == "image_url"
+        assert messages[1]["content"][1]["type"] == "image_url"
+
+
+class TestGgufVisionToolRouting:
+    class _Request:
+        async def is_disconnected(self):
+            return False
+
+    @staticmethod
+    def _drive(coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    @staticmethod
+    def _consume_response(response):
+        async def _consume():
+            chunks = []
+            async for chunk in response.body_iterator:
+                chunks.append(chunk)
+            return chunks
+
+        return TestGgufVisionToolRouting._drive(_consume())
+
+    def test_image_request_with_enabled_tools_enters_gguf_tool_loop(
+        self, monkeypatch
+    ):
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+        captured = {}
+
+        def _plain(**kwargs):
+            raise AssertionError("plain GGUF path should not be used")
+
+        def _tools(**kwargs):
+            captured["kwargs"] = kwargs
+            yield {"type": "content", "text": "done"}
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = True,
+            supports_tools = True,
+            model_identifier = "gemma-4-12b-it-GGUF",
+            generate_chat_completion = _plain,
+            generate_chat_completion_with_tools = _tools,
+        )
+        monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+
+        payload = ChatCompletionRequest(
+            model = "default",
+            enable_tools = True,
+            enabled_tools = ["web_search"],
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is in this image?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": (
+                                    "data:image/png;base64,"
+                                    f"{TestGgufVisionMessages._PNG_B64}"
+                                ),
+                            },
+                        },
+                    ],
+                },
+            ],
+        )
+
+        response = self._drive(
+            openai_chat_completions(
+                payload, request = self._Request(), current_subject = "test"
+            )
+        )
+        self._consume_response(response)
+
+        assert "kwargs" in captured
+        assert captured["kwargs"]["tools"]
+        tool_messages = captured["kwargs"]["messages"]
+        assert tool_messages[0]["role"] == "system"
+        assert tool_messages[1]["role"] == "user"
+        assert tool_messages[1]["content"][1]["type"] == "image_url"

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -786,9 +786,7 @@ class TestGgufVisionToolRouting:
 
         return TestGgufVisionToolRouting._drive(_consume())
 
-    def test_image_request_with_enabled_tools_enters_gguf_tool_loop(
-        self, monkeypatch
-    ):
+    def test_image_request_with_enabled_tools_enters_gguf_tool_loop(self, monkeypatch):
         import routes.inference as inf_mod
 
         reset_tool_policy()

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -762,6 +762,12 @@ class TestGgufVisionMessages:
         assert updated[1]["content"][1]["type"] == "image_url"
         assert messages[1]["content"][1]["type"] == "image_url"
 
+    def test_tool_nudge_system_update_handles_none_messages(self):
+        assert _set_or_prepend_system_message(None, "") == []
+        assert _set_or_prepend_system_message(None, "Use tools.") == [
+            {"role": "system", "content": "Use tools."}
+        ]
+
 
 class TestGgufVisionToolRouting:
     class _Request:
@@ -770,11 +776,7 @@ class TestGgufVisionToolRouting:
 
     @staticmethod
     def _drive(coro):
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
+        return asyncio.run(coro)
 
     @staticmethod
     def _consume_response(response):


### PR DESCRIPTION
## Summary

GGUF chat requests with images were always forced onto the plain generation path, even when tools were enabled. This meant image + Search/Code requests could produce text-only answers without entering the agentic tool loop.

This PR allows tool-capable GGUF vision models to use the tool loop with multimodal messages.

After:
<img width="1438" height="965" alt="image" src="https://github.com/user-attachments/assets/4a739ff9-a96e-49e7-8ced-d67756716db9" />

## Testing

```bash
/home/samle/.unsloth/studio/unsloth_studio/bin/python -m pytest -s studio/backend/tests/test_openai_tool_passthrough.py -q
/home/samle/.unsloth/studio/unsloth_studio/bin/python -m pytest -s studio/backend/tests/test_anthropic_messages.py -q