### PR TITLE
Studio: resolve studio home before the llama-only setup split

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -386,6 +386,70 @@ if [[ "$keynames" == *$'\nCOLAB_'* ]]; then
     IS_COLAB=true
 fi
 
+# Resolve studio home + ownership marker before the llama-only split: the
+# llama.cpp section needs STUDIO_HOME / _STUDIO_HOME_IS_CUSTOM, but
+# UNSLOTH_STUDIO_LLAMA_ONLY=1 ('unsloth studio update') skips the base install.
+# UNSLOTH_STUDIO_HOME (or STUDIO_HOME alias) overrides the install root
+# (mirrors install.sh). UNSLOTH_STUDIO_HOME wins when both are set.
+_studio_override_var=""
+_studio_override="${UNSLOTH_STUDIO_HOME:-}"
+if [ -n "$_studio_override" ]; then
+    _studio_override_var="UNSLOTH_STUDIO_HOME"
+else
+    _studio_override="${STUDIO_HOME:-}"
+    [ -n "$_studio_override" ] && _studio_override_var="STUDIO_HOME"
+fi
+# Strip whitespace so " " is treated as unset (matches Python .strip()).
+_studio_override=$(printf '%s' "$_studio_override" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+case "$_studio_override" in
+    "~") _studio_override="$HOME" ;;
+    "~/"*) _studio_override="$HOME/${_studio_override#'~/'}" ;;
+esac
+if [ -n "$_studio_override" ]; then
+    # setup.sh runs against an existing install (via 'unsloth studio update');
+    # a typo in the override must fail fast instead of materializing an
+    # empty workspace dir. Mirrors setup.ps1 behavior.
+    if [ ! -d "$_studio_override" ]; then
+        echo "ERROR: $_studio_override_var=$_studio_override does not exist." >&2
+        echo "       Run install.sh to create the install root before 'unsloth studio update'." >&2
+        exit 1
+    fi
+    [ -w "$_studio_override" ] || { echo "ERROR: $_studio_override_var=$_studio_override is not writable." >&2; exit 1; }
+    STUDIO_HOME="$(CDPATH= cd -P -- "$_studio_override" && pwd -P)" || exit 1
+else
+    STUDIO_HOME="$HOME/.unsloth/studio"
+fi
+VENV_DIR="$STUDIO_HOME/unsloth_studio"
+VENV_T5_530_DIR="$STUDIO_HOME/.venv_t5_530"
+VENV_T5_550_DIR="$STUDIO_HOME/.venv_t5_550"
+VENV_T5_510_DIR="$STUDIO_HOME/.venv_t5_510"
+
+_STUDIO_OWNED_MARKER=".unsloth-studio-owned"
+_LEGACY_STUDIO_HOME="$HOME/.unsloth/studio"
+_studio_home_canon="$STUDIO_HOME"
+if [ -d "$_studio_home_canon" ]; then
+    _studio_home_canon=$(CDPATH= cd -P -- "$_studio_home_canon" 2>/dev/null && pwd -P) \
+        || _studio_home_canon="$STUDIO_HOME"
+fi
+if [ -d "$_LEGACY_STUDIO_HOME" ]; then
+    _LEGACY_STUDIO_HOME=$(CDPATH= cd -P -- "$_LEGACY_STUDIO_HOME" 2>/dev/null && pwd -P) \
+        || _LEGACY_STUDIO_HOME="$HOME/.unsloth/studio"
+fi
+_STUDIO_HOME_IS_CUSTOM=false
+if [ "$_studio_home_canon" != "$_LEGACY_STUDIO_HOME" ]; then
+    _STUDIO_HOME_IS_CUSTOM=true
+fi
+_assert_studio_owned_or_absent() {
+    _aso_dir="$1"
+    _aso_label="$2"
+    [ -d "$_aso_dir" ] || return 0
+    if [ "$_STUDIO_HOME_IS_CUSTOM" = true ] && [ ! -f "$_aso_dir/$_STUDIO_OWNED_MARKER" ]; then
+        echo "ERROR: $_aso_dir already exists and is not marked as a Studio-owned $_aso_label." >&2
+        echo "       Move it aside or choose an empty UNSLOTH_STUDIO_HOME before re-running." >&2
+        exit 1
+    fi
+}
+
 if [ "$_LLAMA_ONLY" != "1" ]; then
 # ── Detect whether frontend needs building ──
 # Skip if SKIP_STUDIO_FRONTEND=1 (Tauri desktop app bundles its own frontend),
@@ -605,40 +669,6 @@ if [ -d "$SCRIPT_DIR/backend/core/data_recipe/oxc-validator" ] && command -v npm
 fi
 
 # ── Python venv + deps ──
-# UNSLOTH_STUDIO_HOME (or STUDIO_HOME alias) overrides the install root
-# (mirrors install.sh). UNSLOTH_STUDIO_HOME wins when both are set.
-_studio_override_var=""
-_studio_override="${UNSLOTH_STUDIO_HOME:-}"
-if [ -n "$_studio_override" ]; then
-    _studio_override_var="UNSLOTH_STUDIO_HOME"
-else
-    _studio_override="${STUDIO_HOME:-}"
-    [ -n "$_studio_override" ] && _studio_override_var="STUDIO_HOME"
-fi
-# Strip whitespace so " " is treated as unset (matches Python .strip()).
-_studio_override=$(printf '%s' "$_studio_override" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-case "$_studio_override" in
-    "~") _studio_override="$HOME" ;;
-    "~/"*) _studio_override="$HOME/${_studio_override#'~/'}" ;;
-esac
-if [ -n "$_studio_override" ]; then
-    # setup.sh runs against an existing install (via 'unsloth studio update');
-    # a typo in the override must fail fast instead of materializing an
-    # empty workspace dir. Mirrors setup.ps1 behavior.
-    if [ ! -d "$_studio_override" ]; then
-        echo "ERROR: $_studio_override_var=$_studio_override does not exist." >&2
-        echo "       Run install.sh to create the install root before 'unsloth studio update'." >&2
-        exit 1
-    fi
-    [ -w "$_studio_override" ] || { echo "ERROR: $_studio_override_var=$_studio_override is not writable." >&2; exit 1; }
-    STUDIO_HOME="$(CDPATH= cd -P -- "$_studio_override" && pwd -P)" || exit 1
-else
-    STUDIO_HOME="$HOME/.unsloth/studio"
-fi
-VENV_DIR="$STUDIO_HOME/unsloth_studio"
-VENV_T5_530_DIR="$STUDIO_HOME/.venv_t5_530"
-VENV_T5_550_DIR="$STUDIO_HOME/.venv_t5_550"
-VENV_T5_510_DIR="$STUDIO_HOME/.venv_t5_510"
 
 [ -d "$REPO_ROOT/.venv" ] && rm -rf "$REPO_ROOT/.venv"
 [ -d "$REPO_ROOT/.venv_overlay" ] && rm -rf "$REPO_ROOT/.venv_overlay"
@@ -757,38 +787,6 @@ fi
 # Gemma 4 models need transformers>=5.5.0; Gemma 4 Unified needs 5.10.x.
 # Pre-install into separate directories to avoid runtime pip overhead.
 # The training subprocess prepends the appropriate dir to sys.path.
-#
-# Runs outside the _SKIP_PYTHON_DEPS gate so that upgrades from legacy
-# single .venv_t5 are always migrated to the tiered layout.
-# why: in env-override mode $STUDIO_HOME is user-chosen; require the
-# ownership marker before rm -rf so unrelated dirs survive. Gated on the
-# canonical comparison so an override pointing at the legacy default still
-# behaves like a default install.
-_STUDIO_OWNED_MARKER=".unsloth-studio-owned"
-_LEGACY_STUDIO_HOME="$HOME/.unsloth/studio"
-_studio_home_canon="$STUDIO_HOME"
-if [ -d "$_studio_home_canon" ]; then
-    _studio_home_canon=$(CDPATH= cd -P -- "$_studio_home_canon" 2>/dev/null && pwd -P) \
-        || _studio_home_canon="$STUDIO_HOME"
-fi
-if [ -d "$_LEGACY_STUDIO_HOME" ]; then
-    _LEGACY_STUDIO_HOME=$(CDPATH= cd -P -- "$_LEGACY_STUDIO_HOME" 2>/dev/null && pwd -P) \
-        || _LEGACY_STUDIO_HOME="$HOME/.unsloth/studio"
-fi
-_STUDIO_HOME_IS_CUSTOM=false
-if [ "$_studio_home_canon" != "$_LEGACY_STUDIO_HOME" ]; then
-    _STUDIO_HOME_IS_CUSTOM=true
-fi
-_assert_studio_owned_or_absent() {
-    _aso_dir="$1"
-    _aso_label="$2"
-    [ -d "$_aso_dir" ] || return 0
-    if [ "$_STUDIO_HOME_IS_CUSTOM" = true ] && [ ! -f "$_aso_dir/$_STUDIO_OWNED_MARKER" ]; then
-        echo "ERROR: $_aso_dir already exists and is not marked as a Studio-owned $_aso_label." >&2
-        echo "       Move it aside or choose an empty UNSLOTH_STUDIO_HOME before re-running." >&2
-        exit 1
-    fi
-}
 _target_has_pkg_version() {
     _thpv_dir="$1"
     _thpv_pkg="$2"


### PR DESCRIPTION
## Summary

`UNSLOTH_STUDIO_LLAMA_ONLY=1` is the llama.cpp-only fast path in `studio/setup.sh`, i.e. the llama.cpp step that `unsloth studio update` runs. It skips the base-install block, but that block is also where the studio-home resolution lives:

- `STUDIO_HOME`
- `_STUDIO_HOME_IS_CUSTOM`
- `_STUDIO_OWNED_MARKER`
- `_assert_studio_owned_or_absent()`

`setup.sh` runs under `set -euo pipefail`, so the llama.cpp section reads these while undefined and aborts immediately:

```
setup.sh: _STUDIO_HOME_IS_CUSTOM: unbound variable
```

No prebuilt is installed and the run exits 1, so a llama-only update silently does nothing.

## Fix

Hoist the studio-home and ownership resolution above the `if [ "$_LLAMA_ONLY" != "1" ]` guard so the full install and the llama-only path share it. The move is verbatim, so full installs compute the same values, just slightly earlier (before the frontend build rather than after), which also makes a bad `UNSLOTH_STUDIO_HOME` fail faster.

## Verification

`bash -n studio/setup.sh` passes. Ran the patched `setup.sh` in llama-only mode against a downgraded install:

| Scenario | Before | After |
| --- | --- | --- |
| Default home (`~/.unsloth/llama.cpp`) | unbound variable, exit 1 | b9518 to b9611, exit 0 |
| Custom `UNSLOTH_STUDIO_HOME` | unbound variable, exit 1 | b9518 to b9611, ownership marker written |

The custom-home run exercises the moved `_STUDIO_HOME_IS_CUSTOM=true` branch, `_assert_studio_owned_or_absent`, and the marker write, all of which were previously unreachable in llama-only mode.
