### PR TITLE
Align GRPO vllm_enable_sleep_mode with the engine's actual sleep state

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1901,10 +1901,14 @@ def patch_functions(RLTrainer, trainer_file, RLTrainer_name, all_imports, import
                 # If model has vllm_engine, then use vllm in colocate mode. Donot wait for server
                 vllm_setter += " " * 12 + "args.vllm_mode='colocate'\n"
                 if trl_version >= Version("0.23.0"):
-                    # We need to set this flag for sleep mode auto working with trl update
+                    # Align TRL sleep mode with the engine's actual enable_sleep_mode
+                    # (the vision standby gate may have disabled it); fall back to the
+                    # standby env var when the engine cannot be introspected.
                     vllm_setter += (
                         " " * 12
-                        + "if os.environ.get('UNSLOTH_VLLM_STANDBY', '0') == '1':\n"
+                        + "_unsloth_esm = getattr(getattr(getattr(getattr(model.vllm_engine, 'llm_engine', None), 'vllm_config', None), 'model_config', None), 'enable_sleep_mode', None)\n"
+                        + " " * 12
+                        + "if (_unsloth_esm if _unsloth_esm is not None else os.environ.get('UNSLOTH_VLLM_STANDBY', '0') != '0'):\n"
                         + " " * 16
                         + "args.vllm_enable_sleep_mode=True\n"
                     )


### PR DESCRIPTION
## Summary

The colocate GRPO setup generated `args.vllm_enable_sleep_mode = True` straight from the raw `UNSLOTH_VLLM_STANDBY` env var (`== '1'`). That decision can disagree with the engine that was actually built:

- unsloth-zoo#768 adds a vision standby gate: for a multimodal run with `UNSLOTH_VLLM_STANDBY=1` and no `UNSLOTH_VLLM_STANDBY_VISION=1`, the engine is created with `enable_sleep_mode=False`. TRL was still told sleep mode is on, so it could drive sleep/wake against an engine that did not enable it.
- The env check used `== '1'` while `load_vllm` / `patch_vllm` use `!= '0'`, so a truthy value such as `UNSLOTH_VLLM_STANDBY=2` was treated inconsistently.

## Change

`unsloth/models/rl.py` now reads `enable_sleep_mode` from the colocated engine itself:

```
model.vllm_engine.llm_engine.vllm_config.model_config.enable_sleep_mode
```

which is the same path `patch_vllm`'s `check_sleep_mode` uses. It falls back to the standby env var (`!= '0'`, matching `load_vllm` and `patch_vllm`) only when the engine cannot be introspected. The whole block already runs inside `if hasattr(model, 'vllm_engine')`, and every lookup is null guarded, so a missing or restructured config degrades to the env fallback rather than raising.

## Effect

| Case | Before | After |
| --- | --- | --- |
| Text + `STANDBY=1` | sleep on | sleep on |
| Vision + `STANDBY=1`, no override (gate disables it) | sleep on (mismatch) | sleep off (matches engine) |
| Vision + `STANDBY_VISION=1` (forced) | sleep on | sleep on |
| `STANDBY=2` (truthy, non 1) | sleep off | follows engine, else env |

## Validation

AST checked the file and the generated trainer snippet. Exercised end to end with a short text and vision GRPO standby run (Qwen2.5-VL-7B) alongside unsloth-zoo#768: the gated vision run no longer turns on TRL sleep mode, and forced vision standby still runs clean with no `cudaErrorIllegalAddress` or `mm_hash` signatures.

Pairs with unslothai/unsloth-zoo#768.
