### PR TITLE
Disable remote code for Studio config probes

### DIFF
--- a/studio/backend/models/responses.py
+++ b/studio/backend/models/responses.py
@@ -57,3 +57,12 @@ class EmbeddingCheckResponse(BaseModel):
     is_embedding: bool = Field(
         ..., description = "Whether the model is an embedding/sentence-transformer model"
     )
+
+
+class TrustRemoteCodeCheckResponse(BaseModel):
+    """Response for checking whether Studio defaults require custom model code"""
+
+    model_name: str = Field(..., description = "Model identifier")
+    requires_trust_remote_code: bool = Field(
+        ..., description = "Whether Studio defaults require trust_remote_code"
+    )

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1569,8 +1569,7 @@ async def get_model_config(
     response_model = TrustRemoteCodeCheckResponse,
 )
 async def get_model_trust_remote_code_requirement(
-    model_name: str,
-    current_subject: str = Depends(get_current_subject),
+    model_name: str, current_subject: str = Depends(get_current_subject)
 ):
     """Check Studio YAML defaults for a trust_remote_code requirement.
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -148,6 +148,7 @@ from models.responses import (
     LoRABaseModelResponse,
     VisionCheckResponse,
     EmbeddingCheckResponse,
+    TrustRemoteCodeCheckResponse,
 )
 
 router = APIRouter()
@@ -1559,6 +1560,48 @@ async def get_model_config(
             500,
             "Failed to get model config",
             event = "models.get_model_config_failed",
+            log = logger,
+        )
+
+
+@router.get(
+    "/trust-remote-code/{model_name:path}",
+    response_model = TrustRemoteCodeCheckResponse,
+)
+async def get_model_trust_remote_code_requirement(
+    model_name: str,
+    current_subject: str = Depends(get_current_subject),
+):
+    """Check Studio YAML defaults for a trust_remote_code requirement.
+
+    This intentionally avoids AutoConfig/model capability probes so resume
+    confirmation cannot execute repository code before the user consents.
+    """
+    try:
+        if not is_local_path(model_name):
+            resolved = resolve_cached_repo_id_case(model_name)
+            if resolved != model_name:
+                logger.info(
+                    "Using cached repo_id casing '%s' for requested '%s'",
+                    resolved,
+                    model_name,
+                )
+            model_name = resolved
+
+        config_dict = load_model_defaults(model_name)
+        requires_trust_remote_code = bool(
+            config_dict.get("training", {}).get("trust_remote_code", False)
+        )
+        return TrustRemoteCodeCheckResponse(
+            model_name = model_name,
+            requires_trust_remote_code = requires_trust_remote_code,
+        )
+    except Exception as e:
+        raise log_and_http_error(
+            e,
+            500,
+            "Failed to check model trust_remote_code requirement",
+            event = "models.get_model_trust_remote_code_requirement_failed",
             log = logger,
         )
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1526,7 +1526,6 @@ async def get_model_config(
         if max_position_embeddings is None:
             try:
                 from transformers import AutoConfig as _AutoConfig
-
                 _ac = _AutoConfig.from_pretrained(
                     model_name, trust_remote_code = False, token = hf_token
                 )

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1527,9 +1527,8 @@ async def get_model_config(
             try:
                 from transformers import AutoConfig as _AutoConfig
 
-                _trust = model_name.lower().startswith("unsloth/")
                 _ac = _AutoConfig.from_pretrained(
-                    model_name, trust_remote_code = _trust, token = hf_token
+                    model_name, trust_remote_code = False, token = hf_token
                 )
                 max_position_embeddings = _get_max_position_embeddings(_ac)
             except Exception:

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -252,14 +252,14 @@ async def start_training(
             "s3_config": request.s3_config.model_dump() if request.s3_config else None,
         }
 
-        # Training page has no trust_remote_code toggle; as a safety net consult
-        # YAML model defaults directly so models that need it always get it.
         if not training_kwargs["trust_remote_code"]:
             model_defaults = load_model_defaults(request.model_name)
             yaml_trust = model_defaults.get("training", {}).get("trust_remote_code", False)
             if yaml_trust:
-                logger.info(f"YAML config sets trust_remote_code=True for {request.model_name}")
-                training_kwargs["trust_remote_code"] = True
+                raise HTTPException(
+                    status_code = 400,
+                    detail = "This model requires custom code. Confirm it in Studio and try again.",
+                )
 
         # Free GPU memory: shut down any running inference/export subprocesses
         # before training (they'd compete for VRAM otherwise).

--- a/studio/backend/tests/test_export_absolute_paths.py
+++ b/studio/backend/tests/test_export_absolute_paths.py
@@ -204,6 +204,7 @@ def _install_lightweight_backend_stubs(monkeypatch):
         "LoRABaseModelResponse",
         "VisionCheckResponse",
         "EmbeddingCheckResponse",
+        "TrustRemoteCodeCheckResponse",
     ):
         setattr(models_responses, name, object)
     monkeypatch.setitem(sys.modules, "models.responses", models_responses)

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -5,6 +5,7 @@ import asyncio
 import importlib.util
 import os
 import re
+import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -370,6 +371,24 @@ class TestGpuAutoSelection(_GpuCacheResetMixin, unittest.TestCase):
 
         self.assertEqual(model_size_bytes, 1234)
         self.assertEqual(source, "vllm_utils")
+
+    def test_load_config_for_gpu_estimate_disables_remote_code_for_unsloth(self):
+        calls = []
+
+        class AutoConfig:
+            @staticmethod
+            def from_pretrained(model_name, **kwargs):
+                calls.append((model_name, kwargs))
+                return object()
+
+        with patch.dict(sys.modules, {"transformers": SimpleNamespace(AutoConfig = AutoConfig)}):
+            config = _hw_module._load_config_for_gpu_estimate("unsloth/custom-code")
+
+        self.assertIsNotNone(config)
+        self.assertEqual(
+            calls,
+            [("unsloth/custom-code", {"token": None, "trust_remote_code": False})],
+        )
 
     def test_auto_select_gpu_ids_chooses_smallest_fitting_subset(self):
         fake_devices = {

--- a/studio/backend/tests/test_models_get_model_config_case_resolution.py
+++ b/studio/backend/tests/test_models_get_model_config_case_resolution.py
@@ -77,3 +77,36 @@ def test_get_model_config_resolves_cached_case_before_model_checks(monkeypatch):
     assert calls["is_embedding_model"] == "Org/Model"
     assert calls["detect_audio_type"] == "Org/Model"
     assert calls["from_identifier"] == "Org/Model"
+
+
+def test_trust_remote_code_requirement_uses_yaml_defaults_only(monkeypatch):
+    calls: dict[str, str] = {}
+
+    def _record_load(model_name):
+        calls["load_model_defaults"] = model_name
+        return {"training": {"trust_remote_code": True}}
+
+    def _unexpected_probe(*_args, **_kwargs):
+        raise AssertionError("trust check must not run model capability probes")
+
+    monkeypatch.setattr(models_route, "is_local_path", lambda _: False)
+    monkeypatch.setattr(models_route, "resolve_cached_repo_id_case", lambda _: "Org/Requires")
+    monkeypatch.setattr(models_route, "load_model_defaults", _record_load)
+    monkeypatch.setattr(models_route, "is_vision_model", _unexpected_probe)
+    monkeypatch.setattr(models_route, "is_embedding_model", _unexpected_probe)
+    monkeypatch.setattr(
+        models_route.ModelConfig,
+        "from_identifier",
+        classmethod(lambda *_args, **_kwargs: _unexpected_probe()),
+    )
+
+    result = asyncio.run(
+        models_route.get_model_trust_remote_code_requirement(
+            model_name = "org/requires",
+            current_subject = "test-subject",
+        )
+    )
+
+    assert result.model_name == "Org/Requires"
+    assert result.requires_trust_remote_code is True
+    assert calls["load_model_defaults"] == "Org/Requires"

--- a/studio/backend/tests/test_models_get_model_config_case_resolution.py
+++ b/studio/backend/tests/test_models_get_model_config_case_resolution.py
@@ -79,6 +79,45 @@ def test_get_model_config_resolves_cached_case_before_model_checks(monkeypatch):
     assert calls["from_identifier"] == "Org/Model"
 
 
+def test_get_model_config_autoconfig_fallback_disables_remote_code_for_unsloth(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+
+    class _DummyModelConfig:
+        is_lora = False
+        base_model = None
+
+    class _AutoConfig:
+        @staticmethod
+        def from_pretrained(model_name, **kwargs):
+            calls.append((model_name, kwargs))
+            return object()
+
+    monkeypatch.setitem(sys.modules, "transformers", types.SimpleNamespace(AutoConfig = _AutoConfig))
+    monkeypatch.setattr(models_route, "is_local_path", lambda _: False)
+    monkeypatch.setattr(models_route, "resolve_cached_repo_id_case", lambda name: name)
+    monkeypatch.setattr(models_route, "load_model_defaults", lambda _: {})
+    monkeypatch.setattr(models_route, "is_vision_model", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(models_route, "is_embedding_model", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(model_config_module, "detect_audio_type", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        models_route.ModelConfig,
+        "from_identifier",
+        classmethod(lambda *_args, **_kwargs: _DummyModelConfig()),
+    )
+    monkeypatch.setattr(models_route, "_get_max_position_embeddings", lambda _config: None)
+    monkeypatch.setattr(models_route, "_get_model_size_bytes", lambda *_args, **_kwargs: 0)
+
+    asyncio.run(
+        models_route.get_model_config(
+            model_name = "unsloth/custom-code",
+            hf_token = None,
+            current_subject = "test-subject",
+        )
+    )
+
+    assert calls == [("unsloth/custom-code", {"trust_remote_code": False, "token": None})]
+
+
 def test_trust_remote_code_requirement_uses_yaml_defaults_only(monkeypatch):
     calls: dict[str, str] = {}
 

--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -32,6 +32,7 @@ sys.modules.setdefault("loggers", _loggers_stub)
 from utils.models.model_config import (
     ModelConfig,
     is_vision_model,
+    load_model_config,
     _is_vision_model_uncached,
     _vision_detection_cache,
 )
@@ -49,6 +50,27 @@ def _clear_vision_cache():
 
 
 # Cache hit / miss tests
+
+
+class TestRemoteCodeSafety:
+    def test_load_model_config_default_disables_remote_code(self, monkeypatch):
+        calls = []
+
+        class _AutoConfig:
+            @staticmethod
+            def from_pretrained(model_name, **kwargs):
+                calls.append((model_name, kwargs))
+                return object()
+
+        monkeypatch.setitem(
+            sys.modules,
+            "transformers",
+            _types.SimpleNamespace(AutoConfig = _AutoConfig),
+        )
+
+        load_model_config("org/custom", use_auth = True)
+
+        assert calls == [("org/custom", {"trust_remote_code": False})]
 
 
 class TestVisionCacheHitMiss:
@@ -226,8 +248,11 @@ class TestVisionCacheOnException:
         "utils.models.model_config.load_model_config",
         side_effect = ValueError("bad config"),
     )
+    @patch("utils.models.model_config._raw_config_has_vision_config", return_value = None)
     @patch("utils.transformers_version.needs_transformers_5", return_value = False)
-    def test_permanent_exception_result_cached(self, mock_needs_t5, mock_load_config):
+    def test_permanent_exception_result_cached(
+        self, mock_needs_t5, mock_raw_config, mock_load_config
+    ):
         """A permanent failure (ValueError / RepositoryNotFoundError /
         GatedRepoError / JSONDecodeError) is caught, returns False, and
         that False is cached so subsequent calls don't retry. ValueError
@@ -236,13 +261,29 @@ class TestVisionCacheOnException:
         assert is_vision_model("broken/model") is False
         assert is_vision_model("broken/model") is False
         mock_load_config.assert_called_once()
+        mock_raw_config.assert_called_once_with("broken/model", hf_token = None)
+
+    @patch(
+        "utils.models.model_config.load_model_config",
+        side_effect = ValueError("custom code required"),
+    )
+    @patch("utils.models.model_config._raw_config_has_vision_config", return_value = True)
+    @patch("utils.transformers_version.needs_transformers_5", return_value = False)
+    def test_remote_code_config_error_uses_raw_config(
+        self, mock_needs_t5, mock_raw_config, mock_load_config
+    ):
+        assert is_vision_model("custom/vlm") is True
+        assert is_vision_model("custom/vlm") is True
+        mock_load_config.assert_called_once()
+        mock_raw_config.assert_called_once_with("custom/vlm", hf_token = None)
 
     @patch(
         "utils.models.model_config.load_model_config",
         side_effect = OSError("network down"),
     )
+    @patch("utils.models.model_config._raw_config_has_vision_config", return_value = None)
     @patch("utils.transformers_version.needs_transformers_5", return_value = False)
-    def test_transient_exception_not_cached(self, mock_needs_t5, mock_load_config):
+    def test_transient_exception_not_cached(self, mock_needs_t5, mock_raw_config, mock_load_config):
         """A transient failure (OSError, timeouts) returns None from
         _is_vision_model_uncached, surfaces as False, and is NOT cached
         so the next call retries."""
@@ -250,6 +291,7 @@ class TestVisionCacheOnException:
         assert is_vision_model("broken/model") is False
         assert is_vision_model("broken/model") is False
         assert mock_load_config.call_count == 2
+        assert mock_raw_config.call_count == 2
 
 
 # Direct detection path (non-transformers-5 models) caching
@@ -270,8 +312,12 @@ class TestVisionCacheDirectPath:
 
         assert is_vision_model("google/gemma-3-4b-it") is True
         assert is_vision_model("google/gemma-3-4b-it") is True
-        # load_model_config should only be called once
-        mock_load_config.assert_called_once()
+        mock_load_config.assert_called_once_with(
+            "google/gemma-3-4b-it",
+            use_auth = True,
+            token = None,
+            trust_remote_code = False,
+        )
 
     @patch("utils.transformers_version.needs_transformers_5", return_value = False)
     @patch("utils.models.model_config.load_model_config")
@@ -451,6 +497,10 @@ class TestRawConfigVlmDetection:
 class TestSubprocessScript:
     def test_does_not_import_parent_module(self):
         assert "from utils.models.model_config" not in _VISION_CHECK_SCRIPT
+
+    def test_disables_remote_code(self):
+        assert 'kwargs = {"trust_remote_code": False}' in _VISION_CHECK_SCRIPT
+        assert 'kwargs = {"trust_remote_code": True}' not in _VISION_CHECK_SCRIPT
 
     def test_inline_is_vlm_executes_correctly(self):
         ns: dict = {}

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1084,11 +1084,10 @@ def _get_hf_safetensors_total_params(
 def _load_config_for_gpu_estimate(model_name: str, hf_token: Optional[str] = None):
     try:
         from transformers import AutoConfig
-        trust_remote_code = model_name.lower().startswith("unsloth/")
         return AutoConfig.from_pretrained(
             model_name,
             token = hf_token,
-            trust_remote_code = trust_remote_code,
+            trust_remote_code = False,
         )
     except Exception as e:
         logger.warning("Could not load config for '%s': %s", model_name, e)

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -469,7 +469,7 @@ def load_model_config(
     model_name: str,
     use_auth: bool = False,
     token: Optional[str] = None,
-    trust_remote_code: bool = True,
+    trust_remote_code: bool = False,
 ):
     """Load model config with optional authentication control."""
     from transformers import AutoConfig
@@ -609,7 +609,7 @@ if backend_dir not in sys.path:
 try:
     from transformers import AutoConfig
 
-    kwargs = {"trust_remote_code": True}
+    kwargs = {"trust_remote_code": False}
     if token:
         kwargs["token"] = token
     config = AutoConfig.from_pretrained(model_name, **kwargs)
@@ -794,7 +794,12 @@ def _is_vision_model_uncached(model_name: str, hf_token: Optional[str] = None) -
         return _raw_config_has_vision_config(model_name, hf_token = hf_token)
 
     try:
-        config = load_model_config(model_name, use_auth = True, token = hf_token)
+        config = load_model_config(
+            model_name,
+            use_auth = True,
+            token = hf_token,
+            trust_remote_code = False,
+        )
 
         # Exclude audio-only models sharing the ForConditionalGeneration suffix
         # (e.g. CsmForConditionalGeneration, WhisperForConditionalGeneration)
@@ -816,6 +821,9 @@ def _is_vision_model_uncached(model_name: str, hf_token: Optional[str] = None) -
 
     except Exception as e:
         logger.warning(f"Could not determine if {model_name} is vision model: {e}")
+        raw_result = _raw_config_has_vision_config(model_name, hf_token = hf_token)
+        if raw_result is not None:
+            return raw_result
         # Permanent failures (not found, gated, bad config) cache as False;
         # transient ones (network, timeout) should not.
         try:

--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -3,6 +3,7 @@
 
 import {
   shouldShowTrainingView,
+  TrainingTrustRemoteCodeDialog,
   useDatasetPreviewDialogStore,
   useTrainingConfigStore,
   useTrainingRuntimeLifecycle,
@@ -163,6 +164,7 @@ export function StudioPage(): ReactElement {
           initialData={dialogInitial}
           isVlm={config.isVisionModel && config.isDatasetImage === true}
         />
+        <TrainingTrustRemoteCodeDialog />
 
         <div className="mb-6 flex flex-col gap-0.5 sm:mb-8">
           <h1 className="text-[30px] font-semibold leading-[1.04] tracking-[-0.028em] text-foreground sm:text-[34px]">

--- a/studio/frontend/src/features/training/api/models-api.ts
+++ b/studio/frontend/src/features/training/api/models-api.ts
@@ -13,6 +13,11 @@ interface EmbeddingCheckResponse {
   is_embedding: boolean;
 }
 
+interface TrustRemoteCodeCheckResponse {
+  model_name: string;
+  requires_trust_remote_code: boolean;
+}
+
 interface BackendTrainingDefaults {
   max_seq_length?: number;
   num_epochs?: number;
@@ -130,6 +135,20 @@ export async function getModelConfig(
     throw new Error(`Failed to fetch model config (${response.status})`);
   }
   return (await response.json()) as ModelConfigResponse;
+}
+
+export async function getModelTrustRemoteCodeRequirement(
+  modelName: string,
+): Promise<boolean> {
+  const encoded = encodeURIComponent(modelName);
+  const response = await authFetch(`/api/models/trust-remote-code/${encoded}`);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to check model trust_remote_code requirement (${response.status})`,
+    );
+  }
+  const data = (await response.json()) as TrustRemoteCodeCheckResponse;
+  return data.requires_trust_remote_code;
 }
 
 export async function listLocalModels(

--- a/studio/frontend/src/features/training/components/training-trust-remote-code-dialog.tsx
+++ b/studio/frontend/src/features/training/components/training-trust-remote-code-dialog.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useTrainingConfigStore } from "../stores/training-config-store";
+import { useTrainingTrustRemoteCodeDialogStore } from "../stores/training-trust-remote-code-dialog-store";
+
+export function TrainingTrustRemoteCodeDialog() {
+  const open = useTrainingTrustRemoteCodeDialogStore((state) => state.open);
+  const resolve = useTrainingTrustRemoteCodeDialogStore(
+    (state) => state.resolve,
+  );
+  const selectedModel = useTrainingConfigStore((state) => state.selectedModel);
+  const displayName = selectedModel?.split("/").pop() || "This model";
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) resolve(false);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Enable custom code for training?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {displayName} declares custom Python code in its repository.
+            Continue only if you trust the model source.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={() => resolve(true)}>
+            Enable and start
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/studio/frontend/src/features/training/components/training-trust-remote-code-dialog.tsx
+++ b/studio/frontend/src/features/training/components/training-trust-remote-code-dialog.tsx
@@ -19,8 +19,12 @@ export function TrainingTrustRemoteCodeDialog() {
   const resolve = useTrainingTrustRemoteCodeDialogStore(
     (state) => state.resolve,
   );
+  const dialogModelName = useTrainingTrustRemoteCodeDialogStore(
+    (state) => state.modelName,
+  );
   const selectedModel = useTrainingConfigStore((state) => state.selectedModel);
-  const displayName = selectedModel?.split("/").pop() || "This model";
+  const modelName = dialogModelName || selectedModel;
+  const displayName = modelName?.split("/").pop() || "This model";
 
   return (
     <AlertDialog

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -7,7 +7,7 @@ import { toast } from "@/lib/toast";
 import { checkDatasetFormat } from "../api/datasets-api";
 import { emitTrainingRunsChanged } from "../events";
 import { getTrainingRun } from "../api/history-api";
-import { getModelConfig } from "../api/models-api";
+import { getModelTrustRemoteCodeRequirement } from "../api/models-api";
 import { buildTrainingStartPayload } from "../api/mappers";
 import { resetTraining, startTraining, stopTraining } from "../api/train-api";
 import { isRawTextDatasetFormat } from "../lib/training-methods";
@@ -316,12 +316,7 @@ async function resumePayloadRequiresTrustRemoteCode(
   }
 
   try {
-    const modelDetails = await getModelConfig(
-      payload.model_name,
-      undefined,
-      payload.hf_token ?? undefined,
-    );
-    return modelDetails.config?.training?.trust_remote_code === true;
+    return await getModelTrustRemoteCodeRequirement(payload.model_name);
   } catch {
     return false;
   }

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -14,6 +14,7 @@ import { syncTrainingRuntimeFromBackend } from "../lib/sync-runtime";
 import { validateTrainingConfig } from "../lib/validation";
 import { useDatasetPreviewDialogStore } from "../stores/dataset-preview-dialog-store";
 import { useTrainingConfigStore } from "../stores/training-config-store";
+import { useTrainingTrustRemoteCodeDialogStore } from "../stores/training-trust-remote-code-dialog-store";
 import { useTrainingRuntimeStore } from "../stores/training-runtime-store";
 import type { TrainingStartRequest } from "../types/api";
 import type { TrainingConfigState } from "../types/config";
@@ -50,6 +51,10 @@ export function useTrainingActions() {
     const validation = validateTrainingConfig(config);
     if (!validation.ok) {
       runtimeStore.setStartError(validation.message);
+      return false;
+    }
+
+    if (!(await confirmTrustRemoteCodeIfNeeded(config))) {
       return false;
     }
 
@@ -245,6 +250,23 @@ export function useTrainingActions() {
     stopTrainingRun,
     dismissTrainingRun,
   };
+}
+
+async function confirmTrustRemoteCodeIfNeeded(
+  config: TrainingConfigState,
+): Promise<boolean> {
+  if (!config.modelRequiresTrustRemoteCode || config.trustRemoteCode) {
+    return true;
+  }
+
+  const confirmed =
+    await useTrainingTrustRemoteCodeDialogStore.getState().requestConfirmation();
+  if (!confirmed) {
+    return false;
+  }
+
+  useTrainingConfigStore.getState().setTrustRemoteCode(true);
+  return true;
 }
 
 function getDatasetName(config: TrainingConfigState): string | null {

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -7,6 +7,7 @@ import { toast } from "@/lib/toast";
 import { checkDatasetFormat } from "../api/datasets-api";
 import { emitTrainingRunsChanged } from "../events";
 import { getTrainingRun } from "../api/history-api";
+import { getModelConfig } from "../api/models-api";
 import { buildTrainingStartPayload } from "../api/mappers";
 import { resetTraining, startTraining, stopTraining } from "../api/train-api";
 import { isRawTextDatasetFormat } from "../lib/training-methods";
@@ -54,7 +55,14 @@ export function useTrainingActions() {
       return false;
     }
 
-    if (!(await confirmTrustRemoteCodeIfNeeded(config))) {
+    if (
+      !(await confirmTrustRemoteCodeIfNeeded({
+        modelName: config.selectedModel,
+        requiresTrustRemoteCode: config.modelRequiresTrustRemoteCode,
+        trustRemoteCode: config.trustRemoteCode,
+        onConfirm: () => useTrainingConfigStore.getState().setTrustRemoteCode(true),
+      }))
+    ) {
       return false;
     }
 
@@ -203,6 +211,22 @@ export function useTrainingActions() {
       } as TrainingStartRequest;
 
       runtimeStore.setStartResources(payload.model_name, payload.hf_dataset, true);
+      if (
+        !(await confirmTrustRemoteCodeIfNeeded({
+          modelName: payload.model_name,
+          requiresTrustRemoteCode: await resumePayloadRequiresTrustRemoteCode(
+            payload,
+            config,
+          ),
+          trustRemoteCode: payload.trust_remote_code === true,
+          onConfirm: () => {
+            payload.trust_remote_code = true;
+          },
+        }))
+      ) {
+        runtimeStore.setStarting(false);
+        return false;
+      }
 
       const response = await startTraining(payload);
       if (response.status === "error") {
@@ -252,21 +276,54 @@ export function useTrainingActions() {
   };
 }
 
-async function confirmTrustRemoteCodeIfNeeded(
-  config: TrainingConfigState,
-): Promise<boolean> {
-  if (!config.modelRequiresTrustRemoteCode || config.trustRemoteCode) {
+type TrustRemoteCodeConfirmationRequest = {
+  modelName: string | null;
+  requiresTrustRemoteCode: boolean;
+  trustRemoteCode: boolean;
+  onConfirm: () => void;
+};
+
+async function confirmTrustRemoteCodeIfNeeded({
+  modelName,
+  requiresTrustRemoteCode,
+  trustRemoteCode,
+  onConfirm,
+}: TrustRemoteCodeConfirmationRequest): Promise<boolean> {
+  if (!requiresTrustRemoteCode || trustRemoteCode) {
     return true;
   }
 
   const confirmed =
-    await useTrainingTrustRemoteCodeDialogStore.getState().requestConfirmation();
+    await useTrainingTrustRemoteCodeDialogStore.getState().requestConfirmation(modelName);
   if (!confirmed) {
     return false;
   }
 
-  useTrainingConfigStore.getState().setTrustRemoteCode(true);
+  onConfirm();
   return true;
+}
+
+async function resumePayloadRequiresTrustRemoteCode(
+  payload: TrainingStartRequest,
+  currentConfig: TrainingConfigState,
+): Promise<boolean> {
+  if (
+    currentConfig.selectedModel === payload.model_name &&
+    currentConfig.modelRequiresTrustRemoteCode
+  ) {
+    return true;
+  }
+
+  try {
+    const modelDetails = await getModelConfig(
+      payload.model_name,
+      undefined,
+      payload.hf_token ?? undefined,
+    );
+    return modelDetails.config?.training?.trust_remote_code === true;
+  } catch {
+    return false;
+  }
 }
 
 function getDatasetName(config: TrainingConfigState): string | null {

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -317,8 +317,12 @@ async function resumePayloadRequiresTrustRemoteCode(
 
   try {
     return await getModelTrustRemoteCodeRequirement(payload.model_name);
-  } catch {
-    return false;
+  } catch (error) {
+    const detail =
+      error instanceof Error ? error.message : "Unknown trust_remote_code lookup error";
+    throw new Error(
+      `Could not verify whether ${payload.model_name} requires trust_remote_code before resuming training. ${detail}`,
+    );
   }
 }
 

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -211,14 +211,15 @@ export function useTrainingActions() {
       } as TrainingStartRequest;
 
       runtimeStore.setStartResources(payload.model_name, payload.hf_dataset, true);
+      const savedPayloadTrustsRemoteCode = payload.trust_remote_code === true;
+      const requiresTrustRemoteCode =
+        savedPayloadTrustsRemoteCode ||
+        (await resumePayloadRequiresTrustRemoteCode(payload, config));
       if (
         !(await confirmTrustRemoteCodeIfNeeded({
           modelName: payload.model_name,
-          requiresTrustRemoteCode: await resumePayloadRequiresTrustRemoteCode(
-            payload,
-            config,
-          ),
-          trustRemoteCode: payload.trust_remote_code === true,
+          requiresTrustRemoteCode,
+          trustRemoteCode: false,
           onConfirm: () => {
             payload.trust_remote_code = true;
           },

--- a/studio/frontend/src/features/training/index.ts
+++ b/studio/frontend/src/features/training/index.ts
@@ -7,6 +7,7 @@ export {
   useTrainingRuntimeStore,
 } from "./stores/training-runtime-store";
 export { useTrainingActions } from "./hooks/use-training-actions";
+export { TrainingTrustRemoteCodeDialog } from "./components/training-trust-remote-code-dialog";
 export { useTrainingHistorySidebarItems } from "./hooks/use-training-history-sidebar";
 export { useTrainingRuntimeLifecycle } from "./hooks/use-training-runtime-lifecycle";
 export {

--- a/studio/frontend/src/features/training/lib/model-defaults.ts
+++ b/studio/frontend/src/features/training/lib/model-defaults.ts
@@ -35,7 +35,6 @@ type ModelDefaultsPatch = Partial<
     | "tensorboardDir"
     | "logFrequency"
     | "finetuneVisionLayers"
-    | "trustRemoteCode"
     | "finetuneLanguageLayers"
     | "finetuneAttentionModules"
     | "finetuneMLPModules"
@@ -163,9 +162,6 @@ export function mapBackendModelConfigToTrainingPatch(
   if (gradientCheckpointing !== undefined) {
     patch.gradientCheckpointing = gradientCheckpointing;
   }
-
-  const trustRemoteCode = toBoolean(training?.trust_remote_code);
-  if (trustRemoteCode !== undefined) patch.trustRemoteCode = trustRemoteCode;
 
   const loraRank = toNumber(lora?.lora_r);
   if (loraRank !== undefined) patch.loraRank = loraRank;

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -125,6 +125,7 @@ const NON_PERSISTED_STATE_KEYS: ReadonlySet<keyof TrainingConfigState> = new Set
   "isDatasetImage",
   "isDatasetAudio",
   "modelRequiresTrustRemoteCode",
+  "trustRemoteCode",
   "trainOnCompletions",
   "maxPositionEmbeddings",
   "s3Config",
@@ -812,7 +813,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
     },
     {
       name: "unsloth_training_config_v1",
-      version: 10,
+      version: 11,
       migrate: (persisted, version) => {
         const s = persisted as Record<string, unknown>;
         if (version < 2 && s.datasetSubset == null && s.datasetConfig != null) {
@@ -858,6 +859,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           if (s.learningRate == null || s.learningRate === LR_DEFAULT_LORA) {
             s.learningRate = LR_DEFAULT_CPT;
           }
+        }
+        if (version < 11) {
+          delete s.trustRemoteCode;
         }
         return s as unknown as TrainingConfigStore;
       },

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -85,6 +85,7 @@ const initialState: TrainingConfigState = {
   isCheckingDataset: false,
   isDatasetImage: null,
   isDatasetAudio: false,
+  modelRequiresTrustRemoteCode: false,
   maxPositionEmbeddings: null,
   ...DEFAULT_HYPERPARAMS,
 };
@@ -123,6 +124,7 @@ const NON_PERSISTED_STATE_KEYS: ReadonlySet<keyof TrainingConfigState> = new Set
   "isCheckingDataset",
   "isDatasetImage",
   "isDatasetAudio",
+  "modelRequiresTrustRemoteCode",
   "trainOnCompletions",
   "maxPositionEmbeddings",
   "s3Config",
@@ -304,6 +306,8 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             _learningRateManuallySet = false;
             _yamlLearningRate = undefined;
             const patch = mapBackendModelConfigToTrainingPatch(modelDetails.config);
+            const modelRequiresTrustRemoteCode =
+              modelDetails.config?.training?.trust_remote_code === true;
 
             // Treat a model-config LR as authoritative so async auto-select
             // won't overwrite it.
@@ -367,6 +371,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               isVisionModel: modelDetails.is_vision,
               isEmbeddingModel: isEmbedding,
               isAudioModel: isAudio,
+              modelRequiresTrustRemoteCode,
               isLoadingModelDefaults: false,
               isCheckingVision: false,
               modelDefaultsError: null,
@@ -382,6 +387,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               isLoadingModelDefaults: false,
               isEmbeddingModel: false,
               isAudioModel: false,
+              modelRequiresTrustRemoteCode: false,
               modelDefaultsError:
                 error instanceof Error
                   ? error.message
@@ -488,6 +494,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             isVisionModel: false,
             isEmbeddingModel: false,
             isAudioModel: false,
+            modelRequiresTrustRemoteCode: false,
             isDatasetAudio: false,
             isLoadingModelDefaults: false,
             modelDefaultsError: null,
@@ -498,12 +505,18 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           const previousModel = get().selectedModel;
           // Reset vision_image_size on a true switch only; same-model reloads
           // go through the mapper, which preserves the user's choice.
-          const patch: { selectedModel: string | null; modelDefaultsError: null; visionImageSize?: number | null } = {
+          const patch: {
+            selectedModel: string | null;
+            modelDefaultsError: null;
+            visionImageSize?: number | null;
+            trustRemoteCode?: boolean;
+          } = {
             selectedModel,
             modelDefaultsError: null,
           };
           if (selectedModel !== previousModel) {
             patch.visionImageSize = DEFAULT_HYPERPARAMS.visionImageSize;
+            patch.trustRemoteCode = false;
           }
           set(patch);
 
@@ -515,6 +528,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               isVisionModel: false,
               isEmbeddingModel: false,
               isAudioModel: false,
+              modelRequiresTrustRemoteCode: false,
               isDatasetAudio: false,
               isLoadingModelDefaults: false,
               modelDefaultsError: null,
@@ -763,6 +777,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         setFinetuneMLPModules: (finetuneMLPModules) =>
           set({ finetuneMLPModules }),
         setTargetModules: (targetModules) => set({ targetModules }),
+        setTrustRemoteCode: (trustRemoteCode) => set({ trustRemoteCode }),
         setS3Config: (s3Config) => set({ s3Config }),
         canProceed: () => canProceedForStep(get()),
         reset: () => {
@@ -788,7 +803,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           if (patch.learningRate !== undefined) {
             _learningRateManuallySet = false;
           }
-          set(patch);
+          set({
+            ...patch,
+            modelRequiresTrustRemoteCode: config.training?.trust_remote_code === true,
+          });
         },
       };
     },

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -511,6 +511,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             modelDefaultsError: null;
             visionImageSize?: number | null;
             trustRemoteCode?: boolean;
+            modelRequiresTrustRemoteCode?: boolean;
           } = {
             selectedModel,
             modelDefaultsError: null,
@@ -518,6 +519,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           if (selectedModel !== previousModel) {
             patch.visionImageSize = DEFAULT_HYPERPARAMS.visionImageSize;
             patch.trustRemoteCode = false;
+            patch.modelRequiresTrustRemoteCode = false;
           }
           set(patch);
 
@@ -799,6 +801,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         },
         applyConfigPatch: (config: BackendModelConfig) => {
           const patch = mapBackendModelConfigToTrainingPatch(config);
+          const hasTrustRemoteCode = Object.hasOwn(
+            config.training ?? {},
+            "trust_remote_code",
+          );
           // Only clear the manual-edit flag when the config provides a LR,
           // so unrelated config patches don't silently disarm the guard.
           if (patch.learningRate !== undefined) {
@@ -806,7 +812,12 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           }
           set({
             ...patch,
-            modelRequiresTrustRemoteCode: config.training?.trust_remote_code === true,
+            ...(hasTrustRemoteCode
+              ? {
+                  modelRequiresTrustRemoteCode:
+                    config.training?.trust_remote_code === true,
+                }
+              : {}),
           });
         },
       };

--- a/studio/frontend/src/features/training/stores/training-trust-remote-code-dialog-store.ts
+++ b/studio/frontend/src/features/training/stores/training-trust-remote-code-dialog-store.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { create } from "zustand";
+
+type ConfirmationResolver = (confirmed: boolean) => void;
+
+type TrainingTrustRemoteCodeDialogStore = {
+  open: boolean;
+  requestConfirmation: () => Promise<boolean>;
+  resolve: (confirmed: boolean) => void;
+};
+
+let pendingResolver: ConfirmationResolver | null = null;
+
+export const useTrainingTrustRemoteCodeDialogStore =
+  create<TrainingTrustRemoteCodeDialogStore>()((set) => ({
+    open: false,
+    requestConfirmation: () =>
+      new Promise<boolean>((resolve) => {
+        pendingResolver?.(false);
+        pendingResolver = resolve;
+        set({ open: true });
+      }),
+    resolve: (confirmed) => {
+      const resolver = pendingResolver;
+      pendingResolver = null;
+      set({ open: false });
+      resolver?.(confirmed);
+    },
+  }));

--- a/studio/frontend/src/features/training/stores/training-trust-remote-code-dialog-store.ts
+++ b/studio/frontend/src/features/training/stores/training-trust-remote-code-dialog-store.ts
@@ -7,7 +7,8 @@ type ConfirmationResolver = (confirmed: boolean) => void;
 
 type TrainingTrustRemoteCodeDialogStore = {
   open: boolean;
-  requestConfirmation: () => Promise<boolean>;
+  modelName: string | null;
+  requestConfirmation: (modelName?: string | null) => Promise<boolean>;
   resolve: (confirmed: boolean) => void;
 };
 
@@ -16,16 +17,17 @@ let pendingResolver: ConfirmationResolver | null = null;
 export const useTrainingTrustRemoteCodeDialogStore =
   create<TrainingTrustRemoteCodeDialogStore>()((set) => ({
     open: false,
-    requestConfirmation: () =>
+    modelName: null,
+    requestConfirmation: (modelName = null) =>
       new Promise<boolean>((resolve) => {
         pendingResolver?.(false);
         pendingResolver = resolve;
-        set({ open: true });
+        set({ open: true, modelName });
       }),
     resolve: (confirmed) => {
       const resolver = pendingResolver;
       pendingResolver = null;
-      set({ open: false });
+      set({ open: false, modelName: null });
       resolver?.(confirmed);
     },
   }));

--- a/studio/frontend/src/features/training/types/config.ts
+++ b/studio/frontend/src/features/training/types/config.ts
@@ -76,6 +76,7 @@ export interface TrainingConfigState {
   isCheckingDataset: boolean;
   isDatasetImage: boolean | null;
   isDatasetAudio: boolean;
+  modelRequiresTrustRemoteCode: boolean;
   trustRemoteCode: boolean;
   finetuneVisionLayers: boolean;
   finetuneLanguageLayers: boolean;
@@ -150,6 +151,7 @@ export interface TrainingConfigActions {
   setFinetuneAttentionModules: (value: boolean) => void;
   setFinetuneMLPModules: (value: boolean) => void;
   setTargetModules: (value: string[]) => void;
+  setTrustRemoteCode: (value: boolean) => void;
   setS3Config: (value: S3Config | null) => void;
   canProceed: () => boolean;
   reset: () => void;


### PR DESCRIPTION
## Summary
- Default Studio config probes to `trust_remote_code=False`.
- Pass `trust_remote_code=False` explicitly through the vision capability probe and the transformers 5 subprocess branch.
- Fall back to raw `config.json` parsing when `AutoConfig` rejects custom-code configs, preserving vision detection without executing remote code.
- Replace training's silent YAML-driven custom-code enablement with a shared start-time confirmation used by every Studio training start path.
- Add regression coverage for the default sink, direct vision probe arguments, subprocess probe script, and raw-config fallback.

## Verification
- `~/.unsloth/studio/unsloth_studio/bin/python -m py_compile studio/backend/utils/models/model_config.py studio/backend/routes/training.py studio/backend/tests/test_vision_cache.py`
- AST parse of changed backend Python files
- `PYTHONPATH=/home/wasim/code/unsloth/studio/backend ~/.unsloth/studio/unsloth_studio/bin/python -m pytest studio/backend/tests/test_vision_cache.py`
- `npm run typecheck --prefix studio/frontend`
- Patched local marker proof: custom `auto_map` config code was not executed, while raw config still classified the local custom VLM as vision-capable.