### PR TITLE
Studio: shorten speculative decoding tooltips

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -888,10 +888,8 @@ export function ChatSettingsPanel({
                       Speculative Decoding
                     </span>
                     <InfoHint>
-                      Faster generation with 0% accuracy hit. Auto picks
-                      MTP / ngram-mod based on the model and platform.
-                      Pick MTP, Ngram, or MTP+Ngram to force a specific
-                      strategy on both GPU and CPU.
+                      Drafts tokens to speed up generation without changing
+                      results.
                     </InfoHint>
                   </div>
                   <div className="flex shrink-0 items-center gap-1.5">
@@ -931,11 +929,8 @@ export function ChatSettingsPanel({
                         Draft Tokens
                       </span>
                       <InfoHint>
-                        Max MTP draft tokens per step
-                        (--spec-draft-n-max). Lower = less wasted
-                        draft decode; higher = bigger speedup when
-                        acceptance stays high. Default: 2 on GPU,
-                        3 on CPU/Mac.
+                        Max draft tokens per step. Lower wastes less compute;
+                        higher can be faster. Default: 2 GPU, 3 CPU/Mac.
                       </InfoHint>
                     </div>
                     <input


### PR DESCRIPTION
## Summary

Make the Speculative Decoding settings tooltips more concise so they fit better in the chat settings panel.

- Shorten the Speculative Decoding tooltip while preserving the key behavior.
- Shorten the Draft Tokens tooltip while keeping the tuning tradeoff and defaults.

Before:
<img width="952" height="385" alt="image" src="https://github.com/user-attachments/assets/9706eb3f-4446-4d4e-8488-0a8b45bc5d47" />
<img width="470" height="175" alt="image" src="https://github.com/user-attachments/assets/1de14398-9547-4871-9736-15a9bfcffbe8" />


After:
<img width="672" height="93" alt="image" src="https://github.com/user-attachments/assets/719914d5-f453-4dbc-9b1e-432a56166210" />
<img width="659" height="97" alt="image" src="https://github.com/user-attachments/assets/33db2d4b-dc35-41b1-9b6f-a4c8c967b0ad" />

