### PR TITLE
Studio: backfill the DiffusionGemma visual-server on a tag-matching update

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6490,6 +6490,31 @@ def validate_prebuilt_attempts(
     raise PrebuiltFallback("no prebuilt bundle passed validation")
 
 
+def diffusion_visual_server_backfill_needed(
+    install_dir: Path, host: HostInfo, choice: AssetChoice
+) -> bool:
+    """True when an existing install matches the tag but lacks the DiffusionGemma
+    visual-server the chosen bundle ships. An install made before the visual-server
+    entered the copy allowlist matches on tag yet is missing the binary, so the
+    tag-match skip never backfills it (DiffusionGemma then fails with "runner not
+    found"). Gated to the fork ("published") bundles that actually carry it, so
+    upstream installs -- which never ship it -- can't thrash on repeated updates.
+    Once a re-extract lands the binary this returns False, so it self-limits."""
+    if choice.source_label != "published":
+        return False
+    name = "llama-diffusion-gemma-visual-server" + (".exe" if host.is_windows else "")
+    if name not in runtime_patterns_for_choice(choice):
+        return False
+    for cand in (
+        install_dir / name,
+        install_dir / "build" / "bin" / name,
+        install_dir / "build" / "bin" / "Release" / name,
+    ):
+        if cand.is_file():
+            return False
+    return True
+
+
 def install_prebuilt(
     install_dir: Path,
     llama_tag: str,
@@ -6528,11 +6553,17 @@ def install_prebuilt(
             )
             if release_plans and existing_install_matches_plan(install_dir, host, release_plans[0]):
                 current = release_plans[0]
-                log(
-                    "existing llama.cpp install already matches selected release "
-                    f"{current.release_tag} upstream_tag={current.llama_tag}; skipping download and install"
-                )
-                return
+                if diffusion_visual_server_backfill_needed(install_dir, host, current.attempts[0]):
+                    log(
+                        f"existing install matches {current.release_tag} but is missing the "
+                        "DiffusionGemma visual-server; re-extracting the bundle to backfill it"
+                    )
+                else:
+                    log(
+                        "existing llama.cpp install already matches selected release "
+                        f"{current.release_tag} upstream_tag={current.llama_tag}; skipping download and install"
+                    )
+                    return
             with tempfile.TemporaryDirectory(prefix = "unsloth-llama-prebuilt-") as tmp:
                 work_dir = Path(tmp)
                 probe_path = work_dir / "stories260K.gguf"
@@ -6541,11 +6572,17 @@ def install_prebuilt(
                 for release_index, plan in enumerate(release_plans):
                     choice = plan.attempts[0]
                     if existing_install_matches_plan(install_dir, host, plan):
-                        log(
-                            "existing llama.cpp install already matches fallback release "
-                            f"{plan.release_tag} upstream_tag={plan.llama_tag}; skipping reinstall"
-                        )
-                        return
+                        if diffusion_visual_server_backfill_needed(install_dir, host, choice):
+                            log(
+                                f"existing install matches fallback {plan.release_tag} but is missing "
+                                "the DiffusionGemma visual-server; re-extracting to backfill it"
+                            )
+                        else:
+                            log(
+                                "existing llama.cpp install already matches fallback release "
+                                f"{plan.release_tag} upstream_tag={plan.llama_tag}; skipping reinstall"
+                            )
+                            return
                     log(
                         "selected "
                         f"{choice.name} ({choice.source_label}) from published release "

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6571,8 +6571,9 @@ def install_prebuilt(
                 release_count = len(release_plans)
                 for release_index, plan in enumerate(release_plans):
                     choice = plan.attempts[0]
+                    backfill = diffusion_visual_server_backfill_needed(install_dir, host, choice)
                     if existing_install_matches_plan(install_dir, host, plan):
-                        if diffusion_visual_server_backfill_needed(install_dir, host, choice):
+                        if backfill:
                             log(
                                 f"existing install matches fallback {plan.release_tag} but is missing "
                                 "the DiffusionGemma visual-server; re-extracting to backfill it"
@@ -6600,7 +6601,9 @@ def install_prebuilt(
                             release_tag = plan.release_tag,
                             approved_checksums = plan.approved_checksums,
                             initial_fallback_used = release_index > 0,
-                            existing_install_dir = install_dir,
+                            # a backfill must reinstall, so do not let the inner
+                            # existing-install match short-circuit the re-extract
+                            existing_install_dir = None if backfill else install_dir,
                         )
                     except ExistingInstallSatisfied:
                         return


### PR DESCRIPTION
## Problem

On Mac (and in principle any platform) loading DiffusionGemma can fail with:

```
RuntimeError: DiffusionGemma runner not found...
```

even though the prebuilt bundle ships `llama-diffusion-gemma-visual-server`.

This happens when llama.cpp was installed before the visual-server was added to the install copy allowlist (#6254). That older install matches the release tag, so `unsloth studio update` takes the "already matches, skip" path and never re-extracts, leaving the visual-server binary missing for good.

## Fix

On the tag-match skip, `install_prebuilt` now checks whether the selected bundle ships the visual-server but the install is missing it, and if so re-extracts the bundle instead of skipping.

It is gated to:

- fork (`published`) bundles, which are the ones that actually carry the visual-server; upstream ggml-org bundles never do, so they never thrash, and
- the binary being absent on disk.

Once the re-extract lands the binary the check returns False, so it self-limits with no repeated downloads. Fresh installs and non-diffusion installs that already have the binary are unaffected.

## Verification

- `python -m py_compile` on the changed file.
- Gate unit check: `fork + missing -> re-extract`, `upstream + missing -> skip` (loop-safe), `fork + present -> skip` (fresh installs and other models untouched).
