### PR TITLE
Studio: hide the llama-server install validation probe from model pickers

### DIFF
--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -41,12 +41,18 @@ def _safe_is_dir(path) -> bool:
 
 def _is_hidden_model(*values: str | None) -> bool:
     """True if any id/path is the RAG embedding model (EMBEDDING_MODEL or
-    EMBED_GGUF_REPO basename), so pickers hide it (GGUF and non-GGUF)."""
+    EMBED_GGUF_REPO basename) or the llama.cpp install validation probe
+    (ggml-org/models / stories260K), so pickers hide them (GGUF and non-GGUF).
+    None are usable chat models; the probe can be cached as a side effect of
+    installing the prebuilt llama-server and otherwise sorts smallest, so it
+    would be auto-selected."""
     from core.rag import config as rag_config
 
     needles = (
         rag_config.EMBEDDING_MODEL.split("/")[-1].lower(),
         rag_config.EMBED_GGUF_REPO.split("/")[-1].lower(),
+        "ggml-org/models",
+        "stories260k",
     )
     return any(v and any(n in v.lower() for n in needles) for v in values)
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -51,8 +51,11 @@ def _is_hidden_model(*values: str | None) -> bool:
     needles = (
         rag_config.EMBEDDING_MODEL.split("/")[-1].lower(),
         rag_config.EMBED_GGUF_REPO.split("/")[-1].lower(),
+        # The validation probe's repo (matches the cached repo id) and its exact
+        # filename (matches the on-disk path). The filename carries the .gguf so
+        # it does not hide unrelated repos like ``user/stories260K-finetune-GGUF``.
         "ggml-org/models",
-        "stories260k",
+        "stories260k.gguf",
     )
     return any(v and any(n in v.lower() for n in needles) for v in values)
 

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -122,7 +122,9 @@ def test_list_cached_gguf_hides_llama_validation_probe(monkeypatch, tmp_path):
         [_file("gemma-3-270m-it-UD-Q4_K_XL.gguf", 200_000)],
         tmp_path / "models--unsloth--gemma-3-270m-it-GGUF",
     )
-    monkeypatch.setattr(models_route, "_all_hf_cache_scans", lambda: [SimpleNamespace(repos = [probe, real])])
+    monkeypatch.setattr(
+        models_route, "_all_hf_cache_scans", lambda: [SimpleNamespace(repos = [probe, real])]
+    )
 
     result = asyncio.run(models_route.list_cached_gguf(current_subject = "test-user"))
 

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -107,6 +107,19 @@ def test_list_cached_gguf_matches_extension_case_insensitively(monkeypatch, tmp_
     ]
 
 
+def test_is_hidden_model_hides_validation_probe_everywhere():
+    """Every picker (model list, local, cached GGUF, cached models) gates on
+    _is_hidden_model, so hiding the probe here hides it in the search menu too.
+    Cover both forms callers pass: the reconstructed repo id and the on-disk
+    snapshot path."""
+    assert models_route._is_hidden_model("ggml-org/models")
+    assert models_route._is_hidden_model("ggml-org/models/tinyllamas/stories260K.gguf")
+    assert models_route._is_hidden_model(
+        None, "/hf/models--ggml-org--models/snapshots/abc/tinyllamas/stories260K.gguf"
+    )
+    assert not models_route._is_hidden_model("unsloth/gemma-3-270m-it-GGUF")
+
+
 def test_list_cached_gguf_hides_llama_validation_probe(monkeypatch, tmp_path):
     """The ggml-org/models / stories260K install validation probe can land in
     the HF cache as a side effect of installing the prebuilt llama-server.

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -118,6 +118,9 @@ def test_is_hidden_model_hides_validation_probe_everywhere():
         None, "/hf/models--ggml-org--models/snapshots/abc/tinyllamas/stories260K.gguf"
     )
     assert not models_route._is_hidden_model("unsloth/gemma-3-270m-it-GGUF")
+    # The exact-filename needle must not hide a real repo that merely
+    # references stories260K in its name.
+    assert not models_route._is_hidden_model("user/stories260K-finetune-GGUF")
 
 
 def test_list_cached_gguf_hides_llama_validation_probe(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -107,6 +107,30 @@ def test_list_cached_gguf_matches_extension_case_insensitively(monkeypatch, tmp_
     ]
 
 
+def test_list_cached_gguf_hides_llama_validation_probe(monkeypatch, tmp_path):
+    """The ggml-org/models / stories260K install validation probe can land in
+    the HF cache as a side effect of installing the prebuilt llama-server.
+    It is not a chat model (it sorts smallest and would be auto-selected), so
+    pickers must hide it while keeping real cached models."""
+    probe = _repo(
+        "ggml-org/models",
+        [_file("tinyllamas/stories260K.gguf", 1_000)],
+        tmp_path / "models--ggml-org--models",
+    )
+    real = _repo(
+        "unsloth/gemma-3-270m-it-GGUF",
+        [_file("gemma-3-270m-it-UD-Q4_K_XL.gguf", 200_000)],
+        tmp_path / "models--unsloth--gemma-3-270m-it-GGUF",
+    )
+    monkeypatch.setattr(models_route, "_all_hf_cache_scans", lambda: [SimpleNamespace(repos = [probe, real])])
+
+    result = asyncio.run(models_route.list_cached_gguf(current_subject = "test-user"))
+
+    repo_ids = [c["repo_id"] for c in result["cached"]]
+    assert "ggml-org/models" not in repo_ids
+    assert "unsloth/gemma-3-270m-it-GGUF" in repo_ids
+
+
 def test_list_cached_gguf_skips_repos_without_positive_gguf_size(monkeypatch, tmp_path):
     missing = _repo(
         "Org/ReadmeOnly",


### PR DESCRIPTION
## Problem

`install_llama_prebuilt.py` validates the prebuilt llama-server binary against a
tiny probe model, `ggml-org/models / tinyllamas/stories260K.gguf`
(`TEST_MODEL_URL`). Fetching it goes through `hf_hub_download`, so it lands in
the HF cache. From there it shows up as a cached model and, at 260K params, it
sorts smallest, so the chat surface auto-selects it when no model is explicitly
chosen. That is never a usable chat model.

This is what the Studio UI / IME smoke test trips over: the submit probe
auto-loads `stories260K` instead of the intended model.

## Fix

Hide the probe in `_is_hidden_model`, the same mechanism that already hides the
RAG embedding model, so it never surfaces in any picker (cached GGUF list, model
list, auto-select). Real cached models are unaffected.

This complements the existing big-endian variant guard (`_gguf_files_for_variant`
/ `_is_big_endian_gguf_path`): that keeps resolution off the `-be` sibling, this
keeps the probe out of selection in the first place.

## Test

`test_list_cached_gguf_hides_llama_validation_probe`: a cache containing both the
probe and a real repo returns only the real repo.