### PR TITLE
Feature/Voice Conversation Mode

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -697,6 +697,9 @@ class LlamaCppBackend:
         self._is_audio: bool = False
         self._audio_type: Optional[str] = None
         self._audio_probed: bool = False
+        # Set when THIS instance called init_audio_codec(); guards codec teardown
+        # so the voice slot's codec survives main-slot unloads.
+        self._owns_codec: bool = False
         # Monotonic timestamp set in _kill_process; read by load_model
         # to decide whether to wait for the VRAM reclaim to finish.
         self._last_kill_monotonic: float = 0.0
@@ -3945,14 +3948,15 @@ class LlamaCppBackend:
                 except Exception:
                     pass
                 self._chat_template_file = None
-            # Free audio codec GPU memory
-            if LlamaCppBackend._codec_mgr is not None:
+            # Free audio codec GPU memory — only when THIS instance owns it.
+            if self._owns_codec and LlamaCppBackend._codec_mgr is not None:
                 LlamaCppBackend._codec_mgr.unload()
                 LlamaCppBackend._codec_mgr = None
                 import torch
 
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
+            self._owns_codec = False
             return True
 
     def _kill_process(self):
@@ -5648,6 +5652,7 @@ class LlamaCppBackend:
         LlamaCppBackend._codec_mgr.load_codec(
             audio_type, device, model_repo_path = model_repo_path
         )
+        self._owns_codec = True
         logger.info(f"Loaded audio codec for GGUF TTS: {audio_type}")
 
     def generate_audio_response(

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -488,6 +488,7 @@ def _build_csp(script_nonce: "str | None" = None) -> str:
         "https://t1.gstatic.com https://t2.gstatic.com "
         "https://t3.gstatic.com https://www.google.com; "
         f"connect-src {connect_src}; "
+        "media-src 'self' blob:; "
         "style-src 'self' 'unsafe-inline'; "
         f"{script_src}; "
         "font-src 'self' data:; "

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -230,6 +230,7 @@ from datetime import datetime
 
 # Import routers
 from routes import (
+    audio_router,
     auth_router,
     chat_history_router,
     data_recipe_router,
@@ -536,6 +537,7 @@ from utils.upload_limits import (  # noqa: E402
 _BODY_PROTECTED_PREFIXES = (
     "/v1/chat/completions",
     "/v1/completions",
+    "/api/audio",
     "/api/inference",
     "/api/data-recipe",
     "/api/datasets",
@@ -749,6 +751,7 @@ app.add_middleware(
 # ============ Register API Routes ============
 
 # Register routers
+app.include_router(audio_router, prefix = "/api/audio", tags = ["audio"])
 app.include_router(auth_router, prefix = "/api/auth", tags = ["auth"])
 app.include_router(training_router, prefix = "/api/train", tags = ["training"])
 app.include_router(models_router, prefix = "/api/models", tags = ["models"])

--- a/studio/backend/models/models.py
+++ b/studio/backend/models/models.py
@@ -109,6 +109,9 @@ class LoRAInfo(BaseModel):
     export_type: Optional[str] = Field(
         None, description = "'lora', 'merged', or 'gguf' (for exports)"
     )
+    audio_type: Optional[str] = Field(
+        None, description = "Audio codec type if this is a TTS model (snac, csm, bicodec, dac)"
+    )
 
 
 class LoRAScanResponse(BaseModel):

--- a/studio/backend/routes/__init__.py
+++ b/studio/backend/routes/__init__.py
@@ -17,6 +17,7 @@ from routes.training_history import router as training_history_router
 from routes.chat_history import router as chat_history_router
 from routes.providers import router as providers_router
 from routes.mcp_servers import router as mcp_servers_router
+from routes.audio import router as audio_router
 
 __all__ = [
     "training_router",
@@ -31,4 +32,5 @@ __all__ = [
     "chat_history_router",
     "providers_router",
     "mcp_servers_router",
+    "audio_router",
 ]

--- a/studio/backend/routes/audio.py
+++ b/studio/backend/routes/audio.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+OpenAI-compatible audio endpoints.
+"""
+
+import asyncio
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from auth.authentication import get_current_subject
+from loggers import get_logger
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+
+class SpeechRequest(BaseModel):
+    input: str
+    voice: Optional[str] = None
+
+
+@router.post("/speech")
+async def create_speech(
+    payload: SpeechRequest,
+    current_subject: str = Depends(get_current_subject),
+):
+    """
+    Generate speech from text using the currently loaded TTS model.
+    Returns raw WAV audio bytes (Content-Type: audio/wav).
+
+    Mirrors the OpenAI POST /v1/audio/speech interface; `voice` is accepted
+    but ignored until per-voice routing is implemented.
+    """
+    from routes.inference import get_llama_cpp_backend
+    from core.inference import get_inference_backend
+
+    text = payload.input.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="input must not be empty.")
+
+    llama_backend = get_llama_cpp_backend()
+    if llama_backend.is_loaded and getattr(llama_backend, "_is_audio", False):
+        gen = lambda: llama_backend.generate_audio_response(
+            text=text,
+            audio_type=llama_backend._audio_type,
+        )
+    else:
+        backend = get_inference_backend()
+        if not backend.active_model_name:
+            raise HTTPException(status_code=400, detail="No model loaded.")
+        model_info = backend.models.get(backend.active_model_name, {})
+        if not model_info.get("is_audio"):
+            raise HTTPException(
+                status_code=400, detail="Active model is not a TTS model."
+            )
+        gen = lambda: backend.generate_audio_response(text=text)
+
+    try:
+        wav_bytes, _ = await asyncio.get_event_loop().run_in_executor(None, gen)
+    except Exception as e:
+        logger.error("Speech generation error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return Response(content=wav_bytes, media_type="audio/wav")

--- a/studio/backend/routes/audio.py
+++ b/studio/backend/routes/audio.py
@@ -36,15 +36,23 @@ async def create_speech(
     Mirrors the OpenAI POST /v1/audio/speech interface; `voice` is accepted
     but ignored until per-voice routing is implemented.
     """
-    from routes.inference import get_llama_cpp_backend
+    from routes.inference import get_llama_cpp_backend, get_voice_llama_backend
     from core.inference import get_inference_backend
 
     text = payload.input.strip()
     if not text:
         raise HTTPException(status_code=400, detail="input must not be empty.")
 
+    # Priority: voice slot → main llama slot → transformers backend
+    voice_backend = get_voice_llama_backend()
     llama_backend = get_llama_cpp_backend()
-    if llama_backend.is_loaded and getattr(llama_backend, "_is_audio", False):
+
+    if voice_backend.is_loaded and getattr(voice_backend, "_is_audio", False):
+        gen = lambda: voice_backend.generate_audio_response(
+            text=text,
+            audio_type=voice_backend._audio_type,
+        )
+    elif llama_backend.is_loaded and getattr(llama_backend, "_is_audio", False):
         gen = lambda: llama_backend.generate_audio_response(
             text=text,
             audio_type=llama_backend._audio_type,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -12,6 +12,7 @@ import uuid
 from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse, JSONResponse, Response
+from pydantic import BaseModel, Field
 from typing import Any, Optional, Union
 import json
 import httpx
@@ -704,12 +705,22 @@ def _resolve_model_identifier_for_request(
     return str(grant.canonical_path), display_label, True
 
 
-# GGUF inference backend (llama-server)
+# GGUF inference backend (llama-server) — chat / LLM slot
 _llama_cpp_backend = LlamaCppBackend()
+
+# Voice slot — independent llama-server subprocess for GGUF TTS models only
+_voice_llama_backend = LlamaCppBackend()
+
+# Audio types accepted by the voice slot (GGUF TTS via llama-server token generation)
+_VOICE_SLOT_AUDIO_TYPES: frozenset[str] = frozenset({"snac", "bicodec", "dac"})
 
 
 def get_llama_cpp_backend() -> LlamaCppBackend:
     return _llama_cpp_backend
+
+
+def get_voice_llama_backend() -> LlamaCppBackend:
+    return _voice_llama_backend
 
 
 @router.post("/load", response_model = LoadResponse)
@@ -1360,6 +1371,151 @@ async def unload_model(
     except Exception as e:
         logger.error(f"Error unloading model: {e}", exc_info = True)
         raise HTTPException(status_code = 500, detail = f"Failed to unload model: {str(e)}")
+
+
+# =====================================================================
+# Voice Slot  (/voice/load  /voice/unload  /voice/status)
+# =====================================================================
+
+class _VoiceLoadRequest(BaseModel):
+    model_path: str = Field(..., description="GGUF model identifier or local .gguf path")
+    gguf_variant: Optional[str] = Field(None, description="GGUF quantization variant (e.g. 'Q4_K_M')")
+    hf_token: Optional[str] = Field(None, description="HuggingFace token for gated models")
+    n_ctx: int = Field(4096, ge=0, description="Context length (0 = model default)")
+
+
+@router.post("/voice/load")
+async def voice_load_model(
+    request: _VoiceLoadRequest,
+    current_subject: str = Depends(get_current_subject),
+):
+    """
+    Load a TTS model into the voice slot (independent of the main chat slot).
+
+    Only GGUF models whose detected audio_type is snac, bicodec, or dac are
+    accepted.  Any other model (text LLM, csm, whisper, audio_vlm) is rejected
+    with HTTP 400 after detection and the slot is left empty.
+    """
+    voice_backend = get_voice_llama_backend()
+
+    model_identifier = request.model_path.strip()
+
+    # Resolve model config — auto-selects GGUF variant when gguf_variant is None,
+    # exactly mirroring the ModelConfig.from_identifier() call in /load.
+    try:
+        config = ModelConfig.from_identifier(
+            model_id=model_identifier,
+            hf_token=request.hf_token,
+            gguf_variant=request.gguf_variant,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Could not resolve model: {e}")
+
+    if not config or not config.is_gguf:
+        raise HTTPException(
+            status_code=400,
+            detail="Voice slot only accepts GGUF models. The provided identifier did not resolve to a GGUF.",
+        )
+
+    # Already loaded with the same resolved config — skip reload.
+    if (
+        voice_backend.is_loaded
+        and voice_backend.model_identifier
+        and voice_backend.model_identifier.lower() == config.identifier.lower()
+        and (not config.gguf_variant or voice_backend.hf_variant == config.gguf_variant)
+        and getattr(voice_backend, "_is_audio", False)
+    ):
+        return {
+            "status": "already_loaded",
+            "model": voice_backend.model_identifier,
+            "audio_type": getattr(voice_backend, "_audio_type", None),
+        }
+
+    try:
+        if config.gguf_hf_repo:
+            # HF repo mode: llama-server downloads/uses cached GGUF via -hf
+            ok = await asyncio.to_thread(
+                voice_backend.load_model,
+                hf_repo=config.gguf_hf_repo,
+                hf_variant=config.gguf_variant,
+                hf_token=request.hf_token,
+                model_identifier=config.identifier,
+                n_ctx=request.n_ctx,
+            )
+        else:
+            # Local file mode: llama-server loads via -m <path>
+            ok = await asyncio.to_thread(
+                voice_backend.load_model,
+                gguf_path=config.gguf_file,
+                hf_variant=config.gguf_variant,
+                model_identifier=config.identifier,
+                n_ctx=request.n_ctx,
+                hf_token=request.hf_token,
+            )
+    except Exception as e:
+        logger.error("Voice slot load error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to load voice model: {e}")
+
+    if not ok:
+        raise HTTPException(status_code=500, detail="Voice model failed to start.")
+
+    audio_type = getattr(voice_backend, "_audio_type", None)
+    is_audio = getattr(voice_backend, "_is_audio", False)
+
+    if not is_audio or audio_type not in _VOICE_SLOT_AUDIO_TYPES:
+        # Not a supported TTS type — reject and leave slot empty.
+        try:
+            voice_backend.unload_model()
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Model is not a supported TTS type for the voice slot "
+                f"(detected: {audio_type!r}). "
+                f"Only snac, bicodec, and dac GGUF models are accepted."
+            ),
+        )
+
+    logger.info("Voice slot loaded: %s (audio_type=%s)", voice_backend.model_identifier, audio_type)
+    return {
+        "status": "loaded",
+        "model": voice_backend.model_identifier,
+        "audio_type": audio_type,
+    }
+
+
+@router.post("/voice/unload")
+async def voice_unload_model(
+    current_subject: str = Depends(get_current_subject),
+):
+    """Unload whatever model is in the voice slot."""
+    voice_backend = get_voice_llama_backend()
+    if not voice_backend.is_active:
+        return {"status": "not_loaded"}
+    model_id = voice_backend.model_identifier
+    try:
+        voice_backend.unload_model()
+    except Exception as e:
+        logger.error("Voice slot unload error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to unload voice model: {e}")
+    logger.info("Voice slot unloaded: %s", model_id)
+    return {"status": "unloaded", "model": model_id}
+
+
+@router.get("/voice/status")
+async def voice_slot_status(
+    current_subject: str = Depends(get_current_subject),
+):
+    """Return the current state of the voice slot."""
+    voice_backend = get_voice_llama_backend()
+    loaded = voice_backend.is_loaded
+    return {
+        "loaded": loaded,
+        "loading": voice_backend.is_active and not loaded,
+        "model": voice_backend.model_identifier if loaded else None,
+        "audio_type": getattr(voice_backend, "_audio_type", None) if loaded else None,
+    }
 
 
 @studio_router.post("/cancel")

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -67,6 +67,8 @@ try:
         _pick_best_gguf,
         _extract_quant_label,
         is_audio_input_type,
+        detect_audio_type,
+        detect_audio_type_from_local,
     )
     from core.inference import get_inference_backend
     from utils.paths import (
@@ -98,6 +100,8 @@ except ImportError:
         _pick_best_gguf,
         _extract_quant_label,
         is_audio_input_type,
+        detect_audio_type,
+        detect_audio_type_from_local,
     )
     from core.inference import get_inference_backend
     from utils.paths import (
@@ -1644,6 +1648,29 @@ async def get_model_config(
         )
 
 
+def _detect_lora_audio_type(
+    model_path: str, model_type: str, base_model: Optional[str]
+) -> Optional[str]:
+    """Return the audio_type for a training output or export, or None on failure.
+
+    For LoRA adapters the base model (an HF repo ID) holds the tokenizer, so we
+    use the cache-aware detect_audio_type on that.  For merged / full-finetune
+    outputs we read tokenizer_config.json directly from the local path.
+    GGUF exports have no tokenizer on disk, so they always return None.
+    """
+    try:
+        if model_type == "gguf":
+            return None
+        if model_type == "lora":
+            if base_model and "/" in base_model and not base_model.startswith("/"):
+                return detect_audio_type(base_model)
+            return None
+        # merged / full-finetune: read local tokenizer
+        return detect_audio_type_from_local(model_path)
+    except Exception:
+        return None
+
+
 @router.get("/loras")
 async def scan_loras(
     outputs_dir: str = Query(
@@ -1669,6 +1696,7 @@ async def scan_loras(
         trained_models = scan_trained_models(outputs_dir = resolved_outputs_dir)
         for display_name, model_path, model_type in trained_models:
             base_model = get_base_model_from_checkpoint(model_path)
+            audio_type = _detect_lora_audio_type(model_path, model_type, base_model)
             lora_list.append(
                 LoRAInfo(
                     display_name = display_name,
@@ -1676,12 +1704,14 @@ async def scan_loras(
                     base_model = base_model,
                     source = "training",
                     export_type = model_type,
+                    audio_type = audio_type,
                 )
             )
 
         # Scan exported models (merged, LoRA, base — skips GGUF)
         exported = scan_exported_models(exports_dir = resolved_exports_dir)
         for display_name, model_path, export_type, base_model in exported:
+            audio_type = _detect_lora_audio_type(model_path, export_type or "", base_model)
             lora_list.append(
                 LoRAInfo(
                     display_name = display_name,
@@ -1689,6 +1719,7 @@ async def scan_loras(
                     base_model = base_model,
                     source = "exported",
                     export_type = export_type,
+                    audio_type = audio_type,
                 )
             )
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -918,6 +918,36 @@ def _detect_audio_from_tokenizer(
         return None
 
 
+def detect_audio_type_from_local(model_path: str) -> Optional[str]:
+    """Detect audio_type by reading tokenizer_config.json from a local model directory.
+
+    Used for training outputs where the path is local (not an HF repo ID).
+    Skips SNAC because its detection requires counting 10 000+ custom tokens,
+    which is prohibitively expensive at scan time.
+    """
+    from pathlib import Path
+
+    path = Path(model_path)
+    for sub in ("tokenizer_config.json", "LLM/tokenizer_config.json"):
+        tok_file = path / sub
+        if not tok_file.exists():
+            continue
+        try:
+            tok_cfg = json.loads(tok_file.read_text(encoding = "utf-8"))
+            added = tok_cfg.get("added_tokens_decoder", {})
+            if not added:
+                continue
+            tokens = [v.get("content", "") for v in added.values()]
+            for audio_type, check_fn in _AUDIO_TOKEN_PATTERNS.items():
+                if audio_type == "snac":
+                    continue
+                if check_fn(tokens):
+                    return audio_type
+        except Exception:
+            continue
+    return None
+
+
 def is_audio_input_type(audio_type: Optional[str]) -> bool:
     """Check if an audio_type accepts audio input (ASR/speech understanding).
 

--- a/studio/frontend/src/components/assistant-ui/model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector.tsx
@@ -111,6 +111,7 @@ interface ModelSelectorProps {
   onFoldersChange?: () => void;
   onPickLocalModel?: () => void | Promise<void>;
   onModelsChange?: (deletedModel?: DeletedModelRef) => void;
+  onListen?: (adapter: LoraModelOption) => void;
   deleteDisabled?: boolean;
   variant?: "outline" | "ghost" | "muted";
   size?: "sm" | "default" | "lg";
@@ -207,6 +208,7 @@ function ModelSelectorContent({
   onFoldersChange,
   onPickLocalModel,
   onModelsChange,
+  onListen,
   deleteDisabled,
   className,
   dataTour,
@@ -220,6 +222,7 @@ function ModelSelectorContent({
   onFoldersChange?: () => void;
   onPickLocalModel?: () => void;
   onModelsChange?: (deletedModel?: DeletedModelRef) => void;
+  onListen?: (adapter: LoraModelOption) => void;
   deleteDisabled?: boolean;
   className?: string;
   dataTour?: string;
@@ -289,6 +292,7 @@ function ModelSelectorContent({
               value={value}
               onSelect={onSelect}
               onModelsChange={onModelsChange}
+              onListen={onListen}
               deleteDisabled={deleteDisabled}
             />
           </TabsContent>
@@ -347,6 +351,7 @@ export function ModelSelector({
   onFoldersChange,
   onPickLocalModel,
   onModelsChange,
+  onListen,
   deleteDisabled,
   variant = "outline",
   size = "default",
@@ -444,6 +449,11 @@ export function ModelSelector({
     void onPickLocalModel?.();
   }
 
+  function handleListen(adapter: LoraModelOption) {
+    setOpen(false);
+    onListen?.(adapter);
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <ModelSelectorTrigger
@@ -465,6 +475,7 @@ export function ModelSelector({
         onFoldersChange={onFoldersChange}
         onPickLocalModel={onPickLocalModel ? handlePickLocalModel : undefined}
         onModelsChange={onModelsChange}
+        onListen={onListen ? handleListen : undefined}
         deleteDisabled={deleteDisabled}
         className={contentClassName}
         dataTour={contentDataTour}

--- a/studio/frontend/src/components/assistant-ui/model-selector/listen-modal.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/listen-modal.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { useTtsPlayer } from "@/features/chat/hooks/use-tts-player";
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { SquareIcon, Volume2Icon } from "lucide-react";
+import { useEffect, useRef, useState, type FC } from "react";
+import type { LoraModelOption } from "./types";
+
+interface ListenModalProps {
+  adapter: LoraModelOption;
+  onClose: () => void;
+}
+
+export const ListenModal: FC<ListenModalProps> = ({ adapter, onClose }) => {
+  const [text, setText] = useState("Hello, this is a test.");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const checkpoint = useChatRuntimeStore((s) => s.params.checkpoint);
+  const modelLoading = useChatRuntimeStore((s) => s.modelLoading);
+  const isReady = checkpoint === adapter.id && !modelLoading;
+
+  const { isSpeaking, speak, stop } = useTtsPlayer(adapter.audioType ?? null);
+
+  // Focus the input once the model finishes loading.
+  useEffect(() => {
+    if (isReady) inputRef.current?.focus();
+  }, [isReady]);
+
+  const handleClose = () => {
+    stop();
+    onClose();
+  };
+
+  const handlePlay = () => {
+    if (isSpeaking) {
+      stop();
+      return;
+    }
+    const trimmed = text.trim();
+    if (trimmed) speak(trimmed);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && isReady && !isSpeaking) handlePlay();
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) handleClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="truncate pr-6">
+            Listen: {adapter.name}
+          </DialogTitle>
+        </DialogHeader>
+
+        {!isReady ? (
+          <div className="flex items-center gap-3 py-4 text-sm text-muted-foreground">
+            <Spinner className="size-4 shrink-0" />
+            <span>Loading model…</span>
+          </div>
+        ) : (
+          <div className="flex gap-2">
+            <Input
+              ref={inputRef}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Hello, this is a test."
+              className="flex-1"
+              disabled={isSpeaking}
+            />
+            <Button
+              type="button"
+              variant={isSpeaking ? "destructive" : "default"}
+              size="icon"
+              onClick={handlePlay}
+              disabled={!text.trim() && !isSpeaking}
+              aria-label={isSpeaking ? "Stop" : "Play"}
+            >
+              {isSpeaking ? (
+                <SquareIcon className="size-4 fill-current" />
+              ) : (
+                <Volume2Icon className="size-4" />
+              )}
+            </Button>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={handleClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -42,7 +42,8 @@ import { Add01Icon, Cancel01Icon, Folder02Icon, Search01Icon } from "@hugeicons/
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FolderBrowser } from "./folder-browser";
 import { ModelDeleteAction } from "./model-delete-action";
-import { ChevronDownIcon, ChevronRightIcon, DownloadIcon, StarIcon } from "lucide-react";
+import { ChevronDownIcon, ChevronRightIcon, DownloadIcon, HeadphonesIcon, StarIcon } from "lucide-react";
+import { TTS_AUDIO_TYPES } from "@/features/chat/hooks/use-tts-player";
 import {
   type ReactNode,
   useCallback,
@@ -1423,12 +1424,14 @@ export function LoraModelPicker({
   value,
   onSelect,
   onModelsChange,
+  onListen,
   deleteDisabled = false,
 }: {
   loraModels: LoraModelOption[];
   value?: string;
   onSelect: (id: string, meta: ModelSelectorChangeMeta) => void;
   onModelsChange?: (deletedModel?: DeletedModelRef) => void;
+  onListen?: (adapter: LoraModelOption) => void;
   deleteDisabled?: boolean;
 }) {
   const [query, setQuery] = useState("");
@@ -1581,6 +1584,19 @@ export function LoraModelPicker({
                             }
                           />
                         </div>
+                        {onListen && TTS_AUDIO_TYPES.has(adapter.audioType ?? "") && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onListen(adapter);
+                            }}
+                            className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                            aria-label={`Listen: ${adapter.name}`}
+                          >
+                            <HeadphonesIcon className="size-3.5" />
+                          </button>
+                        )}
                         {canDelete && (
                           <ModelDeleteAction
                             ariaLabel={`Delete ${adapter.name}`}

--- a/studio/frontend/src/components/assistant-ui/model-selector/types.ts
+++ b/studio/frontend/src/components/assistant-ui/model-selector/types.ts
@@ -16,6 +16,7 @@ export interface LoraModelOption extends ModelOption {
   updatedAt?: number;
   source?: "training" | "exported" | "local";
   exportType?: "lora" | "merged" | "gguf";
+  audioType?: string | null;
 }
 
 export interface ExternalModelOption extends ModelOption {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1136,9 +1136,15 @@ const ImagesToggle: FC = () => {
   );
 };
 
+// Module-level flag: survives the ThreadWelcome → ThreadComposerDock remount
+// (and the GeneratedImageOverlayProvider key-change remount) that occur when
+// the first message is sent. Without this, VoiceToggle instance #2 would
+// always start with voiceModeEnabled = false, silencing the first response.
+let _voiceModeActive = false;
+
 const VoiceToggle: FC = () => {
   const aui = useAui();
-  const [voiceModeEnabled, setVoiceModeEnabled] = useState(false);
+  const [voiceModeEnabled, setVoiceModeEnabled] = useState(_voiceModeActive);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1146,7 +1152,7 @@ const VoiceToggle: FC = () => {
   // voiceModeRef is only written in toggle — never in the render body —
   // to prevent intermediate re-renders from resetting it before React commits
   // the new voiceModeEnabled state.
-  const voiceModeRef = useRef(false);
+  const voiceModeRef = useRef(_voiceModeActive);
   const isSpeakingRef = useRef(false);
   const auiRef = useRef(aui);
   isSpeakingRef.current = isSpeaking;
@@ -1163,6 +1169,18 @@ const VoiceToggle: FC = () => {
   );
   const isDictating =
     dictationStatusType === "starting" || dictationStatusType === "running";
+
+  // On remount: if voice mode was active when this instance mounted and the
+  // model is already idle, open the mic immediately. The common path
+  // (model still running at remount time) is handled by the run-lifecycle
+  // effect below — this only fires for the rare race where the model
+  // finishes before the new instance's effects run.
+  useEffect(() => {
+    if (!_voiceModeActive || isThreadRunning) return;
+    document
+      .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
+      ?.click();
+  }, []); // mount only
 
   // Run lifecycle: stop dictation + clear timer when model starts generating;
   // speak the response and restart dictation when the run finishes.
@@ -1265,6 +1283,7 @@ const VoiceToggle: FC = () => {
 
   const toggle = useCallback(() => {
     const next = !voiceModeRef.current;
+    _voiceModeActive = next;
     setVoiceModeEnabled(next);
     voiceModeRef.current = next;
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1136,6 +1136,208 @@ const ImagesToggle: FC = () => {
   );
 };
 
+const VoiceToggle: FC = () => {
+  const aui = useAui();
+  const [voiceModeEnabled, setVoiceModeEnabled] = useState(false);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevRunningRef = useRef(false);
+  // voiceModeRef is only written in toggle — never in the render body —
+  // to prevent intermediate re-renders from resetting it before React commits
+  // the new voiceModeEnabled state.
+  const voiceModeRef = useRef(false);
+  const isSpeakingRef = useRef(false);
+  const auiRef = useRef(aui);
+  isSpeakingRef.current = isSpeaking;
+  auiRef.current = aui;
+
+  const isThreadRunning = useAuiState(({ thread }) => thread.isRunning);
+  // dictation?.status.type and transcript come from assistant-ui's built-in
+  // DictationAdapter — the same one the existing Dictate button drives.
+  const dictationStatusType = useAuiState(
+    ({ composer }) => composer.dictation?.status.type,
+  );
+  const dictationTranscript = useAuiState(
+    ({ composer }) => composer.dictation?.transcript ?? "",
+  );
+  const isDictating =
+    dictationStatusType === "starting" || dictationStatusType === "running";
+
+  // Run lifecycle: stop dictation + clear timer when model starts generating;
+  // speak the response and restart dictation when the run finishes.
+  useEffect(() => {
+    if (isThreadRunning) {
+      prevRunningRef.current = true;
+      if (voiceModeRef.current) {
+        if (silenceTimerRef.current) {
+          clearTimeout(silenceTimerRef.current);
+          silenceTimerRef.current = null;
+        }
+        const composer = auiRef.current.composer();
+        if (composer.getState().dictation) composer.stopDictation();
+      }
+      return;
+    }
+    if (!prevRunningRef.current) return;
+    prevRunningRef.current = false;
+
+    console.log("[VoiceToggle] run-end transition detected", {
+      voiceMode: voiceModeRef.current,
+      isSpeaking: isSpeakingRef.current,
+    });
+    if (!voiceModeRef.current || isSpeakingRef.current) return;
+
+    // Called after speaking ends (or immediately if there's nothing to speak).
+    // startDictation() works here because mic permission was already granted
+    // when the user first clicked the Voice pill.
+    const resumeListen = () => {
+      if (voiceModeRef.current) {
+        console.log("[VoiceToggle] resuming dictation after response");
+        document.querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')?.click();
+      }
+    };
+
+    const messages = auiRef.current.thread().getState().messages;
+    let text = "";
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.role !== "assistant") continue;
+      for (const part of msg.content as Array<{
+        type: string;
+        text?: string;
+      }>) {
+        if (part.type === "text" && part.text) text += part.text;
+      }
+      break;
+    }
+    if (!text) {
+      resumeListen();
+      return;
+    }
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.onend = () => {
+      console.log("[VoiceToggle] utterance.onend fired", {
+        voiceMode: voiceModeRef.current,
+      });
+      setIsSpeaking(false);
+      utteranceRef.current = null;
+      resumeListen();
+    };
+    utterance.onerror = () => {
+      setIsSpeaking(false);
+      utteranceRef.current = null;
+      resumeListen();
+    };
+    utteranceRef.current = utterance;
+    console.log(
+      "[VoiceToggle] speechSynthesis.speak called, text length:",
+      text.length,
+    );
+    window.speechSynthesis.speak(utterance);
+    setIsSpeaking(true);
+  }, [isThreadRunning]);
+
+  // Silence timer: reset on each new transcript chunk from the DictationAdapter.
+  // 1.5 s after the last update, stop dictation and auto-send.
+  useEffect(() => {
+    if (dictationStatusType !== "running") return;
+    if (!voiceModeRef.current) return;
+
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+    silenceTimerRef.current = setTimeout(() => {
+      silenceTimerRef.current = null;
+      if (!voiceModeRef.current) return;
+      const composer = auiRef.current.composer();
+      composer.stopDictation();
+      if (composer.getState().isEditing && composer.getState().text.trim()) {
+        composer.send();
+      }
+    }, 1500);
+
+    return () => {
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+        silenceTimerRef.current = null;
+      }
+    };
+  }, [dictationTranscript, dictationStatusType]);
+
+  const toggle = useCallback(() => {
+    const next = !voiceModeRef.current;
+    setVoiceModeEnabled(next);
+    voiceModeRef.current = next;
+
+    if (next) {
+      if (
+        !auiRef.current.thread().getState().isRunning &&
+        !isSpeakingRef.current
+      ) {
+        document.querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')?.click();
+      }
+    } else {
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+        silenceTimerRef.current = null;
+      }
+      if (utteranceRef.current) {
+        window.speechSynthesis.cancel();
+        utteranceRef.current = null;
+        setIsSpeaking(false);
+      }
+      const composer = auiRef.current.composer();
+      if (composer.getState().dictation) composer.stopDictation();
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+      if (utteranceRef.current) window.speechSynthesis.cancel();
+    };
+  }, []);
+
+  if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="composer-pill-btn"
+      data-active={voiceModeEnabled ? "true" : "false"}
+      style={
+        voiceModeEnabled
+          ? isDictating
+            ? { color: "rgb(34 197 94)" }
+            : isSpeaking
+              ? { color: "rgb(59 130 246)" }
+              : isThreadRunning
+                ? { color: "rgb(234 179 8)" }
+                : undefined
+          : undefined
+      }
+      aria-label={voiceModeEnabled ? "Disable voice mode" : "Enable voice mode"}
+    >
+      {isSpeaking && voiceModeEnabled ? (
+        <Volume2Icon className="size-3.5" />
+      ) : (
+        <MicIcon className="size-3.5" />
+      )}
+      <span>
+        {voiceModeEnabled && isDictating
+          ? "Listening"
+          : voiceModeEnabled && isSpeaking
+            ? "Speaking"
+            : voiceModeEnabled && isThreadRunning
+              ? "Thinking"
+              : "Voice"}
+      </span>
+    </button>
+  );
+};
+
 const ArtifactsToggle: FC = () => {
   const modelLoaded = useChatRuntimeStore(
     (s) => !!s.params.checkpoint && !s.modelLoading,
@@ -1233,6 +1435,7 @@ const ComposerAction: FC<{
         <ImagesToggle />
         <ArtifactsToggle />
         <McpComposerButton />
+        <VoiceToggle />
       </div>
       <div className="flex items-center gap-1">
         <ComposerPrimitive.If dictation={false}>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { sentAudioNames } from "@/features/chat/api/chat-adapter";
 import { TTS_AUDIO_TYPES, useTtsPlayer } from "@/features/chat/hooks/use-tts-player";
+import { VoiceOrb } from "@/components/assistant-ui/voice-orb";
 import { parseExternalModelId } from "@/features/chat/external-providers";
 import { McpComposerButton } from "@/features/chat/mcp-composer-button";
 import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
@@ -190,6 +191,7 @@ export const Thread: FC<{
           </ThreadPrimitive.Viewport>
 
           <GeneratedImageViewportOverlay hideComposer={hideComposer} />
+          <VoiceOrb />
 
           {!hideComposer && (
             <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
@@ -302,12 +304,13 @@ const ThreadComposerDock: FC<{
   threadId?: string | null;
 }> = ({ disabled, threadId }) => {
   const { overlay } = useGeneratedImageOverlay();
+  const voiceOrbActive = useChatRuntimeStore((s) => s.voiceOrbState !== null);
 
   return (
     <div
       className={cn(
         "aui-thread-composer-dock pointer-events-none absolute bottom-0 left-0 right-0 md:right-[10px]",
-        overlay ? "z-40" : "z-20",
+        overlay || voiceOrbActive ? "z-40" : "z-20",
       )}
     >
       <div
@@ -1193,6 +1196,15 @@ const VoiceToggle: FC = () => {
   isSpeakingRef.current = isSpeaking;
   const speakRef = useRef(speak);
   speakRef.current = speak;
+
+  // Sync derived orb state to the store so VoiceOrb can read it without prop-drilling.
+  const setVoiceOrbState = useChatRuntimeStore((s) => s.setVoiceOrbState);
+  useEffect(() => {
+    if (voiceMode !== "active") { setVoiceOrbState(null); return; }
+    if (isThreadRunning)        { setVoiceOrbState("thinking"); return; }
+    if (isSpeaking)             { setVoiceOrbState("speaking"); return; }
+    setVoiceOrbState("listening");
+  }, [voiceMode, isThreadRunning, isSpeaking, setVoiceOrbState]);
 
   // Helper: transition to "active" and start the mic.
   const activateLoop = useCallback(() => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1137,28 +1137,24 @@ const ImagesToggle: FC = () => {
   );
 };
 
-// Module-level flag: survives the ThreadWelcome → ThreadComposerDock remount
-// (and the GeneratedImageOverlayProvider key-change remount) that occur when
-// the first message is sent. Without this, VoiceToggle instance #2 would
-// always start with voiceModeEnabled = false, silencing the first response.
-let _voiceModeActive = false;
+// Module-level value: survives the ThreadWelcome → ThreadComposerDock remount
+// that occurs when the first message is sent.
+let _voiceMode: "off" | "configuring" | "active" = "off";
 
 const VoiceToggle: FC = () => {
   const aui = useAui();
-  const [voiceModeEnabled, setVoiceModeEnabled] = useState(_voiceModeActive);
+  const [voiceMode, setVoiceModeState] = useState(_voiceMode);
   const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevRunningRef = useRef(false);
-  // voiceModeRef is only written in toggle — never in the render body —
-  // to prevent intermediate re-renders from resetting it before React commits
-  // the new voiceModeEnabled state.
-  const voiceModeRef = useRef(_voiceModeActive);
+  // voiceModeRef is only written in toggle/activate — never in the render body.
+  const voiceModeRef = useRef(_voiceMode);
   const isSpeakingRef = useRef(false);
   const auiRef = useRef(aui);
   auiRef.current = aui;
 
+  const voiceModeEnabled = voiceMode !== "off";
+
   const isThreadRunning = useAuiState(({ thread }) => thread.isRunning);
-  // dictation?.status.type and transcript come from assistant-ui's built-in
-  // DictationAdapter — the same one the existing Dictate button drives.
   const dictationStatusType = useAuiState(
     ({ composer }) => composer.dictation?.status.type,
   );
@@ -1172,12 +1168,13 @@ const VoiceToggle: FC = () => {
     const m = s.models.find((m) => m.id === s.params.checkpoint);
     return m?.audioType ?? null;
   });
+  const selectedVoiceModelId = useChatRuntimeStore((s) => s.selectedVoiceModelId);
   const isTtsModelLoaded = TTS_AUDIO_TYPES.has(activeAudioType ?? "");
+  const voiceSlotLoaded = voiceMode === "active" && selectedVoiceModelId !== null;
 
   // Called after speaking ends (or immediately if there's nothing to speak).
-  // Stable ref-based callback so useTtsPlayer captures it once.
   const resumeListen = useCallback(() => {
-    if (voiceModeRef.current) {
+    if (voiceModeRef.current === "active") {
       console.log("[VoiceToggle] resuming dictation after response");
       document
         .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
@@ -1185,32 +1182,48 @@ const VoiceToggle: FC = () => {
     }
   }, []);
 
-  const { isSpeaking, speak, stop } = useTtsPlayer(activeAudioType, resumeListen);
+  const { isSpeaking, speak, stop, primeAudio } = useTtsPlayer(activeAudioType, resumeListen, voiceSlotLoaded);
   isSpeakingRef.current = isSpeaking;
-  // Keep a ref so the run-lifecycle effect always calls the latest speak
-  // without adding it to the dependency array (avoids re-running on TTS
-  // model switches mid-conversation).
   const speakRef = useRef(speak);
   speakRef.current = speak;
 
-  // On remount: if voice mode was active when this instance mounted and the
-  // model is already idle, open the mic immediately. The common path
-  // (model still running at remount time) is handled by the run-lifecycle
-  // effect below — this only fires for the rare race where the model
-  // finishes before the new instance's effects run.
+  // Helper: transition to "active" and start the mic.
+  const activateLoop = useCallback(() => {
+    _voiceMode = "active";
+    voiceModeRef.current = "active";
+    setVoiceModeState("active");
+    if (!auiRef.current.thread().getState().isRunning && !isSpeakingRef.current) {
+      document
+        .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
+        ?.click();
+    }
+  }, []);
+
+  // On remount: restore "active" only — "configuring" stays as-is (no mic).
   useEffect(() => {
-    if (!_voiceModeActive || isThreadRunning) return;
+    if (_voiceMode !== "active" || isThreadRunning) return;
     document
       .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
       ?.click();
   }, []); // mount only
 
-  // Run lifecycle: stop dictation + clear timer when model starts generating;
-  // speak the response and restart dictation when the run finishes.
+  // Watch the store: when it transitions from "configuring" → "active"
+  // (triggered externally by the voice-model dropdown pick), activate the loop.
+  const storeVoiceMode = useChatRuntimeStore((s) => s.voiceMode);
+  useEffect(() => {
+    if (
+      storeVoiceMode === "active" &&
+      voiceModeRef.current === "configuring"
+    ) {
+      activateLoop();
+    }
+  }, [storeVoiceMode, activateLoop]);
+
+  // Run lifecycle: stop dictation when model starts; speak + resume mic when done.
   useEffect(() => {
     if (isThreadRunning) {
       prevRunningRef.current = true;
-      if (voiceModeRef.current) {
+      if (voiceModeRef.current === "active") {
         if (silenceTimerRef.current) {
           clearTimeout(silenceTimerRef.current);
           silenceTimerRef.current = null;
@@ -1227,7 +1240,7 @@ const VoiceToggle: FC = () => {
       voiceMode: voiceModeRef.current,
       isSpeaking: isSpeakingRef.current,
     });
-    if (!voiceModeRef.current || isSpeakingRef.current) return;
+    if (voiceModeRef.current !== "active" || isSpeakingRef.current) return;
 
     const messages = auiRef.current.thread().getState().messages;
     let text = "";
@@ -1250,16 +1263,15 @@ const VoiceToggle: FC = () => {
     speakRef.current(text);
   }, [isThreadRunning, resumeListen]);
 
-  // Silence timer: reset on each new transcript chunk from the DictationAdapter.
-  // 1.5 s after the last update, stop dictation and auto-send.
+  // Silence timer: only fires in "active" state.
   useEffect(() => {
     if (dictationStatusType !== "running") return;
-    if (!voiceModeRef.current) return;
+    if (voiceModeRef.current !== "active") return;
 
     if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
     silenceTimerRef.current = setTimeout(() => {
       silenceTimerRef.current = null;
-      if (!voiceModeRef.current) return;
+      if (voiceModeRef.current !== "active") return;
       const composer = auiRef.current.composer();
       composer.stopDictation();
       if (composer.getState().isEditing && composer.getState().text.trim()) {
@@ -1276,21 +1288,21 @@ const VoiceToggle: FC = () => {
   }, [dictationTranscript, dictationStatusType]);
 
   const toggle = useCallback(() => {
-    const next = !voiceModeRef.current;
-    _voiceModeActive = next;
-    setVoiceModeEnabled(next);
+    // OFF → CONFIGURING (show dropdown, don't start mic)
+    // CONFIGURING → OFF (user cancelled before picking)
+    // ACTIVE → OFF (turn off the loop)
+    const next: "off" | "configuring" =
+      voiceModeRef.current === "off" ? "configuring" : "off";
+    _voiceMode = next;
     voiceModeRef.current = next;
+    setVoiceModeState(next);
+    useChatRuntimeStore.getState().setVoiceMode(next);
 
-    if (next) {
-      if (
-        !auiRef.current.thread().getState().isRunning &&
-        !isSpeakingRef.current
-      ) {
-        document
-          .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
-          ?.click();
-      }
-    } else {
+    if (next === "configuring") {
+      primeAudio();
+    }
+
+    if (next === "off") {
       if (silenceTimerRef.current) {
         clearTimeout(silenceTimerRef.current);
         silenceTimerRef.current = null;
@@ -1299,7 +1311,8 @@ const VoiceToggle: FC = () => {
       const composer = auiRef.current.composer();
       if (composer.getState().dictation) composer.stopDictation();
     }
-  }, [stop]);
+    // "configuring": dropdown appears via store; mic stays off.
+  }, [stop, primeAudio]);
 
   useEffect(() => {
     return () => {
@@ -1321,31 +1334,35 @@ const VoiceToggle: FC = () => {
       className="composer-pill-btn"
       data-active={voiceModeEnabled ? "true" : "false"}
       style={
-        voiceModeEnabled
-          ? isDictating
-            ? { color: "rgb(34 197 94)" }
-            : isSpeaking
-              ? { color: "rgb(59 130 246)" }
-              : isThreadRunning
-                ? { color: "rgb(234 179 8)" }
-                : undefined
-          : undefined
+        voiceMode === "configuring"
+          ? { opacity: 0.55 }
+          : voiceMode === "active"
+            ? isDictating
+              ? { color: "rgb(34 197 94)" }
+              : isSpeaking
+                ? { color: "rgb(59 130 246)" }
+                : isThreadRunning
+                  ? { color: "rgb(234 179 8)" }
+                  : undefined
+            : undefined
       }
       aria-label={voiceModeEnabled ? "Disable voice mode" : "Enable voice mode"}
     >
-      {isSpeaking && voiceModeEnabled ? (
+      {isSpeaking && voiceMode === "active" ? (
         <Volume2Icon className="size-3.5" />
       ) : (
         <MicIcon className="size-3.5" />
       )}
       <span>
-        {voiceModeEnabled && isDictating
-          ? "Listening"
-          : voiceModeEnabled && isSpeaking
-            ? "Speaking"
-            : voiceModeEnabled && isThreadRunning
-              ? "Thinking"
-              : "Voice"}
+        {voiceMode === "configuring"
+          ? "Pick a voice"
+          : voiceMode === "active" && isDictating
+            ? "Listening"
+            : voiceMode === "active" && isSpeaking
+              ? "Speaking"
+              : voiceMode === "active" && isThreadRunning
+                ? "Thinking"
+                : "Voice"}
       </span>
     </button>
   );
@@ -1671,7 +1688,10 @@ const SpeakButton: FC = () => {
     const m = s.models.find((m) => m.id === s.params.checkpoint);
     return m?.audioType ?? null;
   });
-  const { isSpeaking, speak, stop } = useTtsPlayer(activeAudioType);
+  const voiceSlotLoaded = useChatRuntimeStore(
+    (s) => s.voiceMode === "active" && s.selectedVoiceModelId !== null,
+  );
+  const { isSpeaking, speak, stop } = useTtsPlayer(activeAudioType, undefined, voiceSlotLoaded);
 
   const handleSpeak = () => {
     if (isSpeaking) {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -85,6 +85,7 @@ import {
   RefreshCwIcon,
   SquareIcon,
   TerminalIcon,
+  Volume2Icon,
   XIcon,
 } from "lucide-react";
 import {
@@ -1448,12 +1449,60 @@ const CopyButton: FC = () => {
   );
 };
 
+const SpeakButton: FC = () => {
+  const aui = useAui();
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (utteranceRef.current) {
+        window.speechSynthesis.cancel();
+      }
+    };
+  }, []);
+
+  const handleSpeak = () => {
+    if (isSpeaking) {
+      window.speechSynthesis.cancel();
+      utteranceRef.current = null;
+      setIsSpeaking(false);
+      return;
+    }
+    const text = aui.message().getCopyText();
+    if (!text) return;
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.onend = () => setIsSpeaking(false);
+    utterance.onerror = () => setIsSpeaking(false);
+    utteranceRef.current = utterance;
+    window.speechSynthesis.speak(utterance);
+    setIsSpeaking(true);
+  };
+
+  return (
+    <TooltipIconButton
+      tooltip={isSpeaking ? "Stop speaking" : "Speak"}
+      onClick={handleSpeak}
+    >
+      {isSpeaking ? (
+        <SquareIcon
+          strokeWidth={1.75}
+          className="size-icon animate-pulse fill-current"
+        />
+      ) : (
+        <Volume2Icon strokeWidth={1.75} className="size-icon" />
+      )}
+    </TooltipIconButton>
+  );
+};
+
 const AssistantActionBar: FC = () => {
   return (
     <ActionBarPrimitive.Root
       hideWhenRunning={true}
       className="aui-assistant-action-bar-root col-start-3 row-start-2 flex items-center gap-1 text-chat-icon-fg [&_button:not([data-slot=message-timing-trigger])]:size-8 [&_button]:!rounded-[10px] [&_button:hover]:bg-chat-icon-bg-hover [&_button:hover]:text-chat-icon-fg-hover"
     >
+      <SpeakButton />
       <CopyButton />
       <ActionBarPrimitive.Reload asChild={true}>
         <TooltipIconButton tooltip="Refresh">

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1176,13 +1176,20 @@ const VoiceToggle: FC = () => {
   const resumeListen = useCallback(() => {
     if (voiceModeRef.current === "active") {
       console.log("[VoiceToggle] resuming dictation after response");
-      document
-        .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
-        ?.click();
+      if (!auiRef.current.composer().getState().dictation) {
+        document
+          .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
+          ?.click();
+      }
     }
   }, []);
 
   const { isSpeaking, speak, stop, primeAudio } = useTtsPlayer(activeAudioType, resumeListen, voiceSlotLoaded);
+  const prevIsSpeakingRef = useRef(isSpeaking);
+  if (prevIsSpeakingRef.current !== isSpeaking) {
+    console.log("[VoiceToggle] isSpeaking:", prevIsSpeakingRef.current, "→", isSpeaking);
+    prevIsSpeakingRef.current = isSpeaking;
+  }
   isSpeakingRef.current = isSpeaking;
   const speakRef = useRef(speak);
   speakRef.current = speak;
@@ -1261,12 +1268,33 @@ const VoiceToggle: FC = () => {
     }
     console.log("[VoiceToggle] speak called, text length:", text.length);
     speakRef.current(text);
+    // Start dictation during TTS so barge-in can fire on transcript updates.
+    // TODO: the mic hears the speaker output — model voice can trigger spurious
+    // transcript updates and barge itself in. Proper fix is echo cancellation or
+    // matching transcripts against the TTS text. Leaving as follow-up.
+    if (!auiRef.current.composer().getState().dictation) {
+      document
+        .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
+        ?.click();
+    }
   }, [isThreadRunning, resumeListen]);
 
   // Silence timer: only fires in "active" state.
   useEffect(() => {
+    console.log("[VoiceToggle] silence-timer effect", {
+      dictationStatusType,
+      dictationTranscript: dictationTranscript.slice(0, 60),
+      isSpeaking: isSpeakingRef.current,
+      voiceMode: voiceModeRef.current,
+    });
     if (dictationStatusType !== "running") return;
     if (voiceModeRef.current !== "active") return;
+
+    // Barge-in: new non-empty transcript fragment while TTS is playing → interrupt immediately.
+    if (isSpeakingRef.current && dictationTranscript.trim()) {
+      console.log("[VoiceToggle] barge-in: calling stop()");
+      stop();
+    }
 
     if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
     silenceTimerRef.current = setTimeout(() => {
@@ -1285,7 +1313,7 @@ const VoiceToggle: FC = () => {
         silenceTimerRef.current = null;
       }
     };
-  }, [dictationTranscript, dictationStatusType]);
+  }, [dictationTranscript, dictationStatusType, stop]);
 
   const toggle = useCallback(() => {
     // OFF → CONFIGURING (show dropdown, don't start mic)

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -43,6 +43,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { sentAudioNames } from "@/features/chat/api/chat-adapter";
+import { TTS_AUDIO_TYPES, useTtsPlayer } from "@/features/chat/hooks/use-tts-player";
 import { parseExternalModelId } from "@/features/chat/external-providers";
 import { McpComposerButton } from "@/features/chat/mcp-composer-button";
 import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
@@ -1145,8 +1146,6 @@ let _voiceModeActive = false;
 const VoiceToggle: FC = () => {
   const aui = useAui();
   const [voiceModeEnabled, setVoiceModeEnabled] = useState(_voiceModeActive);
-  const [isSpeaking, setIsSpeaking] = useState(false);
-  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevRunningRef = useRef(false);
   // voiceModeRef is only written in toggle — never in the render body —
@@ -1155,7 +1154,6 @@ const VoiceToggle: FC = () => {
   const voiceModeRef = useRef(_voiceModeActive);
   const isSpeakingRef = useRef(false);
   const auiRef = useRef(aui);
-  isSpeakingRef.current = isSpeaking;
   auiRef.current = aui;
 
   const isThreadRunning = useAuiState(({ thread }) => thread.isRunning);
@@ -1169,6 +1167,31 @@ const VoiceToggle: FC = () => {
   );
   const isDictating =
     dictationStatusType === "starting" || dictationStatusType === "running";
+
+  const activeAudioType = useChatRuntimeStore((s) => {
+    const m = s.models.find((m) => m.id === s.params.checkpoint);
+    return m?.audioType ?? null;
+  });
+  const isTtsModelLoaded = TTS_AUDIO_TYPES.has(activeAudioType ?? "");
+
+  // Called after speaking ends (or immediately if there's nothing to speak).
+  // Stable ref-based callback so useTtsPlayer captures it once.
+  const resumeListen = useCallback(() => {
+    if (voiceModeRef.current) {
+      console.log("[VoiceToggle] resuming dictation after response");
+      document
+        .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
+        ?.click();
+    }
+  }, []);
+
+  const { isSpeaking, speak, stop } = useTtsPlayer(activeAudioType, resumeListen);
+  isSpeakingRef.current = isSpeaking;
+  // Keep a ref so the run-lifecycle effect always calls the latest speak
+  // without adding it to the dependency array (avoids re-running on TTS
+  // model switches mid-conversation).
+  const speakRef = useRef(speak);
+  speakRef.current = speak;
 
   // On remount: if voice mode was active when this instance mounted and the
   // model is already idle, open the mic immediately. The common path
@@ -1206,16 +1229,6 @@ const VoiceToggle: FC = () => {
     });
     if (!voiceModeRef.current || isSpeakingRef.current) return;
 
-    // Called after speaking ends (or immediately if there's nothing to speak).
-    // startDictation() works here because mic permission was already granted
-    // when the user first clicked the Voice pill.
-    const resumeListen = () => {
-      if (voiceModeRef.current) {
-        console.log("[VoiceToggle] resuming dictation after response");
-        document.querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')?.click();
-      }
-    };
-
     const messages = auiRef.current.thread().getState().messages;
     let text = "";
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -1233,28 +1246,9 @@ const VoiceToggle: FC = () => {
       resumeListen();
       return;
     }
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.onend = () => {
-      console.log("[VoiceToggle] utterance.onend fired", {
-        voiceMode: voiceModeRef.current,
-      });
-      setIsSpeaking(false);
-      utteranceRef.current = null;
-      resumeListen();
-    };
-    utterance.onerror = () => {
-      setIsSpeaking(false);
-      utteranceRef.current = null;
-      resumeListen();
-    };
-    utteranceRef.current = utterance;
-    console.log(
-      "[VoiceToggle] speechSynthesis.speak called, text length:",
-      text.length,
-    );
-    window.speechSynthesis.speak(utterance);
-    setIsSpeaking(true);
-  }, [isThreadRunning]);
+    console.log("[VoiceToggle] speak called, text length:", text.length);
+    speakRef.current(text);
+  }, [isThreadRunning, resumeListen]);
 
   // Silence timer: reset on each new transcript chunk from the DictationAdapter.
   // 1.5 s after the last update, stop dictation and auto-send.
@@ -1292,31 +1286,31 @@ const VoiceToggle: FC = () => {
         !auiRef.current.thread().getState().isRunning &&
         !isSpeakingRef.current
       ) {
-        document.querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')?.click();
+        document
+          .querySelector<HTMLButtonElement>('button[aria-label="Dictate"]')
+          ?.click();
       }
     } else {
       if (silenceTimerRef.current) {
         clearTimeout(silenceTimerRef.current);
         silenceTimerRef.current = null;
       }
-      if (utteranceRef.current) {
-        window.speechSynthesis.cancel();
-        utteranceRef.current = null;
-        setIsSpeaking(false);
-      }
+      stop();
       const composer = auiRef.current.composer();
       if (composer.getState().dictation) composer.stopDictation();
     }
-  }, []);
+  }, [stop]);
 
   useEffect(() => {
     return () => {
       if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
-      if (utteranceRef.current) window.speechSynthesis.cancel();
     };
   }, []);
 
-  if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+  if (
+    typeof window === "undefined" ||
+    (!("speechSynthesis" in window) && !isTtsModelLoaded)
+  ) {
     return null;
   }
 
@@ -1673,32 +1667,20 @@ const CopyButton: FC = () => {
 
 const SpeakButton: FC = () => {
   const aui = useAui();
-  const [isSpeaking, setIsSpeaking] = useState(false);
-  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (utteranceRef.current) {
-        window.speechSynthesis.cancel();
-      }
-    };
-  }, []);
+  const activeAudioType = useChatRuntimeStore((s) => {
+    const m = s.models.find((m) => m.id === s.params.checkpoint);
+    return m?.audioType ?? null;
+  });
+  const { isSpeaking, speak, stop } = useTtsPlayer(activeAudioType);
 
   const handleSpeak = () => {
     if (isSpeaking) {
-      window.speechSynthesis.cancel();
-      utteranceRef.current = null;
-      setIsSpeaking(false);
+      stop();
       return;
     }
     const text = aui.message().getCopyText();
     if (!text) return;
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.onend = () => setIsSpeaking(false);
-    utterance.onerror = () => setIsSpeaking(false);
-    utteranceRef.current = utterance;
-    window.speechSynthesis.speak(utterance);
-    setIsSpeaking(true);
+    speak(text);
   };
 
   return (

--- a/studio/frontend/src/components/assistant-ui/voice-model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/voice-model-selector.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MicVocalIcon } from "lucide-react";
+import { useState, type FC } from "react";
+import type { LoraModelOption } from "./model-selector/types";
+
+interface VoiceModelSelectorProps {
+  models: LoraModelOption[];
+  value: string | null;
+  onValueChange: (id: string | null) => void;
+  loading?: boolean;
+  className?: string;
+}
+
+const BROWSER_VOICE_ID = null;
+const BROWSER_VOICE_LABEL = "Browser voice";
+
+export const VoiceModelSelector: FC<VoiceModelSelectorProps> = ({
+  models,
+  value,
+  onValueChange,
+  loading = false,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const selectedModel = value ? models.find((m) => m.id === value) : null;
+  const displayName = selectedModel?.name ?? BROWSER_VOICE_LABEL;
+
+  const handleSelect = (id: string | null) => {
+    setOpen(false);
+    onValueChange(id);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex min-w-0 items-center gap-2 rounded-[10px] transition-colors hover:bg-[#ececec] dark:hover:bg-[#2d2e32]",
+            "h-9 px-3.5 text-sm",
+            className,
+          )}
+          aria-label="Select voice model"
+        >
+          {loading ? (
+            <Spinner className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <MicVocalIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className="min-w-0 truncate font-heading text-[16px] font-medium leading-tight text-black dark:text-white">
+            {displayName}
+          </span>
+          <span className="flex size-4 shrink-0 items-center justify-center">
+            <HugeiconsIcon
+              icon={ArrowDown01Icon}
+              className="size-3.5 text-muted-foreground"
+              strokeWidth={2}
+            />
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="menu-soft-surface w-[220px] rounded-lg border-0 p-1.5 ring-0"
+      >
+        {/* Browser voice fallback */}
+        <button
+          type="button"
+          onClick={() => handleSelect(BROWSER_VOICE_ID)}
+          className={cn(
+            "flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[13px] font-medium leading-[1.4] tracking-nav transition-colors hover:bg-accent",
+            value === null && "bg-accent",
+          )}
+        >
+          <MicVocalIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 truncate">{BROWSER_VOICE_LABEL}</span>
+          {value === null && (
+            <span className="ml-auto text-[11px] text-muted-foreground">
+              active
+            </span>
+          )}
+        </button>
+
+        {models.length > 0 && (
+          <div className="my-1.5 h-px bg-black/[0.08] dark:bg-white/[0.08]" />
+        )}
+
+        {models.map((model) => (
+          <button
+            key={model.id}
+            type="button"
+            onClick={() => handleSelect(model.id)}
+            className={cn(
+              "flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[13px] font-medium leading-[1.4] tracking-nav transition-colors hover:bg-accent",
+              value === model.id && "bg-accent",
+            )}
+          >
+            <span className="min-w-0 flex-1 truncate">{model.name}</span>
+            {model.isGguf && !model.source && (
+              <span className="shrink-0 text-[11px] text-muted-foreground">
+                GGUF
+              </span>
+            )}
+            {value === model.id && (
+              <span className="ml-auto text-[11px] text-muted-foreground">
+                active
+              </span>
+            )}
+          </button>
+        ))}
+
+        {models.length === 0 && (
+          <p className="px-3 py-2 text-[12px] text-muted-foreground">
+            No TTS models found. Train or export a voice model first.
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/studio/frontend/src/components/assistant-ui/voice-orb.tsx
+++ b/studio/frontend/src/components/assistant-ui/voice-orb.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { cn } from "@/lib/utils";
+import type { FC } from "react";
+
+const orbConfig = {
+  listening: {
+    gradient: "radial-gradient(circle at 40% 35%, #34d399, #059669)",
+    animation: "voice-orb-breathe",
+    duration: "3s",
+    shadow: "0 0 32px 8px rgba(52,211,153,0.35)",
+  },
+  thinking: {
+    gradient: "radial-gradient(circle at 40% 35%, #fbbf24, #d97706)",
+    animation: "voice-orb-pulse",
+    duration: "1s",
+    shadow: "0 0 32px 8px rgba(251,191,36,0.35)",
+  },
+  speaking: {
+    gradient: "radial-gradient(circle at 40% 35%, #38bdf8, #0284c7)",
+    animation: "voice-orb-speak",
+    duration: "0.8s",
+    shadow: "0 0 32px 8px rgba(56,189,248,0.35)",
+  },
+} as const;
+
+export const VoiceOrb: FC = () => {
+  const orbState = useChatRuntimeStore((s) => s.voiceOrbState);
+
+  const cfg = orbState ? orbConfig[orbState] : null;
+
+  return (
+    <>
+      <style>{`
+        @keyframes voice-orb-breathe {
+          0%, 100% { transform: scale(1);    }
+          50%       { transform: scale(1.05); }
+        }
+        @keyframes voice-orb-pulse {
+          0%, 100% { transform: scale(1);    }
+          50%       { transform: scale(1.06); }
+        }
+        @keyframes voice-orb-speak {
+          0%, 100% { transform: scale(1);    }
+          50%       { transform: scale(1.1);  }
+        }
+      `}</style>
+
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-0 z-30 flex items-center justify-center bg-background",
+          "transition-opacity duration-500",
+          orbState ? "opacity-100" : "opacity-0",
+        )}
+        aria-hidden
+      >
+        <div
+          className="transition-all duration-500"
+          style={{
+            width: 140,
+            height: 140,
+            borderRadius: "50%",
+            background: cfg?.gradient ?? orbConfig.listening.gradient,
+            boxShadow: cfg?.shadow ?? "none",
+            animation: cfg
+              ? `${cfg.animation} ${cfg.duration} ease-in-out infinite`
+              : undefined,
+          }}
+        />
+      </div>
+    </>
+  );
+};

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -10,6 +10,9 @@ import {
   ModelSelector,
 } from "@/components/assistant-ui/model-selector";
 import { ListenModal } from "@/components/assistant-ui/model-selector/listen-modal";
+import { VoiceModelSelector } from "@/components/assistant-ui/voice-model-selector";
+import { authFetch } from "@/features/auth";
+import { TTS_AUDIO_TYPES } from "@/features/chat/hooks/use-tts-player";
 import { ProjectComposer, Thread } from "@/components/assistant-ui/thread";
 import {
   ResizableHandle,
@@ -1123,6 +1126,17 @@ export function ChatPage(): ReactElement {
     loadProgress,
     loadToastDismissed,
   } = useChatModelRuntime();
+  const voiceMode = useChatRuntimeStore((s) => s.voiceMode);
+  const selectedVoiceModelId = useChatRuntimeStore(
+    (s) => s.selectedVoiceModelId,
+  );
+  const setSelectedVoiceModelId = useChatRuntimeStore(
+    (s) => s.setSelectedVoiceModelId,
+  );
+  const [voiceSlotLoading, setVoiceSlotLoading] = useState(false);
+  const [cachedGgufs, setCachedGgufs] = useState<LoraModelOption[]>([]);
+  const cachedGgufsFetchedRef = useRef(false);
+
   const [listenAdapter, setListenAdapter] = useState<LoraModelOption | null>(null);
   const handleListen = useCallback(
     (adapter: LoraModelOption) => {
@@ -1137,6 +1151,72 @@ export function ChatPage(): ReactElement {
     },
     [inferenceParams.checkpoint, selectModel],
   );
+  const handleVoiceModelChange = useCallback(
+    async (id: string | null) => {
+      setSelectedVoiceModelId(id);
+      if (!id) {
+        // Browser voice — unload voice slot and activate the loop immediately.
+        void authFetch("/api/inference/voice/unload", { method: "POST" });
+        useChatRuntimeStore.getState().setVoiceMode("active");
+        return;
+      }
+      setVoiceSlotLoading(true);
+      try {
+        const res = await authFetch("/api/inference/voice/load", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model_path: id }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          toast.error("Voice model failed to load", {
+            description: (body as { detail?: string }).detail ?? undefined,
+          });
+          setSelectedVoiceModelId(null);
+        } else {
+          // Model loaded — activate the conversation loop.
+          useChatRuntimeStore.getState().setVoiceMode("active");
+        }
+      } catch {
+        toast.error("Voice model failed to load");
+        setSelectedVoiceModelId(null);
+      } finally {
+        setVoiceSlotLoading(false);
+      }
+    },
+    [setSelectedVoiceModelId],
+  );
+
+  // Unload the voice slot whenever voice mode turns off.
+  useEffect(() => {
+    if (voiceMode === "off" && selectedVoiceModelId) {
+      void authFetch("/api/inference/voice/unload", { method: "POST" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [voiceMode]);
+
+  // Fetch cached GGUFs once when voice mode is first activated.
+  useEffect(() => {
+    if (voiceMode === "off" || cachedGgufsFetchedRef.current) return;
+    cachedGgufsFetchedRef.current = true;
+    const TTS_REPO_KEYWORDS = ["orpheus", "kokoro", "csm", "spark", "bicodec", "dac", "tts"];
+    void authFetch("/api/models/cached-gguf")
+      .then((r) => (r.ok ? r.json() : { cached: [] }))
+      .then((data: { cached: { repo_id: string }[] }) => {
+        const lower = (s: string) => s.toLowerCase();
+        setCachedGgufs(
+          (data.cached ?? [])
+            .filter((c) => TTS_REPO_KEYWORDS.some((kw) => lower(c.repo_id).includes(kw)))
+            .map((c) => ({
+              id: c.repo_id,
+              name: c.repo_id.includes("/") ? (c.repo_id.split("/")[1] ?? c.repo_id) : c.repo_id,
+              isGguf: true,
+            })),
+        );
+      })
+      .catch(() => {});
+  }, [voiceMode]);
+
   const prevConnectionsEnabledRef = useRef(connectionsEnabled);
   useEffect(() => {
     const turnedOff = prevConnectionsEnabledRef.current && !connectionsEnabled;
@@ -1975,6 +2055,13 @@ export function ChatPage(): ReactElement {
     return [...fromLoras, ...localModels];
   }, [lorasFromStore, localModels]);
 
+  const ttsModels = useMemo<LoraModelOption[]>(() => {
+    const fromLoras = loraModels.filter((m) =>
+      TTS_AUDIO_TYPES.has(m.audioType ?? ""),
+    );
+    return [...fromLoras, ...cachedGgufs];
+  }, [loraModels, cachedGgufs]);
+
   useEffect(() => {
     if (getTrainingCompareHandoff()) return;
     void refresh();
@@ -2139,6 +2226,15 @@ export function ChatPage(): ReactElement {
                 contentDataTour="chat-model-selector-popover"
                 showCloudIndicator={isExternalModel}
                 className="max-w-[62vw] !pr-3 sm:max-w-none !h-[34px]"
+              />
+            )}
+            {view.mode !== "compare" && voiceMode !== "off" && (
+              <VoiceModelSelector
+                models={ttsModels}
+                value={selectedVoiceModelId}
+                onValueChange={(id) => void handleVoiceModelChange(id)}
+                loading={voiceSlotLoading}
+                className="!h-[34px]"
               />
             )}
             {view.mode !== "compare" && currentProjectId && (

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -9,6 +9,7 @@ import {
   type ModelOption,
   ModelSelector,
 } from "@/components/assistant-ui/model-selector";
+import { ListenModal } from "@/components/assistant-ui/model-selector/listen-modal";
 import { ProjectComposer, Thread } from "@/components/assistant-ui/thread";
 import {
   ResizableHandle,
@@ -1122,6 +1123,20 @@ export function ChatPage(): ReactElement {
     loadProgress,
     loadToastDismissed,
   } = useChatModelRuntime();
+  const [listenAdapter, setListenAdapter] = useState<LoraModelOption | null>(null);
+  const handleListen = useCallback(
+    (adapter: LoraModelOption) => {
+      setListenAdapter(adapter);
+      if (adapter.id !== inferenceParams.checkpoint) {
+        void selectModel({
+          id: adapter.id,
+          isLora: adapter.exportType !== "merged",
+          isDownloaded: true,
+        });
+      }
+    },
+    [inferenceParams.checkpoint, selectModel],
+  );
   const prevConnectionsEnabledRef = useRef(connectionsEnabled);
   useEffect(() => {
     const turnedOff = prevConnectionsEnabledRef.current && !connectionsEnabled;
@@ -1955,6 +1970,7 @@ export function ChatPage(): ReactElement {
       updatedAt: lora.updatedAt,
       source: lora.source,
       exportType: lora.exportType,
+      audioType: lora.audioType,
     }));
     return [...fromLoras, ...localModels];
   }, [lorasFromStore, localModels]);
@@ -2114,6 +2130,7 @@ export function ChatPage(): ReactElement {
                 onFoldersChange={refreshLocalModels}
                 onPickLocalModel={isTauri ? chooseNativeModel : undefined}
                 onModelsChange={refreshModelLists}
+                onListen={handleListen}
                 deleteDisabled={modelOperationInProgress}
                 variant="ghost"
                 open={modelSelectorOpen}
@@ -2297,6 +2314,12 @@ export function ChatPage(): ReactElement {
           }
         }}
       />
+      {listenAdapter && (
+        <ListenModal
+          adapter={listenAdapter}
+          onClose={() => setListenAdapter(null)}
+        />
+      )}
     </div>
   );
 }

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1160,6 +1160,46 @@ export function ChatPage(): ReactElement {
         useChatRuntimeStore.getState().setVoiceMode("active");
         return;
       }
+
+      // Download-confirmation gate: skip if the repo is already in the local
+      // cache list (fast path). Otherwise ask gguf-variants for the default
+      // variant's size and whether it's already downloaded.
+      const isCached = cachedGgufs.some((g) => g.id === id);
+      if (!isCached) {
+        try {
+          const vr = await authFetch(
+            `/api/models/gguf-variants?repo_id=${encodeURIComponent(id)}`,
+          );
+          if (vr.ok) {
+            const vdata = (await vr.json()) as {
+              default_variant?: string;
+              variants?: { quant: string; size_bytes: number; downloaded: boolean }[];
+            };
+            const defaultVariant =
+              vdata.variants?.find((v) => v.quant === vdata.default_variant) ??
+              vdata.variants?.[0];
+            const HUNDRED_MB = 100 * 1024 * 1024;
+            if (
+              defaultVariant &&
+              !defaultVariant.downloaded &&
+              defaultVariant.size_bytes > HUNDRED_MB
+            ) {
+              const sizeMb = Math.round(defaultVariant.size_bytes / (1024 * 1024));
+              const modelName = id.includes("/") ? (id.split("/")[1] ?? id) : id;
+              const confirmed = window.confirm(
+                `Download ${modelName} (~${sizeMb} MB)? This downloads from HuggingFace.`,
+              );
+              if (!confirmed) {
+                setSelectedVoiceModelId(null);
+                return;
+              }
+            }
+          }
+        } catch {
+          // gguf-variants unavailable (e.g. local LoRA path) — proceed silently
+        }
+      }
+
       setVoiceSlotLoading(true);
       try {
         const res = await authFetch("/api/inference/voice/load", {
@@ -1184,7 +1224,7 @@ export function ChatPage(): ReactElement {
         setVoiceSlotLoading(false);
       }
     },
-    [setSelectedVoiceModelId],
+    [setSelectedVoiceModelId, cachedGgufs],
   );
 
   // Unload the voice slot whenever voice mode turns off.

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -137,6 +137,7 @@ function toLoraSummary(lora: {
   base_model?: string | null;
   source?: "training" | "exported" | null;
   export_type?: "lora" | "merged" | "gguf" | null;
+  audio_type?: string | null;
 }): ChatLoraSummary {
   const idTail = lora.adapter_path.split("/").filter(Boolean).at(-1) ?? "";
   const updatedAt =
@@ -149,6 +150,7 @@ function toLoraSummary(lora: {
     updatedAt,
     source: lora.source ?? undefined,
     exportType: lora.export_type ?? undefined,
+    audioType: lora.audio_type ?? null,
   };
 }
 

--- a/studio/frontend/src/features/chat/hooks/use-tts-player.ts
+++ b/studio/frontend/src/features/chat/hooks/use-tts-player.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const TTS_AUDIO_TYPES = new Set(["snac", "csm", "bicodec", "dac"]);
+
+export function useTtsPlayer(
+  audioType: string | null | undefined,
+  onPlaybackEnd?: () => void,
+): {
+  isSpeaking: boolean;
+  speak(text: string): void;
+  stop(): void;
+} {
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const onPlaybackEndRef = useRef(onPlaybackEnd);
+  onPlaybackEndRef.current = onPlaybackEnd;
+
+  const isTtsModel = TTS_AUDIO_TYPES.has(audioType ?? "");
+
+  const revokeUrl = useCallback(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+  }, []);
+
+  const stopTts = useCallback(() => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.onended = null;
+      audio.onerror = null;
+      audio.pause();
+      audioRef.current = null;
+    }
+    revokeUrl();
+  }, [revokeUrl]);
+
+  const stopSynth = useCallback(() => {
+    if (utteranceRef.current) {
+      window.speechSynthesis.cancel();
+      utteranceRef.current = null;
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    stopTts();
+    stopSynth();
+    setIsSpeaking(false);
+  }, [stopTts, stopSynth]);
+
+  const speak = useCallback(
+    async (text: string) => {
+      stop();
+      if (!text) return;
+
+      if (isTtsModel) {
+        setIsSpeaking(true);
+        try {
+          const response = await authFetch("/api/audio/speech", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ input: text, voice: "default" }),
+          });
+          if (!response.ok) throw new Error("TTS request failed");
+          const blob = await response.blob();
+          const url = URL.createObjectURL(blob);
+          objectUrlRef.current = url;
+          const audio = new Audio(url);
+          audioRef.current = audio;
+          const cleanup = () => {
+            if (objectUrlRef.current === url) {
+              URL.revokeObjectURL(url);
+              objectUrlRef.current = null;
+            }
+            if (audioRef.current === audio) audioRef.current = null;
+            setIsSpeaking(false);
+            onPlaybackEndRef.current?.();
+          };
+          audio.onended = cleanup;
+          audio.onerror = cleanup;
+          audio.play();
+        } catch {
+          setIsSpeaking(false);
+          onPlaybackEndRef.current?.();
+        }
+      } else {
+        if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+          onPlaybackEndRef.current?.();
+          return;
+        }
+        const utterance = new SpeechSynthesisUtterance(text);
+        utterance.onend = () => {
+          utteranceRef.current = null;
+          setIsSpeaking(false);
+          onPlaybackEndRef.current?.();
+        };
+        utterance.onerror = () => {
+          utteranceRef.current = null;
+          setIsSpeaking(false);
+          onPlaybackEndRef.current?.();
+        };
+        utteranceRef.current = utterance;
+        window.speechSynthesis.speak(utterance);
+        setIsSpeaking(true);
+      }
+    },
+    [isTtsModel, stop],
+  );
+
+  useEffect(() => {
+    return () => {
+      stopTts();
+      stopSynth();
+    };
+  }, [stopTts, stopSynth]);
+
+  return { isSpeaking, speak, stop };
+}

--- a/studio/frontend/src/features/chat/hooks/use-tts-player.ts
+++ b/studio/frontend/src/features/chat/hooks/use-tts-player.ts
@@ -9,10 +9,12 @@ export const TTS_AUDIO_TYPES = new Set(["snac", "csm", "bicodec", "dac"]);
 export function useTtsPlayer(
   audioType: string | null | undefined,
   onPlaybackEnd?: () => void,
+  voiceSlotLoaded = false,
 ): {
   isSpeaking: boolean;
   speak(text: string): void;
   stop(): void;
+  primeAudio(): void;
 } {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -21,7 +23,18 @@ export function useTtsPlayer(
   const onPlaybackEndRef = useRef(onPlaybackEnd);
   onPlaybackEndRef.current = onPlaybackEnd;
 
-  const isTtsModel = TTS_AUDIO_TYPES.has(audioType ?? "");
+  const isTtsModel = TTS_AUDIO_TYPES.has(audioType ?? "") || voiceSlotLoaded;
+
+  // Unlock Safari's audio autoplay policy by calling play()+pause() during
+  // a synchronous user gesture. The element is reused for all subsequent plays
+  // so the unlock survives async fetch callbacks.
+  const primeAudio = useCallback(() => {
+    if (typeof window === "undefined") return;
+    if (!audioRef.current) {
+      audioRef.current = new Audio();
+    }
+    audioRef.current.play().then(() => audioRef.current?.pause()).catch(() => {});
+  }, []);
 
   const revokeUrl = useCallback(() => {
     if (objectUrlRef.current) {
@@ -36,7 +49,7 @@ export function useTtsPlayer(
       audio.onended = null;
       audio.onerror = null;
       audio.pause();
-      audioRef.current = null;
+      audio.src = "";  // release current source but keep element alive for reuse
     }
     revokeUrl();
   }, [revokeUrl]);
@@ -71,19 +84,19 @@ export function useTtsPlayer(
           const blob = await response.blob();
           const url = URL.createObjectURL(blob);
           objectUrlRef.current = url;
-          const audio = new Audio(url);
+          const audio = audioRef.current ?? new Audio();
           audioRef.current = audio;
           const cleanup = () => {
             if (objectUrlRef.current === url) {
               URL.revokeObjectURL(url);
               objectUrlRef.current = null;
             }
-            if (audioRef.current === audio) audioRef.current = null;
             setIsSpeaking(false);
             onPlaybackEndRef.current?.();
           };
           audio.onended = cleanup;
           audio.onerror = cleanup;
+          audio.src = url;
           audio.play();
         } catch {
           setIsSpeaking(false);
@@ -120,5 +133,5 @@ export function useTtsPlayer(
     };
   }, [stopTts, stopSynth]);
 
-  return { isSpeaking, speak, stop };
+  return { isSpeaking, speak, stop, primeAudio };
 }

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -32,6 +32,7 @@ import {
   MicIcon,
   PlusIcon,
   SquareIcon,
+  Volume2Icon,
   XIcon,
 } from "lucide-react";
 import { Image03Icon } from "@hugeicons/core-free-icons";
@@ -82,6 +83,8 @@ export interface CompareHandle {
   startRun: (parentId?: string | null) => void;
   cancel: () => void;
   isRunning: () => boolean;
+  /** Returns the plain text of the most recent assistant message. */
+  getLastAssistantText: () => string;
   /** Returns a promise that resolves when the current or next run finishes. */
   waitForRunEnd: () => Promise<void>;
 }
@@ -318,6 +321,22 @@ export function RegisterCompareHandle({
       },
       cancel: () => aui.thread().cancelRun(),
       isRunning: () => aui.thread().getState().isRunning,
+      getLastAssistantText: () => {
+        const msgs = aui.thread().getState().messages;
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          const msg = msgs[i];
+          if (msg.role !== "assistant") continue;
+          let text = "";
+          for (const part of msg.content as Array<{
+            type: string;
+            text?: string;
+          }>) {
+            if (part.type === "text" && part.text) text += part.text;
+          }
+          return text;
+        }
+        return "";
+      },
       waitForRunEnd: () =>
         new Promise<void>((resolve) => {
           let wasRunning = false;
@@ -405,6 +424,14 @@ export function SharedComposer({
   const stuckImeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const audioInputRef = useRef<HTMLInputElement>(null);
+  const [voiceModeEnabled, setVoiceModeEnabled] = useState(false);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const speechUtteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const prevRunningRef = useRef(false);
+  const voiceModeEnabledRef = useRef(false);
+  const isSpeakingRef = useRef(false);
+  voiceModeEnabledRef.current = voiceModeEnabled;
+  isSpeakingRef.current = isSpeaking;
 
   const activeModel = useChatRuntimeStore((s) => {
     const checkpoint = s.params.checkpoint;
@@ -628,6 +655,60 @@ export function SharedComposer({
     ta.style.overflowY = ta.scrollHeight > maxHeight ? "auto" : "hidden";
   }, [text]);
 
+  // Auto-speak the last assistant response when a run finishes in voice mode,
+  // then auto-start dictation so the loop continues.
+  useEffect(() => {
+    if (running) {
+      prevRunningRef.current = true;
+      return;
+    }
+    if (!prevRunningRef.current) return;
+    prevRunningRef.current = false;
+    if (!voiceModeEnabledRef.current || isSpeakingRef.current) return;
+
+    const handles = Object.values(handlesRef.current);
+    const text = handles[0]?.getLastAssistantText() ?? "";
+    if (!text) {
+      startDictation();
+      return;
+    }
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.onend = () => {
+      setIsSpeaking(false);
+      speechUtteranceRef.current = null;
+      if (voiceModeEnabledRef.current) startDictation();
+    };
+    utterance.onerror = () => {
+      setIsSpeaking(false);
+      speechUtteranceRef.current = null;
+    };
+    speechUtteranceRef.current = utterance;
+    window.speechSynthesis.speak(utterance);
+    setIsSpeaking(true);
+  }, [running, startDictation, handlesRef]);
+
+  useEffect(() => {
+    return () => {
+      if (speechUtteranceRef.current) {
+        window.speechSynthesis.cancel();
+      }
+    };
+  }, []);
+
+  const toggleVoiceMode = useCallback(() => {
+    const next = !voiceModeEnabled;
+    setVoiceModeEnabled(next);
+    voiceModeEnabledRef.current = next;
+    if (!next) {
+      if (speechUtteranceRef.current) {
+        window.speechSynthesis.cancel();
+        speechUtteranceRef.current = null;
+        setIsSpeaking(false);
+      }
+      if (isDictating) stopDictation();
+    }
+  }, [voiceModeEnabled, isDictating, stopDictation]);
+
   const addFiles = useCallback(
     (files: FileList | null) => {
       if (!files?.length) return;
@@ -735,6 +816,8 @@ export function SharedComposer({
       toast.error(imageUnavailableReason);
       return;
     }
+
+    if (voiceModeEnabledRef.current && isDictating) stopDictation();
 
     const content: CompareMessagePart[] = [];
     for (const { file } of pendingImages) {
@@ -1437,6 +1520,44 @@ export function SharedComposer({
               <span>Fetch</span>
             </button>
           )}
+          {typeof window !== "undefined" &&
+            "speechSynthesis" in window && (
+              <button
+                type="button"
+                onClick={toggleVoiceMode}
+                className="composer-pill-btn"
+                data-active={voiceModeEnabled ? "true" : "false"}
+                style={
+                  voiceModeEnabled
+                    ? isDictating
+                      ? { color: "rgb(34 197 94)" }
+                      : isSpeaking
+                        ? { color: "rgb(59 130 246)" }
+                        : running
+                          ? { color: "rgb(234 179 8)" }
+                          : undefined
+                    : undefined
+                }
+                aria-label={
+                  voiceModeEnabled ? "Disable voice mode" : "Enable voice mode"
+                }
+              >
+                {isSpeaking && voiceModeEnabled ? (
+                  <Volume2Icon className="size-3.5" />
+                ) : (
+                  <MicIcon className="size-3.5" />
+                )}
+                <span>
+                  {voiceModeEnabled && isDictating
+                    ? "Listening"
+                    : voiceModeEnabled && isSpeaking
+                      ? "Speaking"
+                      : voiceModeEnabled && running
+                        ? "Thinking"
+                        : "Voice"}
+                </span>
+              </button>
+            )}
         </div>
         <div className="flex items-center gap-1">
           {dictationSupported && (

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -358,9 +358,12 @@ type ChatRuntimeStore = {
   voiceMode: "off" | "configuring" | "active";
   /** The LoRA/GGUF model ID the user has chosen for the voice slot. Persisted to localStorage. */
   selectedVoiceModelId: string | null;
+  /** Derived orb state written by VoiceToggle; consumed by VoiceOrb. */
+  voiceOrbState: "listening" | "thinking" | "speaking" | null;
   hydratePersistedSettings: () => Promise<void>;
   setVoiceMode: (mode: "off" | "configuring" | "active") => void;
   setSelectedVoiceModelId: (id: string | null) => void;
+  setVoiceOrbState: (state: "listening" | "thinking" | "speaking" | null) => void;
   setModelLoading: (loading: boolean) => void;
   setModelRequiresTrustRemoteCode: (required: boolean) => void;
   setParams: (params: InferenceParams) => void;
@@ -687,6 +690,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   activeNativePathToken: null,
   voiceMode: "off" as const,
   selectedVoiceModelId: loadString(CHAT_VOICE_MODEL_ID_KEY, "") || null,
+  voiceOrbState: null,
   hydratePersistedSettings: async () => {
     if (get().settingsHydrated) {
       return;
@@ -726,6 +730,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     return settingsHydrationPromise;
   },
   setVoiceMode: (voiceMode) => set({ voiceMode }),
+  setVoiceOrbState: (voiceOrbState) => set({ voiceOrbState }),
   setSelectedVoiceModelId: (selectedVoiceModelId) =>
     set(() => {
       saveString(CHAT_VOICE_MODEL_ID_KEY, selectedVoiceModelId ?? "");

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -35,6 +35,7 @@ export const CHAT_ALLOW_ARTIFACT_NETWORK_ACCESS_KEY =
 export const CHAT_MCP_ENABLED_KEY = "unsloth_chat_mcp_enabled";
 export const CHAT_WEB_FETCH_TOOLS_ENABLED_KEY =
   "unsloth_chat_web_fetch_tools_enabled";
+const CHAT_VOICE_MODEL_ID_KEY = "unsloth_chat_voice_model_id";
 
 // External provider selection is encoded into `params.checkpoint` as
 // `external::<providerId>::<modelId>`. PersistedChatSettings deliberately
@@ -347,7 +348,19 @@ type ChatRuntimeStore = {
   } | null;
   modelLoading: boolean;
   activeNativePathToken: string | null;
+  /**
+   * Voice conversation mode state (set by VoiceToggle / voice selector).
+   * - "off"         — pill inactive
+   * - "configuring" — pill armed, dropdown visible, loop NOT started
+   * - "active"      — loop running (mic auto-start enabled)
+   * Not persisted — resets to "off" on page load.
+   */
+  voiceMode: "off" | "configuring" | "active";
+  /** The LoRA/GGUF model ID the user has chosen for the voice slot. Persisted to localStorage. */
+  selectedVoiceModelId: string | null;
   hydratePersistedSettings: () => Promise<void>;
+  setVoiceMode: (mode: "off" | "configuring" | "active") => void;
+  setSelectedVoiceModelId: (id: string | null) => void;
   setModelLoading: (loading: boolean) => void;
   setModelRequiresTrustRemoteCode: (required: boolean) => void;
   setParams: (params: InferenceParams) => void;
@@ -672,6 +685,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   contextUsage: null,
   modelLoading: false,
   activeNativePathToken: null,
+  voiceMode: "off" as const,
+  selectedVoiceModelId: loadString(CHAT_VOICE_MODEL_ID_KEY, "") || null,
   hydratePersistedSettings: async () => {
     if (get().settingsHydrated) {
       return;
@@ -710,6 +725,12 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     })();
     return settingsHydrationPromise;
   },
+  setVoiceMode: (voiceMode) => set({ voiceMode }),
+  setSelectedVoiceModelId: (selectedVoiceModelId) =>
+    set(() => {
+      saveString(CHAT_VOICE_MODEL_ID_KEY, selectedVoiceModelId ?? "");
+      return { selectedVoiceModelId };
+    }),
   setModelLoading: (loading) => set({ modelLoading: loading }),
   setModelRequiresTrustRemoteCode: (modelRequiresTrustRemoteCode) =>
     set({ modelRequiresTrustRemoteCode }),

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -23,6 +23,7 @@ export interface BackendLoraInfo {
   base_model?: string | null;
   source?: "training" | "exported" | null;
   export_type?: "lora" | "merged" | "gguf" | null;
+  audio_type?: string | null;
 }
 
 export interface ListLorasResponse {

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -56,4 +56,5 @@ export interface ChatLoraSummary {
   updatedAt?: number;
   source?: "training" | "exported";
   exportType?: "lora" | "merged" | "gguf";
+  audioType?: string | null;
 }

--- a/studio/frontend/src/speech-recognition.d.ts
+++ b/studio/frontend/src/speech-recognition.d.ts
@@ -32,6 +32,7 @@ interface SpeechRecognition extends EventTarget {
   continuous: boolean;
   interimResults: boolean;
   lang: string;
+  onstart: (() => void) | null;
   onresult: ((event: SpeechRecognitionEvent) => void) | null;
   onerror: ((event: Event) => void) | null;
   onend: (() => void) | null;


### PR DESCRIPTION
## Summary

Adds voice features to Unsloth Studio:

1. **Voice conversation mode** — ChatGPT-style continuous voice chat with your LLM. Toggle the Voice pill, pick a voice, talk to your model and hear it respond.
2. **Listen button on trained TTS models** — fixes the broken workflow where users fine-tune Orpheus/CSM/Spark/DAC models in Studio but can't hear them without leaving the app. Type text, click play, hear your trained voice.
3. **Two-slot architecture** — LLM brain in the main slot, TTS voice in a temporary secondary slot. Voice slot only activates when voice mode is on, unloads when off. Normal chat is unchanged.

## What's new

**Backend**
- `POST /api/audio/speech` — wraps existing TTS infrastructure into an OpenAI-style endpoint returning raw WAV
- `POST /api/inference/voice/load` / `unload` / `GET status` — independent second `LlamaCppBackend` instance for TTS, restricted to `snac` / `bicodec` / `dac` audio types
- `_owns_codec` flag so main-slot unload doesn't kill the voice slot's codec
- `audio_type` detection threaded through trained LoRA scanning
- CSP `media-src 'self' blob:` so Safari can play the WAV blobs

**Frontend**
- Speaker button on every assistant message
- Voice pill in chat composer with three states: off / configuring / active
- Voice model selector dropdown next to "Select Model" (only shows when voice mode is on)
- Two-step toggle: pill enters configuring, dropdown pick activates the loop
- Auto-speak responses + auto-listen loop with 1.5s silence auto-send
- `useTtsPlayer` hook chooses backend TTS when a voice model is loaded, falls back to `speechSynthesis` otherwise
- Listen button (headphones icon) on TTS-only LoRA rows in the Fine-tuned tab → modal with text input + play
- Safari autoplay unlock via priming a persistent Audio element on the toggle click
- Pre-download confirmation if a picked voice model is >100MB and not cached (per Mike's feedback)

## How to test

1. Load any LLM as your chat brain (e.g. Qwen3-0.6B)
2. Toggle the Voice pill — dropdown appears
3. Pick "Browser voice" → conversation runs with robot TTS
4. Or pick a TTS model (e.g. Orpheus, downloads if not cached) → conversation runs with that voice
5. For Listen button: open model picker, Fine-tuned tab, click headphones on any TTS LoRA

## Known limitations

- Tested end-to-end in Safari; Chrome has a separate `SpeechRecognition` permission quirk on `http://localhost` that breaks the existing dictate button too (not introduced by this PR)
- TTS inference speed is model-bound and hardware-bound — Orpheus 3B is slow on CPU-only Macs
- Text normalization (e.g. `+` → "plus") isn't done before sending to TTS yet — would be a small follow-up

## What's coming next (follow-up commits)

- Barge-in: interrupt TTS when user starts speaking
- Orb animation for voice mode
