### PR TITLE
Add missing RAG deps to no-torch Studio runtime requirements

### DIFF
--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -68,3 +68,9 @@ trl>=0.18.2,!=0.19.0,<=0.24.0
 sentence-transformers
 cut_cross_entropy
 pillow
+
+# RAG store + document parsing, mirroring studio.txt. Pinned here because
+# this file installs --no-deps; without them Studio runs with RAG disabled.
+sqlite-vec==0.1.9
+pymupdf==1.27.2.3
+python-docx==1.2.0


### PR DESCRIPTION
## Problem

A fresh Studio install via the `--local` / GGUF-only path comes up with RAG (knowledge bases) disabled. The backend logs at startup:

```
RAG unavailable: sqlite-vec could not be imported (No module named 'sqlite_vec')
```

the Docs / knowledge-base UI shows "RAG is unavailable: the sqlite-vec extension could not be loaded", and `/api/rag/*` routes return 503.

## Cause

The `--local` / GGUF-only install resolves its Python deps from `studio/backend/requirements/no-torch-runtime.txt`, which is installed with `--no-deps`. That file was missing the RAG dependency group that `studio/backend/requirements/studio.txt` declares:

- `sqlite-vec==0.1.9` (the `vec0` vector index used by the dense store)
- `pymupdf==1.27.2.3` (PDF parsing for ingestion)
- `python-docx==1.2.0` (DOCX parsing)

`storage/rag_db.py` imports `sqlite_vec` at module load inside a `try/except`, so a missing package degrades to RAG-disabled (`RAG_AVAILABLE = False`) rather than crashing the server. Because the file installs with `--no-deps`, the missing entries are never resolved transitively. `python-docx` was also absent, so DOCX ingestion would fail even after `sqlite-vec` is present.

## Fix

Add the three RAG store + document-parsing deps to `no-torch-runtime.txt` with the same pins as `studio.txt`. `sentence-transformers` (dense embeddings) is already pinned in this file, so only the vector store and document parsers were missing.

## Verification

Installing `sqlite-vec==0.1.9` into a no-torch venv and restarting the server clears the warning: `sqlite_vec.load()` loads the `vec0` extension (`vec_version v0.1.9`) on Python 3.13, and the knowledge-base routes serve instead of returning 503.
