### PR TITLE
Speed up Studio/CLI exports and add early Hugging Face Hub validation

### DIFF
--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -70,10 +70,7 @@ def _format_gguf_quant_label(quant_methods: List[str]) -> str:
 
 
 def _precheck_hub_or_fail(
-    push_to_hub: bool,
-    repo_id: Optional[str],
-    hf_token: Optional[str],
-    private: bool,
+    push_to_hub: bool, repo_id: Optional[str], hf_token: Optional[str], private: bool
 ) -> Optional[Tuple[bool, str, None]]:
     """Run Hub preflight when push_to_hub is requested."""
     if not push_to_hub:
@@ -92,11 +89,7 @@ def _precheck_hub_or_fail(
     return None
 
 
-def _resolve_hub_repo_id(
-    repo_id: str,
-    hf_token: Optional[str],
-    private: bool,
-) -> str:
+def _resolve_hub_repo_id(repo_id: str, hf_token: Optional[str], private: bool) -> str:
     """Create or resolve a Hub model repo and return the canonical repo id."""
     hf_api = HfApi(token = hf_token) if hf_token else HfApi()
     if _IS_MLX:
@@ -149,11 +142,7 @@ def _upload_model_folder_to_hub(
     repo_resolved: bool = False,
 ) -> None:
     """Upload an on-disk model folder without re-saving or re-merging."""
-    full_repo_id = (
-        repo_id
-        if repo_resolved
-        else _resolve_hub_repo_id(repo_id, hf_token, private)
-    )
+    full_repo_id = repo_id if repo_resolved else _resolve_hub_repo_id(repo_id, hf_token, private)
     hf_api = HfApi(token = hf_token) if hf_token else HfApi()
     hf_api.upload_folder(
         folder_path = folder_path,
@@ -179,18 +168,11 @@ def _find_export_artifact(save_directory: str, filename: str) -> Optional[str]:
     return None
 
 
-def _gguf_path_in_repo(
-    file_path: str,
-    *,
-    model_name: str,
-    save_directory: str,
-) -> str:
+def _gguf_path_in_repo(file_path: str, *, model_name: str, save_directory: str) -> str:
     """Match unsloth's Hub filename normalization for GGUF uploads."""
     original_name = os.path.basename(file_path)
     if "unsloth_gguf_" in original_name:
-        quant_suffix = (
-            original_name.split(".", 1)[1] if "." in original_name else original_name
-        )
+        quant_suffix = original_name.split(".", 1)[1] if "." in original_name else original_name
         return f"{model_name}.{quant_suffix}"
 
     save_base = os.path.basename(save_directory.rstrip("/\\"))
@@ -200,11 +182,7 @@ def _gguf_path_in_repo(
 
 
 def _build_gguf_hub_readme(
-    *,
-    repo_id: str,
-    upload_names: List[str],
-    is_vlm: bool,
-    has_modelfile: bool,
+    *, repo_id: str, upload_names: List[str], is_vlm: bool, has_modelfile: bool
 ) -> str:
     """Build a Hub README aligned with unsloth_push_to_hub_gguf."""
     model_slug = repo_id.split("/")[-1]
@@ -233,7 +211,9 @@ This model was finetuned and converted to GGUF format using [Unsloth](https://gi
         readme_content += "\n## ⚠️ Ollama Note for Vision Models\n"
         readme_content += "**Important:** Ollama currently does not support separate mmproj files for vision models.\n\n"
         readme_content += "To create an Ollama model from this vision model:\n"
-        readme_content += "1. Place the `Modelfile` in the same directory as the finetuned bf16 merged model\n"
+        readme_content += (
+            "1. Place the `Modelfile` in the same directory as the finetuned bf16 merged model\n"
+        )
         readme_content += "3. Run: `ollama create model_name -f ./Modelfile`\n"
         readme_content += "   (Replace `model_name` with your desired name)\n\n"
         readme_content += "This will create a unified bf16 model that Ollama can use.\n"
@@ -258,9 +238,7 @@ def _upload_gguf_directory_to_hub(
     """Upload already-converted GGUF artifacts without re-running conversion."""
     gguf_files = sorted(glob.glob(os.path.join(save_directory, "*.gguf")))
     if not gguf_files:
-        raise RuntimeError(
-            f"No GGUF files found in {save_directory}. Conversion may have failed."
-        )
+        raise RuntimeError(f"No GGUF files found in {save_directory}. Conversion may have failed.")
 
     hf_api = HfApi(token = hf_token) if hf_token else HfApi()
     full_repo_id = _resolve_hub_repo_id(
@@ -633,9 +611,7 @@ class ExportBackend:
 
         output_path: Optional[str] = None
         try:
-            precheck_failure = _precheck_hub_or_fail(
-                push_to_hub, repo_id, hf_token, private
-            )
+            precheck_failure = _precheck_hub_or_fail(push_to_hub, repo_id, hf_token, private)
             if precheck_failure is not None:
                 return precheck_failure
 
@@ -705,10 +681,14 @@ class ExportBackend:
                 else:
                     if output_path and os.path.isdir(output_path):
                         base_model = (
-                            get_base_model_from_lora(self.current_checkpoint)
-                            if self.current_checkpoint
-                            else None
-                        ) or getattr(self.current_model.config, "_name_or_path", None) or "unknown"
+                            (
+                                get_base_model_from_lora(self.current_checkpoint)
+                                if self.current_checkpoint
+                                else None
+                            )
+                            or getattr(self.current_model.config, "_name_or_path", None)
+                            or "unknown"
+                        )
                         full_repo_id = _resolve_hub_repo_id(repo_id, hf_token, private)
                         _push_hub_model_card(
                             full_repo_id,
@@ -771,9 +751,7 @@ class ExportBackend:
 
         output_path: Optional[str] = None
         try:
-            precheck_failure = _precheck_hub_or_fail(
-                push_to_hub, repo_id, hf_token, private
-            )
+            precheck_failure = _precheck_hub_or_fail(push_to_hub, repo_id, hf_token, private)
             if precheck_failure is not None:
                 return precheck_failure
 
@@ -906,9 +884,7 @@ class ExportBackend:
         output_path: Optional[str] = None
         model_tmp_to_cleanup: Optional[str] = None
         try:
-            precheck_failure = _precheck_hub_or_fail(
-                push_to_hub, repo_id, hf_token, private
-            )
+            precheck_failure = _precheck_hub_or_fail(push_to_hub, repo_id, hf_token, private)
             if precheck_failure is not None:
                 return precheck_failure
 
@@ -1079,9 +1055,7 @@ class ExportBackend:
 
         output_path: Optional[str] = None
         try:
-            precheck_failure = _precheck_hub_or_fail(
-                push_to_hub, repo_id, hf_token, private
-            )
+            precheck_failure = _precheck_hub_or_fail(push_to_hub, repo_id, hf_token, private)
             if precheck_failure is not None:
                 return precheck_failure
 
@@ -1113,10 +1087,14 @@ class ExportBackend:
                 if output_path and os.path.isdir(output_path):
                     full_repo_id = _resolve_hub_repo_id(repo_id, hf_token, private)
                     base_model = (
-                        get_base_model_from_lora(self.current_checkpoint)
-                        if self.current_checkpoint
-                        else None
-                    ) or getattr(self.current_model.config, "_name_or_path", None) or "unknown"
+                        (
+                            get_base_model_from_lora(self.current_checkpoint)
+                            if self.current_checkpoint
+                            else None
+                        )
+                        or getattr(self.current_model.config, "_name_or_path", None)
+                        or "unknown"
+                    )
                     _push_hub_model_card(
                         full_repo_id,
                         hf_token,
@@ -1139,10 +1117,14 @@ class ExportBackend:
                         self.current_tokenizer.save_pretrained(tmp_dir)
                         full_repo_id = _resolve_hub_repo_id(repo_id, hf_token, private)
                         base_model = (
-                            get_base_model_from_lora(self.current_checkpoint)
-                            if self.current_checkpoint
-                            else None
-                        ) or getattr(self.current_model.config, "_name_or_path", None) or "unknown"
+                            (
+                                get_base_model_from_lora(self.current_checkpoint)
+                                if self.current_checkpoint
+                                else None
+                            )
+                            or getattr(self.current_model.config, "_name_or_path", None)
+                            or "unknown"
+                        )
                         _push_hub_model_card(
                             full_repo_id,
                             hf_token,

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -11,7 +11,7 @@ from loggers import get_logger
 import os
 import shutil
 from pathlib import Path
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple, List, Union
 from unsloth import FastLanguageModel, FastVisionModel, _IS_MLX
 from huggingface_hub import HfApi, ModelCard
 from utils.hardware import clear_gpu_cache
@@ -35,6 +35,309 @@ if not _IS_MLX:
 logger = get_logger(__name__)
 
 _LLAMA_CPP_SCRIPTS_WARNING_EMITTED = False
+
+
+def _normalize_gguf_quant_methods(
+    quantization_method: Optional[Union[str, List[str]]] = None,
+    quantization_methods: Optional[List[str]] = None,
+) -> List[str]:
+    """Resolve GGUF quant labels to a lowercase list for unsloth."""
+    if quantization_methods:
+        raw = quantization_methods
+    elif isinstance(quantization_method, list):
+        raw = quantization_method
+    elif quantization_method:
+        raw = [quantization_method]
+    else:
+        raw = ["Q4_K_M"]
+
+    normalized: List[str] = []
+    seen = set()
+    for item in raw:
+        label = str(item).strip()
+        if not label:
+            continue
+        key = label.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(key)
+    return normalized or ["q4_k_m"]
+
+
+def _format_gguf_quant_label(quant_methods: List[str]) -> str:
+    return ", ".join(method.upper() for method in quant_methods)
+
+
+def _precheck_hub_or_fail(
+    push_to_hub: bool,
+    repo_id: Optional[str],
+    hf_token: Optional[str],
+    private: bool,
+) -> Optional[Tuple[bool, str, None]]:
+    """Run Hub preflight when push_to_hub is requested."""
+    if not push_to_hub:
+        return None
+    if not repo_id:
+        return False, "Repository ID is required for Hub upload", None
+    from core.export.hf_precheck import precheck_hub_upload_tuple
+
+    ok, message = precheck_hub_upload_tuple(
+        repo_id = repo_id,
+        hf_token = hf_token,
+        private = private,
+    )
+    if not ok:
+        return False, message, None
+    return None
+
+
+def _resolve_hub_repo_id(
+    repo_id: str,
+    hf_token: Optional[str],
+    private: bool,
+) -> str:
+    """Create or resolve a Hub model repo and return the canonical repo id."""
+    hf_api = HfApi(token = hf_token) if hf_token else HfApi()
+    if _IS_MLX:
+        hf_api.create_repo(repo_id, private = private, exist_ok = True, token = hf_token)
+        return repo_id
+    return PushToHubMixin._create_repo(
+        PushToHubMixin,
+        repo_id = repo_id,
+        private = private,
+        token = hf_token,
+    )
+
+
+def _push_hub_model_card(
+    repo_id: str,
+    hf_token: Optional[str],
+    *,
+    username: str,
+    base_model: str,
+    model_type: str,
+    method: str = "",
+    extra: str = "unsloth",
+) -> None:
+    content = MODEL_CARD.format(
+        username = username,
+        base_model = base_model,
+        model_type = model_type,
+        method = method,
+        extra = extra,
+    )
+    card = ModelCard(content)
+    card.push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
+
+
+def _ensure_full_hub_repo_id(repo_id: str, hf_token: Optional[str]) -> str:
+    """Expand a short repo name to username/model when no namespace is given."""
+    if "/" in repo_id:
+        return repo_id
+    hf_api = HfApi(token = hf_token) if hf_token else HfApi()
+    username = hf_api.whoami(token = hf_token)["name"]
+    return f"{username}/{repo_id}"
+
+
+def _upload_model_folder_to_hub(
+    folder_path: str,
+    repo_id: str,
+    hf_token: Optional[str],
+    private: bool,
+    *,
+    repo_resolved: bool = False,
+) -> None:
+    """Upload an on-disk model folder without re-saving or re-merging."""
+    full_repo_id = (
+        repo_id
+        if repo_resolved
+        else _resolve_hub_repo_id(repo_id, hf_token, private)
+    )
+    hf_api = HfApi(token = hf_token) if hf_token else HfApi()
+    hf_api.upload_folder(
+        folder_path = folder_path,
+        repo_id = full_repo_id,
+        repo_type = "model",
+        token = hf_token,
+    )
+
+
+def _find_export_artifact(save_directory: str, filename: str) -> Optional[str]:
+    """Locate an export artifact in the save dir or a leftover _tmp_model_* subdir."""
+    direct = os.path.join(save_directory, filename)
+    if os.path.isfile(direct):
+        return direct
+    try:
+        for entry in os.scandir(save_directory):
+            if entry.is_dir() and entry.name.startswith("_tmp_model_"):
+                candidate = os.path.join(entry.path, filename)
+                if os.path.isfile(candidate):
+                    return candidate
+    except OSError:
+        pass
+    return None
+
+
+def _gguf_path_in_repo(
+    file_path: str,
+    *,
+    model_name: str,
+    save_directory: str,
+) -> str:
+    """Match unsloth's Hub filename normalization for GGUF uploads."""
+    original_name = os.path.basename(file_path)
+    if "unsloth_gguf_" in original_name:
+        quant_suffix = (
+            original_name.split(".", 1)[1] if "." in original_name else original_name
+        )
+        return f"{model_name}.{quant_suffix}"
+
+    save_base = os.path.basename(save_directory.rstrip("/\\"))
+    if save_base and save_base in original_name:
+        return original_name.replace(save_base, model_name)
+    return original_name
+
+
+def _build_gguf_hub_readme(
+    *,
+    repo_id: str,
+    upload_names: List[str],
+    is_vlm: bool,
+    has_modelfile: bool,
+) -> str:
+    """Build a Hub README aligned with unsloth_push_to_hub_gguf."""
+    model_slug = repo_id.split("/")[-1]
+    readme_content = f"""---
+tags:
+- gguf
+- llama.cpp
+- unsloth
+{"- vision-language-model" if is_vlm else ""}
+---
+
+# {model_slug} : GGUF
+
+This model was finetuned and converted to GGUF format using [Unsloth](https://github.com/unslothai/unsloth).
+
+**Example usage**:
+- For text only LLMs:    `llama-cli -hf {repo_id} --jinja`
+- For multimodal models: `llama-mtmd-cli -hf {repo_id} --jinja`
+
+## Available Model files:
+"""
+    for name in upload_names:
+        readme_content += f"- `{name}`\n"
+
+    if is_vlm and has_modelfile:
+        readme_content += "\n## ⚠️ Ollama Note for Vision Models\n"
+        readme_content += "**Important:** Ollama currently does not support separate mmproj files for vision models.\n\n"
+        readme_content += "To create an Ollama model from this vision model:\n"
+        readme_content += "1. Place the `Modelfile` in the same directory as the finetuned bf16 merged model\n"
+        readme_content += "3. Run: `ollama create model_name -f ./Modelfile`\n"
+        readme_content += "   (Replace `model_name` with your desired name)\n\n"
+        readme_content += "This will create a unified bf16 model that Ollama can use.\n"
+    elif has_modelfile:
+        readme_content += "\n## Ollama\n"
+        readme_content += "An Ollama Modelfile is included for easy deployment.\n"
+
+    readme_content += (
+        "\nThis was trained 2x faster with [Unsloth](https://github.com/unslothai/unsloth)\n"
+        '[<img src="https://raw.githubusercontent.com/unslothai/unsloth/main/images/unsloth%20made%20with%20love.png" width="200"/>](https://github.com/unslothai/unsloth)\n'
+    )
+    return readme_content
+
+
+def _upload_gguf_directory_to_hub(
+    save_directory: str,
+    repo_id: str,
+    hf_token: Optional[str],
+    private: bool = False,
+    is_vlm: bool = False,
+) -> None:
+    """Upload already-converted GGUF artifacts without re-running conversion."""
+    gguf_files = sorted(glob.glob(os.path.join(save_directory, "*.gguf")))
+    if not gguf_files:
+        raise RuntimeError(
+            f"No GGUF files found in {save_directory}. Conversion may have failed."
+        )
+
+    hf_api = HfApi(token = hf_token) if hf_token else HfApi()
+    full_repo_id = _resolve_hub_repo_id(
+        _ensure_full_hub_repo_id(repo_id, hf_token),
+        hf_token,
+        private,
+    )
+    model_name = full_repo_id.split("/")[-1]
+
+    upload_names: List[str] = []
+    for file_path in gguf_files:
+        path_in_repo = _gguf_path_in_repo(
+            file_path,
+            model_name = model_name,
+            save_directory = save_directory,
+        )
+        upload_names.append(path_in_repo)
+        logger.info("Uploading GGUF to Hub: %s", path_in_repo)
+        hf_api.upload_file(
+            path_or_fileobj = file_path,
+            path_in_repo = path_in_repo,
+            repo_id = full_repo_id,
+            repo_type = "model",
+            commit_message = "(Trained with Unsloth)",
+            token = hf_token,
+        )
+
+    config_path = _find_export_artifact(save_directory, "config.json")
+    if config_path:
+        hf_api.upload_file(
+            path_or_fileobj = config_path,
+            path_in_repo = "config.json",
+            repo_id = full_repo_id,
+            repo_type = "model",
+            commit_message = "(Trained with Unsloth) - config",
+            token = hf_token,
+        )
+
+    modelfile_path = _find_export_artifact(save_directory, "Modelfile")
+    has_modelfile = modelfile_path is not None
+    if modelfile_path:
+        hf_api.upload_file(
+            path_or_fileobj = modelfile_path,
+            path_in_repo = "Modelfile",
+            repo_id = full_repo_id,
+            repo_type = "model",
+            commit_message = "(Trained with Unsloth) - Ollama Modelfile",
+            token = hf_token,
+        )
+
+    readme_content = _build_gguf_hub_readme(
+        repo_id = full_repo_id,
+        upload_names = upload_names,
+        is_vlm = is_vlm,
+        has_modelfile = has_modelfile,
+    )
+
+    hf_api.upload_file(
+        path_or_fileobj = readme_content.encode("utf-8"),
+        path_in_repo = "README.md",
+        repo_id = full_repo_id,
+        repo_type = "model",
+        commit_message = "Add README",
+        token = hf_token,
+    )
+
+    tags = ["gguf", "llama-cpp", "unsloth"]
+    if is_vlm:
+        tags.append("vision-language-model")
+    try:
+        hf_api.add_tags(
+            repo_id = full_repo_id,
+            tags = tags,
+            repo_type = "model",
+        )
+    except Exception as exc:
+        logger.warning("Could not add Hub tags to %s: %s", full_repo_id, exc)
 
 
 def _is_wsl():
@@ -330,6 +633,12 @@ class ExportBackend:
 
         output_path: Optional[str] = None
         try:
+            precheck_failure = _precheck_hub_or_fail(
+                push_to_hub, repo_id, hf_token, private
+            )
+            if precheck_failure is not None:
+                return precheck_failure
+
             if _IS_MLX:
                 mlx_save_method = "merged_4bit" if format_type == "4-bit (FP4)" else "merged_16bit"
             else:
@@ -361,10 +670,10 @@ class ExportBackend:
                 output_path = str(Path(save_directory).resolve())
 
             if push_to_hub:
-                if not repo_id or not hf_token:
+                if not repo_id:
                     return (
                         False,
-                        "Repository ID and Hugging Face token required for Hub upload",
+                        "Repository ID is required for Hub upload",
                         None,
                     )
 
@@ -394,14 +703,36 @@ class ExportBackend:
                                 private = private,
                             )
                 else:
-                    hub_save_method = save_method if save_method is not None else "merged_16bit"
-                    self.current_model.push_to_hub_merged(
-                        repo_id,
-                        self.current_tokenizer,
-                        save_method = hub_save_method,
-                        token = hf_token,
-                        private = private,
-                    )
+                    if output_path and os.path.isdir(output_path):
+                        base_model = (
+                            get_base_model_from_lora(self.current_checkpoint)
+                            if self.current_checkpoint
+                            else None
+                        ) or getattr(self.current_model.config, "_name_or_path", None) or "unknown"
+                        full_repo_id = _resolve_hub_repo_id(repo_id, hf_token, private)
+                        _push_hub_model_card(
+                            full_repo_id,
+                            hf_token,
+                            username = full_repo_id.split("/")[0],
+                            base_model = base_model,
+                            model_type = self.current_model.config.model_type,
+                        )
+                        _upload_model_folder_to_hub(
+                            output_path,
+                            full_repo_id,
+                            hf_token,
+                            private,
+                            repo_resolved = True,
+                        )
+                    else:
+                        hub_save_method = save_method if save_method is not None else "merged_16bit"
+                        self.current_model.push_to_hub_merged(
+                            repo_id,
+                            self.current_tokenizer,
+                            save_method = hub_save_method,
+                            token = hf_token,
+                            private = private,
+                        )
                 logger.info(f"Model pushed successfully to {repo_id}")
 
             return True, "Model exported successfully", output_path
@@ -440,6 +771,12 @@ class ExportBackend:
 
         output_path: Optional[str] = None
         try:
+            precheck_failure = _precheck_hub_or_fail(
+                push_to_hub, repo_id, hf_token, private
+            )
+            if precheck_failure is not None:
+                return precheck_failure
+
             if save_directory:
                 save_directory = str(resolve_export_write_dir(save_directory))
                 logger.info(f"Saving base model locally to: {save_directory}")
@@ -463,10 +800,10 @@ class ExportBackend:
                 output_path = str(Path(save_directory).resolve())
 
             if push_to_hub:
-                if not repo_id or not hf_token:
+                if not repo_id:
                     return (
                         False,
-                        "Repository ID and Hugging Face token required for Hub upload",
+                        "Repository ID is required for Hub upload",
                         None,
                     )
 
@@ -496,37 +833,26 @@ class ExportBackend:
                                 private = private,
                             )
                 else:
-                    # Base model name from request or model config
-                    base_model = (
-                        base_model_id or self.current_model.config._name_or_path or "unknown"
-                    )
-
-                    hf_api = HfApi(token = hf_token)
-                    repo_id = PushToHubMixin._create_repo(
-                        PushToHubMixin,
-                        repo_id = repo_id,
-                        private = private,
-                        token = hf_token,
-                    )
-                    username = repo_id.split("/")[0]
-
-                    content = MODEL_CARD.format(
-                        username = username,
-                        base_model = base_model,
-                        model_type = self.current_model.config.model_type,
-                        method = "",
-                        extra = "unsloth",
-                    )
-                    card = ModelCard(content)
-                    card.push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
-
-                    if save_directory:
-                        hf_api.upload_folder(
-                            folder_path = save_directory,
-                            repo_id = repo_id,
-                            repo_type = "model",
+                    if output_path and os.path.isdir(output_path):
+                        base_model = (
+                            base_model_id or self.current_model.config._name_or_path or "unknown"
                         )
-                        logger.info(f"Model pushed successfully to {repo_id}")
+                        full_repo_id = _resolve_hub_repo_id(repo_id, hf_token, private)
+                        _push_hub_model_card(
+                            full_repo_id,
+                            hf_token,
+                            username = full_repo_id.split("/")[0],
+                            base_model = base_model,
+                            model_type = self.current_model.config.model_type,
+                        )
+                        _upload_model_folder_to_hub(
+                            output_path,
+                            full_repo_id,
+                            hf_token,
+                            private,
+                            repo_resolved = True,
+                        )
+                        logger.info(f"Model pushed successfully to {full_repo_id}")
                     else:
                         return (
                             False,
@@ -546,20 +872,24 @@ class ExportBackend:
     def export_gguf(
         self,
         save_directory: str,
-        quantization_method: str = "Q4_K_M",
+        quantization_method: Union[str, List[str], None] = "Q4_K_M",
+        quantization_methods: Optional[List[str]] = None,
         push_to_hub: bool = False,
         repo_id: Optional[str] = None,
         hf_token: Optional[str] = None,
+        private: bool = False,
     ) -> Tuple[bool, str, Optional[str]]:
         """
         Export model in GGUF format.
 
         Args:
             save_directory: Local directory to save model
-            quantization_method: GGUF quantization method (e.g., "Q4_K_M")
+            quantization_method: Single GGUF quant label (legacy)
+            quantization_methods: Multiple GGUF quant labels in one conversion pass
             push_to_hub: Whether to push to Hugging Face Hub
             repo_id: Hub repository ID
             hf_token: Hugging Face token
+            private: Whether to create a private Hub repository
 
         Returns:
             Tuple of (success: bool, message: str, output_path: Optional[str])
@@ -567,11 +897,20 @@ class ExportBackend:
         if not self.current_model or not self.current_tokenizer:
             return False, "No model loaded. Please select a checkpoint first.", None
 
+        quant_methods = _normalize_gguf_quant_methods(
+            quantization_method,
+            quantization_methods,
+        )
+        quant_label = _format_gguf_quant_label(quant_methods)
+
         output_path: Optional[str] = None
         model_tmp_to_cleanup: Optional[str] = None
         try:
-            # unsloth expects lowercase quant method
-            quant_method = quantization_method.lower()
+            precheck_failure = _precheck_hub_or_fail(
+                push_to_hub, repo_id, hf_token, private
+            )
+            if precheck_failure is not None:
+                return precheck_failure
 
             # Pin convert_hf_to_gguf.py to setup.sh's tagged llama.cpp ref so it
             # can't drift past the pinned llama-quantize binary's gguf API.
@@ -597,7 +936,11 @@ class ExportBackend:
                 save_directory = str(resolve_export_write_dir(save_directory))
                 # Keep unsloth relative-path internals anchored to the repo cwd.
                 abs_save_dir = os.path.abspath(save_directory)
-                logger.info(f"Saving GGUF model locally to: {abs_save_dir}")
+                logger.info(
+                    "Saving GGUF model locally to: %s (quantizations: %s)",
+                    abs_save_dir,
+                    quant_label,
+                )
 
                 ensure_dir(Path(abs_save_dir))
 
@@ -619,7 +962,7 @@ class ExportBackend:
                 self.current_model.save_pretrained_gguf(
                     _model_tmp,
                     self.current_tokenizer,
-                    quantization_method = quant_method,
+                    quantization_method = quant_methods,
                 )
 
                 # Relocate the .gguf that convert_to_gguf wrote to cwd (repo root).
@@ -672,26 +1015,36 @@ class ExportBackend:
                 output_path = str(Path(abs_save_dir).resolve())
 
             if push_to_hub:
-                if not repo_id or not hf_token:
+                if not repo_id:
                     return (
                         False,
-                        "Repository ID and Hugging Face token required for Hub upload",
+                        "Repository ID is required for Hub upload",
                         None,
                     )
 
                 logger.info(f"Pushing GGUF model to Hub: {repo_id}")
 
-                self.current_model.push_to_hub_gguf(
-                    repo_id,
-                    self.current_tokenizer,
-                    quantization_method = quant_method,
-                    token = hf_token,
-                )
+                if output_path and os.path.isdir(output_path):
+                    _upload_gguf_directory_to_hub(
+                        output_path,
+                        repo_id,
+                        hf_token,
+                        private = private,
+                        is_vlm = self.is_vision,
+                    )
+                else:
+                    self.current_model.push_to_hub_gguf(
+                        repo_id,
+                        self.current_tokenizer,
+                        quantization_method = quant_methods,
+                        token = hf_token,
+                        private = private,
+                    )
                 logger.info(f"GGUF model pushed successfully to {repo_id}")
 
             return (
                 True,
-                f"GGUF model exported successfully ({quantization_method})",
+                f"GGUF model exported successfully ({quant_label})",
                 output_path,
             )
 
@@ -726,6 +1079,12 @@ class ExportBackend:
 
         output_path: Optional[str] = None
         try:
+            precheck_failure = _precheck_hub_or_fail(
+                push_to_hub, repo_id, hf_token, private
+            )
+            if precheck_failure is not None:
+                return precheck_failure
+
             if save_directory:
                 save_directory = str(resolve_export_write_dir(save_directory))
                 logger.info(f"Saving LoRA adapter locally to: {save_directory}")
@@ -742,25 +1101,63 @@ class ExportBackend:
                 output_path = str(Path(save_directory).resolve())
 
             if push_to_hub:
-                if not repo_id or not hf_token:
+                if not repo_id:
                     return (
                         False,
-                        "Repository ID and Hugging Face token required for Hub upload",
+                        "Repository ID is required for Hub upload",
                         None,
                     )
 
                 logger.info(f"Pushing LoRA adapter to Hub: {repo_id}")
 
-                if _IS_MLX:
+                if output_path and os.path.isdir(output_path):
+                    full_repo_id = _resolve_hub_repo_id(repo_id, hf_token, private)
+                    base_model = (
+                        get_base_model_from_lora(self.current_checkpoint)
+                        if self.current_checkpoint
+                        else None
+                    ) or getattr(self.current_model.config, "_name_or_path", None) or "unknown"
+                    _push_hub_model_card(
+                        full_repo_id,
+                        hf_token,
+                        username = full_repo_id.split("/")[0],
+                        base_model = base_model,
+                        model_type = getattr(self.current_model.config, "model_type", "unknown"),
+                        method = "LoRA adapter",
+                        extra = "lora",
+                    )
+                    _upload_model_folder_to_hub(
+                        output_path,
+                        full_repo_id,
+                        hf_token,
+                        private,
+                        repo_resolved = True,
+                    )
+                elif _IS_MLX:
                     with tempfile.TemporaryDirectory() as tmp_dir:
                         self.current_model.save_lora_adapters(tmp_dir)
                         self.current_tokenizer.save_pretrained(tmp_dir)
-                        hf_api = HfApi(token = hf_token)
-                        hf_api.create_repo(repo_id, private = private, exist_ok = True)
-                        hf_api.upload_folder(
-                            folder_path = tmp_dir,
-                            repo_id = repo_id,
-                            repo_type = "model",
+                        full_repo_id = _resolve_hub_repo_id(repo_id, hf_token, private)
+                        base_model = (
+                            get_base_model_from_lora(self.current_checkpoint)
+                            if self.current_checkpoint
+                            else None
+                        ) or getattr(self.current_model.config, "_name_or_path", None) or "unknown"
+                        _push_hub_model_card(
+                            full_repo_id,
+                            hf_token,
+                            username = full_repo_id.split("/")[0],
+                            base_model = base_model,
+                            model_type = getattr(self.current_model.config, "model_type", "unknown"),
+                            method = "LoRA adapter",
+                            extra = "lora",
+                        )
+                        _upload_model_folder_to_hub(
+                            tmp_dir,
+                            full_repo_id,
+                            hf_token,
+                            private,
+                            repo_resolved = True,
                         )
                 else:
                     self.current_model.push_to_hub(repo_id, token = hf_token, private = private)

--- a/studio/backend/core/export/hf_precheck.py
+++ b/studio/backend/core/export/hf_precheck.py
@@ -73,9 +73,7 @@ def _verify_hub_credentials(
     return whoami, None
 
 
-def precheck_hub_credentials(
-    hf_token: Optional[str] = None,
-) -> HubPrecheckResult:
+def precheck_hub_credentials(hf_token: Optional[str] = None) -> HubPrecheckResult:
     """Validate Hub credentials and return the authenticated username."""
     whoami, failure = _verify_hub_credentials(hf_token)
     if failure is not None:

--- a/studio/backend/core/export/hf_precheck.py
+++ b/studio/backend/core/export/hf_precheck.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Fast Hugging Face Hub preflight checks before long export/upload runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from loggers import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen = True)
+class HubPrecheckResult:
+    ok: bool
+    message: str
+    details: Optional[Dict[str, Any]] = None
+
+
+def _normalize_repo_id(repo_id: str) -> str:
+    return repo_id.strip()
+
+
+def _resolve_writable_namespaces(whoami: dict) -> set[str]:
+    namespaces = {whoami.get("name", "")}
+    for org in whoami.get("orgs") or []:
+        name = org.get("name") if isinstance(org, dict) else None
+        if name:
+            namespaces.add(name)
+    return {name for name in namespaces if name}
+
+
+def _verify_hub_credentials(
+    hf_token: Optional[str] = None,
+) -> Tuple[Optional[dict], Optional[HubPrecheckResult]]:
+    """Return whoami payload or a failure result."""
+    try:
+        from huggingface_hub import HfApi
+        from huggingface_hub.utils import HfHubHTTPError
+    except ImportError as exc:
+        return None, HubPrecheckResult(
+            False,
+            f"Hugging Face Hub client is unavailable: {exc}",
+        )
+
+    api = HfApi(token = hf_token) if hf_token else HfApi()
+
+    try:
+        whoami = api.whoami()
+    except HfHubHTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (401, 403):
+            return None, HubPrecheckResult(
+                False,
+                "Invalid or expired Hugging Face token. "
+                "Check your token or run `huggingface-cli login`.",
+            )
+        logger.warning("Hub precheck whoami failed: %s", exc)
+        return None, HubPrecheckResult(
+            False,
+            f"Could not verify Hugging Face credentials: {exc}",
+        )
+    except Exception as exc:
+        logger.warning("Hub precheck whoami failed: %s", exc)
+        return None, HubPrecheckResult(
+            False,
+            f"Could not verify Hugging Face credentials: {exc}",
+        )
+
+    return whoami, None
+
+
+def precheck_hub_credentials(
+    hf_token: Optional[str] = None,
+) -> HubPrecheckResult:
+    """Validate Hub credentials and return the authenticated username."""
+    whoami, failure = _verify_hub_credentials(hf_token)
+    if failure is not None:
+        return failure
+
+    username = whoami.get("name") or ""
+    writable = _resolve_writable_namespaces(whoami)
+    return HubPrecheckResult(
+        True,
+        f"Logged in to Hugging Face as '{username}'.",
+        details = {
+            "username": username,
+            "writable_namespaces": sorted(writable),
+        },
+    )
+
+
+def precheck_hub_upload(
+    repo_id: str,
+    hf_token: Optional[str] = None,
+    private: bool = False,
+) -> HubPrecheckResult:
+    """Validate token, repo id, and namespace write access before export.
+
+    Returns quickly (network round-trips only) so users do not wait through a
+    full model conversion only to fail at upload time.
+    """
+    repo_id = _normalize_repo_id(repo_id)
+    if not repo_id:
+        return HubPrecheckResult(False, "Repository ID is required for Hub upload")
+
+    from hub.utils.paths import is_valid_repo_id
+
+    if not is_valid_repo_id(repo_id):
+        return HubPrecheckResult(
+            False,
+            "Invalid repository ID. Use the form username/model-name "
+            "(letters, numbers, dots, dashes, underscores only).",
+        )
+
+    if "/" not in repo_id:
+        return HubPrecheckResult(
+            False,
+            "Repository ID must include a namespace, e.g. your-username/my-model.",
+        )
+
+    namespace, model_name = repo_id.split("/", 1)
+    if not model_name:
+        return HubPrecheckResult(False, "Repository ID must include a model name.")
+
+    whoami, failure = _verify_hub_credentials(hf_token)
+    if failure is not None:
+        return failure
+
+    username = whoami.get("name") or ""
+    writable = _resolve_writable_namespaces(whoami)
+    if namespace not in writable:
+        return HubPrecheckResult(
+            False,
+            f"You do not have write access to Hugging Face namespace '{namespace}'. "
+            f"Your account can publish to: {', '.join(sorted(writable)) or username}.",
+            details = {
+                "username": username,
+                "writable_namespaces": sorted(writable),
+            },
+        )
+
+    try:
+        from huggingface_hub import HfApi
+        from huggingface_hub.utils import HfHubHTTPError, RepositoryNotFoundError
+    except ImportError as exc:
+        return HubPrecheckResult(
+            False,
+            f"Hugging Face Hub client is unavailable: {exc}",
+        )
+
+    api = HfApi(token = hf_token) if hf_token else HfApi()
+
+    repo_exists = False
+    try:
+        api.repo_info(repo_id, repo_type = "model", token = hf_token)
+        repo_exists = True
+    except RepositoryNotFoundError:
+        repo_exists = False
+    except HfHubHTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (401, 403):
+            return HubPrecheckResult(
+                False,
+                f"No read/write access to repository '{repo_id}'. "
+                "Check the namespace and your token permissions.",
+                details = {"username": username},
+            )
+        logger.warning("Hub precheck repo_info failed for %s: %s", repo_id, exc)
+        return HubPrecheckResult(
+            False,
+            f"Could not verify repository '{repo_id}': {exc}",
+            details = {"username": username},
+        )
+    except Exception as exc:
+        logger.warning("Hub precheck repo_info failed for %s: %s", repo_id, exc)
+        return HubPrecheckResult(
+            False,
+            f"Could not verify repository '{repo_id}': {exc}",
+            details = {"username": username},
+        )
+
+    # Read-only preflight: do not create or mutate the Hub repo here. Export/upload
+    # creates the repository when the artifacts are actually ready to publish.
+
+    if repo_exists:
+        message = f"Ready to upload to existing repository '{repo_id}'."
+    elif private:
+        message = f"Ready to create private repository '{repo_id}'."
+    else:
+        message = f"Ready to create public repository '{repo_id}'."
+
+    return HubPrecheckResult(
+        True,
+        message,
+        details = {
+            "username": username,
+            "repo_id": repo_id,
+            "repo_exists": repo_exists,
+            "private": private,
+        },
+    )
+
+
+def precheck_hub_upload_tuple(
+    repo_id: str,
+    hf_token: Optional[str] = None,
+    private: bool = False,
+) -> Tuple[bool, str]:
+    """Tuple wrapper used by export backends."""
+    result = precheck_hub_upload(repo_id, hf_token = hf_token, private = private)
+    return result.ok, result.message

--- a/studio/backend/core/export/orchestrator.py
+++ b/studio/backend/core/export/orchestrator.py
@@ -402,9 +402,11 @@ class ExportOrchestrator:
         self,
         save_directory: str,
         quantization_method: str = "Q4_K_M",
+        quantization_methods: Optional[List[str]] = None,
         push_to_hub: bool = False,
         repo_id: Optional[str] = None,
         hf_token: Optional[str] = None,
+        private: bool = False,
     ) -> Tuple[bool, str, Optional[str]]:
         """Export model in GGUF format."""
         return self._run_export(
@@ -412,9 +414,11 @@ class ExportOrchestrator:
             {
                 "save_directory": save_directory,
                 "quantization_method": quantization_method,
+                "quantization_methods": quantization_methods,
                 "push_to_hub": push_to_hub,
                 "repo_id": repo_id,
                 "hf_token": hf_token,
+                "private": private,
             },
         )
 

--- a/studio/backend/core/export/worker.py
+++ b/studio/backend/core/export/worker.py
@@ -276,9 +276,11 @@ def _handle_export(backend, cmd: dict, resp_queue: Any) -> None:
             success, message, output_path = backend.export_gguf(
                 save_directory = cmd.get("save_directory", ""),
                 quantization_method = cmd.get("quantization_method", "Q4_K_M"),
+                quantization_methods = cmd.get("quantization_methods"),
                 push_to_hub = cmd.get("push_to_hub", False),
                 repo_id = cmd.get("repo_id"),
                 hf_token = cmd.get("hf_token"),
+                private = cmd.get("private", False),
             )
         elif export_type == "lora":
             success, message, output_path = backend.export_lora_adapter(

--- a/studio/backend/models/__init__.py
+++ b/studio/backend/models/__init__.py
@@ -40,6 +40,8 @@ from .export import (
     ExportBaseModelRequest,
     ExportGGUFRequest,
     ExportLoRAAdapterRequest,
+    HubPrecheckRequest,
+    HubPrecheckResponse,
 )
 from .users import Token
 from .datasets import (
@@ -104,6 +106,8 @@ __all__ = [
     "ExportBaseModelRequest",
     "ExportGGUFRequest",
     "ExportLoRAAdapterRequest",
+    "HubPrecheckRequest",
+    "HubPrecheckResponse",
     "Token",
     # Dataset schemas
     "CheckFormatRequest",

--- a/studio/backend/models/export.py
+++ b/studio/backend/models/export.py
@@ -146,7 +146,11 @@ class ExportGGUFRequest(BaseModel):
 
     quantization_method: str = Field(
         "Q4_K_M",
-        description = 'GGUF quantization method (e.g. "Q4_K_M")',
+        description = 'Single GGUF quantization method (e.g. "Q4_K_M")',
+    )
+    quantization_methods: Optional[List[str]] = Field(
+        None,
+        description = "Multiple GGUF quantization methods in one conversion pass",
     )
     push_to_hub: bool = Field(
         False,
@@ -159,6 +163,38 @@ class ExportGGUFRequest(BaseModel):
     hf_token: Optional[str] = Field(
         None,
         description = "Hugging Face token for GGUF upload",
+    )
+    private: bool = Field(
+        False,
+        description = "If True, create a private repository on the Hub",
+    )
+
+
+class HubPrecheckRequest(BaseModel):
+    """Request for validating Hugging Face Hub upload settings before export."""
+
+    repo_id: Optional[str] = Field(
+        None,
+        description = "Hugging Face Hub repository ID; omit to verify credentials only",
+    )
+    hf_token: Optional[str] = Field(
+        None,
+        description = "Hugging Face token (optional if logged in via CLI)",
+    )
+    private: bool = Field(
+        False,
+        description = "Whether the target repository should be private",
+    )
+
+
+class HubPrecheckResponse(BaseModel):
+    """Result of a Hugging Face Hub preflight check."""
+
+    valid: bool = Field(..., description = "True when upload settings look good")
+    message: str = Field(..., description = "Human-readable status or error message")
+    details: Optional[Dict[str, Any]] = Field(
+        default = None,
+        description = "Optional metadata such as resolved username",
     )
 
 

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -40,6 +40,8 @@ from models import (
     ExportBaseModelRequest,
     ExportGGUFRequest,
     ExportLoRAAdapterRequest,
+    HubPrecheckRequest,
+    HubPrecheckResponse,
 )
 
 router = APIRouter()
@@ -191,6 +193,40 @@ def _export_details(output_path: Optional[str]) -> Optional[Dict[str, Any]]:
         return {"output_path": output_path}
 
 
+@router.post("/hub-precheck", response_model = HubPrecheckResponse)
+async def precheck_hub_export(
+    request: HubPrecheckRequest, current_subject: str = Depends(get_current_subject)
+):
+    """Validate Hugging Face token, repo id, and write access before export."""
+    try:
+        from core.export.hf_precheck import precheck_hub_credentials, precheck_hub_upload
+
+        repo_id = (request.repo_id or "").strip()
+        if repo_id:
+            precheck_fn = precheck_hub_upload
+            precheck_kwargs = {
+                "repo_id": repo_id,
+                "hf_token": request.hf_token,
+                "private": request.private,
+            }
+        else:
+            precheck_fn = precheck_hub_credentials
+            precheck_kwargs = {"hf_token": request.hf_token}
+
+        result = await asyncio.to_thread(precheck_fn, **precheck_kwargs)
+        return HubPrecheckResponse(
+            valid = result.ok,
+            message = result.message,
+            details = result.details,
+        )
+    except Exception as e:
+        logger.error(f"Error during Hub precheck: {e}", exc_info = True)
+        raise HTTPException(
+            status_code = 500,
+            detail = "Failed to validate Hugging Face Hub settings",
+        )
+
+
 @router.post("/export/merged", response_model = ExportOperationResponse)
 async def export_merged_model(
     request: ExportMergedModelRequest, current_subject: str = Depends(get_current_subject)
@@ -281,9 +317,11 @@ async def export_gguf(
             backend.export_gguf,
             save_directory = request.save_directory,
             quantization_method = request.quantization_method,
+            quantization_methods = request.quantization_methods,
             push_to_hub = request.push_to_hub,
             repo_id = request.repo_id,
             hf_token = request.hf_token,
+            private = request.private,
         )
 
         if not success:

--- a/studio/backend/tests/test_export_absolute_paths.py
+++ b/studio/backend/tests/test_export_absolute_paths.py
@@ -189,7 +189,12 @@ def _install_lightweight_backend_stubs(monkeypatch):
     models_pkg.LocalModelInfo = _LocalModelInfo
 
     class _HubPrecheckResponse:
-        def __init__(self, valid, message, details = None):
+        def __init__(
+            self,
+            valid,
+            message,
+            details = None,
+        ):
             self.valid = valid
             self.message = message
             self.details = details

--- a/studio/backend/tests/test_export_absolute_paths.py
+++ b/studio/backend/tests/test_export_absolute_paths.py
@@ -182,9 +182,19 @@ def _install_lightweight_backend_stubs(monkeypatch):
         "ExportBaseModelRequest",
         "ExportGGUFRequest",
         "ExportLoRAAdapterRequest",
+        "HubPrecheckRequest",
+        "HubPrecheckResponse",
     ):
         setattr(models_pkg, name, object)
     models_pkg.LocalModelInfo = _LocalModelInfo
+
+    class _HubPrecheckResponse:
+        def __init__(self, valid, message, details = None):
+            self.valid = valid
+            self.message = message
+            self.details = details
+
+    models_pkg.HubPrecheckResponse = _HubPrecheckResponse
     monkeypatch.setitem(sys.modules, "models", models_pkg)
 
     models_models = types.ModuleType("models.models")
@@ -471,3 +481,82 @@ def test_registered_absolute_export_folder_is_discoverable(tmp_path, monkeypatch
     assert len(found) == 1
     assert found[0].path == str(gguf_file)
     assert found[0].source == "models_dir"
+
+
+def test_hub_precheck_route_returns_validation(monkeypatch):
+    import asyncio
+
+    _install_lightweight_backend_stubs(monkeypatch)
+
+    core_pkg = types.ModuleType("core")
+    core_export = types.ModuleType("core.export")
+    hf_precheck = types.ModuleType("core.export.hf_precheck")
+
+    class _Result:
+        def __init__(self):
+            self.ok = True
+            self.message = "Ready to create public repository 'alice/new-model'."
+            self.details = {"username": "alice", "repo_exists": False}
+
+    hf_precheck.precheck_hub_upload = lambda **kwargs: _Result()
+    hf_precheck.precheck_hub_credentials = lambda **kwargs: _Result()
+    core_export.get_export_backend = lambda: None
+    monkeypatch.setitem(sys.modules, "core", core_pkg)
+    monkeypatch.setitem(sys.modules, "core.export", core_export)
+    monkeypatch.setitem(sys.modules, "core.export.hf_precheck", hf_precheck)
+
+    export_route = _load_module(
+        "test_routes_export_hub_precheck",
+        "routes/export.py",
+        monkeypatch,
+    )
+
+    request = types.SimpleNamespace(
+        repo_id = "alice/new-model",
+        hf_token = None,
+        private = False,
+    )
+    response = asyncio.run(export_route.precheck_hub_export(request, current_subject = None))
+
+    assert response.valid is True
+    assert "alice/new-model" in response.message
+    assert response.details["username"] == "alice"
+
+
+def test_hub_precheck_route_supports_credentials_only(monkeypatch):
+    import asyncio
+
+    _install_lightweight_backend_stubs(monkeypatch)
+
+    core_pkg = types.ModuleType("core")
+    core_export = types.ModuleType("core.export")
+    hf_precheck = types.ModuleType("core.export.hf_precheck")
+
+    class _Result:
+        def __init__(self):
+            self.ok = True
+            self.message = "Logged in to Hugging Face as 'alice'."
+            self.details = {"username": "alice"}
+
+    hf_precheck.precheck_hub_credentials = lambda **kwargs: _Result()
+    hf_precheck.precheck_hub_upload = lambda **kwargs: _Result()
+    core_export.get_export_backend = lambda: None
+    monkeypatch.setitem(sys.modules, "core", core_pkg)
+    monkeypatch.setitem(sys.modules, "core.export", core_export)
+    monkeypatch.setitem(sys.modules, "core.export.hf_precheck", hf_precheck)
+
+    export_route = _load_module(
+        "test_routes_export_hub_precheck_credentials",
+        "routes/export.py",
+        monkeypatch,
+    )
+
+    request = types.SimpleNamespace(
+        repo_id = None,
+        hf_token = None,
+        private = False,
+    )
+    response = asyncio.run(export_route.precheck_hub_export(request, current_subject = None))
+
+    assert response.valid is True
+    assert response.details["username"] == "alice"

--- a/studio/backend/tests/test_export_gguf_batch.py
+++ b/studio/backend/tests/test_export_gguf_batch.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+EXPORT = _BACKEND_DIR / "core" / "export" / "export.py"
+
+
+def _load_gguf_upload_helpers():
+    from typing import List, Optional
+
+    source = EXPORT.read_text()
+    namespace: dict = {"List": List, "Optional": Optional, "os": __import__("os")}
+    lines = source.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("def _find_export_artifact"))
+    end = next(
+        i for i, line in enumerate(lines) if line.startswith("def _upload_gguf_directory_to_hub")
+    )
+    exec("\n".join(lines[start:end]), namespace)
+    return namespace
+
+
+def _load_quant_helpers():
+    from typing import List, Optional, Union
+
+    source = EXPORT.read_text()
+    namespace: dict = {
+        "List": List,
+        "Optional": Optional,
+        "Union": Union,
+        "os": __import__("os"),
+    }
+    lines = source.splitlines()
+    start = next(
+        i for i, line in enumerate(lines) if line.startswith("def _normalize_gguf_quant_methods")
+    )
+    end = next(i for i, line in enumerate(lines) if line.startswith("def _precheck_hub_or_fail"))
+    exec("\n".join(lines[start:end]), namespace)
+    return namespace
+
+
+def test_export_gguf_supports_batch_quantization_and_upload_helper():
+    source = EXPORT.read_text()
+    assert "quantization_methods: Optional[List[str]] = None" in source
+    assert "quantization_method = quant_methods" in source
+    assert "_upload_gguf_directory_to_hub" in source
+    assert "_gguf_path_in_repo" in source
+    assert "_upload_model_folder_to_hub" in source
+
+
+def test_gguf_path_in_repo_normalizes_temp_prefix():
+    namespace = _load_gguf_upload_helpers()
+    name = namespace["_gguf_path_in_repo"](
+        "/exports/unsloth_gguf_abc123.Q4_K_M.gguf",
+        model_name = "my-model",
+        save_directory = "/exports",
+    )
+    assert name == "my-model.Q4_K_M.gguf"
+
+
+def test_gguf_path_in_repo_replaces_save_dir_basename():
+    namespace = _load_gguf_upload_helpers()
+    name = namespace["_gguf_path_in_repo"](
+        "/exports/checkpoint-100/checkpoint-100.Q8_0.gguf",
+        model_name = "my-model",
+        save_directory = "/exports/checkpoint-100",
+    )
+    assert name == "my-model.Q8_0.gguf"
+
+
+def test_build_gguf_hub_readme_includes_vlm_tag():
+    namespace = _load_gguf_upload_helpers()
+    readme = namespace["_build_gguf_hub_readme"](
+        repo_id = "alice/my-vlm",
+        upload_names = ["my-vlm.Q4_K_M.gguf", "my-vlm-mmproj.Q4_K_M.gguf"],
+        is_vlm = True,
+        has_modelfile = True,
+    )
+    assert "vision-language-model" in readme
+    assert "Ollama Note for Vision Models" in readme
+
+
+def test_normalize_single_gguf_quant_method():
+    ns = _load_quant_helpers()
+    normalized = ns["_normalize_gguf_quant_methods"](
+        quantization_method="Q4_K_M",
+        quantization_methods=None,
+    )
+    assert normalized == ["q4_k_m"]
+
+
+def test_export_gguf_request_schema_accepts_batch_quants():
+    models_path = _BACKEND_DIR / "models" / "export.py"
+    source = models_path.read_text()
+    assert "quantization_methods: Optional[List[str]]" in source
+    assert "class HubPrecheckRequest" in source

--- a/studio/backend/tests/test_export_gguf_batch.py
+++ b/studio/backend/tests/test_export_gguf_batch.py
@@ -84,8 +84,8 @@ def test_build_gguf_hub_readme_includes_vlm_tag():
 def test_normalize_single_gguf_quant_method():
     ns = _load_quant_helpers()
     normalized = ns["_normalize_gguf_quant_methods"](
-        quantization_method="Q4_K_M",
-        quantization_methods=None,
+        quantization_method = "Q4_K_M",
+        quantization_methods = None,
     )
     assert normalized == ["q4_k_m"]
 

--- a/studio/backend/tests/test_export_hf_precheck.py
+++ b/studio/backend/tests/test_export_hf_precheck.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+
+def _load_hf_precheck(monkeypatch):
+    hf_precheck_path = _BACKEND_DIR / "core" / "export" / "hf_precheck.py"
+    spec = importlib.util.spec_from_file_location("test_hf_precheck", hf_precheck_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    hub_paths = types.ModuleType("hub.utils.paths")
+    hub_paths.is_valid_repo_id = lambda repo_id: bool(
+        repo_id and "/" in repo_id and ".." not in repo_id
+    )
+    monkeypatch.setitem(sys.modules, "hub.utils.paths", hub_paths)
+
+    class _FakeResponse:
+        def __init__(self, status_code=200):
+            self.status_code = status_code
+
+    class _FakeHTTPError(Exception):
+        def __init__(self, status_code=401):
+            super().__init__(f"HTTP {status_code}")
+            self.response = _FakeResponse(status_code)
+
+    class _RepositoryNotFoundError(Exception):
+        pass
+
+    hf_utils = types.ModuleType("huggingface_hub.utils")
+    hf_utils.HfHubHTTPError = _FakeHTTPError
+    hf_utils.RepositoryNotFoundError = _RepositoryNotFoundError
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", hf_utils)
+
+    class _FakeHfApi:
+        create_repo_calls = 0
+
+        def __init__(self, token=None):
+            self.token = token
+
+        def whoami(self, token=None):
+            if self.token == "bad":
+                raise _FakeHTTPError(401)
+            return {"name": "alice", "orgs": [{"name": "my-org"}]}
+
+        def repo_info(self, repo_id, repo_type="model", token=None):
+            if repo_id == "alice/existing":
+                return {"id": repo_id}
+            raise _RepositoryNotFoundError()
+
+        def create_repo(self, **kwargs):
+            _FakeHfApi.create_repo_calls += 1
+            if kwargs.get("repo_id", "").startswith("blocked/"):
+                raise _FakeHTTPError(403)
+            return kwargs.get("repo_id")
+
+    huggingface_hub = types.ModuleType("huggingface_hub")
+    huggingface_hub.HfApi = _FakeHfApi
+    monkeypatch.setitem(sys.modules, "huggingface_hub", huggingface_hub)
+
+    loggers = types.ModuleType("loggers")
+    loggers.get_logger = lambda *args, **kwargs: types.SimpleNamespace(
+        warning=lambda *a, **k: None,
+        warning_once=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "loggers", loggers)
+
+    monkeypatch.setitem(sys.modules, "test_hf_precheck", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_precheck_rejects_invalid_repo_id(monkeypatch):
+    mod = _load_hf_precheck(monkeypatch)
+    result = mod.precheck_hub_upload("bad repo id", hf_token="ok")
+    assert result.ok is False
+    assert "Invalid repository ID" in result.message
+
+
+def test_precheck_rejects_wrong_namespace(monkeypatch):
+    mod = _load_hf_precheck(monkeypatch)
+    result = mod.precheck_hub_upload("other-user/model", hf_token="ok")
+    assert result.ok is False
+    assert "write access" in result.message
+
+
+def test_precheck_accepts_new_repo_in_user_namespace(monkeypatch):
+    mod = _load_hf_precheck(monkeypatch)
+    result = mod.precheck_hub_upload("alice/new-model", hf_token="ok", private=True)
+    assert result.ok is True
+    assert "private repository" in result.message
+    assert result.details["repo_exists"] is False
+
+
+def test_precheck_accepts_existing_repo(monkeypatch):
+    mod = _load_hf_precheck(monkeypatch)
+    result = mod.precheck_hub_upload("alice/existing", hf_token="ok")
+    assert result.ok is True
+    assert "existing repository" in result.message
+    assert result.details["repo_exists"] is True
+
+
+def test_precheck_rejects_bad_token(monkeypatch):
+    mod = _load_hf_precheck(monkeypatch)
+    result = mod.precheck_hub_upload("alice/model", hf_token="bad")
+    assert result.ok is False
+    assert "Invalid or expired" in result.message
+
+
+def test_precheck_does_not_create_repo(monkeypatch):
+    mod = _load_hf_precheck(monkeypatch)
+    huggingface_hub = sys.modules["huggingface_hub"]
+    huggingface_hub.HfApi.create_repo_calls = 0
+    result = mod.precheck_hub_upload("alice/new-model", hf_token="ok", private=True)
+    assert result.ok is True
+    assert huggingface_hub.HfApi.create_repo_calls == 0
+
+
+def test_precheck_credentials_only_returns_username(monkeypatch):
+    mod = _load_hf_precheck(monkeypatch)
+    result = mod.precheck_hub_credentials(hf_token="ok")
+    assert result.ok is True
+    assert result.details["username"] == "alice"
+    assert "Logged in to Hugging Face" in result.message

--- a/studio/backend/tests/test_export_hf_precheck.py
+++ b/studio/backend/tests/test_export_hf_precheck.py
@@ -24,11 +24,11 @@ def _load_hf_precheck(monkeypatch):
     monkeypatch.setitem(sys.modules, "hub.utils.paths", hub_paths)
 
     class _FakeResponse:
-        def __init__(self, status_code=200):
+        def __init__(self, status_code = 200):
             self.status_code = status_code
 
     class _FakeHTTPError(Exception):
-        def __init__(self, status_code=401):
+        def __init__(self, status_code = 401):
             super().__init__(f"HTTP {status_code}")
             self.response = _FakeResponse(status_code)
 
@@ -43,15 +43,20 @@ def _load_hf_precheck(monkeypatch):
     class _FakeHfApi:
         create_repo_calls = 0
 
-        def __init__(self, token=None):
+        def __init__(self, token = None):
             self.token = token
 
-        def whoami(self, token=None):
+        def whoami(self, token = None):
             if self.token == "bad":
                 raise _FakeHTTPError(401)
             return {"name": "alice", "orgs": [{"name": "my-org"}]}
 
-        def repo_info(self, repo_id, repo_type="model", token=None):
+        def repo_info(
+            self,
+            repo_id,
+            repo_type = "model",
+            token = None,
+        ):
             if repo_id == "alice/existing":
                 return {"id": repo_id}
             raise _RepositoryNotFoundError()
@@ -68,8 +73,8 @@ def _load_hf_precheck(monkeypatch):
 
     loggers = types.ModuleType("loggers")
     loggers.get_logger = lambda *args, **kwargs: types.SimpleNamespace(
-        warning=lambda *a, **k: None,
-        warning_once=lambda *a, **k: None,
+        warning = lambda *a, **k: None,
+        warning_once = lambda *a, **k: None,
     )
     monkeypatch.setitem(sys.modules, "loggers", loggers)
 
@@ -80,21 +85,21 @@ def _load_hf_precheck(monkeypatch):
 
 def test_precheck_rejects_invalid_repo_id(monkeypatch):
     mod = _load_hf_precheck(monkeypatch)
-    result = mod.precheck_hub_upload("bad repo id", hf_token="ok")
+    result = mod.precheck_hub_upload("bad repo id", hf_token = "ok")
     assert result.ok is False
     assert "Invalid repository ID" in result.message
 
 
 def test_precheck_rejects_wrong_namespace(monkeypatch):
     mod = _load_hf_precheck(monkeypatch)
-    result = mod.precheck_hub_upload("other-user/model", hf_token="ok")
+    result = mod.precheck_hub_upload("other-user/model", hf_token = "ok")
     assert result.ok is False
     assert "write access" in result.message
 
 
 def test_precheck_accepts_new_repo_in_user_namespace(monkeypatch):
     mod = _load_hf_precheck(monkeypatch)
-    result = mod.precheck_hub_upload("alice/new-model", hf_token="ok", private=True)
+    result = mod.precheck_hub_upload("alice/new-model", hf_token = "ok", private = True)
     assert result.ok is True
     assert "private repository" in result.message
     assert result.details["repo_exists"] is False
@@ -102,7 +107,7 @@ def test_precheck_accepts_new_repo_in_user_namespace(monkeypatch):
 
 def test_precheck_accepts_existing_repo(monkeypatch):
     mod = _load_hf_precheck(monkeypatch)
-    result = mod.precheck_hub_upload("alice/existing", hf_token="ok")
+    result = mod.precheck_hub_upload("alice/existing", hf_token = "ok")
     assert result.ok is True
     assert "existing repository" in result.message
     assert result.details["repo_exists"] is True
@@ -110,7 +115,7 @@ def test_precheck_accepts_existing_repo(monkeypatch):
 
 def test_precheck_rejects_bad_token(monkeypatch):
     mod = _load_hf_precheck(monkeypatch)
-    result = mod.precheck_hub_upload("alice/model", hf_token="bad")
+    result = mod.precheck_hub_upload("alice/model", hf_token = "bad")
     assert result.ok is False
     assert "Invalid or expired" in result.message
 
@@ -119,14 +124,14 @@ def test_precheck_does_not_create_repo(monkeypatch):
     mod = _load_hf_precheck(monkeypatch)
     huggingface_hub = sys.modules["huggingface_hub"]
     huggingface_hub.HfApi.create_repo_calls = 0
-    result = mod.precheck_hub_upload("alice/new-model", hf_token="ok", private=True)
+    result = mod.precheck_hub_upload("alice/new-model", hf_token = "ok", private = True)
     assert result.ok is True
     assert huggingface_hub.HfApi.create_repo_calls == 0
 
 
 def test_precheck_credentials_only_returns_username(monkeypatch):
     mod = _load_hf_precheck(monkeypatch)
-    result = mod.precheck_hub_credentials(hf_token="ok")
+    result = mod.precheck_hub_credentials(hf_token = "ok")
     assert result.ok is True
     assert result.details["username"] == "alice"
     assert "Logged in to Hugging Face" in result.message

--- a/studio/frontend/src/features/export/api/export-api.ts
+++ b/studio/frontend/src/features/export/api/export-api.ts
@@ -95,12 +95,33 @@ export async function exportBase(params: {
   return parseJson<ExportOperationResponse>(response);
 }
 
+export interface HubPrecheckResponse {
+  valid: boolean;
+  message: string;
+  details?: Record<string, unknown> | null;
+}
+
+export async function precheckHubExport(params: {
+  repo_id?: string | null;
+  hf_token?: string | null;
+  private?: boolean;
+}): Promise<HubPrecheckResponse> {
+  const response = await authFetch("/api/export/hub-precheck", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  return parseJson<HubPrecheckResponse>(response);
+}
+
 export async function exportGGUF(params: {
   save_directory: string;
-  quantization_method: string;
+  quantization_method?: string;
+  quantization_methods?: string[];
   push_to_hub?: boolean;
   repo_id?: string | null;
   hf_token?: string | null;
+  private?: boolean;
 }): Promise<ExportOperationResponse> {
   const response = await authFetch("/api/export/export/gguf", {
     method: "POST",

--- a/studio/frontend/src/features/export/components/export-dialog.tsx
+++ b/studio/frontend/src/features/export/components/export-dialog.tsx
@@ -31,6 +31,7 @@ import { useEffect, useRef, useState } from "react";
 import { streamExportLogs, type ExportLogEntry } from "../api/export-api";
 import { collapseAnim } from "../anim";
 import { EXPORT_METHODS, type ExportMethod } from "../constants";
+import type { HubPrecheckState } from "@/hooks/use-hub-export-precheck";
 
 // Max log lines kept in local state. Matches the backend ring buffer's maxlen
 // so the UI shows the full server-side scrollback.
@@ -235,6 +236,8 @@ interface ExportDialogProps {
   onHfTokenChange: (v: string) => void;
   privateRepo: boolean;
   onPrivateRepoChange: (v: boolean) => void;
+  hubPrecheck: HubPrecheckState;
+  hubRepoReady: boolean;
   onExport: () => void;
   exporting: boolean;
   exportError: string | null;
@@ -269,6 +272,8 @@ export function ExportDialog({
   onHfTokenChange,
   privateRepo,
   onPrivateRepoChange,
+  hubPrecheck,
+  hubRepoReady,
   onExport,
   exporting,
   exportError,
@@ -519,6 +524,22 @@ export function ExportDialog({
                         Private Repository
                       </label>
                     </div>
+
+                    {(hubPrecheck.isChecking || hubPrecheck.message) && (
+                      <p
+                        className={
+                          hubPrecheck.valid === false
+                            ? "text-xs text-destructive"
+                            : hubPrecheck.valid === true
+                              ? "text-xs text-emerald-600 dark:text-emerald-400"
+                              : "text-xs text-muted-foreground"
+                        }
+                      >
+                        {hubPrecheck.isChecking
+                          ? "Checking Hugging Face access…"
+                          : hubPrecheck.message}
+                      </p>
+                    )}
                   </div>
                 </motion.div>
               )}
@@ -663,7 +684,17 @@ export function ExportDialog({
               >
                 {exportSuccess ? "Done" : "Cancel"}
               </Button>
-              <Button onClick={onExport} disabled={exporting || exportSuccess}>
+              <Button
+                onClick={onExport}
+                disabled={
+                  exporting ||
+                  exportSuccess ||
+                  (destination === "hub" &&
+                    (!hubRepoReady ||
+                      hubPrecheck.isChecking ||
+                      hubPrecheck.valid !== true))
+                }
+              >
                 {exporting ? (
                   <span className="flex items-center gap-2">
                     <Spinner className="size-4" />

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -40,6 +40,7 @@ import {
   useDebouncedValue,
   useHfModelSearch,
   useHfTokenValidation,
+  useHubExportPrecheck,
 } from "@/hooks";
 import {
   AlertCircleIcon,
@@ -401,6 +402,35 @@ export function ExportPage() {
     sourceMode,
   ]);
   const saveDirectory = customSaveDirectory?.trim() || defaultSaveDirectory;
+  const repoId =
+    destination === "hub" && hfUsername && modelName
+      ? `${hfUsername}/${modelName}`
+      : "";
+  const hubPrecheck = useHubExportPrecheck({
+    enabled: destination === "hub" && dialogOpen,
+    repoId,
+    hfToken,
+    privateRepo,
+  });
+
+  const hubRepoReady = !!(
+    hfUsername.trim() &&
+    modelName.trim() &&
+    repoId.includes("/")
+  );
+
+  useEffect(() => {
+    const username = hubPrecheck.details?.username;
+    if (
+      destination === "hub" &&
+      typeof username === "string" &&
+      username &&
+      !hfUsername.trim()
+    ) {
+      setHfUsername(username);
+    }
+  }, [destination, hfUsername, hubPrecheck.details]);
+
   const canExport = !!(
     selectedExportSource &&
     exportMethod &&
@@ -480,9 +510,7 @@ export function ExportPage() {
     setExportOutputPath(null);
 
     const pushToHub = destination === "hub";
-    const repoId = pushToHub && hfUsername && modelName
-      ? `${hfUsername}/${modelName}`
-      : undefined;
+    const resolvedRepoId = pushToHub && repoId ? repoId : undefined;
     const token = pushToHub && hfToken ? hfToken : undefined;
 
     try {
@@ -508,7 +536,7 @@ export function ExportPage() {
           const resp = await exportMerged({
             save_directory: saveDirectory,
             push_to_hub: pushToHub,
-            repo_id: repoId,
+            repo_id: resolvedRepoId,
             hf_token: token,
             private: privateRepo,
           });
@@ -517,7 +545,7 @@ export function ExportPage() {
           const resp = await exportBase({
             save_directory: saveDirectory,
             push_to_hub: pushToHub,
-            repo_id: repoId,
+            repo_id: resolvedRepoId,
             hf_token: token,
             private: privateRepo,
             base_model_id: selectedModelData?.base_model,
@@ -525,21 +553,22 @@ export function ExportPage() {
           lastOutputPath = resp.details?.output_path ?? null;
         }
       } else if (exportMethod === "gguf") {
-        for (const quant of quantLevels) {
-          const resp = await exportGGUF({
-            save_directory: saveDirectory,
-            quantization_method: quant,
-            push_to_hub: pushToHub,
-            repo_id: repoId,
-            hf_token: token,
-          });
-          lastOutputPath = resp.details?.output_path ?? lastOutputPath;
-        }
+        const resp = await exportGGUF({
+          save_directory: saveDirectory,
+          ...(quantLevels.length === 1
+            ? { quantization_method: quantLevels[0] }
+            : { quantization_methods: quantLevels }),
+          push_to_hub: pushToHub,
+          repo_id: resolvedRepoId,
+          hf_token: token,
+          private: privateRepo,
+        });
+        lastOutputPath = resp.details?.output_path ?? null;
       } else if (exportMethod === "lora") {
         const resp = await exportLoRA({
           save_directory: saveDirectory,
           push_to_hub: pushToHub,
-          repo_id: repoId,
+          repo_id: resolvedRepoId,
           hf_token: token,
           private: privateRepo,
         });
@@ -572,8 +601,7 @@ export function ExportPage() {
     quantLevels,
     destination,
     saveDirectory,
-    hfUsername,
-    modelName,
+    repoId,
     hfToken,
     privateRepo,
     modelSource,
@@ -1154,6 +1182,8 @@ export function ExportPage() {
         onHfTokenChange={setHfToken}
         privateRepo={privateRepo}
         onPrivateRepoChange={setPrivateRepo}
+        hubPrecheck={hubPrecheck}
+        hubRepoReady={hubRepoReady}
         onExport={handleExport}
         exporting={exporting}
         exportError={exportError}

--- a/studio/frontend/src/hooks/index.ts
+++ b/studio/frontend/src/hooks/index.ts
@@ -10,6 +10,7 @@ export { useRecommendedModelVram } from "./use-recommended-model-vram";
 export { useHfDatasetSearch } from "./use-hf-dataset-search";
 export { useHfDatasetSplits } from "./use-hf-dataset-splits";
 export { useHfTokenValidation } from "./use-hf-token-validation";
+export { useHubExportPrecheck } from "./use-hub-export-precheck";
 export { useInfiniteScroll } from "./use-infinite-scroll";
 export { useTauriBackend } from "./use-tauri-backend";
 export { useCollapseScrollLock } from "./use-collapse-scroll-lock";

--- a/studio/frontend/src/hooks/use-hub-export-precheck.ts
+++ b/studio/frontend/src/hooks/use-hub-export-precheck.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useDebouncedValue } from "./use-debounced-value";
+
+export interface HubPrecheckState {
+  valid: boolean | null;
+  message: string | null;
+  isChecking: boolean;
+  details?: Record<string, unknown> | null;
+}
+
+const INITIAL: HubPrecheckState = {
+  valid: null,
+  message: null,
+  isChecking: false,
+  details: null,
+};
+
+/**
+ * Validates Hugging Face Hub upload settings before a long export starts.
+ * Debounced to avoid excessive requests while typing repo fields.
+ */
+export function useHubExportPrecheck(params: {
+  enabled: boolean;
+  repoId: string;
+  hfToken: string;
+  privateRepo: boolean;
+}): HubPrecheckState {
+  const debouncedRepoId = useDebouncedValue(params.repoId.trim(), 500);
+  const debouncedToken = useDebouncedValue(
+    params.hfToken.trim().replace(/^["']+|["']+$/g, ""),
+    500,
+  );
+  const [state, setState] = useState<HubPrecheckState>(INITIAL);
+  const versionRef = useRef(0);
+
+  const runCheck = useCallback(
+    async (
+      repoId: string | null,
+      token: string,
+      privateRepo: boolean,
+    ) => {
+      const v = ++versionRef.current;
+      setState((prev) => ({ ...prev, isChecking: true, message: null }));
+
+      try {
+        const { precheckHubExport } = await import(
+          "@/features/export/api/export-api"
+        );
+        const response = await precheckHubExport({
+          ...(repoId ? { repo_id: repoId } : {}),
+          hf_token: token || null,
+          private: privateRepo,
+        });
+        if (versionRef.current !== v) return;
+        setState({
+          valid: response.valid,
+          message: response.message,
+          isChecking: false,
+          details: response.details ?? null,
+        });
+      } catch (err) {
+        if (versionRef.current !== v) return;
+        setState({
+          valid: false,
+          message: err instanceof Error ? err.message : "Hub precheck failed",
+          isChecking: false,
+          details: null,
+        });
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!params.enabled) {
+      setState(INITIAL);
+      return;
+    }
+    if (debouncedRepoId && debouncedRepoId.includes("/")) {
+      runCheck(debouncedRepoId, debouncedToken, params.privateRepo);
+      return;
+    }
+    runCheck(null, debouncedToken, params.privateRepo);
+  }, [
+    params.enabled,
+    debouncedRepoId,
+    debouncedToken,
+    params.privateRepo,
+    runCheck,
+  ]);
+
+  return state;
+}

--- a/unsloth_cli/commands/export.py
+++ b/unsloth_cli/commands/export.py
@@ -2,7 +2,7 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 
@@ -41,11 +41,14 @@ def export(
         "-f",
         help = f"Export format: {', '.join(EXPORT_FORMATS)}",
     ),
-    quantization: str = typer.Option(
-        "q4_k_m",
+    quantization: Optional[List[str]] = typer.Option(
+        None,
         "--quantization",
         "-q",
-        help = f"GGUF quantization method: {', '.join(GGUF_QUANTS)}",
+        help = (
+            f"GGUF quantization method(s). Repeat -q for multiple in one conversion pass. "
+            f"Options: {', '.join(GGUF_QUANTS)}"
+        ),
     ),
     push_to_hub: bool = typer.Option(
         False, "--push-to-hub", help = "Push exported model to HuggingFace Hub."
@@ -57,6 +60,11 @@ def export(
         None, "--hf-token", envvar = "HF_TOKEN", help = "HuggingFace token."
     ),
     private: bool = typer.Option(False, "--private", help = "Make the HuggingFace repo private."),
+    skip_hub_precheck: bool = typer.Option(
+        False,
+        "--skip-hub-precheck",
+        help = "Skip Hugging Face token/repo validation before export.",
+    ),
     max_seq_length: int = typer.Option(2048, "--max-seq-length"),
     load_in_4bit: bool = typer.Option(True, "--load-in-4bit/--no-load-in-4bit"),
 ):
@@ -71,6 +79,30 @@ def export(
     if push_to_hub and not repo_id:
         typer.echo("Error: --repo-id required when using --push-to-hub", err = True)
         raise typer.Exit(code = 2)
+
+    gguf_quants: List[str] = []
+    if format == "gguf":
+        gguf_quants = [q.lower() for q in (quantization or ["q4_k_m"])]
+        for quant in gguf_quants:
+            if quant not in GGUF_QUANTS:
+                typer.echo(
+                    f"Error: Invalid quantization '{quant}'. Choose from: {', '.join(GGUF_QUANTS)}",
+                    err = True,
+                )
+                raise typer.Exit(code = 2)
+
+    if push_to_hub and not skip_hub_precheck:
+        from studio.backend.core.export.hf_precheck import precheck_hub_upload
+
+        precheck = precheck_hub_upload(
+            repo_id = repo_id,
+            hf_token = hf_token,
+            private = private,
+        )
+        if not precheck.ok:
+            typer.echo(f"Error: {precheck.message}", err = True)
+            raise typer.Exit(code = 1)
+        typer.echo(precheck.message)
 
     from studio.backend.core.export import ExportBackend
 
@@ -110,10 +142,11 @@ def export(
     elif format == "gguf":
         success, message, output_path = backend.export_gguf(
             save_directory = str(output_dir),
-            quantization_method = quantization.upper(),
+            quantization_methods = gguf_quants,
             push_to_hub = push_to_hub,
             repo_id = repo_id,
             hf_token = hf_token,
+            private = private,
         )
     elif format == "lora":
         success, message, output_path = backend.export_lora_adapter(


### PR DESCRIPTION
## Summary

This PR improves Unsloth Studio and CLI export performance and reliability when exporting GGUF models and pushing to the Hugging Face Hub.

**Problems addressed:**
- Multi-quant GGUF exports repeated the full conversion pipeline once per quantization level (N× work).
- Local save + Hub push re-ran conversion/upload (`push_to_hub_gguf`, `push_to_hub_merged`, `push_to_hub`) instead of uploading artifacts already on disk.
- Invalid HF tokens, repo IDs, or namespace permissions only failed after long model load/conversion.
- Hub exports required an explicit token even when the user was already logged in via `huggingface-cli login`.

**Key changes:**
- **Batch GGUF quantization** — pass a list of quants to `save_pretrained_gguf()` in one call (Studio, backend, CLI with repeatable `-q`).
- **Upload-from-disk Hub paths** — new helpers upload existing GGUF files or model folders without re-converting/re-merging (GGUF, merged/base GPU, LoRA).
- **Read-only Hub preflight** — new `hf_precheck.py` module + `POST /api/export/hub-precheck` validates token, repo ID, namespace write access, and repo visibility before export starts. Does not create repos during precheck.
- **Studio UX** — debounced live precheck in the export dialog, credentials-only check to auto-fill HF username, Start disabled until repo is validated.
- **CLI parity** — multi-quant GGUF, precheck before checkpoint load (`--skip-hub-precheck` to bypass), `private` flag support.

## Files changed (16)

| Area | Files |
|------|-------|
| Backend export | `export.py`, `orchestrator.py`, `worker.py`, `hf_precheck.py` (new) |
| API models/routes | `models/export.py`, `routes/export.py` |
| Frontend | `export-page.tsx`, `export-dialog.tsx`, `export-api.ts`, `use-hub-export-precheck.ts` (new) |
| CLI | `unsloth_cli/commands/export.py` |
| Tests | `test_export_hf_precheck.py`, `test_export_gguf_batch.py`, `test_export_absolute_paths.py` |

## Backward compatibility

- Single-quant GGUF unchanged (internally a 1-item list).
- Local-only exports unaffected (`push_to_hub=False` skips precheck).
- Legacy `quantization_method` still works; `quantization_methods` takes precedence when set.
- Hub-only GGUF (no local dir) still falls back to `push_to_hub_gguf()`.

## Test plan

- [x] `uv run --with pytest --no-project pytest studio/backend/tests/test_export_hf_precheck.py studio/backend/tests/test_export_gguf_batch.py studio/backend/tests/test_export_absolute_paths.py tests/studio/test_export_output_path_contract.py` — **32/32 passed**
- [x] Frontend `npm run typecheck` — passed
- [ ] Manual: single-quant GGUF → local
- [ ] Manual: multi-quant GGUF → local (confirm one conversion pass in logs)
- [ ] Manual: GGUF local + Hub upload
- [ ] Manual: Hub export with invalid token (fail fast in dialog)
- [ ] Manual: merged local + Hub (no second merge in logs)


Made with [Cursor](https://cursor.com)