### PR TITLE
Studio: keep chat in place when composer attachments resize it

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -134,6 +134,11 @@ const PageDragContext = createContext(false);
 const COMPOSER_SCROLL_GAP_PX = 24;
 // The scroll-to-bottom footer sits 10px below the spacer top.
 const FOOTER_GAP_BELOW_SPACER_PX = 10;
+// Composer shrinks this soon after a run start (send clears the chips)
+// apply immediately: the run-start pin owns the bottom, so the clamp is
+// the intended glide. Covers instant responses where isRunning is
+// already false by the time the dock resize is observed.
+const RUN_SHRINK_WINDOW_MS = 1000;
 
 export const Thread: FC<{
   hideComposer?: boolean;
@@ -218,6 +223,8 @@ export const Thread: FC<{
   );
 
   const prevComposerHeightRef = useRef<number | null>(null);
+  // Set on thread.runStart; see RUN_SHRINK_WINDOW_MS.
+  const runStartAtRef = useRef(0);
   useLayoutEffect(() => {
     const prev = prevComposerHeightRef.current;
     prevComposerHeightRef.current = composerHeight;
@@ -237,7 +244,10 @@ export const Thread: FC<{
       const distance = el
         ? el.scrollHeight - el.scrollTop - el.clientHeight
         : Number.POSITIVE_INFINITY;
-      if (distance >= applied - desired) {
+      const runOwnsBottom =
+        aui.thread().getState().isRunning ||
+        performance.now() - runStartAtRef.current < RUN_SHRINK_WINDOW_MS;
+      if (runOwnsBottom || distance >= applied - desired) {
         applySpacerPx(desired);
       }
       // else: deferred; released on scroll or a bottom-pinning event.
@@ -277,7 +287,11 @@ export const Thread: FC<{
   }, [applySpacerPx]);
 
   // These pin to the bottom, so releasing the excess here is invisible.
-  useAuiEvent("thread.runStart", releaseSpacerExcess);
+  // runStart also opens the shrink window for the send-clears-chips case.
+  useAuiEvent("thread.runStart", () => {
+    runStartAtRef.current = performance.now();
+    releaseSpacerExcess();
+  });
   useAuiEvent("thread.initialize", releaseSpacerExcess);
   useAuiEvent("threadListItem.switchedTo", releaseSpacerExcess);
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -168,11 +168,13 @@ export const Thread: FC<{
       : composerHeight + COMPOSER_SCROLL_GAP_PX - FOOTER_GAP_BELOW_SPACER_PX;
 
   // The viewport element is owned by the autoscroll hook; mirror it
-  // locally for the spacer clamp math below.
-  const localViewportRef = useRef<HTMLElement | null>(null);
+  // locally for the spacer clamp math below. State, not a ref: the keyed
+  // provider below remounts the viewport on thread switches, and the
+  // scroll listener effect must re-attach to the new element.
+  const [viewportEl, setViewportEl] = useState<HTMLElement | null>(null);
   const composedViewportRef = useCallback(
     (node: HTMLElement | null) => {
-      localViewportRef.current = node;
+      setViewportEl(node);
       viewportRef(node);
     },
     [viewportRef],
@@ -240,9 +242,8 @@ export const Thread: FC<{
     if (applied == null || desired >= applied) {
       applySpacerPx(desired);
     } else {
-      const el = localViewportRef.current;
-      const distance = el
-        ? el.scrollHeight - el.scrollTop - el.clientHeight
+      const distance = viewportEl
+        ? viewportEl.scrollHeight - viewportEl.scrollTop - viewportEl.clientHeight
         : Number.POSITIVE_INFINITY;
       const runOwnsBottom =
         aui.thread().getState().isRunning ||
@@ -262,12 +263,13 @@ export const Thread: FC<{
         autoScrollContext.detachFromBottom();
       }
     }
-  }, [composerHeight, hideComposer, autoScrollContext, aui, applySpacerPx]);
+  }, [composerHeight, hideComposer, autoScrollContext, aui, applySpacerPx, viewportEl]);
 
   // Drop deferred spacer excess as soon as the user has scrolled far
   // enough above the bottom that the shrink cannot clamp scrollTop.
+  // Keyed on viewportEl so the listener follows viewport remounts.
   useEffect(() => {
-    const el = localViewportRef.current;
+    const el = viewportEl;
     if (!el) {
       return;
     }
@@ -284,7 +286,7 @@ export const Thread: FC<{
     };
     el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
-  }, [applySpacerPx]);
+  }, [viewportEl, applySpacerPx]);
 
   // These pin to the bottom, so releasing the excess here is invisible.
   // runStart also opens the shrink window for the send-clears-chips case.

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -119,6 +119,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -126,6 +127,13 @@ import {
 // True while a file is dragged anywhere over the chat page (not just the
 // composer), so the composer can show its "Drop files here" affordance.
 const PageDragContext = createContext(false);
+
+// Gap (px) between the last message and the floating composer. The bottom
+// spacer tracks composer height plus this gap so the chat can always be
+// scrolled fully above the composer.
+const COMPOSER_SCROLL_GAP_PX = 24;
+// The scroll-to-bottom footer sits 10px below the spacer top.
+const FOOTER_GAP_BELOW_SPACER_PX = 10;
 
 export const Thread: FC<{
   hideComposer?: boolean;
@@ -144,12 +152,139 @@ export const Thread: FC<{
   );
   const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const threadId = targetThreadId ?? activeThreadId ?? null;
+  const aui = useAui();
+
+  // Measured height of the floating composer dock (null until measured).
+  // Drives the bottom spacer and the scroll-to-bottom footer offset.
+  const [composerHeight, setComposerHeight] = useState<number | null>(null);
+  const footerBottomPx =
+    composerHeight == null
+      ? null
+      : composerHeight + COMPOSER_SCROLL_GAP_PX - FOOTER_GAP_BELOW_SPACER_PX;
+
+  // The viewport element is owned by the autoscroll hook; mirror it
+  // locally for the spacer clamp math below.
+  const localViewportRef = useRef<HTMLElement | null>(null);
+  const composedViewportRef = useCallback(
+    (node: HTMLElement | null) => {
+      localViewportRef.current = node;
+      viewportRef(node);
+    },
+    [viewportRef],
+  );
+
+  // Bottom spacer sizing. Invariant: the chat never moves on its own when
+  // the composer resizes.
+  // - Grow (attachment added, multiline input): grow the spacer at once.
+  //   Growth below the scroll position is invisible and only adds room.
+  // - Shrink (attachment removed): shrinking scrollHeight near the bottom
+  //   would clamp scrollTop and yank the chat down. Defer the shrink until
+  //   it is invisible (user scrolled up) or a bottom-pinning moment.
+  // Applied imperatively so a remounted spacer can be sized from refs even
+  // when composerHeight did not change (e.g. thread switch).
+  const spacerElRef = useRef<HTMLDivElement | null>(null);
+  const desiredSpacerPxRef = useRef<number | null>(null);
+  const appliedSpacerPxRef = useRef<number | null>(null);
+
+  const applySpacerPx = useCallback((px: number) => {
+    appliedSpacerPxRef.current = px;
+    const node = spacerElRef.current;
+    if (node) {
+      node.style.height = `${px}px`;
+    }
+  }, []);
+
+  // Release any deferred shrink; used at moments that pin to the bottom
+  // anyway, where the clamp is the intended motion.
+  const releaseSpacerExcess = useCallback(() => {
+    const desired = desiredSpacerPxRef.current;
+    const applied = appliedSpacerPxRef.current;
+    if (desired != null && applied != null && applied > desired) {
+      applySpacerPx(desired);
+    }
+  }, [applySpacerPx]);
+
+  const spacerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      spacerElRef.current = node;
+      // Fresh mounts (thread switch, first message) start at the desired
+      // size; deferral state from a previous mount is moot.
+      const desired = desiredSpacerPxRef.current;
+      if (node && desired != null) {
+        applySpacerPx(desired);
+      }
+    },
+    [applySpacerPx],
+  );
+
+  const prevComposerHeightRef = useRef<number | null>(null);
+  useLayoutEffect(() => {
+    const prev = prevComposerHeightRef.current;
+    prevComposerHeightRef.current = composerHeight;
+    if (composerHeight == null || hideComposer) {
+      desiredSpacerPxRef.current = null;
+      appliedSpacerPxRef.current = null;
+      spacerElRef.current?.style.removeProperty("height");
+      return;
+    }
+    const desired = composerHeight + COMPOSER_SCROLL_GAP_PX;
+    desiredSpacerPxRef.current = desired;
+    const applied = appliedSpacerPxRef.current;
+    if (applied == null || desired >= applied) {
+      applySpacerPx(desired);
+    } else {
+      const el = localViewportRef.current;
+      const distance = el
+        ? el.scrollHeight - el.scrollTop - el.clientHeight
+        : Number.POSITIVE_INFINITY;
+      if (distance >= applied - desired) {
+        applySpacerPx(desired);
+      }
+      // else: deferred; released on scroll or a bottom-pinning event.
+    }
+    if (prev != null && composerHeight > prev) {
+      // The chat is now above the new bottom. Detach as if the user had
+      // scrolled up so no later signal re-pins and shoves the chat up.
+      // Scrolling back down re-attaches; explicit pins still work.
+      // Mid-run growth comes from tool-status rows, not the user, and
+      // detaching then would break streaming autoscroll, so skip it.
+      if (!aui.thread().getState().isRunning) {
+        autoScrollContext.detachFromBottom();
+      }
+    }
+  }, [composerHeight, hideComposer, autoScrollContext, aui, applySpacerPx]);
+
+  // Drop deferred spacer excess as soon as the user has scrolled far
+  // enough above the bottom that the shrink cannot clamp scrollTop.
+  useEffect(() => {
+    const el = localViewportRef.current;
+    if (!el) {
+      return;
+    }
+    const onScroll = () => {
+      const desired = desiredSpacerPxRef.current;
+      const applied = appliedSpacerPxRef.current;
+      if (desired == null || applied == null || applied <= desired) {
+        return;
+      }
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distance >= applied - desired) {
+        applySpacerPx(desired);
+      }
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [applySpacerPx]);
+
+  // These pin to the bottom, so releasing the excess here is invisible.
+  useAuiEvent("thread.runStart", releaseSpacerExcess);
+  useAuiEvent("thread.initialize", releaseSpacerExcess);
+  useAuiEvent("threadListItem.switchedTo", releaseSpacerExcess);
 
   // Page-wide drag-and-drop: dropping a file anywhere on the chat page (not
   // just on the composer) attaches it and shows the composer drop affordance.
   // The composer's own dropzone still handles drops on the box itself; its
   // handler calls preventDefault, so the page handler skips them (no double-add).
-  const aui = useAui();
   const [pageDragging, setPageDragging] = useState(false);
   const dragDepth = useRef(0);
   const hasFiles = (e: ReactDragEvent) =>
@@ -208,7 +343,7 @@ export const Thread: FC<{
       >
         <IntentAwareScrollProvider value={autoScrollContext}>
           <ThreadPrimitive.Viewport
-            ref={viewportRef}
+            ref={composedViewportRef}
             autoScroll={false}
             scrollToBottomOnRunStart={false}
             scrollToBottomOnInitialize={false}
@@ -240,7 +375,15 @@ export const Thread: FC<{
             sticky footer and feel cramped. */}
             <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
               <div
-                className={cn("shrink-0", hideComposer ? "h-16" : "h-40")}
+                ref={spacerRef}
+                className={cn(
+                  "shrink-0",
+                  hideComposer
+                    ? "h-16"
+                    : composerHeight == null
+                      ? "h-40"
+                      : undefined,
+                )}
                 aria-hidden={true}
               />
             </AuiIf>
@@ -250,21 +393,34 @@ export const Thread: FC<{
                 className={cn(
                   "aui-thread-viewport-footer pointer-events-none sticky z-20 flex w-full justify-center bg-transparent",
                   // 150px (was 140px) to add a small gap above the composer
-                  hideComposer ? "bottom-3" : "bottom-[150px]",
+                  hideComposer
+                    ? "bottom-3"
+                    : footerBottomPx == null
+                      ? "bottom-[150px]"
+                      : undefined,
                 )}
+                style={
+                  !hideComposer && footerBottomPx != null
+                    ? { bottom: footerBottomPx }
+                    : undefined
+                }
               >
                 <ThreadScrollToBottom />
               </ThreadPrimitive.ViewportFooter>
             </AuiIf>
           </ThreadPrimitive.Viewport>
 
-          <GeneratedImageViewportOverlay hideComposer={hideComposer} />
+          <GeneratedImageViewportOverlay
+            hideComposer={hideComposer}
+            bottomOffsetPx={footerBottomPx}
+          />
 
           {!hideComposer && (
             <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
               <ThreadComposerDock
                 disabled={isComposerAttachPending}
                 threadId={threadId}
+                onHeightChange={setComposerHeight}
               />
             </AuiIf>
           )}
@@ -275,9 +431,10 @@ export const Thread: FC<{
   );
 };
 
-const GeneratedImageViewportOverlay: FC<{ hideComposer?: boolean }> = ({
-  hideComposer,
-}) => {
+const GeneratedImageViewportOverlay: FC<{
+  hideComposer?: boolean;
+  bottomOffsetPx?: number | null;
+}> = ({ hideComposer, bottomOffsetPx }) => {
   const { overlay, closeOverlay } = useGeneratedImageOverlay();
 
   useEffect(() => {
@@ -302,8 +459,17 @@ const GeneratedImageViewportOverlay: FC<{ hideComposer?: boolean }> = ({
       <section
         className={cn(
           "pointer-events-none absolute inset-x-5 top-[48px] flex flex-col items-center",
-          hideComposer ? "bottom-4" : "bottom-[150px]",
+          hideComposer
+            ? "bottom-4"
+            : bottomOffsetPx == null
+              ? "bottom-[150px]"
+              : undefined,
         )}
+        style={
+          !hideComposer && bottomOffsetPx != null
+            ? { bottom: bottomOffsetPx }
+            : undefined
+        }
         aria-label="Generated image preview"
       >
         <div className="pointer-events-auto relative flex min-h-0 w-full max-w-[1100px] flex-1 flex-col items-center justify-center gap-3 rounded-3xl bg-muted/10 p-3 ring-1 ring-border/20">
@@ -370,11 +536,29 @@ const GeneratedImageViewportOverlay: FC<{ hideComposer?: boolean }> = ({
 const ThreadComposerDock: FC<{
   disabled?: boolean;
   threadId?: string | null;
-}> = ({ disabled, threadId }) => {
+  onHeightChange?: (height: number | null) => void;
+}> = ({ disabled, threadId, onHeightChange }) => {
   const { overlay } = useGeneratedImageOverlay();
+
+  // Report the dock's rendered height so the viewport can reserve matching
+  // scroll space when attachments or multiline input grow the composer.
+  const dockRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = dockRef.current;
+    if (!el || !onHeightChange) return;
+    const measure = () => onHeightChange(el.offsetHeight);
+    measure();
+    const resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(el);
+    return () => {
+      resizeObserver.disconnect();
+      onHeightChange(null);
+    };
+  }, [onHeightChange]);
 
   return (
     <div
+      ref={dockRef}
       className={cn(
         "aui-thread-composer-dock pointer-events-none absolute bottom-0 left-0 right-0 md:right-[10px]",
         overlay ? "z-40" : "z-20",

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -248,7 +248,13 @@ export const Thread: FC<{
       const runOwnsBottom =
         aui.thread().getState().isRunning ||
         performance.now() - runStartAtRef.current < RUN_SHRINK_WINDOW_MS;
-      if (runOwnsBottom || distance >= applied - desired) {
+      // At the bottom the shrink only drops blank spacer, so apply it now
+      // instead of stranding dead space until the next pin.
+      if (
+        runOwnsBottom ||
+        distance >= applied - desired ||
+        autoScrollContext.getIsAtBottom()
+      ) {
         applySpacerPx(desired);
       }
       // else: deferred; released on scroll or a bottom-pinning event.

--- a/studio/frontend/src/components/assistant-ui/use-intent-aware-autoscroll.tsx
+++ b/studio/frontend/src/components/assistant-ui/use-intent-aware-autoscroll.tsx
@@ -77,6 +77,14 @@ type AutoScrollContextValue = {
   scrollToBottom: ScrollToBottom;
   getIsAtBottom: () => boolean;
   subscribe: (listener: () => void) => () => void;
+  /**
+   * Mark the user as detached from the bottom, as if they had scrolled
+   * up. Called when the composer grows and the bottom spacer grows with
+   * it: the chat is then above the new bottom, and observer-driven pins
+   * must not shove it up. Scrolling back to the bottom re-attaches;
+   * explicit pins (run start, scroll-to-bottom button) still work.
+   */
+  detachFromBottom: () => void;
 };
 
 const noopContext: AutoScrollContextValue = {
@@ -86,6 +94,9 @@ const noopContext: AutoScrollContextValue = {
   getIsAtBottom: () => true,
   subscribe: () => () => {
     /* no-op */
+  },
+  detachFromBottom: () => {
+    /* no viewport mounted */
   },
 };
 
@@ -129,6 +140,9 @@ export function useIntentAwareAutoScroll(): {
   const scrollImplRef = useRef<ScrollToBottom>(() => {
     /* no viewport mounted */
   });
+  const detachImplRef = useRef<() => void>(() => {
+    /* no viewport mounted */
+  });
 
   const getIsAtBottom = useCallback(() => isAtBottomRef.current, []);
 
@@ -153,8 +167,12 @@ export function useIntentAwareAutoScroll(): {
     scrollImplRef.current(behavior);
   }, []);
 
+  const detachFromBottom = useCallback(() => {
+    detachImplRef.current();
+  }, []);
+
   const attach = useCallback(
-    (el: HTMLElement) => {
+    (el: HTMLElement, isRebind: boolean) => {
       let rafId: number | null = null;
       let lastScrollTop = el.scrollTop;
       let lastClientWidth = el.clientWidth;
@@ -283,6 +301,13 @@ export function useIntentAwareAutoScroll(): {
           el.scrollTo({ top: el.scrollHeight, behavior });
         }
         setIsAtBottom(true);
+        requestTick();
+      };
+
+      // Programmatic detach (see detachFromBottom). Same effect as the
+      // user scrolling up; the tick refresh updates isAtBottom.
+      detachImplRef.current = () => {
+        detach();
         requestTick();
       };
 
@@ -476,21 +501,24 @@ export function useIntentAwareAutoScroll(): {
       const mutationObserver = new MutationObserver(onLayoutChange);
       const onViewportResize = onLayoutChange;
 
-      // Fresh attach always starts pinned. `userDetachedRef` survives
-      // ref rebinds (it's hook-scoped), so if the viewport element is
-      // ever unmounted and remounted without an AUI lifecycle event
-      // (e.g. a parent layout refactor that remounts the viewport),
-      // a prior detach would silently disable auto-follow for the
-      // rest of the session.
-      userDetachedRef.current = false;
+      // Fresh attach (a new viewport element) always starts pinned.
+      // Rebinds to the SAME element must not pin or reset detach state:
+      // the Viewport composes refs with an identity that changes on
+      // re-render, so React re-runs the ref (null, then same element)
+      // on unrelated renders such as composer resizes. Pinning here
+      // would yank the chat to the bottom on every such render. The
+      // observers below are re-installed either way.
+      if (!isRebind) {
+        userDetachedRef.current = false;
 
-      // Pin to bottom when the ref first attaches. Covers the case
-      // where `thread.initialize` fires before the ref is bound.
-      extendFollow();
-      if (el.scrollHeight > el.clientHeight) {
-        el.scrollTo({ top: el.scrollHeight, behavior: "instant" });
+        // Pin to bottom when the ref first attaches. Covers the case
+        // where `thread.initialize` fires before the ref is bound.
+        extendFollow();
+        if (el.scrollHeight > el.clientHeight) {
+          el.scrollTo({ top: el.scrollHeight, behavior: "instant" });
+        }
+        setIsAtBottom(true);
       }
-      setIsAtBottom(true);
       requestTick();
 
       // Observe the border box, not the content box. The stabilizer
@@ -544,6 +572,9 @@ export function useIntentAwareAutoScroll(): {
         scrollImplRef.current = () => {
           /* no viewport mounted */
         };
+        detachImplRef.current = () => {
+          /* no viewport mounted */
+        };
       };
     },
     [setIsAtBottom],
@@ -562,6 +593,7 @@ export function useIntentAwareAutoScroll(): {
   useAuiEvent("thread.initialize", () => pinToBottom("instant"));
   useAuiEvent("threadListItem.switchedTo", () => pinToBottom("instant"));
 
+  const lastElRef = useRef<HTMLElement | null>(null);
   const ref = useCallback<RefCallback<HTMLElement>>(
     (el) => {
       if (cleanupRef.current) {
@@ -569,15 +601,20 @@ export function useIntentAwareAutoScroll(): {
         cleanupRef.current = null;
       }
       if (el) {
-        cleanupRef.current = attach(el);
+        // Same-element rebind vs a genuinely new element, see attach().
+        const isRebind = lastElRef.current === el;
+        lastElRef.current = el;
+        cleanupRef.current = attach(el, isRebind);
       }
+      // On null, keep lastElRef so a rebind to the same element is
+      // recognized; a real remount binds a different element anyway.
     },
     [attach],
   );
 
   const context = useMemo<AutoScrollContextValue>(
-    () => ({ scrollToBottom, getIsAtBottom, subscribe }),
-    [scrollToBottom, getIsAtBottom, subscribe],
+    () => ({ scrollToBottom, getIsAtBottom, subscribe, detachFromBottom }),
+    [scrollToBottom, getIsAtBottom, subscribe, detachFromBottom],
   );
 
   return { ref, context };


### PR DESCRIPTION
### What this fixes

Three related problems in Studio chat when the composer changes size:

1. Attaching a file could shove the whole conversation up.
2. The grown composer covered the end of the chat and there was no way to scroll the covered lines back into view (unlike other chat UIs which add scroll room).
3. Removing the attachment could yank the chat again.

### Root cause

`ThreadPrimitive.Viewport` composes the forwarded ref with internal refs via `useComposedRefs`, and the composed ref identity changes on re-render. React then re-runs the ref callback (null, then the same element) on unrelated re-renders, for example when the composer resizes. Our intent-aware autoscroll hook treated every rebind as a fresh mount and ran its "fresh attach starts pinned" `scrollTo`, yanking the chat to the bottom at exactly the moment the composer resized. Direction and frequency depended on whether the pin landed before or after the spacer resize, which is why it looked intermittent.

Separately, the viewport reserved a fixed 160px (`h-40`) under the last message no matter how tall the composer was, so attachment chips simply covered the conversation.

### Changes

`use-intent-aware-autoscroll.tsx`
- Track the last attached element. Rebinds to the same element no longer pin or reset detach state; only a genuinely new viewport element does. Observers are re-installed either way.
- New `detachFromBottom()` on the scroll context: marks the user detached exactly as if they had scrolled up, so observer-driven pins cannot move the chat. Scrolling back to the bottom re-attaches as usual.

`thread.tsx`
- Measure the composer dock with a `ResizeObserver` and size the bottom spacer as composer height plus a 24px gap (also tightens the previous oversized fixed gap). The scroll-to-bottom button and the generated image overlay track the same offset.
- Composer grows (attachment added, multiline input): grow the spacer immediately, which is invisible and only adds scroll room, then detach from the bottom. The chat does not move; the user scrolls down to reveal the covered lines. Growth during a run is ignored so streaming autoscroll is unaffected.
- Composer shrinks (attachment removed): shrinking scroll height near the bottom would clamp `scrollTop` and visibly yank the chat, so the shrink is deferred until the user has scrolled far enough up that it is invisible, or until a moment that pins to the bottom anyway (run start, thread switch, thread load).

### Testing

- Drove the real `Thread` plus the real autoscroll hook on a local runtime with `scrollTo` instrumented (stack traces on every call), which is how the rebind pin was caught.
- Verified end to end: attach at bottom (chat frozen, scroll room added, scroll-to-bottom button appears, zero stray `scrollTo` calls), scroll down to the chip, remove it (chat frozen, no jump), scroll up (deferred spacer released silently), send a message (still pins to the new turn).
- `tsc -b` and `vite build` pass.
