### PR TITLE
Chat search: search all messages, user messages first

### DIFF
--- a/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
+++ b/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
@@ -12,24 +12,32 @@ import { Cancel01Icon, Message01Icon, Search01Icon } from "@hugeicons/core-free-
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { Command as CommandPrimitive } from "cmdk";
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useChatSearchIndex } from "../hooks/use-chat-search-index";
 import { useChatSearchStore } from "../stores/chat-search-store";
 
-// cmdk's default fuzzy scorer keeps non-matching rows visible (issue #5572), so
-// require every whitespace token to be a substring of the item's keywords.
-// `value` is the thread id; keywords carry the title + every message's text.
-export function chatSearchFilter(
-  _value: string,
-  search: string,
-  keywords?: string[],
-): number {
-  const query = search.trim().toLowerCase();
-  if (query === "") return 1;
-  // searchText is already lowercased in the index, so only lowercase the query.
-  const haystack = (keywords ?? []).join(" ");
-  const tokens = query.split(/\s+/);
-  return tokens.every((token) => haystack.includes(token)) ? 1 : 0;
+// Lowercased whitespace tokens of the query (haystacks are lowercased in the index).
+function queryTokens(search: string): string[] {
+  return search.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function haystackMatches(haystack: string, tokens: string[]): boolean {
+  return tokens.every((token) => haystack.includes(token));
+}
+
+// We filter rows here (cmdk runs with shouldFilter=false) so we control the
+// two-tier behavior and avoid cmdk's fuzzy scorer keeping non-matches visible
+// (issue #5572): every whitespace token must be a substring. User messages are
+// searched first; expand to the full conversation only when user text alone
+// matches nothing anywhere (user messages are short, assistant replies can be huge).
+export function selectVisibleChats<
+  T extends { userSearchText: string; searchText: string },
+>(items: T[], search: string): T[] {
+  const tokens = queryTokens(search);
+  if (tokens.length === 0) return items;
+  const userHits = items.filter((it) => haystackMatches(it.userSearchText, tokens));
+  if (userHits.length > 0) return userHits;
+  return items.filter((it) => haystackMatches(it.searchText, tokens));
 }
 
 function formatRelative(createdAt: number): string {
@@ -47,6 +55,16 @@ export function ChatSearchDialog() {
   const close = useChatSearchStore((s) => s.close);
   const navigate = useNavigate();
   const { items, loading } = useChatSearchIndex(isOpen);
+  const [query, setQuery] = useState("");
+
+  const visibleItems = useMemo(
+    () => selectVisibleChats(items, query),
+    [items, query],
+  );
+
+  useEffect(() => {
+    if (!isOpen) setQuery("");
+  }, [isOpen]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -68,7 +86,7 @@ export function ChatSearchDialog() {
       className="chat-search-surface rounded-3xl! top-1/2 -translate-y-1/2 w-[635px] max-w-[calc(100%-2rem)] gap-0 p-0 ring-0 sm:max-w-[635px]"
       overlayClassName="bg-transparent"
     >
-      <Command className="rounded-3xl p-0" filter={chatSearchFilter}>
+      <Command className="rounded-3xl p-0" shouldFilter={false}>
         <div className="flex items-center gap-3 border-b border-border/40 px-4 py-3">
           <HugeiconsIcon
             icon={Search01Icon}
@@ -77,6 +95,7 @@ export function ChatSearchDialog() {
           />
           <CommandPrimitive.Input
             placeholder="Search chats..."
+            onValueChange={setQuery}
             className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
           />
           <button
@@ -97,11 +116,10 @@ export function ChatSearchDialog() {
                 : "No chats match."}
           </CommandEmpty>
           <CommandGroup className="p-0">
-            {items.map((item) => (
+            {visibleItems.map((item) => (
               <CommandPrimitive.Item
                 key={item.id}
                 value={item.id}
-                keywords={[item.searchText]}
                 onSelect={() => {
                   navigate({
                     to: "/chat",

--- a/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
+++ b/studio/frontend/src/features/chat/components/chat-search-dialog.tsx
@@ -18,7 +18,7 @@ import { useChatSearchStore } from "../stores/chat-search-store";
 
 // cmdk's default fuzzy scorer keeps non-matching rows visible (issue #5572), so
 // require every whitespace token to be a substring of the item's keywords.
-// `value` is the unique thread id (cmdk selection); title/preview come via keywords.
+// `value` is the thread id; keywords carry the title + every message's text.
 export function chatSearchFilter(
   _value: string,
   search: string,
@@ -26,7 +26,8 @@ export function chatSearchFilter(
 ): number {
   const query = search.trim().toLowerCase();
   if (query === "") return 1;
-  const haystack = (keywords ?? []).join(" ").toLowerCase();
+  // searchText is already lowercased in the index, so only lowercase the query.
+  const haystack = (keywords ?? []).join(" ");
   const tokens = query.split(/\s+/);
   return tokens.every((token) => haystack.includes(token)) ? 1 : 0;
 }
@@ -100,7 +101,7 @@ export function ChatSearchDialog() {
               <CommandPrimitive.Item
                 key={item.id}
                 value={item.id}
-                keywords={[item.title, item.preview]}
+                keywords={[item.searchText]}
                 onSelect={() => {
                   navigate({
                     to: "/chat",

--- a/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
@@ -14,6 +14,9 @@ export interface ChatSearchItem {
   id: string;
   title: string;
   preview: string;
+  // Lowercased title + text of every message; matched by chatSearchFilter.
+  // Prebuilt once so filtering never re-lowercases this blob per keystroke.
+  searchText: string;
   createdAt: number;
   projectId?: string | null;
 }
@@ -51,7 +54,7 @@ async function buildIndex(): Promise<ChatSearchItem[]> {
 
   const itemThreadIds = new Map<
     string,
-    { item: Omit<ChatSearchItem, "preview">; threadIds: string[] }
+    { item: Omit<ChatSearchItem, "preview" | "searchText">; threadIds: string[] }
   >();
   const seenPairs = new Set<string>();
 
@@ -126,14 +129,16 @@ async function buildIndex(): Promise<ChatSearchItem[]> {
     merged.sort((a, b) => b.createdAt - a.createdAt);
 
     let preview = "";
+    // Title + every message so search spans the whole conversation.
+    const haystackParts: string[] = [item.title];
     for (const m of merged) {
       const text = extractText(m);
-      if (text) {
-        preview = truncate(text, PREVIEW_MAX);
-        break;
-      }
+      if (!text) continue;
+      if (!preview) preview = truncate(text, PREVIEW_MAX); // newest msg (sorted desc)
+      haystackParts.push(text);
     }
-    results.push({ ...item, preview });
+    const searchText = haystackParts.join(" ").toLowerCase();
+    results.push({ ...item, preview, searchText });
   }
 
   results.sort((a, b) => b.createdAt - a.createdAt);

--- a/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
@@ -25,13 +25,31 @@ export interface ChatSearchItem {
 const THREAD_LIMIT = 200;
 const SEARCH_REBUILD_DEBOUNCE_MS = 300;
 
-function safeStringify(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value) ?? "";
-  } catch {
-    return "";
+// Keys whose values are base64 image/audio payloads, not searchable text.
+const BINARY_KEY = /b64|base64|^(images?|audio|video)$/i;
+
+// Readable text from tool args/results, dropping base64 image/audio blobs so
+// they never bloat the index (object fields by key, plus data URLs / long
+// base64 runs and the "__IMAGES__" suffix inside strings).
+function searchableText(value: unknown, depth = 0): string {
+  if (typeof value === "string") {
+    const cut = value.indexOf("\n__IMAGES__:");
+    return (cut === -1 ? value : value.slice(0, cut))
+      .replace(/data:[^;,\s]+;base64,[A-Za-z0-9+/=]+/g, " ")
+      .replace(/[A-Za-z0-9+/]{120,}={0,2}/g, " ");
   }
+  if (value == null || depth > 4) return "";
+  if (Array.isArray(value)) {
+    return value.map((v) => searchableText(v, depth + 1)).join(" ");
+  }
+  if (typeof value === "object") {
+    const out: string[] = [];
+    for (const [k, v] of Object.entries(value)) {
+      if (!BINARY_KEY.test(k)) out.push(searchableText(v, depth + 1));
+    }
+    return out.join(" ");
+  }
+  return "";
 }
 
 // Pull searchable text from a message: plain text, reasoning/thinking, tool
@@ -50,9 +68,10 @@ function extractText(message: MessageRecord): string {
       if (typeof t === "string") parts.push(t);
     } else if (p.type === "tool-call") {
       if (typeof p.toolName === "string") parts.push(p.toolName);
-      const args = typeof p.argsText === "string" ? p.argsText : safeStringify(p.args);
+      const args = searchableText(typeof p.argsText === "string" ? p.argsText : p.args);
       if (args) parts.push(args);
-      if (p.result != null) parts.push(safeStringify(p.result));
+      const result = searchableText(p.result);
+      if (result) parts.push(result);
     } else if (p.type === "source") {
       for (const v of [p.title, p.url]) if (typeof v === "string") parts.push(v);
     }

--- a/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
@@ -14,8 +14,10 @@ export interface ChatSearchItem {
   id: string;
   title: string;
   preview: string;
-  // Lowercased title + text of every message; matched by chatSearchFilter.
-  // Prebuilt once so filtering never re-lowercases this blob per keystroke.
+  // Lowercased title + user messages only (short); searched first.
+  userSearchText: string;
+  // Lowercased title + every message; fallback haystack when user text alone
+  // matches nothing. Prebuilt so filtering never re-lowercases per keystroke.
   searchText: string;
   createdAt: number;
   projectId?: string | null;
@@ -54,7 +56,10 @@ async function buildIndex(): Promise<ChatSearchItem[]> {
 
   const itemThreadIds = new Map<
     string,
-    { item: Omit<ChatSearchItem, "preview" | "searchText">; threadIds: string[] }
+    {
+      item: Omit<ChatSearchItem, "preview" | "searchText" | "userSearchText">;
+      threadIds: string[];
+    }
   >();
   const seenPairs = new Set<string>();
 
@@ -129,16 +134,20 @@ async function buildIndex(): Promise<ChatSearchItem[]> {
     merged.sort((a, b) => b.createdAt - a.createdAt);
 
     let preview = "";
-    // Title + every message so search spans the whole conversation.
-    const haystackParts: string[] = [item.title];
+    // Two tiers: user messages (small, searched first) and the full
+    // conversation (fallback when user text alone matches nothing).
+    const userParts: string[] = [item.title];
+    const allParts: string[] = [item.title];
     for (const m of merged) {
       const text = extractText(m);
       if (!text) continue;
       if (!preview) preview = truncate(text, PREVIEW_MAX); // newest msg (sorted desc)
-      haystackParts.push(text);
+      allParts.push(text);
+      if (m.role === "user") userParts.push(text);
     }
-    const searchText = haystackParts.join(" ").toLowerCase();
-    results.push({ ...item, preview, searchText });
+    const userSearchText = userParts.join(" ").toLowerCase();
+    const searchText = allParts.join(" ").toLowerCase();
+    results.push({ ...item, preview, userSearchText, searchText });
   }
 
   results.sort((a, b) => b.createdAt - a.createdAt);

--- a/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-search-index.ts
@@ -13,40 +13,51 @@ export interface ChatSearchItem {
   type: "single" | "compare";
   id: string;
   title: string;
-  preview: string;
   // Lowercased title + user messages only (short); searched first.
   userSearchText: string;
-  // Lowercased title + every message; fallback haystack when user text alone
-  // matches nothing. Prebuilt so filtering never re-lowercases per keystroke.
+  // Lowercased title + every message (incl. tool calls); fallback when user
+  // text matches nothing. Prebuilt so filtering never re-lowercases per keystroke.
   searchText: string;
   createdAt: number;
   projectId?: string | null;
 }
 
 const THREAD_LIMIT = 200;
-const PREVIEW_MAX = 120;
 const SEARCH_REBUILD_DEBOUNCE_MS = 300;
 
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+// Pull searchable text from a message: plain text, reasoning/thinking, tool
+// calls (name + args + result) and cited sources (title + url).
 function extractText(message: MessageRecord): string {
   const content = message.content;
   if (!Array.isArray(content)) return "";
   const parts: string[] = [];
   for (const part of content) {
     if (!part || typeof part !== "object") continue;
-    const p = part as { type?: string; text?: unknown };
-    if (
-      (p.type === "text" || p.type === "reasoning") &&
-      typeof p.text === "string"
-    ) {
+    const p = part as Record<string, unknown>;
+    if ((p.type === "text" || p.type === "reasoning") && typeof p.text === "string") {
       parts.push(p.text);
+    } else if (p.type === "thinking") {
+      const t = typeof p.thinking === "string" ? p.thinking : p.text;
+      if (typeof t === "string") parts.push(t);
+    } else if (p.type === "tool-call") {
+      if (typeof p.toolName === "string") parts.push(p.toolName);
+      const args = typeof p.argsText === "string" ? p.argsText : safeStringify(p.args);
+      if (args) parts.push(args);
+      if (p.result != null) parts.push(safeStringify(p.result));
+    } else if (p.type === "source") {
+      for (const v of [p.title, p.url]) if (typeof v === "string") parts.push(v);
     }
   }
   return parts.join(" ").replace(/\s+/g, " ").trim();
-}
-
-function truncate(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return `${text.slice(0, max).trimEnd()}…`;
 }
 
 async function buildIndex(): Promise<ChatSearchItem[]> {
@@ -57,7 +68,7 @@ async function buildIndex(): Promise<ChatSearchItem[]> {
   const itemThreadIds = new Map<
     string,
     {
-      item: Omit<ChatSearchItem, "preview" | "searchText" | "userSearchText">;
+      item: Omit<ChatSearchItem, "searchText" | "userSearchText">;
       threadIds: string[];
     }
   >();
@@ -133,21 +144,19 @@ async function buildIndex(): Promise<ChatSearchItem[]> {
     }
     merged.sort((a, b) => b.createdAt - a.createdAt);
 
-    let preview = "";
-    // Two tiers: user messages (small, searched first) and the full
-    // conversation (fallback when user text alone matches nothing).
+    // Two tiers: user messages (short, searched first) and the full
+    // conversation incl. tool calls (fallback when user text matches nothing).
     const userParts: string[] = [item.title];
     const allParts: string[] = [item.title];
     for (const m of merged) {
       const text = extractText(m);
       if (!text) continue;
-      if (!preview) preview = truncate(text, PREVIEW_MAX); // newest msg (sorted desc)
       allParts.push(text);
       if (m.role === "user") userParts.push(text);
     }
     const userSearchText = userParts.join(" ").toLowerCase();
     const searchText = allParts.join(" ").toLowerCase();
-    results.push({ ...item, preview, userSearchText, searchText });
+    results.push({ ...item, userSearchText, searchText });
   }
 
   results.sort((a, b) => b.createdAt - a.createdAt);


### PR DESCRIPTION
### Summary

The chat search dialog (Cmd/Ctrl+K) only matched query tokens against each thread's title and a 120 character preview of its newest message. Anything said in the middle of a conversation was unsearchable.

This makes search span the whole conversation, and does it in two tiers so the common case stays cheap: it matches user messages first and expands to the full conversation (including tool calls) only when nothing matches on user text alone. User messages are short while assistant replies can be very long, so a typical keystroke only scans the small user text.

### Changes

- `use-chat-search-index.ts`: `buildIndex` already fetches every message per thread (it only used them to derive the preview). It now builds two lowercased fields per thread: `userSearchText` (title plus user messages) and `searchText` (title plus every message). `extractText` was extended to also pull reasoning/thinking, tool call name/args/result, and cited source title/url, so tool activity is searchable. Base64 image/audio payloads in tool results (`image_b64`, `images`, `*_base64`, data URLs, the `__IMAGES__` suffix) are stripped so they never bloat the index. Both fields are lowercased once at build time. The now-unused `preview` field is removed.
- `chat-search-dialog.tsx`: row filtering moves into `selectVisibleChats`, with cmdk running `shouldFilter={false}` so the tier choice is deterministic. It matches `userSearchText` first and expands to `searchText` only when no thread matches on user text. Token semantics are unchanged (every whitespace token must be a substring).

### Behavior

- Title and newest-message matches still work.
- A keyword in any user message matches in the first tier.
- A keyword that only appears in an assistant message, a tool call, or a cited source is still found via the expansion pass, as long as no thread matched it on user text.
- When a query matches a user message in one thread, assistant-only matches in other threads are not shown. This is intentional: user messages are short and are usually how people recall a conversation, and it keeps the common case from scanning large assistant text.

### Efficiency

The common case (query present in some user message) only scans the small user text, and both haystacks are lowercased once per index build (debounced, off the keystroke path), so a keystroke never re-lowercases anything. Measured on 200 threads with roughly 400 char user text and 100k char assistant replies (about 20MB total), a user-tier keystroke is about 0.02ms and the rare full expansion pass over about 20MB stays near 1ms.

### Testing

- tsc -b typecheck passes and vite build succeeds.
- Verified end to end with Playwright against a live Studio instance with seeded chat history:
  - keyword in a user message matches the right thread in the first tier
  - keyword only in an assistant message is found via expansion
  - keyword only inside a tool-call (args and textual result fields) is found via expansion
  - a base64 image payload in a tool result is excluded from the index (no false match)
  - a user-message hit in one thread suppresses an assistant-only hit in another
  - title match, empty query, and non-match (empty state) behave as expected