### PR TITLE
Studio: make lifespan shutdown resilient to a dead default executor

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -296,6 +296,7 @@ from utils.hardware import (
 import utils.hardware.hardware as _hw_module
 
 from utils.cache_cleanup import clear_unsloth_compiled_cache
+from utils.lifespan_shutdown import run_lifespan_shutdown
 from utils.native_path_leases import native_path_leases_supported
 from utils.update_status import (
     get_studio_install_source_status,
@@ -463,9 +464,12 @@ async def lifespan(app: FastAPI):
     else:
         app.state.bootstrap_password = storage.get_bootstrap_password()
     yield
-    await asyncio.to_thread(terminate_hub_downloads)
-    _hw_module.DEVICE = None
-    clear_unsloth_compiled_cache()
+
+    await run_lifespan_shutdown(
+        terminate_hub_downloads,
+        clear_unsloth_compiled_cache,
+        _hw_module,
+    )
 
 
 app = FastAPI(

--- a/studio/backend/tests/test_lifespan_shutdown.py
+++ b/studio/backend/tests/test_lifespan_shutdown.py
@@ -1,21 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Regression tests for the FastAPI lifespan shutdown cleanup.
-
-On an abrupt shutdown (closing the Windows console window, or interpreter
-teardown racing uvicorn's graceful stop) the event loop's default thread-pool
-executor can already be shut down by the time the lifespan shutdown runs, so
-``asyncio.to_thread()`` raises ``RuntimeError: cannot schedule new futures after
-shutdown``. Before the fix that raise was the first statement after ``yield``
-and aborted the rest of the shutdown chain (propagating through every nested
-``merged_lifespan`` ``__aexit__``), producing "Application shutdown failed.
-Exiting." ``run_lifespan_shutdown`` must absorb that and still run the later
-cleanup steps.
-
-The helper is dependency-injected and free of the heavy backend import graph,
-so these tests need only ``structlog`` — no torch / unsloth / fastapi install.
-"""
+"""Regression tests for run_lifespan_shutdown: a dead default executor (the
+abrupt-shutdown teardown race) must not abort the remaining cleanup. The helper
+is dependency-injected, so these need only structlog."""
 
 import asyncio
 import contextvars
@@ -40,23 +28,20 @@ def test_run_lifespan_shutdown_survives_dead_default_executor():
 
     async def _drive():
         loop = asyncio.get_running_loop()
-        # Instantiate then kill the default executor to mimic the teardown race
-        # that made asyncio.to_thread() raise in the field report.
+        # Kill the default executor to mimic the teardown race.
         await asyncio.to_thread(lambda: None)
         loop._default_executor.shutdown(wait = True)
-        # Must NOT raise even though the executor backing to_thread is gone.
         await run_lifespan_shutdown(terminate, clear, hw)
 
     asyncio.run(_drive())
 
-    # Inline fallback still terminated downloads, and later cleanup still ran.
     assert term_box["n"] == 1, "terminate must run via inline fallback"
     assert clear_box["n"] == 1, "clear must still run after the to_thread failure"
     assert hw.DEVICE is None
 
 
 def test_run_lifespan_shutdown_normal_path():
-    """With a healthy executor the cleanup runs exactly once via the thread."""
+    """Healthy executor: each step runs exactly once."""
     term_box, terminate = _counter()
     clear_box, clear = _counter()
     hw = types.SimpleNamespace(DEVICE = "cuda:0")
@@ -69,7 +54,7 @@ def test_run_lifespan_shutdown_normal_path():
 
 
 def test_run_lifespan_shutdown_swallows_terminate_errors():
-    """A failure terminating downloads must not prevent later cleanup (no raise)."""
+    """A terminate failure must not block later cleanup."""
     clear_box, clear = _counter()
     hw = types.SimpleNamespace(DEVICE = "cuda:0")
 
@@ -83,14 +68,13 @@ def test_run_lifespan_shutdown_swallows_terminate_errors():
 
 
 def test_run_lifespan_shutdown_swallows_clear_errors():
-    """A failure in the final cleanup step must not raise out of shutdown."""
+    """A clear failure must not raise out of shutdown."""
     term_box, terminate = _counter()
     hw = types.SimpleNamespace(DEVICE = "cuda:0")
 
     def _boom():
         raise ValueError("boom")
 
-    # Should complete without raising.
     asyncio.run(run_lifespan_shutdown(terminate, _boom, hw))
 
     assert term_box["n"] == 1
@@ -98,10 +82,7 @@ def test_run_lifespan_shutdown_swallows_clear_errors():
 
 
 def test_run_lifespan_shutdown_does_not_retry_body_runtime_error():
-    """A RuntimeError raised by the callable body (not a dead executor) must run
-    terminate exactly once. The inline fallback is reserved for the case where
-    the work never got scheduled, so a body-side RuntimeError on a healthy
-    executor must not trigger a second inline execution."""
+    """A body-side RuntimeError (healthy executor) must run terminate once, not retry inline."""
     term_box, _ = _counter()
     clear_box, clear = _counter()
     hw = types.SimpleNamespace(DEVICE = "cuda:0")
@@ -118,9 +99,7 @@ def test_run_lifespan_shutdown_does_not_retry_body_runtime_error():
 
 
 def test_run_lifespan_shutdown_preserves_contextvars():
-    """terminate_downloads runs inside a copy of the caller's context, matching
-    the previous asyncio.to_thread behaviour (which copied contextvars). Without
-    that parity the worker thread would see an empty context."""
+    """terminate runs in a copy of the caller's context (parity with asyncio.to_thread)."""
     cv = contextvars.ContextVar("unsloth_test_cv")
     cv.set("bound-value")
     seen = []

--- a/studio/backend/tests/test_lifespan_shutdown.py
+++ b/studio/backend/tests/test_lifespan_shutdown.py
@@ -18,6 +18,7 @@ so these tests need only ``structlog`` — no torch / unsloth / fastapi install.
 """
 
 import asyncio
+import contextvars
 import types
 
 from utils.lifespan_shutdown import run_lifespan_shutdown
@@ -113,4 +114,24 @@ def test_run_lifespan_shutdown_does_not_retry_body_runtime_error():
 
     assert term_box["n"] == 1, "body RuntimeError must not be retried inline"
     assert clear_box["n"] == 1, "later cleanup must still run"
+    assert hw.DEVICE is None
+
+
+def test_run_lifespan_shutdown_preserves_contextvars():
+    """terminate_downloads runs inside a copy of the caller's context, matching
+    the previous asyncio.to_thread behaviour (which copied contextvars). Without
+    that parity the worker thread would see an empty context."""
+    cv = contextvars.ContextVar("unsloth_test_cv")
+    cv.set("bound-value")
+    seen = []
+    clear_box, clear = _counter()
+    hw = types.SimpleNamespace(DEVICE = "cuda:0")
+
+    def terminate():
+        seen.append(cv.get("UNSET"))
+
+    asyncio.run(run_lifespan_shutdown(terminate, clear, hw))
+
+    assert seen == ["bound-value"], "terminate must run with the caller's contextvars"
+    assert clear_box["n"] == 1
     assert hw.DEVICE is None

--- a/studio/backend/tests/test_lifespan_shutdown.py
+++ b/studio/backend/tests/test_lifespan_shutdown.py
@@ -35,14 +35,14 @@ def _counter():
 def test_run_lifespan_shutdown_survives_dead_default_executor():
     term_box, terminate = _counter()
     clear_box, clear = _counter()
-    hw = types.SimpleNamespace(DEVICE="cuda:0")
+    hw = types.SimpleNamespace(DEVICE = "cuda:0")
 
     async def _drive():
         loop = asyncio.get_running_loop()
         # Instantiate then kill the default executor to mimic the teardown race
         # that made asyncio.to_thread() raise in the field report.
         await asyncio.to_thread(lambda: None)
-        loop._default_executor.shutdown(wait=True)
+        loop._default_executor.shutdown(wait = True)
         # Must NOT raise even though the executor backing to_thread is gone.
         await run_lifespan_shutdown(terminate, clear, hw)
 
@@ -58,7 +58,7 @@ def test_run_lifespan_shutdown_normal_path():
     """With a healthy executor the cleanup runs exactly once via the thread."""
     term_box, terminate = _counter()
     clear_box, clear = _counter()
-    hw = types.SimpleNamespace(DEVICE="cuda:0")
+    hw = types.SimpleNamespace(DEVICE = "cuda:0")
 
     asyncio.run(run_lifespan_shutdown(terminate, clear, hw))
 
@@ -70,7 +70,7 @@ def test_run_lifespan_shutdown_normal_path():
 def test_run_lifespan_shutdown_swallows_terminate_errors():
     """A failure terminating downloads must not prevent later cleanup (no raise)."""
     clear_box, clear = _counter()
-    hw = types.SimpleNamespace(DEVICE="cuda:0")
+    hw = types.SimpleNamespace(DEVICE = "cuda:0")
 
     def _boom():
         raise ValueError("boom")
@@ -84,7 +84,7 @@ def test_run_lifespan_shutdown_swallows_terminate_errors():
 def test_run_lifespan_shutdown_swallows_clear_errors():
     """A failure in the final cleanup step must not raise out of shutdown."""
     term_box, terminate = _counter()
-    hw = types.SimpleNamespace(DEVICE="cuda:0")
+    hw = types.SimpleNamespace(DEVICE = "cuda:0")
 
     def _boom():
         raise ValueError("boom")

--- a/studio/backend/tests/test_lifespan_shutdown.py
+++ b/studio/backend/tests/test_lifespan_shutdown.py
@@ -40,6 +40,24 @@ def test_run_lifespan_shutdown_survives_dead_default_executor():
     assert hw.DEVICE is None
 
 
+def test_run_lifespan_shutdown_survives_shutdown_default_executor():
+    """Production path: loop.shutdown_default_executor() makes run_in_executor raise
+    'Executor shutdown has been called'; the helper must still recover inline."""
+    term_box, terminate = _counter()
+    clear_box, clear = _counter()
+    hw = types.SimpleNamespace(DEVICE = "cuda:0")
+
+    async def _drive():
+        await asyncio.get_running_loop().shutdown_default_executor()
+        await run_lifespan_shutdown(terminate, clear, hw)
+
+    asyncio.run(_drive())
+
+    assert term_box["n"] == 1, "terminate must run via inline fallback"
+    assert clear_box["n"] == 1
+    assert hw.DEVICE is None
+
+
 def test_run_lifespan_shutdown_normal_path():
     """Healthy executor: each step runs exactly once."""
     term_box, terminate = _counter()

--- a/studio/backend/tests/test_lifespan_shutdown.py
+++ b/studio/backend/tests/test_lifespan_shutdown.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for the FastAPI lifespan shutdown cleanup.
+
+On an abrupt shutdown (closing the Windows console window, or interpreter
+teardown racing uvicorn's graceful stop) the event loop's default thread-pool
+executor can already be shut down by the time the lifespan shutdown runs, so
+``asyncio.to_thread()`` raises ``RuntimeError: cannot schedule new futures after
+shutdown``. Before the fix that raise was the first statement after ``yield``
+and aborted the rest of the shutdown chain (propagating through every nested
+``merged_lifespan`` ``__aexit__``), producing "Application shutdown failed.
+Exiting." ``run_lifespan_shutdown`` must absorb that and still run the later
+cleanup steps.
+
+The helper is dependency-injected and free of the heavy backend import graph,
+so these tests need only ``structlog`` — no torch / unsloth / fastapi install.
+"""
+
+import asyncio
+import types
+
+from utils.lifespan_shutdown import run_lifespan_shutdown
+
+
+def _counter():
+    box = {"n": 0}
+
+    def _fn():
+        box["n"] += 1
+
+    return box, _fn
+
+
+def test_run_lifespan_shutdown_survives_dead_default_executor():
+    term_box, terminate = _counter()
+    clear_box, clear = _counter()
+    hw = types.SimpleNamespace(DEVICE="cuda:0")
+
+    async def _drive():
+        loop = asyncio.get_running_loop()
+        # Instantiate then kill the default executor to mimic the teardown race
+        # that made asyncio.to_thread() raise in the field report.
+        await asyncio.to_thread(lambda: None)
+        loop._default_executor.shutdown(wait=True)
+        # Must NOT raise even though the executor backing to_thread is gone.
+        await run_lifespan_shutdown(terminate, clear, hw)
+
+    asyncio.run(_drive())
+
+    # Inline fallback still terminated downloads, and later cleanup still ran.
+    assert term_box["n"] == 1, "terminate must run via inline fallback"
+    assert clear_box["n"] == 1, "clear must still run after the to_thread failure"
+    assert hw.DEVICE is None
+
+
+def test_run_lifespan_shutdown_normal_path():
+    """With a healthy executor the cleanup runs exactly once via the thread."""
+    term_box, terminate = _counter()
+    clear_box, clear = _counter()
+    hw = types.SimpleNamespace(DEVICE="cuda:0")
+
+    asyncio.run(run_lifespan_shutdown(terminate, clear, hw))
+
+    assert term_box["n"] == 1
+    assert clear_box["n"] == 1
+    assert hw.DEVICE is None
+
+
+def test_run_lifespan_shutdown_swallows_terminate_errors():
+    """A failure terminating downloads must not prevent later cleanup (no raise)."""
+    clear_box, clear = _counter()
+    hw = types.SimpleNamespace(DEVICE="cuda:0")
+
+    def _boom():
+        raise ValueError("boom")
+
+    asyncio.run(run_lifespan_shutdown(_boom, clear, hw))
+
+    assert clear_box["n"] == 1, "later cleanup must run even when terminate raises"
+    assert hw.DEVICE is None
+
+
+def test_run_lifespan_shutdown_swallows_clear_errors():
+    """A failure in the final cleanup step must not raise out of shutdown."""
+    term_box, terminate = _counter()
+    hw = types.SimpleNamespace(DEVICE="cuda:0")
+
+    def _boom():
+        raise ValueError("boom")
+
+    # Should complete without raising.
+    asyncio.run(run_lifespan_shutdown(terminate, _boom, hw))
+
+    assert term_box["n"] == 1
+    assert hw.DEVICE is None

--- a/studio/backend/tests/test_lifespan_shutdown.py
+++ b/studio/backend/tests/test_lifespan_shutdown.py
@@ -94,3 +94,23 @@ def test_run_lifespan_shutdown_swallows_clear_errors():
 
     assert term_box["n"] == 1
     assert hw.DEVICE is None
+
+
+def test_run_lifespan_shutdown_does_not_retry_body_runtime_error():
+    """A RuntimeError raised by the callable body (not a dead executor) must run
+    terminate exactly once. The inline fallback is reserved for the case where
+    the work never got scheduled, so a body-side RuntimeError on a healthy
+    executor must not trigger a second inline execution."""
+    term_box, _ = _counter()
+    clear_box, clear = _counter()
+    hw = types.SimpleNamespace(DEVICE = "cuda:0")
+
+    def _boom():
+        term_box["n"] += 1
+        raise RuntimeError("body failed")
+
+    asyncio.run(run_lifespan_shutdown(_boom, clear, hw))
+
+    assert term_box["n"] == 1, "body RuntimeError must not be retried inline"
+    assert clear_box["n"] == 1, "later cleanup must still run"
+    assert hw.DEVICE is None

--- a/studio/backend/utils/lifespan_shutdown.py
+++ b/studio/backend/utils/lifespan_shutdown.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Resilient FastAPI lifespan shutdown cleanup.
+
+On an abrupt shutdown (closing the Windows console window, or interpreter
+teardown racing uvicorn's graceful stop) the event loop's default thread-pool
+executor can already be shut down by the time the lifespan shutdown runs, so
+``asyncio.to_thread()`` raises ``RuntimeError: cannot schedule new futures after
+shutdown``. If that raise escapes, it propagates up through every nested
+``merged_lifespan`` ``__aexit__`` and aborts the rest of the shutdown chain,
+which surfaces as "Application shutdown failed. Exiting." and skips the later
+cleanup steps.
+
+Kept dependency-injected (callables + the hardware module passed in) and free of
+the heavy backend import graph so it can be unit-tested in isolation.
+"""
+
+import asyncio
+from typing import Callable
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def run_lifespan_shutdown(
+    terminate_downloads: Callable[[], None],
+    clear_compiled_cache: Callable[[], None],
+    hw_module,
+) -> None:
+    """Run shutdown cleanup defensively; never raise.
+
+    Each step is guarded independently so a failure in one can't skip the
+    others (the original bug: an unguarded ``to_thread`` failure dropped the
+    later cleanup and the whole nested-lifespan shutdown).
+    """
+    try:
+        await asyncio.to_thread(terminate_downloads)
+    except RuntimeError:
+        # Default executor already gone (teardown race). terminate_downloads is
+        # itself best-effort and quick, so run it inline on the loop thread.
+        try:
+            terminate_downloads()
+        except Exception as exc:
+            logger.warning("terminate_downloads (inline) failed at shutdown: %s", exc)
+    except Exception as exc:
+        logger.warning("terminate_downloads failed at shutdown: %s", exc)
+
+    try:
+        hw_module.DEVICE = None
+    except Exception as exc:
+        logger.warning("clearing hardware DEVICE failed at shutdown: %s", exc)
+
+    try:
+        clear_compiled_cache()
+    except Exception as exc:
+        logger.warning("clear_compiled_cache failed at shutdown: %s", exc)

--- a/studio/backend/utils/lifespan_shutdown.py
+++ b/studio/backend/utils/lifespan_shutdown.py
@@ -12,6 +12,7 @@ unit-tested without the heavy backend import graph.
 
 import asyncio
 import contextvars
+import types
 from typing import Callable
 
 import structlog
@@ -20,12 +21,14 @@ logger = structlog.get_logger(__name__)
 
 
 async def run_lifespan_shutdown(
-    terminate_downloads: Callable[[], None], clear_compiled_cache: Callable[[], None], hw_module
+    terminate_downloads: Callable[[], None],
+    clear_compiled_cache: Callable[[], None],
+    hw_module: types.ModuleType,
 ) -> None:
     """Run each shutdown step guarded so one failure can't skip the others; never raise."""
     loop = asyncio.get_running_loop()
     # Copy context for parity with asyncio.to_thread. Schedule and await
-    # separately so a dead executor (raises at submit) retries inline, while a
+    # separately so a dead executor (raises at submit) runs inline, while a
     # body exception (raised at await) is logged, not re-run.
     ctx = contextvars.copy_context()
     try:

--- a/studio/backend/utils/lifespan_shutdown.py
+++ b/studio/backend/utils/lifespan_shutdown.py
@@ -17,6 +17,7 @@ the heavy backend import graph so it can be unit-tested in isolation.
 """
 
 import asyncio
+import contextvars
 from typing import Callable
 
 import structlog
@@ -40,13 +41,18 @@ async def run_lifespan_shutdown(
     # way we only retry inline when the work never got scheduled, never when the
     # body ran and raised (which would double-execute it).
     loop = asyncio.get_running_loop()
+    # Copy the current context so terminate_downloads runs with the same
+    # contextvars asyncio.to_thread would have given it (exact parity with the
+    # previous implementation). The only intended behaviour change is the inline
+    # fallback below, taken when scheduling onto a dead executor fails.
+    ctx = contextvars.copy_context()
     try:
-        future = loop.run_in_executor(None, terminate_downloads)
+        future = loop.run_in_executor(None, ctx.run, terminate_downloads)
     except RuntimeError:
         # Default executor already gone (teardown race). terminate_downloads is
         # itself best-effort and quick, so run it inline on the loop thread.
         try:
-            terminate_downloads()
+            ctx.run(terminate_downloads)
         except Exception as exc:
             logger.warning("terminate_downloads (inline) failed at shutdown: %s", exc)
     else:

--- a/studio/backend/utils/lifespan_shutdown.py
+++ b/studio/backend/utils/lifespan_shutdown.py
@@ -33,8 +33,15 @@ async def run_lifespan_shutdown(
     others (the original bug: an unguarded ``to_thread`` failure dropped the
     later cleanup and the whole nested-lifespan shutdown).
     """
+    # Schedule and await separately (rather than asyncio.to_thread) so the two
+    # failure modes stay distinct: a dead default executor makes run_in_executor
+    # raise synchronously at submit time, whereas an exception from
+    # terminate_downloads itself only surfaces when the future is awaited. That
+    # way we only retry inline when the work never got scheduled, never when the
+    # body ran and raised (which would double-execute it).
+    loop = asyncio.get_running_loop()
     try:
-        await asyncio.to_thread(terminate_downloads)
+        future = loop.run_in_executor(None, terminate_downloads)
     except RuntimeError:
         # Default executor already gone (teardown race). terminate_downloads is
         # itself best-effort and quick, so run it inline on the loop thread.
@@ -42,8 +49,11 @@ async def run_lifespan_shutdown(
             terminate_downloads()
         except Exception as exc:
             logger.warning("terminate_downloads (inline) failed at shutdown: %s", exc)
-    except Exception as exc:
-        logger.warning("terminate_downloads failed at shutdown: %s", exc)
+    else:
+        try:
+            await future
+        except Exception as exc:
+            logger.warning("terminate_downloads failed at shutdown: %s", exc)
 
     try:
         hw_module.DEVICE = None

--- a/studio/backend/utils/lifespan_shutdown.py
+++ b/studio/backend/utils/lifespan_shutdown.py
@@ -25,9 +25,7 @@ logger = structlog.get_logger(__name__)
 
 
 async def run_lifespan_shutdown(
-    terminate_downloads: Callable[[], None],
-    clear_compiled_cache: Callable[[], None],
-    hw_module,
+    terminate_downloads: Callable[[], None], clear_compiled_cache: Callable[[], None], hw_module
 ) -> None:
     """Run shutdown cleanup defensively; never raise.
 

--- a/studio/backend/utils/lifespan_shutdown.py
+++ b/studio/backend/utils/lifespan_shutdown.py
@@ -3,17 +3,11 @@
 
 """Resilient FastAPI lifespan shutdown cleanup.
 
-On an abrupt shutdown (closing the Windows console window, or interpreter
-teardown racing uvicorn's graceful stop) the event loop's default thread-pool
-executor can already be shut down by the time the lifespan shutdown runs, so
-``asyncio.to_thread()`` raises ``RuntimeError: cannot schedule new futures after
-shutdown``. If that raise escapes, it propagates up through every nested
-``merged_lifespan`` ``__aexit__`` and aborts the rest of the shutdown chain,
-which surfaces as "Application shutdown failed. Exiting." and skips the later
-cleanup steps.
-
-Kept dependency-injected (callables + the hardware module passed in) and free of
-the heavy backend import graph so it can be unit-tested in isolation.
+On an abrupt shutdown (Windows console-close, interpreter teardown racing
+uvicorn) the loop's default executor may already be dead, so an unguarded
+``asyncio.to_thread`` raise here would abort the nested-lifespan unwind and
+surface as "Application shutdown failed". Dependency-injected so it can be
+unit-tested without the heavy backend import graph.
 """
 
 import asyncio
@@ -28,29 +22,16 @@ logger = structlog.get_logger(__name__)
 async def run_lifespan_shutdown(
     terminate_downloads: Callable[[], None], clear_compiled_cache: Callable[[], None], hw_module
 ) -> None:
-    """Run shutdown cleanup defensively; never raise.
-
-    Each step is guarded independently so a failure in one can't skip the
-    others (the original bug: an unguarded ``to_thread`` failure dropped the
-    later cleanup and the whole nested-lifespan shutdown).
-    """
-    # Schedule and await separately (rather than asyncio.to_thread) so the two
-    # failure modes stay distinct: a dead default executor makes run_in_executor
-    # raise synchronously at submit time, whereas an exception from
-    # terminate_downloads itself only surfaces when the future is awaited. That
-    # way we only retry inline when the work never got scheduled, never when the
-    # body ran and raised (which would double-execute it).
+    """Run each shutdown step guarded so one failure can't skip the others; never raise."""
     loop = asyncio.get_running_loop()
-    # Copy the current context so terminate_downloads runs with the same
-    # contextvars asyncio.to_thread would have given it (exact parity with the
-    # previous implementation). The only intended behaviour change is the inline
-    # fallback below, taken when scheduling onto a dead executor fails.
+    # Copy context for parity with asyncio.to_thread. Schedule and await
+    # separately so a dead executor (raises at submit) retries inline, while a
+    # body exception (raised at await) is logged, not re-run.
     ctx = contextvars.copy_context()
     try:
         future = loop.run_in_executor(None, ctx.run, terminate_downloads)
     except RuntimeError:
-        # Default executor already gone (teardown race). terminate_downloads is
-        # itself best-effort and quick, so run it inline on the loop thread.
+        # Executor gone: run inline on the loop thread.
         try:
             ctx.run(terminate_downloads)
         except Exception as exc:


### PR DESCRIPTION
## Summary

Fixes a shutdown crash in Unsloth Studio that aborts the FastAPI lifespan cleanup and surfaces as `Application shutdown failed. Exiting.`

On an abrupt shutdown (closing the Windows console window, or interpreter teardown racing uvicorn's graceful stop) the event loop's default thread-pool executor can already be shut down by the time the lifespan shutdown runs. The first statement after `yield` in `studio/backend/main.py` was an unguarded:

```python
await asyncio.to_thread(terminate_hub_downloads)
```

`asyncio.to_thread` schedules onto the loop's default executor via `executor.submit`, which then raises:

```
RuntimeError: cannot schedule new futures after shutdown
```

Because that raise was unguarded, it propagated up through every nested `merged_lifespan` `__aexit__` and aborted the remaining cleanup (`_hw_module.DEVICE = None`, `clear_unsloth_compiled_cache()`), producing the long shutdown traceback and `Application shutdown failed. Exiting.` Note that `terminate_active_downloads` itself is already best-effort and never raises, so the failure is purely in scheduling the work onto a dead executor, not in the cleanup body.

## Fix

- Extract the post-`yield` cleanup into `utils/lifespan_shutdown.run_lifespan_shutdown(...)`.
- Guard each step independently so one failure cannot skip the others.
- On the `to_thread` `RuntimeError`, fall back to running the terminate inline on the loop thread (it is quick and already best-effort), so shutdown still completes cleanly.

The helper is dependency-injected (the two callables plus the hardware module are passed in) and free of the heavy backend import graph, so it is unit-testable in isolation without torch / unsloth / fastapi.

## Tests

`studio/backend/tests/test_lifespan_shutdown.py`, 4 cases:

- survives a shut-down default executor (the reported failure), via the inline fallback, and still runs later cleanup
- normal path runs each step once
- an error terminating downloads does not abort later cleanup
- an error in the final cleanup step does not raise out of shutdown

The tests need only `structlog` and `pytest`. Validated on `windows-latest` and `ubuntu-latest` runners on Python 3.13 (`4 passed`).

## Not changed

Two unrelated messages reported alongside this are benign and handled gracefully, so they are out of scope here:

- `Skipping import of cpp extensions due to incompatible torch version ... for torchao` is a torchao warning on the ROCm nightly; it falls back to Python paths.
- `sentence-transformers embedder unavailable (...); falling back to the llama-server GGUF embedder` is the intended fallback in `core/rag/embeddings.py` when the torch stack cannot import sentence-transformers; RAG keeps working via the GGUF embedder.
