### PR TITLE
docs: add Codex responses usage example

### DIFF
--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { cn } from "@/lib/utils";
-import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { useT } from "@/i18n";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { cn } from "@/lib/utils";
 import {
   ArrowUpRight01Icon,
   Copy01Icon,
@@ -12,12 +12,13 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMemo, useState } from "react";
 
-type Lang = "curl" | "python" | "tools";
+type Lang = "curl" | "python" | "tools" | "codex";
 
 const TABS: { id: Lang; label: string }[] = [
   { id: "curl", label: "curl" },
   { id: "python", label: "Python" },
   { id: "tools", label: "Tools" },
+  { id: "codex", label: "Codex" },
 ];
 
 const DOC_LINKS = [
@@ -75,6 +76,18 @@ for chunk in response:
     "enabled_tools": ["web_search", "python"],
     "stream": true
   }'`,
+    codex: `# ~/.codex/config.toml
+model = "current"
+model_provider = "unsloth-studio"
+
+[model_providers.unsloth-studio]
+name = "Unsloth Studio"
+base_url = "${base}/v1"
+env_key = "UNSLOTH_API_KEY"
+wire_api = "responses"
+
+# Shell
+export UNSLOTH_API_KEY="sk-unsloth-YOUR_KEY"`,
   };
 }
 

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -87,7 +87,7 @@ env_key = "UNSLOTH_API_KEY"
 wire_api = "responses"
 
 # Shell
-export UNSLOTH_API_KEY="sk-unsloth-YOUR_KEY"`,
+# export UNSLOTH_API_KEY="sk-unsloth-YOUR_KEY"`,
   };
 }
 


### PR DESCRIPTION
## Summary

- add a Codex tab to the Studio API usage examples
- show a copyable `~/.codex/config.toml` provider snippet for Studio's `/v1/responses` endpoint
- point Codex at the current Studio origin with `base_url = ".../v1"` and `wire_api = "responses"`

## Why

Issue #5141 reports that users can find chat-completions examples, but not a concrete Codex configuration for the Studio `/v1/responses` path. The backend already exposes `/v1/responses` and has Responses/tool passthrough coverage, so this surfaces that path in the UI where users copy API examples.

## Validation

- `npm.cmd run typecheck`
- `npx.cmd biome check src\features\settings\components\usage-examples.tsx`
- `npx.cmd eslint src\features\settings\components\usage-examples.tsx`
- `npm.cmd run build`
- `git diff --check`

Note: full-repo `biome:check` and `lint` currently report existing unrelated diagnostics across many frontend files, so I validated the changed file directly plus the production build.

Closes #5141