### PR TITLE
Studio: open the MCP dialog to the server list

### DIFF
--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -178,8 +178,6 @@ function HeadersEditor({
 export interface ChatMcpServersDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Open straight into the "add server" form instead of the list view. */
-  openToCreate?: boolean;
 }
 
 type View =
@@ -190,7 +188,6 @@ type View =
 export function ChatMcpServersDialog({
   open,
   onOpenChange,
-  openToCreate = false,
 }: ChatMcpServersDialogProps) {
   const [servers, setServers] = useState<McpServerConfig[]>([]);
   const [loading, setLoading] = useState(false);
@@ -217,12 +214,10 @@ export function ChatMcpServersDialog({
   useEffect(() => {
     if (!open) return;
     refresh();
-    // Land on the create form when opened via "Add custom MCP".
-    if (openToCreate) {
-      setView({ kind: "create" });
-      setForm(EMPTY_FORM);
-    }
-  }, [open, openToCreate, refresh]);
+    // Reset to the list on each open, else a stale create/edit view persists.
+    setView({ kind: "list" });
+    setForm(EMPTY_FORM);
+  }, [open, refresh]);
 
   function startCreate() {
     setView({ kind: "create" });

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -57,7 +57,7 @@ type McpPreset = {
 };
 
 // Keyless remote MCP presets (rate-limited free tiers, no API key).
-// Hugging Face runs anonymously; add a token via "Add custom MCP".
+// Hugging Face runs anonymously; add a token via "Manage MCP servers".
 const MCP_PRESETS: readonly McpPreset[] = [
   {
     id: "context7",
@@ -296,7 +296,7 @@ export function McpComposerButton({
                 setDialogOpen(true);
               }}
             >
-              Add custom MCP
+              Manage MCP servers
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -331,7 +331,6 @@ export function McpComposerButton({
           // Resync after managing servers.
           if (!next) void refresh();
         }}
-        openToCreate={true}
       />
     </>
   );


### PR DESCRIPTION
Currently the "Add custom MCP" button opens the dialog to add a new server; to reach the dialog to manage servers (edit, remove, etc), it's necessary to first open that dialog and then click Cancel. 

This is unintuitive and a UX gap, see for instance https://github.com/unslothai/unsloth/issues/6042.

### Proposed fix

Replace "Add custom MCP" with "Manage MCP servers", which opens the dialog with the list of servers. To add a new server, the user simply clicks "Add server" in that dialog.

Closes https://github.com/unslothai/unsloth/issues/6042

Maybe makes https://github.com/unslothai/unsloth/pull/6030 unnecessary.

<img width="835" height="552" alt="image" src="https://github.com/user-attachments/assets/749c3de8-2598-4da7-9d6a-55210b14234a" />

