### PR TITLE
Fix: scan_packages.py --fix crash on download_packages() tuple return

### DIFF
--- a/scripts/scan_packages.py
+++ b/scripts/scan_packages.py
@@ -2154,7 +2154,7 @@ def find_safe_version(
         scan_dir = os.path.join(tmpdir, f"{name}_{ver}")
         os.makedirs(scan_dir, exist_ok = True)
 
-        downloaded = download_packages([spec], scan_dir)
+        downloaded, _ = download_packages([spec], scan_dir)
         if not downloaded:
             continue
 
@@ -2288,7 +2288,7 @@ def _run_fix(critical_pkgs: set[str], entries: list[dict], max_search: int) -> N
                 # If no pinned version, download to find what pip resolves
                 dl_dir = os.path.join(tmpdir, f"resolve_{pkg_name}")
                 os.makedirs(dl_dir, exist_ok = True)
-                downloaded = download_packages([pkg_name], dl_dir)
+                downloaded, _ = download_packages([pkg_name], dl_dir)
                 if downloaded:
                     current_ver = get_downloaded_version(downloaded[0][1])
                 shutil.rmtree(dl_dir, ignore_errors = True)

--- a/scripts/scan_packages.py
+++ b/scripts/scan_packages.py
@@ -2154,8 +2154,10 @@ def find_safe_version(
         scan_dir = os.path.join(tmpdir, f"{name}_{ver}")
         os.makedirs(scan_dir, exist_ok = True)
 
-        downloaded, _ = download_packages([spec], scan_dir)
+        downloaded, download_errors = download_packages([spec], scan_dir)
         if not downloaded:
+            for err in download_errors:
+                print(f"    [WARN] {err}", file = sys.stderr)
             continue
 
         clean = True

--- a/scripts/scan_packages.py
+++ b/scripts/scan_packages.py
@@ -2290,9 +2290,12 @@ def _run_fix(critical_pkgs: set[str], entries: list[dict], max_search: int) -> N
                 # If no pinned version, download to find what pip resolves
                 dl_dir = os.path.join(tmpdir, f"resolve_{pkg_name}")
                 os.makedirs(dl_dir, exist_ok = True)
-                downloaded, _ = download_packages([pkg_name], dl_dir)
+                downloaded, download_errors = download_packages([pkg_name], dl_dir)
                 if downloaded:
                     current_ver = get_downloaded_version(downloaded[0][1])
+                else:
+                    for err in download_errors:
+                        print(f"  [WARN] {err}", file = sys.stderr)
                 shutil.rmtree(dl_dir, ignore_errors = True)
 
             if not current_ver:

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -596,3 +596,61 @@ def test_per_spec_sdist_only_is_not_error(tmp_path, monkeypatch):
     sp._resolve_per_spec_with_deps(["x==1.0.0"], str(tmp_path), {}, errors)
     assert errors == []  # sdist-only handled, not an exit-2 failure
     assert any(p.name.endswith(".tar.gz") for p in tmp_path.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# --fix path: download_packages() returns (results, download_errors); both
+# --fix call sites must unpack the tuple, not treat it as the results list.
+# ---------------------------------------------------------------------------
+
+
+def test_find_safe_version_handles_download_tuple(monkeypatch):
+    # One downloaded archive, returned as the real (results, download_errors) tuple.
+    monkeypatch.setattr(sp, "fetch_pypi_versions", lambda name: ["0.9.0", "1.0.0"])
+    monkeypatch.setattr(
+        sp,
+        "download_packages",
+        lambda specs, dest, **kw: ([("foo==0.9.0", "/tmp/foo-0.9.0.whl")], []),
+    )
+    monkeypatch.setattr(sp, "scan_archive", lambda archive_path, name: [])  # clean
+    monkeypatch.setattr(sp.os, "makedirs", lambda *a, **k: None)
+    monkeypatch.setattr(sp.os, "remove", lambda *a, **k: None)
+    monkeypatch.setattr(sp.shutil, "rmtree", lambda *a, **k: None)
+
+    # bad_ver 1.0.0 -> the only older candidate is 0.9.0, which is clean.
+    result = sp.find_safe_version("foo", "1.0.0", "/tmp/ignored", max_search = 10)
+    assert result == "0.9.0"
+
+
+def test_run_fix_uses_first_archive_path(monkeypatch):
+    monkeypatch.setattr(
+        sp,
+        "download_packages",
+        lambda specs, dest, **kw: ([("foo", "/tmp/foo-1.2.3.whl")], []),
+    )
+    seen = {}
+
+    def fake_get_downloaded_version(path):
+        seen["path"] = path
+        return "1.2.3"
+
+    monkeypatch.setattr(sp, "get_downloaded_version", fake_get_downloaded_version)
+    monkeypatch.setattr(sp, "find_safe_version", lambda *a, **k: None)
+    monkeypatch.setattr(sp.os, "makedirs", lambda *a, **k: None)
+    monkeypatch.setattr(sp.shutil, "rmtree", lambda *a, **k: None)
+
+    # CRITICAL package with no pinned version -> must download to resolve it,
+    # reaching downloaded[0][1] (the first archive's path).
+    entries = [
+        {
+            "name": "foo",
+            "is_git": False,
+            "spec": "foo",
+            "source_file": None,
+            "raw_line": "foo",
+            "line_num": 1,
+        }
+    ]
+    sp._run_fix({"foo"}, entries, max_search = 10)  # must not raise
+
+    assert seen.get("path") == "/tmp/foo-1.2.3.whl"


### PR DESCRIPTION
### What

`scripts/scan_packages.py --fix` is the advertised auto-remediation mode (documented in the module docstring: `python scan_packages.py --fix -r requirements.txt`). It crashes the moment it actually tries to remediate a CRITICAL finding, because two callers on the `--fix` path treat `download_packages()`'s return value as the bare results list, but it returns a 2-tuple `(results, download_errors)`:

```python
def download_packages(...) -> tuple[list[tuple[str, str]], list[str]]:
    """Returns ``(results, download_errors)`` ..."""
    ...
    return results, download_errors
```

The main scan path already unpacks it (`downloaded, download_errors = download_packages(...)`), but the two `--fix`-only sites were missed:

- **`find_safe_version`** - `downloaded = download_packages([spec], scan_dir)` followed by `if not downloaded:` (always false: a 2-tuple is truthy even when both inner lists are empty) and `for _, archive_path in downloaded:`, which iterates the *tuple* and tries to unpack the `results` **list** into `(_, archive_path)` → `ValueError: not enough values to unpack` for the normal single-archive `--no-deps` case.
- **`_run_fix`** - `downloaded = download_packages([pkg_name], dl_dir)` then `get_downloaded_version(downloaded[0][1])`. `downloaded[0]` is the `results` list, so `downloaded[0][1]` indexes the *second* archive instead of the first archive's path → `IndexError: list index out of range` when a single archive was downloaded.

Net effect: `--fix` reliably crashes with a traceback exactly when a CRITICAL finding exists and remediation is needed.

### Fix

Unpack the tuple at both `--fix` call sites the same way the main scan path already does:

```python
downloaded, _ = download_packages(...)
```

After this, `find_safe_version`'s `if not downloaded` / iteration and `_run_fix`'s `downloaded[0][1]` operate on the results list as intended.

### Tests

Adds two CPU-only, offline regression tests to `tests/security/test_scan_packages.py` that drive the real `find_safe_version` and `_run_fix` with `download_packages` monkeypatched to return its documented `(results, download_errors)` tuple for one downloaded archive. Both fail on `main` (`ValueError` / `IndexError`) and pass with this change.

Closes #6412
