### PR TITLE
Tone down the green glow on the login and password setup pages

### DIFF
--- a/studio/frontend/src/features/auth/change-password-page.tsx
+++ b/studio/frontend/src/features/auth/change-password-page.tsx
@@ -14,7 +14,7 @@ export function ChangePasswordPage() {
         blur={34}
         speed={15}
         length="70vh"
-        style={{ opacity: 0.15 }}
+        className="opacity-35 dark:opacity-15"
       />
       <Card className="relative z-10 w-full max-w-sm px-5 py-6 shadow-border ring-1 ring-border sm:px-6 sm:py-8">
         <AuthForm mode="change-password" />

--- a/studio/frontend/src/features/auth/change-password-page.tsx
+++ b/studio/frontend/src/features/auth/change-password-page.tsx
@@ -10,11 +10,11 @@ export function ChangePasswordPage() {
     <div className="relative flex min-h-[calc(100dvh-var(--studio-titlebar-height,0px))] items-center justify-center overflow-hidden bg-background px-4 py-8 sm:px-6 sm:py-10 md:px-10">
       <LightRays
         count={6}
-        color="rgba(34, 197, 94, 0.25)"
+        color="rgba(34, 197, 94, 0.1)"
         blur={34}
         speed={15}
         length="70vh"
-        style={{ opacity: 0.4 }}
+        style={{ opacity: 0.15 }}
       />
       <Card className="relative z-10 w-full max-w-sm px-5 py-6 shadow-border ring-1 ring-border sm:px-6 sm:py-8">
         <AuthForm mode="change-password" />

--- a/studio/frontend/src/features/auth/login-page.tsx
+++ b/studio/frontend/src/features/auth/login-page.tsx
@@ -14,7 +14,7 @@ export function LoginPage() {
         blur={34}
         speed={15}
         length="70vh"
-        style={{ opacity: 0.15 }}
+        className="opacity-35 dark:opacity-15"
       />
       <Card className="relative z-10 w-full max-w-sm px-5 py-6 shadow-border ring-0 sm:px-6 sm:py-8">
         <AuthForm mode="login" />

--- a/studio/frontend/src/features/auth/login-page.tsx
+++ b/studio/frontend/src/features/auth/login-page.tsx
@@ -10,11 +10,11 @@ export function LoginPage() {
     <div className="relative flex min-h-[calc(100dvh-var(--studio-titlebar-height,0px))] items-center justify-center overflow-hidden bg-background px-4 py-8 sm:px-6 sm:py-10 md:px-10">
       <LightRays
         count={6}
-        color="rgba(34, 197, 94, 0.25)"
+        color="rgba(34, 197, 94, 0.1)"
         blur={34}
         speed={15}
         length="70vh"
-        style={{ opacity: 0.4 }}
+        style={{ opacity: 0.15 }}
       />
       <Card className="relative z-10 w-full max-w-sm px-5 py-6 shadow-border ring-0 sm:px-6 sm:py-8">
         <AuthForm mode="login" />


### PR DESCRIPTION
## What

The animated green light rays behind the login and change password cards were too strong. This lowers the ray color alpha from 0.25 to 0.1 and makes the layer opacity theme aware: 0.35 in light mode and 0.15 in dark mode (previously 0.4 in both).

## Why

The glow pulled attention away from the auth card and could wash out the top corners of the page on larger screens. The background should read as a hint of brand color, not a spotlight. Dark mode needs a lower opacity than light mode since the glow reads much stronger on a dark background.

## Changes

- studio/frontend/src/features/auth/login-page.tsx: LightRays color alpha 0.25 -> 0.1, opacity moved from an inline style to opacity-35 dark:opacity-15
- studio/frontend/src/features/auth/change-password-page.tsx: same values for parity

## Testing

Built the frontend and checked both auth pages in the browser in light and dark mode. The rays are still visible but sit quietly behind the card.