### PR TITLE
fix(mlx): forward resume_from_checkpoint to MLXTrainer.train()

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1389,6 +1389,12 @@ def _run_mlx_training(event_queue, stop_queue, config):
     # Force text-only for non-image datasets even on vision-capable models
     # (e.g. Qwen3.5-VL trained on plain alpaca text).
     _send("status", status_message = f"Loading {model_name}...")
+    # Pull through resume_from_checkpoint so MLXTrainer.train() can restore
+    # optimizer + step state and continue cleanly. Was previously dropped on
+    # the floor for the MLX path, so the Resume UI button silently restarted
+    # from step 0 (the CUDA path at lines 2729 / 3108 has been forwarding
+    # this all along).
+    resume_from_checkpoint = config.get("resume_from_checkpoint") or None
     is_dataset_image = bool(config.get("is_dataset_image", False))
     training_type = config.get("training_type", "LoRA/QLoRA")
     use_lora = training_type == "LoRA/QLoRA"
@@ -1852,7 +1858,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
     # ── 11. Run training ──
     gc.collect()
     mx.synchronize()
-    trainer.train()
+    trainer.train(resume_from_checkpoint=resume_from_checkpoint)
 
     # ── 12. Save and finalize ──
     if trainer.stop_requested and not _stop_save[0]:


### PR DESCRIPTION
## Summary

Studio's frontend exposes a Resume action and submits requests with `resume_from_checkpoint` set to a previous run's output_dir. The CUDA training paths in `worker.py` read this field from config and pass it to `trainer.train()` (see lines 2729-2787 and 3108-3229). The MLX path `_run_mlx_training` did neither: it never read `config['resume_from_checkpoint']` and called `trainer.train()` with no args.

The MLX trainer also didn't accept the kwarg, so even threading it through would have been a no-op. The trainer-side support is added in [`unslothai/unsloth-zoo#751`](https://github.com/unslothai/unsloth-zoo/pull/751), which:

- Writes `optimizer_state.safetensors` and `trainer_state.json` on every checkpoint
- Adds `resume_from_checkpoint: str | None = None` to `MLXTrainer.train()`
- Loads adapter weights, optimizer state, and trainer scalars when resuming
- Fast-forwards the loop counter and dataloader to the resume position

This PR is the 2-line companion that makes Studio's MLX path actually use the kwarg.

## Changes

1. **Read `resume_from_checkpoint` from config** near the other `config.get()` extractions in `_run_mlx_training`.
2. **Pass it as a kwarg** at the `trainer.train()` call site.

## Verification

Together with `unsloth-zoo#751`, on M2 16GB with `unsloth/Qwen3-0.6B` + `unsloth/LaTeX_OCR`, `max_steps=10`, `save_steps=5`, `grad_accum=4`:

| Step | Fresh loss | Resumed loss |
|------|-----------|--------------|
| 6    | 2.1686279773712158 | 2.168627977371216 |
| 7    | 1.6476788520812988 | 1.6476788520812988 |
| 8    | 1.4659109115600586 | 1.4659109115600586 |
| 9    | 1.4719936847686768 | 1.4719936847686768 |
| 10   | 1.4772168397903442 | 1.4772168397903442 |

Every post-resume loss matches the fresh-run baseline bit for bit.

## Dependency

This PR is a no-op without [unsloth-zoo#751](https://github.com/unslothai/unsloth-zoo/pull/751). Should land in that order (zoo first, then this).