### PR TITLE
Tidy update banner and auth button spacing

### DIFF
--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -203,11 +203,11 @@ export function LlamaUpdateBanner({
                 />
               </div>
             ) : (
-              <div className="mt-4 flex flex-wrap items-center justify-between gap-y-2">
+              <div className="mt-4 flex flex-wrap items-center justify-end gap-x-1 gap-y-2">
                 <Button
                   size="sm"
                   variant="ghost"
-                  className="-ml-2 h-auto rounded-full px-2.5 py-2 text-[13px] font-medium text-foreground"
+                  className="h-auto rounded-full px-3 py-2 text-[13px] font-medium text-foreground"
                   onClick={snooze}
                   data-testid="llama-update-snooze-button"
                 >
@@ -215,8 +215,8 @@ export function LlamaUpdateBanner({
                 </Button>
                 <Button
                   size="sm"
-                  // ml offsets the pill's filled edge so visual gaps stay equal
-                  className="ml-2.5 h-auto rounded-full px-3.5 py-2 text-[13px]"
+                  // -mr optically aligns the filled pill's edge with the card padding
+                  className="-mr-1 h-auto rounded-full px-3.5 py-2 text-[13px]"
                   onClick={handleUpdate}
                   data-testid="llama-update-button"
                 >

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -137,7 +137,8 @@ export function WebUpdateBanner({
               >
                 Release notes
               </a>
-              <div className="flex items-center gap-x-1">
+              {/* wrap + right-align so buttons stack instead of clipping on very narrow banners */}
+              <div className="flex flex-wrap items-center justify-end gap-x-1 gap-y-2">
                 <Button
                   size="sm"
                   variant="ghost"

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -137,24 +137,26 @@ export function WebUpdateBanner({
               >
                 Release notes
               </a>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-auto rounded-full px-2.5 py-2 text-[13px] font-medium text-foreground"
-                onClick={snooze}
-                data-testid="web-update-snooze-button"
-              >
-                Remind me later
-              </Button>
-              <Button
-                size="sm"
-                // ml offsets the pill's filled edge so visual gaps stay equal
-                className="ml-2.5 h-auto rounded-full px-3.5 py-2 text-[13px]"
-                onClick={handleCopyCommand}
-                data-testid="web-update-copy-button"
-              >
-                {copied ? "Copied" : "Copy command"}
-              </Button>
+              <div className="flex items-center gap-x-1">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-auto rounded-full px-3 py-2 text-[13px] font-medium text-foreground"
+                  onClick={snooze}
+                  data-testid="web-update-snooze-button"
+                >
+                  Remind me later
+                </Button>
+                <Button
+                  size="sm"
+                  // -mr optically aligns the filled pill's edge with the card padding
+                  className="-mr-1 h-auto rounded-full px-3.5 py-2 text-[13px]"
+                  onClick={handleCopyCommand}
+                  data-testid="web-update-copy-button"
+                >
+                  {copied ? "Copied" : "Copy command"}
+                </Button>
+              </div>
             </div>
           </div>
         </motion.div>

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -443,7 +443,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
 
         <Button
           type="submit"
-          className="mx-auto flex w-fit px-8"
+          className="mx-auto flex w-fit px-6"
           disabled={
             loading ||
             statusLoading ||


### PR DESCRIPTION
## What

Two small spacing fixes in the Studio frontend.

### Update banners

The action row used `justify-between`, which spreads two buttons to opposite edges of the card and leaves a large empty gap between them. The buttons also carried margin hacks to push each one flush against its edge, fighting the layout. This switches the row to `justify-end` and groups the actions together on the right with an even gap, the standard notification layout.

- `llama-update-banner.tsx`: group "Remind me later" and "Update" on the right with `justify-end` plus `gap-x-1`, and drop the edge-margin hacks.
- `web/update-banner.tsx`: keep the "Release notes" link flush left and wrap the two action buttons in a right-aligned group, so the middle button no longer floats.

### Auth submit button

The "Login" / "Change password" submit button used `px-8`, which looked overly wide. Reduced to `px-6` for slightly tighter horizontal padding.

- `auth-form.tsx`: `px-8` to `px-6` on the submit button.

## Notes

Pure layout changes, no behavior changes. Builds and typechecks clean.