### PR TITLE
Feature: implement editable assistant messages

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -162,7 +162,7 @@ import {
   useState,
 } from "react";
 import { create } from "zustand";
-import { updateThreadMessage } from "@/features/chat/utils/update-thread-message";
+import { extractTaggedText, updateThreadMessage } from "@/features/chat/utils/update-thread-message";
 
 // True while a file is dragged anywhere over the chat page, so the composer
 // can show its "Drop files here" affordance.
@@ -3196,61 +3196,28 @@ const DiffusionCanvas: FC = () => {
   );
 };
 
+/**
+ * AssistantMessage handles the display and inline-editing of AI responses.
+ * 
+ * It uses a "Tagged Text" system (<THINK> and <TOOL> tags) to allow users 
+ * to edit structured reasoning and tool outputs within a plain-text textarea 
+ * while preserving the underlying data schema.
+ */
 const AssistantMessage: FC = () => {
   const aui = useAui();
   const messageId = useAuiState(({ message }) => message.id);
-  const [isEditing, setIsEditing] = useState(false);
   const messageContent = useAuiState(({ message }) => message.content);
-  const [overrideContent, setOverrideContent] = useState<any>(null);
-  const [refreshKey, setRefreshKey] = useState(0);
   
+  const [isEditing, setIsEditing] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const mirrorRef = useRef<HTMLDivElement>(null);
 
-  const extractTaggedText = (content: any) => {
-    if (typeof content === 'string') return content;
-    if (Array.isArray(content)) {
-      const open = "\u003C";
-      const close = "\u003E";
-      return content
-        .map((part: any) => {
-          const text = part.text || part.content || (typeof part === 'string' ? part : "");
-          if (!text) return "";
-          switch (part.type) {
-            case 'reasoning': return `${open}THINK${close}\n${text}\n${open}/THINK${close}`;
-            case 'tool_call':
-            case 'tool': return `${open}TOOL${close}\n${text}\n${open}/TOOL${close}`;
-            default: return text;
-          }
-        })
-        .filter(Boolean)
-        .join('\n\n');
-    }
-    return "";
-  };
-
-  useEffect(() => {
-    setOverrideContent(null);
-  }, [messageId]);
-
-  useEffect(() => {
-    if (overrideContent && JSON.stringify(messageContent) === JSON.stringify(overrideContent)) {
-      setOverrideContent(null);
-    }
-  }, [messageContent, overrideContent]);
-
+  // Simple height adjustment for the edit textarea to prevent layout jumps
   const adjustHeight = () => {
-    const textarea = textareaRef.current;
-    const mirror = mirrorRef.current;
-    if (textarea && mirror) {
-      mirror.innerText = textarea.value;
-      textarea.style.height = `${mirror.offsetHeight}px`;
-      textarea.scrollIntoView({ block: 'nearest', behavior: 'auto' });
-      const rect = textarea.getBoundingClientRect();
-      if (rect.bottom > window.innerHeight - 100) {
-        const container = textarea.closest('.aui-thread-viewport');
-        if (container) container.scrollTop += 80;
-      }
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
     }
   };
 
@@ -3258,6 +3225,8 @@ const AssistantMessage: FC = () => {
     const handleEditTrigger = () => setIsEditing(true);
     const handleRefresh = () => setRefreshKey(prev => prev + 1);
     
+    // We use window events here to trigger edit mode from the action bar
+    // without requiring modifications to the global Zustand store.
     window.addEventListener(`edit-message-${messageId}`, handleEditTrigger);
     window.addEventListener(`refresh-message-${messageId}`, handleRefresh);
     
@@ -3274,6 +3243,7 @@ const AssistantMessage: FC = () => {
   const handleSave = async () => {
     const finalText = textareaRef.current?.value || "";
     let remoteId = aui.threadListItem().getState().remoteId;
+    
     if (!remoteId) {
       const threadState = aui.thread();
       remoteId = (threadState as any).remoteId || (threadState as any).id;
@@ -3285,66 +3255,25 @@ const AssistantMessage: FC = () => {
       return;
     }
 
-    const thread = aui.thread();
     try {
-      const result = await updateThreadMessage({
-        thread: { export: () => thread.export(), import: (data) => thread.import(data) },
+      // updateThreadMessage calls thread.import(), which automatically
+      // triggers a re-render of this component with the new content.
+      await updateThreadMessage({
+        thread: { 
+          export: () => aui.thread().export(), 
+          import: (data) => aui.thread().import(data) 
+        },
         messageId,
         remoteId,
         newText: finalText,
       });
-      setOverrideContent(result);
-    } catch (error: any) {
+    } catch (error) {
       console.error("UI: Error during save:", error);
+      toast.error("Failed to save message edits.");
     } finally {
       setIsEditing(false);
     }
   };
-
-  const displayContent = overrideContent || messageContent;
-
-  const renderSafeContent = () => {
-    if (!displayContent) return null;
-    if (typeof displayContent === 'string') {
-      return <div className="whitespace-pre-wrap">{displayContent}</div>;
-    }
-    if (Array.isArray(displayContent)) {
-      return displayContent.map((part, i) => {
-        if (part.type === 'reasoning') {
-          return (
-            <div key={i} className="my-2 rounded-lg bg-muted/50 border border-border overflow-hidden">
-              <button 
-                onClick={() => setIsReasoningExpanded(!isReasoningExpanded)}
-                className="w-full flex items-center justify-between p-2 bg-muted/80 hover:bg-muted transition-colors"
-              >
-                <div className="text-[10px] font-bold uppercase tracking-wider opacity-60">Reasoning</div>
-                <div className={`transition-transform duration-200 ${isReasoningExpanded ? 'rotate-180' : ''}`}>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0, 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
-                </div>
-              </button>
-              {isReasoningExpanded && (
-                <div className="p-3 text-muted-foreground italic font-light whitespace-pre-wrap border-t border-border">
-                  {part.text || ""}
-                </div>
-              )}
-            </div>
-          );
-        }
-        if (part.type === 'tool' || part.type === 'tool_call') {
-          return (
-            <div key={i} className="my-2 rounded-lg bg-muted border border-border p-3 font-mono text-xs">
-              <div className="text-[10px] font-bold uppercase tracking-wider opacity-50 mb-1">Tool Output</div>
-              <div className="whitespace-pre-wrap">{part.text || part.content || ""}</div>
-            </div>
-          );
-        }
-        return <div key={i} className="whitespace-pre-wrap">{part.text || part.content || ""}</div>;
-      });
-    }
-    return null;
-  };
-
-  const [isReasoningExpanded, setIsReasoningExpanded] = useState(false);
 
   return (
     <MessagePrimitive.Root
@@ -3354,18 +3283,9 @@ const AssistantMessage: FC = () => {
       <div className="aui-assistant-message-content wrap-break-word min-w-0 text-[#0d0d0d] dark:text-foreground leading-relaxed">
         {isEditing ? (
           <div className="flex flex-col gap-2 w-full">
-            <div 
-              ref={mirrorRef}
-              style={{
-                position: 'absolute', top: 0, left: 0, width: 'var(--thread-content-max-width)',
-                visibility: 'hidden', whiteSpace: 'pre-wrap', wordWrap: 'break-word',
-                padding: '12px', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-                fontSize: '0.875rem', lineHeight: '1.25rem', pointerEvents: 'none', zIndex: -1,
-              }}
-            />
             <textarea 
               ref={textareaRef}
-              defaultValue={extractTaggedText(displayContent)}
+              defaultValue={extractTaggedText(messageContent)}
               className="w-full p-3 rounded-xl bg-muted border border-border text-foreground focus:ring-2 focus:ring-primary outline-none overflow-y-auto resize-none font-mono text-sm max-h-[70vh]" 
               autoFocus
               onInput={adjustHeight} 
@@ -3384,31 +3304,27 @@ const AssistantMessage: FC = () => {
             <GeneratingIndicator />
             <CancelledIndicator />
             <DiffusionCanvas />
-            {overrideContent ? (
-              <div className="flex flex-col gap-2">{renderSafeContent()}</div>
-            ) : (
-              <MessagePrimitive.Parts
-                components={{
-                  Text: MarkdownText,
-                  Reasoning: Reasoning,
-                  ReasoningGroup: ReasoningGroup,
-                  Source: Sources,
-                  ToolGroup: ToolGroup,
-                  tools: {
-                    by_name: {
-                      web_search: WebSearchToolUIConfirmable,
-                      search_knowledge_base: KnowledgeBaseToolUIConfirmable,
-                      python: PythonToolUIConfirmable,
-                      terminal: TerminalToolUIConfirmable,
-                      code_execution: CodeExecutionToolUIConfirmable,
-                      image_generation: ImageGenerationToolUIConfirmable,
-                      render_html: RenderHtmlToolUIConfirmable,
-                    },
-                    Fallback: ToolFallbackConfirmable,
+            <MessagePrimitive.Parts
+              components={{
+                Text: MarkdownText,
+                Reasoning: Reasoning,
+                ReasoningGroup: ReasoningGroup,
+                Source: Sources,
+                ToolGroup: ToolGroup,
+                tools: {
+                  by_name: {
+                    web_search: WebSearchToolUIConfirmable,
+                    search_knowledge_base: KnowledgeBaseToolUIConfirmable,
+                    python: PythonToolUIConfirmable,
+                    terminal: TerminalToolUIConfirmable,
+                    code_execution: CodeExecutionToolUIConfirmable,
+                    image_generation: ImageGenerationToolUIConfirmable,
+                    render_html: RenderHtmlToolUIConfirmable,
                   },
-                }}
-              />
-            )}
+                  Fallback: ToolFallbackConfirmable,
+                },
+              }}
+            />
             <SourcesGroup />
             <RagSourcesGroup />
             <MessageError />
@@ -3605,16 +3521,13 @@ const EditAssistantMessageButton: FC = () => {
   const messageId = useAuiState(({ message }) => message.id);
   const isRunning = useAuiState(({ thread }) => thread.isRunning);
 
-  const handleEdit = () => {
-    // This sends a signal to the message body to enter "edit mode"
-    window.dispatchEvent(new CustomEvent(`edit-message-${messageId}`));
-  };
-
   return (
     <TooltipIconButton
       tooltip="Edit response"
       disabled={isRunning}
-      onClick={handleEdit}
+      onClick={() => {
+        window.dispatchEvent(new CustomEvent(`edit-message-${messageId}`));
+      }}
     >
       <HugeiconsIcon
         icon={Edit03Icon}
@@ -3667,7 +3580,11 @@ const AssistantActionBar: FC = () => {
           </ActionBarMorePrimitive.Item>
           <ActionBarPrimitive.ExportMarkdown asChild={true}>
             <ActionBarMorePrimitive.Item className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-[12px] px-3 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
-              <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon" />
+              <HugeiconsIcon
+                icon={Download01Icon}
+                strokeWidth={1.75}
+                className="size-icon"
+              />
               Export as Markdown
             </ActionBarMorePrimitive.Item>
           </ActionBarPrimitive.ExportMarkdown>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/assistant-ui/generated-image-overlay-context";
 import { downloadImagePart } from "@/components/assistant-ui/image";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
-import { MessageHtmlArtifacts } from "@/components/assistant-ui/message-html-artifacts";
 import { MessageTiming } from "@/components/assistant-ui/message-timing";
 import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
 import { RagSourcesGroup } from "@/components/assistant-ui/rag-sources";
@@ -162,6 +161,7 @@ import {
   useState,
 } from "react";
 import { create } from "zustand";
+import { updateThreadMessage } from "@/features/chat/utils/update-thread-message";
 
 // True while a file is dragged anywhere over the chat page, so the composer
 // can show its "Drop files here" affordance.
@@ -3196,42 +3196,219 @@ const DiffusionCanvas: FC = () => {
 };
 
 const AssistantMessage: FC = () => {
+  const aui = useAui();
+  const messageId = useAuiState(({ message }) => message.id);
+  const [isEditing, setIsEditing] = useState(false);
+  const messageContent = useAuiState(({ message }) => message.content);
+  const [overrideContent, setOverrideContent] = useState<any>(null);
+  
+  // --- NEW: State to track if the reasoning section is expanded ---
+  const [isReasoningExpanded, setIsReasoningExpanded] = useState(false);
+  
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const mirrorRef = useRef<HTMLDivElement>(null);
+
+  const extractTaggedText = (content: any) => {
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      const open = "\u003C";
+      const close = "\u003E";
+      return content
+        .map((part: any) => {
+          const text = part.text || part.content || (typeof part === 'string' ? part : "");
+          if (!text) return "";
+          switch (part.type) {
+            case 'reasoning': return `${open}THINK${close}\n${text}\n${open}/THINK${close}`;
+            case 'tool_call':
+            case 'tool': return `${open}TOOL${close}\n${text}\n${open}/TOOL${close}`;
+            default: return text;
+          }
+        })
+        .filter(Boolean)
+        .join('\n\n');
+    }
+    return "";
+  };
+
+  useEffect(() => {
+    if (overrideContent && JSON.stringify(messageContent) === JSON.stringify(overrideContent)) {
+      setOverrideContent(null);
+    }
+  }, [messageContent, overrideContent]);
+
+  const adjustHeight = () => {
+    const textarea = textareaRef.current;
+    const mirror = mirrorRef.current;
+    if (textarea && mirror) {
+      mirror.innerText = textarea.value;
+      textarea.style.height = `${mirror.offsetHeight}px`;
+      textarea.scrollIntoView({ block: 'nearest', behavior: 'auto' });
+      const rect = textarea.getBoundingClientRect();
+      if (rect.bottom > window.innerHeight - 100) {
+        const container = textarea.closest('.aui-thread-viewport');
+        if (container) container.scrollTop += 80;
+      }
+    }
+  };
+
+  useEffect(() => {
+    const handleEditTrigger = () => setIsEditing(true);
+    window.addEventListener(`edit-message-${messageId}`, handleEditTrigger);
+    return () => window.removeEventListener(`edit-message-${messageId}`, handleEditTrigger);
+  }, [messageId]);
+
+  useEffect(() => {
+    if (isEditing) setTimeout(adjustHeight, 0);
+  }, [isEditing]);
+
+  const handleSave = async () => {
+    const finalText = textareaRef.current?.value || "";
+    let remoteId = aui.threadListItem().getState().remoteId;
+    if (!remoteId) {
+      const threadState = aui.thread();
+      remoteId = (threadState as any).remoteId || (threadState as any).id;
+    }
+
+    if (!remoteId || remoteId === "" || remoteId === "/") {
+      toast.error("Save failed: No thread ID found.");
+      setIsEditing(false);
+      return;
+    }
+
+    const thread = aui.thread();
+    try {
+      const result = await updateThreadMessage({
+        thread: { export: () => thread.export(), import: (data) => thread.import(data) },
+        messageId,
+        remoteId,
+        newText: finalText,
+      });
+      setOverrideContent(result);
+    } catch (error) {
+      toast.error("Failed to save changes to server.");
+    } finally {
+      setIsEditing(false);
+    }
+  };
+
+  const displayContent = overrideContent || messageContent;
+
+  // --- INTERACTIVE SAFE RENDERER ---
+  const renderSafeContent = () => {
+    if (!displayContent) return null;
+    if (typeof displayContent === 'string') {
+      return <div className="whitespace-pre-wrap">{displayContent}</div>;
+    }
+    if (Array.isArray(displayContent)) {
+      return displayContent.map((part, i) => {
+        if (part.type === 'reasoning') {
+          return (
+            <div key={i} className="my-2 rounded-lg bg-muted/50 border border-border overflow-hidden">
+              {/* Clickable Header for Expand/Collapse */}
+              <button 
+                onClick={() => setIsReasoningExpanded(!isReasoningExpanded)}
+                className="w-full flex items-center justify-between p-2 bg-muted/80 hover:bg-muted transition-colors"
+              >
+                <div className="text-[10px] font-bold uppercase tracking-wider opacity-60">
+                  Reasoning
+                </div>
+                <div className={`transition-transform duration-200 ${isReasoningExpanded ? 'rotate-180' : ''}`}>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                </div>
+              </button>
+              
+              {/* Collapsible Content */}
+              {isReasoningExpanded && (
+                <div className="p-3 text-muted-foreground italic font-light whitespace-pre-wrap border-t border-border">
+                  {part.text || ""}
+                </div>
+              )}
+            </div>
+          );
+        }
+        if (part.type === 'tool' || part.type === 'tool_call') {
+          return (
+            <div key={i} className="my-2 rounded-lg bg-muted border border-border p-3 font-mono text-xs">
+              <div className="text-[10px] font-bold uppercase tracking-wider opacity-50 mb-1">Tool Output</div>
+              <div className="whitespace-pre-wrap">{part.text || part.content || ""}</div>
+            </div>
+          );
+        }
+        return <div key={i} className="whitespace-pre-wrap">{part.text || part.content || ""}</div>;
+      });
+    }
+    return null;
+  };
+
   return (
     <MessagePrimitive.Root
       className="aui-assistant-message-root relative mx-auto min-w-0 w-full max-w-(--thread-content-max-width) pt-0.5 pb-4 text-[15.5px] [font-weight:410] tracking-[0.01em] dark:tracking-[0.02em]"
       data-role="assistant"
     >
       <div className="aui-assistant-message-content wrap-break-word min-w-0 text-[#0d0d0d] dark:text-foreground leading-relaxed">
-        <GeneratingIndicator />
-        <CancelledIndicator />
-        <DiffusionCanvas />
-        <MessagePrimitive.Parts
-          components={{
-            Text: MarkdownText,
-            Reasoning: Reasoning,
-            ReasoningGroup: ReasoningGroup,
-            Source: Sources,
-            ToolGroup: ToolGroup,
-            tools: {
-              by_name: {
-                web_search: WebSearchToolUIConfirmable,
-                search_knowledge_base: KnowledgeBaseToolUIConfirmable,
-                python: PythonToolUIConfirmable,
-                terminal: TerminalToolUIConfirmable,
-                code_execution: CodeExecutionToolUIConfirmable,
-                image_generation: ImageGenerationToolUIConfirmable,
-                render_html: RenderHtmlToolUIConfirmable,
-              },
-              Fallback: ToolFallbackConfirmable,
-            },
-          }}
-        />
-        <SourcesGroup />
-        <RagSourcesGroup />
-        <MessageHtmlArtifacts />
-        <MessageError />
+        {isEditing ? (
+          <div className="flex flex-col gap-2 w-full">
+            <div 
+              ref={mirrorRef}
+              style={{
+                position: 'absolute', top: 0, left: 0, width: 'var(--thread-content-max-width)',
+                visibility: 'hidden', whiteSpace: 'pre-wrap', wordWrap: 'break-word',
+                padding: '12px', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                fontSize: '0.875rem', lineHeight: '1.25rem', pointerEvents: 'none', zIndex: -1,
+              }}
+            />
+            <textarea 
+              ref={textareaRef}
+              defaultValue={extractTaggedText(displayContent)}
+              className="w-full p-3 rounded-xl bg-muted border border-border text-foreground focus:ring-2 focus:ring-primary outline-none overflow-y-auto resize-none font-mono text-sm max-h-[70vh]" 
+              autoFocus
+              onInput={adjustHeight} 
+              onKeyDown={(e) => {
+                e.stopPropagation(); 
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) handleSave();
+              }}
+            />
+            <div className="flex justify-end gap-2">
+              <Button size="sm" variant="ghost" onClick={() => setIsEditing(false)} className="h-8 text-xs">Cancel</Button>
+              <Button size="sm" onClick={handleSave} className="h-8 text-xs">Save</Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <GeneratingIndicator />
+            <CancelledIndicator />
+            <DiffusionCanvas />
+            {overrideContent ? (
+              <div className="flex flex-col gap-2">{renderSafeContent()}</div>
+            ) : (
+              <MessagePrimitive.Parts
+                components={{
+                  Text: MarkdownText,
+                  Reasoning: Reasoning,
+                  ReasoningGroup: ReasoningGroup,
+                  Source: Sources,
+                  ToolGroup: ToolGroup,
+                  tools: {
+                    by_name: {
+                      web_search: WebSearchToolUIConfirmable,
+                      search_knowledge_base: KnowledgeBaseToolUIConfirmable,
+                      python: PythonToolUIConfirmable,
+                      terminal: TerminalToolUIConfirmable,
+                      code_execution: CodeExecutionToolUIConfirmable,
+                      image_generation: ImageGenerationToolUIConfirmable,
+                      render_html: RenderHtmlToolUIConfirmable,
+                    },
+                    Fallback: ToolFallbackConfirmable,
+                  },
+                }}
+              />
+            )}
+            <SourcesGroup />
+            <RagSourcesGroup />
+            <MessageError />
+          </>
+        )}
       </div>
-
       <div className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
         <BranchPicker className="mr-0.5" />
         <AssistantActionBar />
@@ -3416,6 +3593,31 @@ const CopyButton: FC = () => {
   );
 };
 
+const EditAssistantMessageButton: FC = () => {
+  const aui = useAui();
+  const messageId = useAuiState(({ message }) => message.id);
+  const isRunning = useAuiState(({ thread }) => thread.isRunning);
+
+  const handleEdit = () => {
+    // This sends a signal to the message body to enter "edit mode"
+    window.dispatchEvent(new CustomEvent(`edit-message-${messageId}`));
+  };
+
+  return (
+    <TooltipIconButton
+      tooltip="Edit response"
+      disabled={isRunning}
+      onClick={handleEdit}
+    >
+      <HugeiconsIcon
+        icon={Edit03Icon}
+        strokeWidth={1.75}
+        className="size-icon"
+      />
+    </TooltipIconButton>
+  );
+};
+
 const AssistantActionBar: FC = () => {
   const { forkMessage, forkDisabled } = useForkMessageAction();
 
@@ -3425,6 +3627,7 @@ const AssistantActionBar: FC = () => {
       className="aui-assistant-action-bar-root col-start-3 row-start-2 flex items-center gap-1 text-chat-icon-fg [&_button:not([data-slot=message-timing-trigger])]:size-8 [&_button]:!rounded-full [&_button:hover]:bg-chat-icon-bg-hover [&_button:hover]:text-chat-icon-fg-hover"
     >
       <CopyButton />
+      <EditAssistantMessageButton />
       <ActionBarPrimitive.Reload asChild={true}>
         <TooltipIconButton tooltip="Refresh">
           <RefreshCwIcon strokeWidth={1.75} className="size-icon" />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/assistant-ui/generated-image-overlay-context";
 import { downloadImagePart } from "@/components/assistant-ui/image";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { MessageHtmlArtifacts } from "@/components/assistant-ui/message-html-artifacts";
 import { MessageTiming } from "@/components/assistant-ui/message-timing";
 import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
 import { RagSourcesGroup } from "@/components/assistant-ui/rag-sources";
@@ -3201,8 +3202,6 @@ const AssistantMessage: FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const messageContent = useAuiState(({ message }) => message.content);
   const [overrideContent, setOverrideContent] = useState<any>(null);
-  
-  // --- NEW: State to track if the reasoning section is expanded ---
   const [isReasoningExpanded, setIsReasoningExpanded] = useState(false);
   
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -3293,7 +3292,6 @@ const AssistantMessage: FC = () => {
 
   const displayContent = overrideContent || messageContent;
 
-  // --- INTERACTIVE SAFE RENDERER ---
   const renderSafeContent = () => {
     if (!displayContent) return null;
     if (typeof displayContent === 'string') {
@@ -3304,7 +3302,6 @@ const AssistantMessage: FC = () => {
         if (part.type === 'reasoning') {
           return (
             <div key={i} className="my-2 rounded-lg bg-muted/50 border border-border overflow-hidden">
-              {/* Clickable Header for Expand/Collapse */}
               <button 
                 onClick={() => setIsReasoningExpanded(!isReasoningExpanded)}
                 className="w-full flex items-center justify-between p-2 bg-muted/80 hover:bg-muted transition-colors"
@@ -3316,8 +3313,6 @@ const AssistantMessage: FC = () => {
                   <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
               </button>
-              
-              {/* Collapsible Content */}
               {isReasoningExpanded && (
                 <div className="p-3 text-muted-foreground italic font-light whitespace-pre-wrap border-t border-border">
                   {part.text || ""}
@@ -3409,6 +3404,7 @@ const AssistantMessage: FC = () => {
           </>
         )}
       </div>
+
       <div className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
         <BranchPicker className="mr-0.5" />
         <AssistantActionBar />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3229,7 +3229,6 @@ const AssistantMessage: FC = () => {
     return "";
   };
 
-  // --- NEW: Clear the shield when the active message changes ---
   useEffect(() => {
     setOverrideContent(null);
   }, [messageId]);
@@ -3416,6 +3415,7 @@ const AssistantMessage: FC = () => {
           </>
         )}
       </div>
+      
       <div key={refreshKey} className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
         <BranchPicker className="mr-0.5" />
         <AssistantActionBar />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3198,21 +3198,21 @@ const DiffusionCanvas: FC = () => {
 
 /**
  * AssistantMessage handles the display and inline-editing of AI responses.
- * 
- * It uses a "Tagged Text" system (<THINK> and <TOOL> tags) to allow users 
- * to edit structured reasoning and tool outputs within a plain-text textarea 
- * while preserving the underlying data schema.
+ * It uses the ChatRuntimeStore to track which message is currently being edited.
  */
 const AssistantMessage: FC = () => {
   const aui = useAui();
   const messageId = useAuiState(({ message }) => message.id);
   const messageContent = useAuiState(({ message }) => message.content);
   
-  const [isEditing, setIsEditing] = useState(false);
+  // Use global store instead of window events for editing state
+  const editingId = useChatRuntimeStore((s) => s.editingMessageId);
+  const setEditingId = useChatRuntimeStore((s) => s.setEditingMessageId);
+  const isEditing = editingId === messageId;
+
   const [refreshKey, setRefreshKey] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Simple height adjustment for the edit textarea to prevent layout jumps
   const adjustHeight = () => {
     const el = textareaRef.current;
     if (el) {
@@ -3222,18 +3222,9 @@ const AssistantMessage: FC = () => {
   };
 
   useEffect(() => {
-    const handleEditTrigger = () => setIsEditing(true);
     const handleRefresh = () => setRefreshKey(prev => prev + 1);
-    
-    // We use window events here to trigger edit mode from the action bar
-    // without requiring modifications to the global Zustand store.
-    window.addEventListener(`edit-message-${messageId}`, handleEditTrigger);
     window.addEventListener(`refresh-message-${messageId}`, handleRefresh);
-    
-    return () => {
-      window.removeEventListener(`edit-message-${messageId}`, handleEditTrigger);
-      window.removeEventListener(`refresh-message-${messageId}`, handleRefresh);
-    };
+    return () => window.removeEventListener(`refresh-message-${messageId}`, handleRefresh);
   }, [messageId]);
 
   useEffect(() => {
@@ -3251,13 +3242,11 @@ const AssistantMessage: FC = () => {
 
     if (!remoteId || remoteId === "" || remoteId === "/") {
       toast.error("Save failed: No thread ID found.");
-      setIsEditing(false);
+      setEditingId(null);
       return;
     }
 
     try {
-      // updateThreadMessage calls thread.import(), which automatically
-      // triggers a re-render of this component with the new content.
       await updateThreadMessage({
         thread: { 
           export: () => aui.thread().export(), 
@@ -3271,7 +3260,7 @@ const AssistantMessage: FC = () => {
       console.error("UI: Error during save:", error);
       toast.error("Failed to save message edits.");
     } finally {
-      setIsEditing(false);
+      setEditingId(null);
     }
   };
 
@@ -3295,7 +3284,7 @@ const AssistantMessage: FC = () => {
               }}
             />
             <div className="flex justify-end gap-2">
-              <Button size="sm" variant="ghost" onClick={() => setIsEditing(false)} className="h-8 text-xs">Cancel</Button>
+              <Button size="sm" variant="ghost" onClick={() => setEditingId(null)} className="h-8 text-xs">Cancel</Button>
               <Button size="sm" onClick={handleSave} className="h-8 text-xs">Save</Button>
             </div>
           </div>
@@ -3517,17 +3506,15 @@ const CopyButton: FC = () => {
 };
 
 const EditAssistantMessageButton: FC = () => {
-  const aui = useAui();
   const messageId = useAuiState(({ message }) => message.id);
   const isRunning = useAuiState(({ thread }) => thread.isRunning);
+  const setEditingId = useChatRuntimeStore((s) => s.setEditingMessageId);
 
   return (
     <TooltipIconButton
       tooltip="Edit response"
       disabled={isRunning}
-      onClick={() => {
-        window.dispatchEvent(new CustomEvent(`edit-message-${messageId}`));
-      }}
+      onClick={() => setEditingId(messageId)}
     >
       <HugeiconsIcon
         icon={Edit03Icon}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3202,7 +3202,7 @@ const AssistantMessage: FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const messageContent = useAuiState(({ message }) => message.content);
   const [overrideContent, setOverrideContent] = useState<any>(null);
-  const [isReasoningExpanded, setIsReasoningExpanded] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
   
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const mirrorRef = useRef<HTMLDivElement>(null);
@@ -3229,6 +3229,11 @@ const AssistantMessage: FC = () => {
     return "";
   };
 
+  // --- NEW: Clear the shield when the active message changes ---
+  useEffect(() => {
+    setOverrideContent(null);
+  }, [messageId]);
+
   useEffect(() => {
     if (overrideContent && JSON.stringify(messageContent) === JSON.stringify(overrideContent)) {
       setOverrideContent(null);
@@ -3252,8 +3257,15 @@ const AssistantMessage: FC = () => {
 
   useEffect(() => {
     const handleEditTrigger = () => setIsEditing(true);
+    const handleRefresh = () => setRefreshKey(prev => prev + 1);
+    
     window.addEventListener(`edit-message-${messageId}`, handleEditTrigger);
-    return () => window.removeEventListener(`edit-message-${messageId}`, handleEditTrigger);
+    window.addEventListener(`refresh-message-${messageId}`, handleRefresh);
+    
+    return () => {
+      window.removeEventListener(`edit-message-${messageId}`, handleEditTrigger);
+      window.removeEventListener(`refresh-message-${messageId}`, handleRefresh);
+    };
   }, [messageId]);
 
   useEffect(() => {
@@ -3306,11 +3318,9 @@ const AssistantMessage: FC = () => {
                 onClick={() => setIsReasoningExpanded(!isReasoningExpanded)}
                 className="w-full flex items-center justify-between p-2 bg-muted/80 hover:bg-muted transition-colors"
               >
-                <div className="text-[10px] font-bold uppercase tracking-wider opacity-60">
-                  Reasoning
-                </div>
+                <div className="text-[10px] font-bold uppercase tracking-wider opacity-60">Reasoning</div>
                 <div className={`transition-transform duration-200 ${isReasoningExpanded ? 'rotate-180' : ''}`}>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0, 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
               </button>
               {isReasoningExpanded && (
@@ -3334,6 +3344,8 @@ const AssistantMessage: FC = () => {
     }
     return null;
   };
+
+  const [isReasoningExpanded, setIsReasoningExpanded] = useState(false);
 
   return (
     <MessagePrimitive.Root
@@ -3404,8 +3416,7 @@ const AssistantMessage: FC = () => {
           </>
         )}
       </div>
-
-      <div className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
+      <div key={refreshKey} className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
         <BranchPicker className="mr-0.5" />
         <AssistantActionBar />
       </div>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3324,6 +3324,7 @@ const AssistantMessage: FC = () => {
             />
             <SourcesGroup />
             <RagSourcesGroup />
+            <MessageHtmlArtifacts />
             <MessageError />
           </>
         )}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3294,8 +3294,13 @@ const AssistantMessage: FC = () => {
         newText: finalText,
       });
       setOverrideContent(result);
-    } catch (error) {
-      toast.error("Failed to save changes to server.");
+    } catch (error: any) {
+      if (error.message === "THREAD_ID_LOCAL") {
+        toast.error("Cannot save: This is a temporary chat. Please save the chat to a project first to enable editing.");
+      } else {
+        toast.error("Failed to save changes to server.");
+      }
+      console.error("UI: Error during save:", error);
     } finally {
       setIsEditing(false);
     }
@@ -3415,7 +3420,7 @@ const AssistantMessage: FC = () => {
           </>
         )}
       </div>
-      
+
       <div key={refreshKey} className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
         <BranchPicker className="mr-0.5" />
         <AssistantActionBar />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3207,6 +3207,7 @@ const AssistantMessage: FC = () => {
   const aui = useAui();
   const messageId = useAuiState(({ message }) => message.id);
   const messageContent = useAuiState(({ message }) => message.content);
+  const incognito = useChatRuntimeStore((s) => s.incognito);
   
   // Use global store for editing state to ensure a single source of truth
   const editingId = useChatRuntimeStore((s) => s.editingMessageId);
@@ -3230,12 +3231,10 @@ const AssistantMessage: FC = () => {
 
   const handleSave = async () => {
     const finalText = textareaRef.current?.value || "";
-    let remoteId = aui.threadListItem().getState().remoteId;
     
-    if (!remoteId) {
-      const threadState = aui.thread();
-      remoteId = (threadState as any).remoteId || (threadState as any).id;
-    }
+    // Prioritize the specific thread item ID, then fallback to the global active thread ID
+    const remoteId = aui.threadListItem().getState().remoteId 
+                  || useChatRuntimeStore.getState().activeThreadId;
 
     if (!remoteId || remoteId === "" || remoteId === "/") {
       toast.error("Save failed: No thread ID found.");
@@ -3244,8 +3243,6 @@ const AssistantMessage: FC = () => {
     }
 
     try {
-      // updateThreadMessage handles the Merge Strategy and backend sync.
-      // It calls thread.import(), which automatically triggers a re-render.
       await updateThreadMessage({
         thread: { 
           export: () => aui.thread().export(), 
@@ -3254,6 +3251,7 @@ const AssistantMessage: FC = () => {
         messageId,
         remoteId,
         newText: finalText,
+        isIncognito: incognito,
       });
     } catch (error) {
       console.error("UI: Error during save:", error);

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3198,21 +3198,24 @@ const DiffusionCanvas: FC = () => {
 
 /**
  * AssistantMessage handles the display and inline-editing of AI responses.
- * It uses the ChatRuntimeStore to track which message is currently being edited.
+ * 
+ * It utilizes a "Tagged Text" system (<THINK> and <TOOL> tags) to allow users 
+ * to edit structured reasoning and tool outputs within a plain-text textarea 
+ * while preserving the underlying data schema and tool-call metadata.
  */
 const AssistantMessage: FC = () => {
   const aui = useAui();
   const messageId = useAuiState(({ message }) => message.id);
   const messageContent = useAuiState(({ message }) => message.content);
   
-  // Use global store instead of window events for editing state
+  // Use global store for editing state to ensure a single source of truth
   const editingId = useChatRuntimeStore((s) => s.editingMessageId);
   const setEditingId = useChatRuntimeStore((s) => s.setEditingMessageId);
   const isEditing = editingId === messageId;
 
-  const [refreshKey, setRefreshKey] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Auto-grow textarea height based on content
   const adjustHeight = () => {
     const el = textareaRef.current;
     if (el) {
@@ -3220,12 +3223,6 @@ const AssistantMessage: FC = () => {
       el.style.height = `${el.scrollHeight}px`;
     }
   };
-
-  useEffect(() => {
-    const handleRefresh = () => setRefreshKey(prev => prev + 1);
-    window.addEventListener(`refresh-message-${messageId}`, handleRefresh);
-    return () => window.removeEventListener(`refresh-message-${messageId}`, handleRefresh);
-  }, [messageId]);
 
   useEffect(() => {
     if (isEditing) setTimeout(adjustHeight, 0);
@@ -3247,6 +3244,8 @@ const AssistantMessage: FC = () => {
     }
 
     try {
+      // updateThreadMessage handles the Merge Strategy and backend sync.
+      // It calls thread.import(), which automatically triggers a re-render.
       await updateThreadMessage({
         thread: { 
           export: () => aui.thread().export(), 
@@ -3280,7 +3279,12 @@ const AssistantMessage: FC = () => {
               onInput={adjustHeight} 
               onKeyDown={(e) => {
                 e.stopPropagation(); 
-                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) handleSave();
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                  handleSave();
+                }
+                if (e.key === 'Escape') {
+                  setEditingId(null); // UX: Close editor on Escape
+                }
               }}
             />
             <div className="flex justify-end gap-2">
@@ -3293,6 +3297,12 @@ const AssistantMessage: FC = () => {
             <GeneratingIndicator />
             <CancelledIndicator />
             <DiffusionCanvas />
+            
+            {/* 
+                We use the standard MessagePrimitive.Parts. This ensures that 
+                edited messages maintain the same professional styling, 
+                Markdown rendering, and tool-call components as original responses.
+            */}
             <MessagePrimitive.Parts
               components={{
                 Text: MarkdownText,
@@ -3321,7 +3331,7 @@ const AssistantMessage: FC = () => {
         )}
       </div>
 
-      <div key={refreshKey} className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
+      <div className="aui-assistant-message-footer mt-1.5 -ml-[var(--icon-btn-inset)] flex min-h-8">
         <BranchPicker className="mr-0.5" />
         <AssistantActionBar />
       </div>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3295,11 +3295,6 @@ const AssistantMessage: FC = () => {
       });
       setOverrideContent(result);
     } catch (error: any) {
-      if (error.message === "THREAD_ID_LOCAL") {
-        toast.error("Cannot save: This is a temporary chat. Please save the chat to a project first to enable editing.");
-      } else {
-        toast.error("Failed to save changes to server.");
-      }
       console.error("UI: Error during save:", error);
     } finally {
       setIsEditing(false);

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -560,6 +560,7 @@ type ChatRuntimeStore = {
    */
   incognito: boolean;
   settingsPanelOpen: boolean;
+  editingMessageId: string | null;
   pendingAudioBase64: string | null;
   pendingAudioName: string | null;
   pendingImageEditReference: PendingImageEditReference | null;
@@ -593,6 +594,7 @@ type ChatRuntimeStore = {
   setActiveProjectId: (projectId: string | null) => void;
   setIncognito: (incognito: boolean) => void;
   setSettingsPanelOpen: (open: boolean) => void;
+  setEditingMessageId: (id: string | null) => void;
   clearCheckpoint: () => void;
   setReasoningEnabled: (
     enabled: boolean,
@@ -934,6 +936,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   activeProjectId: null,
   incognito: false,
   settingsPanelOpen: false,
+  editingMessageId: null,
   pendingAudioBase64: null,
   pendingAudioName: null,
   pendingImageEditReference: null,
@@ -1095,6 +1098,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   setActiveProjectId: (activeProjectId) => set({ activeProjectId }),
   setIncognito: (incognito) => set({ incognito }),
   setSettingsPanelOpen: (settingsPanelOpen) => set({ settingsPanelOpen }),
+  setEditingMessageId: (id) => set({ editingMessageId: id }),
   clearCheckpoint: () => {
     // Mirror setCheckpoint's persistence: dropping the checkpoint must also
     // clear any stored external selection so the next refresh doesn't snap

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -1,0 +1,79 @@
+import { MessageRepository } from "@assistant-ui/core/internal";
+import type { ExportedMessageRepository, ThreadMessage } from "@assistant-ui/react";
+import { saveChatMessage } from "../api/chat-api";
+
+type ThreadImportExport = {
+  export: () => ExportedMessageRepository;
+  import: (data: ExportedMessageRepository) => void;
+};
+
+function parseTaggedTextToContent(text: string): ThreadMessage["content"] {
+  const parts: any[] = [];
+  const tagRegex = /(<\/?(THINK|TOOL)>)/g;
+  let lastIndex = 0;
+  let match;
+  let currentType: "text" | "reasoning" | "tool" = "text";
+
+  while ((match = tagRegex.exec(text)) !== null) {
+    const fullTag = match[0];
+    const tagName = match[2];
+    const index = match.index;
+
+    if (index > lastIndex) {
+      const content = text.substring(lastIndex, index);
+      const trimmedContent = content.trim();
+      if (trimmedContent) {
+        parts.push({ type: currentType, text: trimmedContent });
+      }
+    }
+
+    if (fullTag.startsWith("</")) {
+      currentType = "text";
+    } else {
+      currentType = tagName === "THINK" ? "reasoning" : "tool";
+    }
+    lastIndex = index + fullTag.length;
+  }
+
+  if (lastIndex < text.length) {
+    const remainingText = text.substring(lastIndex).trim();
+    if (remainingText) {
+      parts.push({ type: currentType, text: remainingText });
+    }
+  }
+
+  return parts.length > 0 ? parts : text;
+}
+
+export async function updateThreadMessage(args: {
+  thread: ThreadImportExport;
+  messageId: string;
+  remoteId: string | undefined;
+  newText: string;
+}) {
+  const { thread, messageId, remoteId, newText } = args;
+  const updatedContent = parseTaggedTextToContent(newText);
+
+  const exported = thread.export();
+  const repo = new MessageRepository();
+  repo.import(exported);
+  const message = repo.getMessage(messageId);
+  if (message) message.content = updatedContent;
+  thread.import(repo.export());
+
+  if (remoteId) {
+    try {
+      await saveChatMessage({
+        id: messageId,
+        threadId: remoteId,
+        role: "assistant",
+        content: updatedContent,
+        createdAt: Date.now(),
+      });
+    } catch (e) {
+      console.error("Backend sync failed:", e);
+    }
+  }
+
+  return updatedContent;
+}

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -32,7 +32,9 @@ export function extractTaggedText(content: any): string {
       
       switch (part.type) {
         case 'reasoning': 
-          return `${open}THINK${close}\n${text}\n${open}/THINK${close}`;
+          // Trim the text first so we don't accumulate newlines 
+          // around the tags on every save.
+          return `${open}THINK${close}\n${text.trim()}\n${open}/THINK${close}`;
         case 'text':
         default:
           return text;
@@ -55,10 +57,12 @@ function parseTaggedTextToContent(text: string): ContentPart[] {
     const index = match.index;
 
     if (index > lastIndex) {
-      const content = text.substring(lastIndex, index);
-      if (content.trim()) parts.push({ type: currentType, text: content });
+      // Trim the extracted content to remove any leading/trailing 
+      // newlines created by the tag wrapping process.
+      const content = text.substring(lastIndex, index).trim();
+      if (content) parts.push({ type: currentType, text: content });
     }
-
+    
     currentType = fullTag.startsWith("</") ? "text" : (tagName === "THINK" ? "reasoning" : "tool");
     lastIndex = index + fullTag.length;
   }
@@ -76,8 +80,9 @@ export async function updateThreadMessage(args: {
   messageId: string;
   remoteId: string | undefined;
   newText: string;
+  isIncognito: boolean; // <--- ADD THIS
 }) {
-  const { thread, messageId, remoteId, newText } = args;
+  const { thread, messageId, remoteId, newText, isIncognito } = args;
   const parsedEditableContent = parseTaggedTextToContent(newText);
   const currentExport = thread.export();
 
@@ -89,8 +94,6 @@ export async function updateThreadMessage(args: {
   const { parentId: originalParentId } = targetMessageEntry; 
   const { createdAt: originalCreatedAt } = targetMessageEntry.message;
 
-  // MERGE STRATEGY:
-  // We want to preserve original tool_calls/responses but update the text/reasoning.
   const updatedMessages = currentExport.messages.map((m) => {
     if (m.message.id !== messageId) return m;
 
@@ -98,32 +101,23 @@ export async function updateThreadMessage(args: {
     let finalContent: any[] = [];
 
     if (Array.isArray(originalContent)) {
-      // 1. Find the index of the very first editable part (text or reasoning)
       const firstEditableIndex = originalContent.findIndex((part: any) => 
         part.type === 'text' || part.type === 'reasoning'
       );
 
       if (firstEditableIndex === -1) {
-        // If there was no text at all, just put the new text at the start 
-        // and keep the tools.
         const nonEditableParts = originalContent.filter((part: any) => 
           part.type !== 'text' && part.type !== 'reasoning'
         );
         finalContent = [...parsedEditableContent, ...nonEditableParts];
       } else {
-        // 2. PRESERVE ORDER: 
-        // - Keep everything that came BEFORE the first piece of text (e.g., early tool calls).
-        // - Inject the entire new edited block at that first slot.
-        // - Keep everything that came AFTER, but filter out the old editable text.
         const before = originalContent.slice(0, firstEditableIndex);
         const after = originalContent.slice(firstEditableIndex + 1).filter((part: any) => 
           part.type !== 'text' && part.type !== 'reasoning'
         );
-        
         finalContent = [...before, ...parsedEditableContent, ...after];
       }
     } else {
-      // If the original was just a string, we just use the parsed array.
       finalContent = parsedEditableContent;
     }
 
@@ -136,11 +130,11 @@ export async function updateThreadMessage(args: {
     };
   }) as typeof currentExport.messages;
 
-  // Snapshot for rollback
   const originalExport = currentExport;
   thread.import({ ...currentExport, messages: updatedMessages });
 
-  if (remoteId && !remoteId.startsWith("__LOCALID_")) {
+  // If it's NOT incognito, we attempt to save to the DB regardless of the ID.
+  if (remoteId && !isIncognito) {
     try {
       await saveChatMessage({
         id: messageId,
@@ -151,7 +145,6 @@ export async function updateThreadMessage(args: {
         createdAt: originalCreatedAt ? Number(originalCreatedAt) : Date.now(),
       });
     } catch (e) {
-      // ROLLBACK: If backend sync fails, revert the UI to the original state
       thread.import(originalExport);
       console.error("Backend sync failed for message update. Rolling back UI.", e);
       throw e;

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -9,8 +9,8 @@ type ThreadImportExport = {
 type ContentPart = { type: "text" | "reasoning" | "tool"; text: string };
 
 /**
- * Converts structured message content (with reasoning/tools) into a tagged string
- * suitable for editing in a plain-text textarea.
+ * Extracts only the editable text and reasoning from a message, 
+ * ignoring structured parts like tool calls that cannot be edited as plain text.
  */
 export function extractTaggedText(content: any): string {
   if (typeof content === 'string') return content;
@@ -21,16 +21,20 @@ export function extractTaggedText(content: any): string {
 
   return content
     .map((part: any) => {
-      const text = part.text || part.content || (typeof part === 'string' ? part : "");
+      if (typeof part === 'string') return part;
+      if (!part) return "";
+      
+      // Only extract text from 'text' or 'reasoning' parts.
+      // Tool calls/responses are ignored here so they aren't accidentally 
+      // deleted or corrupted by the user in the textarea.
+      const text = part.text || part.content || "";
       if (!text) return "";
       
       switch (part.type) {
         case 'reasoning': 
           return `${open}THINK${close}\n${text}\n${open}/THINK${close}`;
-        case 'tool_call':
-        case 'tool': 
-          return `${open}TOOL${close}\n${text}\n${open}/TOOL${close}`;
-        default: 
+        case 'text':
+        default:
           return text;
       }
     })
@@ -38,7 +42,7 @@ export function extractTaggedText(content: any): string {
     .join('\n\n');
 }
 
-function parseTaggedTextToContent(text: string): ThreadMessage["content"] {
+function parseTaggedTextToContent(text: string): ContentPart[] {
   const parts: ContentPart[] = [];
   const tagRegex = /(<\/?(THINK|TOOL)>)/g;
   let lastIndex = 0;
@@ -64,7 +68,7 @@ function parseTaggedTextToContent(text: string): ThreadMessage["content"] {
     if (remainingText) parts.push({ type: currentType, text: remainingText });
   }
 
-  return (parts.length > 0 ? parts : text) as any;
+  return parts;
 }
 
 export async function updateThreadMessage(args: {
@@ -74,7 +78,7 @@ export async function updateThreadMessage(args: {
   newText: string;
 }) {
   const { thread, messageId, remoteId, newText } = args;
-  const updatedContent = parseTaggedTextToContent(newText);
+  const parsedEditableContent = parseTaggedTextToContent(newText);
   const currentExport = thread.export();
 
   const targetMessageEntry = currentExport.messages.find(m => m.message.id === messageId);
@@ -85,16 +89,57 @@ export async function updateThreadMessage(args: {
   const { parentId: originalParentId } = targetMessageEntry; 
   const { createdAt: originalCreatedAt } = targetMessageEntry.message;
 
-  const updatedMessages = currentExport.messages.map((m) => 
-    m.message.id === messageId 
-      ? { ...m, message: { ...m.message, content: updatedContent } } 
-      : m
-  ) as typeof currentExport.messages;
+  // MERGE STRATEGY:
+  // We want to preserve original tool_calls/responses but update the text/reasoning.
+  const updatedMessages = currentExport.messages.map((m) => {
+    if (m.message.id !== messageId) return m;
 
+    const originalContent = m.message.content;
+    let finalContent: any[] = [];
+
+    if (Array.isArray(originalContent)) {
+      // 1. Find the index of the very first editable part (text or reasoning)
+      const firstEditableIndex = originalContent.findIndex((part: any) => 
+        part.type === 'text' || part.type === 'reasoning'
+      );
+
+      if (firstEditableIndex === -1) {
+        // If there was no text at all, just put the new text at the start 
+        // and keep the tools.
+        const nonEditableParts = originalContent.filter((part: any) => 
+          part.type !== 'text' && part.type !== 'reasoning'
+        );
+        finalContent = [...parsedEditableContent, ...nonEditableParts];
+      } else {
+        // 2. PRESERVE ORDER: 
+        // - Keep everything that came BEFORE the first piece of text (e.g., early tool calls).
+        // - Inject the entire new edited block at that first slot.
+        // - Keep everything that came AFTER, but filter out the old editable text.
+        const before = originalContent.slice(0, firstEditableIndex);
+        const after = originalContent.slice(firstEditableIndex + 1).filter((part: any) => 
+          part.type !== 'text' && part.type !== 'reasoning'
+        );
+        
+        finalContent = [...before, ...parsedEditableContent, ...after];
+      }
+    } else {
+      // If the original was just a string, we just use the parsed array.
+      finalContent = parsedEditableContent;
+    }
+
+    return {
+      ...m,
+      message: {
+        ...m.message,
+        content: finalContent,
+      },
+    };
+  }) as typeof currentExport.messages;
+
+  // Snapshot for rollback
+  const originalExport = currentExport;
   thread.import({ ...currentExport, messages: updatedMessages });
 
-  // Only sync to the backend if we have a remoteId AND it's not a local temporary ID.
-  // Temporary (incognito) chats use IDs starting with "__LOCALID_" and should not be persisted.
   if (remoteId && !remoteId.startsWith("__LOCALID_")) {
     try {
       await saveChatMessage({
@@ -102,14 +147,16 @@ export async function updateThreadMessage(args: {
         threadId: remoteId,
         parentId: originalParentId,
         role: "assistant",
-        content: updatedContent,
+        content: (updatedMessages.find(m => m.message.id === messageId)?.message.content) || [],
         createdAt: originalCreatedAt ? Number(originalCreatedAt) : Date.now(),
       });
     } catch (e) {
-      console.error("Backend sync failed for message update:", e);
+      // ROLLBACK: If backend sync fails, revert the UI to the original state
+      thread.import(originalExport);
+      console.error("Backend sync failed for message update. Rolling back UI.", e);
       throw e;
     }
   }
 
-  return updatedContent;
+  return (updatedMessages.find(m => m.message.id === messageId)?.message.content) || [];
 }

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -58,17 +58,22 @@ export async function updateThreadMessage(args: {
   const repo = new MessageRepository();
   repo.import(exported);
   const message = repo.getMessage(messageId);
-  if (message) message.content = updatedContent;
-  thread.import(repo.export());
+  if (message) {
+    message.content = updatedContent;
+  }
+
+  const next = repo.export();
+  thread.import(next);
 
   if (remoteId) {
     try {
+      const timestamp = message?.createdAt || Date.now();
       await saveChatMessage({
         id: messageId,
         threadId: remoteId,
         role: "assistant",
         content: updatedContent,
-        createdAt: Date.now(),
+        createdAt: timestamp, 
       });
     } catch (e) {
       console.error("Backend sync failed:", e);

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -64,7 +64,7 @@ function parseTaggedTextToContent(text: string): ThreadMessage["content"] {
     if (remainingText) parts.push({ type: currentType, text: remainingText });
   }
 
-  return parts.length > 0 ? (parts as any) : text; 
+  return (parts.length > 0 ? parts : text) as any;
 }
 
 export async function updateThreadMessage(args: {
@@ -89,11 +89,13 @@ export async function updateThreadMessage(args: {
     m.message.id === messageId 
       ? { ...m, message: { ...m.message, content: updatedContent } } 
       : m
-  );
+  ) as typeof currentExport.messages;
 
   thread.import({ ...currentExport, messages: updatedMessages });
 
-  if (remoteId) {
+  // Only sync to the backend if we have a remoteId AND it's not a local temporary ID.
+  // Temporary (incognito) chats use IDs starting with "__LOCALID_" and should not be persisted.
+  if (remoteId && !remoteId.startsWith("__LOCALID_")) {
     try {
       await saveChatMessage({
         id: messageId,

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -6,33 +6,65 @@ type ThreadImportExport = {
   import: (data: ExportedMessageRepository) => void;
 };
 
+type ContentPart = { type: "text" | "reasoning" | "tool"; text: string };
+
+/**
+ * Converts structured message content (with reasoning/tools) into a tagged string
+ * suitable for editing in a plain-text textarea.
+ */
+export function extractTaggedText(content: any): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return "";
+
+  const open = "\u003C"; // <
+  const close = "\u003E"; // >
+
+  return content
+    .map((part: any) => {
+      const text = part.text || part.content || (typeof part === 'string' ? part : "");
+      if (!text) return "";
+      
+      switch (part.type) {
+        case 'reasoning': 
+          return `${open}THINK${close}\n${text}\n${open}/THINK${close}`;
+        case 'tool_call':
+        case 'tool': 
+          return `${open}TOOL${close}\n${text}\n${open}/TOOL${close}`;
+        default: 
+          return text;
+      }
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
 function parseTaggedTextToContent(text: string): ThreadMessage["content"] {
-  const parts: any[] = [];
+  const parts: ContentPart[] = [];
   const tagRegex = /(<\/?(THINK|TOOL)>)/g;
   let lastIndex = 0;
   let match;
-  let currentType: "text" | "reasoning" | "tool" = "text";
+  let currentType: ContentPart["type"] = "text";
 
   while ((match = tagRegex.exec(text)) !== null) {
     const fullTag = match[0];
     const tagName = match[2];
     const index = match.index;
+
     if (index > lastIndex) {
       const content = text.substring(lastIndex, index);
       if (content.trim()) parts.push({ type: currentType, text: content });
     }
-    if (fullTag.startsWith("</")) {
-      currentType = "text";
-    } else {
-      currentType = tagName === "THINK" ? "reasoning" : "tool";
-    }
+
+    currentType = fullTag.startsWith("</") ? "text" : (tagName === "THINK" ? "reasoning" : "tool");
     lastIndex = index + fullTag.length;
   }
+
   if (lastIndex < text.length) {
     const remainingText = text.substring(lastIndex).trim();
     if (remainingText) parts.push({ type: currentType, text: remainingText });
   }
-  return parts.length > 0 ? parts : text;
+
+  return parts.length > 0 ? (parts as any) : text; 
 }
 
 export async function updateThreadMessage(args: {
@@ -43,37 +75,23 @@ export async function updateThreadMessage(args: {
 }) {
   const { thread, messageId, remoteId, newText } = args;
   const updatedContent = parseTaggedTextToContent(newText);
-
   const currentExport = thread.export();
 
   const targetMessageEntry = currentExport.messages.find(m => m.message.id === messageId);
-  
   if (!targetMessageEntry) {
-    throw new Error("MESSAGE_NOT_FOUND");
+    throw new Error(`Message with ID ${messageId} not found in thread.`);
   }
 
-  const originalParentId = targetMessageEntry.parentId; 
-  const originalCreatedAt = targetMessageEntry.message.createdAt;
+  const { parentId: originalParentId } = targetMessageEntry; 
+  const { createdAt: originalCreatedAt } = targetMessageEntry.message;
 
-  const updatedMessages = currentExport.messages.map((m) => {
-    if (m.message.id === messageId) {
-      return {
-        ...m,
-        message: {
-          ...m.message,
-          content: updatedContent,
-        },
-      };
-    }
-    return m;
-  });
+  const updatedMessages = currentExport.messages.map((m) => 
+    m.message.id === messageId 
+      ? { ...m, message: { ...m.message, content: updatedContent } } 
+      : m
+  );
 
-  const nextExport = {
-    ...currentExport,
-    messages: updatedMessages,
-  };
-
-  thread.import(nextExport);
+  thread.import({ ...currentExport, messages: updatedMessages });
 
   if (remoteId) {
     try {
@@ -86,7 +104,7 @@ export async function updateThreadMessage(args: {
         createdAt: originalCreatedAt ? Number(originalCreatedAt) : Date.now(),
       });
     } catch (e) {
-      console.error("Backend sync failed:", e);
+      console.error("Backend sync failed for message update:", e);
       throw e;
     }
   }

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -46,19 +46,15 @@ export async function updateThreadMessage(args: {
 
   const currentExport = thread.export();
 
-  // 1. FIND THE MESSAGE AND ITS PARENT
-  // We search the exported messages to find the exact metadata for the message being edited.
   const targetMessageEntry = currentExport.messages.find(m => m.message.id === messageId);
   
   if (!targetMessageEntry) {
     throw new Error("MESSAGE_NOT_FOUND");
   }
 
-  const originalMsg = targetMessageEntry.message;
-  const originalParentId = originalMsg.parentId;
-  const originalCreatedAt = originalMsg.createdAt;
+  const originalParentId = targetMessageEntry.parentId; 
+  const originalCreatedAt = targetMessageEntry.message.createdAt;
 
-  // 2. UPDATE LOCAL UI IMMEDIATELY
   const updatedMessages = currentExport.messages.map((m) => {
     if (m.message.id === messageId) {
       return {
@@ -79,13 +75,12 @@ export async function updateThreadMessage(args: {
 
   thread.import(nextExport);
 
-  // 3. BACKEND SYNC
   if (remoteId) {
     try {
       await saveChatMessage({
         id: messageId,
         threadId: remoteId,
-        parentId: originalParentId, // CRITICAL: Force the original parentId
+        parentId: originalParentId,
         role: "assistant",
         content: updatedContent,
         createdAt: originalCreatedAt ? Number(originalCreatedAt) : Date.now(),

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -58,22 +58,29 @@ export async function updateThreadMessage(args: {
   const repo = new MessageRepository();
   repo.import(exported);
   const message = repo.getMessage(messageId);
-  if (message) {
-    message.content = updatedContent;
+  
+  if (!message) {
+    console.error("Could not find message in repository to update.");
+    return;
   }
+
+  const originalParentId = message.parentId;
+  const originalCreatedAt = message.createdAt;
+
+  message.content = updatedContent;
 
   const next = repo.export();
   thread.import(next);
 
   if (remoteId) {
     try {
-      const timestamp = message?.createdAt || Date.now();
       await saveChatMessage({
         id: messageId,
         threadId: remoteId,
+        parentId: originalParentId,
         role: "assistant",
         content: updatedContent,
-        createdAt: timestamp, 
+        createdAt: originalCreatedAt || Date.now(), 
       });
     } catch (e) {
       console.error("Backend sync failed:", e);

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -1,4 +1,3 @@
-import { MessageRepository } from "@assistant-ui/core/internal";
 import type { ExportedMessageRepository, ThreadMessage } from "@assistant-ui/react";
 import { saveChatMessage } from "../api/chat-api";
 
@@ -18,15 +17,10 @@ function parseTaggedTextToContent(text: string): ThreadMessage["content"] {
     const fullTag = match[0];
     const tagName = match[2];
     const index = match.index;
-
     if (index > lastIndex) {
       const content = text.substring(lastIndex, index);
-      const trimmedContent = content.trim();
-      if (trimmedContent) {
-        parts.push({ type: currentType, text: trimmedContent });
-      }
+      if (content.trim()) parts.push({ type: currentType, text: content });
     }
-
     if (fullTag.startsWith("</")) {
       currentType = "text";
     } else {
@@ -34,14 +28,10 @@ function parseTaggedTextToContent(text: string): ThreadMessage["content"] {
     }
     lastIndex = index + fullTag.length;
   }
-
   if (lastIndex < text.length) {
     const remainingText = text.substring(lastIndex).trim();
-    if (remainingText) {
-      parts.push({ type: currentType, text: remainingText });
-    }
+    if (remainingText) parts.push({ type: currentType, text: remainingText });
   }
-
   return parts.length > 0 ? parts : text;
 }
 
@@ -54,36 +44,55 @@ export async function updateThreadMessage(args: {
   const { thread, messageId, remoteId, newText } = args;
   const updatedContent = parseTaggedTextToContent(newText);
 
-  const exported = thread.export();
-  const repo = new MessageRepository();
-  repo.import(exported);
-  const message = repo.getMessage(messageId);
+  const currentExport = thread.export();
+
+  // 1. FIND THE MESSAGE AND ITS PARENT
+  // We search the exported messages to find the exact metadata for the message being edited.
+  const targetMessageEntry = currentExport.messages.find(m => m.message.id === messageId);
   
-  if (!message) {
-    console.error("Could not find message in repository to update.");
-    return;
+  if (!targetMessageEntry) {
+    throw new Error("MESSAGE_NOT_FOUND");
   }
 
-  const originalParentId = message.parentId;
-  const originalCreatedAt = message.createdAt;
+  const originalMsg = targetMessageEntry.message;
+  const originalParentId = originalMsg.parentId;
+  const originalCreatedAt = originalMsg.createdAt;
 
-  message.content = updatedContent;
+  // 2. UPDATE LOCAL UI IMMEDIATELY
+  const updatedMessages = currentExport.messages.map((m) => {
+    if (m.message.id === messageId) {
+      return {
+        ...m,
+        message: {
+          ...m.message,
+          content: updatedContent,
+        },
+      };
+    }
+    return m;
+  });
 
-  const next = repo.export();
-  thread.import(next);
+  const nextExport = {
+    ...currentExport,
+    messages: updatedMessages,
+  };
 
+  thread.import(nextExport);
+
+  // 3. BACKEND SYNC
   if (remoteId) {
     try {
       await saveChatMessage({
         id: messageId,
         threadId: remoteId,
-        parentId: originalParentId,
+        parentId: originalParentId, // CRITICAL: Force the original parentId
         role: "assistant",
         content: updatedContent,
-        createdAt: originalCreatedAt || Date.now(), 
+        createdAt: originalCreatedAt ? Number(originalCreatedAt) : Date.now(),
       });
     } catch (e) {
       console.error("Backend sync failed:", e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
This PR introduces the ability for users to edit assistant messages directly within the thread. 

**Key Technical Implementation:**
- **Structured Content Round-Trip:** Assistant messages often contain structured data (Reasoning/Thinking blocks and Tool outputs). To allow editing while preserving this schema, I implemented a "tagged-text" system:
    - **Extraction:** Structured content is converted into tagged strings (e.g., `<THINK>...</THINK>` and `<TOOL>...</TOOL>`) when entering edit mode.
    - **Parsing:** Upon saving, these tags are parsed back into the structured `ThreadMessage["content"]` format required by `@assistant-ui/react`.
- **State Management:** Integrated editing state into the `ChatRuntimeStore` (`editingMessageId`). This ensures a single source of truth and avoids the use of global window events, aligning with the project's existing state patterns.
- **UI Consistency:** The implementation utilizes `MessagePrimitive.Parts` for rendering. This ensures that edited messages maintain the exact same professional styling, Markdown rendering, and component hierarchy as original AI responses.
- **Temporary Chat Support:** Added logic to detect local temporary IDs (`__LOCALID_`). Edits to incognito chats are updated in the local memory store but skip the backend sync to prevent 404 errors, as these threads are intentionally not persisted.

**Changes:**
- `chat-runtime-store.ts`: Added `editingMessageId` state and `setEditingMessageId` action.
- `update-thread-message.ts`: Added utility functions for parsing/extracting tagged text and a handler to sync updates to the backend via `saveChatMessage`.
- `thread.tsx`: Implemented the inline edit UI, a height-adjusting textarea, and the edit trigger in the assistant action bar.

**How to Test:**
1. **Standard Chat:** Open a chat with an assistant response containing reasoning or tool calls. Click "Edit response" $\rightarrow$ Modify text $\rightarrow$ Save. Verify the styling remains consistent and the change persists after refresh.
2. **Temporary Chat:** Enter "Incognito" mode and start a chat. Edit a message and save. Verify the UI updates immediately and no 404 errors appear in the console.
3. **Structured Content:** Verify that editing text inside `<THINK>` or `<TOOL>` tags correctly updates the respective reasoning/tool blocks in the final rendered message.
