### PR TITLE
Studio GGUF CI: fix deterministic JSON-mode failure by bumping the quant, keep hard asserts

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -20,7 +20,7 @@
 #        enable_tools / enabled_tools, and enable_thinking on/off.
 #
 #   3. JSON, images
-#        Qwen3-VL-2B-Instruct UD-IQ2_XXS (~570 MiB) + mmproj-F16 (~780 MiB).
+#        Qwen3-VL-2B-Instruct UD-Q4_K_XL (~1.1 GiB) + mmproj-F16 (~780 MiB).
 #        response_format JSON-schema decoding and OpenAI image_url
 #        (data URI) plus Anthropic source/base64 image inputs.
 #
@@ -792,8 +792,14 @@ jobs:
     timeout-minutes: 30
     env:
       GGUF_REPO: unsloth/Qwen3-VL-2B-Instruct-GGUF
-      GGUF_VARIANT: UD-IQ2_XXS
-      GGUF_FILE: Qwen3-VL-2B-Instruct-UD-IQ2_XXS.gguf
+      # UD-Q4_K_XL, not UD-IQ2_XXS: at 2-bit the temp-0 answer to the JSON
+      # step's capital-of-France probe flips with the host's SIMD kernels
+      # (GitHub runners deterministically answered France while other CPUs
+      # answer Paris; seeds do not rescue it, 1/5 Paris at temp 0.7). The
+      # Q4 quant answered Paris 13/13 across temps and seeds on the same
+      # runners, so the hard Paris assertion below stays reliable.
+      GGUF_VARIANT: UD-Q4_K_XL
+      GGUF_FILE: Qwen3-VL-2B-Instruct-UD-Q4_K_XL.gguf
       MMPROJ_FILE: mmproj-F16.gguf
       STUDIO_PORT: '18890'
       HF_HOME: ${{ github.workspace }}/hf-cache


### PR DESCRIPTION
## What

The `JSON, images` job has been deterministically red on main (`03349d1e`, `256d17e2`, plus two attempts on the #6128 head) with:

```
AssertionError: city != Paris: {'city': 'France', 'country': 'France'}
```

This PR keeps the hard `city contains Paris` assertion exactly as it is and fixes the model instead: the job's quant moves from `UD-IQ2_XXS` to `UD-Q4_K_XL`.

## Root cause

At 2-bit quantization the temp-0 greedy answer to the capital-of-France probe is hardware dependent, not random. GitHub's ubuntu runners deterministically answer `city=France` (identical output across runs and reruns), while the same model, prompt, seed and settings answer `city=Paris` on other Linux CPUs (reproduced end to end against a live Studio). The argmax flips with the SIMD kernel path llama.cpp dispatches to. macOS and Windows json-images jobs never carried this assertion, which is why only Linux was red.

## Why not retry across seeds

Measured, not guessed: a throwaway staging-fork run replayed the exact job (same install path, same Studio boot, same load call, same request) on `ubuntu-latest` and swept seeds and temperatures on both quants:

| Config | UD-IQ2_XXS (current) | UD-Q4_K_XL (this PR) |
| --- | --- | --- |
| temp 0.0, greedy x3 | 0/3 Paris | 3/3 Paris |
| temp 0.7, seeds 3407/1/2/42/123 | 1/5 Paris | 5/5 Paris |
| temp 1.0, seeds 3407/1/2/42/123 | 1/5 Paris | 5/5 Paris |

At 2-bit the per-sample Paris rate is about 20 percent, so a hard "any of 5 seeds answers Paris" assert would still fail roughly a third of runs. Worse, the winning seeds differ per host (seed 3407 and 42 on the runner, different ones on a second machine), so there is no seed list to pin. The 4-bit quant is 13/13 across every temperature and seed, including deterministic greedy at temp 0, which is what a hard assert needs.

## Cost

Model file grows from ~570 MiB to ~1.1 GiB (mmproj unchanged at ~780 MiB). The actions/cache key already includes the variant, so the cache rolls over cleanly; cold-cache download adds well under a minute, warm-cache runs are unchanged.

## Verification

- Staging sweep on `ubuntu-latest` (the affected hardware): UD-Q4_K_XL 13/13 Paris, table above.
- `yaml.safe_load` clean; the embedded Python is untouched (the assertion block is byte-identical to main).
- This PR triggers the modified workflow on its own path filter, so the bumped job runs below with the hard assertion live.
