### PR TITLE
fix(studio/responses): emit placeholder for empty tool output to avoid 500

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2797,6 +2797,13 @@ def _normalise_responses_input(payload: ResponsesRequest) -> list[ChatMessage]:
             output = item.output
             if not isinstance(output, str):
                 output = json.dumps(output)
+            if not output:
+                # An empty/falsy result (e.g. an image-only tool output whose
+                # payload lives outside `output`) would otherwise build a
+                # role="tool" ChatMessage with content="", which the strict
+                # validator rejects with a 500. Emit a placeholder so the turn
+                # normalises gracefully.
+                output = "(no output)"
             messages.append(
                 ChatMessage(
                     role = "tool",

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -374,6 +374,44 @@ class TestNormaliseResponsesInputWithTools:
         # Content is serialised so llama-server sees a string.
         assert json.loads(msgs[0].content) == [{"type": "output_text", "text": "ok"}]
 
+    def test_empty_tool_output_replaced_with_placeholder(self):
+        """Image-only tool results (Anthropic format) send empty output.
+        Before the fix this crashed the validator with
+        "role=\"tool\" messages require non-empty \"content\"".
+        Now it emits "(no output)" so the turn normalises cleanly."""
+        payload = ResponsesRequest(
+            input = [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "",
+                }
+            ],
+        )
+        msgs = _normalise_responses_input(payload)
+        assert msgs[0].role == "tool"
+        assert msgs[0].tool_call_id == "call_1"
+        assert msgs[0].content == "(no output)"
+        # Round-trip through ChatMessage validator must not raise.
+        ChatMessage(**msgs[0].model_dump(exclude_none = True))
+
+    def test_empty_list_output_serialised_to_json_array(self):
+        """Empty list output is not falsy after json.dumps (becomes "[]"),
+        so it should not trigger the placeholder."""
+        payload = ResponsesRequest(
+            input = [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [],
+                }
+            ],
+        )
+        msgs = _normalise_responses_input(payload)
+        assert msgs[0].role == "tool"
+        assert msgs[0].content == "[]"
+        ChatMessage(**msgs[0].model_dump(exclude_none = True))
+
 
 # =====================================================================
 # Response mapping — tool_calls → function_call output items


### PR DESCRIPTION
## Summary

`/v1/responses` returns a 500 when a client replays a tool result whose `output` is empty.

`_normalise_responses_input` converts each `ResponsesFunctionCallOutputInputItem` into a Chat-Completions `role="tool"` `ChatMessage`, taking the content straight from `item.output`:

```python
output = item.output
if not isinstance(output, str):
    output = json.dumps(output)
messages.append(ChatMessage(role="tool", tool_call_id=item.call_id, content=output))
```

When `output` is an empty string (e.g. an image-only tool result whose payload lives outside the `output` field), `content` becomes `""`. `ChatMessage._validate_role_shape` then raises:

```
ValueError: role="tool" messages require non-empty "content".
```

which surfaces as a 500 instead of a normalised turn.

## Fix

Guard the empty/falsy case after the existing string-coercion step and substitute a placeholder, matching the function's existing intent of always producing a non-empty string for `role="tool"` content (the surrounding comment already documents that Chat-Completions tool messages require string content). Empty content-arrays (`[]`) are already non-empty after `json.dumps`, so only the empty-string path changes behaviour.

```python
output = item.output
if not isinstance(output, str):
    output = json.dumps(output)
if not output:
    output = "(no output)"
```

## Test plan
- [ ] Send a `/v1/responses` request whose `input` contains a `function_call_output` item with `output=""`; previously 500, now normalises to a `role="tool"` message with `content="(no output)"`.
- [ ] Existing non-empty string and content-array outputs are unaffected.

Fixes #6047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
