### PR TITLE
install.sh: keep the studio launch from draining the curl | sh script (WSL/dash)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2900,7 +2900,10 @@ if [ -t 1 ]; then
     case "${_reply:-y}" in
         [Yy]*|"")
             step "launch" "starting Unsloth Studio..."
-            "$VENV_DIR/bin/unsloth" studio -p 8888
+            # Detach stdin from the `curl | sh` pipe: as a foreground server the
+            # studio would otherwise drain the rest of this piped script, leaving
+            # the shell to die parsing the now-truncated tail (`unexpected fi`).
+            "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null
             _LAUNCH_EXIT=$?
             if [ "$_LAUNCH_EXIT" -ne 0 ] && [ "$_MIGRATED" = true ]; then
                 echo ""


### PR DESCRIPTION
## Summary

Installing with `curl -fsSL https://unsloth.ai/install.sh | sh` can end with:

```
sh: 2913: Syntax error: end of file unexpected (expecting "fi")
```

The install itself completes (Studio installs, the prebuilt attaches), but the script dies right at the end. Reported on WSL, where `/bin/sh` is `dash`.

## Cause

With `curl | sh` the shell reads the script from the pipe on stdin. The optional "Start Unsloth Studio now?" step launches `unsloth studio` in the foreground, and as a long-running server it inherits that same stdin. It drains the rest of the piped script, so the shell reaches EOF partway through the trailing `if`/`case` and reports `unexpected end of file (expecting fi)`. `dash -n` passes because the file is syntactically valid, the breakage is purely runtime stdin consumption, which is why it shows up under `dash` (strict, reads incrementally) and not always under `bash`.

## Fix

Redirect the launch's stdin away from the pipe (`</dev/null`) so the script stays intact for the shell to finish parsing. The server does not read stdin, and Ctrl+C still works through the controlling terminal.

## Verification

- `dash -n install.sh` and `bash -n install.sh` both pass.
- Repro of the mechanism: a foreground reader that inherits the piped script drains its tail (the shell then dies parsing the unread `fi`); with the stdin redirect the tail is left untouched (0 bytes consumed) and the script finishes.
