### PR TITLE
Studio: add project RAG sources

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -773,6 +773,7 @@ def _search_knowledge_base(arguments: dict, rag_scope: dict | None) -> str:
         query = str(query),
         scope_kb_id = scope.get("kb_id"),
         scope_thread_id = scope.get("thread_id"),
+        scope_project_id = scope.get("project_id"),
         top_k = top_k,
         **_scope_retrieval_kwargs(scope),
     )
@@ -880,6 +881,7 @@ def build_rag_autoinject(conversation: list[dict], rag_scope: dict | None) -> di
             query = query,
             scope_kb_id = rag_scope.get("kb_id"),
             scope_thread_id = rag_scope.get("thread_id"),
+            scope_project_id = rag_scope.get("project_id"),
             top_k = top_k,
             min_dense_score = floor,
             **_scope_retrieval_kwargs(rag_scope),

--- a/studio/backend/core/rag/ingestion.py
+++ b/studio/backend/core/rag/ingestion.py
@@ -152,6 +152,7 @@ def start_ingestion(
     filename: str,
     stored_path: str,
     *,
+    project_id: str | None = None,
     model_name: str | None = None,
 ) -> tuple[str, str]:
     """Create the document + job rows and spawn the worker, returning
@@ -180,6 +181,7 @@ def start_ingestion(
             sha256 = sha,
             kb_id = kb_id,
             thread_id = thread_id,
+            project_id = project_id,
             status = "pending",
             stored_path = stored_path,
         )

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -5,7 +5,7 @@
 
 Module-level functions each take a ``conn`` the caller opens and closes. Inserts
 are incremental: ``add_chunks`` appends one document's rows without rebuilding the
-scope. Scope ("kb_<id>" / "thread_<id>") is a column on every table and the vec0
+scope. Scope ("kb_<id>" / "thread_<id>" / "project_<id>") is a column on every table and the vec0
 partition key.
 """
 
@@ -27,6 +27,10 @@ def kb_scope(kb_id: str) -> str:
 
 def thread_scope(thread_id: str) -> str:
     return f"thread_{thread_id}"
+
+
+def project_scope(project_id: str) -> str:
+    return f"project_{project_id}"
 
 
 def _f32(vector) -> bytes:
@@ -96,19 +100,21 @@ def create_document(
     sha256: str,
     kb_id: str | None = None,
     thread_id: str | None = None,
+    project_id: str | None = None,
     status: str = "pending",
     stored_path: str | None = None,
     document_id: str | None = None,
 ) -> str:
     document_id = document_id or str(uuid.uuid4())
     conn.execute(
-        "INSERT INTO documents(id, scope, kb_id, thread_id, filename, sha256, status, "
-        "stored_path, created_at) VALUES(?,?,?,?,?,?,?,?,?)",
+        "INSERT INTO documents(id, scope, kb_id, thread_id, project_id, filename, sha256, status, "
+        "stored_path, created_at) VALUES(?,?,?,?,?,?,?,?,?,?)",
         (
             document_id,
             scope,
             kb_id,
             thread_id,
+            project_id,
             filename,
             sha256,
             status,
@@ -137,7 +143,8 @@ def set_document_status(
 
 def list_documents(conn: sqlite3.Connection, scope: str) -> list[dict]:
     rows = conn.execute(
-        "SELECT id, scope, kb_id, thread_id, filename, sha256, status, error, num_chunks, created_at "
+        "SELECT id, scope, kb_id, thread_id, project_id, filename, sha256, "
+        "status, error, num_chunks, created_at "
         "FROM documents WHERE scope=? ORDER BY created_at DESC",
         (scope,),
     ).fetchall()
@@ -218,6 +225,15 @@ def delete_document(conn: sqlite3.Connection, document_id: str) -> None:
     conn.execute("DELETE FROM chunks WHERE document_id=?", (document_id,))
     conn.execute("DELETE FROM documents WHERE id=?", (document_id,))
     conn.commit()
+
+
+def delete_scope(conn: sqlite3.Connection, scope: str) -> None:
+    """Delete every document (+ chunks) under a scope."""
+    doc_ids = [
+        r["id"] for r in conn.execute("SELECT id FROM documents WHERE scope=?", (scope,)).fetchall()
+    ]
+    for doc_id in doc_ids:
+        delete_document(conn, doc_id)
 
 
 def search_lexical(conn: sqlite3.Connection, scope: str, query: str, k: int):

--- a/studio/backend/core/rag/tool.py
+++ b/studio/backend/core/rag/tool.py
@@ -15,7 +15,7 @@ from xml.sax.saxutils import quoteattr
 from storage import rag_db
 
 from . import config, retrieval
-from .store import kb_scope, thread_scope
+from .store import kb_scope, project_scope, thread_scope
 
 SEARCH_KNOWLEDGE_BASE_TOOL = {
     "type": "function",
@@ -42,9 +42,15 @@ SEARCH_KNOWLEDGE_BASE_TOOL = {
 }
 
 
-def _resolve_scope(scope_kb_id: str | None, scope_thread_id: str | None) -> str | None:
+def _resolve_scope(
+    scope_kb_id: str | None,
+    scope_thread_id: str | None,
+    scope_project_id: str | None,
+) -> str | None:
     if scope_kb_id:
         return kb_scope(scope_kb_id)
+    if scope_project_id:
+        return project_scope(scope_project_id)
     if scope_thread_id:
         return thread_scope(scope_thread_id)
     return None
@@ -83,6 +89,7 @@ def search_knowledge_base_with_sources(
     query: str,
     scope_kb_id: str | None = None,
     scope_thread_id: str | None = None,
+    scope_project_id: str | None = None,
     top_k: int | None = None,
     min_score: float = 0.0,
     model_name: str | None = None,
@@ -92,7 +99,7 @@ def search_knowledge_base_with_sources(
     rendered ``<chunk>`` block's ``id``."""
     if not query or not query.strip():
         return "Error: query is empty.", []
-    scope = _resolve_scope(scope_kb_id, scope_thread_id)
+    scope = _resolve_scope(scope_kb_id, scope_thread_id, scope_project_id)
     if scope is None:
         return "No documents are attached to this chat.", []
 
@@ -124,6 +131,7 @@ def search_for_autoinject(
     query: str,
     scope_kb_id: str | None = None,
     scope_thread_id: str | None = None,
+    scope_project_id: str | None = None,
     top_k: int | None = None,
     min_dense_score: float = 0.70,
     model_name: str | None = None,
@@ -138,7 +146,7 @@ def search_for_autoinject(
     """
     if not query or not query.strip():
         return None
-    scope = _resolve_scope(scope_kb_id, scope_thread_id)
+    scope = _resolve_scope(scope_kb_id, scope_thread_id, scope_project_id)
     if scope is None:
         return None
     k = top_k or config.TOP_K_HYBRID
@@ -177,6 +185,7 @@ def search_knowledge_base(
     query: str,
     scope_kb_id: str | None = None,
     scope_thread_id: str | None = None,
+    scope_project_id: str | None = None,
     top_k: int | None = None,
     min_score: float = 0.0,
     model_name: str | None = None,
@@ -186,6 +195,7 @@ def search_knowledge_base(
         query = query,
         scope_kb_id = scope_kb_id,
         scope_thread_id = scope_thread_id,
+        scope_project_id = scope_project_id,
         top_k = top_k,
         min_score = min_score,
         model_name = model_name,

--- a/studio/backend/core/rag/tool.py
+++ b/studio/backend/core/rag/tool.py
@@ -43,9 +43,7 @@ SEARCH_KNOWLEDGE_BASE_TOOL = {
 
 
 def _resolve_scope(
-    scope_kb_id: str | None,
-    scope_thread_id: str | None,
-    scope_project_id: str | None,
+    scope_kb_id: str | None, scope_thread_id: str | None, scope_project_id: str | None
 ) -> str | None:
     if scope_kb_id:
         return kb_scope(scope_kb_id)

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -699,7 +699,7 @@ class ChatCompletionRequest(BaseModel):
         None,
         description = (
             "[x-unsloth] Hidden RAG retrieval scope for the search_knowledge_base "
-            "tool: {kb_id?, thread_id?, default_top_k?, mode?, autoinject?, "
+            "tool: {kb_id?, thread_id?, project_id?, default_top_k?, mode?, autoinject?, "
             "autoinject_min_score?}. Candidate pools and the RRF constant come from "
             "server config. The model never sees this; the server resolves which "
             "documents to search."

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -324,9 +324,14 @@ async def patch_project(
 async def delete_project(
     project_id: str,
     delete_files: bool = Query(False),
+    delete_sources: bool = Query(True),
     current_subject: str = Depends(get_current_subject),
 ):
-    project = delete_chat_project(project_id, delete_files = delete_files)
+    project = delete_chat_project(
+        project_id,
+        delete_files = delete_files,
+        delete_sources = delete_sources,
+    )
     if project is None:
         raise HTTPException(
             status_code = 404,

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 from auth.authentication import get_current_subject
 from core.rag import config, ingestion, retrieval, store
 from storage import rag_db
+from storage.studio_db import get_chat_project
 from utils.paths import ensure_dir, rag_uploads_root
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,7 @@ def _doc_view(row: dict) -> dict:
         "numChunks": row.get("num_chunks") or 0,
         "kbId": row.get("kb_id"),
         "threadId": row.get("thread_id"),
+        "projectId": row.get("project_id"),
         "createdAt": row.get("created_at"),
     }
 
@@ -102,9 +104,15 @@ class SearchRequest(BaseModel):
     query: str
     kb_id: str | None = None
     thread_id: str | None = None
+    project_id: str | None = None
     top_k: int = Field(default = config.TOP_K_HYBRID, ge = 1, le = 50)
     min_score: float = 0.0
     mode: str = "hybrid"  # hybrid | lexical | dense
+
+
+def _require_project(project_id: str) -> None:
+    if get_chat_project(project_id) is None:
+        raise HTTPException(status_code = 404, detail = "Project not found")
 
 
 @router.get("/knowledge-bases")
@@ -244,6 +252,38 @@ def list_thread_documents(thread_id: str, subject: str = Depends(get_current_sub
         conn.close()
 
 
+@router.post("/projects/{project_id}/documents")
+async def upload_project_document(
+    project_id: str,
+    file: UploadFile = File(...),
+    subject: str = Depends(get_current_subject),
+) -> dict:
+    _require_rag()
+    _require_project(project_id)
+    stored_path, filename = _save_upload(file)
+    document_id, job_id = ingestion.start_ingestion(
+        store.project_scope(project_id),
+        None,
+        None,
+        filename,
+        stored_path,
+        project_id = project_id,
+    )
+    return {"documentId": document_id, "jobId": job_id, "filename": filename}
+
+
+@router.get("/projects/{project_id}/documents")
+def list_project_documents(project_id: str, subject: str = Depends(get_current_subject)) -> dict:
+    _require_rag()
+    _require_project(project_id)
+    conn = rag_db.get_connection()
+    try:
+        docs = store.list_documents(conn, store.project_scope(project_id))
+        return {"documents": [_doc_view(d) for d in docs]}
+    finally:
+        conn.close()
+
+
 @router.delete("/documents/{document_id}")
 def delete_document(document_id: str, subject: str = Depends(get_current_subject)) -> dict:
     _require_rag()
@@ -297,10 +337,13 @@ def search(payload: SearchRequest, subject: str = Depends(get_current_subject)) 
     _require_rag()
     if payload.kb_id:
         scope = store.kb_scope(payload.kb_id)
+    elif payload.project_id:
+        _require_project(payload.project_id)
+        scope = store.project_scope(payload.project_id)
     elif payload.thread_id:
         scope = store.thread_scope(payload.thread_id)
     else:
-        raise HTTPException(status_code = 400, detail = "Provide kb_id or thread_id")
+        raise HTTPException(status_code = 400, detail = "Provide kb_id, project_id, or thread_id")
 
     conn = rag_db.get_connection()
     try:

--- a/studio/backend/storage/rag_db.py
+++ b/studio/backend/storage/rag_db.py
@@ -57,6 +57,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             scope TEXT NOT NULL,
             kb_id TEXT,
             thread_id TEXT,
+            project_id TEXT,
             filename TEXT NOT NULL,
             sha256 TEXT NOT NULL,
             status TEXT NOT NULL DEFAULT 'pending',
@@ -102,6 +103,10 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         );
         """
     )
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(documents)").fetchall()}
+    if "project_id" not in cols:
+        conn.execute("ALTER TABLE documents ADD COLUMN project_id TEXT")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_documents_project_id ON documents(project_id)")
 
 
 def get_connection() -> sqlite3.Connection:

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -125,6 +125,25 @@ def _delete_project_workspace(project: dict) -> None:
     shutil.rmtree(root_resolved)
 
 
+def _delete_project_rag_sources(project_id: str) -> None:
+    try:
+        from storage import rag_db
+        from core.rag import store as rag_store
+        if not rag_db.RAG_AVAILABLE:
+            logger.warning(
+                "Skipping RAG source deletion for project %s because RAG is unavailable",
+                project_id,
+            )
+            return
+        conn = rag_db.get_connection()
+        try:
+            rag_store.delete_scope(conn, rag_store.project_scope(project_id))
+        finally:
+            conn.close()
+    except Exception:
+        logger.warning("Failed to delete RAG sources for project %s", project_id, exc_info = True)
+
+
 def _ensure_schema(conn: sqlite3.Connection) -> None:
     """Create tables and indexes if they don't exist. Called once per process."""
     conn.execute("PRAGMA journal_mode=WAL")
@@ -1247,7 +1266,11 @@ def list_chat_projects(include_archived: bool = False) -> list[dict]:
         conn.close()
 
 
-def delete_chat_project(id: str, delete_files: bool = False) -> Optional[dict]:
+def delete_chat_project(
+    id: str,
+    delete_files: bool = False,
+    delete_sources: bool = True,
+) -> Optional[dict]:
     conn = get_connection()
     try:
         conn.execute("BEGIN IMMEDIATE")
@@ -1259,6 +1282,8 @@ def delete_chat_project(id: str, delete_files: bool = False) -> Optional[dict]:
         conn.execute("DELETE FROM chat_threads WHERE project_id = ?", (id,))
         conn.execute("DELETE FROM chat_projects WHERE id = ?", (id,))
         conn.commit()
+        if delete_sources:
+            _delete_project_rag_sources(id)
         if delete_files:
             _delete_project_workspace(project)
         return project

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -129,6 +129,7 @@ def _delete_project_rag_sources(project_id: str) -> None:
     try:
         from storage import rag_db
         from core.rag import store as rag_store
+
         if not rag_db.RAG_AVAILABLE:
             logger.warning(
                 "Skipping RAG source deletion for project %s because RAG is unavailable",

--- a/studio/backend/tests/test_chat_history_storage.py
+++ b/studio/backend/tests/test_chat_history_storage.py
@@ -134,6 +134,68 @@ def test_chat_projects_delete_cascades_threads_and_messages(tmp_path, monkeypatc
     assert (tmp_path / "Projects" / "Research-project").exists()
 
 
+def test_chat_project_delete_removes_rag_sources_by_default(tmp_path, monkeypatch):
+    _reset_studio_db(tmp_path, monkeypatch)
+    from storage import rag_db
+    from core.rag import store as rag_store
+
+    if not rag_db.RAG_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+    monkeypatch.setattr(rag_db, "_schema_ready", False)
+    project = studio_db.upsert_chat_project(_project())
+    conn = rag_db.get_connection()
+    try:
+        rag_store.create_document(
+            conn,
+            scope = rag_store.project_scope(project["id"]),
+            project_id = project["id"],
+            filename = "source.txt",
+            sha256 = "sha",
+        )
+        assert rag_store.list_documents(conn, rag_store.project_scope(project["id"]))
+    finally:
+        conn.close()
+
+    studio_db.delete_chat_project(project["id"])
+
+    conn = rag_db.get_connection()
+    try:
+        assert rag_store.list_documents(conn, rag_store.project_scope(project["id"])) == []
+    finally:
+        conn.close()
+
+
+def test_chat_project_delete_can_keep_rag_sources(tmp_path, monkeypatch):
+    _reset_studio_db(tmp_path, monkeypatch)
+    from storage import rag_db
+    from core.rag import store as rag_store
+
+    if not rag_db.RAG_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+    monkeypatch.setattr(rag_db, "_schema_ready", False)
+    project = studio_db.upsert_chat_project(_project())
+    conn = rag_db.get_connection()
+    try:
+        rag_store.create_document(
+            conn,
+            scope = rag_store.project_scope(project["id"]),
+            project_id = project["id"],
+            filename = "source.txt",
+            sha256 = "sha",
+        )
+    finally:
+        conn.close()
+
+    studio_db.delete_chat_project(project["id"], delete_sources = False)
+
+    conn = rag_db.get_connection()
+    try:
+        docs = rag_store.list_documents(conn, rag_store.project_scope(project["id"]))
+        assert [doc["filename"] for doc in docs] == ["source.txt"]
+    finally:
+        conn.close()
+
+
 def test_chat_project_delete_files_removes_workspace(
     tmp_path, monkeypatch, workspace_projects_home
 ):

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -90,6 +90,18 @@ def test_delete_document_purges_all_tables(rag_conn):
     assert store.get_document(rag_conn, "d1") is None
 
 
+def test_project_scope_and_delete_scope(rag_conn):
+    project_scope = store.project_scope("project-1")
+    _add_doc(rag_conn, project_scope, "d1", "project.txt", "h1", ["alpha bravo"])
+    _add_doc(rag_conn, "thread_t1", "d2", "thread.txt", "h2", ["alpha bravo"])
+
+    store.delete_scope(rag_conn, project_scope)
+
+    assert store.list_documents(rag_conn, project_scope) == []
+    assert store.search_lexical(rag_conn, project_scope, "alpha", 10) == []
+    assert [cid for cid, _ in store.search_lexical(rag_conn, "thread_t1", "alpha", 10)] == ["d2:0"]
+
+
 def test_incremental_add_is_flat(rag_conn):
     # Adding doc2 must not touch doc1's fts rowids (append, not rebuild).
     _add_doc(rag_conn, "kb_a", "d1", "f", "h1", ["alpha bravo charlie"])

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -447,10 +447,12 @@ export function AppSidebar() {
   const [confirmingDelete, setConfirmingDelete] =
     useState<DeleteTarget | null>(null);
   const [deleteProjectFiles, setDeleteProjectFiles] = useState(false);
+  const [deleteProjectSources, setDeleteProjectSources] = useState(true);
 
   useEffect(() => {
     if (confirmingDelete?.kind !== "project") {
       setDeleteProjectFiles(false);
+      setDeleteProjectSources(true);
     }
   }, [confirmingDelete]);
 
@@ -459,6 +461,8 @@ export function AppSidebar() {
     if (!target) return;
     const shouldDeleteProjectFiles =
       target.kind === "project" && deleteProjectFiles;
+    const shouldDeleteProjectSources =
+      target.kind !== "project" || deleteProjectSources;
     setConfirmingDelete(null);
     if (target.kind === "chat") {
       try {
@@ -474,6 +478,7 @@ export function AppSidebar() {
       try {
         await deleteChatProject(target.project.id, {
           deleteFiles: shouldDeleteProjectFiles,
+          deleteSources: shouldDeleteProjectSources,
         });
         if (activeProjectId === target.project.id) {
           useChatRuntimeStore.getState().setActiveProjectId(null);
@@ -1204,23 +1209,41 @@ export function AppSidebar() {
           </DialogDescription>
         </DialogHeader>
         {confirmingDelete?.kind === "project" ? (
-          <div className="flex items-start justify-between gap-4 rounded-md border border-border/60 bg-muted/35 px-3 py-2.5">
-            <label htmlFor="delete-project-files" className="min-w-0 space-y-1">
-              <span className="block text-sm font-medium text-foreground">
-                Delete files and sandbox folder
-              </span>
-              <span className="block break-words text-xs leading-5 text-muted-foreground">
-                {confirmingDelete.project.rootPath
-                  ? confirmingDelete.project.rootPath
-                  : "The project workspace folder will be removed from disk."}
-              </span>
-            </label>
-            <Switch
-              id="delete-project-files"
-              checked={deleteProjectFiles}
-              onCheckedChange={setDeleteProjectFiles}
-              aria-label="Delete project files and sandbox folder"
-            />
+          <div className="flex flex-col gap-2">
+            <div className="flex items-start justify-between gap-4 rounded-md border border-border/60 bg-muted/35 px-3 py-2.5">
+              <label htmlFor="delete-project-sources" className="min-w-0 space-y-1">
+                <span className="block text-sm font-medium text-foreground">
+                  Delete project sources
+                </span>
+                <span className="block text-xs leading-5 text-muted-foreground">
+                  Removes indexed RAG uploads for this project.
+                </span>
+              </label>
+              <Switch
+                id="delete-project-sources"
+                checked={deleteProjectSources}
+                onCheckedChange={setDeleteProjectSources}
+                aria-label="Delete project sources"
+              />
+            </div>
+            <div className="flex items-start justify-between gap-4 rounded-md border border-border/60 bg-muted/35 px-3 py-2.5">
+              <label htmlFor="delete-project-files" className="min-w-0 space-y-1">
+                <span className="block text-sm font-medium text-foreground">
+                  Delete files and sandbox folder
+                </span>
+                <span className="block break-words text-xs leading-5 text-muted-foreground">
+                  {confirmingDelete.project.rootPath
+                    ? confirmingDelete.project.rootPath
+                    : "The project workspace folder will be removed from disk."}
+                </span>
+              </label>
+              <Switch
+                id="delete-project-files"
+                checked={deleteProjectFiles}
+                onCheckedChange={setDeleteProjectFiles}
+                aria-label="Delete project files and sandbox folder"
+              />
+            </div>
           </div>
         ) : null}
         <DialogFooter className="flex-wrap gap-2 sm:justify-end">

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -35,6 +35,7 @@ import {
 import {
   type PendingImageEditReference,
   type RagAutoInject,
+  type RagSource,
   resolveToolsEnabledOnLoad,
   useChatRuntimeStore,
 } from "../stores/chat-runtime-store";
@@ -75,6 +76,7 @@ import {
   encryptProviderApiKey,
   isProviderKeyRotationError,
 } from "./providers-api";
+import { loadProjectRagSource } from "@/features/rag/project-rag-preferences";
 
 // Small models (<=9B) answer from memory instead of calling search, so "auto"
 // forces retrieval for them and leaves it to larger ones.
@@ -1099,6 +1101,23 @@ async function resolveSandboxSessionId(
   return projectId ? `project-${projectId}` : threadId;
 }
 
+function resolveEffectiveRagSource(
+  source: RagSource,
+  projectId: string | null,
+): RagSource {
+  if (!projectId) {
+    return source.type === "project" ? { type: "thread" } : source;
+  }
+  const projectSource = loadProjectRagSource(projectId);
+  if (projectSource) {
+    return projectSource;
+  }
+  if (source.type === "project") {
+    return source.projectId === projectId ? source : { type: "thread" };
+  }
+  return source;
+}
+
 /** Wait for an in-progress model load to finish (polls store every 500ms). */
 function waitForModelReady(abortSignal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -1515,6 +1534,11 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
         ragAutoInject,
         ragAutoInjectMinScore,
       } = runtime;
+      const activeProjectIdForRun = await resolveProjectId(resolvedThreadId);
+      const effectiveRagSource = resolveEffectiveRagSource(
+        ragSource,
+        activeProjectIdForRun,
+      );
       const externalSelection = parseExternalModelId(params.checkpoint);
       const isExternalRequest = externalSelection !== null;
       if (
@@ -2429,12 +2453,14 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
                       : []),
                   ],
                   mcp_enabled: mcpEnabledForChat,
-                  // Scope: thread_id = this thread's docs, kb_id = a KB.
+                  // Scope: thread_id = this thread's docs, project_id = project sources, kb_id = a KB.
                   ...(ragEnabled
                     ? {
                         rag_scope: {
-                          ...(ragSource.type === "kb"
-                            ? { kb_id: ragSource.kbId }
+                          ...(effectiveRagSource.type === "kb"
+                            ? { kb_id: effectiveRagSource.kbId }
+                            : effectiveRagSource.type === "project"
+                              ? { project_id: effectiveRagSource.projectId }
                             : resolvedThreadId
                               ? { thread_id: resolvedThreadId }
                               : {}),

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -416,10 +416,11 @@ export async function updateChatProject(
 
 export async function deleteChatProject(
   projectId: string,
-  args: { deleteFiles?: boolean } = {},
+  args: { deleteFiles?: boolean; deleteSources?: boolean } = {},
 ): Promise<void> {
   const params = new URLSearchParams();
   if (args.deleteFiles) params.set("delete_files", "true");
+  if (args.deleteSources === false) params.set("delete_sources", "false");
   const qs = params.toString();
   const response = await authFetch(
     `/api/chat/projects/${encodeURIComponent(projectId)}${qs ? `?${qs}` : ""}`,

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -16,7 +16,6 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { useSidebar } from "@/components/ui/sidebar";
-import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent } from "@/components/ui/tooltip";
 import {
   NativeModelChip,
@@ -32,7 +31,6 @@ import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import {
   Folder02Icon,
-  FolderAddIcon,
   LayoutAlignRightIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -99,6 +97,7 @@ import {
 import { useExternalProvidersStore } from "./stores/external-providers-store";
 import { buildChatTourSteps } from "./tour";
 import { ArtifactSurface } from "./artifacts/artifact-surface";
+import { ProjectSourcesPanel } from "@/features/rag/components/project-sources-panel";
 import {
   clearAutoOpenedArtifacts,
   useChatArtifactsStore,
@@ -970,28 +969,7 @@ function ProjectLanding({
             </div>
 
             {projectTab === "sources" ? (
-              <div className="mt-8 flex flex-col items-center justify-center gap-3 rounded-[16px] border border-dashed border-border/70 bg-muted/30 px-6 py-16 text-center">
-                <span className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                  <HugeiconsIcon
-                    icon={FolderAddIcon}
-                    strokeWidth={1.75}
-                    className="size-6"
-                  />
-                </span>
-                <div className="space-y-1">
-                  <p className="text-[15px] font-semibold text-foreground">
-                    Give this project context
-                  </p>
-                  <p className="max-w-sm text-sm text-muted-foreground">
-                    Upload PDFs, documents, or other text. The model can
-                    reference them in every chat in this project.
-                  </p>
-                </div>
-                <Button type="button" className="mt-1" disabled>
-                  Add sources
-                </Button>
-                <p className="text-[11px] text-muted-foreground">Coming soon</p>
-              </div>
+              <ProjectSourcesPanel projectId={projectId} />
             ) : (
             <div className="mt-8 flex flex-col gap-1">
               {items.map((item) => {

--- a/studio/frontend/src/features/chat/hooks/use-chat-projects.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-projects.ts
@@ -86,7 +86,7 @@ export async function updateChatProjectInstructions(
 
 export async function deleteChatProject(
   projectId: string,
-  args: { deleteFiles?: boolean } = {},
+  args: { deleteFiles?: boolean; deleteSources?: boolean } = {},
 ): Promise<void> {
   await deleteStoredChatProject(projectId, args);
 }

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -92,6 +93,7 @@ export function ProjectsPage() {
   const [renaming, setRenaming] = useState<ProjectRecord | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [deleting, setDeleting] = useState<ProjectRecord | null>(null);
+  const [deleteProjectSources, setDeleteProjectSources] = useState(true);
 
   const globalImportRef = useRef<HTMLInputElement>(null);
   const projectImportRefs = useRef<Map<string, HTMLInputElement>>(new Map());
@@ -220,9 +222,11 @@ export function ProjectsPage() {
   async function commitDelete() {
     const target = deleting;
     if (!target) return;
+    const shouldDeleteSources = deleteProjectSources;
     setDeleting(null);
+    setDeleteProjectSources(true);
     try {
-      await deleteChatProject(target.id);
+      await deleteChatProject(target.id, { deleteSources: shouldDeleteSources });
     } catch (err) {
       toast.error("Failed to delete project", {
         description: err instanceof Error ? err.message : undefined,
@@ -606,7 +610,10 @@ export function ProjectsPage() {
       <Dialog
         open={deleting !== null}
         onOpenChange={(open) => {
-          if (!open) setDeleting(null);
+          if (!open) {
+            setDeleting(null);
+            setDeleteProjectSources(true);
+          }
         }}
       >
         <DialogContent className="menu-flat-destructive corner-squircle dialog-soft-surface sm:max-w-md">
@@ -615,8 +622,24 @@ export function ProjectsPage() {
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
             Are you sure you want to delete <em>{deleting?.name}</em>? Chats in this
-            project will be moved back to Recents.
+            project will be permanently deleted.
           </p>
+          <div className="flex items-start justify-between gap-4 rounded-md border border-border/60 bg-muted/35 px-3 py-2.5">
+            <label htmlFor="delete-project-sources-page" className="min-w-0 space-y-1">
+              <span className="block text-sm font-medium text-foreground">
+                Delete project sources
+              </span>
+              <span className="block text-xs leading-5 text-muted-foreground">
+                Removes indexed RAG uploads for this project.
+              </span>
+            </label>
+            <Switch
+              id="delete-project-sources-page"
+              checked={deleteProjectSources}
+              onCheckedChange={setDeleteProjectSources}
+              aria-label="Delete project sources"
+            />
+          </div>
           <DialogFooter className="flex-wrap gap-2 sm:justify-end">
             <Button type="button" variant="ghost" onClick={() => setDeleting(null)}>
               Cancel

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -45,6 +45,7 @@ export const CHAT_RAG_AUTOINJECT_MIN_SCORE_KEY =
 
 export type RagSource =
   | { type: "thread" }
+  | { type: "project"; projectId: string }
   | { type: "kb"; kbId: string };
 
 export type RagMode = "hybrid" | "lexical" | "dense";
@@ -65,6 +66,9 @@ function loadRagSource(): RagSource {
     const parsed = JSON.parse(raw) as RagSource;
     if (parsed?.type === "kb" && typeof parsed.kbId === "string") {
       return { type: "kb", kbId: parsed.kbId };
+    }
+    if (parsed?.type === "project" && typeof parsed.projectId === "string") {
+      return { type: "project", projectId: parsed.projectId };
     }
     if (parsed?.type === "thread") return { type: "thread" };
     return DEFAULT_RAG_SOURCE;

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -276,9 +276,10 @@ export interface OpenAIChatCompletionsRequest {
   enabled_tools?: string[];
   /** Local models + enable_tools only. */
   mcp_enabled?: boolean;
-  /** Exactly one of `kb_id` (a KB) or `thread_id` (thread docs). */
+  /** Exactly one of `kb_id` (a KB), `project_id` (project sources), or `thread_id` (thread docs). */
   rag_scope?: {
     kb_id?: string;
+    project_id?: string;
     thread_id?: string;
     default_top_k: number;
     mode: "hybrid" | "lexical" | "dense";

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -634,7 +634,7 @@ export async function updateStoredChatProject(
 
 export async function deleteStoredChatProject(
   projectId: string,
-  args: { deleteFiles?: boolean } = {},
+  args: { deleteFiles?: boolean; deleteSources?: boolean } = {},
 ): Promise<void> {
   await deleteChatProject(projectId, args);
 }

--- a/studio/frontend/src/features/rag/api/rag-api.ts
+++ b/studio/frontend/src/features/rag/api/rag-api.ts
@@ -126,6 +126,22 @@ export function uploadThreadDocument(
   return ragUpload(`/threads/${encodeURIComponent(threadId)}/documents`, file);
 }
 
+export async function listProjectDocuments(
+  projectId: string,
+): Promise<RagDocument[]> {
+  const data = await ragRequest<{ documents: RagDocument[] }>(
+    `/projects/${encodeURIComponent(projectId)}/documents`,
+  );
+  return data.documents ?? [];
+}
+
+export function uploadProjectDocument(
+  projectId: string,
+  file: File,
+): Promise<DocumentUploadResult> {
+  return ragUpload(`/projects/${encodeURIComponent(projectId)}/documents`, file);
+}
+
 export function deleteDocument(documentId: string): Promise<{ ok: boolean }> {
   return ragRequest(`/documents/${encodeURIComponent(documentId)}`, {
     method: "DELETE",

--- a/studio/frontend/src/features/rag/components/knowledge-base-composer-button.tsx
+++ b/studio/frontend/src/features/rag/components/knowledge-base-composer-button.tsx
@@ -4,7 +4,7 @@
 import { XIcon } from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FileDatabaseIcon, Tick02Icon } from "@hugeicons/core-free-icons";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   DropdownMenu,
@@ -15,9 +15,16 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useRagToolDisabled } from "@/features/chat/hooks/use-rag-tool-disabled";
-import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import {
+  type RagSource,
+  useChatRuntimeStore,
+} from "@/features/chat/stores/chat-runtime-store";
 
 import { listKnowledgeBases } from "../api/rag-api";
+import {
+  loadProjectRagSource,
+  saveProjectRagSource,
+} from "../project-rag-preferences";
 import type { KnowledgeBase } from "../types/rag";
 import { KnowledgeBaseDialog } from "./knowledge-base-dialog";
 
@@ -50,11 +57,36 @@ export function KnowledgeBaseComposerButton({
   const ragDisabled = useRagToolDisabled();
   const ragSource = useChatRuntimeStore((s) => s.ragSource);
   const setRagSource = useChatRuntimeStore((s) => s.setRagSource);
+  const activeProjectId = useChatRuntimeStore((s) => s.activeProjectId);
 
   const [kbs, setKbs] = useState<KnowledgeBase[]>([]);
   const [kbsLoaded, setKbsLoaded] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [preferenceVersion, setPreferenceVersion] = useState(0);
+  const selectedSource = useMemo(
+    () =>
+      activeProjectId
+        ? (loadProjectRagSource(activeProjectId) ??
+          (ragSource.type === "project" && ragSource.projectId !== activeProjectId
+            ? { type: "thread" as const }
+            : ragSource))
+        : ragSource.type === "project"
+          ? { type: "thread" as const }
+          : ragSource,
+    [activeProjectId, preferenceVersion, ragSource],
+  );
+
+  const selectSource = useCallback(
+    (source: RagSource) => {
+      if (activeProjectId) {
+        saveProjectRagSource(activeProjectId, source);
+        setPreferenceVersion((value) => value + 1);
+      }
+      setRagSource(source);
+    },
+    [activeProjectId, setRagSource],
+  );
 
   const refresh = useCallback(async () => {
     try {
@@ -78,12 +110,12 @@ export function KnowledgeBaseComposerButton({
   useEffect(() => {
     if (
       kbsLoaded &&
-      ragSource.type === "kb" &&
-      !kbs.some((kb) => kb.id === ragSource.kbId)
+      selectedSource.type === "kb" &&
+      !kbs.some((kb) => kb.id === selectedSource.kbId)
     ) {
-      setRagSource({ type: "thread" });
+      selectSource({ type: "thread" });
     }
-  }, [kbs, kbsLoaded, ragSource, setRagSource]);
+  }, [kbs, kbsLoaded, selectedSource, selectSource]);
 
   if (!ragEnabled) return null;
 
@@ -142,16 +174,37 @@ export function KnowledgeBaseComposerButton({
           className="unsloth-plus-menu mcp-menu w-[232px]"
         >
           <DropdownMenuLabel>Retrieve from</DropdownMenuLabel>
+          {activeProjectId ? (
+            <DropdownMenuItem
+              onSelect={() =>
+                selectSource({ type: "project", projectId: activeProjectId })
+              }
+              className={
+                selectedSource.type === "project"
+                  ? "relative text-primary font-medium"
+                  : "relative"
+              }
+            >
+              <span className="truncate">This project's sources</span>
+              {selectedSource.type === "project" ? (
+                <HugeiconsIcon
+                  icon={Tick02Icon}
+                  strokeWidth={2}
+                  className="ml-auto"
+                />
+              ) : null}
+            </DropdownMenuItem>
+          ) : null}
           <DropdownMenuItem
-            onSelect={() => setRagSource({ type: "thread" })}
+            onSelect={() => selectSource({ type: "thread" })}
             className={
-              ragSource.type === "thread"
+              selectedSource.type === "thread"
                 ? "relative text-primary font-medium"
                 : "relative"
             }
           >
             <span className="truncate">This thread's documents</span>
-            {ragSource.type === "thread" ? (
+            {selectedSource.type === "thread" ? (
               <HugeiconsIcon
                 icon={Tick02Icon}
                 strokeWidth={2}
@@ -162,11 +215,11 @@ export function KnowledgeBaseComposerButton({
           {kbs.length > 0 ? <DropdownMenuSeparator /> : null}
           {kbs.map((kb) => {
             const selected =
-              ragSource.type === "kb" && ragSource.kbId === kb.id;
+              selectedSource.type === "kb" && selectedSource.kbId === kb.id;
             return (
               <DropdownMenuItem
                 key={kb.id}
-                onSelect={() => setRagSource({ type: "kb", kbId: kb.id })}
+                onSelect={() => selectSource({ type: "kb", kbId: kb.id })}
                 className={
                   selected ? "relative text-primary font-medium" : "relative"
                 }

--- a/studio/frontend/src/features/rag/components/project-sources-panel.tsx
+++ b/studio/frontend/src/features/rag/components/project-sources-panel.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FileDatabaseIcon } from "@hugeicons/core-free-icons";
+import { UploadIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { toast } from "@/lib/toast";
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+
+import { listProjectDocuments } from "../api/rag-api";
+import {
+  hasProjectRagSourcePreference,
+  loadProjectRagSource,
+  saveProjectRagSource,
+} from "../project-rag-preferences";
+import { RAG_UPLOAD_ACCEPT } from "../types/rag";
+import { DocumentStatusChip } from "./document-status-chip";
+import { useRagDocuments } from "./use-rag-documents";
+
+export function ProjectSourcesPanel({ projectId }: { projectId: string }) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const hadDocumentsRef = useRef(false);
+  const setRagSource = useChatRuntimeStore((s) => s.setRagSource);
+  const [preferenceVersion, setPreferenceVersion] = useState(0);
+  const selectedSource = useMemo(
+    () => loadProjectRagSource(projectId),
+    [preferenceVersion, projectId],
+  );
+  const selectedDefault =
+    selectedSource?.type === "project" && selectedSource.projectId === projectId
+      ? "project"
+      : selectedSource?.type === "kb"
+        ? "kb"
+      : "thread";
+  const lister = useCallback(
+    () => listProjectDocuments(projectId),
+    [projectId],
+  );
+  const { documents, loading, uploading, upload, remove } = useRagDocuments(
+    { type: "project", projectId },
+    lister,
+  );
+
+  const setProjectDefault = useCallback(
+    (value: "project" | "thread") => {
+      const source =
+        value === "project"
+          ? ({ type: "project", projectId } as const)
+          : ({ type: "thread" } as const);
+      saveProjectRagSource(projectId, source);
+      setRagSource(source);
+      setPreferenceVersion((version) => version + 1);
+    },
+    [projectId, setRagSource],
+  );
+
+  useEffect(() => {
+    setPreferenceVersion((version) => version + 1);
+  }, [projectId]);
+
+  const promptForDefault = useCallback(() => {
+    if (hasProjectRagSourcePreference(projectId)) return;
+    toast("Use project sources by default?", {
+      description: "RAG chats in this project can retrieve from these sources.",
+      action: {
+        label: "Use by default",
+        onClick: () => setProjectDefault("project"),
+      },
+      cancel: {
+        label: "Not now",
+        onClick: () => setProjectDefault("thread"),
+      },
+    });
+  }, [projectId, setProjectDefault]);
+
+  useEffect(() => {
+    const hasDocuments = documents.length > 0;
+    if (hasDocuments && !hadDocumentsRef.current) {
+      promptForDefault();
+    }
+    hadDocumentsRef.current = hasDocuments;
+  }, [documents.length, promptForDefault]);
+
+  return (
+    <div className="mt-8 flex min-w-0 flex-col gap-5">
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={RAG_UPLOAD_ACCEPT}
+        className="hidden"
+        onChange={(event) => {
+          const files = Array.from(event.target.files ?? []);
+          event.target.value = "";
+          if (files.length === 0) return;
+          void upload(files);
+        }}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-[16px] font-semibold text-foreground">
+            Project sources
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Upload documents for retrieval across chats in this project.
+          </p>
+        </div>
+        <Button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+        >
+          {uploading ? <Spinner /> : <UploadIcon className="size-4" />}
+          Add sources
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="mr-1 text-sm font-medium text-foreground">
+          Default for project chats
+        </span>
+        <button
+          type="button"
+          onClick={() => setProjectDefault("project")}
+          data-active={selectedDefault === "project"}
+          className="h-8 rounded-full border px-3 text-sm font-medium transition-colors data-[active=true]:border-border data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=false]:border-transparent data-[active=false]:text-muted-foreground data-[active=false]:hover:bg-nav-surface-hover"
+        >
+          Project sources
+        </button>
+        <button
+          type="button"
+          onClick={() => setProjectDefault("thread")}
+          data-active={selectedDefault === "thread"}
+          className="h-8 rounded-full border px-3 text-sm font-medium transition-colors data-[active=true]:border-border data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=false]:border-transparent data-[active=false]:text-muted-foreground data-[active=false]:hover:bg-nav-surface-hover"
+        >
+          Thread documents
+        </button>
+        {selectedDefault === "kb" ? (
+          <span className="text-sm text-muted-foreground">
+            Knowledge base selected in the RAG picker
+          </span>
+        ) : null}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-10">
+          <Spinner />
+        </div>
+      ) : documents.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-[16px] border border-dashed border-border/70 bg-muted/30 px-6 py-14 text-center">
+          <span className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <HugeiconsIcon
+              icon={FileDatabaseIcon}
+              strokeWidth={1.75}
+              className="size-6"
+            />
+          </span>
+          <div className="space-y-1">
+            <p className="text-[15px] font-semibold text-foreground">
+              Give this project context
+            </p>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              Upload PDFs, documents, or other text. The model can reference
+              them in chats when RAG uses project sources.
+            </p>
+          </div>
+          <Button
+            type="button"
+            className="mt-1"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+          >
+            {uploading ? <Spinner /> : null}
+            Add sources
+          </Button>
+        </div>
+      ) : (
+        <div className="flex max-h-[360px] flex-col gap-2 overflow-y-auto rounded-lg border border-border/70 p-2">
+          {documents.map((doc) => (
+            <div
+              key={doc.id}
+              className="flex min-h-11 items-center justify-between gap-3 rounded-md px-2 py-1.5 hover:bg-nav-surface-hover"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <HugeiconsIcon
+                  icon={FileDatabaseIcon}
+                  strokeWidth={1.75}
+                  className="size-4 shrink-0 text-muted-foreground"
+                />
+                <span className="truncate text-sm font-medium text-foreground">
+                  {doc.filename}
+                </span>
+              </div>
+              <DocumentStatusChip
+                filename={doc.filename}
+                status={doc.status}
+                progress={doc.progress}
+                error={doc.error}
+                onRemove={
+                  doc.id.startsWith("pending_")
+                    ? undefined
+                    : () => void remove(doc.id)
+                }
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
+++ b/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
@@ -3,48 +3,16 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { AttachmentIcon, FileDatabaseIcon } from "@hugeicons/core-free-icons";
+import { AttachmentIcon } from "@hugeicons/core-free-icons";
 import { useAui } from "@assistant-ui/react";
 import { cn } from "@/lib/utils";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import { toast } from "@/lib/toast";
-import { listKnowledgeBases, listThreadDocuments } from "../api/rag-api";
+import { listThreadDocuments } from "../api/rag-api";
+import { loadProjectRagSource } from "../project-rag-preferences";
 import { RAG_UPLOAD_ACCEPT } from "../types/rag";
 import { DocumentStatusChip } from "./document-status-chip";
 import { useRagDocuments } from "./use-rag-documents";
-
-// Read-only chip shown when retrieval comes from a KB, so the source isn't invisible.
-function KnowledgeBaseSourceChip({ kbId }: { kbId: string }) {
-  const [name, setName] = useState<string | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    listKnowledgeBases()
-      .then((rows) => {
-        if (!cancelled) setName(rows.find((kb) => kb.id === kbId)?.name ?? null);
-      })
-      .catch(() => {
-        if (!cancelled) setName(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [kbId]);
-  return (
-    <div className="mb-2 flex w-full flex-row items-center gap-1.5 pl-0.5 pr-1.5 pt-0.5 pb-1">
-      <span
-        className="composer-pill-btn shrink-0 cursor-default"
-        title="This chat retrieves from a knowledge base. Change the source in RAG retrieval settings."
-      >
-        <HugeiconsIcon
-          icon={FileDatabaseIcon}
-          strokeWidth={2}
-          className="size-3.5"
-        />
-        <span>{name ? `Knowledge base: ${name}` : "Knowledge base"}</span>
-      </span>
-    </div>
-  );
-}
 
 export function ThreadDocumentsBar({
   threadId,
@@ -55,6 +23,15 @@ export function ThreadDocumentsBar({
 }) {
   const ragEnabled = useChatRuntimeStore((s) => s.ragEnabled);
   const ragSource = useChatRuntimeStore((s) => s.ragSource);
+  const activeProjectId = useChatRuntimeStore((s) => s.activeProjectId);
+  const effectiveRagSource = activeProjectId
+    ? (loadProjectRagSource(activeProjectId) ??
+      (ragSource.type === "project" && ragSource.projectId !== activeProjectId
+        ? { type: "thread" as const }
+        : ragSource))
+    : ragSource.type === "project"
+      ? { type: "thread" as const }
+      : ragSource;
   const aui = useAui();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -76,7 +53,7 @@ export function ThreadDocumentsBar({
     [effectiveThreadId],
   );
   const { documents, uploading, upload, remove } = useRagDocuments(
-    effectiveThreadId && ragEnabled && ragSource.type === "thread"
+    effectiveThreadId && ragEnabled && effectiveRagSource.type === "thread"
       ? { type: "thread", threadId: effectiveThreadId }
       : null,
     lister,
@@ -138,9 +115,9 @@ export function ThreadDocumentsBar({
   // Shown whenever the RAG pill is on: ingestion only needs the embedder, so
   // files can index before a chat model loads.
   if (!ragEnabled) return null;
-  // A KB source uploads via the KB dialog, not here; show which KB is active.
-  if (ragSource.type === "kb") {
-    return <KnowledgeBaseSourceChip kbId={ragSource.kbId} />;
+  // KB and project sources are managed outside this inline thread attachment bar.
+  if (effectiveRagSource.type === "kb" || effectiveRagSource.type === "project") {
+    return null;
   }
 
   return (

--- a/studio/frontend/src/features/rag/components/use-rag-documents.ts
+++ b/studio/frontend/src/features/rag/components/use-rag-documents.ts
@@ -8,6 +8,7 @@ import {
   getJob,
   streamJobEvents,
   uploadKnowledgeBaseDocument,
+  uploadProjectDocument,
   uploadThreadDocument,
 } from "../api/rag-api";
 import type { DocumentStatus, RagDocument } from "../types/rag";
@@ -23,6 +24,7 @@ function fileSignature(file: File): string {
 
 export type RagDocumentScope =
   | { type: "kb"; kbId: string }
+  | { type: "project"; projectId: string }
   | { type: "thread"; threadId: string };
 
 type Lister = () => Promise<RagDocument[]>;
@@ -57,6 +59,8 @@ export function useRagDocuments(
   const scopeKey = scope
     ? scope.type === "kb"
       ? `kb:${scope.kbId}`
+      : scope.type === "project"
+        ? `project:${scope.projectId}`
       : `thread:${scope.threadId}`
     : null;
   const prevScopeKeyRef = useRef<string | null>(null);
@@ -229,7 +233,9 @@ export function useRagDocuments(
         const result =
           activeScope.type === "kb"
             ? await uploadKnowledgeBaseDocument(activeScope.kbId, file)
-            : await uploadThreadDocument(activeScope.threadId, file);
+            : activeScope.type === "project"
+              ? await uploadProjectDocument(activeScope.projectId, file)
+              : await uploadThreadDocument(activeScope.threadId, file);
         sigByDocId.current.set(result.documentId, fileSignature(file));
         if (seenIds.has(result.documentId)) {
           setDocuments((rows) => rows.filter((row) => row.id !== tempId));

--- a/studio/frontend/src/features/rag/project-rag-preferences.ts
+++ b/studio/frontend/src/features/rag/project-rag-preferences.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { RagSource } from "@/features/chat/stores/chat-runtime-store";
+
+const PROJECT_RAG_SOURCE_PREFIX = "unsloth_project_rag_source:";
+
+function key(projectId: string): string {
+  return `${PROJECT_RAG_SOURCE_PREFIX}${projectId}`;
+}
+
+export function loadProjectRagSource(projectId: string): RagSource | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key(projectId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as RagSource;
+    if (parsed?.type === "thread") return { type: "thread" };
+    if (parsed?.type === "project" && parsed.projectId === projectId) {
+      return { type: "project", projectId };
+    }
+    if (parsed?.type === "kb" && typeof parsed.kbId === "string") {
+      return { type: "kb", kbId: parsed.kbId };
+    }
+  } catch {
+  }
+  return null;
+}
+
+export function saveProjectRagSource(projectId: string, source: RagSource): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key(projectId), JSON.stringify(source));
+  } catch {
+  }
+}
+
+export function hasProjectRagSourcePreference(projectId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(key(projectId)) !== null;
+  } catch {
+    return false;
+  }
+}

--- a/studio/frontend/src/features/rag/types/rag.ts
+++ b/studio/frontend/src/features/rag/types/rag.ts
@@ -20,6 +20,7 @@ export interface RagDocument {
   numChunks?: number | null;
   kbId?: string | null;
   threadId?: string | null;
+  projectId?: string | null;
   createdAt?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- add project-scoped RAG documents and retrieval scope
- replace the Projects Sources placeholder with upload/default-source UI
- add default-on project source cleanup separate from workspace deletion

## Validation
- PYTHONPATH=studio/backend uv run --no-project --with pytest --with fastapi --with pydantic --with sqlite-vec --with structlog --with psutil --with python-multipart --with starlette python -m pytest -s studio/backend/tests/test_rag_store.py studio/backend/tests/test_chat_history_storage.py -q
- python -m py_compile studio/backend/storage/rag_db.py studio/backend/core/rag/store.py studio/backend/core/rag/ingestion.py studio/backend/core/rag/tool.py studio/backend/core/inference/tools.py studio/backend/models/inference.py studio/backend/routes/rag.py studio/backend/routes/chat_history.py studio/backend/storage/studio_db.py studio/backend/tests/test_rag_store.py studio/backend/tests/test_chat_history_storage.py
- git diff --check

## Notes
- Frontend typecheck was not run locally because only Windows Node/npm is available in this WSL environment, and it cannot execute from the /home worktree path.