### PR TITLE
fix: decode subprocess output as UTF-8 in save.py on Windows

### DIFF
--- a/tests/saving/test_save_subprocess_utf8_encoding.py
+++ b/tests/saving/test_save_subprocess_utf8_encoding.py
@@ -1,0 +1,152 @@
+# Unsloth - 2x faster, 60% less VRAM LLM training and finetuning
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+"""Regression tests for unslothai/unsloth#2660.
+
+On Windows the default text encoding is the locale code page (e.g. cp1252),
+not UTF-8. ``subprocess.Popen`` / ``subprocess.run`` opened in text mode
+(``text=True`` / ``universal_newlines=True``) without an explicit
+``encoding`` therefore decode child-process output with cp1252. When
+llama.cpp / Ollama emit a byte that is undefined in cp1252 (e.g. ``0x9d``,
+which appears inside the UTF-8 encoding of common punctuation and box-drawing
+glyphs), the read raises ``UnicodeDecodeError`` and aborts the GGUF export.
+
+Two checks:
+
+* ``test_save_subprocess_text_calls_declare_utf8_encoding`` -- a source-level
+  drift detector. It parses ``unsloth/save.py`` (no import, so it runs under
+  the GPU/torch-free harness) and fails if any text-mode subprocess call is
+  missing ``encoding="utf-8"``. This is the regression guard: it is red
+  before the fix and green after.
+* ``test_utf8_replace_decodes_non_cp1252_subprocess_output`` -- a behavioural
+  check that documents the bug and the fix deterministically on any platform:
+  raw child output that is invalid under cp1252 raises, while the
+  ``encoding="utf-8", errors="replace"`` kwargs used by the fix read it
+  cleanly.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SAVE_PY = Path(__file__).resolve().parents[2] / "unsloth" / "save.py"
+
+
+def _is_subprocess_call(node: ast.Call) -> bool:
+    """True for ``subprocess.Popen(...)`` / ``subprocess.run(...)``."""
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in {"Popen", "run"}
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    )
+
+
+def _kw(node: ast.Call, name: str):
+    for kw in node.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _is_true(value) -> bool:
+    return isinstance(value, ast.Constant) and value.value is True
+
+
+def _is_text_mode(node: ast.Call) -> bool:
+    """Text mode = ``text=True`` or ``universal_newlines=True``."""
+    return _is_true(_kw(node, "text")) or _is_true(_kw(node, "universal_newlines"))
+
+
+def _collect_text_mode_subprocess_calls() -> list[ast.Call]:
+    tree = ast.parse(SAVE_PY.read_text(encoding = "utf-8"), filename = str(SAVE_PY))
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and _is_subprocess_call(node)
+        and _is_text_mode(node)
+    ]
+
+
+def test_text_mode_subprocess_calls_exist():
+    """Guard the guard: if save.py stops using text-mode subprocess calls the
+    drift test below would vacuously pass, so make sure we are actually
+    inspecting something."""
+    calls = _collect_text_mode_subprocess_calls()
+    assert len(calls) >= 6, (
+        f"Expected several text-mode subprocess calls in {SAVE_PY.name}, "
+        f"found {len(calls)} -- has the file been restructured?"
+    )
+
+
+def test_save_subprocess_text_calls_declare_utf8_encoding():
+    """Every text-mode subprocess call in save.py must pin encoding='utf-8'.
+
+    Without it, reading llama.cpp/Ollama output crashes on Windows (cp1252).
+    Fails before the #2660 fix, passes after.
+    """
+    offenders = []
+    for node in _collect_text_mode_subprocess_calls():
+        enc = _kw(node, "encoding")
+        ok = isinstance(enc, ast.Constant) and enc.value == "utf-8"
+        if not ok:
+            offenders.append(node.lineno)
+
+    assert not offenders, (
+        "Text-mode subprocess call(s) in unsloth/save.py missing "
+        'encoding="utf-8" (UnicodeDecodeError on Windows, #2660) at line(s): '
+        + ", ".join(map(str, sorted(offenders)))
+    )
+
+
+def test_utf8_replace_decodes_non_cp1252_subprocess_output():
+    """Document the failure and the fix with a real subprocess.
+
+    The child emits U+201D (right double quote), whose UTF-8 encoding
+    ``E2 80 9D`` contains byte 0x9D -- undefined in cp1252. Decoding the raw
+    bytes as cp1252 raises (the bug); the fix's kwargs read it cleanly.
+    """
+    # All-ASCII argv; the child builds the non-ASCII char itself so this is
+    # deterministic regardless of the parent's locale.
+    child = (
+        "import sys; "
+        "sys.stdout.buffer.write(('tensor ' + chr(0x201D) + ' x\\n').encode('utf-8'))"
+    )
+
+    raw = subprocess.run(
+        [sys.executable, "-c", child], capture_output = True
+    ).stdout
+    assert b"\x9d" in raw  # precondition: output carries the cp1252-undefined byte
+
+    # Failing behaviour before the fix: cp1252 (the Windows default) cannot
+    # decode this output.
+    with pytest.raises(UnicodeDecodeError):
+        raw.decode("cp1252")
+
+    # Correct behaviour after the fix: the exact kwargs save.py now uses.
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        capture_output = True,
+        text = True,
+        encoding = "utf-8",
+        errors = "replace",
+    )
+    assert result.stdout.startswith("tensor ")
+    assert "”" in result.stdout

--- a/tests/saving/test_save_subprocess_utf8_encoding.py
+++ b/tests/saving/test_save_subprocess_utf8_encoding.py
@@ -79,9 +79,7 @@ def _collect_text_mode_subprocess_calls() -> list[ast.Call]:
     return [
         node
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and _is_subprocess_call(node)
-        and _is_text_mode(node)
+        if isinstance(node, ast.Call) and _is_subprocess_call(node) and _is_text_mode(node)
     ]
 
 
@@ -130,9 +128,7 @@ def test_utf8_replace_decodes_non_cp1252_subprocess_output():
         "sys.stdout.buffer.write(('tensor ' + chr(0x201D) + ' x\\n').encode('utf-8'))"
     )
 
-    raw = subprocess.run(
-        [sys.executable, "-c", child], capture_output = True
-    ).stdout
+    raw = subprocess.run([sys.executable, "-c", child], capture_output = True).stdout
     assert b"\x9d" in raw  # precondition: output carries the cp1252-undefined byte
 
     # Failing behaviour before the fix: cp1252 (the Windows default) cannot

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -189,6 +189,8 @@ def _quantize_q2_k_l(
                 command,
                 shell = False,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 stdout = subprocess.PIPE,
                 stderr = subprocess.STDOUT,
                 bufsize = 1,
@@ -209,6 +211,8 @@ def _quantize_q2_k_l(
                 check = True,
                 capture_output = True,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
             )
     except subprocess.CalledProcessError as e:
         if print_output and hasattr(e, "stdout") and e.stdout:
@@ -2030,6 +2034,8 @@ def create_ollama_model(username: str, model_name: str, tag: str, modelfile_path
             ["curl", "http://localhost:11434"],
             capture_output = True,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 3,
         )
         if init_check.returncode == 0:
@@ -2052,6 +2058,8 @@ def create_ollama_model(username: str, model_name: str, tag: str, modelfile_path
         text = True,
         bufsize = 1,
         universal_newlines = True,
+        encoding = "utf-8",
+        errors = "replace",
     )
 
     for line in iter(process.stdout.readline, ""):
@@ -2072,6 +2080,8 @@ def push_to_ollama_hub(username: str, model_name: str, tag: str):
             ["curl", "http://localhost:11434"],
             capture_output = True,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 3,
         )
         if init_check.returncode == 0:
@@ -2088,6 +2098,8 @@ def push_to_ollama_hub(username: str, model_name: str, tag: str):
         text = True,
         bufsize = 1,
         universal_newlines = True,
+        encoding = "utf-8",
+        errors = "replace",
     )
 
     for line in iter(process.stdout.readline, ""):
@@ -2836,6 +2848,8 @@ def unsloth_convert_lora_to_ggml_and_push_to_hub(
             stderr = subprocess.PIPE,
             bufsize = 1,
             universal_newlines = True,
+            encoding = "utf-8",
+            errors = "replace",
         ) as sp:
             for line in sp.stdout:
                 print(line, end = "", flush = True)
@@ -2918,6 +2932,8 @@ def unsloth_convert_lora_to_ggml_and_save_locally(
             stderr = subprocess.PIPE,
             bufsize = 1,
             universal_newlines = True,
+            encoding = "utf-8",
+            errors = "replace",
         ) as sp:
             for line in sp.stdout:
                 print(line, end = "", flush = True)


### PR DESCRIPTION
Part of #2660

## Problem

On Windows, Python's default text encoding is the locale code page (cp1252), not UTF-8. The text-mode subprocess calls in `unsloth/save.py` (`text=True` / `universal_newlines=True`) don't set an `encoding`, so they decode llama.cpp and Ollama output as cp1252. That pipeline prints non-ASCII (progress and box-drawing glyphs, model names, file paths like `C:\Users\José\...`), so the moment a byte cp1252 can't map shows up (0x9d is a common one, it lives inside the UTF-8 encoding of ordinary curly quotes) the read raises `UnicodeDecodeError` and the export dies. Valid-but-wrong bytes corrupt the captured text silently instead.

Reproduced on Windows (cp1252, `PYTHONUTF8` unset):

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 16: character maps to <undefined>
```

The original import-time crash in #2660 was already fixed in unsloth-zoo; this is the save/export half in this repo. The unsloth-zoo llama.cpp engine half is unslothai/unsloth-zoo#764.

## Fix

- `unsloth/save.py`
  - add `encoding="utf-8", errors="replace"` to all 8 text-mode subprocess calls (`_quantize_q2_k_l` quantize + capture, the two `create_ollama_model` / `push_to_ollama_hub` curl + Popen pairs, and the two `convert-lora-to-ggml` Popens). `errors="replace"` means a stray byte can neither crash an export nor silently corrupt the captured output.
- `tests/saving/test_save_subprocess_utf8_encoding.py` (new)
  - AST drift test: parses `save.py` and fails if any text-mode subprocess call is missing `encoding="utf-8"`. No `unsloth` import, so it runs without torch or a GPU. Red before the change, green after.
  - behavioural test: spawns a real subprocess emitting a curly quote, asserts the raw bytes fail under cp1252 and read cleanly with the new kwargs.

Validation: `pytest tests/saving/test_save_subprocess_utf8_encoding.py` passes 3/3 (the drift test fails before the fix); `ruff check` and the kwarg-spacing hook are clean.
