### PR TITLE
Upgrade setuptools and wheel in the auto-install command

### DIFF
--- a/unsloth/_auto_install.py
+++ b/unsloth/_auto_install.py
@@ -40,4 +40,4 @@ else: raise RuntimeError(f"Torch = {v} too new!")
 if v > V('2.6.9') and cuda not in ("11.8", "12.6", "12.8", "13.0"): raise RuntimeError(f"CUDA = {cuda} not supported!")
 if v >= V('2.10.0') and cuda not in ("12.6", "12.8", "13.0"): raise RuntimeError(f"Torch 2.10 requires CUDA 12.6, 12.8, or 13.0! Got CUDA = {cuda}")
 x = x.format(cuda.replace(".", ""), "-ampere" if False else "") # is_ampere is broken due to flash-attn
-print(f'pip install --upgrade pip && pip install --no-deps git+https://github.com/unslothai/unsloth-zoo.git && pip install "unsloth[{x}] @ git+https://github.com/unslothai/unsloth.git" --no-build-isolation')
+print(f'pip install --upgrade pip setuptools wheel && pip install --no-deps git+https://github.com/unslothai/unsloth-zoo.git && pip install "unsloth[{x}] @ git+https://github.com/unslothai/unsloth.git" --no-build-isolation')


### PR DESCRIPTION
## Summary

Fixes #6277.

The auto-install command generated by `unsloth/_auto_install.py` builds unsloth from git with `--no-build-isolation`:

```
pip install --upgrade pip && pip install --no-deps git+...unsloth-zoo.git && pip install "unsloth[...] @ git+...unsloth.git" --no-build-isolation
```

`--no-build-isolation` tells pip to build using whatever setuptools already exists in the environment, ignoring the `setuptools==80.9.0` pin in `build-system.requires`. Our `pyproject.toml` declares the license with the PEP 639 SPDX string form (`license = "Apache-2.0"`), which is only understood by setuptools >= 77. On an environment with an older setuptools the build aborts during metadata preparation:

```
configuration error: `project.license` must be valid exactly by one definition ...
ValueError: invalid pyproject.toml config: `project.license`.
```

## Fix

Upgrade setuptools (and wheel) alongside pip in the first step of the generated command, so the source build always has PEP 639 support:

```diff
-pip install --upgrade pip && ...
+pip install --upgrade pip setuptools wheel && ...
```

This keeps the modern SPDX string license (and the resulting `License-Expression` core metadata) instead of reverting to the deprecated `license = {text = "..."}` table form, which setuptools has scheduled for removal.

## Scope

Only `_auto_install.py` is affected. The `install.sh` / `install.ps1` installers build through `uv`, which uses isolated builds that honor the pinned setuptools, and the Studio worker's `--no-build-isolation` path compiles third party packages (flash-attn and similar), not unsloth itself.

## Verification

Reproduced in a clean venv seeded with setuptools 75.8.0 against the current repo:

- Before: building unsloth with `--no-build-isolation` fails with the `project.license` error above.
- After running `pip install --upgrade pip setuptools wheel` (setuptools 75.8.0 -> 82.0.1): the source build succeeds and produces `License-Expression: Apache-2.0` metadata.
