### PR TITLE
Studio: force-refresh the llama.cpp update check so new builds are not masked by the 24h cache

### DIFF
--- a/studio/frontend/src/hooks/use-llama-update-check.ts
+++ b/studio/frontend/src/hooks/use-llama-update-check.ts
@@ -68,6 +68,11 @@ async function fetchStatus(
   }
 }
 
+// Update probes force a refresh so a newly published build is not masked by the
+// backend's 24h release cache (the banner would otherwise lag up to a day). The
+// job-progress poll below stays cached; it only reads local job state.
+const recheckStatus = () => fetchStatus(true);
+
 interface UseLlamaUpdateCheckOptions {
   enabled?: boolean;
 }
@@ -161,13 +166,13 @@ export function useLlamaUpdateCheck({
     let canceled = false;
 
     const firstTimer = setTimeout(() => {
-      fetchStatus().then((s) => {
+      recheckStatus().then((s) => {
         if (!canceled) surfaceIfAvailable(s);
       });
     }, FIRST_CHECK_DELAY_MS);
 
     const reminder = setInterval(() => {
-      fetchStatus().then((s) => {
+      recheckStatus().then((s) => {
         if (!canceled) surfaceIfAvailable(s);
       });
     }, REMINDER_INTERVAL_MS);
@@ -194,7 +199,7 @@ export function useLlamaUpdateCheck({
     if (snoozeTimer.current) clearTimeout(snoozeTimer.current);
     snoozeTimer.current = setTimeout(() => {
       snoozeTimer.current = null;
-      fetchStatus().then(surfaceIfAvailable);
+      recheckStatus().then(surfaceIfAvailable);
     }, SNOOZE_DELAY_MS);
   }, [surfaceIfAvailable]);
 


### PR DESCRIPTION
## Problem

The "New llama.cpp version" banner often never appears even when a newer prebuilt has been published.

The banner is driven by `useLlamaUpdateCheck`, which polls `GET /api/llama/update-status`. On the backend, the latest GitHub release tag is memoized for 24 hours, in memory and on disk, so the value survives restarts. That cache is there to keep the hot `/api/inference/status` read cheap.

`fetchStatus()` in the hook already supports a `forceRefresh` flag that maps to `?force_refresh=true`, which the route runs on a worker thread and which bypasses the cache. The problem is that no caller ever passed it: the first check, the hourly reminder, and the snooze re-check all read the cached value. So once the cache is primed, a build published afterwards stays invisible for up to a full day, and restarting does not help because the cache is also on disk. Since we ship llama.cpp prebuilts multiple times a day, the banner routinely lags behind a real release.

## Fix

Route the three "is there a newer build?" probes through a small `recheckStatus = () => fetchStatus(true)` helper so they force a refresh. The 500ms job-progress poll stays on the cached path on purpose: it only reads local job state and should not hit GitHub. Forcing on these probes also keeps the shared cache warm for `/api/inference/status`.

No backend change. The `/update-status` route already offloads the GitHub fetch to a worker thread, so the event loop is never blocked.

## Verification

- Reproduced against the real freshness module: with a stale 24h cache, the old path reports `update_available=false` (banner hidden); the force-refresh path re-queries GitHub and reports `update_available=true` (banner shows).
- Backend tests pass: `test_llama_route.py`, `test_llama_cpp_freshness.py`, `test_llama_cpp_update.py` (83 passed).
- Frontend typechecks and builds cleanly.
