### PR TITLE
Studio: decide diffusion routing before the SWA resolver

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2380,6 +2380,15 @@ class LlamaCppBackend:
                         # what we have.
                         break
 
+            # Decide diffusion routing before the SWA resolver below: it can raise on an arch transformers
+            # does not know, which would otherwise drop a DiffusionGemma model to plain llama-server.
+            self._is_diffusion = bool((arch and arch.lower().startswith("diffusion")) or canvas_seen)
+            if self._is_diffusion:
+                logger.info(
+                    f"GGUF metadata: diffusion model detected (architecture={arch}); "
+                    "will serve via the diffusion runner"
+                )
+
             # Expand a scalar period straight from the GGUF first.
             if (
                 self._sliding_window_pattern is None
@@ -2390,9 +2399,10 @@ class LlamaCppBackend:
                     (i + 1) % sliding_window_pattern_period != 0 for i in range(self._n_layers)
                 ]
 
-            # Otherwise hand off to the resolver (cache / bootstrap /
-            # transformers / HF); see `_resolve_swa_pattern`.
-            if self._sliding_window_pattern is None and self._sliding_window and self._n_layers:
+            # Otherwise hand off to the resolver (cache / bootstrap / transformers / HF). Diffusion models
+            # skip it: they do not use Studio's SWA pattern and the resolver can raise for them.
+            if (self._sliding_window_pattern is None and self._sliding_window
+                    and self._n_layers and not self._is_diffusion):
                 hf_repo_candidates = (
                     general.get("general.source.huggingface.repository"),
                     _hf_repo_from_url(general.get("general.source.url")),
@@ -2417,17 +2427,6 @@ class LlamaCppBackend:
                     arch,
                     self._n_layers,
                     hf_repo_candidates,
-                )
-
-            # Block-diffusion models (DiffusionGemma) report a diffusion arch
-            # and/or a diffusion.canvas_length KV; they need the diffusion runner.
-            self._is_diffusion = bool(
-                (arch and arch.lower().startswith("diffusion")) or canvas_seen
-            )
-            if self._is_diffusion:
-                logger.info(
-                    f"GGUF metadata: diffusion model detected (architecture={arch}); "
-                    "will serve via the diffusion runner"
                 )
 
             if self._context_length:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2382,7 +2382,9 @@ class LlamaCppBackend:
 
             # Decide diffusion routing before the SWA resolver below: it can raise on an arch transformers
             # does not know, which would otherwise drop a DiffusionGemma model to plain llama-server.
-            self._is_diffusion = bool((arch and arch.lower().startswith("diffusion")) or canvas_seen)
+            self._is_diffusion = bool(
+                (arch and arch.lower().startswith("diffusion")) or canvas_seen
+            )
             if self._is_diffusion:
                 logger.info(
                     f"GGUF metadata: diffusion model detected (architecture={arch}); "
@@ -2401,8 +2403,12 @@ class LlamaCppBackend:
 
             # Otherwise hand off to the resolver (cache / bootstrap / transformers / HF). Diffusion models
             # skip it: they do not use Studio's SWA pattern and the resolver can raise for them.
-            if (self._sliding_window_pattern is None and self._sliding_window
-                    and self._n_layers and not self._is_diffusion):
+            if (
+                self._sliding_window_pattern is None
+                and self._sliding_window
+                and self._n_layers
+                and not self._is_diffusion
+            ):
                 hf_repo_candidates = (
                     general.get("general.source.huggingface.repository"),
                     _hf_repo_from_url(general.get("general.source.url")),


### PR DESCRIPTION
## Problem
Loading a DiffusionGemma GGUF in Studio could fail with `llama-server failed to start. Check that the GGUF file is valid`, even though `llama-diffusion-cli` runs the same model fine.

`_read_gguf_metadata` assigned `self._is_diffusion` after calling `_resolve_swa_pattern`, both inside one `try/except`. The resolver reaches into transformers/HF, which can raise for an architecture transformers does not know (`diffusion-gemma`). When it raised, the shared `except` swallowed it and left `_is_diffusion` False, so the model was routed to plain llama-server (which cannot serve a block-diffusion GGUF) instead of the diffusion runner. It only reproduced on hosts where the SWA pattern was not already cached or inline in the GGUF.

## Fix
- Set `_is_diffusion` right after the KV parse loop (it only needs `arch` / `canvas_seen`), before the resolver, so a resolver error can no longer drop the diffusion routing.
- Skip the SWA resolver for diffusion models: they do not use Studio's SWA pattern (the visual server reads its own metadata), and it can raise for them.

## Verification
Monkeypatching `_resolve_swa_pattern` to raise on a real DiffusionGemma GGUF: `_is_diffusion` is now True (was False), the resolver is invoked 0 times, and the remaining metadata (context_length, chat_template, reasoning, tools) is still read. No change for non-diffusion models.
