### PR TITLE
Studio: harden GPU startup detection and clarify multi-GPU listing

### DIFF
--- a/studio/backend/tests/test_utils.py
+++ b/studio/backend/tests/test_utils.py
@@ -88,6 +88,19 @@ class TestGetDevice:
         ):
             assert _reset_and_detect() == DeviceType.CUDA
 
+    @needs_torch
+    def test_detect_survives_device0_probe_failure(self, capsys):
+        # is_available() True but the device-0 name probe raises: startup must
+        # still resolve CUDA rather than crash.
+        with (
+            patch("utils.hardware.hardware._has_torch", return_value = True),
+            patch("torch.cuda.is_available", return_value = True),
+            patch("torch.cuda.device_count", return_value = 1),
+            patch("torch.cuda.get_device_properties", side_effect = RuntimeError("probe")),
+        ):
+            assert _reset_and_detect() == DeviceType.CUDA
+        assert "<unavailable>" in capsys.readouterr().out
+
     @needs_mlx
     def test_returns_mlx_when_on_apple_silicon_with_mlx(self):
         with (
@@ -382,6 +395,22 @@ class TestPrintCudaDeviceList:
         with patch("torch.cuda.device_count", side_effect = RuntimeError("no cuda")):
             _hw_module._print_cuda_device_list(is_rocm = False)
         assert capsys.readouterr().out == ""
+
+    @needs_torch
+    def test_rocm_label_omits_cuda_device_order(self, capsys):
+        # CUDA_DEVICE_ORDER governs CUDA only, so the ROCm listing must not claim it.
+        props = [MagicMock(), MagicMock()]
+        props[0].name = "AMD Instinct MI300X"
+        props[1].name = "AMD Instinct MI300X"
+        with (
+            patch("torch.cuda.device_count", return_value = 2),
+            patch("torch.cuda.get_device_properties", side_effect = lambda i: props[i]),
+        ):
+            _hw_module._print_cuda_device_list(is_rocm = True)
+        out = capsys.readouterr().out
+        assert "ROCm devices (2):" in out
+        assert "CUDA_DEVICE_ORDER" not in out
+        assert "[0] AMD Instinct MI300X" in out
 
 
 # ========== format_error_message() ==========

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -131,7 +131,8 @@ def _print_cuda_device_list(is_rocm: bool) -> None:
         for i in range(count):
             try:
                 name = torch.cuda.get_device_properties(i).name
-            except Exception:
+            except Exception as e:
+                logger.debug("CUDA device %d property probe failed: %s", i, e)
                 name = "<unavailable>"
             lines.append(f"  [{i}] {name}")
         print("\n".join(lines))
@@ -162,7 +163,8 @@ def detect_hardware() -> DeviceType:
             CHAT_ONLY = False
             try:
                 device_name = torch.cuda.get_device_properties(0).name
-            except Exception:
+            except Exception as e:
+                logger.debug("CUDA device 0 property probe failed: %s", e)
                 device_name = "<unavailable>"
 
             # Distinguish ROCm from CUDA for display only (DeviceType stays CUDA).

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -107,12 +107,13 @@ def _has_mlx() -> bool:
 
 
 def _print_cuda_device_list(is_rocm: bool) -> None:
-    """Print every visible CUDA/ROCm GPU with its index.
+    """List every visible CUDA/ROCm GPU with its index at startup.
 
     The "Hardware detected" banner names only device 0, which hides the other
-    cards on a multi-GPU host and obscures which physical GPU each index maps to.
-    Listing all devices in the pinned PCI_BUS_ID order (see CUDA_DEVICE_ORDER at
-    module top) makes the available set explicit and matches `nvidia-smi -L`.
+    cards on a multi-GPU host. This lists the full visible set in CUDA-ordinal
+    order, matching `nvidia-smi -L` when no CUDA_VISIBLE_DEVICES mask is set
+    (under a mask the indices are visible ordinals, not physical PCI ids).
+    CUDA_DEVICE_ORDER governs only CUDA, so it is shown for CUDA but not ROCm.
     No-ops on single-GPU hosts and never raises -- it is purely informational.
     """
     try:
@@ -121,9 +122,12 @@ def _print_cuda_device_list(is_rocm: bool) -> None:
         count = torch.cuda.device_count()
         if count <= 1:
             return
-        label = "ROCm" if is_rocm else "CUDA"
-        order = os.environ.get("CUDA_DEVICE_ORDER", "default")
-        lines = [f"{label} devices ({count}, CUDA_DEVICE_ORDER={order}):"]
+        if is_rocm:
+            header = f"ROCm devices ({count}):"
+        else:
+            order = os.environ.get("CUDA_DEVICE_ORDER", "default")
+            header = f"CUDA devices ({count}, CUDA_DEVICE_ORDER={order}):"
+        lines = [header]
         for i in range(count):
             try:
                 name = torch.cuda.get_device_properties(i).name
@@ -156,7 +160,10 @@ def detect_hardware() -> DeviceType:
         if torch.cuda.is_available():
             DEVICE = DeviceType.CUDA
             CHAT_ONLY = False
-            device_name = torch.cuda.get_device_properties(0).name
+            try:
+                device_name = torch.cuda.get_device_properties(0).name
+            except Exception:
+                device_name = "<unavailable>"
 
             # Distinguish ROCm from CUDA for display only (DeviceType stays CUDA).
             # AMD SDK wheels don't set torch.version.hip, so fall back to __version__.


### PR DESCRIPTION
Follow-up to #6353. Small hardening and clarity fixes to the startup GPU detection added there.

### Changes

- Guard the "Hardware detected" banner probe. `detect_hardware()` called `torch.cuda.get_device_properties(0).name` unguarded, so a transient driver or probe error while `torch.cuda.is_available()` is True would crash Studio startup. It now falls back to `<unavailable>` and continues, matching how the device listing already handles per-device probe failures.
- Drop the CUDA-only `CUDA_DEVICE_ORDER` annotation from the ROCm listing. `CUDA_DEVICE_ORDER` governs CUDA enumeration only and is a no-op under HIP, so printing it under the ROCm label was misleading. CUDA hosts still show it.
- Clarify the `_print_cuda_device_list` docstring. The listing is in CUDA-ordinal order and matches `nvidia-smi -L` only when no `CUDA_VISIBLE_DEVICES` mask is set; under a mask the printed indices are visible ordinals, not physical PCI ids.

### Tests

- `test_detect_survives_device0_probe_failure`: `is_available()` True but the device-0 probe raises, detection still resolves CUDA and the banner shows `<unavailable>`.
- `test_rocm_label_omits_cuda_device_order`: the ROCm listing prints `ROCm devices (N):` with device names and no `CUDA_DEVICE_ORDER`.

`studio/backend/tests/test_utils.py` passes (36 passed, 4 skipped) and `python3.9 -m py_compile` is clean on both files.
