### PR TITLE
Restore UNSLOTH_RETURN_LOGITS after prediction_step instead of forcing it to 0

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -276,6 +276,9 @@ def PatchRL(FastLanguageModel):
         else:
             labels = None
 
+        # Force logits during eval, but restore the user's prior setting after
+        # so an explicit UNSLOTH_RETURN_LOGITS="1" is not silently turned off.
+        _old_return_logits = os.environ.get("UNSLOTH_RETURN_LOGITS", "0")
         os.environ["UNSLOTH_RETURN_LOGITS"] = "1"
         with torch.no_grad():
             if has_labels or loss_without_labels:
@@ -315,7 +318,7 @@ def PatchRL(FastLanguageModel):
                 # TODO: this needs to be fixed and made cleaner later.
                 if self.args.past_index >= 0:
                     self._past = outputs[self.args.past_index - 1]
-        os.environ["UNSLOTH_RETURN_LOGITS"] = "0"
+        os.environ["UNSLOTH_RETURN_LOGITS"] = _old_return_logits
         if prediction_loss_only:
             return (loss, None, None)
 


### PR DESCRIPTION
### Problem

`unsloth_prediction_step` (the global `Trainer.prediction_step` patch in `unsloth/models/rl.py`) forces `UNSLOTH_RETURN_LOGITS="1"` so logits are materialized during evaluation, then hardcodes it back to `"0"` afterwards:

```python
os.environ["UNSLOTH_RETURN_LOGITS"] = "1"
with torch.no_grad():
    ...
os.environ["UNSLOTH_RETURN_LOGITS"] = "0"
```

This silently overrides an explicit user setting. A user who sets `UNSLOTH_RETURN_LOGITS="1"` before training (the documented way to keep real logits) has it reset to `"0"` after the first evaluation step, so subsequent training forwards stop returning logits.

### Fix

Save the prior value before forcing `"1"` and restore it afterwards, so the default behavior is unchanged but an explicit user setting survives:

```python
_old_return_logits = os.environ.get("UNSLOTH_RETURN_LOGITS", "0")
os.environ["UNSLOTH_RETURN_LOGITS"] = "1"
...
os.environ["UNSLOTH_RETURN_LOGITS"] = _old_return_logits
```

### Verification

Tiny SFT model, `trainer.evaluate()`:
- With `UNSLOTH_RETURN_LOGITS="1"` set before eval: value is still `"1"` afterwards (was `"0"` before this change).
- With the default: value is `"0"` afterwards, identical to previous behavior.

`ruff check` clean, AST parses.
