### PR TITLE
Run cross-platform parity test on Windows and macOS in CI

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Runs tests/python/test_cross_platform_parity.py on Windows and macOS.
+#
+# Why: that test is the guard that install.sh and install.ps1 stay in
+# sync, but today it only runs on ubuntu-latest (auto-discovered by
+# studio-backend-ci.yml's "Repo tests (CPU)" job). The test reads both
+# installer scripts, and on Windows Path.read_text() defaults to the
+# cp1252 locale encoding, so a non-cp1252 byte in install.sh (it already
+# contains a U+274C) raises UnicodeDecodeError there even though Linux and
+# macOS default to UTF-8. The reads were pinned to encoding="utf-8" in
+# #6166; this job keeps that from silently regressing by exercising the
+# test on the platforms it claims parity for. Pure pytest, no GPU,
+# sub-second, so the matrix is cheap.
+
+name: Cross-platform parity
+
+on:
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'install.ps1'
+      - 'tests/python/test_cross_platform_parity.py'
+      - '.github/workflows/cross-platform-parity-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'install.sh'
+      - 'install.ps1'
+      - 'tests/python/test_cross_platform_parity.py'
+      - '.github/workflows/cross-platform-parity-ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    name: parity (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - run: python -m pip install -U pip pytest
+      - name: Cross-platform parity test
+        run: python -m pytest tests/python/test_cross_platform_parity.py -q


### PR DESCRIPTION
## Summary

Adds a small CI job that runs `tests/python/test_cross_platform_parity.py` on `windows-latest` and `macos-latest`.

## Why

That test is the guard that `install.sh` and `install.ps1` stay in sync, but today it only runs on `ubuntu-latest` (auto-discovered by `studio-backend-ci.yml`'s "Repo tests (CPU)" job). The test reads both installer scripts, and on Windows `Path.read_text()` defaults to the cp1252 locale encoding, so a non-cp1252 byte in `install.sh` (it already contains a U+274C) raises `UnicodeDecodeError` there, even though Linux and macOS default to UTF-8.

#6166 hit exactly this: its new tests, and the existing ones, failed on Windows until the reads were pinned to `encoding="utf-8"`. Because the parity test never ran on Windows, the breakage was invisible in CI. This job closes that gap so a future non-UTF-8 character in either installer cannot silently regress the test.

## Notes

- Pure pytest, no GPU, sub-second, so the Windows + macOS matrix is cheap.
- Scoped with a `paths` filter to `install.sh`, `install.ps1`, the test file, and this workflow, so it only runs when relevant.
- ubuntu is intentionally not duplicated here; it is already covered by `studio-backend-ci.yml`.
