### PR TITLE
Studio: model selector and settings polish

### DIFF
--- a/studio/frontend/src/components/assistant-ui/model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector.tsx
@@ -189,7 +189,7 @@ function ModelSelectorTrigger({
           <HugeiconsIcon
             icon={ArrowDown01Icon}
             strokeWidth={1.75}
-            className="relative top-0.5 size-3.5 text-muted-foreground"
+            className="size-3.5 text-muted-foreground"
           />
         </span>
       </button>
@@ -247,7 +247,7 @@ function ModelSelectorContent({
       alignOffset={10}
       data-tour={dataTour}
       className={cn(
-        "unsloth-model-selector-menu menu-soft-surface ring-0 w-[min(440px,calc(100vw-1rem))] max-w-[calc(100vw-1rem)] min-w-0 gap-0 p-3",
+        "unsloth-model-selector-menu menu-soft-surface ring-0 w-[min(440px,calc(100vw-1rem))] max-w-[calc(100vw-1rem)] min-w-0 gap-0 px-3 pt-3 pb-2",
         className,
       )}
     >
@@ -307,7 +307,7 @@ function ModelSelectorContent({
       )}
 
       {onPickLocalModel ? (
-        <div className="mt-2 border-t border-border/70 pt-2">
+        <div className="mt-1.5 border-t border-border/70 pt-1.5">
           <button
             type="button"
             onClick={onPickLocalModel}
@@ -320,7 +320,7 @@ function ModelSelectorContent({
         </div>
       ) : null}
       {hasSelection && onEject ? (
-        <div className="mt-2 border-t border-border/70 pt-2">
+        <div className="mt-1.5 border-t border-border/70 pt-1.5">
           <button
             type="button"
             onClick={onEject}

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1061,9 +1061,12 @@ export function ChatSettingsPanel({
                 )}
               </>
             )}
-            <ChatTemplateFields />
+            {/* Apply/Reset belongs to the model-reload settings above (context
+                length, KV cache, speculative decoding). Render it here, before
+                the Chat Template row, so it never reads as attached to Chat
+                Template (which is edited via its own dialog). */}
             {modelSettingsDirty && (
-              <div className="flex flex-wrap gap-1.5 pt-1">
+              <div className="flex flex-wrap gap-1.5">
                 <Button
                   type="button"
                   onClick={() => onReloadModel?.()}
@@ -1089,6 +1092,7 @@ export function ChatSettingsPanel({
                 </Button>
               </div>
             )}
+            <ChatTemplateFields />
           </div>
         </CollapsibleSection>
         )}

--- a/studio/frontend/src/features/chat/components/project-switcher.tsx
+++ b/studio/frontend/src/features/chat/components/project-switcher.tsx
@@ -62,7 +62,7 @@ export function ProjectSwitcher({
             <HugeiconsIcon
               icon={ArrowDown01Icon}
               strokeWidth={1.75}
-              className="relative top-0.5 size-3.5 text-muted-foreground"
+              className="size-3.5 text-muted-foreground"
               aria-hidden={true}
             />
           </span>

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -139,7 +139,7 @@ export function SettingsDialog() {
           {t("settings.dialog.description")}
         </DialogDescription>
         <div className="flex h-full min-h-0 max-sm:flex-col">
-          <aside className="font-heading flex w-[216px] shrink-0 flex-col border-r border-border bg-muted/20 p-2 dark:border-r-0 max-sm:w-full max-sm:border-r-0 max-sm:border-b max-sm:border-border">
+          <aside className="font-heading flex w-[216px] shrink-0 flex-col border-r border-sidebar-border bg-muted/20 p-2 dark:border-r-0 max-sm:w-full max-sm:border-r-0 max-sm:border-b max-sm:border-sidebar-border">
             <h2 className="pl-3 pr-2.5 pt-3.5 pb-3.5 text-[19px] font-semibold text-foreground max-sm:hidden">
               {t("settings.dialog.title")}
             </h2>

--- a/studio/frontend/src/features/settings/tabs/about-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/about-tab.tsx
@@ -134,7 +134,7 @@ export function AboutTab() {
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-1">
-        <h1 className="text-lg font-semibold font-heading">
+        <h1 className="text-xl font-semibold font-heading">
           {t("settings.about.title")}
         </h1>
         <p className="text-xs text-muted-foreground">

--- a/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
@@ -86,7 +86,7 @@ export function ApiKeysTab() {
   return (
     <div className="flex min-w-0 max-w-full flex-col gap-6">
       <header className="flex min-w-0 flex-col gap-1">
-        <h1 className="text-lg font-semibold font-heading">
+        <h1 className="text-xl font-semibold font-heading">
           {t("settings.apiKeys.title")}
         </h1>
         <p className="text-xs text-muted-foreground">

--- a/studio/frontend/src/features/settings/tabs/appearance-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/appearance-tab.tsx
@@ -15,7 +15,7 @@ export function AppearanceTab() {
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-1">
-        <h1 className="text-lg font-semibold font-heading">
+        <h1 className="text-xl font-semibold font-heading">
           {t("settings.appearance.title")}
         </h1>
         <p className="text-xs text-muted-foreground">

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -244,7 +244,7 @@ export function GeneralTab() {
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-1">
-        <h1 className="text-lg font-semibold font-heading">
+        <h1 className="text-xl font-semibold font-heading">
           {t("settings.general.title")}
         </h1>
         <p className="text-xs text-muted-foreground">

--- a/studio/frontend/src/features/settings/tabs/profile-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/profile-tab.tsx
@@ -10,7 +10,7 @@ export function ProfileTab() {
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-1">
-        <h1 className="text-lg font-semibold font-heading">
+        <h1 className="text-xl font-semibold font-heading">
           {t("settings.profile.title")}
         </h1>
         <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
### What this does

Small UI fixes across the model selector, run settings, and the settings dialog.

### Changes

- `components/assistant-ui/model-selector.tsx`: the popover loses the empty band under "Eject loaded model" (tighter bottom padding plus tighter footer spacing for the eject and pick-from-disk rows), and the trigger chevron is vertically centered by dropping its `top-0.5` nudge.
- `features/chat/components/project-switcher.tsx`: same chevron centering for the Projects trigger.
- `features/chat/chat-settings-sheet.tsx`: the model reload Apply and Reset buttons now render above Chat Template, directly under the settings they actually apply (context length, KV cache dtype, speculative decoding). They previously appeared right below the Chat Template row and read as belonging to it, even though Chat Template is edited through its own dialog.
- `features/settings/settings-dialog.tsx`: the left nav divider uses `border-sidebar-border` so it matches the main sidebar line in light mode instead of the slightly warmer `border-border`.
- `features/settings/tabs/*`: tab headings go from `text-lg` to `text-xl`. The chat tab gets the same bump in the plus menu PR since that PR owns the file.

### Notes

- Verified in a local build: model selector bottom spacing with a loaded model, centered chevrons, Apply and Reset placement when changing the KV cache dtype, and the settings divider color.
