### PR TITLE
Studio: forward audio input to llama-server for GGUF models

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4259,17 +4259,14 @@ class LlamaCppBackend:
     def _build_openai_messages(
         messages: list[dict],
         image_b64: Optional[str] = None,
-        audio_b64: Optional[str] = None,
-        audio_format: str = "wav",
     ) -> list[dict]:
         """
-        Build OpenAI-format messages, optionally injecting image_url and/or
-        input_audio content parts into the last user message for multimodal
-        models.
+        Build OpenAI-format messages, optionally injecting an image_url
+        content part into the last user message for vision models.
 
-        If no media is provided, returns messages as-is.
+        If no image is provided, returns messages as-is.
         """
-        if not image_b64 and not audio_b64:
+        if not image_b64:
             return messages
 
         # Find the last user message and convert to multimodal content parts
@@ -4280,30 +4277,16 @@ class LlamaCppBackend:
                 last_user_idx = i
 
         if last_user_idx is not None:
-            existing = result[last_user_idx].get("content", "")
-            # Content may already be a list of parts (e.g. a vision turn with
-            # image_url parts baked in upstream); preserve those and append to
-            # them rather than wrapping the list inside a text part.
-            if isinstance(existing, list):
-                parts: list[dict] = list(existing)
-            else:
-                parts = [{"type": "text", "text": existing or ""}]
-            if image_b64:
-                parts.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{image_b64}"},
-                    }
-                )
-            if audio_b64:
-                # llama-server's audio decoder only accepts wav/mp3.
-                parts.append(
-                    {
-                        "type": "input_audio",
-                        "input_audio": {"data": audio_b64, "format": audio_format},
-                    }
-                )
-            result[last_user_idx]["content"] = parts
+            text_content = result[last_user_idx].get("content", "")
+            result[last_user_idx]["content"] = [
+                {"type": "text", "text": text_content},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{image_b64}",
+                    },
+                },
+            ]
 
         return result
 
@@ -4434,8 +4417,6 @@ class LlamaCppBackend:
         self,
         messages: list[dict],
         image_b64: Optional[str] = None,
-        audio_b64: Optional[str] = None,
-        audio_format: str = "wav",
         temperature: float = 0.6,
         top_p: float = 0.95,
         top_k: int = 20,
@@ -4460,9 +4441,7 @@ class LlamaCppBackend:
         if not self.is_loaded:
             raise RuntimeError("llama-server is not loaded")
 
-        openai_messages = self._build_openai_messages(
-            messages, image_b64, audio_b64, audio_format
-        )
+        openai_messages = self._build_openai_messages(messages, image_b64)
 
         payload = {
             "messages": openai_messages,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4260,6 +4260,7 @@ class LlamaCppBackend:
         messages: list[dict],
         image_b64: Optional[str] = None,
         audio_b64: Optional[str] = None,
+        audio_format: str = "wav",
     ) -> list[dict]:
         """
         Build OpenAI-format messages, optionally injecting image_url and/or
@@ -4286,7 +4287,7 @@ class LlamaCppBackend:
             if isinstance(existing, list):
                 parts: list[dict] = list(existing)
             else:
-                parts = [{"type": "text", "text": existing}]
+                parts = [{"type": "text", "text": existing or ""}]
             if image_b64:
                 parts.append(
                     {
@@ -4295,12 +4296,11 @@ class LlamaCppBackend:
                     }
                 )
             if audio_b64:
-                # llama-server's audio decoder only accepts wav/mp3; callers
-                # pass a wav payload here.
+                # llama-server's audio decoder only accepts wav/mp3.
                 parts.append(
                     {
                         "type": "input_audio",
-                        "input_audio": {"data": audio_b64, "format": "wav"},
+                        "input_audio": {"data": audio_b64, "format": audio_format},
                     }
                 )
             result[last_user_idx]["content"] = parts
@@ -4435,6 +4435,7 @@ class LlamaCppBackend:
         messages: list[dict],
         image_b64: Optional[str] = None,
         audio_b64: Optional[str] = None,
+        audio_format: str = "wav",
         temperature: float = 0.6,
         top_p: float = 0.95,
         top_k: int = 20,
@@ -4459,7 +4460,9 @@ class LlamaCppBackend:
         if not self.is_loaded:
             raise RuntimeError("llama-server is not loaded")
 
-        openai_messages = self._build_openai_messages(messages, image_b64, audio_b64)
+        openai_messages = self._build_openai_messages(
+            messages, image_b64, audio_b64, audio_format
+        )
 
         payload = {
             "messages": openai_messages,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4259,14 +4259,16 @@ class LlamaCppBackend:
     def _build_openai_messages(
         messages: list[dict],
         image_b64: Optional[str] = None,
+        audio_b64: Optional[str] = None,
     ) -> list[dict]:
         """
-        Build OpenAI-format messages, optionally injecting an image_url
-        content part into the last user message for vision models.
+        Build OpenAI-format messages, optionally injecting image_url and/or
+        input_audio content parts into the last user message for multimodal
+        models.
 
-        If no image is provided, returns messages as-is.
+        If no media is provided, returns messages as-is.
         """
-        if not image_b64:
+        if not image_b64 and not audio_b64:
             return messages
 
         # Find the last user message and convert to multimodal content parts
@@ -4277,16 +4279,31 @@ class LlamaCppBackend:
                 last_user_idx = i
 
         if last_user_idx is not None:
-            text_content = result[last_user_idx].get("content", "")
-            result[last_user_idx]["content"] = [
-                {"type": "text", "text": text_content},
-                {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": f"data:image/png;base64,{image_b64}",
-                    },
-                },
-            ]
+            existing = result[last_user_idx].get("content", "")
+            # Content may already be a list of parts (e.g. a vision turn with
+            # image_url parts baked in upstream); preserve those and append to
+            # them rather than wrapping the list inside a text part.
+            if isinstance(existing, list):
+                parts: list[dict] = list(existing)
+            else:
+                parts = [{"type": "text", "text": existing}]
+            if image_b64:
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image_b64}"},
+                    }
+                )
+            if audio_b64:
+                # llama-server's audio decoder only accepts wav/mp3; callers
+                # pass a wav payload here.
+                parts.append(
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": audio_b64, "format": "wav"},
+                    }
+                )
+            result[last_user_idx]["content"] = parts
 
         return result
 
@@ -4417,6 +4434,7 @@ class LlamaCppBackend:
         self,
         messages: list[dict],
         image_b64: Optional[str] = None,
+        audio_b64: Optional[str] = None,
         temperature: float = 0.6,
         top_p: float = 0.95,
         top_k: int = 20,
@@ -4441,7 +4459,7 @@ class LlamaCppBackend:
         if not self.is_loaded:
             raise RuntimeError("llama-server is not loaded")
 
-        openai_messages = self._build_openai_messages(messages, image_b64)
+        openai_messages = self._build_openai_messages(messages, image_b64, audio_b64)
 
         payload = {
             "messages": openai_messages,

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -676,7 +676,8 @@ class ChatCompletionRequest(BaseModel):
         None, description = "[x-unsloth] Base64-encoded image for vision models"
     )
     audio_base64: Optional[str] = Field(
-        None, description = "[x-unsloth] Base64-encoded WAV for audio-input models (ASR)"
+        None,
+        description = "[x-unsloth] Base64-encoded audio (wav/mp3/ogg/flac/m4a) for audio-input models",
     )
     use_adapter: Optional[Union[bool, str]] = Field(
         None,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1744,18 +1744,16 @@ async def generate_audio(
 
 
 def _decode_audio_base64(b64: str) -> np.ndarray:
-    """Decode base64 audio (any format) → float32 mono numpy array at 16kHz."""
-    import librosa
+    """Decode base64 audio (any format) → float32 numpy array at 16kHz."""
+    import torch
+    import torchaudio
     import tempfile
     import os
     from utils.paths import ensure_dir, tmp_root
 
-    if b64.startswith("data:"):
-        b64 = b64.split(",", 1)[1]
     raw = base64.b64decode(b64)
-    # librosa's audioread/ffmpeg fallback (mp3/m4a) needs a real path, so write
-    # the bytes to a temp file; the format is auto-detected from the content.
-    # sr=16000 resamples and mono=True downmixes.
+    # torchaudio.load needs a file path or file-like object with format hint
+    # Write to a temp file so torchaudio can auto-detect the format
     with tempfile.NamedTemporaryFile(
         suffix = ".audio",
         delete = False,
@@ -1764,25 +1762,126 @@ def _decode_audio_base64(b64: str) -> np.ndarray:
         tmp.write(raw)
         tmp_path = tmp.name
     try:
-        waveform, _ = librosa.load(tmp_path, sr = 16000, mono = True)
+        waveform, sr = torchaudio.load(tmp_path)
     finally:
         os.unlink(tmp_path)
 
-    return waveform
+    # Convert to mono if stereo
+    if waveform.shape[0] > 1:
+        waveform = waveform.mean(dim = 0, keepdim = True)
+
+    # Resample to 16kHz if needed
+    if sr != 16000:
+        resampler = torchaudio.transforms.Resample(orig_freq = sr, new_freq = 16000)
+        waveform = resampler(waveform)
+
+    return waveform.squeeze(0).numpy()
 
 
-def _transcode_audio_to_wav_b64(b64: str) -> str:
-    """Decode base64 audio (any container) and re-encode as base64 16 kHz mono WAV.
+# Reject oversized audio before decoding. base64 inflates raw bytes by ~4/3, so
+# cap the encoded length to bound the upload and the decode that follows.
+_MAX_AUDIO_RAW_BYTES = 25 * 1024 * 1024
+_MAX_AUDIO_B64_CHARS = _MAX_AUDIO_RAW_BYTES * 4 // 3
 
-    llama-server's audio decoder only accepts wav/mp3, so uploads in other
-    containers (m4a/ogg/webm/flac) are normalized here. Blocking (torchaudio +
-    temp file); call via a thread from async paths.
+
+def _sniff_audio_container(raw: bytes) -> Optional[str]:
+    """Return 'wav' or 'mp3' if the bytes are a container llama-server accepts
+    directly (so we can forward them untouched), else None (needs transcoding)."""
+    if len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WAVE":
+        return "wav"
+    # mp3: ID3 tag, or an MPEG audio frame sync (no other accepted format leads
+    # with 0xFF, so the simple sync check doesn't collide).
+    if raw[:3] == b"ID3" or (len(raw) >= 2 and raw[0] == 0xFF and (raw[1] & 0xE0) == 0xE0):
+        return "mp3"
+    return None
+
+
+def _mono_f32_to_wav_bytes(arr: np.ndarray, sample_rate: int) -> bytes:
+    """Encode a mono float32 array as 16-bit PCM WAV bytes.
+
+    Torch-free (numpy + stdlib only) so it works on no-torch GGUF-only installs;
+    the shared audio_codecs helper pulls in torch at import time.
     """
-    from core.inference.audio_codecs import _numpy_to_wav_bytes
+    import io
+    import wave
 
-    return base64.b64encode(
-        _numpy_to_wav_bytes(_decode_audio_base64(b64), 16000)
-    ).decode("ascii")
+    arr = np.nan_to_num(
+        np.asarray(arr, dtype = np.float32).flatten(), posinf = 0.0, neginf = 0.0
+    )
+    if arr.size == 0:
+        raise ValueError("decoded audio is empty")
+    peak = float(np.abs(arr).max())
+    if peak > 1.0:
+        arr = arr / peak
+    pcm = (arr * 32767.0).astype(np.int16)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(int(sample_rate))
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def _decode_audio_mono(raw: bytes) -> tuple[np.ndarray, int]:
+    """Decode audio bytes to (mono float32 array, native sample_rate).
+
+    soundfile (libsndfile, always installed) reads wav/mp3/ogg/flac straight
+    from memory. librosa (ffmpeg-backed) additionally covers m4a/webm but needs
+    a real path and is skipped on no-torch GGUF-only installs, so those
+    containers raise a clear error there while the common formats keep working.
+    """
+    import io
+    import soundfile as sf
+
+    try:
+        arr, sr = sf.read(io.BytesIO(raw), dtype = "float32")
+    except Exception:
+        try:
+            import librosa
+        except ModuleNotFoundError as e:
+            raise RuntimeError(
+                "this audio format needs librosa, which is not installed in "
+                "GGUF-only environments; use wav, mp3, ogg or flac"
+            ) from e
+        import os
+        import tempfile
+        from utils.paths import ensure_dir, tmp_root
+
+        with tempfile.NamedTemporaryFile(
+            suffix = ".audio",
+            delete = False,
+            dir = str(ensure_dir(tmp_root())),
+        ) as tmp:
+            tmp.write(raw)
+            tmp_path = tmp.name
+        try:
+            arr, sr = librosa.load(tmp_path, sr = None, mono = True)
+        finally:
+            os.unlink(tmp_path)
+    if arr.ndim > 1:
+        arr = arr.mean(axis = 1)
+    return arr, sr
+
+
+def _prepare_audio_for_llama(b64: str) -> tuple[str, str]:
+    """Return (base64, format) ready for llama-server's input_audio part.
+
+    llama-server's API only accepts wav/mp3, and decodes/resamples/down-mixes
+    them itself, so wav and mp3 uploads are forwarded untouched (no decode, no
+    PCM payload inflation). Other containers (m4a/ogg/webm/flac) are decoded to
+    a mono WAV. Blocking; call via a thread from async paths.
+    """
+    if b64.startswith("data:"):
+        b64 = b64.split(",", 1)[1] if "," in b64 else ""
+    raw = base64.b64decode(b64)
+    passthrough = _sniff_audio_container(raw)
+    if passthrough is not None:
+        return b64, passthrough
+
+    arr, sr = _decode_audio_mono(raw)
+    return base64.b64encode(_mono_f32_to_wav_bytes(arr, sr)).decode("ascii"), "wav"
 
 
 def _extract_content_parts(
@@ -2781,25 +2880,32 @@ async def openai_chat_completions(
 
     # ── GGUF path: proxy to llama-server /v1/chat/completions ──
     if using_gguf:
-        # Transcode any uploaded audio to 16 kHz mono WAV and forward it as an
-        # input_audio part. llama-server reads audio natively via the mmproj
-        # audio encoder, but its decoder only accepts wav/mp3, so we normalize
-        # here (the upload may be m4a/ogg/webm/flac).
+        # Forward uploaded audio as an input_audio part. wav/mp3 pass through
+        # untouched (llama-server decodes and resamples them via the mmproj
+        # audio encoder); other containers are transcoded to WAV here. The
+        # audio+tools combination is rejected further below.
         audio_b64 = None
+        audio_format = "wav"
         if payload.audio_base64:
             if not getattr(llama_backend, "_has_audio_input", False):
                 raise HTTPException(
                     status_code = 400,
                     detail = "Audio provided but current GGUF model does not support audio input.",
                 )
+            if len(payload.audio_base64) > _MAX_AUDIO_B64_CHARS:
+                raise HTTPException(
+                    status_code = 413,
+                    detail = "Audio file is too large (max ~25 MB).",
+                )
             try:
-                audio_b64 = await asyncio.to_thread(
-                    _transcode_audio_to_wav_b64, payload.audio_base64
+                audio_b64, audio_format = await asyncio.to_thread(
+                    _prepare_audio_for_llama, payload.audio_base64
                 )
             except Exception as e:
+                logger.warning("Audio decode failed: %s", e, exc_info = True)
                 raise HTTPException(
                     status_code = 400,
-                    detail = f"Could not decode the provided audio: {e}",
+                    detail = "Could not decode the provided audio file.",
                 )
 
         gguf_messages, _ = _openai_messages_for_gguf_chat(
@@ -3116,6 +3222,7 @@ async def openai_chat_completions(
                 messages = gguf_messages,
                 image_b64 = image_b64,
                 audio_b64 = audio_b64,
+                audio_format = audio_format,
                 temperature = payload.temperature,
                 top_p = payload.top_p,
                 top_k = payload.top_k,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1886,6 +1886,26 @@ def _prepare_audio_for_llama(b64: str) -> tuple[str, str]:
     return base64.b64encode(_mono_f32_to_wav_bytes(arr, sr)).decode("ascii"), "wav"
 
 
+def _inject_audio_part(messages: list[dict], audio_b64: str, audio_format: str) -> None:
+    """Append an input_audio part to the last user message, in place.
+
+    Audio rides in the message list like image_url parts do, so it flows through
+    both the plain and tool-calling generation paths.
+    """
+    part = {
+        "type": "input_audio",
+        "input_audio": {"data": audio_b64, "format": audio_format},
+    }
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content")
+            if isinstance(content, list):
+                content.append(part)
+            else:
+                msg["content"] = [{"type": "text", "text": content or ""}, part]
+            return
+
+
 def _extract_content_parts(
     messages: list,
 ) -> tuple[str, list[dict], "Optional[str]"]:
@@ -2827,9 +2847,12 @@ async def openai_chat_completions(
         and (_tools_passthrough or _has_response_format)
     ):
         if payload.audio_base64:
+            # This path forwards the request verbatim, so the transcoded audio
+            # never gets injected. (The agentic tool loop below does support
+            # audio.)
             raise HTTPException(
                 status_code = 400,
-                detail = "Audio input is not supported together with tools or guided decoding yet.",
+                detail = "Audio input is not supported together with guided decoding or client-supplied tools yet.",
             )
 
         # Preserve the vision guard that would otherwise run in the
@@ -2884,8 +2907,9 @@ async def openai_chat_completions(
     if using_gguf:
         # Forward uploaded audio as an input_audio part. wav/mp3 pass through
         # untouched (llama-server decodes and resamples them via the mmproj
-        # audio encoder); other containers are transcoded to WAV here. The
-        # audio+tools combination is rejected further below.
+        # audio encoder); other containers are transcoded to WAV here. The part
+        # is injected into the message list below so it rides through both the
+        # plain and tool-calling paths, exactly like image_url parts.
         audio_b64 = None
         audio_format = "wav"
         if payload.audio_base64:
@@ -2915,6 +2939,8 @@ async def openai_chat_completions(
             llama_backend.is_vision,
         )
         image_b64 = None
+        if audio_b64:
+            _inject_audio_part(gguf_messages, audio_b64, audio_format)
 
         cancel_event = threading.Event()
 
@@ -2962,12 +2988,6 @@ async def openai_chat_completions(
             # genuinely empty.
             if not tools_to_use:
                 use_tools = False
-
-        if use_tools and audio_b64:
-            raise HTTPException(
-                status_code = 400,
-                detail = "Audio input is not supported together with tools yet.",
-            )
 
         if use_tools:
             # ── Tool-use system prompt nudge ──────────────────────
@@ -3223,8 +3243,6 @@ async def openai_chat_completions(
             return llama_backend.generate_chat_completion(
                 messages = gguf_messages,
                 image_b64 = image_b64,
-                audio_b64 = audio_b64,
-                audio_format = audio_format,
                 temperature = payload.temperature,
                 top_p = payload.top_p,
                 top_k = payload.top_k,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1779,9 +1779,12 @@ def _decode_audio_base64(b64: str) -> np.ndarray:
 
 
 # Reject oversized audio before decoding. base64 inflates raw bytes by ~4/3, so
-# cap the encoded length to bound the upload and the decode that follows.
+# cap the encoded length to bound the upload. _MAX_AUDIO_SECONDS additionally
+# bounds the *decoded* length, since a small compressed file (opus/flac/etc.)
+# can expand to a far larger PCM array than the encoded-size cap implies.
 _MAX_AUDIO_RAW_BYTES = 25 * 1024 * 1024
 _MAX_AUDIO_B64_CHARS = _MAX_AUDIO_RAW_BYTES * 4 // 3
+_MAX_AUDIO_SECONDS = 30 * 60
 
 
 def _sniff_audio_container(raw: bytes) -> Optional[str]:
@@ -1829,15 +1832,17 @@ def _mono_f32_to_wav_bytes(arr: np.ndarray, sample_rate: int) -> bytes:
 def _decode_audio_mono(raw: bytes) -> tuple[np.ndarray, int]:
     """Decode audio bytes to (mono float32 array, native sample_rate).
 
-    soundfile (libsndfile, always installed) reads wav/mp3/ogg/flac straight
-    from memory. librosa (ffmpeg-backed) additionally covers m4a/webm but needs
-    a real path and is skipped on no-torch GGUF-only installs, so those
-    containers raise a clear error there while the common formats keep working.
+    soundfile (libsndfile) reads wav/mp3/ogg/flac straight from memory. librosa
+    (ffmpeg-backed) additionally covers m4a/webm but needs a real path and is
+    absent on no-torch GGUF-only installs. Both imports are inside the fallback
+    so a missing decoder degrades to the next one (and finally a clear error)
+    rather than crashing.
     """
     import io
-    import soundfile as sf
 
     try:
+        import soundfile as sf
+
         arr, sr = sf.read(io.BytesIO(raw), dtype = "float32")
     except Exception:
         try:
@@ -1864,6 +1869,10 @@ def _decode_audio_mono(raw: bytes) -> tuple[np.ndarray, int]:
             os.unlink(tmp_path)
     if arr.ndim > 1:
         arr = arr.mean(axis = 1)
+    if sr > 0 and len(arr) > sr * _MAX_AUDIO_SECONDS:
+        raise ValueError(
+            f"decoded audio exceeds the {_MAX_AUDIO_SECONDS // 60}-minute limit"
+        )
     return arr, sr
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1744,16 +1744,18 @@ async def generate_audio(
 
 
 def _decode_audio_base64(b64: str) -> np.ndarray:
-    """Decode base64 audio (any format) → float32 numpy array at 16kHz."""
-    import torch
-    import torchaudio
+    """Decode base64 audio (any format) → float32 mono numpy array at 16kHz."""
+    import librosa
     import tempfile
     import os
     from utils.paths import ensure_dir, tmp_root
 
+    if b64.startswith("data:"):
+        b64 = b64.split(",", 1)[1]
     raw = base64.b64decode(b64)
-    # torchaudio.load needs a file path or file-like object with format hint
-    # Write to a temp file so torchaudio can auto-detect the format
+    # librosa's audioread/ffmpeg fallback (mp3/m4a) needs a real path, so write
+    # the bytes to a temp file; the format is auto-detected from the content.
+    # sr=16000 resamples and mono=True downmixes.
     with tempfile.NamedTemporaryFile(
         suffix = ".audio",
         delete = False,
@@ -1762,20 +1764,25 @@ def _decode_audio_base64(b64: str) -> np.ndarray:
         tmp.write(raw)
         tmp_path = tmp.name
     try:
-        waveform, sr = torchaudio.load(tmp_path)
+        waveform, _ = librosa.load(tmp_path, sr = 16000, mono = True)
     finally:
         os.unlink(tmp_path)
 
-    # Convert to mono if stereo
-    if waveform.shape[0] > 1:
-        waveform = waveform.mean(dim = 0, keepdim = True)
+    return waveform
 
-    # Resample to 16kHz if needed
-    if sr != 16000:
-        resampler = torchaudio.transforms.Resample(orig_freq = sr, new_freq = 16000)
-        waveform = resampler(waveform)
 
-    return waveform.squeeze(0).numpy()
+def _transcode_audio_to_wav_b64(b64: str) -> str:
+    """Decode base64 audio (any container) and re-encode as base64 16 kHz mono WAV.
+
+    llama-server's audio decoder only accepts wav/mp3, so uploads in other
+    containers (m4a/ogg/webm/flac) are normalized here. Blocking (torchaudio +
+    temp file); call via a thread from async paths.
+    """
+    from core.inference.audio_codecs import _numpy_to_wav_bytes
+
+    return base64.b64encode(
+        _numpy_to_wav_bytes(_decode_audio_base64(b64), 16000)
+    ).decode("ascii")
 
 
 def _extract_content_parts(
@@ -2721,7 +2728,7 @@ async def openai_chat_completions(
         if payload.audio_base64:
             raise HTTPException(
                 status_code = 400,
-                detail = "Audio input is not supported for GGUF chat models yet.",
+                detail = "Audio input is not supported together with tools or guided decoding yet.",
             )
 
         # Preserve the vision guard that would otherwise run in the
@@ -2774,11 +2781,26 @@ async def openai_chat_completions(
 
     # ── GGUF path: proxy to llama-server /v1/chat/completions ──
     if using_gguf:
+        # Transcode any uploaded audio to 16 kHz mono WAV and forward it as an
+        # input_audio part. llama-server reads audio natively via the mmproj
+        # audio encoder, but its decoder only accepts wav/mp3, so we normalize
+        # here (the upload may be m4a/ogg/webm/flac).
+        audio_b64 = None
         if payload.audio_base64:
-            raise HTTPException(
-                status_code = 400,
-                detail = "Audio input is not supported for GGUF chat models yet.",
-            )
+            if not getattr(llama_backend, "_has_audio_input", False):
+                raise HTTPException(
+                    status_code = 400,
+                    detail = "Audio provided but current GGUF model does not support audio input.",
+                )
+            try:
+                audio_b64 = await asyncio.to_thread(
+                    _transcode_audio_to_wav_b64, payload.audio_base64
+                )
+            except Exception as e:
+                raise HTTPException(
+                    status_code = 400,
+                    detail = f"Could not decode the provided audio: {e}",
+                )
 
         gguf_messages, _ = _openai_messages_for_gguf_chat(
             payload,
@@ -2832,6 +2854,12 @@ async def openai_chat_completions(
             # genuinely empty.
             if not tools_to_use:
                 use_tools = False
+
+        if use_tools and audio_b64:
+            raise HTTPException(
+                status_code = 400,
+                detail = "Audio input is not supported together with tools yet.",
+            )
 
         if use_tools:
             # ── Tool-use system prompt nudge ──────────────────────
@@ -3087,6 +3115,7 @@ async def openai_chat_completions(
             return llama_backend.generate_chat_completion(
                 messages = gguf_messages,
                 image_b64 = image_b64,
+                audio_b64 = audio_b64,
                 temperature = payload.temperature,
                 top_p = payload.top_p,
                 top_k = payload.top_k,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1791,7 +1791,9 @@ def _sniff_audio_container(raw: bytes) -> Optional[str]:
         return "wav"
     # mp3: ID3 tag, or an MPEG audio frame sync (no other accepted format leads
     # with 0xFF, so the simple sync check doesn't collide).
-    if raw[:3] == b"ID3" or (len(raw) >= 2 and raw[0] == 0xFF and (raw[1] & 0xE0) == 0xE0):
+    if raw[:3] == b"ID3" or (
+        len(raw) >= 2 and raw[0] == 0xFF and (raw[1] & 0xE0) == 0xE0
+    ):
         return "mp3"
     return None
 


### PR DESCRIPTION
This targets the #6064 branch (not `main`), so it ships with the frontend work when #6064 merges.

#6064 is frontend-only; the backend still rejects GGUF audio with a 400. This adds the missing backend piece: it forwards uploaded audio to llama-server as an `input_audio` part.

How it works:
- wav and mp3 are forwarded untouched (llama-server decodes, resamples and down-mixes them itself).
- Other containers (ogg, flac, m4a, webm) are decoded to a mono WAV first, via soundfile, falling back to librosa for the formats libsndfile can't read (m4a/webm).
- The audio part is injected into the message list the same way image parts are, so it works on both the plain and tool-calling paths.
- Guards: uploads over ~25 MB are rejected (413), and audio that decodes to over 30 minutes is rejected, to bound memory.

Dependencies: soundfile and librosa are declared unsloth deps. wav/mp3/ogg/flac work on every install including no-torch (soundfile is always present); m4a/webm additionally need librosa + ffmpeg and otherwise return a clear error. The previous torchaudio path was dropped (torchaudio isn't a declared dependency and fails to load in the studio venv).

Tested locally end to end against gemma-4-12B: wav, mp3, ogg, flac, m4a, webm, stereo and 44.1 kHz inputs, streaming and non-streaming, plus audio combined with tool calling.
