### PR TITLE
CLI: fix --local-dataset being parsed as a string instead of a list

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -2231,6 +2231,9 @@ class UnslothTrainer:
         for dataset_file in file_paths:
             if os.path.isabs(dataset_file):
                 file_path = dataset_file
+            elif os.path.exists(dataset_file):
+                # A path relative to the current working directory (CLI usage)
+                file_path = os.path.abspath(dataset_file)
             else:
                 file_path = str(resolve_dataset_path(dataset_file))
 

--- a/unsloth_cli/options.py
+++ b/unsloth_cli/options.py
@@ -35,8 +35,9 @@ def _is_bool_field(annotation: Any) -> bool:
 
 
 def _is_list_type(annotation: Any) -> bool:
-    """Check if type is a List (including Optional[List[...]])."""
-    return get_origin(_unwrap_optional(annotation)) is list
+    """Check if type is a List (including Optional[List[...]] and bare list)."""
+    unwrapped = _unwrap_optional(annotation)
+    return unwrapped is list or get_origin(unwrapped) is list
 
 
 def _list_element_type(annotation: Any) -> type:

--- a/unsloth_cli/options.py
+++ b/unsloth_cli/options.py
@@ -6,7 +6,7 @@
 import functools
 import inspect
 from pathlib import Path
-from typing import Any, Callable, Optional, get_args, get_origin
+from typing import Any, Callable, List, Optional, get_args, get_origin
 
 import typer
 from pydantic import BaseModel
@@ -35,8 +35,15 @@ def _is_bool_field(annotation: Any) -> bool:
 
 
 def _is_list_type(annotation: Any) -> bool:
-    """Check if type is a List."""
-    return get_origin(annotation) is list
+    """Check if type is a List (including Optional[List[...]])."""
+    return get_origin(_unwrap_optional(annotation)) is list
+
+
+def _list_element_type(annotation: Any) -> type:
+    """Element type for a List field; falls back to str for complex inners."""
+    args = get_args(_unwrap_optional(annotation))
+    elem = args[0] if args else str
+    return elem if elem in (str, int, float, Path) else str
 
 
 def _get_python_type(annotation: Any) -> type:
@@ -80,7 +87,7 @@ def add_options_from_config(config_class: type[BaseModel]) -> Callable:
     which will receive a dict of all CLI-provided config values.
     """
     fields = _collect_config_fields(config_class)
-    field_names = {name for name, field_info in fields if not _is_list_type(field_info.annotation)}
+    field_names = {name for name, _field_info in fields}
 
     def decorator(func: Callable) -> Callable:
         sig = inspect.signature(func)
@@ -95,11 +102,20 @@ def add_options_from_config(config_class: type[BaseModel]) -> Callable:
             if field_name in original_param_names:
                 continue
             annotation = field_info.annotation
-            if _is_list_type(annotation):
-                continue
-
             flag_name = _python_name_to_cli_flag(field_name)
             help_text = field_info.description or ""
+
+            if _is_list_type(annotation):
+                # Repeatable option: --flag a --flag b -> ["a", "b"]
+                default = typer.Option(None, flag_name, help = help_text)
+                param = inspect.Parameter(
+                    field_name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default = default,
+                    annotation = Optional[List[_list_element_type(annotation)]],
+                )
+                new_params.append(param)
+                continue
 
             if _is_bool_field(annotation):
                 default = typer.Option(


### PR DESCRIPTION
## Summary
`unsloth train --local-dataset ./dataset.jsonl` always failed with `No supported data files in directory: /` — the flag never worked.

## Root cause
`--local-dataset` is typed `Optional[List[str]]`, but the option generator checked for lists with `get_origin(annotation) is list`. For `Optional[List[str]]` the origin is `Union`, so it built a scalar string option. That string reached `_resolve_local_files` (which expects a list) and got walked character-by-character — the `/` parsed as the root directory.

## Fix
- `unsloth_cli/options.py`: unwrap `Optional` before the list check and emit a real repeatable list option (`--local-dataset a --local-dataset b` → `["a", "b"]`).
- `studio/backend/core/training/trainer.py`: resolve CWD-relative paths so `./dataset.jsonl` is found instead of being relocated to the Studio uploads root.