### PR TITLE
Studio: center account avatar vertically in sidebar footer pill

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1008,7 +1008,7 @@ export function AppSidebar() {
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
                   className="sidebar-nav-btn !h-[44px] gap-[9px] px-2 py-[3px] rounded-[14px]"
                 >
-                  <div className="shrink-0">
+                  <div className="flex shrink-0 items-center">
                     <UserAvatar
                       name={displayTitle}
                       imageUrl={avatarDataUrl}


### PR DESCRIPTION
## Problem

The circular profile picture in the sidebar footer account pill sits about 2.5px above true center.

## Cause

The avatar's wrapper div is a plain block element holding an inline-flex avatar span. Inline-level boxes align to the text baseline, which leaves descender space below the 32px avatar and makes the wrapper roughly 36px tall with the avatar pinned to its top. The button row's items-center then centers that taller wrapper, pushing the circle up.

## Fix

Make the wrapper a flex container (flex shrink-0 items-center) so its height collapses to exactly the avatar's 32px and the row centers it correctly. One line changed.

## Verification

Measured the rendered geometry against the built CSS bundle:

| | top gap | bottom gap | off-center |
|---|---|---|---|
| Before | 3.5px | 8.5px | 2.5px high |
| After | 6px | 6px | 0px |

Both the image avatar and the initials fallback branch of UserAvatar are covered since the fix is on the shared wrapper.