### PR TITLE
Fix dark mode toasts merging into card-colored surfaces

### DIFF
--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1751,10 +1751,11 @@
 	margin: 0 !important;
 }
 
-/* Boost shadow on dark surfaces; mirrors .shadow-border / .menu-soft-surface pattern. */
+/* Composer shadow on the dark background color so toasts
+   do not merge into card-colored surfaces behind them. */
 .dark [data-sonner-toast][data-styled='true'] {
-	background-color: var(--card) !important;
-	box-shadow: none !important;
+	background-color: var(--background) !important;
+	box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16) !important;
 }
 
 /* Selectable toast text; non-selectable toast buttons. */


### PR DESCRIPTION
## What

In dark mode, toast notifications used the card background color with no box shadow, so they could visually merge into panels and other card-colored elements behind them. This gives dark mode toasts the same drop shadow as the chat composer and switches their background to the page background color.

## Why

A toast that lands on top of a card-colored surface (for example the model panel) had no edge at all, since both surfaces shared var(--card) and the toast had box-shadow: none. Easy to reproduce with the model loaded toast over the right side panel.

## Changes

- studio/frontend/src/index.css: dark mode [data-sonner-toast] now uses var(--background) instead of var(--card) and the composer shadow (0 2px 8px -2px rgba(0, 0, 0, 0.16)) instead of none

Light mode toasts already used the composer shadow and are untouched.

## Testing

Built the frontend and triggered model load toasts in dark mode over the side panel. The toast now reads as its own surface instead of blending in.