### PR TITLE
Studio CI: stop the stale sidebar descender guard from failing Repo tests on every PR

### DIFF
--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -37,7 +37,7 @@ def test_model_selector_trigger_label_uses_leading_tight():
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
     pattern = re.compile(
-        r'<div\s+className="flex\s+flex-col\s+gap-0\.5\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
+        r'<div\s+className="flex\s+flex-col\s+gap-px\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
     )
     matches = pattern.findall(src)
     assert matches, "could not find sidebar account-block parent div"


### PR DESCRIPTION
### Problem

The `Repo tests (CPU)` job in Backend CI has been failing on every PR (e.g. #6219) with `could not find sidebar account-block parent div`. The failure is unrelated to the change under test.

`test_sidebar_account_block_uses_leading_tight` matches the sidebar account-block div with a regex that hard-codes the `gap-0.5` class. #6196 renamed that class to `gap-px`, so the regex no longer matched and the test failed.

### Fix

Update the regex to `gap-px`. One token, nothing else changes.

Verification: `python -m pytest tests/studio/test_studio_text_descender_clipping.py` -> 3 passed.
