### PR TITLE
Studio: guard Apple GPU power against negative counter-reset readings

### DIFF
--- a/studio/backend/utils/hardware/apple.py
+++ b/studio/backend/utils/hardware/apple.py
@@ -386,7 +386,9 @@ class _IOReportEnergy:
             watts = _watts(energy, unit, elapsed_s)
             if watts is not None:
                 total = (total or 0.0) + watts
-        return round(total, 1) if total is not None else None
+        if total is None or total < 0:  # negative = counter reset; show -- not a bogus draw
+            return None
+        return round(total, 1)
 
 
 # ========== Public API (module singletons, failure-latched) ==========


### PR DESCRIPTION
Small follow-up to #6187.

IOReport energy counters can reset (sleep/wake, GPU power gating), which makes a poll's delta negative. The aggregator would then surface a negative wattage for that one poll. This returns None for a negative total so the GPU monitor shows `--` for that poll instead of a bogus negative draw; it self-corrects on the next poll.

Read-only and contained to the Apple power path; non Mac and locked down hosts are unaffected (they already return None). Verified with a cross platform simulation of the IOReport layer: a negative delta now yields None, and all existing temperature and power cases still pass on Linux, Windows, and macOS.
