### PR TITLE
Fix UnboundLocalError in ROCm version detection dpkg/rpm fallback

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -212,7 +212,6 @@ def _detect_rocm_version() -> tuple[int, int] | None:
                 env = _amd_smi_env(),
             )
             if result.returncode == 0:
-                import re
                 m = re.search(r"ROCm version:\s*(\d+)\.(\d+)", result.stdout)
                 if m:
                     return int(m.group(1)), int(m.group(2))

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -485,6 +485,20 @@ class TestDetectRocmVersion:
                     result = _detect_rocm_version()
                     assert result == (6, 3)
 
+    def test_dpkg_fallback_without_hipconfig(self, tmp_path):
+        """dpkg rocm-core fallback works when amd-smi and hipconfig are absent
+        (regression: a shadowing local re import raised UnboundLocalError)."""
+        def which(cmd):
+            return "/usr/bin/dpkg-query" if cmd == "dpkg-query" else None
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "1:6.3.0-1\n"
+        with patch.dict(os.environ, {"ROCM_PATH": str(tmp_path / "nonexistent")}):
+            with patch("shutil.which", side_effect = which):
+                with patch("subprocess.run", return_value = mock_result):
+                    assert _detect_rocm_version() == (6, 3)
+
     def test_empty_version_file(self, tmp_path):
         """Empty version file should return None."""
         info_dir = tmp_path / ".info"

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -488,6 +488,7 @@ class TestDetectRocmVersion:
     def test_dpkg_fallback_without_hipconfig(self, tmp_path):
         """dpkg rocm-core fallback works when amd-smi and hipconfig are absent
         (regression: a shadowing local re import raised UnboundLocalError)."""
+
         def which(cmd):
             return "/usr/bin/dpkg-query" if cmd == "dpkg-query" else None
 


### PR DESCRIPTION
## Summary

`_detect_rocm_version()` in `studio/install_python_stack.py` crashes with `UnboundLocalError` on Linux AMD machines where ROCm was installed through the distro package manager. A leftover `import re` inside the amd-smi branch makes `re` function local for the entire scope, so when `amd-smi` and `hipconfig` are absent and `dpkg-query` (or `rpm`) reports `rocm-core`, the Debian epoch strip reaches `re.sub` before any local binding exists and the installer dies:

```
UnboundLocalError: cannot access local variable 're' where it is not associated with a value
```

Reachable on a stock Debian/Ubuntu ROCm package install (rocm-core present, hipconfig not on PATH), where the function should instead return the parsed version and let torch wheel selection proceed.

## Fix

- Drop the shadowing local `import re` (the module already imports `re` at top level).
- Add a regression test exercising the dpkg fallback with `amd-smi`/`hipconfig` absent and an epoch-prefixed version (`1:6.3.0-1` parses to `(6, 3)`). The test fails with `UnboundLocalError` before the fix and passes after.

## Validation

- `python -m pytest tests/studio/install/test_rocm_support.py` passes (281 passed, 1 skipped)
- `ruff check` clean, `git diff --check` clean
