### PR TITLE
Fix Studio S3 dataset panel layout

### DIFF
--- a/studio/frontend/src/features/studio/sections/s3-config-form.tsx
+++ b/studio/frontend/src/features/studio/sections/s3-config-form.tsx
@@ -19,7 +19,7 @@ const DEFAULT_S3_CONFIG: S3Config = {
 };
 
 /**
- * Inline S3 dataset configuration card. Shown in the dataset section when the
+ * Inline S3 dataset configuration form. Shown in the dataset section when the
  * selected source is "s3"; reads and writes the shared training-config store.
  */
 export function S3ConfigForm() {
@@ -46,7 +46,7 @@ export function S3ConfigForm() {
   };
 
   return (
-    <div className="flex min-w-0 flex-col gap-3 rounded-lg border bg-muted/20 px-3.5 py-3">
+    <div className="flex min-w-0 flex-col gap-3">
       <div>
         <p className="text-xs font-medium text-foreground">
           {t("studio.dataset.s3.title")}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1568,11 +1568,11 @@
 
 	/* Fine-tuning Studio: equal default height, expandable when needed (md+) */
 	.min-h-studio-config-column {
-		@apply md:min-h-[470px];
+		@apply md:min-h-[520px];
 	}
 
 	.h-studio-config-column {
-		@apply md:h-[470px];
+		@apply md:h-[520px];
 	}
 
 	[data-streamdown="unordered-list"] {


### PR DESCRIPTION
## Summary
- increase the shared Studio config card height from 470px to 520px
- render S3 dataset settings inline instead of as a nested card inside Dataset

## Testing
- npm run build
- git diff --check
