### PR TITLE
Studio: fix nested dropdown submenus clipped by the menu alignment nudge

### DIFF
--- a/studio/frontend/src/components/ui/dropdown-menu.tsx
+++ b/studio/frontend/src/components/ui/dropdown-menu.tsx
@@ -46,7 +46,10 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         align={align}
         className={cn(
-          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-48 rounded-lg p-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-[calc(var(--radix-dropdown-menu-trigger-width)_+_6px)] data-[align=start]:-translate-x-[3px] data-[align=end]:translate-x-[3px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
+          // The 3px alignment nudge must be margin, not translate: a transform
+          // here makes this scroll container the containing block for nested
+          // position:fixed submenu wrappers, clipping every submenu.
+          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-48 rounded-lg p-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-[calc(var(--radix-dropdown-menu-trigger-width)_+_6px)] data-[align=start]:-ml-[3px] data-[align=end]:ml-[3px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
           className,
         )}
         {...props}

--- a/studio/frontend/src/components/ui/dropdown-menu.tsx
+++ b/studio/frontend/src/components/ui/dropdown-menu.tsx
@@ -244,14 +244,19 @@ function DropdownMenuSubContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-36 rounded-lg p-1 duration-100 z-50 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden",
-        className,
-      )}
-      {...props}
-    />
+    // Portaled like DropdownMenuContent: rendered inline, the fixed popper
+    // wrapper is a descendant of the parent menu's scroll container, so any
+    // transform there turns on overflow clipping and hides the submenu.
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-36 rounded-lg p-1 duration-100 z-50 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
   );
 }
 


### PR DESCRIPTION
## What this does

Fixes every nested dropdown submenu failing to open since #6116 (the plus menu More and Projects submenus, the sidebar chat item Move to project and Export submenus, the Recents bulk export menus), and hardens the menu primitives so this class of regression cannot recur.

## Root cause

#6116 added a 3px alignment nudge to DropdownMenuContent via `data-[align=start]:-translate-x-[3px]`. Tailwind v4 emits that as the standalone `translate` property, and any transform property turns the element into the containing block for `position: fixed` descendants. Radix renders non-portaled SubContent popper wrappers as fixed-position children inside the parent content, which also has `overflow-x-hidden overflow-y-auto`. Once the content became the containing block, its overflow clipped the submenu wrappers, which by definition sit outside the parent menu box. Submenus reached data-state open at the right coordinates with opacity 1, fully clipped.

## Fix, two layers

1. The 3px nudge is now margin (`data-[align=start]:-ml-[3px]`, `data-[align=end]:ml-[3px]`): same visual shift, no containing block.
2. DropdownMenuSubContent is wrapped in DropdownMenuPrimitive.Portal, matching DropdownMenuContent. Portaled to body, submenu wrappers are no longer descendants of the parent menu's scroll container, so no future transform, filter, or will-change on the content can clip them.

## Testing

Driven in a live Studio session with Chromium against the built frontend:
- More, Projects, and the third-level Saved prompts submenus render, hit-test at their center point, and accept clicks (selecting Canvas from More toggles the pill).
- Robustness check: re-injecting `translate: -3px 0` on the open menu content no longer hides the submenu.
- Submenus inside the Settings dialog work and a format click triggers the actual export download; the sidebar Recents export submenus work.
- The 3px alignment offset is preserved.
