### PR TITLE
fix(rocm): stop overwriting ROCR_VISIBLE_DEVICES in apply_gpu_ids

### DIFF
--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1818,7 +1818,13 @@ def apply_gpu_ids(gpu_ids) -> None:
             )
     if _is_rocm:
         os.environ["HIP_VISIBLE_DEVICES"] = value
-        os.environ["ROCR_VISIBLE_DEVICES"] = value
+        # ROCR_VISIBLE_DEVICES operates at the HSA agent level and uses
+        # different indexing semantics to HIP_VISIBLE_DEVICES. Setting it
+        # to a physical GPU index breaks multi-GPU ROCm systems where the
+        # parent already set ROCR_VISIBLE_DEVICES (e.g. "0,1"): narrowing
+        # to "1" causes torch.cuda.is_available() to return False in the
+        # worker subprocess. HIP_VISIBLE_DEVICES is sufficient for GPU
+        # selection on ROCm -- leave ROCR_VISIBLE_DEVICES inherited.
     _visible_gpu_count = None
     if _is_rocm:
         logger.info("Applied gpu_ids: CUDA_VISIBLE_DEVICES='%s' (rocm)", value)

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -1614,14 +1614,18 @@ class TestApplyGpuIdsRocmFallback:
         func_body = source[func_start : source.find("\ndef ", func_start + 1)]
         assert 'getattr(_torch.version, "hip", None)' in func_body
 
-    def test_apply_gpu_ids_sets_hip_and_rocr_visible_devices(self):
-        """apply_gpu_ids should set both HIP_VISIBLE_DEVICES and ROCR_VISIBLE_DEVICES on ROCm."""
+    def test_apply_gpu_ids_sets_hip_but_not_rocr_visible_devices(self):
+        """apply_gpu_ids should set HIP_VISIBLE_DEVICES but leave ROCR_VISIBLE_DEVICES inherited.
+
+        ROCR_VISIBLE_DEVICES uses HSA agent-level indexing, not physical GPU indices.
+        Overwriting it breaks multi-GPU ROCm systems (see issue #6118).
+        """
         hw_path = PACKAGE_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
         source = hw_path.read_text(encoding = "utf-8")
         func_start = source.find("def apply_gpu_ids")
         func_body = source[func_start : source.find("\ndef ", func_start + 1)]
         assert 'os.environ["HIP_VISIBLE_DEVICES"] = value' in func_body
-        assert 'os.environ["ROCR_VISIBLE_DEVICES"] = value' in func_body
+        assert 'os.environ["ROCR_VISIBLE_DEVICES"] = value' not in func_body
 
     def test_apply_gpu_ids_rocm_fallback_is_guarded_by_try_except(self):
         """torch import in apply_gpu_ids must be wrapped in try/except so a missing torch never crashes."""


### PR DESCRIPTION
Fixes #6118

## Problem

`apply_gpu_ids()` sets all three visibility env vars to the same physical GPU index:

```
CUDA_VISIBLE_DEVICES=1
HIP_VISIBLE_DEVICES=1
ROCR_VISIBLE_DEVICES=1
```

`ROCR_VISIBLE_DEVICES` operates at the HSA agent level and uses different indexing semantics to `HIP_VISIBLE_DEVICES`. On multi-GPU ROCm systems where the parent set `ROCR_VISIBLE_DEVICES=0,1`, narrowing it to `1` causes the ROCr runtime to expose only one agent, but `HIP_VISIBLE_DEVICES=1` then asks for index 1 from a list that only has index 0, making `torch.cuda.is_available()` return False in the training worker. GPU 0 works by coincidence (index 0 exists in both views), GPU 1 and above fail.

## Fix

Stop setting `ROCR_VISIBLE_DEVICES` in `apply_gpu_ids()`. `HIP_VISIBLE_DEVICES` is sufficient for GPU selection on ROCm. `_get_parent_visible_gpu_spec()` already prefers `HIP_VISIBLE_DEVICES` over `ROCR_VISIBLE_DEVICES` when both are set, so leaving `ROCR_VISIBLE_DEVICES` inherited from the parent is safe and correct.

## Testing

Verified fix logic against `_get_parent_visible_gpu_spec()`: with `HIP_VISIBLE_DEVICES=1` set and `ROCR_VISIBLE_DEVICES=0,1` inherited, the spec function reads `HIP_VISIBLE_DEVICES` first and correctly resolves `numeric_ids=[1]`.

Hardware test needed: 2x AMD ROCm GPU system selecting GPU 1 for training (reporter's setup: 2x RX 9070 XT, ROCm 7.2.4, OpenSUSE Tumbleweed).