### PR TITLE
Fix/ Allow empty tool content and system role in API messages

### DIFF
--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -533,7 +533,7 @@ class ChatMessage(BaseModel):
 
         if self.role == "tool":
             # tool_call_id resolution happens at ChatCompletionRequest scope.
-            if not self.content:
+            if self.content is None:
                 raise ValueError('role="tool" messages require non-empty "content".')
         elif self.role == "assistant":
             # Post-Stop sentinel: collapse content="" / [] to None.


### PR DESCRIPTION
Bug 1:
When an agent sends a tool result with empty content ("content": ""), e.g. a WebFetch that returns nothing, the Pydantic validator if not self.content treats the empty string as falsy and returns a 422. The OpenAI API spec allows empty strings in tool results. LM Studio accepts them. This breaks OpenCode, Cursor, Cline, and any client on the OpenAI-compatible path. Reported by Etherl in the screenshots.

Bug 2:
AnthropicMessage restricts role to Literal["user", "assistant"]. Claude Code sends a role: "system" message in every request. Unsloth rejects it before the model sees anything:
"Input should be 'user' or 'assistant' | input: "system"
This completely blocks Claude Code. The OpenAI-compatible path already allows "system", but the Anthropic path was missing it.

<img width="2539" height="1371" alt="image1" src="https://github.com/user-attachments/assets/f3b8c58a-8a67-4aab-a0a2-d62c8597a57a" />
<img width="2550" height="1361" alt="image2" src="https://github.com/user-attachments/assets/5bb1bc8d-622f-4b16-bfd3-379d563e889b" />
