### PR TITLE
Studio: keep llama-server discovery from crashing on an access-denied candidate

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1071,7 +1071,7 @@ class LlamaCppBackend:
     # ── Binary discovery ──────────────────────────────────────────
 
     @staticmethod
-    def _find_llama_server_binary() -> Optional[str]:
+    def _find_llama_server_binary(*, include_denied: bool = False) -> Optional[str]:
         """
         Locate the llama-server binary.
 
@@ -1125,13 +1125,14 @@ class LlamaCppBackend:
         def _scan_pinned(paths: list):
             # first existing candidate wins -> (path, None); a present-but-denied
             # one -> (None, denied_path) so the caller reports it rather than
-            # skipping to a lower-priority location
+            # skipping to a lower-priority location. include_denied returns the
+            # locked path instead: diffusion asset lookup only needs its dir.
             for p in paths:
                 st = _file_status(p)
                 if st == "file":
                     return str(p), None
                 if st == "denied":
-                    return None, p
+                    return (str(p), None) if include_denied else (None, p)
             return None, None
 
         # 1. Env var: direct path to binary
@@ -2466,7 +2467,9 @@ class LlamaCppBackend:
         visual_bin = os.environ.get("DG_VISUAL_BIN")
         if not visual_bin:
             name = "llama-diffusion-gemma-visual-server" + (".exe" if os.name == "nt" else "")
-            base = self._find_llama_server_binary()
+            # include_denied: a transiently locked llama-server still pins the
+            # install dir so the adjacent visual-server can be found
+            base = self._find_llama_server_binary(include_denied = True)
             if base:
                 base_dir = Path(base).parent
                 for cand in (

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1105,39 +1105,52 @@ class LlamaCppBackend:
         def _is_file(p: Path) -> bool:
             return _file_status(p) == "file"
 
+        def _layout_candidates(d: Path) -> list:
+            # build layouts probed under a llama.cpp dir, highest priority first
+            cands = [d / binary_name, d / "build" / "bin" / binary_name]
+            if sys.platform == "win32":
+                cands.append(d / "build" / "bin" / "Release" / binary_name)
+            return cands
+
+        def _unavailable(p: object) -> None:
+            # a pinned or managed binary that exists but is access-denied: report
+            # it instead of silently downgrading to a lower-priority llama-server
+            logger.warning(
+                f"llama-server at {p} exists but is access-denied (antivirus or "
+                "an in-flight install); not falling back to another binary, "
+                "retry once it is released"
+            )
+            return None
+
+        def _scan_pinned(paths: list):
+            # first existing candidate wins -> (path, None); a present-but-denied
+            # one -> (None, denied_path) so the caller reports it rather than
+            # skipping to a lower-priority location
+            for p in paths:
+                st = _file_status(p)
+                if st == "file":
+                    return str(p), None
+                if st == "denied":
+                    return None, p
+            return None, None
+
         # 1. Env var: direct path to binary
         env_path = os.environ.get("LLAMA_SERVER_PATH")
         if env_path:
-            status = _file_status(Path(env_path))
-            if status == "file":
-                return env_path
-            if status == "denied":
-                # an explicit pin that exists but is locked: report it instead
-                # of silently falling back to a different llama-server
-                logger.warning(
-                    f"LLAMA_SERVER_PATH={env_path} exists but is access-denied "
-                    "(antivirus or an in-flight install); not falling back to "
-                    "another binary, retry once it is released"
-                )
-                return None
+            hit, locked = _scan_pinned([Path(env_path)])
+            if locked is not None:
+                return _unavailable(locked)
+            if hit:
+                return hit
 
         # 1b. UNSLOTH_LLAMA_CPP_PATH: custom llama.cpp install dir
         custom_llama_cpp = os.environ.get("UNSLOTH_LLAMA_CPP_PATH")
         if custom_llama_cpp:
-            custom_dir = Path(custom_llama_cpp)
-            # Root dir (make builds)
-            root_bin = custom_dir / binary_name
-            if _is_file(root_bin):
-                return str(root_bin)
-            # build/bin/ (cmake on Linux)
-            cmake_bin = custom_dir / "build" / "bin" / binary_name
-            if _is_file(cmake_bin):
-                return str(cmake_bin)
-            # build/bin/Release/ (cmake on Windows)
-            if sys.platform == "win32":
-                win_bin = custom_dir / "build" / "bin" / "Release" / binary_name
-                if _is_file(win_bin):
-                    return str(win_bin)
+            hit, locked = _scan_pinned(_layout_candidates(Path(custom_llama_cpp)))
+            if locked is not None:
+                return _unavailable(locked)
+            if hit:
+                return hit
 
         # 2-4. Match installer layout: env-mode -> $STUDIO_HOME/llama.cpp;
         # default/HOME-redirect -> ~/.unsloth/llama.cpp (sibling of studio).
@@ -1169,31 +1182,18 @@ class LlamaCppBackend:
                 _seen_roots.add(k)
                 _unique_roots.append(r)
         for unsloth_home in _unique_roots:
-            home_root = unsloth_home / binary_name
-            if _is_file(home_root):
-                return str(home_root)
-            home_linux = unsloth_home / "build" / "bin" / binary_name
-            if _is_file(home_linux):
-                return str(home_linux)
-            if sys.platform == "win32":
-                home_win = unsloth_home / "build" / "bin" / "Release" / binary_name
-                if _is_file(home_win):
-                    return str(home_win)
+            hit, locked = _scan_pinned(_layout_candidates(unsloth_home))
+            if locked is not None:
+                return _unavailable(locked)
+            if hit:
+                return hit
 
-        # 5-6. Legacy: in-tree build (older setup.sh / setup.ps1)
+        # 5-6. Legacy: in-tree build (older setup.sh / setup.ps1). A fallback,
+        # so a denied candidate here just continues (no no-fallback halt).
         project_root = Path(__file__).resolve().parents[4]
-        # Root dir (make builds)
-        root_path = project_root / "llama.cpp" / binary_name
-        if _is_file(root_path):
-            return str(root_path)
-        # build/bin/ (cmake builds)
-        build_path = project_root / "llama.cpp" / "build" / "bin" / binary_name
-        if _is_file(build_path):
-            return str(build_path)
-        if sys.platform == "win32":
-            win_path = project_root / "llama.cpp" / "build" / "bin" / "Release" / binary_name
-            if _is_file(win_path):
-                return str(win_path)
+        for p in _layout_candidates(project_root / "llama.cpp"):
+            if _is_file(p):
+                return str(p)
 
         # 7. System PATH
         system_path = shutil.which("llama-server")

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1088,25 +1088,38 @@ class LlamaCppBackend:
         """
         binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
 
-        def _is_file(p: Path) -> bool:
-            # is_file() returns False for an absent path but raises
-            # PermissionError (WinError 5) when the path exists yet is briefly
-            # locked (antivirus, or an install replace in flight). Retry so a
-            # transient lock clears; never return a path we still cannot stat so
-            # downstream probes do not hit the same error.
+        def _file_status(p: Path) -> str:
+            # "file", "absent", or "denied" (exists but stays access-denied
+            # across a short retry: Windows AV/ACL or an install replace in
+            # flight). is_file() raises PermissionError (WinError 5) instead of
+            # returning False for the locked case, so never treat it as missing.
             for _ in range(5):
                 try:
-                    return p.is_file()
+                    return "file" if p.is_file() else "absent"
                 except PermissionError:
                     time.sleep(0.2)
                 except OSError:
-                    return False
-            return False
+                    return "absent"
+            return "denied"
+
+        def _is_file(p: Path) -> bool:
+            return _file_status(p) == "file"
 
         # 1. Env var: direct path to binary
         env_path = os.environ.get("LLAMA_SERVER_PATH")
-        if env_path and _is_file(Path(env_path)):
-            return env_path
+        if env_path:
+            status = _file_status(Path(env_path))
+            if status == "file":
+                return env_path
+            if status == "denied":
+                # an explicit pin that exists but is locked: report it instead
+                # of silently falling back to a different llama-server
+                logger.warning(
+                    f"LLAMA_SERVER_PATH={env_path} exists but is access-denied "
+                    "(antivirus or an in-flight install); not falling back to "
+                    "another binary, retry once it is released"
+                )
+                return None
 
         # 1b. UNSLOTH_LLAMA_CPP_PATH: custom llama.cpp install dir
         custom_llama_cpp = os.environ.get("UNSLOTH_LLAMA_CPP_PATH")

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3534,6 +3534,15 @@ class LlamaCppBackend:
                     )
 
             if not binary:
+                # distinguish a transiently locked binary (antivirus / in-flight
+                # install) from a missing one so the user retries, not reinstalls
+                locked = self._find_llama_server_binary(include_denied = True)
+                if locked:
+                    raise RuntimeError(
+                        f"llama-server at {locked} is temporarily unavailable "
+                        "(access-denied; antivirus or an in-flight install). "
+                        "Retry the load once it is released."
+                    )
                 raise RuntimeError(
                     "llama-server binary not found. "
                     "Run setup.sh to build it, install llama.cpp, "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1088,9 +1088,23 @@ class LlamaCppBackend:
         """
         binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
 
+        def _is_file(p: Path) -> bool:
+            # is_file() returns False for an absent path but *raises*
+            # PermissionError (WinError 5) when the path exists yet is momentarily
+            # inaccessible -- an antivirus lock, an install replace in flight, or
+            # an elevated-install ACL. Treat that as present so discovery returns
+            # the real binary (the caller retries the exec) instead of skipping it
+            # and reporting "not found". Other stat errors fall back to "not here".
+            try:
+                return p.is_file()
+            except PermissionError:
+                return True
+            except OSError:
+                return False
+
         # 1. Env var: direct path to binary
         env_path = os.environ.get("LLAMA_SERVER_PATH")
-        if env_path and Path(env_path).is_file():
+        if env_path and _is_file(Path(env_path)):
             return env_path
 
         # 1b. UNSLOTH_LLAMA_CPP_PATH: custom llama.cpp install dir
@@ -1099,16 +1113,16 @@ class LlamaCppBackend:
             custom_dir = Path(custom_llama_cpp)
             # Root dir (make builds)
             root_bin = custom_dir / binary_name
-            if root_bin.is_file():
+            if _is_file(root_bin):
                 return str(root_bin)
             # build/bin/ (cmake on Linux)
             cmake_bin = custom_dir / "build" / "bin" / binary_name
-            if cmake_bin.is_file():
+            if _is_file(cmake_bin):
                 return str(cmake_bin)
             # build/bin/Release/ (cmake on Windows)
             if sys.platform == "win32":
                 win_bin = custom_dir / "build" / "bin" / "Release" / binary_name
-                if win_bin.is_file():
+                if _is_file(win_bin):
                     return str(win_bin)
 
         # 2-4. Match installer layout: env-mode -> $STUDIO_HOME/llama.cpp;
@@ -1142,29 +1156,29 @@ class LlamaCppBackend:
                 _unique_roots.append(r)
         for unsloth_home in _unique_roots:
             home_root = unsloth_home / binary_name
-            if home_root.is_file():
+            if _is_file(home_root):
                 return str(home_root)
             home_linux = unsloth_home / "build" / "bin" / binary_name
-            if home_linux.is_file():
+            if _is_file(home_linux):
                 return str(home_linux)
             if sys.platform == "win32":
                 home_win = unsloth_home / "build" / "bin" / "Release" / binary_name
-                if home_win.is_file():
+                if _is_file(home_win):
                     return str(home_win)
 
         # 5-6. Legacy: in-tree build (older setup.sh / setup.ps1)
         project_root = Path(__file__).resolve().parents[4]
         # Root dir (make builds)
         root_path = project_root / "llama.cpp" / binary_name
-        if root_path.is_file():
+        if _is_file(root_path):
             return str(root_path)
         # build/bin/ (cmake builds)
         build_path = project_root / "llama.cpp" / "build" / "bin" / binary_name
-        if build_path.is_file():
+        if _is_file(build_path):
             return str(build_path)
         if sys.platform == "win32":
             win_path = project_root / "llama.cpp" / "build" / "bin" / "Release" / binary_name
-            if win_path.is_file():
+            if _is_file(win_path):
                 return str(win_path)
 
         # 7. System PATH
@@ -1174,7 +1188,7 @@ class LlamaCppBackend:
 
         # 8. Legacy: extracted to bin/
         bin_path = project_root / "bin" / binary_name
-        if bin_path.is_file():
+        if _is_file(bin_path):
             return str(bin_path)
 
         return None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1089,18 +1089,19 @@ class LlamaCppBackend:
         binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
 
         def _is_file(p: Path) -> bool:
-            # is_file() returns False for an absent path but *raises*
-            # PermissionError (WinError 5) when the path exists yet is momentarily
-            # inaccessible -- an antivirus lock, an install replace in flight, or
-            # an elevated-install ACL. Treat that as present so discovery returns
-            # the real binary (the caller retries the exec) instead of skipping it
-            # and reporting "not found". Other stat errors fall back to "not here".
-            try:
-                return p.is_file()
-            except PermissionError:
-                return True
-            except OSError:
-                return False
+            # is_file() returns False for an absent path but raises
+            # PermissionError (WinError 5) when the path exists yet is briefly
+            # locked (antivirus, or an install replace in flight). Retry so a
+            # transient lock clears; never return a path we still cannot stat so
+            # downstream probes do not hit the same error.
+            for _ in range(5):
+                try:
+                    return p.is_file()
+                except PermissionError:
+                    time.sleep(0.2)
+                except OSError:
+                    return False
+            return False
 
         # 1. Env var: direct path to binary
         env_path = os.environ.get("LLAMA_SERVER_PATH")

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -2361,10 +2361,13 @@ class ModelConfig:
             # Does the HF repo contain GGUF files?
             gguf_filename = detect_gguf_model_remote(identifier, hf_token = hf_token)
             if gguf_filename:
-                # Preflight: verify llama-server binary exists before a multi-GB download
+                # Preflight: verify llama-server binary exists before a multi-GB
+                # download. include_denied: a transiently locked binary still
+                # exists (the lock clears long before the download finishes; the
+                # load itself reports a still-locked binary distinctly).
                 from core.inference.llama_cpp import LlamaCppBackend
 
-                if not LlamaCppBackend._find_llama_server_binary():
+                if not LlamaCppBackend._find_llama_server_binary(include_denied = True):
                     raise RuntimeError(
                         "llama-server binary not found — cannot load GGUF models. "
                         "Run setup.sh to build it, or set LLAMA_SERVER_PATH."


### PR DESCRIPTION
## Problem

On Windows, loading a model could fail validation with:

```
PermissionError: [WinError 5] Access is denied:
'C:\Users\...\.unsloth\llama.cpp\build\bin\Release\llama-server.exe'
```

`_find_llama_server_binary` probes candidate paths with `Path.is_file()`. `is_file()` returns False for an absent path but raises `PermissionError` when the path exists yet is momentarily inaccessible (an antivirus lock, an install replace in flight, or an elevated-install ACL). That raise propagated out of discovery and aborted `/api/inference/validate`.

## Fix

A small `_is_file` guard wraps the probes:

- absent path: skip and keep searching (unchanged)
- present path: return it (unchanged)
- exists but access-denied (WinError 5): treat as present and return it, so discovery hands back the real binary instead of reporting "not found"; the caller retries the exec once the lock clears
- any other stat error: skip

Returning the real path (rather than silently skipping it) is what actually lets the locked-binary case load: validation passes and the diffusion runner can then locate the visual-server next to `llama-server`. A permanently blocked binary is environmental (antivirus exclusion, or do not install elevated) and no discovery change can paper over that.

## Verification

- `python -m py_compile` on the changed file.
- Behavior matrix: `absent -> skip`, `present -> return`, `denied -> return`, `other OSError -> skip`.
- Accessible paths behave exactly as before, so general (non-diffusion) model load is unaffected.
