### PR TITLE
studio: declare UNSLOTH_IS_PRESENT at backend startup (clean-install + Windows)

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -193,6 +193,11 @@ if _STUDIO_ROOT_RESOLVED != _LEGACY_STUDIO_ROOT:
     if not os.environ.get("UNSLOTH_LLAMA_CPP_PATH"):
         os.environ["UNSLOTH_LLAMA_CPP_PATH"] = str(_STUDIO_ROOT_RESOLVED / "llama.cpp")
 
+# The studio bundles unsloth_zoo; declare unsloth present (as `import unsloth`
+# does) so its lazy submodule imports (export, hardware, mlx) and the
+# DiffusionGemma runner never trip the install guard on a clean install.
+os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+
 import hashlib
 import mimetypes
 import re as _re

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -545,6 +545,11 @@ if _STUDIO_ROOT_RESOLVED != _LEGACY_STUDIO_ROOT:
     if not os.environ.get("UNSLOTH_LLAMA_CPP_PATH"):
         os.environ["UNSLOTH_LLAMA_CPP_PATH"] = str(_STUDIO_ROOT_RESOLVED / "llama.cpp")
 
+# The studio bundles unsloth_zoo; declare unsloth present (as `import unsloth`
+# does) so its lazy submodule imports (export, hardware, mlx) and the
+# DiffusionGemma runner never trip the install guard on a clean install.
+os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+
 
 def _write_pid_file():
     """Write the current process PID to the studio PID file."""


### PR DESCRIPTION
## Summary

Follow-up to #6259. That PR set `UNSLOTH_IS_PRESENT` for the DiffusionGemma shim subprocess, but the studio backend process has the same problem: it lazily imports `unsloth_zoo` submodules in several places, and each import of the top-level `unsloth_zoo` raises

```
ImportError: Please install Unsloth via `pip install unsloth`!
```

unless `UNSLOTH_IS_PRESENT` is in the environment (normally set by `import unsloth`, which the backend deliberately avoids importing for startup speed).

Affected sites (all import `unsloth_zoo` unguarded today):
- `core/export/export.py` (`unsloth_zoo.llama_cpp`, GGUF export)
- `utils/hardware/hardware.py` (`vllm_utils`) - already set the flag per-site
- `core/inference/mlx_inference.py`, `core/training/worker.py` (`unsloth_zoo.mlx`)
- `utils/datasets/chat_templates.py` (`unsloth_zoo.mlx`)

Only `hardware.py` was patched; the rest crash on a clean install, which is why a clean Windows setup hit the ImportError even with the shim fix in place.

## Fix

Set `UNSLOTH_IS_PRESENT=1` once at backend startup (in `main.py` and `run.py`, alongside the existing `UNSLOTH_STUDIO_HOME` setup), as `unsloth` does on import. This covers every current and future `unsloth_zoo` import site in the backend and is inherited by the shim subprocess. Uses `setdefault`, so an explicit value is preserved. The per-site guard in `hardware.py` becomes redundant but is left in place.

## Verification

- In a clean env (`UNSLOTH_IS_PRESENT` unset), the startup `setdefault` makes the previously-crashing imports succeed: `from unsloth_zoo import vllm_utils` and `import unsloth_zoo.llama_cpp` both import cleanly.
- `python -m py_compile` passes for both entry points; the `setdefault` is module-top, before any lazy import runs.
