### PR TITLE
Studio: don't silently fall back to a CPU prebuilt on NVIDIA Linux GPU hosts

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5932,9 +5932,9 @@ def resolve_install_attempts(
 
 def _linux_published_attempts(host: HostInfo, bundle: PublishedReleaseBundle) -> list[AssetChoice]:
     """Build the install attempts for a fork Linux host from a manifest-described
-    bundle: CUDA (with a CPU fallback), per-gfx ROCm, or CPU. Same selection the
-    upstream filename path used, just sourced from the manifest instead of
-    reconstructed from asset names."""
+    bundle: CUDA, per-gfx ROCm, or (non-GPU) CPU. Same selection the upstream
+    filename path used, just sourced from the manifest instead of reconstructed
+    from asset names."""
     attempts: list[AssetChoice] = []
     if host.has_usable_nvidia:
         # Prefer the cudart major Studio loads at runtime (torch's bundled
@@ -5949,7 +5949,7 @@ def _linux_published_attempts(host: HostInfo, bundle: PublishedReleaseBundle) ->
         )
         if selection is not None:
             attempts.extend(selection.attempts)
-    if host.has_rocm and not host.has_usable_nvidia:
+    elif host.has_rocm:
         # Use the fork's own per-gfx ROCm bundle (hash-approved, ships the full
         # ROCm runtime). Do NOT append the CPU asset for ROCm-only hosts: if no
         # bundle covers the GPU we want validate_prebuilt_attempts to raise
@@ -5959,6 +5959,10 @@ def _linux_published_attempts(host: HostInfo, bundle: PublishedReleaseBundle) ->
         if published_rocm is not None:
             attempts.append(published_rocm)
     else:
+        # CPU-only host. A usable-NVIDIA host never reaches here -- if its CUDA
+        # selection produced nothing we want an empty attempt list so the caller
+        # source-builds with CUDA, not a CPU-only binary silently installed on a
+        # GPU host (mirrors the ROCm branch, and Windows NVIDIA).
         cpu_choice = published_asset_choice_for_kind(bundle, "linux-cpu")
         if cpu_choice is not None:
             attempts.append(cpu_choice)

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -2611,6 +2611,59 @@ class TestDirectLinuxNvidiaCpuGate:
         assert [a.install_kind for a in plan.attempts] == ["linux-cpu"]
 
 
+class TestLinuxPublishedAttemptsNvidiaCpuGate:
+    """Live fork-manifest path (_linux_published_attempts): an NVIDIA host whose
+    CUDA selection finds nothing must NOT be handed the manifest's CPU bundle --
+    the attempt list stays empty so the caller source-builds with CUDA instead of
+    silently installing a CPU-only binary on a GPU host. CPU-only hosts still get
+    the CPU bundle. Mirrors the ROCm policy and TestDirectLinuxNvidiaCpuGate (the
+    latter covers direct_linux_release_plan, which is off the live path, this the
+    live path)."""
+
+    def _cpu_only_bundle(self):
+        return make_release(
+            [
+                make_artifact(
+                    "app-b8508-linux-x64-cpu.tar.gz",
+                    install_kind = "linux-cpu",
+                    runtime_line = None,
+                    coverage_class = None,
+                    supported_sms = [],
+                    min_sm = None,
+                    max_sm = None,
+                    bundle_profile = None,
+                    rank = 1000,
+                ),
+            ]
+        )
+
+    def test_nvidia_host_without_cuda_line_gets_no_cpu_attempt(self, monkeypatch):
+        monkeypatch.setattr(
+            INSTALL_LLAMA_PREBUILT,
+            "detect_torch_cuda_runtime_preference",
+            lambda host: CudaRuntimePreference(runtime_line = None, selection_log = []),
+        )
+        monkeypatch.setattr(
+            INSTALL_LLAMA_PREBUILT,
+            "detected_linux_runtime_lines",
+            lambda: (["cuda13"], {"cuda13": ["/usr/local/cuda/lib64"]}),
+        )
+        host = make_host(driver_cuda_version = (13, 1), compute_caps = ["100"])
+        attempts = INSTALL_LLAMA_PREBUILT._linux_published_attempts(host, self._cpu_only_bundle())
+        assert attempts == []
+
+    def test_cpu_host_gets_cpu_attempt(self):
+        host = make_host(
+            nvidia_smi = None,
+            driver_cuda_version = None,
+            compute_caps = [],
+            has_physical_nvidia = False,
+            has_usable_nvidia = False,
+        )
+        attempts = INSTALL_LLAMA_PREBUILT._linux_published_attempts(host, self._cpu_only_bundle())
+        assert [a.install_kind for a in attempts] == ["linux-cpu"]
+
+
 # ===========================================================================
 # N.1d. published_windows_cuda_attempts -- version-dynamic ordering seed
 # ===========================================================================


### PR DESCRIPTION
This PR is a preparation for merging https://github.com/unslothai/llama.cpp/pull/23.

Currently, on a Linux device with a usable NVIDIA GPU, if no CUDA prebuilt covers the GPU, a source compilation is triggered. After unslothai/llama.cpp#23 is merged and runs, the manifest will also include CPU builds, and `_linux_published_attempts` would then fall through a bare `else` and append the manifest's `linux-cpu` bundle. That silently installs a CPU-only llama.cpp on a GPU box, instead of raising so the caller source-builds with CUDA.

Every other GPU path already avoids this (ROCm excludes CPU, Windows NVIDIA returns before its CPU line). The bare `else` came in with #5963.

## Fix

Exclude usable-NVIDIA hosts from the CPU branch (now a flat `if has_usable_nvidia / elif has_rocm / else`), so an empty CUDA selection source-builds with CUDA instead. No effect today; this lands ahead of unslothai/llama.cpp#23 so its CPU builds don't start shadowing GPU hosts.

Added a live-path test; `test_selection_logic.py` 246 passed.
