### PR TITLE
Studio: arm the VRAM-settle wait after the startup orphan reaper

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -803,7 +803,11 @@ class LlamaCppBackend:
         # to decide whether to wait for the VRAM reclaim to finish.
         self._last_kill_monotonic: float = 0.0
 
-        self._kill_orphaned_servers()
+        _reaped = self._kill_orphaned_servers()
+        if _reaped:
+            # Reaped VRAM frees lazily; arm the settle wait so the first load
+            # waits before ranking GPUs by free memory.
+            self._last_kill_monotonic = time.monotonic()
         atexit.register(self._cleanup)
 
     # ── Properties ────────────────────────────────────────────────
@@ -5013,7 +5017,7 @@ class LlamaCppBackend:
                 self._llama_log_fh = None
 
     @staticmethod
-    def _kill_orphaned_servers():
+    def _kill_orphaned_servers() -> int:
         """Kill orphaned llama-server processes started by studio.
 
         Only kills processes whose resolved binary lives under a known
@@ -5025,7 +5029,11 @@ class LlamaCppBackend:
         Uses psutil for cross-platform support (Linux, macOS, Windows);
         falls back to pgrep + /proc/<pid>/exe on Linux when psutil is
         absent.
+
+        Returns the count of processes killed; callers arm the VRAM-settle
+        wait on a positive count.
         """
+        killed = 0
         try:
             # -- Build the ownership allowlist --------------------------------
             # exact_binaries -- env var overrides (exact path match).
@@ -5117,6 +5125,7 @@ class LlamaCppBackend:
                             continue
 
                         proc.kill()
+                        killed += 1
                         logger.info(
                             f"Killed orphaned llama-server process (pid={proc.info['pid']})"
                         )
@@ -5129,7 +5138,7 @@ class LlamaCppBackend:
             else:
                 # -- Fallback: pgrep + /proc/<pid>/exe (Linux only) -----------
                 if sys.platform != "linux":
-                    return
+                    return killed
                 result = subprocess.run(
                     ["pgrep", "-a", "-f", "llama-server"],
                     capture_output = True,
@@ -5138,7 +5147,7 @@ class LlamaCppBackend:
                     env = child_env_without_native_path_secret(),
                 )
                 if result.returncode != 0:
-                    return
+                    return killed
 
                 for line in result.stdout.strip().splitlines():
                     parts = line.strip().split(None, 1)
@@ -5169,6 +5178,7 @@ class LlamaCppBackend:
 
                     try:
                         os.kill(pid, signal.SIGKILL)
+                        killed += 1
                         logger.info(f"Killed orphaned llama-server process (pid={pid})")
                     except ProcessLookupError:
                         pass
@@ -5176,6 +5186,7 @@ class LlamaCppBackend:
                         pass
         except Exception:
             logger.warning("Error during orphan server cleanup", exc_info = True)
+        return killed
 
     def _cleanup(self):
         """atexit handler to ensure llama-server is terminated."""

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -315,3 +315,73 @@ def test_helper_is_static_method_callable_off_class():
         LlamaCppBackend._wait_for_vram_settle(
             **_kw(max_wait = 0.1, interval = 0.05),
         )
+
+
+# ---------------------------------------------------------------------------
+# Startup orphan-reaper arms the settle clock (the "wrong card after restart"
+# root cause: reaped VRAM frees lazily, so the first load must wait).
+# ---------------------------------------------------------------------------
+
+
+def test_kill_orphaned_servers_returns_count():
+    """The reaper reports how many owned orphans it killed, so __init__ can
+    arm the settle wait. Only Studio-owned llama-server procs count."""
+    import os
+
+    mypid = os.getpid()
+    fake_path = "/tmp/unsloth-test-llama/llama-server"
+    killed: list[int] = []
+
+    class _FakeProc:
+        def __init__(self, pid, name, exe):
+            self.info = {"pid": pid, "name": name, "exe": exe}
+
+        def kill(self):
+            killed.append(self.info["pid"])
+
+    owned = _FakeProc(mypid + 1, "llama-server", fake_path)  # exact-path match
+    foreign = _FakeProc(mypid + 2, "llama-server", "/usr/bin/llama-server")
+    unrelated = _FakeProc(mypid + 3, "python3", "/usr/bin/python3")
+
+    fake_psutil = _types.ModuleType("psutil")
+    fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+    fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    fake_psutil.ZombieProcess = type("ZombieProcess", (Exception,), {})
+    fake_psutil.process_iter = lambda attrs = None: [owned, foreign, unrelated]
+
+    with (
+        patch.dict(sys.modules, {"psutil": fake_psutil}),
+        patch.dict(os.environ, {"LLAMA_SERVER_PATH": fake_path}),
+    ):
+        n = LlamaCppBackend._kill_orphaned_servers()
+    assert n == 1, "only the Studio-owned orphan should be counted"
+    assert killed == [mypid + 1]
+
+    # No owned orphans -> zero, so __init__ leaves the cold-start sentinel.
+    fake_psutil.process_iter = lambda attrs = None: [foreign, unrelated]
+    killed.clear()
+    with (
+        patch.dict(sys.modules, {"psutil": fake_psutil}),
+        patch.dict(os.environ, {"LLAMA_SERVER_PATH": fake_path}),
+    ):
+        assert LlamaCppBackend._kill_orphaned_servers() == 0
+    assert killed == []
+
+
+def test_startup_reaper_arms_settle_timestamp():
+    """__init__ arms ``_last_kill_monotonic`` when the startup reaper kills an
+    orphan (so the first load_model waits for VRAM to settle), and leaves the
+    0.0 cold-start sentinel when nothing was reaped."""
+    with patch.object(LlamaCppBackend, "_kill_orphaned_servers", staticmethod(lambda: 1)):
+        before = time.monotonic()
+        backend = LlamaCppBackend()
+        after = time.monotonic()
+    assert (
+        before <= backend._last_kill_monotonic <= after
+    ), "a positive reap count must arm the settle clock"
+
+    with patch.object(LlamaCppBackend, "_kill_orphaned_servers", staticmethod(lambda: 0)):
+        backend_cold = LlamaCppBackend()
+    assert (
+        backend_cold._last_kill_monotonic == 0.0
+    ), "no reap must leave the cold-start sentinel so the wait is skipped"


### PR DESCRIPTION
## Problem

On a multi-GPU box (reported with an RTX 5090 32GB plus an RTX PRO 6000 Blackwell 96GB), after a few Studio open/close cycles a GGUF starts loading onto the smaller card and then hangs at the first prompt. GPU selection ranks cards by free VRAM, so a card that momentarily reads low gets ranked below a smaller card.

Root cause: on startup `__init__` reaps the previous run's orphaned `llama-server`, but the driver does not reclaim that VRAM synchronously. Studio already has `_wait_for_vram_settle` to bridge the kill to reclaim window, but it was never armed for the startup reap: `_kill_orphaned_servers` returned nothing and `_last_kill_monotonic` stayed `0.0`, so the settle guard (`since_kill <= 0.0`) short-circuited the wait on the first load. That first load samples VRAM while the previously used (larger) card still looks occupied, ranks it below the smaller card, and pins there.

## Fix

`_kill_orphaned_servers` now returns the number of processes it killed, and `__init__` arms `_last_kill_monotonic` when that count is positive. The first `load_model` after a restart then waits for VRAM to settle before ranking GPUs, so the model loads back onto the larger card.

This is intentionally narrow. The compute-graph and auto-fit VRAM budget (the other half of the original report) is handled separately and more thoroughly in #6312, so the graph-reserve changes that were in an earlier revision of this PR have been dropped to avoid overlap.

## Tests

`test_llama_cpp_wait_for_vram_settle.py`: the reaper returns an accurate kill count (only Studio-owned `llama-server` processes are counted), and `__init__` arms the settle clock only on a positive count, leaving the `0.0` cold-start sentinel otherwise. The settle suite stays green.

Relates to #5106 and #5680. Complements #6312.
