### PR TITLE
Fix Gemma 4 QAT GGUF tool calling: retype special control tokens to CONTROL

### DIFF
--- a/tests/saving/test_fix_gguf_special_token_types.py
+++ b/tests/saving/test_fix_gguf_special_token_types.py
@@ -1,0 +1,189 @@
+import json
+import os
+import struct
+
+os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
+
+from unsloth.tokenizer_utils import fix_gguf_special_token_types
+
+
+NORMAL, CONTROL, USER_DEFINED = 1, 3, 4
+
+# GGUF metadata value/array element type ids.
+_T_INT32 = 5
+_T_STRING = 8
+_T_ARRAY = 9
+
+
+def _u64(n):
+    return struct.pack("<Q", n)
+
+
+def _gguf_string(s):
+    b = s.encode("utf-8")
+    return _u64(len(b)) + b
+
+
+def _kv_string(key, value):
+    return _gguf_string(key) + struct.pack("<I", _T_STRING) + _gguf_string(value)
+
+
+def _kv_string_array(key, values):
+    out = _gguf_string(key) + struct.pack("<I", _T_ARRAY)
+    out += struct.pack("<I", _T_STRING) + _u64(len(values))
+    for v in values:
+        out += _gguf_string(v)
+    return out
+
+
+def _kv_int32_array(key, values):
+    out = _gguf_string(key) + struct.pack("<I", _T_ARRAY)
+    out += struct.pack("<I", _T_INT32) + _u64(len(values))
+    out += b"".join(struct.pack("<i", v) for v in values)
+    return out
+
+
+def _write_gguf(path, tokens, token_types, trailing_merges=None):
+    """Minimal GGUF v3 with tokens then token_type (mirrors llama.cpp ordering).
+
+    A merges array is written *after* token_type so the test also exercises the
+    early-break: the function must locate token_type without walking merges.
+    """
+    kvs = [
+        _kv_string("general.architecture", "gemma4"),
+        _kv_string_array("tokenizer.ggml.tokens", tokens),
+        _kv_int32_array("tokenizer.ggml.token_type", token_types),
+        _kv_string_array("tokenizer.ggml.merges", trailing_merges or ["a b", "c d"]),
+    ]
+    body = b"GGUF" + struct.pack("<I", 3) + _u64(0) + _u64(len(kvs)) + b"".join(kvs)
+    with open(path, "wb") as f:
+        f.write(body)
+
+
+def _read_token_types(path):
+    buf = open(path, "rb").read()
+    pos = [4]
+
+    def rd(fmt):
+        v = struct.unpack_from(fmt, buf, pos[0])
+        pos[0] += struct.calcsize(fmt)
+        return v[0]
+
+    rd("<I")  # version
+    rd("<Q")  # tensor count
+    n_kv = rd("<Q")
+    scalar = {0: "<B", 1: "<b", 2: "<H", 3: "<h", 4: "<I", 5: "<i", 6: "<f", 7: "<?", 10: "<Q", 11: "<q", 12: "<d"}
+    for _ in range(n_kv):
+        klen = rd("<Q")
+        key = buf[pos[0]:pos[0] + klen].decode()
+        pos[0] += klen
+        vt = rd("<I")
+        if vt == _T_STRING:
+            slen = rd("<Q")
+            pos[0] += slen
+        elif vt == _T_ARRAY:
+            et = rd("<I")
+            n = rd("<Q")
+            if et == _T_STRING:
+                for _ in range(n):
+                    slen = rd("<Q")
+                    pos[0] += slen
+            elif key == "tokenizer.ggml.token_type":
+                return list(struct.unpack_from("<%di" % n, buf, pos[0]))
+            else:
+                pos[0] += struct.calcsize(scalar[et]) * n
+        else:
+            pos[0] += struct.calcsize(scalar[vt])
+    raise AssertionError("token_type not found")
+
+
+def _write_tokenizer_json(path, added):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"added_tokens": added}, f)
+
+
+# Token layout shared by several tests: id 0 normal text, id 1 already-control
+# delimiter, ids 2-3 special delimiters mistyped USER_DEFINED, id 4 a stray
+# control-looking vocab token that is NOT in added_tokens.
+def _gemma4_like(tmp_path):
+    gguf = tmp_path / "model.gguf"
+    tokens = ["hello", "<turn|>", "<|tool_response>", "<|channel>", "</s>"]
+    types = [NORMAL, CONTROL, USER_DEFINED, USER_DEFINED, NORMAL]
+    _write_gguf(str(gguf), tokens, types)
+    _write_tokenizer_json(
+        str(tmp_path / "tokenizer.json"),
+        [
+            {"id": 1, "content": "<turn|>", "special": True},
+            {"id": 2, "content": "<|tool_response>", "special": True},
+            {"id": 3, "content": "<|channel>", "special": True},
+        ],
+    )
+    return gguf
+
+
+def test_user_defined_special_delimiters_become_control(tmp_path):
+    gguf = _gemma4_like(tmp_path)
+    patched = fix_gguf_special_token_types(str(gguf))
+    assert patched == 2
+    types = _read_token_types(str(gguf))
+    assert types[2] == CONTROL  # <|tool_response>
+    assert types[3] == CONTROL  # <|channel>
+
+
+def test_already_control_and_plain_tokens_untouched(tmp_path):
+    gguf = _gemma4_like(tmp_path)
+    fix_gguf_special_token_types(str(gguf))
+    types = _read_token_types(str(gguf))
+    assert types[0] == NORMAL    # "hello" plain text
+    assert types[1] == CONTROL   # already correct
+    assert types[4] == NORMAL    # "</s>" not in added_tokens -> left for llama.cpp
+
+
+def test_idempotent_second_run_patches_nothing(tmp_path):
+    gguf = _gemma4_like(tmp_path)
+    assert fix_gguf_special_token_types(str(gguf)) == 2
+    assert fix_gguf_special_token_types(str(gguf)) == 0
+
+
+def test_non_control_looking_special_is_not_retyped(tmp_path):
+    gguf = tmp_path / "model.gguf"
+    _write_gguf(str(gguf), ["plainword"], [USER_DEFINED])
+    _write_tokenizer_json(
+        str(tmp_path / "tokenizer.json"),
+        [{"id": 0, "content": "plainword", "special": True}],
+    )
+    assert fix_gguf_special_token_types(str(gguf)) == 0
+    assert _read_token_types(str(gguf))[0] == USER_DEFINED
+
+
+def test_id_content_mismatch_is_skipped(tmp_path):
+    gguf = tmp_path / "model.gguf"
+    _write_gguf(str(gguf), ["<|tool_response>"], [USER_DEFINED])
+    # tokenizer.json claims a different content at id 0 -> ids drifted, skip.
+    _write_tokenizer_json(
+        str(tmp_path / "tokenizer.json"),
+        [{"id": 0, "content": "<|something_else>", "special": True}],
+    )
+    assert fix_gguf_special_token_types(str(gguf)) == 0
+    assert _read_token_types(str(gguf))[0] == USER_DEFINED
+
+
+def test_missing_tokenizer_json_is_noop(tmp_path):
+    gguf = tmp_path / "model.gguf"
+    _write_gguf(str(gguf), ["<|tool_response>"], [USER_DEFINED])
+    assert fix_gguf_special_token_types(str(gguf)) == 0
+
+
+def test_missing_gguf_is_noop(tmp_path):
+    assert fix_gguf_special_token_types(str(tmp_path / "nope.gguf")) == 0
+
+
+def test_explicit_tokenizer_json_path_is_used(tmp_path):
+    gguf = tmp_path / "out" / "model.gguf"
+    gguf.parent.mkdir()
+    _write_gguf(str(gguf), ["<|tool_call>"], [USER_DEFINED])
+    tok = tmp_path / "src" / "tokenizer.json"
+    tok.parent.mkdir()
+    _write_tokenizer_json(str(tok), [{"id": 0, "content": "<|tool_call>", "special": True}])
+    assert fix_gguf_special_token_types(str(gguf), tokenizer_json=str(tok)) == 1
+    assert _read_token_types(str(gguf))[0] == CONTROL

--- a/tests/saving/test_fix_gguf_special_token_types.py
+++ b/tests/saving/test_fix_gguf_special_token_types.py
@@ -43,7 +43,12 @@ def _kv_int32_array(key, values):
     return out
 
 
-def _write_gguf(path, tokens, token_types, trailing_merges=None):
+def _write_gguf(
+    path,
+    tokens,
+    token_types,
+    trailing_merges = None,
+):
     """Minimal GGUF v3 with tokens then token_type (mirrors llama.cpp ordering).
 
     A merges array is written *after* token_type so the test also exercises the
@@ -72,10 +77,22 @@ def _read_token_types(path):
     rd("<I")  # version
     rd("<Q")  # tensor count
     n_kv = rd("<Q")
-    scalar = {0: "<B", 1: "<b", 2: "<H", 3: "<h", 4: "<I", 5: "<i", 6: "<f", 7: "<?", 10: "<Q", 11: "<q", 12: "<d"}
+    scalar = {
+        0: "<B",
+        1: "<b",
+        2: "<H",
+        3: "<h",
+        4: "<I",
+        5: "<i",
+        6: "<f",
+        7: "<?",
+        10: "<Q",
+        11: "<q",
+        12: "<d",
+    }
     for _ in range(n_kv):
         klen = rd("<Q")
-        key = buf[pos[0]:pos[0] + klen].decode()
+        key = buf[pos[0] : pos[0] + klen].decode()
         pos[0] += klen
         vt = rd("<I")
         if vt == _T_STRING:
@@ -98,7 +115,7 @@ def _read_token_types(path):
 
 
 def _write_tokenizer_json(path, added):
-    with open(path, "w", encoding="utf-8") as f:
+    with open(path, "w", encoding = "utf-8") as f:
         json.dump({"added_tokens": added}, f)
 
 
@@ -134,9 +151,9 @@ def test_already_control_and_plain_tokens_untouched(tmp_path):
     gguf = _gemma4_like(tmp_path)
     fix_gguf_special_token_types(str(gguf))
     types = _read_token_types(str(gguf))
-    assert types[0] == NORMAL    # "hello" plain text
-    assert types[1] == CONTROL   # already correct
-    assert types[4] == NORMAL    # "</s>" not in added_tokens -> left for llama.cpp
+    assert types[0] == NORMAL  # "hello" plain text
+    assert types[1] == CONTROL  # already correct
+    assert types[4] == NORMAL  # "</s>" not in added_tokens -> left for llama.cpp
 
 
 def test_idempotent_second_run_patches_nothing(tmp_path):
@@ -185,5 +202,5 @@ def test_explicit_tokenizer_json_path_is_used(tmp_path):
     tok = tmp_path / "src" / "tokenizer.json"
     tok.parent.mkdir()
     _write_tokenizer_json(str(tok), [{"id": 0, "content": "<|tool_call>", "special": True}])
-    assert fix_gguf_special_token_types(str(gguf), tokenizer_json=str(tok)) == 1
+    assert fix_gguf_special_token_types(str(gguf), tokenizer_json = str(tok)) == 1
     assert _read_token_types(str(gguf))[0] == CONTROL

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -2336,6 +2336,21 @@ def unsloth_save_pretrained_gguf(
         else:
             raise RuntimeError(f"Unsloth: GGUF conversion failed: {e}")
 
+    # Retype special tokens to CONTROL in the produced GGUF(s). Needed for
+    # tokenizers/BPE models (e.g. Gemma 4) that ship no tokenizer.model, so
+    # fix_sentencepiece_gguf above is a no-op and llama.cpp's converter leaves
+    # delimiters like <|tool_call> / <|tool_response> as USER_DEFINED, breaking
+    # tool calling. Patches token_type in place; failures are non-fatal.
+    try:
+        from .tokenizer_utils import fix_gguf_special_token_types
+        tokenizer_json = os.path.join(save_directory, "tokenizer.json")
+        for gguf_file in all_file_locations or []:
+            fix_gguf_special_token_types(gguf_file, tokenizer_json = tokenizer_json)
+    except Exception as e:
+        logger.warning(
+            f"Unsloth: fix_gguf_special_token_types skipped ({type(e).__name__}): {e}"
+        )
+
     # Step 9: Create Ollama modelfile
     gguf_directory = f"{save_directory}_gguf"
     modelfile_location = None

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -2347,9 +2347,7 @@ def unsloth_save_pretrained_gguf(
         for gguf_file in all_file_locations or []:
             fix_gguf_special_token_types(gguf_file, tokenizer_json = tokenizer_json)
     except Exception as e:
-        logger.warning(
-            f"Unsloth: fix_gguf_special_token_types skipped ({type(e).__name__}): {e}"
-        )
+        logger.warning(f"Unsloth: fix_gguf_special_token_types skipped ({type(e).__name__}): {e}")
 
     # Step 9: Create Ollama modelfile
     gguf_directory = f"{save_directory}_gguf"

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -552,8 +552,17 @@ def fix_sentencepiece_gguf(saved_location):
 # GGUF value/array element types we need to walk the metadata KV section.
 # Mirrors gguf.GGUFValueType so we don't add a hard dependency on the gguf package.
 _GGUF_SCALAR_FMT = {
-    0: "<B", 1: "<b", 2: "<H", 3: "<h", 4: "<I",
-    5: "<i", 6: "<f", 7: "<?", 10: "<Q", 11: "<q", 12: "<d",
+    0: "<B",
+    1: "<b",
+    2: "<H",
+    3: "<h",
+    4: "<I",
+    5: "<i",
+    6: "<f",
+    7: "<?",
+    10: "<Q",
+    11: "<q",
+    12: "<d",
 }
 _GGUF_TYPE_STRING = 8
 _GGUF_TYPE_ARRAY = 9

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -42,6 +42,7 @@ __all__ = [
     "check_tokenizer",
     "add_new_tokens",
     "fix_sentencepiece_gguf",
+    "fix_gguf_special_token_types",
     "get_tokenizer_info",
 ]
 
@@ -546,6 +547,182 @@ def fix_sentencepiece_gguf(saved_location):
     # actual_vocab_size = model.config.vocab_size
     # padding = actual_vocab_size - len(tokenizer_file.pieces)
     return
+
+
+# GGUF value/array element types we need to walk the metadata KV section.
+# Mirrors gguf.GGUFValueType so we don't add a hard dependency on the gguf package.
+_GGUF_SCALAR_FMT = {
+    0: "<B", 1: "<b", 2: "<H", 3: "<h", 4: "<I",
+    5: "<i", 6: "<f", 7: "<?", 10: "<Q", 11: "<q", 12: "<d",
+}
+_GGUF_TYPE_STRING = 8
+_GGUF_TYPE_ARRAY = 9
+
+# SentencePiece / GGUF token type values (see SentencePieceTokenTypes above).
+_GGUF_TOKEN_TYPE_NORMAL = 1
+_GGUF_TOKEN_TYPE_CONTROL = 3
+_GGUF_TOKEN_TYPE_USER_DEFINED = 4
+
+
+def _looks_like_control_token(content):
+    # llama.cpp warns about and overrides tokens shaped like <...> that are not
+    # control-type. We mirror that shape test so we only ever retype delimiters.
+    return (
+        isinstance(content, str)
+        and len(content) > 2
+        and content.startswith("<")
+        and content.endswith(">")
+    )
+
+
+def fix_gguf_special_token_types(gguf_location, tokenizer_json = None):
+    """
+    Patch a GGUF file's `tokenizer.ggml.token_type` array so special tokens are
+    typed CONTROL (3) instead of NORMAL (1) or USER_DEFINED (4).
+
+    Some converters only mark a hardcoded subset of structural tokens as CONTROL.
+    On Gemma 4 (and its QAT GGUFs) llama.cpp leaves newer delimiters such as
+    `<|tool_call>`, `<|tool_response>` and `<|channel>` as USER_DEFINED even
+    though tokenizer.json marks them special. llama.cpp then logs
+    "control-looking token ... was not control-type" and tool calling / thinking
+    boundaries break. `fix_sentencepiece_gguf` cannot help here because Gemma 4
+    ships no `tokenizer.model` (pure tokenizers/BPE backend), so its retyping
+    runs against the produced GGUF instead.
+
+    The `token_type` array is a fixed-size int32 array, so we rewrite individual
+    entries in place: only values change, never the file layout.
+
+    `tokenizer_json` defaults to a `tokenizer.json` next to the GGUF. Returns the
+    number of token types patched.
+    """
+    import json
+    import struct
+
+    if not os.path.isfile(gguf_location):
+        return 0
+
+    # Resolve tokenizer.json: it carries the authoritative `special` flags.
+    if tokenizer_json is None:
+        gguf_dir = os.path.dirname(os.path.abspath(gguf_location))
+        for candidate in (
+            os.path.join(gguf_dir, "tokenizer.json"),
+            os.path.join(os.path.dirname(gguf_dir), "tokenizer.json"),
+        ):
+            if os.path.isfile(candidate):
+                tokenizer_json = candidate
+                break
+    if tokenizer_json is None or not os.path.isfile(tokenizer_json):
+        return 0
+
+    with open(tokenizer_json, "r", encoding = "utf-8") as f:
+        tokenizer_json_data = json.load(f)
+    special_contents = {}
+    for entry in tokenizer_json_data.get("added_tokens", []):
+        token_id = entry.get("id")
+        content = entry.get("content")
+        if entry.get("special", False) and isinstance(token_id, int):
+            special_contents[token_id] = content
+    if not special_contents:
+        return 0
+
+    def _read(file, fmt):
+        size = struct.calcsize(fmt)
+        data = file.read(size)
+        if len(data) != size:
+            raise EOFError
+        return struct.unpack(fmt, data)[0]
+
+    token_type_offset = None
+    token_type_count = 0
+    gguf_tokens = {}  # id -> text, captured for cross-checking against tokenizer.json
+
+    with open(gguf_location, "rb") as file:
+        if file.read(4) != b"GGUF":
+            return 0
+        version = _read(file, "<I")
+        # GGUF v1 used 32-bit counts/lengths; v2+ use 64-bit.
+        count_fmt = "<I" if version == 1 else "<Q"
+
+        def _read_len():
+            return _read(file, count_fmt)
+
+        def _skip_value(value_type):
+            if value_type == _GGUF_TYPE_STRING:
+                file.seek(_read_len(), os.SEEK_CUR)
+            elif value_type == _GGUF_TYPE_ARRAY:
+                elem_type = _read(file, "<I")
+                count = _read_len()
+                if elem_type == _GGUF_TYPE_STRING:
+                    for _ in range(count):
+                        file.seek(_read_len(), os.SEEK_CUR)
+                else:
+                    file.seek(struct.calcsize(_GGUF_SCALAR_FMT[elem_type]) * count, os.SEEK_CUR)
+            else:
+                file.seek(struct.calcsize(_GGUF_SCALAR_FMT[value_type]), os.SEEK_CUR)
+
+        n_tensors = _read(file, "<Q")
+        n_kv = _read(file, "<Q")
+        for _ in range(n_kv):
+            key_len = _read_len()
+            key = file.read(key_len).decode("utf-8", "replace")
+            value_type = _read(file, "<I")
+
+            if key == "tokenizer.ggml.tokens" and value_type == _GGUF_TYPE_ARRAY:
+                elem_type = _read(file, "<I")
+                count = _read_len()
+                for token_id in range(count):
+                    str_len = _read_len()
+                    if token_id in special_contents:
+                        gguf_tokens[token_id] = file.read(str_len).decode("utf-8", "replace")
+                    else:
+                        file.seek(str_len, os.SEEK_CUR)
+            elif key == "tokenizer.ggml.token_type" and value_type == _GGUF_TYPE_ARRAY:
+                elem_type = _read(file, "<I")
+                token_type_count = _read_len()
+                token_type_offset = file.tell()
+                # token_type is int32 (5) or uint32 (4); both are 4 bytes wide.
+                elem_size = struct.calcsize(_GGUF_SCALAR_FMT[elem_type])
+                file.seek(elem_size * token_type_count, os.SEEK_CUR)
+                # token_type always follows tokens in llama.cpp output, so stop here
+                # and avoid walking the (large) merges array and tensor section.
+                break
+            else:
+                _skip_value(value_type)
+
+    if token_type_offset is None or token_type_count == 0:
+        return 0
+
+    # Decide which entries to flip, validating content where we have it.
+    patches = []
+    with open(gguf_location, "rb") as file:
+        for token_id, content in special_contents.items():
+            if not (0 <= token_id < token_type_count):
+                continue
+            # If the GGUF token text disagrees with tokenizer.json, the ids have
+            # drifted; skip rather than risk corrupting an unrelated entry.
+            if token_id in gguf_tokens and gguf_tokens[token_id] != content:
+                continue
+            if not _looks_like_control_token(content):
+                continue
+            file.seek(token_type_offset + 4 * token_id)
+            current = struct.unpack("<i", file.read(4))[0]
+            if current in (_GGUF_TOKEN_TYPE_NORMAL, _GGUF_TOKEN_TYPE_USER_DEFINED):
+                patches.append((token_id, content))
+
+    if not patches:
+        return 0
+
+    with open(gguf_location, "r+b") as file:
+        for token_id, _ in patches:
+            file.seek(token_type_offset + 4 * token_id)
+            file.write(struct.pack("<i", _GGUF_TOKEN_TYPE_CONTROL))
+
+    logger.warning(
+        f"Unsloth: Patched {len(patches)} special token(s) in {gguf_location} "
+        f"to CONTROL type so llama.cpp tool calling / chat boundaries work correctly "
+        f"(e.g. {', '.join(repr(c) for _, c in patches[:4])})."
+    )
+    return len(patches)
 
 
 def _load_correct_tokenizer(


### PR DESCRIPTION
Fixes #6228

## Problem

Tool calling is broken on the Gemma 4 12B QAT GGUF. llama.cpp logs at load:

```
W load: control-looking token: 50 '<|tool_response>' was not control-type; ... its type will be overridden
W load: special_eog_ids contains '<|tool_response|>', removing '</s>' token from EOG list
```

Reading the `tokenizer.ggml.token_type` array straight out of the published
`gemma-4-12B-it-qat-UD-Q4_K_XL.gguf` shows seven special tokens typed
USER_DEFINED (4) when they should be CONTROL (3), even though all are
`"special": true` in tokenizer.json:

```
48  <|tool_call>       49  <tool_call|>
50  <|tool_response>   51  <tool_response|>
52  <|"|>
100 <|channel>         101 <channel|>
```

These are exactly the tool-calling and thinking-channel delimiters, so the
boundaries between thinking, tool calls, and content blur.

## Why the existing fix does not catch it

`fix_sentencepiece_gguf` patches a SentencePiece tokenizer.model before
conversion. Gemma 4 ships a pure tokenizers/BPE tokenizer (tokenizer.json only,
no tokenizer.model), so that function hits its early return and does nothing.
The token types then come straight from llama.cpp's convert_hf_to_gguf.py
gemma4 path, which only marks a hardcoded subset of delimiters CONTROL and
misses the newer tool_call / tool_response / channel / escape tokens. There is
no SentencePiece layer to intercept at; the wrong types only exist in the
produced GGUF.

## Fix

Add `fix_gguf_special_token_types(gguf, tokenizer_json)`. It reads the
`"special": true` ids from tokenizer.json and rewrites their token_type entries
to CONTROL directly in the GGUF. The token_type array is fixed-size int32, so
entries are patched in place: only values change, never the file layout. It is
gated to control-looking `<...>` tokens and cross-checks the GGUF token text
against tokenizer.json to avoid touching anything if ids have drifted.

Wired into `unsloth_save_pretrained_gguf` right after `save_to_gguf`, alongside
the existing `fix_sentencepiece_gguf` call, and guarded so a failure never
breaks an otherwise-successful export. It is also usable standalone to patch an
existing GGUF without re-exporting:

```python
from unsloth.tokenizer_utils import fix_gguf_special_token_types
fix_gguf_special_token_types("model.gguf", tokenizer_json="tokenizer.json")
```

## Testing

- `tests/saving/test_fix_gguf_special_token_types.py`: 8 tests with a synthetic
  GGUF builder (no network). Covers USER_DEFINED and NORMAL retyping,
  already-CONTROL and plain-text tokens left untouched, idempotency,
  non-control-looking special tokens skipped, id/content mismatch skipped, and
  the missing-file no-ops.
- Verified against the real published GGUF: the function flips exactly the seven
  mistyped tokens to CONTROL, leaves the correct ones and the stray `</s>`
  (id 212, not in added_tokens) alone, and is idempotent on re-run.

## Note

This corrects newly-exported GGUFs and lets existing ones be patched in place.
The already-published unsloth/gemma-4-12B-it-qat-GGUF files would still need a
re-patch / re-upload to fix copies already out there.
