### PR TITLE
Studio: fix Repo tests (CPU) by stopping the ROCm test from leaking a fake utils into sys.modules

### DIFF
--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -1123,7 +1123,7 @@ class TestWorkerRocmMambaSsm:
         source = _WHEEL_UTILS_PATH.read_text(encoding = "utf-8")
         assert "getattr(torch.version, 'hip', None)" in source
 
-    def test_direct_wheel_url_returns_none_without_cuda_major(self):
+    def test_direct_wheel_url_returns_none_without_cuda_major(self, monkeypatch):
         """_direct_wheel_url should return None when cuda_major is empty (ROCm)."""
         # Load module for function access
         _worker_spec = importlib.util.spec_from_file_location(
@@ -1132,12 +1132,15 @@ class TestWorkerRocmMambaSsm:
         assert _worker_spec is not None and _worker_spec.loader is not None
         worker_mod = importlib.util.module_from_spec(_worker_spec)
 
-        # Mock all the imports worker.py needs
-        sys.modules["structlog"] = MagicMock()
-        sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
-        sys.modules["utils"] = MagicMock()
-        sys.modules["utils.hardware"] = MagicMock()
+        # Stub worker.py's imports via monkeypatch so the fakes (notably a
+        # non-package "utils") are undone and don't break later tests that
+        # import the real utils.* package.
+        loggers_mock = MagicMock()
+        loggers_mock.get_logger = MagicMock(return_value = MagicMock())
+        monkeypatch.setitem(sys.modules, "structlog", MagicMock())
+        monkeypatch.setitem(sys.modules, "loggers", loggers_mock)
+        monkeypatch.setitem(sys.modules, "utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "utils.hardware", MagicMock())
 
         try:
             _worker_spec.loader.exec_module(worker_mod)


### PR DESCRIPTION
## Summary

Fixes the `Repo tests (CPU)` job, which is currently red on `main`. `tests/studio/install/test_selection_logic.py::TestStudioLocalhostIpv6Warning` fails with:

```
ModuleNotFoundError: No module named 'utils.cpu_threads'; 'utils' is not a package
```

## Root cause

`tests/studio/install/test_rocm_support.py::TestWorkerRocmMambaSsm::test_direct_wheel_url_returns_none_without_cuda_major` stubbed worker.py's imports by assigning straight into `sys.modules`:

```python
sys.modules["utils"] = MagicMock()
sys.modules["utils.hardware"] = MagicMock()
```

These were never restored, so a non-package `utils` MagicMock leaked into global `sys.modules`. This was harmless until #5760 added `from utils.cpu_threads import configure_cpu_threads` to the top of `studio/backend/run.py`. `test_selection_logic.py` loads `run.py` via `importlib`, so once the rocm test runs first (same directory, alphabetical order), the leaked MagicMock makes that import fail, taking out all of `TestStudioLocalhostIpv6Warning`.

It only surfaced now because the IPv6 warning tests that load `run.py` landed in #5994, after #5760.

## Fix

Use `monkeypatch.setitem(sys.modules, ...)` in the rocm test so the stubs are undone at teardown and never leak into later tests. No production code changes.

## Verification

Reproduced locally (cwd repo root, `PYTHONPATH=studio`, matching the CI job):

Before:
```
pytest tests/studio/install/test_rocm_support.py \
       tests/studio/install/test_selection_logic.py::TestStudioLocalhostIpv6Warning
# 15 failed, 248 passed
```

After:
```
# 263 passed, 1 skipped
pytest tests/studio/install/   # 632 passed, 1 skipped
```
