### PR TITLE
DiffusionGemma: set UNSLOTH_IS_PRESENT so the shim runs on a clean install

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2527,6 +2527,10 @@ class LlamaCppBackend:
         ]
 
         env = child_env_without_native_path_secret()
+        # `python -m unsloth_zoo.diffusion_studio.shim` imports unsloth_zoo, which
+        # refuses to load unless UNSLOTH_IS_PRESENT is set (normally by `import
+        # unsloth`). The shim never imports unsloth, so set it here as unsloth does.
+        env["UNSLOTH_IS_PRESENT"] = "1"
         env["DG_VISUAL_BIN"] = visual_bin
         env["DG_GPU"] = gpu
         # The file-override shim imports its sibling visual_engine; put its dir on PYTHONPATH.


### PR DESCRIPTION
## Summary

A clean install cannot run DiffusionGemma. The runner spawns `python -m unsloth_zoo.diffusion_studio.shim`, and `unsloth_zoo/__init__.py` refuses to import unless `UNSLOTH_IS_PRESENT` is in the environment (normally set by `import unsloth`). The shim never imports `unsloth`, so on a fresh PyPI/install.sh setup the subprocess dies with:

```
ImportError: Please install Unsloth via `pip install unsloth`!
```

and the model load returns a 500 (`DiffusionGemma runner failed to become healthy`). It only appeared to work in dev because an already-exported `UNSLOTH_IS_PRESENT` was inherited from the shell.

## Fix

Set `UNSLOTH_IS_PRESENT=1` in the runner child environment, exactly as `unsloth` does on import. Follow-up to #6255 (the flag belongs with the runner launch but landed after that PR merged).

## Verification

Launched Studio with `UNSLOTH_IS_PRESENT` stripped from the parent env (the clean-install condition): loading `unsloth/diffusiongemma-26B-A4B-it-GGUF` now returns 200, the shim child has `UNSLOTH_IS_PRESENT=1`, the visual-server reaches READY, and a streaming request produces `diffusion_frame` events. Previously this was a 500 with the ImportError.
