### PR TITLE
Studio: unify shadows, backgrounds and dark mode consistency in chat UI

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1007,7 +1007,7 @@ export function AppSidebar() {
                 <SidebarMenuButton
                   size="lg"
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
-                  className="sidebar-nav-btn !h-[38px] gap-[9px] px-2 py-[3px] rounded-[14px]"
+                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-[14px]"
                 >
                   <div className="shrink-0">
                     <UserAvatar

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -210,7 +210,7 @@ function NavItem({
           onClick={onClick}
           isActive={active}
           data-tour={dataTour}
-          className="sidebar-nav-btn h-[33px] rounded-[11px] gap-[8.5px] px-2.5 font-medium group-data-[collapsible=icon]:!w-[32px] group-data-[collapsible=icon]:!rounded-[10px] group-data-[collapsible=icon]:mx-auto"
+          className="sidebar-nav-btn h-[33px] rounded-[14px] gap-[8.5px] px-2.5 font-medium group-data-[collapsible=icon]:!w-[32px] group-data-[collapsible=icon]:!rounded-[10px] group-data-[collapsible=icon]:mx-auto"
         >
           <HugeiconsIcon icon={icon} strokeWidth={1.75} className="size-icon! shrink-0 group-hover/menu-button:animate-icon-pop" />
           <span className="text-[14.5px] leading-[19px] tracking-nav">{label}</span>
@@ -549,7 +549,7 @@ export function AppSidebar() {
         ? "sidebar-row-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
         : "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
     const buttonClass = cn(
-      "sidebar-nav-btn h-[33px] cursor-pointer rounded-[11px] pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
+      "sidebar-nav-btn h-[33px] cursor-pointer rounded-[14px] pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
       variant === "project" ? "pl-[37px]" : "pl-2.5",
       variant === "project"
         ? "group-hover/project-chat-item:pr-8 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-8"
@@ -738,7 +738,7 @@ export function AppSidebar() {
         )}
       </SidebarHeader>
 
-      <SidebarGroup className="group-data-[collapsible=icon]:px-0 px-2 pt-[9px] pb-px shrink-0">
+      <SidebarGroup className="group-data-[collapsible=icon]:px-0 px-1.5 pt-[9px] pb-px shrink-0">
         <SidebarGroupContent>
           <SidebarMenu>
             <NavItem
@@ -778,7 +778,7 @@ export function AppSidebar() {
           scrolled && "is-scrolled",
         )}
       >
-        <SidebarGroup className="group-data-[collapsible=icon]:px-0 px-2 py-0 shrink-0">
+        <SidebarGroup className="group-data-[collapsible=icon]:px-0 px-1.5 py-0 shrink-0">
           <SidebarGroupContent>
             <SidebarMenu>
               <NavItem
@@ -829,7 +829,7 @@ export function AppSidebar() {
               </CollapsibleTrigger>
             </SidebarGroupLabel>
             <CollapsibleContent>
-              <SidebarGroupContent className="px-2">
+              <SidebarGroupContent className="px-1.5">
                 <SidebarMenu>
                   <NavItem
                     icon={TestTubeOutlineIcon}
@@ -878,7 +878,7 @@ export function AppSidebar() {
                 </CollapsibleTrigger>
               </SidebarGroupLabel>
               <CollapsibleContent>
-                <SidebarGroupContent className="px-2">
+                <SidebarGroupContent className="px-1.5">
                   <SidebarMenu>
                     {recentChatItems.map((item) =>
                       renderChatSidebarItem(item, "recent"),
@@ -918,7 +918,7 @@ export function AppSidebar() {
                       >
                         <SidebarMenuButton
                           isActive={isActiveRun}
-                          className="sidebar-nav-btn h-auto flex-col items-start gap-0.5 py-[5px] rounded-[11px] pl-2.5 pr-7 text-[14.5px] tracking-nav font-medium"
+                          className="sidebar-nav-btn h-auto flex-col items-start gap-0.5 py-[5px] rounded-[14px] pl-2.5 pr-7 text-[14.5px] tracking-nav font-medium"
                           onClick={() => {
                             setSelectedHistoryRunId(run.id);
                             closeMobileIfOpen();

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -210,7 +210,7 @@ function NavItem({
           onClick={onClick}
           isActive={active}
           data-tour={dataTour}
-          className="sidebar-nav-btn h-[33px] rounded-[14px] gap-[8.5px] px-2.5 font-medium group-data-[collapsible=icon]:!w-[32px] group-data-[collapsible=icon]:!rounded-[10px] group-data-[collapsible=icon]:mx-auto"
+          className="sidebar-nav-btn h-[33px] rounded-full gap-[8.5px] px-2.5 font-medium group-data-[collapsible=icon]:!w-[32px] group-data-[collapsible=icon]:!rounded-full group-data-[collapsible=icon]:mx-auto"
         >
           <HugeiconsIcon icon={icon} strokeWidth={1.75} className="size-icon! shrink-0 group-hover/menu-button:animate-icon-pop" />
           <span className="text-[14.5px] leading-[19px] tracking-nav">{label}</span>
@@ -549,7 +549,7 @@ export function AppSidebar() {
         ? "sidebar-row-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
         : "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
     const buttonClass = cn(
-      "sidebar-nav-btn h-[33px] cursor-pointer rounded-[14px] pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
+      "sidebar-nav-btn h-[33px] cursor-pointer rounded-full pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
       variant === "project" ? "pl-[37px]" : "pl-2.5",
       variant === "project"
         ? "group-hover/project-chat-item:pr-8 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-8"
@@ -918,7 +918,7 @@ export function AppSidebar() {
                       >
                         <SidebarMenuButton
                           isActive={isActiveRun}
-                          className="sidebar-nav-btn h-auto flex-col items-start gap-0.5 py-[5px] rounded-[14px] pl-2.5 pr-7 text-[14.5px] tracking-nav font-medium"
+                          className="sidebar-nav-btn h-auto flex-col items-start gap-0.5 py-[5px] rounded-full pl-2.5 pr-7 text-[14.5px] tracking-nav font-medium"
                           onClick={() => {
                             setSelectedHistoryRunId(run.id);
                             closeMobileIfOpen();
@@ -960,7 +960,7 @@ export function AppSidebar() {
                             side="bottom"
                             align="end"
                             sideOffset={0}
-                            className="app-user-menu menu-soft-surface menu-flat-destructive ring-0 w-44 py-2 font-heading rounded-[14px] border-0"
+                            className="app-user-menu menu-soft-surface menu-flat-destructive ring-0 w-44 py-2 font-heading rounded-full border-0"
                           >
                             <DropdownMenuItem onSelect={() => openRenameRun(run)}>
                               <HugeiconsIcon icon={Edit03Icon} strokeWidth={1.75} className="size-icon" />
@@ -1007,7 +1007,7 @@ export function AppSidebar() {
                 <SidebarMenuButton
                   size="lg"
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
-                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-[14px]"
+                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-full"
                 >
                   <div className="shrink-0">
                     <UserAvatar

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1027,7 +1027,7 @@ export function AppSidebar() {
               <DropdownMenuContent
                 side="top"
                 align="center"
-                sideOffset={0}
+                sideOffset={4}
                 className="app-user-menu menu-soft-surface-up ring-0 w-[16rem] px-1.5 py-2.5 font-heading rounded-[20px] border-0"
               >
                 <DropdownMenuGroup>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1007,7 +1007,7 @@ export function AppSidebar() {
                 <SidebarMenuButton
                   size="lg"
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
-                  className="sidebar-nav-btn !h-[44px] gap-[9px] px-2 py-[3px] rounded-[14px]"
+                  className="sidebar-nav-btn !h-[38px] gap-[9px] px-2 py-[3px] rounded-[14px]"
                 >
                   <div className="shrink-0">
                     <UserAvatar

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -599,7 +599,7 @@ export function AppSidebar() {
           <DropdownMenuContent
             side="bottom"
             align="start"
-            sideOffset={6}
+            sideOffset={0}
             className="unsloth-plus-menu menu-flat-destructive w-52"
           >
             <DropdownMenuItem onSelect={() => openRenameChat(item)}>
@@ -612,7 +612,7 @@ export function AppSidebar() {
                 <span>Move to project</span>
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent
-                sideOffset={8}
+                sideOffset={0}
                 alignOffset={-4}
                 className="unsloth-plus-menu w-52"
               >
@@ -959,7 +959,7 @@ export function AppSidebar() {
                           <DropdownMenuContent
                             side="bottom"
                             align="end"
-                            sideOffset={4}
+                            sideOffset={0}
                             className="app-user-menu menu-soft-surface menu-flat-destructive ring-0 w-44 py-2 font-heading rounded-[14px] border-0"
                           >
                             <DropdownMenuItem onSelect={() => openRenameRun(run)}>
@@ -1027,7 +1027,7 @@ export function AppSidebar() {
               <DropdownMenuContent
                 side="top"
                 align="center"
-                sideOffset={6}
+                sideOffset={0}
                 className="app-user-menu menu-soft-surface-up ring-0 w-[16rem] px-1.5 py-2.5 font-heading rounded-[20px] border-0"
               >
                 <DropdownMenuGroup>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1007,7 +1007,7 @@ export function AppSidebar() {
                 <SidebarMenuButton
                   size="lg"
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
-                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-full"
+                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-[14px]"
                 >
                   <div className="shrink-0">
                     <UserAvatar

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1174,7 +1174,7 @@ export function AppSidebar() {
               <DropdownMenuContent
                 side="top"
                 align="center"
-                sideOffset={4}
+                sideOffset={8}
                 className="app-user-menu menu-soft-surface-up ring-0 w-[16rem] px-1.5 py-2.5 font-heading rounded-[20px] border-0"
               >
                 <DropdownMenuGroup>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2260,7 +2260,7 @@ const AssistantActionBar: FC = () => {
           side="bottom"
           align="start"
           onCloseAutoFocus={(e) => e.preventDefault()}
-          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md [--radius:1.1rem] bg-popover p-1 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
+          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md [--radius:1.1rem] bg-popover p-1 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
         >
           <ActionBarPrimitive.ExportMarkdown asChild={true}>
             <ActionBarMorePrimitive.Item className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -688,7 +688,7 @@ const ThreadWelcome: FC<{
 
   return (
     <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-(--thread-max-width) grow flex-col">
-      <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-start pt-[calc(28vh-5px)]">
+      <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-start pt-[28.5vh]">
         <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-4">
           {/* Center the greeting (sloth + title) over the composer. */}
           <div className="flex flex-row items-center justify-center gap-[15px]">

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2260,7 +2260,7 @@ const AssistantActionBar: FC = () => {
           side="bottom"
           align="start"
           onCloseAutoFocus={(e) => e.preventDefault()}
-          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md [--radius:1.1rem] bg-popover p-1 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(27,27,31,0.16)] dark:shadow-none"
+          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md [--radius:1.1rem] bg-popover p-1 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
         >
           <ActionBarPrimitive.ExportMarkdown asChild={true}>
             <ActionBarMorePrimitive.Item className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -643,8 +643,8 @@ function buildWelcome(hour: number, name: string): Welcome {
   // Use the name on ~a third of lines (only direct salutations where it reads
   // naturally); the rest stay name-free so greetings don't feel repetitive.
   const base: Welcome[] = [
-    g(name ? `Good to see you, ${name}.` : "Good to see you.", "large sloth wave.png"),
-    g("Ready when you are.", "large sloth thumbs.png"),
+    g(name ? `Good to see you, ${name}` : "Good to see you", "large sloth wave.png"),
+    g("Ready when you are", "large sloth thumbs.png"),
     DEFAULT_WELCOME,
     g("How can I help?", "sloth sir large.png"),
   ];

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2260,7 +2260,7 @@ const AssistantActionBar: FC = () => {
           side="bottom"
           align="start"
           onCloseAutoFocus={(e) => e.preventDefault()}
-          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md [--radius:1.1rem] bg-popover p-1 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
+          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md [--radius:1.1rem] bg-popover p-1 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
         >
           <ActionBarPrimitive.ExportMarkdown asChild={true}>
             <ActionBarMorePrimitive.Item className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1873,7 +1873,7 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
       <DropdownMenuContent
         side={side}
         align="start"
-        sideOffset={2}
+        sideOffset={0}
         avoidCollisions={true}
         className="unsloth-plus-menu w-[212px]"
         // Don't refocus the + on close; restored focus showed a stray ring.

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -688,7 +688,7 @@ const ThreadWelcome: FC<{
 
   return (
     <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-(--thread-max-width) grow flex-col">
-      <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-start pt-[28vh]">
+      <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-start pt-[calc(28vh-5px)]">
         <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-4">
           {/* Center the greeting (sloth + title) over the composer. */}
           <div className="flex flex-row items-center justify-center gap-[15px]">

--- a/studio/frontend/src/components/ui/button.tsx
+++ b/studio/frontend/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 export const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-[14px] border border-transparent text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none cursor-pointer",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-full border border-transparent text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none cursor-pointer",
   {
     variants: {
       variant: {

--- a/studio/frontend/src/components/ui/button.tsx
+++ b/studio/frontend/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 export const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-4xl border border-transparent text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none cursor-pointer",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-[14px] border border-transparent text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none cursor-pointer",
   {
     variants: {
       variant: {

--- a/studio/frontend/src/components/ui/combobox.tsx
+++ b/studio/frontend/src/components/ui/combobox.tsx
@@ -146,7 +146,7 @@ function ComboboxInput({
 function ComboboxContent({
   className,
   side = "bottom",
-  sideOffset = 6,
+  sideOffset = 0,
   align = "start",
   alignOffset = 0,
   anchor,

--- a/studio/frontend/src/components/ui/dropdown-menu.tsx
+++ b/studio/frontend/src/components/ui/dropdown-menu.tsx
@@ -46,7 +46,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         align={align}
         className={cn(
-          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-48 rounded-lg p-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-[calc(var(--radix-dropdown-menu-trigger-width)_-_10px)] data-[align=start]:translate-x-[5px] data-[align=end]:-translate-x-[5px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
+          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-48 rounded-lg p-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-[calc(var(--radix-dropdown-menu-trigger-width)_+_6px)] data-[align=start]:-translate-x-[3px] data-[align=end]:translate-x-[3px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
           className,
         )}
         {...props}

--- a/studio/frontend/src/components/ui/dropdown-menu.tsx
+++ b/studio/frontend/src/components/ui/dropdown-menu.tsx
@@ -46,7 +46,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         align={align}
         className={cn(
-          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-48 rounded-lg p-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
+          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-48 rounded-lg p-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-[calc(var(--radix-dropdown-menu-trigger-width)_-_10px)] data-[align=start]:translate-x-[5px] data-[align=end]:-translate-x-[5px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
           className,
         )}
         {...props}

--- a/studio/frontend/src/components/ui/dropdown-menu.tsx
+++ b/studio/frontend/src/components/ui/dropdown-menu.tsx
@@ -36,7 +36,7 @@ function DropdownMenuTrigger({
 function DropdownMenuContent({
   className,
   align = "start",
-  sideOffset = 4,
+  sideOffset = 0,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (

--- a/studio/frontend/src/components/ui/dropdown-menu.tsx
+++ b/studio/frontend/src/components/ui/dropdown-menu.tsx
@@ -78,7 +78,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2.5 rounded-lg px-3 py-2 text-sm [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2.5 rounded-full px-3 py-2 text-sm [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -96,7 +96,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2.5 rounded-lg py-2 pr-8 pl-3 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2.5 rounded-full py-2 pr-8 pl-3 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       checked={checked}
@@ -135,7 +135,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2.5 rounded-lg py-2 pr-8 pl-3 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2.5 rounded-full py-2 pr-8 pl-3 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -221,7 +221,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-lg px-3 py-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex cursor-pointer items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-full px-3 py-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex cursor-pointer items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/studio/frontend/src/components/ui/menubar.tsx
+++ b/studio/frontend/src/components/ui/menubar.tsx
@@ -72,7 +72,7 @@ function MenubarContent({
   className,
   align = "start",
   alignOffset = -4,
-  sideOffset = 8,
+  sideOffset = 0,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Content>) {
   return (

--- a/studio/frontend/src/components/ui/popover.tsx
+++ b/studio/frontend/src/components/ui/popover.tsx
@@ -23,7 +23,7 @@ function PopoverTrigger({
 function PopoverContent({
   className,
   align = "center",
-  sideOffset = 4,
+  sideOffset = 0,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (

--- a/studio/frontend/src/components/ui/select.tsx
+++ b/studio/frontend/src/components/ui/select.tsx
@@ -128,8 +128,7 @@ function SelectContent({
         data-align-trigger={position === "item-aligned"}
         className={cn(
           "bg-popover text-popover-foreground font-heading data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-36 rounded-xl p-1 corner-squircle duration-100 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto ",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          // No popper translate offset: the menu sits flush against the trigger.
           className,
         )}
         position={position}

--- a/studio/frontend/src/components/ui/select.tsx
+++ b/studio/frontend/src/components/ui/select.tsx
@@ -111,7 +111,7 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
+  position = "popper",
   align = "center",
   container,
   ...props
@@ -125,7 +125,7 @@ function SelectContent({
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
         className={cn(
-          "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-36 rounded-xl p-1 corner-squircle duration-100 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto ",
+          "bg-popover text-popover-foreground font-heading data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-36 rounded-xl p-1 corner-squircle duration-100 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto ",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/studio/frontend/src/components/ui/select.tsx
+++ b/studio/frontend/src/components/ui/select.tsx
@@ -63,7 +63,9 @@ function SelectTrigger({
   children,
   icon,
   iconClassName,
-  animateRadius = true,
+  /* Off by default: the radius morph matched the old item-aligned popup
+     that overlaid the trigger; popper menus drop below it instead. */
+  animateRadius = false,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
   size?: "sm" | "default";

--- a/studio/frontend/src/components/ui/select.tsx
+++ b/studio/frontend/src/components/ui/select.tsx
@@ -173,7 +173,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2.5 rounded-xl corner-squircle py-2 pr-8 pl-3 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2.5 rounded-full py-2 pr-8 pl-3 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-pointer items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -305,9 +305,8 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
           className={cn(
-            "bg-sidebar flex size-full flex-col overflow-hidden border-r border-sidebar-border",
+            "bg-sidebar flex size-full flex-col overflow-hidden",
             "group-data-[variant=floating]:ring-sidebar-border group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1",
-            hasPinMode && "ring-1 ring-sidebar-border/60",
           )}
         >
           {children}

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -305,7 +305,7 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
           className={cn(
-            "bg-sidebar flex size-full flex-col overflow-hidden",
+            "bg-sidebar flex size-full flex-col overflow-hidden border-r border-sidebar-border dark:border-r-0",
             "group-data-[variant=floating]:ring-sidebar-border group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1",
           )}
         >

--- a/studio/frontend/src/features/auth/login-page.tsx
+++ b/studio/frontend/src/features/auth/login-page.tsx
@@ -16,7 +16,7 @@ export function LoginPage() {
         length="70vh"
         style={{ opacity: 0.4 }}
       />
-      <Card className="relative z-10 w-full max-w-sm px-5 py-6 shadow-border ring-1 ring-border sm:px-6 sm:py-8">
+      <Card className="relative z-10 w-full max-w-sm px-5 py-6 shadow-border ring-0 sm:px-6 sm:py-8">
         <AuthForm mode="login" />
       </Card>
     </div>

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2076,12 +2076,12 @@ export function ChatPage(): ReactElement {
 
   if (!isCurrentChatRoute) {
     return (
-      <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fcfcfd] dark:bg-background" />
+      <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-background" />
     );
   }
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fcfcfd] dark:bg-background overflow-hidden">
+    <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-background overflow-hidden">
       <GuidedTour {...tour.tourProps} />
       <div className="relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden">
         <NativeModelDropOverlay state={nativeModelDropState} />
@@ -2090,12 +2090,12 @@ export function ChatPage(): ReactElement {
         {view.mode !== "compare" && (
           <div
             aria-hidden
-            className="pointer-events-none absolute left-0 right-[10px] top-[48px] z-20 h-6 bg-gradient-to-b from-[#fcfcfd] dark:from-background to-transparent"
+            className="pointer-events-none absolute left-0 right-[10px] top-[48px] z-20 h-6 bg-gradient-to-b from-background to-transparent"
           />
         )}
         <div
           className={cn(
-            "absolute top-0 left-0 right-[10px] z-30 flex h-[48px] shrink-0 items-start pt-[11px] pr-2 bg-[#fcfcfd] dark:bg-background",
+            "absolute top-0 left-0 right-[10px] z-30 flex h-[48px] shrink-0 items-start pt-[11px] pr-2 bg-background",
             isMobile ? "pl-12 pr-1.5" : "pl-2",
             view.mode === "compare" &&
               "right-[10px] left-auto w-auto bg-transparent pl-0 pr-2",

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2076,12 +2076,12 @@ export function ChatPage(): ReactElement {
 
   if (!isCurrentChatRoute) {
     return (
-      <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-background" />
+      <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fbfbfc] dark:bg-background" />
     );
   }
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-background overflow-hidden">
+    <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fbfbfc] dark:bg-background overflow-hidden">
       <GuidedTour {...tour.tourProps} />
       <div className="relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden">
         <NativeModelDropOverlay state={nativeModelDropState} />
@@ -2090,12 +2090,12 @@ export function ChatPage(): ReactElement {
         {view.mode !== "compare" && (
           <div
             aria-hidden
-            className="pointer-events-none absolute left-0 right-[10px] top-[48px] z-20 h-6 bg-gradient-to-b from-background to-transparent"
+            className="pointer-events-none absolute left-0 right-[10px] top-[48px] z-20 h-6 bg-gradient-to-b from-[#fbfbfc] dark:from-background to-transparent"
           />
         )}
         <div
           className={cn(
-            "absolute top-0 left-0 right-[10px] z-30 flex h-[48px] shrink-0 items-start pt-[11px] pr-2 bg-background",
+            "absolute top-0 left-0 right-[10px] z-30 flex h-[48px] shrink-0 items-start pt-[11px] pr-2 bg-[#fbfbfc] dark:bg-background",
             isMobile ? "pl-12 pr-1.5" : "pl-2",
             view.mode === "compare" &&
               "right-[10px] left-auto w-auto bg-transparent pl-0 pr-2",

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2076,12 +2076,12 @@ export function ChatPage(): ReactElement {
 
   if (!isCurrentChatRoute) {
     return (
-      <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fbfbfc] dark:bg-background" />
+      <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fcfcfd] dark:bg-background" />
     );
   }
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fbfbfc] dark:bg-background overflow-hidden">
+    <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-[#fcfcfd] dark:bg-background overflow-hidden">
       <GuidedTour {...tour.tourProps} />
       <div className="relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden">
         <NativeModelDropOverlay state={nativeModelDropState} />
@@ -2090,12 +2090,12 @@ export function ChatPage(): ReactElement {
         {view.mode !== "compare" && (
           <div
             aria-hidden
-            className="pointer-events-none absolute left-0 right-[10px] top-[48px] z-20 h-6 bg-gradient-to-b from-[#fbfbfc] dark:from-background to-transparent"
+            className="pointer-events-none absolute left-0 right-[10px] top-[48px] z-20 h-6 bg-gradient-to-b from-[#fcfcfd] dark:from-background to-transparent"
           />
         )}
         <div
           className={cn(
-            "absolute top-0 left-0 right-[10px] z-30 flex h-[48px] shrink-0 items-start pt-[11px] pr-2 bg-[#fbfbfc] dark:bg-background",
+            "absolute top-0 left-0 right-[10px] z-30 flex h-[48px] shrink-0 items-start pt-[11px] pr-2 bg-[#fcfcfd] dark:bg-background",
             isMobile ? "pl-12 pr-1.5" : "pl-2",
             view.mode === "compare" &&
               "right-[10px] left-auto w-auto bg-transparent pl-0 pr-2",

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -996,7 +996,7 @@ function ProjectLanding({
                             : { compare: item.id, project: projectId },
                       });
                     }}
-                    className="group flex min-h-[58px] w-full items-center gap-4 rounded-[10px] px-4 py-2 text-left transition-colors hover:bg-nav-surface-hover"
+                    className="group flex min-h-[58px] w-full items-center gap-4 rounded-full px-4 py-2 text-left transition-colors hover:bg-nav-surface-hover"
                   >
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-[15px] font-semibold leading-5 text-foreground">

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -262,7 +262,7 @@ function ParamSlider({
           onChange={onChange}
           displayValue={displayValue}
           ariaLabel={label}
-          size={valueSize ?? 6}
+          size={valueSize ?? 4}
         />
       </div>
       <Slider

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1091,7 +1091,7 @@ export function ChatSettingsPanel({
                 variant={presetSaveState.isSaveReady ? "default" : "outline"}
                 size="sm"
                 className={cn(
-                  "h-9 w-full rounded-[10px] text-[13px] font-medium tracking-nav",
+                  "h-9 w-full rounded-full text-[13px] font-medium tracking-nav",
                   presetSaveState.isSaveReady &&
                     "bg-primary text-primary-foreground hover:bg-primary/90",
                 )}
@@ -1106,7 +1106,7 @@ export function ChatSettingsPanel({
                 disabled={!(settingsHydrated && activeCustomPreset)}
                 variant="outline"
                 size="sm"
-                className="h-9 w-full rounded-[10px] text-[13px] font-medium tracking-nav text-muted-foreground"
+                className="h-9 w-full rounded-full text-[13px] font-medium tracking-nav text-muted-foreground"
                 title={
                   activeCustomPreset
                     ? activeBuiltinPreset

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1057,7 +1057,7 @@ export function ChatSettingsPanel({
               </DropdownMenuTrigger>
               <DropdownMenuContent
                 align="start"
-                sideOffset={6}
+                sideOffset={0}
                 className="menu-soft-surface ring-0 border-0 rounded-lg p-1.5"
               >
                 {presets.map((p, index) => (

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -836,7 +836,7 @@ export function ChatSettingsPanel({
                         animateRadius={false}
                         icon={ArrowDown01Icon}
                         iconClassName="size-3.5"
-                        className="grid h-7 w-[60px] min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-[10px] border-transparent bg-black/[0.04] dark:bg-white/[0.05] hover:bg-black/[0.06] dark:hover:bg-white/[0.07] px-2 py-0 text-[13px]! font-medium text-nav-fg focus-visible:ring-0 focus-visible:border-transparent [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate [&>svg]:shrink-0"
+                        className="grid h-7 w-[60px] min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-[10px] border-transparent bg-black/[0.04] dark:bg-white/[0.05] hover:bg-black/[0.06] dark:hover:bg-white/[0.1] px-2 py-0 text-[13px]! font-medium text-nav-fg focus-visible:ring-0 focus-visible:border-transparent [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate [&>svg]:shrink-0"
                       >
                         <SelectValue />
                       </SelectTrigger>
@@ -876,7 +876,7 @@ export function ChatSettingsPanel({
                         animateRadius={false}
                         icon={ArrowDown01Icon}
                         iconClassName="size-3.5"
-                        className="grid h-7 w-[120px] min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-[10px] border-transparent bg-black/[0.04] dark:bg-white/[0.05] hover:bg-black/[0.06] dark:hover:bg-white/[0.07] px-2 py-0 text-[13px]! font-medium text-nav-fg focus-visible:ring-0 focus-visible:border-transparent [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate [&>svg]:shrink-0"
+                        className="grid h-7 w-[120px] min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-[10px] border-transparent bg-black/[0.04] dark:bg-white/[0.05] hover:bg-black/[0.06] dark:hover:bg-white/[0.1] px-2 py-0 text-[13px]! font-medium text-nav-fg focus-visible:ring-0 focus-visible:border-transparent [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate [&>svg]:shrink-0"
                         data-test-id="speculative-type-select"
                       >
                         <SelectValue />
@@ -927,7 +927,7 @@ export function ChatSettingsPanel({
                       }}
                       data-test-id="spec-draft-n-max-input"
                       aria-label="Speculative decoding draft tokens"
-                      className="h-7 w-[72px] rounded-[10px] border-transparent bg-black/[0.04] dark:bg-white/[0.05] hover:bg-black/[0.06] dark:hover:bg-white/[0.07] px-2 py-0 text-[13px] font-medium text-nav-fg outline-none focus-visible:ring-0"
+                      className="h-7 w-[72px] rounded-[10px] border-transparent bg-black/[0.04] dark:bg-white/[0.05] hover:bg-black/[0.06] dark:hover:bg-white/[0.1] px-2 py-0 text-[13px] font-medium text-nav-fg outline-none focus-visible:ring-0"
                     />
                   </div>
                 )}

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -194,8 +194,8 @@ function NumericValueInput({
       type="text"
       inputMode="decimal"
       size={sizeAttr}
-      /* Width hugs the value; ch tracks tabular digits in every engine. */
-      style={{ width: `calc(${Math.max(displayed.length, 1)}ch + 18px)` }}
+      /* Fixed 4ch pill; grows only when a longer value would clip. */
+      style={{ width: `calc(${Math.max(displayed.length, 4)}ch + 18px)` }}
       value={displayed}
       aria-label={ariaLabel}
       onFocus={(e) => {

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -187,12 +187,16 @@ function NumericValueInput({
     }
   };
 
+  const displayed = focused ? draft : (displayValue ?? String(value));
+
   return (
     <input
       type="text"
       inputMode="decimal"
       size={sizeAttr}
-      value={focused ? draft : (displayValue ?? String(value))}
+      /* Width hugs the value; ch tracks tabular digits in every engine. */
+      style={{ width: `calc(${Math.max(displayed.length, 1)}ch + 18px)` }}
+      value={displayed}
       aria-label={ariaLabel}
       onFocus={(e) => {
         cancelBlurCommitRef.current = false;

--- a/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
+++ b/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
@@ -64,7 +64,7 @@ export function ChatSearchDialog() {
     <CommandDialog
       open={isOpen}
       onOpenChange={setOpen}
-      className="chat-search-surface corner-squircle top-[25%] w-[635px] max-w-[calc(100%-2rem)] gap-0 p-0 sm:max-w-[635px]"
+      className="chat-search-surface corner-squircle top-[25%] w-[635px] max-w-[calc(100%-2rem)] gap-0 p-0 ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none sm:max-w-[635px]"
       overlayClassName="bg-transparent"
     >
       <Command className="rounded-4xl p-0" filter={chatSearchFilter}>

--- a/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
+++ b/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
@@ -64,7 +64,7 @@ export function ChatSearchDialog() {
     <CommandDialog
       open={isOpen}
       onOpenChange={setOpen}
-      className="chat-search-surface corner-squircle top-[25%] w-[635px] max-w-[calc(100%-2rem)] gap-0 p-0 ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none sm:max-w-[635px]"
+      className="chat-search-surface corner-squircle top-[25%] w-[635px] max-w-[calc(100%-2rem)] gap-0 p-0 ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)] sm:max-w-[635px]"
       overlayClassName="bg-transparent"
     >
       <Command className="rounded-4xl p-0" filter={chatSearchFilter}>

--- a/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
+++ b/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
@@ -117,7 +117,7 @@ export function ChatSearchDialog() {
                   });
                   close();
                 }}
-                className="relative flex cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-2.5 text-sm outline-hidden data-selected:bg-muted data-selected:text-foreground"
+                className="relative flex cursor-pointer select-none items-center gap-3 rounded-full px-3 py-2.5 text-sm outline-hidden data-selected:bg-muted data-selected:text-foreground"
               >
                 <HugeiconsIcon
                   icon={Message01Icon}

--- a/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
+++ b/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
@@ -64,7 +64,7 @@ export function ChatSearchDialog() {
     <CommandDialog
       open={isOpen}
       onOpenChange={setOpen}
-      className="chat-search-surface corner-squircle top-[25%] w-[635px] max-w-[calc(100%-2rem)] gap-0 p-0 ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)] sm:max-w-[635px]"
+      className="chat-search-surface corner-squircle top-[25%] w-[635px] max-w-[calc(100%-2rem)] gap-0 p-0 ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none sm:max-w-[635px]"
       overlayClassName="bg-transparent"
     >
       <Command className="rounded-4xl p-0" filter={chatSearchFilter}>

--- a/studio/frontend/src/features/chat/components/project-switcher.tsx
+++ b/studio/frontend/src/features/chat/components/project-switcher.tsx
@@ -71,7 +71,7 @@ export function ProjectSwitcher({
       <DropdownMenuContent
         side="bottom"
         align="start"
-        sideOffset={6}
+        sideOffset={0}
         className="app-user-menu menu-soft-surface ring-0 min-w-56 max-w-72 max-h-72 py-2 font-heading rounded-[14px] border-0"
       >
         {showLoadingRow ? (

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -259,7 +259,7 @@ export function McpComposerButton({
           <DropdownMenuContent
             side={side}
             align="start"
-            sideOffset={2}
+            sideOffset={0}
             avoidCollisions={true}
             className="unsloth-plus-menu mcp-menu w-[232px]"
           >

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -154,7 +154,7 @@ export function ProjectsPage() {
               value={sortMode}
               onValueChange={(v) => setSortMode(v as SortMode)}
             >
-              <SelectTrigger className="h-9 w-[130px]">
+              <SelectTrigger className="h-9 w-[130px] rounded-full border-none bg-background shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-none">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -182,7 +182,7 @@ export function ProjectsPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-11 pl-10"
+          className="h-11 rounded-full border-none bg-background pl-10 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-none"
           aria-label="Search projects"
         />
       </div>
@@ -192,7 +192,7 @@ export function ProjectsPage() {
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className="min-h-[160px] rounded-[14px] border border-border/70 bg-card p-5"
+              className="min-h-[160px] rounded-[14px] bg-card p-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
             >
               <Skeleton className="h-5 w-2/3 rounded-[6px]" />
               <Skeleton className="mt-3 h-4 w-full rounded-[6px]" />
@@ -211,7 +211,7 @@ export function ProjectsPage() {
           {projects.length === 0 && (
             <Button
               variant="outline"
-              className="mt-2"
+              className="mt-2 border-none bg-background shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-none"
               onClick={() => {
                 setNameDraft("");
                 setCreating(true);
@@ -236,7 +236,7 @@ export function ProjectsPage() {
                   openProject(project.id);
                 }
               }}
-              className="group/project-card relative flex min-h-[160px] cursor-pointer flex-col rounded-[14px] border border-border/70 bg-card p-5 text-left transition-colors hover:border-border hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="group/project-card relative flex min-h-[160px] cursor-pointer flex-col rounded-[14px] bg-card p-5 text-left shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-accent/40 dark:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <div className="flex items-start justify-between gap-2">
                 <h2 className="truncate pr-2 text-[16px] font-semibold text-foreground">

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -182,7 +182,7 @@ export function ProjectsPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.07)] dark:bg-card dark:shadow-none"
+          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.07)] dark:bg-card dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
           aria-label="Search projects"
         />
       </div>
@@ -192,7 +192,7 @@ export function ProjectsPage() {
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className="min-h-[160px] rounded-[14px] bg-card p-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
+              className="min-h-[160px] rounded-[14px] bg-card p-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
             >
               <Skeleton className="h-5 w-2/3 rounded-[6px]" />
               <Skeleton className="mt-3 h-4 w-full rounded-[6px]" />
@@ -211,7 +211,7 @@ export function ProjectsPage() {
           {projects.length === 0 && (
             <Button
               variant="outline"
-              className="mt-2 border-none bg-background shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-none"
+              className="mt-2 border-none bg-background shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
               onClick={() => {
                 setNameDraft("");
                 setCreating(true);
@@ -236,7 +236,7 @@ export function ProjectsPage() {
                   openProject(project.id);
                 }
               }}
-              className="group/project-card relative flex min-h-[160px] cursor-pointer flex-col rounded-[14px] bg-card p-5 text-left shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-accent/40 dark:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="group/project-card relative flex min-h-[160px] cursor-pointer flex-col rounded-[14px] bg-card p-5 text-left shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-accent/40 dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <div className="flex items-start justify-between gap-2">
                 <h2 className="truncate pr-2 text-[16px] font-semibold text-foreground">

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -154,7 +154,7 @@ export function ProjectsPage() {
               value={sortMode}
               onValueChange={(v) => setSortMode(v as SortMode)}
             >
-              <SelectTrigger className="h-9 w-[130px] rounded-full border-none bg-background shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-none">
+              <SelectTrigger className="h-9 w-[130px] rounded-full border-none bg-muted shadow-none dark:bg-card">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -174,7 +174,7 @@ export function ProjectsPage() {
         </div>
       </div>
 
-      <div className="relative mt-6">
+      <div className="relative mx-auto mt-10 w-full max-w-[640px]">
         <span className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-muted-foreground">
           <HugeiconsIcon icon={Search01Icon} strokeWidth={1.75} className="size-icon" />
         </span>
@@ -182,7 +182,7 @@ export function ProjectsPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.09)] dark:bg-card dark:shadow-none"
+          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.13)] dark:bg-card dark:shadow-none"
           aria-label="Search projects"
         />
       </div>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -175,14 +175,14 @@ export function ProjectsPage() {
       </div>
 
       <div className="relative mt-6">
-        <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+        <span className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-muted-foreground">
           <HugeiconsIcon icon={Search01Icon} strokeWidth={1.75} className="size-icon" />
         </span>
         <Input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-11 rounded-full border-none bg-background pl-10 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-none"
+          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.09)] dark:bg-card dark:shadow-none"
           aria-label="Search projects"
         />
       </div>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -182,7 +182,7 @@ export function ProjectsPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.11)] dark:bg-card dark:shadow-none"
+          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.09)] dark:bg-card dark:shadow-none"
           aria-label="Search projects"
         />
       </div>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -182,7 +182,7 @@ export function ProjectsPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.09)] dark:bg-card dark:shadow-none"
+          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.07)] dark:bg-card dark:shadow-none"
           aria-label="Search projects"
         />
       </div>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -256,7 +256,7 @@ export function ProjectsPage() {
                   <DropdownMenuContent
                     side="bottom"
                     align="end"
-                    sideOffset={4}
+                    sideOffset={0}
                     onClick={(e) => e.stopPropagation()}
                     onKeyDown={(e) => e.stopPropagation()}
                     className="app-user-menu menu-soft-surface menu-flat-destructive ring-0 w-44 py-2 font-heading rounded-[14px] border-0"

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -174,7 +174,7 @@ export function ProjectsPage() {
         </div>
       </div>
 
-      <div className="relative mx-auto mt-10 w-full max-w-[640px]">
+      <div className="relative mx-auto mt-10 w-full max-w-[720px]">
         <span className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-muted-foreground">
           <HugeiconsIcon icon={Search01Icon} strokeWidth={1.75} className="size-icon" />
         </span>
@@ -182,7 +182,7 @@ export function ProjectsPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.13)] dark:bg-card dark:shadow-none"
+          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.11)] dark:bg-card dark:shadow-none"
           aria-label="Search projects"
         />
       </div>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -182,7 +182,7 @@ export function ProjectsPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search projects..."
-          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.07)] dark:bg-card dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
+          className="h-14 rounded-full border-none bg-background pl-13 pr-5 shadow-[0_0_20px_0_rgba(0,0,0,0.07)] dark:bg-card dark:shadow-none"
           aria-label="Search projects"
         />
       </div>
@@ -192,7 +192,7 @@ export function ProjectsPage() {
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className="min-h-[160px] rounded-[14px] bg-card p-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
+              className="min-h-[160px] rounded-[14px] bg-card p-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
             >
               <Skeleton className="h-5 w-2/3 rounded-[6px]" />
               <Skeleton className="mt-3 h-4 w-full rounded-[6px]" />
@@ -211,7 +211,7 @@ export function ProjectsPage() {
           {projects.length === 0 && (
             <Button
               variant="outline"
-              className="mt-2 border-none bg-background shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
+              className="mt-2 border-none bg-background shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-none"
               onClick={() => {
                 setNameDraft("");
                 setCreating(true);
@@ -236,7 +236,7 @@ export function ProjectsPage() {
                   openProject(project.id);
                 }
               }}
-              className="group/project-card relative flex min-h-[160px] cursor-pointer flex-col rounded-[14px] bg-card p-5 text-left shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-accent/40 dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="group/project-card relative flex min-h-[160px] cursor-pointer flex-col rounded-[14px] bg-card p-5 text-left shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-accent/40 dark:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <div className="flex items-start justify-between gap-2">
                 <h2 className="truncate pr-2 text-[16px] font-semibold text-foreground">

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1133,7 +1133,7 @@ export function SharedComposer({
             <DropdownMenuContent
               side="top"
               align="start"
-              sideOffset={2}
+              sideOffset={0}
               avoidCollisions={true}
               className="unsloth-plus-menu w-[212px]"
               onCloseAutoFocus={(event) => event.preventDefault()}

--- a/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
+++ b/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
@@ -75,7 +75,7 @@ const TEMPLATE_CARDS: TemplateCard[] = [
     difficulty: "Easy",
     learningBadges: ["Seed Dataset", "LLM Text", "Prompting"],
     surfaceClassName:
-      "from-emerald-500/15 via-green-500/5 to-transparent dark:from-emerald-400/30 dark:via-green-400/14 dark:to-emerald-950/16",
+      "from-emerald-500/15 via-green-500/5 to-transparent dark:from-emerald-400/20 dark:via-green-400/10 dark:to-emerald-950/16",
     shineColor: [
       "rgb(16 185 129 / 0.45)",
       "rgb(34 197 94 / 0.4)",
@@ -91,7 +91,7 @@ const TEMPLATE_CARDS: TemplateCard[] = [
     difficulty: "Easy",
     learningBadges: ["Unstructured", "LLM Text"],
     surfaceClassName:
-      "from-violet-500/15 via-fuchsia-500/5 to-transparent dark:from-violet-400/30 dark:via-fuchsia-400/14 dark:to-violet-950/16",
+      "from-violet-500/15 via-fuchsia-500/5 to-transparent dark:from-violet-400/20 dark:via-fuchsia-400/10 dark:to-violet-950/16",
     shineColor: [
       "rgb(139 92 246 / 0.45)",
       "rgb(217 70 239 / 0.4)",
@@ -107,7 +107,7 @@ const TEMPLATE_CARDS: TemplateCard[] = [
     difficulty: "Starter",
     learningBadges: ["Vision", "LLM Text", "Image Context"],
     surfaceClassName:
-      "from-lime-500/15 via-emerald-500/5 to-transparent dark:from-lime-400/30 dark:via-emerald-400/14 dark:to-lime-950/16",
+      "from-lime-500/15 via-emerald-500/5 to-transparent dark:from-lime-400/20 dark:via-emerald-400/10 dark:to-lime-950/16",
     shineColor: [
       "rgb(132 204 22 / 0.45)",
       "rgb(16 185 129 / 0.4)",
@@ -123,7 +123,7 @@ const TEMPLATE_CARDS: TemplateCard[] = [
     difficulty: "Intermediate",
     learningBadges: ["LLM Judge", "LLM Code", "Subcategory", "Category"],
     surfaceClassName:
-      "from-amber-500/15 via-orange-500/5 to-transparent dark:from-amber-400/30 dark:via-orange-400/14 dark:to-amber-950/16",
+      "from-amber-500/15 via-orange-500/5 to-transparent dark:from-amber-400/20 dark:via-orange-400/10 dark:to-amber-950/16",
     shineColor: [
       "rgb(245 158 11 / 0.45)",
       "rgb(249 115 22 / 0.4)",
@@ -139,7 +139,7 @@ const TEMPLATE_CARDS: TemplateCard[] = [
     difficulty: "Intermediate",
     learningBadges: ["LLM Code", "Prompting", "Drop Columns"],
     surfaceClassName:
-      "from-blue-500/15 via-indigo-500/5 to-transparent dark:from-blue-400/30 dark:via-indigo-400/14 dark:to-blue-950/16",
+      "from-blue-500/15 via-indigo-500/5 to-transparent dark:from-blue-400/20 dark:via-indigo-400/10 dark:to-blue-950/16",
     shineColor: [
       "rgb(59 130 246 / 0.45)",
       "rgb(99 102 241 / 0.4)",
@@ -155,7 +155,7 @@ const TEMPLATE_CARDS: TemplateCard[] = [
     difficulty: "Advanced",
     learningBadges: ["Structured LLM", "Expression", "Jinja"],
     surfaceClassName:
-      "from-cyan-500/15 via-sky-500/5 to-transparent dark:from-cyan-400/30 dark:via-sky-400/14 dark:to-cyan-950/16",
+      "from-cyan-500/15 via-sky-500/5 to-transparent dark:from-cyan-400/20 dark:via-sky-400/10 dark:to-cyan-950/16",
     shineColor: [
       "rgb(6 182 212 / 0.45)",
       "rgb(56 189 248 / 0.4)",
@@ -171,7 +171,7 @@ const TEMPLATE_CARDS: TemplateCard[] = [
     difficulty: "Intermediate",
     learningBadges: ["GitHub", "LLM Text", "Structured LLM"],
     surfaceClassName:
-      "from-slate-500/15 via-zinc-500/5 to-transparent dark:from-slate-400/30 dark:via-zinc-400/14 dark:to-slate-950/16",
+      "from-slate-500/15 via-zinc-500/5 to-transparent dark:from-slate-400/20 dark:via-zinc-400/10 dark:to-slate-950/16",
     shineColor: [
       "rgb(71 85 105 / 0.45)",
       "rgb(100 116 139 / 0.4)",

--- a/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
+++ b/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
@@ -241,7 +241,7 @@ function LearningRecipeCards({
             type="button"
             disabled={isDisabled}
             onClick={() => onSelect(template)}
-            className={`group shadow-border relative overflow-hidden rounded-2xl bg-gradient-to-br dark:bg-white/[0.05] text-left transition-transform ${template.surfaceClassName} enabled:cursor-pointer enabled:hover:-translate-y-0.5 enabled:hover:shadow-md dark:enabled:hover:shadow-none disabled:cursor-not-allowed disabled:opacity-70`}
+            className={`group shadow-border relative overflow-hidden rounded-2xl bg-gradient-to-br dark:bg-white/[0.05] text-left transition-transform ${template.surfaceClassName} enabled:cursor-pointer enabled:hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70`}
           >
             <ShineBorder
               borderWidth={1.2}

--- a/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
+++ b/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
@@ -267,7 +267,7 @@ function LearningRecipeCards({
                 <p className="line-clamp-2 text-sm font-semibold leading-tight text-foreground">
                   {template.title}
                 </p>
-                <p className="line-clamp-2 text-xs text-muted-foreground">
+                <p className="line-clamp-2 text-xs text-muted-foreground dark:text-zinc-300">
                   {template.description}
                 </p>
               </div>
@@ -280,7 +280,7 @@ function LearningRecipeCards({
                       <Badge
                         key={`${template.title}-${badge}`}
                         variant="outline"
-                        className="h-5 shrink-0 px-1.5 text-[10px]"
+                        className="h-5 shrink-0 px-1.5 text-[10px] dark:text-zinc-300"
                       >
                         {badge}
                       </Badge>
@@ -288,7 +288,7 @@ function LearningRecipeCards({
                     {extraLearningBadgeCount > 0 ? (
                       <Badge
                         variant="outline"
-                        className="h-5 shrink-0 px-1.5 text-[10px]"
+                        className="h-5 shrink-0 px-1.5 text-[10px] dark:text-zinc-300"
                       >
                         +{extraLearningBadgeCount}
                       </Badge>
@@ -296,7 +296,7 @@ function LearningRecipeCards({
                     {isReady ? null : (
                       <Badge
                         variant="secondary"
-                        className="h-5 shrink-0 px-1.5 text-[10px]"
+                        className="h-5 shrink-0 px-1.5 text-[10px] dark:text-zinc-300"
                       >
                         Soon
                       </Badge>

--- a/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
+++ b/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
@@ -241,7 +241,7 @@ function LearningRecipeCards({
             type="button"
             disabled={isDisabled}
             onClick={() => onSelect(template)}
-            className={`group shadow-border relative overflow-hidden rounded-2xl bg-gradient-to-br text-left transition-transform ${template.surfaceClassName} enabled:cursor-pointer enabled:hover:-translate-y-0.5 enabled:hover:shadow-md disabled:cursor-not-allowed disabled:opacity-70`}
+            className={`group shadow-border relative overflow-hidden rounded-2xl bg-gradient-to-br dark:bg-white/[0.05] text-left transition-transform ${template.surfaceClassName} enabled:cursor-pointer enabled:hover:-translate-y-0.5 enabled:hover:shadow-md dark:enabled:hover:shadow-none disabled:cursor-not-allowed disabled:opacity-70`}
           >
             <ShineBorder
               borderWidth={1.2}

--- a/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
+++ b/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
@@ -449,7 +449,7 @@ export function DataRecipesPage(): ReactElement {
             </p>
           </div>
         ) : recipes.length === 0 ? (
-          <Empty className="mt-8 border border-dashed border-border/70">
+          <Empty className="mt-8 border border-dashed border-border/70 dark:border-none">
             <EmptyHeader>
               <EmptyMedia variant="icon">
                 <HugeiconsIcon icon={CookBookIcon} className="size-5" />

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -539,7 +539,7 @@ export function ExportPage() {
           description="Select source, method, and quantization"
           accent="emerald"
           featured={true}
-          className="ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
+          className="ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
         >
           {/* Loading / error states */}
           {loadingCheckpoints && (

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -539,7 +539,7 @@ export function ExportPage() {
           description="Select source, method, and quantization"
           accent="emerald"
           featured={true}
-          className="ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
+          className="ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
         >
           {/* Loading / error states */}
           {loadingCheckpoints && (

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -539,7 +539,7 @@ export function ExportPage() {
           description="Select source, method, and quantization"
           accent="emerald"
           featured={true}
-          className="shadow-border ring-1 ring-border"
+          className="ring-0 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
         >
           {/* Loading / error states */}
           {loadingCheckpoints && (

--- a/studio/frontend/src/features/hub/catalog/catalog-states.tsx
+++ b/studio/frontend/src/features/hub/catalog/catalog-states.tsx
@@ -58,7 +58,7 @@ export function NetworkErrorState({
         <button
           type="button"
           onClick={onRetry}
-          className="inline-flex h-8 items-center gap-1.5 rounded-[10px] bg-transparent px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-foreground/[0.04] dark:hover:bg-white/[0.05]"
+          className="inline-flex h-8 items-center gap-1.5 rounded-[10px] bg-transparent px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-foreground/[0.04] dark:hover:bg-white/[0.1]"
         >
           <HugeiconsIcon
             icon={RefreshIcon}
@@ -113,7 +113,7 @@ export function DiscoverFetchMoreState({
           type="button"
           onClick={onFetchMore}
           disabled={isLoadingMore}
-          className="inline-flex h-8 items-center gap-1.5 rounded-[10px] bg-transparent px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/[0.05]"
+          className="inline-flex h-8 items-center gap-1.5 rounded-[10px] bg-transparent px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/[0.1]"
         >
           <HugeiconsIcon
             icon={RefreshIcon}
@@ -191,7 +191,7 @@ export function InventoryErrorState({
       <button
         type="button"
         onClick={onRetry}
-        className="inline-flex h-8 items-center gap-1.5 rounded-[10px] bg-transparent px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-foreground/[0.04] dark:hover:bg-white/[0.05]"
+        className="inline-flex h-8 items-center gap-1.5 rounded-[10px] bg-transparent px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-foreground/[0.04] dark:hover:bg-white/[0.1]"
       >
         <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.75} className="size-3.5" />
         Try again

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -723,7 +723,7 @@ export function GgufDownloadCard({
           <PopoverContent
             align="start"
             side="bottom"
-            sideOffset={8}
+            sideOffset={0}
             avoidCollisions={false}
             className="hub-menu-instant menu-soft-surface w-[var(--radix-popover-trigger-width)] min-w-[200px] gap-0 overflow-hidden p-0 py-2 ring-0"
           >

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -666,7 +666,7 @@ export function GgufDownloadCard({
                 e.preventDefault();
                 setOpen((o) => !o);
               }}
-              className="hub-menu-trigger flex h-9 min-w-0 flex-1 cursor-pointer items-center gap-2.5 rounded-[12px] px-3 text-left transition-colors hover:bg-foreground/[0.04] data-[state=open]:bg-foreground/[0.06] dark:hover:bg-white/[0.04] dark:data-[state=open]:bg-white/[0.06]"
+              className="hub-menu-trigger flex h-9 min-w-0 flex-1 cursor-pointer items-center gap-2.5 rounded-[12px] px-3 text-left transition-colors hover:bg-foreground/[0.04] data-[state=open]:bg-foreground/[0.06] dark:hover:bg-white/[0.1] dark:data-[state=open]:bg-white/[0.06]"
             >
               {selected ? (
                 <QuantBadge

--- a/studio/frontend/src/features/hub/catalog/hub-option-menu.tsx
+++ b/studio/frontend/src/features/hub/catalog/hub-option-menu.tsx
@@ -181,7 +181,7 @@ export function HubOptionMenu<T extends string>({
       <PopoverContent
         align={align}
         side="bottom"
-        sideOffset={8}
+        sideOffset={0}
         collisionPadding={12}
         onCloseAutoFocus={(event) => event.preventDefault()}
         className={cn(

--- a/studio/frontend/src/features/hub/catalog/local-on-device-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/local-on-device-card.tsx
@@ -352,7 +352,7 @@ export function LocalOnDeviceCard({
                   <PopoverContent
                     align="start"
                     side="bottom"
-                    sideOffset={8}
+                    sideOffset={0}
                     avoidCollisions={false}
                     className="hub-menu-instant menu-soft-surface w-[var(--radix-popover-trigger-width)] min-w-[220px] gap-0 overflow-hidden p-0 py-2 ring-0"
                   >

--- a/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
@@ -139,7 +139,7 @@ function DownloadRow({ jobKey }: { jobKey: string }) {
               }
               className={cn(
                 "inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-[7px] text-muted-foreground transition-colors",
-                "hover:bg-foreground/[0.06] hover:text-foreground disabled:cursor-default disabled:opacity-50 dark:hover:bg-white/[0.06]",
+                "hover:bg-foreground/[0.06] hover:text-foreground disabled:cursor-default disabled:opacity-50 dark:hover:bg-white/[0.1]",
               )}
             >
               <HugeiconsIcon
@@ -234,7 +234,7 @@ export function DownloadManagerPanel() {
               type="button"
               aria-label="Collapse downloads"
               onClick={() => setCollapsed(true)}
-              className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-[7px] text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-white/[0.06]"
+              className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-[7px] text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-white/[0.1]"
             >
               <HugeiconsIcon
                 icon={ArrowDown01Icon}

--- a/studio/frontend/src/features/profile/components/profile-personalization-panel.tsx
+++ b/studio/frontend/src/features/profile/components/profile-personalization-panel.tsx
@@ -118,7 +118,7 @@ export function ProfilePersonalizationPanel() {
         <button
           type="button"
           onClick={() => fileInputRef.current?.click()}
-          className="absolute right-0 bottom-0 -translate-x-[15.625%] -translate-y-[15.625%] flex size-8 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-[0_2px_8px_-2px_rgba(27,27,31,0.16)] transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          className="absolute right-0 bottom-0 -translate-x-[15.625%] -translate-y-[15.625%] flex size-8 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           aria-label={t("settings.profile.changePicture")}
         >
           <HugeiconsIcon icon={Camera01Icon} className="size-3.5" strokeWidth={2} />

--- a/studio/frontend/src/features/recipe-studio/dialogs/models/local-recipe-model-selector.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/models/local-recipe-model-selector.tsx
@@ -591,7 +591,7 @@ export function LocalRecipeModelSelector({
       </PopoverTrigger>
       <PopoverContent
         align="start"
-        sideOffset={6}
+        sideOffset={0}
         className="menu-soft-surface nodrag nowheel gap-0 overflow-hidden p-0"
         style={{
           width:

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -160,13 +160,13 @@ export function SettingsDialog() {
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
                       active
                         ? "text-black dark:text-white"
-                        : "text-[#383835] dark:text-[#c7c7c4] hover:bg-[#ececec] dark:hover:bg-[#2d2f33] hover:text-black dark:hover:text-white",
+                        : "text-[#383835] dark:text-[#c7c7c4] hover:bg-[#ececec] dark:hover:bg-[#3a3d43] hover:text-black dark:hover:text-white",
                     )}
                   >
                     {active && (
                       <motion.span
                         layoutId="settings-active-pill"
-                        className="absolute inset-0 rounded-[11px] bg-[#ececec] dark:bg-[#2d2f33]"
+                        className="absolute inset-0 rounded-[11px] bg-[#ececec] dark:bg-[#3a3d43]"
                         transition={
                           reduced
                             ? { duration: 0 }
@@ -202,7 +202,7 @@ export function SettingsDialog() {
             <button
               type="button"
               onClick={closeDialog}
-              className="absolute top-3 right-3 z-10 flex size-7 items-center justify-center rounded-full text-[#383835] dark:text-[#c7c7c4] transition-colors hover:bg-[#ececec] dark:hover:bg-[#2d2f33] hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="absolute top-3 right-3 z-10 flex size-7 items-center justify-center rounded-full text-[#383835] dark:text-[#c7c7c4] transition-colors hover:bg-[#ececec] dark:hover:bg-[#3a3d43] hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-label={t("settings.dialog.closeAriaLabel")}
             >
               <HugeiconsIcon icon={Cancel01Icon} className="size-4" />

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -155,7 +155,7 @@ export function SettingsDialog() {
                     type="button"
                     onClick={() => setActiveTab(tab.id)}
                     className={cn(
-                      "relative flex h-[32px] items-center gap-2.5 rounded-[11px] pl-3 pr-2.5 text-[14.5px] leading-[19px] tracking-nav font-medium transition-colors",
+                      "relative flex h-[32px] items-center gap-2.5 rounded-full pl-3 pr-2.5 text-[14.5px] leading-[19px] tracking-nav font-medium transition-colors",
                       "max-sm:shrink-0",
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
                       active
@@ -166,7 +166,7 @@ export function SettingsDialog() {
                     {active && (
                       <motion.span
                         layoutId="settings-active-pill"
-                        className="absolute inset-0 rounded-[11px] bg-[#ececec] dark:bg-[#3a3d43]"
+                        className="absolute inset-0 rounded-full bg-[#ececec] dark:bg-[#3a3d43]"
                         transition={
                           reduced
                             ? { duration: 0 }

--- a/studio/frontend/src/features/tour/components/guided-tour.tsx
+++ b/studio/frontend/src/features/tour/components/guided-tour.tsx
@@ -332,7 +332,7 @@ export function GuidedTour({
                       <Button
                         variant="ghost"
                         size="icon-sm"
-                        className="text-foreground/60 hover:text-foreground hover:bg-black/[0.05] dark:text-zinc-300/70 dark:hover:text-zinc-100 dark:hover:bg-white/[0.08]"
+                        className="text-foreground/60 hover:text-foreground hover:bg-black/[0.05] dark:text-zinc-300/70 dark:hover:text-zinc-100 dark:hover:bg-white/[0.1]"
                         onClick={() => requestClose("skip")}
                         aria-label="Skip tour"
                       >
@@ -343,7 +343,7 @@ export function GuidedTour({
                     <div className="mt-5 flex items-center justify-between gap-3">
                       <Button
                         variant="ghost"
-                        className="text-foreground/60 hover:text-foreground hover:bg-black/[0.05] dark:text-zinc-300/70 dark:hover:text-zinc-100 dark:hover:bg-white/[0.08]"
+                        className="text-foreground/60 hover:text-foreground hover:bg-black/[0.05] dark:text-zinc-300/70 dark:hover:text-zinc-100 dark:hover:bg-white/[0.1]"
                         onClick={() => requestClose("skip")}
                       >
                         Skip

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -128,9 +128,9 @@
 	--chart-4: oklch(0.6926 0.1112 346.5775);
 	--chart-5: oklch(0.7497 0.1003 85.0057);
 	--radius: 1.1rem;
-	/* A step greyer than the page (Gemini-style) so the sidebar reads as its
-	   own surface now that the right-edge divider is gone. */
-	--sidebar: #f7f6f5;
+	/* White sidebar against the warm off-white page; the tone difference is
+	   the separator now that the right-edge divider is gone. */
+	--sidebar: #ffffff;
 	--sidebar-foreground: oklch(0.1281 0.0179 169.2764);
 	--sidebar-primary: #17b88b;
 	--sidebar-primary-foreground: oklch(1 0 0);
@@ -174,7 +174,7 @@
 	/* Hex (not OKLCH) so the rendered surface matches the design mockup pixel-for-pixel. */
 	--nav-fg: #383835;
 	--nav-fg-muted: #858279;
-	--nav-surface-hover: #edebe9;
+	--nav-surface-hover: #f0f0f0;
 	--nav-icon-idle: #8f8f8f;
 	--nav-beta-border: #e0ded6;
 	--panel-surface-hover: #ebebeb;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -103,7 +103,8 @@
 	--ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
 	--ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
 
-	--background: oklch(1 0 0);
+	/* Slightly warm off white; every page (and the chat surface) shares it. */
+	--background: #fdfdfc;
 	--foreground: oklch(0.2686 0 0);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.1281 0.0179 169.2764);
@@ -129,7 +130,7 @@
 	--radius: 1.1rem;
 	/* Match the page background so the sidebar reads as one surface with the
 	   content; the faint --sidebar-border on its right edge is the separator. */
-	--sidebar: oklch(1 0 0);
+	--sidebar: #fdfdfc;
 	--sidebar-foreground: oklch(0.1281 0.0179 169.2764);
 	--sidebar-primary: #17b88b;
 	--sidebar-primary-foreground: oklch(1 0 0);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -717,13 +717,12 @@
 	/* Inline numeric input — used for slider values and Context Length.
 	   Designed to read as *editable text* rather than a pill button so
 	   it doesn't mirror the Select/dropdown components on the panel.
-	   Default: transparent box, no border, no ring, width hugging the
-	   value via field-sizing (the `size` attribute is the fallback for
-	   engines without it). Hover/focus: very light bg fade-in, just
-	   enough to read as interactive without competing with the slider
-	   row's quiet aesthetic. */
+	   Default: transparent box, no border, no ring; the component sets
+	   an inline width that hugs the value. Hover/focus: very light bg
+	   fade-in, just enough to read as interactive without competing
+	   with the slider row's quiet aesthetic. */
 	.panel-number-input {
-		@apply h-7 min-w-8 shrink-0 rounded-full border-0 bg-transparent px-2 text-right text-[13px]! font-medium tabular-nums text-nav-fg shadow-none transition-colors field-sizing-content hover:bg-black/[0.04] focus:bg-black/[0.05] focus-visible:ring-0! focus-visible:outline-none md:text-[13px]!;
+		@apply h-7 min-w-8 shrink-0 rounded-full border-0 bg-transparent px-2 text-right text-[13px]! font-medium tabular-nums text-nav-fg shadow-none transition-colors hover:bg-black/[0.04] focus:bg-black/[0.05] focus-visible:ring-0! focus-visible:outline-none md:text-[13px]!;
 	}
 	.dark .panel-number-input {
 		@apply hover:bg-white/[0.04] focus:bg-white/[0.06];

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -962,12 +962,14 @@
 		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-1 pt-2 outline-none transition-shadow;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
-		box-shadow: 0 2px 8px -2px rgba(27, 27, 31, 0.16);
+		/* Gemini-style composer shadow. */
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
+		transition: box-shadow 0.1s;
 	}
 
 	.dark .chat-composer-surface {
 		background-color: #2a2a2c;
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.4);
 	}
 
 	.composer-pill-btn {
@@ -1048,17 +1050,18 @@
 		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-3 py-3 outline-none transition-shadow;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
-		/* Gemini search pill: soft, centered shadow, no downward offset. */
-		box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.09);
+		/* Gemini-style composer shadow. */
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
+		transition: box-shadow 0.1s;
 	}
 
 	.unsloth-composer-surface:focus-within {
-		box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.09);
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 	}
 
 	.dark .unsloth-composer-surface {
 		background-color: #2a2a2c;
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.4);
 	}
 
 	/* Keep the expand/collapse width swap instant. A transition on width (e.g.

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -846,6 +846,12 @@
 		box-shadow: none;
 	}
 
+	/* Lift the dialog off the page bg; halfway to --card keeps the inner
+	   bg-muted / bg-background fills readable. */
+	.dark .settings-surface {
+		background-color: color-mix(in srgb, var(--background) 50%, var(--card));
+	}
+
 	/* App-wide: every clickable control shows the hand cursor. Disabled ones
 	   (native :disabled, aria-disabled, Radix data-disabled) keep the default. */
 	button:not(:disabled):not([aria-disabled="true"]),

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -942,6 +942,15 @@
 		box-shadow: none;
 	}
 
+	/* List menus: one radius in both themes, slightly tighter than --radius-lg
+	   and matching the sidebar buttons. !important beats per-menu rounded-*. */
+	[data-slot="dropdown-menu-content"],
+	[data-slot="dropdown-menu-sub-content"],
+	[data-slot="select-content"],
+	[data-slot="combobox-content"] {
+		border-radius: 14px !important;
+	}
+
 	/* Every dropdown/menu/select/popover: borderless, chatbox shadow in light,
 	   none in dark. !important so it also overrides the bespoke menu shadows. */
 	[data-slot="dropdown-menu-content"],

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -104,7 +104,7 @@
 	--ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
 
 	/* Slightly warm off white; every page (and the chat surface) shares it. */
-	--background: #fdfdfc;
+	--background: #fdfcfb;
 	--foreground: oklch(0.2686 0 0);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.1281 0.0179 169.2764);
@@ -130,7 +130,7 @@
 	--radius: 1.1rem;
 	/* Match the page background so the sidebar reads as one surface with the
 	   content; the faint --sidebar-border on its right edge is the separator. */
-	--sidebar: #fdfdfc;
+	--sidebar: #fdfcfb;
 	--sidebar-foreground: oklch(0.1281 0.0179 169.2764);
 	--sidebar-primary: #17b88b;
 	--sidebar-primary-foreground: oklch(1 0 0);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -114,7 +114,7 @@
 	--ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
 
 	/* Slightly warm off white; every page (and the chat surface) shares it. */
-	--background: #fdfcfb;
+	--background: #fefdfc;
 	--foreground: oklch(0.2686 0 0);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.1281 0.0179 169.2764);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -961,8 +961,11 @@
 		box-shadow: 0 4px 14px var(--background) !important;
 	}
 
-	/* Model selector and account menu: flat in dark. */
-	.dark .unsloth-model-selector-menu,
+	/* Model selector: shadow in the page-bg color so it lifts off the
+	   composer it overlaps (chatbox geometry). Account menu stays flat. */
+	.dark .unsloth-model-selector-menu {
+		box-shadow: 0 2px 8px -2px var(--background) !important;
+	}
 	.dark .app-user-menu.menu-soft-surface-up {
 		box-shadow: none !important;
 	}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -796,6 +796,9 @@
 	.dark .app-user-menu [data-slot="dropdown-menu-item"]:focus,
 	.dark .app-user-menu [data-slot="dropdown-menu-sub-trigger"]:focus,
 	.dark .app-user-menu [data-slot="dropdown-menu-sub-trigger"][data-state="open"] {
+		/* --nav-surface-hover is tuned for the page bg; on the lighter menu
+		   surface it is invisible, so use the menu hover token instead. */
+		background-color: var(--accent);
 		color: #fff;
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"]:focus *,
@@ -1253,7 +1256,7 @@
 			[data-slot="dropdown-menu-item"],
 			[data-slot="dropdown-menu-sub-trigger"]
 		):is(:hover, :focus, :focus-visible, [data-highlighted], [data-state="open"]) {
-		background-color: rgba(255, 255, 255, 0.08) !important;
+		background-color: rgba(255, 255, 255, 0.1) !important;
 	}
 
 	/* Hover tints only the background; the item and every descendant (text, icons,

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -883,7 +883,7 @@
 		   both themes; rounded-4xl here and on the inner Command follow this. */
 		--radius: 0.625rem;
 		/* Match the chat box: soft elevation in light, none in dark. */
-		box-shadow: 0 2px 8px -2px rgba(27, 27, 31, 0.16);
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 	}
 
 	.dark .chat-search-surface {
@@ -892,25 +892,29 @@
 
 	.menu-soft-surface,
 	.menu-soft-surface-up {
+		/* Light: chatbox shadow geometry. */
 		--menu-soft-edge: rgba(0, 0, 0, 0.14);
-		--menu-soft-shadow: rgba(0, 0, 0, 0.18);
-		--menu-soft-offset-y: 8px;
-		--menu-soft-blur: 28px;
-		--menu-soft-spread: -6px;
+		--menu-soft-shadow: rgba(0, 0, 0, 0.16);
+		--menu-soft-offset-y: 2px;
+		--menu-soft-blur: 8px;
+		--menu-soft-spread: -2px;
 		@apply bg-popover text-popover-foreground;
 		box-shadow:
 			inset 0 0 0 1px var(--menu-soft-edge),
 			0 var(--menu-soft-offset-y) var(--menu-soft-blur)
 				var(--menu-soft-spread) var(--menu-soft-shadow);
 	}
-	.menu-soft-surface-up {
-		--menu-soft-offset-y: -6px;
-		--menu-soft-spread: -8px;
-	}
 	.dark .menu-soft-surface,
 	.dark .menu-soft-surface-up {
 		--menu-soft-edge: rgba(255, 255, 255, 0.07);
 		--menu-soft-shadow: rgba(0, 0, 0, 0.28);
+		--menu-soft-offset-y: 8px;
+		--menu-soft-blur: 28px;
+		--menu-soft-spread: -6px;
+	}
+	.dark .menu-soft-surface-up {
+		--menu-soft-offset-y: -6px;
+		--menu-soft-spread: -8px;
 	}
 
 	/* Model selector: drop the inset edge ring, keep the soft drop shadow.
@@ -932,7 +936,7 @@
 	[data-slot="select-content"],
 	[data-slot="combobox-content"],
 	[data-slot="popover-content"] {
-		box-shadow: 0 2px 8px -2px rgba(27, 27, 31, 0.16) !important;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16) !important;
 	}
 	/* Dark: keep the chat-box dropdown shadow so menus don't merge into a
 	   same-color surface (e.g. a menu overlapping the composer). */
@@ -952,7 +956,7 @@
 
 	/* Account menu: drop the inset edge ring and use the composer's soft shadow. */
 	.app-user-menu.menu-soft-surface-up {
-		box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.09);
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 	}
 	.dark .app-user-menu.menu-soft-surface-up {
 		box-shadow: 0 8px 28px -6px rgba(0, 0, 0, 0.28);
@@ -1199,9 +1203,7 @@
 		border-radius: 18px;
 		padding-top: 0.5rem;
 		padding-bottom: 0.5rem;
-		box-shadow:
-			0 1px 2px oklch(0 0 0 / 0.04),
-			0 6px 18px oklch(0 0 0 / 0.08);
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 	}
 
 	/* MCP menu is wider (232px), so nudge the radius up so it reads as round as
@@ -1295,7 +1297,7 @@
 		white-space: nowrap;
 	}
 	.artifact-panel-shell {
-		box-shadow: 0 2px 8px -2px rgba(27, 27, 31, 0.16);
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 	}
 
 	.dark .artifact-panel-shell {
@@ -1627,7 +1629,7 @@
    !important because Sonner injects its base rules at runtime. */
 [data-sonner-toast][data-styled='true'] {
 	padding: 12px 18px !important;
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08) !important;
+	box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16) !important;
 }
 
 [data-sonner-toast][data-styled='true']:has([data-close-button]):not(:has([data-cancel])) {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -114,7 +114,7 @@
 	--ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
 
 	/* Slightly warm off white; every page (and the chat surface) shares it. */
-	--background: #fefdfc;
+	--background: #fefefd;
 	--foreground: oklch(0.2686 0 0);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.1281 0.0179 169.2764);
@@ -1007,8 +1007,7 @@
 		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-1 pt-2 outline-none transition-shadow;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
-		/* A hair warmer than pure white. */
-		background-color: #fffefd;
+		background-color: #ffffff;
 		/* Gemini-style composer shadow. */
 		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 		transition: box-shadow 0.1s;
@@ -1097,8 +1096,7 @@
 		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-3 py-3 outline-none transition-shadow;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
-		/* A hair warmer than pure white. */
-		background-color: #fffefd;
+		background-color: #ffffff;
 		/* Gemini-style composer shadow. */
 		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 		transition: box-shadow 0.1s;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -128,9 +128,9 @@
 	--chart-4: oklch(0.6926 0.1112 346.5775);
 	--chart-5: oklch(0.7497 0.1003 85.0057);
 	--radius: 1.1rem;
-	/* Match the page background so the sidebar reads as one surface with the
-	   content; the faint --sidebar-border on its right edge is the separator. */
-	--sidebar: #fdfcfb;
+	/* A step greyer than the page (Gemini-style) so the sidebar reads as its
+	   own surface now that the right-edge divider is gone. */
+	--sidebar: #f7f6f5;
 	--sidebar-foreground: oklch(0.1281 0.0179 169.2764);
 	--sidebar-primary: #17b88b;
 	--sidebar-primary-foreground: oklch(1 0 0);
@@ -174,7 +174,7 @@
 	/* Hex (not OKLCH) so the rendered surface matches the design mockup pixel-for-pixel. */
 	--nav-fg: #383835;
 	--nav-fg-muted: #858279;
-	--nav-surface-hover: #f0f0f0;
+	--nav-surface-hover: #edebe9;
 	--nav-icon-idle: #8f8f8f;
 	--nav-beta-border: #e0ded6;
 	--panel-surface-hover: #ebebeb;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -969,7 +969,8 @@
 
 	.dark .chat-composer-surface {
 		background-color: #2a2a2c;
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.4);
+		/* Stronger values so the shadow stays visible on dark surfaces. */
+		box-shadow: 0 2px 12px -2px rgba(0, 0, 0, 0.7);
 	}
 
 	.composer-pill-btn {
@@ -1061,7 +1062,8 @@
 
 	.dark .unsloth-composer-surface {
 		background-color: #2a2a2c;
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.4);
+		/* Stronger values so the shadow stays visible on dark surfaces. */
+		box-shadow: 0 2px 12px -2px rgba(0, 0, 0, 0.7);
 	}
 
 	/* Keep the expand/collapse width swap instant. A transition on width (e.g.

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -235,7 +235,8 @@
 	--secondary-foreground: #ececee;
 	--muted: #2e3035;
 	--muted-foreground: #999999;
-	--accent: #2e3035;
+	/* One step lighter than --popover so menu item hover reads clearly. */
+	--accent: #3a3d43;
 	--accent-foreground: #ececee;
 	--destructive: oklch(0.6368 0.2078 25.3313);
 	/* --border / --input one step lighter than --muted so outlines and form
@@ -254,9 +255,9 @@
 	--sidebar-foreground: #ececee;
 	--sidebar-primary: #17b88b;
 	--sidebar-primary-foreground: oklch(1 0 0);
-	--sidebar-accent: #2f2f31;
+	--sidebar-accent: #2e3035;
 	--sidebar-accent-foreground: #ececee;
-	--sidebar-border: #2d2d2f;
+	--sidebar-border: #2d2e32;
 	--sidebar-ring: #17b88b;
 	--destructive-foreground: oklch(1 0 0);
 	/* Match light's radius so every rounded-* element is the same in both themes. */
@@ -283,7 +284,7 @@
 
 	--nav-fg: #c7c7c4;
 	--nav-fg-muted: #96979b;
-	--nav-surface-hover: #2e2e30;
+	--nav-surface-hover: #2e3035;
 	--nav-icon-idle: #5c5c5c;
 	--nav-beta-border: #3a3c3f;
 	--panel-surface-hover: #3a3c42;
@@ -295,7 +296,7 @@
 	--panel-surface: var(--background);
 	--panel-surface-fg: var(--foreground);
 	--panel-input-surface: #2a2b2e;
-	--panel-input-surface-hover: #2e3033;
+	--panel-input-surface-hover: #34373c;
 	/* Soft neutral gray for muted text and sliders. Pure-ish #ababab
 	   reads as quiet on the dark panel without going colored. */
 	--panel-surface-fg-muted: #ababab;
@@ -972,12 +973,12 @@
 	}
 
 	.dark .chat-composer-surface {
-		background-color: #2a2a2c;
+		background-color: var(--card);
 		box-shadow: none;
 	}
 
 	.composer-pill-btn {
-		@apply flex cursor-pointer items-center gap-1.5 rounded-full py-1.5 pl-2 pr-2.5 text-[14px] font-medium text-muted-foreground/70 transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-40;
+		@apply flex cursor-pointer items-center gap-1.5 rounded-full py-1.5 pl-2 pr-2.5 text-[14px] font-medium text-muted-foreground/70 transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.1] disabled:cursor-not-allowed disabled:opacity-40;
 	}
 
 	/* Icon-only (compact) pills drop their label, so make the button a square
@@ -1064,7 +1065,7 @@
 	}
 
 	.dark .unsloth-composer-surface {
-		background-color: #2a2a2c;
+		background-color: var(--card);
 		box-shadow: none;
 	}
 
@@ -1174,7 +1175,7 @@
 	/* Right-side Thinking pill (toggle or dropdown). pl-2 matches the left
 	   pills so the hover X is not pushed in too far. */
 	.unsloth-thinking-pill {
-		@apply inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-full py-1.5 pl-2 pr-2.5 text-[14px] font-medium text-muted-foreground transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-40;
+		@apply inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-full py-1.5 pl-2 pr-2.5 text-[14px] font-medium text-muted-foreground transition-colors hover:bg-primary/10 dark:hover:bg-white/[0.1] disabled:cursor-not-allowed disabled:opacity-40;
 		/* Reserve a text line so the icon-only (inactive) pill matches the
 		   text pills' height instead of collapsing to the icon. */
 		min-height: calc(1lh + 0.75rem);
@@ -1213,7 +1214,7 @@
 	}
 
 	.dark .unsloth-plus-menu[data-slot] {
-		background-color: #2a2a2c;
+		background-color: var(--card);
 		/* Shadow tinted to the page bg so it blends, not a dark halo. */
 		box-shadow: 0 4px 14px var(--background);
 	}
@@ -1666,7 +1667,7 @@
 
 /* Boost shadow on dark surfaces; mirrors .shadow-border / .menu-soft-surface pattern. */
 .dark [data-sonner-toast][data-styled='true'] {
-	background-color: #2a2a2c !important;
+	background-color: var(--card) !important;
 	box-shadow: none !important;
 }
 
@@ -1918,7 +1919,7 @@
 
 /* Keep the (borderless) close button blended with the dark toast surface. */
 .dark [data-sonner-toast][data-styled="true"] [data-close-button] {
-	background: #2a2a2c !important;
+	background: var(--card) !important;
 }
 
 [data-sonner-toast][data-styled="true"] [data-close-button] svg {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -611,7 +611,7 @@
 	   prompt button, and the chat-template textarea so all three read
 	   as one quiet gray family, matching the focused-edit-number tint. */
 	.panel-input-group {
-		@apply !h-9 min-h-9 min-w-0 items-stretch gap-0 rounded-[10px] pr-0 transition-colors focus-within:ring-0 focus-within:shadow-none;
+		@apply !h-9 min-h-9 min-w-0 items-stretch gap-0 rounded-[14px] pr-0 transition-colors focus-within:ring-0 focus-within:shadow-none;
 		border: 0 !important;
 		background-color: var(--panel-input-surface);
 	}
@@ -713,7 +713,7 @@
 	   enough to read as interactive, not enough to compete with the
 	   slider row's quiet aesthetic. */
 	.panel-number-input {
-		@apply h-7 rounded-md border-0 bg-transparent px-1.5 text-right text-[13px]! font-medium tabular-nums text-nav-fg shadow-none transition-colors hover:bg-black/[0.04] focus:bg-black/[0.05] focus-visible:ring-0! focus-visible:outline-none md:text-[13px]!;
+		@apply h-7 rounded-full border-0 bg-transparent px-1.5 text-right text-[13px]! font-medium tabular-nums text-nav-fg shadow-none transition-colors hover:bg-black/[0.04] focus:bg-black/[0.05] focus-visible:ring-0! focus-visible:outline-none md:text-[13px]!;
 	}
 	.dark .panel-number-input {
 		@apply hover:bg-white/[0.04] focus:bg-white/[0.06];
@@ -772,7 +772,7 @@
 		height: 36px;
 		padding: 0 0.75rem !important;
 		gap: 9.5px !important;
-		border-radius: 12px;
+		border-radius: 9999px;
 		font-weight: 500;
 		font-size: 15px;
 		line-height: 20px;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -840,13 +840,9 @@
 			var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 	}
 
+	/* Dark: chatbox geometry, stronger color so it reads on dark surfaces. */
 	.dark .shadow-border {
-		box-shadow: none;
-	}
-
-	/* Settings dialog: no shadow in dark mode. */
-	.dark .settings-surface.shadow-border {
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	/* Lift the dialog off the page bg; halfway to --card keeps the inner
@@ -900,7 +896,7 @@
 	}
 
 	.dark .chat-search-surface {
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	.menu-soft-surface,
@@ -917,17 +913,11 @@
 			0 var(--menu-soft-offset-y) var(--menu-soft-blur)
 				var(--menu-soft-spread) var(--menu-soft-shadow);
 	}
+	/* Dark: chatbox geometry, stronger color. */
 	.dark .menu-soft-surface,
 	.dark .menu-soft-surface-up {
 		--menu-soft-edge: rgba(255, 255, 255, 0.07);
-		--menu-soft-shadow: rgba(0, 0, 0, 0.28);
-		--menu-soft-offset-y: 8px;
-		--menu-soft-blur: 28px;
-		--menu-soft-spread: -6px;
-	}
-	.dark .menu-soft-surface-up {
-		--menu-soft-offset-y: -6px;
-		--menu-soft-spread: -8px;
+		--menu-soft-shadow: rgba(0, 0, 0, 0.5);
 	}
 
 	/* Model selector: drop the inset edge ring, keep the soft drop shadow.
@@ -939,7 +929,7 @@
 	}
 
 	.dark .unsloth-model-selector-menu.menu-soft-surface {
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	/* Every dropdown/menu/select/popover: borderless, chatbox shadow in light,
@@ -958,7 +948,7 @@
 	.dark [data-slot="select-content"],
 	.dark [data-slot="combobox-content"],
 	.dark [data-slot="popover-content"] {
-		box-shadow: 0 4px 14px var(--background) !important;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5) !important;
 	}
 
 	/* Context menus (chat, run, project): drop the inset edge ring, keep the soft shadow. */
@@ -972,7 +962,7 @@
 		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 	}
 	.dark .app-user-menu.menu-soft-surface-up {
-		box-shadow: 0 8px 28px -6px rgba(0, 0, 0, 0.28);
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	.chat-composer-surface {
@@ -988,7 +978,7 @@
 
 	.dark .chat-composer-surface {
 		background-color: var(--card);
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	.composer-pill-btn {
@@ -1082,7 +1072,7 @@
 
 	.dark .unsloth-composer-surface {
 		background-color: var(--card);
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	/* Keep the expand/collapse width swap instant. A transition on width (e.g.
@@ -1231,8 +1221,7 @@
 
 	.dark .unsloth-plus-menu[data-slot] {
 		background-color: var(--card);
-		/* Shadow tinted to the page bg so it blends, not a dark halo. */
-		box-shadow: 0 4px 14px var(--background);
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	/* Compact items; also applied to portaled sub-content. */
@@ -1318,7 +1307,7 @@
 	}
 
 	.dark .artifact-panel-shell {
-		box-shadow: none;
+		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
 	}
 
 	.chat-artifact-split[data-artifact-layout-animating="true"] > [data-panel] {
@@ -1684,7 +1673,7 @@
 /* Boost shadow on dark surfaces; mirrors .shadow-border / .menu-soft-surface pattern. */
 .dark [data-sonner-toast][data-styled='true'] {
 	background-color: var(--card) !important;
-	box-shadow: none !important;
+	box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5) !important;
 }
 
 /* Selectable toast text; non-selectable toast buttons. */

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -961,6 +961,12 @@
 		box-shadow: 0 4px 14px var(--background) !important;
 	}
 
+	/* Model selector and account menu: flat in dark. */
+	.dark .unsloth-model-selector-menu,
+	.dark .app-user-menu.menu-soft-surface-up {
+		box-shadow: none !important;
+	}
+
 	/* Context menus (chat, run, project): drop the inset edge ring, keep the soft shadow. */
 	.app-user-menu.menu-soft-surface {
 		box-shadow: 0 var(--menu-soft-offset-y) var(--menu-soft-blur)

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -831,14 +831,15 @@
 
 	/* Elevated surface shadow (use ring-* for borders) */
 	.shadow-border {
-		--tw-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-		--tw-shadow-colored: 0 4px 16px var(--tw-shadow-color);
+		/* Chatbox shadow; dark mode drops it. */
+		--tw-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
+		--tw-shadow-colored: 0 2px 8px -2px var(--tw-shadow-color);
 		box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
 			var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 	}
 
 	.dark .shadow-border {
-		--tw-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+		box-shadow: none;
 	}
 
 	/* Settings dialog: no shadow in dark mode. */
@@ -976,6 +977,8 @@
 		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-1 pt-2 outline-none transition-shadow;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
+		/* A hair warmer than pure white. */
+		background-color: #fffefd;
 		/* Gemini-style composer shadow. */
 		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 		transition: box-shadow 0.1s;
@@ -1064,6 +1067,8 @@
 		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-3 py-3 outline-none transition-shadow;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
+		/* A hair warmer than pure white. */
+		background-color: #fffefd;
 		/* Gemini-style composer shadow. */
 		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 		transition: box-shadow 0.1s;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -717,13 +717,13 @@
 	/* Inline numeric input — used for slider values and Context Length.
 	   Designed to read as *editable text* rather than a pill button so
 	   it doesn't mirror the Select/dropdown components on the panel.
-	   Default: transparent box, no border, no ring, sized by the
-	   `size` HTML attribute (each consumer picks 6 / 8 / etc. chars).
-	   Hover/focus: very light bg fade-in to signal editability — just
-	   enough to read as interactive, not enough to compete with the
-	   slider row's quiet aesthetic. */
+	   Default: transparent box, no border, no ring, width hugging the
+	   value via field-sizing (the `size` attribute is the fallback for
+	   engines without it). Hover/focus: very light bg fade-in, just
+	   enough to read as interactive without competing with the slider
+	   row's quiet aesthetic. */
 	.panel-number-input {
-		@apply h-7 rounded-full border-0 bg-transparent px-1.5 text-right text-[13px]! font-medium tabular-nums text-nav-fg shadow-none transition-colors hover:bg-black/[0.04] focus:bg-black/[0.05] focus-visible:ring-0! focus-visible:outline-none md:text-[13px]!;
+		@apply h-7 min-w-8 shrink-0 rounded-full border-0 bg-transparent px-2 text-right text-[13px]! font-medium tabular-nums text-nav-fg shadow-none transition-colors field-sizing-content hover:bg-black/[0.04] focus:bg-black/[0.05] focus-visible:ring-0! focus-visible:outline-none md:text-[13px]!;
 	}
 	.dark .panel-number-input {
 		@apply hover:bg-white/[0.04] focus:bg-white/[0.06];

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -224,7 +224,8 @@
 	/* Exact palette from apps/studio/index_chat.html mockup. Using hex so the
 	   rendered surface matches the mockup pixel-for-pixel — OKLCH conversion
 	   drifted ~3% darker and shifted the neutral hue. */
-	--background: #1f2023;
+	/* Slightly darker than --sidebar so the sidebar reads as its own surface. */
+	--background: #1a1b1e;
 	--foreground: #ececee;
 	--card: #2d2e32;
 	--card-foreground: #ececee;
@@ -251,7 +252,7 @@
 	--chart-3: oklch(0.7554 0.1285 197.339);
 	--chart-4: oklch(0.7503 0.1199 346.7805);
 	--chart-5: oklch(0.799 0.1196 84.6633);
-	/* Match the page background (dark); --sidebar-border is the right-edge separator. */
+	/* A step lighter than --background; the tone difference is the separator. */
 	--sidebar: #1f2023;
 	--sidebar-foreground: #ececee;
 	--sidebar-primary: #17b88b;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -969,8 +969,7 @@
 
 	.dark .chat-composer-surface {
 		background-color: #2a2a2c;
-		/* Stronger values so the shadow stays visible on dark surfaces. */
-		box-shadow: 0 2px 12px -2px rgba(0, 0, 0, 0.7);
+		box-shadow: none;
 	}
 
 	.composer-pill-btn {
@@ -1062,8 +1061,7 @@
 
 	.dark .unsloth-composer-surface {
 		background-color: #2a2a2c;
-		/* Stronger values so the shadow stays visible on dark surfaces. */
-		box-shadow: 0 2px 12px -2px rgba(0, 0, 0, 0.7);
+		box-shadow: none;
 	}
 
 	/* Keep the expand/collapse width swap instant. A transition on width (e.g.

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -840,9 +840,13 @@
 			var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 	}
 
-	/* Dark: chatbox geometry, stronger color so it reads on dark surfaces. */
 	.dark .shadow-border {
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		box-shadow: none;
+	}
+
+	/* Settings dialog: no shadow in dark mode. */
+	.dark .settings-surface.shadow-border {
+		box-shadow: none;
 	}
 
 	/* Lift the dialog off the page bg; halfway to --card keeps the inner
@@ -896,7 +900,7 @@
 	}
 
 	.dark .chat-search-surface {
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		box-shadow: none;
 	}
 
 	.menu-soft-surface,
@@ -913,11 +917,17 @@
 			0 var(--menu-soft-offset-y) var(--menu-soft-blur)
 				var(--menu-soft-spread) var(--menu-soft-shadow);
 	}
-	/* Dark: chatbox geometry, stronger color. */
 	.dark .menu-soft-surface,
 	.dark .menu-soft-surface-up {
 		--menu-soft-edge: rgba(255, 255, 255, 0.07);
-		--menu-soft-shadow: rgba(0, 0, 0, 0.5);
+		--menu-soft-shadow: rgba(0, 0, 0, 0.28);
+		--menu-soft-offset-y: 8px;
+		--menu-soft-blur: 28px;
+		--menu-soft-spread: -6px;
+	}
+	.dark .menu-soft-surface-up {
+		--menu-soft-offset-y: -6px;
+		--menu-soft-spread: -8px;
 	}
 
 	/* Model selector: drop the inset edge ring, keep the soft drop shadow.
@@ -929,7 +939,7 @@
 	}
 
 	.dark .unsloth-model-selector-menu.menu-soft-surface {
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		box-shadow: none;
 	}
 
 	/* Every dropdown/menu/select/popover: borderless, chatbox shadow in light,
@@ -948,7 +958,7 @@
 	.dark [data-slot="select-content"],
 	.dark [data-slot="combobox-content"],
 	.dark [data-slot="popover-content"] {
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5) !important;
+		box-shadow: 0 4px 14px var(--background) !important;
 	}
 
 	/* Context menus (chat, run, project): drop the inset edge ring, keep the soft shadow. */
@@ -962,7 +972,7 @@
 		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
 	}
 	.dark .app-user-menu.menu-soft-surface-up {
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		box-shadow: 0 8px 28px -6px rgba(0, 0, 0, 0.28);
 	}
 
 	.chat-composer-surface {
@@ -978,7 +988,7 @@
 
 	.dark .chat-composer-surface {
 		background-color: var(--card);
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		box-shadow: none;
 	}
 
 	.composer-pill-btn {
@@ -1072,7 +1082,7 @@
 
 	.dark .unsloth-composer-surface {
 		background-color: var(--card);
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		box-shadow: none;
 	}
 
 	/* Keep the expand/collapse width swap instant. A transition on width (e.g.
@@ -1221,7 +1231,8 @@
 
 	.dark .unsloth-plus-menu[data-slot] {
 		background-color: var(--card);
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		/* Shadow tinted to the page bg so it blends, not a dark halo. */
+		box-shadow: 0 4px 14px var(--background);
 	}
 
 	/* Compact items; also applied to portaled sub-content. */
@@ -1307,7 +1318,7 @@
 	}
 
 	.dark .artifact-panel-shell {
-		box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5);
+		box-shadow: none;
 	}
 
 	.chat-artifact-split[data-artifact-layout-animating="true"] > [data-panel] {
@@ -1673,7 +1684,7 @@
 /* Boost shadow on dark surfaces; mirrors .shadow-border / .menu-soft-surface pattern. */
 .dark [data-sonner-toast][data-styled='true'] {
 	background-color: var(--card) !important;
-	box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.5) !important;
+	box-shadow: none !important;
 }
 
 /* Selectable toast text; non-selectable toast buttons. */


### PR DESCRIPTION
## Summary

UI polish pass over the Studio chat interface: one consistent shadow for light mode, a softer chat background, no sidebar divider, and a consistency pass over dark mode surfaces and hover states.

## Light mode

- **One shadow everywhere:** every elevated surface now uses the same Gemini style shadow `0 2px 8px -2px rgba(0, 0, 0, 0.16)` with a short `box-shadow` transition. This covers both chat composers, the chat search palette, all dropdowns, selects, comboboxes and popovers, the account and context menus, the plus and MCP menus, the artifact panel, toasts, the message action menu and the profile personalization panel. Previously these mixed five different shadow recipes.
- **Chat background:** the main chat surface uses a soft off white `#fcfcfd` so the white composer reads as a card on top of it.
- **Sidebar divider:** removed the border line between the side menu and the page.

## Dark mode

- **Consistent surfaces:** composers, the plus and MCP menus and toasts hardcoded `#2a2a2c` while cards and popovers used `#2d2e32`. All elevated surfaces now share `var(--card)`. Stray neutral grays (`--sidebar-accent`, `--nav-surface-hover`, `--sidebar-border`) were aligned to the same blue gray family.
- **Visible hover states:** menu item hover (`--accent`) was nearly identical to the popover surface it sits on. It is now one clear step lighter (`#3a3d43`). White overlay hovers were scattered across 4 to 8 percent and are normalized to 10 percent. The account menu and settings tab pills had bespoke hover colors tuned for the page background that vanished on lighter menu surfaces; they now use the accent token.
- **Settings dialog:** its background matched the page exactly and dark mode drops dialog shadows, so it merged with the page. It now sits halfway between the page background and the card color via `color-mix`, keeping the inner muted fills readable.
- Composer shadows stay disabled in dark mode.

## Changes

- `studio/frontend/src/index.css`: shadow unification, dark surface and hover tokens, settings dialog surface.
- `studio/frontend/src/features/chat/chat-page.tsx`: off white chat background (light mode only).
- `studio/frontend/src/components/ui/sidebar.tsx`: drop the sidebar right border and pin mode ring.
- `studio/frontend/src/features/settings/settings-dialog.tsx`: tab pill hover uses the accent token.
- `studio/frontend/src/components/assistant-ui/thread.tsx`, `features/profile/components/profile-personalization-panel.tsx`: align two hardcoded shadow utilities.
- `features/chat/chat-settings-sheet.tsx`, `features/tour/components/guided-tour.tsx`, `features/hub/catalog/*`, `features/hub/download-manager/download-manager-panel.tsx`: normalize dark hover overlays.

## Testing

- `bun run build` passes.
- Verified locally in light and dark mode: composer, dropdown menus, account menu, settings dialog, sidebar hover states and toasts.