### PR TITLE
Run the HF cache redirect before import fixes that can freeze Hub constants

### DIFF
--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -48,6 +48,7 @@ from .import_fixes import (
 try:
     import importlib.util as _importlib_util
     from pathlib import Path as _Path
+
     _zoo_spec = _importlib_util.find_spec("unsloth_zoo")
     if _zoo_spec is not None and _zoo_spec.origin:
         _hf_cache_file = _Path(_zoo_spec.origin).with_name("hf_cache.py")

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -35,6 +35,35 @@ from .import_fixes import (
     fix_huggingface_hub,
 )
 
+# Redirect a read-only Hugging Face cache before anything below can import
+# huggingface_hub / transformers / vllm (disable_broken_vllm probes
+# `import vllm`, check_fbgemm_gpu_version imports transformers, and
+# fix_huggingface_hub imports huggingface_hub itself), all of which can
+# freeze Hub's cache constants with the un-redirected paths. unsloth_zoo
+# runs the same redirect at import, but that happens after these probes.
+# hf_cache.py is stdlib-only, so load it straight from its file without
+# triggering the full unsloth_zoo package init this early; the zoo's own
+# call later is an idempotent no-op. Older unsloth_zoo without hf_cache.py
+# is skipped silently.
+try:
+    import importlib.util as _importlib_util
+    from pathlib import Path as _Path
+    _zoo_spec = _importlib_util.find_spec("unsloth_zoo")
+    if _zoo_spec is not None and _zoo_spec.origin:
+        _hf_cache_file = _Path(_zoo_spec.origin).with_name("hf_cache.py")
+        if _hf_cache_file.is_file():
+            _hf_cache_spec = _importlib_util.spec_from_file_location(
+                "unsloth_zoo._early_hf_cache", _hf_cache_file
+            )
+            _hf_cache = _importlib_util.module_from_spec(_hf_cache_spec)
+            _hf_cache_spec.loader.exec_module(_hf_cache)
+            _hf_cache.redirect_hf_cache_if_readonly()
+            del _hf_cache, _hf_cache_spec
+        del _hf_cache_file
+    del _zoo_spec, _importlib_util, _Path
+except Exception:
+    pass
+
 # Configure libdrm ids table path early so ROCm can resolve AMD GPU names.
 configure_amdgpu_asic_id_table_path()
 disable_broken_causal_conv1d()


### PR DESCRIPTION
## Summary

Companion to unslothai/unsloth-zoo#719, which redirects `HF_HOME` / `HF_HUB_CACHE` / `HF_XET_CACHE` at `unsloth_zoo` import time when the default Hugging Face cache is read-only.

In `_gpu_init.py` the early fix block runs before `import unsloth_zoo`, and three of its probes can import the HF stack first:

- `disable_broken_vllm()` runs `import vllm` whenever vllm is installed
- `check_fbgemm_gpu_version()` imports `transformers` when fbgemm_gpu is present
- `fix_huggingface_hub()` imports `huggingface_hub` itself

`huggingface_hub` computes its cache constants when its `constants` module first executes. If any of the above materializes it before the zoo redirect runs, the constants freeze on the old read-only paths and the redirect never reaches Hub: the env vars change but `snapshot_download()` still writes to the unwritable location.

Recent releases mask this by accident: huggingface_hub 0.36 and vllm 0.15 both have lazy top-level imports. Older supported versions are exposed (older vllm imported transformers at top level; on hub versions where `is_offline_mode` still exists, the `hasattr` probe materializes the constants module).

## Change

Load `unsloth_zoo/hf_cache.py` directly from its file and call `redirect_hf_cache_if_readonly()` before the fix calls. The module is stdlib-only, so this does not trigger the full `unsloth_zoo` package init that early. The zoo's own call later is an idempotent no-op, and an older unsloth_zoo without `hf_cache.py` is skipped silently.

## Testing

- Repro with a stub vllm package that imports transformers at top level (mimicking older vllm) and a read-only `HF_HOME`: before this change, the env was redirected but `huggingface_hub.constants.HF_HUB_CACHE` stayed on the read-only path; after, the constants match the redirected env.
- Read-only-cache end to end (real `snapshot_download` through `import unsloth`): redirects to a private 0700 fallback and the download lands there; writable-cache machines see a no-op import.
- `ruff check --select E9,F63,F7,F82` and `python -m compileall` on the changed file pass.