### PR TITLE
Tests: follow Compare chat into the More submenu in the extra UI driver

### DIFF
--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -332,6 +332,21 @@ with sync_playwright() as p:
         plus_btn.click(force = True)
         page.wait_for_timeout(400)
         compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
+        if compare_item.count() == 0:
+            # Compare chat moved into the "More" submenu; hover, then click fallback.
+            more_trigger = page.get_by_role("menuitem", name = re.compile(r"^More$", re.I)).first
+            if more_trigger.count() > 0:
+                more_trigger.hover()
+                page.wait_for_timeout(400)
+                compare_item = page.get_by_role(
+                    "menuitem", name = re.compile(r"Compare chat", re.I)
+                ).first
+                if compare_item.count() == 0:
+                    more_trigger.click(force = True)
+                    page.wait_for_timeout(400)
+                    compare_item = page.get_by_role(
+                        "menuitem", name = re.compile(r"Compare chat", re.I)
+                    ).first
         if compare_item.count() > 0:
             compare_item.click(force = True)
             compare_opened = True


### PR DESCRIPTION
## What

All three Studio UI CI workflows (Linux, macOS, Windows) have been red on every run since the plus-menu declutter landed, failing with:

```
[ui-extra] FAIL: Compare nav not found
```

#6140 moved the Compare chat entry from the top level of the composer plus menu into the More submenu. #6153 updated `tests/studio/playwright_chat_ui.py` for the new location, but `tests/studio/playwright_extra_ui.py` still looks for the old top-level menu item, so its Compare step soft-fails on every run.

This applies the same fallback the chat UI driver uses: if the top-level item is missing, hover the More subtrigger (click as fallback) and look for Compare chat inside the submenu.

## Verification

Validated on a staging fork running the exact three UI workflows against current main plus this change: Studio UI CI, Mac Studio UI CI and Windows Studio UI CI all pass. The Compare step now opens the compare view and runs its composer flow; the two-bubble generation checks remain runtime warnings by design since CI panes have no per-pane model selected.

First red run on main for reference: https://github.com/unslothai/unsloth/actions/runs/27297164248