### PR TITLE
Fix Llama 3.1+ rope scaling dropped on the FastLanguageModel path (long inputs become gibberish past ~29K tokens)

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -334,21 +334,11 @@ jobs:
           python -m pytest -v --tb=short tests/test_callback_signature_drift.py
 
       - name: generation correctness guards (HARD GATE)
-        # Two deterministic CPU guards for generation bug classes that shipped
-        # to users because nothing tested them:
-        # 1. tests/utils/test_prepare_inputs_leftpad.py - left-padded batched
-        #    generation (issues #1066 / #3699: position_ids from cache_position,
-        #    truncated 2D mask; fixed by #2216 + #4100). Validated to fail on
-        #    the pre-#2216 and pre-#4100 code states; staging proof:
-        #    danielhanchen/unsloth-staging-2 PR 170 (green) / PR 172 (red).
-        # 2. tests/utils/test_rope_scaling_drift.py - config.rope_scaling
-        #    dropped by the replaced rotary classes (issue #2405: Llama-3.1
-        #    gibberish past ~29K tokens because llama3 rope scaling was
-        #    silently ignored on the FastLanguageModel path). Validated to
-        #    fail on the unfixed code state.
-        # Both files put stdlib-ast-only checks first (survive unsloth import
-        # breakage) and behavioral checks second (real functions on CPU via
-        # the tests/conftest.py CUDA spoof).
+        # Deterministic CPU guards, each validated to fail on its pre-fix code:
+        # leftpad = batched left-padded generation (#1066/#3699, fixed by
+        # #2216 + #4100; staging proof: unsloth-staging-2 PRs 170/172);
+        # rope_scaling_drift = config.rope_scaling dropped by replaced rotary
+        # classes (#2405). AST checks run first so import breakage cannot mask them.
         run: |
           python -m pytest -v --tb=short \
             tests/utils/test_prepare_inputs_leftpad.py \

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -333,19 +333,26 @@ jobs:
         run: |
           python -m pytest -v --tb=short tests/test_callback_signature_drift.py
 
-      - name: batched left-padding generation guard (HARD GATE)
-        # Guards _fast_prepare_inputs_for_generation against the bug class of
-        # issues #1066 / #3699: position_ids taken from cache_position (which
-        # counts left-pad tokens) or the 2D attention mask truncated to its
-        # last column. Both shipped in cc4c5d77 and were fixed by #2216 and
-        # #4100; nothing tested this path, so each regression reached users.
-        # Layer 1 in the file is stdlib-ast-only (survives unsloth import
-        # breakage), layer 2 calls the real function on CPU via the
-        # tests/conftest.py CUDA spoof. Validated to fail on the pre-#2216
-        # and pre-#4100 code states; staging proof on GPU-less runners:
-        # danielhanchen/unsloth-staging-2 PR 170 (green, gate passed in all combos) / PR 172 (red, gate failed in all combos).
+      - name: generation correctness guards (HARD GATE)
+        # Two deterministic CPU guards for generation bug classes that shipped
+        # to users because nothing tested them:
+        # 1. tests/utils/test_prepare_inputs_leftpad.py - left-padded batched
+        #    generation (issues #1066 / #3699: position_ids from cache_position,
+        #    truncated 2D mask; fixed by #2216 + #4100). Validated to fail on
+        #    the pre-#2216 and pre-#4100 code states; staging proof:
+        #    danielhanchen/unsloth-staging-2 PR 170 (green) / PR 172 (red).
+        # 2. tests/utils/test_rope_scaling_drift.py - config.rope_scaling
+        #    dropped by the replaced rotary classes (issue #2405: Llama-3.1
+        #    gibberish past ~29K tokens because llama3 rope scaling was
+        #    silently ignored on the FastLanguageModel path). Validated to
+        #    fail on the unfixed code state.
+        # Both files put stdlib-ast-only checks first (survive unsloth import
+        # breakage) and behavioral checks second (real functions on CPU via
+        # the tests/conftest.py CUDA spoof).
         run: |
-          python -m pytest -v --tb=short tests/utils/test_prepare_inputs_leftpad.py
+          python -m pytest -v --tb=short \
+            tests/utils/test_prepare_inputs_leftpad.py \
+            tests/utils/test_rope_scaling_drift.py
 
       - name: unsloth Bucket-A — CPU tests not in Repo tests (CPU)
         # CPU tests across 6 files under tests/saving/, tests/utils/, tests/python/

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -1,0 +1,226 @@
+"""Regression guard for RoPE scaling being silently dropped (issue #2405).
+
+Llama-3.1 (and any model with `config.rope_scaling`) ships an `inv_freq`
+rescaling, e.g. `{"rope_type": "llama3", "factor": 8.0, ...}`. Unsloth replaces
+transformers' rotary classes with its own (`unsloth/models/llama.py`), but the
+*config* constructor path of the base `LlamaRotaryEmbedding` only reads
+`rope_theta`, `head_dim` and `max_position_embeddings`. It never inspects
+`config.rope_scaling`, so the scaled `LlamaExtendedRotaryEmbedding` is only used
+when the (legacy) `LlamaAttention.__init__` rewrite in `patch_llama_rope_scaling`
+fires. On modern transformers (rotary moved to `LlamaModel`) that rewrite no
+longer matches, the unscaled base class wins, and long-context inference
+(> ~32k tokens) collapses into repeated-pattern gibberish (issue #2405).
+
+Two layers, both CPU-only and deterministic:
+
+  1. AST structural tripwire (no unsloth import): parse llama.py and assert the
+     config path of `LlamaRotaryEmbedding.__init__` references `rope_scaling`.
+  2. Behavioral checks: instantiate the real `LlamaRotaryEmbedding(config=...)`
+     and assert its `inv_freq` matches transformers'
+     `ROPE_INIT_FUNCTIONS[rope_type]` (scaled for llama3, vanilla for None).
+
+The behavioral layer FAILS on current unfixed main (inv_freq is unscaled for a
+llama3 config). Pattern mirrors tests/utils/test_prepare_inputs_leftpad.py.
+"""
+
+import ast
+import math
+from pathlib import Path
+
+import pytest
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LLAMA_PY = REPO_ROOT / "unsloth" / "models" / "llama.py"
+
+CLASS_NAME = "LlamaRotaryEmbedding"
+
+# A Llama-3.1-style rope_scaling block (matches the hardcoded grid-search
+# constants in LlamaExtendedRotaryEmbedding._apply_inv_freq_scaling).
+LLAMA3_ROPE_SCALING = {
+    "rope_type": "llama3",
+    "factor": 8.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+}
+ROPE_THETA = 500000.0
+HEAD_DIM = 128
+MAX_POS = 131072
+
+
+# --------------------------------------------------------------------------
+# Layer 1: AST structural tripwire (stdlib only, no unsloth import)
+# --------------------------------------------------------------------------
+
+
+def _load_class_init():
+    tree = ast.parse(LLAMA_PY.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == CLASS_NAME:
+            for sub in node.body:
+                if isinstance(sub, ast.FunctionDef) and sub.name == "__init__":
+                    return sub
+    raise AssertionError(
+        f"{CLASS_NAME}.__init__ not found in {LLAMA_PY}; if it was renamed or "
+        "moved, update this guard so RoPE scaling stays protected (issue #2405)"
+    )
+
+
+def _config_branch(init_fn):
+    """The `if config is not None:` block at the top of __init__."""
+    for node in init_fn.body:
+        if isinstance(node, ast.If):
+            test = node.test
+            # match `config is not None`
+            is_config_test = (
+                isinstance(test, ast.Compare)
+                and isinstance(test.left, ast.Name)
+                and test.left.id == "config"
+            )
+            if is_config_test:
+                return node
+    return None
+
+
+def test_config_path_inspects_rope_scaling():
+    init_fn = _load_class_init()
+    branch = _config_branch(init_fn)
+    assert branch is not None, (
+        f"{CLASS_NAME}.__init__ no longer has an `if config is not None:` "
+        "branch; the config constructor path must read config.rope_scaling so "
+        "scaled models (llama3/linear/longrope) are not silently unscaled "
+        "(issue #2405)"
+    )
+
+    names = set()
+    for stmt in branch.body:
+        for sub in ast.walk(stmt):
+            if isinstance(sub, ast.Attribute):
+                names.add(sub.attr)
+            elif isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                names.add(sub.value)
+    assert "rope_scaling" in names, (
+        f"{CLASS_NAME}.__init__ config path does not reference `rope_scaling`. "
+        "When a rotary class is built straight from a config (the path modern "
+        "transformers takes, since rotary moved to LlamaModel), the llama3 / "
+        "linear / longrope scaling must still be applied; otherwise long inputs "
+        "produce repeated-pattern gibberish (issue #2405)."
+    )
+
+
+# --------------------------------------------------------------------------
+# Layer 2: behavioral guard (instantiates the real class, lazy unsloth import)
+# --------------------------------------------------------------------------
+
+
+def _make_config(rope_scaling):
+    from transformers import LlamaConfig
+
+    return LlamaConfig(
+        hidden_size=256,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=HEAD_DIM,
+        rope_theta=ROPE_THETA,
+        max_position_embeddings=MAX_POS,
+        rope_scaling=rope_scaling,
+    )
+
+
+def _unsloth_rotary(config):
+    from unsloth.models import llama as llama_mod
+
+    return llama_mod.LlamaRotaryEmbedding(config=config)
+
+
+def _reference_inv_freq(config, rope_type):
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    inv_freq, _attention_factor = ROPE_INIT_FUNCTIONS[rope_type](config, "cpu")
+    return inv_freq.float().cpu()
+
+
+def _vanilla_inv_freq():
+    return 1.0 / (
+        ROPE_THETA ** (torch.arange(0, HEAD_DIM, 2, dtype=torch.int64).float() / HEAD_DIM)
+    )
+
+
+def test_llama3_scaling_applied_to_inv_freq():
+    config = _make_config(LLAMA3_ROPE_SCALING)
+    rot = _unsloth_rotary(config)
+
+    got = rot.inv_freq.float().cpu()
+    expected = _reference_inv_freq(config, "llama3")
+    vanilla = _vanilla_inv_freq()
+
+    # Sanity: the scaled reference really does differ from vanilla, else the
+    # test would be vacuous.
+    assert not torch.allclose(expected, vanilla, rtol=1e-4), (
+        "test setup error: llama3-scaled inv_freq should differ from vanilla"
+    )
+    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+        "LlamaRotaryEmbedding built from a llama3 config produced inv_freq that "
+        "does not match transformers' llama3 RoPE scaling. The config path is "
+        "ignoring config.rope_scaling, so long-context inference degrades into "
+        "repeated-pattern gibberish (issue #2405).\n"
+        f"got[:6]={got[:6].tolist()}\nexpected[:6]={expected[:6].tolist()}"
+    )
+
+
+def test_unscaled_config_uses_vanilla_inv_freq():
+    config = _make_config(None)
+    rot = _unsloth_rotary(config)
+
+    got = rot.inv_freq.float().cpu()
+    vanilla = _vanilla_inv_freq()
+    assert torch.allclose(got, vanilla, rtol=1e-4, atol=1e-6), (
+        "LlamaRotaryEmbedding with no rope_scaling must use the vanilla "
+        f"inv_freq; got[:6]={got[:6].tolist()} vanilla[:6]={vanilla[:6].tolist()}"
+    )
+
+
+def _cos_at_position(rot, position):
+    """cos row for a single position, computed from the class's own inv_freq.
+
+    Uses the same construction as _set_cos_sin_cache so we read what the model
+    actually applies, but stays on CPU and independent of device caches.
+    """
+    inv_freq = rot.inv_freq.float().cpu()
+    t = torch.tensor([position], dtype=torch.float32)
+    t = rot._apply_time_scaling(t.clone()) if hasattr(rot, "_apply_time_scaling") else t
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    return emb.cos().squeeze(0)
+
+
+def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
+    scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
+    unscaled = _unsloth_rotary(_make_config(None))
+
+    pos = 10000
+    cos_scaled = _cos_at_position(scaled, pos)
+    cos_unscaled = _cos_at_position(unscaled, pos)
+    assert not torch.allclose(cos_scaled, cos_unscaled, rtol=1e-4, atol=1e-5), (
+        f"cos values at position {pos} are identical for a llama3-scaled and an "
+        "unscaled rotary embedding, which means scaling was dropped (issue "
+        "#2405). With correct llama3 scaling the low-frequency bands shrink by "
+        "up to 8x and must change the angles at long positions."
+    )
+
+
+def test_extended_cache_keeps_scaling_after_growth():
+    scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
+    # Grow the rope cache past its initial size (mirrors long-context decode).
+    dummy = torch.zeros(1, dtype=torch.float32)
+    scaled.extend_rope_embedding(dummy, seq_len=40960)
+
+    config = _make_config(LLAMA3_ROPE_SCALING)
+    expected = _reference_inv_freq(config, "llama3")
+    got = scaled.inv_freq.float().cpu()
+    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+        "growing the RoPE cache (extend_rope_embedding) must preserve llama3 "
+        "scaling of inv_freq; long-context decode loses scaling otherwise "
+        "(issue #2405)."
+    )

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -30,7 +30,7 @@ def _has_real_cuda():
 HAS_REAL_CUDA = _has_real_cuda()
 requires_cuda = pytest.mark.skipif(
     not HAS_REAL_CUDA,
-    reason="LlamaRotaryEmbedding builds per-device CUDA caches in __init__",
+    reason = "LlamaRotaryEmbedding builds per-device CUDA caches in __init__",
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -126,40 +126,36 @@ def test_config_path_inspects_rope_scaling():
 
 def _make_config(rope_scaling):
     from transformers import LlamaConfig
-
     return LlamaConfig(
-        hidden_size=256,
-        num_attention_heads=2,
-        num_key_value_heads=2,
-        head_dim=HEAD_DIM,
-        rope_theta=ROPE_THETA,
-        max_position_embeddings=MAX_POS,
-        rope_scaling=rope_scaling,
+        hidden_size = 256,
+        num_attention_heads = 2,
+        num_key_value_heads = 2,
+        head_dim = HEAD_DIM,
+        rope_theta = ROPE_THETA,
+        max_position_embeddings = MAX_POS,
+        rope_scaling = rope_scaling,
     )
 
 
 def _unsloth_rotary(config):
     from unsloth.models import llama as llama_mod
-
-    return llama_mod.LlamaRotaryEmbedding(config=config)
+    return llama_mod.LlamaRotaryEmbedding(config = config)
 
 
 def _reference_inv_freq(config, rope_type):
     from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
-
     inv_freq, _attention_factor = ROPE_INIT_FUNCTIONS[rope_type](config, "cpu")
     return inv_freq.float().cpu()
 
 
 def _vanilla_inv_freq():
     return 1.0 / (
-        ROPE_THETA ** (torch.arange(0, HEAD_DIM, 2, dtype=torch.int64).float() / HEAD_DIM)
+        ROPE_THETA ** (torch.arange(0, HEAD_DIM, 2, dtype = torch.int64).float() / HEAD_DIM)
     )
 
 
 def _compute_helper(config, rope_scaling):
     from unsloth.models.llama import _compute_config_rope_inv_freq
-
     return _compute_config_rope_inv_freq(config, rope_scaling)
 
 
@@ -170,16 +166,16 @@ def test_llama3_scaling_applied_to_inv_freq():
     vanilla = _vanilla_inv_freq()
 
     # Guard against a vacuous test.
-    assert not torch.allclose(expected, vanilla, rtol=1e-4), (
-        "test setup error: llama3-scaled inv_freq should differ from vanilla"
-    )
+    assert not torch.allclose(
+        expected, vanilla, rtol = 1e-4
+    ), "test setup error: llama3-scaled inv_freq should differ from vanilla"
     assert got is not None, (
         "_compute_config_rope_inv_freq returned None for a llama3 config; the "
         "config path is dropping config.rope_scaling, so long-context inference "
         "degrades into repeated-pattern gibberish (issue #2405)."
     )
     got = got.float().cpu()
-    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
         "inv_freq for a llama3 config does not match transformers' llama3 RoPE "
         "scaling (issue #2405).\n"
         f"got[:6]={got[:6].tolist()}\nexpected[:6]={expected[:6].tolist()}"
@@ -191,7 +187,7 @@ def test_default_rope_type_matches_vanilla_inv_freq():
     got, attention_scaling = _compute_helper(config, {"rope_type": "default"})
     assert got is not None
     vanilla = _vanilla_inv_freq()
-    assert torch.allclose(got.float().cpu(), vanilla, rtol=1e-4, atol=1e-6), (
+    assert torch.allclose(got.float().cpu(), vanilla, rtol = 1e-4, atol = 1e-6), (
         "default rope_type must equal the vanilla inv_freq; "
         f"got[:6]={got[:6].tolist()} vanilla[:6]={vanilla[:6].tolist()}"
     )
@@ -200,10 +196,10 @@ def test_default_rope_type_matches_vanilla_inv_freq():
 def _cos_at_position(rot, position):
     """cos row at one position, built like _set_cos_sin_cache but CPU-only."""
     inv_freq = rot.inv_freq.float().cpu()
-    t = torch.tensor([position], dtype=torch.float32)
+    t = torch.tensor([position], dtype = torch.float32)
     t = rot._apply_time_scaling(t.clone()) if hasattr(rot, "_apply_time_scaling") else t
     freqs = torch.outer(t, inv_freq)
-    emb = torch.cat((freqs, freqs), dim=-1)
+    emb = torch.cat((freqs, freqs), dim = -1)
     return emb.cos().squeeze(0)
 
 
@@ -216,9 +212,9 @@ def test_constructor_applies_llama3_scaling():
     rot = _unsloth_rotary(config)
     got = rot.inv_freq.float().cpu()
     expected = _reference_inv_freq(config, "llama3")
-    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
-        "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
-    )
+    assert torch.allclose(
+        got, expected, rtol = 1e-4, atol = 1e-6
+    ), "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
 
 
 @requires_cuda
@@ -226,9 +222,9 @@ def test_constructor_unscaled_config_uses_vanilla_inv_freq():
     rot = _unsloth_rotary(_make_config(None))
     got = rot.inv_freq.float().cpu()
     vanilla = _vanilla_inv_freq()
-    assert torch.allclose(got, vanilla, rtol=1e-4, atol=1e-6), (
-        "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
-    )
+    assert torch.allclose(
+        got, vanilla, rtol = 1e-4, atol = 1e-6
+    ), "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
 
 
 @requires_cuda
@@ -239,7 +235,7 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
     pos = 10000
     cos_scaled = _cos_at_position(scaled, pos)
     cos_unscaled = _cos_at_position(unscaled, pos)
-    assert not torch.allclose(cos_scaled, cos_unscaled, rtol=1e-4, atol=1e-5), (
+    assert not torch.allclose(cos_scaled, cos_unscaled, rtol = 1e-4, atol = 1e-5), (
         f"cos values at position {pos} are identical for a llama3-scaled and an "
         "unscaled rotary embedding, which means scaling was dropped (issue "
         "#2405). With correct llama3 scaling the low-frequency bands shrink by "
@@ -251,13 +247,13 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
 def test_extended_cache_keeps_scaling_after_growth():
     scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
     # Grow past the initial cache size (mirrors long-context decode).
-    dummy = torch.zeros(1, dtype=torch.float32)
-    scaled.extend_rope_embedding(dummy, seq_len=40960)
+    dummy = torch.zeros(1, dtype = torch.float32)
+    scaled.extend_rope_embedding(dummy, seq_len = 40960)
 
     config = _make_config(LLAMA3_ROPE_SCALING)
     expected = _reference_inv_freq(config, "llama3")
     got = scaled.inv_freq.float().cpu()
-    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
         "growing the RoPE cache (extend_rope_embedding) must preserve llama3 "
         "scaling of inv_freq; long-context decode loses scaling otherwise "
         "(issue #2405)."
@@ -286,7 +282,7 @@ def test_object_style_rope_scaling_does_not_crash():
         "(issue #2405)."
     )
     expected = _reference_inv_freq(config, "llama3")
-    assert torch.allclose(inv_freq.float().cpu(), expected, rtol=1e-4, atol=1e-6)
+    assert torch.allclose(inv_freq.float().cpu(), expected, rtol = 1e-4, atol = 1e-6)
 
 
 def test_object_style_rope_scaling_on_config_delegates_correctly():
@@ -313,4 +309,4 @@ def test_object_style_rope_scaling_on_config_delegates_correctly():
         "delegation must retry with a config copy carrying the normalized dict "
         "(issue #2405)."
     )
-    assert torch.allclose(inv_freq.float().cpu(), expected, rtol=1e-4, atol=1e-6)
+    assert torch.allclose(inv_freq.float().cpu(), expected, rtol = 1e-4, atol = 1e-6)

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -1,33 +1,14 @@
-"""Regression guard for RoPE scaling being silently dropped (issue #2405).
+"""Guard for config.rope_scaling being silently dropped (issue #2405).
 
-Llama-3.1 (and any model with `config.rope_scaling`) ships an `inv_freq`
-rescaling, e.g. `{"rope_type": "llama3", "factor": 8.0, ...}`. Unsloth replaces
-transformers' rotary classes with its own (`unsloth/models/llama.py`), but the
-*config* constructor path of the base `LlamaRotaryEmbedding` only reads
-`rope_theta`, `head_dim` and `max_position_embeddings`. It never inspects
-`config.rope_scaling`, so the scaled `LlamaExtendedRotaryEmbedding` is only used
-when the (legacy) `LlamaAttention.__init__` rewrite in `patch_llama_rope_scaling`
-fires. On modern transformers (rotary moved to `LlamaModel`) that rewrite no
-longer matches, the unscaled base class wins, and long-context inference
-(> ~32k tokens) collapses into repeated-pattern gibberish (issue #2405).
+Unsloth's replacement rotary classes ignored rope_scaling when constructed
+from a config (the modern-transformers path), so Llama-3.1 ran with unscaled
+RoPE and collapsed into gibberish past ~32K tokens.
 
-Three layers, deterministic:
-
-  1. AST structural tripwire (no unsloth import): parse llama.py and assert the
-     config path of `LlamaRotaryEmbedding.__init__` references `rope_scaling`
-     and wires into `_compute_config_rope_inv_freq`.
-  2. CPU behavioral checks: call `_compute_config_rope_inv_freq` (the pure
-     function the constructor delegates to) and assert the result matches
-     transformers' `ROPE_INIT_FUNCTIONS[rope_type]`, for dict and object-style
-     rope_scaling. No rotary instantiation, so this runs on GPU-less CI.
-  3. CUDA behavioral checks (skipped without a real device, probed by actually
-     allocating a tensor so import-time CUDA spoofs cannot fool the gate):
-     instantiate the real class and verify inv_freq, the cos cache at long
-     positions and persistence across extend_rope_embedding. The constructor
-     builds per-device caches via torch.cuda, so it cannot run on CPU.
-
-Layers 2 and 3 FAIL on the unfixed code (inv_freq is unscaled for a llama3
-config). Pattern mirrors tests/utils/test_prepare_inputs_leftpad.py.
+Layers: (1) AST tripwire, stdlib only; (2) CPU checks of the pure helper
+_compute_config_rope_inv_freq against transformers' ROPE_INIT_FUNCTIONS;
+(3) CUDA checks instantiating the real class (skipped without a real device,
+probed by allocating a tensor so import-time CUDA spoofs cannot fool the gate).
+Layers 2 and 3 fail on the unfixed code.
 """
 
 import ast
@@ -57,8 +38,7 @@ LLAMA_PY = REPO_ROOT / "unsloth" / "models" / "llama.py"
 
 CLASS_NAME = "LlamaRotaryEmbedding"
 
-# A Llama-3.1-style rope_scaling block (matches the hardcoded grid-search
-# constants in LlamaExtendedRotaryEmbedding._apply_inv_freq_scaling).
+# Llama-3.1-style rope_scaling.
 LLAMA3_ROPE_SCALING = {
     "rope_type": "llama3",
     "factor": 8.0,
@@ -71,9 +51,7 @@ HEAD_DIM = 128
 MAX_POS = 131072
 
 
-# --------------------------------------------------------------------------
-# Layer 1: AST structural tripwire (stdlib only, no unsloth import)
-# --------------------------------------------------------------------------
+# --- Layer 1: AST structural tripwire (stdlib only, no unsloth import) ---
 
 
 def _load_class_init():
@@ -94,7 +72,6 @@ def _config_branch(init_fn):
     for node in init_fn.body:
         if isinstance(node, ast.If):
             test = node.test
-            # match `config is not None`
             is_config_test = (
                 isinstance(test, ast.Compare)
                 and isinstance(test.left, ast.Name)
@@ -144,9 +121,7 @@ def test_config_path_inspects_rope_scaling():
     )
 
 
-# --------------------------------------------------------------------------
-# Layer 2: CPU behavioral guard (pure helper function, no instantiation)
-# --------------------------------------------------------------------------
+# --- Layer 2: CPU behavioral guard (pure helper, no instantiation) ---
 
 
 def _make_config(rope_scaling):
@@ -194,8 +169,7 @@ def test_llama3_scaling_applied_to_inv_freq():
     expected = _reference_inv_freq(config, "llama3")
     vanilla = _vanilla_inv_freq()
 
-    # Sanity: the scaled reference really does differ from vanilla, else the
-    # test would be vacuous.
+    # Guard against a vacuous test.
     assert not torch.allclose(expected, vanilla, rtol=1e-4), (
         "test setup error: llama3-scaled inv_freq should differ from vanilla"
     )
@@ -213,8 +187,6 @@ def test_llama3_scaling_applied_to_inv_freq():
 
 
 def test_default_rope_type_matches_vanilla_inv_freq():
-    # 'default' must reproduce the vanilla (unscaled) frequencies, proving the
-    # helper does not distort unscaled models.
     config = _make_config(None)
     got, attention_scaling = _compute_helper(config, {"rope_type": "default"})
     assert got is not None
@@ -226,11 +198,7 @@ def test_default_rope_type_matches_vanilla_inv_freq():
 
 
 def _cos_at_position(rot, position):
-    """cos row for a single position, computed from the class's own inv_freq.
-
-    Uses the same construction as _set_cos_sin_cache so we read what the model
-    actually applies, but stays on CPU and independent of device caches.
-    """
+    """cos row at one position, built like _set_cos_sin_cache but CPU-only."""
     inv_freq = rot.inv_freq.float().cpu()
     t = torch.tensor([position], dtype=torch.float32)
     t = rot._apply_time_scaling(t.clone()) if hasattr(rot, "_apply_time_scaling") else t
@@ -239,10 +207,7 @@ def _cos_at_position(rot, position):
     return emb.cos().squeeze(0)
 
 
-# --------------------------------------------------------------------------
-# Layer 3: CUDA behavioral guard (real instantiation; constructor builds
-# per-device CUDA caches, so these need a real device)
-# --------------------------------------------------------------------------
+# --- Layer 3: CUDA behavioral guard (real instantiation needs a device) ---
 
 
 @requires_cuda
@@ -285,7 +250,7 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
 @requires_cuda
 def test_extended_cache_keeps_scaling_after_growth():
     scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
-    # Grow the rope cache past its initial size (mirrors long-context decode).
+    # Grow past the initial cache size (mirrors long-context decode).
     dummy = torch.zeros(1, dtype=torch.float32)
     scaled.extend_rope_embedding(dummy, seq_len=40960)
 
@@ -300,9 +265,7 @@ def test_extended_cache_keeps_scaling_after_growth():
 
 
 def test_object_style_rope_scaling_does_not_crash():
-    # Newer transformers may expose config.rope_scaling as a config object
-    # (e.g. a RopeScalingConfig dataclass) instead of a raw dict. The scaling
-    # computation must normalize it instead of calling .get() on it directly.
+    # Object-style rope_scaling must be normalized, not .get()'d directly.
     from dataclasses import dataclass
 
     from unsloth.models.llama import _compute_config_rope_inv_freq
@@ -327,9 +290,7 @@ def test_object_style_rope_scaling_does_not_crash():
 
 
 def test_object_style_rope_scaling_on_config_delegates_correctly():
-    # When the object sits ON the config itself (not just the passed argument),
-    # delegation to ROPE_INIT_FUNCTIONS must retry with a normalized config
-    # copy. 'linear' has no inline fallback, so only that retry can save it.
+    # 'linear' has no inline fallback; only the normalized-config retry passes this.
     from dataclasses import dataclass
 
     from unsloth.models.llama import _compute_config_rope_inv_freq

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -221,3 +221,30 @@ def test_extended_cache_keeps_scaling_after_growth():
         "scaling of inv_freq; long-context decode loses scaling otherwise "
         "(issue #2405)."
     )
+
+
+def test_object_style_rope_scaling_does_not_crash():
+    # Newer transformers may expose config.rope_scaling as a config object
+    # (e.g. a RopeScalingConfig dataclass) instead of a raw dict. The scaling
+    # computation must normalize it instead of calling .get() on it directly.
+    from dataclasses import dataclass
+
+    from unsloth.models.llama import _compute_config_rope_inv_freq
+
+    @dataclass
+    class FakeRopeScalingConfig:
+        rope_type: str = "llama3"
+        factor: float = 8.0
+        low_freq_factor: float = 1.0
+        high_freq_factor: float = 4.0
+        original_max_position_embeddings: int = 8192
+
+    config = _make_config(LLAMA3_ROPE_SCALING)
+    inv_freq, attention_scaling = _compute_config_rope_inv_freq(config, FakeRopeScalingConfig())
+    assert inv_freq is not None, (
+        "object-style (non-dict) config.rope_scaling must be normalized, not "
+        "dropped; otherwise scaled models silently lose RoPE scaling again "
+        "(issue #2405)."
+    )
+    expected = _reference_inv_freq(config, "llama3")
+    assert torch.allclose(inv_freq.float().cpu(), expected, rtol=1e-4, atol=1e-6)

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -116,34 +116,31 @@ def test_config_path_inspects_rope_scaling():
 
 def _make_config(rope_scaling):
     from transformers import LlamaConfig
-
     return LlamaConfig(
-        hidden_size=256,
-        num_attention_heads=2,
-        num_key_value_heads=2,
-        head_dim=HEAD_DIM,
-        rope_theta=ROPE_THETA,
-        max_position_embeddings=MAX_POS,
-        rope_scaling=rope_scaling,
+        hidden_size = 256,
+        num_attention_heads = 2,
+        num_key_value_heads = 2,
+        head_dim = HEAD_DIM,
+        rope_theta = ROPE_THETA,
+        max_position_embeddings = MAX_POS,
+        rope_scaling = rope_scaling,
     )
 
 
 def _unsloth_rotary(config):
     from unsloth.models import llama as llama_mod
-
-    return llama_mod.LlamaRotaryEmbedding(config=config)
+    return llama_mod.LlamaRotaryEmbedding(config = config)
 
 
 def _reference_inv_freq(config, rope_type):
     from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
-
     inv_freq, _attention_factor = ROPE_INIT_FUNCTIONS[rope_type](config, "cpu")
     return inv_freq.float().cpu()
 
 
 def _vanilla_inv_freq():
     return 1.0 / (
-        ROPE_THETA ** (torch.arange(0, HEAD_DIM, 2, dtype=torch.int64).float() / HEAD_DIM)
+        ROPE_THETA ** (torch.arange(0, HEAD_DIM, 2, dtype = torch.int64).float() / HEAD_DIM)
     )
 
 
@@ -157,10 +154,10 @@ def test_llama3_scaling_applied_to_inv_freq():
 
     # Sanity: the scaled reference really does differ from vanilla, else the
     # test would be vacuous.
-    assert not torch.allclose(expected, vanilla, rtol=1e-4), (
-        "test setup error: llama3-scaled inv_freq should differ from vanilla"
-    )
-    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+    assert not torch.allclose(
+        expected, vanilla, rtol = 1e-4
+    ), "test setup error: llama3-scaled inv_freq should differ from vanilla"
+    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
         "LlamaRotaryEmbedding built from a llama3 config produced inv_freq that "
         "does not match transformers' llama3 RoPE scaling. The config path is "
         "ignoring config.rope_scaling, so long-context inference degrades into "
@@ -175,7 +172,7 @@ def test_unscaled_config_uses_vanilla_inv_freq():
 
     got = rot.inv_freq.float().cpu()
     vanilla = _vanilla_inv_freq()
-    assert torch.allclose(got, vanilla, rtol=1e-4, atol=1e-6), (
+    assert torch.allclose(got, vanilla, rtol = 1e-4, atol = 1e-6), (
         "LlamaRotaryEmbedding with no rope_scaling must use the vanilla "
         f"inv_freq; got[:6]={got[:6].tolist()} vanilla[:6]={vanilla[:6].tolist()}"
     )
@@ -188,10 +185,10 @@ def _cos_at_position(rot, position):
     actually applies, but stays on CPU and independent of device caches.
     """
     inv_freq = rot.inv_freq.float().cpu()
-    t = torch.tensor([position], dtype=torch.float32)
+    t = torch.tensor([position], dtype = torch.float32)
     t = rot._apply_time_scaling(t.clone()) if hasattr(rot, "_apply_time_scaling") else t
     freqs = torch.outer(t, inv_freq)
-    emb = torch.cat((freqs, freqs), dim=-1)
+    emb = torch.cat((freqs, freqs), dim = -1)
     return emb.cos().squeeze(0)
 
 
@@ -202,7 +199,7 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
     pos = 10000
     cos_scaled = _cos_at_position(scaled, pos)
     cos_unscaled = _cos_at_position(unscaled, pos)
-    assert not torch.allclose(cos_scaled, cos_unscaled, rtol=1e-4, atol=1e-5), (
+    assert not torch.allclose(cos_scaled, cos_unscaled, rtol = 1e-4, atol = 1e-5), (
         f"cos values at position {pos} are identical for a llama3-scaled and an "
         "unscaled rotary embedding, which means scaling was dropped (issue "
         "#2405). With correct llama3 scaling the low-frequency bands shrink by "
@@ -213,13 +210,13 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
 def test_extended_cache_keeps_scaling_after_growth():
     scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
     # Grow the rope cache past its initial size (mirrors long-context decode).
-    dummy = torch.zeros(1, dtype=torch.float32)
-    scaled.extend_rope_embedding(dummy, seq_len=40960)
+    dummy = torch.zeros(1, dtype = torch.float32)
+    scaled.extend_rope_embedding(dummy, seq_len = 40960)
 
     config = _make_config(LLAMA3_ROPE_SCALING)
     expected = _reference_inv_freq(config, "llama3")
     got = scaled.inv_freq.float().cpu()
-    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
         "growing the RoPE cache (extend_rope_embedding) must preserve llama3 "
         "scaling of inv_freq; long-context decode loses scaling otherwise "
         "(issue #2405)."

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -11,16 +11,23 @@ fires. On modern transformers (rotary moved to `LlamaModel`) that rewrite no
 longer matches, the unscaled base class wins, and long-context inference
 (> ~32k tokens) collapses into repeated-pattern gibberish (issue #2405).
 
-Two layers, both CPU-only and deterministic:
+Three layers, deterministic:
 
   1. AST structural tripwire (no unsloth import): parse llama.py and assert the
-     config path of `LlamaRotaryEmbedding.__init__` references `rope_scaling`.
-  2. Behavioral checks: instantiate the real `LlamaRotaryEmbedding(config=...)`
-     and assert its `inv_freq` matches transformers'
-     `ROPE_INIT_FUNCTIONS[rope_type]` (scaled for llama3, vanilla for None).
+     config path of `LlamaRotaryEmbedding.__init__` references `rope_scaling`
+     and wires into `_compute_config_rope_inv_freq`.
+  2. CPU behavioral checks: call `_compute_config_rope_inv_freq` (the pure
+     function the constructor delegates to) and assert the result matches
+     transformers' `ROPE_INIT_FUNCTIONS[rope_type]`, for dict and object-style
+     rope_scaling. No rotary instantiation, so this runs on GPU-less CI.
+  3. CUDA behavioral checks (skipped without a real device, probed by actually
+     allocating a tensor so import-time CUDA spoofs cannot fool the gate):
+     instantiate the real class and verify inv_freq, the cos cache at long
+     positions and persistence across extend_rope_embedding. The constructor
+     builds per-device caches via torch.cuda, so it cannot run on CPU.
 
-The behavioral layer FAILS on current unfixed main (inv_freq is unscaled for a
-llama3 config). Pattern mirrors tests/utils/test_prepare_inputs_leftpad.py.
+Layers 2 and 3 FAIL on the unfixed code (inv_freq is unscaled for a llama3
+config). Pattern mirrors tests/utils/test_prepare_inputs_leftpad.py.
 """
 
 import ast
@@ -29,6 +36,21 @@ from pathlib import Path
 
 import pytest
 import torch
+
+
+def _has_real_cuda():
+    try:
+        torch.zeros(1).to("cuda")
+        return True
+    except Exception:
+        return False
+
+
+HAS_REAL_CUDA = _has_real_cuda()
+requires_cuda = pytest.mark.skipif(
+    not HAS_REAL_CUDA,
+    reason="LlamaRotaryEmbedding builds per-device CUDA caches in __init__",
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LLAMA_PY = REPO_ROOT / "unsloth" / "models" / "llama.py"
@@ -108,73 +130,98 @@ def test_config_path_inspects_rope_scaling():
         "produce repeated-pattern gibberish (issue #2405)."
     )
 
+    called = {
+        sub.func.id
+        for stmt in branch.body
+        for sub in ast.walk(stmt)
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+    }
+    assert "_compute_config_rope_inv_freq" in called, (
+        f"{CLASS_NAME}.__init__ config path no longer calls "
+        "_compute_config_rope_inv_freq; the CPU behavioral tests below cover "
+        "that helper directly, so the constructor must stay wired to it or "
+        "scaled configs silently lose RoPE scaling again (issue #2405)."
+    )
+
 
 # --------------------------------------------------------------------------
-# Layer 2: behavioral guard (instantiates the real class, lazy unsloth import)
+# Layer 2: CPU behavioral guard (pure helper function, no instantiation)
 # --------------------------------------------------------------------------
 
 
 def _make_config(rope_scaling):
     from transformers import LlamaConfig
+
     return LlamaConfig(
-        hidden_size = 256,
-        num_attention_heads = 2,
-        num_key_value_heads = 2,
-        head_dim = HEAD_DIM,
-        rope_theta = ROPE_THETA,
-        max_position_embeddings = MAX_POS,
-        rope_scaling = rope_scaling,
+        hidden_size=256,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=HEAD_DIM,
+        rope_theta=ROPE_THETA,
+        max_position_embeddings=MAX_POS,
+        rope_scaling=rope_scaling,
     )
 
 
 def _unsloth_rotary(config):
     from unsloth.models import llama as llama_mod
-    return llama_mod.LlamaRotaryEmbedding(config = config)
+
+    return llama_mod.LlamaRotaryEmbedding(config=config)
 
 
 def _reference_inv_freq(config, rope_type):
     from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
     inv_freq, _attention_factor = ROPE_INIT_FUNCTIONS[rope_type](config, "cpu")
     return inv_freq.float().cpu()
 
 
 def _vanilla_inv_freq():
     return 1.0 / (
-        ROPE_THETA ** (torch.arange(0, HEAD_DIM, 2, dtype = torch.int64).float() / HEAD_DIM)
+        ROPE_THETA ** (torch.arange(0, HEAD_DIM, 2, dtype=torch.int64).float() / HEAD_DIM)
     )
+
+
+def _compute_helper(config, rope_scaling):
+    from unsloth.models.llama import _compute_config_rope_inv_freq
+
+    return _compute_config_rope_inv_freq(config, rope_scaling)
 
 
 def test_llama3_scaling_applied_to_inv_freq():
     config = _make_config(LLAMA3_ROPE_SCALING)
-    rot = _unsloth_rotary(config)
-
-    got = rot.inv_freq.float().cpu()
+    got, attention_scaling = _compute_helper(config, config.rope_scaling)
     expected = _reference_inv_freq(config, "llama3")
     vanilla = _vanilla_inv_freq()
 
     # Sanity: the scaled reference really does differ from vanilla, else the
     # test would be vacuous.
-    assert not torch.allclose(
-        expected, vanilla, rtol = 1e-4
-    ), "test setup error: llama3-scaled inv_freq should differ from vanilla"
-    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
-        "LlamaRotaryEmbedding built from a llama3 config produced inv_freq that "
-        "does not match transformers' llama3 RoPE scaling. The config path is "
-        "ignoring config.rope_scaling, so long-context inference degrades into "
-        "repeated-pattern gibberish (issue #2405).\n"
+    assert not torch.allclose(expected, vanilla, rtol=1e-4), (
+        "test setup error: llama3-scaled inv_freq should differ from vanilla"
+    )
+    assert got is not None, (
+        "_compute_config_rope_inv_freq returned None for a llama3 config; the "
+        "config path is dropping config.rope_scaling, so long-context inference "
+        "degrades into repeated-pattern gibberish (issue #2405)."
+    )
+    got = got.float().cpu()
+    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+        "inv_freq for a llama3 config does not match transformers' llama3 RoPE "
+        "scaling (issue #2405).\n"
         f"got[:6]={got[:6].tolist()}\nexpected[:6]={expected[:6].tolist()}"
     )
 
 
-def test_unscaled_config_uses_vanilla_inv_freq():
+def test_default_rope_type_matches_vanilla_inv_freq():
+    # 'default' must reproduce the vanilla (unscaled) frequencies, proving the
+    # helper does not distort unscaled models.
     config = _make_config(None)
-    rot = _unsloth_rotary(config)
-
-    got = rot.inv_freq.float().cpu()
+    got, attention_scaling = _compute_helper(config, {"rope_type": "default"})
+    assert got is not None
     vanilla = _vanilla_inv_freq()
-    assert torch.allclose(got, vanilla, rtol = 1e-4, atol = 1e-6), (
-        "LlamaRotaryEmbedding with no rope_scaling must use the vanilla "
-        f"inv_freq; got[:6]={got[:6].tolist()} vanilla[:6]={vanilla[:6].tolist()}"
+    assert torch.allclose(got.float().cpu(), vanilla, rtol=1e-4, atol=1e-6), (
+        "default rope_type must equal the vanilla inv_freq; "
+        f"got[:6]={got[:6].tolist()} vanilla[:6]={vanilla[:6].tolist()}"
     )
 
 
@@ -185,13 +232,41 @@ def _cos_at_position(rot, position):
     actually applies, but stays on CPU and independent of device caches.
     """
     inv_freq = rot.inv_freq.float().cpu()
-    t = torch.tensor([position], dtype = torch.float32)
+    t = torch.tensor([position], dtype=torch.float32)
     t = rot._apply_time_scaling(t.clone()) if hasattr(rot, "_apply_time_scaling") else t
     freqs = torch.outer(t, inv_freq)
-    emb = torch.cat((freqs, freqs), dim = -1)
+    emb = torch.cat((freqs, freqs), dim=-1)
     return emb.cos().squeeze(0)
 
 
+# --------------------------------------------------------------------------
+# Layer 3: CUDA behavioral guard (real instantiation; constructor builds
+# per-device CUDA caches, so these need a real device)
+# --------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_constructor_applies_llama3_scaling():
+    config = _make_config(LLAMA3_ROPE_SCALING)
+    rot = _unsloth_rotary(config)
+    got = rot.inv_freq.float().cpu()
+    expected = _reference_inv_freq(config, "llama3")
+    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
+        "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
+    )
+
+
+@requires_cuda
+def test_constructor_unscaled_config_uses_vanilla_inv_freq():
+    rot = _unsloth_rotary(_make_config(None))
+    got = rot.inv_freq.float().cpu()
+    vanilla = _vanilla_inv_freq()
+    assert torch.allclose(got, vanilla, rtol=1e-4, atol=1e-6), (
+        "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
+    )
+
+
+@requires_cuda
 def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
     scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
     unscaled = _unsloth_rotary(_make_config(None))
@@ -199,7 +274,7 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
     pos = 10000
     cos_scaled = _cos_at_position(scaled, pos)
     cos_unscaled = _cos_at_position(unscaled, pos)
-    assert not torch.allclose(cos_scaled, cos_unscaled, rtol = 1e-4, atol = 1e-5), (
+    assert not torch.allclose(cos_scaled, cos_unscaled, rtol=1e-4, atol=1e-5), (
         f"cos values at position {pos} are identical for a llama3-scaled and an "
         "unscaled rotary embedding, which means scaling was dropped (issue "
         "#2405). With correct llama3 scaling the low-frequency bands shrink by "
@@ -207,16 +282,17 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
     )
 
 
+@requires_cuda
 def test_extended_cache_keeps_scaling_after_growth():
     scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
     # Grow the rope cache past its initial size (mirrors long-context decode).
-    dummy = torch.zeros(1, dtype = torch.float32)
-    scaled.extend_rope_embedding(dummy, seq_len = 40960)
+    dummy = torch.zeros(1, dtype=torch.float32)
+    scaled.extend_rope_embedding(dummy, seq_len=40960)
 
     config = _make_config(LLAMA3_ROPE_SCALING)
     expected = _reference_inv_freq(config, "llama3")
     got = scaled.inv_freq.float().cpu()
-    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
+    assert torch.allclose(got, expected, rtol=1e-4, atol=1e-6), (
         "growing the RoPE cache (extend_rope_embedding) must preserve llama3 "
         "scaling of inv_freq; long-context decode loses scaling otherwise "
         "(issue #2405)."
@@ -247,4 +323,33 @@ def test_object_style_rope_scaling_does_not_crash():
         "(issue #2405)."
     )
     expected = _reference_inv_freq(config, "llama3")
-    assert torch.allclose(inv_freq.float().cpu(), expected, rtol = 1e-4, atol = 1e-6)
+    assert torch.allclose(inv_freq.float().cpu(), expected, rtol=1e-4, atol=1e-6)
+
+
+def test_object_style_rope_scaling_on_config_delegates_correctly():
+    # When the object sits ON the config itself (not just the passed argument),
+    # delegation to ROPE_INIT_FUNCTIONS must retry with a normalized config
+    # copy. 'linear' has no inline fallback, so only that retry can save it.
+    from dataclasses import dataclass
+
+    from unsloth.models.llama import _compute_config_rope_inv_freq
+
+    @dataclass
+    class FakeLinearRopeScalingConfig:
+        rope_type: str = "linear"
+        factor: float = 4.0
+
+    dict_config = _make_config({"rope_type": "linear", "factor": 4.0})
+    expected = _reference_inv_freq(dict_config, "linear")
+
+    object_config = _make_config({"rope_type": "linear", "factor": 4.0})
+    object_config.rope_scaling = FakeLinearRopeScalingConfig()
+    inv_freq, attention_scaling = _compute_config_rope_inv_freq(
+        object_config, object_config.rope_scaling
+    )
+    assert inv_freq is not None, (
+        "linear rope_scaling exposed as a config object was silently dropped; "
+        "delegation must retry with a config copy carrying the normalized dict "
+        "(issue #2405)."
+    )
+    assert torch.allclose(inv_freq.float().cpu(), expected, rtol=1e-4, atol=1e-6)

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -247,4 +247,4 @@ def test_object_style_rope_scaling_does_not_crash():
         "(issue #2405)."
     )
     expected = _reference_inv_freq(config, "llama3")
-    assert torch.allclose(inv_freq.float().cpu(), expected, rtol=1e-4, atol=1e-6)
+    assert torch.allclose(inv_freq.float().cpu(), expected, rtol = 1e-4, atol = 1e-6)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1622,6 +1622,74 @@ def _get_rope_theta(config, default = 10000.0):
     return default
 
 
+def _llama3_inv_freq_from_config(config, rope_scaling, device = "cpu"):
+    """Inline llama3 RoPE inv_freq using factors read from config.rope_scaling.
+
+    Fallback for transformers versions without modeling_rope_utils. Mirrors
+    meta-llama's llama3 scaling and LlamaExtendedRotaryEmbedding, but reads the
+    factors from config rather than hardcoding them.
+    """
+    base = _get_rope_theta(config, default = 10000.0)
+    dim = getattr(config, "head_dim", None)
+    if dim is None:
+        dim = int(config.hidden_size // config.num_attention_heads)
+    inv_freq = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim)
+    )
+
+    scale_factor = rope_scaling.get("factor", 8.0)
+    low_freq_factor = rope_scaling.get("low_freq_factor", 1.0)
+    high_freq_factor = rope_scaling.get("high_freq_factor", 4.0)
+    old_context_len = rope_scaling.get("original_max_position_embeddings", 8192)
+
+    low_freq_wavelen = old_context_len / low_freq_factor
+    high_freq_wavelen = old_context_len / high_freq_factor
+    new_freqs = []
+    for freq in inv_freq:
+        wavelen = 2 * math.pi / freq
+        if wavelen < high_freq_wavelen:
+            new_freqs.append(freq)
+        elif wavelen > low_freq_wavelen:
+            new_freqs.append(freq / scale_factor)
+        else:
+            assert low_freq_wavelen != high_freq_wavelen
+            smooth = (old_context_len / wavelen - low_freq_factor) / (
+                high_freq_factor - low_freq_factor
+            )
+            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+    return torch.tensor(new_freqs, dtype = inv_freq.dtype, device = inv_freq.device)
+
+
+def _compute_config_rope_inv_freq(config, rope_scaling):
+    """Return (inv_freq, attention_scaling) honoring config.rope_scaling.
+
+    Delegates to transformers' ROPE_INIT_FUNCTIONS so the result matches stock
+    transformers exactly (default / linear / dynamic / yarn / longrope / llama3).
+    Falls back to an inline llama3 computation on older transformers. On any
+    unexpected failure returns (None, 1.0) so the caller keeps the prior vanilla
+    behavior rather than crashing.
+    """
+    rope_type = rope_scaling.get("rope_type", None) or rope_scaling.get("type", None)
+    try:
+        from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+        rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
+        inv_freq, attention_scaling = rope_init_fn(config, torch.device("cpu"))
+        return inv_freq.to(dtype = torch.float32, device = "cpu"), float(attention_scaling)
+    except Exception as exception:
+        if rope_type == "llama3":
+            try:
+                return _llama3_inv_freq_from_config(config, rope_scaling), 1.0
+            except Exception:
+                pass
+        logger.warning_once(
+            f"Unsloth: Could not apply RoPE scaling '{rope_type}' from config "
+            f"({type(exception).__name__}: {exception}); falling back to unscaled RoPE. "
+            "Long-context generation may degrade."
+        )
+        return None, 1.0
+
+
 # Solves https://github.com/unslothai/unsloth/issues/168
 # Static KV Cache was introduced in 4.38.0, causing training to be much slower.
 # Inference can now be CUDAGraphed, but we shall retain the old rotary embeddings.
@@ -1640,6 +1708,17 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
+        # RoPE long-context attention scaling (multiplies cos/sin). 1.0 for
+        # vanilla / llama3; non-1.0 for yarn / longrope. Set before any
+        # _set_cos_sin_cache call so the cache build always sees it.
+        self.attention_scaling = 1.0
+        # When config carries a rope_scaling spec and we are the base class used
+        # directly (the modern-transformers path where LlamaModel builds the
+        # rotary from config), derive inv_freq the same way transformers does so
+        # the scaling is not silently dropped. Fixes #2405 (llama3 long-context
+        # gibberish). Subclasses that scale via _apply_inv_freq_scaling /
+        # _apply_time_scaling are excluded so scaling is never applied twice.
+        config_inv_freq = None
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
             base = _get_rope_theta(config, default = base)
@@ -1652,6 +1731,12 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             device = DEVICE_TYPE_TORCH
             max_position_embeddings = config.max_position_embeddings
 
+            rope_scaling = getattr(config, "rope_scaling", None)
+            if rope_scaling is not None and type(self) is LlamaRotaryEmbedding:
+                config_inv_freq, self.attention_scaling = _compute_config_rope_inv_freq(
+                    config, rope_scaling,
+                )
+
         self.dim = dim
         self.max_position_embeddings = max_position_embeddings
         self.base = base
@@ -1660,12 +1745,16 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         self.multi_gpu_cos_cached = [None] * DEVICE_COUNT
         self.multi_gpu_sin_cached = [None] * DEVICE_COUNT
 
-        # Normal Llama-3 RoPE
-        inv_freq = 1.0 / (
-            self.base
-            ** (torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim)
-        )
-        inv_freq = self._apply_inv_freq_scaling(inv_freq)
+        if config_inv_freq is not None:
+            # Already scaled per config.rope_scaling; do not scale again.
+            inv_freq = config_inv_freq
+        else:
+            # Normal Llama-3 RoPE
+            inv_freq = 1.0 / (
+                self.base
+                ** (torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim)
+            )
+            inv_freq = self._apply_inv_freq_scaling(inv_freq)
         self.register_buffer("inv_freq", inv_freq, persistent = False)
 
         # Build here to make `torch.jit.trace` work.
@@ -1704,8 +1793,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
         emb = torch.cat((freqs, freqs), dim = -1)
-        cos = emb.cos().to(dtype = dtype, device = device, non_blocking = True)
-        sin = emb.sin().to(dtype = dtype, device = device, non_blocking = True)
+        # attention_scaling is 1.0 except for long-context schemes (yarn /
+        # longrope); multiplying here keeps it applied across cache rebuilds in
+        # extend_rope_embedding. Default 1.0 leaves every existing path bit-identical.
+        cos = (emb.cos() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
+        sin = (emb.sin() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
         self.multi_gpu_cos_cached[device.index] = cos
         self.multi_gpu_sin_cached[device.index] = sin
         return cos, sin

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1622,7 +1622,11 @@ def _get_rope_theta(config, default = 10000.0):
     return default
 
 
-def _llama3_inv_freq_from_config(config, rope_scaling, device = "cpu"):
+def _llama3_inv_freq_from_config(
+    config,
+    rope_scaling,
+    device = "cpu",
+):
     """Inline llama3 RoPE inv_freq using factors read from config.rope_scaling.
 
     Fallback for transformers versions without modeling_rope_utils. Mirrors
@@ -1734,7 +1738,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             rope_scaling = getattr(config, "rope_scaling", None)
             if rope_scaling is not None and type(self) is LlamaRotaryEmbedding:
                 config_inv_freq, self.attention_scaling = _compute_config_rope_inv_freq(
-                    config, rope_scaling,
+                    config,
+                    rope_scaling,
                 )
 
         self.dim = dim
@@ -1752,7 +1757,9 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             # Normal Llama-3 RoPE
             inv_freq = 1.0 / (
                 self.base
-                ** (torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim)
+                ** (
+                    torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim
+                )
             )
             inv_freq = self._apply_inv_freq_scaling(inv_freq)
         self.register_buffer("inv_freq", inv_freq, persistent = False)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -172,12 +172,12 @@ def _offload_frozen_module_for_training(
         # Tesla T4 must use float32 and not float16
         new_dtype = torch.float32
 
-    module.modules_to_save.default.to(device = device_type, dtype = new_dtype, non_blocking = True)
+    module.modules_to_save.default.to(device=device_type, dtype=new_dtype, non_blocking=True)
     module.modules_to_save.default.requires_grad_(True)
 
     # [TODO] Move old module to CPU - should be disk!
     if offload_device is not None:
-        module.original_module.to(device = offload_device, non_blocking = True)
+        module.original_module.to(device=offload_device, non_blocking=True)
     module.original_module.requires_grad_(False)
 
 
@@ -185,8 +185,8 @@ def _offload_frozen_module_for_training(
 def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
-    attention_mask = None,
-    inputs_embeds = None,
+    attention_mask=None,
+    inputs_embeds=None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -249,8 +249,8 @@ def _fast_prepare_inputs_for_generation(
                 kwargs["cache_position"] = torch.arange(
                     past_len,
                     past_len + seq_length,
-                    device = device,
-                    dtype = torch.long,
+                    device=device,
+                    dtype=torch.long,
                 )
             else:
                 if hasattr(cache_position, "device") and cache_position.device != device:
@@ -346,9 +346,9 @@ def LlamaAttention_fast_forward_inference(
     hidden_states: torch.Tensor,
     past_key_value: Optional[Tuple[torch.Tensor]],
     position_ids,
-    do_prefill = False,
-    attention_mask = None,
-    rotary_seq_len = None,
+    do_prefill=False,
+    attention_mask=None,
+    rotary_seq_len=None,
 ):
     """
     https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L406
@@ -400,25 +400,25 @@ def LlamaAttention_fast_forward_inference(
     if do_prefill:
         self.paged_attention = torch.empty(
             (KV_CACHE_INCREMENT + seq_len + 1, 2, bsz, n_kv_heads, head_dim),
-            dtype = dtype,
-            device = device,
+            dtype=dtype,
+            device=device,
         )
         self.paged_attention_K = self.paged_attention[:, 0]
         self.paged_attention_V = self.paged_attention[:, 1]
         self.paged_attention_K[:seq_len] = K1.permute(2, 0, 1, 3)
         self.paged_attention_V[:seq_len] = V1.permute(2, 0, 1, 3)
-        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype = dtype, device = device)
-        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype = dtype, device = device)
-        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
+        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype=dtype, device=device)
+        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype=dtype, device=device)
+        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype=dtype, device=device)
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype=dtype, device=device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 
         self.attention = torch.empty(
-            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
+            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype=dtype, device=device
         )
         self.scalar = 1.0 / math_sqrt(self.head_dim)
         self.half_head_dim = head_dim // 2
@@ -436,9 +436,9 @@ def LlamaAttention_fast_forward_inference(
         self.paged_attention_V = self.paged_attention[:, 1]
         self.attention.resize_((bsz, n_heads, 1, self.attention.shape[-1] + KV_CACHE_INCREMENT))
 
-    Qn = fast_linear_forward(self.q_proj, Xn, out = self.temp_QA[0])
-    Kn = fast_linear_forward(self.k_proj, Xn, out = self.temp_KV[0])
-    Vn = fast_linear_forward(self.v_proj, Xn, out = self.temp_KV[1])
+    Qn = fast_linear_forward(self.q_proj, Xn, out=self.temp_QA[0])
+    Kn = fast_linear_forward(self.k_proj, Xn, out=self.temp_KV[0])
+    Vn = fast_linear_forward(self.v_proj, Xn, out=self.temp_KV[1])
     Qn = Qn.view(bsz, 1, n_heads, head_dim).transpose(1, 2)
     Kn = Kn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
     Vn = Vn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
@@ -461,8 +461,8 @@ def LlamaAttention_fast_forward_inference(
     self.rotary_emb.extend_rope_embedding(Vn, rotary_seq_len + 1)  # +1 slack
     cos, sin = self.rotary_emb.get_cached(rotary_seq_len, Qn.device.index or 0)
 
-    cos = cos[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
-    sin = sin[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
+    cos = cos[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
+    sin = sin[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
 
     h = self.half_head_dim
 
@@ -523,9 +523,9 @@ def LlamaAttention_fast_forward_inference(
             self.scalar
         )  # See https://github.com/ggerganov/llama.cpp/issues/7805#issuecomment-2153349963
         # It seems like doing (Q * scalar) @ K is better than (Q @ K) * scalar to stop overflows
-        A = torch_matmul(Qn, Knn.transpose(2, 3), out = self.attention[:, :, :, :cached_len])
-        A[:] = torch_nn_functional_softmax(A, dim = -1, dtype = torch.float32)  # .to(A.dtype)
-        A = torch_matmul(A, Vnn, out = Qn)
+        A = torch_matmul(Qn, Knn.transpose(2, 3), out=self.attention[:, :, :, :cached_len])
+        A[:] = torch_nn_functional_softmax(A, dim=-1, dtype=torch.float32)  # .to(A.dtype)
+        A = torch_matmul(A, Vnn, out=Qn)
     # --- attention_mask fixup for SDPA if user passes 2D padding mask
     else:
         if attention_mask is not None and attention_mask.dim() == 2:
@@ -544,17 +544,17 @@ def LlamaAttention_fast_forward_inference(
                 Qn,
                 Knn,
                 Vnn,
-                attn_mask = attention_mask,
-                is_causal = is_causal,
-                enable_gqa = True,
+                attn_mask=attention_mask,
+                is_causal=is_causal,
+                enable_gqa=True,
             )
         else:
             A = scaled_dot_product_attention(
-                Qn, Knn, Vnn, attn_mask = attention_mask, is_causal = is_causal
+                Qn, Knn, Vnn, attn_mask=attention_mask, is_causal=is_causal
             )
     A = A.transpose(1, 2)
     A = A.reshape(bsz, 1, attention_size)
-    A = fast_linear_forward(self.o_proj, A, out = self.temp_O)
+    A = fast_linear_forward(self.o_proj, A, out=self.temp_O)
     return A, (Kn, Vn)
 
 
@@ -564,10 +564,10 @@ torch_nn_functional_silu = torch.nn.functional.silu
 def fast_swiglu_inference(
     self,
     X,
-    temp_gate = None,
-    temp_up = None,
-    gate_multiplier = None,
-    down_multiplier = None,
+    temp_gate=None,
+    temp_up=None,
+    gate_multiplier=None,
+    down_multiplier=None,
 ):
     # gate = self.gate_proj(X)
     # up   = self.up_proj(X)
@@ -575,18 +575,18 @@ def fast_swiglu_inference(
     # mlp_size = self.config.intermediate_size
     # temp = torch.empty((2, bsz, 1, mlp_size), dtype = X.dtype, device = "cuda:0")
 
-    gate = fast_linear_forward(self.gate_proj, X, out = temp_gate)
+    gate = fast_linear_forward(self.gate_proj, X, out=temp_gate)
 
     if gate_multiplier is not None:
         gate *= gate_multiplier
 
-    up = fast_linear_forward(self.up_proj, X, out = temp_up)
+    up = fast_linear_forward(self.up_proj, X, out=temp_up)
 
-    gate = torch_nn_functional_silu(gate, inplace = True)
+    gate = torch_nn_functional_silu(gate, inplace=True)
     gate *= up
 
     # X = self.down_proj(gate)
-    down = fast_linear_forward(self.down_proj, gate, out = up[:, :, :hd])
+    down = fast_linear_forward(self.down_proj, gate, out=up[:, :, :hd])
 
     if down_multiplier is not None:
         down *= down_multiplier
@@ -601,17 +601,17 @@ torch_mean = torch.mean
 def fast_rms_layernorm_inference(
     self,
     X,
-    XX = None,
-    XX2 = None,
-    variance = None,
+    XX=None,
+    XX2=None,
+    variance=None,
 ):
     old_dtype = X.dtype
     if XX is None:
         XX = X.to(torch.float32)
-        variance = XX.square().mean(-1, keepdim = True)
+        variance = XX.square().mean(-1, keepdim=True)
     else:
         XX.copy_(X)
-        torch_mean(torch_square(XX, out = XX2), -1, keepdim = True, out = variance)
+        torch_mean(torch_square(XX, out=XX2), -1, keepdim=True, out=variance)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -627,10 +627,10 @@ def fast_rms_layernorm_inference(
 def fast_rms_layernorm_inference_gemma(
     self,
     X,
-    out_weight = None,
+    out_weight=None,
 ):
     XX = X.to(torch.float32)
-    variance = XX.square().mean(-1, keepdim = True)
+    variance = XX.square().mean(-1, keepdim=True)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -645,15 +645,15 @@ def fast_rms_layernorm_inference_gemma(
 
 
 # Normal layernorm with mean removal
-@torch.compile(fullgraph = False, dynamic = True, options = torch_compile_options)
+@torch.compile(fullgraph=False, dynamic=True, options=torch_compile_options)
 def fast_layernorm_compiled(layernorm, X):
     old_dtype = X.dtype
     X = X.float()
-    mean = X.mean(-1, keepdim = True)
+    mean = X.mean(-1, keepdim=True)
     Xbar = X - mean
     X = (
         Xbar
-        * torch.rsqrt(Xbar.square().mean(-1, keepdim = True) + layernorm.variance_epsilon)
+        * torch.rsqrt(Xbar.square().mean(-1, keepdim=True) + layernorm.variance_epsilon)
         * layernorm.weight.float()
     )
     return X.to(old_dtype)
@@ -705,10 +705,10 @@ def LlamaAttention_fast_forward(
         cos, sin = position_embeddings
     else:
         rotary_emb = self.rotary_emb
-        rotary_emb.extend_rope_embedding(V, seq_len = kv_seq_len)
+        rotary_emb.extend_rope_embedding(V, seq_len=kv_seq_len)
         cos, sin = rotary_emb.get_cached(kv_seq_len, Q.device.index)
-        cos = cos.to(device = Q.device, dtype = Q.dtype)
-        sin = sin.to(device = Q.device, dtype = Q.dtype)
+        cos = cos.to(device=Q.device, dtype=Q.dtype)
+        sin = sin.to(device=Q.device, dtype=Q.dtype)
 
     rope_position_ids = position_ids
     if rope_position_ids is None and seq_info is not None:
@@ -722,8 +722,8 @@ def LlamaAttention_fast_forward(
     Q, K = fast_rope_embedding(Q, K, cos, sin, rope_position_ids)
 
     if past_key_value is not None:
-        K = torch.cat([past_key_value[0], K], dim = 2)
-        V = torch.cat([past_key_value[1], V], dim = 2)
+        K = torch.cat([past_key_value[0], K], dim=2)
+        V = torch.cat([past_key_value[1], V], dim=2)
     past_key_value = (K, V) if use_cache else None
 
     # Attention module
@@ -732,25 +732,25 @@ def LlamaAttention_fast_forward(
 
     # should dropout be hardcoded to 0.0?
     config = AttentionConfig(
-        backend = backend,
-        n_kv_heads = n_kv_heads,
-        n_groups = n_groups,
-        flash_dense_kwargs = {"causal": True},
-        flash_varlen_kwargs = {"dropout_p": 0.0, "causal": True},
+        backend=backend,
+        n_kv_heads=n_kv_heads,
+        n_groups=n_groups,
+        flash_dense_kwargs={"causal": True},
+        flash_varlen_kwargs={"dropout_p": 0.0, "causal": True},
     )
     context = AttentionContext(
-        bsz = bsz,
-        q_len = q_len,
-        kv_seq_len = kv_seq_len,
-        n_heads = n_heads,
-        head_dim = head_dim,
-        requires_grad = hidden_states.requires_grad,
-        seq_info = seq_info,
-        attention_mask = attention_mask,
-        causal_mask = causal_mask,
+        bsz=bsz,
+        q_len=q_len,
+        kv_seq_len=kv_seq_len,
+        n_heads=n_heads,
+        head_dim=head_dim,
+        requires_grad=hidden_states.requires_grad,
+        seq_info=seq_info,
+        attention_mask=attention_mask,
+        causal_mask=causal_mask,
     )
 
-    A = run_attention(config = config, context = context, Q = Q, K = K, V = V)
+    A = run_attention(config=config, context=context, Q=Q, K=K, V=V)
     attn_output = A.reshape(bsz, q_len, n_heads * head_dim)
     attn_output = self.apply_o(self, attn_output)
     attn_weights = None
@@ -761,7 +761,7 @@ def LlamaAttention_fast_forward(
 def LlamaDecoderLayer_fast_forward(
     self,
     hidden_states: torch.Tensor,
-    causal_mask = None,
+    causal_mask=None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
     past_key_value: Optional[Tuple[torch.Tensor]] = None,
@@ -789,15 +789,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states += residual
@@ -811,15 +811,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -923,8 +923,8 @@ def LlamaModel_fast_forward(
         position_ids = torch.arange(
             past_key_values_length,
             seq_length + past_key_values_length,
-            dtype = torch.int32,
-            device = f"{DEVICE_TYPE_TORCH}:0",
+            dtype=torch.int32,
+            device=f"{DEVICE_TYPE_TORCH}:0",
         )
         position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
     elif position_ids is not None:
@@ -956,7 +956,7 @@ def LlamaModel_fast_forward(
         # inputs_embeds *= math_sqrt(self.config.hidden_size)
         # Ie 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
         # &  2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
-        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype = inputs_embeds.dtype)
+        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype=inputs_embeds.dtype)
 
         if train_embed_tokens:
             # Careful we must not do an inplace op!
@@ -1013,7 +1013,7 @@ def LlamaModel_fast_forward(
             (batch_size, seq_length),
             inputs_embeds,
             past_key_values_length,
-            sliding_window = getattr(self.config, "sliding_window", None),
+            sliding_window=getattr(self.config, "sliding_window", None),
         )
         # Must NOT convert to bool - weirdly this causes stuff to error out!
         # if attention_mask is not None:
@@ -1068,14 +1068,14 @@ def LlamaModel_fast_forward(
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window = self.config.sliding_window,
+                sliding_window=self.config.sliding_window,
             )
             dynamic_GA_mask = _prepare_4d_causal_attention_mask_for_sdpa(
                 attention_mask,
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window = None,
+                sliding_window=None,
             )
             use_static_mask = False
 
@@ -1095,15 +1095,15 @@ def LlamaModel_fast_forward(
 
                 self.SWA_mask = (
                     AttentionMaskConverter(
-                        is_causal = True,
-                        sliding_window = self.config.sliding_window,
+                        is_causal=True,
+                        sliding_window=self.config.sliding_window,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype = inputs_embeds.dtype,
-                        device = DEVICE_TYPE_TORCH,
+                        dtype=inputs_embeds.dtype,
+                        device=DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1111,14 +1111,14 @@ def LlamaModel_fast_forward(
 
                 self.GA_mask = (
                     AttentionMaskConverter(
-                        is_causal = True,
+                        is_causal=True,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype = inputs_embeds.dtype,
-                        device = DEVICE_TYPE_TORCH,
+                        dtype=inputs_embeds.dtype,
+                        device=DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1161,8 +1161,8 @@ def LlamaModel_fast_forward(
                         *inputs,
                         past_key_value,
                         output_attentions,
-                        padding_mask = padding_mask,
-                        position_embeddings = position_embeddings,
+                        padding_mask=padding_mask,
+                        position_embeddings=position_embeddings,
                         **kwargs,
                     )
 
@@ -1174,22 +1174,22 @@ def LlamaModel_fast_forward(
                 mask,
                 attention_mask,
                 position_ids,
-                use_reentrant = True,
-                preserve_rng_state = False,
+                use_reentrant=True,
+                preserve_rng_state=False,
             )
             hidden_states = layer_outputs[0]
 
         else:
             layer_outputs = decoder_layer(
                 hidden_states,
-                causal_mask = mask,
-                attention_mask = attention_mask,
-                position_ids = position_ids,
-                past_key_value = past_key_value,
-                output_attentions = output_attentions,
-                use_cache = use_cache,
-                padding_mask = padding_mask,
-                position_embeddings = position_embeddings,
+                causal_mask=mask,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                padding_mask=padding_mask,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
             hidden_states = layer_outputs[0]
@@ -1210,9 +1210,9 @@ def LlamaModel_fast_forward(
     elif IS_COHERE:
         hidden_states = self.norm(hidden_states)
     elif IS_FALCON_H1:
-        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma = IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma=IS_GEMMA)
     else:
-        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma = IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma=IS_GEMMA)
 
     if output_hidden_states:
         all_hidden_states += (hidden_states,)
@@ -1225,17 +1225,17 @@ def LlamaModel_fast_forward(
             if v is not None
         )
     return BaseModelOutputWithPast(
-        last_hidden_state = hidden_states,
-        past_key_values = next_cache,
-        hidden_states = all_hidden_states,
-        attentions = all_self_attns,
+        last_hidden_state=hidden_states,
+        past_key_values=next_cache,
+        hidden_states=all_hidden_states,
+        attentions=all_self_attns,
     )
 
 
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L825
 def _LlamaModel_fast_forward_inference(
-    attention_fast_forward_inference = LlamaAttention_fast_forward_inference,
-    mlp_fast_forward_inference = fast_swiglu_inference,
+    attention_fast_forward_inference=LlamaAttention_fast_forward_inference,
+    mlp_fast_forward_inference=fast_swiglu_inference,
 ):
     # Makes attention and MLP customisable for models like qwen3/cohere.
     def LlamaModel_fast_forward_inference_custom(
@@ -1243,7 +1243,7 @@ def _LlamaModel_fast_forward_inference(
         input_ids,
         past_key_values,
         position_ids,
-        attention_mask = None,
+        attention_mask=None,
         **kwargs,
     ):
         input_ids = input_ids[:, : self.max_seq_length]
@@ -1257,15 +1257,15 @@ def _LlamaModel_fast_forward_inference(
         assert q_len == 1
         # Get saved buffers to reduce memory movement
         residual = torch.empty(
-            (bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
         )
-        _XX = torch.empty((2, bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0")
+        _XX = torch.empty((2, bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0")
         XX, XX2 = _XX[0], _XX[1]
         variance = torch.empty(
-            (bsz, q_len, 1), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, 1), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_mlp = torch.empty(
-            (2, bsz, 1, mlp_size), dtype = X.dtype, device = f"{DEVICE_TYPE_TORCH}:0"
+            (2, bsz, 1, mlp_size), dtype=X.dtype, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_gates, temp_ups = (
             tuple(temp_mlp[0].to(torch.device(x)) for x in range(DEVICE_COUNT)),
@@ -1280,7 +1280,7 @@ def _LlamaModel_fast_forward_inference(
                 (bsz, q_len),
                 X,
                 seq_len,
-                sliding_window = getattr(self.config, "sliding_window", None),
+                sliding_window=getattr(self.config, "sliding_window", None),
             )
             # Pre-convert to bool once for all layers (avoids per-layer .eq(0))
             if attention_mask is not None and attention_mask.dtype != torch.bool:
@@ -1300,18 +1300,18 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.input_layernorm,
                 X,
-                XX = XX,
-                XX2 = XX2,
-                variance = variance,
+                XX=XX,
+                XX2=XX2,
+                variance=variance,
             )
             X, present_key_value = attention_fast_forward_inference(
                 decoder_layer.self_attn,
-                hidden_states = X,
-                past_key_value = past_key_values[idx],
-                position_ids = position_ids,
-                attention_mask = attention_mask,
-                do_prefill = not hasattr(decoder_layer.self_attn, "paged_attention"),
-                rotary_seq_len = rotary_seq_len,
+                hidden_states=X,
+                past_key_value=past_key_values[idx],
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                do_prefill=not hasattr(decoder_layer.self_attn, "paged_attention"),
+                rotary_seq_len=rotary_seq_len,
             )
             X += residual
 
@@ -1319,15 +1319,15 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.post_attention_layernorm,
                 X,
-                XX = XX,
-                XX2 = XX2,
-                variance = variance,
+                XX=XX,
+                XX2=XX2,
+                variance=variance,
             )
             X = mlp_fast_forward_inference(
                 decoder_layer.mlp,
                 X,
-                temp_gate = temp_gates[device_index],
-                temp_up = temp_ups[device_index],
+                temp_gate=temp_gates[device_index],
+                temp_up=temp_ups[device_index],
             )
             X += residual
 
@@ -1335,16 +1335,16 @@ def _LlamaModel_fast_forward_inference(
         X = fast_rms_layernorm_inference(
             self.model.norm,
             X,
-            XX = XX,
-            XX2 = XX2,
-            variance = variance,
+            XX=XX,
+            XX2=XX2,
+            variance=variance,
         )
 
         return BaseModelOutputWithPast(
-            last_hidden_state = X,
-            past_key_values = next_decoder_cache,
-            hidden_states = [],
-            attentions = [],
+            last_hidden_state=X,
+            past_key_values=next_decoder_cache,
+            hidden_states=[],
+            attentions=[],
         )
 
     return LlamaModel_fast_forward_inference_custom
@@ -1378,8 +1378,8 @@ def CausalLM_fast_forward(fast_forward_inference):
                 self,
                 input_ids,
                 past_key_values,
-                position_ids = position_ids,
-                attention_mask = attention_mask,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
                 **kwargs,
             )
         else:
@@ -1399,16 +1399,16 @@ def CausalLM_fast_forward(fast_forward_inference):
             # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
             self.model._has_no_labels = labels is None
             outputs = self.model(
-                input_ids = input_ids,
-                causal_mask = causal_mask,
-                attention_mask = attention_mask,
-                position_ids = position_ids,
-                past_key_values = past_key_values,
-                inputs_embeds = inputs_embeds,
-                use_cache = use_cache,
-                output_attentions = output_attentions,
-                output_hidden_states = output_hidden_states,
-                return_dict = return_dict,
+                input_ids=input_ids,
+                causal_mask=causal_mask,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
                 **kwargs,
             )
         hidden_states = outputs[0]
@@ -1436,11 +1436,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if num_logits_to_keep != 0:
                 hidden_states = hidden_states[:, -num_logits_to_keep:, :]
             return CausalLMOutputWithPast(
-                loss = None,
-                logits = hidden_states,
-                past_key_values = outputs.past_key_values,
-                hidden_states = outputs.hidden_states,
-                attentions = outputs.attentions,
+                loss=None,
+                logits=hidden_states,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
             )
 
         if bsz == 1 and q_len == 1:
@@ -1473,28 +1473,28 @@ def CausalLM_fast_forward(fast_forward_inference):
                 #     logit_softcapping  = logit_softcapping,
                 # )
                 loss = unsloth_fused_ce_loss(
-                    trainer = None,
-                    hidden_states = hidden_states,
-                    lm_head_weight = lm_head,
-                    lm_head_bias = None,
-                    labels = labels,
-                    mask = None,
-                    n_items = n_items,
-                    scaling = getattr(self, "accelerator_scaler", None),
-                    target_gb = None,
-                    torch_compile = True,
-                    logit_softcapping = logit_softcapping,
+                    trainer=None,
+                    hidden_states=hidden_states,
+                    lm_head_weight=lm_head,
+                    lm_head_bias=None,
+                    labels=labels,
+                    mask=None,
+                    n_items=n_items,
+                    scaling=getattr(self, "accelerator_scaler", None),
+                    target_gb=None,
+                    torch_compile=True,
+                    logit_softcapping=logit_softcapping,
                 )
                 if not return_dict:
                     output = (logits,) + outputs[1:]
                     return (loss,) + output if loss is not None else output
 
                 output = CausalLMOutputWithPast(
-                    loss = loss,
-                    logits = EMPTY_LOGITS,
-                    past_key_values = outputs.past_key_values,
-                    hidden_states = outputs.hidden_states,
-                    attentions = outputs.attentions,
+                    loss=loss,
+                    logits=EMPTY_LOGITS,
+                    past_key_values=outputs.past_key_values,
+                    hidden_states=outputs.hidden_states,
+                    attentions=outputs.attentions,
                 )
                 return output
             pass
@@ -1530,11 +1530,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if n_items is None:
                 n_items = kwargs.get("n_items", None)
             loss = fast_cross_entropy_loss(
-                logits = shift_logits,
-                labels = shift_labels,
-                logit_softcapping = logit_softcapping,
-                logit_scaling = logit_scaling,
-                n_items = n_items,
+                logits=shift_logits,
+                labels=shift_labels,
+                logit_softcapping=logit_softcapping,
+                logit_scaling=logit_scaling,
+                n_items=n_items,
             )
         else:
             if logit_scaling != 0:
@@ -1556,11 +1556,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             output = (logits,) + outputs[1:]
             return (loss,) + output if loss is not None else output
         return CausalLMOutputWithPast(
-            loss = loss,
-            logits = logits,
-            past_key_values = outputs.past_key_values,
-            hidden_states = outputs.hidden_states,
-            attentions = outputs.attentions,
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
     return _CausalLM_fast_forward
@@ -1569,48 +1569,48 @@ def CausalLM_fast_forward(fast_forward_inference):
 @torch._disable_dynamo
 def PeftModel_fast_forward(
     self,
-    input_ids = None,
-    causal_mask = None,
-    attention_mask = None,
-    inputs_embeds = None,
-    labels = None,
-    output_attentions = None,
-    output_hidden_states = None,
-    return_dict = None,
-    task_ids = None,
-    num_logits_to_keep = 0,
-    logits_to_keep = 0,
+    input_ids=None,
+    causal_mask=None,
+    attention_mask=None,
+    inputs_embeds=None,
+    labels=None,
+    output_attentions=None,
+    output_hidden_states=None,
+    return_dict=None,
+    task_ids=None,
+    num_logits_to_keep=0,
+    logits_to_keep=0,
     **kwargs,
 ):
     is_classification = "Classification" in str(type(self.base_model.model))
     if is_classification:
         return self.base_model(
-            input_ids = input_ids,
-            attention_mask = attention_mask,
-            inputs_embeds = inputs_embeds,
-            labels = labels,
-            output_attentions = output_attentions,
-            output_hidden_states = output_hidden_states,
-            return_dict = return_dict,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
             **kwargs,
         )
     else:
         return self.base_model(
-            input_ids = input_ids,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            inputs_embeds = inputs_embeds,
-            labels = labels,
-            output_attentions = output_attentions,
-            output_hidden_states = output_hidden_states,
-            return_dict = return_dict,
-            num_logits_to_keep = num_logits_to_keep,
-            logits_to_keep = logits_to_keep,
+            input_ids=input_ids,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            num_logits_to_keep=num_logits_to_keep,
+            logits_to_keep=logits_to_keep,
             **kwargs,
         )
 
 
-def _get_rope_theta(config, default = 10000.0):
+def _get_rope_theta(config, default=10000.0):
     """Get rope_theta from config, handling both transformers 4.x and 5.x."""
     try:
         return config.rope_theta
@@ -1622,23 +1622,43 @@ def _get_rope_theta(config, default = 10000.0):
     return default
 
 
-def _llama3_inv_freq_from_config(
-    config,
-    rope_scaling,
-    device = "cpu",
-):
+def _rope_scaling_as_dict(rope_scaling):
+    """Normalize config.rope_scaling to a plain dict.
+
+    Newer transformers may expose rope_scaling as a config object (e.g. a
+    RopeScalingConfig dataclass) instead of a raw dict; calling .get() on it
+    would raise AttributeError. Returns {} when nothing usable is found.
+    """
+    if isinstance(rope_scaling, dict):
+        return rope_scaling
+    for converter in ("to_dict", "dict"):
+        fn = getattr(rope_scaling, converter, None)
+        if callable(fn):
+            try:
+                d = fn()
+                if isinstance(d, dict):
+                    return d
+            except Exception:
+                pass
+    try:
+        return {k: v for k, v in vars(rope_scaling).items() if not k.startswith("_")}
+    except TypeError:
+        return {}
+
+
+def _llama3_inv_freq_from_config(config, rope_scaling, device="cpu"):
     """Inline llama3 RoPE inv_freq using factors read from config.rope_scaling.
 
     Fallback for transformers versions without modeling_rope_utils. Mirrors
     meta-llama's llama3 scaling and LlamaExtendedRotaryEmbedding, but reads the
     factors from config rather than hardcoding them.
     """
-    base = _get_rope_theta(config, default = 10000.0)
+    base = _get_rope_theta(config, default=10000.0)
     dim = getattr(config, "head_dim", None)
     if dim is None:
         dim = int(config.hidden_size // config.num_attention_heads)
     inv_freq = 1.0 / (
-        base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim)
+        base ** (torch.arange(0, dim, 2, dtype=torch.int64, device=device).float() / dim)
     )
 
     scale_factor = rope_scaling.get("factor", 8.0)
@@ -1648,20 +1668,17 @@ def _llama3_inv_freq_from_config(
 
     low_freq_wavelen = old_context_len / low_freq_factor
     high_freq_wavelen = old_context_len / high_freq_factor
-    new_freqs = []
-    for freq in inv_freq:
-        wavelen = 2 * math.pi / freq
-        if wavelen < high_freq_wavelen:
-            new_freqs.append(freq)
-        elif wavelen > low_freq_wavelen:
-            new_freqs.append(freq / scale_factor)
-        else:
-            assert low_freq_wavelen != high_freq_wavelen
-            smooth = (old_context_len / wavelen - low_freq_factor) / (
-                high_freq_factor - low_freq_factor
-            )
-            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-    return torch.tensor(new_freqs, dtype = inv_freq.dtype, device = inv_freq.device)
+    assert low_freq_wavelen != high_freq_wavelen
+
+    # Vectorized version of meta-llama's per-frequency loop. Bands match the
+    # reference exactly: wavelen < high_wl keeps the frequency, wavelen >
+    # low_wl divides by the scale factor, the medium band blends the two.
+    wavelen = 2 * math.pi / inv_freq
+    scaled = torch.where(wavelen > low_freq_wavelen, inv_freq / scale_factor, inv_freq)
+    smooth = (old_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
+    smoothed = (1 - smooth) * inv_freq / scale_factor + smooth * inv_freq
+    is_medium = (wavelen >= high_freq_wavelen) & (wavelen <= low_freq_wavelen)
+    return torch.where(is_medium, smoothed, scaled)
 
 
 def _compute_config_rope_inv_freq(config, rope_scaling):
@@ -1673,13 +1690,14 @@ def _compute_config_rope_inv_freq(config, rope_scaling):
     unexpected failure returns (None, 1.0) so the caller keeps the prior vanilla
     behavior rather than crashing.
     """
+    rope_scaling = _rope_scaling_as_dict(rope_scaling)
     rope_type = rope_scaling.get("rope_type", None) or rope_scaling.get("type", None)
     try:
         from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 
         rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
         inv_freq, attention_scaling = rope_init_fn(config, torch.device("cpu"))
-        return inv_freq.to(dtype = torch.float32, device = "cpu"), float(attention_scaling)
+        return inv_freq.to(dtype=torch.float32, device="cpu"), float(attention_scaling)
     except Exception as exception:
         if rope_type == "llama3":
             try:
@@ -1705,11 +1723,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         # RoPE long-context attention scaling (multiplies cos/sin). 1.0 for
@@ -1725,7 +1743,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         config_inv_freq = None
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default = base)
+            base = _get_rope_theta(config, default=base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1762,22 +1780,22 @@ class LlamaRotaryEmbedding(torch.nn.Module):
                 )
             )
             inv_freq = self._apply_inv_freq_scaling(inv_freq)
-        self.register_buffer("inv_freq", inv_freq, persistent = False)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
 
         # Build here to make `torch.jit.trace` work.
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                seq_len = self.current_rope_size,
-                device = torch.device(device_idx),
-                dtype = torch.get_default_dtype(),
+                seq_len=self.current_rope_size,
+                device=torch.device(device_idx),
+                dtype=torch.get_default_dtype(),
             )
 
         # dummy so that patch_utils doesn't fail for now
         self.cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
 
     def _apply_inv_freq_scaling(self, inv_freq):
@@ -1793,18 +1811,18 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
         t = torch.arange(
-            self.current_rope_size, device = self.inv_freq.device, dtype = torch.int64
+            self.current_rope_size, device=self.inv_freq.device, dtype=torch.int64
         ).float()
         t = self._apply_time_scaling(t)
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
         # attention_scaling is 1.0 except for long-context schemes (yarn /
         # longrope); multiplying here keeps it applied across cache rebuilds in
         # extend_rope_embedding. Default 1.0 leaves every existing path bit-identical.
-        cos = (emb.cos() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
-        sin = (emb.sin() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
+        cos = (emb.cos() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
+        sin = (emb.sin() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
         self.multi_gpu_cos_cached[device.index] = cos
         self.multi_gpu_sin_cached[device.index] = sin
         return cos, sin
@@ -1812,12 +1830,12 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids = None,
-        seq_len = None,
+        position_ids=None,
+        seq_len=None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
 
         device_index = x.device.index
         return (
@@ -1827,8 +1845,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len = None,
-        device_index = None,
+        seq_len=None,
+        device_index=None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -1841,7 +1859,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
+                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
             )
 
 
@@ -1853,20 +1871,20 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        scaling_factor = 1.0,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        scaling_factor=1.0,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         self.scaling_factor = scaling_factor
         super().__init__(
-            dim = dim,
-            max_position_embeddings = max_position_embeddings,
-            base = base,
-            device = device,
-            config = config,
+            dim=dim,
+            max_position_embeddings=max_position_embeddings,
+            base=base,
+            device=device,
+            config=config,
         )
 
     def _apply_time_scaling(self, t):
@@ -1879,18 +1897,18 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
 class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__(
-            dim = dim,
-            max_position_embeddings = max_position_embeddings,
-            base = base,
-            device = device,
-            config = config,
+            dim=dim,
+            max_position_embeddings=max_position_embeddings,
+            base=base,
+            device=device,
+            config=config,
         )
 
     # From https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/api/model.py#L41
@@ -1916,21 +1934,21 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
                     high_freq_factor - low_freq_factor
                 )
                 new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-        return torch.tensor(new_freqs, dtype = freqs.dtype, device = freqs.device)
+        return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
 class LongRopeRotaryEmbedding(torch.nn.Module):
     # For Phi 3.5 128K https://huggingface.co/microsoft/Phi-3.5-mini-instruct/blob/main/modeling_phi3.py
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 131072,
-        original_max_position_embeddings = 4096,
-        base = 10000,
-        short_factor = None,
-        long_factor = None,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=131072,
+        original_max_position_embeddings=4096,
+        base=10000,
+        short_factor=None,
+        long_factor=None,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         assert short_factor is not None
@@ -1939,7 +1957,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default = base)
+            base = _get_rope_theta(config, default=base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1961,10 +1979,10 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         # Long RoPE similar to RoPE except short sequences have 1 cos / sin
         # and long sequences have another cos / sin
         inv_freq_shape = (
-            torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim
+            torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float() / self.dim
         )
-        short_factor = torch.tensor(short_factor, device = "cpu", dtype = torch.float32)
-        long_factor = torch.tensor(long_factor, device = "cpu", dtype = torch.float32)
+        short_factor = torch.tensor(short_factor, device="cpu", dtype=torch.float32)
+        long_factor = torch.tensor(long_factor, device="cpu", dtype=torch.float32)
         short_inv_freq = 1.0 / (short_factor * self.base**inv_freq_shape)
         long_inv_freq = 1.0 / (long_factor * self.base**inv_freq_shape)
 
@@ -1979,43 +1997,43 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.scaling_factor = scaling_factor
 
         # Short and long inv_freq
-        self.register_buffer("short_inv_freq", short_inv_freq, persistent = False)
-        self.register_buffer("long_inv_freq", long_inv_freq, persistent = False)
+        self.register_buffer("short_inv_freq", short_inv_freq, persistent=False)
+        self.register_buffer("long_inv_freq", long_inv_freq, persistent=False)
 
         # Build here to make `torch.jit.trace` work.
         # Initialize short sequences cache for all devices
         dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
         t = torch.arange(
             original_max_position_embeddings,
-            device = self.short_inv_freq.device,
-            dtype = torch.int64,
+            device=self.short_inv_freq.device,
+            dtype=torch.int64,
         ).float()
         freqs = torch.outer(t, self.short_inv_freq)
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
 
         for device_idx in range(DEVICE_COUNT):
             device_obj = torch.device(device_idx)
             cos_cached = (emb.cos() * self.scaling_factor).to(
-                dtype = dtype, device = device_obj, non_blocking = True
+                dtype=dtype, device=device_obj, non_blocking=True
             )
             sin_cached = (emb.sin() * self.scaling_factor).to(
-                dtype = dtype, device = device_obj, non_blocking = True
+                dtype=dtype, device=device_obj, non_blocking=True
             )
             self.multi_gpu_short_cos_cached[device_idx] = cos_cached
             self.multi_gpu_short_sin_cached[device_idx] = sin_cached
 
         # dummy so that patch_utils doesn't fail for now
         self.short_cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.short_sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.long_cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.long_sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
@@ -2024,16 +2042,16 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = seq_len
 
         t = torch.arange(
-            self.current_rope_size, device = self.long_inv_freq.device, dtype = torch.int64
+            self.current_rope_size, device=self.long_inv_freq.device, dtype=torch.int64
         ).float()
         # Long sequences
         freqs = torch.outer(t, self.long_inv_freq)
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
         cos_cached = (emb.cos() * self.scaling_factor).to(
-            dtype = dtype, device = device, non_blocking = True
+            dtype=dtype, device=device, non_blocking=True
         )
         sin_cached = (emb.sin() * self.scaling_factor).to(
-            dtype = dtype, device = device, non_blocking = True
+            dtype=dtype, device=device, non_blocking=True
         )
         self.multi_gpu_long_cos_cached[device.index] = cos_cached
         self.multi_gpu_long_sin_cached[device.index] = sin_cached
@@ -2042,12 +2060,12 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids = None,
-        seq_len = None,
+        position_ids=None,
+        seq_len=None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
 
         device_index = x.device.index
 
@@ -2064,8 +2082,8 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len = None,
-        device_index = None,
+        seq_len=None,
+        device_index=None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -2084,7 +2102,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
+                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
             )
 
 
@@ -2165,7 +2183,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     # Mixed precision autocast
     with (
         _get_inference_mode_context_manager(self),
-        torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = dtype),
+        torch.autocast(device_type=DEVICE_TYPE_TORCH, dtype=dtype),
     ):
         output = self._old_generate(*args, **kwargs)
 
@@ -2177,7 +2195,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     if restore_training_mode:
         FastLlamaModel.for_training(
             self,
-            use_gradient_checkpointing = use_gradient_checkpointing,
+            use_gradient_checkpointing=use_gradient_checkpointing,
         )
 
     return output
@@ -2192,12 +2210,12 @@ class FastLlamaModel:
     @staticmethod
     def pre_patch():
         init_name, function = patch_llama_rope_scaling(
-            model_name = "llama",
-            rope_module = LlamaRotaryEmbedding,
-            scaled_rope_module = LlamaLinearScalingRotaryEmbedding,
-            extended_rope_module = LlamaExtendedRotaryEmbedding,
-            attention_module = LlamaAttention,
-            longrope_module = LongRopeRotaryEmbedding,
+            model_name="llama",
+            rope_module=LlamaRotaryEmbedding,
+            scaled_rope_module=LlamaLinearScalingRotaryEmbedding,
+            extended_rope_module=LlamaExtendedRotaryEmbedding,
+            attention_module=LlamaAttention,
+            longrope_module=LongRopeRotaryEmbedding,
         )
         if init_name is not None:
             exec(function, globals())
@@ -2226,28 +2244,28 @@ class FastLlamaModel:
 
     @staticmethod
     def from_pretrained(
-        model_name = "unsloth/llama-3-8b-bnb-4bit",
-        max_seq_length = None,
-        dtype = None,
-        load_in_4bit = True,
-        token = None,
-        device_map = "sequential",
-        rope_scaling = None,
-        fix_tokenizer = True,
-        model_patcher = None,
-        tokenizer_name = None,
-        trust_remote_code = False,
-        revision = None,
-        fast_inference = False,  # uses vLLM
-        gpu_memory_utilization = 0.5,
-        float8_kv_cache = False,
-        random_state = 3407,
-        max_lora_rank = 16,
-        disable_log_stats = False,
-        unsloth_vllm_standby = False,
-        num_labels = None,
-        qat_scheme = None,
-        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
+        model_name="unsloth/llama-3-8b-bnb-4bit",
+        max_seq_length=None,
+        dtype=None,
+        load_in_4bit=True,
+        token=None,
+        device_map="sequential",
+        rope_scaling=None,
+        fix_tokenizer=True,
+        model_patcher=None,
+        tokenizer_name=None,
+        trust_remote_code=False,
+        revision=None,
+        fast_inference=False,  # uses vLLM
+        gpu_memory_utilization=0.5,
+        float8_kv_cache=False,
+        random_state=3407,
+        max_lora_rank=16,
+        disable_log_stats=False,
+        unsloth_vllm_standby=False,
+        num_labels=None,
+        qat_scheme=None,
+        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
         **kwargs,
     ):
         os.environ["UNSLOTH_USE_NEW_MODEL"] = "0"
@@ -2363,8 +2381,8 @@ class FastLlamaModel:
         # RoPE Scaling
         model_config = AutoConfig.from_pretrained(
             model_name,
-            token = token,
-            attn_implementation = "sdpa",
+            token=token,
+            attn_implementation="sdpa",
         )
         model_config.model_name = model_name
         model_max_seq_length = model_config.max_position_embeddings
@@ -2379,7 +2397,7 @@ class FastLlamaModel:
 
         has_rope_scaling = False
         try:
-            with open(inspect.getfile(model_function), "r", encoding = "utf-8") as file:
+            with open(inspect.getfile(model_function), "r", encoding="utf-8") as file:
                 has_rope_scaling = "self.config.rope_scaling" in file.read()
         except:
             pass
@@ -2427,7 +2445,7 @@ class FastLlamaModel:
 
         # Check and disable bitsandbytes loading if model has non-bitsandbytes quantization
         load_in_4bit, load_in_8bit, _ckpt_quant_method = check_and_disable_bitsandbytes_loading(
-            model_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit
+            model_config, load_in_4bit=load_in_4bit, load_in_8bit=load_in_8bit
         )
 
         bnb_config = None
@@ -2439,11 +2457,11 @@ class FastLlamaModel:
                 # we cannot quantize out_proj layer due to mamba kernels: https://github.com/tiiuae/Falcon-H1/issues/13#issuecomment-2918671274
                 llm_int8_skip_modules.append("out_proj")
             bnb_config = BitsAndBytesConfig(
-                load_in_4bit = True,
-                bnb_4bit_use_double_quant = True,
-                bnb_4bit_quant_type = "nf4",
-                bnb_4bit_compute_dtype = dtype,
-                llm_int8_skip_modules = llm_int8_skip_modules,
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=dtype,
+                llm_int8_skip_modules=llm_int8_skip_modules,
             )
             # Pre-quantized checkpoints (e.g. unsloth/Qwen3-4B-bnb-4bit) use the
             # quantization_config baked into config.json, ignoring our runtime
@@ -2492,13 +2510,13 @@ class FastLlamaModel:
                     setattr(model_config, _cfg_key, _cfg_val)
             model = AutoModelForSequenceClassification.from_pretrained(
                 model_name,
-                config = model_config,
-                device_map = device_map,
+                config=model_config,
+                device_map=device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token = token,
-                trust_remote_code = trust_remote_code,
-                attn_implementation = preferred_attn_impl,
+                token=token,
+                trust_remote_code=trust_remote_code,
+                attn_implementation=preferred_attn_impl,
                 **kwargs,
             )
             # Defensive: ensure the task head is in a floating dtype, guarding
@@ -2516,21 +2534,21 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = kwargs.get("load_in_8bit", False),
-                offload_embedding = False,
-                fast_inference = fast_inference,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=kwargs.get("load_in_8bit", False),
+                offload_embedding=False,
+                fast_inference=fast_inference,
             )
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(
                 model_name,
-                device_map = device_map,
+                device_map=device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token = token,
-                max_position_embeddings = max_position_embeddings,
-                trust_remote_code = trust_remote_code,
-                attn_implementation = preferred_attn_impl,
+                token=token,
+                max_position_embeddings=max_position_embeddings,
+                trust_remote_code=trust_remote_code,
+                attn_implementation=preferred_attn_impl,
                 **kwargs,
             )
             # Attach dispatch hooks for bnb multi-device loads.
@@ -2538,10 +2556,10 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = kwargs.get("load_in_8bit", False),
-                offload_embedding = False,
-                fast_inference = False,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=kwargs.get("load_in_8bit", False),
+                offload_embedding=False,
+                fast_inference=False,
             )
             model.fast_generate = make_fast_generate_wrapper(model.generate)
             model.fast_generate_batches = None
@@ -2562,18 +2580,18 @@ class FastLlamaModel:
 
             allowed_args = inspect.getfullargspec(load_vllm).args
             load_vllm_kwargs = dict(
-                model_name = model_name,
-                config = model_config,
-                gpu_memory_utilization = gpu_memory_utilization,
-                max_seq_length = max_seq_length,
-                dtype = dtype,
-                float8_kv_cache = float8_kv_cache,
-                enable_lora = True,
-                max_lora_rank = max_lora_rank,
-                disable_log_stats = disable_log_stats,
-                use_bitsandbytes = load_in_4bit,
-                unsloth_vllm_standby = unsloth_vllm_standby,
-                fp8_mode = fp8_mode,
+                model_name=model_name,
+                config=model_config,
+                gpu_memory_utilization=gpu_memory_utilization,
+                max_seq_length=max_seq_length,
+                dtype=dtype,
+                float8_kv_cache=float8_kv_cache,
+                enable_lora=True,
+                max_lora_rank=max_lora_rank,
+                disable_log_stats=disable_log_stats,
+                use_bitsandbytes=load_in_4bit,
+                unsloth_vllm_standby=unsloth_vllm_standby,
+                fp8_mode=fp8_mode,
             )
             for allowed_arg in allowed_args:
                 if allowed_arg not in load_vllm_kwargs and allowed_arg in kwargs:
@@ -2586,8 +2604,8 @@ class FastLlamaModel:
             # Convert to HF format
             _, quant_state_dict = get_vllm_state_dict(
                 llm,
-                config = model_config,
-                load_in_fp8 = load_in_fp8,
+                config=model_config,
+                load_in_fp8=load_in_fp8,
             )
             model = convert_vllm_to_huggingface(quant_state_dict, model_config, dtype, bnb_config)
             model.vllm_engine = llm
@@ -2601,16 +2619,16 @@ class FastLlamaModel:
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name
         tokenizer = load_correct_tokenizer(
-            tokenizer_name = tokenizer_name,
-            model_max_length = max_position_embeddings,
-            padding_side = "right",
-            token = token,
-            trust_remote_code = trust_remote_code,
-            fix_tokenizer = fix_tokenizer,
+            tokenizer_name=tokenizer_name,
+            model_max_length=max_position_embeddings,
+            padding_side="right",
+            token=token,
+            trust_remote_code=trust_remote_code,
+            fix_tokenizer=fix_tokenizer,
         )
 
         model, tokenizer = patch_tokenizer(model, tokenizer)
-        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype = dtype)
+        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype=dtype)
 
         # Patch up QKV / O and MLP
         for idx, layer in enumerate(model.model.layers):
@@ -2681,7 +2699,7 @@ class FastLlamaModel:
 
         front_spaces = re.match(r"[\t\s]{1,}", inner_training_loop).group(0)
         inner_training_loop = re.sub(
-            r"^" + front_spaces, "", inner_training_loop, flags = re.MULTILINE
+            r"^" + front_spaces, "", inner_training_loop, flags=re.MULTILINE
         )
         inner_training_loop = inner_training_loop.replace(
             "train_dataloader = tpu_spmd_dataloader(train_dataloader)",
@@ -2713,12 +2731,12 @@ class FastLlamaModel:
         # We check the tokenizer first for errors
         if fix_tokenizer:
             tokenizer = check_tokenizer(
-                model = model,
-                tokenizer = tokenizer,
-                model_name = model_name,
-                model_max_length = max_position_embeddings,
-                padding_side = "right",
-                token = token,
+                model=model,
+                tokenizer=tokenizer,
+                model_name=model_name,
+                model_max_length=max_position_embeddings,
+                padding_side="right",
+                token=token,
             )
         patch_saving_functions(tokenizer)
 
@@ -2805,18 +2823,18 @@ class FastLlamaModel:
     def post_patch(
         model,
         tokenizer,
-        correct_dtype = None,
+        correct_dtype=None,
     ):
         model, tokenizer = patch_model_and_tokenizer(
-            model, tokenizer, downcast_rope = True, correct_dtype = correct_dtype
+            model, tokenizer, downcast_rope=True, correct_dtype=correct_dtype
         )
         return model, tokenizer
 
     @staticmethod
     def get_peft_model(
         model,
-        r = 16,
-        target_modules = [
+        r=16,
+        target_modules=[
             "q_proj",
             "k_proj",
             "v_proj",
@@ -2825,23 +2843,23 @@ class FastLlamaModel:
             "up_proj",
             "down_proj",
         ],
-        lora_alpha = 16,
-        lora_dropout = 0.0,
-        bias = "none",
-        layers_to_transform = None,
-        layers_pattern = None,
-        finetune_last_n_layers = None,
-        use_gradient_checkpointing = "unsloth",
-        random_state = 3407,
-        max_seq_length = 2048,  # not used anymore
-        use_rslora = False,
-        modules_to_save = None,
-        init_lora_weights = True,
-        loftq_config = {},
-        temporary_location = "_unsloth_temporary_saved_buffers",
-        qat_scheme = None,
-        target_parameters = None,  # For MoE expert layers (nn.Parameter)
-        ensure_weight_tying = False,
+        lora_alpha=16,
+        lora_dropout=0.0,
+        bias="none",
+        layers_to_transform=None,
+        layers_pattern=None,
+        finetune_last_n_layers=None,
+        use_gradient_checkpointing="unsloth",
+        random_state=3407,
+        max_seq_length=2048,  # not used anymore
+        use_rslora=False,
+        modules_to_save=None,
+        init_lora_weights=True,
+        loftq_config={},
+        temporary_location="_unsloth_temporary_saved_buffers",
+        qat_scheme=None,
+        target_parameters=None,  # For MoE expert layers (nn.Parameter)
+        ensure_weight_tying=False,
         **kwargs,
     ):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
@@ -2855,25 +2873,25 @@ class FastLlamaModel:
                 if peft_arg not in kwargs:
                     kwargs[peft_arg] = flag
             return FastBaseModel.get_peft_model(
-                model = model,
-                r = r,
-                target_modules = target_modules,
-                lora_alpha = lora_alpha,
-                lora_dropout = lora_dropout,
-                bias = bias,
-                layers_to_transform = layers_to_transform,
-                layers_pattern = layers_pattern,
-                finetune_last_n_layers = finetune_last_n_layers,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                random_state = random_state,
-                max_seq_length = max_seq_length,
-                use_rslora = use_rslora,
-                modules_to_save = modules_to_save,
-                init_lora_weights = init_lora_weights,
-                loftq_config = loftq_config,
-                temporary_location = temporary_location,
-                target_parameters = target_parameters,
-                ensure_weight_tying = ensure_weight_tying,
+                model=model,
+                r=r,
+                target_modules=target_modules,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                bias=bias,
+                layers_to_transform=layers_to_transform,
+                layers_pattern=layers_pattern,
+                finetune_last_n_layers=finetune_last_n_layers,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                random_state=random_state,
+                max_seq_length=max_seq_length,
+                use_rslora=use_rslora,
+                modules_to_save=modules_to_save,
+                init_lora_weights=init_lora_weights,
+                loftq_config=loftq_config,
+                temporary_location=temporary_location,
+                target_parameters=target_parameters,
+                ensure_weight_tying=ensure_weight_tying,
                 **kwargs,
             )
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
@@ -2994,6 +3012,7 @@ class FastLlamaModel:
         if init_lora_weights == "loftq":
             if not SUPPORTS_LOFTQ:
                 import peft
+
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support LoftQ init.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3002,11 +3021,12 @@ class FastLlamaModel:
 
             if loftq_config == {}:
                 from peft import LoftQConfig
+
                 logger.warning_once(
                     "Unsloth: init_lora_weights = `loftq` is set, but `loftq_config` is None.\n"
                     "We shall use `loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)`."
                 )
-                loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)
+                loftq_config = LoftQConfig(loftq_bits=4, loftq_iter=1)
 
             if hasattr(model.config, "quantization_config"):
                 raise ValueError(
@@ -3019,6 +3039,7 @@ class FastLlamaModel:
             if not SUPPORTS_RSLORA:
                 # We manually check for PEFT
                 import peft
+
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support `use_rslora`.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3147,25 +3168,26 @@ class FastLlamaModel:
 
         if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers
+
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:
                 _n = max(1, min(int(finetune_last_n_layers), _total_layers))
                 layers_to_transform = list(range(_total_layers - _n, _total_layers))
 
         arguments = dict(
-            r = r,
-            lora_alpha = lora_alpha,
-            target_modules = final_modules,
-            lora_dropout = lora_dropout,
-            bias = bias,
-            task_type = TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
-            layers_to_transform = layers_to_transform,
-            init_lora_weights = init_lora_weights,
-            loftq_config = loftq_config,
-            use_rslora = use_rslora,
-            modules_to_save = modules_to_save,
-            target_parameters = target_parameters,
-            ensure_weight_tying = ensure_weight_tying,
+            r=r,
+            lora_alpha=lora_alpha,
+            target_modules=final_modules,
+            lora_dropout=lora_dropout,
+            bias=bias,
+            task_type=TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
+            layers_to_transform=layers_to_transform,
+            init_lora_weights=init_lora_weights,
+            loftq_config=loftq_config,
+            use_rslora=use_rslora,
+            modules_to_save=modules_to_save,
+            target_parameters=target_parameters,
+            ensure_weight_tying=ensure_weight_tying,
             **kwargs,
         )
         if not SUPPORTS_LOFTQ:
@@ -3269,7 +3291,7 @@ class FastLlamaModel:
             assert hasattr(model.get_input_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
             )
 
         if train_lm_head:
@@ -3277,7 +3299,7 @@ class FastLlamaModel:
             assert hasattr(model.get_output_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
             )
 
         # Patch tokenizer to pad to the right
@@ -3311,11 +3333,11 @@ class FastLlamaModel:
         return model
 
     @staticmethod
-    def patch_peft_model(model, use_gradient_checkpointing = "unsloth"):
+    def patch_peft_model(model, use_gradient_checkpointing="unsloth"):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
             return FastBaseModel.patch_peft_model(
-                model = model,
-                use_gradient_checkpointing = use_gradient_checkpointing,
+                model=model,
+                use_gradient_checkpointing=use_gradient_checkpointing,
             )
         if not isinstance(model, PeftModelForCausalLM) and not isinstance(
             model, PeftModelForSequenceClassification
@@ -3350,8 +3372,8 @@ class FastLlamaModel:
 
         model = prepare_model_for_kbit_training(
             model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
-            use_reentrant = True,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            use_reentrant=True,
         )
 
         # Fix up config for transformers uploading PEFT
@@ -3397,7 +3419,7 @@ class FastLlamaModel:
 
         # We also do not inplace edit QKV for Cohere!
         _apply_lora_mlp = (
-            functools.partial(apply_lora_mlp, inplace = False)
+            functools.partial(apply_lora_mlp, inplace=False)
             if model_type == "cohere"
             else apply_lora_mlp
         )
@@ -3571,13 +3593,14 @@ class FastLlamaModel:
         # for gradient checkpointing (older unsloth_zoo has no restore helper)
         try:
             from unsloth_zoo.training_utils import restore_use_cache
+
             restore_use_cache(model)
         except ImportError:
             pass
         return model
 
     @staticmethod
-    def for_training(model, use_gradient_checkpointing = True):
+    def for_training(model, use_gradient_checkpointing=True):
         if not hasattr(model, "parameters"):
             raise TypeError(
                 "Unsloth: I think you're passing a tokenizer, not the model to for_training!"
@@ -3630,6 +3653,7 @@ class FastLlamaModel:
         ):
             try:
                 from unsloth_zoo.training_utils import disable_use_cache
+
                 disable_use_cache(model)
             except ImportError:
                 pass
@@ -3638,4 +3662,4 @@ class FastLlamaModel:
 
 from .rl import PatchFastRL
 
-PatchFastRL(FastLanguageModel = FastLlamaModel)
+PatchFastRL(FastLanguageModel=FastLlamaModel)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -172,12 +172,12 @@ def _offload_frozen_module_for_training(
         # Tesla T4 must use float32 and not float16
         new_dtype = torch.float32
 
-    module.modules_to_save.default.to(device=device_type, dtype=new_dtype, non_blocking=True)
+    module.modules_to_save.default.to(device = device_type, dtype = new_dtype, non_blocking = True)
     module.modules_to_save.default.requires_grad_(True)
 
     # [TODO] Move old module to CPU - should be disk!
     if offload_device is not None:
-        module.original_module.to(device=offload_device, non_blocking=True)
+        module.original_module.to(device = offload_device, non_blocking = True)
     module.original_module.requires_grad_(False)
 
 
@@ -185,8 +185,8 @@ def _offload_frozen_module_for_training(
 def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
-    attention_mask=None,
-    inputs_embeds=None,
+    attention_mask = None,
+    inputs_embeds = None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -249,8 +249,8 @@ def _fast_prepare_inputs_for_generation(
                 kwargs["cache_position"] = torch.arange(
                     past_len,
                     past_len + seq_length,
-                    device=device,
-                    dtype=torch.long,
+                    device = device,
+                    dtype = torch.long,
                 )
             else:
                 if hasattr(cache_position, "device") and cache_position.device != device:
@@ -346,9 +346,9 @@ def LlamaAttention_fast_forward_inference(
     hidden_states: torch.Tensor,
     past_key_value: Optional[Tuple[torch.Tensor]],
     position_ids,
-    do_prefill=False,
-    attention_mask=None,
-    rotary_seq_len=None,
+    do_prefill = False,
+    attention_mask = None,
+    rotary_seq_len = None,
 ):
     """
     https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L406
@@ -400,25 +400,25 @@ def LlamaAttention_fast_forward_inference(
     if do_prefill:
         self.paged_attention = torch.empty(
             (KV_CACHE_INCREMENT + seq_len + 1, 2, bsz, n_kv_heads, head_dim),
-            dtype=dtype,
-            device=device,
+            dtype = dtype,
+            device = device,
         )
         self.paged_attention_K = self.paged_attention[:, 0]
         self.paged_attention_V = self.paged_attention[:, 1]
         self.paged_attention_K[:seq_len] = K1.permute(2, 0, 1, 3)
         self.paged_attention_V[:seq_len] = V1.permute(2, 0, 1, 3)
-        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype=dtype, device=device)
-        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype=dtype, device=device)
-        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype=dtype, device=device)
+        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype = dtype, device = device)
+        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype = dtype, device = device)
+        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype=dtype, device=device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 
         self.attention = torch.empty(
-            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype=dtype, device=device
+            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
         )
         self.scalar = 1.0 / math_sqrt(self.head_dim)
         self.half_head_dim = head_dim // 2
@@ -436,9 +436,9 @@ def LlamaAttention_fast_forward_inference(
         self.paged_attention_V = self.paged_attention[:, 1]
         self.attention.resize_((bsz, n_heads, 1, self.attention.shape[-1] + KV_CACHE_INCREMENT))
 
-    Qn = fast_linear_forward(self.q_proj, Xn, out=self.temp_QA[0])
-    Kn = fast_linear_forward(self.k_proj, Xn, out=self.temp_KV[0])
-    Vn = fast_linear_forward(self.v_proj, Xn, out=self.temp_KV[1])
+    Qn = fast_linear_forward(self.q_proj, Xn, out = self.temp_QA[0])
+    Kn = fast_linear_forward(self.k_proj, Xn, out = self.temp_KV[0])
+    Vn = fast_linear_forward(self.v_proj, Xn, out = self.temp_KV[1])
     Qn = Qn.view(bsz, 1, n_heads, head_dim).transpose(1, 2)
     Kn = Kn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
     Vn = Vn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
@@ -461,8 +461,8 @@ def LlamaAttention_fast_forward_inference(
     self.rotary_emb.extend_rope_embedding(Vn, rotary_seq_len + 1)  # +1 slack
     cos, sin = self.rotary_emb.get_cached(rotary_seq_len, Qn.device.index or 0)
 
-    cos = cos[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
-    sin = sin[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
+    cos = cos[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
+    sin = sin[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
 
     h = self.half_head_dim
 
@@ -523,9 +523,9 @@ def LlamaAttention_fast_forward_inference(
             self.scalar
         )  # See https://github.com/ggerganov/llama.cpp/issues/7805#issuecomment-2153349963
         # It seems like doing (Q * scalar) @ K is better than (Q @ K) * scalar to stop overflows
-        A = torch_matmul(Qn, Knn.transpose(2, 3), out=self.attention[:, :, :, :cached_len])
-        A[:] = torch_nn_functional_softmax(A, dim=-1, dtype=torch.float32)  # .to(A.dtype)
-        A = torch_matmul(A, Vnn, out=Qn)
+        A = torch_matmul(Qn, Knn.transpose(2, 3), out = self.attention[:, :, :, :cached_len])
+        A[:] = torch_nn_functional_softmax(A, dim = -1, dtype = torch.float32)  # .to(A.dtype)
+        A = torch_matmul(A, Vnn, out = Qn)
     # --- attention_mask fixup for SDPA if user passes 2D padding mask
     else:
         if attention_mask is not None and attention_mask.dim() == 2:
@@ -544,17 +544,17 @@ def LlamaAttention_fast_forward_inference(
                 Qn,
                 Knn,
                 Vnn,
-                attn_mask=attention_mask,
-                is_causal=is_causal,
-                enable_gqa=True,
+                attn_mask = attention_mask,
+                is_causal = is_causal,
+                enable_gqa = True,
             )
         else:
             A = scaled_dot_product_attention(
-                Qn, Knn, Vnn, attn_mask=attention_mask, is_causal=is_causal
+                Qn, Knn, Vnn, attn_mask = attention_mask, is_causal = is_causal
             )
     A = A.transpose(1, 2)
     A = A.reshape(bsz, 1, attention_size)
-    A = fast_linear_forward(self.o_proj, A, out=self.temp_O)
+    A = fast_linear_forward(self.o_proj, A, out = self.temp_O)
     return A, (Kn, Vn)
 
 
@@ -564,10 +564,10 @@ torch_nn_functional_silu = torch.nn.functional.silu
 def fast_swiglu_inference(
     self,
     X,
-    temp_gate=None,
-    temp_up=None,
-    gate_multiplier=None,
-    down_multiplier=None,
+    temp_gate = None,
+    temp_up = None,
+    gate_multiplier = None,
+    down_multiplier = None,
 ):
     # gate = self.gate_proj(X)
     # up   = self.up_proj(X)
@@ -575,18 +575,18 @@ def fast_swiglu_inference(
     # mlp_size = self.config.intermediate_size
     # temp = torch.empty((2, bsz, 1, mlp_size), dtype = X.dtype, device = "cuda:0")
 
-    gate = fast_linear_forward(self.gate_proj, X, out=temp_gate)
+    gate = fast_linear_forward(self.gate_proj, X, out = temp_gate)
 
     if gate_multiplier is not None:
         gate *= gate_multiplier
 
-    up = fast_linear_forward(self.up_proj, X, out=temp_up)
+    up = fast_linear_forward(self.up_proj, X, out = temp_up)
 
-    gate = torch_nn_functional_silu(gate, inplace=True)
+    gate = torch_nn_functional_silu(gate, inplace = True)
     gate *= up
 
     # X = self.down_proj(gate)
-    down = fast_linear_forward(self.down_proj, gate, out=up[:, :, :hd])
+    down = fast_linear_forward(self.down_proj, gate, out = up[:, :, :hd])
 
     if down_multiplier is not None:
         down *= down_multiplier
@@ -601,17 +601,17 @@ torch_mean = torch.mean
 def fast_rms_layernorm_inference(
     self,
     X,
-    XX=None,
-    XX2=None,
-    variance=None,
+    XX = None,
+    XX2 = None,
+    variance = None,
 ):
     old_dtype = X.dtype
     if XX is None:
         XX = X.to(torch.float32)
-        variance = XX.square().mean(-1, keepdim=True)
+        variance = XX.square().mean(-1, keepdim = True)
     else:
         XX.copy_(X)
-        torch_mean(torch_square(XX, out=XX2), -1, keepdim=True, out=variance)
+        torch_mean(torch_square(XX, out = XX2), -1, keepdim = True, out = variance)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -627,10 +627,10 @@ def fast_rms_layernorm_inference(
 def fast_rms_layernorm_inference_gemma(
     self,
     X,
-    out_weight=None,
+    out_weight = None,
 ):
     XX = X.to(torch.float32)
-    variance = XX.square().mean(-1, keepdim=True)
+    variance = XX.square().mean(-1, keepdim = True)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -645,15 +645,15 @@ def fast_rms_layernorm_inference_gemma(
 
 
 # Normal layernorm with mean removal
-@torch.compile(fullgraph=False, dynamic=True, options=torch_compile_options)
+@torch.compile(fullgraph = False, dynamic = True, options = torch_compile_options)
 def fast_layernorm_compiled(layernorm, X):
     old_dtype = X.dtype
     X = X.float()
-    mean = X.mean(-1, keepdim=True)
+    mean = X.mean(-1, keepdim = True)
     Xbar = X - mean
     X = (
         Xbar
-        * torch.rsqrt(Xbar.square().mean(-1, keepdim=True) + layernorm.variance_epsilon)
+        * torch.rsqrt(Xbar.square().mean(-1, keepdim = True) + layernorm.variance_epsilon)
         * layernorm.weight.float()
     )
     return X.to(old_dtype)
@@ -705,10 +705,10 @@ def LlamaAttention_fast_forward(
         cos, sin = position_embeddings
     else:
         rotary_emb = self.rotary_emb
-        rotary_emb.extend_rope_embedding(V, seq_len=kv_seq_len)
+        rotary_emb.extend_rope_embedding(V, seq_len = kv_seq_len)
         cos, sin = rotary_emb.get_cached(kv_seq_len, Q.device.index)
-        cos = cos.to(device=Q.device, dtype=Q.dtype)
-        sin = sin.to(device=Q.device, dtype=Q.dtype)
+        cos = cos.to(device = Q.device, dtype = Q.dtype)
+        sin = sin.to(device = Q.device, dtype = Q.dtype)
 
     rope_position_ids = position_ids
     if rope_position_ids is None and seq_info is not None:
@@ -722,8 +722,8 @@ def LlamaAttention_fast_forward(
     Q, K = fast_rope_embedding(Q, K, cos, sin, rope_position_ids)
 
     if past_key_value is not None:
-        K = torch.cat([past_key_value[0], K], dim=2)
-        V = torch.cat([past_key_value[1], V], dim=2)
+        K = torch.cat([past_key_value[0], K], dim = 2)
+        V = torch.cat([past_key_value[1], V], dim = 2)
     past_key_value = (K, V) if use_cache else None
 
     # Attention module
@@ -732,25 +732,25 @@ def LlamaAttention_fast_forward(
 
     # should dropout be hardcoded to 0.0?
     config = AttentionConfig(
-        backend=backend,
-        n_kv_heads=n_kv_heads,
-        n_groups=n_groups,
-        flash_dense_kwargs={"causal": True},
-        flash_varlen_kwargs={"dropout_p": 0.0, "causal": True},
+        backend = backend,
+        n_kv_heads = n_kv_heads,
+        n_groups = n_groups,
+        flash_dense_kwargs = {"causal": True},
+        flash_varlen_kwargs = {"dropout_p": 0.0, "causal": True},
     )
     context = AttentionContext(
-        bsz=bsz,
-        q_len=q_len,
-        kv_seq_len=kv_seq_len,
-        n_heads=n_heads,
-        head_dim=head_dim,
-        requires_grad=hidden_states.requires_grad,
-        seq_info=seq_info,
-        attention_mask=attention_mask,
-        causal_mask=causal_mask,
+        bsz = bsz,
+        q_len = q_len,
+        kv_seq_len = kv_seq_len,
+        n_heads = n_heads,
+        head_dim = head_dim,
+        requires_grad = hidden_states.requires_grad,
+        seq_info = seq_info,
+        attention_mask = attention_mask,
+        causal_mask = causal_mask,
     )
 
-    A = run_attention(config=config, context=context, Q=Q, K=K, V=V)
+    A = run_attention(config = config, context = context, Q = Q, K = K, V = V)
     attn_output = A.reshape(bsz, q_len, n_heads * head_dim)
     attn_output = self.apply_o(self, attn_output)
     attn_weights = None
@@ -761,7 +761,7 @@ def LlamaAttention_fast_forward(
 def LlamaDecoderLayer_fast_forward(
     self,
     hidden_states: torch.Tensor,
-    causal_mask=None,
+    causal_mask = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
     past_key_value: Optional[Tuple[torch.Tensor]] = None,
@@ -789,15 +789,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states=hidden_states,
-            causal_mask=causal_mask,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_value=past_key_value,
-            output_attentions=output_attentions,
-            use_cache=use_cache,
-            padding_mask=padding_mask,
-            position_embeddings=position_embeddings,
+            hidden_states = hidden_states,
+            causal_mask = causal_mask,
+            attention_mask = attention_mask,
+            position_ids = position_ids,
+            past_key_value = past_key_value,
+            output_attentions = output_attentions,
+            use_cache = use_cache,
+            padding_mask = padding_mask,
+            position_embeddings = position_embeddings,
             **kwargs,
         )
         hidden_states += residual
@@ -811,15 +811,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states=hidden_states,
-            causal_mask=causal_mask,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_value=past_key_value,
-            output_attentions=output_attentions,
-            use_cache=use_cache,
-            padding_mask=padding_mask,
-            position_embeddings=position_embeddings,
+            hidden_states = hidden_states,
+            causal_mask = causal_mask,
+            attention_mask = attention_mask,
+            position_ids = position_ids,
+            past_key_value = past_key_value,
+            output_attentions = output_attentions,
+            use_cache = use_cache,
+            padding_mask = padding_mask,
+            position_embeddings = position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -923,8 +923,8 @@ def LlamaModel_fast_forward(
         position_ids = torch.arange(
             past_key_values_length,
             seq_length + past_key_values_length,
-            dtype=torch.int32,
-            device=f"{DEVICE_TYPE_TORCH}:0",
+            dtype = torch.int32,
+            device = f"{DEVICE_TYPE_TORCH}:0",
         )
         position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
     elif position_ids is not None:
@@ -956,7 +956,7 @@ def LlamaModel_fast_forward(
         # inputs_embeds *= math_sqrt(self.config.hidden_size)
         # Ie 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
         # &  2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
-        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype=inputs_embeds.dtype)
+        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype = inputs_embeds.dtype)
 
         if train_embed_tokens:
             # Careful we must not do an inplace op!
@@ -1013,7 +1013,7 @@ def LlamaModel_fast_forward(
             (batch_size, seq_length),
             inputs_embeds,
             past_key_values_length,
-            sliding_window=getattr(self.config, "sliding_window", None),
+            sliding_window = getattr(self.config, "sliding_window", None),
         )
         # Must NOT convert to bool - weirdly this causes stuff to error out!
         # if attention_mask is not None:
@@ -1068,14 +1068,14 @@ def LlamaModel_fast_forward(
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window=self.config.sliding_window,
+                sliding_window = self.config.sliding_window,
             )
             dynamic_GA_mask = _prepare_4d_causal_attention_mask_for_sdpa(
                 attention_mask,
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window=None,
+                sliding_window = None,
             )
             use_static_mask = False
 
@@ -1095,15 +1095,15 @@ def LlamaModel_fast_forward(
 
                 self.SWA_mask = (
                     AttentionMaskConverter(
-                        is_causal=True,
-                        sliding_window=self.config.sliding_window,
+                        is_causal = True,
+                        sliding_window = self.config.sliding_window,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype=inputs_embeds.dtype,
-                        device=DEVICE_TYPE_TORCH,
+                        dtype = inputs_embeds.dtype,
+                        device = DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1111,14 +1111,14 @@ def LlamaModel_fast_forward(
 
                 self.GA_mask = (
                     AttentionMaskConverter(
-                        is_causal=True,
+                        is_causal = True,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype=inputs_embeds.dtype,
-                        device=DEVICE_TYPE_TORCH,
+                        dtype = inputs_embeds.dtype,
+                        device = DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1161,8 +1161,8 @@ def LlamaModel_fast_forward(
                         *inputs,
                         past_key_value,
                         output_attentions,
-                        padding_mask=padding_mask,
-                        position_embeddings=position_embeddings,
+                        padding_mask = padding_mask,
+                        position_embeddings = position_embeddings,
                         **kwargs,
                     )
 
@@ -1174,22 +1174,22 @@ def LlamaModel_fast_forward(
                 mask,
                 attention_mask,
                 position_ids,
-                use_reentrant=True,
-                preserve_rng_state=False,
+                use_reentrant = True,
+                preserve_rng_state = False,
             )
             hidden_states = layer_outputs[0]
 
         else:
             layer_outputs = decoder_layer(
                 hidden_states,
-                causal_mask=mask,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_value=past_key_value,
-                output_attentions=output_attentions,
-                use_cache=use_cache,
-                padding_mask=padding_mask,
-                position_embeddings=position_embeddings,
+                causal_mask = mask,
+                attention_mask = attention_mask,
+                position_ids = position_ids,
+                past_key_value = past_key_value,
+                output_attentions = output_attentions,
+                use_cache = use_cache,
+                padding_mask = padding_mask,
+                position_embeddings = position_embeddings,
                 **kwargs,
             )
             hidden_states = layer_outputs[0]
@@ -1210,9 +1210,9 @@ def LlamaModel_fast_forward(
     elif IS_COHERE:
         hidden_states = self.norm(hidden_states)
     elif IS_FALCON_H1:
-        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma=IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma = IS_GEMMA)
     else:
-        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma=IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma = IS_GEMMA)
 
     if output_hidden_states:
         all_hidden_states += (hidden_states,)
@@ -1225,17 +1225,17 @@ def LlamaModel_fast_forward(
             if v is not None
         )
     return BaseModelOutputWithPast(
-        last_hidden_state=hidden_states,
-        past_key_values=next_cache,
-        hidden_states=all_hidden_states,
-        attentions=all_self_attns,
+        last_hidden_state = hidden_states,
+        past_key_values = next_cache,
+        hidden_states = all_hidden_states,
+        attentions = all_self_attns,
     )
 
 
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L825
 def _LlamaModel_fast_forward_inference(
-    attention_fast_forward_inference=LlamaAttention_fast_forward_inference,
-    mlp_fast_forward_inference=fast_swiglu_inference,
+    attention_fast_forward_inference = LlamaAttention_fast_forward_inference,
+    mlp_fast_forward_inference = fast_swiglu_inference,
 ):
     # Makes attention and MLP customisable for models like qwen3/cohere.
     def LlamaModel_fast_forward_inference_custom(
@@ -1243,7 +1243,7 @@ def _LlamaModel_fast_forward_inference(
         input_ids,
         past_key_values,
         position_ids,
-        attention_mask=None,
+        attention_mask = None,
         **kwargs,
     ):
         input_ids = input_ids[:, : self.max_seq_length]
@@ -1257,15 +1257,15 @@ def _LlamaModel_fast_forward_inference(
         assert q_len == 1
         # Get saved buffers to reduce memory movement
         residual = torch.empty(
-            (bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
         )
-        _XX = torch.empty((2, bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0")
+        _XX = torch.empty((2, bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0")
         XX, XX2 = _XX[0], _XX[1]
         variance = torch.empty(
-            (bsz, q_len, 1), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, 1), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_mlp = torch.empty(
-            (2, bsz, 1, mlp_size), dtype=X.dtype, device=f"{DEVICE_TYPE_TORCH}:0"
+            (2, bsz, 1, mlp_size), dtype = X.dtype, device = f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_gates, temp_ups = (
             tuple(temp_mlp[0].to(torch.device(x)) for x in range(DEVICE_COUNT)),
@@ -1280,7 +1280,7 @@ def _LlamaModel_fast_forward_inference(
                 (bsz, q_len),
                 X,
                 seq_len,
-                sliding_window=getattr(self.config, "sliding_window", None),
+                sliding_window = getattr(self.config, "sliding_window", None),
             )
             # Pre-convert to bool once for all layers (avoids per-layer .eq(0))
             if attention_mask is not None and attention_mask.dtype != torch.bool:
@@ -1300,18 +1300,18 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.input_layernorm,
                 X,
-                XX=XX,
-                XX2=XX2,
-                variance=variance,
+                XX = XX,
+                XX2 = XX2,
+                variance = variance,
             )
             X, present_key_value = attention_fast_forward_inference(
                 decoder_layer.self_attn,
-                hidden_states=X,
-                past_key_value=past_key_values[idx],
-                position_ids=position_ids,
-                attention_mask=attention_mask,
-                do_prefill=not hasattr(decoder_layer.self_attn, "paged_attention"),
-                rotary_seq_len=rotary_seq_len,
+                hidden_states = X,
+                past_key_value = past_key_values[idx],
+                position_ids = position_ids,
+                attention_mask = attention_mask,
+                do_prefill = not hasattr(decoder_layer.self_attn, "paged_attention"),
+                rotary_seq_len = rotary_seq_len,
             )
             X += residual
 
@@ -1319,15 +1319,15 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.post_attention_layernorm,
                 X,
-                XX=XX,
-                XX2=XX2,
-                variance=variance,
+                XX = XX,
+                XX2 = XX2,
+                variance = variance,
             )
             X = mlp_fast_forward_inference(
                 decoder_layer.mlp,
                 X,
-                temp_gate=temp_gates[device_index],
-                temp_up=temp_ups[device_index],
+                temp_gate = temp_gates[device_index],
+                temp_up = temp_ups[device_index],
             )
             X += residual
 
@@ -1335,16 +1335,16 @@ def _LlamaModel_fast_forward_inference(
         X = fast_rms_layernorm_inference(
             self.model.norm,
             X,
-            XX=XX,
-            XX2=XX2,
-            variance=variance,
+            XX = XX,
+            XX2 = XX2,
+            variance = variance,
         )
 
         return BaseModelOutputWithPast(
-            last_hidden_state=X,
-            past_key_values=next_decoder_cache,
-            hidden_states=[],
-            attentions=[],
+            last_hidden_state = X,
+            past_key_values = next_decoder_cache,
+            hidden_states = [],
+            attentions = [],
         )
 
     return LlamaModel_fast_forward_inference_custom
@@ -1378,8 +1378,8 @@ def CausalLM_fast_forward(fast_forward_inference):
                 self,
                 input_ids,
                 past_key_values,
-                position_ids=position_ids,
-                attention_mask=attention_mask,
+                position_ids = position_ids,
+                attention_mask = attention_mask,
                 **kwargs,
             )
         else:
@@ -1399,16 +1399,16 @@ def CausalLM_fast_forward(fast_forward_inference):
             # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
             self.model._has_no_labels = labels is None
             outputs = self.model(
-                input_ids=input_ids,
-                causal_mask=causal_mask,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_values=past_key_values,
-                inputs_embeds=inputs_embeds,
-                use_cache=use_cache,
-                output_attentions=output_attentions,
-                output_hidden_states=output_hidden_states,
-                return_dict=return_dict,
+                input_ids = input_ids,
+                causal_mask = causal_mask,
+                attention_mask = attention_mask,
+                position_ids = position_ids,
+                past_key_values = past_key_values,
+                inputs_embeds = inputs_embeds,
+                use_cache = use_cache,
+                output_attentions = output_attentions,
+                output_hidden_states = output_hidden_states,
+                return_dict = return_dict,
                 **kwargs,
             )
         hidden_states = outputs[0]
@@ -1436,11 +1436,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if num_logits_to_keep != 0:
                 hidden_states = hidden_states[:, -num_logits_to_keep:, :]
             return CausalLMOutputWithPast(
-                loss=None,
-                logits=hidden_states,
-                past_key_values=outputs.past_key_values,
-                hidden_states=outputs.hidden_states,
-                attentions=outputs.attentions,
+                loss = None,
+                logits = hidden_states,
+                past_key_values = outputs.past_key_values,
+                hidden_states = outputs.hidden_states,
+                attentions = outputs.attentions,
             )
 
         if bsz == 1 and q_len == 1:
@@ -1473,28 +1473,28 @@ def CausalLM_fast_forward(fast_forward_inference):
                 #     logit_softcapping  = logit_softcapping,
                 # )
                 loss = unsloth_fused_ce_loss(
-                    trainer=None,
-                    hidden_states=hidden_states,
-                    lm_head_weight=lm_head,
-                    lm_head_bias=None,
-                    labels=labels,
-                    mask=None,
-                    n_items=n_items,
-                    scaling=getattr(self, "accelerator_scaler", None),
-                    target_gb=None,
-                    torch_compile=True,
-                    logit_softcapping=logit_softcapping,
+                    trainer = None,
+                    hidden_states = hidden_states,
+                    lm_head_weight = lm_head,
+                    lm_head_bias = None,
+                    labels = labels,
+                    mask = None,
+                    n_items = n_items,
+                    scaling = getattr(self, "accelerator_scaler", None),
+                    target_gb = None,
+                    torch_compile = True,
+                    logit_softcapping = logit_softcapping,
                 )
                 if not return_dict:
                     output = (logits,) + outputs[1:]
                     return (loss,) + output if loss is not None else output
 
                 output = CausalLMOutputWithPast(
-                    loss=loss,
-                    logits=EMPTY_LOGITS,
-                    past_key_values=outputs.past_key_values,
-                    hidden_states=outputs.hidden_states,
-                    attentions=outputs.attentions,
+                    loss = loss,
+                    logits = EMPTY_LOGITS,
+                    past_key_values = outputs.past_key_values,
+                    hidden_states = outputs.hidden_states,
+                    attentions = outputs.attentions,
                 )
                 return output
             pass
@@ -1530,11 +1530,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if n_items is None:
                 n_items = kwargs.get("n_items", None)
             loss = fast_cross_entropy_loss(
-                logits=shift_logits,
-                labels=shift_labels,
-                logit_softcapping=logit_softcapping,
-                logit_scaling=logit_scaling,
-                n_items=n_items,
+                logits = shift_logits,
+                labels = shift_labels,
+                logit_softcapping = logit_softcapping,
+                logit_scaling = logit_scaling,
+                n_items = n_items,
             )
         else:
             if logit_scaling != 0:
@@ -1556,11 +1556,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             output = (logits,) + outputs[1:]
             return (loss,) + output if loss is not None else output
         return CausalLMOutputWithPast(
-            loss=loss,
-            logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
+            loss = loss,
+            logits = logits,
+            past_key_values = outputs.past_key_values,
+            hidden_states = outputs.hidden_states,
+            attentions = outputs.attentions,
         )
 
     return _CausalLM_fast_forward
@@ -1569,48 +1569,48 @@ def CausalLM_fast_forward(fast_forward_inference):
 @torch._disable_dynamo
 def PeftModel_fast_forward(
     self,
-    input_ids=None,
-    causal_mask=None,
-    attention_mask=None,
-    inputs_embeds=None,
-    labels=None,
-    output_attentions=None,
-    output_hidden_states=None,
-    return_dict=None,
-    task_ids=None,
-    num_logits_to_keep=0,
-    logits_to_keep=0,
+    input_ids = None,
+    causal_mask = None,
+    attention_mask = None,
+    inputs_embeds = None,
+    labels = None,
+    output_attentions = None,
+    output_hidden_states = None,
+    return_dict = None,
+    task_ids = None,
+    num_logits_to_keep = 0,
+    logits_to_keep = 0,
     **kwargs,
 ):
     is_classification = "Classification" in str(type(self.base_model.model))
     if is_classification:
         return self.base_model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            inputs_embeds=inputs_embeds,
-            labels=labels,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            input_ids = input_ids,
+            attention_mask = attention_mask,
+            inputs_embeds = inputs_embeds,
+            labels = labels,
+            output_attentions = output_attentions,
+            output_hidden_states = output_hidden_states,
+            return_dict = return_dict,
             **kwargs,
         )
     else:
         return self.base_model(
-            input_ids=input_ids,
-            causal_mask=causal_mask,
-            attention_mask=attention_mask,
-            inputs_embeds=inputs_embeds,
-            labels=labels,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
-            num_logits_to_keep=num_logits_to_keep,
-            logits_to_keep=logits_to_keep,
+            input_ids = input_ids,
+            causal_mask = causal_mask,
+            attention_mask = attention_mask,
+            inputs_embeds = inputs_embeds,
+            labels = labels,
+            output_attentions = output_attentions,
+            output_hidden_states = output_hidden_states,
+            return_dict = return_dict,
+            num_logits_to_keep = num_logits_to_keep,
+            logits_to_keep = logits_to_keep,
             **kwargs,
         )
 
 
-def _get_rope_theta(config, default=10000.0):
+def _get_rope_theta(config, default = 10000.0):
     """Get rope_theta from config, handling both transformers 4.x and 5.x."""
     try:
         return config.rope_theta
@@ -1641,14 +1641,18 @@ def _rope_scaling_as_dict(rope_scaling):
         return {}
 
 
-def _llama3_inv_freq_from_config(config, rope_scaling, device="cpu"):
+def _llama3_inv_freq_from_config(
+    config,
+    rope_scaling,
+    device = "cpu",
+):
     """llama3 inv_freq with factors from config; fallback when modeling_rope_utils is missing."""
-    base = _get_rope_theta(config, default=10000.0)
+    base = _get_rope_theta(config, default = 10000.0)
     dim = getattr(config, "head_dim", None)
     if dim is None:
         dim = int(config.hidden_size // config.num_attention_heads)
     inv_freq = 1.0 / (
-        base ** (torch.arange(0, dim, 2, dtype=torch.int64, device=device).float() / dim)
+        base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim)
     )
 
     scale_factor = rope_scaling.get("factor", 8.0)
@@ -1690,7 +1694,7 @@ def _compute_config_rope_inv_freq(config, rope_scaling):
             config_copy = _copy.copy(config)
             config_copy.rope_scaling = rope_scaling
             inv_freq, attention_scaling = rope_init_fn(config_copy, torch.device("cpu"))
-        return inv_freq.to(dtype=torch.float32, device="cpu"), float(attention_scaling)
+        return inv_freq.to(dtype = torch.float32, device = "cpu"), float(attention_scaling)
     except Exception as exception:
         if rope_type == "llama3":
             try:
@@ -1716,11 +1720,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 2048,
+        base = 10000,
+        device = None,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         # cos/sin multiplier (1.0 except yarn / longrope); set before any cache build.
@@ -1731,7 +1735,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         config_inv_freq = None
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default=base)
+            base = _get_rope_theta(config, default = base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1763,26 +1767,26 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             inv_freq = 1.0 / (
                 self.base
                 ** (
-                    torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float() / self.dim
+                    torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim
                 )
             )
             inv_freq = self._apply_inv_freq_scaling(inv_freq)
-        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("inv_freq", inv_freq, persistent = False)
 
         # Build here to make `torch.jit.trace` work.
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                seq_len=self.current_rope_size,
-                device=torch.device(device_idx),
-                dtype=torch.get_default_dtype(),
+                seq_len = self.current_rope_size,
+                device = torch.device(device_idx),
+                dtype = torch.get_default_dtype(),
             )
 
         # dummy so that patch_utils doesn't fail for now
         self.cos_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.sin_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
 
     def _apply_inv_freq_scaling(self, inv_freq):
@@ -1798,17 +1802,17 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
         t = torch.arange(
-            self.current_rope_size, device=self.inv_freq.device, dtype=torch.int64
+            self.current_rope_size, device = self.inv_freq.device, dtype = torch.int64
         ).float()
         t = self._apply_time_scaling(t)
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
-        emb = torch.cat((freqs, freqs), dim=-1)
+        emb = torch.cat((freqs, freqs), dim = -1)
         # Applied here so attention_scaling survives extend_rope_embedding rebuilds;
         # default 1.0 keeps unscaled paths bit-identical.
-        cos = (emb.cos() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
-        sin = (emb.sin() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
+        cos = (emb.cos() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
+        sin = (emb.sin() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
         self.multi_gpu_cos_cached[device.index] = cos
         self.multi_gpu_sin_cached[device.index] = sin
         return cos, sin
@@ -1816,12 +1820,12 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids=None,
-        seq_len=None,
+        position_ids = None,
+        seq_len = None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
+            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
 
         device_index = x.device.index
         return (
@@ -1831,8 +1835,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len=None,
-        device_index=None,
+        seq_len = None,
+        device_index = None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -1845,7 +1849,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
+                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
             )
 
 
@@ -1857,20 +1861,20 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        scaling_factor=1.0,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 2048,
+        base = 10000,
+        device = None,
+        scaling_factor = 1.0,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         self.scaling_factor = scaling_factor
         super().__init__(
-            dim=dim,
-            max_position_embeddings=max_position_embeddings,
-            base=base,
-            device=device,
-            config=config,
+            dim = dim,
+            max_position_embeddings = max_position_embeddings,
+            base = base,
+            device = device,
+            config = config,
         )
 
     def _apply_time_scaling(self, t):
@@ -1883,18 +1887,18 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
 class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 2048,
+        base = 10000,
+        device = None,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__(
-            dim=dim,
-            max_position_embeddings=max_position_embeddings,
-            base=base,
-            device=device,
-            config=config,
+            dim = dim,
+            max_position_embeddings = max_position_embeddings,
+            base = base,
+            device = device,
+            config = config,
         )
 
     # From https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/api/model.py#L41
@@ -1920,21 +1924,21 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
                     high_freq_factor - low_freq_factor
                 )
                 new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-        return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+        return torch.tensor(new_freqs, dtype = freqs.dtype, device = freqs.device)
 
 
 class LongRopeRotaryEmbedding(torch.nn.Module):
     # For Phi 3.5 128K https://huggingface.co/microsoft/Phi-3.5-mini-instruct/blob/main/modeling_phi3.py
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=131072,
-        original_max_position_embeddings=4096,
-        base=10000,
-        short_factor=None,
-        long_factor=None,
-        device=None,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 131072,
+        original_max_position_embeddings = 4096,
+        base = 10000,
+        short_factor = None,
+        long_factor = None,
+        device = None,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         assert short_factor is not None
@@ -1943,7 +1947,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default=base)
+            base = _get_rope_theta(config, default = base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1965,10 +1969,10 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         # Long RoPE similar to RoPE except short sequences have 1 cos / sin
         # and long sequences have another cos / sin
         inv_freq_shape = (
-            torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float() / self.dim
+            torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim
         )
-        short_factor = torch.tensor(short_factor, device="cpu", dtype=torch.float32)
-        long_factor = torch.tensor(long_factor, device="cpu", dtype=torch.float32)
+        short_factor = torch.tensor(short_factor, device = "cpu", dtype = torch.float32)
+        long_factor = torch.tensor(long_factor, device = "cpu", dtype = torch.float32)
         short_inv_freq = 1.0 / (short_factor * self.base**inv_freq_shape)
         long_inv_freq = 1.0 / (long_factor * self.base**inv_freq_shape)
 
@@ -1983,43 +1987,43 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.scaling_factor = scaling_factor
 
         # Short and long inv_freq
-        self.register_buffer("short_inv_freq", short_inv_freq, persistent=False)
-        self.register_buffer("long_inv_freq", long_inv_freq, persistent=False)
+        self.register_buffer("short_inv_freq", short_inv_freq, persistent = False)
+        self.register_buffer("long_inv_freq", long_inv_freq, persistent = False)
 
         # Build here to make `torch.jit.trace` work.
         # Initialize short sequences cache for all devices
         dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
         t = torch.arange(
             original_max_position_embeddings,
-            device=self.short_inv_freq.device,
-            dtype=torch.int64,
+            device = self.short_inv_freq.device,
+            dtype = torch.int64,
         ).float()
         freqs = torch.outer(t, self.short_inv_freq)
-        emb = torch.cat((freqs, freqs), dim=-1)
+        emb = torch.cat((freqs, freqs), dim = -1)
 
         for device_idx in range(DEVICE_COUNT):
             device_obj = torch.device(device_idx)
             cos_cached = (emb.cos() * self.scaling_factor).to(
-                dtype=dtype, device=device_obj, non_blocking=True
+                dtype = dtype, device = device_obj, non_blocking = True
             )
             sin_cached = (emb.sin() * self.scaling_factor).to(
-                dtype=dtype, device=device_obj, non_blocking=True
+                dtype = dtype, device = device_obj, non_blocking = True
             )
             self.multi_gpu_short_cos_cached[device_idx] = cos_cached
             self.multi_gpu_short_sin_cached[device_idx] = sin_cached
 
         # dummy so that patch_utils doesn't fail for now
         self.short_cos_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.short_sin_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.long_cos_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.long_sin_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
@@ -2028,16 +2032,16 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = seq_len
 
         t = torch.arange(
-            self.current_rope_size, device=self.long_inv_freq.device, dtype=torch.int64
+            self.current_rope_size, device = self.long_inv_freq.device, dtype = torch.int64
         ).float()
         # Long sequences
         freqs = torch.outer(t, self.long_inv_freq)
-        emb = torch.cat((freqs, freqs), dim=-1)
+        emb = torch.cat((freqs, freqs), dim = -1)
         cos_cached = (emb.cos() * self.scaling_factor).to(
-            dtype=dtype, device=device, non_blocking=True
+            dtype = dtype, device = device, non_blocking = True
         )
         sin_cached = (emb.sin() * self.scaling_factor).to(
-            dtype=dtype, device=device, non_blocking=True
+            dtype = dtype, device = device, non_blocking = True
         )
         self.multi_gpu_long_cos_cached[device.index] = cos_cached
         self.multi_gpu_long_sin_cached[device.index] = sin_cached
@@ -2046,12 +2050,12 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids=None,
-        seq_len=None,
+        position_ids = None,
+        seq_len = None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
+            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
 
         device_index = x.device.index
 
@@ -2068,8 +2072,8 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len=None,
-        device_index=None,
+        seq_len = None,
+        device_index = None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -2088,7 +2092,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
+                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
             )
 
 
@@ -2169,7 +2173,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     # Mixed precision autocast
     with (
         _get_inference_mode_context_manager(self),
-        torch.autocast(device_type=DEVICE_TYPE_TORCH, dtype=dtype),
+        torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = dtype),
     ):
         output = self._old_generate(*args, **kwargs)
 
@@ -2181,7 +2185,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     if restore_training_mode:
         FastLlamaModel.for_training(
             self,
-            use_gradient_checkpointing=use_gradient_checkpointing,
+            use_gradient_checkpointing = use_gradient_checkpointing,
         )
 
     return output
@@ -2196,12 +2200,12 @@ class FastLlamaModel:
     @staticmethod
     def pre_patch():
         init_name, function = patch_llama_rope_scaling(
-            model_name="llama",
-            rope_module=LlamaRotaryEmbedding,
-            scaled_rope_module=LlamaLinearScalingRotaryEmbedding,
-            extended_rope_module=LlamaExtendedRotaryEmbedding,
-            attention_module=LlamaAttention,
-            longrope_module=LongRopeRotaryEmbedding,
+            model_name = "llama",
+            rope_module = LlamaRotaryEmbedding,
+            scaled_rope_module = LlamaLinearScalingRotaryEmbedding,
+            extended_rope_module = LlamaExtendedRotaryEmbedding,
+            attention_module = LlamaAttention,
+            longrope_module = LongRopeRotaryEmbedding,
         )
         if init_name is not None:
             exec(function, globals())
@@ -2230,28 +2234,28 @@ class FastLlamaModel:
 
     @staticmethod
     def from_pretrained(
-        model_name="unsloth/llama-3-8b-bnb-4bit",
-        max_seq_length=None,
-        dtype=None,
-        load_in_4bit=True,
-        token=None,
-        device_map="sequential",
-        rope_scaling=None,
-        fix_tokenizer=True,
-        model_patcher=None,
-        tokenizer_name=None,
-        trust_remote_code=False,
-        revision=None,
-        fast_inference=False,  # uses vLLM
-        gpu_memory_utilization=0.5,
-        float8_kv_cache=False,
-        random_state=3407,
-        max_lora_rank=16,
-        disable_log_stats=False,
-        unsloth_vllm_standby=False,
-        num_labels=None,
-        qat_scheme=None,
-        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
+        model_name = "unsloth/llama-3-8b-bnb-4bit",
+        max_seq_length = None,
+        dtype = None,
+        load_in_4bit = True,
+        token = None,
+        device_map = "sequential",
+        rope_scaling = None,
+        fix_tokenizer = True,
+        model_patcher = None,
+        tokenizer_name = None,
+        trust_remote_code = False,
+        revision = None,
+        fast_inference = False,  # uses vLLM
+        gpu_memory_utilization = 0.5,
+        float8_kv_cache = False,
+        random_state = 3407,
+        max_lora_rank = 16,
+        disable_log_stats = False,
+        unsloth_vllm_standby = False,
+        num_labels = None,
+        qat_scheme = None,
+        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
         **kwargs,
     ):
         os.environ["UNSLOTH_USE_NEW_MODEL"] = "0"
@@ -2367,8 +2371,8 @@ class FastLlamaModel:
         # RoPE Scaling
         model_config = AutoConfig.from_pretrained(
             model_name,
-            token=token,
-            attn_implementation="sdpa",
+            token = token,
+            attn_implementation = "sdpa",
         )
         model_config.model_name = model_name
         model_max_seq_length = model_config.max_position_embeddings
@@ -2383,7 +2387,7 @@ class FastLlamaModel:
 
         has_rope_scaling = False
         try:
-            with open(inspect.getfile(model_function), "r", encoding="utf-8") as file:
+            with open(inspect.getfile(model_function), "r", encoding = "utf-8") as file:
                 has_rope_scaling = "self.config.rope_scaling" in file.read()
         except:
             pass
@@ -2431,7 +2435,7 @@ class FastLlamaModel:
 
         # Check and disable bitsandbytes loading if model has non-bitsandbytes quantization
         load_in_4bit, load_in_8bit, _ckpt_quant_method = check_and_disable_bitsandbytes_loading(
-            model_config, load_in_4bit=load_in_4bit, load_in_8bit=load_in_8bit
+            model_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit
         )
 
         bnb_config = None
@@ -2443,11 +2447,11 @@ class FastLlamaModel:
                 # we cannot quantize out_proj layer due to mamba kernels: https://github.com/tiiuae/Falcon-H1/issues/13#issuecomment-2918671274
                 llm_int8_skip_modules.append("out_proj")
             bnb_config = BitsAndBytesConfig(
-                load_in_4bit=True,
-                bnb_4bit_use_double_quant=True,
-                bnb_4bit_quant_type="nf4",
-                bnb_4bit_compute_dtype=dtype,
-                llm_int8_skip_modules=llm_int8_skip_modules,
+                load_in_4bit = True,
+                bnb_4bit_use_double_quant = True,
+                bnb_4bit_quant_type = "nf4",
+                bnb_4bit_compute_dtype = dtype,
+                llm_int8_skip_modules = llm_int8_skip_modules,
             )
             # Pre-quantized checkpoints (e.g. unsloth/Qwen3-4B-bnb-4bit) use the
             # quantization_config baked into config.json, ignoring our runtime
@@ -2496,13 +2500,13 @@ class FastLlamaModel:
                     setattr(model_config, _cfg_key, _cfg_val)
             model = AutoModelForSequenceClassification.from_pretrained(
                 model_name,
-                config=model_config,
-                device_map=device_map,
+                config = model_config,
+                device_map = device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token=token,
-                trust_remote_code=trust_remote_code,
-                attn_implementation=preferred_attn_impl,
+                token = token,
+                trust_remote_code = trust_remote_code,
+                attn_implementation = preferred_attn_impl,
                 **kwargs,
             )
             # Defensive: ensure the task head is in a floating dtype, guarding
@@ -2520,21 +2524,21 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit=load_in_4bit,
-                load_in_8bit=kwargs.get("load_in_8bit", False),
-                offload_embedding=False,
-                fast_inference=fast_inference,
+                load_in_4bit = load_in_4bit,
+                load_in_8bit = kwargs.get("load_in_8bit", False),
+                offload_embedding = False,
+                fast_inference = fast_inference,
             )
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(
                 model_name,
-                device_map=device_map,
+                device_map = device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token=token,
-                max_position_embeddings=max_position_embeddings,
-                trust_remote_code=trust_remote_code,
-                attn_implementation=preferred_attn_impl,
+                token = token,
+                max_position_embeddings = max_position_embeddings,
+                trust_remote_code = trust_remote_code,
+                attn_implementation = preferred_attn_impl,
                 **kwargs,
             )
             # Attach dispatch hooks for bnb multi-device loads.
@@ -2542,10 +2546,10 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit=load_in_4bit,
-                load_in_8bit=kwargs.get("load_in_8bit", False),
-                offload_embedding=False,
-                fast_inference=False,
+                load_in_4bit = load_in_4bit,
+                load_in_8bit = kwargs.get("load_in_8bit", False),
+                offload_embedding = False,
+                fast_inference = False,
             )
             model.fast_generate = make_fast_generate_wrapper(model.generate)
             model.fast_generate_batches = None
@@ -2566,18 +2570,18 @@ class FastLlamaModel:
 
             allowed_args = inspect.getfullargspec(load_vllm).args
             load_vllm_kwargs = dict(
-                model_name=model_name,
-                config=model_config,
-                gpu_memory_utilization=gpu_memory_utilization,
-                max_seq_length=max_seq_length,
-                dtype=dtype,
-                float8_kv_cache=float8_kv_cache,
-                enable_lora=True,
-                max_lora_rank=max_lora_rank,
-                disable_log_stats=disable_log_stats,
-                use_bitsandbytes=load_in_4bit,
-                unsloth_vllm_standby=unsloth_vllm_standby,
-                fp8_mode=fp8_mode,
+                model_name = model_name,
+                config = model_config,
+                gpu_memory_utilization = gpu_memory_utilization,
+                max_seq_length = max_seq_length,
+                dtype = dtype,
+                float8_kv_cache = float8_kv_cache,
+                enable_lora = True,
+                max_lora_rank = max_lora_rank,
+                disable_log_stats = disable_log_stats,
+                use_bitsandbytes = load_in_4bit,
+                unsloth_vllm_standby = unsloth_vllm_standby,
+                fp8_mode = fp8_mode,
             )
             for allowed_arg in allowed_args:
                 if allowed_arg not in load_vllm_kwargs and allowed_arg in kwargs:
@@ -2590,8 +2594,8 @@ class FastLlamaModel:
             # Convert to HF format
             _, quant_state_dict = get_vllm_state_dict(
                 llm,
-                config=model_config,
-                load_in_fp8=load_in_fp8,
+                config = model_config,
+                load_in_fp8 = load_in_fp8,
             )
             model = convert_vllm_to_huggingface(quant_state_dict, model_config, dtype, bnb_config)
             model.vllm_engine = llm
@@ -2605,16 +2609,16 @@ class FastLlamaModel:
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name
         tokenizer = load_correct_tokenizer(
-            tokenizer_name=tokenizer_name,
-            model_max_length=max_position_embeddings,
-            padding_side="right",
-            token=token,
-            trust_remote_code=trust_remote_code,
-            fix_tokenizer=fix_tokenizer,
+            tokenizer_name = tokenizer_name,
+            model_max_length = max_position_embeddings,
+            padding_side = "right",
+            token = token,
+            trust_remote_code = trust_remote_code,
+            fix_tokenizer = fix_tokenizer,
         )
 
         model, tokenizer = patch_tokenizer(model, tokenizer)
-        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype=dtype)
+        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype = dtype)
 
         # Patch up QKV / O and MLP
         for idx, layer in enumerate(model.model.layers):
@@ -2685,7 +2689,7 @@ class FastLlamaModel:
 
         front_spaces = re.match(r"[\t\s]{1,}", inner_training_loop).group(0)
         inner_training_loop = re.sub(
-            r"^" + front_spaces, "", inner_training_loop, flags=re.MULTILINE
+            r"^" + front_spaces, "", inner_training_loop, flags = re.MULTILINE
         )
         inner_training_loop = inner_training_loop.replace(
             "train_dataloader = tpu_spmd_dataloader(train_dataloader)",
@@ -2717,12 +2721,12 @@ class FastLlamaModel:
         # We check the tokenizer first for errors
         if fix_tokenizer:
             tokenizer = check_tokenizer(
-                model=model,
-                tokenizer=tokenizer,
-                model_name=model_name,
-                model_max_length=max_position_embeddings,
-                padding_side="right",
-                token=token,
+                model = model,
+                tokenizer = tokenizer,
+                model_name = model_name,
+                model_max_length = max_position_embeddings,
+                padding_side = "right",
+                token = token,
             )
         patch_saving_functions(tokenizer)
 
@@ -2809,18 +2813,18 @@ class FastLlamaModel:
     def post_patch(
         model,
         tokenizer,
-        correct_dtype=None,
+        correct_dtype = None,
     ):
         model, tokenizer = patch_model_and_tokenizer(
-            model, tokenizer, downcast_rope=True, correct_dtype=correct_dtype
+            model, tokenizer, downcast_rope = True, correct_dtype = correct_dtype
         )
         return model, tokenizer
 
     @staticmethod
     def get_peft_model(
         model,
-        r=16,
-        target_modules=[
+        r = 16,
+        target_modules = [
             "q_proj",
             "k_proj",
             "v_proj",
@@ -2829,23 +2833,23 @@ class FastLlamaModel:
             "up_proj",
             "down_proj",
         ],
-        lora_alpha=16,
-        lora_dropout=0.0,
-        bias="none",
-        layers_to_transform=None,
-        layers_pattern=None,
-        finetune_last_n_layers=None,
-        use_gradient_checkpointing="unsloth",
-        random_state=3407,
-        max_seq_length=2048,  # not used anymore
-        use_rslora=False,
-        modules_to_save=None,
-        init_lora_weights=True,
-        loftq_config={},
-        temporary_location="_unsloth_temporary_saved_buffers",
-        qat_scheme=None,
-        target_parameters=None,  # For MoE expert layers (nn.Parameter)
-        ensure_weight_tying=False,
+        lora_alpha = 16,
+        lora_dropout = 0.0,
+        bias = "none",
+        layers_to_transform = None,
+        layers_pattern = None,
+        finetune_last_n_layers = None,
+        use_gradient_checkpointing = "unsloth",
+        random_state = 3407,
+        max_seq_length = 2048,  # not used anymore
+        use_rslora = False,
+        modules_to_save = None,
+        init_lora_weights = True,
+        loftq_config = {},
+        temporary_location = "_unsloth_temporary_saved_buffers",
+        qat_scheme = None,
+        target_parameters = None,  # For MoE expert layers (nn.Parameter)
+        ensure_weight_tying = False,
         **kwargs,
     ):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
@@ -2859,25 +2863,25 @@ class FastLlamaModel:
                 if peft_arg not in kwargs:
                     kwargs[peft_arg] = flag
             return FastBaseModel.get_peft_model(
-                model=model,
-                r=r,
-                target_modules=target_modules,
-                lora_alpha=lora_alpha,
-                lora_dropout=lora_dropout,
-                bias=bias,
-                layers_to_transform=layers_to_transform,
-                layers_pattern=layers_pattern,
-                finetune_last_n_layers=finetune_last_n_layers,
-                use_gradient_checkpointing=use_gradient_checkpointing,
-                random_state=random_state,
-                max_seq_length=max_seq_length,
-                use_rslora=use_rslora,
-                modules_to_save=modules_to_save,
-                init_lora_weights=init_lora_weights,
-                loftq_config=loftq_config,
-                temporary_location=temporary_location,
-                target_parameters=target_parameters,
-                ensure_weight_tying=ensure_weight_tying,
+                model = model,
+                r = r,
+                target_modules = target_modules,
+                lora_alpha = lora_alpha,
+                lora_dropout = lora_dropout,
+                bias = bias,
+                layers_to_transform = layers_to_transform,
+                layers_pattern = layers_pattern,
+                finetune_last_n_layers = finetune_last_n_layers,
+                use_gradient_checkpointing = use_gradient_checkpointing,
+                random_state = random_state,
+                max_seq_length = max_seq_length,
+                use_rslora = use_rslora,
+                modules_to_save = modules_to_save,
+                init_lora_weights = init_lora_weights,
+                loftq_config = loftq_config,
+                temporary_location = temporary_location,
+                target_parameters = target_parameters,
+                ensure_weight_tying = ensure_weight_tying,
                 **kwargs,
             )
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
@@ -2998,7 +3002,6 @@ class FastLlamaModel:
         if init_lora_weights == "loftq":
             if not SUPPORTS_LOFTQ:
                 import peft
-
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support LoftQ init.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3007,12 +3010,11 @@ class FastLlamaModel:
 
             if loftq_config == {}:
                 from peft import LoftQConfig
-
                 logger.warning_once(
                     "Unsloth: init_lora_weights = `loftq` is set, but `loftq_config` is None.\n"
                     "We shall use `loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)`."
                 )
-                loftq_config = LoftQConfig(loftq_bits=4, loftq_iter=1)
+                loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)
 
             if hasattr(model.config, "quantization_config"):
                 raise ValueError(
@@ -3025,7 +3027,6 @@ class FastLlamaModel:
             if not SUPPORTS_RSLORA:
                 # We manually check for PEFT
                 import peft
-
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support `use_rslora`.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3154,26 +3155,25 @@ class FastLlamaModel:
 
         if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers
-
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:
                 _n = max(1, min(int(finetune_last_n_layers), _total_layers))
                 layers_to_transform = list(range(_total_layers - _n, _total_layers))
 
         arguments = dict(
-            r=r,
-            lora_alpha=lora_alpha,
-            target_modules=final_modules,
-            lora_dropout=lora_dropout,
-            bias=bias,
-            task_type=TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
-            layers_to_transform=layers_to_transform,
-            init_lora_weights=init_lora_weights,
-            loftq_config=loftq_config,
-            use_rslora=use_rslora,
-            modules_to_save=modules_to_save,
-            target_parameters=target_parameters,
-            ensure_weight_tying=ensure_weight_tying,
+            r = r,
+            lora_alpha = lora_alpha,
+            target_modules = final_modules,
+            lora_dropout = lora_dropout,
+            bias = bias,
+            task_type = TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
+            layers_to_transform = layers_to_transform,
+            init_lora_weights = init_lora_weights,
+            loftq_config = loftq_config,
+            use_rslora = use_rslora,
+            modules_to_save = modules_to_save,
+            target_parameters = target_parameters,
+            ensure_weight_tying = ensure_weight_tying,
             **kwargs,
         )
         if not SUPPORTS_LOFTQ:
@@ -3277,7 +3277,7 @@ class FastLlamaModel:
             assert hasattr(model.get_input_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
+                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
             )
 
         if train_lm_head:
@@ -3285,7 +3285,7 @@ class FastLlamaModel:
             assert hasattr(model.get_output_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
+                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
             )
 
         # Patch tokenizer to pad to the right
@@ -3319,11 +3319,11 @@ class FastLlamaModel:
         return model
 
     @staticmethod
-    def patch_peft_model(model, use_gradient_checkpointing="unsloth"):
+    def patch_peft_model(model, use_gradient_checkpointing = "unsloth"):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
             return FastBaseModel.patch_peft_model(
-                model=model,
-                use_gradient_checkpointing=use_gradient_checkpointing,
+                model = model,
+                use_gradient_checkpointing = use_gradient_checkpointing,
             )
         if not isinstance(model, PeftModelForCausalLM) and not isinstance(
             model, PeftModelForSequenceClassification
@@ -3358,8 +3358,8 @@ class FastLlamaModel:
 
         model = prepare_model_for_kbit_training(
             model,
-            use_gradient_checkpointing=use_gradient_checkpointing,
-            use_reentrant=True,
+            use_gradient_checkpointing = use_gradient_checkpointing,
+            use_reentrant = True,
         )
 
         # Fix up config for transformers uploading PEFT
@@ -3405,7 +3405,7 @@ class FastLlamaModel:
 
         # We also do not inplace edit QKV for Cohere!
         _apply_lora_mlp = (
-            functools.partial(apply_lora_mlp, inplace=False)
+            functools.partial(apply_lora_mlp, inplace = False)
             if model_type == "cohere"
             else apply_lora_mlp
         )
@@ -3579,14 +3579,13 @@ class FastLlamaModel:
         # for gradient checkpointing (older unsloth_zoo has no restore helper)
         try:
             from unsloth_zoo.training_utils import restore_use_cache
-
             restore_use_cache(model)
         except ImportError:
             pass
         return model
 
     @staticmethod
-    def for_training(model, use_gradient_checkpointing=True):
+    def for_training(model, use_gradient_checkpointing = True):
         if not hasattr(model, "parameters"):
             raise TypeError(
                 "Unsloth: I think you're passing a tokenizer, not the model to for_training!"
@@ -3639,7 +3638,6 @@ class FastLlamaModel:
         ):
             try:
                 from unsloth_zoo.training_utils import disable_use_cache
-
                 disable_use_cache(model)
             except ImportError:
                 pass
@@ -3648,4 +3646,4 @@ class FastLlamaModel:
 
 from .rl import PatchFastRL
 
-PatchFastRL(FastLanguageModel=FastLlamaModel)
+PatchFastRL(FastLanguageModel = FastLlamaModel)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -172,12 +172,12 @@ def _offload_frozen_module_for_training(
         # Tesla T4 must use float32 and not float16
         new_dtype = torch.float32
 
-    module.modules_to_save.default.to(device = device_type, dtype = new_dtype, non_blocking = True)
+    module.modules_to_save.default.to(device=device_type, dtype=new_dtype, non_blocking=True)
     module.modules_to_save.default.requires_grad_(True)
 
     # [TODO] Move old module to CPU - should be disk!
     if offload_device is not None:
-        module.original_module.to(device = offload_device, non_blocking = True)
+        module.original_module.to(device=offload_device, non_blocking=True)
     module.original_module.requires_grad_(False)
 
 
@@ -185,8 +185,8 @@ def _offload_frozen_module_for_training(
 def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
-    attention_mask = None,
-    inputs_embeds = None,
+    attention_mask=None,
+    inputs_embeds=None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -249,8 +249,8 @@ def _fast_prepare_inputs_for_generation(
                 kwargs["cache_position"] = torch.arange(
                     past_len,
                     past_len + seq_length,
-                    device = device,
-                    dtype = torch.long,
+                    device=device,
+                    dtype=torch.long,
                 )
             else:
                 if hasattr(cache_position, "device") and cache_position.device != device:
@@ -346,9 +346,9 @@ def LlamaAttention_fast_forward_inference(
     hidden_states: torch.Tensor,
     past_key_value: Optional[Tuple[torch.Tensor]],
     position_ids,
-    do_prefill = False,
-    attention_mask = None,
-    rotary_seq_len = None,
+    do_prefill=False,
+    attention_mask=None,
+    rotary_seq_len=None,
 ):
     """
     https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L406
@@ -400,25 +400,25 @@ def LlamaAttention_fast_forward_inference(
     if do_prefill:
         self.paged_attention = torch.empty(
             (KV_CACHE_INCREMENT + seq_len + 1, 2, bsz, n_kv_heads, head_dim),
-            dtype = dtype,
-            device = device,
+            dtype=dtype,
+            device=device,
         )
         self.paged_attention_K = self.paged_attention[:, 0]
         self.paged_attention_V = self.paged_attention[:, 1]
         self.paged_attention_K[:seq_len] = K1.permute(2, 0, 1, 3)
         self.paged_attention_V[:seq_len] = V1.permute(2, 0, 1, 3)
-        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype = dtype, device = device)
-        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype = dtype, device = device)
-        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
+        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype=dtype, device=device)
+        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype=dtype, device=device)
+        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype=dtype, device=device)
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype=dtype, device=device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 
         self.attention = torch.empty(
-            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
+            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype=dtype, device=device
         )
         self.scalar = 1.0 / math_sqrt(self.head_dim)
         self.half_head_dim = head_dim // 2
@@ -436,9 +436,9 @@ def LlamaAttention_fast_forward_inference(
         self.paged_attention_V = self.paged_attention[:, 1]
         self.attention.resize_((bsz, n_heads, 1, self.attention.shape[-1] + KV_CACHE_INCREMENT))
 
-    Qn = fast_linear_forward(self.q_proj, Xn, out = self.temp_QA[0])
-    Kn = fast_linear_forward(self.k_proj, Xn, out = self.temp_KV[0])
-    Vn = fast_linear_forward(self.v_proj, Xn, out = self.temp_KV[1])
+    Qn = fast_linear_forward(self.q_proj, Xn, out=self.temp_QA[0])
+    Kn = fast_linear_forward(self.k_proj, Xn, out=self.temp_KV[0])
+    Vn = fast_linear_forward(self.v_proj, Xn, out=self.temp_KV[1])
     Qn = Qn.view(bsz, 1, n_heads, head_dim).transpose(1, 2)
     Kn = Kn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
     Vn = Vn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
@@ -461,8 +461,8 @@ def LlamaAttention_fast_forward_inference(
     self.rotary_emb.extend_rope_embedding(Vn, rotary_seq_len + 1)  # +1 slack
     cos, sin = self.rotary_emb.get_cached(rotary_seq_len, Qn.device.index or 0)
 
-    cos = cos[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
-    sin = sin[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
+    cos = cos[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
+    sin = sin[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
 
     h = self.half_head_dim
 
@@ -523,9 +523,9 @@ def LlamaAttention_fast_forward_inference(
             self.scalar
         )  # See https://github.com/ggerganov/llama.cpp/issues/7805#issuecomment-2153349963
         # It seems like doing (Q * scalar) @ K is better than (Q @ K) * scalar to stop overflows
-        A = torch_matmul(Qn, Knn.transpose(2, 3), out = self.attention[:, :, :, :cached_len])
-        A[:] = torch_nn_functional_softmax(A, dim = -1, dtype = torch.float32)  # .to(A.dtype)
-        A = torch_matmul(A, Vnn, out = Qn)
+        A = torch_matmul(Qn, Knn.transpose(2, 3), out=self.attention[:, :, :, :cached_len])
+        A[:] = torch_nn_functional_softmax(A, dim=-1, dtype=torch.float32)  # .to(A.dtype)
+        A = torch_matmul(A, Vnn, out=Qn)
     # --- attention_mask fixup for SDPA if user passes 2D padding mask
     else:
         if attention_mask is not None and attention_mask.dim() == 2:
@@ -544,17 +544,17 @@ def LlamaAttention_fast_forward_inference(
                 Qn,
                 Knn,
                 Vnn,
-                attn_mask = attention_mask,
-                is_causal = is_causal,
-                enable_gqa = True,
+                attn_mask=attention_mask,
+                is_causal=is_causal,
+                enable_gqa=True,
             )
         else:
             A = scaled_dot_product_attention(
-                Qn, Knn, Vnn, attn_mask = attention_mask, is_causal = is_causal
+                Qn, Knn, Vnn, attn_mask=attention_mask, is_causal=is_causal
             )
     A = A.transpose(1, 2)
     A = A.reshape(bsz, 1, attention_size)
-    A = fast_linear_forward(self.o_proj, A, out = self.temp_O)
+    A = fast_linear_forward(self.o_proj, A, out=self.temp_O)
     return A, (Kn, Vn)
 
 
@@ -564,10 +564,10 @@ torch_nn_functional_silu = torch.nn.functional.silu
 def fast_swiglu_inference(
     self,
     X,
-    temp_gate = None,
-    temp_up = None,
-    gate_multiplier = None,
-    down_multiplier = None,
+    temp_gate=None,
+    temp_up=None,
+    gate_multiplier=None,
+    down_multiplier=None,
 ):
     # gate = self.gate_proj(X)
     # up   = self.up_proj(X)
@@ -575,18 +575,18 @@ def fast_swiglu_inference(
     # mlp_size = self.config.intermediate_size
     # temp = torch.empty((2, bsz, 1, mlp_size), dtype = X.dtype, device = "cuda:0")
 
-    gate = fast_linear_forward(self.gate_proj, X, out = temp_gate)
+    gate = fast_linear_forward(self.gate_proj, X, out=temp_gate)
 
     if gate_multiplier is not None:
         gate *= gate_multiplier
 
-    up = fast_linear_forward(self.up_proj, X, out = temp_up)
+    up = fast_linear_forward(self.up_proj, X, out=temp_up)
 
-    gate = torch_nn_functional_silu(gate, inplace = True)
+    gate = torch_nn_functional_silu(gate, inplace=True)
     gate *= up
 
     # X = self.down_proj(gate)
-    down = fast_linear_forward(self.down_proj, gate, out = up[:, :, :hd])
+    down = fast_linear_forward(self.down_proj, gate, out=up[:, :, :hd])
 
     if down_multiplier is not None:
         down *= down_multiplier
@@ -601,17 +601,17 @@ torch_mean = torch.mean
 def fast_rms_layernorm_inference(
     self,
     X,
-    XX = None,
-    XX2 = None,
-    variance = None,
+    XX=None,
+    XX2=None,
+    variance=None,
 ):
     old_dtype = X.dtype
     if XX is None:
         XX = X.to(torch.float32)
-        variance = XX.square().mean(-1, keepdim = True)
+        variance = XX.square().mean(-1, keepdim=True)
     else:
         XX.copy_(X)
-        torch_mean(torch_square(XX, out = XX2), -1, keepdim = True, out = variance)
+        torch_mean(torch_square(XX, out=XX2), -1, keepdim=True, out=variance)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -627,10 +627,10 @@ def fast_rms_layernorm_inference(
 def fast_rms_layernorm_inference_gemma(
     self,
     X,
-    out_weight = None,
+    out_weight=None,
 ):
     XX = X.to(torch.float32)
-    variance = XX.square().mean(-1, keepdim = True)
+    variance = XX.square().mean(-1, keepdim=True)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -645,15 +645,15 @@ def fast_rms_layernorm_inference_gemma(
 
 
 # Normal layernorm with mean removal
-@torch.compile(fullgraph = False, dynamic = True, options = torch_compile_options)
+@torch.compile(fullgraph=False, dynamic=True, options=torch_compile_options)
 def fast_layernorm_compiled(layernorm, X):
     old_dtype = X.dtype
     X = X.float()
-    mean = X.mean(-1, keepdim = True)
+    mean = X.mean(-1, keepdim=True)
     Xbar = X - mean
     X = (
         Xbar
-        * torch.rsqrt(Xbar.square().mean(-1, keepdim = True) + layernorm.variance_epsilon)
+        * torch.rsqrt(Xbar.square().mean(-1, keepdim=True) + layernorm.variance_epsilon)
         * layernorm.weight.float()
     )
     return X.to(old_dtype)
@@ -705,10 +705,10 @@ def LlamaAttention_fast_forward(
         cos, sin = position_embeddings
     else:
         rotary_emb = self.rotary_emb
-        rotary_emb.extend_rope_embedding(V, seq_len = kv_seq_len)
+        rotary_emb.extend_rope_embedding(V, seq_len=kv_seq_len)
         cos, sin = rotary_emb.get_cached(kv_seq_len, Q.device.index)
-        cos = cos.to(device = Q.device, dtype = Q.dtype)
-        sin = sin.to(device = Q.device, dtype = Q.dtype)
+        cos = cos.to(device=Q.device, dtype=Q.dtype)
+        sin = sin.to(device=Q.device, dtype=Q.dtype)
 
     rope_position_ids = position_ids
     if rope_position_ids is None and seq_info is not None:
@@ -722,8 +722,8 @@ def LlamaAttention_fast_forward(
     Q, K = fast_rope_embedding(Q, K, cos, sin, rope_position_ids)
 
     if past_key_value is not None:
-        K = torch.cat([past_key_value[0], K], dim = 2)
-        V = torch.cat([past_key_value[1], V], dim = 2)
+        K = torch.cat([past_key_value[0], K], dim=2)
+        V = torch.cat([past_key_value[1], V], dim=2)
     past_key_value = (K, V) if use_cache else None
 
     # Attention module
@@ -732,25 +732,25 @@ def LlamaAttention_fast_forward(
 
     # should dropout be hardcoded to 0.0?
     config = AttentionConfig(
-        backend = backend,
-        n_kv_heads = n_kv_heads,
-        n_groups = n_groups,
-        flash_dense_kwargs = {"causal": True},
-        flash_varlen_kwargs = {"dropout_p": 0.0, "causal": True},
+        backend=backend,
+        n_kv_heads=n_kv_heads,
+        n_groups=n_groups,
+        flash_dense_kwargs={"causal": True},
+        flash_varlen_kwargs={"dropout_p": 0.0, "causal": True},
     )
     context = AttentionContext(
-        bsz = bsz,
-        q_len = q_len,
-        kv_seq_len = kv_seq_len,
-        n_heads = n_heads,
-        head_dim = head_dim,
-        requires_grad = hidden_states.requires_grad,
-        seq_info = seq_info,
-        attention_mask = attention_mask,
-        causal_mask = causal_mask,
+        bsz=bsz,
+        q_len=q_len,
+        kv_seq_len=kv_seq_len,
+        n_heads=n_heads,
+        head_dim=head_dim,
+        requires_grad=hidden_states.requires_grad,
+        seq_info=seq_info,
+        attention_mask=attention_mask,
+        causal_mask=causal_mask,
     )
 
-    A = run_attention(config = config, context = context, Q = Q, K = K, V = V)
+    A = run_attention(config=config, context=context, Q=Q, K=K, V=V)
     attn_output = A.reshape(bsz, q_len, n_heads * head_dim)
     attn_output = self.apply_o(self, attn_output)
     attn_weights = None
@@ -761,7 +761,7 @@ def LlamaAttention_fast_forward(
 def LlamaDecoderLayer_fast_forward(
     self,
     hidden_states: torch.Tensor,
-    causal_mask = None,
+    causal_mask=None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
     past_key_value: Optional[Tuple[torch.Tensor]] = None,
@@ -789,15 +789,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states += residual
@@ -811,15 +811,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states = hidden_states,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            position_ids = position_ids,
-            past_key_value = past_key_value,
-            output_attentions = output_attentions,
-            use_cache = use_cache,
-            padding_mask = padding_mask,
-            position_embeddings = position_embeddings,
+            hidden_states=hidden_states,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            padding_mask=padding_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -923,8 +923,8 @@ def LlamaModel_fast_forward(
         position_ids = torch.arange(
             past_key_values_length,
             seq_length + past_key_values_length,
-            dtype = torch.int32,
-            device = f"{DEVICE_TYPE_TORCH}:0",
+            dtype=torch.int32,
+            device=f"{DEVICE_TYPE_TORCH}:0",
         )
         position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
     elif position_ids is not None:
@@ -956,7 +956,7 @@ def LlamaModel_fast_forward(
         # inputs_embeds *= math_sqrt(self.config.hidden_size)
         # Ie 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
         # &  2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
-        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype = inputs_embeds.dtype)
+        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype=inputs_embeds.dtype)
 
         if train_embed_tokens:
             # Careful we must not do an inplace op!
@@ -1013,7 +1013,7 @@ def LlamaModel_fast_forward(
             (batch_size, seq_length),
             inputs_embeds,
             past_key_values_length,
-            sliding_window = getattr(self.config, "sliding_window", None),
+            sliding_window=getattr(self.config, "sliding_window", None),
         )
         # Must NOT convert to bool - weirdly this causes stuff to error out!
         # if attention_mask is not None:
@@ -1068,14 +1068,14 @@ def LlamaModel_fast_forward(
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window = self.config.sliding_window,
+                sliding_window=self.config.sliding_window,
             )
             dynamic_GA_mask = _prepare_4d_causal_attention_mask_for_sdpa(
                 attention_mask,
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window = None,
+                sliding_window=None,
             )
             use_static_mask = False
 
@@ -1095,15 +1095,15 @@ def LlamaModel_fast_forward(
 
                 self.SWA_mask = (
                     AttentionMaskConverter(
-                        is_causal = True,
-                        sliding_window = self.config.sliding_window,
+                        is_causal=True,
+                        sliding_window=self.config.sliding_window,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype = inputs_embeds.dtype,
-                        device = DEVICE_TYPE_TORCH,
+                        dtype=inputs_embeds.dtype,
+                        device=DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1111,14 +1111,14 @@ def LlamaModel_fast_forward(
 
                 self.GA_mask = (
                     AttentionMaskConverter(
-                        is_causal = True,
+                        is_causal=True,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype = inputs_embeds.dtype,
-                        device = DEVICE_TYPE_TORCH,
+                        dtype=inputs_embeds.dtype,
+                        device=DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1161,8 +1161,8 @@ def LlamaModel_fast_forward(
                         *inputs,
                         past_key_value,
                         output_attentions,
-                        padding_mask = padding_mask,
-                        position_embeddings = position_embeddings,
+                        padding_mask=padding_mask,
+                        position_embeddings=position_embeddings,
                         **kwargs,
                     )
 
@@ -1174,22 +1174,22 @@ def LlamaModel_fast_forward(
                 mask,
                 attention_mask,
                 position_ids,
-                use_reentrant = True,
-                preserve_rng_state = False,
+                use_reentrant=True,
+                preserve_rng_state=False,
             )
             hidden_states = layer_outputs[0]
 
         else:
             layer_outputs = decoder_layer(
                 hidden_states,
-                causal_mask = mask,
-                attention_mask = attention_mask,
-                position_ids = position_ids,
-                past_key_value = past_key_value,
-                output_attentions = output_attentions,
-                use_cache = use_cache,
-                padding_mask = padding_mask,
-                position_embeddings = position_embeddings,
+                causal_mask=mask,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                padding_mask=padding_mask,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
             hidden_states = layer_outputs[0]
@@ -1210,9 +1210,9 @@ def LlamaModel_fast_forward(
     elif IS_COHERE:
         hidden_states = self.norm(hidden_states)
     elif IS_FALCON_H1:
-        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma = IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma=IS_GEMMA)
     else:
-        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma = IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma=IS_GEMMA)
 
     if output_hidden_states:
         all_hidden_states += (hidden_states,)
@@ -1225,17 +1225,17 @@ def LlamaModel_fast_forward(
             if v is not None
         )
     return BaseModelOutputWithPast(
-        last_hidden_state = hidden_states,
-        past_key_values = next_cache,
-        hidden_states = all_hidden_states,
-        attentions = all_self_attns,
+        last_hidden_state=hidden_states,
+        past_key_values=next_cache,
+        hidden_states=all_hidden_states,
+        attentions=all_self_attns,
     )
 
 
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L825
 def _LlamaModel_fast_forward_inference(
-    attention_fast_forward_inference = LlamaAttention_fast_forward_inference,
-    mlp_fast_forward_inference = fast_swiglu_inference,
+    attention_fast_forward_inference=LlamaAttention_fast_forward_inference,
+    mlp_fast_forward_inference=fast_swiglu_inference,
 ):
     # Makes attention and MLP customisable for models like qwen3/cohere.
     def LlamaModel_fast_forward_inference_custom(
@@ -1243,7 +1243,7 @@ def _LlamaModel_fast_forward_inference(
         input_ids,
         past_key_values,
         position_ids,
-        attention_mask = None,
+        attention_mask=None,
         **kwargs,
     ):
         input_ids = input_ids[:, : self.max_seq_length]
@@ -1257,15 +1257,15 @@ def _LlamaModel_fast_forward_inference(
         assert q_len == 1
         # Get saved buffers to reduce memory movement
         residual = torch.empty(
-            (bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
         )
-        _XX = torch.empty((2, bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0")
+        _XX = torch.empty((2, bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0")
         XX, XX2 = _XX[0], _XX[1]
         variance = torch.empty(
-            (bsz, q_len, 1), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, 1), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_mlp = torch.empty(
-            (2, bsz, 1, mlp_size), dtype = X.dtype, device = f"{DEVICE_TYPE_TORCH}:0"
+            (2, bsz, 1, mlp_size), dtype=X.dtype, device=f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_gates, temp_ups = (
             tuple(temp_mlp[0].to(torch.device(x)) for x in range(DEVICE_COUNT)),
@@ -1280,7 +1280,7 @@ def _LlamaModel_fast_forward_inference(
                 (bsz, q_len),
                 X,
                 seq_len,
-                sliding_window = getattr(self.config, "sliding_window", None),
+                sliding_window=getattr(self.config, "sliding_window", None),
             )
             # Pre-convert to bool once for all layers (avoids per-layer .eq(0))
             if attention_mask is not None and attention_mask.dtype != torch.bool:
@@ -1300,18 +1300,18 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.input_layernorm,
                 X,
-                XX = XX,
-                XX2 = XX2,
-                variance = variance,
+                XX=XX,
+                XX2=XX2,
+                variance=variance,
             )
             X, present_key_value = attention_fast_forward_inference(
                 decoder_layer.self_attn,
-                hidden_states = X,
-                past_key_value = past_key_values[idx],
-                position_ids = position_ids,
-                attention_mask = attention_mask,
-                do_prefill = not hasattr(decoder_layer.self_attn, "paged_attention"),
-                rotary_seq_len = rotary_seq_len,
+                hidden_states=X,
+                past_key_value=past_key_values[idx],
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                do_prefill=not hasattr(decoder_layer.self_attn, "paged_attention"),
+                rotary_seq_len=rotary_seq_len,
             )
             X += residual
 
@@ -1319,15 +1319,15 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.post_attention_layernorm,
                 X,
-                XX = XX,
-                XX2 = XX2,
-                variance = variance,
+                XX=XX,
+                XX2=XX2,
+                variance=variance,
             )
             X = mlp_fast_forward_inference(
                 decoder_layer.mlp,
                 X,
-                temp_gate = temp_gates[device_index],
-                temp_up = temp_ups[device_index],
+                temp_gate=temp_gates[device_index],
+                temp_up=temp_ups[device_index],
             )
             X += residual
 
@@ -1335,16 +1335,16 @@ def _LlamaModel_fast_forward_inference(
         X = fast_rms_layernorm_inference(
             self.model.norm,
             X,
-            XX = XX,
-            XX2 = XX2,
-            variance = variance,
+            XX=XX,
+            XX2=XX2,
+            variance=variance,
         )
 
         return BaseModelOutputWithPast(
-            last_hidden_state = X,
-            past_key_values = next_decoder_cache,
-            hidden_states = [],
-            attentions = [],
+            last_hidden_state=X,
+            past_key_values=next_decoder_cache,
+            hidden_states=[],
+            attentions=[],
         )
 
     return LlamaModel_fast_forward_inference_custom
@@ -1378,8 +1378,8 @@ def CausalLM_fast_forward(fast_forward_inference):
                 self,
                 input_ids,
                 past_key_values,
-                position_ids = position_ids,
-                attention_mask = attention_mask,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
                 **kwargs,
             )
         else:
@@ -1399,16 +1399,16 @@ def CausalLM_fast_forward(fast_forward_inference):
             # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
             self.model._has_no_labels = labels is None
             outputs = self.model(
-                input_ids = input_ids,
-                causal_mask = causal_mask,
-                attention_mask = attention_mask,
-                position_ids = position_ids,
-                past_key_values = past_key_values,
-                inputs_embeds = inputs_embeds,
-                use_cache = use_cache,
-                output_attentions = output_attentions,
-                output_hidden_states = output_hidden_states,
-                return_dict = return_dict,
+                input_ids=input_ids,
+                causal_mask=causal_mask,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
                 **kwargs,
             )
         hidden_states = outputs[0]
@@ -1436,11 +1436,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if num_logits_to_keep != 0:
                 hidden_states = hidden_states[:, -num_logits_to_keep:, :]
             return CausalLMOutputWithPast(
-                loss = None,
-                logits = hidden_states,
-                past_key_values = outputs.past_key_values,
-                hidden_states = outputs.hidden_states,
-                attentions = outputs.attentions,
+                loss=None,
+                logits=hidden_states,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
             )
 
         if bsz == 1 and q_len == 1:
@@ -1473,28 +1473,28 @@ def CausalLM_fast_forward(fast_forward_inference):
                 #     logit_softcapping  = logit_softcapping,
                 # )
                 loss = unsloth_fused_ce_loss(
-                    trainer = None,
-                    hidden_states = hidden_states,
-                    lm_head_weight = lm_head,
-                    lm_head_bias = None,
-                    labels = labels,
-                    mask = None,
-                    n_items = n_items,
-                    scaling = getattr(self, "accelerator_scaler", None),
-                    target_gb = None,
-                    torch_compile = True,
-                    logit_softcapping = logit_softcapping,
+                    trainer=None,
+                    hidden_states=hidden_states,
+                    lm_head_weight=lm_head,
+                    lm_head_bias=None,
+                    labels=labels,
+                    mask=None,
+                    n_items=n_items,
+                    scaling=getattr(self, "accelerator_scaler", None),
+                    target_gb=None,
+                    torch_compile=True,
+                    logit_softcapping=logit_softcapping,
                 )
                 if not return_dict:
                     output = (logits,) + outputs[1:]
                     return (loss,) + output if loss is not None else output
 
                 output = CausalLMOutputWithPast(
-                    loss = loss,
-                    logits = EMPTY_LOGITS,
-                    past_key_values = outputs.past_key_values,
-                    hidden_states = outputs.hidden_states,
-                    attentions = outputs.attentions,
+                    loss=loss,
+                    logits=EMPTY_LOGITS,
+                    past_key_values=outputs.past_key_values,
+                    hidden_states=outputs.hidden_states,
+                    attentions=outputs.attentions,
                 )
                 return output
             pass
@@ -1530,11 +1530,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if n_items is None:
                 n_items = kwargs.get("n_items", None)
             loss = fast_cross_entropy_loss(
-                logits = shift_logits,
-                labels = shift_labels,
-                logit_softcapping = logit_softcapping,
-                logit_scaling = logit_scaling,
-                n_items = n_items,
+                logits=shift_logits,
+                labels=shift_labels,
+                logit_softcapping=logit_softcapping,
+                logit_scaling=logit_scaling,
+                n_items=n_items,
             )
         else:
             if logit_scaling != 0:
@@ -1556,11 +1556,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             output = (logits,) + outputs[1:]
             return (loss,) + output if loss is not None else output
         return CausalLMOutputWithPast(
-            loss = loss,
-            logits = logits,
-            past_key_values = outputs.past_key_values,
-            hidden_states = outputs.hidden_states,
-            attentions = outputs.attentions,
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
     return _CausalLM_fast_forward
@@ -1569,48 +1569,48 @@ def CausalLM_fast_forward(fast_forward_inference):
 @torch._disable_dynamo
 def PeftModel_fast_forward(
     self,
-    input_ids = None,
-    causal_mask = None,
-    attention_mask = None,
-    inputs_embeds = None,
-    labels = None,
-    output_attentions = None,
-    output_hidden_states = None,
-    return_dict = None,
-    task_ids = None,
-    num_logits_to_keep = 0,
-    logits_to_keep = 0,
+    input_ids=None,
+    causal_mask=None,
+    attention_mask=None,
+    inputs_embeds=None,
+    labels=None,
+    output_attentions=None,
+    output_hidden_states=None,
+    return_dict=None,
+    task_ids=None,
+    num_logits_to_keep=0,
+    logits_to_keep=0,
     **kwargs,
 ):
     is_classification = "Classification" in str(type(self.base_model.model))
     if is_classification:
         return self.base_model(
-            input_ids = input_ids,
-            attention_mask = attention_mask,
-            inputs_embeds = inputs_embeds,
-            labels = labels,
-            output_attentions = output_attentions,
-            output_hidden_states = output_hidden_states,
-            return_dict = return_dict,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
             **kwargs,
         )
     else:
         return self.base_model(
-            input_ids = input_ids,
-            causal_mask = causal_mask,
-            attention_mask = attention_mask,
-            inputs_embeds = inputs_embeds,
-            labels = labels,
-            output_attentions = output_attentions,
-            output_hidden_states = output_hidden_states,
-            return_dict = return_dict,
-            num_logits_to_keep = num_logits_to_keep,
-            logits_to_keep = logits_to_keep,
+            input_ids=input_ids,
+            causal_mask=causal_mask,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            num_logits_to_keep=num_logits_to_keep,
+            logits_to_keep=logits_to_keep,
             **kwargs,
         )
 
 
-def _get_rope_theta(config, default = 10000.0):
+def _get_rope_theta(config, default=10000.0):
     """Get rope_theta from config, handling both transformers 4.x and 5.x."""
     try:
         return config.rope_theta
@@ -1646,23 +1646,19 @@ def _rope_scaling_as_dict(rope_scaling):
         return {}
 
 
-def _llama3_inv_freq_from_config(
-    config,
-    rope_scaling,
-    device = "cpu",
-):
+def _llama3_inv_freq_from_config(config, rope_scaling, device="cpu"):
     """Inline llama3 RoPE inv_freq using factors read from config.rope_scaling.
 
     Fallback for transformers versions without modeling_rope_utils. Mirrors
     meta-llama's llama3 scaling and LlamaExtendedRotaryEmbedding, but reads the
     factors from config rather than hardcoding them.
     """
-    base = _get_rope_theta(config, default = 10000.0)
+    base = _get_rope_theta(config, default=10000.0)
     dim = getattr(config, "head_dim", None)
     if dim is None:
         dim = int(config.hidden_size // config.num_attention_heads)
     inv_freq = 1.0 / (
-        base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim)
+        base ** (torch.arange(0, dim, 2, dtype=torch.int64, device=device).float() / dim)
     )
 
     scale_factor = rope_scaling.get("factor", 8.0)
@@ -1694,14 +1690,27 @@ def _compute_config_rope_inv_freq(config, rope_scaling):
     unexpected failure returns (None, 1.0) so the caller keeps the prior vanilla
     behavior rather than crashing.
     """
+    original_rope_scaling = rope_scaling
     rope_scaling = _rope_scaling_as_dict(rope_scaling)
     rope_type = rope_scaling.get("rope_type", None) or rope_scaling.get("type", None)
     try:
         from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 
         rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
-        inv_freq, attention_scaling = rope_init_fn(config, torch.device("cpu"))
-        return inv_freq.to(dtype = torch.float32, device = "cpu"), float(attention_scaling)
+        try:
+            inv_freq, attention_scaling = rope_init_fn(config, torch.device("cpu"))
+        except Exception:
+            # config.rope_scaling may be an object the installed transformers
+            # cannot subscript; retry with a shallow config copy carrying the
+            # normalized dict so the delegate sees plain dict access again.
+            if isinstance(original_rope_scaling, dict):
+                raise
+            import copy as _copy
+
+            config_copy = _copy.copy(config)
+            config_copy.rope_scaling = rope_scaling
+            inv_freq, attention_scaling = rope_init_fn(config_copy, torch.device("cpu"))
+        return inv_freq.to(dtype=torch.float32, device="cpu"), float(attention_scaling)
     except Exception as exception:
         if rope_type == "llama3":
             try:
@@ -1727,11 +1736,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         # RoPE long-context attention scaling (multiplies cos/sin). 1.0 for
@@ -1747,7 +1756,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         config_inv_freq = None
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default = base)
+            base = _get_rope_theta(config, default=base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1780,26 +1789,26 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             inv_freq = 1.0 / (
                 self.base
                 ** (
-                    torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim
+                    torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float() / self.dim
                 )
             )
             inv_freq = self._apply_inv_freq_scaling(inv_freq)
-        self.register_buffer("inv_freq", inv_freq, persistent = False)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
 
         # Build here to make `torch.jit.trace` work.
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                seq_len = self.current_rope_size,
-                device = torch.device(device_idx),
-                dtype = torch.get_default_dtype(),
+                seq_len=self.current_rope_size,
+                device=torch.device(device_idx),
+                dtype=torch.get_default_dtype(),
             )
 
         # dummy so that patch_utils doesn't fail for now
         self.cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
 
     def _apply_inv_freq_scaling(self, inv_freq):
@@ -1815,18 +1824,18 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
         t = torch.arange(
-            self.current_rope_size, device = self.inv_freq.device, dtype = torch.int64
+            self.current_rope_size, device=self.inv_freq.device, dtype=torch.int64
         ).float()
         t = self._apply_time_scaling(t)
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
         # attention_scaling is 1.0 except for long-context schemes (yarn /
         # longrope); multiplying here keeps it applied across cache rebuilds in
         # extend_rope_embedding. Default 1.0 leaves every existing path bit-identical.
-        cos = (emb.cos() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
-        sin = (emb.sin() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
+        cos = (emb.cos() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
+        sin = (emb.sin() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
         self.multi_gpu_cos_cached[device.index] = cos
         self.multi_gpu_sin_cached[device.index] = sin
         return cos, sin
@@ -1834,12 +1843,12 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids = None,
-        seq_len = None,
+        position_ids=None,
+        seq_len=None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
 
         device_index = x.device.index
         return (
@@ -1849,8 +1858,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len = None,
-        device_index = None,
+        seq_len=None,
+        device_index=None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -1863,7 +1872,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
+                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
             )
 
 
@@ -1875,20 +1884,20 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        scaling_factor = 1.0,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        scaling_factor=1.0,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         self.scaling_factor = scaling_factor
         super().__init__(
-            dim = dim,
-            max_position_embeddings = max_position_embeddings,
-            base = base,
-            device = device,
-            config = config,
+            dim=dim,
+            max_position_embeddings=max_position_embeddings,
+            base=base,
+            device=device,
+            config=config,
         )
 
     def _apply_time_scaling(self, t):
@@ -1901,18 +1910,18 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
 class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 2048,
-        base = 10000,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__(
-            dim = dim,
-            max_position_embeddings = max_position_embeddings,
-            base = base,
-            device = device,
-            config = config,
+            dim=dim,
+            max_position_embeddings=max_position_embeddings,
+            base=base,
+            device=device,
+            config=config,
         )
 
     # From https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/api/model.py#L41
@@ -1938,21 +1947,21 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
                     high_freq_factor - low_freq_factor
                 )
                 new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-        return torch.tensor(new_freqs, dtype = freqs.dtype, device = freqs.device)
+        return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
 class LongRopeRotaryEmbedding(torch.nn.Module):
     # For Phi 3.5 128K https://huggingface.co/microsoft/Phi-3.5-mini-instruct/blob/main/modeling_phi3.py
     def __init__(
         self,
-        dim = None,
-        max_position_embeddings = 131072,
-        original_max_position_embeddings = 4096,
-        base = 10000,
-        short_factor = None,
-        long_factor = None,
-        device = None,
-        config = None,  # [TODO] Hack to pass in config - need to remove later
+        dim=None,
+        max_position_embeddings=131072,
+        original_max_position_embeddings=4096,
+        base=10000,
+        short_factor=None,
+        long_factor=None,
+        device=None,
+        config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         assert short_factor is not None
@@ -1961,7 +1970,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default = base)
+            base = _get_rope_theta(config, default=base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1983,10 +1992,10 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         # Long RoPE similar to RoPE except short sequences have 1 cos / sin
         # and long sequences have another cos / sin
         inv_freq_shape = (
-            torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim
+            torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float() / self.dim
         )
-        short_factor = torch.tensor(short_factor, device = "cpu", dtype = torch.float32)
-        long_factor = torch.tensor(long_factor, device = "cpu", dtype = torch.float32)
+        short_factor = torch.tensor(short_factor, device="cpu", dtype=torch.float32)
+        long_factor = torch.tensor(long_factor, device="cpu", dtype=torch.float32)
         short_inv_freq = 1.0 / (short_factor * self.base**inv_freq_shape)
         long_inv_freq = 1.0 / (long_factor * self.base**inv_freq_shape)
 
@@ -2001,43 +2010,43 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.scaling_factor = scaling_factor
 
         # Short and long inv_freq
-        self.register_buffer("short_inv_freq", short_inv_freq, persistent = False)
-        self.register_buffer("long_inv_freq", long_inv_freq, persistent = False)
+        self.register_buffer("short_inv_freq", short_inv_freq, persistent=False)
+        self.register_buffer("long_inv_freq", long_inv_freq, persistent=False)
 
         # Build here to make `torch.jit.trace` work.
         # Initialize short sequences cache for all devices
         dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
         t = torch.arange(
             original_max_position_embeddings,
-            device = self.short_inv_freq.device,
-            dtype = torch.int64,
+            device=self.short_inv_freq.device,
+            dtype=torch.int64,
         ).float()
         freqs = torch.outer(t, self.short_inv_freq)
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
 
         for device_idx in range(DEVICE_COUNT):
             device_obj = torch.device(device_idx)
             cos_cached = (emb.cos() * self.scaling_factor).to(
-                dtype = dtype, device = device_obj, non_blocking = True
+                dtype=dtype, device=device_obj, non_blocking=True
             )
             sin_cached = (emb.sin() * self.scaling_factor).to(
-                dtype = dtype, device = device_obj, non_blocking = True
+                dtype=dtype, device=device_obj, non_blocking=True
             )
             self.multi_gpu_short_cos_cached[device_idx] = cos_cached
             self.multi_gpu_short_sin_cached[device_idx] = sin_cached
 
         # dummy so that patch_utils doesn't fail for now
         self.short_cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.short_sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.long_cos_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
         self.long_sin_cached = torch.empty(
-            1, device = get_current_device(), dtype = torch.get_default_dtype()
+            1, device=get_current_device(), dtype=torch.get_default_dtype()
         )
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
@@ -2046,16 +2055,16 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = seq_len
 
         t = torch.arange(
-            self.current_rope_size, device = self.long_inv_freq.device, dtype = torch.int64
+            self.current_rope_size, device=self.long_inv_freq.device, dtype=torch.int64
         ).float()
         # Long sequences
         freqs = torch.outer(t, self.long_inv_freq)
-        emb = torch.cat((freqs, freqs), dim = -1)
+        emb = torch.cat((freqs, freqs), dim=-1)
         cos_cached = (emb.cos() * self.scaling_factor).to(
-            dtype = dtype, device = device, non_blocking = True
+            dtype=dtype, device=device, non_blocking=True
         )
         sin_cached = (emb.sin() * self.scaling_factor).to(
-            dtype = dtype, device = device, non_blocking = True
+            dtype=dtype, device=device, non_blocking=True
         )
         self.multi_gpu_long_cos_cached[device.index] = cos_cached
         self.multi_gpu_long_sin_cached[device.index] = sin_cached
@@ -2064,12 +2073,12 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids = None,
-        seq_len = None,
+        position_ids=None,
+        seq_len=None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
 
         device_index = x.device.index
 
@@ -2086,8 +2095,8 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len = None,
-        device_index = None,
+        seq_len=None,
+        device_index=None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -2106,7 +2115,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
+                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
             )
 
 
@@ -2187,7 +2196,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     # Mixed precision autocast
     with (
         _get_inference_mode_context_manager(self),
-        torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = dtype),
+        torch.autocast(device_type=DEVICE_TYPE_TORCH, dtype=dtype),
     ):
         output = self._old_generate(*args, **kwargs)
 
@@ -2199,7 +2208,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     if restore_training_mode:
         FastLlamaModel.for_training(
             self,
-            use_gradient_checkpointing = use_gradient_checkpointing,
+            use_gradient_checkpointing=use_gradient_checkpointing,
         )
 
     return output
@@ -2214,12 +2223,12 @@ class FastLlamaModel:
     @staticmethod
     def pre_patch():
         init_name, function = patch_llama_rope_scaling(
-            model_name = "llama",
-            rope_module = LlamaRotaryEmbedding,
-            scaled_rope_module = LlamaLinearScalingRotaryEmbedding,
-            extended_rope_module = LlamaExtendedRotaryEmbedding,
-            attention_module = LlamaAttention,
-            longrope_module = LongRopeRotaryEmbedding,
+            model_name="llama",
+            rope_module=LlamaRotaryEmbedding,
+            scaled_rope_module=LlamaLinearScalingRotaryEmbedding,
+            extended_rope_module=LlamaExtendedRotaryEmbedding,
+            attention_module=LlamaAttention,
+            longrope_module=LongRopeRotaryEmbedding,
         )
         if init_name is not None:
             exec(function, globals())
@@ -2248,28 +2257,28 @@ class FastLlamaModel:
 
     @staticmethod
     def from_pretrained(
-        model_name = "unsloth/llama-3-8b-bnb-4bit",
-        max_seq_length = None,
-        dtype = None,
-        load_in_4bit = True,
-        token = None,
-        device_map = "sequential",
-        rope_scaling = None,
-        fix_tokenizer = True,
-        model_patcher = None,
-        tokenizer_name = None,
-        trust_remote_code = False,
-        revision = None,
-        fast_inference = False,  # uses vLLM
-        gpu_memory_utilization = 0.5,
-        float8_kv_cache = False,
-        random_state = 3407,
-        max_lora_rank = 16,
-        disable_log_stats = False,
-        unsloth_vllm_standby = False,
-        num_labels = None,
-        qat_scheme = None,
-        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
+        model_name="unsloth/llama-3-8b-bnb-4bit",
+        max_seq_length=None,
+        dtype=None,
+        load_in_4bit=True,
+        token=None,
+        device_map="sequential",
+        rope_scaling=None,
+        fix_tokenizer=True,
+        model_patcher=None,
+        tokenizer_name=None,
+        trust_remote_code=False,
+        revision=None,
+        fast_inference=False,  # uses vLLM
+        gpu_memory_utilization=0.5,
+        float8_kv_cache=False,
+        random_state=3407,
+        max_lora_rank=16,
+        disable_log_stats=False,
+        unsloth_vllm_standby=False,
+        num_labels=None,
+        qat_scheme=None,
+        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
         **kwargs,
     ):
         os.environ["UNSLOTH_USE_NEW_MODEL"] = "0"
@@ -2385,8 +2394,8 @@ class FastLlamaModel:
         # RoPE Scaling
         model_config = AutoConfig.from_pretrained(
             model_name,
-            token = token,
-            attn_implementation = "sdpa",
+            token=token,
+            attn_implementation="sdpa",
         )
         model_config.model_name = model_name
         model_max_seq_length = model_config.max_position_embeddings
@@ -2401,7 +2410,7 @@ class FastLlamaModel:
 
         has_rope_scaling = False
         try:
-            with open(inspect.getfile(model_function), "r", encoding = "utf-8") as file:
+            with open(inspect.getfile(model_function), "r", encoding="utf-8") as file:
                 has_rope_scaling = "self.config.rope_scaling" in file.read()
         except:
             pass
@@ -2449,7 +2458,7 @@ class FastLlamaModel:
 
         # Check and disable bitsandbytes loading if model has non-bitsandbytes quantization
         load_in_4bit, load_in_8bit, _ckpt_quant_method = check_and_disable_bitsandbytes_loading(
-            model_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit
+            model_config, load_in_4bit=load_in_4bit, load_in_8bit=load_in_8bit
         )
 
         bnb_config = None
@@ -2461,11 +2470,11 @@ class FastLlamaModel:
                 # we cannot quantize out_proj layer due to mamba kernels: https://github.com/tiiuae/Falcon-H1/issues/13#issuecomment-2918671274
                 llm_int8_skip_modules.append("out_proj")
             bnb_config = BitsAndBytesConfig(
-                load_in_4bit = True,
-                bnb_4bit_use_double_quant = True,
-                bnb_4bit_quant_type = "nf4",
-                bnb_4bit_compute_dtype = dtype,
-                llm_int8_skip_modules = llm_int8_skip_modules,
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=dtype,
+                llm_int8_skip_modules=llm_int8_skip_modules,
             )
             # Pre-quantized checkpoints (e.g. unsloth/Qwen3-4B-bnb-4bit) use the
             # quantization_config baked into config.json, ignoring our runtime
@@ -2514,13 +2523,13 @@ class FastLlamaModel:
                     setattr(model_config, _cfg_key, _cfg_val)
             model = AutoModelForSequenceClassification.from_pretrained(
                 model_name,
-                config = model_config,
-                device_map = device_map,
+                config=model_config,
+                device_map=device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token = token,
-                trust_remote_code = trust_remote_code,
-                attn_implementation = preferred_attn_impl,
+                token=token,
+                trust_remote_code=trust_remote_code,
+                attn_implementation=preferred_attn_impl,
                 **kwargs,
             )
             # Defensive: ensure the task head is in a floating dtype, guarding
@@ -2538,21 +2547,21 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = kwargs.get("load_in_8bit", False),
-                offload_embedding = False,
-                fast_inference = fast_inference,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=kwargs.get("load_in_8bit", False),
+                offload_embedding=False,
+                fast_inference=fast_inference,
             )
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(
                 model_name,
-                device_map = device_map,
+                device_map=device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token = token,
-                max_position_embeddings = max_position_embeddings,
-                trust_remote_code = trust_remote_code,
-                attn_implementation = preferred_attn_impl,
+                token=token,
+                max_position_embeddings=max_position_embeddings,
+                trust_remote_code=trust_remote_code,
+                attn_implementation=preferred_attn_impl,
                 **kwargs,
             )
             # Attach dispatch hooks for bnb multi-device loads.
@@ -2560,10 +2569,10 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = kwargs.get("load_in_8bit", False),
-                offload_embedding = False,
-                fast_inference = False,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=kwargs.get("load_in_8bit", False),
+                offload_embedding=False,
+                fast_inference=False,
             )
             model.fast_generate = make_fast_generate_wrapper(model.generate)
             model.fast_generate_batches = None
@@ -2584,18 +2593,18 @@ class FastLlamaModel:
 
             allowed_args = inspect.getfullargspec(load_vllm).args
             load_vllm_kwargs = dict(
-                model_name = model_name,
-                config = model_config,
-                gpu_memory_utilization = gpu_memory_utilization,
-                max_seq_length = max_seq_length,
-                dtype = dtype,
-                float8_kv_cache = float8_kv_cache,
-                enable_lora = True,
-                max_lora_rank = max_lora_rank,
-                disable_log_stats = disable_log_stats,
-                use_bitsandbytes = load_in_4bit,
-                unsloth_vllm_standby = unsloth_vllm_standby,
-                fp8_mode = fp8_mode,
+                model_name=model_name,
+                config=model_config,
+                gpu_memory_utilization=gpu_memory_utilization,
+                max_seq_length=max_seq_length,
+                dtype=dtype,
+                float8_kv_cache=float8_kv_cache,
+                enable_lora=True,
+                max_lora_rank=max_lora_rank,
+                disable_log_stats=disable_log_stats,
+                use_bitsandbytes=load_in_4bit,
+                unsloth_vllm_standby=unsloth_vllm_standby,
+                fp8_mode=fp8_mode,
             )
             for allowed_arg in allowed_args:
                 if allowed_arg not in load_vllm_kwargs and allowed_arg in kwargs:
@@ -2608,8 +2617,8 @@ class FastLlamaModel:
             # Convert to HF format
             _, quant_state_dict = get_vllm_state_dict(
                 llm,
-                config = model_config,
-                load_in_fp8 = load_in_fp8,
+                config=model_config,
+                load_in_fp8=load_in_fp8,
             )
             model = convert_vllm_to_huggingface(quant_state_dict, model_config, dtype, bnb_config)
             model.vllm_engine = llm
@@ -2623,16 +2632,16 @@ class FastLlamaModel:
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name
         tokenizer = load_correct_tokenizer(
-            tokenizer_name = tokenizer_name,
-            model_max_length = max_position_embeddings,
-            padding_side = "right",
-            token = token,
-            trust_remote_code = trust_remote_code,
-            fix_tokenizer = fix_tokenizer,
+            tokenizer_name=tokenizer_name,
+            model_max_length=max_position_embeddings,
+            padding_side="right",
+            token=token,
+            trust_remote_code=trust_remote_code,
+            fix_tokenizer=fix_tokenizer,
         )
 
         model, tokenizer = patch_tokenizer(model, tokenizer)
-        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype = dtype)
+        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype=dtype)
 
         # Patch up QKV / O and MLP
         for idx, layer in enumerate(model.model.layers):
@@ -2703,7 +2712,7 @@ class FastLlamaModel:
 
         front_spaces = re.match(r"[\t\s]{1,}", inner_training_loop).group(0)
         inner_training_loop = re.sub(
-            r"^" + front_spaces, "", inner_training_loop, flags = re.MULTILINE
+            r"^" + front_spaces, "", inner_training_loop, flags=re.MULTILINE
         )
         inner_training_loop = inner_training_loop.replace(
             "train_dataloader = tpu_spmd_dataloader(train_dataloader)",
@@ -2735,12 +2744,12 @@ class FastLlamaModel:
         # We check the tokenizer first for errors
         if fix_tokenizer:
             tokenizer = check_tokenizer(
-                model = model,
-                tokenizer = tokenizer,
-                model_name = model_name,
-                model_max_length = max_position_embeddings,
-                padding_side = "right",
-                token = token,
+                model=model,
+                tokenizer=tokenizer,
+                model_name=model_name,
+                model_max_length=max_position_embeddings,
+                padding_side="right",
+                token=token,
             )
         patch_saving_functions(tokenizer)
 
@@ -2827,18 +2836,18 @@ class FastLlamaModel:
     def post_patch(
         model,
         tokenizer,
-        correct_dtype = None,
+        correct_dtype=None,
     ):
         model, tokenizer = patch_model_and_tokenizer(
-            model, tokenizer, downcast_rope = True, correct_dtype = correct_dtype
+            model, tokenizer, downcast_rope=True, correct_dtype=correct_dtype
         )
         return model, tokenizer
 
     @staticmethod
     def get_peft_model(
         model,
-        r = 16,
-        target_modules = [
+        r=16,
+        target_modules=[
             "q_proj",
             "k_proj",
             "v_proj",
@@ -2847,23 +2856,23 @@ class FastLlamaModel:
             "up_proj",
             "down_proj",
         ],
-        lora_alpha = 16,
-        lora_dropout = 0.0,
-        bias = "none",
-        layers_to_transform = None,
-        layers_pattern = None,
-        finetune_last_n_layers = None,
-        use_gradient_checkpointing = "unsloth",
-        random_state = 3407,
-        max_seq_length = 2048,  # not used anymore
-        use_rslora = False,
-        modules_to_save = None,
-        init_lora_weights = True,
-        loftq_config = {},
-        temporary_location = "_unsloth_temporary_saved_buffers",
-        qat_scheme = None,
-        target_parameters = None,  # For MoE expert layers (nn.Parameter)
-        ensure_weight_tying = False,
+        lora_alpha=16,
+        lora_dropout=0.0,
+        bias="none",
+        layers_to_transform=None,
+        layers_pattern=None,
+        finetune_last_n_layers=None,
+        use_gradient_checkpointing="unsloth",
+        random_state=3407,
+        max_seq_length=2048,  # not used anymore
+        use_rslora=False,
+        modules_to_save=None,
+        init_lora_weights=True,
+        loftq_config={},
+        temporary_location="_unsloth_temporary_saved_buffers",
+        qat_scheme=None,
+        target_parameters=None,  # For MoE expert layers (nn.Parameter)
+        ensure_weight_tying=False,
         **kwargs,
     ):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
@@ -2877,25 +2886,25 @@ class FastLlamaModel:
                 if peft_arg not in kwargs:
                     kwargs[peft_arg] = flag
             return FastBaseModel.get_peft_model(
-                model = model,
-                r = r,
-                target_modules = target_modules,
-                lora_alpha = lora_alpha,
-                lora_dropout = lora_dropout,
-                bias = bias,
-                layers_to_transform = layers_to_transform,
-                layers_pattern = layers_pattern,
-                finetune_last_n_layers = finetune_last_n_layers,
-                use_gradient_checkpointing = use_gradient_checkpointing,
-                random_state = random_state,
-                max_seq_length = max_seq_length,
-                use_rslora = use_rslora,
-                modules_to_save = modules_to_save,
-                init_lora_weights = init_lora_weights,
-                loftq_config = loftq_config,
-                temporary_location = temporary_location,
-                target_parameters = target_parameters,
-                ensure_weight_tying = ensure_weight_tying,
+                model=model,
+                r=r,
+                target_modules=target_modules,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                bias=bias,
+                layers_to_transform=layers_to_transform,
+                layers_pattern=layers_pattern,
+                finetune_last_n_layers=finetune_last_n_layers,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                random_state=random_state,
+                max_seq_length=max_seq_length,
+                use_rslora=use_rslora,
+                modules_to_save=modules_to_save,
+                init_lora_weights=init_lora_weights,
+                loftq_config=loftq_config,
+                temporary_location=temporary_location,
+                target_parameters=target_parameters,
+                ensure_weight_tying=ensure_weight_tying,
                 **kwargs,
             )
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
@@ -3016,6 +3025,7 @@ class FastLlamaModel:
         if init_lora_weights == "loftq":
             if not SUPPORTS_LOFTQ:
                 import peft
+
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support LoftQ init.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3024,11 +3034,12 @@ class FastLlamaModel:
 
             if loftq_config == {}:
                 from peft import LoftQConfig
+
                 logger.warning_once(
                     "Unsloth: init_lora_weights = `loftq` is set, but `loftq_config` is None.\n"
                     "We shall use `loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)`."
                 )
-                loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)
+                loftq_config = LoftQConfig(loftq_bits=4, loftq_iter=1)
 
             if hasattr(model.config, "quantization_config"):
                 raise ValueError(
@@ -3041,6 +3052,7 @@ class FastLlamaModel:
             if not SUPPORTS_RSLORA:
                 # We manually check for PEFT
                 import peft
+
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support `use_rslora`.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3169,25 +3181,26 @@ class FastLlamaModel:
 
         if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers
+
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:
                 _n = max(1, min(int(finetune_last_n_layers), _total_layers))
                 layers_to_transform = list(range(_total_layers - _n, _total_layers))
 
         arguments = dict(
-            r = r,
-            lora_alpha = lora_alpha,
-            target_modules = final_modules,
-            lora_dropout = lora_dropout,
-            bias = bias,
-            task_type = TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
-            layers_to_transform = layers_to_transform,
-            init_lora_weights = init_lora_weights,
-            loftq_config = loftq_config,
-            use_rslora = use_rslora,
-            modules_to_save = modules_to_save,
-            target_parameters = target_parameters,
-            ensure_weight_tying = ensure_weight_tying,
+            r=r,
+            lora_alpha=lora_alpha,
+            target_modules=final_modules,
+            lora_dropout=lora_dropout,
+            bias=bias,
+            task_type=TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
+            layers_to_transform=layers_to_transform,
+            init_lora_weights=init_lora_weights,
+            loftq_config=loftq_config,
+            use_rslora=use_rslora,
+            modules_to_save=modules_to_save,
+            target_parameters=target_parameters,
+            ensure_weight_tying=ensure_weight_tying,
             **kwargs,
         )
         if not SUPPORTS_LOFTQ:
@@ -3291,7 +3304,7 @@ class FastLlamaModel:
             assert hasattr(model.get_input_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
             )
 
         if train_lm_head:
@@ -3299,7 +3312,7 @@ class FastLlamaModel:
             assert hasattr(model.get_output_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
             )
 
         # Patch tokenizer to pad to the right
@@ -3333,11 +3346,11 @@ class FastLlamaModel:
         return model
 
     @staticmethod
-    def patch_peft_model(model, use_gradient_checkpointing = "unsloth"):
+    def patch_peft_model(model, use_gradient_checkpointing="unsloth"):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
             return FastBaseModel.patch_peft_model(
-                model = model,
-                use_gradient_checkpointing = use_gradient_checkpointing,
+                model=model,
+                use_gradient_checkpointing=use_gradient_checkpointing,
             )
         if not isinstance(model, PeftModelForCausalLM) and not isinstance(
             model, PeftModelForSequenceClassification
@@ -3372,8 +3385,8 @@ class FastLlamaModel:
 
         model = prepare_model_for_kbit_training(
             model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
-            use_reentrant = True,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            use_reentrant=True,
         )
 
         # Fix up config for transformers uploading PEFT
@@ -3419,7 +3432,7 @@ class FastLlamaModel:
 
         # We also do not inplace edit QKV for Cohere!
         _apply_lora_mlp = (
-            functools.partial(apply_lora_mlp, inplace = False)
+            functools.partial(apply_lora_mlp, inplace=False)
             if model_type == "cohere"
             else apply_lora_mlp
         )
@@ -3593,13 +3606,14 @@ class FastLlamaModel:
         # for gradient checkpointing (older unsloth_zoo has no restore helper)
         try:
             from unsloth_zoo.training_utils import restore_use_cache
+
             restore_use_cache(model)
         except ImportError:
             pass
         return model
 
     @staticmethod
-    def for_training(model, use_gradient_checkpointing = True):
+    def for_training(model, use_gradient_checkpointing=True):
         if not hasattr(model, "parameters"):
             raise TypeError(
                 "Unsloth: I think you're passing a tokenizer, not the model to for_training!"
@@ -3652,6 +3666,7 @@ class FastLlamaModel:
         ):
             try:
                 from unsloth_zoo.training_utils import disable_use_cache
+
                 disable_use_cache(model)
             except ImportError:
                 pass
@@ -3660,4 +3675,4 @@ class FastLlamaModel:
 
 from .rl import PatchFastRL
 
-PatchFastRL(FastLanguageModel = FastLlamaModel)
+PatchFastRL(FastLanguageModel=FastLlamaModel)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1623,12 +1623,7 @@ def _get_rope_theta(config, default=10000.0):
 
 
 def _rope_scaling_as_dict(rope_scaling):
-    """Normalize config.rope_scaling to a plain dict.
-
-    Newer transformers may expose rope_scaling as a config object (e.g. a
-    RopeScalingConfig dataclass) instead of a raw dict; calling .get() on it
-    would raise AttributeError. Returns {} when nothing usable is found.
-    """
+    """Normalize config.rope_scaling (dict or config object) to a dict; {} on failure."""
     if isinstance(rope_scaling, dict):
         return rope_scaling
     for converter in ("to_dict", "dict"):
@@ -1647,12 +1642,7 @@ def _rope_scaling_as_dict(rope_scaling):
 
 
 def _llama3_inv_freq_from_config(config, rope_scaling, device="cpu"):
-    """Inline llama3 RoPE inv_freq using factors read from config.rope_scaling.
-
-    Fallback for transformers versions without modeling_rope_utils. Mirrors
-    meta-llama's llama3 scaling and LlamaExtendedRotaryEmbedding, but reads the
-    factors from config rather than hardcoding them.
-    """
+    """llama3 inv_freq with factors from config; fallback when modeling_rope_utils is missing."""
     base = _get_rope_theta(config, default=10000.0)
     dim = getattr(config, "head_dim", None)
     if dim is None:
@@ -1670,9 +1660,7 @@ def _llama3_inv_freq_from_config(config, rope_scaling, device="cpu"):
     high_freq_wavelen = old_context_len / high_freq_factor
     assert low_freq_wavelen != high_freq_wavelen
 
-    # Vectorized version of meta-llama's per-frequency loop. Bands match the
-    # reference exactly: wavelen < high_wl keeps the frequency, wavelen >
-    # low_wl divides by the scale factor, the medium band blends the two.
+    # Vectorized meta-llama bands: high freqs kept, low divided by factor, medium blended.
     wavelen = 2 * math.pi / inv_freq
     scaled = torch.where(wavelen > low_freq_wavelen, inv_freq / scale_factor, inv_freq)
     smooth = (old_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
@@ -1682,14 +1670,8 @@ def _llama3_inv_freq_from_config(config, rope_scaling, device="cpu"):
 
 
 def _compute_config_rope_inv_freq(config, rope_scaling):
-    """Return (inv_freq, attention_scaling) honoring config.rope_scaling.
-
-    Delegates to transformers' ROPE_INIT_FUNCTIONS so the result matches stock
-    transformers exactly (default / linear / dynamic / yarn / longrope / llama3).
-    Falls back to an inline llama3 computation on older transformers. On any
-    unexpected failure returns (None, 1.0) so the caller keeps the prior vanilla
-    behavior rather than crashing.
-    """
+    """(inv_freq, attention_scaling) per config.rope_scaling via transformers'
+    ROPE_INIT_FUNCTIONS, with an inline llama3 fallback; (None, 1.0) on failure."""
     original_rope_scaling = rope_scaling
     rope_scaling = _rope_scaling_as_dict(rope_scaling)
     rope_type = rope_scaling.get("rope_type", None) or rope_scaling.get("type", None)
@@ -1700,9 +1682,7 @@ def _compute_config_rope_inv_freq(config, rope_scaling):
         try:
             inv_freq, attention_scaling = rope_init_fn(config, torch.device("cpu"))
         except Exception:
-            # config.rope_scaling may be an object the installed transformers
-            # cannot subscript; retry with a shallow config copy carrying the
-            # normalized dict so the delegate sees plain dict access again.
+            # Object-style rope_scaling: retry with a config copy carrying the plain dict.
             if isinstance(original_rope_scaling, dict):
                 raise
             import copy as _copy
@@ -1743,16 +1723,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         config=None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
-        # RoPE long-context attention scaling (multiplies cos/sin). 1.0 for
-        # vanilla / llama3; non-1.0 for yarn / longrope. Set before any
-        # _set_cos_sin_cache call so the cache build always sees it.
+        # cos/sin multiplier (1.0 except yarn / longrope); set before any cache build.
         self.attention_scaling = 1.0
-        # When config carries a rope_scaling spec and we are the base class used
-        # directly (the modern-transformers path where LlamaModel builds the
-        # rotary from config), derive inv_freq the same way transformers does so
-        # the scaling is not silently dropped. Fixes #2405 (llama3 long-context
-        # gibberish). Subclasses that scale via _apply_inv_freq_scaling /
-        # _apply_time_scaling are excluded so scaling is never applied twice.
+        # Base-class-from-config path (modern transformers): derive inv_freq like
+        # transformers so config.rope_scaling is not dropped (#2405). Scaled
+        # subclasses are excluded to avoid double-scaling.
         config_inv_freq = None
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
@@ -1782,8 +1757,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         self.multi_gpu_sin_cached = [None] * DEVICE_COUNT
 
         if config_inv_freq is not None:
-            # Already scaled per config.rope_scaling; do not scale again.
-            inv_freq = config_inv_freq
+            inv_freq = config_inv_freq  # already scaled; skip subclass scaling
         else:
             # Normal Llama-3 RoPE
             inv_freq = 1.0 / (
@@ -1831,9 +1805,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
         emb = torch.cat((freqs, freqs), dim=-1)
-        # attention_scaling is 1.0 except for long-context schemes (yarn /
-        # longrope); multiplying here keeps it applied across cache rebuilds in
-        # extend_rope_embedding. Default 1.0 leaves every existing path bit-identical.
+        # Applied here so attention_scaling survives extend_rope_embedding rebuilds;
+        # default 1.0 keeps unscaled paths bit-identical.
         cos = (emb.cos() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
         sin = (emb.sin() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
         self.multi_gpu_cos_cached[device.index] = cos

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -172,12 +172,12 @@ def _offload_frozen_module_for_training(
         # Tesla T4 must use float32 and not float16
         new_dtype = torch.float32
 
-    module.modules_to_save.default.to(device=device_type, dtype=new_dtype, non_blocking=True)
+    module.modules_to_save.default.to(device = device_type, dtype = new_dtype, non_blocking = True)
     module.modules_to_save.default.requires_grad_(True)
 
     # [TODO] Move old module to CPU - should be disk!
     if offload_device is not None:
-        module.original_module.to(device=offload_device, non_blocking=True)
+        module.original_module.to(device = offload_device, non_blocking = True)
     module.original_module.requires_grad_(False)
 
 
@@ -185,8 +185,8 @@ def _offload_frozen_module_for_training(
 def _fast_prepare_inputs_for_generation(
     self,
     input_ids,
-    attention_mask=None,
-    inputs_embeds=None,
+    attention_mask = None,
+    inputs_embeds = None,
     **kwargs,
 ):
     past_key_values = kwargs.get("past_key_values", None)
@@ -249,8 +249,8 @@ def _fast_prepare_inputs_for_generation(
                 kwargs["cache_position"] = torch.arange(
                     past_len,
                     past_len + seq_length,
-                    device=device,
-                    dtype=torch.long,
+                    device = device,
+                    dtype = torch.long,
                 )
             else:
                 if hasattr(cache_position, "device") and cache_position.device != device:
@@ -346,9 +346,9 @@ def LlamaAttention_fast_forward_inference(
     hidden_states: torch.Tensor,
     past_key_value: Optional[Tuple[torch.Tensor]],
     position_ids,
-    do_prefill=False,
-    attention_mask=None,
-    rotary_seq_len=None,
+    do_prefill = False,
+    attention_mask = None,
+    rotary_seq_len = None,
 ):
     """
     https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L406
@@ -400,25 +400,25 @@ def LlamaAttention_fast_forward_inference(
     if do_prefill:
         self.paged_attention = torch.empty(
             (KV_CACHE_INCREMENT + seq_len + 1, 2, bsz, n_kv_heads, head_dim),
-            dtype=dtype,
-            device=device,
+            dtype = dtype,
+            device = device,
         )
         self.paged_attention_K = self.paged_attention[:, 0]
         self.paged_attention_V = self.paged_attention[:, 1]
         self.paged_attention_K[:seq_len] = K1.permute(2, 0, 1, 3)
         self.paged_attention_V[:seq_len] = V1.permute(2, 0, 1, 3)
-        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype=dtype, device=device)
-        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype=dtype, device=device)
-        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype=dtype, device=device)
+        self.temp_QA = torch.empty((2, bsz, 1, attention_size), dtype = dtype, device = device)
+        self.temp_KV = torch.empty((2, bsz, 1, n_kv_heads * head_dim), dtype = dtype, device = device)
+        self.RH_Q = torch.empty((bsz, n_heads, 1, head_dim), dtype = dtype, device = device)
 
         # Mistral Nemo 12b has weird dimensions
         if attention_size != hidden_size:
-            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype=dtype, device=device)
+            self.temp_O = torch.empty((bsz, 1, hidden_size), dtype = dtype, device = device)
         else:
             self.temp_O = self.temp_QA[1][:, :, :hidden_size]
 
         self.attention = torch.empty(
-            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype=dtype, device=device
+            (bsz, n_heads, 1, KV_CACHE_INCREMENT + seq_len), dtype = dtype, device = device
         )
         self.scalar = 1.0 / math_sqrt(self.head_dim)
         self.half_head_dim = head_dim // 2
@@ -436,9 +436,9 @@ def LlamaAttention_fast_forward_inference(
         self.paged_attention_V = self.paged_attention[:, 1]
         self.attention.resize_((bsz, n_heads, 1, self.attention.shape[-1] + KV_CACHE_INCREMENT))
 
-    Qn = fast_linear_forward(self.q_proj, Xn, out=self.temp_QA[0])
-    Kn = fast_linear_forward(self.k_proj, Xn, out=self.temp_KV[0])
-    Vn = fast_linear_forward(self.v_proj, Xn, out=self.temp_KV[1])
+    Qn = fast_linear_forward(self.q_proj, Xn, out = self.temp_QA[0])
+    Kn = fast_linear_forward(self.k_proj, Xn, out = self.temp_KV[0])
+    Vn = fast_linear_forward(self.v_proj, Xn, out = self.temp_KV[1])
     Qn = Qn.view(bsz, 1, n_heads, head_dim).transpose(1, 2)
     Kn = Kn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
     Vn = Vn.view(bsz, 1, n_kv_heads, head_dim).transpose(1, 2)
@@ -461,8 +461,8 @@ def LlamaAttention_fast_forward_inference(
     self.rotary_emb.extend_rope_embedding(Vn, rotary_seq_len + 1)  # +1 slack
     cos, sin = self.rotary_emb.get_cached(rotary_seq_len, Qn.device.index or 0)
 
-    cos = cos[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
-    sin = sin[position_ids].unsqueeze(1).to(device=Qn.device, dtype=Qn.dtype)
+    cos = cos[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
+    sin = sin[position_ids].unsqueeze(1).to(device = Qn.device, dtype = Qn.dtype)
 
     h = self.half_head_dim
 
@@ -523,9 +523,9 @@ def LlamaAttention_fast_forward_inference(
             self.scalar
         )  # See https://github.com/ggerganov/llama.cpp/issues/7805#issuecomment-2153349963
         # It seems like doing (Q * scalar) @ K is better than (Q @ K) * scalar to stop overflows
-        A = torch_matmul(Qn, Knn.transpose(2, 3), out=self.attention[:, :, :, :cached_len])
-        A[:] = torch_nn_functional_softmax(A, dim=-1, dtype=torch.float32)  # .to(A.dtype)
-        A = torch_matmul(A, Vnn, out=Qn)
+        A = torch_matmul(Qn, Knn.transpose(2, 3), out = self.attention[:, :, :, :cached_len])
+        A[:] = torch_nn_functional_softmax(A, dim = -1, dtype = torch.float32)  # .to(A.dtype)
+        A = torch_matmul(A, Vnn, out = Qn)
     # --- attention_mask fixup for SDPA if user passes 2D padding mask
     else:
         if attention_mask is not None and attention_mask.dim() == 2:
@@ -544,17 +544,17 @@ def LlamaAttention_fast_forward_inference(
                 Qn,
                 Knn,
                 Vnn,
-                attn_mask=attention_mask,
-                is_causal=is_causal,
-                enable_gqa=True,
+                attn_mask = attention_mask,
+                is_causal = is_causal,
+                enable_gqa = True,
             )
         else:
             A = scaled_dot_product_attention(
-                Qn, Knn, Vnn, attn_mask=attention_mask, is_causal=is_causal
+                Qn, Knn, Vnn, attn_mask = attention_mask, is_causal = is_causal
             )
     A = A.transpose(1, 2)
     A = A.reshape(bsz, 1, attention_size)
-    A = fast_linear_forward(self.o_proj, A, out=self.temp_O)
+    A = fast_linear_forward(self.o_proj, A, out = self.temp_O)
     return A, (Kn, Vn)
 
 
@@ -564,10 +564,10 @@ torch_nn_functional_silu = torch.nn.functional.silu
 def fast_swiglu_inference(
     self,
     X,
-    temp_gate=None,
-    temp_up=None,
-    gate_multiplier=None,
-    down_multiplier=None,
+    temp_gate = None,
+    temp_up = None,
+    gate_multiplier = None,
+    down_multiplier = None,
 ):
     # gate = self.gate_proj(X)
     # up   = self.up_proj(X)
@@ -575,18 +575,18 @@ def fast_swiglu_inference(
     # mlp_size = self.config.intermediate_size
     # temp = torch.empty((2, bsz, 1, mlp_size), dtype = X.dtype, device = "cuda:0")
 
-    gate = fast_linear_forward(self.gate_proj, X, out=temp_gate)
+    gate = fast_linear_forward(self.gate_proj, X, out = temp_gate)
 
     if gate_multiplier is not None:
         gate *= gate_multiplier
 
-    up = fast_linear_forward(self.up_proj, X, out=temp_up)
+    up = fast_linear_forward(self.up_proj, X, out = temp_up)
 
-    gate = torch_nn_functional_silu(gate, inplace=True)
+    gate = torch_nn_functional_silu(gate, inplace = True)
     gate *= up
 
     # X = self.down_proj(gate)
-    down = fast_linear_forward(self.down_proj, gate, out=up[:, :, :hd])
+    down = fast_linear_forward(self.down_proj, gate, out = up[:, :, :hd])
 
     if down_multiplier is not None:
         down *= down_multiplier
@@ -601,17 +601,17 @@ torch_mean = torch.mean
 def fast_rms_layernorm_inference(
     self,
     X,
-    XX=None,
-    XX2=None,
-    variance=None,
+    XX = None,
+    XX2 = None,
+    variance = None,
 ):
     old_dtype = X.dtype
     if XX is None:
         XX = X.to(torch.float32)
-        variance = XX.square().mean(-1, keepdim=True)
+        variance = XX.square().mean(-1, keepdim = True)
     else:
         XX.copy_(X)
-        torch_mean(torch_square(XX, out=XX2), -1, keepdim=True, out=variance)
+        torch_mean(torch_square(XX, out = XX2), -1, keepdim = True, out = variance)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -627,10 +627,10 @@ def fast_rms_layernorm_inference(
 def fast_rms_layernorm_inference_gemma(
     self,
     X,
-    out_weight=None,
+    out_weight = None,
 ):
     XX = X.to(torch.float32)
-    variance = XX.square().mean(-1, keepdim=True)
+    variance = XX.square().mean(-1, keepdim = True)
     variance += self.variance_epsilon
     XX *= variance.rsqrt_()
 
@@ -645,15 +645,15 @@ def fast_rms_layernorm_inference_gemma(
 
 
 # Normal layernorm with mean removal
-@torch.compile(fullgraph=False, dynamic=True, options=torch_compile_options)
+@torch.compile(fullgraph = False, dynamic = True, options = torch_compile_options)
 def fast_layernorm_compiled(layernorm, X):
     old_dtype = X.dtype
     X = X.float()
-    mean = X.mean(-1, keepdim=True)
+    mean = X.mean(-1, keepdim = True)
     Xbar = X - mean
     X = (
         Xbar
-        * torch.rsqrt(Xbar.square().mean(-1, keepdim=True) + layernorm.variance_epsilon)
+        * torch.rsqrt(Xbar.square().mean(-1, keepdim = True) + layernorm.variance_epsilon)
         * layernorm.weight.float()
     )
     return X.to(old_dtype)
@@ -705,10 +705,10 @@ def LlamaAttention_fast_forward(
         cos, sin = position_embeddings
     else:
         rotary_emb = self.rotary_emb
-        rotary_emb.extend_rope_embedding(V, seq_len=kv_seq_len)
+        rotary_emb.extend_rope_embedding(V, seq_len = kv_seq_len)
         cos, sin = rotary_emb.get_cached(kv_seq_len, Q.device.index)
-        cos = cos.to(device=Q.device, dtype=Q.dtype)
-        sin = sin.to(device=Q.device, dtype=Q.dtype)
+        cos = cos.to(device = Q.device, dtype = Q.dtype)
+        sin = sin.to(device = Q.device, dtype = Q.dtype)
 
     rope_position_ids = position_ids
     if rope_position_ids is None and seq_info is not None:
@@ -722,8 +722,8 @@ def LlamaAttention_fast_forward(
     Q, K = fast_rope_embedding(Q, K, cos, sin, rope_position_ids)
 
     if past_key_value is not None:
-        K = torch.cat([past_key_value[0], K], dim=2)
-        V = torch.cat([past_key_value[1], V], dim=2)
+        K = torch.cat([past_key_value[0], K], dim = 2)
+        V = torch.cat([past_key_value[1], V], dim = 2)
     past_key_value = (K, V) if use_cache else None
 
     # Attention module
@@ -732,25 +732,25 @@ def LlamaAttention_fast_forward(
 
     # should dropout be hardcoded to 0.0?
     config = AttentionConfig(
-        backend=backend,
-        n_kv_heads=n_kv_heads,
-        n_groups=n_groups,
-        flash_dense_kwargs={"causal": True},
-        flash_varlen_kwargs={"dropout_p": 0.0, "causal": True},
+        backend = backend,
+        n_kv_heads = n_kv_heads,
+        n_groups = n_groups,
+        flash_dense_kwargs = {"causal": True},
+        flash_varlen_kwargs = {"dropout_p": 0.0, "causal": True},
     )
     context = AttentionContext(
-        bsz=bsz,
-        q_len=q_len,
-        kv_seq_len=kv_seq_len,
-        n_heads=n_heads,
-        head_dim=head_dim,
-        requires_grad=hidden_states.requires_grad,
-        seq_info=seq_info,
-        attention_mask=attention_mask,
-        causal_mask=causal_mask,
+        bsz = bsz,
+        q_len = q_len,
+        kv_seq_len = kv_seq_len,
+        n_heads = n_heads,
+        head_dim = head_dim,
+        requires_grad = hidden_states.requires_grad,
+        seq_info = seq_info,
+        attention_mask = attention_mask,
+        causal_mask = causal_mask,
     )
 
-    A = run_attention(config=config, context=context, Q=Q, K=K, V=V)
+    A = run_attention(config = config, context = context, Q = Q, K = K, V = V)
     attn_output = A.reshape(bsz, q_len, n_heads * head_dim)
     attn_output = self.apply_o(self, attn_output)
     attn_weights = None
@@ -761,7 +761,7 @@ def LlamaAttention_fast_forward(
 def LlamaDecoderLayer_fast_forward(
     self,
     hidden_states: torch.Tensor,
-    causal_mask=None,
+    causal_mask = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
     past_key_value: Optional[Tuple[torch.Tensor]] = None,
@@ -789,15 +789,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm_inference(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states=hidden_states,
-            causal_mask=causal_mask,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_value=past_key_value,
-            output_attentions=output_attentions,
-            use_cache=use_cache,
-            padding_mask=padding_mask,
-            position_embeddings=position_embeddings,
+            hidden_states = hidden_states,
+            causal_mask = causal_mask,
+            attention_mask = attention_mask,
+            position_ids = position_ids,
+            past_key_value = past_key_value,
+            output_attentions = output_attentions,
+            use_cache = use_cache,
+            padding_mask = padding_mask,
+            position_embeddings = position_embeddings,
             **kwargs,
         )
         hidden_states += residual
@@ -811,15 +811,15 @@ def LlamaDecoderLayer_fast_forward(
         residual = hidden_states
         hidden_states = fast_rms_layernorm(self.input_layernorm, hidden_states)
         hidden_states, self_attn_weights, present_key_value = self.self_attn(
-            hidden_states=hidden_states,
-            causal_mask=causal_mask,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_value=past_key_value,
-            output_attentions=output_attentions,
-            use_cache=use_cache,
-            padding_mask=padding_mask,
-            position_embeddings=position_embeddings,
+            hidden_states = hidden_states,
+            causal_mask = causal_mask,
+            attention_mask = attention_mask,
+            position_ids = position_ids,
+            past_key_value = past_key_value,
+            output_attentions = output_attentions,
+            use_cache = use_cache,
+            padding_mask = padding_mask,
+            position_embeddings = position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -923,8 +923,8 @@ def LlamaModel_fast_forward(
         position_ids = torch.arange(
             past_key_values_length,
             seq_length + past_key_values_length,
-            dtype=torch.int32,
-            device=f"{DEVICE_TYPE_TORCH}:0",
+            dtype = torch.int32,
+            device = f"{DEVICE_TYPE_TORCH}:0",
         )
         position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
     elif position_ids is not None:
@@ -956,7 +956,7 @@ def LlamaModel_fast_forward(
         # inputs_embeds *= math_sqrt(self.config.hidden_size)
         # Ie 3072**0.5 = 55.5000 in bfloat16, whilst 55.4256 in float32
         # &  2048**0.5 = 45.2500 in bfloat16, whilst 45.2548 in float32
-        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype=inputs_embeds.dtype)
+        normalizer = torch.tensor(math_sqrt(self.config.hidden_size), dtype = inputs_embeds.dtype)
 
         if train_embed_tokens:
             # Careful we must not do an inplace op!
@@ -1013,7 +1013,7 @@ def LlamaModel_fast_forward(
             (batch_size, seq_length),
             inputs_embeds,
             past_key_values_length,
-            sliding_window=getattr(self.config, "sliding_window", None),
+            sliding_window = getattr(self.config, "sliding_window", None),
         )
         # Must NOT convert to bool - weirdly this causes stuff to error out!
         # if attention_mask is not None:
@@ -1068,14 +1068,14 @@ def LlamaModel_fast_forward(
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window=self.config.sliding_window,
+                sliding_window = self.config.sliding_window,
             )
             dynamic_GA_mask = _prepare_4d_causal_attention_mask_for_sdpa(
                 attention_mask,
                 (batch_size, seq_length),
                 inputs_embeds,
                 past_key_values_length,
-                sliding_window=None,
+                sliding_window = None,
             )
             use_static_mask = False
 
@@ -1095,15 +1095,15 @@ def LlamaModel_fast_forward(
 
                 self.SWA_mask = (
                     AttentionMaskConverter(
-                        is_causal=True,
-                        sliding_window=self.config.sliding_window,
+                        is_causal = True,
+                        sliding_window = self.config.sliding_window,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype=inputs_embeds.dtype,
-                        device=DEVICE_TYPE_TORCH,
+                        dtype = inputs_embeds.dtype,
+                        device = DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1111,14 +1111,14 @@ def LlamaModel_fast_forward(
 
                 self.GA_mask = (
                     AttentionMaskConverter(
-                        is_causal=True,
+                        is_causal = True,
                     )
                     .to_causal_4d(
                         1,
                         n,
                         n,
-                        dtype=inputs_embeds.dtype,
-                        device=DEVICE_TYPE_TORCH,
+                        dtype = inputs_embeds.dtype,
+                        device = DEVICE_TYPE_TORCH,
                     )
                     .squeeze(0)
                     .squeeze(0)
@@ -1161,8 +1161,8 @@ def LlamaModel_fast_forward(
                         *inputs,
                         past_key_value,
                         output_attentions,
-                        padding_mask=padding_mask,
-                        position_embeddings=position_embeddings,
+                        padding_mask = padding_mask,
+                        position_embeddings = position_embeddings,
                         **kwargs,
                     )
 
@@ -1174,22 +1174,22 @@ def LlamaModel_fast_forward(
                 mask,
                 attention_mask,
                 position_ids,
-                use_reentrant=True,
-                preserve_rng_state=False,
+                use_reentrant = True,
+                preserve_rng_state = False,
             )
             hidden_states = layer_outputs[0]
 
         else:
             layer_outputs = decoder_layer(
                 hidden_states,
-                causal_mask=mask,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_value=past_key_value,
-                output_attentions=output_attentions,
-                use_cache=use_cache,
-                padding_mask=padding_mask,
-                position_embeddings=position_embeddings,
+                causal_mask = mask,
+                attention_mask = attention_mask,
+                position_ids = position_ids,
+                past_key_value = past_key_value,
+                output_attentions = output_attentions,
+                use_cache = use_cache,
+                padding_mask = padding_mask,
+                position_embeddings = position_embeddings,
                 **kwargs,
             )
             hidden_states = layer_outputs[0]
@@ -1210,9 +1210,9 @@ def LlamaModel_fast_forward(
     elif IS_COHERE:
         hidden_states = self.norm(hidden_states)
     elif IS_FALCON_H1:
-        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma=IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.final_layernorm, hidden_states, gemma = IS_GEMMA)
     else:
-        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma=IS_GEMMA)
+        hidden_states = fast_rms_layernorm(self.norm, hidden_states, gemma = IS_GEMMA)
 
     if output_hidden_states:
         all_hidden_states += (hidden_states,)
@@ -1225,17 +1225,17 @@ def LlamaModel_fast_forward(
             if v is not None
         )
     return BaseModelOutputWithPast(
-        last_hidden_state=hidden_states,
-        past_key_values=next_cache,
-        hidden_states=all_hidden_states,
-        attentions=all_self_attns,
+        last_hidden_state = hidden_states,
+        past_key_values = next_cache,
+        hidden_states = all_hidden_states,
+        attentions = all_self_attns,
     )
 
 
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L825
 def _LlamaModel_fast_forward_inference(
-    attention_fast_forward_inference=LlamaAttention_fast_forward_inference,
-    mlp_fast_forward_inference=fast_swiglu_inference,
+    attention_fast_forward_inference = LlamaAttention_fast_forward_inference,
+    mlp_fast_forward_inference = fast_swiglu_inference,
 ):
     # Makes attention and MLP customisable for models like qwen3/cohere.
     def LlamaModel_fast_forward_inference_custom(
@@ -1243,7 +1243,7 @@ def _LlamaModel_fast_forward_inference(
         input_ids,
         past_key_values,
         position_ids,
-        attention_mask=None,
+        attention_mask = None,
         **kwargs,
     ):
         input_ids = input_ids[:, : self.max_seq_length]
@@ -1257,15 +1257,15 @@ def _LlamaModel_fast_forward_inference(
         assert q_len == 1
         # Get saved buffers to reduce memory movement
         residual = torch.empty(
-            (bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
         )
-        _XX = torch.empty((2, bsz, q_len, hd), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0")
+        _XX = torch.empty((2, bsz, q_len, hd), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0")
         XX, XX2 = _XX[0], _XX[1]
         variance = torch.empty(
-            (bsz, q_len, 1), dtype=torch.float32, device=f"{DEVICE_TYPE_TORCH}:0"
+            (bsz, q_len, 1), dtype = torch.float32, device = f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_mlp = torch.empty(
-            (2, bsz, 1, mlp_size), dtype=X.dtype, device=f"{DEVICE_TYPE_TORCH}:0"
+            (2, bsz, 1, mlp_size), dtype = X.dtype, device = f"{DEVICE_TYPE_TORCH}:0"
         )
         temp_gates, temp_ups = (
             tuple(temp_mlp[0].to(torch.device(x)) for x in range(DEVICE_COUNT)),
@@ -1280,7 +1280,7 @@ def _LlamaModel_fast_forward_inference(
                 (bsz, q_len),
                 X,
                 seq_len,
-                sliding_window=getattr(self.config, "sliding_window", None),
+                sliding_window = getattr(self.config, "sliding_window", None),
             )
             # Pre-convert to bool once for all layers (avoids per-layer .eq(0))
             if attention_mask is not None and attention_mask.dtype != torch.bool:
@@ -1300,18 +1300,18 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.input_layernorm,
                 X,
-                XX=XX,
-                XX2=XX2,
-                variance=variance,
+                XX = XX,
+                XX2 = XX2,
+                variance = variance,
             )
             X, present_key_value = attention_fast_forward_inference(
                 decoder_layer.self_attn,
-                hidden_states=X,
-                past_key_value=past_key_values[idx],
-                position_ids=position_ids,
-                attention_mask=attention_mask,
-                do_prefill=not hasattr(decoder_layer.self_attn, "paged_attention"),
-                rotary_seq_len=rotary_seq_len,
+                hidden_states = X,
+                past_key_value = past_key_values[idx],
+                position_ids = position_ids,
+                attention_mask = attention_mask,
+                do_prefill = not hasattr(decoder_layer.self_attn, "paged_attention"),
+                rotary_seq_len = rotary_seq_len,
             )
             X += residual
 
@@ -1319,15 +1319,15 @@ def _LlamaModel_fast_forward_inference(
             X = fast_rms_layernorm_inference(
                 decoder_layer.post_attention_layernorm,
                 X,
-                XX=XX,
-                XX2=XX2,
-                variance=variance,
+                XX = XX,
+                XX2 = XX2,
+                variance = variance,
             )
             X = mlp_fast_forward_inference(
                 decoder_layer.mlp,
                 X,
-                temp_gate=temp_gates[device_index],
-                temp_up=temp_ups[device_index],
+                temp_gate = temp_gates[device_index],
+                temp_up = temp_ups[device_index],
             )
             X += residual
 
@@ -1335,16 +1335,16 @@ def _LlamaModel_fast_forward_inference(
         X = fast_rms_layernorm_inference(
             self.model.norm,
             X,
-            XX=XX,
-            XX2=XX2,
-            variance=variance,
+            XX = XX,
+            XX2 = XX2,
+            variance = variance,
         )
 
         return BaseModelOutputWithPast(
-            last_hidden_state=X,
-            past_key_values=next_decoder_cache,
-            hidden_states=[],
-            attentions=[],
+            last_hidden_state = X,
+            past_key_values = next_decoder_cache,
+            hidden_states = [],
+            attentions = [],
         )
 
     return LlamaModel_fast_forward_inference_custom
@@ -1378,8 +1378,8 @@ def CausalLM_fast_forward(fast_forward_inference):
                 self,
                 input_ids,
                 past_key_values,
-                position_ids=position_ids,
-                attention_mask=attention_mask,
+                position_ids = position_ids,
+                attention_mask = attention_mask,
                 **kwargs,
             )
         else:
@@ -1399,16 +1399,16 @@ def CausalLM_fast_forward(fast_forward_inference):
             # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
             self.model._has_no_labels = labels is None
             outputs = self.model(
-                input_ids=input_ids,
-                causal_mask=causal_mask,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_values=past_key_values,
-                inputs_embeds=inputs_embeds,
-                use_cache=use_cache,
-                output_attentions=output_attentions,
-                output_hidden_states=output_hidden_states,
-                return_dict=return_dict,
+                input_ids = input_ids,
+                causal_mask = causal_mask,
+                attention_mask = attention_mask,
+                position_ids = position_ids,
+                past_key_values = past_key_values,
+                inputs_embeds = inputs_embeds,
+                use_cache = use_cache,
+                output_attentions = output_attentions,
+                output_hidden_states = output_hidden_states,
+                return_dict = return_dict,
                 **kwargs,
             )
         hidden_states = outputs[0]
@@ -1436,11 +1436,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if num_logits_to_keep != 0:
                 hidden_states = hidden_states[:, -num_logits_to_keep:, :]
             return CausalLMOutputWithPast(
-                loss=None,
-                logits=hidden_states,
-                past_key_values=outputs.past_key_values,
-                hidden_states=outputs.hidden_states,
-                attentions=outputs.attentions,
+                loss = None,
+                logits = hidden_states,
+                past_key_values = outputs.past_key_values,
+                hidden_states = outputs.hidden_states,
+                attentions = outputs.attentions,
             )
 
         if bsz == 1 and q_len == 1:
@@ -1473,28 +1473,28 @@ def CausalLM_fast_forward(fast_forward_inference):
                 #     logit_softcapping  = logit_softcapping,
                 # )
                 loss = unsloth_fused_ce_loss(
-                    trainer=None,
-                    hidden_states=hidden_states,
-                    lm_head_weight=lm_head,
-                    lm_head_bias=None,
-                    labels=labels,
-                    mask=None,
-                    n_items=n_items,
-                    scaling=getattr(self, "accelerator_scaler", None),
-                    target_gb=None,
-                    torch_compile=True,
-                    logit_softcapping=logit_softcapping,
+                    trainer = None,
+                    hidden_states = hidden_states,
+                    lm_head_weight = lm_head,
+                    lm_head_bias = None,
+                    labels = labels,
+                    mask = None,
+                    n_items = n_items,
+                    scaling = getattr(self, "accelerator_scaler", None),
+                    target_gb = None,
+                    torch_compile = True,
+                    logit_softcapping = logit_softcapping,
                 )
                 if not return_dict:
                     output = (logits,) + outputs[1:]
                     return (loss,) + output if loss is not None else output
 
                 output = CausalLMOutputWithPast(
-                    loss=loss,
-                    logits=EMPTY_LOGITS,
-                    past_key_values=outputs.past_key_values,
-                    hidden_states=outputs.hidden_states,
-                    attentions=outputs.attentions,
+                    loss = loss,
+                    logits = EMPTY_LOGITS,
+                    past_key_values = outputs.past_key_values,
+                    hidden_states = outputs.hidden_states,
+                    attentions = outputs.attentions,
                 )
                 return output
             pass
@@ -1530,11 +1530,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             if n_items is None:
                 n_items = kwargs.get("n_items", None)
             loss = fast_cross_entropy_loss(
-                logits=shift_logits,
-                labels=shift_labels,
-                logit_softcapping=logit_softcapping,
-                logit_scaling=logit_scaling,
-                n_items=n_items,
+                logits = shift_logits,
+                labels = shift_labels,
+                logit_softcapping = logit_softcapping,
+                logit_scaling = logit_scaling,
+                n_items = n_items,
             )
         else:
             if logit_scaling != 0:
@@ -1556,11 +1556,11 @@ def CausalLM_fast_forward(fast_forward_inference):
             output = (logits,) + outputs[1:]
             return (loss,) + output if loss is not None else output
         return CausalLMOutputWithPast(
-            loss=loss,
-            logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
+            loss = loss,
+            logits = logits,
+            past_key_values = outputs.past_key_values,
+            hidden_states = outputs.hidden_states,
+            attentions = outputs.attentions,
         )
 
     return _CausalLM_fast_forward
@@ -1569,48 +1569,48 @@ def CausalLM_fast_forward(fast_forward_inference):
 @torch._disable_dynamo
 def PeftModel_fast_forward(
     self,
-    input_ids=None,
-    causal_mask=None,
-    attention_mask=None,
-    inputs_embeds=None,
-    labels=None,
-    output_attentions=None,
-    output_hidden_states=None,
-    return_dict=None,
-    task_ids=None,
-    num_logits_to_keep=0,
-    logits_to_keep=0,
+    input_ids = None,
+    causal_mask = None,
+    attention_mask = None,
+    inputs_embeds = None,
+    labels = None,
+    output_attentions = None,
+    output_hidden_states = None,
+    return_dict = None,
+    task_ids = None,
+    num_logits_to_keep = 0,
+    logits_to_keep = 0,
     **kwargs,
 ):
     is_classification = "Classification" in str(type(self.base_model.model))
     if is_classification:
         return self.base_model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            inputs_embeds=inputs_embeds,
-            labels=labels,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            input_ids = input_ids,
+            attention_mask = attention_mask,
+            inputs_embeds = inputs_embeds,
+            labels = labels,
+            output_attentions = output_attentions,
+            output_hidden_states = output_hidden_states,
+            return_dict = return_dict,
             **kwargs,
         )
     else:
         return self.base_model(
-            input_ids=input_ids,
-            causal_mask=causal_mask,
-            attention_mask=attention_mask,
-            inputs_embeds=inputs_embeds,
-            labels=labels,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
-            num_logits_to_keep=num_logits_to_keep,
-            logits_to_keep=logits_to_keep,
+            input_ids = input_ids,
+            causal_mask = causal_mask,
+            attention_mask = attention_mask,
+            inputs_embeds = inputs_embeds,
+            labels = labels,
+            output_attentions = output_attentions,
+            output_hidden_states = output_hidden_states,
+            return_dict = return_dict,
+            num_logits_to_keep = num_logits_to_keep,
+            logits_to_keep = logits_to_keep,
             **kwargs,
         )
 
 
-def _get_rope_theta(config, default=10000.0):
+def _get_rope_theta(config, default = 10000.0):
     """Get rope_theta from config, handling both transformers 4.x and 5.x."""
     try:
         return config.rope_theta
@@ -1646,19 +1646,23 @@ def _rope_scaling_as_dict(rope_scaling):
         return {}
 
 
-def _llama3_inv_freq_from_config(config, rope_scaling, device="cpu"):
+def _llama3_inv_freq_from_config(
+    config,
+    rope_scaling,
+    device = "cpu",
+):
     """Inline llama3 RoPE inv_freq using factors read from config.rope_scaling.
 
     Fallback for transformers versions without modeling_rope_utils. Mirrors
     meta-llama's llama3 scaling and LlamaExtendedRotaryEmbedding, but reads the
     factors from config rather than hardcoding them.
     """
-    base = _get_rope_theta(config, default=10000.0)
+    base = _get_rope_theta(config, default = 10000.0)
     dim = getattr(config, "head_dim", None)
     if dim is None:
         dim = int(config.hidden_size // config.num_attention_heads)
     inv_freq = 1.0 / (
-        base ** (torch.arange(0, dim, 2, dtype=torch.int64, device=device).float() / dim)
+        base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim)
     )
 
     scale_factor = rope_scaling.get("factor", 8.0)
@@ -1697,7 +1701,7 @@ def _compute_config_rope_inv_freq(config, rope_scaling):
 
         rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
         inv_freq, attention_scaling = rope_init_fn(config, torch.device("cpu"))
-        return inv_freq.to(dtype=torch.float32, device="cpu"), float(attention_scaling)
+        return inv_freq.to(dtype = torch.float32, device = "cpu"), float(attention_scaling)
     except Exception as exception:
         if rope_type == "llama3":
             try:
@@ -1723,11 +1727,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 2048,
+        base = 10000,
+        device = None,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         # RoPE long-context attention scaling (multiplies cos/sin). 1.0 for
@@ -1743,7 +1747,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         config_inv_freq = None
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default=base)
+            base = _get_rope_theta(config, default = base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1780,22 +1784,22 @@ class LlamaRotaryEmbedding(torch.nn.Module):
                 )
             )
             inv_freq = self._apply_inv_freq_scaling(inv_freq)
-        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("inv_freq", inv_freq, persistent = False)
 
         # Build here to make `torch.jit.trace` work.
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                seq_len=self.current_rope_size,
-                device=torch.device(device_idx),
-                dtype=torch.get_default_dtype(),
+                seq_len = self.current_rope_size,
+                device = torch.device(device_idx),
+                dtype = torch.get_default_dtype(),
             )
 
         # dummy so that patch_utils doesn't fail for now
         self.cos_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.sin_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
 
     def _apply_inv_freq_scaling(self, inv_freq):
@@ -1811,18 +1815,18 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         # in FP32. They are applied (multiplied) in FP32 as well.
         self.current_rope_size = seq_len
         t = torch.arange(
-            self.current_rope_size, device=self.inv_freq.device, dtype=torch.int64
+            self.current_rope_size, device = self.inv_freq.device, dtype = torch.int64
         ).float()
         t = self._apply_time_scaling(t)
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
-        emb = torch.cat((freqs, freqs), dim=-1)
+        emb = torch.cat((freqs, freqs), dim = -1)
         # attention_scaling is 1.0 except for long-context schemes (yarn /
         # longrope); multiplying here keeps it applied across cache rebuilds in
         # extend_rope_embedding. Default 1.0 leaves every existing path bit-identical.
-        cos = (emb.cos() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
-        sin = (emb.sin() * self.attention_scaling).to(dtype=dtype, device=device, non_blocking=True)
+        cos = (emb.cos() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
+        sin = (emb.sin() * self.attention_scaling).to(dtype = dtype, device = device, non_blocking = True)
         self.multi_gpu_cos_cached[device.index] = cos
         self.multi_gpu_sin_cached[device.index] = sin
         return cos, sin
@@ -1830,12 +1834,12 @@ class LlamaRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids=None,
-        seq_len=None,
+        position_ids = None,
+        seq_len = None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
+            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
 
         device_index = x.device.index
         return (
@@ -1845,8 +1849,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len=None,
-        device_index=None,
+        seq_len = None,
+        device_index = None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -1859,7 +1863,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
+                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
             )
 
 
@@ -1871,20 +1875,20 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
     # The precision of RoPE buffers is not correct, so we cast to int64.
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        scaling_factor=1.0,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 2048,
+        base = 10000,
+        device = None,
+        scaling_factor = 1.0,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         self.scaling_factor = scaling_factor
         super().__init__(
-            dim=dim,
-            max_position_embeddings=max_position_embeddings,
-            base=base,
-            device=device,
-            config=config,
+            dim = dim,
+            max_position_embeddings = max_position_embeddings,
+            base = base,
+            device = device,
+            config = config,
         )
 
     def _apply_time_scaling(self, t):
@@ -1897,18 +1901,18 @@ class LlamaLinearScalingRotaryEmbedding(LlamaRotaryEmbedding):
 class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 2048,
+        base = 10000,
+        device = None,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__(
-            dim=dim,
-            max_position_embeddings=max_position_embeddings,
-            base=base,
-            device=device,
-            config=config,
+            dim = dim,
+            max_position_embeddings = max_position_embeddings,
+            base = base,
+            device = device,
+            config = config,
         )
 
     # From https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/api/model.py#L41
@@ -1934,21 +1938,21 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
                     high_freq_factor - low_freq_factor
                 )
                 new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-        return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+        return torch.tensor(new_freqs, dtype = freqs.dtype, device = freqs.device)
 
 
 class LongRopeRotaryEmbedding(torch.nn.Module):
     # For Phi 3.5 128K https://huggingface.co/microsoft/Phi-3.5-mini-instruct/blob/main/modeling_phi3.py
     def __init__(
         self,
-        dim=None,
-        max_position_embeddings=131072,
-        original_max_position_embeddings=4096,
-        base=10000,
-        short_factor=None,
-        long_factor=None,
-        device=None,
-        config=None,  # [TODO] Hack to pass in config - need to remove later
+        dim = None,
+        max_position_embeddings = 131072,
+        original_max_position_embeddings = 4096,
+        base = 10000,
+        short_factor = None,
+        long_factor = None,
+        device = None,
+        config = None,  # [TODO] Hack to pass in config - need to remove later
     ):
         super().__init__()
         assert short_factor is not None
@@ -1957,7 +1961,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
         if config is not None:
             # [TODO] Hack to pass in config - need to remove later
-            base = _get_rope_theta(config, default=base)
+            base = _get_rope_theta(config, default = base)
             partial_rotary_factor = (
                 config.partial_rotary_factor if hasattr(config, "partial_rotary_factor") else 1.0
             )
@@ -1979,10 +1983,10 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         # Long RoPE similar to RoPE except short sequences have 1 cos / sin
         # and long sequences have another cos / sin
         inv_freq_shape = (
-            torch.arange(0, self.dim, 2, dtype=torch.int64, device="cpu").float() / self.dim
+            torch.arange(0, self.dim, 2, dtype = torch.int64, device = "cpu").float() / self.dim
         )
-        short_factor = torch.tensor(short_factor, device="cpu", dtype=torch.float32)
-        long_factor = torch.tensor(long_factor, device="cpu", dtype=torch.float32)
+        short_factor = torch.tensor(short_factor, device = "cpu", dtype = torch.float32)
+        long_factor = torch.tensor(long_factor, device = "cpu", dtype = torch.float32)
         short_inv_freq = 1.0 / (short_factor * self.base**inv_freq_shape)
         long_inv_freq = 1.0 / (long_factor * self.base**inv_freq_shape)
 
@@ -1997,43 +2001,43 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.scaling_factor = scaling_factor
 
         # Short and long inv_freq
-        self.register_buffer("short_inv_freq", short_inv_freq, persistent=False)
-        self.register_buffer("long_inv_freq", long_inv_freq, persistent=False)
+        self.register_buffer("short_inv_freq", short_inv_freq, persistent = False)
+        self.register_buffer("long_inv_freq", long_inv_freq, persistent = False)
 
         # Build here to make `torch.jit.trace` work.
         # Initialize short sequences cache for all devices
         dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
         t = torch.arange(
             original_max_position_embeddings,
-            device=self.short_inv_freq.device,
-            dtype=torch.int64,
+            device = self.short_inv_freq.device,
+            dtype = torch.int64,
         ).float()
         freqs = torch.outer(t, self.short_inv_freq)
-        emb = torch.cat((freqs, freqs), dim=-1)
+        emb = torch.cat((freqs, freqs), dim = -1)
 
         for device_idx in range(DEVICE_COUNT):
             device_obj = torch.device(device_idx)
             cos_cached = (emb.cos() * self.scaling_factor).to(
-                dtype=dtype, device=device_obj, non_blocking=True
+                dtype = dtype, device = device_obj, non_blocking = True
             )
             sin_cached = (emb.sin() * self.scaling_factor).to(
-                dtype=dtype, device=device_obj, non_blocking=True
+                dtype = dtype, device = device_obj, non_blocking = True
             )
             self.multi_gpu_short_cos_cached[device_idx] = cos_cached
             self.multi_gpu_short_sin_cached[device_idx] = sin_cached
 
         # dummy so that patch_utils doesn't fail for now
         self.short_cos_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.short_sin_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.long_cos_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
         self.long_sin_cached = torch.empty(
-            1, device=get_current_device(), dtype=torch.get_default_dtype()
+            1, device = get_current_device(), dtype = torch.get_default_dtype()
         )
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
@@ -2042,16 +2046,16 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = seq_len
 
         t = torch.arange(
-            self.current_rope_size, device=self.long_inv_freq.device, dtype=torch.int64
+            self.current_rope_size, device = self.long_inv_freq.device, dtype = torch.int64
         ).float()
         # Long sequences
         freqs = torch.outer(t, self.long_inv_freq)
-        emb = torch.cat((freqs, freqs), dim=-1)
+        emb = torch.cat((freqs, freqs), dim = -1)
         cos_cached = (emb.cos() * self.scaling_factor).to(
-            dtype=dtype, device=device, non_blocking=True
+            dtype = dtype, device = device, non_blocking = True
         )
         sin_cached = (emb.sin() * self.scaling_factor).to(
-            dtype=dtype, device=device, non_blocking=True
+            dtype = dtype, device = device, non_blocking = True
         )
         self.multi_gpu_long_cos_cached[device.index] = cos_cached
         self.multi_gpu_long_sin_cached[device.index] = sin_cached
@@ -2060,12 +2064,12 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
     def forward(
         self,
         x,
-        position_ids=None,
-        seq_len=None,
+        position_ids = None,
+        seq_len = None,
     ):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len is not None and seq_len > self.current_rope_size:
-            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
+            self._set_cos_sin_cache(seq_len = seq_len, device = x.device, dtype = x.dtype)
 
         device_index = x.device.index
 
@@ -2082,8 +2086,8 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
 
     def get_cached(
         self,
-        seq_len=None,
-        device_index=None,
+        seq_len = None,
+        device_index = None,
     ):
         if device_index is None:
             device_index = get_current_device()
@@ -2102,7 +2106,7 @@ class LongRopeRotaryEmbedding(torch.nn.Module):
         self.current_rope_size = ((seq_len // 8192) + ((seq_len % 8192) != 0)) * 8192
         for device_idx in range(DEVICE_COUNT):
             self._set_cos_sin_cache(
-                self.current_rope_size, device=torch.device(device_idx), dtype=x.dtype
+                self.current_rope_size, device = torch.device(device_idx), dtype = x.dtype
             )
 
 
@@ -2183,7 +2187,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     # Mixed precision autocast
     with (
         _get_inference_mode_context_manager(self),
-        torch.autocast(device_type=DEVICE_TYPE_TORCH, dtype=dtype),
+        torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = dtype),
     ):
         output = self._old_generate(*args, **kwargs)
 
@@ -2195,7 +2199,7 @@ def unsloth_fast_generate(self, *args, **kwargs):
     if restore_training_mode:
         FastLlamaModel.for_training(
             self,
-            use_gradient_checkpointing=use_gradient_checkpointing,
+            use_gradient_checkpointing = use_gradient_checkpointing,
         )
 
     return output
@@ -2210,12 +2214,12 @@ class FastLlamaModel:
     @staticmethod
     def pre_patch():
         init_name, function = patch_llama_rope_scaling(
-            model_name="llama",
-            rope_module=LlamaRotaryEmbedding,
-            scaled_rope_module=LlamaLinearScalingRotaryEmbedding,
-            extended_rope_module=LlamaExtendedRotaryEmbedding,
-            attention_module=LlamaAttention,
-            longrope_module=LongRopeRotaryEmbedding,
+            model_name = "llama",
+            rope_module = LlamaRotaryEmbedding,
+            scaled_rope_module = LlamaLinearScalingRotaryEmbedding,
+            extended_rope_module = LlamaExtendedRotaryEmbedding,
+            attention_module = LlamaAttention,
+            longrope_module = LongRopeRotaryEmbedding,
         )
         if init_name is not None:
             exec(function, globals())
@@ -2244,28 +2248,28 @@ class FastLlamaModel:
 
     @staticmethod
     def from_pretrained(
-        model_name="unsloth/llama-3-8b-bnb-4bit",
-        max_seq_length=None,
-        dtype=None,
-        load_in_4bit=True,
-        token=None,
-        device_map="sequential",
-        rope_scaling=None,
-        fix_tokenizer=True,
-        model_patcher=None,
-        tokenizer_name=None,
-        trust_remote_code=False,
-        revision=None,
-        fast_inference=False,  # uses vLLM
-        gpu_memory_utilization=0.5,
-        float8_kv_cache=False,
-        random_state=3407,
-        max_lora_rank=16,
-        disable_log_stats=False,
-        unsloth_vllm_standby=False,
-        num_labels=None,
-        qat_scheme=None,
-        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
+        model_name = "unsloth/llama-3-8b-bnb-4bit",
+        max_seq_length = None,
+        dtype = None,
+        load_in_4bit = True,
+        token = None,
+        device_map = "sequential",
+        rope_scaling = None,
+        fix_tokenizer = True,
+        model_patcher = None,
+        tokenizer_name = None,
+        trust_remote_code = False,
+        revision = None,
+        fast_inference = False,  # uses vLLM
+        gpu_memory_utilization = 0.5,
+        float8_kv_cache = False,
+        random_state = 3407,
+        max_lora_rank = 16,
+        disable_log_stats = False,
+        unsloth_vllm_standby = False,
+        num_labels = None,
+        qat_scheme = None,
+        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
         **kwargs,
     ):
         os.environ["UNSLOTH_USE_NEW_MODEL"] = "0"
@@ -2381,8 +2385,8 @@ class FastLlamaModel:
         # RoPE Scaling
         model_config = AutoConfig.from_pretrained(
             model_name,
-            token=token,
-            attn_implementation="sdpa",
+            token = token,
+            attn_implementation = "sdpa",
         )
         model_config.model_name = model_name
         model_max_seq_length = model_config.max_position_embeddings
@@ -2397,7 +2401,7 @@ class FastLlamaModel:
 
         has_rope_scaling = False
         try:
-            with open(inspect.getfile(model_function), "r", encoding="utf-8") as file:
+            with open(inspect.getfile(model_function), "r", encoding = "utf-8") as file:
                 has_rope_scaling = "self.config.rope_scaling" in file.read()
         except:
             pass
@@ -2445,7 +2449,7 @@ class FastLlamaModel:
 
         # Check and disable bitsandbytes loading if model has non-bitsandbytes quantization
         load_in_4bit, load_in_8bit, _ckpt_quant_method = check_and_disable_bitsandbytes_loading(
-            model_config, load_in_4bit=load_in_4bit, load_in_8bit=load_in_8bit
+            model_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit
         )
 
         bnb_config = None
@@ -2457,11 +2461,11 @@ class FastLlamaModel:
                 # we cannot quantize out_proj layer due to mamba kernels: https://github.com/tiiuae/Falcon-H1/issues/13#issuecomment-2918671274
                 llm_int8_skip_modules.append("out_proj")
             bnb_config = BitsAndBytesConfig(
-                load_in_4bit=True,
-                bnb_4bit_use_double_quant=True,
-                bnb_4bit_quant_type="nf4",
-                bnb_4bit_compute_dtype=dtype,
-                llm_int8_skip_modules=llm_int8_skip_modules,
+                load_in_4bit = True,
+                bnb_4bit_use_double_quant = True,
+                bnb_4bit_quant_type = "nf4",
+                bnb_4bit_compute_dtype = dtype,
+                llm_int8_skip_modules = llm_int8_skip_modules,
             )
             # Pre-quantized checkpoints (e.g. unsloth/Qwen3-4B-bnb-4bit) use the
             # quantization_config baked into config.json, ignoring our runtime
@@ -2510,13 +2514,13 @@ class FastLlamaModel:
                     setattr(model_config, _cfg_key, _cfg_val)
             model = AutoModelForSequenceClassification.from_pretrained(
                 model_name,
-                config=model_config,
-                device_map=device_map,
+                config = model_config,
+                device_map = device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token=token,
-                trust_remote_code=trust_remote_code,
-                attn_implementation=preferred_attn_impl,
+                token = token,
+                trust_remote_code = trust_remote_code,
+                attn_implementation = preferred_attn_impl,
                 **kwargs,
             )
             # Defensive: ensure the task head is in a floating dtype, guarding
@@ -2534,21 +2538,21 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit=load_in_4bit,
-                load_in_8bit=kwargs.get("load_in_8bit", False),
-                offload_embedding=False,
-                fast_inference=fast_inference,
+                load_in_4bit = load_in_4bit,
+                load_in_8bit = kwargs.get("load_in_8bit", False),
+                offload_embedding = False,
+                fast_inference = fast_inference,
             )
         elif not fast_inference:
             model = AutoModelForCausalLM.from_pretrained(
                 model_name,
-                device_map=device_map,
+                device_map = device_map,
                 # torch_dtype             = dtype, # transformers changed torch_dtype to dtype
                 # quantization_config     = bnb_config,
-                token=token,
-                max_position_embeddings=max_position_embeddings,
-                trust_remote_code=trust_remote_code,
-                attn_implementation=preferred_attn_impl,
+                token = token,
+                max_position_embeddings = max_position_embeddings,
+                trust_remote_code = trust_remote_code,
+                attn_implementation = preferred_attn_impl,
                 **kwargs,
             )
             # Attach dispatch hooks for bnb multi-device loads.
@@ -2556,10 +2560,10 @@ class FastLlamaModel:
 
             _attach_bnb_multidevice_hooks(
                 model,
-                load_in_4bit=load_in_4bit,
-                load_in_8bit=kwargs.get("load_in_8bit", False),
-                offload_embedding=False,
-                fast_inference=False,
+                load_in_4bit = load_in_4bit,
+                load_in_8bit = kwargs.get("load_in_8bit", False),
+                offload_embedding = False,
+                fast_inference = False,
             )
             model.fast_generate = make_fast_generate_wrapper(model.generate)
             model.fast_generate_batches = None
@@ -2580,18 +2584,18 @@ class FastLlamaModel:
 
             allowed_args = inspect.getfullargspec(load_vllm).args
             load_vllm_kwargs = dict(
-                model_name=model_name,
-                config=model_config,
-                gpu_memory_utilization=gpu_memory_utilization,
-                max_seq_length=max_seq_length,
-                dtype=dtype,
-                float8_kv_cache=float8_kv_cache,
-                enable_lora=True,
-                max_lora_rank=max_lora_rank,
-                disable_log_stats=disable_log_stats,
-                use_bitsandbytes=load_in_4bit,
-                unsloth_vllm_standby=unsloth_vllm_standby,
-                fp8_mode=fp8_mode,
+                model_name = model_name,
+                config = model_config,
+                gpu_memory_utilization = gpu_memory_utilization,
+                max_seq_length = max_seq_length,
+                dtype = dtype,
+                float8_kv_cache = float8_kv_cache,
+                enable_lora = True,
+                max_lora_rank = max_lora_rank,
+                disable_log_stats = disable_log_stats,
+                use_bitsandbytes = load_in_4bit,
+                unsloth_vllm_standby = unsloth_vllm_standby,
+                fp8_mode = fp8_mode,
             )
             for allowed_arg in allowed_args:
                 if allowed_arg not in load_vllm_kwargs and allowed_arg in kwargs:
@@ -2604,8 +2608,8 @@ class FastLlamaModel:
             # Convert to HF format
             _, quant_state_dict = get_vllm_state_dict(
                 llm,
-                config=model_config,
-                load_in_fp8=load_in_fp8,
+                config = model_config,
+                load_in_fp8 = load_in_fp8,
             )
             model = convert_vllm_to_huggingface(quant_state_dict, model_config, dtype, bnb_config)
             model.vllm_engine = llm
@@ -2619,16 +2623,16 @@ class FastLlamaModel:
         # Counteract saved tokenizers
         tokenizer_name = model_name if tokenizer_name is None else tokenizer_name
         tokenizer = load_correct_tokenizer(
-            tokenizer_name=tokenizer_name,
-            model_max_length=max_position_embeddings,
-            padding_side="right",
-            token=token,
-            trust_remote_code=trust_remote_code,
-            fix_tokenizer=fix_tokenizer,
+            tokenizer_name = tokenizer_name,
+            model_max_length = max_position_embeddings,
+            padding_side = "right",
+            token = token,
+            trust_remote_code = trust_remote_code,
+            fix_tokenizer = fix_tokenizer,
         )
 
         model, tokenizer = patch_tokenizer(model, tokenizer)
-        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype=dtype)
+        model, tokenizer = model_patcher.post_patch(model, tokenizer, correct_dtype = dtype)
 
         # Patch up QKV / O and MLP
         for idx, layer in enumerate(model.model.layers):
@@ -2699,7 +2703,7 @@ class FastLlamaModel:
 
         front_spaces = re.match(r"[\t\s]{1,}", inner_training_loop).group(0)
         inner_training_loop = re.sub(
-            r"^" + front_spaces, "", inner_training_loop, flags=re.MULTILINE
+            r"^" + front_spaces, "", inner_training_loop, flags = re.MULTILINE
         )
         inner_training_loop = inner_training_loop.replace(
             "train_dataloader = tpu_spmd_dataloader(train_dataloader)",
@@ -2731,12 +2735,12 @@ class FastLlamaModel:
         # We check the tokenizer first for errors
         if fix_tokenizer:
             tokenizer = check_tokenizer(
-                model=model,
-                tokenizer=tokenizer,
-                model_name=model_name,
-                model_max_length=max_position_embeddings,
-                padding_side="right",
-                token=token,
+                model = model,
+                tokenizer = tokenizer,
+                model_name = model_name,
+                model_max_length = max_position_embeddings,
+                padding_side = "right",
+                token = token,
             )
         patch_saving_functions(tokenizer)
 
@@ -2823,18 +2827,18 @@ class FastLlamaModel:
     def post_patch(
         model,
         tokenizer,
-        correct_dtype=None,
+        correct_dtype = None,
     ):
         model, tokenizer = patch_model_and_tokenizer(
-            model, tokenizer, downcast_rope=True, correct_dtype=correct_dtype
+            model, tokenizer, downcast_rope = True, correct_dtype = correct_dtype
         )
         return model, tokenizer
 
     @staticmethod
     def get_peft_model(
         model,
-        r=16,
-        target_modules=[
+        r = 16,
+        target_modules = [
             "q_proj",
             "k_proj",
             "v_proj",
@@ -2843,23 +2847,23 @@ class FastLlamaModel:
             "up_proj",
             "down_proj",
         ],
-        lora_alpha=16,
-        lora_dropout=0.0,
-        bias="none",
-        layers_to_transform=None,
-        layers_pattern=None,
-        finetune_last_n_layers=None,
-        use_gradient_checkpointing="unsloth",
-        random_state=3407,
-        max_seq_length=2048,  # not used anymore
-        use_rslora=False,
-        modules_to_save=None,
-        init_lora_weights=True,
-        loftq_config={},
-        temporary_location="_unsloth_temporary_saved_buffers",
-        qat_scheme=None,
-        target_parameters=None,  # For MoE expert layers (nn.Parameter)
-        ensure_weight_tying=False,
+        lora_alpha = 16,
+        lora_dropout = 0.0,
+        bias = "none",
+        layers_to_transform = None,
+        layers_pattern = None,
+        finetune_last_n_layers = None,
+        use_gradient_checkpointing = "unsloth",
+        random_state = 3407,
+        max_seq_length = 2048,  # not used anymore
+        use_rslora = False,
+        modules_to_save = None,
+        init_lora_weights = True,
+        loftq_config = {},
+        temporary_location = "_unsloth_temporary_saved_buffers",
+        qat_scheme = None,
+        target_parameters = None,  # For MoE expert layers (nn.Parameter)
+        ensure_weight_tying = False,
         **kwargs,
     ):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
@@ -2873,25 +2877,25 @@ class FastLlamaModel:
                 if peft_arg not in kwargs:
                     kwargs[peft_arg] = flag
             return FastBaseModel.get_peft_model(
-                model=model,
-                r=r,
-                target_modules=target_modules,
-                lora_alpha=lora_alpha,
-                lora_dropout=lora_dropout,
-                bias=bias,
-                layers_to_transform=layers_to_transform,
-                layers_pattern=layers_pattern,
-                finetune_last_n_layers=finetune_last_n_layers,
-                use_gradient_checkpointing=use_gradient_checkpointing,
-                random_state=random_state,
-                max_seq_length=max_seq_length,
-                use_rslora=use_rslora,
-                modules_to_save=modules_to_save,
-                init_lora_weights=init_lora_weights,
-                loftq_config=loftq_config,
-                temporary_location=temporary_location,
-                target_parameters=target_parameters,
-                ensure_weight_tying=ensure_weight_tying,
+                model = model,
+                r = r,
+                target_modules = target_modules,
+                lora_alpha = lora_alpha,
+                lora_dropout = lora_dropout,
+                bias = bias,
+                layers_to_transform = layers_to_transform,
+                layers_pattern = layers_pattern,
+                finetune_last_n_layers = finetune_last_n_layers,
+                use_gradient_checkpointing = use_gradient_checkpointing,
+                random_state = random_state,
+                max_seq_length = max_seq_length,
+                use_rslora = use_rslora,
+                modules_to_save = modules_to_save,
+                init_lora_weights = init_lora_weights,
+                loftq_config = loftq_config,
+                temporary_location = temporary_location,
+                target_parameters = target_parameters,
+                ensure_weight_tying = ensure_weight_tying,
                 **kwargs,
             )
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
@@ -3012,7 +3016,6 @@ class FastLlamaModel:
         if init_lora_weights == "loftq":
             if not SUPPORTS_LOFTQ:
                 import peft
-
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support LoftQ init.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3021,12 +3024,11 @@ class FastLlamaModel:
 
             if loftq_config == {}:
                 from peft import LoftQConfig
-
                 logger.warning_once(
                     "Unsloth: init_lora_weights = `loftq` is set, but `loftq_config` is None.\n"
                     "We shall use `loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)`."
                 )
-                loftq_config = LoftQConfig(loftq_bits=4, loftq_iter=1)
+                loftq_config = LoftQConfig(loftq_bits = 4, loftq_iter = 1)
 
             if hasattr(model.config, "quantization_config"):
                 raise ValueError(
@@ -3039,7 +3041,6 @@ class FastLlamaModel:
             if not SUPPORTS_RSLORA:
                 # We manually check for PEFT
                 import peft
-
                 raise RuntimeError(
                     f"Unsloth: Your PEFT version of {peft.__version__} does not support `use_rslora`.\n"
                     "Please install PEFT 0.7.2 or higher.\n"
@@ -3168,26 +3169,25 @@ class FastLlamaModel:
 
         if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers
-
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:
                 _n = max(1, min(int(finetune_last_n_layers), _total_layers))
                 layers_to_transform = list(range(_total_layers - _n, _total_layers))
 
         arguments = dict(
-            r=r,
-            lora_alpha=lora_alpha,
-            target_modules=final_modules,
-            lora_dropout=lora_dropout,
-            bias=bias,
-            task_type=TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
-            layers_to_transform=layers_to_transform,
-            init_lora_weights=init_lora_weights,
-            loftq_config=loftq_config,
-            use_rslora=use_rslora,
-            modules_to_save=modules_to_save,
-            target_parameters=target_parameters,
-            ensure_weight_tying=ensure_weight_tying,
+            r = r,
+            lora_alpha = lora_alpha,
+            target_modules = final_modules,
+            lora_dropout = lora_dropout,
+            bias = bias,
+            task_type = TaskType.CAUSAL_LM if not is_classification else TaskType.SEQ_CLS,
+            layers_to_transform = layers_to_transform,
+            init_lora_weights = init_lora_weights,
+            loftq_config = loftq_config,
+            use_rslora = use_rslora,
+            modules_to_save = modules_to_save,
+            target_parameters = target_parameters,
+            ensure_weight_tying = ensure_weight_tying,
             **kwargs,
         )
         if not SUPPORTS_LOFTQ:
@@ -3291,7 +3291,7 @@ class FastLlamaModel:
             assert hasattr(model.get_input_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
+                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
             )
 
         if train_lm_head:
@@ -3299,7 +3299,7 @@ class FastLlamaModel:
             assert hasattr(model.get_output_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device=None
+                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
             )
 
         # Patch tokenizer to pad to the right
@@ -3333,11 +3333,11 @@ class FastLlamaModel:
         return model
 
     @staticmethod
-    def patch_peft_model(model, use_gradient_checkpointing="unsloth"):
+    def patch_peft_model(model, use_gradient_checkpointing = "unsloth"):
         if os.environ.get("UNSLOTH_USE_NEW_MODEL", "0") == "1":
             return FastBaseModel.patch_peft_model(
-                model=model,
-                use_gradient_checkpointing=use_gradient_checkpointing,
+                model = model,
+                use_gradient_checkpointing = use_gradient_checkpointing,
             )
         if not isinstance(model, PeftModelForCausalLM) and not isinstance(
             model, PeftModelForSequenceClassification
@@ -3372,8 +3372,8 @@ class FastLlamaModel:
 
         model = prepare_model_for_kbit_training(
             model,
-            use_gradient_checkpointing=use_gradient_checkpointing,
-            use_reentrant=True,
+            use_gradient_checkpointing = use_gradient_checkpointing,
+            use_reentrant = True,
         )
 
         # Fix up config for transformers uploading PEFT
@@ -3419,7 +3419,7 @@ class FastLlamaModel:
 
         # We also do not inplace edit QKV for Cohere!
         _apply_lora_mlp = (
-            functools.partial(apply_lora_mlp, inplace=False)
+            functools.partial(apply_lora_mlp, inplace = False)
             if model_type == "cohere"
             else apply_lora_mlp
         )
@@ -3593,14 +3593,13 @@ class FastLlamaModel:
         # for gradient checkpointing (older unsloth_zoo has no restore helper)
         try:
             from unsloth_zoo.training_utils import restore_use_cache
-
             restore_use_cache(model)
         except ImportError:
             pass
         return model
 
     @staticmethod
-    def for_training(model, use_gradient_checkpointing=True):
+    def for_training(model, use_gradient_checkpointing = True):
         if not hasattr(model, "parameters"):
             raise TypeError(
                 "Unsloth: I think you're passing a tokenizer, not the model to for_training!"
@@ -3653,7 +3652,6 @@ class FastLlamaModel:
         ):
             try:
                 from unsloth_zoo.training_utils import disable_use_cache
-
                 disable_use_cache(model)
             except ImportError:
                 pass
@@ -3662,4 +3660,4 @@ class FastLlamaModel:
 
 from .rl import PatchFastRL
 
-PatchFastRL(FastLanguageModel=FastLlamaModel)
+PatchFastRL(FastLanguageModel = FastLlamaModel)


### PR DESCRIPTION
Fixes #2405.

## Root cause

On modern transformers, `LlamaModel` builds the rotary embedding from config using Unsloth's replacement `LlamaRotaryEmbedding` class (`llama.py` swaps it into `transformers.models.llama.modeling_llama`). That class's config path computed vanilla `inv_freq` and never read `config.rope_scaling`. The existing llama3/linear/longrope dispatch in `patch_llama_rope_scaling` rewrites `LlamaAttention.__init__`, but modern transformers no longer constructs rotary embeddings there, so the dispatch never fires, and the model-level (unscaled) rotary is then copied onto every attention layer.

Net effect: Llama-3.1 / 3.2 / 3.3 ran with unscaled RoPE on the FastLanguageModel path. Unscaled rope at theta 500000 holds up to roughly 29K tokens and then collapses, which is exactly the reported "long inputs produce repeated patterns, short inputs fine".

## Evidence

Needle-in-haystack retrieval, Llama-3.1-8B-Instruct, max_seq_length 65536, greedy:

| Configuration | 48K tokens before | 48K tokens after |
|---|---|---|
| FastLanguageModel bf16 | FAIL ("The 1. The 1. The 1...") | PASS ("47291") |
| FastLanguageModel 4-bit | FAIL (wrong answer) | PASS |
| FastModel bf16 / 4-bit | PASS (kept transformers' rotary, immune) | PASS |

Boundary on the broken path: PASS at 28,867 input tokens, FAIL at 31,767. Probing the loaded model confirmed `inv_freq` matched the unscaled formula exactly and not the llama3-scaled one; after this fix it matches transformers' `ROPE_INIT_FUNCTIONS["llama3"]` output exactly.

Blast radius: qwen2, qwen3, qwen3_moe, mistral and cohere assign the same base class with no scaling dispatch at all, so any rope-scaled config of those families (e.g. yarn long-context variants) was equally exposed. Fixing the base class covers all of them at once.

## The fix

In the config path of the base `LlamaRotaryEmbedding`:

- compute `inv_freq` and `attention_scaling` via transformers' `ROPE_INIT_FUNCTIONS[rope_type](config, device)` (covers default, llama3, linear, dynamic, yarn, longrope), with an inline llama3 fallback that reads the factors from config for older transformers, degrading to the previous behavior on any failure rather than crashing;
- apply `attention_scaling` in `_set_cos_sin_cache` (default 1.0, an exact no-op for unscaled paths) so it persists across `extend_rope_embedding` growth;
- a `type(self)` guard ensures the legacy scaled subclasses (`LlamaExtendedRotaryEmbedding`, `LlamaLinearScalingRotaryEmbedding`) never double-apply scaling on old-transformers paths.

No behavior change when `rope_scaling` is None or when constructed without a config.

## Tests

`tests/utils/test_rope_scaling_drift.py`, same two-layer pattern as the left-padding guard: a stdlib-ast tripwire (the config path must reference rope_scaling) plus behavioral checks (inv_freq matches transformers' llama3 init exactly and not vanilla; vanilla config control; cos cache at long positions differs scaled vs unscaled; scaling survives extend_rope_embedding growth). Validated to fail 4 of 5 on the unfixed code and pass 5 of 5 with the fix. Wired into the existing consolidated CI HARD GATE step (renamed to "generation correctness guards"), so no new CI job.

Also verified the left-padded batched generation guard still passes end to end on this branch (exact solo-vs-batched token matches), and 20K-token inputs are unchanged (PASS before and after).
