### PR TITLE
CI: allowlist deepseek_ocr2 in compiler full-model-sweep

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -992,6 +992,7 @@ jobs:
               "beit":            "TimeoutError: compile exceeds per-model budget",
               "sam":             "TimeoutError: compile exceeds per-model budget",
               "sam_hq":          "TimeoutError: compile exceeds per-model budget",
+              "deepseek_ocr2":   "TimeoutError: compile exceeds per-model budget",
           }
 
 


### PR DESCRIPTION
## Summary

transformers-latest adds a new `deepseek_ocr2` model. In the Core "Compiler full-model-sweep" test it compiles but exceeds the 60s per-model budget on the CI runner, so the sweep reports it as a new failure (`TimeoutError: compile exceeded per-model budget`).

This is the same category as the existing `beit`/`sam`/`sam_hq` entries, so add `deepseek_ocr2` to `KNOWN_BROKEN_COMPILE` (Category F). It unblocks the HF=latest + TRL=latest Core job, which currently fails on every PR and on main solely because of this new upstream model.

## Notes

- The sweep still compiles 450 model types fine; this is a per-model timeout on a large OCR model, not a correctness regression.
- Making the rewriter faster on `deepseek_ocr2` remains a follow-up in unsloth_zoo, as already noted in the Category F comment.