### PR TITLE
Studio: stop ROCm amd-smi tests leaking a fake loggers into sys.modules (follow-up to #6027)

### DIFF
--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -1206,15 +1206,16 @@ class TestAmdGpuMonitoring:
         assert "def get_primary_gpu_utilization" in source
         assert "def get_visible_gpu_utilization" in source
 
-    def test_amd_smi_json_parsing(self):
+    def test_amd_smi_json_parsing(self, monkeypatch):
         """Verify _extract_gpu_metrics parses amd-smi JSON correctly."""
         amd_path = PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "amd.py"
         _amd_spec = importlib.util.spec_from_file_location("test_amd", amd_path)
         assert _amd_spec is not None and _amd_spec.loader is not None
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
-        sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        loggers_mock = MagicMock()
+        loggers_mock.get_logger = MagicMock(return_value = MagicMock())
+        monkeypatch.setitem(sys.modules, "loggers", loggers_mock)
 
         try:
             _amd_spec.loader.exec_module(amd_mod)
@@ -1251,8 +1252,9 @@ class TestAmdGpuMonitoring:
         assert _amd_spec is not None and _amd_spec.loader is not None
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
-        sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        loggers_mock = MagicMock()
+        loggers_mock.get_logger = MagicMock(return_value = MagicMock())
+        monkeypatch.setitem(sys.modules, "loggers", loggers_mock)
 
         try:
             _amd_spec.loader.exec_module(amd_mod)
@@ -1290,15 +1292,16 @@ class TestAmdGpuMonitoring:
         assert result["gpu_utilization_pct"] == 50.0
         assert result["temperature_c"] == 65.0
 
-    def test_amd_smi_not_found_returns_unavailable(self):
+    def test_amd_smi_not_found_returns_unavailable(self, monkeypatch):
         """get_primary_gpu_utilization returns available=False when amd-smi is missing."""
         amd_path = PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "amd.py"
         _amd_spec = importlib.util.spec_from_file_location("test_amd3", amd_path)
         assert _amd_spec is not None and _amd_spec.loader is not None
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
-        sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        loggers_mock = MagicMock()
+        loggers_mock.get_logger = MagicMock(return_value = MagicMock())
+        monkeypatch.setitem(sys.modules, "loggers", loggers_mock)
 
         try:
             _amd_spec.loader.exec_module(amd_mod)
@@ -1309,15 +1312,16 @@ class TestAmdGpuMonitoring:
             result = amd_mod.get_primary_gpu_utilization()
         assert result["available"] is False
 
-    def test_amd_timeout_returns_unavailable(self):
+    def test_amd_timeout_returns_unavailable(self, monkeypatch):
         """get_primary_gpu_utilization handles timeout gracefully."""
         amd_path = PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "amd.py"
         _amd_spec = importlib.util.spec_from_file_location("test_amd4", amd_path)
         assert _amd_spec is not None and _amd_spec.loader is not None
         amd_mod = importlib.util.module_from_spec(_amd_spec)
 
-        sys.modules["loggers"] = MagicMock()
-        sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
+        loggers_mock = MagicMock()
+        loggers_mock.get_logger = MagicMock(return_value = MagicMock())
+        monkeypatch.setitem(sys.modules, "loggers", loggers_mock)
 
         try:
             _amd_spec.loader.exec_module(amd_mod)


### PR DESCRIPTION
## Summary

Follow-up hardening to #6027. The four `TestAmdGpuMonitoring` tests in `tests/studio/install/test_rocm_support.py` also stubbed worker/amd imports by assigning straight into `sys.modules`:

```python
sys.modules["loggers"] = MagicMock()
sys.modules["loggers"].get_logger = MagicMock(return_value = MagicMock())
```

These were never restored, so a mock `loggers` module leaked into global `sys.modules` for any later test in the same job. That is the same leak pattern that caused the `Repo tests (CPU)` failures fixed in #6027 (there it was a non-package `utils`). No failures are pinned to the `loggers` leak today, but it is latent and worth closing off.

## Fix

Switch the four tests to `monkeypatch.setitem(sys.modules, "loggers", ...)` so the stub is undone at teardown. Test-only change.

## Verification

cwd repo root, `PYTHONPATH=studio` (matching the CI job):

```
pytest tests/studio/install/test_rocm_support.py tests/studio/install/test_selection_logic.py
# 455 passed, 1 skipped
pytest tests/studio/install/        # 632 passed, 1 skipped
# the 4 amd tests run (not skipped):
pytest tests/studio/install/test_rocm_support.py -k "amd_smi_json_parsing or amd_primary_gpu_with_mock or amd_smi_not_found or amd_timeout"
# 4 passed
```
