### PR TITLE
Studio: prefer native cuda13 over torch's cuda12 line on Blackwell Linux hosts

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2178,6 +2178,30 @@ def _sm_range(artifact: PublishedLlamaArtifact) -> int:
     return 9999
 
 
+def _blackwell_capable_linux_runtime_lines(
+    host_sms: list[str], artifacts: list[PublishedLlamaArtifact]
+) -> list[str]:
+    """CUDA runtime lines (highest major first) shipping a bundle that covers every
+    visible host SM. Lets a Blackwell host prefer a native sm_120 line over torch's
+    reported line, mirroring the Windows Blackwell preference."""
+    lines: set[str] = set()
+    for artifact in artifacts:
+        line = artifact.runtime_line
+        # Only rank "cuda<major>" lines; ignore malformed/future-format values
+        # (e.g. "cuda13.1") so they are skipped, as pre-existing code does, rather
+        # than crashing the major sort.
+        if not (line and line.startswith("cuda") and line[len("cuda") :].isdigit()):
+            continue
+        if not artifact.supported_sms or artifact.min_sm is None or artifact.max_sm is None:
+            continue
+        supported = {str(value) for value in artifact.supported_sms}
+        if all(
+            sm in supported and artifact.min_sm <= int(sm) <= artifact.max_sm for sm in host_sms
+        ):
+            lines.add(line)
+    return sorted(lines, key = lambda line: int(line[len("cuda") :]), reverse = True)
+
+
 def linux_cuda_choice_from_release(
     host: HostInfo,
     release: PublishedReleaseBundle,
@@ -2240,7 +2264,27 @@ def linux_cuda_choice_from_release(
         )
         return None
 
-    if preferred_runtime_line:
+    blackwell_lines = (
+        [
+            line
+            for line in _blackwell_capable_linux_runtime_lines(host_sms, published_artifacts)
+            if line in ordered_runtime_lines
+        ]
+        if _host_is_blackwell(host)
+        else []
+    )
+    if blackwell_lines:
+        # Blackwell host: prefer the highest CUDA-major line shipping an sm_120 bundle
+        # over torch's line (matches the Windows Blackwell preference).
+        ordered_runtime_lines = blackwell_lines + [
+            line for line in ordered_runtime_lines if line not in blackwell_lines
+        ]
+        selection_log.append(
+            "linux_cuda_selection: blackwell_runtime_override prefer="
+            + ",".join(blackwell_lines)
+            + (f" over torch_preferred={preferred_runtime_line}" if preferred_runtime_line else "")
+        )
+    elif preferred_runtime_line:
         if preferred_runtime_line in ordered_runtime_lines:
             ordered_runtime_lines = [preferred_runtime_line] + [
                 runtime_line

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1248,6 +1248,136 @@ class TestLinuxCudaChoiceFromRelease:
         log_entries = result.selection_log
         assert any("unavailable_on_host" in entry for entry in log_entries)
 
+    def test_blackwell_prefers_cuda13_over_torch_cuda12(self, monkeypatch):
+        # Blackwell host with both lines sm_120-capable: cuda13 wins over torch's cuda12.
+        mock_linux_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(driver_cuda_version = (13, 0), compute_caps = ["120"])
+        art12 = make_artifact(
+            "bundle-cuda12-newer.tar.gz",
+            runtime_line = "cuda12",
+            supported_sms = ["86", "120"],
+            min_sm = 86,
+            max_sm = 120,
+        )
+        art13 = make_artifact(
+            "bundle-cuda13-newer.tar.gz",
+            runtime_line = "cuda13",
+            supported_sms = ["86", "120"],
+            min_sm = 86,
+            max_sm = 120,
+        )
+        release = make_release([art12, art13])
+        result = linux_cuda_choice_from_release(host, release, preferred_runtime_line = "cuda12")
+        assert result is not None
+        assert result.primary.runtime_line == "cuda13"
+        assert any("blackwell_runtime_override" in entry for entry in result.selection_log)
+
+    def test_blackwell_skips_incapable_cuda13_line(self, monkeypatch):
+        # cuda13 line cannot cover sm_120 (only an -older bundle): stay on native cuda12.
+        mock_linux_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(driver_cuda_version = (13, 0), compute_caps = ["120"])
+        art13_older = make_artifact(
+            "bundle-cuda13-older.tar.gz",
+            runtime_line = "cuda13",
+            supported_sms = ["75", "86", "89"],
+            min_sm = 75,
+            max_sm = 89,
+        )
+        art12_newer = make_artifact(
+            "bundle-cuda12-newer.tar.gz",
+            runtime_line = "cuda12",
+            supported_sms = ["86", "120"],
+            min_sm = 86,
+            max_sm = 120,
+        )
+        release = make_release([art13_older, art12_newer])
+        result = linux_cuda_choice_from_release(host, release, preferred_runtime_line = "cuda12")
+        assert result is not None
+        assert result.primary.runtime_line == "cuda12"
+        assert result.primary.name == "bundle-cuda12-newer.tar.gz"
+
+    def test_blackwell_cuda13_unavailable_uses_cuda12(self, monkeypatch):
+        # cuda13 runtime libs absent: override never forces an undetected line.
+        mock_linux_runtime(monkeypatch, ["cuda12"])
+        host = make_host(driver_cuda_version = (13, 0), compute_caps = ["120"])
+        art12 = make_artifact(
+            "bundle-cuda12-newer.tar.gz",
+            runtime_line = "cuda12",
+            supported_sms = ["86", "120"],
+            min_sm = 86,
+            max_sm = 120,
+        )
+        release = make_release([art12])
+        result = linux_cuda_choice_from_release(host, release, preferred_runtime_line = "cuda12")
+        assert result is not None
+        assert result.primary.runtime_line == "cuda12"
+
+    def test_non_blackwell_keeps_torch_preference(self, monkeypatch):
+        # Non-Blackwell host: torch preference is untouched, no override.
+        mock_linux_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(driver_cuda_version = (13, 0), compute_caps = ["86"])
+        art12 = make_artifact(
+            "bundle-cuda12.tar.gz",
+            runtime_line = "cuda12",
+            supported_sms = ["86"],
+            min_sm = 86,
+            max_sm = 86,
+        )
+        art13 = make_artifact(
+            "bundle-cuda13.tar.gz",
+            runtime_line = "cuda13",
+            supported_sms = ["86"],
+            min_sm = 86,
+            max_sm = 86,
+        )
+        release = make_release([art12, art13])
+        result = linux_cuda_choice_from_release(host, release, preferred_runtime_line = "cuda12")
+        assert result is not None
+        assert result.primary.runtime_line == "cuda12"
+        assert not any("blackwell_runtime_override" in entry for entry in result.selection_log)
+
+    def test_blackwell_ignores_malformed_runtime_line(self, monkeypatch):
+        # A malformed/future-format runtime_line must be skipped, never crash the major sort.
+        mock_linux_runtime(monkeypatch, ["cuda13", "cuda12"])
+        host = make_host(driver_cuda_version = (13, 0), compute_caps = ["120"])
+        bad = make_artifact(
+            "bundle-cudaX.tar.gz",
+            runtime_line = "cudaX",
+            supported_sms = ["86", "120"],
+            min_sm = 86,
+            max_sm = 120,
+        )
+        art13 = make_artifact(
+            "bundle-cuda13-newer.tar.gz",
+            runtime_line = "cuda13",
+            supported_sms = ["86", "120"],
+            min_sm = 86,
+            max_sm = 120,
+        )
+        release = make_release([bad, art13])
+        result = linux_cuda_choice_from_release(host, release, preferred_runtime_line = "cuda12")
+        assert result is not None
+        assert result.primary.runtime_line == "cuda13"
+
+    def test_blackwell_prefers_cuda14_over_lower_majors(self, monkeypatch):
+        # Forward-compat: the highest sm_120-capable CUDA major wins.
+        mock_linux_runtime(monkeypatch, ["cuda14", "cuda13", "cuda12"])
+        host = make_host(driver_cuda_version = (14, 0), compute_caps = ["120"])
+        arts = [
+            make_artifact(
+                f"bundle-{rtl}.tar.gz",
+                runtime_line = rtl,
+                supported_sms = ["86", "120"],
+                min_sm = 86,
+                max_sm = 120,
+            )
+            for rtl in ("cuda12", "cuda13", "cuda14")
+        ]
+        release = make_release(arts)
+        result = linux_cuda_choice_from_release(host, release, preferred_runtime_line = "cuda12")
+        assert result is not None
+        assert result.primary.runtime_line == "cuda14"
+
     def test_arm64_host_selects_linux_arm64_cuda_kind(self, monkeypatch):
         # An arm64 CUDA host (DGX Spark / Grace Hopper) selects the
         # linux-arm64-cuda bundle and ignores the x64 linux-cuda one.


### PR DESCRIPTION
## Summary

On a Blackwell (sm_120) Linux host, the installer ordered its CUDA runtime-line attempts purely by torch's reported CUDA major (`preferred_runtime_line` from `detect_torch_cuda_runtime_preference`). A host running a `cu12x` torch build therefore hoisted `cuda12` ahead of an available native `cuda13` bundle, even though both cover sm_120.

This brings `linux_cuda_choice_from_release` to parity with the existing Windows Blackwell preference (`_drop_blackwell_incapable_windows_cuda` / the Windows cuda13 pin): on an sm_120 host, prefer the highest CUDA-major runtime line that ships a bundle covering every visible host SM, then fall back to the torch-preferred line.

## What it does

- Adds `_blackwell_capable_linux_runtime_lines(host_sms, artifacts)`: the runtime lines (highest CUDA major first) whose bundles cover every visible host SM. Its coverage test mirrors the existing per-artifact SM filter, so any line it hoists is guaranteed to yield an accepted artifact.
- Wraps the existing torch-preference reorder: when the host is Blackwell and a capable line exists, prefer it (cuda13 before cuda12) and log `blackwell_runtime_override`; otherwise the torch-preference path is unchanged.

## Why it is low risk

- Selection-time only. No external pin and no source build: the in-release `cuda13-newer` / `cuda13-portable` bundles already cover sm_120, so a Linux pin would add checksum and maintenance cost without solving a current missing-artifact gap.
- Gated on `_host_is_blackwell`, which is false when compute caps are unknown, so the existing unknown-caps portable path is untouched.
- `blackwell_lines` is intersected with the already-computed selectable lines (detected runtime libraries that are also driver-compatible), so the override never forces `cuda13` when `libcudart.so.13` is absent or the driver is pre-13. It only reorders lines that were already attemptable.
- Keeps `cuda12` as a fallback after `cuda13`. The per-artifact SM filter still drops incapable bundles (`cuda12-older` / `cuda13-older`, max_sm 89) and prevents any fall-through to a non-Blackwell build.
- Non-Blackwell hosts keep the exact current torch-preference behavior.

## Tests

Adds four focused cases to `TestLinuxCudaChoiceFromRelease`:

- `test_blackwell_prefers_cuda13_over_torch_cuda12`: both lines sm_120-capable, torch prefers cuda12, primary is cuda13.
- `test_blackwell_skips_incapable_cuda13_line`: cuda13 has only an `-older` bundle, so it is not hoisted and the native cuda12 bundle is selected.
- `test_blackwell_cuda13_unavailable_uses_cuda12`: cuda13 runtime libs absent, override does not force an undetected line.
- `test_non_blackwell_keeps_torch_preference`: non-Blackwell host keeps torch ordering and emits no override.

`python -m pytest tests/studio/install/test_selection_logic.py` passes (250 tests), and `python -m py_compile studio/install_llama_prebuilt.py` is clean.