### PR TITLE
Fix stale sidebar regression test to match the gap-px markup

### DIFF
--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -36,8 +36,10 @@ def test_model_selector_trigger_label_uses_leading_tight():
 
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
+    # Match the account-block parent div regardless of its gap utility (gap-0.5,
+    # gap-px, ...); this guard is about the leading-* class, not the spacing.
     pattern = re.compile(
-        r'<div\s+className="flex\s+flex-col\s+gap-0\.5\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
+        r'<div\s+className="flex\s+flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
     )
     matches = pattern.findall(src)
     assert matches, "could not find sidebar account-block parent div"


### PR DESCRIPTION
## Summary

`test_sidebar_account_block_uses_leading_tight` in `tests/studio/test_studio_text_descender_clipping.py` hardcoded `gap-0.5` in its regex selector for the sidebar account-block div. UI polish in #6196 moved that div to `gap-px`, so the regex stopped matching and the test began failing on `main` and across every open studio PR's `Repo tests (CPU)` job (`1 failed, 1567 passed`).

The guard exists to ensure that div uses a `leading-*` class (descender-clipping protection), not to pin the gap utility. This loosens the gap match to `gap-\S+` so the test locates the div regardless of spacing tweaks while still asserting `leading-tight`.

## Test plan

- `pytest tests/studio/test_studio_text_descender_clipping.py` now reports 3 passed (was 1 failed beforehand).
