### PR TITLE
Fix _kill_process AttributeError when _stats_logger is unset

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6125,10 +6125,8 @@ class LlamaCppBackend:
         except Exception as e:
             logger.warning(f"Error killing llama-server process: {e}")
         finally:
-            # getattr guard: _kill_process runs on the cleanup/teardown path, which
-            # must tolerate a partially-constructed backend (e.g. __init__ raising
-            # before `self._stats_logger = None`, or a __new__-built instance). Mirrors
-            # the `hasattr(self, "_chat_template_file")` guard used elsewhere here.
+            # getattr: teardown must tolerate a partially-built backend (failed
+            # __init__ or a __new__-built instance), as with _llama_log_fh below.
             if getattr(self, "_stats_logger", None) is not None:
                 self._stats_logger.stop()
                 self._stats_logger = None
@@ -6139,8 +6137,9 @@ class LlamaCppBackend:
             # Drives _wait_for_vram_settle in the next load_model; set in finally
             # so both in-process and frontend Apply paths record the kill.
             self._last_kill_monotonic = time.monotonic()
-            if self._stdout_thread is not None:
-                self._stdout_thread.join(timeout = 2)
+            stdout_thread = getattr(self, "_stdout_thread", None)
+            if stdout_thread is not None:
+                stdout_thread.join(timeout = 2)
                 self._stdout_thread = None
             fh = getattr(self, "_llama_log_fh", None)
             if fh is not None:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6125,7 +6125,11 @@ class LlamaCppBackend:
         except Exception as e:
             logger.warning(f"Error killing llama-server process: {e}")
         finally:
-            if self._stats_logger is not None:
+            # getattr guard: _kill_process runs on the cleanup/teardown path, which
+            # must tolerate a partially-constructed backend (e.g. __init__ raising
+            # before `self._stats_logger = None`, or a __new__-built instance). Mirrors
+            # the `hasattr(self, "_chat_template_file")` guard used elsewhere here.
+            if getattr(self, "_stats_logger", None) is not None:
                 self._stats_logger.stop()
                 self._stats_logger = None
             self._process = None

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -309,6 +309,26 @@ def test_kill_process_records_timestamp_on_actual_kill():
     assert before <= backend._last_kill_monotonic <= after
 
 
+def test_kill_process_tolerates_partially_constructed_backend():
+    # Teardown must not AttributeError on a __new__-built backend that never ran
+    # __init__: _stats_logger / _stdout_thread / _llama_log_fh are left unset.
+    backend = LlamaCppBackend.__new__(LlamaCppBackend)
+
+    class _FakeProcess:
+        def terminate(self):
+            pass
+
+        def wait(self, timeout = None):
+            return 0
+
+        def kill(self):
+            pass
+
+    backend._process = _FakeProcess()
+    backend._kill_process()
+    assert backend._process is None
+
+
 def test_helper_is_static_method_callable_off_class():
     """Pin the @staticmethod binding so call sites can invoke off the class."""
     ctx, _state = _patch_probe([[]])


### PR DESCRIPTION
## Problem

`LlamaCppBackend._kill_process()` references `self._stats_logger` in its `finally` block, but `__init__` only sets `self._stats_logger = None` partway through construction. If `__init__` raises before that line, or the backend is built via `__new__` (as the kill-path unit test does), the teardown path crashes with:

```
AttributeError: 'LlamaCppBackend' object has no attribute '_stats_logger'
```

instead of cleaning up the process. This currently fails `studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py::test_kill_process_records_timestamp_on_actual_kill`, which turns the Python and Repo-tests CI jobs red on `main` (and on every branch cut from it).

## Fix

Guard the reference with `getattr(self, "_stats_logger", None)`. The teardown path must tolerate a partially-constructed backend, and this mirrors the `hasattr(self, "_chat_template_file")` guard already used a few lines above in the same `finally` block. `None` is the correct "no stats poller running" state, so the cleanup logic is unchanged for fully-constructed instances.

## Testing

```
PYTHONPATH=studio/backend python -m pytest \
  studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py -q
# 16 passed (was 1 failed, 15 passed)

PYTHONPATH=studio/backend python -m pytest \
  studio/backend/tests/test_llama_stats.py -q
# 4 passed (engine-stats poller unaffected)
```
