### PR TITLE
AMD Docker support (stacks on #5748)

### DIFF
--- a/.github/workflows/docker-publish-rocm.yml
+++ b/.github/workflows/docker-publish-rocm.yml
@@ -1,0 +1,212 @@
+# Builds and publishes the AMD ROCm Unsloth Docker image.
+#
+# The build runs on free GitHub-hosted Ubuntu runners with NO GPU attached.
+# This is possible because:
+#   1. ROCm PyTorch wheels from download.pytorch.org/whl/rocmX.Y are
+#      self-contained — they do not introspect the host GPU at install time.
+#   2. The build-time sanity check uses torch.version.hip (a string constant
+#      baked into the wheel), which does NOT require a ROCm device.
+#   3. UNSLOTH_DOCKER_ROCM=1 + UNSLOTH_TORCH_INDEX_URL prevent unsloth's
+#      install logic from probing the (absent) GPU during pip install.
+#
+# Architecture: amd64 only.
+#   pytorch.org does not publish ROCm wheels for aarch64 as of ROCm 6.2.
+#   When official arm64 ROCm wheels land, add an arm64 matrix leg here.
+#
+# Required repository secrets:
+#   DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+#
+# Optional repository variable (gates the smoke-test job):
+#   HAS_AMD_GPU_RUNNER = 'true' if a self-hosted AMD GPU runner is available
+
+name: Publish ROCm Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  schedule:
+    - cron: '23 5 * * 2'   # weekly Tue 05:23 UTC (offset from CUDA workflow)
+  workflow_dispatch:
+    inputs:
+      unsloth_ref:
+        description: 'unsloth git ref to bake in'
+        required: false
+        default: 'main'
+      unsloth_zoo_ref:
+        description: 'unsloth-zoo git ref to bake in'
+        required: false
+        default: 'main'
+      rocm_version:
+        description: 'ROCm base image version (e.g. 6.2.4)'
+        required: false
+        default: '6.2.4'
+      torch_index_url:
+        description: 'PyTorch ROCm wheel index URL'
+        required: false
+        default: 'https://download.pytorch.org/whl/rocm6.2'
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: unsloth/unsloth-rocm
+
+# Serialise per-ref runs so two pushes don't both retag :latest from different
+# commits simultaneously. Don't cancel in-progress runs — a half-built image
+# on Docker Hub is worse than a slightly stale :latest for a few minutes.
+concurrency:
+  group: docker-publish-rocm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build the ROCm image on an amd64 runner and push it by digest.
+  # No GPU is required — the build-time verification checks torch.version.hip,
+  # which is set in the wheel metadata, not by querying a device.
+  # ---------------------------------------------------------------------------
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Free up ~20 GB so the ROCm base image + wheel cache fit.
+      - name: Reclaim disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL "$AGENT_TOOLSDIRECTORY" || true
+          df -h /
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push (by digest)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile.rocm
+          platforms: linux/amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=build-rocm-amd64
+          cache-to:   type=gha,scope=build-rocm-amd64,mode=max
+          outputs:    type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            ROCM_VERSION=${{ github.event.inputs.rocm_version || '6.2.4' }}
+            PYTHON_VERSION=3.12
+            TORCH_INDEX_URL=${{ github.event.inputs.torch_index_url || 'https://download.pytorch.org/whl/rocm6.2' }}
+            UNSLOTH_REF=${{ github.event.inputs.unsloth_ref || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || github.sha || 'main' }}
+            UNSLOTH_ZOO_REF=${{ github.event.inputs.unsloth_zoo_ref || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || 'main' }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-rocm-amd64
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Attach human-readable tags to the digest pushed above.
+  # ---------------------------------------------------------------------------
+  tag:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-rocm-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' }}
+            type=ref,event=tag
+            type=schedule,pattern=nightly
+            type=sha,prefix=sha-,format=short
+
+      - name: Create manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+              $(jq -cr '.tags | map("-t " + .) | join(" ")' <<<"$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect the result
+        run: |
+          for tag in $(jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON"); do
+              echo "=== $tag ==="
+              docker buildx imagetools inspect "$tag"
+          done
+
+  # ---------------------------------------------------------------------------
+  # Optional: pull the image onto a self-hosted AMD GPU runner and smoke test.
+  # Gated by the HAS_AMD_GPU_RUNNER repository variable.
+  # ---------------------------------------------------------------------------
+  smoke-test:
+    needs: tag
+    if: ${{ vars.HAS_AMD_GPU_RUNNER == 'true' }}
+    runs-on: [self-hosted, amd-gpu]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve published tag
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' }}
+            type=ref,event=tag
+            type=schedule,pattern=nightly
+            type=sha,prefix=sha-,format=short
+
+      - name: Pull and smoke-test
+        run: |
+          TAG="$(jq -r '.tags[0] // ""' <<<"$DOCKER_METADATA_OUTPUT_JSON")"
+          if [ -z "$TAG" ]; then
+              TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          fi
+          echo "smoke-testing $TAG"
+          docker pull "$TAG"
+          docker run --rm \
+              --device /dev/kfd --device /dev/dri --group-add video \
+              "$TAG" python /workspace/smoke_test_rocm.py

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,7 +1,11 @@
 **
 !Dockerfile
+!Dockerfile.rocm
+!Dockerfile.studio-rocm
 !entrypoint.sh
+!entrypoint-rocm.sh
 !smoke_test.py
+!smoke_test_rocm.py
 !fetch_llama_prebuilt.py
 !supervisord.conf
 !studio_launch.sh

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,182 @@
+# syntax=docker/dockerfile:1.7
+# ---------------------------------------------------------------------------
+# Unsloth for AMD GPUs (ROCm).
+#
+# GPU coverage depends on the ROCm base image version:
+#
+#   Default build (ROCM_VERSION=6.2.4, TORCH_INDEX_URL=.../rocm6.2):
+#     RDNA2  gfx1030  RX 6800 / 6800 XT / 6900 XT
+#     RDNA3  gfx1100-1103  RX 7900 XTX, RX 7600, Phoenix iGPU (780M)
+#
+#   Extended build for RDNA4 + Strix (torch 2.11.0 required):
+#     RDNA 3.5 iGPU  gfx1150 (Strix Point), gfx1151 (Strix Halo / 8060S)
+#     RDNA 4         gfx1200 (RX 9070), gfx1201 (RX 9070 XT / 9080)
+#     Use: ROCM_VERSION=7.x.x TORCH_INDEX_URL=.../rocm7.2 bash docker/build.sh --rocm
+#
+# Why single-stage (unlike the CUDA Dockerfile):
+#   ROCm does not publish a separate "base" image without dev headers.
+#   The rocm/dev-ubuntu-22.04 image is already the smallest usable base,
+#   so splitting builder/runtime does not save meaningful image size here.
+#
+# Build host requirements:
+#   * Docker with buildkit (default since 23.x)
+#   * A GPU is NOT required at build time.
+#   * ROCm does not support arm64 wheel builds from pytorch.org; amd64 only.
+#
+# Build:
+#   docker build -f docker/Dockerfile.rocm -t unsloth-rocm:latest docker/
+#   # Or: bash docker/build.sh --rocm
+#
+# Run:
+#   bash docker/run.sh --rocm
+#   # Or manually:
+#   docker run --device /dev/kfd --device /dev/dri \
+#              --group-add video --ipc=host \
+#              unsloth-rocm:latest python /workspace/smoke_test_rocm.py
+# ---------------------------------------------------------------------------
+
+ARG ROCM_VERSION=6.2.4
+ARG PYTHON_VERSION=3.12
+
+FROM rocm/dev-ubuntu-22.04:${ROCM_VERSION}
+
+ARG PYTHON_VERSION
+ARG UNSLOTH_REF=main
+ARG UNSLOTH_ZOO_REF=main
+# Match the pytorch.org wheel index to the ROCm base image.
+# For RDNA4 / Strix (gfx1150/1151/1200/1201): use rocm7.2 here and set
+# ROCM_VERSION to a 7.x image -- those GPUs require torch 2.11.0.
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/rocm6.2
+
+LABEL org.opencontainers.image.title="Unsloth (AMD ROCm)" \
+      org.opencontainers.image.description="Unsloth fine-tuning for AMD RDNA2/RDNA3/RDNA4 GPUs"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    ROCBLAS_USE_HIPBLASLT=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv \
+        curl wget git \
+        cmake build-essential libcurl4-openssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV VENV=/opt/unsloth-venv
+RUN python3 -m venv ${VENV} \
+ && ${VENV}/bin/pip install -U pip wheel setuptools uv
+
+# Install PyTorch (ROCm wheels) first so the ROCm torch is locked in before
+# dependent packages resolve. The ROCm index also pulls the matching
+# triton-rocm as a hard dep, so we don't pin triton separately.
+#
+# Why --index-url (primary) + --extra-index-url (pypi fallback):
+#   torch ROCm builds live on download.pytorch.org/whl/rocmX.Y only.
+#   Everything else (datasets, transformers, etc.) comes from PyPI.
+#   unsafe-best-match lets uv pick the best wheel from either index.
+RUN ${VENV}/bin/uv pip install \
+        --python ${VENV}/bin/python \
+        --index-strategy unsafe-best-match \
+        --index-url "${TORCH_INDEX_URL}" \
+        --extra-index-url https://pypi.org/simple \
+        "torch" "torchvision" "torchaudio"
+
+# Install the rest of the Unsloth stack.
+#
+# Why [huggingface] extra:
+#   xformers has no ROCm wheel. The [huggingface] extra skips xformers;
+#   Unsloth falls back to its built-in SDPA path (~5-10% slower but
+#   functionally complete for LoRA fine-tuning on AMD hardware).
+RUN ${VENV}/bin/uv pip install \
+        --python ${VENV}/bin/python \
+        --index-strategy unsafe-best-match \
+        --extra-index-url "${TORCH_INDEX_URL}" \
+        "unsloth_zoo @ git+https://github.com/unslothai/unsloth-zoo@${UNSLOTH_ZOO_REF}" \
+        "unsloth[huggingface] @ git+https://github.com/unslothai/unsloth@${UNSLOTH_REF}" \
+        "timm>=1.0.11" "addict"
+
+# Install bitsandbytes via pip (NOT uv) using the pre-release wheel that
+# contains the ROCm 4-bit GEMV fix (bitsandbytes PR #1887).
+# bnb <= 0.49.2 produces NaNs at decode shape on every AMD GPU.
+# The continuous-release_main wheel filename version (1.33.7rc0) does not
+# match its embedded metadata version (0.50.0.dev0); uv rejects this
+# mismatch and refuses to install, so pip is used here instead.
+# Drop this block and use uv once bnb 0.50+ ships on PyPI.
+# Source: install.sh _install_bnb_rocm()
+RUN _BNB_WHL="https://github.com/bitsandbytes-foundation/bitsandbytes/releases/download/continuous-release_main/bitsandbytes-1.33.7.preview-py3-none-manylinux_2_24_x86_64.whl" \
+ && (${VENV}/bin/python -m pip install \
+        --force-reinstall --no-cache-dir --no-deps "${_BNB_WHL}" \
+    || (echo "[WARN] bnb pre-release install failed; falling back to PyPI (4-bit decode broken on ROCm)" >&2 \
+        && ${VENV}/bin/python -m pip install \
+            --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"))
+
+# Pin record (informational only, not a reproducible lockfile).
+# Read with: docker run --rm <image> cat /opt/unsloth-venv/requirements.lock.txt
+RUN ${VENV}/bin/pip freeze --exclude-editable > ${VENV}/requirements.lock.txt \
+ && head -30 ${VENV}/requirements.lock.txt
+
+# Build-time verification (no GPU required).
+# torch.version.hip is a string constant baked into the ROCm wheel; it is
+# None in CUDA builds. Checking it requires no GPU device.
+RUN ${VENV}/bin/python - <<'PY'
+import torch
+assert torch.version.hip is not None, (
+    f"Expected a ROCm torch wheel but got: {torch.__version__}. "
+    "Check that TORCH_INDEX_URL points to the ROCm index."
+)
+print(f"OK: torch {torch.__version__}  HIP {torch.version.hip}")
+
+from importlib.metadata import version, PackageNotFoundError
+REQUIRED = [
+    "torch", "bitsandbytes", "unsloth", "unsloth-zoo",
+    "transformers", "trl", "peft", "accelerate",
+]
+missing = []
+for pkg in REQUIRED:
+    try:
+        v = version(pkg)
+        print(f"  {pkg:14s} {v}")
+    except PackageNotFoundError:
+        missing.append(pkg)
+if missing:
+    raise SystemExit(f"FAIL: missing packages: {missing}")
+print("OK: all required packages present")
+
+# bitsandbytes is installed from a ROCm pre-release wheel above (the 4-bit
+# decode fix). Importing it here catches a broken/ABI-mismatched wheel at
+# build time instead of at the first training step on a real GPU.
+import bitsandbytes  # noqa: F401
+print(f"OK: bitsandbytes {bitsandbytes.__version__} imports cleanly on no-GPU host")
+PY
+
+# Strip __pycache__ and bundled test suites to shrink the layer.
+RUN find ${VENV} -depth -type d -name __pycache__ -exec rm -rf {} + \
+ && find ${VENV} -depth -type d -name tests \
+        ! -path "*numpy/_core/tests*" \
+        ! -path "*numpy/tests*" \
+        ! -path "*numpy/ma/tests*" \
+        -exec rm -rf {} + \
+ && rm -rf /root/.cache/pip /root/.cache/uv
+
+ENV PATH=/opt/unsloth-venv/bin:${PATH} \
+    HF_HOME=/workspace/.cache/huggingface \
+    TRITON_CACHE_DIR=/workspace/.cache/triton \
+    # Expose ROCM_HOME so any extension that source-builds at runtime
+    # (e.g. bitsandbytes custom ops) can find the toolkit.
+    ROCM_HOME=/opt/rocm
+
+WORKDIR /workspace
+RUN mkdir -p ${HF_HOME} ${TRITON_CACHE_DIR}
+
+COPY smoke_test_rocm.py /workspace/smoke_test_rocm.py
+COPY entrypoint-rocm.sh /usr/local/bin/unsloth-entrypoint-rocm
+RUN chmod +x /usr/local/bin/unsloth-entrypoint-rocm
+
+# Entrypoint runs two pre-flight checks before user code:
+#   1. rocm-smi sees at least one GPU      (catches missing /dev/kfd passthrough)
+#   2. torch.cuda.is_available() is True   (ROCm maps to the CUDA Python API)
+# Bypass: docker run -e UNSLOTH_SKIP_GPU_CHECK=1 ...
+ENTRYPOINT ["/usr/local/bin/unsloth-entrypoint-rocm"]
+CMD ["python"]

--- a/docker/Dockerfile.studio-rocm
+++ b/docker/Dockerfile.studio-rocm
@@ -1,0 +1,53 @@
+# Unsloth Studio variant of the ROCm image.
+#
+# Builds on top of unsloth-rocm:<tag> (default `test`) and runs
+# `install.sh --local` to lay down the Studio venv under $UNSLOTH_STUDIO_HOME.
+# SKIP_TORCH=true is set so install.sh does not re-install torch -- the base
+# image already ships ROCm torch and reinstalling from auto-detect would fail
+# at build time when no GPU is present.
+#
+# Build:
+#   docker buildx build \
+#     --build-arg BASE_TAG=test \
+#     -f docker/Dockerfile.studio-rocm \
+#     -t unsloth-rocm:studio docker/
+#
+# Run (RDNA2/3):
+#   docker run --rm \
+#     --device /dev/kfd --device /dev/dri --group-add video \
+#     -p 8888:8888 \
+#     -v $HOME/.cache/huggingface:/workspace/.cache/huggingface \
+#     unsloth-rocm:studio
+#
+# For RDNA4 / Strix Halo, set HSA_OVERRIDE_GFX_VERSION or UNSLOTH_ROCM_GFX_ARCH
+# as documented in docker/run.sh (--rocm).
+#
+# Open http://localhost:8888 . First-boot admin password is printed in the
+# container logs and persisted under /opt/unsloth-studio/auth/.bootstrap_password.
+
+ARG BASE_TAG=test
+FROM unsloth-rocm:${BASE_TAG}
+
+ARG UNSLOTH_STUDIO_REF=main
+
+USER root
+ENV UNSLOTH_STUDIO_HOME=/opt/unsloth-studio \
+    DEBIAN_FRONTEND=noninteractive \
+    # torch is already installed in the base image (ROCm wheels).
+    # Prevent install.sh from re-running get_torch_index_url() which would
+    # probe the absent build-host GPU and silently install a CPU wheel on top.
+    SKIP_TORCH=true
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p "${UNSLOTH_STUDIO_HOME}" \
+ && git clone --depth 1 --branch "${UNSLOTH_STUDIO_REF}" https://github.com/unslothai/unsloth "${UNSLOTH_STUDIO_HOME}/src" \
+ && cd "${UNSLOTH_STUDIO_HOME}/src" \
+ && UNSLOTH_STUDIO_HOME="${UNSLOTH_STUDIO_HOME}" bash install.sh --local \
+ && rm -rf "${UNSLOTH_STUDIO_HOME}/src/.git" /root/.cache
+
+EXPOSE 8888
+
+CMD ["sh", "-c", "${UNSLOTH_STUDIO_HOME}/bin/unsloth studio -H 0.0.0.0 -p 8888"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,46 +1,87 @@
 #!/usr/bin/env bash
-# Build the unsloth-blackwell image on this B200 host (or any Linux host with Docker).
-# The build host's GPU is NOT used -- nvcc cross-compiles for sm_100 + sm_120.
+# Build an Unsloth Docker image (NVIDIA CUDA or AMD ROCm).
+# The build host's GPU is NOT used at build time.
 #
 # Usage:
-#   ./build.sh                 # builds unsloth-blackwell:latest pinned to unsloth main
-#   TAG=2026.05.1 ./build.sh   # custom tag
-#   UNSLOTH_REF=v2026.5.6 UNSLOTH_ZOO_REF=v2026.5.4 ./build.sh   # pin git refs
+#   ./build.sh                          # CUDA/Blackwell (default)
+#   ./build.sh --rocm                   # AMD ROCm
+#   TAG=2026.05.1 ./build.sh            # custom tag
+#   UNSLOTH_REF=v2026.5.6 UNSLOTH_ZOO_REF=v2026.5.4 ./build.sh
+#
+# ROCm: for RDNA4 / Strix Halo (gfx1150/1151/1200/1201) override:
+#   ROCM_VERSION=7.x.x TORCH_INDEX_URL=https://download.pytorch.org/whl/rocm7.2 \
+#     ./build.sh --rocm
 set -euo pipefail
 
 cd "$(dirname "$0")"
 
-IMAGE_NAME="${IMAGE_NAME:-unsloth-blackwell}"
-TAG="${TAG:-latest}"
-CUDA_VERSION="${CUDA_VERSION:-12.8.1}"
-UBUNTU_VERSION="${UBUNTU_VERSION:-24.04}"
-PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
+ROCM=0
+for arg in "$@"; do
+    [[ "$arg" == "--rocm" ]] && ROCM=1
+done
+
 UNSLOTH_REF="${UNSLOTH_REF:-main}"
 UNSLOTH_ZOO_REF="${UNSLOTH_ZOO_REF:-main}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
+TAG="${TAG:-latest}"
 
-echo "Building ${IMAGE_NAME}:${TAG}"
-echo "  CUDA           ${CUDA_VERSION}  Ubuntu ${UBUNTU_VERSION}  Python ${PYTHON_VERSION}"
-echo "  unsloth        @${UNSLOTH_REF}"
-echo "  unsloth-zoo    @${UNSLOTH_ZOO_REF}"
-echo "  arch list      8.0;8.6;8.9;9.0;10.0;12.0+PTX"
-echo
+if [[ $ROCM -eq 1 ]]; then
+    IMAGE_NAME="${IMAGE_NAME:-unsloth-rocm}"
+    ROCM_VERSION="${ROCM_VERSION:-6.2.4}"
+    TORCH_INDEX_URL="${TORCH_INDEX_URL:-https://download.pytorch.org/whl/rocm6.2}"
 
-DOCKER_BUILDKIT=1 docker build \
-    --progress=plain \
-    --build-arg CUDA_VERSION="${CUDA_VERSION}" \
-    --build-arg UBUNTU_VERSION="${UBUNTU_VERSION}" \
-    --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
-    --build-arg UNSLOTH_REF="${UNSLOTH_REF}" \
-    --build-arg UNSLOTH_ZOO_REF="${UNSLOTH_ZOO_REF}" \
-    -t "${IMAGE_NAME}:${TAG}" \
-    .
+    echo "Building ${IMAGE_NAME}:${TAG}  [AMD ROCm]"
+    echo "  ROCm           ${ROCM_VERSION}  Python ${PYTHON_VERSION}"
+    echo "  torch index    ${TORCH_INDEX_URL}"
+    echo "  unsloth        @${UNSLOTH_REF}"
+    echo "  unsloth-zoo    @${UNSLOTH_ZOO_REF}"
+    echo
 
-echo
-echo "Built ${IMAGE_NAME}:${TAG}"
-echo
-echo "Smoke test on this host (B200, sm_100):"
-echo "  docker run --rm --gpus all ${IMAGE_NAME}:${TAG} python /workspace/smoke_test.py"
-echo
-echo "Smoke test on an RTX 5090 host (sm_120):"
-echo "  docker pull ${IMAGE_NAME}:${TAG}   # or load .tar"
-echo "  docker run --rm --gpus all ${IMAGE_NAME}:${TAG} python /workspace/smoke_test.py"
+    DOCKER_BUILDKIT=1 docker build \
+        --progress=plain \
+        -f Dockerfile.rocm \
+        --build-arg ROCM_VERSION="${ROCM_VERSION}" \
+        --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+        --build-arg TORCH_INDEX_URL="${TORCH_INDEX_URL}" \
+        --build-arg UNSLOTH_REF="${UNSLOTH_REF}" \
+        --build-arg UNSLOTH_ZOO_REF="${UNSLOTH_ZOO_REF}" \
+        -t "${IMAGE_NAME}:${TAG}" \
+        .
+
+    echo
+    echo "Built ${IMAGE_NAME}:${TAG}"
+    echo
+    echo "Smoke test (requires AMD GPU passthrough):"
+    echo "  bash run.sh --rocm python /workspace/smoke_test_rocm.py"
+else
+    IMAGE_NAME="${IMAGE_NAME:-unsloth-blackwell}"
+    CUDA_VERSION="${CUDA_VERSION:-12.8.1}"
+    UBUNTU_VERSION="${UBUNTU_VERSION:-24.04}"
+
+    echo "Building ${IMAGE_NAME}:${TAG}  [NVIDIA CUDA]"
+    echo "  CUDA           ${CUDA_VERSION}  Ubuntu ${UBUNTU_VERSION}  Python ${PYTHON_VERSION}"
+    echo "  unsloth        @${UNSLOTH_REF}"
+    echo "  unsloth-zoo    @${UNSLOTH_ZOO_REF}"
+    echo "  arch list      8.0;8.6;8.9;9.0;10.0;12.0+PTX"
+    echo
+
+    DOCKER_BUILDKIT=1 docker build \
+        --progress=plain \
+        --build-arg CUDA_VERSION="${CUDA_VERSION}" \
+        --build-arg UBUNTU_VERSION="${UBUNTU_VERSION}" \
+        --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+        --build-arg UNSLOTH_REF="${UNSLOTH_REF}" \
+        --build-arg UNSLOTH_ZOO_REF="${UNSLOTH_ZOO_REF}" \
+        -t "${IMAGE_NAME}:${TAG}" \
+        .
+
+    echo
+    echo "Built ${IMAGE_NAME}:${TAG}"
+    echo
+    echo "Smoke test on this host (B200, sm_100):"
+    echo "  bash run.sh python /workspace/smoke_test.py"
+    echo
+    echo "Smoke test on an RTX 5090 host (sm_120):"
+    echo "  docker pull ${IMAGE_NAME}:${TAG}   # or load .tar"
+    echo "  bash run.sh python /workspace/smoke_test.py"
+fi

--- a/docker/entrypoint-rocm.sh
+++ b/docker/entrypoint-rocm.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Container startup checks for Unsloth (AMD ROCm build).
+#
+# Fails fast with actionable messages when the host GPU is not reachable.
+# Covers the most common failure modes, in the order they tend to bite:
+#
+#   1. /dev/kfd missing or unreadable
+#        - User forgot --device /dev/kfd (or --group-add video for permission)
+#        - Host amdgpu / amdkfd kernel module not loaded
+#   2. rocm-smi can't see any GPU from inside the container
+#        - User forgot --device /dev/dri, or host driver too old
+#   3. rocm-smi works but torch.cuda.is_available() is False
+#        - ROCm runtime version mismatch between host and image
+#   4. The detected gfx arch is not in the precompiled list
+#        - Hint to set HSA_OVERRIDE_GFX_VERSION to the nearest supported arch
+#
+# Bypass for offline tooling / CI:
+#   docker run -e UNSLOTH_SKIP_GPU_CHECK=1 ...
+set -euo pipefail
+
+err()  { printf "\033[1;31mERROR:\033[0m %s\n" "$*" >&2; }
+warn() { printf "\033[1;33mWARN:\033[0m %s\n"  "$*" >&2; }
+
+if [[ "${UNSLOTH_SKIP_GPU_CHECK:-0}" == "1" ]]; then
+    exec "$@"
+fi
+
+# --- Check 1: /dev/kfd is accessible ----------------------------------------
+# /dev/kfd is the AMD Kernel Fusion Driver node. It must exist AND be readable
+# by the container user before any HIP / torch.cuda call can succeed.
+if [[ ! -e /dev/kfd ]]; then
+    err "/dev/kfd not found inside the container."
+    cat >&2 <<'MSG'
+
+The AMD GPU device node is missing. Likely causes:
+
+  1. You started the container without --device /dev/kfd --device /dev/dri.
+     Re-launch with:
+       docker run --device /dev/kfd --device /dev/dri --group-add video \
+         <other-flags> unsloth/unsloth-rocm:latest <cmd>
+     Or use the bundled wrapper:
+       bash docker/run.sh --rocm <cmd>
+
+  2. The host is missing the amdgpu / amdkfd kernel module.
+     Check with:  lsmod | grep amdgpu
+     Load with:   sudo modprobe amdgpu
+
+To bypass this check (e.g. offline tooling), set UNSLOTH_SKIP_GPU_CHECK=1.
+MSG
+    exit 1
+fi
+
+if [[ ! -r /dev/kfd ]]; then
+    err "/dev/kfd exists but is not readable by the container user."
+    cat >&2 <<'MSG'
+Add --group-add video (or --group-add render on newer kernels) to your
+docker run command so the container user has permission to open /dev/kfd.
+MSG
+    exit 1
+fi
+
+# --- Check 2: rocm-smi present and can see at least one GPU -----------------
+if ! command -v rocm-smi >/dev/null 2>&1; then
+    err "rocm-smi not found inside the container."
+    err "The ROCm runtime in this image is broken. Re-pull the image."
+    exit 1
+fi
+
+if ! rocm-smi --showid 2>/dev/null | grep -q 'GPU\['; then
+    err "No GPU visible to rocm-smi from inside the container."
+    cat >&2 <<'MSG'
+
+Likely causes (in order of frequency):
+
+  1. You started the container without the AMD GPU device flags.
+     Re-launch with:
+       docker run --device /dev/kfd --device /dev/dri \
+                  --group-add video <other-flags> \
+                  unsloth/unsloth-rocm:latest <cmd>
+     Or use the bundled wrapper:
+       bash docker/run.sh --rocm <cmd>
+
+  2. Your user is not in the 'video' group on the host.
+     Fix:  sudo usermod -aG video,render $USER
+     Then: log out and back in (or newgrp video)
+
+  3. Host amdgpu driver too old for the ROCm version baked into this image.
+     Check the host: rocm-smi --version  (and  rocminfo  to list the card)
+
+To bypass this check (e.g. offline tooling), set UNSLOTH_SKIP_GPU_CHECK=1.
+MSG
+    exit 1
+fi
+
+# --- Check 3: torch.cuda.is_available() (ROCm maps the CUDA Python API) ----
+python - >&2 <<'PY' || exit 1
+import sys
+import torch
+
+hip_ver = getattr(torch.version, "hip", None)
+print(f"torch {torch.__version__}  HIP={hip_ver}")
+
+if torch.cuda.is_available():
+    sys.exit(0)
+print("ERROR: torch.cuda.is_available() is False despite rocm-smi working.")
+print()
+print("This image was built against ROCm 6.2.  The host ROCm stack must be")
+print("6.2 or newer.  Check the host (NOT the container) with:")
+print("  rocm-smi --version")
+print()
+print("If the host ROCm version is older than 6.2, either upgrade the host")
+print("drivers or use an image built against an older ROCm version.")
+print("If HSA_OVERRIDE_GFX_VERSION is set, an incorrect value can also cause this.")
+sys.exit(1)
+PY
+
+# --- Check 4: detected gfx arch is in the supported list ---------------------
+# PyTorch ROCm surfaces the gfx code in gcnArchName (e.g. "gfx1100:sramecc+").
+# We don't gate on it -- ROCm can often JIT-compile for unlisted archs -- but
+# we print a clear HSA_OVERRIDE hint when the card isn't precompiled.
+python - >&2 <<'PY' || exit 1
+import sys
+import torch
+
+# SUPPORTED maps gfx arch string -> (family, example cards).
+SUPPORTED = {
+    "gfx906":  ("Vega20 / CDNA0", "Radeon VII"),
+    "gfx908":  ("CDNA1",          "Instinct MI100"),
+    "gfx90a":  ("CDNA2",          "Instinct MI200 / MI210 / MI250"),
+    "gfx940":  ("CDNA3",          "Instinct MI300A"),
+    "gfx942":  ("CDNA3",          "Instinct MI300X"),
+    "gfx1030": ("RDNA2",          "RX 6800 / 6800 XT / 6900 XT"),
+    "gfx1031": ("RDNA2",          "RX 6700 XT"),
+    "gfx1100": ("RDNA3",          "RX 7900 XTX / XT"),
+    "gfx1101": ("RDNA3",          "RX 7800 / 7700 XT"),
+    "gfx1102": ("RDNA3",          "RX 7600"),
+    "gfx1150": ("RDNA3.5 APU",    "Strix Point (needs rocm7.2 image)"),
+    "gfx1151": ("RDNA3.5 APU",    "Strix Halo / 8060S (needs rocm7.2 image)"),
+    "gfx1200": ("RDNA4",          "RX 9060 (needs rocm7.2 image)"),
+    "gfx1201": ("RDNA4",          "RX 9070 / 9070 XT (needs rocm7.2 image)"),
+}
+
+n = torch.cuda.device_count()
+for i in range(n):
+    name  = torch.cuda.get_device_name(i)
+    props = torch.cuda.get_device_properties(i)
+    arch  = getattr(props, "gcnArchName", "").split(":")[0]  # strip e.g. :sramecc+
+    bf16  = torch.cuda.is_bf16_supported()
+    print(f"GPU {i}: {name}  arch={arch}  bf16={bf16}")
+    if arch and arch in SUPPORTED:
+        fam, ex = SUPPORTED[arch]
+        print(f"  -> Supported: {fam} ({ex})")
+    elif arch:
+        print(f"  NOTE: {arch} is not in the precompiled arch list.")
+        print( "        Training may still work if ROCm can JIT-compile for it.")
+        print( "        If it fails, set HSA_OVERRIDE_GFX_VERSION to the nearest")
+        print( "        supported arch (e.g. RX 6800 -> HSA_OVERRIDE_GFX_VERSION=10.3.0),")
+        print( "        or rebuild for RDNA3.5/RDNA4 with a rocm7.2 image:")
+        print( "          ROCM_VERSION=7.x.x TORCH_INDEX_URL=https://download.pytorch.org/whl/rocm7.2 \\")
+        print( "            bash docker/build.sh --rocm")
+        print( "        Tip: UNSLOTH_ROCM_GFX_ARCH=gfx1151 (or your arch) pins the target.")
+
+sys.exit(0)
+PY
+
+exec "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,92 +1,118 @@
 #!/usr/bin/env bash
-# Convenience wrapper for `docker run unsloth/unsloth`. Sets the flags that
-# people most often forget and that cause the most confusing failures:
+# Convenience wrapper for `docker run unsloth/unsloth[-rocm]`.
+# Sets the GPU passthrough flags and mounts that people most often forget.
 #
+# NVIDIA (default):
 #   --gpus all           Without this, no GPU is attached and the container's
 #                        entrypoint will refuse to start.
+#
+# AMD (--rocm):
+#   --device /dev/kfd    AMD GPU compute node -- required for any torch.cuda call.
+#   --device /dev/dri    AMD render nodes -- required for ROCm libs.
+#   --group-add video    Grants render group access inside the container.
+#
+# Both backends:
 #   --ipc=host           PyTorch DataLoader workers need ample /dev/shm. The
 #                        default 64MB causes "DataLoader worker (pid X) exited
 #                        unexpectedly" on any non-trivial dataset.
-#   --ulimit memlock=-1  Unlimited pinned memory for NCCL / CUDA pinned host
-#                        buffers. Without this, multi-GPU training stalls.
-#   --ulimit stack=64MB  Larger thread stack for libtorch (some kernels OOM
-#                        the default 8MB stack).
-#
-# Plus mounts the host Hugging Face cache and Triton JIT cache so model
-# downloads and compiled kernels persist across container runs.
+#   --ulimit memlock=-1  Unlimited pinned memory for NCCL / ROCm pinned buffers.
+#   --ulimit stack=64MB  Larger thread stack for libtorch.
 #
 # Usage:
-#   bash docker/run.sh                                  # interactive python REPL
-#   bash docker/run.sh bash                             # shell in the container
-#   bash docker/run.sh python /workspace/smoke_test.py  # run the smoke test
-#   bash docker/run.sh python /workspace/host/train.py  # run your training script
-#                                                         ($PWD is mounted at
-#                                                          /workspace/host)
+#   bash docker/run.sh [--rocm] [cmd...]
 #
-# The full image (unsloth/unsloth:latest) starts Studio (8000) + JupyterLab
-# (8888) by default; publish the ports when you want them:
+#   bash docker/run.sh                                   # NVIDIA, python REPL
+#   bash docker/run.sh python /workspace/smoke_test.py   # NVIDIA smoke test
+#   bash docker/run.sh --rocm                            # AMD, python REPL
+#   bash docker/run.sh --rocm python /workspace/smoke_test_rocm.py
+#   bash docker/run.sh --rocm bash                       # AMD shell
+#
+# The full NVIDIA image (unsloth/unsloth:latest) starts Studio (8000) +
+# JupyterLab (8888) by default; publish the ports when you want them:
 #   UNSLOTH_PORTS="-p 8000:8000 -p 8888:8888" bash docker/run.sh
-# JupyterLab on the lean base image (unsloth/unsloth:base):
-#   UNSLOTH_PORTS="-p 8888:8888" UNSLOTH_IMAGE=unsloth/unsloth:base \
-#       bash docker/run.sh jupyter lab --ip 0.0.0.0 --port 8888 --allow-root
 # CPU-only hosts (Docker Desktop on macOS, Windows without WSL2 GPU, plain
 # CPU Linux): no --gpus and set UNSLOTH_ALLOW_CPU=1. Training is unavailable
 # but Studio chat / Data Recipes, Jupyter and GGUF tooling work:
 #   UNSLOTH_GPUS=none UNSLOTH_ALLOW_CPU=1 \
 #       UNSLOTH_PORTS="-p 8000:8000 -p 8888:8888" bash docker/run.sh
 #
-# Overridable env:
-#   UNSLOTH_IMAGE=unsloth/unsloth:latest    image and tag to pull/run
-#   UNSLOTH_GPUS=all                        GPUs to expose ("all" | "0" | "0,1"
-#                                           | "none" to run without GPU)
-#   UNSLOTH_ALLOW_CPU=                      set to 1 to allow GPU-less runs
-#   UNSLOTH_PORTS=                          extra -p publish flags, e.g.
-#                                           "-p 8000:8000 -p 8888:8888"
-#   HF_HOME=$HOME/.cache/huggingface        host HF cache dir to mount
-#   TRITON_CACHE_DIR=$HOME/.cache/unsloth-triton
-#                                           host Triton cache dir to mount
-#   UNSLOTH_WORKDIR=$PWD                    host dir mounted at /workspace/host
+# Overridable env (both backends):
+#   UNSLOTH_IMAGE          image:tag to pull/run
+#   UNSLOTH_PORTS=         extra -p publish flags, e.g. "-p 8000:8000 -p 8888:8888"
+#   HF_HOME                host HF cache dir (default $HOME/.cache/huggingface)
+#   TRITON_CACHE_DIR       host Triton cache dir
+#   UNSLOTH_WORKDIR        host dir mounted at /workspace/host (default $PWD)
+#
+# NVIDIA-only env:
+#   UNSLOTH_GPUS=all       GPUs to expose ("all" | "0" | "0,1" | "none" for CPU)
+#   UNSLOTH_ALLOW_CPU=     set to 1 to allow GPU-less runs
+#
+# AMD-only env:
+#   HSA_OVERRIDE_GFX_VERSION   force gfx version (e.g. 10.3.0 for RX 6800)
+#   UNSLOTH_ROCM_GFX_ARCH      gfx target override (e.g. gfx1151 for Strix Halo)
 set -euo pipefail
 
-IMAGE="${UNSLOTH_IMAGE:-unsloth/unsloth:latest}"
-GPUS="${UNSLOTH_GPUS:-all}"
-# Translate index selectors to Docker's `device=` form. The header docstring
-# advertises UNSLOTH_GPUS values like "0" and "0,1" but Docker reads a bare
-# integer for --gpus as a COUNT, not an INDEX, so `UNSLOTH_GPUS=0` would
-# expose zero GPUs and the entrypoint would refuse to start. `all` and
-# already-quoted `device=...` / `"device=..."` selectors pass through.
-# "none" omits --gpus entirely (CPU mode; pair with UNSLOTH_ALLOW_CPU=1).
-GPU_FLAG=(--gpus "$GPUS")
-case "$GPUS" in
-    none)     GPU_FLAG=()                ;;
-    all|"")                              ;;
-    \"device=*|device=*)                 ;;
-    *[!0-9]*) GPU_FLAG=(--gpus "\"device=${GPUS}\"") ;;  # comma list / UUID
-    *)        GPU_FLAG=(--gpus "\"device=${GPUS}\"") ;;  # bare integer index
-esac
+# --- Parse --rocm; everything else is passed through to the container --------
+ROCM=0
+PASSTHROUGH=()
+for arg in "$@"; do
+    if [[ "$arg" == "--rocm" ]]; then
+        ROCM=1
+    else
+        PASSTHROUGH+=("$arg")
+    fi
+done
+set -- "${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}"
+
 HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}"
 TRITON_CACHE="${TRITON_CACHE_DIR:-$HOME/.cache/unsloth-triton}"
 WORK_DIR="${UNSLOTH_WORKDIR:-$PWD}"
 
 mkdir -p "$HF_CACHE" "$TRITON_CACHE"
 
-# Warn early if the host doesn't have the nvidia runtime registered.
-# We let `docker run` fail loudly rather than abort here -- some setups
-# (rootless docker, custom runtimes) report runtimes differently.
-if ! docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'; then
-    printf "\033[1;33mWARN:\033[0m 'docker info' does not list 'nvidia' as a runtime.\n" >&2
-    printf "      If --gpus all fails below, install nvidia-container-toolkit:\n" >&2
-    printf "      https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html\n\n" >&2
+declare -a GPU_FLAGS=()
+declare -a ENV_FORWARD=(-e HF_HUB_ENABLE_HF_TRANSFER=1)
+
+if [[ $ROCM -eq 1 ]]; then
+    IMAGE="${UNSLOTH_IMAGE:-unsloth/unsloth-rocm:latest}"
+
+    if [[ ! -e /dev/kfd ]]; then
+        printf "\033[1;33mWARN:\033[0m /dev/kfd not found -- ROCm drivers may not be installed.\n" >&2
+        printf "      sudo usermod -aG video,render \$USER  then log out/in.\n\n" >&2
+    fi
+
+    GPU_FLAGS+=(--device /dev/kfd --device /dev/dri --group-add video)
+    [[ -n "${HSA_OVERRIDE_GFX_VERSION:-}" ]] && ENV_FORWARD+=(-e HSA_OVERRIDE_GFX_VERSION)
+    [[ -n "${UNSLOTH_ROCM_GFX_ARCH:-}"   ]] && ENV_FORWARD+=(-e UNSLOTH_ROCM_GFX_ARCH)
+else
+    IMAGE="${UNSLOTH_IMAGE:-unsloth/unsloth:latest}"
+    GPUS="${UNSLOTH_GPUS:-all}"
+
+    # Translate index selectors to Docker's `device=` form. Docker reads a bare
+    # integer for --gpus as a COUNT, not an INDEX, so `UNSLOTH_GPUS=0` would
+    # expose zero GPUs and the entrypoint would refuse to start. `all` and
+    # already-quoted `device=...` selectors pass through. "none" omits --gpus
+    # entirely (CPU mode; pair with UNSLOTH_ALLOW_CPU=1).
+    GPU_FLAGS=(--gpus "$GPUS")
+    case "$GPUS" in
+        none)     GPU_FLAGS=()                            ;;
+        all|"")                                           ;;
+        \"device=*|device=*)                              ;;
+        *[!0-9]*) GPU_FLAGS=(--gpus "\"device=${GPUS}\"") ;;  # comma list / UUID
+        *)        GPU_FLAGS=(--gpus "\"device=${GPUS}\"") ;;  # bare integer index
+    esac
+
+    if [[ "$GPUS" != "none" ]] && ! docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'; then
+        printf "\033[1;33mWARN:\033[0m 'docker info' does not list 'nvidia' as a runtime.\n" >&2
+        printf "      Install nvidia-container-toolkit if --gpus all fails:\n" >&2
+        printf "      https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html\n\n" >&2
+    fi
 fi
 
-# Forward common secrets only if they're set in the host environment.
-# Empty strings would shadow whatever is already inside the image.
-# IMPORTANT: use the dash-only form `-e VAR` (no `=VALUE`). Docker reads
-# the value from the parent shell, so the literal secret never lands in
-# argv where it would be visible to any user on the host via
-# `ps auxe` / `/proc/<pid>/cmdline` for the lifetime of the docker CLI
-# process.
-declare -a ENV_FORWARD=(-e HF_HUB_ENABLE_HF_TRANSFER=1)
+# Forward common secrets only if set in the host environment. Use the dash-only
+# form `-e VAR` (no `=VALUE`): Docker reads the value from the parent shell, so
+# the literal secret never lands in argv where `ps auxe` / /proc/<pid>/cmdline
+# would expose it. An empty string would shadow whatever is baked in the image.
 [[ -n "${HF_TOKEN:-}"          ]] && ENV_FORWARD+=(-e HF_TOKEN)
 [[ -n "${WANDB_API_KEY:-}"     ]] && ENV_FORWARD+=(-e WANDB_API_KEY)
 [[ -n "${UNSLOTH_LICENSE:-}"   ]] && ENV_FORWARD+=(-e UNSLOTH_LICENSE)
@@ -99,18 +125,13 @@ if [[ -n "${UNSLOTH_PORTS:-}" ]]; then
     PORT_FLAGS=(${UNSLOTH_PORTS})
 fi
 
-# Only attach -t when our own stdin/stdout are a TTY; CI / piped invocations
-# otherwise hit `the input device is not a TTY` and never reach the entrypoint.
 TTY_FLAG=()
 if [ -t 0 ] && [ -t 1 ]; then
     TTY_FLAG=(-it)
 fi
 
-# Avoid `set -x` here so the literal HF_TOKEN / WANDB_API_KEY / UNSLOTH_LICENSE
-# values do not get echoed to stdout/CI logs. The forwarded env vars are
-# already in ENV_FORWARD; printing them again was a secret leak.
 exec docker run --rm "${TTY_FLAG[@]}" \
-    "${GPU_FLAG[@]}" \
+    "${GPU_FLAGS[@]}" \
     --ipc=host \
     --ulimit memlock=-1 \
     --ulimit stack=67108864 \

--- a/docker/smoke_test_rocm.py
+++ b/docker/smoke_test_rocm.py
@@ -1,0 +1,184 @@
+"""
+Smoke test for the Unsloth ROCm image (AMD GPU build).
+
+What this checks (in order, fail-fast):
+  1. torch is a ROCm build (torch.version.hip is not None).
+  2. The runtime device is visible and its gfx arch is supported (RDNA2+).
+  3. bitsandbytes / triton import without ImportError.
+  4. unsloth imports and exposes FastLanguageModel.
+  5. A 5-step LoRA train on a tiny model actually runs forward + backward.
+
+Run inside the container:
+    docker run --rm --device /dev/kfd --device /dev/dri --group-add video \\
+        unsloth/unsloth-rocm:latest python /workspace/smoke_test_rocm.py
+
+Skip step 5 (faster, no model download):
+    ... python /workspace/smoke_test_rocm.py --skip-train
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def banner(title: str) -> None:
+    print(f"\n=== {title} ===", flush=True)
+
+
+def check_torch() -> None:
+    banner("torch ROCm build")
+    import torch
+
+    # torch.version.hip is the canonical indicator of a ROCm wheel.
+    # It is None for CUDA builds.
+    if torch.version.hip is None:
+        sys.exit(
+            f"FAIL: this is not a ROCm torch build ({torch.__version__}). "
+            "Re-pull the unsloth-rocm image."
+        )
+    print(f"torch       {torch.__version__}")
+    print(f"HIP         {torch.version.hip}")
+
+    assert torch.cuda.is_available(), (
+        "torch.cuda.is_available() is False — did you pass "
+        "--device /dev/kfd --device /dev/dri --group-add video?"
+    )
+    n = torch.cuda.device_count()
+    print(f"GPU count   {n}")
+    for i in range(n):
+        name  = torch.cuda.get_device_name(i)
+        props = torch.cuda.get_device_properties(i)
+        # PyTorch ROCm surfaces the gfx code in gcnArchName (e.g.
+        # "gfx1100:sramecc+"); strip the feature suffix for readability.
+        arch  = getattr(props, "gcnArchName", "").split(":")[0]
+        bf16  = torch.cuda.is_bf16_supported()
+        print(f"device {i}    {name}  arch={arch}  bf16={bf16}")
+    print()
+    # ROCm does not expose a reliable sm_X.Y compute capability the way NVIDIA
+    # does -- the values from get_device_properties() vary by ROCm version and
+    # don't map cleanly to gfx codes. GPU support is determined by the ROCm
+    # version and TORCH_INDEX_URL the image was built with:
+    #   rocm6.2 image: RDNA2 (gfx1030), RDNA3 (gfx1100-1103)
+    #   rocm7.2 image: adds RDNA3.5 (gfx1150/1151) + RDNA4 (gfx1200/1201)
+
+
+def check_imports() -> None:
+    banner("dep imports")
+    # unsloth must be imported before transformers/trl/peft so its
+    # monkey-patches land, and before unsloth_zoo so it sees
+    # UNSLOTH_IS_PRESENT. Import order matches the CUDA smoke test.
+    import unsloth
+
+    print(f"unsloth     {unsloth.__version__}")
+    import unsloth_zoo
+
+    print(f"unsloth_zoo {unsloth_zoo.__version__}")
+
+    try:
+        import triton
+        print(f"triton      {triton.__version__}")
+    except ImportError:
+        print("triton      (not installed — ROCm path uses HIP kernels directly)")
+
+    import bitsandbytes as bnb
+    print(f"bnb         {bnb.__version__}")
+
+    import transformers
+    print(f"transformers {transformers.__version__}")
+
+    import trl
+    print(f"trl         {trl.__version__}")
+
+    import peft
+    print(f"peft        {peft.__version__}")
+
+    # xformers has no ROCm wheel; its absence is expected.
+    try:
+        import xformers
+        print(f"xformers    {xformers.__version__}")
+    except ImportError:
+        print("xformers    (not installed -- expected; ROCm uses SDPA fallback)")
+
+
+def check_unsloth_import() -> None:
+    banner("unsloth FastLanguageModel reachable")
+    import unsloth
+    from unsloth import FastLanguageModel
+
+    print(f"unsloth     {unsloth.__version__}")
+    print(f"FastLanguageModel  {FastLanguageModel}")
+
+
+def check_tiny_train() -> None:
+    banner("tiny LoRA train (5 steps)")
+    import unsloth  # noqa: F401
+    from unsloth import FastLanguageModel
+    import torch
+
+    model_name = "unsloth/Llama-3.2-1B-Instruct-bnb-4bit"
+    print(f"loading     {model_name}")
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=model_name,
+        max_seq_length=512,
+        dtype=None,
+        load_in_4bit=True,
+    )
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r=8,
+        lora_alpha=16,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        lora_dropout=0.0,
+        bias="none",
+        use_gradient_checkpointing="unsloth",
+        random_state=0,
+    )
+
+    prompts = [
+        "Q: What is the capital of France?\nA:",
+        "Q: 2 + 2 = ?\nA:",
+        "Q: Name a primary color.\nA:",
+        "Q: Hello, who are you?\nA:",
+    ] * 2
+    enc = tokenizer(
+        prompts, return_tensors="pt", padding=True, truncation=True, max_length=64
+    )
+    enc = {k: v.cuda() for k, v in enc.items()}
+    labels = enc["input_ids"].clone()
+
+    model.train()
+    optim = torch.optim.AdamW(
+        [p for p in model.parameters() if p.requires_grad], lr=1e-4
+    )
+    for step in range(5):
+        out = model(**enc, labels=labels)
+        out.loss.backward()
+        optim.step()
+        optim.zero_grad(set_to_none=True)
+        print(f"step {step}  loss={out.loss.item():.4f}", flush=True)
+
+    print("OK: 5 LoRA steps completed")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--skip-train",
+        action="store_true",
+        help="Skip the tiny LoRA training step (no HF download).",
+    )
+    args = ap.parse_args()
+
+    check_torch()
+    check_imports()
+    check_unsloth_import()
+    if not args.skip_train:
+        check_tiny_train()
+
+    banner("all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/test_locally-rocm.sh
+++ b/docker/test_locally-rocm.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# End-to-end Docker validation for the unsloth-rocm image.
+#
+# Runs three blocks:
+#   1. Host pre-flight (docker, rocm-smi, /dev/kfd accessible)
+#   2. Build the image (no GPU required at build time)
+#   3a. Smoke test: 5-step LoRA on Llama-3.2-1B (~1-2 min)
+#   3b. Real workload: gpt-oss-20B fine-tuning notebook with max_steps=10
+#       (~10 min, needs ~30GB free for the model cache)
+#
+# Usage:
+#   bash docker/test_locally-rocm.sh                   # all blocks
+#   bash docker/test_locally-rocm.sh --skip-notebook   # blocks 1-3a only (fast)
+#   bash docker/test_locally-rocm.sh --skip-build      # assume $TAG already built
+#   TAG=my-image:latest bash docker/test_locally-rocm.sh
+#   HF_TOKEN=hf_xxx bash docker/test_locally-rocm.sh
+#
+# For RDNA4 / Strix Halo (gfx1150/1151/1200/1201), build with:
+#   ROCM_VERSION=7.x.x TORCH_INDEX_URL=https://download.pytorch.org/whl/rocm7.2 \
+#     TAG=unsloth-rocm-rdna4:test bash docker/test_locally-rocm.sh
+#
+# All output is teed to $LOG_DIR (default /tmp/unsloth-rocm-test/).
+set -uo pipefail
+
+TAG="${TAG:-unsloth-rocm:test}"
+LOG_DIR="${LOG_DIR:-/tmp/unsloth-rocm-test}"
+SKIP_BUILD=0
+SKIP_NOTEBOOK=0
+ROCM_VERSION="${ROCM_VERSION:-6.2.4}"
+TORCH_INDEX_URL="${TORCH_INDEX_URL:-https://download.pytorch.org/whl/rocm6.2}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-build)    SKIP_BUILD=1; shift ;;
+        --skip-notebook) SKIP_NOTEBOOK=1; shift ;;
+        --tag)           TAG="$2"; shift 2 ;;
+        --log-dir)       LOG_DIR="$2"; shift 2 ;;
+        --help|-h)       sed -n '2,18p' "$0"; exit 0 ;;
+        *) echo "Unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+mkdir -p "$LOG_DIR"
+
+GREEN='\033[1;32m'; RED='\033[1;31m'; YELLOW='\033[1;33m'; BLUE='\033[1;34m'; NC='\033[0m'
+banner() { printf "\n${BLUE}==== %s ====${NC}\n" "$*"; }
+ok()     { printf "${GREEN}OK${NC}    %s\n" "$*"; }
+warn()   { printf "${YELLOW}WARN${NC}  %s\n" "$*"; }
+err()    { printf "${RED}ERROR${NC} %s\n" "$*" >&2; }
+fail()   { err "$*"; exit 1; }
+
+# AMD GPU device flags used for all `docker run` invocations.
+AMD_DEVICE_FLAGS=(--device /dev/kfd --device /dev/dri --group-add video)
+
+# ============================================================================
+# Block 1: pre-flight
+# ============================================================================
+banner "Block 1: host pre-flight"
+
+command -v docker >/dev/null 2>&1 || fail "docker not found on PATH"
+echo "  docker:       $(docker --version)"
+
+DOCKER_INFO_OUT=$(docker info 2>&1)
+DOCKER_INFO_RC=$?
+if [[ $DOCKER_INFO_RC -ne 0 ]]; then
+    err "Cannot talk to the docker daemon as user '$USER'."
+    cat >&2 <<MSG
+
+docker info exited $DOCKER_INFO_RC. The most common cause is that your user
+is not in the 'docker' group. Fix:
+
+  sudo usermod -aG docker \$USER
+  newgrp docker
+  docker info | head -3
+
+MSG
+    fail "docker daemon unreachable"
+fi
+echo "  daemon:       reachable as '$USER'"
+
+if [[ -e /dev/kfd ]]; then
+    echo "  /dev/kfd:     present"
+    if command -v rocm-smi >/dev/null 2>&1; then
+        echo "  host gpu:     $(rocm-smi --showproductname 2>/dev/null | grep -m1 'GPU\[' | sed 's/.*: //' || echo '(rocm-smi present)')"
+    else
+        warn "rocm-smi not on the host PATH (ROCm may still work inside the container)"
+    fi
+else
+    warn "/dev/kfd not found -- ROCm drivers may not be installed or user lacks access"
+    warn "Install ROCm: https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html"
+    warn "Then: sudo usermod -aG video,render \$USER  (log out and back in)"
+fi
+
+# Check the user is in the video group -- required for /dev/dri access.
+if id -nG 2>/dev/null | grep -qw video; then
+    echo "  video group:  ok (current user is a member)"
+else
+    warn "current user is not in the 'video' group"
+    warn "Fix: sudo usermod -aG video,render \$USER  (log out/in after)"
+fi
+
+ok "pre-flight done"
+
+# ============================================================================
+# Block 2: build
+# ============================================================================
+if [[ $SKIP_BUILD -eq 1 ]]; then
+    warn "skipping build (--skip-build); expecting $TAG to exist"
+else
+    banner "Block 2: build $TAG"
+
+    if [[ -f "Dockerfile.rocm" && -f "smoke_test_rocm.py" ]]; then
+        BUILD_CTX="$PWD"
+    elif [[ -f "docker/Dockerfile.rocm" ]]; then
+        BUILD_CTX="$PWD/docker"
+    else
+        fail "Cannot find Dockerfile.rocm. Run from the repo root or docker/ directory."
+    fi
+    echo "  build context: $BUILD_CTX"
+    echo "  ROCm version:  $ROCM_VERSION"
+    echo "  torch index:   $TORCH_INDEX_URL"
+
+    BUILD_LOG="$LOG_DIR/build.log"
+    echo "  log:           $BUILD_LOG"
+
+    if ! docker buildx version >/dev/null 2>&1; then
+        fail "docker buildx is not installed. Install: sudo apt-get install -y docker-buildx"
+    fi
+    echo "  builder:       docker buildx ($(docker buildx version | head -1))"
+
+    docker buildx build \
+        --progress=plain \
+        --load \
+        --build-arg ROCM_VERSION="${ROCM_VERSION}" \
+        --build-arg TORCH_INDEX_URL="${TORCH_INDEX_URL}" \
+        -f "${BUILD_CTX}/Dockerfile.rocm" \
+        -t "$TAG" \
+        "$BUILD_CTX" 2>&1 | tee "$BUILD_LOG"
+    rc=${PIPESTATUS[0]}
+    if [[ $rc -ne 0 ]]; then
+        fail "docker build exited $rc -- see $BUILD_LOG"
+    fi
+
+    # Sanity-check the build's own self-test ran and passed.
+    if grep -q "FAIL: missing packages\|Expected a ROCm torch wheel" "$BUILD_LOG"; then
+        fail "build-time sanity check failed -- see $BUILD_LOG"
+    fi
+    grep -E "OK: torch .* HIP|OK: all required packages" "$BUILD_LOG" || \
+        warn "could not find 'OK:' lines in build log -- did the verification step run?"
+    ok "built $TAG"
+fi
+
+# ============================================================================
+# Block 3a: smoke test
+# ============================================================================
+banner "Block 3a: smoke test (5-step LoRA on Llama-3.2-1B)"
+SMOKE_LOG="$LOG_DIR/smoke.log"
+echo "  log: $SMOKE_LOG"
+docker run --rm \
+    "${AMD_DEVICE_FLAGS[@]}" \
+    "$TAG" python /workspace/smoke_test_rocm.py 2>&1 | tee "$SMOKE_LOG"
+rc=${PIPESTATUS[0]}
+if [[ $rc -ne 0 ]]; then
+    fail "smoke test exited $rc -- see $SMOKE_LOG"
+fi
+if ! grep -q "all checks passed" "$SMOKE_LOG"; then
+    fail "smoke test did not print 'all checks passed' -- see $SMOKE_LOG"
+fi
+ok "smoke test passed"
+
+# ============================================================================
+# Block 3b: gpt-oss-20B fine-tuning notebook
+# ============================================================================
+if [[ $SKIP_NOTEBOOK -eq 1 ]]; then
+    warn "skipping gpt-oss-20B notebook (--skip-notebook)"
+else
+    banner "Block 3b: gpt-oss-20B fine-tuning notebook (10 LoRA steps)"
+    GPT_LOG="$LOG_DIR/gpt_oss.log"
+    HOST_RUN_DIR="$LOG_DIR/host"
+    mkdir -p "$HOST_RUN_DIR"
+    echo "  log:        $GPT_LOG"
+    echo "  host dir:   $HOST_RUN_DIR"
+
+    cat > "$HOST_RUN_DIR/run_notebook.sh" <<'INNER'
+#!/bin/bash
+set -e
+cd /workspace/host
+
+echo "=== fetch + convert notebook ==="
+pip install -q nbformat
+NB_REPO_REF="${NB_REPO_REF:-efe20c97a5bba3088b25fe068a4b1c98c0cf3a3a}"
+curl -fsSL "https://raw.githubusercontent.com/unslothai/notebooks/${NB_REPO_REF}/nb/gpt-oss-(20B)-Fine-tuning.ipynb" -o nb.ipynb
+test -s nb.ipynb || { echo "FAIL: nb.ipynb was not downloaded"; exit 1; }
+python - <<'PY'
+import nbformat, re
+nb = nbformat.read('nb.ipynb', as_version=4)
+out, skipped = [], 0
+INSTALL_MARKERS = (
+    "pip install", "uv pip install", "apt-get install",
+    "_original_packages", "COLAB_", "importlib.util.find_spec",
+)
+for c in nb.cells:
+    if c.cell_type != "code":
+        continue
+    src = c.source or ""
+    if any(m in src for m in INSTALL_MARKERS):
+        skipped += 1
+        first = next((ln for ln in src.splitlines() if ln.strip()), "")[:80]
+        out.append(f"# (skipped install/setup cell: {first!r})")
+        out.append("")
+        continue
+    for line in src.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(("!", "%")):
+            out.append(f"# (jupyter magic stripped) {line}")
+        else:
+            out.append(line)
+    out.append("")
+with open("nb.py", "w") as f:
+    f.write("\n".join(out) + "\n")
+print(f"  converted nb.py: {sum(1 for _ in open('nb.py'))} lines, {skipped} install cell(s) skipped")
+PY
+test -s nb.py || { echo "FAIL: nb.py was not produced"; exit 1; }
+python -c "import ast; ast.parse(open('nb.py').read()); print('  nb.py is valid Python')"
+
+echo
+echo "=== patch nb.py: max_steps 30 -> 10 ==="
+python - <<'PY'
+import re
+src = open('nb.py').read()
+src = src.replace('max_steps = 30', 'max_steps = 10')
+open('nb.py', 'w').write(src)
+print('  patched. max_steps now:', re.search(r'max_steps = (\d+)', src).group(1))
+PY
+
+echo
+echo "=== run gpt-oss-20B fine-tuning ==="
+python -u nb.py
+INNER
+    chmod +x "$HOST_RUN_DIR/run_notebook.sh"
+
+    HF_ARGS=()
+    [[ -n "${HF_TOKEN:-}" ]] && HF_ARGS+=(-e HF_TOKEN)
+    docker run --rm \
+        "${AMD_DEVICE_FLAGS[@]}" \
+        --ipc=host \
+        --ulimit memlock=-1 \
+        --ulimit stack=67108864 \
+        -v "$HOST_RUN_DIR:/workspace/host" \
+        -v "$HOME/.cache/huggingface:/workspace/.cache/huggingface" \
+        "${HF_ARGS[@]}" \
+        -e HF_HUB_ENABLE_HF_TRANSFER=1 \
+        "$TAG" \
+        bash /workspace/host/run_notebook.sh 2>&1 | tee "$GPT_LOG"
+    rc=${PIPESTATUS[0]}
+    if [[ $rc -ne 0 ]]; then
+        fail "gpt-oss-20B notebook exited $rc -- see $GPT_LOG"
+    fi
+    ok "gpt-oss-20B notebook completed"
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+banner "summary"
+echo "  image:    $TAG"
+echo "  log dir:  $LOG_DIR"
+echo
+echo "  to paste back for PR validation:"
+[[ $SKIP_BUILD    -eq 0 ]] && echo "    tail -40 $LOG_DIR/build.log"
+echo "    cat      $LOG_DIR/smoke.log"
+[[ $SKIP_NOTEBOOK -eq 0 ]] && echo "    tail -100 $LOG_DIR/gpt_oss.log"
+echo
+ok "all blocks completed"


### PR DESCRIPTION
Part of #6230. This is the AMD ROCm counterpart to the Blackwell CUDA docker work in #5748, stacked directly on the docker-blackwell-build branch so the diff is AMD-only.

## What

Adds an AMD ROCm variant of the Docker setup alongside the NVIDIA/Blackwell image, so Unsloth runs in a container on AMD GPUs (RDNA2/3/4 and CDNA/Instinct). Same docker/ layout, same build.sh / run.sh entry points, same smoke-test shape as the CUDA side.

## What's included

- docker/Dockerfile.rocm: ROCm torch wheels + the bitsandbytes pre-release wheel that carries the 4-bit decode fix (bnb <= 0.49.2 NaNs at decode on AMD). [huggingface] extra, SDPA fallback (no xformers on ROCm).
- docker/Dockerfile.studio-rocm: Studio variant layered on the ROCm base.
- docker/entrypoint-rocm.sh: preflight (/dev/kfd reachable, rocm-smi, HIP torch, gfx-arch check with HSA_OVERRIDE hints).
- docker/smoke_test_rocm.py: ROCm smoke test incl. a 5-step LoRA train.
- docker/test_locally-rocm.sh: end-to-end local build + smoke + notebook check.
- .github/workflows/docker-publish-rocm.yml: GPU-free amd64 build + publish to Docker Hub.
- build.sh / run.sh gain a --rocm flag; .dockerignore allowlists the new files.

## Diff scope

9 files on top of #5748: 6 net-new rocm files plus the --rocm hooks in build.sh / run.sh / .dockerignore. No changes to the CUDA or Studio files, so the NVIDIA path is untouched.

## GPU coverage

- Default build (ROCM_VERSION=6.2.4, torch rocm6.2): RDNA2/RDNA3, CDNA/Instinct.
- RDNA4 / Strix (gfx1200/1201, gfx1150/1151): ROCM_VERSION=7.2.4 + torch rocm7.2.

## Validation so far

- Base RDNA4 image (ROCM_VERSION=7.2.4, torch rocm7.2) builds cleanly on a GPU-free host, verified end to end at build time: torch 2.12.0+rocm7.2, HIP 7.2.53211, bitsandbytes 0.50.0.dev0 imports cleanly, all required packages present.
- Static checks pass (shell, python, workflow yaml, .dockerignore COPY coverage).
- Not yet built: the default rocm6.2 image and the Studio image (Dockerfile.studio-rocm).
- Pending: the GPU smoke test (5-step LoRA) on real AMD hardware. Needs an AMD GPU runner or a cloud instance; the workflow's self-hosted amd-gpu smoke job can also cover it.

## Base note

Targeting docker-blackwell-build so the diff is AMD-only. Will retarget to main once #5748 merges.
