### PR TITLE
Studio: remove red border on chat error messages

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1894,7 +1894,7 @@ const ComposerRightControls: FC<{
 const MessageError: FC = () => {
   return (
     <MessagePrimitive.Error>
-      <ErrorPrimitive.Root className="aui-message-error-root mt-2 rounded-md border border-destructive bg-destructive/10 p-3 text-destructive text-sm dark:bg-destructive/5 dark:text-red-200">
+      <ErrorPrimitive.Root className="aui-message-error-root mt-2 rounded-md bg-destructive/10 p-3 text-destructive text-sm dark:bg-destructive/5 dark:text-red-200">
         <ErrorPrimitive.Message className="aui-message-error-message line-clamp-2" />
       </ErrorPrimitive.Root>
     </MessagePrimitive.Error>


### PR DESCRIPTION
## What

Removes the red border around error message bubbles in Studio Chat, for example the "Audio input is not supported for GGUF chat models yet." error.

## Why

The bordered bubble was visually heavy against the dark theme. The error already stands out through its tinted background and red text, so the border adds noise without improving readability.

## Change

One line in `studio/frontend/src/components/assistant-ui/thread.tsx`: drop `border border-destructive` from the `MessageError` bubble. The tinted background (`bg-destructive/10`, `dark:bg-destructive/5`) and red text are kept, so errors remain clearly distinguishable in both light and dark mode.

This component renders every chat error message, so all errors pick up the cleaner style.

## Testing

- Rebuilt the frontend and served it from a fresh local Studio install
- Verified the rendered error bubble has computed `border-width: 0px` in both light and dark mode
- Confirmed background tint and text color are unchanged