### PR TITLE
Studio: llama.cpp update banner redesign, About tab license info, UI polish

### DIFF
--- a/studio/backend/routes/llama.py
+++ b/studio/backend/routes/llama.py
@@ -31,6 +31,7 @@ class LlamaUpdateJob(BaseModel):
     from_tag: Optional[str] = None
     to_tag: Optional[str] = None
     error: Optional[str] = None
+    progress: Optional[float] = Field(None, description = "0..1 while running, 1 on success.")
     started_at: Optional[str] = None
     finished_at: Optional[str] = None
 

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -28,6 +28,55 @@ import utils.llama_cpp_update as upd  # noqa: E402
 MARKER = "UNSLOTH_PREBUILT_INFO.json"
 
 
+class _FakeInstallerPopen:
+    """Stands in for the streamed installer process in _run_update."""
+
+    def __init__(
+        self,
+        cmd,
+        *,
+        returncode = 0,
+        lines = None,
+        on_start = None,
+        captured_kwargs = None,
+        **kwargs,
+    ):
+        if captured_kwargs is not None:
+            captured_kwargs.update(kwargs)
+        if on_start is not None:
+            on_start(list(cmd))
+        self.returncode = returncode
+        self.stdout = iter(lines or [])
+
+    def wait(self):
+        return self.returncode
+
+    def kill(self):
+        pass
+
+
+def _patch_installer_popen(
+    monkeypatch,
+    *,
+    returncode = 0,
+    lines = None,
+    on_start = None,
+    captured_kwargs = None,
+):
+    monkeypatch.setattr(
+        upd.subprocess,
+        "Popen",
+        lambda cmd, **kw: _FakeInstallerPopen(
+            cmd,
+            returncode = returncode,
+            lines = lines,
+            on_start = on_start,
+            captured_kwargs = captured_kwargs,
+            **kw,
+        ),
+    )
+
+
 def _write_install(
     dir_: Path,
     tag: str,
@@ -260,14 +309,15 @@ def test_start_update_source_build_installs_prebuilt(monkeypatch, tmp_path):
 
     def _fake_run(cmd, **kwargs):
         cmd = list(cmd)
-        # Status polls probe `llama-server --version`; keep the installer argv.
-        if "--version" in cmd:
-            return _Proc()
-        captured["cmd"] = cmd
-        _write_install(install_dir, "b9585")  # installer writes the marker
+        assert "--version" in cmd  # only status polls still use run()
         return _Proc()
 
+    def _on_start(cmd):
+        captured["cmd"] = cmd
+        _write_install(install_dir, "b9585")  # installer writes the marker
+
     monkeypatch.setattr(upd.subprocess, "run", _fake_run)
+    _patch_installer_popen(monkeypatch, on_start = _on_start)
 
     res = upd.start_update()
     assert res["started"] is True, res
@@ -298,21 +348,27 @@ def test_start_update_happy_path(monkeypatch, tmp_path):
         stdout = "installed"
         stderr = ""
 
-    def _fake_run(cmd, **kwargs):
-        cmd = list(cmd)
-        # Status polls probe `llama-server --version`; keep the installer argv.
-        if "--version" in cmd:
-            return _Proc()
+    def _on_start(cmd):
         captured["cmd"] = cmd
         # Simulate the installer writing a new marker with the latest tag.
         _write_install(install_dir, "b9518")
-        return _Proc()
 
-    monkeypatch.setattr(upd.subprocess, "run", _fake_run)
+    popen_kwargs: dict = {}
+    _patch_installer_popen(
+        monkeypatch,
+        lines = [
+            "[llama-prebuilt] resolving release\n",
+            "Downloading llama.zip:  35.0% (12.0 MiB/35.0 MiB) at 9.0 MiB/s\n",
+            "Downloading llama.zip:  80.0% (28.0 MiB/35.0 MiB) at 9.0 MiB/s\n",
+        ],
+        on_start = _on_start,
+        captured_kwargs = popen_kwargs,
+    )
 
     res = upd.start_update()
     assert res["started"] is True
     assert res["job"]["from_tag"] == "b9493"
+    assert res["job"]["progress"] == 0.0
 
     # Wait for the background worker.
     deadline = time.time() + 10
@@ -328,6 +384,10 @@ def test_start_update_happy_path(monkeypatch, tmp_path):
     assert str(install_dir) in captured["cmd"]
     assert "--llama-tag" in captured["cmd"] and "latest" in captured["cmd"]
     assert "unslothai/llama.cpp" in captured["cmd"]
+    # Progress lines were parsed and success pins progress at 1.0.
+    assert job["progress"] == 1.0
+    # The worker asks the installer for fine-grained progress milestones.
+    assert popen_kwargs["env"]["UNSLOTH_PROGRESS_PERCENT_STEP"] == "5"
 
 
 def test_start_update_installer_failure_reports_error(monkeypatch, tmp_path):
@@ -336,12 +396,7 @@ def test_start_update_installer_failure_reports_error(monkeypatch, tmp_path):
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
 
-    class _Proc:
-        returncode = 2
-        stdout = ""
-        stderr = "boom: network error"
-
-    monkeypatch.setattr(upd.subprocess, "run", lambda cmd, **kw: _Proc())
+    _patch_installer_popen(monkeypatch, returncode = 2, lines = ["boom: network error\n"])
 
     res = upd.start_update()
     assert res["started"] is True
@@ -410,14 +465,15 @@ def _capture_install_cmd(
 
     def _fake_run(cmd, **kwargs):
         cmd = list(cmd)
-        # Status polls probe `llama-server --version`; keep the installer argv.
-        if "--version" in cmd:
-            return _Proc()
-        captured["cmd"] = cmd
-        _write_install(install_dir, latest, repo = repo, asset = asset)
+        assert "--version" in cmd  # only status polls still use run()
         return _Proc()
 
+    def _on_start(cmd):
+        captured["cmd"] = cmd
+        _write_install(install_dir, latest, repo = repo, asset = asset)
+
     monkeypatch.setattr(upd.subprocess, "run", _fake_run)
+    _patch_installer_popen(monkeypatch, on_start = _on_start)
 
     res = upd.start_update()
     assert res["started"] is True, res
@@ -535,18 +591,12 @@ def test_update_sets_maintenance_flag_and_unloads(monkeypatch, tmp_path):
 
     seen = {}
 
-    class _Proc:
-        returncode = 0
-        stdout = "ok"
-        stderr = ""
-
-    def _fake_run(cmd, **kwargs):
+    def _on_start(cmd):
         # The maintenance flag must be set while the installer runs.
         seen["flag_during_install"] = backend._llama_update_in_progress
         _write_install(install_dir, "b9518")
-        return _Proc()
 
-    monkeypatch.setattr(upd.subprocess, "run", _fake_run)
+    _patch_installer_popen(monkeypatch, on_start = _on_start)
 
     res = upd.start_update()
     assert res["started"] is True
@@ -571,12 +621,7 @@ def test_update_clears_maintenance_flag_on_installer_failure(monkeypatch, tmp_pa
     backend = _FakeBackend()
     _inject_backend(monkeypatch, backend)
 
-    class _Proc:
-        returncode = 1
-        stdout = ""
-        stderr = "boom"
-
-    monkeypatch.setattr(upd.subprocess, "run", lambda cmd, **kw: _Proc())
+    _patch_installer_popen(monkeypatch, returncode = 1, lines = ["boom\n"])
 
     res = upd.start_update()
     assert res["started"] is True
@@ -606,16 +651,7 @@ def test_update_fails_open_when_backend_unavailable(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "routes", routes_pkg)
     monkeypatch.setitem(sys.modules, "routes.inference", inference_mod)
 
-    class _Proc:
-        returncode = 0
-        stdout = "ok"
-        stderr = ""
-
-    def _fake_run(cmd, **kwargs):
-        _write_install(install_dir, "b9518")
-        return _Proc()
-
-    monkeypatch.setattr(upd.subprocess, "run", _fake_run)
+    _patch_installer_popen(monkeypatch, on_start = lambda cmd: _write_install(install_dir, "b9518"))
 
     res = upd.start_update()
     assert res["started"] is True

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -59,9 +59,16 @@ _job: dict = {
     "from_tag": None,
     "to_tag": None,
     "error": None,
+    "progress": None,
     "started_at": None,
     "finished_at": None,
 }
+
+# Matches the installer's download progress lines, e.g.
+# "Downloading x.zip:  35.0% (12.3 MiB/35.1 MiB) at 8.2 MiB/s".
+_PROGRESS_LINE_RE = re.compile(r"(\d+(?:\.\d+)?)%\s*\(")
+# The download dominates the update; extract/validate fill the last slice.
+_DOWNLOAD_PROGRESS_CEILING = 0.95
 
 
 def _utcnow() -> str:
@@ -357,15 +364,46 @@ def _run_update(install_dir: Path, repo: str, asset: Optional[str], script: Path
         ]
         cmd.extend(_rocm_install_args(asset))
         logger.info("llama update: installing", cmd = " ".join(cmd))
-        proc = subprocess.run(
+        # Stream the installer output so download percent lines feed
+        # job["progress"]; finer milestones via UNSLOTH_PROGRESS_PERCENT_STEP.
+        env = dict(os.environ, UNSLOTH_PROGRESS_PERCENT_STEP = "5")
+        proc = subprocess.Popen(
             cmd,
-            capture_output = True,
+            stdout = subprocess.PIPE,
+            stderr = subprocess.STDOUT,
             text = True,
-            timeout = _INSTALL_TIMEOUT_SECONDS,
+            env = env,
         )
-        if proc.returncode != 0:
-            tail = (proc.stderr or proc.stdout or "").strip()[-1500:]
-            raise RuntimeError(f"installer exited {proc.returncode}: {tail or 'no output'}")
+        timed_out = threading.Event()
+
+        def _kill_on_timeout() -> None:
+            timed_out.set()
+            proc.kill()
+
+        watchdog = threading.Timer(_INSTALL_TIMEOUT_SECONDS, _kill_on_timeout)
+        watchdog.daemon = True
+        watchdog.start()
+        tail_lines: list[str] = []
+        try:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                tail_lines.append(line)
+                if len(tail_lines) > 80:
+                    del tail_lines[0]
+                m = _PROGRESS_LINE_RE.search(line)
+                if m is None:
+                    continue
+                fraction = min(float(m.group(1)) / 100.0, 1.0) * _DOWNLOAD_PROGRESS_CEILING
+                with _job_lock:
+                    _job["progress"] = max(_job.get("progress") or 0.0, fraction)
+            returncode = proc.wait()
+        finally:
+            watchdog.cancel()
+        if timed_out.is_set():
+            raise RuntimeError(f"installer timed out after {_INSTALL_TIMEOUT_SECONDS}s")
+        if returncode != 0:
+            tail = "".join(tail_lines).strip()[-1500:]
+            raise RuntimeError(f"installer exited {returncode}: {tail or 'no output'}")
 
         # New UNSLOTH_PREBUILT_INFO.json is on disk; drop caches so the next
         # status read reflects the freshly installed tag.
@@ -382,6 +420,7 @@ def _run_update(install_dir: Path, repo: str, asset: Optional[str], script: Path
                 ),
                 to_tag = new_tag,
                 error = None,
+                progress = 1.0,
                 finished_at = _utcnow(),
             )
         logger.info("llama update: success", to_tag = new_tag)
@@ -467,6 +506,7 @@ def start_update() -> dict:
             from_tag = from_tag,
             to_tag = None,
             error = None,
+            progress = 0.0,
             started_at = _utcnow(),
             finished_at = None,
         )
@@ -491,6 +531,7 @@ def _reset_job_for_tests() -> None:
             from_tag = None,
             to_tag = None,
             error = None,
+            progress = None,
             started_at = None,
             finished_at = None,
         )

--- a/studio/backend/utils/studio_version.py
+++ b/studio/backend/utils/studio_version.py
@@ -15,6 +15,7 @@ _DEV_VERSION = "dev"
 _GIT_TIMEOUT_SECONDS = 1.0
 _STUDIO_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.][0-9A-Za-z.-]*)?$")
 _GIT_DESCRIBE_SUFFIX_RE = re.compile(r"-\d+-g[0-9A-Fa-f]+(?:-dirty)?$")
+_GIT_BRANCH_RE = re.compile(r"^[0-9A-Za-z._/-]+$")
 _MAX_VERSION_LENGTH = 64
 
 
@@ -71,6 +72,35 @@ def _exact_git_studio_tag(repo_root: Path) -> str | None:
     return tag if is_valid_studio_release_version(tag) else None
 
 
+def _git_branch(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd = repo_root,
+            check = False,
+            stdout = subprocess.PIPE,
+            stderr = subprocess.DEVNULL,
+            text = True,
+            timeout = _GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    branch = result.stdout.strip()
+    # "HEAD" means detached, e.g. a tag or commit checkout.
+    if (
+        not branch
+        or branch == "HEAD"
+        or len(branch) > _MAX_VERSION_LENGTH
+        or _GIT_BRANCH_RE.fullmatch(branch) is None
+    ):
+        return None
+    return branch
+
+
 def get_studio_version(repo_root: Path | None = None) -> str:
     """Return the installed Studio release tag for display, or ``dev``.
 
@@ -81,7 +111,10 @@ def get_studio_version(repo_root: Path | None = None) -> str:
 
     if _is_source_checkout(resolved_repo_root):
         git_tag = _exact_git_studio_tag(resolved_repo_root)
-        return git_tag if git_tag is not None else _DEV_VERSION
+        if git_tag is not None:
+            return git_tag
+        branch = _git_branch(resolved_repo_root)
+        return f"GitHub {branch}" if branch is not None else _DEV_VERSION
 
     stamped_version = _studio_release_build.STUDIO_RELEASE_VERSION
     if is_valid_studio_release_version(stamped_version):

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -856,7 +856,7 @@ export function AppSidebar() {
                     <HugeiconsIcon
                       icon={PlusSignIcon}
                       strokeWidth={1.75}
-                      className="size-icon"
+                      className="size-4"
                     />
                   </span>
                 </button>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1065,7 +1065,7 @@ export function AppSidebar() {
                       className="!size-[32px]"
                     />
                   </div>
-                  <div className="flex flex-col gap-0 leading-tight group-data-[collapsible=icon]:hidden">
+                  <div className="flex flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden">
                     <span className="truncate font-heading text-[13.5px] tracking-[0.025em] dark:tracking-[0.04em] font-semibold text-nav-fg">{displayTitle}</span>
                     <span className="truncate text-[11.5px] tracking-nav text-muted-foreground">Unsloth</span>
                   </div>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1065,7 +1065,7 @@ export function AppSidebar() {
                       className="!size-[32px]"
                     />
                   </div>
-                  <div className="flex flex-col gap-0.5 leading-tight group-data-[collapsible=icon]:hidden">
+                  <div className="flex flex-col gap-0 leading-tight group-data-[collapsible=icon]:hidden">
                     <span className="truncate font-heading text-[13.5px] tracking-[0.025em] dark:tracking-[0.04em] font-semibold text-nav-fg">{displayTitle}</span>
                     <span className="truncate text-[11.5px] tracking-nav text-muted-foreground">Unsloth</span>
                   </div>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -60,6 +60,7 @@ import {
   Logout05Icon,
   MoreVerticalIcon,
   Search01Icon,
+  PlusSignIcon,
   PowerIcon,
   PencilEdit02Icon,
   LayoutAlignLeftIcon,
@@ -558,7 +559,8 @@ export function AppSidebar() {
         : "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
     const buttonClass = cn(
       "sidebar-nav-btn h-[33px] cursor-pointer rounded-full pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
-      variant === "project" ? "pl-[39px]" : "pl-3",
+      // pl-3.5 starts the title at the same x as the Recents label text.
+      variant === "project" ? "pl-[39px]" : "pl-3.5",
       variant === "project"
         ? "group-hover/project-chat-item:pr-8 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-8"
         : "group-hover/recent-item:pr-8 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-8",
@@ -837,7 +839,28 @@ export function AppSidebar() {
                   navigate({ to: "/projects" });
                   closeMobileIfOpen();
                 }}
-              />
+                className="group/projects-item relative"
+              >
+                <button
+                  type="button"
+                  aria-label="New project"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setProjectCreateMoveTarget(null);
+                    setProjectNameDraft("");
+                    setCreatingProject(true);
+                  }}
+                  className="sidebar-row-action group-hover/projects-item:opacity-100 group-hover/projects-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto group-data-[collapsible=icon]:hidden"
+                >
+                  <span className="sidebar-row-action-glyph">
+                    <HugeiconsIcon
+                      icon={PlusSignIcon}
+                      strokeWidth={1.75}
+                      className="size-icon"
+                    />
+                  </span>
+                </button>
+              </NavItem>
               <NavItem
                 icon={DashboardCircleIcon}
                 label={t("shell.navigation.hub")}

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -45,6 +45,7 @@ export function LlamaUpdateBanner({
 
   const show =
     visible && status != null && (status.update_available || applying);
+  const updateProgress = status?.job.progress ?? null;
 
   return (
     <AnimatePresence>
@@ -100,9 +101,25 @@ export function LlamaUpdateBanner({
                 className="mb-1.5 mt-4 h-1 overflow-hidden rounded-full bg-muted"
                 role="progressbar"
                 aria-label="Updating llama.cpp"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={
+                  updateProgress != null
+                    ? Math.round(updateProgress * 100)
+                    : undefined
+                }
                 data-testid="llama-update-progress"
               >
-                <div className="loading-bar-slide h-full w-1/3 rounded-full bg-primary" />
+                {updateProgress != null && updateProgress > 0 ? (
+                  <div
+                    className="h-full rounded-full bg-primary transition-[width] duration-700 ease-out"
+                    style={{ width: `${Math.round(updateProgress * 100)}%` }}
+                  />
+                ) : (
+                  // No percent yet (resolving the release): sweep until the
+                  // first download progress arrives.
+                  <div className="loading-bar-slide h-full w-1/3 rounded-full bg-primary" />
+                )}
               </div>
             ) : (
               <div className="mt-3 flex items-center gap-2">

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -3,9 +3,10 @@
 
 import { Button } from "@/components/ui/button";
 import { useLlamaUpdateCheck } from "@/hooks/use-llama-update-check";
+import { useShowLlamaUpdateBanner } from "@/hooks/use-llama-update-pref";
 import { toast } from "@/lib/toast";
 import { AnimatePresence, motion } from "motion/react";
-import { type ReactElement, useEffect, useRef } from "react";
+import type { ReactElement } from "react";
 
 const EASE_OUT_QUART: [number, number, number, number] = [0.165, 0.84, 0.44, 1];
 
@@ -15,15 +16,19 @@ interface LlamaUpdateBannerProps {
 
 /**
  * Non-invasive "Update llama.cpp" affordance. Appears bottom-right ~1s after a
- * newer prebuilt is detected and stays up until dismissed (click outside / X)
- * or updated. Clicking Update swaps the prebuilt in place via POST /api/llama/update.
+ * newer prebuilt is detected and stays up until the user explicitly acts on it
+ * (X, Update, or Remind me later). Clicking Update swaps the prebuilt in place
+ * via POST /api/llama/update. Can be turned off entirely in Settings ->
+ * General -> Notifications (on by default).
  */
 export function LlamaUpdateBanner({
   enabled = true,
 }: LlamaUpdateBannerProps): ReactElement | null {
-  const { status, visible, applying, apply, dismiss } = useLlamaUpdateCheck({
-    enabled,
-  });
+  const showBannerPref = useShowLlamaUpdateBanner();
+  const { status, visible, applying, apply, dismiss, snooze } =
+    useLlamaUpdateCheck({
+      enabled: enabled && showBannerPref,
+    });
 
   async function handleUpdate() {
     const result = await apply();
@@ -40,30 +45,11 @@ export function LlamaUpdateBanner({
 
   const show =
     visible && status != null && (status.update_available || applying);
-  const bannerRef = useRef<HTMLDivElement>(null);
-
-  // Dismiss when the user clicks anything outside the banner. Kept off while an
-  // update is applying so the progress stays visible.
-  useEffect(() => {
-    if (!show || applying) return;
-    function onPointerDown(event: PointerEvent) {
-      if (
-        bannerRef.current &&
-        !bannerRef.current.contains(event.target as Node)
-      ) {
-        dismiss();
-      }
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    return () =>
-      document.removeEventListener("pointerdown", onPointerDown, true);
-  }, [show, applying, dismiss]);
 
   return (
     <AnimatePresence>
       {show ? (
         <motion.div
-          ref={bannerRef}
           initial={{ opacity: 0, y: 12, scale: 0.96 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
           exit={{ opacity: 0, y: 8, scale: 0.97 }}
@@ -71,12 +57,12 @@ export function LlamaUpdateBanner({
           className="fixed bottom-4 right-4 z-[9998] w-[calc(100vw-2rem)] max-w-[340px]"
           data-testid="llama-update-banner"
         >
-          <div className="corner-squircle relative overflow-hidden border border-border/60 bg-background/95 px-4 py-3 shadow-lg backdrop-blur-md">
+          <div className="relative overflow-hidden rounded-[24px] bg-white px-4 py-5 pl-6 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
             {applying ? null : (
               <button
                 type="button"
                 onClick={dismiss}
-                className="absolute top-2.5 right-2.5 flex size-5 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+                className="absolute top-2.5 right-3 flex size-6 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
                 aria-label="Dismiss llama.cpp update notification"
               >
                 <svg
@@ -97,31 +83,39 @@ export function LlamaUpdateBanner({
               </button>
             )}
 
-            <div className="flex items-center gap-2 pr-5">
-              <span className="text-base" aria-hidden="true">
-                🦥
-              </span>
-              <p className="text-sm font-medium text-foreground">
-                {applying ? "Updating llama.cpp..." : "New llama.cpp prebuilt"}
+            <div className="min-w-0 pr-6">
+              <p className="font-heading text-base font-medium text-foreground">
+                {applying ? "Updating llama.cpp..." : "New llama.cpp version"}
+              </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {status?.installed_tag ?? "unknown"} &rarr;{" "}
+                <span className="font-medium text-foreground">
+                  {status?.latest_tag ?? ""}
+                </span>
               </p>
             </div>
-            <p className="mt-0.5 pl-7 text-xs text-muted-foreground">
-              {status?.installed_tag ?? "unknown"} &rarr;{" "}
-              <span className="font-medium text-foreground">
-                {status?.latest_tag ?? ""}
-              </span>
-            </p>
 
-            <div className="mt-2.5 pl-7">
+            <div className="mt-3 flex items-center gap-2">
               <Button
                 size="sm"
-                className="corner-squircle"
+                className="h-auto rounded-full px-3.5 py-2 text-[13px]"
                 onClick={handleUpdate}
                 disabled={applying}
                 data-testid="llama-update-button"
               >
-                {applying ? "Updating..." : "Update llama.cpp"}
+                {applying ? "Updating..." : "Update"}
               </Button>
+              {applying ? null : (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-auto rounded-full px-2.5 py-2 text-[13px] text-muted-foreground hover:text-foreground"
+                  onClick={snooze}
+                  data-testid="llama-update-snooze-button"
+                >
+                  Remind me later
+                </Button>
+              )}
             </div>
           </div>
         </motion.div>

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -57,7 +57,7 @@ export function LlamaUpdateBanner({
           className="fixed bottom-4 right-4 z-[9998] w-[calc(100vw-2rem)] max-w-[340px]"
           data-testid="llama-update-banner"
         >
-          <div className="relative overflow-hidden rounded-[24px] bg-white px-4 py-5 pl-6 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
+          <div className="relative overflow-hidden rounded-[24px] bg-white px-4 pb-6 pl-6 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
             {applying ? null : (
               <button
                 type="button"

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -95,17 +95,25 @@ export function LlamaUpdateBanner({
               </p>
             </div>
 
-            <div className="mt-3 flex items-center gap-2">
-              <Button
-                size="sm"
-                className="h-auto rounded-full px-3.5 py-2 text-[13px]"
-                onClick={handleUpdate}
-                disabled={applying}
-                data-testid="llama-update-button"
+            {applying ? (
+              <div
+                className="mb-1.5 mt-4 h-1 overflow-hidden rounded-full bg-muted"
+                role="progressbar"
+                aria-label="Updating llama.cpp"
+                data-testid="llama-update-progress"
               >
-                {applying ? "Updating..." : "Update"}
-              </Button>
-              {applying ? null : (
+                <div className="loading-bar-slide h-full w-1/3 rounded-full bg-primary" />
+              </div>
+            ) : (
+              <div className="mt-3 flex items-center gap-2">
+                <Button
+                  size="sm"
+                  className="h-auto rounded-full px-3.5 py-2 text-[13px]"
+                  onClick={handleUpdate}
+                  data-testid="llama-update-button"
+                >
+                  Update
+                </Button>
                 <Button
                   size="sm"
                   variant="ghost"
@@ -115,8 +123,8 @@ export function LlamaUpdateBanner({
                 >
                   Remind me later
                 </Button>
-              )}
-            </div>
+              </div>
+            )}
           </div>
         </motion.div>
       ) : null}

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -57,7 +57,7 @@ export function LlamaUpdateBanner({
           className="fixed bottom-4 right-4 z-[9998] w-[calc(100vw-2rem)] max-w-[340px]"
           data-testid="llama-update-banner"
         >
-          <div className="relative overflow-hidden rounded-[24px] bg-white px-4 pb-6 pl-6 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
+          <div className="relative overflow-hidden rounded-[24px] bg-white px-4 pb-[22px] pl-6 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
             {applying ? null : (
               <button
                 type="button"

--- a/studio/frontend/src/components/tauri/startup-screen.tsx
+++ b/studio/frontend/src/components/tauri/startup-screen.tsx
@@ -228,7 +228,7 @@ function RepairingContent({
       </div>
       <div className="mb-10 flex flex-col items-center gap-2">
         <TealSpinner />
-        <p className="text-sm font-bold text-foreground">Updating existing Studio install...</p>
+        <p className="text-sm font-bold text-foreground">Updating existing Unsloth install...</p>
         {latest && (
           <p className="max-w-xs text-center text-xs text-muted-foreground">{latest}</p>
         )}

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -98,9 +98,27 @@ function TooltipContent({
 }: React.ComponentProps<typeof TooltipPrimitive.Content> & {
   variant?: TooltipVariant;
 }) {
+  // Single-line compact tooltips render as a full pill; wrapped ones keep
+  // the squarer corners so tall pills do not look like capsules. A ref
+  // callback measures on mount: Radix mounts the portal content without
+  // re-rendering this wrapper, so an effect here would never see the node.
+  const measureRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (!el || variant !== "default") return;
+      const cs = getComputedStyle(el);
+      const lineHeight = Number.parseFloat(cs.lineHeight) || 16;
+      const innerHeight =
+        el.clientHeight -
+        Number.parseFloat(cs.paddingTop) -
+        Number.parseFloat(cs.paddingBottom);
+      el.classList.toggle("rounded-full!", innerHeight < lineHeight * 1.5);
+    },
+    [variant],
+  );
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
+        ref={measureRef}
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -2,13 +2,16 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { Button } from "@/components/ui/button";
+import { usePlatformStore } from "@/config/env";
 import { useWebUpdateCheck } from "@/hooks/use-web-update-check";
 import { isTauri } from "@/lib/api-base";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { AnimatePresence, motion } from "motion/react";
 import { type ReactElement, useEffect, useRef, useState } from "react";
 
-const STUDIO_UPDATE_CMD = "unsloth studio update";
+const STUDIO_INSTALL_UNIX_CMD =
+  "curl -fsSL https://unsloth.ai/install.sh | sh";
+const STUDIO_INSTALL_WINDOWS_CMD = "irm https://unsloth.ai/install.ps1 | iex";
 const RELEASE_NOTES_URL = "https://unsloth.ai/docs/new/changelog";
 const EASE_OUT_QUART: [number, number, number, number] = [0.165, 0.84, 0.44, 1];
 
@@ -20,6 +23,11 @@ export function WebUpdateBanner({
   enabled = true,
 }: WebUpdateBannerProps): ReactElement | null {
   const { status, dismiss } = useWebUpdateCheck({ enabled });
+  const deviceType = usePlatformStore((s) => s.deviceType);
+  const installCmd =
+    deviceType === "windows"
+      ? STUDIO_INSTALL_WINDOWS_CMD
+      : STUDIO_INSTALL_UNIX_CMD;
   const [copiedVersion, setCopiedVersion] = useState<string | null>(null);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -36,7 +44,7 @@ export function WebUpdateBanner({
   }
 
   async function handleCopyCommand() {
-    if (!(await copyToClipboard(STUDIO_UPDATE_CMD))) {
+    if (!(await copyToClipboard(installCmd))) {
       return;
     }
     setCopiedVersion(status?.latestVersion ?? null);

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -89,8 +89,8 @@ export function WebUpdateBanner({
                   Package update available: {status.latestVersion}
                 </p>
                 <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                  Installed package: {status.currentVersion}. To update Studio,
-                  run this in your terminal, then restart Studio.
+                  Installed package: {status.currentVersion}. To update Unsloth,
+                  run this in your terminal, then restart Unsloth.
                 </p>
               </div>
             </div>

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -46,12 +46,28 @@ export async function fetchDeviceType(): Promise<DeviceType> {
   if (fetched) return usePlatformStore.getState().deviceType;
 
   try {
-    const res = await fetch(apiUrl("/api/health"));
+    // /api/health only reports the server's device_type to authed callers.
+    // Read the token from storage directly: importing features/auth here
+    // would be an import cycle (auth/session imports this store).
+    const token =
+      typeof window === "undefined"
+        ? null
+        : localStorage.getItem("unsloth_auth_token");
+    const res = await fetch(apiUrl("/api/health"), {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
     if (res.ok) {
       const data = (await res.json()) as { device_type?: string; chat_only?: boolean };
       const deviceType = data.device_type ?? detectLocalPlatform();
       const chatOnly = data.chat_only ?? false;
-      usePlatformStore.setState({ deviceType, chatOnly, fetched: true });
+      // Cache only a server-reported platform. Unauthenticated responses fall
+      // back to the browser platform, which can differ from the host (WSL,
+      // SSH); keeping fetched=false retries once a token exists.
+      usePlatformStore.setState({
+        deviceType,
+        chatOnly,
+        fetched: data.device_type !== undefined,
+      });
       return deviceType;
     }
   } catch {

--- a/studio/frontend/src/features/auth/api.ts
+++ b/studio/frontend/src/features/auth/api.ts
@@ -175,7 +175,7 @@ export async function authFetch(
           "You appear to be offline. Check your network connection and try again.",
         );
       }
-      throw new Error("Studio isn't running -- please relaunch it.");
+      throw new Error("Unsloth isn't running -- please relaunch it.");
     }
     throw err;
   }

--- a/studio/frontend/src/features/auth/tauri-auto-auth.ts
+++ b/studio/frontend/src/features/auth/tauri-auto-auth.ts
@@ -26,7 +26,7 @@ let pending: { promise: Promise<boolean>; force: boolean } | null = null;
 let lastTauriAuthFailure: string | null = null;
 
 const TAURI_AUTH_FAILURE_FALLBACK =
-  "Desktop authentication failed. Update or repair the managed Studio install, then restart Studio.";
+  "Desktop authentication failed. Update or repair the managed Unsloth install, then restart Unsloth.";
 const BACKEND_NOT_READY_MESSAGE = "Backend is not ready";
 
 function authFailureMessage(error: unknown): string {

--- a/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
@@ -18,7 +18,7 @@ const describeMediaError = (error: unknown): string => {
     return "Dictation could not access the microphone.";
   }
   if (error.name === "NotAllowedError") {
-    return "Microphone access is blocked. Allow microphone access for this Studio page, then try again.";
+    return "Microphone access is blocked. Allow microphone access for this Unsloth page, then try again.";
   }
   if (error.name === "NotFoundError") {
     return "No microphone was found for dictation.";
@@ -31,7 +31,7 @@ const describeMediaError = (error: unknown): string => {
 
 const describeSpeechError = (error: string, message?: string): string => {
   if (error === "not-allowed") {
-    return "Speech recognition was blocked by the browser. Check microphone permissions for this Studio page.";
+    return "Speech recognition was blocked by the browser. Check microphone permissions for this Unsloth page.";
   }
   if (error === "service-not-allowed") {
     return "Speech recognition is blocked by the browser speech service.";

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -1511,7 +1511,7 @@ export function ChatProvidersSettings({
         <div className="flex min-w-0 flex-col gap-1">
           <h1 className="font-heading text-lg font-semibold">Connections</h1>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            Manage model connections for chat through the Studio proxy.
+            Manage model connections for chat through the Unsloth proxy.
           </p>
         </div>
       </header>

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -1511,7 +1511,7 @@ export function ChatProvidersSettings({
         <div className="flex min-w-0 flex-col gap-1">
           <h1 className="font-heading text-lg font-semibold">Connections</h1>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            Manage model connections for chat through the Unsloth proxy.
+            Manage model connections for chat.
           </p>
         </div>
       </header>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1295,28 +1295,36 @@ export function ChatSettingsPanel({
             </Tooltip>
           }
         >
-          <textarea
-            ref={systemPromptBoxRef}
-            value={params.systemPrompt}
-            onChange={(e) => set("systemPrompt")(e.target.value)}
-            onMouseDown={(e) => {
-              // Overflowing prompt: click opens the popup editor instead.
-              // While focused, clicks still move the caret normally.
-              if (
-                systemPromptOverflows &&
-                document.activeElement !== e.currentTarget
-              ) {
-                e.preventDefault();
-                openSystemPromptEditor();
-              }
-            }}
-            placeholder="Example: You are a helpful assistant..."
-            aria-label="System prompt"
+          {/* Rounded wrapper clips overflowing text and the scrollbar. */}
+          <div
             className={cn(
-              "panel-text-surface -mt-1 block w-full h-20 resize-none px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed corner-squircle text-nav-fg placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[1px] focus-visible:ring-ring/40",
+              "panel-text-surface -mt-1 h-20 w-full overflow-hidden corner-squircle focus-within:ring-[1px] focus-within:ring-ring/40",
               systemPromptOverflows && "cursor-pointer",
             )}
-          />
+          >
+            <textarea
+              ref={systemPromptBoxRef}
+              value={params.systemPrompt}
+              onChange={(e) => set("systemPrompt")(e.target.value)}
+              onMouseDown={(e) => {
+                // Overflowing prompt: click opens the popup editor instead.
+                // While focused, clicks still move the caret normally.
+                if (
+                  systemPromptOverflows &&
+                  document.activeElement !== e.currentTarget
+                ) {
+                  e.preventDefault();
+                  openSystemPromptEditor();
+                }
+              }}
+              placeholder="Example: You are a helpful assistant..."
+              aria-label="System prompt"
+              className={cn(
+                "block size-full resize-none bg-transparent px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed text-nav-fg outline-none placeholder:text-muted-foreground",
+                systemPromptOverflows && "cursor-pointer",
+              )}
+            />
+          </div>
         </CollapsibleSection>
 
         <CollapsibleSection label="Sampling" defaultOpen={true}>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -749,7 +749,10 @@ export function ChatSettingsPanel({
   useEffect(() => {
     const el = systemPromptBoxRef.current;
     setSystemPromptOverflows(
-      el != null && el.scrollHeight > el.clientHeight + 1,
+      params.systemPrompt.length > 0 &&
+        el != null &&
+        el.clientHeight > 0 &&
+        el.scrollHeight > el.clientHeight + 1,
     );
   }, [params.systemPrompt, open]);
 

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -324,6 +324,7 @@ function CollapsibleSection({
   label,
   labelHref,
   headerAction,
+  onLabelClick,
   children,
   defaultOpen = false,
   first = false,
@@ -341,6 +342,8 @@ function CollapsibleSection({
    * nested in a button.
    */
   headerAction?: ReactNode;
+  /** When set, clicking the label runs this instead of toggling collapse. */
+  onLabelClick?: () => void;
   children?: ReactNode;
   defaultOpen?: boolean;
   first?: boolean;
@@ -394,7 +397,7 @@ function CollapsibleSection({
         <div className={headerClasses}>
           <button
             type="button"
-            onClick={toggle}
+            onClick={onLabelClick ?? toggle}
             className="flex min-w-0 flex-1 cursor-pointer items-center text-left leading-none transition-colors hover:text-nav-fg"
           >
             <span className="leading-none">{label}</span>
@@ -536,6 +539,9 @@ export function ChatSettingsPanel({
   const [presetNameInput, setPresetNameInput] = useState(activePreset);
   const [systemPromptEditorOpen, setSystemPromptEditorOpen] = useState(false);
   const [systemPromptDraft, setSystemPromptDraft] = useState("");
+  // When the prompt overflows the inline box, clicking opens the popup editor.
+  const systemPromptBoxRef = useRef<HTMLTextAreaElement>(null);
+  const [systemPromptOverflows, setSystemPromptOverflows] = useState(false);
   const [activePresetBaseline, setActivePresetBaseline] = useState(params);
   const presets = useMemo(() => {
     return getOrderedPresets(customPresets);
@@ -739,6 +745,13 @@ export function ChatSettingsPanel({
       setSystemPromptEditorOpen(false);
     }
   }, [open]);
+
+  useEffect(() => {
+    const el = systemPromptBoxRef.current;
+    setSystemPromptOverflows(
+      el != null && el.scrollHeight > el.clientHeight + 1,
+    );
+  }, [params.systemPrompt, open]);
 
   const settingsScrollRef = useRef<HTMLDivElement>(null);
 
@@ -1252,6 +1265,7 @@ export function ChatSettingsPanel({
         <CollapsibleSection
           label="System Prompt"
           defaultOpen={true}
+          onLabelClick={openSystemPromptEditor}
           headerAction={
             <Tooltip>
               <TooltipPrimitive.Trigger asChild>
@@ -1278,20 +1292,28 @@ export function ChatSettingsPanel({
             </Tooltip>
           }
         >
-          <button
-            type="button"
-            onClick={openSystemPromptEditor}
-            aria-label="Edit system prompt"
+          <textarea
+            ref={systemPromptBoxRef}
+            value={params.systemPrompt}
+            onChange={(e) => set("systemPrompt")(e.target.value)}
+            onMouseDown={(e) => {
+              // Overflowing prompt: click opens the popup editor instead.
+              // While focused, clicks still move the caret normally.
+              if (
+                systemPromptOverflows &&
+                document.activeElement !== e.currentTarget
+              ) {
+                e.preventDefault();
+                openSystemPromptEditor();
+              }
+            }}
+            placeholder="Example: You are a helpful assistant..."
+            aria-label="System prompt"
             className={cn(
-              "panel-text-surface -mt-1 flex w-full h-20 overflow-hidden cursor-pointer items-start px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed corner-squircle focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[1px] focus-visible:ring-ring/40",
-              params.systemPrompt ? "text-nav-fg" : "text-muted-foreground",
+              "panel-text-surface -mt-1 block w-full h-20 resize-none px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed corner-squircle text-nav-fg placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[1px] focus-visible:ring-ring/40",
+              systemPromptOverflows && "cursor-pointer",
             )}
-          >
-            <span className="block line-clamp-3 whitespace-pre-wrap break-words">
-              {params.systemPrompt ||
-                "Example: You are a helpful assistant..."}
-            </span>
-          </button>
+          />
         </CollapsibleSection>
 
         <CollapsibleSection label="Sampling" defaultOpen={true}>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -536,6 +536,9 @@ export function ChatSettingsPanel({
   const [presetNameInput, setPresetNameInput] = useState(activePreset);
   const [systemPromptEditorOpen, setSystemPromptEditorOpen] = useState(false);
   const [systemPromptDraft, setSystemPromptDraft] = useState("");
+  // When the prompt overflows the inline box, clicking opens the popup editor.
+  const systemPromptBoxRef = useRef<HTMLTextAreaElement>(null);
+  const [systemPromptOverflows, setSystemPromptOverflows] = useState(false);
   const [activePresetBaseline, setActivePresetBaseline] = useState(params);
   const presets = useMemo(() => {
     return getOrderedPresets(customPresets);
@@ -739,6 +742,13 @@ export function ChatSettingsPanel({
       setSystemPromptEditorOpen(false);
     }
   }, [open]);
+
+  useEffect(() => {
+    const el = systemPromptBoxRef.current;
+    setSystemPromptOverflows(
+      el != null && el.scrollHeight > el.clientHeight + 1,
+    );
+  }, [params.systemPrompt, open]);
 
   const settingsScrollRef = useRef<HTMLDivElement>(null);
 
@@ -1071,7 +1081,7 @@ export function ChatSettingsPanel({
                     />
                     <InputGroupAddon
                       align="inline-end"
-                      className="min-h-0 shrink-0 gap-0 self-stretch border-0 py-0 pl-0 !pr-1 has-[>button]:mr-0"
+                      className="min-h-0 shrink-0 gap-0 self-stretch border-0 py-0 pl-0 !pr-1 has-[>button]:mr-0 !cursor-pointer"
                     >
                       <span
                         className="!h-7 min-h-7 !w-7 min-w-7 shrink-0 self-center inline-flex items-center justify-center rounded-full border-0 px-0 text-[#a0a097] dark:text-nav-fg pointer-events-none"
@@ -1278,22 +1288,28 @@ export function ChatSettingsPanel({
             </Tooltip>
           }
         >
-          <button
-            type="button"
-            onClick={openSystemPromptEditor}
-            aria-label="Edit system prompt"
+          <textarea
+            ref={systemPromptBoxRef}
+            value={params.systemPrompt}
+            onChange={(e) => set("systemPrompt")(e.target.value)}
+            onMouseDown={(e) => {
+              // Overflowing prompt: click opens the popup editor instead.
+              // While focused, clicks still move the caret normally.
+              if (
+                systemPromptOverflows &&
+                document.activeElement !== e.currentTarget
+              ) {
+                e.preventDefault();
+                openSystemPromptEditor();
+              }
+            }}
+            placeholder="Example: You are a helpful assistant..."
+            aria-label="System prompt"
             className={cn(
-              "panel-text-surface -mt-1 flex w-full h-20 overflow-hidden cursor-pointer items-start px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed corner-squircle focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[1px] focus-visible:ring-ring/40",
-              params.systemPrompt
-                ? "text-nav-fg"
-                : "text-muted-foreground",
+              "panel-text-surface -mt-1 block w-full h-20 resize-none px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed corner-squircle text-nav-fg placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[1px] focus-visible:ring-ring/40",
+              systemPromptOverflows && "cursor-pointer",
             )}
-          >
-            <span className="block line-clamp-3 whitespace-pre-wrap break-words">
-              {params.systemPrompt ||
-                "Example: You are a helpful assistant..."}
-            </span>
-          </button>
+          />
         </CollapsibleSection>
 
         <CollapsibleSection label="Sampling" defaultOpen={true}>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -536,9 +536,6 @@ export function ChatSettingsPanel({
   const [presetNameInput, setPresetNameInput] = useState(activePreset);
   const [systemPromptEditorOpen, setSystemPromptEditorOpen] = useState(false);
   const [systemPromptDraft, setSystemPromptDraft] = useState("");
-  // When the prompt overflows the inline box, clicking opens the popup editor.
-  const systemPromptBoxRef = useRef<HTMLTextAreaElement>(null);
-  const [systemPromptOverflows, setSystemPromptOverflows] = useState(false);
   const [activePresetBaseline, setActivePresetBaseline] = useState(params);
   const presets = useMemo(() => {
     return getOrderedPresets(customPresets);
@@ -742,13 +739,6 @@ export function ChatSettingsPanel({
       setSystemPromptEditorOpen(false);
     }
   }, [open]);
-
-  useEffect(() => {
-    const el = systemPromptBoxRef.current;
-    setSystemPromptOverflows(
-      el != null && el.scrollHeight > el.clientHeight + 1,
-    );
-  }, [params.systemPrompt, open]);
 
   const settingsScrollRef = useRef<HTMLDivElement>(null);
 
@@ -1288,28 +1278,20 @@ export function ChatSettingsPanel({
             </Tooltip>
           }
         >
-          <textarea
-            ref={systemPromptBoxRef}
-            value={params.systemPrompt}
-            onChange={(e) => set("systemPrompt")(e.target.value)}
-            onMouseDown={(e) => {
-              // Overflowing prompt: click opens the popup editor instead.
-              // While focused, clicks still move the caret normally.
-              if (
-                systemPromptOverflows &&
-                document.activeElement !== e.currentTarget
-              ) {
-                e.preventDefault();
-                openSystemPromptEditor();
-              }
-            }}
-            placeholder="Example: You are a helpful assistant..."
-            aria-label="System prompt"
+          <button
+            type="button"
+            onClick={openSystemPromptEditor}
+            aria-label="Edit system prompt"
             className={cn(
-              "panel-text-surface -mt-1 block w-full h-20 resize-none px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed corner-squircle text-nav-fg placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[1px] focus-visible:ring-ring/40",
-              systemPromptOverflows && "cursor-pointer",
+              "panel-text-surface -mt-1 flex w-full h-20 overflow-hidden cursor-pointer items-start px-3.5 py-2.5 text-left text-[13px] font-medium leading-relaxed corner-squircle focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[1px] focus-visible:ring-ring/40",
+              params.systemPrompt ? "text-nav-fg" : "text-muted-foreground",
             )}
-          />
+          >
+            <span className="block line-clamp-3 whitespace-pre-wrap break-words">
+              {params.systemPrompt ||
+                "Example: You are a helpful assistant..."}
+            </span>
+          </button>
         </CollapsibleSection>
 
         <CollapsibleSection label="Sampling" defaultOpen={true}>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1346,7 +1346,7 @@ export function ChatSettingsPanel({
           {/* Rounded wrapper clips overflowing text and the scrollbar. */}
           <div
             className={cn(
-              "panel-text-surface -mt-1 h-20 w-full overflow-hidden corner-squircle focus-within:ring-[1px] focus-within:ring-ring/40",
+              "panel-text-surface -mt-1 h-20 w-full overflow-hidden corner-squircle",
               systemPromptOverflows && "cursor-pointer",
             )}
           >

--- a/studio/frontend/src/features/chat/tour/steps.tsx
+++ b/studio/frontend/src/features/chat/tour/steps.tsx
@@ -28,7 +28,7 @@ export function buildChatTourSteps({
       body: (
         <>
           This selects what’s loaded for inference. Hub = base models. Fine-tuned
-          = trained Studio outputs, including LoRA adapters and full finetunes.
+          = trained Unsloth outputs, including LoRA adapters and full finetunes.
         </>
       ),
     },
@@ -38,7 +38,7 @@ export function buildChatTourSteps({
       title: "Two tabs",
       body: (
         <>
-          Hub: search Hugging Face models. Fine-tuned: local Studio outputs you’ve
+          Hub: search Hugging Face models. Fine-tuned: local Unsloth outputs you’ve
           trained or exported. If results look off, compare base vs fine-tuned
           outputs to see what changed.
         </>

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -134,7 +134,7 @@ export function isExpectedBackgroundChatStorageError(error: unknown): boolean {
     (error.message === "Invalid or expired token" ||
       error.message === "Not authenticated" ||
       error.message === "Request failed (401)" ||
-      error.message === "Studio isn't running -- please relaunch it.")
+      error.message === "Unsloth isn't running -- please relaunch it.")
   );
 }
 

--- a/studio/frontend/src/features/hub/download-manager/api.ts
+++ b/studio/frontend/src/features/hub/download-manager/api.ts
@@ -12,14 +12,14 @@ function parseErrorText(status: number, body: unknown): string {
     const detail = (body as { detail?: unknown }).detail;
     const formatted = formatFastApiDetail(detail);
     if (status === 405) {
-      return `${formatted || "Method Not Allowed"} - the Studio backend did not accept this API method. Restart Studio so the frontend and backend are on the same build.`;
+      return `${formatted || "Method Not Allowed"} - the Unsloth backend did not accept this API method. Restart Unsloth so the frontend and backend are on the same build.`;
     }
     if (formatted) return formatted;
     const message = (body as { message?: unknown }).message;
     if (typeof message === "string" && message) return message;
   }
   if (status === 405) {
-    return "Method Not Allowed - the Studio backend did not accept this API method. Restart Studio so the frontend and backend are on the same build.";
+    return "Method Not Allowed - the Unsloth backend did not accept this API method. Restart Unsloth so the frontend and backend are on the same build.";
   }
   return `Request failed (${status})`;
 }
@@ -137,7 +137,7 @@ const DOWNLOAD_TRANSPORT_CAPABILITIES_FALLBACK: DownloadTransportCapabilities = 
   http: { available: true, reason: null },
   xet: {
     available: null,
-    reason: "Couldn't verify Xet support with the Studio backend.",
+    reason: "Couldn't verify Xet support with the Unsloth backend.",
   },
 };
 let downloadTransportCapabilitiesCache: DownloadTransportCapabilities | null =

--- a/studio/frontend/src/features/hub/download-manager/download-api-adapter.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-api-adapter.ts
@@ -184,7 +184,7 @@ export async function effectiveTransportMode(
     return preferred;
   }
   const reason =
-    capabilities.xet.reason ?? "Studio will use HTTP downloads instead.";
+    capabilities.xet.reason ?? "Unsloth will use HTTP downloads instead.";
   if (lastXetUnavailableWarningReason !== reason) {
     lastXetUnavailableWarningReason = reason;
     toast.warning("Xet download transport unavailable", {

--- a/studio/frontend/src/features/recipe-studio/components/executions/execution-data-tab.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/executions/execution-data-tab.tsx
@@ -45,7 +45,7 @@ function formatGitHubSourceMessage(execution: RecipeExecutionRecord): string {
     return "Collecting repository threads before rows are available.";
   }
   if (source.status === "rate_limited") {
-    return source.message ?? "Waiting for GitHub rate limit. Studio will resume automatically.";
+    return source.message ?? "Waiting for GitHub rate limit. Unsloth will resume automatically.";
   }
   return source.message ?? "Collecting repository threads before rows are available.";
 }

--- a/studio/frontend/src/features/recipe-studio/components/executions/execution-overview-tab.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/executions/execution-overview-tab.tsx
@@ -41,7 +41,7 @@ function formatSourceMessage(execution: RecipeExecutionRecord): string {
       typeof source.retry_after_sec === "number" && source.retry_after_sec > 0
         ? ` Waiting ~${formatMetricValue(source.retry_after_sec)}s.`
         : "";
-    return `Waiting for GitHub rate limit. Studio will resume automatically.${wait}`;
+    return `Waiting for GitHub rate limit. Unsloth will resume automatically.${wait}`;
   }
   return source.message ?? "Crawling GitHub source.";
 }

--- a/studio/frontend/src/features/recipe-studio/components/runtime/execution-progress-island.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/runtime/execution-progress-island.tsx
@@ -68,7 +68,7 @@ function formatGitHubSourceSummary(
       typeof source.retry_after_sec === "number" && source.retry_after_sec > 0
         ? ` ~${formatMetricValue(source.retry_after_sec)}s`
         : "";
-    return `Waiting for GitHub rate limit${wait}. Studio will resume automatically.`;
+    return `Waiting for GitHub rate limit${wait}. Unsloth will resume automatically.`;
   }
   if (source.status === "retrying") {
     return source.message ?? "GitHub request failed; retrying automatically.";

--- a/studio/frontend/src/features/recipe-studio/dialogs/seed/seed-dialog.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/seed/seed-dialog.tsx
@@ -334,8 +334,8 @@ export function GithubRepoSeedForm({
         />
         <p id={tokenHelpId} className="text-xs text-muted-foreground">
           {usingEnvToken
-            ? "Studio detected a server env token, so saved/shared recipes can leave this blank."
-            : "Blank is safest for saved/shared recipes because Studio will read the server environment at run time."}
+            ? "Unsloth detected a server env token, so saved/shared recipes can leave this blank."
+            : "Blank is safest for saved/shared recipes because Unsloth will read the server environment at run time."}
         </p>
         {hasToken && (
           <p className="rounded-md bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300">
@@ -450,7 +450,7 @@ export function GithubRepoSeedForm({
       </fieldset>
 
       <p className="text-xs text-muted-foreground">
-        Backed by Studio's built-in <code>github_repo</code> seed reader. Large
+        Backed by Unsloth's built-in <code>github_repo</code> seed reader. Large
         repos can take minutes, so start with small limits for previews.
       </p>
     </div>

--- a/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
+++ b/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
@@ -187,10 +187,10 @@ function ShellToggleButton({
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        "rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors",
+        "rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors",
         active
-          ? "border-transparent bg-foreground/[0.08] text-foreground dark:bg-white/[0.12]"
-          : "border-border text-muted-foreground hover:text-foreground",
+          ? "bg-foreground/[0.08] text-foreground dark:bg-white/[0.12]"
+          : "text-muted-foreground hover:text-foreground",
       )}
     >
       {label}

--- a/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
+++ b/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
@@ -172,28 +172,29 @@ function UpdateDocsLinks(): ReactElement {
   );
 }
 
-function StandardInstallCommands(): ReactElement {
-  const t = useT();
+function ShellToggleButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}): ReactElement {
   return (
-    <>
-      <p className="text-xs text-muted-foreground leading-relaxed">
-        {t("settings.about.update.installIntro")}
-      </p>
-      <p className="text-xs font-semibold text-foreground">
-        {t("settings.about.update.unixLabel")}
-      </p>
-      <CopyableCommand
-        command={STUDIO_INSTALL_UNIX_CMD}
-        copyLabel={t("settings.about.update.installCommandUnix")}
-      />
-      <p className="text-xs font-semibold text-foreground">
-        {t("settings.about.update.windowsLabel")}
-      </p>
-      <CopyableCommand
-        command={STUDIO_INSTALL_WINDOWS_CMD}
-        copyLabel={t("settings.about.update.installCommandWindows")}
-      />
-    </>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors",
+        active
+          ? "border-transparent bg-foreground/[0.08] text-foreground dark:bg-white/[0.12]"
+          : "border-border text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -245,34 +246,17 @@ export function UpdateStudioInstructions({
             {t("settings.about.update.title")}
           </p>
         ) : null}
-        <div className="flex shrink-0 items-center gap-0.5 text-[11px]">
-          <button
-            type="button"
-            onClick={() => setShellOverride("windows")}
-            className={cn(
-              "px-0.5 py-0.5 font-medium transition-colors",
-              windows
-                ? "text-foreground"
-                : "text-muted-foreground hover:text-emerald-600",
-            )}
-            aria-pressed={windows}
-          >
-            Windows
-          </button>
-          <span className="text-border">/</span>
-          <button
-            type="button"
+        <div className="flex shrink-0 items-center gap-1.5">
+          <ShellToggleButton
+            active={!windows}
+            label="MacOS / Linux"
             onClick={() => setShellOverride("unix")}
-            className={cn(
-              "px-0.5 py-0.5 font-medium transition-colors",
-              windows
-                ? "text-muted-foreground hover:text-emerald-600"
-                : "text-foreground",
-            )}
-            aria-pressed={!windows}
-          >
-            macOS/Linux
-          </button>
+          />
+          <ShellToggleButton
+            active={windows}
+            label="Windows"
+            onClick={() => setShellOverride("windows")}
+          />
         </div>
       </div>
       {loadingInstallSource ? (
@@ -280,10 +264,37 @@ export function UpdateStudioInstructions({
           {t("settings.about.update.checkingInstall")}
         </p>
       ) : (
-        <StandardInstallCommands />
+        <>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            {t("settings.about.update.installIntro")}
+          </p>
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={`install-${shell}`}
+              initial={fadeInitial}
+              animate={fadeAnimate}
+              exit={fadeExit}
+              transition={fadeTransition}
+            >
+              <CopyableCommand
+                command={
+                  windows ? STUDIO_INSTALL_WINDOWS_CMD : STUDIO_INSTALL_UNIX_CMD
+                }
+                copyLabel={
+                  windows
+                    ? t("settings.about.update.installCommandWindows")
+                    : t("settings.about.update.installCommandUnix")
+                }
+              />
+            </motion.div>
+          </AnimatePresence>
+        </>
       )}
       {loadingInstallSource ? null : localInstallSource ? (
         <>
+          <p className="text-xs font-semibold text-foreground">
+            {t("settings.about.update.localUpdateHeading")}
+          </p>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.localInstallDetected")}
           </p>
@@ -353,6 +364,9 @@ export function UpdateStudioInstructions({
         <>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.unknownInstall")}
+          </p>
+          <p className="text-xs font-semibold text-foreground">
+            {t("settings.about.update.localUpdateHeading")}
           </p>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.localCheckout")}

--- a/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
+++ b/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
@@ -215,6 +215,9 @@ export function UpdateStudioInstructions({
   const shell = shellOverride ?? defaultShell;
   const prefersReducedMotion = useReducedMotion();
   const windows = shell === "windows";
+  // null means the desktop app: its bundled backend updates through the
+  // built-in updater, so terminal commands would target the wrong install.
+  const desktopManaged = installSource === null;
   const localInstallSource = isLocalInstallSource(installSource);
   const checkoutInstallSource =
     installSource === "editable" || installSource === "local_repo";
@@ -232,6 +235,22 @@ export function UpdateStudioInstructions({
   const fadeExit = prefersReducedMotion
     ? { opacity: 1 }
     : { opacity: 0, y: -2 };
+
+  if (desktopManaged) {
+    return (
+      <div className={cn("flex flex-col gap-3", className)}>
+        {showTitle ? (
+          <p className="shrink-0 whitespace-nowrap text-sm font-semibold font-heading">
+            {t("settings.about.update.title")}
+          </p>
+        ) : null}
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          {t("settings.about.update.desktopManaged")}
+        </p>
+        <UpdateDocsLinks />
+      </div>
+    );
+  }
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>

--- a/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
+++ b/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
@@ -4,21 +4,28 @@
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
-import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowUpRight01Icon,
+  Copy01Icon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 
-const STUDIO_UPDATE_CMD = "unsloth studio update";
-const STUDIO_UPDATE_FALLBACK_UNIX_CMD =
+const STUDIO_INSTALL_UNIX_CMD =
   "curl -fsSL https://unsloth.ai/install.sh | sh";
-const STUDIO_UPDATE_FALLBACK_WINDOWS_CMD =
-  "irm https://unsloth.ai/install.ps1 | iex";
+const STUDIO_INSTALL_WINDOWS_CMD = "irm https://unsloth.ai/install.ps1 | iex";
 const STUDIO_LOCAL_PULL_CMD = "git pull --ff-only";
-const STUDIO_LOCAL_UPDATE_CMD = "unsloth studio update --local";
-const STUDIO_LOCAL_FALLBACK_UNIX_CMD = "./install.sh --local";
-const STUDIO_LOCAL_FALLBACK_WINDOWS_CMD = ".\\install.ps1 --local";
+const STUDIO_LOCAL_INSTALL_UNIX_CMD = "./install.sh --local";
+const STUDIO_LOCAL_INSTALL_WINDOWS_CMD = ".\\install.ps1 --local";
+
+const DOCS_INSTALL_URL = "https://unsloth.ai/docs/get-started/install";
+const DOCS_UPDATING_URL =
+  "https://unsloth.ai/docs/get-started/install/updating";
+const DOCS_WINDOWS_URL =
+  "https://unsloth.ai/docs/get-started/install/windows-installation";
 
 export type UpdateShell = "windows" | "unix";
 export type UpdateInstallSource =
@@ -128,6 +135,47 @@ function CopyableCommand({
   );
 }
 
+function DocsLink({
+  href,
+  label,
+}: {
+  href: string;
+  label: string;
+}): ReactElement {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-0.5 font-medium text-muted-foreground hover:text-foreground"
+    >
+      {label}
+      <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3" />
+    </a>
+  );
+}
+
+function UpdateDocsLinks(): ReactElement {
+  const t = useT();
+  return (
+    <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground leading-relaxed">
+      {t("settings.about.update.docs")}
+      <DocsLink
+        href={DOCS_INSTALL_URL}
+        label={t("settings.about.update.docsInstall")}
+      />
+      <DocsLink
+        href={DOCS_UPDATING_URL}
+        label={t("settings.about.update.docsUpdating")}
+      />
+      <DocsLink
+        href={DOCS_WINDOWS_URL}
+        label={t("settings.about.update.docsWindows")}
+      />
+    </p>
+  );
+}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: keep source-specific update guidance in one component so the command matrix stays visible.
 export function UpdateStudioInstructions({
   className,
@@ -210,7 +258,12 @@ export function UpdateStudioInstructions({
         <p className="text-xs text-muted-foreground leading-relaxed">
           {t("settings.about.update.checkingInstall")}
         </p>
-      ) : localInstallSource ? (
+      ) : (
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          {t("settings.about.update.deprecatedNotice")}
+        </p>
+      )}
+      {loadingInstallSource ? null : localInstallSource ? (
         <>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.localInstallDetected")}
@@ -224,16 +277,9 @@ export function UpdateStudioInstructions({
                 command={STUDIO_LOCAL_PULL_CMD}
                 copyLabel={t("settings.about.update.gitPullCommand")}
               />
-              <CopyableCommand
-                command={STUDIO_LOCAL_UPDATE_CMD}
-                copyLabel={t("settings.about.update.localUpdateCommand")}
-              />
-              <p className="text-xs text-muted-foreground leading-relaxed">
-                {t("settings.about.update.localInstallerFallback")}
-              </p>
               <AnimatePresence mode="wait" initial={false}>
                 <motion.div
-                  key={`local-fallback-${shell}`}
+                  key={`local-installer-${shell}`}
                   initial={fadeInitial}
                   animate={fadeAnimate}
                   exit={fadeExit}
@@ -242,8 +288,8 @@ export function UpdateStudioInstructions({
                   <CopyableCommand
                     command={
                       windows
-                        ? STUDIO_LOCAL_FALLBACK_WINDOWS_CMD
-                        : STUDIO_LOCAL_FALLBACK_UNIX_CMD
+                        ? STUDIO_LOCAL_INSTALL_WINDOWS_CMD
+                        : STUDIO_LOCAL_INSTALL_UNIX_CMD
                     }
                     copyLabel={t("settings.about.update.localInstallerCommand")}
                   />
@@ -261,7 +307,7 @@ export function UpdateStudioInstructions({
               </p>
               <AnimatePresence mode="wait" initial={false}>
                 <motion.div
-                  key={`source-fallback-${shell}`}
+                  key={`source-installer-${shell}`}
                   initial={fadeInitial}
                   animate={fadeAnimate}
                   exit={fadeExit}
@@ -270,8 +316,8 @@ export function UpdateStudioInstructions({
                   <CopyableCommand
                     command={
                       windows
-                        ? STUDIO_LOCAL_FALLBACK_WINDOWS_CMD
-                        : STUDIO_LOCAL_FALLBACK_UNIX_CMD
+                        ? STUDIO_LOCAL_INSTALL_WINDOWS_CMD
+                        : STUDIO_LOCAL_INSTALL_UNIX_CMD
                     }
                     copyLabel={t("settings.about.update.localInstallerCommand")}
                   />
@@ -282,29 +328,56 @@ export function UpdateStudioInstructions({
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.restartAfterUpdate")}
           </p>
+          <UpdateDocsLinks />
         </>
       ) : unknownInstallSource ? (
         <>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.unknownInstall")}
           </p>
-          <p className="text-xs text-muted-foreground leading-relaxed">
-            {t("settings.about.update.curlOrPypi")}
-          </p>
-          <CopyableCommand
-            command={STUDIO_UPDATE_CMD}
-            copyLabel={t("settings.about.update.updateCommand")}
-          />
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={`install-${shell}`}
+              initial={fadeInitial}
+              animate={fadeAnimate}
+              exit={fadeExit}
+              transition={fadeTransition}
+            >
+              <CopyableCommand
+                command={
+                  windows
+                    ? STUDIO_INSTALL_WINDOWS_CMD
+                    : STUDIO_INSTALL_UNIX_CMD
+                }
+                copyLabel={t("settings.about.update.installCommand")}
+              />
+            </motion.div>
+          </AnimatePresence>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.localCheckout")}
           </p>
-          <CopyableCommand
-            command={STUDIO_LOCAL_UPDATE_CMD}
-            copyLabel={t("settings.about.update.localUpdateCommand")}
-          />
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={`local-installer-${shell}`}
+              initial={fadeInitial}
+              animate={fadeAnimate}
+              exit={fadeExit}
+              transition={fadeTransition}
+            >
+              <CopyableCommand
+                command={
+                  windows
+                    ? STUDIO_LOCAL_INSTALL_WINDOWS_CMD
+                    : STUDIO_LOCAL_INSTALL_UNIX_CMD
+                }
+                copyLabel={t("settings.about.update.localInstallerCommand")}
+              />
+            </motion.div>
+          </AnimatePresence>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.restartAfterUpdate")}
           </p>
+          <UpdateDocsLinks />
         </>
       ) : (
         <>
@@ -320,16 +393,9 @@ export function UpdateStudioInstructions({
               {getStudioUpdateInstructionLine(shell, t)}
             </motion.p>
           </AnimatePresence>
-          <CopyableCommand
-            command={STUDIO_UPDATE_CMD}
-            copyLabel={t("settings.about.update.updateCommand")}
-          />
-          <p className="text-xs text-muted-foreground leading-relaxed">
-            {t("settings.about.update.fallbackInstruction")}
-          </p>
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
-              key={`fallback-${shell}`}
+              key={`install-${shell}`}
               initial={fadeInitial}
               animate={fadeAnimate}
               exit={fadeExit}
@@ -338,16 +404,17 @@ export function UpdateStudioInstructions({
               <CopyableCommand
                 command={
                   windows
-                    ? STUDIO_UPDATE_FALLBACK_WINDOWS_CMD
-                    : STUDIO_UPDATE_FALLBACK_UNIX_CMD
+                    ? STUDIO_INSTALL_WINDOWS_CMD
+                    : STUDIO_INSTALL_UNIX_CMD
                 }
-                copyLabel={t("settings.about.update.fallbackCommand")}
+                copyLabel={t("settings.about.update.installCommand")}
               />
             </motion.div>
           </AnimatePresence>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.restartAfterUpdate")}
           </p>
+          <UpdateDocsLinks />
         </>
       )}
     </div>

--- a/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
+++ b/studio/frontend/src/features/settings/components/update-studio-instructions.tsx
@@ -24,6 +24,7 @@ const STUDIO_LOCAL_INSTALL_WINDOWS_CMD = ".\\install.ps1 --local";
 const DOCS_INSTALL_URL = "https://unsloth.ai/docs/get-started/install";
 const DOCS_UPDATING_URL =
   "https://unsloth.ai/docs/get-started/install/updating";
+const DOCS_MAC_URL = "https://unsloth.ai/docs/get-started/install/mac";
 const DOCS_WINDOWS_URL =
   "https://unsloth.ai/docs/get-started/install/windows-installation";
 
@@ -36,15 +37,6 @@ export type UpdateInstallSource =
   | "local_repo"
   | "unknown";
 type UpdateInstallSourceState = UpdateInstallSource | "loading";
-
-function getStudioUpdateInstructionLine(
-  shell: UpdateShell,
-  t: ReturnType<typeof useT>,
-): string {
-  return shell === "windows"
-    ? t("settings.about.update.openPowerShell")
-    : t("settings.about.update.openTerminal");
-}
 
 function isLocalInstallSource(
   installSource?: UpdateInstallSourceState | null,
@@ -169,10 +161,39 @@ function UpdateDocsLinks(): ReactElement {
         label={t("settings.about.update.docsUpdating")}
       />
       <DocsLink
+        href={DOCS_MAC_URL}
+        label={t("settings.about.update.docsMac")}
+      />
+      <DocsLink
         href={DOCS_WINDOWS_URL}
         label={t("settings.about.update.docsWindows")}
       />
     </p>
+  );
+}
+
+function StandardInstallCommands(): ReactElement {
+  const t = useT();
+  return (
+    <>
+      <p className="text-xs text-muted-foreground leading-relaxed">
+        {t("settings.about.update.installIntro")}
+      </p>
+      <p className="text-xs font-semibold text-foreground">
+        {t("settings.about.update.unixLabel")}
+      </p>
+      <CopyableCommand
+        command={STUDIO_INSTALL_UNIX_CMD}
+        copyLabel={t("settings.about.update.installCommandUnix")}
+      />
+      <p className="text-xs font-semibold text-foreground">
+        {t("settings.about.update.windowsLabel")}
+      </p>
+      <CopyableCommand
+        command={STUDIO_INSTALL_WINDOWS_CMD}
+        copyLabel={t("settings.about.update.installCommandWindows")}
+      />
+    </>
   );
 }
 
@@ -259,9 +280,7 @@ export function UpdateStudioInstructions({
           {t("settings.about.update.checkingInstall")}
         </p>
       ) : (
-        <p className="text-xs text-muted-foreground leading-relaxed">
-          {t("settings.about.update.deprecatedNotice")}
-        </p>
+        <StandardInstallCommands />
       )}
       {loadingInstallSource ? null : localInstallSource ? (
         <>
@@ -335,24 +354,6 @@ export function UpdateStudioInstructions({
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.unknownInstall")}
           </p>
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.div
-              key={`install-${shell}`}
-              initial={fadeInitial}
-              animate={fadeAnimate}
-              exit={fadeExit}
-              transition={fadeTransition}
-            >
-              <CopyableCommand
-                command={
-                  windows
-                    ? STUDIO_INSTALL_WINDOWS_CMD
-                    : STUDIO_INSTALL_UNIX_CMD
-                }
-                copyLabel={t("settings.about.update.installCommand")}
-              />
-            </motion.div>
-          </AnimatePresence>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.localCheckout")}
           </p>
@@ -381,36 +382,6 @@ export function UpdateStudioInstructions({
         </>
       ) : (
         <>
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.p
-              key={`instruction-${shell}`}
-              initial={fadeInitial}
-              animate={fadeAnimate}
-              exit={fadeExit}
-              transition={fadeTransition}
-              className="text-xs text-muted-foreground leading-relaxed"
-            >
-              {getStudioUpdateInstructionLine(shell, t)}
-            </motion.p>
-          </AnimatePresence>
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.div
-              key={`install-${shell}`}
-              initial={fadeInitial}
-              animate={fadeAnimate}
-              exit={fadeExit}
-              transition={fadeTransition}
-            >
-              <CopyableCommand
-                command={
-                  windows
-                    ? STUDIO_INSTALL_WINDOWS_CMD
-                    : STUDIO_INSTALL_UNIX_CMD
-                }
-                copyLabel={t("settings.about.update.installCommand")}
-              />
-            </motion.div>
-          </AnimatePresence>
           <p className="text-xs text-muted-foreground leading-relaxed">
             {t("settings.about.update.restartAfterUpdate")}
           </p>

--- a/studio/frontend/src/features/settings/tabs/about-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/about-tab.tsx
@@ -142,7 +142,7 @@ export function AboutTab() {
         </p>
       </header>
 
-      <SettingsSection title="Studio">
+      <SettingsSection title="Unsloth">
         <SettingsRow label={t("settings.about.studioVersion")}>
           <code className="font-mono text-xs text-muted-foreground">
             {studioVersion}
@@ -202,6 +202,37 @@ export function AboutTab() {
               className="size-3.5"
             />
             {t("settings.about.reportIssue")}
+            <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3" />
+          </a>
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection title={t("settings.about.license.sectionTitle")}>
+        <SettingsRow
+          label={t("settings.about.license.studioLabel")}
+          description={t("settings.about.license.studioDescription")}
+        >
+          <a
+            href="https://github.com/unslothai/unsloth/blob/main/studio/LICENSE.AGPL-3.0"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-mono text-xs font-medium text-muted-foreground hover:text-foreground"
+          >
+            {t("settings.about.license.studioLicense")}
+            <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3" />
+          </a>
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.about.license.libraryLabel")}
+          description={t("settings.about.license.libraryDescription")}
+        >
+          <a
+            href="https://github.com/unslothai/unsloth/blob/main/LICENSE"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-mono text-xs font-medium text-muted-foreground hover:text-foreground"
+          >
+            {t("settings.about.license.libraryLicense")}
             <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3" />
           </a>
         </SettingsRow>

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -16,6 +16,10 @@ import { usePlatformStore } from "@/config/env";
 import { resetOnboardingDone } from "@/features/auth";
 import { useChatRuntimeStore } from "@/features/chat";
 import {
+  setShowLlamaUpdateBanner,
+  useShowLlamaUpdateBanner,
+} from "@/hooks/use-llama-update-pref";
+import {
   loadHelperPrecacheSettings,
   updateHelperPrecacheSettings,
   type HelperPrecacheSettings,
@@ -68,6 +72,8 @@ const PREFS_KEYS: string[] = [
   "unsloth_user_profile",
   // Guided tour flags
   "tour:studio:v1",
+  // Update notifications
+  "unsloth_show_llama_update_banner",
 ];
 
 // Set by resetAllPrefs so the unmount-commit effect skips writing back the
@@ -106,6 +112,7 @@ export function GeneralTab() {
   const autoTitle = useChatRuntimeStore((s) => s.autoTitle);
   const setAutoTitle = useChatRuntimeStore((s) => s.setAutoTitle);
   const chatOnly = usePlatformStore((s) => s.chatOnly);
+  const showLlamaUpdates = useShowLlamaUpdateBanner();
   const redirectTo = `${pathname}${search}`;
 
   const [draftToken, setDraftToken] = useState(hfToken ?? "");
@@ -312,6 +319,20 @@ export function GeneralTab() {
               </span>
             ) : null}
           </div>
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection title={t("settings.general.notifications.sectionTitle")}>
+        <SettingsRow
+          label={t("settings.general.notifications.showLlamaUpdates")}
+          description={t(
+            "settings.general.notifications.showLlamaUpdatesDescription",
+          )}
+        >
+          <Switch
+            checked={showLlamaUpdates}
+            onCheckedChange={setShowLlamaUpdateBanner}
+          />
         </SettingsRow>
       </SettingsSection>
 

--- a/studio/frontend/src/features/studio/tour/steps/nav.tsx
+++ b/studio/frontend/src/features/studio/tour/steps/nav.tsx
@@ -9,7 +9,7 @@ export const studioNavStep: TourStep = {
   title: "Quick orientation",
   body: (
     <>
-      Studio: pick base model, dataset, hyperparams, then start training. After
+      Unsloth: pick base model, dataset, hyperparams, then start training. After
       you start, you’ll see a Training view with live loss/metrics. Chat is for
       testing base vs LoRA adapters. Export packages checkpoints for deployment.{" "}
       <ReadMore href="https://unsloth.ai/docs/get-started/fine-tuning-for-beginners" />

--- a/studio/frontend/src/hooks/use-llama-update-check.ts
+++ b/studio/frontend/src/hooks/use-llama-update-check.ts
@@ -12,7 +12,7 @@ const REMINDER_INTERVAL_MS = 60 * 60 * 1000; // ~1 hour
 // "Remind me later" re-surfaces sooner than the hourly reminder.
 const SNOOZE_DELAY_MS = 15 * 60 * 1000; // ~15 minutes
 // While an update is applying, poll the job state at this cadence.
-const JOB_POLL_INTERVAL_MS = 3000;
+const JOB_POLL_INTERVAL_MS = 1500;
 
 export interface LlamaUpdateJob {
   state: "idle" | "running" | "success" | "error";
@@ -20,6 +20,8 @@ export interface LlamaUpdateJob {
   from_tag: string | null;
   to_tag: string | null;
   error: string | null;
+  // Download fraction (0..1) while running, 1 on success, null when unknown.
+  progress: number | null;
 }
 
 export interface LlamaUpdateStatus {
@@ -45,6 +47,7 @@ function parseStatus(value: unknown): LlamaUpdateStatus | null {
       from_tag: typeof job.from_tag === "string" ? job.from_tag : null,
       to_tag: typeof job.to_tag === "string" ? job.to_tag : null,
       error: typeof job.error === "string" ? job.error : null,
+      progress: typeof job.progress === "number" ? job.progress : null,
     },
   };
 }

--- a/studio/frontend/src/hooks/use-llama-update-check.ts
+++ b/studio/frontend/src/hooks/use-llama-update-check.ts
@@ -5,9 +5,12 @@ import { authFetch, getAuthToken } from "@/features/auth";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 // First check shortly after load, then re-surface as an hourly reminder. The
-// banner stays up until the user dismisses it (click outside / X) or updates.
+// banner stays up until the user explicitly acts on it (X, Update, or
+// Remind me later).
 const FIRST_CHECK_DELAY_MS = 1000;
 const REMINDER_INTERVAL_MS = 60 * 60 * 1000; // ~1 hour
+// "Remind me later" re-surfaces sooner than the hourly reminder.
+const SNOOZE_DELAY_MS = 15 * 60 * 1000; // ~15 minutes
 // While an update is applying, poll the job state at this cadence.
 const JOB_POLL_INTERVAL_MS = 3000;
 
@@ -73,9 +76,10 @@ export interface LlamaApplyResult {
 
 /**
  * Polls the backend for a newer llama.cpp prebuilt. When one exists, `visible`
- * becomes true ~1s after load and stays up until the user dismisses it (click
- * outside / X) or updates; it re-surfaces every ~hour as a reminder. `apply()`
- * triggers the in-place swap and tracks the job.
+ * becomes true ~1s after load and stays up until the user dismisses it (X),
+ * snoozes it ("Remind me later", ~15 min), or updates; it re-surfaces every
+ * ~hour as a reminder. `apply()` triggers the in-place swap and tracks the
+ * job.
  */
 export function useLlamaUpdateCheck({
   enabled = true,
@@ -84,6 +88,7 @@ export function useLlamaUpdateCheck({
   const [visible, setVisible] = useState(false);
   const [applying, setApplying] = useState(false);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const snoozeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearPollTimer = useCallback(() => {
     if (pollTimer.current) {
@@ -161,12 +166,26 @@ export function useLlamaUpdateCheck({
       clearTimeout(firstTimer);
       clearInterval(reminder);
       clearPollTimer();
+      if (snoozeTimer.current) {
+        clearTimeout(snoozeTimer.current);
+        snoozeTimer.current = null;
+      }
     };
   }, [enabled, surfaceIfAvailable, clearPollTimer]);
 
   const dismiss = useCallback(() => {
     setVisible(false);
   }, []);
+
+  // Hide now, re-check and re-surface after SNOOZE_DELAY_MS.
+  const snooze = useCallback(() => {
+    setVisible(false);
+    if (snoozeTimer.current) clearTimeout(snoozeTimer.current);
+    snoozeTimer.current = setTimeout(() => {
+      snoozeTimer.current = null;
+      fetchStatus().then(surfaceIfAvailable);
+    }, SNOOZE_DELAY_MS);
+  }, [surfaceIfAvailable]);
 
   const apply = useCallback(async (): Promise<LlamaApplyResult> => {
     if (applying) return { ok: false, error: "already running" };
@@ -219,5 +238,6 @@ export function useLlamaUpdateCheck({
     applying,
     apply,
     dismiss,
+    snooze,
   };
 }

--- a/studio/frontend/src/hooks/use-llama-update-pref.ts
+++ b/studio/frontend/src/hooks/use-llama-update-pref.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useSyncExternalStore } from "react";
+
+// Whether the llama.cpp update banner may appear. On by default; only an
+// explicit "false" (Settings -> General -> Notifications) disables it.
+const STORAGE_KEY = "unsloth_show_llama_update_banner";
+
+const listeners = new Set<() => void>();
+
+export function getShowLlamaUpdateBanner(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function setShowLlamaUpdateBanner(show: boolean): void {
+  try {
+    if (show) {
+      // Remove rather than store "true" so the default stays on.
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, "false");
+    }
+  } catch {
+    // storage unavailable
+  }
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  // Sync toggles made in another tab.
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) listener();
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+export function useShowLlamaUpdateBanner(): boolean {
+  return useSyncExternalStore(subscribe, getShowLlamaUpdateBanner);
+}

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -56,23 +56,23 @@ function wait(ms: number) {
 function externalConflictMessage(preflight: DesktopPreflightResult) {
   if (preflight.reason === "desktop_owned_backend_active") {
     return preflight.port
-      ? `A desktop-owned Studio server for this install is already running on port ${preflight.port}. Quit the other desktop app instance, then try again.`
-      : "A desktop-owned Studio server for this install is already running. Quit the other desktop app instance, then try again.";
+      ? `A desktop-owned Unsloth server for this install is already running on port ${preflight.port}. Quit the other desktop app instance, then try again.`
+      : "A desktop-owned Unsloth server for this install is already running. Quit the other desktop app instance, then try again.";
   }
 
   if (preflight.reason === "desktop_owned_backend_starting") {
-    return "The desktop-owned Studio backend is still starting. Wait a moment, then try again.";
+    return "The desktop-owned Unsloth backend is still starting. Wait a moment, then try again.";
   }
 
   if (preflight.reason?.startsWith("desktop_owned_backend_unmanageable:")) {
     return preflight.port
-      ? `A desktop-owned Studio backend on port ${preflight.port} cannot be safely controlled by this desktop app. Stop that backend, then reopen Studio.`
-      : "A desktop-owned Studio backend cannot be safely controlled by this desktop app. Stop that backend, then reopen Studio.";
+      ? `A desktop-owned Unsloth backend on port ${preflight.port} cannot be safely controlled by this desktop app. Stop that backend, then reopen Unsloth.`
+      : "A desktop-owned Unsloth backend cannot be safely controlled by this desktop app. Stop that backend, then reopen Unsloth.";
   }
 
   return preflight.port
-    ? `A Studio server for this install is already running from a terminal on port ${preflight.port}. Stop that server, or run \`unsloth studio update\` from that terminal before using the desktop app.`
-    : "A Studio server for this install is already running from a terminal. Stop that server, or run `unsloth studio update` from that terminal before using the desktop app.";
+    ? `A Unsloth server for this install is already running from a terminal on port ${preflight.port}. Stop that server, or run \`unsloth studio update\` from that terminal before using the desktop app.`
+    : "A Unsloth server for this install is already running from a terminal. Stop that server, or run `unsloth studio update` from that terminal before using the desktop app.";
 }
 
 async function waitForManagedServerReady(
@@ -248,8 +248,8 @@ export function useTauriBackend() {
           } else {
             setBackendError(
               preflight.disposition === "owned_stale"
-                ? "Desktop-owned Studio backend is too old for this desktop app. Run `unsloth studio update`, then restart Studio."
-                : "Managed Studio install is too old. Run `unsloth studio update`.",
+                ? "Desktop-owned Unsloth backend is too old for this desktop app. Run `unsloth studio update`, then restart Unsloth."
+                : "Managed Unsloth install is too old. Run `unsloth studio update`.",
             );
           }
           return;
@@ -304,7 +304,7 @@ export function useTauriBackend() {
       if (msg.includes("already running")) {
         startingRef.current = false;
         setBackendError(
-          "Managed server is already running but did not report a port. Restart Studio and try again.",
+          "Managed server is already running but did not report a port. Restart Unsloth and try again.",
         );
         return;
       }
@@ -596,7 +596,7 @@ export function useTauriBackend() {
       const detail =
         event instanceof CustomEvent && typeof event.detail === "string"
           ? event.detail
-          : "Desktop authentication failed. Update or repair the managed Studio install, then restart Studio.";
+          : "Desktop authentication failed. Update or repair the managed Unsloth install, then restart Unsloth.";
       setAuthFailure(detail);
     };
     window.addEventListener("tauri-auth-failed", onAuthFailed);

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -312,7 +312,7 @@ export const en = {
         "Documentation, release notes, feedback, and Unsloth build info.",
       studioVersion: "Unsloth Version",
       packageVersion: "Package Version",
-      updates: "Updates",
+      updates: "Update",
       help: "Help",
       documentation: "Documentation",
       releaseNotes: "Release notes",
@@ -342,10 +342,8 @@ export const en = {
         commandCopied: "{label} copied",
         copyNamedCommand: "Copy {label}",
         checkingInstall: "Checking how Unsloth was installed...",
-        installIntro:
-          "Standard install commands. Running them again updates an existing install.",
-        unixLabel: "MacOS, Linux, WSL:",
-        windowsLabel: "Windows PowerShell:",
+        installIntro: "To install or update Unsloth:",
+        localUpdateHeading: "Local update",
         installCommandUnix: "macOS/Linux install command",
         installCommandWindows: "Windows install command",
         localInstallDetected:

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -336,16 +336,18 @@ export const en = {
       shutDown: "Shut down",
       update: {
         title: "Update Unsloth Studio",
-        openPowerShell: "Open PowerShell and run:",
-        openTerminal: "Open Terminal and run:",
         commandText: "{label} text",
         copied: "Copied",
         copyCommand: "Copy command",
         commandCopied: "{label} copied",
         copyNamedCommand: "Copy {label}",
         checkingInstall: "Checking how Unsloth was installed...",
-        deprecatedNotice:
-          "Note: the unsloth studio update command is no longer supported. Use the install command instead; it also updates existing installs.",
+        installIntro:
+          "Standard install commands. Running them again updates an existing install.",
+        unixLabel: "MacOS, Linux, WSL:",
+        windowsLabel: "Windows PowerShell:",
+        installCommandUnix: "macOS/Linux install command",
+        installCommandWindows: "Windows install command",
         localInstallDetected:
           "Source or local install detected. To avoid replacing it with PyPI, update from the checkout or source you originally installed from.",
         pullThenUpdate:
@@ -359,13 +361,13 @@ export const en = {
         restartAfterUpdate:
           "Restart Unsloth after updating for changes to take effect.",
         unknownInstall:
-          "Unsloth could not detect how it was installed. If you used the one-line installer or PyPI, run the install command below.",
-        installCommand: "install command",
+          "Unsloth could not detect how it was installed. For installer or PyPI installs, use the commands above.",
         localCheckout:
           "For local checkout installs, run the local installer from that checkout instead:",
         docs: "Install docs:",
         docsInstall: "Installation",
         docsUpdating: "Updating",
+        docsMac: "Mac guide",
         docsWindows: "Windows guide",
       },
     },

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -93,7 +93,7 @@ export const en = {
       chat: "Chat",
       connections: "Connections",
       apiKeys: "API",
-      about: "Help",
+      about: "About",
     },
     general: {
       title: "General",
@@ -112,11 +112,17 @@ export const en = {
         sectionTitle: "Helper LLM",
         preloadOnStartup: "Pre-cache Helper LLM on startup",
         preloadOnStartupDescription:
-          "Download and cache the AI Assist helper model in the background when Studio starts. Off by default; AI Assist can still download it on demand when clicked.",
+          "Download and cache the AI Assist helper model in the background when Unsloth starts. Off by default; AI Assist can still download it on demand when clicked.",
         disabledByEnv:
           "Disabled by UNSLOTH_HELPER_MODEL_DISABLE in the backend environment.",
         loadError: "Failed to load Helper LLM settings.",
         saveError: "Failed to save Helper LLM settings.",
+      },
+      notifications: {
+        sectionTitle: "Notifications",
+        showLlamaUpdates: "llama.cpp update notifications",
+        showLlamaUpdatesDescription:
+          "Show a notification when a newer llama.cpp build is available. Turn off if you only use Unsloth for training.",
       },
       gettingStarted: "Getting started",
       startOnboarding: "Start onboarding",
@@ -137,13 +143,13 @@ export const en = {
         action: "Reset preferences",
         confirmTitle: "Reset all local preferences?",
         confirmDescription:
-          "This clears local-only preferences, then reloads Studio. Chats, API access, and DB-backed settings are not affected.",
+          "This clears local-only preferences, then reloads Unsloth. Chats, API access, and DB-backed settings are not affected.",
         confirmAction: "Reset and reload",
       },
     },
     profile: {
       title: "Profile",
-      description: "Update how your profile appears in Studio.",
+      description: "Update how your profile appears in Unsloth.",
       changePicture: "Change profile picture",
       displayName: "Display name",
       nameSaved: "Profile name saved",
@@ -171,7 +177,7 @@ export const en = {
       language: {
         title: "Language",
         label: "Display language",
-        description: "Choose the language used by Studio.",
+        description: "Choose the language used by Unsloth.",
       },
       layout: {
         title: "Layout",
@@ -303,8 +309,8 @@ export const en = {
     about: {
       title: "About",
       description:
-        "Documentation, release notes, feedback, and Studio build info.",
-      studioVersion: "Studio Version",
+        "Documentation, release notes, feedback, and Unsloth build info.",
+      studioVersion: "Unsloth Version",
       packageVersion: "Package Version",
       updates: "Updates",
       help: "Help",
@@ -313,10 +319,20 @@ export const en = {
       whatsNew: "What's new",
       feedback: "Feedback",
       reportIssue: "Report an issue",
+      license: {
+        sectionTitle: "License",
+        studioLabel: "Unsloth Studio",
+        studioLicense: "AGPL-3.0",
+        studioDescription:
+          "Open source under the GNU Affero General Public License v3.0.",
+        libraryLabel: "Unsloth Core",
+        libraryLicense: "Apache-2.0",
+        libraryDescription: "Licensed under the Apache License 2.0.",
+      },
       dangerZone: "Danger zone",
       shutDownStudio: "Shut down Unsloth Studio",
       shutDownStudioDescription:
-        "Stops the Studio server process and ends your session.",
+        "Stops the Unsloth server process and ends your session.",
       shutDown: "Shut down",
       update: {
         title: "Update Unsloth Studio",
@@ -327,24 +343,24 @@ export const en = {
         copyCommand: "Copy command",
         commandCopied: "{label} copied",
         copyNamedCommand: "Copy {label}",
-        checkingInstall: "Checking how Studio was installed...",
+        checkingInstall: "Checking how Unsloth was installed...",
         localInstallDetected:
           "Source or local install detected. To avoid replacing it with PyPI, update from the checkout or source you originally installed from.",
         pullThenUpdate:
-          "Pull latest changes from your Unsloth repo checkout, then update Studio locally:",
+          "Pull latest changes from your Unsloth repo checkout, then update Unsloth locally:",
         gitPullCommand: "git pull command",
         localUpdateCommand: "local update command",
         localInstallerFallback:
-          "If the Studio update command is unavailable, run the local installer from that checkout:",
+          "If the Unsloth update command is unavailable, run the local installer from that checkout:",
         localInstallerCommand: "local installer command",
         sourceInstallDetected:
           "This looks like a source or VCS package install. Reinstall from the original local path or Git URL you used.",
         repoCheckoutFallback:
           "If you still have the Unsloth repo checkout, run the local installer from that checkout:",
         restartAfterUpdate:
-          "Restart Studio after updating for changes to take effect.",
+          "Restart Unsloth after updating for changes to take effect.",
         unknownInstall:
-          "Studio could not detect how it was installed. Check how you installed Studio first, then choose the matching update path.",
+          "Unsloth could not detect how it was installed. Check how you installed Unsloth first, then choose the matching update path.",
         curlOrPypi: "For curl or PyPI installs, run:",
         updateCommand: "update command",
         localCheckout:

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -83,7 +83,7 @@ export const en = {
     title: "Settings",
     dialog: {
       title: "Settings",
-      description: "Manage your Unsloth Studio preferences.",
+      description: "Manage your Unsloth preferences.",
       closeAriaLabel: "Close settings",
     },
     tabs: {
@@ -97,7 +97,7 @@ export const en = {
     },
     general: {
       title: "General",
-      description: "Global preferences for Unsloth Studio.",
+      description: "Global preferences for Unsloth.",
       account: "Account",
       huggingFaceToken: "Hugging Face token",
       huggingFaceTokenDescription:
@@ -112,7 +112,7 @@ export const en = {
         sectionTitle: "Helper LLM",
         preloadOnStartup: "Pre-cache Helper LLM on startup",
         preloadOnStartupDescription:
-          "Download and cache the AI Assist helper model in the background when Unsloth starts. Off by default; AI Assist can still download it on demand when clicked.",
+          "Download the AI Assist helper model in the background on startup. Off by default; AI Assist can still fetch it on demand.",
         disabledByEnv:
           "Disabled by UNSLOTH_HELPER_MODEL_DISABLE in the backend environment.",
         loadError: "Failed to load Helper LLM settings.",
@@ -122,34 +122,34 @@ export const en = {
         sectionTitle: "Notifications",
         showLlamaUpdates: "llama.cpp update notifications",
         showLlamaUpdatesDescription:
-          "Show a notification when a newer llama.cpp build is available. Turn off if you only use Unsloth for training.",
+          "Notify when a newer llama.cpp build is available. Turn off if you only train.",
       },
       gettingStarted: "Getting started",
       startOnboarding: "Start onboarding",
       startOnboardingDescription:
-        "Open the setup wizard again without changing your account.",
+        "Reopen the setup wizard without changing your account.",
       startOnboardingAction: "Start onboarding",
       uploads: {
         sectionTitle: "Uploads",
         maxUploadSize: "Training dataset upload cap",
         maxUploadSizeDescription:
-          "Applies to training dataset uploads. Default is {defaultSize} MB.",
+          "Default is {defaultSize} MB.",
       },
       resetPreferences: {
         sectionTitle: "Danger zone",
         label: "Reset all local preferences",
         description:
-          "Clears local-only preferences. Chats, API access, and DB-backed settings are not affected.",
+          "Clears local-only preferences. Chats, API access, and DB-backed settings are kept.",
         action: "Reset preferences",
         confirmTitle: "Reset all local preferences?",
         confirmDescription:
-          "This clears local-only preferences, then reloads Unsloth. Chats, API access, and DB-backed settings are not affected.",
+          "Clears local-only preferences and reloads Unsloth. Chats, API access, and DB-backed settings are kept.",
         confirmAction: "Reset and reload",
       },
     },
     profile: {
       title: "Profile",
-      description: "Update how your profile appears in Unsloth.",
+      description: "How your profile appears in Unsloth.",
       changePicture: "Change profile picture",
       displayName: "Display name",
       nameSaved: "Profile name saved",
@@ -169,7 +169,7 @@ export const en = {
       theme: {
         title: "Theme",
         label: "Color scheme",
-        description: "Choose light, dark, or follow your system.",
+        description: "Light, dark, or follow your system.",
         system: "System",
         light: "Light",
         dark: "Dark",
@@ -177,7 +177,7 @@ export const en = {
       language: {
         title: "Language",
         label: "Display language",
-        description: "Choose the language used by Unsloth.",
+        description: "The language used by Unsloth.",
       },
       layout: {
         title: "Layout",
@@ -188,25 +188,25 @@ export const en = {
     },
     chat: {
       title: "Chat",
-      description: "Manage your chat history stored on this device.",
+      description: "Manage chat history stored on this device.",
       artifacts: {
         title: "Artifacts",
         collapseHtmlBlocks: "Collapse HTML blocks",
         collapseHtmlBlocksDescription:
-          "Artifacts mode collapses full HTML fallback automatically. Turn this on to also collapse full fenced HTML documents when Artifacts is off.",
+          "Artifacts mode collapses full HTML automatically. Turn on to also collapse fenced HTML documents when Artifacts is off.",
         allowNetworkAccess: "Allow artifact network access",
         allowNetworkAccessDescription:
-          "Let artifact previews load scripts, styles, fonts, media, fetch, and WebSocket resources from HTTP(S) CDNs. Keep off for fully offline previews.",
+          "Let artifact previews load scripts, styles, fonts, media, and network resources from CDNs. Keep off for fully offline previews.",
       },
       data: "Data",
       exportHistory: "Export chat history",
       exportHistoryDescription:
-        "Download all chats and messages as a JSON file.",
+        "Download all chats and messages as JSON.",
       exportAction: "Export",
       exportingAction: "Exporting...",
       exportConversations: "Export Recents and Projects",
       exportConversationsDescription:
-        "Download Recents only, or Recents plus project chats, as Raw JSONL, CSV, or ShareGPT JSONL, combined or one file per chat.",
+        "Download Recents or Recents plus project chats as Raw JSONL, CSV, or ShareGPT JSONL, combined or per chat.",
       exportConversationsAction: "Export",
       exportScopeRecents: "Recents",
       exportScopeAll: "Recents + Projects",
@@ -214,14 +214,14 @@ export const en = {
       exportPerChatSuffix: "(per chat)",
       importChats: "Import chats",
       importChatsDescription:
-        "Add conversations from a JSONL, NDJSON, or CSV export to Recents.",
+        "Import a JSONL, NDJSON, or CSV export into Recents.",
       importChatsAction: "Import",
       importNoConversations: "No conversations found in file.",
       importedOneChat: "Imported 1 conversation to Recents.",
       importedChatCount: "Imported {count} conversations to Recents.",
       importFailed: "Import failed.",
       clearHistory: "Clear chat history",
-      clearHistoryDescription: "Delete local chat history from this device.",
+      clearHistoryDescription: "Delete chat history from this device.",
       clearAction: "Clear",
       clearAllChats: "Clear all chats",
       clearAllChatsDescription: "Permanently delete every chat on this device.",
@@ -234,7 +234,7 @@ export const en = {
       clearOneChatTitle: "Clear 1 chat?",
       clearChatsTitle: "Clear {count} chats?",
       clearChatsConfirmDescription:
-        "This permanently deletes every chat and message stored on this device. This cannot be undone.",
+        "Permanently deletes every chat on this device. This cannot be undone.",
       clearingAction: "Clearing...",
       clearOneChatAction: "Clear 1 chat",
       clearChatCountAction: "Clear {count} chats",
@@ -257,12 +257,12 @@ export const en = {
     },
     connections: {
       title: "Connections",
-      description: "Manage providers and external service connections.",
+      description: "Manage providers and external connections.",
     },
     apiKeys: {
       title: "API",
       description:
-        "Access Unsloth programmatically via the OpenAI-compatible API.",
+        "Access Unsloth via the OpenAI-compatible API.",
       readDocs: "Read the API docs",
       noAccess: "No API access yet.",
       newBadge: "New",
@@ -302,14 +302,14 @@ export const en = {
       revokeToken: "Revoke token",
       revokeTitle: 'Revoke access token "{name}"?',
       revokeDescription:
-        "Applications using this token will immediately lose access. This cannot be undone.",
+        "Apps using this token immediately lose access. This cannot be undone.",
       revokeAction: 'Revoke "{name}"',
       revoking: "Revoking...",
     },
     about: {
       title: "About",
       description:
-        "Documentation, release notes, feedback, and Unsloth build info.",
+        "Docs, release notes, feedback, and build info.",
       studioVersion: "Unsloth Version",
       packageVersion: "Package Version",
       updates: "Update",
@@ -324,15 +324,15 @@ export const en = {
         studioLabel: "Unsloth Studio",
         studioLicense: "AGPL-3.0",
         studioDescription:
-          "Open source under the GNU Affero General Public License v3.0.",
+          "Open source under the GNU AGPL v3.0.",
         libraryLabel: "Unsloth Core",
         libraryLicense: "Apache-2.0",
-        libraryDescription: "Licensed under the Apache License 2.0.",
+        libraryDescription: "Licensed under Apache 2.0.",
       },
       dangerZone: "Danger zone",
       shutDownStudio: "Shut down Unsloth Studio",
       shutDownStudioDescription:
-        "Stops the Unsloth server process and ends your session.",
+        "Stops the Unsloth server and ends your session.",
       shutDown: "Shut down",
       update: {
         title: "Update Unsloth Studio",
@@ -352,14 +352,14 @@ export const en = {
         gitPullCommand: "git pull command",
         localInstallerCommand: "local installer command",
         sourceInstallDetected:
-          "This looks like a source or VCS package install. Reinstall from the original local path or Git URL you used.",
+          "Source or VCS package install detected. Reinstall from the original local path or Git URL.",
         repoCheckoutFallback:
-          "If you still have the Unsloth repo checkout, run the local installer from that checkout:",
+          "If you still have the repo checkout, run the local installer from it:",
         restartAfterUpdate: "Restart Unsloth after updating.",
         unknownInstall:
-          "Unsloth could not detect how it was installed. For installer or PyPI installs, use the commands above.",
+          "Could not detect how Unsloth was installed. For installer or PyPI installs, use the commands above.",
         localCheckout:
-          "For local checkout installs, run the local installer from that checkout instead:",
+          "For local checkout installs, run the local installer from that checkout:",
         docs: "Install docs:",
         docsInstall: "Installation",
         docsUpdating: "Updating",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -347,17 +347,15 @@ export const en = {
         installCommandUnix: "macOS/Linux install command",
         installCommandWindows: "Windows install command",
         localInstallDetected:
-          "Source or local install detected. To avoid replacing it with PyPI, update from the checkout or source you originally installed from.",
-        pullThenUpdate:
-          "Pull latest changes from your Unsloth repo checkout, then run the local installer:",
+          "Local install detected. Update from your original checkout to avoid replacing it with PyPI.",
+        pullThenUpdate: "Pull the latest changes, then run the local installer:",
         gitPullCommand: "git pull command",
         localInstallerCommand: "local installer command",
         sourceInstallDetected:
           "This looks like a source or VCS package install. Reinstall from the original local path or Git URL you used.",
         repoCheckoutFallback:
           "If you still have the Unsloth repo checkout, run the local installer from that checkout:",
-        restartAfterUpdate:
-          "Restart Unsloth after updating for changes to take effect.",
+        restartAfterUpdate: "Restart Unsloth after updating.",
         unknownInstall:
           "Unsloth could not detect how it was installed. For installer or PyPI installs, use the commands above.",
         localCheckout:
@@ -365,8 +363,8 @@ export const en = {
         docs: "Install docs:",
         docsInstall: "Installation",
         docsUpdating: "Updating",
-        docsMac: "Mac guide",
-        docsWindows: "Windows guide",
+        docsMac: "Mac",
+        docsWindows: "Windows",
       },
     },
   },

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -356,6 +356,8 @@ export const en = {
         repoCheckoutFallback:
           "If you still have the repo checkout, run the local installer from it:",
         restartAfterUpdate: "Restart Unsloth after updating.",
+        desktopManaged:
+          "The desktop app keeps its bundled backend updated and will prompt when a new version is available.",
         unknownInstall:
           "Could not detect how Unsloth was installed. For installer or PyPI installs, use the commands above.",
         localCheckout:

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -344,14 +344,13 @@ export const en = {
         commandCopied: "{label} copied",
         copyNamedCommand: "Copy {label}",
         checkingInstall: "Checking how Unsloth was installed...",
+        deprecatedNotice:
+          "Note: the unsloth studio update command is no longer supported. Use the install command instead; it also updates existing installs.",
         localInstallDetected:
           "Source or local install detected. To avoid replacing it with PyPI, update from the checkout or source you originally installed from.",
         pullThenUpdate:
-          "Pull latest changes from your Unsloth repo checkout, then update Unsloth locally:",
+          "Pull latest changes from your Unsloth repo checkout, then run the local installer:",
         gitPullCommand: "git pull command",
-        localUpdateCommand: "local update command",
-        localInstallerFallback:
-          "If the Unsloth update command is unavailable, run the local installer from that checkout:",
         localInstallerCommand: "local installer command",
         sourceInstallDetected:
           "This looks like a source or VCS package install. Reinstall from the original local path or Git URL you used.",
@@ -360,14 +359,14 @@ export const en = {
         restartAfterUpdate:
           "Restart Unsloth after updating for changes to take effect.",
         unknownInstall:
-          "Unsloth could not detect how it was installed. Check how you installed Unsloth first, then choose the matching update path.",
-        curlOrPypi: "For curl or PyPI installs, run:",
-        updateCommand: "update command",
+          "Unsloth could not detect how it was installed. If you used the one-line installer or PyPI, run the install command below.",
+        installCommand: "install command",
         localCheckout:
-          "For local checkout installs, update from that checkout instead and use the local update command:",
-        fallbackInstruction:
-          "If that fails or unsloth studio update is unavailable, run:",
-        fallbackCommand: "fallback command",
+          "For local checkout installs, run the local installer from that checkout instead:",
+        docs: "Install docs:",
+        docsInstall: "Installation",
+        docsUpdating: "Updating",
+        docsWindows: "Windows guide",
       },
     },
   },

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -297,9 +297,8 @@ export const zhCN = {
         commandCopied: "{label} 已复制",
         copyNamedCommand: "复制 {label}",
         checkingInstall: "正在检查 Unsloth 的安装方式...",
-        installIntro: "标准安装命令。再次运行即可更新现有安装。",
-        unixLabel: "MacOS、Linux、WSL：",
-        windowsLabel: "Windows PowerShell：",
+        installIntro: "安装或更新 Unsloth：",
+        localUpdateHeading: "本地更新",
         installCommandUnix: "macOS/Linux 安装命令",
         installCommandWindows: "Windows 安装命令",
         localInstallDetected:

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -302,16 +302,15 @@ export const zhCN = {
         installCommandUnix: "macOS/Linux 安装命令",
         installCommandWindows: "Windows 安装命令",
         localInstallDetected:
-          "检测到源码或本地安装。为避免替换为 PyPI 版本，请从最初安装时使用的 checkout 或源码位置更新。",
-        pullThenUpdate:
-          "从你的 Unsloth 仓库 checkout 拉取最新变更，然后运行本地安装器：",
+          "检测到本地安装。请从最初的 checkout 更新，以免被 PyPI 版本替换。",
+        pullThenUpdate: "拉取最新变更，然后运行本地安装器：",
         gitPullCommand: "git pull 命令",
         localInstallerCommand: "本地安装器命令",
         sourceInstallDetected:
           "这看起来是源码或 VCS 包安装。请从最初使用的本地路径或 Git URL 重新安装。",
         repoCheckoutFallback:
           "如果你仍保留 Unsloth 仓库 checkout，请从该 checkout 运行本地安装器：",
-        restartAfterUpdate: "更新后重启 Unsloth，使变更生效。",
+        restartAfterUpdate: "更新后请重启 Unsloth。",
         unknownInstall:
           "Unsloth 无法检测安装方式。如果你使用一键安装器或 PyPI 安装，请使用上面的命令。",
         localCheckout:
@@ -319,8 +318,8 @@ export const zhCN = {
         docs: "安装文档：",
         docsInstall: "安装",
         docsUpdating: "更新",
-        docsMac: "Mac 指南",
-        docsWindows: "Windows 指南",
+        docsMac: "Mac",
+        docsWindows: "Windows",
       },
     },
   },

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -291,16 +291,17 @@ export const zhCN = {
       shutDown: "关闭",
       update: {
         title: "更新 Unsloth Studio",
-        openPowerShell: "打开 PowerShell 并运行：",
-        openTerminal: "打开终端并运行：",
         commandText: "{label} 文本",
         copied: "已复制",
         copyCommand: "复制命令",
         commandCopied: "{label} 已复制",
         copyNamedCommand: "复制 {label}",
         checkingInstall: "正在检查 Unsloth 的安装方式...",
-        deprecatedNotice:
-          "提示：unsloth studio update 命令已不再受支持。请改用安装命令，它同样会更新现有安装。",
+        installIntro: "标准安装命令。再次运行即可更新现有安装。",
+        unixLabel: "MacOS、Linux、WSL：",
+        windowsLabel: "Windows PowerShell：",
+        installCommandUnix: "macOS/Linux 安装命令",
+        installCommandWindows: "Windows 安装命令",
         localInstallDetected:
           "检测到源码或本地安装。为避免替换为 PyPI 版本，请从最初安装时使用的 checkout 或源码位置更新。",
         pullThenUpdate:
@@ -313,13 +314,13 @@ export const zhCN = {
           "如果你仍保留 Unsloth 仓库 checkout，请从该 checkout 运行本地安装器：",
         restartAfterUpdate: "更新后重启 Unsloth，使变更生效。",
         unknownInstall:
-          "Unsloth 无法检测安装方式。如果你使用一键安装器或 PyPI 安装，请运行下面的安装命令。",
-        installCommand: "安装命令",
+          "Unsloth 无法检测安装方式。如果你使用一键安装器或 PyPI 安装，请使用上面的命令。",
         localCheckout:
           "对于本地 checkout 安装，请改为从该 checkout 运行本地安装器：",
         docs: "安装文档：",
         docsInstall: "安装",
         docsUpdating: "更新",
+        docsMac: "Mac 指南",
         docsWindows: "Windows 指南",
       },
     },

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -106,6 +106,12 @@ export const zhCN = {
       chatDefaults: "聊天默认设置",
       autoTitleNewChats: "自动为新聊天命名",
       autoTitleNewChatsDescription: "根据第一条消息生成简短标题。",
+      notifications: {
+        sectionTitle: "通知",
+        showLlamaUpdates: "llama.cpp 更新通知",
+        showLlamaUpdatesDescription:
+          "有新的 llama.cpp 构建时提醒。如果只用于训练可以关闭。",
+      },
       gettingStarted: "入门",
       startOnboarding: "开始引导",
       startOnboardingDescription: "重新打开设置向导，不会更改你的账号。",
@@ -274,7 +280,7 @@ export const zhCN = {
       revoking: "撤销中...",
     },
     about: {
-      title: "帮助",
+      title: "关于",
       description: "文档、发布说明、反馈和 Unsloth 构建信息。",
       studioVersion: "Unsloth 版本",
       packageVersion: "包版本",
@@ -285,6 +291,15 @@ export const zhCN = {
       whatsNew: "最新内容",
       feedback: "反馈",
       reportIssue: "报告问题",
+      license: {
+        sectionTitle: "许可证",
+        studioLabel: "Unsloth Studio",
+        studioLicense: "AGPL-3.0",
+        studioDescription: "基于 GNU AGPL v3.0 开源。",
+        libraryLabel: "Unsloth Core",
+        libraryLicense: "Apache-2.0",
+        libraryDescription: "基于 Apache License 2.0 许可。",
+      },
       dangerZone: "危险区域",
       shutDownStudio: "关闭 Unsloth Studio",
       shutDownStudioDescription: "停止 Unsloth 服务进程并结束你的会话。",
@@ -311,6 +326,8 @@ export const zhCN = {
         repoCheckoutFallback:
           "如果你仍保留 Unsloth 仓库 checkout，请从该 checkout 运行本地安装器：",
         restartAfterUpdate: "更新后请重启 Unsloth。",
+        desktopManaged:
+          "桌面应用会自动更新其内置后端，有新版本时会提示。",
         unknownInstall:
           "Unsloth 无法检测安装方式。如果你使用一键安装器或 PyPI 安装，请使用上面的命令。",
         localCheckout:

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -93,7 +93,7 @@ export const zhCN = {
       chat: "聊天",
       connections: "连接",
       apiKeys: "API",
-      about: "帮助",
+      about: "关于",
     },
     general: {
       title: "通用",
@@ -124,13 +124,13 @@ export const zhCN = {
         action: "重置偏好设置",
         confirmTitle: "重置所有本地偏好设置？",
         confirmDescription:
-          "这会清除仅保存在本地的偏好设置，然后重新加载 Studio。聊天、API 访问权限和数据库中的设置不会受到影响。",
+          "这会清除仅保存在本地的偏好设置，然后重新加载 Unsloth。聊天、API 访问权限和数据库中的设置不会受到影响。",
         confirmAction: "重置并重新加载",
       },
     },
     profile: {
       title: "个人资料",
-      description: "更新你在 Studio 中显示的个人资料。",
+      description: "更新你在 Unsloth 中显示的个人资料。",
       changePicture: "更换头像",
       displayName: "显示名称",
       nameSaved: "个人资料名称已保存",
@@ -150,7 +150,7 @@ export const zhCN = {
       language: {
         title: "语言",
         label: "显示语言",
-        description: "选择 Studio 使用的语言。",
+        description: "选择 Unsloth 使用的语言。",
       },
       theme: {
         title: "主题",
@@ -275,8 +275,8 @@ export const zhCN = {
     },
     about: {
       title: "帮助",
-      description: "文档、发布说明、反馈和 Studio 构建信息。",
-      studioVersion: "Studio 版本",
+      description: "文档、发布说明、反馈和 Unsloth 构建信息。",
+      studioVersion: "Unsloth 版本",
       packageVersion: "包版本",
       updates: "更新",
       help: "帮助",
@@ -287,7 +287,7 @@ export const zhCN = {
       reportIssue: "报告问题",
       dangerZone: "危险区域",
       shutDownStudio: "关闭 Unsloth Studio",
-      shutDownStudioDescription: "停止 Studio 服务进程并结束你的会话。",
+      shutDownStudioDescription: "停止 Unsloth 服务进程并结束你的会话。",
       shutDown: "关闭",
       update: {
         title: "更新 Unsloth Studio",
@@ -298,23 +298,23 @@ export const zhCN = {
         copyCommand: "复制命令",
         commandCopied: "{label} 已复制",
         copyNamedCommand: "复制 {label}",
-        checkingInstall: "正在检查 Studio 的安装方式...",
+        checkingInstall: "正在检查 Unsloth 的安装方式...",
         localInstallDetected:
           "检测到源码或本地安装。为避免替换为 PyPI 版本，请从最初安装时使用的 checkout 或源码位置更新。",
         pullThenUpdate:
-          "从你的 Unsloth 仓库 checkout 拉取最新变更，然后本地更新 Studio：",
+          "从你的 Unsloth 仓库 checkout 拉取最新变更，然后本地更新 Unsloth：",
         gitPullCommand: "git pull 命令",
         localUpdateCommand: "本地更新命令",
         localInstallerFallback:
-          "如果 Studio 更新命令不可用，请从该 checkout 运行本地安装器：",
+          "如果 Unsloth 更新命令不可用，请从该 checkout 运行本地安装器：",
         localInstallerCommand: "本地安装器命令",
         sourceInstallDetected:
           "这看起来是源码或 VCS 包安装。请从最初使用的本地路径或 Git URL 重新安装。",
         repoCheckoutFallback:
           "如果你仍保留 Unsloth 仓库 checkout，请从该 checkout 运行本地安装器：",
-        restartAfterUpdate: "更新后重启 Studio，使变更生效。",
+        restartAfterUpdate: "更新后重启 Unsloth，使变更生效。",
         unknownInstall:
-          "Studio 无法检测安装方式。请先确认你如何安装 Studio，然后选择匹配的更新方式。",
+          "Unsloth 无法检测安装方式。请先确认你如何安装 Unsloth，然后选择匹配的更新方式。",
         curlOrPypi: "对于 curl 或 PyPI 安装，请运行：",
         updateCommand: "更新命令",
         localCheckout:

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -299,14 +299,13 @@ export const zhCN = {
         commandCopied: "{label} 已复制",
         copyNamedCommand: "复制 {label}",
         checkingInstall: "正在检查 Unsloth 的安装方式...",
+        deprecatedNotice:
+          "提示：unsloth studio update 命令已不再受支持。请改用安装命令，它同样会更新现有安装。",
         localInstallDetected:
           "检测到源码或本地安装。为避免替换为 PyPI 版本，请从最初安装时使用的 checkout 或源码位置更新。",
         pullThenUpdate:
-          "从你的 Unsloth 仓库 checkout 拉取最新变更，然后本地更新 Unsloth：",
+          "从你的 Unsloth 仓库 checkout 拉取最新变更，然后运行本地安装器：",
         gitPullCommand: "git pull 命令",
-        localUpdateCommand: "本地更新命令",
-        localInstallerFallback:
-          "如果 Unsloth 更新命令不可用，请从该 checkout 运行本地安装器：",
         localInstallerCommand: "本地安装器命令",
         sourceInstallDetected:
           "这看起来是源码或 VCS 包安装。请从最初使用的本地路径或 Git URL 重新安装。",
@@ -314,14 +313,14 @@ export const zhCN = {
           "如果你仍保留 Unsloth 仓库 checkout，请从该 checkout 运行本地安装器：",
         restartAfterUpdate: "更新后重启 Unsloth，使变更生效。",
         unknownInstall:
-          "Unsloth 无法检测安装方式。请先确认你如何安装 Unsloth，然后选择匹配的更新方式。",
-        curlOrPypi: "对于 curl 或 PyPI 安装，请运行：",
-        updateCommand: "更新命令",
+          "Unsloth 无法检测安装方式。如果你使用一键安装器或 PyPI 安装，请运行下面的安装命令。",
+        installCommand: "安装命令",
         localCheckout:
-          "对于本地 checkout 安装，请改为从该 checkout 更新并使用本地更新命令：",
-        fallbackInstruction:
-          "如果失败，或 unsloth studio update 不可用，请运行：",
-        fallbackCommand: "备用命令",
+          "对于本地 checkout 安装，请改为从该 checkout 运行本地安装器：",
+        docs: "安装文档：",
+        docsInstall: "安装",
+        docsUpdating: "更新",
+        docsWindows: "Windows 指南",
       },
     },
   },

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1523,6 +1523,20 @@
 		}
 	}
 
+	/* Indeterminate loading bar: a 1/3-width segment sweeping the track. */
+	.loading-bar-slide {
+		animation: loading-bar-slide 1.3s ease-in-out infinite;
+	}
+
+	@keyframes loading-bar-slide {
+		from {
+			transform: translateX(-110%);
+		}
+		to {
+			transform: translateX(420%);
+		}
+	}
+
 	@keyframes artifact-loading-line {
 		0% {
 			transform: translate3d(-125%, 0, 0) scaleX(0.78);
@@ -2107,6 +2121,11 @@
 
 	.generated-image-loading-dot {
 		animation-duration: 1850ms !important;
+		animation-iteration-count: infinite !important;
+	}
+
+	.loading-bar-slide {
+		animation-duration: 1.3s !important;
 		animation-iteration-count: infinite !important;
 	}
 

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -552,6 +552,7 @@
 	.sidebar-nav-btn[data-state="open"],
 	.group\/project-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
 	.group\/project-chat-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
+	.group\/projects-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
 	.group\/recent-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
 	.group\/run-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn {
 		background-color: var(--nav-surface-hover) !important;
@@ -562,6 +563,7 @@
 	.dark .sidebar-nav-btn[data-state="open"],
 	.dark .group\/project-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
 	.dark .group\/project-chat-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
+	.dark .group\/projects-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
 	.dark .group\/recent-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn,
 	.dark .group\/run-item:hover:not(:has(.sidebar-row-action:hover)) .sidebar-nav-btn {
 		color: #fff !important;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1751,10 +1751,10 @@
 	margin: 0 !important;
 }
 
-/* Composer shadow on the dark background color so toasts
-   do not merge into card-colored surfaces behind them. */
+/* Dark toasts share the chatbox surface color (.chat-composer-surface
+   uses var(--card) in dark); the composer shadow lifts them off the page. */
 .dark [data-sonner-toast][data-styled='true'] {
-	background-color: var(--background) !important;
+	background-color: var(--card) !important;
 	box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16) !important;
 }
 

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -958,6 +958,11 @@
 		border-radius: 14px !important;
 	}
 
+	/* Account menu: a touch rounder than standard list menus. */
+	[data-slot="dropdown-menu-content"].app-user-menu.menu-soft-surface-up {
+		border-radius: 18px !important;
+	}
+
 	/* Every dropdown/menu/select/popover: borderless, chatbox shadow in light,
 	   none in dark. !important so it also overrides the bespoke menu shadows. */
 	[data-slot="dropdown-menu-content"],

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1084,13 +1084,16 @@
 	[data-pill-compact="true"]
 		.composer-pill-btn:not([data-keep-label])[data-pill-label]:hover::after {
 		content: attr(data-pill-label);
-		@apply pointer-events-none absolute bottom-[calc(100%+6px)] left-1/2 z-50 -translate-x-1/2 rounded-[9px] bg-black px-2.5 py-1.5 text-[11px] font-medium leading-snug whitespace-nowrap text-white shadow-md;
+		/* Always one nowrap line, so always a full pill. */
+		@apply pointer-events-none absolute bottom-[calc(100%+6px)] left-1/2 z-50 -translate-x-1/2 rounded-full bg-black px-2.5 py-1.5 text-[11px] font-medium leading-snug whitespace-nowrap text-white shadow-md;
 	}
 
 	/* Compact caret pills (RAG, MCP) open their menu on click instead of
-	   toggling off, so keep the icon and skip the X swap. */
+	   toggling off, so keep the icon and skip the X swap. No data-active
+	   requirement: the off-switch glyph rules below hide the icon on hover
+	   even for inactive pills, which left a blank slot in compact mode. */
 	[data-pill-compact="true"]
-		.composer-pill-btn:not([data-keep-label]):has(.composer-pill-caret)[data-active="true"]:hover
+		.composer-pill-btn:not([data-keep-label]):has(.composer-pill-caret):hover
 		.composer-pill-glyph
 		> :not(.composer-pill-x) {
 		opacity: 1;

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -856,6 +856,16 @@ def format_byte_count(num_bytes: float) -> str:
     return f"{num_bytes:.1f} B"
 
 
+def _progress_percent_step() -> int:
+    """Non-tty milestone granularity. The in-app updater sets
+    UNSLOTH_PROGRESS_PERCENT_STEP=5 to stream finer progress lines."""
+    try:
+        step = int(os.environ.get("UNSLOTH_PROGRESS_PERCENT_STEP", "25"))
+    except ValueError:
+        return 25
+    return min(max(step, 1), 50)
+
+
 class DownloadProgress:
     def __init__(self, label: str, total_bytes: int | None) -> None:
         self.label = label
@@ -868,6 +878,7 @@ class DownloadProgress:
         )
         self.is_tty = term_ok and self.stream.isatty()
         self.completed = False
+        self.milestone_step = _progress_percent_step()
         self.last_milestone_percent = -1
         self.last_milestone_bytes = 0
         self.has_rendered_tty_progress = False
@@ -918,7 +929,8 @@ class DownloadProgress:
         should_emit = False
         if self.total_bytes is not None:
             percent = int((downloaded_bytes * 100) / max(self.total_bytes, 1))
-            milestone_percent = min((percent // 25) * 25, 100)
+            step = self.milestone_step
+            milestone_percent = min((percent // step) * step, 100)
             if milestone_percent > self.last_milestone_percent and milestone_percent < 100:
                 self.last_milestone_percent = milestone_percent
                 should_emit = True


### PR DESCRIPTION
## Overview

A set of Studio UI improvements centered on the llama.cpp update banner, plus settings, chat run settings, update guidance, and wording polish.

## llama.cpp update banner

- Redesigned to match the chat composer surface: borderless rounded card (24px radius), the composer drop shadow, Hellix Medium title
- Title is now "New llama.cpp version" and the primary action is just "Update"
- New "Remind me later" action snoozes the banner for 15 minutes, then re-checks the backend before re-surfacing so it stays quiet if the update was applied elsewhere
- The banner no longer dismisses on outside clicks; it only closes from the X, Update, or Remind me later
- While an update is applying, the banner shows a progress bar in place of the buttons that tracks the real download: the update worker streams the installer output, parses its download percent lines into the job state, and the update-status API exposes the fraction. The installer emits 5 percent milestones for the updater via UNSLOTH_PROGRESS_PERCENT_STEP (default output unchanged). The bar sweeps until the first percent arrives and keeps animating under reduced motion like the other loading indicators
- New toggle under Settings > General > Notifications to turn the banner off entirely for people who only use Studio for training. On by default, stored in localStorage, syncs across tabs, and is included in "Reset all local preferences"

## Settings

- Renamed the Help tab to About (en and zh-CN)
- zh-CN translations for the new notification and license keys and the desktop update note
- Added a License section to the About tab: Unsloth Studio under AGPL-3.0 and Unsloth Core under Apache-2.0, with each badge linking to the license file in this repo
- Source checkouts that are not on an exact release tag now report GitHub <branch> (e.g. GitHub main) as the Studio version instead of dev

## Update guidance

- The `unsloth studio update` command no longer works, so the About tab Update section now shows the standard one-line install command, which also updates an existing install
- The platform is picked with a MacOS / Linux and Windows button toggle, and only the selected platform's command is shown
- Repo checkouts additionally get a Local update section with `git pull` plus the local installer so a local install is not replaced with PyPI
- Added links to the Installation, Updating, Mac, and Windows install docs pages
- In the desktop app the About tab shows a note pointing to the built-in updater instead of terminal commands, since the bundled backend updates through the managed path
- fetchDeviceType now authenticates against /api/health so the copied command matches the server platform rather than the browser when they differ (WSL, SSH), and the browser fallback is no longer cached
- The package update banner now copies the platform installer command instead of `unsloth studio update`

## Chat run settings

- The system prompt box is an inline editable textarea. Clicking the "System Prompt" label or the pencil opens the Edit System Prompt dialog, and when the prompt overflows the box a click on the box opens the dialog too
- Overflowing prompt text and the scrollbar are clipped inside the rounded box instead of bleeding past its corners
- The preset dropdown chevron now shows a pointer cursor on hover
- The inline system prompt box no longer shows a focus ring while typing

## Settings copy

- Settings descriptions across General, Profile, Appearance, Chat, Connections, API, and About are shortened without losing meaning, e.g. the Helper LLM and llama.cpp notification blurbs

## Sidebar

- The account menu corners are slightly rounder (18px instead of the 14px shared by standard list menus)
- Tighter line spacing between the display name and the Unsloth label in the account button
- Hovering the Projects nav item reveals a plus button that opens the New project dialog, with the same circular hover treatment as the chat row actions
- The Projects plus icon is slightly smaller (16px instead of the 18px standard icon size)
- Recent chat titles line up with the Recents section label

## Composer and tooltips

- Fixed the compact (icon-only) MCP and RAG pills losing their icon on hover: the off switch hover rules hid the icon while compact mode hid the X, leaving an empty slot under the tooltip
- Compact icon tooltips and other single line tooltips now render as fully rounded pills; tooltips that wrap to multiple lines keep the squarer 9px corners

## Theming and wording

- Dark mode toasts now use the chat composer surface color (var(--card)) instead of the page background
- Replaced standalone "Studio" with "Unsloth" in user facing strings. Kept "Unsloth Studio", "LM Studio", "Fine-tuning Studio", "Recipe Studio", code identifiers, and lowercase CLI commands unchanged

## Testing

- `bun run build` passes (tsc and vite)
- `bun run i18n:check` passes, locale overlays keep parity
- Verified in the browser against a running Studio: banner styling, snooze and re-surface, settings toggle on/off round trip, system prompt behavior, dark toast color matches the composer surface, About tab license links, update section commands for both platform toggles, docs links resolve, the Projects plus opens the New project dialog, recents align with their label, the compact pill icon stays visible on hover, overflowing system prompts clip inside the rounded box, and a real in-place update run showed the progress bar tracking the download percentages before the swap completed













