### PR TITLE
Studio: use the shared spinner for loading toasts

### DIFF
--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -5,10 +5,10 @@ import {
   Alert02Icon,
   CheckmarkCircle02Icon,
   InformationCircleIcon,
-  Loading03Icon,
   MultiplicationSignCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { Spinner } from "@/components/ui/spinner";
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
@@ -51,13 +51,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
             className="size-4"
           />
         ),
-        loading: (
-          <HugeiconsIcon
-            icon={Loading03Icon}
-            strokeWidth={2}
-            className="size-4 animate-spin"
-          />
-        ),
+        // App-wide arc spinner so loading toasts match the "Downloading model" toast.
+        loading: <Spinner className="size-4 text-muted-foreground" />,
       }}
       style={
         {


### PR DESCRIPTION
## What

The toast loading spinner did not match the one shown while a model downloads, so notifications like "Unloading model" and "Downloading model" looked inconsistent.

This switches the sonner loading icon to the app wide `Spinner` (the circular arc spinner the download toast already renders), so every loading toast uses the same indicator.

## Changes

- `studio/frontend/src/components/ui/sonner.tsx`: use the shared `Spinner` component for the toast `loading` icon, replacing the separate hugeicons spinner.

## Notes

Frontend only, no behaviour change beyond the icon. Verified with a production `vite build`.
