### PR TITLE
docs: add AI Badgr hosted GPU launch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Use the same command to update.
 ```bash
 unsloth studio -p 8888
 ```
-For cloud or global access, add `-H 0.0.0.0`. By default, Unsloth is accessible only locally.
+For cloud or global access, add `-H 0.0.0.0`. By default, Unsloth is accessible only locally. You can also launch a hosted GPU on [AI Badgr](https://aibadgr.com/gpu/launch?template=unsloth).
 
 #### Docker
 Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth``` container. Run:


### PR DESCRIPTION
## Summary

Adds AI Badgr as an optional hosted GPU launch path for Unsloth users.

The value is that fine-tuning users often care deeply about VRAM availability, GPU cost, and avoiding long manual cloud setup. This link gives users a prefilled hosted GPU option for running Unsloth when local hardware is not enough.

AI Badgr template:

https://aibadgr.com/gpu/launch?template=unsloth

This is a documentation-only change. It does not modify Unsloth code, package behavior, Docker behavior, or local setup instructions.

## Motivation

Unsloth is commonly used for fine-tuning workflows where local VRAM, GPU availability, and cost can be limiting factors.

This PR adds a small cloud GPU launch link so users can discover an optional hosted GPU path without changing the existing local, Docker, or Studio setup flow.

## Testing

Docs-only change.

I checked that:

* the README markdown renders correctly
* the AI Badgr link points to the `unsloth` launch template
* the existing Unsloth command examples remain unchanged

## AI Usage Disclaimer

Yes — ChatGPT/Copilot assisted with drafting the documentation wording. I reviewed and edited the final submitted change.
