### PR TITLE
Studio: npm v12 readiness (allowScripts policy, npmrc cleanup, bun bootstrap fix)

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -69,12 +69,11 @@ jobs:
         run: python3 scripts/lockfile_supply_chain_audit.py
 
       - name: Lockfile must agree with package.json (npm ci is strict)
-        # Lifecycle scripts (esbuild native-binary postinstall, etc.) are
-        # required for `vite build`. The pre-install lockfile structural
-        # audit (lockfile_supply_chain_audit.py) is the practical defence
-        # against the npm postinstall-dropper class -- it fires BEFORE any
-        # tarball runs, on the injection pattern itself rather than an
-        # advisory-DB lookup.
+        # The vite 8 chain (rolldown, lightningcss, tailwind oxide) ships napi
+        # binaries with no install scripts. The only script-bearing deps are
+        # covered by `allowScripts` in package.json (npm >=11.16, default in
+        # npm 12). The pre-install lockfile audit above stays the first line
+        # of defence -- it fires before any tarball can run code.
         run: npm ci --no-fund --no-audit
 
       - name: npm ci must not have modified the working tree

--- a/studio/frontend/.npmrc
+++ b/studio/frontend/.npmrc
@@ -6,11 +6,8 @@
 # upstream removal. npm interprets the bare integer as DAYS; do not
 # append `d`, npm 11.x will parse `7d` as a Date string and abort.
 min-release-age=7
-# Defensive alias: `minimum-release-age` takes minutes (10080 = 7 days).
-# Some npm versions / wrappers consult one key but not the other; setting
-# both means a single setting-name parse change upstream cannot silently
-# disable the cooldown. The two keys MUST agree; do not let them drift.
-minimum-release-age=10080
+# Do not re-add the old `minimum-release-age` alias: npm >=11.16 warns on
+# unknown project configs and npm 12 stops accepting them.
 # Belt-and-braces: refuse to write back loose `^x.y.z` ranges into
 # package.json when a maintainer runs `npm install <pkg>` locally. This
 # does NOT rewrite already-present ranges (those need an explicit

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -108,5 +108,10 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.55.0",
     "vite": "^8.0.1"
+  },
+  "allowScripts": {
+    "@biomejs/biome@1.9.4": true,
+    "msw@2.14.3": true,
+    "fsevents": true
   }
 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1404,7 +1404,9 @@ if ($IsPipInstall) {
         substep "installing bun (faster frontend package installs)..."
         $prevEAP_bun = $ErrorActionPreference
         $ErrorActionPreference = "Continue"
-        Invoke-SetupCommand { npm install -g bun } | Out-Null
+        # --allow-scripts=bun: npm >=11.16 gates install scripts and bun's
+        # postinstall fetches its binary; without it the install is a broken stub.
+        Invoke-SetupCommand { npm install -g bun --allow-scripts=bun } | Out-Null
         $ErrorActionPreference = $prevEAP_bun
         Refresh-Environment
         if (Get-Command bun -ErrorAction SilentlyContinue) {

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -333,7 +333,9 @@ verbose_substep "node check: NEED_NODE=$NEED_NODE NODE_OK=${NODE_OK:-unknown} NP
 # avoids platform-specific installers, PATH issues, and admin requirements.
 if ! command -v bun &>/dev/null; then
     substep "installing bun..."
-    if run_maybe_quiet npm install -g bun && command -v bun &>/dev/null; then
+    # --allow-scripts=bun: npm >=11.16 gates install scripts and bun's
+    # postinstall fetches its binary; without it the install is a broken stub.
+    if run_maybe_quiet npm install -g bun --allow-scripts=bun && command -v bun &>/dev/null; then
         substep "bun installed ($(bun --version))"
     else
         substep "bun install skipped (npm will be used instead)"


### PR DESCRIPTION
## What

GitHub announced the npm v12 breaking changes for around July 2026 (https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/): dependency install scripts stop running unless approved via an `allowScripts` policy, and git / remote URL dependencies stop resolving by default. npm 11.16.0 already ships the whole mechanism (`npm approve-scripts`, `npm deny-scripts`, `--strict-allow-scripts`) and starts warning on every install, so this prepares Studio now.

I audited all three npm projects (`studio/frontend`, the `studio/` Tauri CLI lockfile holder, `studio/backend/core/data_recipe/oxc-validator`): zero git dependencies and zero remote URL dependencies anywhere, every `resolved` entry points at registry.npmjs.org. Script gating is the only real exposure, and only three packages in the frontend lockfile carry install scripts: `@biomejs/biome@1.9.4`, `msw@2.14.3` (transitive via shadcn) and `fsevents@2.3.3` (darwin-only optional).

## Changes

1. `studio/frontend/package.json`: commit the `allowScripts` policy. The biome and msw entries are exactly what `npm approve-scripts` writes (version pinned). `fsevents` is added by hand because the tooling cannot match a darwin-only optional dep from Linux (`ENOMATCH`), yet `--strict-allow-scripts` walks the platform independent ideal tree and flags it anyway. Older npms ignore the unknown field, verified on npm 11.9.
2. `studio/frontend/.npmrc`: drop the `minimum-release-age` alias. npm >=11.16 warns it is an unknown project config that stops working in npm 12. The canonical `min-release-age=7` stays and is honored (verified on 11.16.0 and 12.0.0-pre.0.0).
3. `studio/setup.sh` and `studio/setup.ps1`: `npm install -g bun --allow-scripts=bun`. bun's npm package fetches its binary in a postinstall, so under npm 12 defaults the global install otherwise leaves a broken stub. Setup survives that today (the binary verification catches it and falls back to npm installs), but this keeps the fast bun path working. The `allow-scripts` config is the documented mechanism for exactly this global-install context. On npm <=11.15 the flag is a one-line "Unknown cli config" warning and changes nothing.
4. `.github/workflows/studio-frontend-ci.yml`: replace the stale comment claiming esbuild postinstalls are required for `vite build`. The vite 8 chain (rolldown, lightningcss, tailwind oxide) ships napi binaries with no install scripts, so a script-free install builds fine.

## Why approve instead of deny

Denied packages skip the whole reify build step including bin linking, so denying `@biomejs/biome` silently removes `node_modules/.bin/biome` and breaks `biome:check`. Approving keeps behavior identical to today. All three scripts are benign: biome's postinstall only sanity-checks its platform binary (which arrives via optionalDependencies), msw's prints a silently caught notice, and fsevents is a darwin-only node-gyp build that the watcher stack treats as optional.

## Verification

Everything below ran against npm 11.16.0 (the release carrying the v12 machinery), with backward compat checks on npm 11.9.0:

| Scenario | Result |
| --- | --- |
| `npm ci --strict-allow-scripts` + `vite build` with this policy | pass, biome bin linked and working, CSS gate 472939 bytes |
| `npm ci --strict-allow-scripts` without the policy | fails, `ESTRICTALLOWSCRIPTS` listing exactly the 3 packages |
| `npm ci --ignore-scripts` + `vite build` (v12 skip semantics) | pass, identical build output |
| plain `npm ci` on npm 11.9 with the policy committed | pass, unknown field ignored |
| Tauri CLI holder script-free | pass, `tauri --version` -> tauri-cli 2.10.1 |
| oxc-validator script-free | pass, oxlint 1.65.0 and oxc-parser napi parse work |
| `npm install -g bun --allow-scripts=bun` under strict enforcement | pass, bun 1.3.14 functional |
| same without the flag (control) | blocked on `bun@1.3.14 (postinstall: node install.js)` |
| `npm install -g bun --allow-scripts=bun` on npm 11.9 | pass, warn-only, bun functional |

I also did a full clean-room run: fresh clone, `./install.sh --local` under a pinned `UNSLOTH_STUDIO_HOME` with install scripts globally disabled to mirror npm 12 defaults, bun hidden from PATH. The installer recovered from the broken bun stub, built the frontend over the npm path, finished the Python stack and llama.cpp, and the resulting Studio launched: healthz 200, login, forced password change, and the chat composer all render correctly in Chromium.

Syntax checks on the touched files: `bash -n` for setup.sh, a PowerShell `[scriptblock]::Create` parse for setup.ps1, `json.load` for package.json, `yaml.safe_load` for the workflow file.

## Notes

- CI is not affected today: the runner images bundle npm 10/11 and the Windows smokes pin `npm@^11`, so nothing flips until we bump Node or npm deliberately.
- After dependency bumps that change the biome or msw versions, re-run `npm approve-scripts` so the pinned entries follow (the 11.16 advisory warning will point at exactly the packages that need it).
- A follow-up could add `--strict-allow-scripts` to the Frontend CI `npm ci` once the runners carry npm >=11.16, turning unreviewed install scripts into a hard CI failure. Left out here to keep this change behavior-neutral.
