### PR TITLE
fix(studio/rocm): Fixed CPU fallback on multi-GPU ROCm

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3442,7 +3442,7 @@ class LlamaCppBackend:
 
                 # Pin to selected GPU(s). On ROCm, narrowing only
                 # CUDA_VISIBLE_DEVICES leaves an AMD child seeing the full
-                # HIP/ROCR set, so set those too.
+                # set, so set HIP_VISIBLE_DEVICES too.
                 if gpu_indices is not None:
                     pinned = ",".join(str(i) for i in gpu_indices)
                     env["CUDA_VISIBLE_DEVICES"] = pinned
@@ -3450,7 +3450,19 @@ class LlamaCppBackend:
                         import torch as _torch
                         if getattr(_torch.version, "hip", None) is not None:
                             env["HIP_VISIBLE_DEVICES"] = pinned
-                            env["ROCR_VISIBLE_DEVICES"] = pinned
+                            # Do NOT also set ROCR_VISIBLE_DEVICES to the same
+                            # value. ROCR_VISIBLE_DEVICES filters at the HSA/ROCr
+                            # layer and HIP_VISIBLE_DEVICES at the HIP layer, so
+                            # setting both with the same physical indices applies
+                            # the mask twice: ROCR reduces the visible set and
+                            # re-indexes it from 0, then HIP indexes into the
+                            # already-reduced set. A single non-zero pin (e.g.
+                            # "1") then points out of range at the HIP layer, HIP
+                            # enumerates 0 devices, and llama.cpp falls back to
+                            # CPU ("ggml_cuda_init: no ROCm-capable device is
+                            # detected"). The HIP mask alone narrows correctly;
+                            # clear any inherited ROCR mask so it can't double up.
+                            env.pop("ROCR_VISIBLE_DEVICES", None)
                     except Exception as e:
                         logger.debug("Failed to set ROCm visibility env vars for child: %s", e)
 


### PR DESCRIPTION
## Fix ROCm CPU fallback when a single non-zero GPU is pinned

Fixes #6175

### Problem
When pinning GPUs for the `llama-server` child, the ROCm path set **both** `HIP_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES` to the same indices. They filter at different layers and stack: `ROCR_VISIBLE_DEVICES` reduces the set at the HSA/ROCr layer and re-indexes from 0, then `HIP_VISIBLE_DEVICES` indexes into that reduced set. Since `_select_gpus` picks the most-free card, a single non-zero pin (e.g. `"1"`) ends up out of range at the HIP layer → 0 devices → silent CPU fallback (`ggml_cuda_init: failed to initialize ROCm: no ROCm-capable device is detected`).

### Fix
Set only `HIP_VISIBLE_DEVICES` (it narrows correctly on its own) and clear any inherited `ROCR_VISIBLE_DEVICES` so it can't double up. One file: `studio/backend/core/inference/llama_cpp.py`.

### Verification
2× Radeon AI PRO R9700 (gfx1201), ROCm 7.1.1: the same `selected=[1]` load that fell back to CPU, now runs on the GPU (VRAM usage is visible on amd-smi, faster generation).