### PR TITLE
Attach DiffusionGemma visual-server from the prebuilt bundle

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4768,8 +4768,10 @@ def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
     # repackage the SO/DLL set (e.g. ggml-org/llama.cpp#23462 split the
     # per-binary entry code into paired ``lib<binary>-impl.so`` shared
     # libraries between b9279 and b9283) without us re-enumerating
-    # every new file. Studio only invokes llama-server and llama-quantize;
-    # other CLIs upstream ships (llama-cli, llama-bench, ...) are skipped.
+    # every new file. Studio invokes llama-server, llama-quantize, and the
+    # DiffusionGemma visual-server (when the bundle ships it, for native
+    # DiffusionGemma serving); other CLIs upstream ships (llama-cli,
+    # llama-bench, ...) are skipped.
     if choice.install_kind in {
         "linux-cpu",
         "linux-cuda",
@@ -4777,9 +4779,9 @@ def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
         "linux-rocm",
         "linux-arm64",
     }:
-        return ["llama-server", "llama-quantize", "lib*.so*"]
+        return ["llama-server", "llama-quantize", "llama-diffusion-gemma-visual-server", "lib*.so*"]
     if choice.install_kind in {"macos-arm64", "macos-x64"}:
-        return ["llama-server", "llama-quantize", "lib*.dylib"]
+        return ["llama-server", "llama-quantize", "llama-diffusion-gemma-visual-server", "lib*.dylib"]
     if choice.install_kind in {
         "windows-cpu",
         "windows-cuda",
@@ -4787,7 +4789,7 @@ def runtime_patterns_for_choice(choice: AssetChoice) -> list[str]:
         "windows-rocm",
         "windows-arm64",
     }:
-        return ["llama-server.exe", "llama-quantize.exe", "*.dll"]
+        return ["llama-server.exe", "llama-quantize.exe", "llama-diffusion-gemma-visual-server.exe", "*.dll"]
     raise PrebuiltFallback(f"unsupported install kind for runtime overlay: {choice.install_kind}")
 
 

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -393,6 +393,19 @@ class TestRuntimePatterns:
         patterns = runtime_patterns_for_choice(choice)
         assert "lib*.dylib" in patterns
 
+    def test_diffusion_visual_server_kept(self):
+        # The DiffusionGemma visual-server ships in the prebuilt bundle and must
+        # survive the prune so Studio can serve DiffusionGemma GGUFs natively.
+        for kind, name in (
+            ("linux-cuda", "llama-diffusion-gemma-visual-server"),
+            ("macos-arm64", "llama-diffusion-gemma-visual-server"),
+            ("windows-cuda", "llama-diffusion-gemma-visual-server.exe"),
+        ):
+            choice = AssetChoice(
+                repo = "", tag = "", name = "", url = "", source_label = "", install_kind = kind
+            )
+            assert name in runtime_patterns_for_choice(choice)
+
 
 # TEST: install_llama_prebuilt.py -- HostInfo.has_rocm field
 


### PR DESCRIPTION
## Summary

A fresh Studio install resolves and downloads the published llama.cpp prebuilt bundle (currently `unslothai/llama.cpp@b9601-mix-a0e2906`), which ships `llama-diffusion-gemma-visual-server` alongside `llama-server`. The runtime overlay allowlist in `runtime_patterns_for_choice` only kept `llama-server`, `llama-quantize` and the shared libs, so the visual-server was pruned during the staging copy and never made it into `build/bin`.

`ensure_diffusion_visual_server` runs after activation but, finding nothing in `build/bin` and no standalone release asset by that name, quietly skipped. The net effect: a from-`main` install could not serve DiffusionGemma GGUFs natively and fell back to requiring `DG_VISUAL_BIN` or a source build, even though the binary was already present in the downloaded bundle.

## Change

Add `llama-diffusion-gemma-visual-server` (`.exe` on Windows) to the runtime allowlist for Linux, macOS and Windows. The binary is copied into `build/bin` like `llama-server`, where the existing `ensure_diffusion_visual_server` `target.exists()` path marks it executable. Bundles that do not ship it are unaffected, since the other patterns still match and the copy is never empty.

## Verification

- Fresh `./install.sh --local` install on a CUDA host: `build/bin/llama-diffusion-gemma-visual-server` is now present (valid ELF, links against the bundled ggml/llama libs) and the Studio backend's visual-server lookup resolves it.
- Added a `TestRuntimePatterns` case asserting the visual-server is kept for the linux, macos and windows install kinds.
