### PR TITLE
Bump hono to 4.12.21, fixes CVE-2026-47676

### DIFF
--- a/studio/frontend/package-lock.json
+++ b/studio/frontend/package-lock.json
@@ -9985,9 +9985,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -84,7 +84,7 @@
     "@tanstack/router-core": "1.169.2",
     "@tanstack/history": "1.161.6",
     "mermaid": "11.15.0",
-    "hono": "4.12.18",
+    "hono": "4.12.21",
     "qs": "6.15.2",
     "ip-address": "10.1.1",
     "brace-expansion@5.0.5": "5.0.6"


### PR DESCRIPTION
I ran osv_scanner on this repo, and it found a few vulns for hono at 4.12.18.
Bumped to 4.12.21 and ran npm install to update `package-lock.json`.