### PR TITLE
Studio: fail fast on an invalid first training batch (base VLM empty chat template)

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -2778,6 +2778,84 @@ class UnslothTrainer:
             logger.error(f"Failed to start training thread: {e}")
             return False
 
+    def _chat_template_renders_empty(self) -> bool:
+        """True when the model's chat template renders one sample to empty text --
+        the signature of a base (pretrained) model whose template cannot render
+        conversational data (e.g. base Qwen2-VL, whose media-only template emits
+        nothing for role messages). Best-effort; never raises."""
+        try:
+            ds = getattr(self.trainer, "train_dataset", None)
+            if ds is None or len(ds) == 0:
+                return False
+            row = ds[0]
+            messages = row.get("messages") if isinstance(row, dict) else None
+            if not messages:
+                return False
+            tok = self.tokenizer  # processor for VLM; both expose apply_chat_template
+            if not hasattr(tok, "apply_chat_template"):
+                return False
+            rendered = tok.apply_chat_template(
+                messages, tokenize = False, add_generation_prompt = False
+            )
+            return not (isinstance(rendered, str) and rendered.strip())
+        except Exception:
+            return False
+
+    def _preflight_first_batch(self) -> Optional[str]:
+        """Run one real batch through tokenization + collation before train() so an
+        invalid first batch fails fast with an actionable message instead of a
+        cryptic step-1 crash. The classic case: a base model whose chat template
+        renders empty makes the processor return empty `input_ids`, which torch
+        defaults to float32, and the embedding lookup rejects a float tensor.
+
+        Returns None when the batch is fine, else a user-facing error string.
+        Faithful for every path (text SFT is already tokenized so this only
+        collates; VLM/audio-VLM collate the one batch). Self-guarded so it can
+        never spuriously fail a run whose first batch is valid."""
+        try:
+            loader = self.trainer.get_train_dataloader()
+            batch = next(iter(loader))
+        except StopIteration:
+            return None  # empty dataset is reported by other guards
+        except Exception as e:
+            model = self.model_name or "this model"
+            return (
+                f"Cannot start training: failed to build the first training batch "
+                f"for '{model}': {e}"
+            )
+
+        try:
+            input_ids = batch["input_ids"] if "input_ids" in batch else None
+        except Exception:
+            input_ids = getattr(batch, "input_ids", None)
+        if input_ids is None:
+            return None  # custom collators may omit input_ids; don't false-positive
+
+        seq_len = input_ids.shape[-1] if input_ids.ndim > 0 else 0
+        if not (input_ids.is_floating_point() or input_ids.numel() == 0 or seq_len == 0):
+            return None  # valid integer, non-empty batch
+
+        model = self.model_name or "this model"
+        if self._chat_template_renders_empty():
+            low = model.lower()
+            suffix = (
+                f" such as '{model}-Instruct'"
+                if not any(t in low for t in ("instruct", "chat", "-it", "_it"))
+                else ""
+            )
+            return (
+                f"Cannot start training: the chat template for '{model}' produced "
+                f"no text for your dataset, so the first batch had empty token IDs. "
+                f"'{model}' looks like a base (pretrained) model without a chat "
+                f"template suited to conversational fine-tuning. Use the "
+                f"instruction-tuned variant{suffix} or provide a chat template."
+            )
+        return (
+            f"Cannot start training: the first batch produced invalid token IDs "
+            f"(dtype={input_ids.dtype}, length={seq_len}). Check that your dataset "
+            f"columns are mapped correctly for '{model}'."
+        )
+
     def _train_worker(self, dataset: Dataset, **training_args):
         """Worker function for training (runs in separate thread)"""
         try:
@@ -3471,6 +3549,15 @@ class UnslothTrainer:
                 training_args.get("max_steps", 0),
             )
             # ========== START TRAINING ==========
+            # Preflight: validate the first real batch so an invalid one (e.g. a
+            # base model whose chat template renders empty -> empty float input_ids)
+            # fails fast with a clear message instead of a cryptic step-1 crash.
+            preflight_error = self._preflight_first_batch()
+            if preflight_error:
+                logger.error(preflight_error)
+                self._update_progress(error = preflight_error, is_training = False)
+                return
+
             self._update_progress(total_steps = total_steps, status_message = "Starting training...")
             logger.info("Starting training...\n")
             self.trainer.train(resume_from_checkpoint = training_args.get("resume_from_checkpoint"))

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -2779,10 +2779,7 @@ class UnslothTrainer:
             return False
 
     def _chat_template_renders_empty(self) -> bool:
-        """True when the model's chat template renders one sample to empty text --
-        the signature of a base (pretrained) model whose template cannot render
-        conversational data (e.g. base Qwen2-VL, whose media-only template emits
-        nothing for role messages). Best-effort; never raises."""
+        """True when the chat template renders a sample to empty text (base-model signature)."""
         try:
             ds = getattr(self.trainer, "train_dataset", None)
             if ds is None or len(ds) == 0:
@@ -2791,7 +2788,7 @@ class UnslothTrainer:
             messages = row.get("messages") if isinstance(row, dict) else None
             if not messages:
                 return False
-            tok = self.tokenizer  # processor for VLM; both expose apply_chat_template
+            tok = self.tokenizer
             if not hasattr(tok, "apply_chat_template"):
                 return False
             rendered = tok.apply_chat_template(
@@ -2802,21 +2799,14 @@ class UnslothTrainer:
             return False
 
     def _preflight_first_batch(self) -> Optional[str]:
-        """Run one real batch through tokenization + collation before train() so an
-        invalid first batch fails fast with an actionable message instead of a
-        cryptic step-1 crash. The classic case: a base model whose chat template
-        renders empty makes the processor return empty `input_ids`, which torch
-        defaults to float32, and the embedding lookup rejects a float tensor.
-
-        Returns None when the batch is fine, else a user-facing error string.
-        Faithful for every path (text SFT is already tokenized so this only
-        collates; VLM/audio-VLM collate the one batch). Self-guarded so it can
-        never spuriously fail a run whose first batch is valid."""
+        """Validate the first real batch before train(). A base model whose chat
+        template renders empty yields empty float32 input_ids that crash the
+        embedding on step 1; catch it here. Returns None for a valid batch."""
         try:
             loader = self.trainer.get_train_dataloader()
             batch = next(iter(loader))
         except StopIteration:
-            return None  # empty dataset is reported by other guards
+            return None
         except Exception as e:
             model = self.model_name or "this model"
             return (
@@ -2829,11 +2819,11 @@ class UnslothTrainer:
         except Exception:
             input_ids = getattr(batch, "input_ids", None)
         if input_ids is None:
-            return None  # custom collators may omit input_ids; don't false-positive
+            return None  # some collators omit input_ids
 
         seq_len = input_ids.shape[-1] if input_ids.ndim > 0 else 0
         if not (input_ids.is_floating_point() or input_ids.numel() == 0 or seq_len == 0):
-            return None  # valid integer, non-empty batch
+            return None
 
         model = self.model_name or "this model"
         if self._chat_template_renders_empty():
@@ -3549,9 +3539,7 @@ class UnslothTrainer:
                 training_args.get("max_steps", 0),
             )
             # ========== START TRAINING ==========
-            # Preflight: validate the first real batch so an invalid one (e.g. a
-            # base model whose chat template renders empty -> empty float input_ids)
-            # fails fast with a clear message instead of a cryptic step-1 crash.
+            # Fail fast on an invalid first batch (empty/float input_ids) vs a step-1 crash.
             preflight_error = self._preflight_first_batch()
             if preflight_error:
                 logger.error(preflight_error)

--- a/studio/backend/tests/test_training_preflight.py
+++ b/studio/backend/tests/test_training_preflight.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""
+Before training starts, _preflight_first_batch runs one real batch through the
+trainer's own tokenization + collation and fails fast with an actionable message
+when input_ids is empty or non-integer -- the signature of the base-model
+empty-chat-template crash (empty -> float32 input_ids -> embedding dtype error)
+that otherwise blows up deep in the model forward on step 1.
+
+The real UnslothTrainer methods are borrowed onto a light fake `self` so the
+logic exercised is the production code, driven with controlled batches.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from core.training.trainer import UnslothTrainer
+
+_preflight = UnslothTrainer._preflight_first_batch
+_renders_empty = UnslothTrainer._chat_template_renders_empty
+
+
+class _FakeInnerTrainer:
+    """Stand-in for self.trainer (the HF/SFT Trainer)."""
+
+    def __init__(self, *, batch=None, dataloader_error=None, train_dataset=None):
+        self._batch = batch
+        self._dataloader_error = dataloader_error
+        self.train_dataset = train_dataset
+
+    def get_train_dataloader(self):
+        if self._dataloader_error is not None:
+            raise self._dataloader_error
+        return [self._batch]
+
+
+def _fake_self(*, inner, model_name="org/Some-Model", tokenizer=None):
+    s = SimpleNamespace(trainer=inner, model_name=model_name, tokenizer=tokenizer)
+    # Bind the real methods so self._chat_template_renders_empty() resolves.
+    s._preflight_first_batch = _preflight.__get__(s)
+    s._chat_template_renders_empty = _renders_empty.__get__(s)
+    return s
+
+
+class _EmptyTemplateTokenizer:
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        return ""  # base model: renders nothing for role messages
+
+
+class _RealTemplateTokenizer:
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        return "<|im_start|>user\nhi<|im_end|>"
+
+
+class TestPreflightFirstBatch(unittest.TestCase):
+    def test_float_input_ids_with_empty_template_suggests_instruct(self):
+        ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
+        inner = _FakeInnerTrainer(
+            batch={"input_ids": torch.zeros((1, 0), dtype=torch.float32)},
+            train_dataset=ds,
+        )
+        s = _fake_self(inner=inner, model_name="Qwen/Qwen2-VL-7B", tokenizer=_EmptyTemplateTokenizer())
+        msg = s._preflight_first_batch()
+        self.assertIsNotNone(msg)
+        self.assertIn("chat template", msg)
+        self.assertIn("Qwen/Qwen2-VL-7B-Instruct", msg)  # soft -Instruct hint
+        self.assertIn("base (pretrained) model", msg)
+
+    def test_no_instruct_hint_when_model_already_instruct(self):
+        ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
+        inner = _FakeInnerTrainer(
+            batch={"input_ids": torch.zeros((1, 0), dtype=torch.float32)},
+            train_dataset=ds,
+        )
+        s = _fake_self(inner=inner, model_name="org/Foo-Instruct", tokenizer=_EmptyTemplateTokenizer())
+        msg = s._preflight_first_batch()
+        self.assertIsNotNone(msg)
+        # No "such as '...-Instruct'" suggestion when the model is already Instruct.
+        self.assertNotIn("such as", msg)
+        self.assertIn("instruction-tuned variant", msg)
+
+    def test_empty_int_input_ids_generic_message(self):
+        # Empty but integer, template renders fine -> generic invalid-token message.
+        inner = _FakeInnerTrainer(
+            batch={"input_ids": torch.zeros((1, 0), dtype=torch.long)},
+            train_dataset=[{"text": "already tokenized path"}],
+        )
+        s = _fake_self(inner=inner, tokenizer=_RealTemplateTokenizer())
+        msg = s._preflight_first_batch()
+        self.assertIsNotNone(msg)
+        self.assertIn("invalid token IDs", msg)
+        self.assertNotIn("chat template", msg)
+
+    def test_valid_batch_returns_none(self):
+        inner = _FakeInnerTrainer(
+            batch={"input_ids": torch.randint(0, 1000, (2, 34), dtype=torch.long)},
+        )
+        s = _fake_self(inner=inner)
+        self.assertIsNone(s._preflight_first_batch())
+
+    def test_dataloader_error_is_surfaced(self):
+        inner = _FakeInnerTrainer(dataloader_error=RuntimeError("boom"))
+        s = _fake_self(inner=inner, model_name="org/M")
+        msg = s._preflight_first_batch()
+        self.assertIsNotNone(msg)
+        self.assertIn("failed to build the first training batch", msg)
+        self.assertIn("org/M", msg)
+
+    def test_missing_input_ids_does_not_false_positive(self):
+        inner = _FakeInnerTrainer(batch={"pixel_values": torch.zeros((1, 3))})
+        s = _fake_self(inner=inner)
+        self.assertIsNone(s._preflight_first_batch())
+
+
+class TestChatTemplateRendersEmpty(unittest.TestCase):
+    def _self(self, *, train_dataset, tokenizer):
+        inner = _FakeInnerTrainer(train_dataset=train_dataset)
+        return _fake_self(inner=inner, tokenizer=tokenizer)
+
+    def test_empty_render_detected(self):
+        ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
+        s = self._self(train_dataset=ds, tokenizer=_EmptyTemplateTokenizer())
+        self.assertTrue(s._chat_template_renders_empty())
+
+    def test_nonempty_render_not_flagged(self):
+        ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
+        s = self._self(train_dataset=ds, tokenizer=_RealTemplateTokenizer())
+        self.assertFalse(s._chat_template_renders_empty())
+
+    def test_no_messages_key_not_flagged(self):
+        s = self._self(train_dataset=[{"text": "raw"}], tokenizer=_EmptyTemplateTokenizer())
+        self.assertFalse(s._chat_template_renders_empty())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/studio/backend/tests/test_training_preflight.py
+++ b/studio/backend/tests/test_training_preflight.py
@@ -1,16 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""
-Before training starts, _preflight_first_batch runs one real batch through the
-trainer's own tokenization + collation and fails fast with an actionable message
-when input_ids is empty or non-integer -- the signature of the base-model
-empty-chat-template crash (empty -> float32 input_ids -> embedding dtype error)
-that otherwise blows up deep in the model forward on step 1.
-
-The real UnslothTrainer methods are borrowed onto a light fake `self` so the
-logic exercised is the production code, driven with controlled batches.
-"""
+"""_preflight_first_batch rejects an empty/non-integer first batch (the base-model
+empty-chat-template crash) before train(). The real methods are bound onto a light
+fake self so the production logic runs against controlled batches."""
 
 import unittest
 from types import SimpleNamespace
@@ -24,8 +17,6 @@ _renders_empty = UnslothTrainer._chat_template_renders_empty
 
 
 class _FakeInnerTrainer:
-    """Stand-in for self.trainer (the HF/SFT Trainer)."""
-
     def __init__(
         self,
         *,
@@ -50,7 +41,7 @@ def _fake_self(
     tokenizer = None,
 ):
     s = SimpleNamespace(trainer = inner, model_name = model_name, tokenizer = tokenizer)
-    # Bind the real methods so self._chat_template_renders_empty() resolves.
+    # Bind real methods so self._chat_template_renders_empty() resolves.
     s._preflight_first_batch = _preflight.__get__(s)
     s._chat_template_renders_empty = _renders_empty.__get__(s)
     return s
@@ -63,7 +54,7 @@ class _EmptyTemplateTokenizer:
         tokenize = False,
         add_generation_prompt = False,
     ):
-        return ""  # base model: renders nothing for role messages
+        return ""
 
 
 class _RealTemplateTokenizer:
@@ -89,7 +80,7 @@ class TestPreflightFirstBatch(unittest.TestCase):
         msg = s._preflight_first_batch()
         self.assertIsNotNone(msg)
         self.assertIn("chat template", msg)
-        self.assertIn("Qwen/Qwen2-VL-7B-Instruct", msg)  # soft -Instruct hint
+        self.assertIn("Qwen/Qwen2-VL-7B-Instruct", msg)
         self.assertIn("base (pretrained) model", msg)
 
     def test_no_instruct_hint_when_model_already_instruct(self):
@@ -103,12 +94,10 @@ class TestPreflightFirstBatch(unittest.TestCase):
         )
         msg = s._preflight_first_batch()
         self.assertIsNotNone(msg)
-        # No "such as '...-Instruct'" suggestion when the model is already Instruct.
-        self.assertNotIn("such as", msg)
+        self.assertNotIn("such as", msg)  # no Instruct suggestion for an Instruct model
         self.assertIn("instruction-tuned variant", msg)
 
     def test_empty_int_input_ids_generic_message(self):
-        # Empty but integer, template renders fine -> generic invalid-token message.
         inner = _FakeInnerTrainer(
             batch = {"input_ids": torch.zeros((1, 0), dtype = torch.long)},
             train_dataset = [{"text": "already tokenized path"}],

--- a/studio/backend/tests/test_training_preflight.py
+++ b/studio/backend/tests/test_training_preflight.py
@@ -26,7 +26,13 @@ _renders_empty = UnslothTrainer._chat_template_renders_empty
 class _FakeInnerTrainer:
     """Stand-in for self.trainer (the HF/SFT Trainer)."""
 
-    def __init__(self, *, batch=None, dataloader_error=None, train_dataset=None):
+    def __init__(
+        self,
+        *,
+        batch = None,
+        dataloader_error = None,
+        train_dataset = None,
+    ):
         self._batch = batch
         self._dataloader_error = dataloader_error
         self.train_dataset = train_dataset
@@ -37,8 +43,13 @@ class _FakeInnerTrainer:
         return [self._batch]
 
 
-def _fake_self(*, inner, model_name="org/Some-Model", tokenizer=None):
-    s = SimpleNamespace(trainer=inner, model_name=model_name, tokenizer=tokenizer)
+def _fake_self(
+    *,
+    inner,
+    model_name = "org/Some-Model",
+    tokenizer = None,
+):
+    s = SimpleNamespace(trainer = inner, model_name = model_name, tokenizer = tokenizer)
     # Bind the real methods so self._chat_template_renders_empty() resolves.
     s._preflight_first_batch = _preflight.__get__(s)
     s._chat_template_renders_empty = _renders_empty.__get__(s)
@@ -46,12 +57,22 @@ def _fake_self(*, inner, model_name="org/Some-Model", tokenizer=None):
 
 
 class _EmptyTemplateTokenizer:
-    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize = False,
+        add_generation_prompt = False,
+    ):
         return ""  # base model: renders nothing for role messages
 
 
 class _RealTemplateTokenizer:
-    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize = False,
+        add_generation_prompt = False,
+    ):
         return "<|im_start|>user\nhi<|im_end|>"
 
 
@@ -59,10 +80,12 @@ class TestPreflightFirstBatch(unittest.TestCase):
     def test_float_input_ids_with_empty_template_suggests_instruct(self):
         ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
         inner = _FakeInnerTrainer(
-            batch={"input_ids": torch.zeros((1, 0), dtype=torch.float32)},
-            train_dataset=ds,
+            batch = {"input_ids": torch.zeros((1, 0), dtype = torch.float32)},
+            train_dataset = ds,
         )
-        s = _fake_self(inner=inner, model_name="Qwen/Qwen2-VL-7B", tokenizer=_EmptyTemplateTokenizer())
+        s = _fake_self(
+            inner = inner, model_name = "Qwen/Qwen2-VL-7B", tokenizer = _EmptyTemplateTokenizer()
+        )
         msg = s._preflight_first_batch()
         self.assertIsNotNone(msg)
         self.assertIn("chat template", msg)
@@ -72,10 +95,12 @@ class TestPreflightFirstBatch(unittest.TestCase):
     def test_no_instruct_hint_when_model_already_instruct(self):
         ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
         inner = _FakeInnerTrainer(
-            batch={"input_ids": torch.zeros((1, 0), dtype=torch.float32)},
-            train_dataset=ds,
+            batch = {"input_ids": torch.zeros((1, 0), dtype = torch.float32)},
+            train_dataset = ds,
         )
-        s = _fake_self(inner=inner, model_name="org/Foo-Instruct", tokenizer=_EmptyTemplateTokenizer())
+        s = _fake_self(
+            inner = inner, model_name = "org/Foo-Instruct", tokenizer = _EmptyTemplateTokenizer()
+        )
         msg = s._preflight_first_batch()
         self.assertIsNotNone(msg)
         # No "such as '...-Instruct'" suggestion when the model is already Instruct.
@@ -85,10 +110,10 @@ class TestPreflightFirstBatch(unittest.TestCase):
     def test_empty_int_input_ids_generic_message(self):
         # Empty but integer, template renders fine -> generic invalid-token message.
         inner = _FakeInnerTrainer(
-            batch={"input_ids": torch.zeros((1, 0), dtype=torch.long)},
-            train_dataset=[{"text": "already tokenized path"}],
+            batch = {"input_ids": torch.zeros((1, 0), dtype = torch.long)},
+            train_dataset = [{"text": "already tokenized path"}],
         )
-        s = _fake_self(inner=inner, tokenizer=_RealTemplateTokenizer())
+        s = _fake_self(inner = inner, tokenizer = _RealTemplateTokenizer())
         msg = s._preflight_first_batch()
         self.assertIsNotNone(msg)
         self.assertIn("invalid token IDs", msg)
@@ -96,42 +121,42 @@ class TestPreflightFirstBatch(unittest.TestCase):
 
     def test_valid_batch_returns_none(self):
         inner = _FakeInnerTrainer(
-            batch={"input_ids": torch.randint(0, 1000, (2, 34), dtype=torch.long)},
+            batch = {"input_ids": torch.randint(0, 1000, (2, 34), dtype = torch.long)},
         )
-        s = _fake_self(inner=inner)
+        s = _fake_self(inner = inner)
         self.assertIsNone(s._preflight_first_batch())
 
     def test_dataloader_error_is_surfaced(self):
-        inner = _FakeInnerTrainer(dataloader_error=RuntimeError("boom"))
-        s = _fake_self(inner=inner, model_name="org/M")
+        inner = _FakeInnerTrainer(dataloader_error = RuntimeError("boom"))
+        s = _fake_self(inner = inner, model_name = "org/M")
         msg = s._preflight_first_batch()
         self.assertIsNotNone(msg)
         self.assertIn("failed to build the first training batch", msg)
         self.assertIn("org/M", msg)
 
     def test_missing_input_ids_does_not_false_positive(self):
-        inner = _FakeInnerTrainer(batch={"pixel_values": torch.zeros((1, 3))})
-        s = _fake_self(inner=inner)
+        inner = _FakeInnerTrainer(batch = {"pixel_values": torch.zeros((1, 3))})
+        s = _fake_self(inner = inner)
         self.assertIsNone(s._preflight_first_batch())
 
 
 class TestChatTemplateRendersEmpty(unittest.TestCase):
     def _self(self, *, train_dataset, tokenizer):
-        inner = _FakeInnerTrainer(train_dataset=train_dataset)
-        return _fake_self(inner=inner, tokenizer=tokenizer)
+        inner = _FakeInnerTrainer(train_dataset = train_dataset)
+        return _fake_self(inner = inner, tokenizer = tokenizer)
 
     def test_empty_render_detected(self):
         ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
-        s = self._self(train_dataset=ds, tokenizer=_EmptyTemplateTokenizer())
+        s = self._self(train_dataset = ds, tokenizer = _EmptyTemplateTokenizer())
         self.assertTrue(s._chat_template_renders_empty())
 
     def test_nonempty_render_not_flagged(self):
         ds = [{"messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}]}]
-        s = self._self(train_dataset=ds, tokenizer=_RealTemplateTokenizer())
+        s = self._self(train_dataset = ds, tokenizer = _RealTemplateTokenizer())
         self.assertFalse(s._chat_template_renders_empty())
 
     def test_no_messages_key_not_flagged(self):
-        s = self._self(train_dataset=[{"text": "raw"}], tokenizer=_EmptyTemplateTokenizer())
+        s = self._self(train_dataset = [{"text": "raw"}], tokenizer = _EmptyTemplateTokenizer())
         self.assertFalse(s._chat_template_renders_empty())
 
 

--- a/studio/backend/tests/test_training_preflight.py
+++ b/studio/backend/tests/test_training_preflight.py
@@ -5,12 +5,47 @@
 empty-chat-template crash) before train(). The real methods are bound onto a light
 fake self so the production logic runs against controlled batches."""
 
+import importlib
+import sys
+import types
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
-from core.training.trainer import UnslothTrainer
+
+def _stub_if_missing(name, attrs):
+    """Register a stub module for a dep the CPU backend CI job does not install.
+
+    The pytest job has studio.txt + torch + transformers but not unsloth/trl,
+    which core.training.trainer imports at module scope. Stub the absent ones
+    (real installs are left alone) so importing it for the two pure helper
+    methods never breaks test collection. __spec__ = None keeps the trainer's
+    own _ensure_real_packages namespace-shadow guard a no-op on the stub.
+    """
+    if name in sys.modules:
+        return
+    try:
+        importlib.import_module(name)
+        return
+    except Exception:
+        pass
+    mod = types.ModuleType(name)
+    mod.__spec__ = None
+    for attr in attrs:
+        setattr(mod, attr, MagicMock())
+    sys.modules[name] = mod
+    parent, _, child = name.rpartition(".")
+    if parent and parent in sys.modules:
+        setattr(sys.modules[parent], child, mod)
+
+
+_stub_if_missing("unsloth", ("FastLanguageModel", "FastVisionModel", "is_bfloat16_supported"))
+_stub_if_missing("unsloth.chat_templates", ("get_chat_template",))
+_stub_if_missing("trl", ("SFTTrainer", "SFTConfig"))
+
+from core.training.trainer import UnslothTrainer  # noqa: E402
 
 _preflight = UnslothTrainer._preflight_first_batch
 _renders_empty = UnslothTrainer._chat_template_renders_empty


### PR DESCRIPTION
## Summary

Training a base vision-language model on a conversational image dataset crashed on the first step with a cryptic embedding dtype error. This adds a preflight that validates the first real training batch and fails fast with an actionable message instead.

## The bug

Selecting a base VLM (e.g. `Qwen/Qwen2-VL-7B` or `unsloth/Qwen2-VL-7B`) with an image SFT dataset (e.g. `unsloth/LaTeX_OCR`) dies about one step in:

```
Expected tensor for argument #1 'indices' to have one of the following scalar
types: Long, Int; but got torch.cuda.FloatTensor (while checking arguments for embedding)
```

## Root cause

The base model's chat template is a flat, media-only template that renders to an empty string for role-based SFT messages. `UnslothVisionDataCollator` then calls the processor with empty text, the processor returns empty `input_ids`, torch defaults an empty tensor to `float32`, and the embedding lookup rejects a float tensor.

| Model | rendered text | input_ids |
|---|---|---|
| `Qwen/Qwen2-VL-7B` (base) | "" | `float32 (B,0)` -> crashes |
| `unsloth/Qwen2-VL-7B` (base) | "" | `float32 (B,0)` -> crashes |
| `*-Instruct` | non-empty | `int64 (B,T)` -> OK |

The text path is already protected (it routes through `get_tokenizer_chat_template`, which falls back to a default ChatML template for base models). The VLM path collates at runtime and never validated the rendered template.

## What changed

`core/training/trainer.py` adds `_preflight_first_batch`, called right before `self.trainer.train(...)`:

- Fetches one real batch via `self.trainer.get_train_dataloader()`, the exact tokenization and collation the first step runs, so it is faithful for the text, vision and audio-VLM paths.
- If `input_ids` is empty or non-integer, it stops the run through the existing clean-error channel (`_update_progress(error=..., is_training=False)`), which surfaces the message to the UI without a traceback (mirrors the existing train-on-responses drop-rate guard).
- When the model's chat template renders empty (the base-model signature), the message names the model and points to the instruction-tuned variant; otherwise it reports the invalid token IDs.
- Self-guarded: it only ever converts a would-be step-1 crash into a clear message, and never blocks a run whose first batch is valid.

## Tests

New `tests/test_training_preflight.py` (9 cases): float input_ids plus empty template gives the Instruct hint; an already-Instruct model gets no Instruct suggestion; empty-int gives the generic message; a valid batch passes; a raising dataloader gives a clear message; a batch without input_ids passes; plus the empty-template detector.

Verified end to end on the real components (real `UnslothVisionDataCollator`, real processor, real `unsloth/LaTeX_OCR` rows): base `Qwen/Qwen2-VL-7B` produces `float32 (2,0)` and is blocked with the Instruct message, while `Qwen/Qwen2-VL-7B-Instruct` produces `int64 (2,90)` and passes.
