### PR TITLE
fix(rocm): cap RDNA2 to rocm6.4 torch and fix inference crash on gfx1030-gfx1036

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2046,13 +2046,24 @@ case "$TORCH_INDEX_URL" in
             gfx1030|gfx1031|gfx1032|gfx1033|gfx1034|gfx1035|gfx1036)
                 _pytorch_base="${UNSLOTH_PYTORCH_MIRROR:-https://download.pytorch.org/whl}"
                 _pytorch_base="${_pytorch_base%/}"
+                # rocm6.2 wheels only go up to Python 3.12 (cp312). For Python 3.13+
+                # use rocm6.4 which ships torch 2.7.x with cp313 wheels and is also
+                # a stable (non-dev) build that works on RDNA2.
+                _py_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null || echo "12")
+                if [ "$_py_minor" -ge 13 ] 2>/dev/null; then
+                    _rdna2_rocm_tag="rocm6.4"
+                    _rdna2_torch_ver="2.7.x"
+                else
+                    _rdna2_rocm_tag="rocm6.2"
+                    _rdna2_torch_ver="2.5.x"
+                fi
                 echo "" >&2
                 echo "  [WARN] $_rdna2_runtime_gfx (RDNA2) + ROCm 7.x detected" >&2
                 echo "  [WARN] ROCm 7.x PyTorch wheels are dev/nightly builds on gfx103x" >&2
                 echo "  [WARN] and cause segfaults during unsloth import on RDNA2 hardware." >&2
-                echo "  [WARN] Capping to rocm6.2 (torch 2.7.x) -- the last stable wheel." >&2
+                echo "  [WARN] Capping to ${_rdna2_rocm_tag} (torch ${_rdna2_torch_ver}) -- the last stable wheel." >&2
                 echo "" >&2
-                TORCH_INDEX_URL="${_pytorch_base}/rocm6.2"
+                TORCH_INDEX_URL="${_pytorch_base}/${_rdna2_rocm_tag}"
                 TORCH_CONSTRAINT="torch>=2.4,<2.11.0"
                 ;;
         esac

--- a/install.sh
+++ b/install.sh
@@ -2016,12 +2016,12 @@ case "$TORCH_INDEX_URL" in
     */rocm7.*)
         _rdna2_gfx_all=""
         if command -v rocminfo >/dev/null 2>&1; then
-            _rdna2_gfx_all=$(rocminfo 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}')
+            _rdna2_gfx_all=$(rocminfo 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         fi
         if [ -z "$_rdna2_gfx_all" ] && command -v amd-smi >/dev/null 2>&1; then
-            _rdna2_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}')
+            _rdna2_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
             if [ -z "$_rdna2_gfx_all" ]; then
-                _rdna2_gfx_all=$(amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}')
+                _rdna2_gfx_all=$(amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
             fi
         fi
         _rdna2_runtime_gfx=""

--- a/install.sh
+++ b/install.sh
@@ -2006,12 +2006,12 @@ case "$TORCH_INDEX_URL" in
         fi
         ;;
 esac
-# ── RDNA2 (gfx1030-gfx1036, e.g. RX 6600/6700/6800/6900): cap to rocm6.2 ────
+# ── RDNA2 (gfx1030-gfx1036, e.g. RX 6600/6700/6800/6900): cap to stable ROCm ──
 # ROCm 7.x PyTorch wheels for gfx103x are dev/nightly builds (version string
 # contains a git hash like 2.10.0+rocm7.2.0.gitXXXXXXXX) that segfault during
-# unsloth import on RDNA2.  The last stable, tested wheel is rocm6.2 (torch
-# 2.7.x).  When the system has ROCm 7.x but the runtime GPU is RDNA2, override
-# TORCH_INDEX_URL to the rocm6.2 index so users get a stable install.
+# unsloth import on RDNA2.  When the runtime GPU is RDNA2, override
+# TORCH_INDEX_URL: rocm6.2 for Python <=3.12, rocm6.4 for Python 3.13+
+# (rocm6.2 wheels top out at cp312; rocm6.4 ships stable cp313 wheels).
 case "$TORCH_INDEX_URL" in
     */rocm7.*)
         _rdna2_gfx_all=""

--- a/install.sh
+++ b/install.sh
@@ -2006,6 +2006,58 @@ case "$TORCH_INDEX_URL" in
         fi
         ;;
 esac
+# ── RDNA2 (gfx1030-gfx1036, e.g. RX 6600/6700/6800/6900): cap to rocm6.2 ────
+# ROCm 7.x PyTorch wheels for gfx103x are dev/nightly builds (version string
+# contains a git hash like 2.10.0+rocm7.2.0.gitXXXXXXXX) that segfault during
+# unsloth import on RDNA2.  The last stable, tested wheel is rocm6.2 (torch
+# 2.7.x).  When the system has ROCm 7.x but the runtime GPU is RDNA2, override
+# TORCH_INDEX_URL to the rocm6.2 index so users get a stable install.
+case "$TORCH_INDEX_URL" in
+    */rocm7.*)
+        _rdna2_gfx_all=""
+        if command -v rocminfo >/dev/null 2>&1; then
+            _rdna2_gfx_all=$(rocminfo 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}')
+        fi
+        if [ -z "$_rdna2_gfx_all" ] && command -v amd-smi >/dev/null 2>&1; then
+            _rdna2_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}')
+            if [ -z "$_rdna2_gfx_all" ]; then
+                _rdna2_gfx_all=$(amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}')
+            fi
+        fi
+        _rdna2_runtime_gfx=""
+        if [ -n "$_rdna2_gfx_all" ]; then
+            _vis="${HIP_VISIBLE_DEVICES:-${ROCR_VISIBLE_DEVICES:-}}"
+            _idx=0
+            if [ -n "$_vis" ] && [ "$_vis" != "-1" ]; then
+                _first=${_vis%%,*}
+                case "$_first" in
+                    ''|*[!0-9]*) _idx=0 ;;
+                    *) _idx=$_first ;;
+                esac
+            fi
+            _rdna2_runtime_gfx=$(printf '%s\n' "$_rdna2_gfx_all" | awk -v idx="$_idx" '
+                NF && !seen[$0]++ { vals[n++] = $0 }
+                END {
+                    if (idx < 0 || idx >= n) idx = 0
+                    if (n > 0) print vals[idx]
+                }')
+        fi
+        case "$_rdna2_runtime_gfx" in
+            gfx1030|gfx1031|gfx1032|gfx1033|gfx1034|gfx1035|gfx1036)
+                _pytorch_base="${UNSLOTH_PYTORCH_MIRROR:-https://download.pytorch.org/whl}"
+                _pytorch_base="${_pytorch_base%/}"
+                echo "" >&2
+                echo "  [WARN] $_rdna2_runtime_gfx (RDNA2) + ROCm 7.x detected" >&2
+                echo "  [WARN] ROCm 7.x PyTorch wheels are dev/nightly builds on gfx103x" >&2
+                echo "  [WARN] and cause segfaults during unsloth import on RDNA2 hardware." >&2
+                echo "  [WARN] Capping to rocm6.2 (torch 2.7.x) -- the last stable wheel." >&2
+                echo "" >&2
+                TORCH_INDEX_URL="${_pytorch_base}/rocm6.2"
+                TORCH_CONSTRAINT="torch>=2.4,<2.11.0"
+                ;;
+        esac
+        ;;
+esac
 _TAURI_TORCH_INDEX_FAMILY=$(_tauri_torch_index_family "$TORCH_INDEX_URL")
 if [ "$_amd_gpu_radeon" = true ] && [ "$SKIP_TORCH" = false ]; then
     _TAURI_TORCH_INDEX_FAMILY="radeon"

--- a/install.sh
+++ b/install.sh
@@ -2064,7 +2064,8 @@ case "$TORCH_INDEX_URL" in
                 echo "  [WARN] Capping to ${_rdna2_rocm_tag} (torch ${_rdna2_torch_ver}) -- the last stable wheel." >&2
                 echo "" >&2
                 TORCH_INDEX_URL="${_pytorch_base}/${_rdna2_rocm_tag}"
-                TORCH_CONSTRAINT="torch>=2.4,<2.11.0"
+                # TORCH_CONSTRAINT keeps its default (torch>=2.4,<2.11.0) which
+                # covers both the rocm6.2 and rocm6.4 wheel ranges.
                 ;;
         esac
         ;;

--- a/install.sh
+++ b/install.sh
@@ -2085,8 +2085,18 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
     _gpu_disp_mkt=""
     if command -v rocminfo >/dev/null 2>&1; then
         _gpu_disp_gfx_all=$(rocminfo 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-        _gpu_disp_mkt=$(rocminfo 2>/dev/null | awk -F': ' \
-            '/Marketing Name:/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
+        _gpu_disp_mkt=$(rocminfo 2>/dev/null | awk '
+            # rocminfo lists CPU agents before GPU agents; each agent block has
+            # a "Name:" line (gfx code for GPUs, CPU name for CPUs) followed by
+            # "Marketing Name:". Only emit the Marketing Name from GPU agents
+            # (identified by having a gfx ISA in their Name field).
+            /^Agent [0-9]/ { in_gpu_agent=0 }
+            /Name:/ && /gfx[0-9]/ { in_gpu_agent=1 }
+            /Marketing Name:/ && in_gpu_agent {
+                sub(/.*Marketing Name:[[:space:]]*/,"")
+                gsub(/^[[:space:]]+|[[:space:]]+$/,"")
+                if ($0 != "") { print; exit }
+            }' || true)
     fi
     if [ -z "$_gpu_disp_gfx_all" ] && command -v amd-smi >/dev/null 2>&1; then
         _gpu_disp_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -420,10 +420,12 @@ class InferenceBackend:
             # AMD RDNA2 (gfx1030-gfx1036, e.g. RX 6600) crashes with an LLVM error
             # ("Cannot select: intrinsic %llvm.amdgcn.fdot2.bf16.bf16") at the first
             # bf16 kernel dispatch when dtype=None lets unsloth auto-pick bf16.
-            # models/_utils.py now sets SUPPORTS_BFLOAT16=False for RDNA2, which
-            # makes unsloth's loader and Triton kernels use fp16 paths. This block
-            # is belt-and-suspenders: it forces dtype=float16 at load time even if
-            # rocminfo was unavailable during _utils.py import and the flag stayed True.
+            # models/_utils.py now sets SUPPORTS_BFLOAT16=False for RDNA2 so
+            # unsloth's loader and Triton kernels use fp16 paths. This block is
+            # belt-and-suspenders: forces dtype=float16 at load time in case arch
+            # detection failed at import time and the flag stayed True.
+            # Uses gcnArchName from already-initialized torch device properties
+            # (no subprocess, no extra HIP context initialization).
             _is_rocm = (
                 bool(getattr(torch.version, "hip", None))
                 or "rocm" in torch.__version__.lower()
@@ -434,16 +436,12 @@ class InferenceBackend:
                     {"gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036"}
                 )
                 try:
-                    import re
-                    import subprocess
-
-                    _ri = subprocess.run(
-                        ["rocminfo"], capture_output = True, text = True, timeout = 5
-                    )
-                    _is_rdna2 = any(
-                        c in _RDNA2_GFX
-                        for c in re.findall(r"gfx[0-9a-z]+", _ri.stdout.lower())
-                    )
+                    _hip_arch = ""
+                    if torch.cuda.is_available() and torch.cuda.device_count() > 0:
+                        _hip_arch = getattr(
+                            torch.cuda.get_device_properties(0), "gcnArchName", ""
+                        ).lower()
+                    _is_rdna2 = _hip_arch in _RDNA2_GFX
                 except Exception:
                     pass
             _auto_dtype = torch.float16 if _is_rdna2 else None

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -438,9 +438,11 @@ class InferenceBackend:
                 try:
                     _hip_arch = ""
                     if torch.cuda.is_available() and torch.cuda.device_count() > 0:
-                        _hip_arch = getattr(
-                            torch.cuda.get_device_properties(0), "gcnArchName", ""
-                        ).lower()
+                        _props = torch.cuda.get_device_properties(0)
+                        for _attr in ("gcnArchName", "gcn_arch_name", "arch_name", "gfx_arch_name"):
+                            _hip_arch = getattr(_props, _attr, "").lower()
+                            if _hip_arch:
+                                break
                     _is_rdna2 = _hip_arch in _RDNA2_GFX
                 except Exception:
                     pass

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -3,7 +3,7 @@
 
 """Core inference backend."""
 
-from unsloth import FastLanguageModel, FastVisionModel
+from unsloth import FastLanguageModel, FastVisionModel, is_bfloat16_supported
 from unsloth.chat_templates import get_chat_template
 from transformers import TextStreamer
 from peft import PeftModel, PeftModelForCausalLM
@@ -417,13 +417,26 @@ class InferenceBackend:
             logger.info(f"Loading {model_type} model{adapter_info}: {model_name}")
             log_gpu_memory(f"Before loading {model_name}")
 
-            # Same load path for base models and LoRA adapters
+            # AMD ROCm hardware without native bfloat16 (e.g. RDNA2 / gfx103x) crashes
+            # with an LLVM error at the first bf16 kernel dispatch when dtype=None lets
+            # unsloth auto-pick bf16. Force float16 there. NVIDIA keeps dtype=None so
+            # unsloth's own bf16/fp16/float32 auto-detection is honored.
+            _is_rocm = (
+                bool(getattr(torch.version, "hip", None))
+                or "rocm" in torch.__version__.lower()
+            )
+            _auto_dtype = (
+                torch.float16 if (_is_rocm and not is_bfloat16_supported()) else None
+            )
+            _effective_dtype = dtype if dtype is not None else _auto_dtype
+
+            # Load model - same approach for base models and LoRA adapters
             if config.is_vision:
                 # Vision model (or vision LoRA adapter)
                 model, processor = FastVisionModel.from_pretrained(
                     model_name = config.path,  # Can be base model OR LoRA adapter path
                     max_seq_length = max_seq_length,
-                    dtype = dtype,
+                    dtype = _effective_dtype,
                     load_in_4bit = load_in_4bit,
                     device_map = device_map,
                     token = hf_token if hf_token and hf_token.strip() else None,
@@ -472,7 +485,7 @@ class InferenceBackend:
                 model, tokenizer = FastLanguageModel.from_pretrained(
                     model_name = config.path,  # Can be base model OR LoRA adapter path
                     max_seq_length = max_seq_length,
-                    dtype = dtype,
+                    dtype = _effective_dtype,
                     load_in_4bit = load_in_4bit,
                     device_map = device_map,
                     token = hf_token if hf_token and hf_token.strip() else None,

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -417,17 +417,28 @@ class InferenceBackend:
             logger.info(f"Loading {model_type} model{adapter_info}: {model_name}")
             log_gpu_memory(f"Before loading {model_name}")
 
-            # AMD ROCm hardware without native bfloat16 (e.g. RDNA2 / gfx103x) crashes
-            # with an LLVM error at the first bf16 kernel dispatch when dtype=None lets
-            # unsloth auto-pick bf16. Force float16 there. NVIDIA keeps dtype=None so
-            # unsloth's own bf16/fp16/float32 auto-detection is honored.
-            _is_rocm = (
-                bool(getattr(torch.version, "hip", None))
-                or "rocm" in torch.__version__.lower()
-            )
-            _auto_dtype = (
-                torch.float16 if (_is_rocm and not is_bfloat16_supported()) else None
-            )
+            # AMD RDNA2 (gfx1030-gfx1036, e.g. RX 6600) crashes with an LLVM error
+            # ("Cannot select: intrinsic %llvm.amdgcn.fdot2.bf16.bf16") at the first
+            # bf16 kernel dispatch when dtype=None lets unsloth auto-pick bf16.
+            # NOTE: unsloth's is_bfloat16_supported() returns True unconditionally for
+            # ALL HIP devices (see models/_utils.py DEVICE_TYPE=="hip" branch), so we
+            # cannot rely on it here. Detect RDNA2 by gfx architecture code instead.
+            _is_rocm = bool(getattr(torch.version, "hip", None)) or "rocm" in torch.__version__.lower()
+            _is_rdna2 = False
+            if _is_rocm:
+                _RDNA2_GFX = frozenset(
+                    {"gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036"}
+                )
+                try:
+                    import subprocess as _sp, re as _re
+                    _ri = _sp.run(["rocminfo"], capture_output=True, text=True, timeout=5)
+                    _is_rdna2 = any(
+                        c in _RDNA2_GFX
+                        for c in _re.findall(r"gfx[0-9a-z]+", _ri.stdout.lower())
+                    )
+                except Exception:
+                    pass
+            _auto_dtype = torch.float16 if _is_rdna2 else None
             _effective_dtype = dtype if dtype is not None else _auto_dtype
 
             # Load model - same approach for base models and LoRA adapters

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -3,7 +3,7 @@
 
 """Core inference backend."""
 
-from unsloth import FastLanguageModel, FastVisionModel, is_bfloat16_supported
+from unsloth import FastLanguageModel, FastVisionModel
 from unsloth.chat_templates import get_chat_template
 from transformers import TextStreamer
 from peft import PeftModel, PeftModelForCausalLM
@@ -430,11 +430,15 @@ class InferenceBackend:
                     {"gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036"}
                 )
                 try:
-                    import subprocess as _sp, re as _re
-                    _ri = _sp.run(["rocminfo"], capture_output=True, text=True, timeout=5)
+                    import re
+                    import subprocess
+
+                    _ri = subprocess.run(
+                        ["rocminfo"], capture_output = True, text = True, timeout = 5
+                    )
                     _is_rdna2 = any(
                         c in _RDNA2_GFX
-                        for c in _re.findall(r"gfx[0-9a-z]+", _ri.stdout.lower())
+                        for c in re.findall(r"gfx[0-9a-z]+", _ri.stdout.lower())
                     )
                 except Exception:
                     pass

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -420,10 +420,14 @@ class InferenceBackend:
             # AMD RDNA2 (gfx1030-gfx1036, e.g. RX 6600) crashes with an LLVM error
             # ("Cannot select: intrinsic %llvm.amdgcn.fdot2.bf16.bf16") at the first
             # bf16 kernel dispatch when dtype=None lets unsloth auto-pick bf16.
-            # NOTE: unsloth's is_bfloat16_supported() returns True unconditionally for
-            # ALL HIP devices (see models/_utils.py DEVICE_TYPE=="hip" branch), so we
-            # cannot rely on it here. Detect RDNA2 by gfx architecture code instead.
-            _is_rocm = bool(getattr(torch.version, "hip", None)) or "rocm" in torch.__version__.lower()
+            # models/_utils.py now sets SUPPORTS_BFLOAT16=False for RDNA2, which
+            # makes unsloth's loader and Triton kernels use fp16 paths. This block
+            # is belt-and-suspenders: it forces dtype=float16 at load time even if
+            # rocminfo was unavailable during _utils.py import and the flag stayed True.
+            _is_rocm = (
+                bool(getattr(torch.version, "hip", None))
+                or "rocm" in torch.__version__.lower()
+            )
             _is_rdna2 = False
             if _is_rocm:
                 _RDNA2_GFX = frozenset(

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -462,7 +462,11 @@ class InferenceBackend:
                     trust_remote_code = trust_remote_code,
                 )
 
-                FastVisionModel.for_inference(model)
+                # Skip unsloth's Triton kernel patching on RDNA2: the compiled
+                # HIP modules fail to load on gfx103x, crashing with
+                # "Module not initialized". Stock transformers inference works.
+                if not _is_rdna2:
+                    FastVisionModel.for_inference(model)
 
                 # FastVisionModel may return a raw tokenizer instead of a
                 # Processor for some models (e.g. Gemma-3); load the real one.
@@ -511,7 +515,11 @@ class InferenceBackend:
                     trust_remote_code = trust_remote_code,
                 )
 
-                FastLanguageModel.for_inference(model)
+                # Skip unsloth's Triton kernel patching on RDNA2: the compiled
+                # HIP modules fail to load on gfx103x, crashing with
+                # "Module not initialized". Stock transformers inference works.
+                if not _is_rdna2:
+                    FastLanguageModel.for_inference(model)
 
                 self.models[model_name]["model"] = model
                 self.models[model_name]["tokenizer"] = tokenizer

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -427,8 +427,7 @@ class InferenceBackend:
             # Uses gcnArchName from already-initialized torch device properties
             # (no subprocess, no extra HIP context initialization).
             _is_rocm = (
-                bool(getattr(torch.version, "hip", None))
-                or "rocm" in torch.__version__.lower()
+                bool(getattr(torch.version, "hip", None)) or "rocm" in torch.__version__.lower()
             )
             _is_rdna2 = False
             if _is_rocm:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -674,12 +674,10 @@ def _ensure_rocm_torch() -> None:
 
     # RDNA2 (gfx1030-gfx1036, e.g. RX 6600/6700/6800/6900) cap
     # ─────────────────────────────────────────────────────────────
-    # ROCm 7.x PyTorch builds are unstable on RDNA2: the gfx103x PyTorch wheels
-    # for ROCm 7.x are dev/nightly builds (version suffix .gitXXXXXXXX) that
-    # segfault during unsloth import on these GPUs.  The last stable, tested
-    # PyTorch for RDNA2 is the rocm6.2 wheel.  When the runtime GPU is RDNA2
-    # and the system has ROCm 7.x installed, override the tag selection to
-    # rocm6.2 so users get a stable torch regardless of their ROCm stack version.
+    # ROCm 7.x PyTorch builds are unstable on RDNA2: the gfx103x wheels are
+    # dev/nightly builds (version suffix .gitXXXXXXXX) that segfault during
+    # unsloth import.  Cap to the last stable wheel: rocm6.2 for Python <=3.12,
+    # rocm6.4 for Python 3.13+ (rocm6.2 tops out at cp312).
     _RDNA2_GFX = {"gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036"}
     _rdna2_cap_tag: "str | None" = None
     if ver >= (7, 0):

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -682,9 +682,7 @@ def _ensure_rocm_torch() -> None:
     _rdna2_cap_tag: "str | None" = None
     if ver >= (7, 0):
         gfx_codes = _detect_amd_gfx_codes()
-        _runtime_gfx = (
-            gfx_codes[_pick_visible_index(len(gfx_codes))] if gfx_codes else None
-        )
+        _runtime_gfx = gfx_codes[_pick_visible_index(len(gfx_codes))] if gfx_codes else None
         if _runtime_gfx in _RDNA2_GFX:
             # rocm6.2 only has wheels up to Python 3.12 (cp312). For Python 3.13+
             # use rocm6.4 which ships torch 2.7.x with cp313 wheels and is also a
@@ -791,7 +789,9 @@ def _ensure_rocm_torch() -> None:
         else:
             index_url = f"{_PYTORCH_WHL_BASE}/{tag}"
             if _rdna2_cap_tag is not None:
-                print(f"   RDNA2 cap (system ROCm {ver[0]}.{ver[1]}) -- installing torch from {index_url}")
+                print(
+                    f"   RDNA2 cap (system ROCm {ver[0]}.{ver[1]}) -- installing torch from {index_url}"
+                )
             else:
                 print(f"   ROCm {ver[0]}.{ver[1]} -- installing torch from {index_url}")
             _torch_pkg, _vision_pkg, _audio_pkg = _ROCM_TORCH_PKG_SPECS.get(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -792,7 +792,10 @@ def _ensure_rocm_torch() -> None:
             print(f"   No PyTorch wheel for ROCm {ver[0]}.{ver[1]} -- " f"skipping torch reinstall")
         else:
             index_url = f"{_PYTORCH_WHL_BASE}/{tag}"
-            print(f"   ROCm {ver[0]}.{ver[1]} -- installing torch from {index_url}")
+            if _rdna2_cap_tag is not None:
+                print(f"   RDNA2 cap (system ROCm {ver[0]}.{ver[1]}) -- installing torch from {index_url}")
+            else:
+                print(f"   ROCm {ver[0]}.{ver[1]} -- installing torch from {index_url}")
             _torch_pkg, _vision_pkg, _audio_pkg = _ROCM_TORCH_PKG_SPECS.get(
                 tag, _ROCM_TORCH_PKG_SPECS["_default"]
             )

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -672,6 +672,30 @@ def _ensure_rocm_torch() -> None:
 
     rocm_torch_ready = has_hip_torch
 
+    # RDNA2 (gfx1030-gfx1036, e.g. RX 6600/6700/6800/6900) cap
+    # ─────────────────────────────────────────────────────────────
+    # ROCm 7.x PyTorch builds are unstable on RDNA2: the gfx103x PyTorch wheels
+    # for ROCm 7.x are dev/nightly builds (version suffix .gitXXXXXXXX) that
+    # segfault during unsloth import on these GPUs.  The last stable, tested
+    # PyTorch for RDNA2 is the rocm6.2 wheel.  When the runtime GPU is RDNA2
+    # and the system has ROCm 7.x installed, override the tag selection to
+    # rocm6.2 so users get a stable torch regardless of their ROCm stack version.
+    _RDNA2_GFX = {"gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036"}
+    _rdna2_cap_tag: "str | None" = None
+    if ver >= (7, 0):
+        gfx_codes = _detect_amd_gfx_codes()
+        _runtime_gfx = (
+            gfx_codes[_pick_visible_index(len(gfx_codes))] if gfx_codes else None
+        )
+        if _runtime_gfx in _RDNA2_GFX:
+            _rdna2_cap_tag = "rocm6.2"
+            print(
+                f"\n   {_runtime_gfx} (RDNA2) detected with ROCm {ver[0]}.{ver[1]}.\n"
+                f"   ROCm 7.x PyTorch wheels are unstable on RDNA2 (dev builds that\n"
+                f"   segfault on import). Capping torch install to the last known-good\n"
+                f"   wheel: pytorch.org/whl/rocm6.2 (torch 2.7.x).\n"
+            )
+
     # Strix Halo / Strix Point (gfx1151 / gfx1150) segfault under ROCm 7.1
     # in torch._grouped_mm. AMD's per-gfx repo ships torch 2.11.0+rocm7.13.0
     # with the real fix, so route those hosts there instead of the generic
@@ -743,16 +767,22 @@ def _ensure_rocm_torch() -> None:
             constrain = False,
         )
         rocm_torch_ready = True
-    elif not has_hip_torch:
-        # Select best matching wheel tag (newest ROCm version <= installed)
-        tag = next(
-            (
-                t
-                for (maj, mn), t in sorted(_ROCM_TORCH_INDEX.items(), reverse = True)
-                if ver >= (maj, mn)
-            ),
-            None,
-        )
+    elif _rdna2_cap_tag is not None or not has_hip_torch:
+        # RDNA2 with ROCm 7.x: force the capped tag regardless of whether
+        # a hip torch is already present -- the dev build that ends up there
+        # is exactly what we need to replace.
+        # Otherwise: select best matching wheel tag (newest ROCm version <= installed).
+        if _rdna2_cap_tag is not None:
+            tag = _rdna2_cap_tag
+        else:
+            tag = next(
+                (
+                    t
+                    for (maj, mn), t in sorted(_ROCM_TORCH_INDEX.items(), reverse = True)
+                    if ver >= (maj, mn)
+                ),
+                None,
+            )
         if tag is None:
             print(f"   No PyTorch wheel for ROCm {ver[0]}.{ver[1]} -- " f"skipping torch reinstall")
         else:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -688,12 +688,17 @@ def _ensure_rocm_torch() -> None:
             gfx_codes[_pick_visible_index(len(gfx_codes))] if gfx_codes else None
         )
         if _runtime_gfx in _RDNA2_GFX:
-            _rdna2_cap_tag = "rocm6.2"
+            # rocm6.2 only has wheels up to Python 3.12 (cp312). For Python 3.13+
+            # use rocm6.4 which ships torch 2.7.x with cp313 wheels and is also a
+            # stable (non-dev) build that works on RDNA2.
+            _py = sys.version_info
+            _rdna2_cap_tag = "rocm6.2" if (_py.major, _py.minor) <= (3, 12) else "rocm6.4"
+            _cap_torch = "2.5.x" if _rdna2_cap_tag == "rocm6.2" else "2.7.x"
             print(
                 f"\n   {_runtime_gfx} (RDNA2) detected with ROCm {ver[0]}.{ver[1]}.\n"
                 f"   ROCm 7.x PyTorch wheels are unstable on RDNA2 (dev builds that\n"
                 f"   segfault on import). Capping torch install to the last known-good\n"
-                f"   wheel: pytorch.org/whl/rocm6.2 (torch 2.7.x).\n"
+                f"   wheel: pytorch.org/whl/{_rdna2_cap_tag} (torch {_cap_torch}).\n"
             )
 
     # Strix Halo / Strix Point (gfx1151 / gfx1150) segfault under ROCm 7.1

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -676,8 +676,18 @@ if command -v rocminfo >/dev/null 2>&1 && \
    rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx[1-9][0-9]/{found=1} END{exit !found}'; then
     _setup_amd_detected=true
     _setup_gfx_all=$(rocminfo 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-    _setup_mkt=$(rocminfo 2>/dev/null | awk -F': ' \
-        '/Marketing Name:/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
+    _setup_mkt=$(rocminfo 2>/dev/null | awk '
+            # rocminfo lists CPU agents before GPU agents; each agent block has
+            # a "Name:" line (gfx code for GPUs, CPU name for CPUs) followed by
+            # "Marketing Name:". Only emit the Marketing Name from GPU agents
+            # (identified by having a gfx ISA in their Name field).
+            /^Agent [0-9]/ { in_gpu_agent=0 }
+            /Name:/ && /gfx[0-9]/ { in_gpu_agent=1 }
+            /Marketing Name:/ && in_gpu_agent {
+                sub(/.*Marketing Name:[[:space:]]*/,"")
+                gsub(/^[[:space:]]+|[[:space:]]+$/,"")
+                if ($0 != "") { print; exit }
+            }' || true)
 elif command -v amd-smi >/dev/null 2>&1 && \
      amd-smi list 2>/dev/null | awk '/^GPU[[:space:]]*[:\[][[:space:]]*[0-9]/{ found=1 } END{ exit !found }'; then
     _setup_amd_detected=true

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1225,7 +1225,24 @@ if DEVICE_TYPE == "cuda":
         # Tri Dao's benchmark shows xformers is faster for now.
         HAS_FLASH_ATTENTION = False
 elif DEVICE_TYPE == "hip":
-    SUPPORTS_BFLOAT16 = True
+    # RDNA2 (gfx1030-gfx1036, e.g. RX 6600/6700/6800/6900) lacks the bf16
+    # dot-product intrinsic (%llvm.amdgcn.fdot2.bf16.bf16) used by some Triton
+    # kernels. Detect via rocminfo and mark bf16 as unsupported on those GPUs so
+    # unsloth's kernel selector falls back to fp16 paths for both loading and
+    # generation. All other ROCm GPUs (RDNA3+, CDNA) keep bf16 enabled.
+    _RDNA2_GFX = frozenset(
+        {"gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036"}
+    )
+    try:
+        import subprocess
+
+        _rocm_info = subprocess.run(
+            ["rocminfo"], capture_output=True, text=True, timeout=5
+        )
+        _detected_gfx = set(re.findall(r"gfx[0-9a-z]+", _rocm_info.stdout.lower()))
+        SUPPORTS_BFLOAT16 = not bool(_detected_gfx & _RDNA2_GFX)
+    except Exception:
+        SUPPORTS_BFLOAT16 = True  # assume supported if rocminfo unavailable
     if _is_package_available("flash_attn"):
         # Check for CUDA linking errors "undefined symbol: _ZNK3c106SymIntltEl"
         try:

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1238,10 +1238,13 @@ elif DEVICE_TYPE == "hip":
     try:
         _hip_arch = ""
         if torch.cuda.is_available() and torch.cuda.device_count() > 0:
-            _hip_arch = getattr(
-                torch.cuda.get_device_properties(0), "gcnArchName", ""
-            ).lower()
-        SUPPORTS_BFLOAT16 = _hip_arch not in _RDNA2_GFX
+            _props = torch.cuda.get_device_properties(0)
+            # Try known attribute spellings across ROCm torch versions
+            for _attr in ("gcnArchName", "gcn_arch_name", "arch_name", "gfx_arch_name"):
+                _hip_arch = getattr(_props, _attr, "").lower()
+                if _hip_arch:
+                    break
+        SUPPORTS_BFLOAT16 = _hip_arch not in _RDNA2_GFX if _hip_arch else True
     except Exception:
         SUPPORTS_BFLOAT16 = True  # assume supported if arch detection fails
     if _is_package_available("flash_attn"):

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -1227,22 +1227,23 @@ if DEVICE_TYPE == "cuda":
 elif DEVICE_TYPE == "hip":
     # RDNA2 (gfx1030-gfx1036, e.g. RX 6600/6700/6800/6900) lacks the bf16
     # dot-product intrinsic (%llvm.amdgcn.fdot2.bf16.bf16) used by some Triton
-    # kernels. Detect via rocminfo and mark bf16 as unsupported on those GPUs so
-    # unsloth's kernel selector falls back to fp16 paths for both loading and
-    # generation. All other ROCm GPUs (RDNA3+, CDNA) keep bf16 enabled.
+    # kernels. Mark bf16 as unsupported on those GPUs so unsloth's kernel
+    # selector falls back to fp16 paths for both loading and generation.
+    # All other ROCm GPUs (RDNA3+, CDNA) keep bf16 enabled.
+    # Detection uses gcnArchName from torch device properties -- no subprocess,
+    # no extra HIP context initialization, safe to call at import time.
     _RDNA2_GFX = frozenset(
         {"gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036"}
     )
     try:
-        import subprocess
-
-        _rocm_info = subprocess.run(
-            ["rocminfo"], capture_output=True, text=True, timeout=5
-        )
-        _detected_gfx = set(re.findall(r"gfx[0-9a-z]+", _rocm_info.stdout.lower()))
-        SUPPORTS_BFLOAT16 = not bool(_detected_gfx & _RDNA2_GFX)
+        _hip_arch = ""
+        if torch.cuda.is_available() and torch.cuda.device_count() > 0:
+            _hip_arch = getattr(
+                torch.cuda.get_device_properties(0), "gcnArchName", ""
+            ).lower()
+        SUPPORTS_BFLOAT16 = _hip_arch not in _RDNA2_GFX
     except Exception:
-        SUPPORTS_BFLOAT16 = True  # assume supported if rocminfo unavailable
+        SUPPORTS_BFLOAT16 = True  # assume supported if arch detection fails
     if _is_package_available("flash_attn"):
         # Check for CUDA linking errors "undefined symbol: _ZNK3c106SymIntltEl"
         try:


### PR DESCRIPTION
Fixes https://github.com/unslothai/unsloth/issues/5337

Two bugs affecting RDNA2 (gfx1030-gfx1036, e.g. RX 6600) with ROCm 7.x:

1. **Install**: Installer selects the rocm7.x PyTorch index when ROCm 7.x is detected, landing dev/nightly PyTorch builds (e.g. 2.10.0+rocm7.2.0.gitXXXXXXXX) in the Studio venv. These segfault during unsloth import on RDNA2. Fix: detect RDNA2 gfx code at install time and cap to pytorch.org/whl/rocm6.4 (torch 2.7.x, the last stable wheel for gfx103x) in both install.sh and install_python_stack.py. On Python 3.13+ rocm6.4 is used; on Python <=3.12 rocm6.2 is used (rocm6.2 wheels top out at cp312). Also skips CPU agents when parsing rocminfo so the GPU label shows correctly.

2. **Inference**: Generation crashes with `Module not initialized` from hip_global.cpp on RDNA2. Root cause: `FastLanguageModel.for_inference()` installs custom Triton JIT kernels that have ISA-level incompatibilities with gfx103x -- the compiled HIP module binaries fail to load regardless of dtype, so `SUPPORTS_BFLOAT16=False` alone is not enough. Fix: detect RDNA2 via `gcnArchName` at load time and skip `for_inference()` on gfx1030-gfx1036, falling back to stock transformers inference. Also sets `SUPPORTS_BFLOAT16=False` in `_utils.py` for RDNA2 so unsloth's kernel selector uses fp16 paths elsewhere.

Related: #5964 (previous attempt, closed due to scope creep)