### PR TITLE
Studio: use px-2.5 for Hub option menu padding

### DIFF
--- a/studio/frontend/src/features/hub/catalog/hub-option-menu.tsx
+++ b/studio/frontend/src/features/hub/catalog/hub-option-menu.tsx
@@ -185,7 +185,7 @@ export function HubOptionMenu<T extends string>({
         collisionPadding={12}
         onCloseAutoFocus={(event) => event.preventDefault()}
         className={cn(
-          "hub-menu-instant menu-soft-surface w-max min-w-[var(--radix-popover-trigger-width)] max-w-[min(var(--radix-popover-content-available-width),calc(100vw-1rem))] rounded-[22px] px-[10px] py-2 ring-0",
+          "hub-menu-instant menu-soft-surface w-max min-w-[var(--radix-popover-trigger-width)] max-w-[min(var(--radix-popover-content-available-width),calc(100vw-1rem))] rounded-[22px] px-2.5 py-2 ring-0",
           contentClassName,
         )}
       >


### PR DESCRIPTION
### What this does

Follow-up to #6248. Swaps the one arbitrary `px-[10px]` on the Hub option menu surface for the standard `px-2.5` utility, addressing the review note on that PR.

Both resolve to exactly `10px` (`0.625rem` at the default 16px root), so this is a no-op visually and only keeps the menu padding on the standard Tailwind spacing scale. The composer "+" menu it mirrors uses a literal `10px` in `index.css`, so the two stay aligned.

### Notes

- Single-line change, no behavior or visual change.
- Verified in a local build that `px-2.5` computes to `10px`, identical to the previous value.
