### PR TITLE
fix: avoid false flash-attn warning with transformers 5

### DIFF
--- a/tests/test_package_availability.py
+++ b/tests/test_package_availability.py
@@ -1,5 +1,5 @@
 import ast
-import importlib
+import importlib.util
 from pathlib import Path
 
 

--- a/tests/test_package_availability.py
+++ b/tests/test_package_availability.py
@@ -1,0 +1,36 @@
+import ast
+import importlib
+from pathlib import Path
+
+
+_UTILS_PATH = Path(__file__).resolve().parents[1] / 'unsloth' / 'models' / '_utils.py'
+
+
+def _load_package_available_bool():
+    source = _UTILS_PATH.read_text(encoding = 'utf-8')
+    tree = ast.parse(source)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == '_is_package_available_bool'
+    )
+    module = ast.Module(body = [function], type_ignores = [])
+    ast.fix_missing_locations(module)
+    namespace = {'importlib': importlib}
+    exec(compile(module, str(_UTILS_PATH), 'exec'), namespace)
+    return namespace['_is_package_available_bool']
+
+
+def test_package_available_bool_returns_false_for_absent_package():
+    is_package_available = _load_package_available_bool()
+
+    assert is_package_available('_definitely_missing_unsloth_dependency_') is False
+
+
+def test_utils_does_not_call_transformers_private_package_helper():
+    source = _UTILS_PATH.read_text(encoding = 'utf-8')
+
+    assert 'from transformers.utils.import_utils import _is_package_available' not in source
+    assert '_is_package_available("flash_attn")' not in source
+    assert 'return _is_package_available("vllm")' not in source

--- a/tests/test_package_availability.py
+++ b/tests/test_package_availability.py
@@ -3,34 +3,33 @@ import importlib
 from pathlib import Path
 
 
-_UTILS_PATH = Path(__file__).resolve().parents[1] / 'unsloth' / 'models' / '_utils.py'
+_UTILS_PATH = Path(__file__).resolve().parents[1] / "unsloth" / "models" / "_utils.py"
 
 
 def _load_package_available_bool():
-    source = _UTILS_PATH.read_text(encoding = 'utf-8')
+    source = _UTILS_PATH.read_text(encoding = "utf-8")
     tree = ast.parse(source)
     function = next(
         node
         for node in tree.body
-        if isinstance(node, ast.FunctionDef)
-        and node.name == '_is_package_available_bool'
+        if isinstance(node, ast.FunctionDef) and node.name == "_is_package_available_bool"
     )
     module = ast.Module(body = [function], type_ignores = [])
     ast.fix_missing_locations(module)
-    namespace = {'importlib': importlib}
-    exec(compile(module, str(_UTILS_PATH), 'exec'), namespace)
-    return namespace['_is_package_available_bool']
+    namespace = {"importlib": importlib}
+    exec(compile(module, str(_UTILS_PATH), "exec"), namespace)
+    return namespace["_is_package_available_bool"]
 
 
 def test_package_available_bool_returns_false_for_absent_package():
     is_package_available = _load_package_available_bool()
 
-    assert is_package_available('_definitely_missing_unsloth_dependency_') is False
+    assert is_package_available("_definitely_missing_unsloth_dependency_") is False
 
 
 def test_utils_does_not_call_transformers_private_package_helper():
-    source = _UTILS_PATH.read_text(encoding = 'utf-8')
+    source = _UTILS_PATH.read_text(encoding = "utf-8")
 
-    assert 'from transformers.utils.import_utils import _is_package_available' not in source
+    assert "from transformers.utils.import_utils import _is_package_available" not in source
     assert '_is_package_available("flash_attn")' not in source
     assert 'return _is_package_available("vllm")' not in source

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -93,7 +93,7 @@ platform_system = platform_system()
 import numpy as np
 import contextlib
 import copy
-import importlib
+import importlib.util
 import re
 from dataclasses import dataclass, field
 import functools

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -93,6 +93,7 @@ platform_system = platform_system()
 import numpy as np
 import contextlib
 import copy
+import importlib
 import re
 from dataclasses import dataclass, field
 import functools
@@ -1262,7 +1263,11 @@ if is_openai_available():
 # =============================================
 # Get Flash Attention v2 if Ampere (RTX 30xx, A100)
 from transformers import AutoTokenizer
-from transformers.utils.import_utils import _is_package_available
+
+
+def _is_package_available_bool(package_name):
+    return importlib.util.find_spec(package_name) is not None
+
 
 SUPPORTS_BFLOAT16 = False
 HAS_FLASH_ATTENTION = False
@@ -1274,7 +1279,7 @@ if DEVICE_TYPE == "cuda":
 
     if major_version >= 8:
         SUPPORTS_BFLOAT16 = True
-        if _is_package_available("flash_attn"):
+        if _is_package_available_bool("flash_attn"):
             # Check for CUDA linking errors "undefined symbol: _ZNK3c106SymIntltEl"
             try:
                 try:
@@ -1319,7 +1324,7 @@ if DEVICE_TYPE == "cuda":
         HAS_FLASH_ATTENTION = False
 elif DEVICE_TYPE == "hip":
     SUPPORTS_BFLOAT16 = True
-    if _is_package_available("flash_attn"):
+    if _is_package_available_bool("flash_attn"):
         # Check for CUDA linking errors "undefined symbol: _ZNK3c106SymIntltEl"
         try:
             try:
@@ -1651,8 +1656,6 @@ if Version(peft_version) < Version("0.12.0"):
         )
 
 # =============================================
-import importlib
-
 global USE_MODELSCOPE
 USE_MODELSCOPE = os.environ.get("UNSLOTH_USE_MODELSCOPE", "0") == "1"
 if USE_MODELSCOPE:
@@ -1981,7 +1984,7 @@ def is_bfloat16_supported():
 
 
 def is_vLLM_available():
-    return _is_package_available("vllm")
+    return _is_package_available_bool("vllm")
 
 
 # Patches models to add RoPE Scaling


### PR DESCRIPTION
Resolved issue #6155 by removing Unsloth’s dependency on Transformers’ private `_is_package_available()` helper for these boolean package checks.

What changed:
- Added a local `_is_package_available_bool(package_name)` helper in `unsloth/models/_utils.py`.
- The helper uses `importlib.util.find_spec(package_name) is not None`.
- Updated both `flash_attn` checks to use the new helper.
- Updated `is_vLLM_available()` to return a real bool from the same helper.

Why this fixes it:
- In Transformers 5.x, `_is_package_available("flash_attn")` returns `(False, None)`.
- Non-empty tuples are truthy in Python.
- Unsloth was treating that tuple as a bool, entering the Flash Attention branch even when `flash-attn` was absent.
- That caused the misleading warning: `Flash Attention 2 installation seems to be broken`.
- `find_spec()` directly checks whether the package exists, so absent packages correctly return `False`.

Added regression coverage:
- Added `tests/test_package_availability.py`.
- It verifies the helper returns `False` for a missing package.
- It also guards against reintroducing direct `_is_package_available("flash_attn")` or `_is_package_available("vllm")` usage.

Verification run:
- `python -m py_compile unsloth/models/_utils.py tests/test_package_availability.py`
- `ruff check unsloth/models/_utils.py tests/test_package_availability.py`
- `python -m pytest tests/test_package_availability.py`