### PR TITLE
Studio: fix load_freeze audio-type tests for #6000's Gemma 4 `<|audio|>` probe

### DIFF
--- a/tests/studio/load_freeze/test_load_orchestrator.py
+++ b/tests/studio/load_freeze/test_load_orchestrator.py
@@ -3,7 +3,7 @@
 Covers:
   1.  Behavioural canary (the bug class)             — 2 tests
   2.  Behavioural fix-validation                     — 1 test
-  3.  Functional equivalence (sync == to_thread)     — 5 tests, one per codec branch
+  3.  Functional equivalence (sync == to_thread)     — 6 tests, one per codec branch
   4.  Failure modes (HTTP 500, malformed JSON,
       connection reset, unreachable, not-loaded)     — 5 tests
   5.  Stress (50 concurrent probes / 100 healths)    — 2 tests
@@ -254,6 +254,7 @@ def shim_no_match():
             "<|audio_eos|>": [0, 1],
             "<|startoftranscript|>": [0, 1],
             "<audio_soft_token>": [0, 1],
+            "<|audio|>": [0, 1],
             "<|bicodec_semantic_0|>": [0, 1],
             "<|bicodec_global_0|>": [0, 1],
             "<|c1_0|>": [0, 1],
@@ -314,6 +315,28 @@ def test_functional_equivalence_whisper_match():
     assert sync_result == threaded
 
 
+def test_functional_equivalence_audio_vlm_match():
+    # audio_vlm: snac/csm/whisper fail first, then the Gemma 4 <|audio|>
+    # probe tokenises to a single token. #6000 added this arm alongside
+    # Gemma 3n's <audio_soft_token>; keep <audio_soft_token> at 2 tokens so
+    # it is specifically the new <|audio|> arm that triggers the match.
+    with FakeLlamaServer(
+        detok_map = {128258: "non-snac", 128259: "non-snac"},
+        tok_response_map = {
+            "<|AUDIO|>": [0, 1],              # csm fails (>1 token)
+            "<|audio_eos|>": [0, 1],
+            "<|startoftranscript|>": [0, 1],  # whisper fails
+            "<audio_soft_token>": [0, 1],     # Gemma 3n arm fails ...
+            "<|audio|>": [0],                 # ... Gemma 4 arm matches (#6000)
+        },
+    ) as srv:
+        backend = _make_backend(srv.port)
+        sync_result = backend.detect_audio_type()
+        threaded = asyncio.run(asyncio.to_thread(backend.detect_audio_type))
+    assert sync_result == "audio_vlm"
+    assert sync_result == threaded
+
+
 def test_functional_equivalence_bicodec_match():
     # bicodec: snac/csm/whisper/audio_vlm all fail first, then both
     # bicodec_semantic_0 and bicodec_global_0 are single tokens.
@@ -324,6 +347,7 @@ def test_functional_equivalence_bicodec_match():
             "<|audio_eos|>": [0, 1],
             "<|startoftranscript|>": [0, 1],
             "<audio_soft_token>": [0, 1],
+            "<|audio|>": [0, 1],
             "<|bicodec_semantic_0|>": [0],
             "<|bicodec_global_0|>": [0],
         },
@@ -644,6 +668,7 @@ def test_response_shape_matches_pre_fix_for_no_match():
             "<|audio_eos|>": [0, 1],
             "<|startoftranscript|>": [0, 1],
             "<audio_soft_token>": [0, 1],
+            "<|audio|>": [0, 1],
             "<|bicodec_semantic_0|>": [0, 1],
             "<|bicodec_global_0|>": [0, 1],
             "<|c1_0|>": [0, 1],

--- a/tests/studio/load_freeze/test_load_orchestrator.py
+++ b/tests/studio/load_freeze/test_load_orchestrator.py
@@ -323,11 +323,11 @@ def test_functional_equivalence_audio_vlm_match():
     with FakeLlamaServer(
         detok_map = {128258: "non-snac", 128259: "non-snac"},
         tok_response_map = {
-            "<|AUDIO|>": [0, 1],              # csm fails (>1 token)
+            "<|AUDIO|>": [0, 1],  # csm fails (>1 token)
             "<|audio_eos|>": [0, 1],
             "<|startoftranscript|>": [0, 1],  # whisper fails
-            "<audio_soft_token>": [0, 1],     # Gemma 3n arm fails ...
-            "<|audio|>": [0],                 # ... Gemma 4 arm matches (#6000)
+            "<audio_soft_token>": [0, 1],  # Gemma 3n arm fails ...
+            "<|audio|>": [0],  # ... Gemma 4 arm matches (#6000)
         },
     ) as srv:
         backend = _make_backend(srv.port)


### PR DESCRIPTION
## What

Update the `load_freeze` simulation suite (`tests/studio/load_freeze/test_load_orchestrator.py`) so it reflects the audio-detection behavior introduced by #6000.

## Why

#6000 ("Studio: enable audio input for Gemma 4 GGUFs") extended `LlamaCppBackend._detect_audio_type_strict`'s `audio_vlm` arm to also probe Gemma 4's `<|audio|>` token, in addition to Gemma 3n's `<audio_soft_token>`:

```python
# Gemma 3n: <audio_soft_token>; Gemma 4: <|audio|> (not csm's <|AUDIO|>).
if len(_tok("<audio_soft_token>")) == 1 or len(_tok("<|audio|>")) == 1:
    return "audio_vlm"
```

That change is correct, but #6000 did **not** update this test file (last touched by #5922). Its "no-match" and "bicodec" fixtures only mapped `<audio_soft_token>` to a 2-token response to defeat the (pre-#6000) Gemma 3n arm. The new `<|audio|>` probe is left unmapped, so it falls through to `FakeLlamaServer`'s default (`tokens = list(range(max(1, len(content.split()) or 1)))` → **1 token** for a no-whitespace marker), which now satisfies the `audio_vlm` check.

As a result three equivalence/shape tests fail on `main` (`4c06c1d`), all because `detect_audio_type` now returns `'audio_vlm'`:

- `test_functional_equivalence_no_match` — expected `None`
- `test_functional_equivalence_bicodec_match` — expected `'bicodec'` (audio_vlm matches before bicodec in detection order)
- `test_response_shape_matches_pre_fix_for_no_match` — expected `{'audio_type': None}`

This isn't caught by `main`'s push-CI because "Repo tests (CPU)" only runs on `pull_request`, so the breakage surfaces in every open PR's merge-ref (e.g. it's currently red on the unrelated AMD installer PR #5940).

## Fix

Touches only the test file:

- Map `<|audio|>` to a 2-token response in the three fixtures whose intent is a non-`audio_vlm` outcome (`shim_no_match`, the bicodec fixture, and the `test_response_shape_matches_pre_fix_for_no_match` fixture). This restores their original semantics now that `<|audio|>` is a probed marker — exactly mirroring how they already defeat `<audio_soft_token>`.
- Add a positive `test_functional_equivalence_audio_vlm_match` that keeps `<audio_soft_token>` at 2 tokens and sets `<|audio|>` to 1 token, so it specifically exercises and locks in #6000's new Gemma 4 `<|audio|>` arm (sync == `to_thread` like the other per-codec cases).

## Test

```
$ pytest tests/studio/load_freeze/test_load_orchestrator.py -q
23 passed

$ pytest tests/test_studio_install_workspace_guard.py -q
44 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
