### PR TITLE
studio: fix tests turning main CI red/flaky (kill-process, install overrides, UI re-login)

### DIFF
--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -281,6 +281,7 @@ def test_kill_process_records_timestamp_on_actual_kill():
     backend = LlamaCppBackend.__new__(LlamaCppBackend)
     backend._process = None
     backend._healthy = False
+    backend._stats_logger = None  # _kill_process stops it in finally
     backend._stdout_thread = None
     backend._llama_log_fh = None
     backend._last_kill_monotonic = 0.0

--- a/tests/python/test_no_torch_filtering.py
+++ b/tests/python/test_no_torch_filtering.py
@@ -471,11 +471,15 @@ class TestInstallPythonStackSubprocessMock:
     # -- Normal Linux path (NO_TORCH=False, IS_MACOS=False, IS_WINDOWS=False) --
 
     def test_normal_linux_includes_overrides(self):
-        """Normal Linux: overrides.txt IS called."""
+        """Normal Linux: the torchao override step IS called.
+
+        The override step installs a torch-matched torchao spec via
+        --force-reinstall (uv: --reinstall), not overrides.txt directly.
+        """
         cmds = self._capture_install(no_torch = False, is_macos = False, is_windows = False)
-        assert self._cmds_contain_file(
-            cmds, "overrides.txt"
-        ), "overrides.txt should be called on normal Linux"
+        assert any(
+            "--reinstall" in cmd for cmd in cmds
+        ), "torchao override step (--reinstall) should be called on normal Linux"
 
     def test_normal_linux_includes_triton(self):
         """Normal Linux: triton-kernels.txt IS called."""

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1430,7 +1430,16 @@ with sync_playwright() as p:
     # Re-login through the UI with NEW2 so the browser has a valid
     # access token for the /api/shutdown call (the previous one
     # was invalidated by the CLI rotation above).
-    page.goto(f"{BASE}/login")
+    # The CLI rotation left a stale token, so the SPA auth guard can
+    # client-side-redirect mid-navigation and abort this goto with
+    # net::ERR_ABORTED. Resolve on domcontentloaded and tolerate the
+    # abort; the password-field wait below confirms we reached /login.
+    try:
+        page.goto(f"{BASE}/login", wait_until = "domcontentloaded", timeout = 60_000)
+    except Exception as exc:
+        if "ERR_ABORTED" not in str(exc):
+            raise
+        info(f"goto /login aborted ({exc!r}); password-field wait will confirm /login")
     pw_field = page.locator("#password")
     pw_field.wait_for(state = "visible", timeout = 60_000)
     pw_field.fill(NEW2)


### PR DESCRIPTION
## Summary

`main` CI is red/flaky from three tests left behind by the recent merge wave (#6377, #6400, #6405). None is a real product regression; each tests removed/old behavior or races a navigation. This PR makes the affected jobs green.

### 1. `Repo tests (CPU)` / Python matrix: `test_kill_process_records_timestamp_on_actual_kill`

`AttributeError: 'LlamaCppBackend' object has no attribute '_stats_logger'`. #6377 added a `self._stats_logger` cleanup to `_kill_process()`'s `finally`; #6400's test builds the backend via `LlamaCppBackend.__new__(...)`, bypassing `__init__` where `_stats_logger` is set. Fix: set `_stats_logger` on the hand-built backend, alongside the other attributes it already seeds. Production code unchanged.

### 2. `Repo tests (CPU)`: `test_normal_linux_includes_overrides`

`overrides.txt should be called on normal Linux`. #6400 moved the torchao override from a fixed pin in `overrides.txt` to a torch-matched spec installed via `--force-reinstall` (`_select_torchao_spec`), leaving `overrides.txt` as a comment-only pointer. It updated the Windows variant to assert `--reinstall` but not the Linux one. Fix: assert the override step (`--reinstall`) on Linux too, matching the Windows test and the real install behavior.

### 3. `Chat UI Tests`: flaky `net::ERR_ABORTED` on `/login`

The Shutdown step re-logs in after a CLI password rotation that revoked the prior token. The SPA auth guard can client-side-redirect mid-navigation against the stale token, aborting `page.goto("/login")` with `net::ERR_ABORTED` (a race; passes on `main` most of the time). Fix: resolve on `domcontentloaded` and tolerate the abort, relying on the password-field wait that follows to confirm `/login` (matching the `wait_until` other navigations in this file already use).

## Verification

```
tests/python/test_no_torch_filtering.py                      -> 51 passed
studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py  -> 16 passed
python -m py_compile tests/studio/playwright_chat_ui.py       -> ok
```

The Chat UI script is a full live-Studio + browser e2e flow, so the navigation change is verified by `py_compile` and the standard Playwright robustness pattern rather than a local run.
