### PR TITLE
Studio Hub: preview first README in split view and round status chips into pills

### DIFF
--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -201,7 +201,7 @@ function StatusChip({
   return (
     <span
       className={cn(
-        "inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-[7px] border bg-transparent px-1.5 text-[11px] font-medium leading-none",
+        "inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-full border bg-transparent px-2 text-[11px] font-medium leading-none",
         toneClass,
         className,
       )}

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -926,10 +926,11 @@ export function ModelsPage() {
     }
   }, [allModelsView]);
 
-  // Split view previews the first row so the detail pane isn't empty, except in
-  // feed mode where the feed must stay visible.
+  // Split view previews the first row so the detail pane isn't empty. Feed mode
+  // included: split view hides the trending feed and shows only the master list,
+  // so previewing its first row lands on a real README instead of a placeholder.
   useEffect(() => {
-    if (allModelsView !== "split" || urlModel || isFeedMode) return;
+    if (allModelsView !== "split" || urlModel) return;
     // Use the filtered rows the master pane renders, not raw inventory, so the
     // preview never lands on a filtered-out row.
     const firstId = isDiscoverTab
@@ -945,7 +946,6 @@ export function ModelsPage() {
   }, [
     allModelsView,
     urlModel,
-    isFeedMode,
     isDiscoverTab,
     listRows,
     filteredCachedRows,


### PR DESCRIPTION
## What this does

Two small Hub fixes in Studio.

### 1. Split view previews the first README

When opening the Hub in split view, the detail pane started empty with a "Select a model to preview its details" placeholder while sitting on the feed (Latest Unsloth Models). The auto preview effect already filled the detail pane for every other layout, but it explicitly skipped feed mode.

In split view the trending feed is hidden and only the master list is shown, so there is no reason to skip it. The effect now previews the first list row in feed mode too, so the detail pane lands on a real README right away. Non split feed mode is unchanged, since the effect only runs in split view.

### 2. Status chips are now fully rounded pills

The Hub status indicators ("Over VRAM budget", "Tight fit", "Likely fits", "May not be supported") used a `rounded-[7px]` corner. They are now `rounded-full` pills with slightly wider padding so the shape stays balanced.

## Testing

- `vite build` passes.
- Confirmed the built bundle uses the `rounded-full` pill and no longer ships the old corner radius.
- Verified split view feed mode now selects the first row and leaves non split feed untouched.
