### PR TITLE
Studio Hub: show Google logo for diffusiongemma and future gemma derivatives

### DIFF
--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -47,10 +47,10 @@ export interface ProviderLogo {
 	 */
 	prefixes: readonly string[];
 	/**
-	 * Lowercase family stems matched as a case-insensitive substring, only as a
-	 * fallback after all prefixes miss. Catches qualifier-prefixed derivatives
-	 * (e.g. `diffusiongemma-` for Google). Use only for stems unique to one
-	 * provider, since substring matching is broad.
+	 * Lowercase family stems matched case-insensitively, only as a fallback after
+	 * all prefixes miss. A stem matches when it ends at a word boundary (the next
+	 * char is not a letter), so `gemma` catches `diffusiongemma-` and `gemma-3n`
+	 * but not `gemmafy`. Use only for stems unique to one provider.
 	 */
 	stems?: readonly string[];
 }
@@ -257,10 +257,21 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 	},
 ];
 
+// True if `stem` occurs in `haystack` (already lowercased) ending at a word
+// boundary: the char after it is absent or not a letter. So `gemma` matches
+// `diffusiongemma-` and `gemma-3n` but not `gemmafy`.
+function stemMatchesAtBoundary(haystack: string, stem: string): boolean {
+	for (let at = haystack.indexOf(stem); at !== -1; at = haystack.indexOf(stem, at + 1)) {
+		const next = haystack[at + stem.length];
+		if (next === undefined || next < "a" || next > "z") return true;
+	}
+	return false;
+}
+
 /**
  * Resolve a repo name (after `owner/`) to its upstream provider, or null.
  * Pass 1: case-sensitive prefix match (declaration order, first wins). Pass 2:
- * case-insensitive `stems` substring fallback. Prefixes always win, so the
+ * case-insensitive `stems` boundary fallback. Prefixes always win, so the
  * ordered precedence above is never weakened by the broader stem match.
  */
 export function matchProviderLogo(repoName: string): ProviderLogo | null {
@@ -272,7 +283,7 @@ export function matchProviderLogo(repoName: string): ProviderLogo | null {
 	}
 	const lower = repoName.toLowerCase();
 	for (const provider of PROVIDER_LOGOS) {
-		if (provider.stems?.some((stem) => lower.includes(stem))) {
+		if (provider.stems?.some((stem) => stemMatchesAtBoundary(lower, stem))) {
 			return provider;
 		}
 	}

--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -47,10 +47,8 @@ export interface ProviderLogo {
 	 */
 	prefixes: readonly string[];
 	/**
-	 * Lowercase family stems matched case-insensitively, only as a fallback after
-	 * all prefixes miss. A stem matches when it ends at a word boundary (the next
-	 * char is not a letter), so `gemma` catches `diffusiongemma-` and `gemma-3n`
-	 * but not `gemmafy`. Use only for stems unique to one provider.
+	 * Case-insensitive fallback after all prefixes miss; matched at a word boundary
+	 * (`gemma` -> `diffusiongemma-`, `gemma-3n`, not `gemmafy`). Use stems unique to one provider.
 	 */
 	stems?: readonly string[];
 }
@@ -224,7 +222,6 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"metricx-",
 			"bert-",
 		],
-		// Catches `<qualifier>gemma` derivatives (e.g. diffusiongemma-).
 		stems: ["gemma"],
 	},
 
@@ -257,9 +254,6 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 	},
 ];
 
-// True if `stem` occurs in `haystack` (already lowercased) ending at a word
-// boundary: the char after it is absent or not a letter. So `gemma` matches
-// `diffusiongemma-` and `gemma-3n` but not `gemmafy`.
 function stemMatchesAtBoundary(haystack: string, stem: string): boolean {
 	for (let at = haystack.indexOf(stem); at !== -1; at = haystack.indexOf(stem, at + 1)) {
 		const next = haystack[at + stem.length];
@@ -269,10 +263,9 @@ function stemMatchesAtBoundary(haystack: string, stem: string): boolean {
 }
 
 /**
- * Resolve a repo name (after `owner/`) to its upstream provider, or null.
- * Pass 1: case-sensitive prefix match (declaration order, first wins). Pass 2:
- * case-insensitive `stems` boundary fallback. Prefixes always win, so the
- * ordered precedence above is never weakened by the broader stem match.
+ * Resolve a repo name (after `owner/`) to its provider, or null. Pass 1: prefix
+ * match in declaration order (first wins). Pass 2: case-insensitive `stems`
+ * boundary fallback; prefixes always win.
  */
 export function matchProviderLogo(repoName: string): ProviderLogo | null {
 	if (!repoName) return null;

--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -46,6 +46,13 @@ export interface ProviderLogo {
 	 * on the family stem so future minor versions are picked up automatically.
 	 */
 	prefixes: readonly string[];
+	/**
+	 * Lowercase family stems matched as a case-insensitive substring, only as a
+	 * fallback after all prefixes miss. Catches qualifier-prefixed derivatives
+	 * (e.g. `diffusiongemma-` for Google). Use only for stems unique to one
+	 * provider, since substring matching is broad.
+	 */
+	stems?: readonly string[];
 }
 
 export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
@@ -217,6 +224,8 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"metricx-",
 			"bert-",
 		],
+		// Catches `<qualifier>gemma` derivatives (e.g. diffusiongemma-).
+		stems: ["gemma"],
 	},
 
 	// After NVIDIA so `Mistral-NeMo-` wins; generic Mistral-/Mixtral- fall through here.
@@ -250,12 +259,20 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 
 /**
  * Resolve a repo name (after `owner/`) to its upstream provider, or null.
- * Iterates PROVIDER_LOGOS in declaration order; first prefix match wins.
+ * Pass 1: case-sensitive prefix match (declaration order, first wins). Pass 2:
+ * case-insensitive `stems` substring fallback. Prefixes always win, so the
+ * ordered precedence above is never weakened by the broader stem match.
  */
 export function matchProviderLogo(repoName: string): ProviderLogo | null {
 	if (!repoName) return null;
 	for (const provider of PROVIDER_LOGOS) {
 		if (provider.prefixes.some((prefix) => repoName.startsWith(prefix))) {
+			return provider;
+		}
+	}
+	const lower = repoName.toLowerCase();
+	for (const provider of PROVIDER_LOGOS) {
+		if (provider.stems?.some((stem) => lower.includes(stem))) {
 			return provider;
 		}
 	}


### PR DESCRIPTION
### Problem

In the Studio Models hub, `diffusiongemma-26B-A4B-it-GGUF` showed the generic Unsloth "U" tile instead of the Google logo that every other Gemma model gets.

The provider-logo matcher in `provider-logos.ts` only did a `startsWith()` prefix match. Google's prefixes are `gemma-`, `paligemma-`, `codegemma-`, and so on, which all assume the family stem is at the start of the repo name. `diffusiongemma-*` prepends a qualifier in front of `gemma`, so `startsWith("gemma-")` is false, no provider matches, and the card falls back to the owner's first initial ("U").

This is the one naming shape the prefix scheme cannot catch: every other org appends qualifiers, but Google prepends them onto `gemma` (`pali`, `code`, `med`, `shield`, `diffusion`, and so on).

### Fix

Rather than hardcode a single `diffusiongemma-` prefix, this adds a reusable fallback so the whole class of bug cannot recur:

- New optional `stems` field on `ProviderLogo`: lowercase substrings matched case-insensitively anywhere in the repo name.
- `matchProviderLogo` is now two passes. Pass 1 is the existing case-sensitive prefix match, so the carefully ordered precedence (for example `DeepSeek-R1-Distill-` beating Qwen) is untouched. Pass 2 is the `stems` fallback, reached only when every prefix misses. Prefixes always win, so the broader stem match can never weaken precedence.
- Google gets `stems: ["gemma"]`, which future-proofs the entire `*gemma` family without enumerating each variant.

### Verification

Resolving against the real module:

| Repo | Before | After |
| --- | --- | --- |
| `diffusiongemma-26B-A4B-it-GGUF` | U fallback | Google |
| `gemma-4-12b-it-GGUF` | Google | Google |
| `paligemma-3b-pt-224` | Google | Google |
| `Qwen3.6-27B-MTP-GGUF` | Qwen | Qwen |
| `DeepSeek-R1-Distill-Qwen-7B` | DeepSeek | DeepSeek |

`npm run typecheck` and `npm run build` both pass. No other providers change behaviour.
