### PR TITLE
Tests: follow Compare chat into the More submenu in the Playwright chat UI driver

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1107,11 +1107,15 @@ with sync_playwright() as p:
             if more_trigger.count() > 0:
                 more_trigger.hover()
                 page.wait_for_timeout(400)
-                compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
+                compare_item = page.get_by_role(
+                    "menuitem", name = re.compile(r"Compare chat", re.I)
+                ).first
                 if compare_item.count() == 0:
                     more_trigger.click(force = True)
                     page.wait_for_timeout(400)
-                    compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
+                    compare_item = page.get_by_role(
+                        "menuitem", name = re.compile(r"Compare chat", re.I)
+                    ).first
         if compare_item.count() > 0:
             compare_item.click(force = True)
             page.wait_for_timeout(800)

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1100,6 +1100,18 @@ with sync_playwright() as p:
         plus_btn.click(force = True)
         page.wait_for_timeout(400)
         compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
+        if compare_item.count() == 0:
+            # The plus menu was decluttered: Compare chat now lives in the
+            # "More" submenu; hover (then click as fallback) to open it.
+            more_trigger = page.get_by_role("menuitem", name = re.compile(r"^More$", re.I)).first
+            if more_trigger.count() > 0:
+                more_trigger.hover()
+                page.wait_for_timeout(400)
+                compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
+                if compare_item.count() == 0:
+                    more_trigger.click(force = True)
+                    page.wait_for_timeout(400)
+                    compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
         if compare_item.count() > 0:
             compare_item.click(force = True)
             page.wait_for_timeout(800)


### PR DESCRIPTION
## Summary

Chat UI Tests has been red on every PR since this morning (for example #6146 and #6148, whose diffs touch unrelated code) with:

```
AssertionError: [ui] FAIL: composer + menu: 'Compare chat' item not found
```

Root cause: the plus-menu declutter (#6140) moved the Compare chat item into a nested "More" submenu (`DropdownMenuSub` in `thread.tsx` and `shared-composer.tsx`), and the Playwright driver still looked for it at the top level of the plus menu. The UI itself is fine for users; this is driver-vs-UI drift.

## Change

After opening the plus menu, if Compare chat is not directly present, open the "More" sub-trigger (hover first, click as a fallback for environments where hover does not expand Radix submenus) and look again. The direct lookup stays first, so the driver keeps passing if the item ever moves back to the top level.

## Testing

`py_compile` passes; the real verification is this PR's own Chat UI Tests check, which exercises the driver against the built UI. Note the same runs also confirmed the b9585 prebuilt installs and validates in CI ("prebuilt installed and validated"), so once this lands the Chat UI lane should be fully green again.

## Related

The other repo-wide red (Core HF=latest) is the transformers v5 strict-config break in unsloth_zoo's use_cache tests, fixed separately in unslothai/unsloth-zoo#746.
