### PR TITLE
Call patch_compiling_bitsandbytes on the FastLanguageModel path

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -722,8 +722,13 @@ class FastLanguageModel(FastLlamaModel):
             load_in_4bit_kwargs = False
             load_in_8bit_kwargs = False
 
-        # Mirror FastModel: bitsandbytes < 0.46.0 needs dynamo disabled
-        patch_compiling_bitsandbytes()
+        # Mirror FastModel: bitsandbytes < 0.46.0 needs dynamo disabled.
+        # Best effort: never crash the load (old unsloth_zoo without the
+        # zoo #710 fix raises NameError here on Python 3.13).
+        try:
+            patch_compiling_bitsandbytes()
+        except Exception as e:
+            print(f"Unsloth: Could not patch bitsandbytes for torch.compile - {e}")
 
         model, tokenizer = dispatch_model.from_pretrained(
             model_name = model_name,

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -722,6 +722,9 @@ class FastLanguageModel(FastLlamaModel):
             load_in_4bit_kwargs = False
             load_in_8bit_kwargs = False
 
+        # Mirror FastModel: bitsandbytes < 0.46.0 needs dynamo disabled
+        patch_compiling_bitsandbytes()
+
         model, tokenizer = dispatch_model.from_pretrained(
             model_name = model_name,
             max_seq_length = max_seq_length,


### PR DESCRIPTION
`patch_compiling_bitsandbytes()` was only invoked in `FastModel.from_pretrained`, so the `FastLanguageModel` dispatch path (llama, mistral, gemma, qwen, etc) never disabled dynamo on bitsandbytes < 0.46.0. Found while validating unslothai/unsloth-zoo#710.

This adds the same call right before `dispatch_model.from_pretrained`, mirroring `FastModel`. The call only has an effect on bitsandbytes < 0.46.0; on >= 0.46.0 it is a guaranteed no-op. It is wrapped in try/except so a zoo version without the unslothai/unsloth-zoo#710 fix (latest published zoo 2026.6.1) can never crash a load: the worst case is the pre-PR behavior plus a visible warning.

Verification with Qwen2.5 0.5B Instruct bnb 4bit via `FastLanguageModel`, using a call recorder around the patch function:

- Before this PR: the patch never ran on this path.
- Fixed zoo (main with #710) and bitsandbytes version forced below 0.46.0: the patch runs and bitsandbytes forwards are dynamo disabled at call time, model loads and trains.
- Fixed zoo and bitsandbytes 0.49.2: no-op, loading unchanged.
- Stock published zoo 2026.6.1 (still has the exec/eval bug) and bitsandbytes forced below 0.46.0 on Python 3.13: the NameError is caught, a warning is printed ("Unsloth: Could not patch bitsandbytes for torch.compile - name 'peft' is not defined"), and the model loads fine.

`patch_compiled_autograd` is deliberately left untouched to keep this change minimal.
