### PR TITLE
Fix Responses tool output content arrays

### DIFF
--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -416,7 +416,7 @@ class ImageUrl(BaseModel):
     """Image URL object — supports data URIs and remote URLs."""
 
     url: str = Field(..., description = "data:image/png;base64,... or https://...")
-    detail: Optional[Literal["auto", "low", "high"]] = "auto"
+    detail: Optional[Literal["auto", "low", "high", "original"]] = "auto"
 
 
 class ImageContentPart(BaseModel):
@@ -1125,7 +1125,7 @@ class ResponsesInputImagePart(BaseModel):
 
     type: Literal["input_image"]
     image_url: str = Field(..., description = "data:image/png;base64,... or https://...")
-    detail: Optional[Literal["auto", "low", "high"]] = "auto"
+    detail: Optional[Literal["auto", "low", "high", "original"]] = "auto"
 
 
 class ResponsesOutputTextPart(BaseModel):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5309,7 +5309,7 @@ def _responses_message_text(content: Union[str, list]) -> str:
     return "\n".join(parts)
 
 
-def _responses_tool_output_content(output: Union[str, list]) -> str:
+def _responses_tool_output_content(output: Union[str, list]) -> Union[str, list]:
     """Return Chat Completions-safe content for a Responses tool result."""
     if isinstance(output, str):
         return output if output.strip() else "(no output)"
@@ -5318,6 +5318,8 @@ def _responses_tool_output_content(output: Union[str, list]) -> str:
         return "(no output)"
 
     text_parts: list[str] = []
+    chat_parts: list = []
+    has_multimodal = False
     for part in output:
         if not isinstance(part, dict):
             return json.dumps(output)
@@ -5325,10 +5327,51 @@ def _responses_tool_output_content(output: Union[str, list]) -> str:
         if part_type in ("input_text", "output_text", "text"):
             text = part.get("text")
             if text is None:
-                return json.dumps(output)
-            text_parts.append(str(text))
+                _raise_unsupported_openai_parameter(
+                    "input",
+                    "Responses function_call_output.output text parts require a text field.",
+                )
+            text = str(text)
+            text_parts.append(text)
+            chat_parts.append(TextContentPart(type = "text", text = text))
             continue
+        if part_type == "input_image":
+            image_url = part.get("image_url")
+            if not isinstance(image_url, str) or not image_url:
+                if part.get("file_id"):
+                    _raise_unsupported_openai_parameter(
+                        "input",
+                        "Responses function_call_output.output input_image parts with file_id are not supported by the local adapter. Use image_url instead.",
+                    )
+                _raise_unsupported_openai_parameter(
+                    "input",
+                    "Responses function_call_output.output input_image parts require an image_url string.",
+                )
+            detail = part.get("detail", "auto")
+            if detail is None:
+                detail = "auto"
+            if detail not in ("auto", "low", "high"):
+                _raise_unsupported_openai_parameter(
+                    "input",
+                    "Responses function_call_output.output input_image detail must be auto, low, or high.",
+                )
+            chat_parts.append(
+                ImageContentPart(
+                    type = "image_url",
+                    image_url = ImageUrl(url = image_url, detail = detail),
+                )
+            )
+            has_multimodal = True
+            continue
+        if part_type == "input_file":
+            _raise_unsupported_openai_parameter(
+                "input",
+                "Responses function_call_output.output input_file parts are not supported by the local adapter.",
+            )
         return json.dumps(output)
+
+    if has_multimodal:
+        return chat_parts
 
     text = "\n".join(text_parts)
     return text if text.strip() else "(no output)"
@@ -5535,9 +5578,8 @@ def _normalise_responses_input(payload: ResponsesRequest) -> list[ChatMessage]:
             continue
 
         if isinstance(item, ResponsesFunctionCallOutputInputItem):
-            # Chat Completions tool messages are text-only. Flatten pure text
-            # content arrays, but preserve mixed / unsupported arrays as JSON
-            # rather than silently dropping file/image parts.
+            # Flatten pure text arrays for broad template compatibility, and
+            # forward image URL outputs as real multimodal parts for vision models.
             output = _responses_tool_output_content(item.output)
             messages.append(
                 ChatMessage(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5350,10 +5350,10 @@ def _responses_tool_output_content(output: Union[str, list]) -> Union[str, list]
             detail = part.get("detail", "auto")
             if detail is None:
                 detail = "auto"
-            if detail not in ("auto", "low", "high"):
+            if detail not in ("auto", "low", "high", "original"):
                 _raise_unsupported_openai_parameter(
                     "input",
-                    "Responses function_call_output.output input_image detail must be auto, low, or high.",
+                    "Responses function_call_output.output input_image detail must be auto, low, high, or original.",
                 )
             chat_parts.append(
                 ImageContentPart(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5309,15 +5309,29 @@ def _responses_message_text(content: Union[str, list]) -> str:
     return "\n".join(parts)
 
 
-def _responses_tool_output_text(output: Union[str, list]) -> str:
+def _responses_tool_output_content(output: Union[str, list]) -> str:
     """Return Chat Completions-safe content for a Responses tool result."""
     if isinstance(output, str):
         return output if output.strip() else "(no output)"
 
-    if output:
+    if not output:
+        return "(no output)"
+
+    text_parts: list[str] = []
+    for part in output:
+        if not isinstance(part, dict):
+            return json.dumps(output)
+        part_type = part.get("type")
+        if part_type in ("input_text", "output_text", "text"):
+            text = part.get("text")
+            if text is None:
+                return json.dumps(output)
+            text_parts.append(str(text))
+            continue
         return json.dumps(output)
 
-    return "(no output)"
+    text = "\n".join(text_parts)
+    return text if text.strip() else "(no output)"
 
 
 _RESPONSES_THINK_OPEN = "<think>"
@@ -5521,10 +5535,10 @@ def _normalise_responses_input(payload: ResponsesRequest) -> list[ChatMessage]:
             continue
 
         if isinstance(item, ResponsesFunctionCallOutputInputItem):
-            # Chat Completions `role="tool"` requires string content; serialize
-            # a Responses content-array output and keep empty outputs from
-            # tripping the stricter ChatMessage role validator.
-            output = _responses_tool_output_text(item.output)
+            # Chat Completions tool messages are text-only. Flatten pure text
+            # content arrays, but preserve mixed / unsupported arrays as JSON
+            # rather than silently dropping file/image parts.
+            output = _responses_tool_output_content(item.output)
             messages.append(
                 ChatMessage(
                     role = "tool",

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -60,7 +60,7 @@ from routes.inference import (
     _build_chat_request,
     _chat_tool_calls_to_responses_output,
     _normalise_responses_input,
-    _responses_tool_output_text,
+    _responses_tool_output_content,
     _responses_non_streaming,
     _responses_stream,
     _translate_responses_tool_choice_to_chat,
@@ -435,20 +435,96 @@ class TestNormaliseResponsesInputWithTools:
         assert sum(1 for m in msgs if m.role == "system") == 1
         assert "A" in msgs[0].content and "B" in msgs[0].content
 
-    def test_content_array_output_serialised_to_json_string(self):
+    def test_content_array_text_output_flattens_to_tool_text(self):
         payload = ResponsesRequest(
             input = [
                 {
                     "type": "function_call_output",
                     "call_id": "call_1",
-                    "output": [{"type": "output_text", "text": "ok"}],
+                    "output": [{"type": "input_text", "text": "ok"}],
                 }
             ],
         )
         msgs = _normalise_responses_input(payload)
         assert msgs[0].role == "tool"
-        # Content is serialised so llama-server sees a string.
-        assert json.loads(msgs[0].content) == [{"type": "output_text", "text": "ok"}]
+        assert msgs[0].content == "ok"
+
+    def test_content_array_image_output_preserves_raw_payload(self):
+        payload = ResponsesRequest(
+            input = [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [
+                        {"type": "input_text", "text": "see image"},
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,AAA",
+                            "detail": "high",
+                        },
+                    ],
+                }
+            ],
+        )
+        msgs = _normalise_responses_input(payload)
+        assert msgs[0].role == "tool"
+        assert msgs[0].tool_call_id == "call_1"
+        assert json.loads(msgs[0].content) == [
+            {"type": "input_text", "text": "see image"},
+            {
+                "type": "input_image",
+                "image_url": "data:image/png;base64,AAA",
+                "detail": "high",
+            },
+        ]
+
+    def test_content_array_file_id_image_output_preserves_raw_payload(self):
+        payload = ResponsesRequest(
+            input = [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [
+                        {"type": "input_text", "text": "see image"},
+                        {"type": "input_image", "file_id": "file_abc"},
+                    ],
+                }
+            ],
+        )
+        msgs = _normalise_responses_input(payload)
+        assert msgs[0].role == "tool"
+        assert json.loads(msgs[0].content) == [
+            {"type": "input_text", "text": "see image"},
+            {"type": "input_image", "file_id": "file_abc"},
+        ]
+
+    def test_content_array_file_output_preserves_raw_payload(self):
+        payload = ResponsesRequest(
+            input = [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [
+                        {"type": "input_text", "text": "see file"},
+                        {
+                            "type": "input_file",
+                            "file_data": "data:application/pdf;base64,AAA",
+                            "filename": "report.pdf",
+                        },
+                    ],
+                }
+            ],
+        )
+        msgs = _normalise_responses_input(payload)
+        assert msgs[0].role == "tool"
+        assert json.loads(msgs[0].content) == [
+            {"type": "input_text", "text": "see file"},
+            {
+                "type": "input_file",
+                "file_data": "data:application/pdf;base64,AAA",
+                "filename": "report.pdf",
+            },
+        ]
 
     def test_empty_function_call_output_gets_no_output_sentinel(self):
         payload = ResponsesRequest(
@@ -541,8 +617,8 @@ class TestNormaliseResponsesInputWithTools:
         assert msgs[0].content == "(no output)"
 
     def test_tool_output_serializer_preserves_non_empty_text(self):
-        assert _responses_tool_output_text("done") == "done"
-        assert _responses_tool_output_text("  done  ") == "  done  "
+        assert _responses_tool_output_content("done") == "done"
+        assert _responses_tool_output_content("  done  ") == "  done  "
 
 
 # =====================================================================

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -36,6 +36,7 @@ import json
 
 import httpx
 import pytest
+from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
@@ -449,7 +450,7 @@ class TestNormaliseResponsesInputWithTools:
         assert msgs[0].role == "tool"
         assert msgs[0].content == "ok"
 
-    def test_content_array_image_output_preserves_raw_payload(self):
+    def test_content_array_image_output_becomes_multimodal_tool_content(self):
         payload = ResponsesRequest(
             input = [
                 {
@@ -469,16 +470,30 @@ class TestNormaliseResponsesInputWithTools:
         msgs = _normalise_responses_input(payload)
         assert msgs[0].role == "tool"
         assert msgs[0].tool_call_id == "call_1"
-        assert json.loads(msgs[0].content) == [
-            {"type": "input_text", "text": "see image"},
+        assert msgs[0].model_dump(exclude_none = True)["content"] == [
+            {"type": "text", "text": "see image"},
             {
-                "type": "input_image",
-                "image_url": "data:image/png;base64,AAA",
-                "detail": "high",
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/png;base64,AAA",
+                    "detail": "high",
+                },
             },
         ]
 
-    def test_content_array_file_id_image_output_preserves_raw_payload(self):
+        chat_req = _build_chat_request(payload, msgs, stream = False)
+        assert chat_req.model_dump(exclude_none = True)["messages"][0]["content"] == [
+            {"type": "text", "text": "see image"},
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/png;base64,AAA",
+                    "detail": "high",
+                },
+            },
+        ]
+
+    def test_content_array_file_id_image_output_rejected_clearly(self):
         payload = ResponsesRequest(
             input = [
                 {
@@ -491,14 +506,12 @@ class TestNormaliseResponsesInputWithTools:
                 }
             ],
         )
-        msgs = _normalise_responses_input(payload)
-        assert msgs[0].role == "tool"
-        assert json.loads(msgs[0].content) == [
-            {"type": "input_text", "text": "see image"},
-            {"type": "input_image", "file_id": "file_abc"},
-        ]
+        with pytest.raises(HTTPException) as exc:
+            _normalise_responses_input(payload)
+        assert exc.value.status_code == 400
+        assert "file_id" in str(exc.value.detail)
 
-    def test_content_array_file_output_preserves_raw_payload(self):
+    def test_content_array_file_output_rejected_clearly(self):
         payload = ResponsesRequest(
             input = [
                 {
@@ -515,16 +528,25 @@ class TestNormaliseResponsesInputWithTools:
                 }
             ],
         )
-        msgs = _normalise_responses_input(payload)
-        assert msgs[0].role == "tool"
-        assert json.loads(msgs[0].content) == [
-            {"type": "input_text", "text": "see file"},
-            {
-                "type": "input_file",
-                "file_data": "data:application/pdf;base64,AAA",
-                "filename": "report.pdf",
-            },
-        ]
+        with pytest.raises(HTTPException) as exc:
+            _normalise_responses_input(payload)
+        assert exc.value.status_code == 400
+        assert "input_file" in str(exc.value.detail)
+
+    def test_content_array_malformed_image_output_rejected_clearly(self):
+        payload = ResponsesRequest(
+            input = [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [{"type": "input_image", "detail": "high"}],
+                }
+            ],
+        )
+        with pytest.raises(HTTPException) as exc:
+            _normalise_responses_input(payload)
+        assert exc.value.status_code == 400
+        assert "image_url" in str(exc.value.detail)
 
     def test_empty_function_call_output_gets_no_output_sentinel(self):
         payload = ResponsesRequest(

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -493,6 +493,33 @@ class TestNormaliseResponsesInputWithTools:
             },
         ]
 
+    def test_content_array_image_output_allows_original_detail(self):
+        payload = ResponsesRequest(
+            input = [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [
+                        {
+                            "type": "input_image",
+                            "image_url": "https://example.com/screenshot.png",
+                            "detail": "original",
+                        },
+                    ],
+                }
+            ],
+        )
+        msgs = _normalise_responses_input(payload)
+        assert msgs[0].model_dump(exclude_none = True)["content"] == [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "https://example.com/screenshot.png",
+                    "detail": "original",
+                },
+            },
+        ]
+
     def test_content_array_file_id_image_output_rejected_clearly(self):
         payload = ResponsesRequest(
             input = [


### PR DESCRIPTION
## Summary
- Preserve Responses `function_call_output.output` text and image content arrays instead of JSON-serializing them.
- This prevents structured tool outputs from being shown to the model as raw JSON and allows image-bearing tool results to reach vision models.

## Tests
- pytest studio/backend/tests/test_responses_tool_passthrough.py

Closes #6271