### PR TITLE
Studio: make toast text selectable

### DIFF
--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -19,8 +19,11 @@ import { Toaster as Sonner, type ToasterProps } from "sonner";
 const handleToastPointerDownCapture = (
   event: React.PointerEvent<HTMLDivElement>,
 ) => {
-  const target = event.target as HTMLElement | null;
-  if (!target?.closest("[data-sonner-toast]")) return;
+  // closest() lives on Element, so this also covers SVG icon targets; guard
+  // against non-Element targets defensively.
+  const target = event.target as Element | null;
+  if (typeof target?.closest !== "function") return;
+  if (!target.closest("[data-sonner-toast]")) return;
   if (
     target.closest("button,[data-button],[data-close-button],[data-cancel]")
   ) {

--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -12,73 +12,97 @@ import { Spinner } from "@/components/ui/spinner";
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+// Make toast text selectable. Sonner's onPointerDown calls setPointerCapture(),
+// which steals the drag and blocks text selection. dismissible:false would stop
+// it but also kills the close button. So we swallow pointerdown on toast text
+// (never on its buttons) before sonner sees it.
+const handleToastPointerDownCapture = (
+  event: React.PointerEvent<HTMLDivElement>,
+) => {
+  const target = event.target as HTMLElement | null;
+  if (!target?.closest("[data-sonner-toast]")) return;
+  if (
+    target.closest("button,[data-button],[data-close-button],[data-cancel]")
+  ) {
+    return;
+  }
+  event.stopPropagation();
+};
+
 const Toaster = ({ ...props }: ToasterProps) => {
   // Use resolvedTheme so sonner's data-sonner-theme always matches the class
   // next-themes puts on <html>; sonner-side "system" resolution can drift.
   const { resolvedTheme } = useTheme();
 
   return (
-    <Sonner
-      theme={(resolvedTheme as ToasterProps["theme"]) ?? "light"}
-      className="toaster group"
-      duration={5000}
-      icons={{
-        success: (
-          <HugeiconsIcon
-            icon={CheckmarkCircle02Icon}
-            strokeWidth={2}
-            className="size-4"
-          />
-        ),
-        info: (
-          <HugeiconsIcon
-            icon={InformationCircleIcon}
-            strokeWidth={2}
-            className="size-4"
-          />
-        ),
-        warning: (
-          <HugeiconsIcon
-            icon={Alert02Icon}
-            strokeWidth={2}
-            className="size-4"
-          />
-        ),
-        error: (
-          <HugeiconsIcon
-            icon={MultiplicationSignCircleIcon}
-            strokeWidth={2}
-            className="size-4"
-          />
-        ),
-        // App-wide arc spinner so loading toasts match the "Downloading model" toast.
-        loading: <Spinner className="size-4 text-muted-foreground" />,
-      }}
-      style={
-        {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          // No border line; elevation comes from the composer's drop shadow.
-          "--normal-border": "transparent",
-          "--border-radius": "var(--radius)",
-          // Pin the close button inside the toast's top-right corner.
-          // Sonner defaults to the left/outside edge, so keep the horizontal
-          // override here and the top offset in index.css.
-          "--toast-close-button-start": "unset",
-          "--toast-close-button-end": "8px",
-          "--toast-close-button-transform": "none",
-        } as React.CSSProperties
-      }
-      // No swipe gestures; keeps toast text selectable.
-      swipeDirections={[]}
-      toastOptions={{
-        classNames: {
-          toast: "cn-toast",
-          description: "!text-muted-foreground",
-        },
-      }}
-      {...props}
-    />
+    // display:contents adds no box; only carries the selection-fix handler.
+    // biome-ignore lint/a11y/noStaticElementInteractions: capture-only guard, not interactive
+    <div
+      style={{ display: "contents" }}
+      onPointerDownCapture={handleToastPointerDownCapture}
+    >
+      <Sonner
+        theme={(resolvedTheme as ToasterProps["theme"]) ?? "light"}
+        className="toaster group"
+        duration={5000}
+        icons={{
+          success: (
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              strokeWidth={2}
+              className="size-4"
+            />
+          ),
+          info: (
+            <HugeiconsIcon
+              icon={InformationCircleIcon}
+              strokeWidth={2}
+              className="size-4"
+            />
+          ),
+          warning: (
+            <HugeiconsIcon
+              icon={Alert02Icon}
+              strokeWidth={2}
+              className="size-4"
+            />
+          ),
+          error: (
+            <HugeiconsIcon
+              icon={MultiplicationSignCircleIcon}
+              strokeWidth={2}
+              className="size-4"
+            />
+          ),
+          // App-wide arc spinner so loading toasts match the "Downloading model" toast.
+          loading: <Spinner className="size-4 text-muted-foreground" />,
+        }}
+        style={
+          {
+            "--normal-bg": "var(--popover)",
+            "--normal-text": "var(--popover-foreground)",
+            // No border line; elevation comes from the composer's drop shadow.
+            "--normal-border": "transparent",
+            "--border-radius": "var(--radius)",
+            // Pin the close button inside the toast's top-right corner.
+            // Sonner defaults to the left/outside edge, so keep the horizontal
+            // override here and the top offset in index.css.
+            "--toast-close-button-start": "unset",
+            "--toast-close-button-end": "8px",
+            "--toast-close-button-transform": "none",
+          } as React.CSSProperties
+        }
+        // No swipe gestures; text selection handled by the wrapper above.
+        swipeDirections={[]}
+        toastOptions={{
+          classNames: {
+            toast: "cn-toast",
+            description: "!text-muted-foreground",
+          },
+        }}
+        {...props}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

Toast notifications (for example the "... loaded" toast in Chat) could not be highlighted or copied. This makes it hard to grab a model name or an error string out of a toast.

The text was already styled `user-select: text` and swipe was already disabled via `swipeDirections={[]}`, so this was not a CSS issue. The real cause is in sonner itself: its per-toast `onPointerDown` calls `setPointerCapture()` as soon as you press on the toast. Pointer capture redirects the drag to the toast element, so the browser never starts a native text selection.

The obvious switch, `dismissible: false`, does stop the capture, but it also breaks the close button: sonner gates the close button's `onClick` on the same `dismissible` flag, so the X becomes a no-op.

## Fix

Wrap the `Toaster` in a `display: contents` element that carries a capture-phase `onPointerDownCapture` handler. It swallows `pointerdown` on toast text before sonner sees it, but never on the toast's buttons (close / action / cancel), so:

- toast text is selectable and copyable again
- the close button and auto-dismiss still work (`dismissible` stays `true`)
- swipe stays off (`swipeDirections={[]}`)

It runs through React's event tree, so it still applies if sonner renders toasts through a portal.

## Testing

- Confirmed in the running app that `setPointerCapture` no longer fires on a text press, while it still fired before the change.
- Confirmed a selection placed over the toast title persists (text is highlightable / copyable).
- Confirmed the close button still dismisses and `data-dismissible` stays `true`.
- `npm run typecheck` passes. Change is a single file.
