### PR TITLE
Studio: clearer error when adding a stdio (local command) MCP server

### DIFF
--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -77,13 +77,17 @@ def _validate_url(url: str) -> str:
         return trimmed
     parsed = urlparse(trimmed)
     if parsed.scheme not in ("http", "https"):
-        detail = (
-            "MCP server address must start with http:// or https:// "
-            "(for example https://example.com/mcp)."
-        )
-        # Host-scoped wording: self-hosted hosts can opt in via the env var.
         if _looks_like_command(trimmed):
-            detail += " Running a local command is not enabled on this server."
+            detail = (
+                "Local commands aren't enabled on this server. To allow them, "
+                "set UNSLOTH_STUDIO_ALLOW_STDIO_MCP=1 and restart Studio, or use "
+                "an http:// or https:// URL instead."
+            )
+        else:
+            detail = (
+                "MCP server address must start with http:// or https:// "
+                "(for example https://example.com/mcp)."
+            )
         raise HTTPException(status_code = 400, detail = detail)
     if not parsed.netloc:
         raise HTTPException(status_code = 400, detail = "url is missing a host")


### PR DESCRIPTION
Improves the validation error shown when a user tries to add a local-command (stdio) MCP server while local commands are disabled. Previously the request failed with the generic "`address must start with http:// or https://`" message, with a short note tacked on. That didn't tell users how to actually enable local commands.

Now the stdio case gets its own actionable message:
`Local commands aren't enabled on this server. To allow them, set UNSLOTH_STUDIO_ALLOW_STDIO_MCP=1 and restart Studio, or use an http:// or https:// URL instead.
`