### PR TITLE
Windows: retry renaming running unsloth.exe before pip overwrites it

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2414,6 +2414,9 @@ if (-not $ROCmIndexUrl -and $CuTag -eq "cpu") {
 }
 
 # Rename running unsloth.exe so pip can replace it (Windows refuses to delete a mapped .exe).
+# Renaming a *running* exe is allowed on Windows -- that is the whole trick. A transient
+# sharing violation (Defender/AV scan, search indexer, Explorer preview, or a second
+# unsloth process) can still block the first attempt, so retry with a short backoff.
 $VenvScriptsDir = Join-Path $VenvDir "Scripts"
 $RunningUnslothExe = Join-Path $VenvScriptsDir "unsloth.exe"
 if (Test-Path -LiteralPath $RunningUnslothExe -PathType Leaf) {
@@ -2421,10 +2424,19 @@ if (Test-Path -LiteralPath $RunningUnslothExe -PathType Leaf) {
     if (Test-Path -LiteralPath $StaleUnslothExe) {
         Remove-Item -LiteralPath $StaleUnslothExe -Force -ErrorAction SilentlyContinue
     }
-    try {
-        Rename-Item -LiteralPath $RunningUnslothExe -NewName "unsloth.exe.deleteme" -Force -ErrorAction Stop
-    } catch {
-        substep "could not rename unsloth.exe ($($_.Exception.Message)); pip may fail with WinError 32" "Yellow"
+    $renameErr = $null
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            Rename-Item -LiteralPath $RunningUnslothExe -NewName "unsloth.exe.deleteme" -Force -ErrorAction Stop
+            $renameErr = $null
+            break
+        } catch {
+            $renameErr = $_.Exception.Message
+            if ($attempt -lt 5) { Start-Sleep -Milliseconds 400 }
+        }
+    }
+    if ($renameErr) {
+        substep "could not rename unsloth.exe after retries ($renameErr); pip may fail with WinError 32" "Yellow"
     }
 }
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1610,13 +1610,22 @@ def _release_self_exe_lock_windows() -> None:
     if not exe.exists():
         return
     stale = exe.with_suffix(".exe.deleteme")
-    try:
-        # os.replace is atomic-overwrite on Windows; os.rename would raise
-        # FileExistsError if a prior aborted update left a .deleteme behind.
-        os.replace(exe, stale)
-    except OSError as e:
-        # Not fatal; setup.ps1 retries from a sibling process.
-        print(f"[update] could not rename {exe.name} -> {stale.name}: {e}")
+    # Renaming a running exe is allowed on Windows, but a transient sharing
+    # violation (Defender/AV scan, search indexer, a second unsloth process)
+    # can block the first attempt -- retry briefly before giving up.
+    last_err: OSError | None = None
+    for attempt in range(5):
+        try:
+            # os.replace is atomic-overwrite on Windows; os.rename would raise
+            # FileExistsError if a prior aborted update left a .deleteme behind.
+            os.replace(exe, stale)
+            return
+        except OSError as e:
+            last_err = e
+            if attempt < 4:
+                time.sleep(0.4)
+    # Not fatal; setup.ps1 retries from a sibling process.
+    print(f"[update] could not rename {exe.name} -> {stale.name} after retries: {last_err}")
 
 
 def _restore_self_exe_lock_windows() -> None:


### PR DESCRIPTION
## Problem

On Windows, install/update prints a warning and can fail:

```
could not rename unsloth.exe (The process cannot access the file because it is being used by another process.); pip may fail with WinError 32
```

To let pip overwrite the CLI launcher, the running `unsloth.exe` is moved aside to `unsloth.exe.deleteme` first. Renaming a running exe is allowed on Windows, so this normally works. A `WinError 32` sharing violation means something else briefly has the file open without share-delete: Windows Defender or another AV real-time scan, the Search indexer, an Explorer preview, or a second `unsloth` process. Those locks clear in well under a second.

The rename was single-shot. It fired the warning on a momentary lock. If the lock lasted a beat longer, pip would hit `WinError 32` and fail the `unsloth` reinstall. In the reported log the lock cleared on its own and pip still succeeded, so the warning was a false alarm. The failure mode is still real.

## Fix

Retry the rename 5 times with a 400 ms backoff in both places that do it, and warn only after every attempt fails:

- `studio/setup.ps1`: the installer path, where the reported warning is printed.
- `unsloth_cli/commands/studio.py` (`_release_self_exe_lock_windows`): the `unsloth studio update` path.

The `unsloth.exe.deleteme` sidecar name is unchanged, so restore and cleanup logic is untouched.
