### PR TITLE
studio: select torchao version from the installed torch

### DIFF
--- a/studio/backend/requirements/overrides.txt
+++ b/studio/backend/requirements/overrides.txt
@@ -1,2 +1,5 @@
-# Torch AO overrides (installed with --force-reinstall --no-cache-dir)
-torchao==0.14.0
+# torchao is installed by studio/install_python_stack.py, which selects the
+# version matching the torch release actually installed in the venv (torchao's
+# C++ extensions are built against one exact torch version, so a fixed pin here
+# would skip them on a newer torch). See _select_torchao_spec /
+# _probe_installed_torch_version in that file.

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for _select_torchao_spec in install_python_stack.py.
+
+torchao's C++ extensions are built against one exact torch release, so the
+installer must pick the torchao version matching the torch installed in the
+venv (otherwise the cpp kernels are skipped). This pins that mapping.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# install_python_stack.py lives at repo_root/studio/install_python_stack.py
+_INSTALL_SCRIPT = Path(__file__).resolve().parents[2] / "install_python_stack.py"
+
+
+def _load_module(monkeypatch):
+    """(Re-)import install_python_stack and return it (mirrors test_pytorch_mirror)."""
+    sys.modules.pop("install_python_stack", None)
+    monkeypatch.syspath_prepend(str(_INSTALL_SCRIPT.parent))
+    import install_python_stack
+
+    return install_python_stack
+
+
+@pytest.mark.parametrize(
+    "torch_version, expected",
+    [
+        # torch 2.10 (the reported bug: cu130 resolves 2.10.0) -> 0.16.0,
+        # independent of the local +cuXXX/+rocm/+cpu suffix or patch level.
+        ("2.10.0+cu130", "torchao==0.16.0"),
+        ("2.10.0+rocm6.4", "torchao==0.16.0"),
+        ("2.10.0+cpu", "torchao==0.16.0"),
+        ("2.10.1", "torchao==0.16.0"),
+        ("2.10.0", "torchao==0.16.0"),
+        # torch 2.11 (reachable via ROCm rocm7.2) and forward -> 0.17.0.
+        ("2.11.0+cu130", "torchao==0.17.0"),
+        ("2.11.0", "torchao==0.17.0"),
+        ("2.12.0", "torchao==0.17.0"),
+        # torch <=2.9 keeps today's pin (already a correct match for 2.9.0).
+        ("2.9.0+cu128", "torchao==0.14.0"),
+        ("2.9.1", "torchao==0.14.0"),
+        ("2.8.0", "torchao==0.14.0"),
+        ("2.4.0", "torchao==0.14.0"),
+        # Unparseable / missing / non-2.x major -> conservative default.
+        (None, "torchao==0.14.0"),
+        ("", "torchao==0.14.0"),
+        ("garbage", "torchao==0.14.0"),
+        ("2", "torchao==0.14.0"),
+        ("3.0.0", "torchao==0.14.0"),
+    ],
+)
+def test_select_torchao_spec(monkeypatch, torch_version, expected):
+    mod = _load_module(monkeypatch)
+    assert mod._select_torchao_spec(torch_version) == expected
+
+
+def test_default_spec_matches_table(monkeypatch):
+    """The default/floor stays the historical pin so older torch is unchanged."""
+    mod = _load_module(monkeypatch)
+    assert mod._TORCHAO_DEFAULT_SPEC == "torchao==0.14.0"
+    assert mod._select_torchao_spec("2.9.0") == mod._TORCHAO_DEFAULT_SPEC

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -38,6 +38,10 @@ def _load_module(monkeypatch):
         ("2.10.0+cpu", "torchao==0.16.0"),
         ("2.10.1", "torchao==0.16.0"),
         ("2.10.0", "torchao==0.16.0"),
+        # Pre-release / dev / rc builds: the minor is cleaned of non-digits.
+        ("2.10.0rc1", "torchao==0.16.0"),
+        ("2.10.0.dev20250804+cu130", "torchao==0.16.0"),
+        ("2.10rc1", "torchao==0.16.0"),
         # torch 2.11 (reachable via ROCm rocm7.2) and forward -> 0.17.0.
         ("2.11.0+cu130", "torchao==0.17.0"),
         ("2.11.0", "torchao==0.17.0"),

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -129,7 +129,10 @@ def _select_torchao_spec(torch_version: str | None) -> str:
     release = str(torch_version).split("+", 1)[0]  # drop +cu130/+rocm6.4/+cpu
     parts = release.split(".")
     try:
-        major, minor = int(parts[0]), int(parts[1])
+        # Strip any pre-release/dev suffix from the minor (e.g. '10rc1' -> '10'),
+        # matching wheel_utils.probe_torch_wheel_env.
+        minor_str = re.sub(r"[^0-9].*", "", parts[1]) if len(parts) > 1 else ""
+        major, minor = int(parts[0]), int(minor_str)
     except (IndexError, ValueError):
         return _TORCHAO_DEFAULT_SPEC
     if major != 2:
@@ -155,6 +158,7 @@ def _probe_installed_torch_version() -> str | None:
             stderr = subprocess.DEVNULL,
             text = True,
             timeout = 90,
+            **_windows_hidden_subprocess_kwargs(),
         )
     except (OSError, subprocess.TimeoutExpired):
         return None
@@ -2144,7 +2148,7 @@ def install_python_stack() -> int:
         _progress("dependency overrides")
         _torch_ver = _probe_installed_torch_version()
         _torchao_spec = _select_torchao_spec(_torch_ver)
-        print(f"   torch {_torch_ver or 'unknown'} detected -- installing {_torchao_spec}")
+        _safe_print(f"   torch {_torch_ver or 'unknown'} detected -- installing {_torchao_spec}")
         _override_extra_args: tuple[str, ...] = ()
         if _rocm_windows_torch_installed:
             # torchao declares torch as a dependency; without --no-deps uv would

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -163,6 +163,7 @@ def _probe_installed_torch_version() -> str | None:
     lines = [line.strip() for line in (probe.stdout or "").splitlines() if line.strip()]
     return lines[-1] if lines else None
 
+
 # AMD Windows ROCm wheels (repo.amd.com/rocm/whl/{arch_family}/).
 # Override with UNSLOTH_ROCM_WINDOWS_MIRROR for air-gapped/mirror installs.
 _ROCM_WINDOWS_INDEX_BASE = (

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -102,6 +102,67 @@ _CUDA_TORCH_PKG_SPEC: tuple[str, str, str] = (
     "torchaudio>=2.4,<2.11.0",
 )
 
+# torchao's C++ extensions are built against ONE exact torch release; a newer
+# torch makes torchao skip its cpp kernels ("Skipping import of cpp extensions
+# due to incompatible torch version ...") and fall back to slow Python. Because
+# the torch pin above is a range (and every CUDA index now tops out at torch
+# 2.10), the torch actually installed drifts ahead of a fixed torchao pin. So
+# pick the torchao whose build matches the torch in the venv. Table: pytorch/ao#2919.
+#   torch 2.9.x  -> torchao 0.14.0 (today's pin; built for torch 2.9.0)
+#   torch 2.10.x -> torchao 0.16.0 (built for torch 2.10.0)
+#   torch 2.11.x -> torchao 0.17.0 (built for torch 2.11.0; reachable via ROCm rocm7.2)
+# Unknown/older torch keeps the conservative default (no regression vs today).
+_TORCHAO_DEFAULT_SPEC = "torchao==0.14.0"
+_TORCHAO_BY_TORCH_MINOR: dict[int, str] = {
+    10: "torchao==0.16.0",
+    11: "torchao==0.17.0",
+}
+
+
+def _select_torchao_spec(torch_version: str | None) -> str:
+    """Map an installed torch version string (e.g. '2.10.0+cu130') to the torchao
+    pip spec whose cpp extensions match it. Falls back to _TORCHAO_DEFAULT_SPEC for
+    torch <=2.9, a non-2.x major, or an unparseable/missing version. Pure function.
+    """
+    if not torch_version:
+        return _TORCHAO_DEFAULT_SPEC
+    release = str(torch_version).split("+", 1)[0]  # drop +cu130/+rocm6.4/+cpu
+    parts = release.split(".")
+    try:
+        major, minor = int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):
+        return _TORCHAO_DEFAULT_SPEC
+    if major != 2:
+        return _TORCHAO_DEFAULT_SPEC
+    if minor >= 11:
+        return _TORCHAO_BY_TORCH_MINOR[11]  # newest known build; covers 2.11+
+    return _TORCHAO_BY_TORCH_MINOR.get(minor, _TORCHAO_DEFAULT_SPEC)
+
+
+def _probe_installed_torch_version() -> str | None:
+    """Return torch.__version__ from the target venv (sys.executable), or None if
+    torch is absent/unimportable. Cross-platform (unlike probe_torch_wheel_env,
+    which is Linux-only); mirrors the subprocess probe in _ensure_cuda_torch.
+    """
+    try:
+        probe = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import torch, sys; sys.stdout.write(getattr(torch, '__version__', ''))",
+            ],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.DEVNULL,
+            text = True,
+            timeout = 90,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if probe.returncode != 0:
+        return None
+    lines = [line.strip() for line in (probe.stdout or "").splitlines() if line.strip()]
+    return lines[-1] if lines else None
+
 # AMD Windows ROCm wheels (repo.amd.com/rocm/whl/{arch_family}/).
 # Override with UNSLOTH_ROCM_WINDOWS_MIRROR for air-gapped/mirror installs.
 _ROCM_WINDOWS_INDEX_BASE = (
@@ -2072,25 +2133,29 @@ def install_python_stack() -> int:
         req = REQ_ROOT / "extras-no-deps.txt",
     )
 
-    # 4. Overrides (torchao, transformers) -- force-reinstall.
-    #    Skip when torch is unavailable (e.g. Intel Mac GGUF-only mode):
-    #    overrides.txt contains torchao, which requires torch.
+    # 4. Overrides (torchao) -- force-reinstall. The torchao version is chosen to
+    #    match the torch installed in the venv so its C++ extensions load (see
+    #    _select_torchao_spec). Skip when torch is unavailable (e.g. Intel Mac
+    #    GGUF-only mode): torchao requires torch.
     if NO_TORCH:
         _progress("dependency overrides (skipped, no torch)")
     else:
         _progress("dependency overrides")
+        _torch_ver = _probe_installed_torch_version()
+        _torchao_spec = _select_torchao_spec(_torch_ver)
+        print(f"   torch {_torch_ver or 'unknown'} detected -- installing {_torchao_spec}")
         _override_extra_args: tuple[str, ...] = ()
         if _rocm_windows_torch_installed:
-            # torchao in overrides.txt declares torch as a dependency; without
-            # --no-deps uv would install CPU torch from PyPI, overwriting the
-            # AMD ROCm wheels we just installed.
+            # torchao declares torch as a dependency; without --no-deps uv would
+            # install CPU torch from PyPI, overwriting the AMD ROCm wheels we just
+            # installed.
             _override_extra_args = ("--no-deps",)
         pip_install(
             "Installing dependency overrides",
             "--force-reinstall",
             "--no-cache-dir",
             *_override_extra_args,
-            req = REQ_ROOT / "overrides.txt",
+            _torchao_spec,
         )
 
     # 5. Triton kernels (no-deps, from source). Skip on Windows and macOS


### PR DESCRIPTION
## What

Studio's GGUF installer now picks the torchao version from the torch actually installed in the venv, instead of a fixed `torchao==0.14.0` pin, so torchao's C++ extensions load instead of being silently skipped.

## Why

A user reported (Windows, torch 2.10.0+cu130):

```
Skipping import of cpp extensions due to incompatible torch version 2.10.0+cu130 for torchao version 0.14.0
```

torchao then falls back to its pure-Python path (slower, no compiled kernels).

Root cause: `studio/install_python_stack.py` pins CUDA torch to `torch>=2.4,<2.11` and its driver ladder selects the `cu130` wheel index on recent NVIDIA drivers, so pip resolves `torch 2.10.0`. `studio/backend/requirements/overrides.txt` hard-pinned `torchao==0.14.0`, whose C++ extensions are built against torch 2.9.0. torch 2.10.0 is outside that build, so the cpp kernels are skipped. Every CUDA index (cu126/cu128/cu130) now tops out at torch 2.10.0, so this affects most modern installs, not just cu130. The torch pin and the torchao pin drifted apart as PyTorch shipped 2.10.

## Fix

Select the torchao version matching the installed torch, per the official torchao compatibility table (pytorch/ao#2919):

| installed torch | torchao |
|---|---|
| 2.10.x | 0.16.0 |
| 2.11.x | 0.17.0 |
| <= 2.9 (and unknown/older) | 0.14.0 (unchanged) |

- `_select_torchao_spec(torch_version)` is a small pure mapping (unit-tested). It ignores the local `+cu130`/`+rocm`/`+cpu` suffix and falls back to the previous `0.14.0` for any non-2.x major or unparseable/missing version.
- `_probe_installed_torch_version()` reads `torch.__version__` from the venv via a `sys.executable` subprocess. This is cross-platform on purpose: the existing `probe_torch_wheel_env()` returns `None` off-Linux, and the report is from Windows.
- The override step passes the computed spec positionally to the same force-reinstall `pip_install` call. The flags are unchanged (`--force-reinstall --no-cache-dir`, plus `--no-deps` on Windows ROCm), so torch resolution behaves exactly as before; only the torchao version differs, and only for torch >= 2.10. torch <= 2.9 is byte-identical to today.
- `overrides.txt` now documents that torchao is selected dynamically.

Backwards-compatible: torch <= 2.9 still gets `torchao==0.14.0` (already the correct match for 2.9.0), so existing installs are unchanged.

## Notes

Unsloth only consumes torchao's Python API (`from torchao.quantization import Float8Tensor`, `unsloth/kernels/utils.py`), which already tolerates torchao >= 0.15.0 and imports cleanly on 0.16.0 and 0.17.0 (verified against torch 2.9.1). So the change is safe for the Float8 path regardless of whether the cpp extensions load.

## Tests

- New `studio/backend/tests/test_torchao_select.py` (18 cases): the torch -> torchao mapping, local version suffixes ignored, patch levels, and unparseable/missing/non-2.x fall back to the default.
- Existing `test_pytorch_mirror.py` still passes (no installer import regression).
- `from torchao.quantization import Float8Tensor` confirmed importable on torchao 0.16.0 and 0.17.0.
