### PR TITLE
Stop false RoPE 'default' warning and fix rope drift gate on transformers 5

### DIFF
--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -300,7 +300,14 @@ def test_object_style_rope_scaling_on_config_delegates_correctly():
     expected = _reference_inv_freq(dict_config, "linear")
 
     object_config = _make_config({"rope_type": "linear", "factor": 4.0})
-    object_config.rope_scaling = FakeLinearRopeScalingConfig()
+    try:
+        object_config.rope_scaling = FakeLinearRopeScalingConfig()
+    except Exception:
+        pytest.skip(
+            "transformers strict-validates rope_scaling to dict/RopeParameters/None, "
+            "so object-style config.rope_scaling (and the delegation retry it "
+            "exercises) is unreachable on this version."
+        )
     inv_freq, attention_scaling = _compute_config_rope_inv_freq(
         object_config, object_config.rope_scaling
     )

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1679,9 +1679,7 @@ def _vanilla_inv_freq_from_config(config, device = "cpu"):
     dim = getattr(config, "head_dim", None)
     if dim is None:
         dim = int(config.hidden_size // config.num_attention_heads)
-    return 1.0 / (
-        base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim)
-    )
+    return 1.0 / (base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim))
 
 
 def _compute_config_rope_inv_freq(config, rope_scaling):

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1673,12 +1673,28 @@ def _llama3_inv_freq_from_config(
     return torch.where(is_medium, smoothed, scaled)
 
 
+def _vanilla_inv_freq_from_config(config, device = "cpu"):
+    """Unscaled RoPE inv_freq (rope_type 'default'/None), matching the constructor's fallback."""
+    base = _get_rope_theta(config, default = 10000.0)
+    dim = getattr(config, "head_dim", None)
+    if dim is None:
+        dim = int(config.hidden_size // config.num_attention_heads)
+    return 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype = torch.int64, device = device).float() / dim)
+    )
+
+
 def _compute_config_rope_inv_freq(config, rope_scaling):
     """(inv_freq, attention_scaling) per config.rope_scaling via transformers'
     ROPE_INIT_FUNCTIONS, with an inline llama3 fallback; (None, 1.0) on failure."""
     original_rope_scaling = rope_scaling
     rope_scaling = _rope_scaling_as_dict(rope_scaling)
     rope_type = rope_scaling.get("rope_type", None) or rope_scaling.get("type", None)
+    # "default"/unset means unscaled RoPE. transformers >=5 reports
+    # rope_type="default" for every plain config and dropped "default" from
+    # ROPE_INIT_FUNCTIONS, so compute it directly instead of warning per load.
+    if rope_type in (None, "default"):
+        return _vanilla_inv_freq_from_config(config).to(dtype = torch.float32, device = "cpu"), 1.0
     try:
         from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 


### PR DESCRIPTION
## Problem

The `Core (HF=latest)` and `Core (HF=default)` CI cells fail on `tests/utils/test_rope_scaling_drift.py` (the generation-correctness HARD GATE), while `Core (HF=4.57.6 + TRL<1)` passes. The failures are real and reproduce on `transformers>=5,<6` (verified locally on transformers 5.11.0).

Two distinct causes, one a real bug and one a test-setup incompatibility:

### 1. Real bug: false RoPE warning on every plain model (transformers 5)

transformers 5 changed two things:

- `ROPE_INIT_FUNCTIONS` no longer has a `"default"` key (now: dynamic, linear, llama3, longrope, proportional, yarn).
- A plain config with no scaling now reports `config.rope_scaling = {"rope_type": "default", ...}` instead of `None`.

So `_compute_config_rope_inv_freq` is now entered for every unscaled model, does `ROPE_INIT_FUNCTIONS["default"]`, hits `KeyError: 'default'`, returns `None`, and logs:

```
Unsloth: Could not apply RoPE scaling 'default' from config (KeyError: 'default'); falling back to unscaled RoPE. Long-context generation may degrade.
```

The `inv_freq` itself stays correct (the constructor recomputes vanilla on `None`), but the warning is a false alarm fired on every plain model load, and `test_default_rope_type_matches_vanilla_inv_freq` rightly fails because the helper returns `None` instead of the vanilla `inv_freq`.

### 2. Test issue: object-style rope_scaling is unreachable on transformers 5

`test_object_style_rope_scaling_on_config_delegates_correctly` sets `config.rope_scaling = <object>` to exercise the object-normalization retry. transformers 5 strict-validates that field to `dict` / `RopeParameters` / `None`, so the assignment raises `StrictDataclassFieldValidationError` during test setup, before any Unsloth code runs. The scenario cannot exist on that version.

## Fix

- `unsloth/models/llama.py`: treat `rope_type` `"default"`/`None` as unscaled and compute the vanilla `inv_freq` directly (new `_vanilla_inv_freq_from_config`), instead of going through `ROPE_INIT_FUNCTIONS`. Plain configs now return the correct value with no warning. Scaled types (llama3/linear/yarn/longrope/dynamic) are untouched.
- `tests/utils/test_rope_scaling_drift.py`: skip the object-style delegation test when transformers refuses a non-dict `rope_scaling`. The test still runs and asserts on transformers <5, where the path is reachable.

## Verification

Ran the gate in two isolated envs (CPU, mirroring the CI cells):

| transformers | `test_rope_scaling_drift.py` before | after |
|---|---|---|
| 5.11.0 | 2 failed, 3 passed, 4 skipped | 0 failed (4 passed, 5 skipped) |
| 4.57.6 | 5 passed, 4 skipped | 5 passed, 4 skipped (unchanged; object-style test still runs and passes) |

- Full HARD-GATE step (`test_prepare_inputs_leftpad.py` + `test_rope_scaling_drift.py`) on transformers 5.11.0: 15 passed, 5 skipped, 0 failed.
- Direct check on a plain transformers 5 config: helper now returns vanilla `inv_freq` (matches `1/theta^(arange/dim)`), `attention_scaling = 1.0`, and emits no warning.
- No regression on the pinned `transformers==4.57.6 + TRL<1` line.
