### PR TITLE
Studio: reword the Cloudflare line when the public probe fails

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -232,6 +232,9 @@ def _verify_global_reachability(display_host: str, port: int) -> None:
     public internet. Synchronous so output lands between the banner URLs and the
     stop hint. Bounded at ~15s; failures swallowed (verifier failing != Studio
     failing). Only meaningful for a wildcard bind."""
+    global _public_reachable
+    # Reset to "unknown" each run; set True/False only when the probe decides.
+    _public_reachable = None
     import ipaddress
     import json
     import time
@@ -324,12 +327,14 @@ def _verify_global_reachability(display_host: str, port: int) -> None:
 
         print("", flush = True)
         if ok_nodes:
+            _public_reachable = True
             print(
                 f"{ok_c}  Reachability check: {url}/ is reachable from the "
                 f"public internet ({ok_nodes}/{total} probe nodes connected).{reset}",
                 flush = True,
             )
         elif err_nodes:
+            _public_reachable = False
             print(
                 f"{err_c}  Reachability check: {url}/ is NOT reachable from "
                 f"the public internet ({err_nodes}/{total} probe nodes failed).{reset}",
@@ -422,7 +427,9 @@ def _print_cloudflare_line() -> None:
     """Print the Cloudflare quick-tunnel URL for 0.0.0.0 binds, if one is up.
 
     Reads the module-level URL set by ``run_server``. Prints nothing when the
-    tunnel is disabled or failed -- failures are silently ignored.
+    tunnel is disabled or failed -- failures are silently ignored. When the public
+    reachability probe just failed (``_public_reachable is False``) but the tunnel
+    is up, reword to point the user at the Cloudflare link as the way in.
     """
     if not _cloudflare_url:
         return
@@ -430,7 +437,10 @@ def _print_cloudflare_line() -> None:
 
     accent = "\033[38;5;150;1m"
     reset = "\033[0m"
-    line = f"  Secure link access via Cloudflare: {_cloudflare_url}"
+    if _public_reachable is False:
+        line = f"  Use the secure link access via Cloudflare instead: {_cloudflare_url}"
+    else:
+        line = f"  Secure link access via Cloudflare: {_cloudflare_url}"
     print(f"{accent}{line}{reset}" if stdout_supports_color() else line)
 
 
@@ -621,6 +631,12 @@ _shutdown_event = None
 # trycloudflare.com URL for 0.0.0.0 binds (set by run_server, read by the banner);
 # None when there is no tunnel (loopback, disabled, or a silently-ignored failure).
 _cloudflare_url = None
+
+# Public reachability from the last _verify_global_reachability run, read by the
+# Cloudflare banner line. True when the public ip:port probe confirmed reachable,
+# False when it confirmed NOT reachable, None when the probe did not run or could
+# not decide (timeout, blocked, private address).
+_public_reachable = None
 
 
 _DEFAULT_FRONTEND_PATH = Path(__file__).resolve().parent.parent / "frontend" / "dist"

--- a/studio/backend/tests/test_cloudflare_tunnel.py
+++ b/studio/backend/tests/test_cloudflare_tunnel.py
@@ -13,6 +13,7 @@ import importlib.util
 import io
 import sys
 import tarfile
+import types
 from pathlib import Path
 
 import pytest
@@ -423,3 +424,56 @@ def test_run_server_gates_tunnel_on_wildcard():
     source = _RUN_PY.read_text()
     assert "_cloudflare_enabled" in source
     assert 'host == "0.0.0.0"' in source
+
+
+def _run_print_cloudflare_line(monkeypatch, *, cloudflare_url, public_reachable):
+    """Exec the real _print_cloudflare_line source in isolation (run.py has heavy
+    deps), with the two module globals injected and startup_banner stubbed."""
+    src = _RUN_PY.read_text()
+    tree = ast.parse(src)
+    func_src = next(
+        ast.get_source_segment(src, n)
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_print_cloudflare_line"
+    )
+    stub = types.ModuleType("startup_banner")
+    stub.stdout_supports_color = lambda: False
+    monkeypatch.setitem(sys.modules, "startup_banner", stub)
+    captured: list[str] = []
+    ns = {
+        "_cloudflare_url": cloudflare_url,
+        "_public_reachable": public_reachable,
+        "print": lambda *a, **k: captured.append(" ".join(str(x) for x in a)),
+    }
+    exec(compile(func_src, "<print_cloudflare_line>", "exec"), ns)
+    ns["_print_cloudflare_line"]()
+    return "\n".join(captured)
+
+
+def test_cloudflare_line_reworded_when_public_unreachable(monkeypatch):
+    out = _run_print_cloudflare_line(
+        monkeypatch, cloudflare_url = "https://x.trycloudflare.com", public_reachable = False
+    )
+    assert "Use the secure link access via Cloudflare instead: https://x.trycloudflare.com" in out
+
+
+def test_cloudflare_line_default_wording_when_reachable(monkeypatch):
+    out = _run_print_cloudflare_line(
+        monkeypatch, cloudflare_url = "https://x.trycloudflare.com", public_reachable = True
+    )
+    assert "Secure link access via Cloudflare: https://x.trycloudflare.com" in out
+    assert "Use the secure link" not in out
+
+
+def test_cloudflare_line_default_wording_when_unknown(monkeypatch):
+    # Probe did not run / could not decide -> keep the existing wording.
+    out = _run_print_cloudflare_line(
+        monkeypatch, cloudflare_url = "https://x.trycloudflare.com", public_reachable = None
+    )
+    assert "Secure link access via Cloudflare: https://x.trycloudflare.com" in out
+    assert "Use the secure link" not in out
+
+
+def test_cloudflare_line_prints_nothing_without_tunnel(monkeypatch):
+    out = _run_print_cloudflare_line(monkeypatch, cloudflare_url = None, public_reachable = False)
+    assert out == ""


### PR DESCRIPTION
## Summary

On a `0.0.0.0` bind whose public ip:port is not reachable (a typical cloud firewall or security group), the startup banner printed "Secure link access via Cloudflare: <url>" immediately after "is NOT reachable from the public internet". That reads as if the tunnel might also be blocked, when the Cloudflare quick-tunnel actually works regardless.

## Fix

Thread the reachability probe result through a module-level `_public_reachable` tri-state (True, False, None), mirroring the existing `_cloudflare_url` flag. When the public probe definitively failed but the tunnel is up, print "Use the secure link access via Cloudflare instead: <url>" to point the user at the working way in. Reachable or undecided cases (timeout, blocked, private address) keep the existing wording.

## Test plan

- Added tests in `test_cloudflare_tunnel.py` covering the reworded line when the public probe failed, the unchanged wording when reachable or undecided, and nothing printed when there is no tunnel.
- Validated on Linux, macOS, and Windows CI.
