### PR TITLE
Studio: require an installed ROCm DLL before forcing BNB_ROCM_VERSION; drop shadowing shutil imports in save.py

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2150,6 +2150,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                 or os.environ.get("UNSLOTH_BNB_ROCM_VERSION_SOURCE") == "sitecustomize"
             ):
                 _bnb_rocm_ver = None
+                _found_rocm_bnb = False
                 try:
                     import glob as _glob
                     import importlib.util as _ilu
@@ -2162,6 +2163,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                             for _dll in _glob.glob(
                                 os.path.join(_pkg_dir, "libbitsandbytes_rocm*.dll")
                             ):
+                                _found_rocm_bnb = True
                                 _m = _re.search(
                                     r"libbitsandbytes_rocm(\d+)\.dll",
                                     os.path.basename(_dll),
@@ -2173,10 +2175,12 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                             _bnb_rocm_ver = max(_all_vers, key = lambda v: int(v))
                 except Exception:
                     pass
-                # No DLL found and nothing seeded: don't force a ROCm backend
-                # onto a non-ROCm bitsandbytes wheel.
-                _bnb_rocm_ver = _bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION")
-                if _bnb_rocm_ver:
+                # Only when a ROCm bnb DLL actually exists (mirrors main.py):
+                # without one the seeded value and its marker stay untouched,
+                # so later import fixes can still redetect or opt out. DLL
+                # with unparsable name -> seeded value or "72".
+                if _found_rocm_bnb:
+                    _bnb_rocm_ver = _bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION") or "72"
                     os.environ["BNB_ROCM_VERSION"] = _bnb_rocm_ver
                     os.environ["UNSLOTH_BNB_ROCM_VERSION_SOURCE"] = "detected"
                     logger.info(

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2143,9 +2143,8 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
 
             # BNB picks a rocm DLL from torch.version.hip, but AMD's Windows BNB
             # wheel may ship a DLL whose suffix doesn't match. Detect the actual
-            # DLL name and override; "72" is a safe fallback. Values seeded by
-            # the installer are redetectable defaults, while caller overrides
-            # remain authoritative.
+            # DLL name and override. Values seeded by the installer are
+            # redetectable defaults, while caller overrides remain authoritative.
             if (
                 "BNB_ROCM_VERSION" not in os.environ
                 or os.environ.get("UNSLOTH_BNB_ROCM_VERSION_SOURCE") == "sitecustomize"
@@ -2174,15 +2173,18 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                             _bnb_rocm_ver = max(_all_vers, key = lambda v: int(v))
                 except Exception:
                     pass
-                _bnb_rocm_ver = _bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION") or "72"
-                os.environ["BNB_ROCM_VERSION"] = _bnb_rocm_ver
-                os.environ["UNSLOTH_BNB_ROCM_VERSION_SOURCE"] = "detected"
-                logger.info(
-                    "Windows ROCm: set BNB_ROCM_VERSION=%s "
-                    "(detected from installed BNB wheel; "
-                    "overrides torch.version.hip auto-detection)",
-                    _bnb_rocm_ver,
-                )
+                # No DLL found and nothing seeded: don't force a ROCm backend
+                # onto a non-ROCm bitsandbytes wheel.
+                _bnb_rocm_ver = _bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION")
+                if _bnb_rocm_ver:
+                    os.environ["BNB_ROCM_VERSION"] = _bnb_rocm_ver
+                    os.environ["UNSLOTH_BNB_ROCM_VERSION_SOURCE"] = "detected"
+                    logger.info(
+                        "Windows ROCm: set BNB_ROCM_VERSION=%s "
+                        "(detected from installed BNB wheel; "
+                        "overrides torch.version.hip auto-detection)",
+                        _bnb_rocm_ver,
+                    )
 
             # Parse HIP version for the kernel-fix gate below, falling back to
             # the rocm version embedded in torch.__version__ when version.hip is

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -83,9 +83,9 @@ if sys.platform == "win32":
     # ── Windows AMD ROCm: set BNB_ROCM_VERSION before any bitsandbytes import ─
     # bitsandbytes derives the rocm<ver>.dll name from torch.version.hip, but the
     # wheel ships rocm72.dll, so the server crashes ("Configured ROCm binary not
-    # found") without this. Detect the shipped DLL and fall back to "72" (mirrors
-    # worker.py). Gate on the rocm bnb DLL / HIP_PATH rather than torch.version.hip
-    # to avoid importing torch on every Windows host.
+    # found") without this. Detect the shipped DLL (mirrors worker.py); gate on
+    # the rocm bnb DLL rather than torch.version.hip to avoid importing torch on
+    # every Windows host.
     # Values seeded by the installer's sitecustomize.py are redetectable
     # defaults; explicit caller values remain authoritative.
     if (
@@ -95,7 +95,6 @@ if sys.platform == "win32":
         import glob as _glob
         import logging as _logging
 
-        _hip_env = bool(os.environ.get("HIP_PATH") or os.environ.get("ROCM_PATH"))
         _bnb_rocm_ver = None
         _found_rocm_bnb = False
         try:
@@ -118,11 +117,13 @@ if sys.platform == "win32":
                     _bnb_rocm_ver = max(_all_vers_main, key = lambda v: int(v))
         except Exception as _e:
             _logging.getLogger(__name__).warning(
-                "Windows ROCm: BNB DLL detection failed (%s); falling back to version '72'",
+                "Windows ROCm: BNB DLL detection failed (%s); leaving BNB_ROCM_VERSION as is",
                 _e,
             )
-        # rocm bnb DLL present, or HIP_PATH/ROCM_PATH set (DLL unparsable -> "72")
-        if _found_rocm_bnb or _hip_env:
+        # Only when a ROCm bnb DLL actually exists: HIP_PATH/ROCM_PATH alone
+        # (HIP SDK on a CUDA/CPU box) must not force a ROCm backend onto a
+        # non-ROCm bitsandbytes, which raises at import. DLL unparsable -> "72".
+        if _found_rocm_bnb:
             _bnb_rocm_ver_final = _bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION") or "72"
             os.environ["BNB_ROCM_VERSION"] = _bnb_rocm_ver_final
             os.environ["UNSLOTH_BNB_ROCM_VERSION_SOURCE"] = "detected"

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2239,9 +2239,24 @@ class TestRuntimeBnbRocmSourceGuards:
 
     def test_fallback_prefers_seeded_value_over_hardcoded_72(self):
         """A failed redetect must not downgrade a persisted suffix to '72'."""
-        for path in (self._MAIN_PATH, self._TRAINING_WORKER_PATH):
-            source = path.read_text(encoding = "utf-8")
-            assert 'os.environ.get("BNB_ROCM_VERSION") or "72"' in source, path.name
+        main_source = self._MAIN_PATH.read_text(encoding = "utf-8")
+        assert '_bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION") or "72"' in main_source
+        worker_source = self._TRAINING_WORKER_PATH.read_text(encoding = "utf-8")
+        assert '_bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION")\n' in worker_source
+
+    def test_main_requires_found_rocm_dll(self):
+        """HIP_PATH/ROCM_PATH alone (HIP SDK on a CUDA/CPU box) must not force
+        a ROCm backend onto a non-ROCm bitsandbytes."""
+        source = self._MAIN_PATH.read_text(encoding = "utf-8")
+        assert "if _found_rocm_bnb:" in source
+        assert "_hip_env" not in source
+
+    def test_worker_does_not_force_72_without_dll_or_seed(self):
+        """With no DLL found and nothing seeded, the worker must not write a
+        blind '72' override."""
+        source = self._TRAINING_WORKER_PATH.read_text(encoding = "utf-8")
+        assert 'os.environ.get("BNB_ROCM_VERSION") or "72"' not in source
+        assert "if _bnb_rocm_ver:" in source
 
 
 class TestDetectBnbRocmDllVer:
@@ -2443,8 +2458,9 @@ class TestWorkerWindowsRocmPatches:
         assert "BNB_ROCM_VERSION" in source
         # Detection helper must be used
         assert "_detect_bnb_rocm_dll_ver" in source or "libbitsandbytes_rocm" in source
-        # "72" must appear as the safe fallback
-        assert '"72"' in source or "'72'" in source
+        # Falls back to the seeded value, never a blind "72" (which would
+        # force a ROCm backend onto a non-ROCm bitsandbytes wheel)
+        assert '_bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION")' in source
 
     def test_bnb_rocm_version_set_before_ml_imports(self):
         """BNB_ROCM_VERSION must appear in section 1f, before section 2 ML imports."""

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2239,10 +2239,11 @@ class TestRuntimeBnbRocmSourceGuards:
 
     def test_fallback_prefers_seeded_value_over_hardcoded_72(self):
         """A failed redetect must not downgrade a persisted suffix to '72'."""
-        main_source = self._MAIN_PATH.read_text(encoding = "utf-8")
-        assert '_bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION") or "72"' in main_source
-        worker_source = self._TRAINING_WORKER_PATH.read_text(encoding = "utf-8")
-        assert '_bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION")\n' in worker_source
+        for path in (self._MAIN_PATH, self._TRAINING_WORKER_PATH):
+            source = path.read_text(encoding = "utf-8")
+            assert (
+                '_bnb_rocm_ver or os.environ.get("BNB_ROCM_VERSION") or "72"' in source
+            ), path.name
 
     def test_main_requires_found_rocm_dll(self):
         """HIP_PATH/ROCM_PATH alone (HIP SDK on a CUDA/CPU box) must not force
@@ -2251,12 +2252,11 @@ class TestRuntimeBnbRocmSourceGuards:
         assert "if _found_rocm_bnb:" in source
         assert "_hip_env" not in source
 
-    def test_worker_does_not_force_72_without_dll_or_seed(self):
-        """With no DLL found and nothing seeded, the worker must not write a
-        blind '72' override."""
+    def test_worker_requires_found_rocm_dll(self):
+        """No DLL found: the worker must not write any override or touch the
+        seeded marker (later import fixes must still see sitecustomize)."""
         source = self._TRAINING_WORKER_PATH.read_text(encoding = "utf-8")
-        assert 'os.environ.get("BNB_ROCM_VERSION") or "72"' not in source
-        assert "if _bnb_rocm_ver:" in source
+        assert "if _found_rocm_bnb:" in source
 
 
 class TestDetectBnbRocmDllVer:

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1092,7 +1092,6 @@ def unsloth_save_model(
     gc.collect()
 
     # Remove temporary location
-    import shutil
 
     shutil.rmtree(temporary_location, ignore_errors = True)
 
@@ -1224,7 +1223,6 @@ def install_llama_cpp_old(version = -10):
         for i in range(30):
             print(f"**[WARNING]** Deleting llama.cpp directory... {30-i} seconds left.")
             time.sleep(1)
-        import shutil
 
         shutil.rmtree("llama.cpp", ignore_errors = True)
 
@@ -2494,7 +2492,6 @@ def unsloth_push_to_hub_gguf(
 
     except Exception as e:
         if cleanup_temp:
-            import shutil
             for d in [save_directory, f"{save_directory}_gguf"]:
                 try:
                     shutil.rmtree(d)
@@ -2681,7 +2678,6 @@ This model was finetuned and converted to GGUF format using [Unsloth](https://gi
         # Clean up temporary directory
         if cleanup_temp:
             print("Unsloth: Cleaning up temporary files...")
-            import shutil
             for d in [save_directory, f"{save_directory}_gguf"]:
                 if os.path.exists(d):
                     try:


### PR DESCRIPTION
## Summary

Two hardening items that came out of the review passes on #6048 / #5986 / #6149.

### 1. Studio runtime paths no longer force a ROCm backend without an installed ROCm DLL

`studio/backend/main.py` set `BNB_ROCM_VERSION=72` whenever `HIP_PATH` or `ROCM_PATH` was present, and the training worker fell back to a blind `"72"` when DLL detection found nothing. On a Windows machine with the AMD HIP SDK installed but CUDA or CPU torch, that forces a ROCm backend onto a non-ROCm bitsandbytes wheel, which raises at import. Both paths now write the override only when a `libbitsandbytes_rocm*.dll` actually exists in the installed wheel, or when keeping an already seeded value. This matches the strict gates `unsloth/import_fixes.py` already uses, so all four stages of the `BNB_ROCM_VERSION` pipeline (venv sitecustomize, server, worker, library import) now apply the same rule. Genuine Windows ROCm Studio venvs are unaffected: the installed AMD wheel ships the DLL, and the sitecustomize default covers detection hiccups.

### 2. Remove shadowing local `import shutil` statements in `unsloth/save.py`

Four function-local `import shutil` statements shadowed the module-level import (line 44). All were dormant, but this is the exact pattern that produced the installer `UnboundLocalError` fixed in #6149, and any refactor separating the import from its use would make it live. The module-level import now serves all uses.

## Validation

- `python -m pytest tests/studio/install/test_rocm_support.py tests/test_windows_rocm_bnb_version.py` passes (317 passed, 1 skipped); source-shape guard tests updated to assert the stricter gates
- Full BNB_ROCM_VERSION pipeline simulation rig (lifecycle, platform gating, writer edge cases, precedence truth table) passes 113/113 against this branch
- `ruff check` clean, `ast.parse` clean on all touched files, `git diff --check` clean
