### PR TITLE
Studio: tune llama.cpp env for data-center GPUs

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1243,6 +1243,94 @@ class LlamaCppBackend:
             return False
         return False
 
+    # Datacenter / professional NVIDIA parts where the llama.cpp FP32-accumulation
+    # and peer-to-peer tunings help (and where FP32-accum has negligible cost,
+    # unlike GeForce). Matched as case-insensitive substrings of the torch device
+    # name (e.g. "NVIDIA A100-SXM4-80GB", "NVIDIA H100 80GB HBM3",
+    # "NVIDIA RTX PRO 6000 Blackwell Server Edition").
+    _DATACENTER_GPU_MARKERS = (
+        "a100", "a30", "h100", "h200", "h800", "gh200",
+        "b200", "b100", "b300", "gb200", "gb300",
+        "l40", "l4", "rtx pro 6000", "rtx 6000 ada",
+    )
+
+    @staticmethod
+    def _is_datacenter_gpu(gpu_indices=None) -> bool:
+        """True when every selected NVIDIA GPU is a datacenter/professional part
+        (A100/H100/H200/B200/GB200/GB300/L40/RTX PRO 6000 ...). Drives the DC
+        llama.cpp env tuning. NVIDIA-only and fails open to False, so consumer
+        GeForce, ROCm, CPU and any error path are left untouched. A mixed box
+        (one DC + one consumer GPU in the selection) is treated as non-DC so the
+        tuning never lands on a GeForce card."""
+        try:
+            import torch
+
+            if getattr(torch.version, "hip", None) is not None:
+                return False  # ROCm reuses torch.cuda.*; not a CUDA datacenter part
+            if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
+                return False
+            count = torch.cuda.device_count()
+            indices = list(gpu_indices) if gpu_indices else list(range(count))
+            markers = LlamaCppBackend._DATACENTER_GPU_MARKERS
+            saw = False
+            for _i in indices:
+                if _i is None or _i < 0 or _i >= count:
+                    continue
+                try:
+                    name = (torch.cuda.get_device_properties(_i).name or "").lower()
+                except Exception:
+                    continue
+                saw = True
+                if not any(marker in name for marker in markers):
+                    return False
+            return saw
+        except Exception:
+            return False
+
+    @staticmethod
+    def _effective_gpu_count(gpu_indices=None) -> int:
+        """Number of GPUs llama-server will actually use: the length of an
+        explicit selection, else the count of visible CUDA devices (gpu_indices
+        is None when we let llama.cpp use every visible GPU). Returns 0 on any
+        error so multi-GPU tuning stays off when the count is unknown."""
+        if gpu_indices is not None:
+            return len(gpu_indices)
+        try:
+            import torch
+
+            if hasattr(torch, "cuda") and torch.cuda.is_available():
+                return torch.cuda.device_count()
+        except Exception:
+            return 0
+        return 0
+
+    @staticmethod
+    def _apply_datacenter_env(env: dict, gpu_indices=None) -> bool:
+        """Inject data-center llama.cpp tuning into ``env`` in place and report
+        whether this box qualified. All writes use ``setdefault`` so a
+        user-supplied value always wins. Behaviour:
+
+        - opt out entirely with ``UNSLOTH_DISABLE_DC_TUNING=1`` (returns False);
+        - only datacenter/professional NVIDIA parts qualify (see
+          ``_is_datacenter_gpu``); consumer/ROCm/CPU/error are a no-op;
+        - ``GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F=1`` is set for any qualifying GPU
+          (FP32 cuBLAS accumulation: ~0% throughput cost and identical perplexity
+          on B200, vs a real cost on GeForce);
+        - ``GGML_CUDA_P2P=1`` + ``CUDA_SCALE_LAUNCH_QUEUES=4x`` are added only for
+          multi-GPU (benchmarked +33-51% prompt processing on tensor-split and
+          +8-16% on pipeline split across B200s).
+
+        Returns True iff the box qualified (so the caller can log)."""
+        if os.environ.get("UNSLOTH_DISABLE_DC_TUNING") == "1":
+            return False
+        if not LlamaCppBackend._is_datacenter_gpu(gpu_indices):
+            return False
+        env.setdefault("GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F", "1")
+        if LlamaCppBackend._effective_gpu_count(gpu_indices) > 1:
+            env.setdefault("GGML_CUDA_P2P", "1")
+            env.setdefault("CUDA_SCALE_LAUNCH_QUEUES", "4x")
+        return True
+
     @staticmethod
     def _get_gpu_free_memory() -> list[tuple[int, int]]:
         """Query free memory per GPU.
@@ -3194,6 +3282,16 @@ class LlamaCppBackend:
                 if self._amd_apu_wants_unified_memory():
                     env.setdefault("GGML_CUDA_ENABLE_UNIFIED_MEMORY", "1")
                     logger.info("AMD unified-memory APU: set GGML_CUDA_ENABLE_UNIFIED_MEMORY=1")
+
+                # Datacenter / professional NVIDIA GPUs: FP32 cuBLAS accumulation
+                # (+ peer-to-peer / larger launch queues for multi-GPU). See
+                # _apply_datacenter_env for the rationale and the benchmark
+                # numbers; opt out with UNSLOTH_DISABLE_DC_TUNING=1.
+                if self._apply_datacenter_env(env, gpu_indices):
+                    multi_gpu = self._effective_gpu_count(gpu_indices) > 1
+                    logger.info(
+                        f"Data-center GPU detected: applied DC llama.cpp env tuning (multi_gpu={multi_gpu})"
+                    )
 
                 if sys.platform == "win32":
                     # See _build_windows_path_dirs for ordering. #5106.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1245,25 +1245,15 @@ class LlamaCppBackend:
 
     # Datacenter / professional NVIDIA parts where the llama.cpp FP32-accumulation
     # and peer-to-peer tunings help (and where FP32-accum has negligible cost,
-    # unlike GeForce). Matched as case-insensitive substrings of the torch device
-    # name (e.g. "NVIDIA A100-SXM4-80GB", "NVIDIA H100 80GB HBM3",
-    # "NVIDIA RTX PRO 6000 Blackwell Server Edition").
-    _DATACENTER_GPU_MARKERS = (
-        "a100",
-        "a30",
-        "h100",
-        "h200",
-        "h800",
-        "gh200",
-        "b200",
-        "b100",
-        "b300",
-        "gb200",
-        "gb300",
-        "l40",
-        "l4",
-        "rtx pro 6000",
-        "rtx 6000 ada",
+    # unlike GeForce). Matched as whole-word (case-insensitive) patterns of the
+    # torch device name (e.g. "NVIDIA A100-SXM4-80GB", "NVIDIA H100 80GB HBM3",
+    # "NVIDIA RTX PRO 6000 Blackwell Server Edition"). The \b word boundaries keep
+    # the short markers from matching workstation/laptop parts as substrings: "a100"
+    # must not fire on "NVIDIA RTX A1000" nor "a30" on "NVIDIA RTX A3000" (there is
+    # no boundary between the trailing "0"s). "l40s?" matches both "L40" and "L40S".
+    _DATACENTER_GPU_RE = re.compile(
+        r"\b(?:a100|a30|h100|h200|h800|gh200|b200|b100|b300|gb200|gb300|"
+        r"l40s?|l4|rtx pro 6000|rtx 6000 ada)\b"
     )
 
     @staticmethod
@@ -1273,7 +1263,17 @@ class LlamaCppBackend:
         llama.cpp env tuning. NVIDIA-only and fails open to False, so consumer
         GeForce, ROCm, CPU and any error path are left untouched. A mixed box
         (one DC + one consumer GPU in the selection) is treated as non-DC so the
-        tuning never lands on a GeForce card."""
+        tuning never lands on a GeForce card.
+
+        ``gpu_indices`` carries PHYSICAL GPU ids: ``_get_gpu_free_memory``
+        translates torch visible ordinals back to physical ids via
+        ``CUDA_VISIBLE_DEVICES`` so the selection can be handed to the
+        llama-server child. ``torch.cuda.get_device_properties`` instead expects
+        ordinals relative to that mask, so we rebuild the same ordinal->physical
+        map here and key device names by physical id. Otherwise a masked host
+        (e.g. ``CUDA_VISIBLE_DEVICES=4,5,6,7`` with selection ``[4, 5]``) would
+        index out of range and silently drop the tuning on real datacenter GPUs,
+        or probe the wrong physical GPU on a mixed mask."""
         try:
             import torch
 
@@ -1282,18 +1282,41 @@ class LlamaCppBackend:
             if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
                 return False
             count = torch.cuda.device_count()
-            indices = list(gpu_indices) if gpu_indices else list(range(count))
-            markers = LlamaCppBackend._DATACENTER_GPU_MARKERS
-            saw = False
-            for _i in indices:
-                if _i is None or _i < 0 or _i >= count:
-                    continue
+
+            # Mirror _get_gpu_free_memory: a numeric CUDA_VISIBLE_DEVICES mask
+            # maps visible ordinal -> physical id. An unset mask (or one we
+            # cannot parse as integers, e.g. UUID-style ids) leaves physical id
+            # == ordinal, consistent with the sibling helper.
+            physical_ids: Optional[list[int]] = None
+            cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+            if cvd is not None:
                 try:
-                    name = (torch.cuda.get_device_properties(_i).name or "").lower()
+                    physical_ids = [int(x.strip()) for x in cvd.split(",") if x.strip()]
+                except ValueError:
+                    physical_ids = None
+
+            pattern = LlamaCppBackend._DATACENTER_GPU_RE
+            names_by_id: dict[int, str] = {}
+            for ordinal in range(count):
+                try:
+                    name = (torch.cuda.get_device_properties(ordinal).name or "").lower()
                 except Exception:
                     continue
+                pid = (
+                    physical_ids[ordinal]
+                    if physical_ids is not None and ordinal < len(physical_ids)
+                    else ordinal
+                )
+                names_by_id[pid] = name
+
+            indices = list(gpu_indices) if gpu_indices else list(names_by_id)
+            saw = False
+            for _i in indices:
+                name = names_by_id.get(_i)
+                if name is None:
+                    continue  # physical id not visible -> skip (fail conservative)
                 saw = True
-                if not any(marker in name for marker in markers):
+                if not pattern.search(name):
                     return False
             return saw
         except Exception:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1249,13 +1249,25 @@ class LlamaCppBackend:
     # name (e.g. "NVIDIA A100-SXM4-80GB", "NVIDIA H100 80GB HBM3",
     # "NVIDIA RTX PRO 6000 Blackwell Server Edition").
     _DATACENTER_GPU_MARKERS = (
-        "a100", "a30", "h100", "h200", "h800", "gh200",
-        "b200", "b100", "b300", "gb200", "gb300",
-        "l40", "l4", "rtx pro 6000", "rtx 6000 ada",
+        "a100",
+        "a30",
+        "h100",
+        "h200",
+        "h800",
+        "gh200",
+        "b200",
+        "b100",
+        "b300",
+        "gb200",
+        "gb300",
+        "l40",
+        "l4",
+        "rtx pro 6000",
+        "rtx 6000 ada",
     )
 
     @staticmethod
-    def _is_datacenter_gpu(gpu_indices=None) -> bool:
+    def _is_datacenter_gpu(gpu_indices = None) -> bool:
         """True when every selected NVIDIA GPU is a datacenter/professional part
         (A100/H100/H200/B200/GB200/GB300/L40/RTX PRO 6000 ...). Drives the DC
         llama.cpp env tuning. NVIDIA-only and fails open to False, so consumer
@@ -1288,7 +1300,7 @@ class LlamaCppBackend:
             return False
 
     @staticmethod
-    def _effective_gpu_count(gpu_indices=None) -> int:
+    def _effective_gpu_count(gpu_indices = None) -> int:
         """Number of GPUs llama-server will actually use: the length of an
         explicit selection, else the count of visible CUDA devices (gpu_indices
         is None when we let llama.cpp use every visible GPU). Returns 0 on any
@@ -1297,7 +1309,6 @@ class LlamaCppBackend:
             return len(gpu_indices)
         try:
             import torch
-
             if hasattr(torch, "cuda") and torch.cuda.is_available():
                 return torch.cuda.device_count()
         except Exception:
@@ -1305,7 +1316,7 @@ class LlamaCppBackend:
         return 0
 
     @staticmethod
-    def _apply_datacenter_env(env: dict, gpu_indices=None) -> bool:
+    def _apply_datacenter_env(env: dict, gpu_indices = None) -> bool:
         """Inject data-center llama.cpp tuning into ``env`` in place and report
         whether this box qualified. All writes use ``setdefault`` so a
         user-supplied value always wins. Behaviour:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1243,14 +1243,9 @@ class LlamaCppBackend:
             return False
         return False
 
-    # Datacenter / professional NVIDIA parts where the llama.cpp FP32-accumulation
-    # and peer-to-peer tunings help (and where FP32-accum has negligible cost,
-    # unlike GeForce). Matched as whole-word (case-insensitive) patterns of the
-    # torch device name (e.g. "NVIDIA A100-SXM4-80GB", "NVIDIA H100 80GB HBM3",
-    # "NVIDIA RTX PRO 6000 Blackwell Server Edition"). The \b word boundaries keep
-    # the short markers from matching workstation/laptop parts as substrings: "a100"
-    # must not fire on "NVIDIA RTX A1000" nor "a30" on "NVIDIA RTX A3000" (there is
-    # no boundary between the trailing "0"s). "l40s?" matches both "L40" and "L40S".
+    # Datacenter / professional NVIDIA parts that benefit from the llama.cpp
+    # FP32-accum / P2P tunings. Whole-word (\b) so short markers don't match
+    # workstation parts as substrings: "a100" must not fire on "RTX A1000".
     _DATACENTER_GPU_RE = re.compile(
         r"\b(?:a100|a30|h100|h200|h800|gh200|b200|b100|b300|gb200|gb300|"
         r"l40s?|l4|rtx pro 6000|rtx 6000 ada)\b"
@@ -1258,35 +1253,26 @@ class LlamaCppBackend:
 
     @staticmethod
     def _is_datacenter_gpu(gpu_indices = None) -> bool:
-        """True when every selected NVIDIA GPU is a datacenter/professional part
-        (A100/H100/H200/B200/GB200/GB300/L40/RTX PRO 6000 ...). Drives the DC
-        llama.cpp env tuning. NVIDIA-only and fails open to False, so consumer
-        GeForce, ROCm, CPU and any error path are left untouched. A mixed box
-        (one DC + one consumer GPU in the selection) is treated as non-DC so the
-        tuning never lands on a GeForce card.
+        """True iff every selected NVIDIA GPU is a datacenter/professional part.
+        NVIDIA-only, fails open to False (consumer GeForce, ROCm, CPU and errors
+        are left untouched); a mixed DC+consumer selection counts as non-DC.
 
-        ``gpu_indices`` carries PHYSICAL GPU ids: ``_get_gpu_free_memory``
-        translates torch visible ordinals back to physical ids via
-        ``CUDA_VISIBLE_DEVICES`` so the selection can be handed to the
-        llama-server child. ``torch.cuda.get_device_properties`` instead expects
-        ordinals relative to that mask, so we rebuild the same ordinal->physical
-        map here and key device names by physical id. Otherwise a masked host
-        (e.g. ``CUDA_VISIBLE_DEVICES=4,5,6,7`` with selection ``[4, 5]``) would
-        index out of range and silently drop the tuning on real datacenter GPUs,
-        or probe the wrong physical GPU on a mixed mask."""
+        gpu_indices are PHYSICAL ids (see _get_gpu_free_memory), but
+        get_device_properties wants mask-relative ordinals, so we rebuild the
+        ordinal->physical map from CUDA_VISIBLE_DEVICES and key names by physical
+        id. Otherwise a masked host (CUDA_VISIBLE_DEVICES=4,5,6,7, selection [4,5])
+        would drop the tuning or probe the wrong GPU."""
         try:
             import torch
 
             if getattr(torch.version, "hip", None) is not None:
-                return False  # ROCm reuses torch.cuda.*; not a CUDA datacenter part
+                return False  # ROCm reuses torch.cuda.*; not a CUDA part
             if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
                 return False
             count = torch.cuda.device_count()
 
-            # Mirror _get_gpu_free_memory: a numeric CUDA_VISIBLE_DEVICES mask
-            # maps visible ordinal -> physical id. An unset mask (or one we
-            # cannot parse as integers, e.g. UUID-style ids) leaves physical id
-            # == ordinal, consistent with the sibling helper.
+            # Mirror _get_gpu_free_memory: map visible ordinal -> physical id via
+            # CUDA_VISIBLE_DEVICES; unset/unparsable leaves physical id == ordinal.
             physical_ids: Optional[list[int]] = None
             cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
             if cvd is not None:
@@ -1314,7 +1300,7 @@ class LlamaCppBackend:
             for _i in indices:
                 name = names_by_id.get(_i)
                 if name is None:
-                    continue  # physical id not visible -> skip (fail conservative)
+                    continue  # not visible -> skip (fail conservative)
                 saw = True
                 if not pattern.search(name):
                     return False
@@ -1324,10 +1310,9 @@ class LlamaCppBackend:
 
     @staticmethod
     def _effective_gpu_count(gpu_indices = None) -> int:
-        """Number of GPUs llama-server will actually use: the length of an
-        explicit selection, else the count of visible CUDA devices (gpu_indices
-        is None when we let llama.cpp use every visible GPU). Returns 0 on any
-        error so multi-GPU tuning stays off when the count is unknown."""
+        """GPUs llama-server will use: len(selection), else the visible CUDA
+        device count (None = every visible GPU). 0 on error so multi-GPU tuning
+        stays off when the count is unknown."""
         if gpu_indices is not None:
             return len(gpu_indices)
         try:
@@ -1340,21 +1325,13 @@ class LlamaCppBackend:
 
     @staticmethod
     def _apply_datacenter_env(env: dict, gpu_indices = None) -> bool:
-        """Inject data-center llama.cpp tuning into ``env`` in place and report
-        whether this box qualified. All writes use ``setdefault`` so a
-        user-supplied value always wins. Behaviour:
-
-        - opt out entirely with ``UNSLOTH_DISABLE_DC_TUNING=1`` (returns False);
-        - only datacenter/professional NVIDIA parts qualify (see
-          ``_is_datacenter_gpu``); consumer/ROCm/CPU/error are a no-op;
-        - ``GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F=1`` is set for any qualifying GPU
-          (FP32 cuBLAS accumulation: ~0% throughput cost and identical perplexity
-          on B200, vs a real cost on GeForce);
-        - ``GGML_CUDA_P2P=1`` + ``CUDA_SCALE_LAUNCH_QUEUES=4x`` are added only for
-          multi-GPU (benchmarked +33-51% prompt processing on tensor-split and
-          +8-16% on pipeline split across B200s).
-
-        Returns True iff the box qualified (so the caller can log)."""
+        """Inject DC llama.cpp tuning into env in place via setdefault (user
+        values win); return whether the box qualified. Opt out with
+        UNSLOTH_DISABLE_DC_TUNING=1; only datacenter NVIDIA parts qualify
+        (consumer/ROCm/CPU/error are a no-op). Sets GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F
+        for any qualifying GPU (FP32 accum: ~0% cost on B200, real cost on GeForce),
+        plus GGML_CUDA_P2P + CUDA_SCALE_LAUNCH_QUEUES=4x for multi-GPU (+33-51% pp
+        tensor-split, +8-16% pipeline split on B200)."""
         if os.environ.get("UNSLOTH_DISABLE_DC_TUNING") == "1":
             return False
         if not LlamaCppBackend._is_datacenter_gpu(gpu_indices):
@@ -3317,10 +3294,8 @@ class LlamaCppBackend:
                     env.setdefault("GGML_CUDA_ENABLE_UNIFIED_MEMORY", "1")
                     logger.info("AMD unified-memory APU: set GGML_CUDA_ENABLE_UNIFIED_MEMORY=1")
 
-                # Datacenter / professional NVIDIA GPUs: FP32 cuBLAS accumulation
-                # (+ peer-to-peer / larger launch queues for multi-GPU). See
-                # _apply_datacenter_env for the rationale and the benchmark
-                # numbers; opt out with UNSLOTH_DISABLE_DC_TUNING=1.
+                # DC NVIDIA GPUs: FP32 accum (+ P2P / launch queues for multi-GPU).
+                # See _apply_datacenter_env; opt out with UNSLOTH_DISABLE_DC_TUNING=1.
                 if self._apply_datacenter_env(env, gpu_indices):
                     multi_gpu = self._effective_gpu_count(gpu_indices) > 1
                     logger.info(

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -22,7 +22,12 @@ import pytest
 from core.inference.llama_cpp import LlamaCppBackend
 
 
-def _fake_torch(names, *, hip = None, cuda_ok = True):
+def _fake_torch(
+    names,
+    *,
+    hip = None,
+    cuda_ok = True,
+):
     """A torch stub exposing only what _is_datacenter_gpu / _effective_gpu_count
     touch: torch.version.hip, torch.cuda.is_available/device_count and
     get_device_properties(i).name."""
@@ -39,6 +44,7 @@ def _fake_torch(names, *, hip = None, cuda_ok = True):
 # ---------------------------------------------------------------------------
 # _is_datacenter_gpu
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize(
     "names,expected",
@@ -78,7 +84,8 @@ def test_is_datacenter_gpu(monkeypatch, names, expected):
 def test_is_datacenter_gpu_respects_selection(monkeypatch):
     # A mixed box where only the DC GPU is selected -> True; only consumer -> False.
     monkeypatch.setitem(
-        sys.modules, "torch",
+        sys.modules,
+        "torch",
         _fake_torch(["NVIDIA B200", "NVIDIA GeForce RTX 4090"]),
     )
     assert LlamaCppBackend._is_datacenter_gpu([0]) is True
@@ -97,7 +104,8 @@ def test_is_datacenter_gpu_out_of_range_indices_skipped(monkeypatch):
 def test_is_datacenter_gpu_rocm_is_false(monkeypatch):
     # ROCm reuses torch.cuda.*; even an MI300X-named part must not qualify here.
     monkeypatch.setitem(
-        sys.modules, "torch",
+        sys.modules,
+        "torch",
         _fake_torch(["AMD Instinct MI300X"], hip = "6.2.0"),
     )
     assert LlamaCppBackend._is_datacenter_gpu() is False
@@ -116,6 +124,7 @@ def test_is_datacenter_gpu_missing_torch_is_false(monkeypatch):
 # ---------------------------------------------------------------------------
 # _effective_gpu_count
 # ---------------------------------------------------------------------------
+
 
 def test_effective_gpu_count_explicit_selection(monkeypatch):
     # Explicit selection: length of the list, regardless of how many are visible.
@@ -143,6 +152,7 @@ def test_effective_gpu_count_missing_torch_is_zero(monkeypatch):
 # ---------------------------------------------------------------------------
 # _apply_datacenter_env (the env-injection decision)
 # ---------------------------------------------------------------------------
+
 
 def test_apply_env_single_dc_gpu_sets_only_fp32(monkeypatch):
     monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
@@ -188,7 +198,7 @@ def test_apply_env_user_value_wins(monkeypatch):
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 2))
     env = {
         "GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F": "0",  # user explicitly disabled
-        "CUDA_SCALE_LAUNCH_QUEUES": "8x",           # user override
+        "CUDA_SCALE_LAUNCH_QUEUES": "8x",  # user override
     }
     assert LlamaCppBackend._apply_datacenter_env(env, [0, 1]) is True
     # setdefault must not clobber user-provided values.

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Data-center llama.cpp env tuning.
+
+FP32 cuBLAS accumulation (GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F) plus, for
+multi-GPU, peer-to-peer (GGML_CUDA_P2P) and larger launch queues
+(CUDA_SCALE_LAUNCH_QUEUES) must be set only for datacenter/professional NVIDIA
+GPUs (A100/H100/H200/B200/GB200/GB300/L40/RTX PRO 6000 ...), never for consumer
+GeForce, AMD/ROCm, CPU or macOS, where FP32-accum carries a real throughput
+cost. A user-supplied value must always win, and UNSLOTH_DISABLE_DC_TUNING=1
+must turn the whole thing off.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from core.inference.llama_cpp import LlamaCppBackend
+
+
+def _fake_torch(names, *, hip = None, cuda_ok = True):
+    """A torch stub exposing only what _is_datacenter_gpu / _effective_gpu_count
+    touch: torch.version.hip, torch.cuda.is_available/device_count and
+    get_device_properties(i).name."""
+    t = types.ModuleType("torch")
+    t.version = types.SimpleNamespace(hip = hip)
+    t.cuda = types.SimpleNamespace(
+        is_available = lambda: cuda_ok,
+        device_count = lambda: len(names),
+        get_device_properties = lambda i: types.SimpleNamespace(name = names[i]),
+    )
+    return t
+
+
+# ---------------------------------------------------------------------------
+# _is_datacenter_gpu
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "names,expected",
+    [
+        # Datacenter / professional parts (real torch device names, lower/mixed case).
+        (["NVIDIA A100-SXM4-80GB"], True),
+        (["NVIDIA A30"], True),
+        (["NVIDIA H100 80GB HBM3"], True),
+        (["NVIDIA H200"], True),
+        (["NVIDIA H800"], True),
+        (["NVIDIA GH200 480GB"], True),
+        (["NVIDIA B200"], True),
+        (["NVIDIA GB200"], True),
+        (["NVIDIA L40S"], True),
+        (["NVIDIA L4"], True),
+        (["NVIDIA RTX PRO 6000 Blackwell Server Edition"], True),
+        (["NVIDIA RTX 6000 Ada Generation"], True),
+        # Consumer GeForce: never.
+        (["NVIDIA GeForce RTX 4090"], False),
+        (["NVIDIA GeForce RTX 5090"], False),
+        (["NVIDIA GeForce RTX 3090"], False),
+        (["NVIDIA GeForce RTX 2080 Ti"], False),
+        (["NVIDIA GeForce GTX 1080"], False),
+        # Homogeneous multi-DC: all must match.
+        (["NVIDIA B200", "NVIDIA B200"], True),
+        (["NVIDIA H100 80GB HBM3", "NVIDIA H100 80GB HBM3"], True),
+        # Mixed DC + consumer: treated as non-DC so tuning never lands on GeForce.
+        (["NVIDIA B200", "NVIDIA GeForce RTX 4090"], False),
+        (["NVIDIA GeForce RTX 4090", "NVIDIA B200"], False),
+    ],
+)
+def test_is_datacenter_gpu(monkeypatch, names, expected):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(names))
+    assert LlamaCppBackend._is_datacenter_gpu() is expected
+
+
+def test_is_datacenter_gpu_respects_selection(monkeypatch):
+    # A mixed box where only the DC GPU is selected -> True; only consumer -> False.
+    monkeypatch.setitem(
+        sys.modules, "torch",
+        _fake_torch(["NVIDIA B200", "NVIDIA GeForce RTX 4090"]),
+    )
+    assert LlamaCppBackend._is_datacenter_gpu([0]) is True
+    assert LlamaCppBackend._is_datacenter_gpu([1]) is False
+    assert LlamaCppBackend._is_datacenter_gpu([0, 1]) is False
+
+
+def test_is_datacenter_gpu_out_of_range_indices_skipped(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"]))
+    # Out-of-range / negative indices are skipped; the one valid DC GPU still wins.
+    assert LlamaCppBackend._is_datacenter_gpu([0, 5, -1]) is True
+    # Only invalid indices -> nothing seen -> False (fail closed for the flag).
+    assert LlamaCppBackend._is_datacenter_gpu([5, 9]) is False
+
+
+def test_is_datacenter_gpu_rocm_is_false(monkeypatch):
+    # ROCm reuses torch.cuda.*; even an MI300X-named part must not qualify here.
+    monkeypatch.setitem(
+        sys.modules, "torch",
+        _fake_torch(["AMD Instinct MI300X"], hip = "6.2.0"),
+    )
+    assert LlamaCppBackend._is_datacenter_gpu() is False
+
+
+def test_is_datacenter_gpu_no_cuda_is_false(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch([], cuda_ok = False))
+    assert LlamaCppBackend._is_datacenter_gpu() is False
+
+
+def test_is_datacenter_gpu_missing_torch_is_false(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", None)
+    assert LlamaCppBackend._is_datacenter_gpu() is False
+
+
+# ---------------------------------------------------------------------------
+# _effective_gpu_count
+# ---------------------------------------------------------------------------
+
+def test_effective_gpu_count_explicit_selection(monkeypatch):
+    # Explicit selection: length of the list, regardless of how many are visible.
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    assert LlamaCppBackend._effective_gpu_count([0]) == 1
+    assert LlamaCppBackend._effective_gpu_count([0, 1, 2]) == 3
+
+
+def test_effective_gpu_count_none_uses_visible(monkeypatch):
+    # None == "use every visible GPU" -> visible device count.
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    assert LlamaCppBackend._effective_gpu_count(None) == 4
+
+
+def test_effective_gpu_count_no_cuda_is_zero(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch([], cuda_ok = False))
+    assert LlamaCppBackend._effective_gpu_count(None) == 0
+
+
+def test_effective_gpu_count_missing_torch_is_zero(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", None)
+    assert LlamaCppBackend._effective_gpu_count(None) == 0
+
+
+# ---------------------------------------------------------------------------
+# _apply_datacenter_env (the env-injection decision)
+# ---------------------------------------------------------------------------
+
+def test_apply_env_single_dc_gpu_sets_only_fp32(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"]))
+    env: dict = {}
+    assert LlamaCppBackend._apply_datacenter_env(env, [0]) is True
+    assert env == {"GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F": "1"}
+    # No multi-GPU flags on a single GPU.
+    assert "GGML_CUDA_P2P" not in env
+    assert "CUDA_SCALE_LAUNCH_QUEUES" not in env
+
+
+def test_apply_env_multi_dc_gpu_sets_all(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    env: dict = {}
+    assert LlamaCppBackend._apply_datacenter_env(env, [0, 1]) is True
+    assert env["GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F"] == "1"
+    assert env["GGML_CUDA_P2P"] == "1"
+    assert env["CUDA_SCALE_LAUNCH_QUEUES"] == "4x"
+
+
+def test_apply_env_none_indices_uses_visible_count(monkeypatch):
+    # gpu_indices None on a 2x DC box -> multi-GPU flags applied.
+    monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA H100", "NVIDIA H100"]))
+    env: dict = {}
+    assert LlamaCppBackend._apply_datacenter_env(env, None) is True
+    assert env["GGML_CUDA_P2P"] == "1"
+    assert env["CUDA_SCALE_LAUNCH_QUEUES"] == "4x"
+
+
+def test_apply_env_consumer_gpu_is_noop(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA GeForce RTX 4090"] * 2))
+    env: dict = {}
+    assert LlamaCppBackend._apply_datacenter_env(env, [0, 1]) is False
+    assert env == {}
+
+
+def test_apply_env_user_value_wins(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 2))
+    env = {
+        "GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F": "0",  # user explicitly disabled
+        "CUDA_SCALE_LAUNCH_QUEUES": "8x",           # user override
+    }
+    assert LlamaCppBackend._apply_datacenter_env(env, [0, 1]) is True
+    # setdefault must not clobber user-provided values.
+    assert env["GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F"] == "0"
+    assert env["CUDA_SCALE_LAUNCH_QUEUES"] == "8x"
+    # The one the user didn't set still gets the default.
+    assert env["GGML_CUDA_P2P"] == "1"
+
+
+def test_apply_env_disable_flag_respected(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_DISABLE_DC_TUNING", "1")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 2))
+    env: dict = {}
+    assert LlamaCppBackend._apply_datacenter_env(env, [0, 1]) is False
+    assert env == {}
+
+
+def test_apply_env_fail_open_on_detection_error(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
+    monkeypatch.setitem(sys.modules, "torch", None)  # detection raises -> False
+    env: dict = {}
+    assert LlamaCppBackend._apply_datacenter_env(env, [0]) is False
+    assert env == {}

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -132,9 +132,7 @@ def test_is_datacenter_gpu_masked_host_physical_ids(monkeypatch):
 def test_is_datacenter_gpu_masked_host_reordered(monkeypatch):
     # A reordered mask must preserve order: ordinal 0 -> physical 7, 1 -> 4, ...
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7,4,5,6")
-    monkeypatch.setitem(
-        sys.modules, "torch", _fake_torch(["NVIDIA H100 80GB HBM3"] * 4)
-    )
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA H100 80GB HBM3"] * 4))
     assert LlamaCppBackend._is_datacenter_gpu([7, 4]) is True
 
 

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -41,6 +41,15 @@ def _fake_torch(
     return t
 
 
+@pytest.fixture(autouse = True)
+def _clear_cuda_visible_devices(monkeypatch):
+    """_is_datacenter_gpu now reads CUDA_VISIBLE_DEVICES to map physical GPU ids
+    back to torch ordinals. Tests that don't exercise masking must run as if the
+    process were unmasked (physical id == ordinal) regardless of the host's real
+    mask, so clear it by default; the masked-host tests set it explicitly."""
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising = False)
+
+
 # ---------------------------------------------------------------------------
 # _is_datacenter_gpu
 # ---------------------------------------------------------------------------
@@ -68,6 +77,11 @@ def _fake_torch(
         (["NVIDIA GeForce RTX 3090"], False),
         (["NVIDIA GeForce RTX 2080 Ti"], False),
         (["NVIDIA GeForce GTX 1080"], False),
+        # Workstation / laptop Ampere: short markers must not match as substrings
+        # ("a100" in "A1000", "a30" in "A3000"). Whole-word matching rejects these.
+        (["NVIDIA RTX A1000 Laptop GPU"], False),
+        (["NVIDIA RTX A1000 6GB Laptop GPU"], False),
+        (["NVIDIA RTX A3000 Laptop GPU"], False),
         # Homogeneous multi-DC: all must match.
         (["NVIDIA B200", "NVIDIA B200"], True),
         (["NVIDIA H100 80GB HBM3", "NVIDIA H100 80GB HBM3"], True),
@@ -99,6 +113,53 @@ def test_is_datacenter_gpu_out_of_range_indices_skipped(monkeypatch):
     assert LlamaCppBackend._is_datacenter_gpu([0, 5, -1]) is True
     # Only invalid indices -> nothing seen -> False (fail closed for the flag).
     assert LlamaCppBackend._is_datacenter_gpu([5, 9]) is False
+
+
+def test_is_datacenter_gpu_masked_host_physical_ids(monkeypatch):
+    # CUDA_VISIBLE_DEVICES=4,5,6,7 -> torch ordinals 0..3 == physical 4..7 (all
+    # B200). gpu_indices carries PHYSICAL ids (from _get_gpu_free_memory), so the
+    # selection [4, 5] must resolve to ordinals 0, 1 rather than indexing out of
+    # range (the pre-fix bug, where 4 >= device_count silently skipped the GPU).
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    assert LlamaCppBackend._is_datacenter_gpu([4, 5]) is True
+    assert LlamaCppBackend._is_datacenter_gpu([4, 5, 6, 7]) is True
+    assert LlamaCppBackend._is_datacenter_gpu(None) is True
+    # Physical ids outside the mask are not visible -> skipped (fail conservative).
+    assert LlamaCppBackend._is_datacenter_gpu([0, 1]) is False
+
+
+def test_is_datacenter_gpu_masked_host_reordered(monkeypatch):
+    # A reordered mask must preserve order: ordinal 0 -> physical 7, 1 -> 4, ...
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7,4,5,6")
+    monkeypatch.setitem(
+        sys.modules, "torch", _fake_torch(["NVIDIA H100 80GB HBM3"] * 4)
+    )
+    assert LlamaCppBackend._is_datacenter_gpu([7, 4]) is True
+
+
+def test_is_datacenter_gpu_masked_host_mixed_class(monkeypatch):
+    # CUDA_VISIBLE_DEVICES=4,5 with physical 4 = GeForce, physical 5 = B200.
+    # The DC tuning must follow the actual selected physical GPU, not a same-
+    # numbered ordinal, so selecting the GeForce must not qualify.
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        _fake_torch(["NVIDIA GeForce RTX 4090", "NVIDIA B200"]),
+    )
+    assert LlamaCppBackend._is_datacenter_gpu([4]) is False
+    assert LlamaCppBackend._is_datacenter_gpu([5]) is True
+    assert LlamaCppBackend._is_datacenter_gpu([4, 5]) is False
+
+
+def test_is_datacenter_gpu_unparsable_mask_falls_back(monkeypatch):
+    # A UUID / non-integer mask cannot be parsed to physical ids; we fall back to
+    # physical id == ordinal, mirroring _get_gpu_free_memory, so ordinal lookup
+    # still classifies the visible device.
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abcdef12")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"]))
+    assert LlamaCppBackend._is_datacenter_gpu([0]) is True
 
 
 def test_is_datacenter_gpu_rocm_is_false(monkeypatch):
@@ -222,3 +283,17 @@ def test_apply_env_fail_open_on_detection_error(monkeypatch):
     env: dict = {}
     assert LlamaCppBackend._apply_datacenter_env(env, [0]) is False
     assert env == {}
+
+
+def test_apply_env_masked_host_multi_dc(monkeypatch):
+    # End-to-end on a masked multi-GPU host: CUDA_VISIBLE_DEVICES=4,5,6,7, 4x B200,
+    # physical selection [4, 5]. Pre-fix this returned no tuning (physical ids out
+    # of ordinal range); now all three multi-GPU flags must be applied.
+    monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    env: dict = {}
+    assert LlamaCppBackend._apply_datacenter_env(env, [4, 5]) is True
+    assert env["GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F"] == "1"
+    assert env["GGML_CUDA_P2P"] == "1"
+    assert env["CUDA_SCALE_LAUNCH_QUEUES"] == "4x"

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1,15 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Data-center llama.cpp env tuning.
-
-FP32 cuBLAS accumulation (GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F) plus, for
-multi-GPU, peer-to-peer (GGML_CUDA_P2P) and larger launch queues
-(CUDA_SCALE_LAUNCH_QUEUES) must be set only for datacenter/professional NVIDIA
-GPUs (A100/H100/H200/B200/GB200/GB300/L40/RTX PRO 6000 ...), never for consumer
-GeForce, AMD/ROCm, CPU or macOS, where FP32-accum carries a real throughput
-cost. A user-supplied value must always win, and UNSLOTH_DISABLE_DC_TUNING=1
-must turn the whole thing off.
+"""Data-center llama.cpp env tuning: FP32 accum (+ P2P / launch queues for
+multi-GPU) must apply only to datacenter NVIDIA parts, never consumer GeForce,
+AMD/ROCm, CPU or macOS. User values win; UNSLOTH_DISABLE_DC_TUNING=1 disables.
 """
 
 from __future__ import annotations
@@ -28,9 +22,7 @@ def _fake_torch(
     hip = None,
     cuda_ok = True,
 ):
-    """A torch stub exposing only what _is_datacenter_gpu / _effective_gpu_count
-    touch: torch.version.hip, torch.cuda.is_available/device_count and
-    get_device_properties(i).name."""
+    """torch stub: version.hip, cuda.is_available/device_count, get_device_properties(i).name."""
     t = types.ModuleType("torch")
     t.version = types.SimpleNamespace(hip = hip)
     t.cuda = types.SimpleNamespace(
@@ -43,10 +35,8 @@ def _fake_torch(
 
 @pytest.fixture(autouse = True)
 def _clear_cuda_visible_devices(monkeypatch):
-    """_is_datacenter_gpu now reads CUDA_VISIBLE_DEVICES to map physical GPU ids
-    back to torch ordinals. Tests that don't exercise masking must run as if the
-    process were unmasked (physical id == ordinal) regardless of the host's real
-    mask, so clear it by default; the masked-host tests set it explicitly."""
+    """Detection reads CUDA_VISIBLE_DEVICES, so clear it by default (run unmasked,
+    physical id == ordinal) regardless of host; masked tests set it explicitly."""
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising = False)
 
 
@@ -58,7 +48,7 @@ def _clear_cuda_visible_devices(monkeypatch):
 @pytest.mark.parametrize(
     "names,expected",
     [
-        # Datacenter / professional parts (real torch device names, lower/mixed case).
+        # Datacenter / professional parts.
         (["NVIDIA A100-SXM4-80GB"], True),
         (["NVIDIA A30"], True),
         (["NVIDIA H100 80GB HBM3"], True),
@@ -77,15 +67,15 @@ def _clear_cuda_visible_devices(monkeypatch):
         (["NVIDIA GeForce RTX 3090"], False),
         (["NVIDIA GeForce RTX 2080 Ti"], False),
         (["NVIDIA GeForce GTX 1080"], False),
-        # Workstation / laptop Ampere: short markers must not match as substrings
-        # ("a100" in "A1000", "a30" in "A3000"). Whole-word matching rejects these.
+        # Workstation/laptop: short markers must not match as substrings
+        # ("a100" in "A1000", "a30" in "A3000").
         (["NVIDIA RTX A1000 Laptop GPU"], False),
         (["NVIDIA RTX A1000 6GB Laptop GPU"], False),
         (["NVIDIA RTX A3000 Laptop GPU"], False),
         # Homogeneous multi-DC: all must match.
         (["NVIDIA B200", "NVIDIA B200"], True),
         (["NVIDIA H100 80GB HBM3", "NVIDIA H100 80GB HBM3"], True),
-        # Mixed DC + consumer: treated as non-DC so tuning never lands on GeForce.
+        # Mixed DC + consumer: non-DC, so tuning never lands on the GeForce.
         (["NVIDIA B200", "NVIDIA GeForce RTX 4090"], False),
         (["NVIDIA GeForce RTX 4090", "NVIDIA B200"], False),
     ],
@@ -116,30 +106,26 @@ def test_is_datacenter_gpu_out_of_range_indices_skipped(monkeypatch):
 
 
 def test_is_datacenter_gpu_masked_host_physical_ids(monkeypatch):
-    # CUDA_VISIBLE_DEVICES=4,5,6,7 -> torch ordinals 0..3 == physical 4..7 (all
-    # B200). gpu_indices carries PHYSICAL ids (from _get_gpu_free_memory), so the
-    # selection [4, 5] must resolve to ordinals 0, 1 rather than indexing out of
-    # range (the pre-fix bug, where 4 >= device_count silently skipped the GPU).
+    # Mask 4,5,6,7 -> ordinals 0..3 == physical 4..7. PHYSICAL selection [4,5]
+    # must resolve, not index out of range (the pre-fix bug: 4 >= device_count).
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
     assert LlamaCppBackend._is_datacenter_gpu([4, 5]) is True
     assert LlamaCppBackend._is_datacenter_gpu([4, 5, 6, 7]) is True
     assert LlamaCppBackend._is_datacenter_gpu(None) is True
-    # Physical ids outside the mask are not visible -> skipped (fail conservative).
-    assert LlamaCppBackend._is_datacenter_gpu([0, 1]) is False
+    assert LlamaCppBackend._is_datacenter_gpu([0, 1]) is False  # not visible -> skip
 
 
 def test_is_datacenter_gpu_masked_host_reordered(monkeypatch):
-    # A reordered mask must preserve order: ordinal 0 -> physical 7, 1 -> 4, ...
+    # Reordered mask preserves order: ordinal 0 -> physical 7, 1 -> 4, ...
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7,4,5,6")
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA H100 80GB HBM3"] * 4))
     assert LlamaCppBackend._is_datacenter_gpu([7, 4]) is True
 
 
 def test_is_datacenter_gpu_masked_host_mixed_class(monkeypatch):
-    # CUDA_VISIBLE_DEVICES=4,5 with physical 4 = GeForce, physical 5 = B200.
-    # The DC tuning must follow the actual selected physical GPU, not a same-
-    # numbered ordinal, so selecting the GeForce must not qualify.
+    # Mask 4,5: physical 4 = GeForce, physical 5 = B200. Detection must follow the
+    # selected physical GPU, not a same-numbered ordinal.
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
     monkeypatch.setitem(
         sys.modules,
@@ -152,16 +138,15 @@ def test_is_datacenter_gpu_masked_host_mixed_class(monkeypatch):
 
 
 def test_is_datacenter_gpu_unparsable_mask_falls_back(monkeypatch):
-    # A UUID / non-integer mask cannot be parsed to physical ids; we fall back to
-    # physical id == ordinal, mirroring _get_gpu_free_memory, so ordinal lookup
-    # still classifies the visible device.
+    # Unparsable (UUID) mask falls back to physical id == ordinal (mirrors
+    # _get_gpu_free_memory), so ordinal lookup still classifies the device.
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abcdef12")
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"]))
     assert LlamaCppBackend._is_datacenter_gpu([0]) is True
 
 
 def test_is_datacenter_gpu_rocm_is_false(monkeypatch):
-    # ROCm reuses torch.cuda.*; even an MI300X-named part must not qualify here.
+    # ROCm reuses torch.cuda.*; an MI300X must not qualify.
     monkeypatch.setitem(
         sys.modules,
         "torch",
@@ -186,14 +171,13 @@ def test_is_datacenter_gpu_missing_torch_is_false(monkeypatch):
 
 
 def test_effective_gpu_count_explicit_selection(monkeypatch):
-    # Explicit selection: length of the list, regardless of how many are visible.
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
     assert LlamaCppBackend._effective_gpu_count([0]) == 1
     assert LlamaCppBackend._effective_gpu_count([0, 1, 2]) == 3
 
 
 def test_effective_gpu_count_none_uses_visible(monkeypatch):
-    # None == "use every visible GPU" -> visible device count.
+    # None -> visible device count.
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
     assert LlamaCppBackend._effective_gpu_count(None) == 4
 
@@ -219,8 +203,7 @@ def test_apply_env_single_dc_gpu_sets_only_fp32(monkeypatch):
     env: dict = {}
     assert LlamaCppBackend._apply_datacenter_env(env, [0]) is True
     assert env == {"GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F": "1"}
-    # No multi-GPU flags on a single GPU.
-    assert "GGML_CUDA_P2P" not in env
+    assert "GGML_CUDA_P2P" not in env  # no multi-GPU flags on one GPU
     assert "CUDA_SCALE_LAUNCH_QUEUES" not in env
 
 
@@ -235,7 +218,7 @@ def test_apply_env_multi_dc_gpu_sets_all(monkeypatch):
 
 
 def test_apply_env_none_indices_uses_visible_count(monkeypatch):
-    # gpu_indices None on a 2x DC box -> multi-GPU flags applied.
+    # None on a 2x DC box -> multi-GPU flags applied.
     monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA H100", "NVIDIA H100"]))
     env: dict = {}
@@ -260,10 +243,9 @@ def test_apply_env_user_value_wins(monkeypatch):
         "CUDA_SCALE_LAUNCH_QUEUES": "8x",  # user override
     }
     assert LlamaCppBackend._apply_datacenter_env(env, [0, 1]) is True
-    # setdefault must not clobber user-provided values.
+    # setdefault must not clobber user values; the unset one still defaults.
     assert env["GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F"] == "0"
     assert env["CUDA_SCALE_LAUNCH_QUEUES"] == "8x"
-    # The one the user didn't set still gets the default.
     assert env["GGML_CUDA_P2P"] == "1"
 
 
@@ -284,9 +266,8 @@ def test_apply_env_fail_open_on_detection_error(monkeypatch):
 
 
 def test_apply_env_masked_host_multi_dc(monkeypatch):
-    # End-to-end on a masked multi-GPU host: CUDA_VISIBLE_DEVICES=4,5,6,7, 4x B200,
-    # physical selection [4, 5]. Pre-fix this returned no tuning (physical ids out
-    # of ordinal range); now all three multi-GPU flags must be applied.
+    # End-to-end masked host (mask 4,5,6,7, physical selection [4,5]): pre-fix
+    # applied no tuning; now all three multi-GPU flags must be set.
     monkeypatch.delenv("UNSLOTH_DISABLE_DC_TUNING", raising = False)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))


### PR DESCRIPTION
## Summary

Studio now detects datacenter / professional NVIDIA GPUs at llama-server launch and sets the llama.cpp env flags that help them, gated so consumer GeForce, AMD/ROCm, CPU and macOS are never touched. This is runtime-only (no new prebuilt binary, no manifest or installer changes): the flags are injected into the llama-server child process env via `setdefault`, right next to the existing AMD unified-memory APU block.

The flags and the gate come from a benchmark on this 6x B200 box (NVLink, driver 13.1), built from llama.cpp b9518 with `CMAKE_CUDA_ARCHITECTURES=80;90;100;120`. Runtime flags were toggled per run, no rebuild.

## What it sets

| flag | scope | effect |
|------|-------|--------|
| `GGML_CUDA_FORCE_CUBLAS_COMPUTE_32F=1` | every DC GPU | FP32 cuBLAS accumulation (prevents FP16 overflow) |
| `GGML_CUDA_P2P=1` | DC multi-GPU | peer-to-peer transfers over NVLink |
| `CUDA_SCALE_LAUNCH_QUEUES=4x` | DC multi-GPU | larger CUDA command buffer |

All three use `setdefault`, so a user-supplied value always wins, and `UNSLOTH_DISABLE_DC_TUNING=1` turns the whole thing off.

## Why these flags (B200 benchmark)

FP32 accumulation, single B200 (tokens/s):

| model | test | baseline | fp32acc | delta |
|-------|------|----------|---------|-------|
| 8B-Q4 | pp512 | 10271 | 9758 | -5.0% |
| 8B-Q4 | pp2048 | 10510 | 10499 | -0.1% |
| 8B-Q4 | tg128 | 279.4 | 279.5 | +0.0% |
| 8B-BF16 | pp2048 | 24659 | 24663 | +0.0% |
| 8B-BF16 | tg128 | 179.0 | 178.9 | -0.1% |

Perplexity (wikitext-2-raw, 8B-Q4) is identical: 7.3230 +/- 0.04674 with and without the flag. Cost on B200 is ~0% everywhere except one short-prefill corner; on GeForce the same flag carries a real throughput cost, which is exactly why it is DC-gated.

Multi-GPU, 70B-Q4 across B200s (prompt processing / token gen, tokens/s):

| GPUs | split | env | pp2048 | tg128 |
|------|-------|-----|--------|-------|
| 4 | layer (default) | none | 2408 | 45.6 |
| 4 | layer (default) | p2p+lq | 2812 (+16.8%) | 45.7 |
| 2 | row (tensor) | none | 988 | 20.2 |
| 2 | row (tensor) | p2p+lq | 1492 (+51.1%) | 26.8 (+32.6%) |
| 4 | row (tensor) | p2p+lq | 973 (+46.0%) | 24.4 (+48.9%) |

P2P carries the tensor (row) split (+33-49%), launch-queues carries the default pipeline (layer) split (+8-16% prompt processing); together they never regress, so both are enabled for any multi-DC-GPU launch.

`GGML_CUDA_PEER_MAX_BATCH_SIZE` is intentionally left out: it is compile-time and would need a separate binary, and this change is runtime-only.

## Detection

`_is_datacenter_gpu(gpu_indices)` reads `torch.cuda.get_device_properties(i).name` for the selected GPUs and matches a case-insensitive allowlist (A100, A30, H100, H200, H800, GH200, B200, B100, B300, GB200, GB300, L40/L40S, L4, RTX PRO 6000, RTX 6000 Ada). It is NVIDIA-only and fails open to False, so consumer GeForce, ROCm, CPU, macOS and any error path are untouched. A mixed box with one consumer GPU in the selection is treated as non-DC so the tuning never lands on a GeForce card.

## Tests

`studio/backend/tests/test_datacenter_gpu_tuning.py` (37 tests): DC names match, consumer GeForce (4090/5090/3090/2080/1080) rejected, mixed box rejected, per-selection gating, out-of-range indices skipped, ROCm/no-CUDA/missing-torch fail open, single vs multi-GPU flag set, `gpu_indices=None` falls back to visible device count, user-supplied env value wins over setdefault, and `UNSLOTH_DISABLE_DC_TUNING=1` respected.

```
37 passed in 0.36s
```

The neighboring `test_amd_apu_unified_memory.py` / `test_rocm_oom_guard.py` still pass (43 passed).