### PR TITLE
Studio: training survives a non-writable HF datasets cache

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -58,7 +58,8 @@ from pathlib import Path
 from typing import Optional, Callable
 from dataclasses import dataclass
 import pandas as pd
-from datasets import Dataset, load_dataset
+from datasets import Dataset
+from utils.datasets.cache_safe import load_dataset_cache_safe as load_dataset
 
 from core.inference.llama_cpp import _hf_offline_if_dns_dead
 from utils.models import is_vision_model, detect_audio_type

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1261,7 +1261,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
             "(unsloth_zoo.mlx.loader / unsloth_zoo.mlx.trainer). Reinstall via "
             "install.sh on Apple Silicon."
         ) from e
-    from datasets import load_dataset
+    from utils.datasets.cache_safe import load_dataset_cache_safe as load_dataset
 
     if mx.metal.is_available():
         info = mx.device_info()
@@ -2757,7 +2757,8 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
         )
         from sentence_transformers.losses import MultipleNegativesRankingLoss
         from sentence_transformers.training_args import BatchSamplers
-        from datasets import load_dataset, Dataset
+        from datasets import Dataset
+        from utils.datasets.cache_safe import load_dataset_cache_safe as load_dataset
         from transformers import TrainerCallback
         from utils.paths import datasets_root, resolve_output_dir
     except ImportError as e:

--- a/studio/backend/hub/services/datasets/formatting.py
+++ b/studio/backend/hub/services/datasets/formatting.py
@@ -223,7 +223,10 @@ def _load_processed_hf_preview_slice(
     if not _is_valid_repo_id(request.dataset_name):
         return None
     try:
-        from datasets import DownloadConfig, load_dataset
+        from datasets import DownloadConfig
+
+        # Non-streaming loads take the cached builder lock; use the EACCES-safe wrapper.
+        from utils.datasets.cache_safe import load_dataset_cache_safe as load_dataset
     except Exception:
         return None
 

--- a/studio/backend/hub/services/datasets/local.py
+++ b/studio/backend/hub/services/datasets/local.py
@@ -224,7 +224,8 @@ def _stream_file_preview_slice(path: Path, preview_size: int):
 
 
 def _load_local_preview_slice(*, dataset_path: Path, train_split: str, preview_size: int):
-    from datasets import load_dataset
+    # Non-streaming loads take the cached builder lock; use the EACCES-safe wrapper.
+    from utils.datasets.cache_safe import load_dataset_cache_safe as load_dataset
 
     if dataset_path.is_dir():
         parquet_dir = (

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -412,7 +412,8 @@ def _build_local_dataset_items() -> list[LocalDatasetItem]:
 
 
 def _load_local_preview_slice(*, dataset_path: Path, train_split: str, preview_size: int):
-    from datasets import load_dataset
+    # Non-streaming loads take the cached builder lock; use the EACCES-safe wrapper.
+    from utils.datasets.cache_safe import load_dataset_cache_safe as load_dataset
 
     if dataset_path.is_dir():
         parquet_dir = (

--- a/studio/backend/utils/datasets/cache_safe.py
+++ b/studio/backend/utils/datasets/cache_safe.py
@@ -37,7 +37,15 @@ def load_dataset_cache_safe(*args, **kwargs):
             error,
             fallback,
         )
-        # Nested builders consult the env var, so move it alongside cache_dir.
-        os.environ["HF_DATASETS_CACHE"] = fallback
         kwargs["cache_dir"] = fallback
-        return load_dataset(*args, **kwargs)
+        # Nested builders consult the env var while the load runs; restore it
+        # after so other datasets keep trying the shared cache first.
+        old_env = os.environ.get("HF_DATASETS_CACHE")
+        os.environ["HF_DATASETS_CACHE"] = fallback
+        try:
+            return load_dataset(*args, **kwargs)
+        finally:
+            if old_env is None:
+                os.environ.pop("HF_DATASETS_CACHE", None)
+            else:
+                os.environ["HF_DATASETS_CACHE"] = old_env

--- a/studio/backend/utils/datasets/cache_safe.py
+++ b/studio/backend/utils/datasets/cache_safe.py
@@ -28,7 +28,6 @@ def studio_datasets_cache() -> str:
 def load_dataset_cache_safe(*args, **kwargs):
     """datasets.load_dataset, retried in a Studio-owned cache on EACCES."""
     from datasets import load_dataset
-
     try:
         return load_dataset(*args, **kwargs)
     except PermissionError as error:

--- a/studio/backend/utils/datasets/cache_safe.py
+++ b/studio/backend/utils/datasets/cache_safe.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Permission-safe wrapper around datasets.load_dataset.
+
+A shared HF datasets cache can contain subtrees owned by another user (for
+example populated by an earlier root-run job). datasets then raises
+"[Errno 13] Permission denied: ..._builder.lock" while locking the cached
+builder, killing the training run even though the dataset itself is fine.
+Retry such loads in a Studio-owned cache so the run proceeds; the worst case
+is one rebuild of the dataset in the fallback location.
+"""
+
+import logging
+import os
+
+from utils.paths.storage_roots import cache_root
+
+logger = logging.getLogger(__name__)
+
+
+def studio_datasets_cache() -> str:
+    path = cache_root() / "hf-datasets"
+    path.mkdir(parents = True, exist_ok = True)
+    return str(path)
+
+
+def load_dataset_cache_safe(*args, **kwargs):
+    """datasets.load_dataset, retried in a Studio-owned cache on EACCES."""
+    from datasets import load_dataset
+
+    try:
+        return load_dataset(*args, **kwargs)
+    except PermissionError as error:
+        fallback = studio_datasets_cache()
+        logger.warning(
+            "HF datasets cache is not writable (%s); rebuilding in %s",
+            error,
+            fallback,
+        )
+        # Nested builders consult the env var, so move it alongside cache_dir.
+        os.environ["HF_DATASETS_CACHE"] = fallback
+        kwargs["cache_dir"] = fallback
+        return load_dataset(*args, **kwargs)


### PR DESCRIPTION
## What this does

Fixes training runs dying with:

```
[Errno 13] Permission denied: '~/.cache/huggingface/datasets/mlabonne___fine_tome-100k/default/0.0.0/<hash>_builder.lock'
```

## Root cause

`datasets` takes a file lock next to the cached builder before reusing it. When the shared HF datasets cache contains a subtree owned by another user, most commonly because an earlier job ran as root and populated `datasets/{name}/{config}/{version}/` with root ownership, the Studio worker (running as the login user) cannot create the lock file inside that directory and `load_dataset` raises EACCES. Studio honors a pre-set `HF_DATASETS_CACHE`/`HF_HOME`, so any environment pointing at a shared cache is exposed. The run then fails even though the dataset is fully cached and readable.

## Fix

`load_dataset` calls in the training worker and trainer now go through `load_dataset_cache_safe` (`utils/datasets/cache_safe.py`): on `PermissionError` it logs a warning and retries with `cache_dir` pointed at a Studio-owned cache under `cache_root()/hf-datasets`, also moving `HF_DATASETS_CACHE` so nested builders follow. Worst case is one rebuild of the dataset in the fallback location; the foreign-owned cache is left untouched. The wrapper is aliased at the existing import sites, so all eleven call sites across `worker.py` and `trainer.py` are covered without touching call-site code.

The non-streaming dataset preview loads (`routes/datasets.py`, `hub/services/datasets/local.py`, `hub/services/datasets/formatting.py`) go through the same wrapper, since previewing a cached or local dataset takes the same builder lock and would fail the same way. Streaming previews never call `download_and_prepare`, so they are unaffected and keep importing `datasets.load_dataset` directly.

## Testing

Reproduced on a machine exhibiting the exact failure (root-owned `mlabonne___fine_tome-100k/default/0.0.0/`, worker running as `ubuntu`):

- Plain `load_dataset("mlabonne/FineTome-100k", split="train")` raises the reported `PermissionError` on the builder lock.
- `load_dataset_cache_safe` with identical arguments logs the fallback warning, rebuilds the dataset under `cache_root()/hf-datasets`, and returns all 100000 rows.
- `py_compile` passes on the three touched files; the worker spawns as a fresh subprocess per run, so the fix applies to the next training run without restarting the server.

