### PR TITLE
fix(studio): reject unsupported MLX CPT and embedding training

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1311,6 +1311,14 @@ def _run_mlx_training(event_queue, stop_queue, config):
         message = "LoftQ is not supported for MLX training yet."
         _send("error", error = message)
         raise NotImplementedError(message)
+    if config.get("is_embedding"):
+        message = "Embedding model training is not supported for MLX training yet."
+        _send("error", error = message)
+        raise NotImplementedError(message)
+    if config.get("training_type") == "Continued Pretraining":
+        message = "Continued Pretraining is not supported for MLX training yet."
+        _send("error", error = message)
+        raise NotImplementedError(message)
 
     optim_name = _normalize_mlx_studio_optimizer(config.get("optim", "adamw_8bit"))
     lr_scheduler_type = _normalize_mlx_studio_scheduler(


### PR DESCRIPTION
This PR fixes unsupported MLX Studio training modes being routed into the wrong trainer path.

When running on MLX:
- setting `Method` to `Continued Pretraining` was effectively treated as full finetuning by `_run_mlx_training()`
- training an embedding model was routed to `_run_mlx_training()` instead of the embedding-specific trainer path

Both modes are not supported by the MLX training path yet, so this PR raises a clear unsupported-mode error instead of mistakenly proceeding with training.

## Fix

Add MLX unsupported-mode checks next to the existing LoFTQ unsupported check:
- reject `is_embedding`
- reject `training_type == "Continued Pretraining"`

Both emit an error event and raise `NotImplementedError`.