### PR TITLE
Restore config use_cache in for_inference after gradient checkpointing prep

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3525,7 +3525,10 @@ class FastLlamaModel:
 
         # Re-disable use_cache if prepare_model_for_training had disabled it
         # and for_inference restored it (record only exists after a disable)
-        if use_gradient_checkpointing and getattr(model, "_unsloth_use_cache_originals", None) is not None:
+        if (
+            use_gradient_checkpointing
+            and getattr(model, "_unsloth_use_cache_originals", None) is not None
+        ):
             try:
                 from unsloth_zoo.training_utils import disable_use_cache
                 disable_use_cache(model)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3467,6 +3467,14 @@ class FastLlamaModel:
             embeddings = model.get_output_embeddings()
             if hasattr(embeddings, "training"):
                 embeddings.training = False
+
+        # Restore use_cache values that prepare_model_for_training disabled
+        # for gradient checkpointing (older unsloth_zoo has no restore helper)
+        try:
+            from unsloth_zoo.training_utils import restore_use_cache
+            restore_use_cache(model)
+        except ImportError:
+            pass
         return model
 
     @staticmethod
@@ -3514,6 +3522,15 @@ class FastLlamaModel:
             embeddings = model.get_output_embeddings()
             if hasattr(embeddings, "training"):
                 embeddings.training = True
+
+        # Re-disable use_cache if prepare_model_for_training had disabled it
+        # and for_inference restored it (record only exists after a disable)
+        if use_gradient_checkpointing and getattr(model, "_unsloth_use_cache_originals", None) is not None:
+            try:
+                from unsloth_zoo.training_utils import disable_use_cache
+                disable_use_cache(model)
+            except ImportError:
+                pass
         return model
 
 

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1774,7 +1774,10 @@ class FastBaseModel:
                 embeddings.training = True
         # Re-disable use_cache if prepare_model_for_training had disabled it
         # and for_inference restored it (record only exists after a disable)
-        if use_gradient_checkpointing and getattr(model, "_unsloth_use_cache_originals", None) is not None:
+        if (
+            use_gradient_checkpointing
+            and getattr(model, "_unsloth_use_cache_originals", None) is not None
+        ):
             try:
                 from unsloth_zoo.training_utils import disable_use_cache
                 disable_use_cache(model)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1706,6 +1706,14 @@ class FastBaseModel:
             embeddings = model.get_output_embeddings()
             if hasattr(embeddings, "training"):
                 embeddings.training = False
+        # Restore use_cache values that prepare_model_for_training disabled
+        # for gradient checkpointing (older unsloth_zoo has no restore helper)
+        try:
+            from unsloth_zoo.training_utils import restore_use_cache
+            restore_use_cache(model)
+        except ImportError:
+            pass
+
         # Must disable returning hidden states in the case for GRPO
         os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "0"
         # Must enable returning logits
@@ -1764,6 +1772,15 @@ class FastBaseModel:
             embeddings = model.get_output_embeddings()
             if hasattr(embeddings, "training"):
                 embeddings.training = True
+        # Re-disable use_cache if prepare_model_for_training had disabled it
+        # and for_inference restored it (record only exists after a disable)
+        if use_gradient_checkpointing and getattr(model, "_unsloth_use_cache_originals", None) is not None:
+            try:
+                from unsloth_zoo.training_utils import disable_use_cache
+                disable_use_cache(model)
+            except ImportError:
+                pass
+
         # Can re-enable not returning logits
         os.environ["UNSLOTH_RETURN_LOGITS"] = "0"
         # Turn off skip guards and set stance to default


### PR DESCRIPTION
Companion to unslothai/unsloth-zoo#715, which sets use_cache=False on the model config and nested sub-configs (VLM text_config etc.) during training preparation when gradient checkpointing is enabled, and records the original values on the model.

This wires the counterpart into unsloth:

- FastLlamaModel.for_inference and FastBaseModel.for_inference call unsloth_zoo.training_utils.restore_use_cache, putting the recorded original values back so inference sees use_cache=True again (or whatever the model shipped with). Values that were None or False before training are never recorded, so restore cannot invent True on configs that never had it.
- Both for_training implementations re-disable via disable_use_cache when a record exists and gradient checkpointing is requested, so train -> infer -> train round trips keep the config consistent without re-recording.
- Both calls import lazily inside the function and swallow ImportError, so new unsloth with old unsloth_zoo (no helpers) and old unsloth with new unsloth_zoo both degrade to current behavior. The MLX no-op shims in __init__.py are untouched, keeping Apple Silicon isolated.

Verified on a B200 with zoo at unsloth-zoo#715 head merged with main:

- Qwen2.5-0.5B (kbit path): use_cache False after get_peft_model, True after for_inference, generate works, False again after for_training, True after a second for_inference.
- gemma-3-4b-it (vision path): nested text_config.use_cache False after load, True after for_inference, False after for_training.
- Old-zoo guard: deleting the helpers from unsloth_zoo.training_utils and calling for_inference / for_training raises nothing.

The zoo side ships its own CPU tests (tests/test_training_utils_use_cache.py, 14 cases) covering the record/restore cycle, falsy preservation and double-prepare semantics.
