### PR TITLE
Studio: faithful conversation export and import round trips (ShareGPT system role, CSV quoted newlines)

### DIFF
--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -331,7 +331,7 @@ function messageToOpenAI(msg: { role: unknown; content: unknown; attachments?: u
   return contentParts.length > 0 ? [{ role: role as "user" | "system", content: contentParts }] : [];
 }
 
-// ShareGPT training JSONL (human/gpt turns).
+// ShareGPT training JSONL (human/system/gpt turns).
 export async function exportConversationShareGPT(threadId: string): Promise<void> {
   const messages = await loadConversationMessages(threadId);
   if (!messages) return;
@@ -339,7 +339,7 @@ export async function exportConversationShareGPT(threadId: string): Promise<void
   const conversations: Array<{ from: string; value: string }> = [];
   for (const msg of messages) {
     const role = msg.role as string;
-    const from = role === "user" ? "human" : "gpt";
+    const from = role === "user" ? "human" : role === "system" ? "system" : "gpt";
     const value = messageToText(msg);
     if (value.trim()) conversations.push({ from, value });
   }
@@ -413,7 +413,7 @@ async function buildThreadContent(
     for (const msg of messages) {
       const role = msg.role as string;
       const value = messageToText(msg);
-      if (value.trim()) conversations.push({ from: role === "user" ? "human" : "gpt", value });
+      if (value.trim()) conversations.push({ from: role === "user" ? "human" : role === "system" ? "system" : "gpt", value });
     }
     if (conversations.length === 0) return null;
     return JSON.stringify({ conversations });

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -626,30 +626,16 @@ function sharegptToRecords(
 }
 
 function csvToRecords(csvText: string, threadId: string, baseTs: number): MessageRecord[] {
-  const lines = csvText.split(/\r?\n/);
+  // parseCsv handles quoted newlines, so multi-line message content
+  // round-trips; a naive per-line split would break those records.
+  const rows = parseCsv(csvText).slice(1);
   const records: MessageRecord[] = [];
   let prevId: string | null = null;
   let idx = 0;
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (!line) continue;
-    let role = "";
-    let content = "";
-    if (line.startsWith('"')) {
-      const m = line.match(/^"((?:[^"]|"")*)"\s*,\s*([\s\S]*)$/);
-      if (!m) continue;
-      role = m[1].replace(/""/g, '"');
-      content = m[2].startsWith('"')
-        ? m[2].slice(1, m[2].endsWith('"') ? -1 : undefined).replace(/""/g, '"')
-        : m[2];
-    } else {
-      const comma = line.indexOf(",");
-      if (comma === -1) continue;
-      role = line.slice(0, comma);
-      content = line.slice(comma + 1).startsWith('"')
-        ? line.slice(comma + 2, line.endsWith('"') ? -1 : undefined).replace(/""/g, '"')
-        : line.slice(comma + 1);
-    }
+  for (const row of rows) {
+    if (row.length < 2) continue;
+    const role = row[0].trim();
+    const content = row.slice(1).join(",");
     if (!content.trim()) continue;
     const validRole = role === "user" || role === "assistant" || role === "system" ? role : "user";
     const id = crypto.randomUUID();


### PR DESCRIPTION
## Summary

Two small correctness fixes to the prompt-storage conversation export/import that landed via #5910, both verified with a simulation suite that runs the real module in Node and in real browser engines.

### 1. Preserve system role in ShareGPT exports

System messages were serialized as gpt turns:

```json
{"conversations": [{"from": "gpt", "value": "You are a helpful assistant..."}]}
```

That silently corrupts exported training data: the system instruction becomes a model output, so a fine-tune learns to emit instructions instead of following them. Verified against real consumers: after unsloth standardize_sharegpt and apply_chat_template (Qwen2.5 ChatML, Llama 3.2), the old format renders the instruction inside an assistant region (a training target under response-only masking); the fixed format renders it in the system region. The importer (sharegptToRecords) already maps from system back to a system role, so this also restores export/import symmetry: a round trip previously turned a system prompt into an assistant message.

Credit to @LeoBorcherding, this is his fix from #5606 (commit 7b277913), applied on top of current main.

### 2. Parse quoted newlines when importing conversation CSV

csvToRecords split the file on raw newlines before parsing quotes, so any exported message containing a newline was cut mid-field on re-import and the remainder dropped. The module already ships an RFC 4180 parser (parseCsv) used by the prompt and list importers; conversation CSV import now uses it too. Multi-line content, embedded quotes/commas, and CRLF files round-trip. This was flagged in the #5606 review (Preserve quoted newlines when importing CSV) and never addressed.

## Test plan

- [x] 80-test vitest suite driving the real module (mocked IO only), run against both this branch and main: proves the bugs on main, the fixes here, and via a 300-conversation differential fuzz that exports differ only in system from fields
- [x] Same scenarios executed in real Chromium (= Edge engine), Firefox and WebKit (= Safari engine) via Playwright: 13/13 per engine, exported bytes identical across engines
- [x] Consumer validation: real exported artifacts fed to unsloth standardize_sharegpt and to apply_chat_template for Qwen2.5, Llama 3.2 and Gemma 2 in an isolated venv
- [x] Round trips: export, import via File, re-export is byte-stable; CRLF and UTF-8 BOM files import correctly
- [x] tsc -b and vite build green (7585 modules)