### PR TITLE
Lint CI: diff import-hoist check against the PR merge-base, not the base tip

### DIFF
--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -105,29 +105,37 @@ jobs:
         # exactly where a hoist refactor lives, and it skips brand-new
         # files whose re-export imports would otherwise look "unused".
         #
-        # actions/checkout uses fetch-depth: 1, so the base branch is not
-        # present locally. Fetch the single base commit with an explicit
-        # refspec so origin/<base> is reliably created (a bare
-        # `git fetch origin <ref>` only updates FETCH_HEAD in some
-        # configs). Two-dot diff avoids needing a merge-base on a shallow
-        # clone.
+        # Diff against the true merge-base, not the base tip. A two-dot
+        # diff against the tip re-lints every file the base branch
+        # changed after the PR branched, comparing newer base code
+        # (BEFORE) against the PR's older snapshot (AFTER) - a
+        # time-reversed comparison that flags the base branch's own
+        # refactors as blockers on PRs that never touched those files.
+        # The compare API returns the merge-base without needing local
+        # history, and fetching that single commit by SHA keeps the
+        # shallow (fetch-depth: 1) clone.
         if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git fetch --no-tags --depth=1 origin \
-            "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          MERGE_BASE=$(gh api \
+            "repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            --jq .merge_base_commit.sha)
+          git fetch --no-tags --depth=1 origin "$MERGE_BASE"
           mapfile -t CHANGED < <(
             git diff --name-only --diff-filter=M \
-              "origin/${{ github.base_ref }}" HEAD -- '*.py' \
+              "$MERGE_BASE" HEAD -- '*.py' \
               | grep -vE '(^|/)(unsloth_compiled_cache|node_modules|build|dist)/' || true
           )
           if [ "${#CHANGED[@]}" -eq 0 ]; then
             echo "no in-place-modified Python files to check"
             exit 0
           fi
+          printf 'merge base: %s\n' "$MERGE_BASE"
           printf 'checking %d file(s):\n' "${#CHANGED[@]}"
           printf '  %s\n' "${CHANGED[@]}"
           python scripts/verify_import_hoist.py \
-            --before "origin/${{ github.base_ref }}" --after HEAD "${CHANGED[@]}"
+            --before "$MERGE_BASE" --after HEAD "${CHANGED[@]}"
 
       - name: No leftover debugger / pdb / breakpoint calls
         # Catches the "I'll just stick a breakpoint() here" mistake


### PR DESCRIPTION
The import-hoist safety step in Lint CI builds its changed-file list with a two-dot diff against the base branch tip on a shallow clone. Once main moves past a PR's branch point, that diff includes every file main changed since the branch point, and the verifier then runs with BEFORE = newer main code and AFTER = the PR's older snapshot. That time-reversed comparison reports main's own (clean) refactors as blockers on PRs that never touched those files, which forces pointless branch updates or admin merges.

Concrete case: the lint run on #6137 flagged a blocker in studio/backend/tests/test_llama_cpp_wait_for_health.py, a file that PR never modified. The file had been changed on main by #5940 after the PR branched. Running the verifier forward over #5940 (parent vs commit) is CLEAN, and the PR's own two files were also CLEAN, so the failure was purely an artifact of diffing against the base tip.

Fix: resolve the true merge-base through the compare API (no local history needed), fetch that single commit by SHA so the clone stays at fetch-depth 1, and use it for both the changed-file list and --before.

Verified locally against the real #6137 refs:

- base-tip diff (old logic): changed set includes studio files, verifier reports the false blocker, OVERALL: FAIL
- merge-base diff (new logic): changed set is exactly unsloth/models/llama.py and unsloth/models/vision.py, both CLEAN, OVERALL: PASS

scripts/verify_import_hoist.py --self-test still passes; the verifier itself is untouched.
