### PR TITLE
ci(studio): fix Linux tool-calling flake (Q4_K_XL) and capture server logs on 500

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -317,7 +317,7 @@ jobs:
     timeout-minutes: 25
     env:
       # Tool calling is the highest-volume GGUF in this workflow
-      # (Qwen3.5-2B at IQ3_XXS = ~890 MiB). Caching HF_HOME would
+      # (Qwen3.5-2B at Q4_K_XL = ~1.28 GiB). Caching HF_HOME would
       # store xet chunks + blobs + snapshots = ~4 GiB compressed --
       # 4-5x file-size inflation, dominated by xet chunks. Use main's
       # `--local-dir gguf-cache` pattern to cache the flat .gguf only.
@@ -326,8 +326,11 @@ jobs:
       # path keeps the test off HF_HOME entirely so the cache size
       # tracks the GGUF file 1:1. The OpenAI/Anth and JSON+images
       # jobs still cover the gguf_variant resolution path.
+      # Q4_K_XL, not IQ3_XXS: at IQ3_XXS this model emits malformed
+      # tool calls that llama-server's peg-native parser rejects with a
+      # 500. Mac/Windows already use Q4_K_XL for the same reason.
       GGUF_REPO: unsloth/Qwen3.5-2B-GGUF
-      GGUF_FILE: Qwen3.5-2B-UD-IQ3_XXS.gguf
+      GGUF_FILE: Qwen3.5-2B-UD-Q4_K_XL.gguf
       STUDIO_PORT: '18889'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -772,6 +775,9 @@ jobs:
           kill "${STUDIO_PID}" 2>/dev/null || true
           sleep 2
           ss -tln | grep ":${STUDIO_PORT}" || true
+          # Capture backend + llama-server logs so a 500 has a server-side traceback.
+          mkdir -p logs/server-logs
+          cp -r ~/.unsloth/studio/logs/. logs/server-logs/ 2>/dev/null || true
 
       - name: Upload logs
         # Always upload so green runs are still reviewable.
@@ -784,6 +790,7 @@ jobs:
           path: |
             logs/studio.log
             logs/install.log
+            logs/server-logs/
           retention-days: 7
 
   # ─────────────────────────────────────────────────────────────────────

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -276,6 +276,10 @@ jobs:
         run: |
           kill "${STUDIO_IME_PID}" 2>/dev/null || true
           sleep 2
+          # Capture backend + llama-server logs (all three Studios share this
+          # dir) so a stray 500 has a server-side traceback.
+          mkdir -p logs/server-logs
+          cp -r ~/.unsloth/studio/logs/. logs/server-logs/ 2>/dev/null || true
 
       - name: Upload Playwright artifacts
         # Always upload so a green run's screenshots stay reviewable --
@@ -289,6 +293,7 @@ jobs:
             logs/studio_extra.log
             logs/studio_ime.log
             logs/install.log
+            logs/server-logs/
             logs/playwright
             logs/playwright_extra
             logs/playwright_ime


### PR DESCRIPTION
## Tool calling (the fix)

The Linux tool-calling smoke ran Qwen3.5-2B at **IQ3_XXS**. That quant is
aggressive enough that the model intermittently emits a malformed tool call,
for example:

```
<function=get_weather>
<parameter=city>
Paris
</parameter>
</parameter>   <- doubled close
</function>
</tool_call>   <- stray close
```

llama-server's peg-native parser rejects this and returns a 500:

```
common_chat_peg_parse: unparsed peg-native output: <function=get_weather> ...
srv operator(): got exception: {"error":{"code":500,"message":"The model produced
   output that does not match the expected peg-native format","type":"server_error"}}
```

which fails the job. Mac and Windows already run this exact test at **Q4_K_XL**
for the same reason (their workflows note that low quants make Qwen3.5-2B emit
garbage). This aligns Linux with them: `Qwen3.5-2B-UD-IQ3_XXS.gguf` ->
`Qwen3.5-2B-UD-Q4_K_XL.gguf`.

## Server logs on 500 (the diagnostic)

The tool-calling and ui-smoke jobs only uploaded `studio.log` + `install.log`,
which record the request boundary (`status_code 500`) but not the server-side
exception. The real cause lives in the backend server log and the llama-server
log under `~/.unsloth/studio/logs`. Copy that tree into the artifact on stop so
a `/v1/chat/completions` or `/api/inference/load` 500 is diagnosable from CI
alone. This is what surfaced the peg-native parser error above.

## Validation

Ran both workflows on a fork before/after:

- `studio-inference-smoke` (tool calling): IQ3_XXS reproduces the 500; **Q4_K_XL
  passes** (all three inference jobs green).
- `studio-ui-smoke`: the new capture step produced the server logs in the
  artifact (confirmed the copy works and does not affect job outcome).