### PR TITLE
Studio: install optional RAG dependencies on demand

### DIFF
--- a/studio/backend/core/rag/deps.py
+++ b/studio/backend/core/rag/deps.py
@@ -42,7 +42,6 @@ def missing_packages() -> list[str]:
 
 def status() -> dict:
     from storage import rag_db
-
     return {
         "available": rag_db.RAG_AVAILABLE,
         "installing": _installing,
@@ -109,6 +108,4 @@ def ensure_async(*, force: bool = False) -> None:
             rag_db.refresh_rag_available()
             return
         _installing, _error = True, None
-    threading.Thread(
-        target = _install, args = (missing,), name = "rag-deps-install", daemon = True
-    ).start()
+    threading.Thread(target = _install, args = (missing,), name = "rag-deps-install", daemon = True).start()

--- a/studio/backend/core/rag/deps.py
+++ b/studio/backend/core/rag/deps.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""On-demand install of the optional RAG Python dependencies.
+
+The no-torch Studio install omits the RAG group, so RAG starts disabled. On
+first use while unavailable, ``ensure_async()`` pip-installs the pinned group
+(matching ``studio.txt``) in the background and re-enables RAG via
+``rag_db.refresh_rag_available()`` without a restart.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import shutil
+import subprocess
+import sys
+import threading
+
+logger = logging.getLogger(__name__)
+
+# (pip requirement spec, import name)
+_RAG_PACKAGES = (
+    ("sqlite-vec==0.1.9", "sqlite_vec"),
+    ("pymupdf==1.27.2.3", "pymupdf"),
+    ("python-docx==1.2.0", "docx"),
+)
+
+_INSTALL_TIMEOUT_S = 600
+
+_lock = threading.Lock()
+_installing = False
+_error: str | None = None
+
+
+def missing_packages() -> list[str]:
+    """Requirement specs whose import is not resolvable in this interpreter."""
+    return [req for req, mod in _RAG_PACKAGES if importlib.util.find_spec(mod) is None]
+
+
+def status() -> dict:
+    from storage import rag_db
+
+    return {
+        "available": rag_db.RAG_AVAILABLE,
+        "installing": _installing,
+        "missing": missing_packages(),
+        "error": _error,
+    }
+
+
+def _pip_install_cmd(*args: str) -> list[str]:
+    """`uv pip install` if uv is on PATH, else `python -m pip install`."""
+    if shutil.which("uv"):
+        return ["uv", "pip", "install", "--python", sys.executable, *args]
+    return [sys.executable, "-m", "pip", "install", *args]
+
+
+def _install(reqs: list[str]) -> None:
+    global _installing, _error
+    try:
+        logger.info("Installing RAG dependencies: %s", " ".join(reqs))
+        result = subprocess.run(
+            _pip_install_cmd(*reqs),
+            stdout = subprocess.PIPE,
+            stderr = subprocess.STDOUT,
+            text = True,
+            timeout = _INSTALL_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            _error = f"pip install failed: {(result.stdout or '').strip()[-500:]}"
+            logger.warning("RAG dependency install failed:\n%s", result.stdout)
+            return
+        importlib.invalidate_caches()
+        from storage import rag_db
+
+        rag_db.refresh_rag_available()
+        _error = None
+        logger.info("RAG dependencies installed; available=%s", rag_db.RAG_AVAILABLE)
+    except subprocess.TimeoutExpired:
+        _error = "RAG dependency install timed out."
+        logger.warning(_error)
+    except Exception as exc:  # noqa: BLE001 - report any install failure, never crash
+        _error = f"{type(exc).__name__}: {exc}"
+        logger.warning("RAG dependency install error: %s", exc)
+    finally:
+        _installing = False
+
+
+def ensure_async(*, force: bool = False) -> None:
+    """Start a background install of any missing RAG deps. Idempotent, non-blocking.
+
+    No-op if RAG is available or an install is running. A prior failure is
+    sticky so the status poller cannot respin pip; ``force`` (Retry) clears it
+    and re-attempts. If the deps are already present, just re-checks the import.
+    """
+    from storage import rag_db
+
+    if rag_db.RAG_AVAILABLE:
+        return
+    global _installing, _error
+    with _lock:
+        if _installing or (_error is not None and not force):
+            return
+        missing = missing_packages()
+        if not missing:
+            rag_db.refresh_rag_available()
+            return
+        _installing, _error = True, None
+    threading.Thread(
+        target = _install, args = (missing,), name = "rag-deps-install", daemon = True
+    ).start()

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -24,7 +24,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from auth.authentication import get_current_subject
-from core.rag import config, ingestion, retrieval, store
+from core.rag import config, deps, ingestion, retrieval, store
 from storage import rag_db
 from utils.paths import ensure_dir, rag_uploads_root
 
@@ -34,11 +34,38 @@ router = APIRouter()
 
 
 def _require_rag() -> None:
-    if not rag_db.RAG_AVAILABLE:
-        raise HTTPException(
-            status_code = 503,
-            detail = "RAG is unavailable: the sqlite-vec extension could not be loaded.",
-        )
+    """Gate every RAG endpoint. When unavailable, start a one-time background
+    install of the RAG deps and 503 with the current state, so the UI can poll
+    /status and retry once it finishes."""
+    if rag_db.RAG_AVAILABLE or rag_db.refresh_rag_available():
+        return
+    deps.ensure_async()
+    st = deps.status()
+    if st["installing"]:
+        detail = "Setting up RAG (installing dependencies). Please retry shortly."
+    elif st["error"]:
+        detail = f"RAG setup failed: {st['error']}"
+    else:
+        detail = "RAG is unavailable: the sqlite-vec extension could not be loaded."
+    raise HTTPException(status_code = 503, detail = detail)
+
+
+@router.get("/status")
+def rag_status(subject: str = Depends(get_current_subject)) -> dict:
+    """RAG availability + dependency-install state for the UI to poll. Triggers
+    the background install when unavailable (idempotent)."""
+    if not (rag_db.RAG_AVAILABLE or rag_db.refresh_rag_available()):
+        deps.ensure_async()
+    return deps.status()
+
+
+@router.post("/install")
+def rag_install(subject: str = Depends(get_current_subject)) -> dict:
+    """Force a retry of the RAG dependency install (the UI Retry button),
+    clearing a prior sticky failure."""
+    if not (rag_db.RAG_AVAILABLE or rag_db.refresh_rag_available()):
+        deps.ensure_async(force = True)
+    return deps.status()
 
 
 _SAFE = re.compile(r"[^A-Za-z0-9._-]+")

--- a/studio/backend/storage/rag_db.py
+++ b/studio/backend/storage/rag_db.py
@@ -14,6 +14,7 @@ by ensure_vec once the embedding dim is known, since vec0 bakes the dim into the
 column type).
 """
 
+import importlib
 import logging
 import sqlite3
 import threading
@@ -22,14 +23,41 @@ logger = logging.getLogger(__name__)
 
 from utils.paths import rag_db_path, ensure_dir
 
-# Optional dep: import must never crash this module (imported unconditionally).
-try:
-    import sqlite_vec
-    RAG_AVAILABLE = True
-except Exception as exc:  # noqa: BLE001 - any import failure disables RAG
-    sqlite_vec = None
-    RAG_AVAILABLE = False
-    logger.warning("RAG unavailable: sqlite-vec could not be imported (%s)", exc)
+# Optional dep: never crash on import. Module globals so a runtime install
+# (core/rag/deps.py) can re-enable RAG via refresh_rag_available(), no restart.
+sqlite_vec = None
+RAG_AVAILABLE = False
+_import_lock = threading.Lock()
+
+
+def _try_import_sqlite_vec() -> bool:
+    global sqlite_vec, RAG_AVAILABLE
+    try:
+        import sqlite_vec as _sv
+    except Exception as exc:  # noqa: BLE001 - any import failure disables RAG
+        sqlite_vec, RAG_AVAILABLE = None, False
+        logger.warning("RAG unavailable: sqlite-vec could not be imported (%s)", exc)
+    else:
+        sqlite_vec, RAG_AVAILABLE = _sv, True
+    return RAG_AVAILABLE
+
+
+def refresh_rag_available() -> bool:
+    """Re-attempt the sqlite-vec import after a possible runtime install.
+
+    Fast no-op once available; otherwise invalidates import caches and retries
+    (a failed import is never cached in sys.modules). Thread-safe.
+    """
+    if RAG_AVAILABLE:
+        return True
+    with _import_lock:
+        if RAG_AVAILABLE:
+            return True
+        importlib.invalidate_caches()
+        return _try_import_sqlite_vec()
+
+
+_try_import_sqlite_vec()
 
 _RAG_UNAVAILABLE_MSG = "RAG unavailable: sqlite-vec extension could not be loaded"
 

--- a/studio/backend/tests/test_rag_deps.py
+++ b/studio/backend/tests/test_rag_deps.py
@@ -82,15 +82,18 @@ def test_status_shape(monkeypatch):
 def test_pip_install_cmd_prefers_uv(monkeypatch):
     monkeypatch.setattr(deps.shutil, "which", lambda name: "/usr/bin/uv")
     assert deps._pip_install_cmd("x==1") == [
-        "uv", "pip", "install", "--python", sys.executable, "x==1",
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        sys.executable,
+        "x==1",
     ]
 
 
 def test_pip_install_cmd_falls_back_to_pip(monkeypatch):
     monkeypatch.setattr(deps.shutil, "which", lambda name: None)
-    assert deps._pip_install_cmd("x==1") == [
-        sys.executable, "-m", "pip", "install", "x==1",
-    ]
+    assert deps._pip_install_cmd("x==1") == [sys.executable, "-m", "pip", "install", "x==1"]
 
 
 # _install body

--- a/studio/backend/tests/test_rag_deps.py
+++ b/studio/backend/tests/test_rag_deps.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unit tests for the on-demand RAG dependency installer.
+
+Real pip is never invoked: ``subprocess.run`` / ``find_spec`` / the sqlite-vec
+import are monkeypatched so the install-to-available transition, idempotency,
+the sticky-failure guard and pip command construction are checked in isolation.
+Module globals are saved and restored per test.
+"""
+
+import subprocess
+import sys
+import time
+import types
+
+import pytest
+
+from core.rag import deps
+from storage import rag_db
+
+
+@pytest.fixture(autouse = True)
+def _reset_state():
+    saved = (rag_db.RAG_AVAILABLE, rag_db.sqlite_vec, deps._installing, deps._error)
+    had_module = "sqlite_vec" in sys.modules
+    saved_module = sys.modules.get("sqlite_vec")
+    yield
+    rag_db.RAG_AVAILABLE, rag_db.sqlite_vec, deps._installing, deps._error = saved
+    if had_module:
+        sys.modules["sqlite_vec"] = saved_module
+    else:
+        sys.modules.pop("sqlite_vec", None)
+
+
+def _recording_thread(counter):
+    class _Thread:
+        def __init__(self, *args, **kwargs):
+            self.target = kwargs.get("target")
+            self.args = kwargs.get("args", ())
+
+        def start(self):
+            counter["n"] += 1
+
+    return _Thread
+
+
+# missing_packages
+
+
+def test_missing_packages_none_when_all_present(monkeypatch):
+    monkeypatch.setattr(deps.importlib.util, "find_spec", lambda name: object())
+    assert deps.missing_packages() == []
+
+
+def test_missing_packages_reports_absent_spec(monkeypatch):
+    monkeypatch.setattr(
+        deps.importlib.util,
+        "find_spec",
+        lambda name: None if name == "docx" else object(),
+    )
+    assert deps.missing_packages() == ["python-docx==1.2.0"]
+
+
+# status
+
+
+def test_status_shape(monkeypatch):
+    monkeypatch.setattr(deps.importlib.util, "find_spec", lambda name: object())
+    rag_db.RAG_AVAILABLE = True
+    st = deps.status()
+    assert set(st) == {"available", "installing", "missing", "error"}
+    assert st["available"] is True
+    assert st["installing"] is False
+    assert st["missing"] == []
+    assert st["error"] is None
+
+
+# pip command construction
+
+
+def test_pip_install_cmd_prefers_uv(monkeypatch):
+    monkeypatch.setattr(deps.shutil, "which", lambda name: "/usr/bin/uv")
+    assert deps._pip_install_cmd("x==1") == [
+        "uv", "pip", "install", "--python", sys.executable, "x==1",
+    ]
+
+
+def test_pip_install_cmd_falls_back_to_pip(monkeypatch):
+    monkeypatch.setattr(deps.shutil, "which", lambda name: None)
+    assert deps._pip_install_cmd("x==1") == [
+        sys.executable, "-m", "pip", "install", "x==1",
+    ]
+
+
+# _install body
+
+
+def test_install_success_enables_rag(monkeypatch):
+    seen = {}
+
+    def fake_run(cmd, **kw):
+        seen["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout = "ok")
+
+    monkeypatch.setattr(deps.subprocess, "run", fake_run)
+
+    def fake_refresh():
+        rag_db.RAG_AVAILABLE = True
+        return True
+
+    monkeypatch.setattr(rag_db, "refresh_rag_available", fake_refresh)
+    rag_db.RAG_AVAILABLE, deps._installing, deps._error = False, True, None
+
+    deps._install(["x==1"])
+
+    assert "x==1" in seen["cmd"]
+    assert deps._installing is False
+    assert deps._error is None
+    assert rag_db.RAG_AVAILABLE is True
+
+
+def test_install_failure_records_error(monkeypatch):
+    monkeypatch.setattr(
+        deps.subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, stdout = "boom"),
+    )
+    rag_db.RAG_AVAILABLE, deps._installing, deps._error = False, True, None
+
+    deps._install(["x==1"])
+
+    assert deps._installing is False
+    assert deps._error and "pip install failed" in deps._error
+
+
+# ensure_async gating
+
+
+def test_ensure_async_noop_when_available(monkeypatch):
+    spawned = {"n": 0}
+    monkeypatch.setattr(deps.threading, "Thread", _recording_thread(spawned))
+    rag_db.RAG_AVAILABLE = True
+    deps.ensure_async()
+    assert spawned["n"] == 0
+
+
+def test_ensure_async_error_is_sticky_without_force(monkeypatch):
+    spawned = {"n": 0}
+    monkeypatch.setattr(deps.threading, "Thread", _recording_thread(spawned))
+    monkeypatch.setattr(deps, "missing_packages", lambda: ["x==1"])
+    rag_db.RAG_AVAILABLE, deps._installing, deps._error = False, False, "prev"
+
+    deps.ensure_async()
+    assert spawned["n"] == 0  # not retried automatically
+
+    deps.ensure_async(force = True)
+    assert spawned["n"] == 1  # forced retry spawns and clears the error
+    assert deps._installing is True
+    assert deps._error is None
+
+
+def test_ensure_async_installs_and_enables(monkeypatch):
+    monkeypatch.setattr(deps, "missing_packages", lambda: ["x==1"])
+    monkeypatch.setattr(
+        deps.subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout = "ok"),
+    )
+
+    def fake_refresh():
+        rag_db.RAG_AVAILABLE = True
+        return True
+
+    monkeypatch.setattr(rag_db, "refresh_rag_available", fake_refresh)
+    rag_db.RAG_AVAILABLE, deps._installing, deps._error = False, False, None
+
+    deps.ensure_async()
+    deadline = time.time() + 5
+    while deps.status()["installing"] and time.time() < deadline:
+        time.sleep(0.02)
+
+    assert rag_db.RAG_AVAILABLE is True
+    assert deps._installing is False
+    assert deps._error is None
+
+
+# refresh_rag_available re-check
+
+
+def test_refresh_rag_available_noop_when_true():
+    rag_db.RAG_AVAILABLE = True
+    assert rag_db.refresh_rag_available() is True
+
+
+def test_refresh_rag_available_rechecks_after_install():
+    fake = types.ModuleType("sqlite_vec")
+    sys.modules["sqlite_vec"] = fake
+    rag_db.RAG_AVAILABLE, rag_db.sqlite_vec = False, None
+
+    assert rag_db.refresh_rag_available() is True
+    assert rag_db.RAG_AVAILABLE is True
+    assert rag_db.sqlite_vec is fake

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -397,6 +397,10 @@ type ChatRuntimeStore = {
   allowArtifactNetworkAccess: boolean;
   mcpEnabledForChat: boolean;
   ragEnabled: boolean;
+  // Backend RAG availability + on-demand dependency-install state (null = unknown).
+  ragAvailable: boolean | null;
+  ragInstalling: boolean;
+  ragSetupError: string | null;
   ragSource: RagSource;
   ragMode: RagMode;
   ragTopK: number;
@@ -522,6 +526,11 @@ type ChatRuntimeStore = {
   clearToolConfirmation: (toolCallId: string) => void;
   setWebFetchToolsEnabled: (enabled: boolean) => void;
   setRagEnabled: (enabled: boolean) => void;
+  setRagStatus: (s: {
+    available: boolean;
+    installing: boolean;
+    error: string | null;
+  }) => void;
   setRagSource: (source: RagSource) => void;
   setRagMode: (mode: RagMode) => void;
   setRagTopK: (topK: number) => void;
@@ -793,6 +802,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   webFetchToolsEnabled: loadBool(CHAT_WEB_FETCH_TOOLS_ENABLED_KEY, false),
   // RAG is opt-in per session: always starts off, never restored from storage.
   ragEnabled: false,
+  ragAvailable: null,
+  ragInstalling: false,
+  ragSetupError: null,
   ragSource: loadRagSource(),
   ragMode: loadRagMode(),
   ragTopK: loadRagTopK(),
@@ -1159,6 +1171,12 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       return { webFetchToolsEnabled };
     }),
   setRagEnabled: (ragEnabled) => set(() => ({ ragEnabled })),
+  setRagStatus: ({ available, installing, error }) =>
+    set(() => ({
+      ragAvailable: available,
+      ragInstalling: installing,
+      ragSetupError: error,
+    })),
   setRagSource: (ragSource) =>
     set(() => {
       saveRagSource(ragSource);

--- a/studio/frontend/src/features/rag/api/rag-api.ts
+++ b/studio/frontend/src/features/rag/api/rag-api.ts
@@ -52,6 +52,23 @@ async function ragUpload(path: string, file: File): Promise<DocumentUploadResult
   return json as DocumentUploadResult;
 }
 
+export interface RagStatus {
+  available: boolean;
+  installing: boolean;
+  missing: string[];
+  error: string | null;
+}
+
+// Always 200; reports RAG availability + on-demand dependency install state.
+export function getRagStatus(): Promise<RagStatus> {
+  return ragRequest<RagStatus>("/status");
+}
+
+// Force-retry the dependency install after a failure (the UI Retry button).
+export function retryRagSetup(): Promise<RagStatus> {
+  return ragRequest<RagStatus>("/install", { method: "POST" });
+}
+
 export async function listKnowledgeBases(): Promise<KnowledgeBase[]> {
   const data = await ragRequest<{ knowledgeBases: KnowledgeBase[] }>(
     "/knowledge-bases",

--- a/studio/frontend/src/features/rag/components/knowledge-base-composer-button.tsx
+++ b/studio/frontend/src/features/rag/components/knowledge-base-composer-button.tsx
@@ -20,6 +20,7 @@ import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import { listKnowledgeBases } from "../api/rag-api";
 import type { KnowledgeBase } from "../types/rag";
 import { KnowledgeBaseDialog } from "./knowledge-base-dialog";
+import { useRagStatus } from "./use-rag-status";
 
 // Matches the Thinking/MCP pill chevron.
 const ArrowDownStandardIcon: FC<{ className?: string }> = ({ className }) => (
@@ -50,6 +51,11 @@ export function KnowledgeBaseComposerButton({
   const ragDisabled = useRagToolDisabled();
   const ragSource = useChatRuntimeStore((s) => s.ragSource);
   const setRagSource = useChatRuntimeStore((s) => s.setRagSource);
+
+  // Enabling RAG starts the one-time background dep install (status poll is the
+  // trigger). When still unavailable the menu shows a "setting up" line.
+  useRagStatus(ragEnabled);
+  const ragAvailable = useChatRuntimeStore((s) => s.ragAvailable);
 
   const [kbs, setKbs] = useState<KnowledgeBase[]>([]);
   const [kbsLoaded, setKbsLoaded] = useState(false);
@@ -141,6 +147,11 @@ export function KnowledgeBaseComposerButton({
           avoidCollisions={true}
           className="unsloth-plus-menu mcp-menu w-[232px]"
         >
+          {ragAvailable === false ? (
+            <DropdownMenuLabel className="font-normal text-muted-foreground">
+              Setting up RAG (installing dependencies)…
+            </DropdownMenuLabel>
+          ) : null}
           <DropdownMenuLabel>Retrieve from</DropdownMenuLabel>
           <DropdownMenuItem
             onSelect={() => setRagSource({ type: "thread" })}

--- a/studio/frontend/src/features/rag/components/knowledge-base-dialog.tsx
+++ b/studio/frontend/src/features/rag/components/knowledge-base-dialog.tsx
@@ -24,16 +24,20 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/lib/toast";
 
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+
 import {
   createKnowledgeBase,
   deleteKnowledgeBase,
   listKnowledgeBaseDocuments,
   listKnowledgeBases,
+  retryRagSetup,
   updateKnowledgeBase,
 } from "../api/rag-api";
 import { RAG_UPLOAD_ACCEPT, type KnowledgeBase } from "../types/rag";
 import { DocumentStatusChip } from "./document-status-chip";
 import { useRagDocuments } from "./use-rag-documents";
+import { useRagStatus } from "./use-rag-status";
 
 type View =
   | { kind: "list" }
@@ -57,11 +61,21 @@ export function KnowledgeBaseDialog({
   const [description, setDescription] = useState("");
   const [saving, setSaving] = useState(false);
 
+  // Poll RAG status while the dialog is open; this also triggers the one-time
+  // background install of the RAG deps when they are missing.
+  useRagStatus(open);
+  const ragAvailable = useChatRuntimeStore((s) => s.ragAvailable);
+  const ragInstalling = useChatRuntimeStore((s) => s.ragInstalling);
+  const ragSetupError = useChatRuntimeStore((s) => s.ragSetupError);
+
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
       setKbs(await listKnowledgeBases());
     } catch (err) {
+      // While the deps are still installing the list endpoint 503s; the setup
+      // notice already explains that, so don't also toast.
+      if (useChatRuntimeStore.getState().ragAvailable === false) return;
       toast.error("Failed to load knowledge bases", {
         description: err instanceof Error ? err.message : String(err),
       });
@@ -75,6 +89,11 @@ export function KnowledgeBaseDialog({
     setView({ kind: "list" });
     void refresh();
   }, [open, refresh]);
+
+  // Reload once the deps finish installing and RAG flips to available.
+  useEffect(() => {
+    if (open && ragAvailable === true) void refresh();
+  }, [open, ragAvailable, refresh]);
 
   function startCreate() {
     setName("");
@@ -162,6 +181,16 @@ export function KnowledgeBaseDialog({
 
         {view.kind === "documents" ? (
           <KnowledgeBaseDocuments kb={view.kb} onBack={backToList} />
+        ) : ragAvailable === false ? (
+          <RagSetupNotice
+            installing={ragInstalling}
+            error={ragSetupError}
+            onRetry={() => {
+              void retryRagSetup().then((s) =>
+                useChatRuntimeStore.getState().setRagStatus(s),
+              );
+            }}
+          />
         ) : showForm ? (
           <div className="flex flex-col gap-4">
             <div className="grid gap-2">
@@ -256,6 +285,38 @@ export function KnowledgeBaseDialog({
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function RagSetupNotice({
+  installing,
+  error,
+  onRetry,
+}: {
+  installing: boolean;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  if (error && !installing) {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-md border border-dashed py-10 text-center">
+        <p className="text-sm font-medium">RAG setup failed</p>
+        <p className="max-w-md text-xs text-muted-foreground">{error}</p>
+        <Button size="sm" variant="outline" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-md border border-dashed py-10 text-center">
+      <Spinner />
+      <p className="text-sm font-medium">Setting up RAG (installing dependencies)…</p>
+      <p className="max-w-md text-xs text-muted-foreground">
+        This runs once and takes a moment. This view updates automatically when
+        it is ready.
+      </p>
+    </div>
   );
 }
 

--- a/studio/frontend/src/features/rag/components/use-rag-status.ts
+++ b/studio/frontend/src/features/rag/components/use-rag-status.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useEffect } from "react";
+
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { getRagStatus } from "@/features/rag/api/rag-api";
+
+const RAG_STATUS_POLL_MS = 2000;
+
+/**
+ * Polls `GET /api/rag/status` into the store while `active` and RAG is not yet
+ * available, surfacing a "setting up RAG" state; the poll itself triggers the
+ * background install. Visibility-aware; stops once available.
+ */
+export function useRagStatus(active: boolean): void {
+  const setRagStatus = useChatRuntimeStore((s) => s.setRagStatus);
+  const available = useChatRuntimeStore((s) => s.ragAvailable);
+
+  useEffect(() => {
+    if (!active || available === true) return;
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const s = await getRagStatus();
+        if (!cancelled) setRagStatus(s);
+      } catch {
+        // Transient network/auth error; the next tick retries.
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === "visible") void poll();
+    }, RAG_STATUS_POLL_MS);
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") void poll();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [active, available, setRagStatus]);
+}


### PR DESCRIPTION
## Summary

The lightweight no-torch Studio install does not ship the RAG group (`sqlite-vec`, `pymupdf`, `python-docx`), so a fresh `--local` install starts with RAG disabled and the user hits `RAG is unavailable: the sqlite-vec extension could not be loaded` (and later `No module named 'docx'`).

This makes RAG self-heal at runtime: the first time RAG is used while unavailable, Studio installs the pinned RAG group in a background thread and re-enables RAG without a server restart.

It complements the static requirements pin in #6236 (offline installs still need the dependency present up front); it does not change the torch/GPU path, which already ships the RAG group via `studio.txt`.

## Backend

- `storage/rag_db.py`: the `sqlite-vec` import is now re-checkable via `refresh_rag_available()` (thread-safe, `importlib.invalidate_caches()` then retry), so a runtime install takes effect in-process. The import is still attempted once at module load, preserving current behaviour.
- `core/rag/deps.py` (new): `ensure_async()` installs the missing pins (same versions as `studio.txt`) with `uv pip` when available, falling back to `python -m pip`, then re-enables RAG. It is idempotent and non-blocking. A failure is sticky so the status poller does not respin pip; `force=True` (Retry) clears the error and re-attempts.
- `routes/rag.py`: `_require_rag()` triggers the install and returns a `503` whose detail reflects state (installing, failed, or unavailable). `GET /api/rag/status` lets the UI poll availability and is itself the implicit trigger, and `POST /api/rag/install` forces a retry.

## Frontend

- `use-rag-status.ts` (new): a visibility-aware poller that writes availability into the chat runtime store; polling is the implicit install trigger.
- The knowledge-base dialog shows a `Setting up RAG (installing dependencies)` notice with a Retry on failure, and the composer RAG menu shows an inline setup line. Enabling "Chat with Files" starts the install.

## Tests

`studio/backend/tests/test_rag_deps.py` covers `missing_packages`, `status` shape, pip command construction (uv vs pip), `ensure_async` idempotency and the sticky-failure guard, the install-to-available transition (with `subprocess.run` and the import monkeypatched, so no real pip runs), and `refresh_rag_available`.

## Verification

- `pytest studio/backend/tests/test_rag_deps.py`: 12 passed. Existing RAG and route suites stay green.
- Frontend `tsc -b` typecheck clean.
- End-to-end in a clean virtualenv with the RAG group absent: status started unavailable with the three packages missing, the first poll kicked off the background install, and availability flipped to ready with no restart.
