### PR TITLE
Keep audio feature extractors right padded when loading processors

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1285,7 +1285,10 @@ class FastBaseModel:
         # left padding shifts mel content (Whisper) and desyncs mel frame masks
         # from audio placeholder counts (crashes Gemma 4 on transformers < 5.10).
         feature_extractor = getattr(tokenizer, "feature_extractor", None)
-        if feature_extractor is not None and getattr(feature_extractor, "padding_side", None) == "left":
+        if (
+            feature_extractor is not None
+            and getattr(feature_extractor, "padding_side", None) == "left"
+        ):
             feature_extractor.padding_side = "right"
         m = model
         while hasattr(m, "model"):

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1280,10 +1280,9 @@ class FastBaseModel:
         tokenizer.padding_side = "left"  # Force inference
         if hasattr(tokenizer, "tokenizer"):
             tokenizer.tokenizer.padding_side = "left"  # Force inference
-        # padding_side = "left" above is a text setting, but from_pretrained also
-        # forwarded it into audio feature extractors, which must stay right padded:
-        # left padding shifts mel content (Whisper) and desyncs mel frame masks
-        # from audio placeholder counts (crashes Gemma 4 on transformers < 5.10).
+        # Audio feature extractors must stay right padded: left (a text setting,
+        # forwarded by from_pretrained) shifts Whisper mels and desyncs Gemma 4
+        # audio token counts (crash on transformers < 5.10).
         feature_extractor = getattr(tokenizer, "feature_extractor", None)
         if feature_extractor is not None and getattr(feature_extractor, "padding_side", None) == "left":
             feature_extractor.padding_side = "right"

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1285,7 +1285,7 @@ class FastBaseModel:
         # left padding shifts mel content (Whisper) and desyncs mel frame masks
         # from audio placeholder counts (crashes Gemma 4 on transformers < 5.10).
         feature_extractor = getattr(tokenizer, "feature_extractor", None)
-        if getattr(feature_extractor, "padding_side", None) == "left":
+        if feature_extractor is not None and getattr(feature_extractor, "padding_side", None) == "left":
             feature_extractor.padding_side = "right"
         m = model
         while hasattr(m, "model"):

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1280,6 +1280,13 @@ class FastBaseModel:
         tokenizer.padding_side = "left"  # Force inference
         if hasattr(tokenizer, "tokenizer"):
             tokenizer.tokenizer.padding_side = "left"  # Force inference
+        # padding_side = "left" above is a text setting, but from_pretrained also
+        # forwarded it into audio feature extractors, which must stay right padded:
+        # left padding shifts mel content (Whisper) and desyncs mel frame masks
+        # from audio placeholder counts (crashes Gemma 4 on transformers < 5.10).
+        feature_extractor = getattr(tokenizer, "feature_extractor", None)
+        if getattr(feature_extractor, "padding_side", None) == "left":
+            feature_extractor.padding_side = "right"
         m = model
         while hasattr(m, "model"):
             m.max_seq_length = max_seq_length


### PR DESCRIPTION
## Problem

`FastBaseModel.from_pretrained` passes `padding_side="left"` to `AutoProcessor.from_pretrained` (a text generation setting). `ProcessorMixin` forwards unconsumed kwargs to every sub-component, so audio feature extractors also flip to left padding. Stock transformers right-pads audio: frame-validity masks and downstream consumers assume trailing padding.

Two measured consequences:

1. **Gemma 4 audio (crash on transformers 5.5.0 to 5.9.x).** A left padded waveform gains one extra valid mel frame on clip lengths that do not land on a hop boundary, so the audio tower emits more pooled features than the processor counted `<|audio|>` placeholders. SFT then dies with `Audio features and audio tokens do not match, tokens: 99, features: 153600`. The shipped Gemma 4 audio notebooks pin transformers==5.5.0. On 5.10+ the placeholder count is mask derived so there is no crash, but training silently uses one extra audio token per clip vs stock.
2. **Whisper (silent fidelity bug, all versions).** The 30 s mel window becomes end aligned: a 1 s clip lands in frames 2900-3000 instead of 0-100. Models fine-tuned this way see start-aligned audio at inference time in stock pipelines.

The stock 5.5.0 processor is self-consistent: a 9-combination Gemma 4 clip-length forward probe passes 9/9 without unsloth involved, and fails 4/9 with the left padded extractor.

## Fix

Reset the feature extractor to right padding at the single processor finalization point in `unsloth/models/vision.py` (all FastModel load paths flow through it). The text tokenizer keeps left padding for generation. `FastLanguageModel` (llama.py) loads text-only tokenizers, so it needs no change.

## Validation (transformers 5.5.0, unsloth 2026.6.1, gemma-4-E2B-it)

- Loaded processor now matches a fresh stock `AutoProcessor` exactly (feature extractor config diff empty; 3.97 s clip: 396 valid frames and 99 tokens both ways)
- 9-combination clip-length forward probe: 4 failures before, 9/9 OK after
- LibriSpeech SFT smoke (LoRA, 20 steps): crashed on step 0 before, now trains end to end with loss 5.12 -> 0.97
- Whisper mechanism verified at the feature extractor level: right padding restores start-aligned mels identical to stock
- transformers 5.10.2 re-probe: 9/9 OK and token counts now match stock transformers exactly

Companion collator-side fix (covers released unsloth versions once the zoo updates): unslothai/unsloth-zoo#747