### PR TITLE
Studio: fix WSL Strix Halo GPU on reinstall (ROCDXG drop-in + system HIP before bundle)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2043,6 +2043,40 @@ _pick_radeon_wheel() {
 # CPU, non-Strix WSL) skips it and normal detection runs unchanged. NEVER aborts
 # the installer -- always returns 0. Runs the idempotent helper (ROCm 7.2 +
 # librocdxg), then sources the env it persisted so detection finds the GPU.
+# Persist the ROCm-on-WSL env to /etc/profile.d so non-login Studio / llama
+# launches inherit HSA_ENABLE_DXG_DETECTION + the rocm PATH/LD_LIBRARY_PATH.
+# Also exports the env into the current process. Idempotent: only (re)writes the
+# drop-in when it is missing. No-op unless librocdxg (the WSL bridge) is present,
+# so it never writes a WSL drop-in on a non-WSL or non-ROCDXG host.
+# /etc/profile.d is root-owned: a plain redirect fails for a non-root reinstall
+# (ROCm would silently disappear after this shell), so tee through sudo when not
+# root. Best-effort -- the current shell already has the env either way.
+_persist_rocm_wsl_dropin() {
+    [ -e /opt/rocm/lib/librocdxg.so ] || [ -e /opt/rocm/lib64/librocdxg.so ] || return 0
+    _rw_rocm=/opt/rocm
+    export HSA_ENABLE_DXG_DETECTION=1
+    export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
+    case ":${PATH}:" in
+        *":${_rw_rocm}/bin:"*) ;;
+        *) export PATH="${_rw_rocm}/bin:${PATH}" ;;
+    esac
+    export LD_LIBRARY_PATH="${_rw_rocm}/lib:${LD_LIBRARY_PATH:-}"
+    [ -r /etc/profile.d/unsloth-rocm-wsl.sh ] && return 0
+    _rw_dropin="$(
+        printf '# >>> Unsloth ROCm-on-WSL (gfx1151) >>>\n'
+        printf 'export HSA_ENABLE_DXG_DETECTION=1\n'
+        printf 'export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1\n'
+        printf 'export PATH="%s/bin:${PATH}"\n' "${_rw_rocm}"
+        printf 'export LD_LIBRARY_PATH="%s/lib:${LD_LIBRARY_PATH:-}"\n' "${_rw_rocm}"
+        printf '# <<< Unsloth ROCm-on-WSL (gfx1151) <<<\n'
+    )"
+    if [ "$(id -u)" = "0" ]; then
+        printf '%s\n' "$_rw_dropin" > /etc/profile.d/unsloth-rocm-wsl.sh 2>/dev/null || true
+    elif command -v sudo >/dev/null 2>&1; then
+        printf '%s\n' "$_rw_dropin" | sudo tee /etc/profile.d/unsloth-rocm-wsl.sh >/dev/null 2>&1 || true
+    fi
+}
+
 _maybe_bootstrap_rocm_wsl() {
     [ "${OS:-}" = "wsl" ] || return 0
     [ "${SKIP_TORCH:-false}" = "false" ] || return 0
@@ -2056,6 +2090,14 @@ _maybe_bootstrap_rocm_wsl() {
     _ensure_rocm_probe_env
     if command -v rocminfo >/dev/null 2>&1 && \
        rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx1151/{found=1} END{exit !found}'; then
+        # rocminfo sees the GPU -- but possibly ONLY because the line above
+        # (_ensure_rocm_probe_env) put a transient HSA/PATH env on THIS process.
+        # That env vanishes when the installer exits, so future login shells
+        # (Studio, llama.cpp) would still see no GPU. Persist the drop-in before
+        # returning so they inherit it. Without this, every reinstall over an
+        # existing /opt/rocm (the common case -- uninstall keeps shared ROCm but
+        # removes the drop-in) leaves the GPU invisible to Studio at runtime.
+        _persist_rocm_wsl_dropin
         return 0
     fi
     # WSL GPU passthrough device must exist (present on any WSL2 GPU host).
@@ -2073,31 +2115,8 @@ _maybe_bootstrap_rocm_wsl() {
             . /etc/profile.d/unsloth-rocm-wsl.sh || true
         else
             # librocdxg present but the env drop-in is gone (e.g. a Studio
-            # uninstall removed it while keeping shared ROCm). Restore the FULL
-            # env inline (so rocminfo is on PATH) and recreate the drop-in.
-            _rw_rocm=/opt/rocm
-            export HSA_ENABLE_DXG_DETECTION=1
-            export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
-            export PATH="${_rw_rocm}/bin:${PATH}"
-            export LD_LIBRARY_PATH="${_rw_rocm}/lib:${LD_LIBRARY_PATH:-}"
-            # Persist the drop-in so later non-login Studio launches get the env
-            # too. /etc/profile.d is root-owned: a plain redirect fails for a
-            # non-root reinstall (ROCm would silently disappear after this shell),
-            # so tee through sudo when not root. Best-effort -- the current shell
-            # already has the env, so the install proceeds either way.
-            _rw_dropin="$(
-                printf '# >>> Unsloth ROCm-on-WSL (gfx1151) >>>\n'
-                printf 'export HSA_ENABLE_DXG_DETECTION=1\n'
-                printf 'export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1\n'
-                printf 'export PATH="%s/bin:${PATH}"\n' "${_rw_rocm}"
-                printf 'export LD_LIBRARY_PATH="%s/lib:${LD_LIBRARY_PATH:-}"\n' "${_rw_rocm}"
-                printf '# <<< Unsloth ROCm-on-WSL (gfx1151) <<<\n'
-            )"
-            if [ "$(id -u)" = "0" ]; then
-                printf '%s\n' "$_rw_dropin" > /etc/profile.d/unsloth-rocm-wsl.sh 2>/dev/null || true
-            elif command -v sudo >/dev/null 2>&1; then
-                printf '%s\n' "$_rw_dropin" | sudo tee /etc/profile.d/unsloth-rocm-wsl.sh >/dev/null 2>&1 || true
-            fi
+            # uninstall removed it while keeping shared ROCm). Restore the env.
+            _persist_rocm_wsl_dropin
         fi
         return 0
     fi

--- a/install.sh
+++ b/install.sh
@@ -2043,14 +2043,11 @@ _pick_radeon_wheel() {
 # CPU, non-Strix WSL) skips it and normal detection runs unchanged. NEVER aborts
 # the installer -- always returns 0. Runs the idempotent helper (ROCm 7.2 +
 # librocdxg), then sources the env it persisted so detection finds the GPU.
-# Persist the ROCm-on-WSL env to /etc/profile.d so non-login Studio / llama
-# launches inherit HSA_ENABLE_DXG_DETECTION + the rocm PATH/LD_LIBRARY_PATH.
-# Also exports the env into the current process. Idempotent: only (re)writes the
-# drop-in when it is missing. No-op unless librocdxg (the WSL bridge) is present,
-# so it never writes a WSL drop-in on a non-WSL or non-ROCDXG host.
-# /etc/profile.d is root-owned: a plain redirect fails for a non-root reinstall
-# (ROCm would silently disappear after this shell), so tee through sudo when not
-# root. Best-effort -- the current shell already has the env either way.
+# Export the ROCm-on-WSL env into this process and persist it to /etc/profile.d
+# so non-login Studio/llama launches inherit it. Idempotent (writes only when
+# the drop-in is missing); no-op without librocdxg, so never fires off WSL.
+# /etc/profile.d is root-owned -- sudo-tee when not root, else ROCm vanishes
+# after this shell on a non-root reinstall. Best-effort either way.
 _persist_rocm_wsl_dropin() {
     [ -e /opt/rocm/lib/librocdxg.so ] || [ -e /opt/rocm/lib64/librocdxg.so ] || return 0
     _rw_rocm=/opt/rocm
@@ -2090,13 +2087,10 @@ _maybe_bootstrap_rocm_wsl() {
     _ensure_rocm_probe_env
     if command -v rocminfo >/dev/null 2>&1 && \
        rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx1151/{found=1} END{exit !found}'; then
-        # rocminfo sees the GPU -- but possibly ONLY because the line above
-        # (_ensure_rocm_probe_env) put a transient HSA/PATH env on THIS process.
-        # That env vanishes when the installer exits, so future login shells
-        # (Studio, llama.cpp) would still see no GPU. Persist the drop-in before
-        # returning so they inherit it. Without this, every reinstall over an
-        # existing /opt/rocm (the common case -- uninstall keeps shared ROCm but
-        # removes the drop-in) leaves the GPU invisible to Studio at runtime.
+        # rocminfo may work only via the transient env _ensure_rocm_probe_env
+        # just set, which dies with the installer. Persist the drop-in so login
+        # shells (Studio, llama.cpp) inherit it -- else a reinstall over an
+        # existing /opt/rocm (uninstall keeps ROCm but drops it) loses the GPU.
         _persist_rocm_wsl_dropin
         return 0
     fi

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -63,6 +63,38 @@ from core.inference.tool_loop_controller import (
 logger = get_logger(__name__)
 
 
+def _wsl_system_rocm_lib_dirs() -> "list[str]":
+    """System ROCm lib dir(s) to load before a prebuilt's bundled HIP, on WSL.
+
+    In WSL the GPU is reached through the system ROCm's librocdxg bridge over
+    /dev/dxg. A llama.cpp ROCm prebuilt bundles its own (often newer) HIP
+    runtime built for bare-metal Linux, which cannot drive /dev/dxg and
+    segfaults on the first GPU call. Putting the system ROCm lib dir ahead of
+    the bundle on LD_LIBRARY_PATH loads the WSL-capable HIP runtime while the
+    bundle still supplies libggml-hip / librocblas (with the gfx1151 kernels).
+
+    Mirrors install_llama_prebuilt._wsl_system_rocm_lib_dirs so a prebuilt that
+    passed install validation runs identically at serve time. Strict no-op off
+    a ROCDXG WSL host (requires /dev/dxg, "microsoft" /proc/version, and a
+    librocdxg-providing /opt/rocm).
+    """
+    try:
+        if not os.path.exists("/dev/dxg"):
+            return []
+        with open("/proc/version", encoding = "utf-8", errors = "replace") as fh:
+            if "microsoft" not in fh.read().lower():
+                return []
+    except OSError:
+        return []
+    out: "list[str]" = []
+    for d in ("/opt/rocm/lib", "/opt/rocm/lib64"):
+        if os.path.exists(os.path.join(d, "librocdxg.so")) or os.path.exists(
+            os.path.join(d, "librocdxg.so.1")
+        ):
+            out.append(d)
+    return out
+
+
 # ── Pre-compiled patterns for plan-without-action re-prompt ──
 # Forward-looking intent signals: the model is describing what it *will*
 # do rather than giving a final answer.
@@ -3420,7 +3452,21 @@ class LlamaCppBackend:
                     # plus CUDA runtime libs (libcudart, libcublas, etc.)
                     import platform
 
-                    lib_dirs = [binary_dir]
+                    lib_dirs = []
+                    # WSL ROCDXG: the system HIP runtime (libamdhip64 +
+                    # librocdxg) must load BEFORE the prebuilt's bundled one,
+                    # which is built for bare-metal and segfaults reaching the
+                    # GPU over /dev/dxg. The bundle still supplies libggml-hip /
+                    # librocblas (with the gfx1151 kernels). Must mirror
+                    # install_llama_prebuilt.binary_env, which validates the
+                    # prebuilt with this same ordering -- otherwise a prebuilt
+                    # that passed install validation would crash at runtime.
+                    # Strict no-op off a ROCDXG WSL host.
+                    for _wsl_rocm in _wsl_system_rocm_lib_dirs():
+                        lib_dirs.append(_wsl_rocm)
+                    if lib_dirs:
+                        env.setdefault("HSA_ENABLE_DXG_DETECTION", "1")
+                    lib_dirs.append(binary_dir)
                     _arch = platform.machine()  # x86_64, aarch64, etc.
 
                     # Pip-installed nvidia CUDA runtime libs. The prebuilt

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -66,17 +66,12 @@ logger = get_logger(__name__)
 def _wsl_system_rocm_lib_dirs() -> "list[str]":
     """System ROCm lib dir(s) to load before a prebuilt's bundled HIP, on WSL.
 
-    In WSL the GPU is reached through the system ROCm's librocdxg bridge over
-    /dev/dxg. A llama.cpp ROCm prebuilt bundles its own (often newer) HIP
-    runtime built for bare-metal Linux, which cannot drive /dev/dxg and
-    segfaults on the first GPU call. Putting the system ROCm lib dir ahead of
-    the bundle on LD_LIBRARY_PATH loads the WSL-capable HIP runtime while the
-    bundle still supplies libggml-hip / librocblas (with the gfx1151 kernels).
-
+    The bundled bare-metal HIP can't drive WSL's /dev/dxg and segfaults on the
+    first GPU call; the system ROCm libs (libamdhip64 + librocdxg) can, while
+    the bundle still supplies libggml-hip / librocblas (gfx1151 kernels).
     Mirrors install_llama_prebuilt._wsl_system_rocm_lib_dirs so a prebuilt that
-    passed install validation runs identically at serve time. Strict no-op off
-    a ROCDXG WSL host (requires /dev/dxg, "microsoft" /proc/version, and a
-    librocdxg-providing /opt/rocm).
+    passed install validation runs the same at serve time. No-op off a ROCDXG
+    WSL host (needs /dev/dxg, "microsoft" /proc/version, librocdxg in /opt/rocm).
     """
     try:
         if not os.path.exists("/dev/dxg"):
@@ -3453,15 +3448,9 @@ class LlamaCppBackend:
                     import platform
 
                     lib_dirs = []
-                    # WSL ROCDXG: the system HIP runtime (libamdhip64 +
-                    # librocdxg) must load BEFORE the prebuilt's bundled one,
-                    # which is built for bare-metal and segfaults reaching the
-                    # GPU over /dev/dxg. The bundle still supplies libggml-hip /
-                    # librocblas (with the gfx1151 kernels). Must mirror
-                    # install_llama_prebuilt.binary_env, which validates the
-                    # prebuilt with this same ordering -- otherwise a prebuilt
-                    # that passed install validation would crash at runtime.
-                    # Strict no-op off a ROCDXG WSL host.
+                    # WSL: system HIP before the bundle's (which segfaults on
+                    # /dev/dxg). Mirror install_llama_prebuilt.binary_env, which
+                    # validates the prebuilt with this same ordering.
                     for _wsl_rocm in _wsl_system_rocm_lib_dirs():
                         lib_dirs.append(_wsl_rocm)
                     if lib_dirs:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5641,19 +5641,14 @@ def windows_runtime_dirs_for_runtime_line(runtime_line: str | None) -> list[str]
 
 
 def _wsl_system_rocm_lib_dirs() -> list[str]:
-    """System ROCm lib dir(s) to prefer over a prebuilt's bundled HIP, on WSL.
+    """System ROCm lib dir(s) for binary_env to load before a prebuilt's HIP.
 
-    In WSL the GPU is reached through the system ROCm's librocdxg bridge over
-    /dev/dxg. A llama.cpp ROCm prebuilt bundles its own (often newer) HIP
-    runtime built for bare-metal Linux; that runtime cannot drive /dev/dxg and
-    segfaults on the first GPU call, so the prebuilt fails validation and the
-    install silently falls back to a CPU build. Returning the system ROCm lib
-    dir here lets binary_env put it AHEAD of the bundle, so the WSL-capable HIP
-    runtime (libamdhip64 + librocdxg) is loaded while the bundle still supplies
-    libggml-hip / librocblas with the gfx1151 kernels.
-
-    Strict no-op off WSL: requires both /dev/dxg and a "microsoft" /proc/version,
-    and a librocdxg-providing ROCm install. Bare-metal Linux returns [].
+    A prebuilt bundles a bare-metal HIP runtime that can't drive WSL's /dev/dxg
+    and segfaults on the first GPU call -> validation fails, install falls back
+    to a CPU build. Putting the system ROCm libs first loads the WSL-capable
+    HIP (libamdhip64 + librocdxg) while the bundle still supplies libggml-hip /
+    librocblas with the gfx1151 kernels. Strict no-op off WSL (needs /dev/dxg, a
+    "microsoft" /proc/version, and a librocdxg-providing ROCm).
     """
     try:
         if not os.path.exists("/dev/dxg"):
@@ -5693,9 +5688,7 @@ def binary_env(
             str(install_dir),
             *linux_runtime_dirs(binary_path),
         ]
-        # WSL ROCDXG: load the system HIP runtime ahead of the prebuilt's
-        # bundled one (which segfaults reaching the GPU over /dev/dxg). The
-        # bundle still provides libggml-hip / librocblas. No-op on bare metal.
+        # WSL: system HIP before the bundle's (which segfaults on /dev/dxg).
         _wsl_rocm = _wsl_system_rocm_lib_dirs()
         if _wsl_rocm:
             ld_dirs = [*_wsl_rocm, *ld_dirs]

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5640,6 +5640,38 @@ def windows_runtime_dirs_for_runtime_line(runtime_line: str | None) -> list[str]
     return windows_runtime_dirs_for_patterns(patterns)
 
 
+def _wsl_system_rocm_lib_dirs() -> list[str]:
+    """System ROCm lib dir(s) to prefer over a prebuilt's bundled HIP, on WSL.
+
+    In WSL the GPU is reached through the system ROCm's librocdxg bridge over
+    /dev/dxg. A llama.cpp ROCm prebuilt bundles its own (often newer) HIP
+    runtime built for bare-metal Linux; that runtime cannot drive /dev/dxg and
+    segfaults on the first GPU call, so the prebuilt fails validation and the
+    install silently falls back to a CPU build. Returning the system ROCm lib
+    dir here lets binary_env put it AHEAD of the bundle, so the WSL-capable HIP
+    runtime (libamdhip64 + librocdxg) is loaded while the bundle still supplies
+    libggml-hip / librocblas with the gfx1151 kernels.
+
+    Strict no-op off WSL: requires both /dev/dxg and a "microsoft" /proc/version,
+    and a librocdxg-providing ROCm install. Bare-metal Linux returns [].
+    """
+    try:
+        if not os.path.exists("/dev/dxg"):
+            return []
+        with open("/proc/version", encoding = "utf-8", errors = "replace") as fh:
+            if "microsoft" not in fh.read().lower():
+                return []
+    except OSError:
+        return []
+    out: list[str] = []
+    for d in ("/opt/rocm/lib", "/opt/rocm/lib64"):
+        if os.path.exists(os.path.join(d, "librocdxg.so")) or os.path.exists(
+            os.path.join(d, "librocdxg.so.1")
+        ):
+            out.append(d)
+    return out
+
+
 def binary_env(
     binary_path: Path,
     install_dir: Path,
@@ -5661,6 +5693,13 @@ def binary_env(
             str(install_dir),
             *linux_runtime_dirs(binary_path),
         ]
+        # WSL ROCDXG: load the system HIP runtime ahead of the prebuilt's
+        # bundled one (which segfaults reaching the GPU over /dev/dxg). The
+        # bundle still provides libggml-hip / librocblas. No-op on bare metal.
+        _wsl_rocm = _wsl_system_rocm_lib_dirs()
+        if _wsl_rocm:
+            ld_dirs = [*_wsl_rocm, *ld_dirs]
+            env.setdefault("HSA_ENABLE_DXG_DETECTION", "1")
         existing = [part for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part]
         env["LD_LIBRARY_PATH"] = os.pathsep.join(dedupe_existing_dirs([*ld_dirs, *existing]))
     elif host.is_macos:

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, mock_open, patch, PropertyMock
 
 import pytest
 
@@ -3205,6 +3205,162 @@ class TestRocmGfxForwarding:
         source = _SETUP_PS1_PATH.read_text(encoding = "utf-8")
         assert "--rocm-gfx" in source
         assert "$script:ROCmGfxArch" in source
+
+
+# TEST: WSL ROCDXG fixes -- drop-in persistence + system-HIP-before-bundle
+
+
+_INSTALL_SH_PATH = PACKAGE_ROOT / "install.sh"
+_LLAMA_CPP_PATH = (
+    PACKAGE_ROOT / "studio" / "backend" / "core" / "inference" / "llama_cpp.py"
+)
+
+
+class TestWslSystemRocmLibDirs:
+    """install_llama_prebuilt._wsl_system_rocm_lib_dirs: a strict no-op off a
+    ROCDXG WSL host; returns the system ROCm lib dir there so binary_env can
+    load the WSL-capable HIP runtime before a prebuilt's bundled one."""
+
+    def test_empty_without_dev_dxg(self):
+        with patch("os.path.exists", return_value = False):
+            assert prebuilt_mod._wsl_system_rocm_lib_dirs() == []
+
+    def test_empty_on_bare_metal_linux(self):
+        # /dev/dxg present but /proc/version is not a WSL kernel.
+        with patch("os.path.exists", lambda p: p == "/dev/dxg"):
+            with patch(
+                "builtins.open",
+                mock_open(read_data = "Linux version 6.8.0-generic"),
+            ):
+                assert prebuilt_mod._wsl_system_rocm_lib_dirs() == []
+
+    def test_returns_system_lib_on_wsl_with_librocdxg(self):
+        # Normalize separators: os.path.join uses "\" on the Windows test host
+        # though the target path is Linux.
+        def _exists(p):
+            p = str(p).replace("\\", "/")
+            return p in ("/dev/dxg", "/opt/rocm/lib/librocdxg.so")
+
+        with patch("os.path.exists", _exists):
+            with patch(
+                "builtins.open",
+                mock_open(read_data = "Linux version 5.15.0-microsoft-standard-WSL2"),
+            ):
+                assert prebuilt_mod._wsl_system_rocm_lib_dirs() == ["/opt/rocm/lib"]
+
+    def test_empty_on_wsl_without_librocdxg(self):
+        # WSL kernel + /dev/dxg but no librocdxg -> not a ROCDXG ROCm install.
+        with patch("os.path.exists", lambda p: p == "/dev/dxg"):
+            with patch(
+                "builtins.open",
+                mock_open(read_data = "microsoft-standard-WSL2"),
+            ):
+                assert prebuilt_mod._wsl_system_rocm_lib_dirs() == []
+
+
+class TestBinaryEnvWslOrdering:
+    """binary_env must put the system ROCm lib dir AHEAD of the prebuilt's
+    bundle dir on a ROCDXG WSL host, and set HSA_ENABLE_DXG_DETECTION; no-op
+    on bare-metal Linux."""
+
+    @staticmethod
+    def _linux_host():
+        return HostInfo(
+            system = "Linux",
+            machine = "x86_64",
+            is_windows = False,
+            is_linux = True,
+            is_macos = False,
+            is_x86_64 = True,
+            is_arm64 = False,
+            nvidia_smi = None,
+            driver_cuda_version = None,
+            compute_caps = [],
+            visible_cuda_devices = None,
+            has_physical_nvidia = False,
+            has_usable_nvidia = False,
+            has_rocm = True,
+        )
+
+    def test_wsl_prepends_system_rocm_and_sets_hsa(self, tmp_path):
+        binary = tmp_path / "bundle" / "llama-server"
+        binary.parent.mkdir(parents = True)
+        binary.write_text("")
+        # binary_env's dedupe_existing_dirs drops non-existent dirs, so use a
+        # real dir to stand in for the system ROCm lib path.
+        sys_rocm = tmp_path / "sysrocm"
+        sys_rocm.mkdir()
+        with patch.object(
+            prebuilt_mod, "_wsl_system_rocm_lib_dirs", return_value = [str(sys_rocm)]
+        ):
+            with patch.dict(os.environ, {}, clear = True):
+                env = prebuilt_mod.binary_env(binary, tmp_path, self._linux_host())
+        ld = env["LD_LIBRARY_PATH"].split(os.pathsep)
+        # Compare resolved paths (dedupe_existing_dirs calls Path.resolve()).
+        ld_resolved = [str(Path(p).resolve()) for p in ld]
+        assert ld_resolved[0] == str(sys_rocm.resolve())
+        assert str(binary.parent.resolve()) in ld_resolved
+        assert ld_resolved.index(str(sys_rocm.resolve())) < ld_resolved.index(
+            str(binary.parent.resolve())
+        )
+        assert env.get("HSA_ENABLE_DXG_DETECTION") == "1"
+
+    def test_bare_metal_linux_unchanged(self, tmp_path):
+        binary = tmp_path / "bundle" / "llama-server"
+        binary.parent.mkdir(parents = True)
+        binary.write_text("")
+        with patch.object(prebuilt_mod, "_wsl_system_rocm_lib_dirs", return_value = []):
+            with patch.dict(os.environ, {}, clear = True):
+                env = prebuilt_mod.binary_env(binary, tmp_path, self._linux_host())
+        ld = env["LD_LIBRARY_PATH"].split(os.pathsep)
+        assert ld[0] == str(binary.parent)  # bundle dir first, as before
+        assert "HSA_ENABLE_DXG_DETECTION" not in env
+
+
+class TestInstallShDropinPersistence:
+    """install.sh must persist the ROCm-on-WSL drop-in even when rocminfo
+    already enumerates the GPU (via the transient probe env), so a reinstall
+    over an existing /opt/rocm doesn't leave login shells without the env."""
+
+    def test_has_persist_helper(self):
+        source = _INSTALL_SH_PATH.read_text(encoding = "utf-8")
+        assert "_persist_rocm_wsl_dropin()" in source
+
+    def test_gate5_early_return_persists_dropin(self):
+        """The rocminfo-already-works early return must call the persist helper
+        BEFORE returning."""
+        source = _INSTALL_SH_PATH.read_text(encoding = "utf-8")
+        # Find the rocminfo gfx1151 gate and assert the persist call precedes
+        # its `return 0`.
+        gate = source.find("Name:[[:space:]]*gfx1151")
+        assert gate != -1
+        window = source[gate : gate + 900]
+        assert "_persist_rocm_wsl_dropin" in window
+        assert window.find("_persist_rocm_wsl_dropin") < window.find("return 0")
+
+    def test_persist_helper_gated_on_librocdxg(self):
+        source = _INSTALL_SH_PATH.read_text(encoding = "utf-8")
+        body_start = source.find("_persist_rocm_wsl_dropin()")
+        body = source[body_start : body_start + 1200]
+        assert "librocdxg.so" in body
+        assert "profile.d/unsloth-rocm-wsl.sh" in body
+
+
+class TestLlamaCppRuntimeWslOrdering:
+    """The serve-time launcher must mirror binary_env: system HIP before the
+    bundle dir on WSL, so a prebuilt that passed install validation runs."""
+
+    def test_has_wsl_helper(self):
+        source = _LLAMA_CPP_PATH.read_text(encoding = "utf-8")
+        assert "_wsl_system_rocm_lib_dirs" in source
+
+    def test_prepends_before_binary_dir(self):
+        source = _LLAMA_CPP_PATH.read_text(encoding = "utf-8")
+        # The Linux lib_dirs build must add WSL rocm dirs before binary_dir.
+        idx_helper = source.find("for _wsl_rocm in _wsl_system_rocm_lib_dirs()")
+        idx_binary = source.find("lib_dirs.append(binary_dir)")
+        assert idx_helper != -1 and idx_binary != -1
+        assert idx_helper < idx_binary
 
 
 if __name__ == "__main__":

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -3211,9 +3211,7 @@ class TestRocmGfxForwarding:
 
 
 _INSTALL_SH_PATH = PACKAGE_ROOT / "install.sh"
-_LLAMA_CPP_PATH = (
-    PACKAGE_ROOT / "studio" / "backend" / "core" / "inference" / "llama_cpp.py"
-)
+_LLAMA_CPP_PATH = PACKAGE_ROOT / "studio" / "backend" / "core" / "inference" / "llama_cpp.py"
 
 
 class TestWslSystemRocmLibDirs:
@@ -3290,9 +3288,7 @@ class TestBinaryEnvWslOrdering:
         # real dir to stand in for the system ROCm lib path.
         sys_rocm = tmp_path / "sysrocm"
         sys_rocm.mkdir()
-        with patch.object(
-            prebuilt_mod, "_wsl_system_rocm_lib_dirs", return_value = [str(sys_rocm)]
-        ):
+        with patch.object(prebuilt_mod, "_wsl_system_rocm_lib_dirs", return_value = [str(sys_rocm)]):
             with patch.dict(os.environ, {}, clear = True):
                 env = prebuilt_mod.binary_env(binary, tmp_path, self._linux_host())
         ld = env["LD_LIBRARY_PATH"].split(os.pathsep)


### PR DESCRIPTION
## Summary

Three fixes that restore **gfx1151 GPU on WSL** for Unsloth Studio after PR #5940 landed. All are strictly WSL-gated (no-op on bare-metal Linux, NVIDIA, macOS, Windows). Found while re-running the full teardown→reinstall→verify cycle on a real Strix Halo (Radeon 8060S) under WSL2.

### 1. `install.sh`: persist the ROCm-on-WSL drop-in even when rocminfo already works
`_maybe_bootstrap_rocm_wsl` calls `_ensure_rocm_probe_env` (transient `HSA_ENABLE_DXG_DETECTION` + `/opt/rocm/bin` on PATH) right before the "rocminfo enumerates gfx1151 → return early" gate. On **any reinstall over an existing `/opt/rocm`** — the common case, since the uninstaller keeps shared ROCm but removes `/etc/profile.d/unsloth-rocm-wsl.sh` — that probe env makes rocminfo succeed, so the gate returns **without persisting the drop-in**. The transient env dies with the installer, so the next login shell (Studio, llama-server) sees no GPU: torch `cuda_avail=False`, rocminfo finds nothing. Factored `_persist_rocm_wsl_dropin()` and call it before the early return.

### 2 + 3. WSL: load the system HIP runtime before a prebuilt's bundled one (`install_llama_prebuilt.py` + `llama_cpp.py`)
The llama.cpp ROCm prebuilts bundle their own HIP runtime built for bare-metal Linux. In WSL the GPU is reached through the **system** ROCm's `librocdxg` bridge over `/dev/dxg`, which the bundled runtime can't drive — it **segfaults** on the first GPU call. So the prebuilt fails validation (empty stderr) and the install silently falls back to a CPU source build. Fix: on a ROCDXG WSL host, prepend the system ROCm lib dir to `LD_LIBRARY_PATH` (in both the install-time validator and the serve-time launcher, kept identical) so the WSL-capable `libamdhip64` + `librocdxg` load first while the bundle still supplies `libggml-hip`/`librocblas` with the gfx1151 kernels.

## Verification (real gfx1151, Radeon 8060S, WSL2 + ROCm 7.2.1 + librocdxg)
- **Before**: reinstall left the drop-in absent → torch `cuda_avail=False`; the lemonade gfx1151 prebuilt segfaulted → install fell back to a broken CPU build.
- **After**: fresh login shell reports `cuda_avail=True`; `install_llama_prebuilt` validates and keeps the GPU prebuilt (`prebuilt_fallback_used=False`); **Studio serves Qwen3-1.7B-GGUF at 53 tok/s with the model resident in GPU memory** (llama-server `device_info: ROCm0 = AMD Radeon 8060S`); the 3-engine cross-origin HTML client test passes.
- Drop-in fix reproduced + verified under both `dash` (the `curl|sh` shell) and `bash`, idempotent.
- New unit/structural tests; `test_rocm_support.py` 308 passed, backend prebuilt/llama tests 59 passed. The 2 pre-existing flash-attn test failures on this host are unrelated (fail identically on base `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)