### PR TITLE
Fix llama.cpp prebuilt: skip already-installed same-release fallback

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6436,13 +6436,21 @@ def validate_prebuilt_attempts(
                 f"runtime_line={attempt.runtime_line} coverage_class={attempt.coverage_class}"
             )
 
-        if existing_install_dir is not None and existing_install_matches_choice(
-            existing_install_dir,
-            host,
-            llama_tag = llama_tag,
-            release_tag = release_tag,
-            choice = attempt,
-            approved_checksums = approved_checksums,
+        if (
+            existing_install_dir is not None
+            and existing_install_matches_choice(
+                existing_install_dir,
+                host,
+                llama_tag = llama_tag,
+                release_tag = release_tag,
+                choice = attempt,
+                approved_checksums = approved_checksums,
+            )
+            # Skip a matching candidate unless it still needs the DiffusionGemma
+            # backfill re-extract (gated per-attempt, not per-plan).
+            and not diffusion_visual_server_backfill_needed(
+                existing_install_dir, host, attempt
+            )
         ):
             log(
                 "existing llama.cpp install already matches fallback candidate "
@@ -6601,9 +6609,8 @@ def install_prebuilt(
                             release_tag = plan.release_tag,
                             approved_checksums = plan.approved_checksums,
                             initial_fallback_used = release_index > 0,
-                            # a backfill must reinstall, so do not let the inner
-                            # existing-install match short-circuit the re-extract
-                            existing_install_dir = None if backfill else install_dir,
+                            # Skip is gated per-attempt inside, so pass the dir always.
+                            existing_install_dir = install_dir,
                         )
                     except ExistingInstallSatisfied:
                         return

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6448,9 +6448,7 @@ def validate_prebuilt_attempts(
             )
             # Skip a matching candidate unless it still needs the DiffusionGemma
             # backfill re-extract (gated per-attempt, not per-plan).
-            and not diffusion_visual_server_backfill_needed(
-                existing_install_dir, host, attempt
-            )
+            and not diffusion_visual_server_backfill_needed(existing_install_dir, host, attempt)
         ):
             log(
                 "existing llama.cpp install already matches fallback candidate "

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -873,15 +873,22 @@ def test_llama_cpp_search_roots_handles_studio_root_oserror():
     llama_cpp = (
         REPO_ROOT / "studio" / "backend" / "core" / "inference" / "llama_cpp.py"
     ).read_text()
-    find_block_start = llama_cpp.index("_find_llama_server_binary")
-    find_block = llama_cpp[find_block_start : find_block_start + 4000]
+
+    def _method_body(name: str) -> str:
+        # Whole method body (def to next sibling def), so the check survives the
+        # function growing past any fixed-size window.
+        start = llama_cpp.index(f"def {name}")
+        indent = " " * (start - llama_cpp.rfind("\n", 0, start) - 1)
+        nxt = llama_cpp.find(f"\n{indent}def ", start + 1)
+        return llama_cpp[start : nxt if nxt != -1 else len(llama_cpp)]
+
     assert (
-        "except (ImportError, OSError, ValueError):" in find_block
+        "except (ImportError, OSError, ValueError):"
+        in _method_body("_find_llama_server_binary")
     ), "_find_llama_server_binary must catch (ImportError, OSError, ValueError) from studio_root()"
-    kill_def_idx = llama_cpp.index("def _kill_orphaned_servers")
-    kill_block = llama_cpp[kill_def_idx : kill_def_idx + 4000]
     assert (
-        "except (ImportError, OSError, ValueError):" in kill_block
+        "except (ImportError, OSError, ValueError):"
+        in _method_body("_kill_orphaned_servers")
     ), "sibling _kill_orphaned_servers must keep its (ImportError, OSError, ValueError) handler"
 
 

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -882,13 +882,11 @@ def test_llama_cpp_search_roots_handles_studio_root_oserror():
         nxt = llama_cpp.find(f"\n{indent}def ", start + 1)
         return llama_cpp[start : nxt if nxt != -1 else len(llama_cpp)]
 
-    assert (
-        "except (ImportError, OSError, ValueError):"
-        in _method_body("_find_llama_server_binary")
+    assert "except (ImportError, OSError, ValueError):" in _method_body(
+        "_find_llama_server_binary"
     ), "_find_llama_server_binary must catch (ImportError, OSError, ValueError) from studio_root()"
-    assert (
-        "except (ImportError, OSError, ValueError):"
-        in _method_body("_kill_orphaned_servers")
+    assert "except (ImportError, OSError, ValueError):" in _method_body(
+        "_kill_orphaned_servers"
     ), "sibling _kill_orphaned_servers must keep its (ImportError, OSError, ValueError) handler"
 
 


### PR DESCRIPTION
## Summary

Fixes two failing tests on `main`, one a real installer bug and one a brittle guard.

### 1. `install_prebuilt` re-installs an already-installed fallback bundle (real bug)

`install_prebuilt` computes `diffusion_visual_server_backfill_needed` from the newest candidate (`plan.attempts[0]`). When that is `True`, it passed `existing_install_dir=None` to `validate_prebuilt_attempts`, which disables the "existing install already matches this candidate, skip the reinstall" check for the **whole plan**.

So when the newest published bundle needs a DiffusionGemma backfill **and** fails validation, the installer falls back to an older bundle that is **already correctly installed**, and re-downloads + re-extracts it over the working install instead of keeping it.

Fix: pass the real install dir always, and gate the skip **per-attempt** in `validate_prebuilt_attempts` (a matching candidate is skipped unless that specific candidate still needs the backfill re-extract). The newest candidate still re-extracts when it needs the backfill; the already-installed older fallback is now correctly skipped.

Covered by `test_install_prebuilt_skips_same_release_fallback_attempt_when_installed`.

### 2. `test_llama_cpp_search_roots_handles_studio_root_oserror` (brittle test)

This guard asserts `_find_llama_server_binary` catches `(ImportError, OSError, ValueError)` from `studio_root()`. The handler **already exists** and is correct, but the test read a fixed 4000-char window from the function start; the function grew past that (its except sits ~4900 chars in), so the guard silently failed without any code regression.

Fix: slice from `def <name>` to the next sibling `def` at the same indent so the check covers the whole method however large it grows. Applied to both `_find_llama_server_binary` and `_kill_orphaned_servers`.

## Tests

- Both previously-failing tests pass.
- `tests/studio/install/test_install_llama_prebuilt_logic.py`, `tests/studio/install/test_selection_logic.py`, `tests/studio/install/smoke_test_llama_prebuilt.py`, and `tests/test_studio_install_workspace_guard.py` all pass (285 + 85 green locally), so the per-attempt skip change does not regress the fallback / backfill paths.
