### PR TITLE
Fix kwarg spacing in training files to satisfy pre-commit

### DIFF
--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -534,9 +534,7 @@ class TrainingBackend:
                 except (TypeError, ValueError):
                     logger.debug("Could not convert loss to float: %s", _raw_loss)
                     _safe_loss = None
-                _loss_is_nonfinite = (
-                    _safe_loss is not None and not math.isfinite(_safe_loss)
-                )
+                _loss_is_nonfinite = _safe_loss is not None and not math.isfinite(_safe_loss)
                 if _loss_is_nonfinite:
                     # Drop the value rather than laundering it back to the last
                     # finite loss; clients see loss=None at this step so the NaN

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1858,7 +1858,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
     # ── 11. Run training ──
     gc.collect()
     mx.synchronize()
-    trainer.train(resume_from_checkpoint=resume_from_checkpoint)
+    trainer.train(resume_from_checkpoint = resume_from_checkpoint)
 
     # ── 12. Save and finalize ──
     if trainer.stop_requested and not _stop_save[0]:

--- a/studio/backend/tests/test_training_nan_loss_handling.py
+++ b/studio/backend/tests/test_training_nan_loss_handling.py
@@ -29,7 +29,11 @@ def _make_backend() -> TrainingBackend:
     return TrainingBackend()
 
 
-def _progress_event(step: int, loss: float, lr: float = 1e-4) -> dict:
+def _progress_event(
+    step: int,
+    loss: float,
+    lr: float = 1e-4,
+) -> dict:
     return {
         "type": "progress",
         "step": step,
@@ -43,7 +47,7 @@ def _progress_event(step: int, loss: float, lr: float = 1e-4) -> dict:
 class TestNonfiniteLossSoftHandling:
     def test_finite_loss_updates_progress_normally(self):
         b = _make_backend()
-        b._handle_event(_progress_event(step=1, loss=0.97))
+        b._handle_event(_progress_event(step = 1, loss = 0.97))
         assert b._progress.loss == pytest.approx(0.97)
         assert b._progress.error is None
         assert b._should_stop is False
@@ -51,9 +55,9 @@ class TestNonfiniteLossSoftHandling:
 
     def test_nan_loss_clears_progress_loss(self):
         b = _make_backend()
-        b._handle_event(_progress_event(step=1, loss=0.97))
+        b._handle_event(_progress_event(step = 1, loss = 0.97))
         assert b._progress.loss == pytest.approx(0.97)
-        b._handle_event(_progress_event(step=2, loss=float("nan")))
+        b._handle_event(_progress_event(step = 2, loss = float("nan")))
         # Stale finite loss must NOT leak through
         assert b._progress.loss is None
         # Run is not marked failed
@@ -64,7 +68,7 @@ class TestNonfiniteLossSoftHandling:
 
     def test_inf_loss_clears_progress_loss(self):
         b = _make_backend()
-        b._handle_event(_progress_event(step=1, loss=float("inf")))
+        b._handle_event(_progress_event(step = 1, loss = float("inf")))
         assert b._progress.loss is None
         assert b._progress.error is None
         assert b._should_stop is False
@@ -72,7 +76,7 @@ class TestNonfiniteLossSoftHandling:
 
     def test_negative_inf_loss_clears_progress_loss(self):
         b = _make_backend()
-        b._handle_event(_progress_event(step=1, loss=float("-inf")))
+        b._handle_event(_progress_event(step = 1, loss = float("-inf")))
         assert b._progress.loss is None
         assert b._progress.error is None
         assert b._should_stop is False
@@ -82,12 +86,12 @@ class TestNonfiniteLossSoftHandling:
         """Subsequent NaN events must not re-fire the warning flag setter.
         The flag should already be True after the first NaN."""
         b = _make_backend()
-        b._handle_event(_progress_event(step=1, loss=0.97))
-        b._handle_event(_progress_event(step=2, loss=float("nan")))
+        b._handle_event(_progress_event(step = 1, loss = 0.97))
+        b._handle_event(_progress_event(step = 2, loss = float("nan")))
         assert b._progress._nonfinite_loss_warned is True
         # Further NaN steps don't change anything we care about
-        b._handle_event(_progress_event(step=3, loss=float("nan")))
-        b._handle_event(_progress_event(step=4, loss=float("nan")))
+        b._handle_event(_progress_event(step = 3, loss = float("nan")))
+        b._handle_event(_progress_event(step = 4, loss = float("nan")))
         assert b._progress._nonfinite_loss_warned is True
         assert b._progress.loss is None
         assert b._progress.error is None
@@ -97,10 +101,10 @@ class TestNonfiniteLossSoftHandling:
         """If a NaN step is followed by a finite step, progress.loss must
         reflect the new finite value (not stay stuck at None)."""
         b = _make_backend()
-        b._handle_event(_progress_event(step=1, loss=0.97))
-        b._handle_event(_progress_event(step=2, loss=float("nan")))
+        b._handle_event(_progress_event(step = 1, loss = 0.97))
+        b._handle_event(_progress_event(step = 2, loss = float("nan")))
         assert b._progress.loss is None
-        b._handle_event(_progress_event(step=3, loss=0.85))
+        b._handle_event(_progress_event(step = 3, loss = 0.85))
         assert b._progress.loss == pytest.approx(0.85)
         # Warning flag stays set (we don't reset it on recovery)
         assert b._progress._nonfinite_loss_warned is True


### PR DESCRIPTION
## Overview

The ruff-format-with-kwargs pre-commit hook reformats three files that landed on main recently, so the pre-commit.ci check fails on every open PR (for example #6196).

## Changes

- Reran the hook on studio/backend/core/training/training.py, studio/backend/core/training/worker.py, and studio/backend/tests/test_training_nan_loss_handling.py
- Formatting only: kwarg spacing and line wrapping. Verified the AST is identical to main for all three files and that the hook is idempotent on the result

## Testing

- scripts/run_ruff_format.py (ruff 0.6.9, same pin as the hook) produces no further changes on these files
- ruff check passes on all three files