### PR TITLE
DiffusionGemma Studio: disable tools, enable artifacts canvas by default

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1042,6 +1042,10 @@ class LlamaCppBackend:
 
     @property
     def supports_tools(self) -> bool:
+        # DiffusionGemma serves via the visual runner, whose live per-step canvas
+        # frames are dropped by the agentic tool loop; never route it through tools.
+        if self._is_diffusion:
+            return False
         return self._supports_tools
 
     @property

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -285,11 +285,14 @@ function CodeBlockActions({
 }
 
 // DiffusionGemma renders its denoising live in the bubble (see DiffusionCanvas in
-// thread.tsx), so it no longer forces HTML into an iframe artifact; it follows the
-// same artifact rules as every other model.
+// thread.tsx) and has the artifacts canvas on by default, so a full-HTML answer
+// (e.g. a playable game) renders as an interactive card without the global toggle.
 function StreamdownBlock(props: BlockProps) {
   const shouldCollapseHtmlArtifacts = useChatRuntimeStore(
-    (state) => state.artifactsEnabled || state.collapseHtmlArtifacts,
+    (state) =>
+      state.artifactsEnabled ||
+      state.collapseHtmlArtifacts ||
+      state.loadedIsDiffusion,
   );
   const messageHasRenderableRenderHtmlTool = useAuiState(({ message }) =>
     message.parts.some(isRenderableRenderHtmlToolPart),


### PR DESCRIPTION
## Summary

Three fixes so DiffusionGemma works end to end in Studio from a clean release install.

## 1. Set UNSLOTH_IS_PRESENT for the shim subprocess (fresh-install blocker)

The runner spawns `python -m unsloth_zoo.diffusion_studio.shim`. `unsloth_zoo/__init__.py` refuses to import unless `UNSLOTH_IS_PRESENT` is in the environment (normally set by `import unsloth`). The shim never imports `unsloth`, so on a clean install the subprocess died with `Please install Unsloth via pip install unsloth!` and the model load returned 500. The runner now sets `UNSLOTH_IS_PRESENT=1` in the child env, exactly as `unsloth` does on import.

## 2. Disable tools for DiffusionGemma

DiffusionGemma streams per-step canvas frames so the answer resolves live in the bubble. The agentic tool loop does not forward those `diffusion_frame` events, so whenever a tool pill (Search/Code) was on, the live canvas silently disappeared while text still streamed. `supports_tools` now returns `False` for `is_diffusion`: the chat always takes the frame-forwarding path, the Search/Code pills disable themselves (a local model has no builtin web search either), and `resolveToolsEnabledOnLoad` leaves tools off. Other models are unchanged.

## 3. Artifacts canvas on by default for DiffusionGemma

A full-HTML answer (for example a small playable game) now renders as an interactive sandboxed card for DiffusionGemma without the user flipping the global artifacts toggle. Scoped to diffusion via `loadedIsDiffusion`; other models keep the default behavior.

## Verification

- Launched Studio with `UNSLOTH_IS_PRESENT` stripped from the parent env (the clean-install condition): loading `unsloth/diffusiongemma-26B-A4B-it-GGUF` now returns 200, the shim child has `UNSLOTH_IS_PRESENT=1`, and the visual-server reaches READY (previously a 500 with the ImportError).
- Status reports `supports_tools=false`; a streaming request with `enabled_tools` set still produced `diffusion_frame` events and no tool events.
- Non-diffusion GGUFs keep tools and the default artifact behavior.