### PR TITLE
Frontend CI: hard-fail unreviewed npm install scripts (--strict-allow-scripts)

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -62,6 +62,19 @@ jobs:
         with:
           node-version: '22'
 
+      # node 22 bundles npm 10.x, which predates allowScripts. Move to the
+      # 11.x line and fail loudly if the gate is still missing, so the
+      # strict flag below can never silently degrade into a warning.
+      - name: Upgrade npm to 11.x (allowScripts enforcement)
+        working-directory: ${{ github.workspace }}
+        run: |
+          npm install -g npm@^11 --no-fund --no-audit
+          V=$(npm -v)
+          case "$V" in
+            11.1[6-9].*|11.[2-9][0-9].*|1[2-9].*) echo "npm $V has allowScripts" ;;
+            *) echo "::error::npm $V lacks allowScripts (need >=11.16)"; exit 1 ;;
+          esac
+
       # Run the structural lockfile scan BEFORE npm ci. A compromised
       # tarball runs its `prepare` / `postinstall` during `npm ci`,
       # so any catch has to fire upstream of that. The scanner is
@@ -84,7 +97,9 @@ jobs:
         # covered by `allowScripts` in package.json (npm >=11.16, default in
         # npm 12). The pre-install lockfile audit above stays the first line
         # of defence -- it fires before any tarball can run code.
-        run: npm ci --no-fund --no-audit
+        # --strict-allow-scripts: any unreviewed install script hard-fails
+        # the job; the sync hook keeps the pins fresh after bumps.
+        run: npm ci --strict-allow-scripts --no-fund --no-audit
 
       - name: npm ci must not have modified the working tree
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## What

Completes the allowScripts rollout from #6128 and #6136: Frontend CI now hard-fails any dependency install script that is not covered by the committed `allowScripts` policy, instead of running it with a warning.

## Changes

1. Upgrade CI npm to the 11.x line right after `setup-node` (node 22 bundles npm 10.x, which predates the gate), with a version guard that fails the job loudly if the resolved npm still lacks allowScripts. Without the guard, an unknown `--strict-allow-scripts` flag on old npm is a one-line warning and the gate silently does not exist.
2. `npm ci --no-fund --no-audit` becomes `npm ci --strict-allow-scripts --no-fund --no-audit`.

## Behavior

- A PR adding a dependency whose install scripts are unreviewed now fails the job with npm's own actionable error (it names the packages and says to run `npm approve-scripts` or `npm deny-scripts`).
- Version bumps of already-approved packages stay green: the pre-commit sync hook from #6136 re-pins the policy on the PR itself, with the pins-check CI step as backstop.

## Verification

- Guard matrix: 10.9.4, 11.9.0, 11.15.0 blocked; 11.16.0, 11.20.1, 12.x pass.
- The exact new command sequence run locally with npm 11.16.0 against this tree: `npm ci --strict-allow-scripts` exits 0 (policy covers the only three script-bearing packages) and leaves the working tree unmodified, so the downstream lockfile-freshness gate is unaffected.
- Negative control verified during the #6128 work: the same command without the committed policy fails with `ESTRICTALLOWSCRIPTS` naming the three packages.
- `min-release-age=7` interaction checked: npm 11.16.0 published 2026-05-27, outside the cooldown window, and the upgrade step runs from the repo root where the frontend `.npmrc` is not in scope anyway.
- `yaml.safe_load` clean.
