### PR TITLE
Studio Hub: default downloads to Xet transport

### DIFF
--- a/studio/backend/hub/schemas/downloads.py
+++ b/studio/backend/hub/schemas/downloads.py
@@ -25,8 +25,8 @@ class DownloadModelRequest(BaseModel):
         description = "Quantization label (e.g. 'Q4_K_M'). Required for GGUF repos.",
     )
     use_xet: bool = Field(
-        False,
-        description = "Enable Xet parallel chunked transport. Default False uses HTTP Range-resume.",
+        True,
+        description = "Use Xet parallel chunked transport. Default True; set False for HTTP Range-resume.",
     )
 
 
@@ -125,8 +125,8 @@ class DownloadDatasetRequest(BaseModel):
 
     repo_id: str = Field(..., description = "HuggingFace dataset repo ID")
     use_xet: bool = Field(
-        False,
-        description = "Enable Xet parallel chunked transport. Default False uses HTTP Range-resume.",
+        True,
+        description = "Use Xet parallel chunked transport. Default True; set False for HTTP Range-resume.",
     )
 
 

--- a/studio/backend/hub/services/datasets/downloads.py
+++ b/studio/backend/hub/services/datasets/downloads.py
@@ -157,7 +157,8 @@ async def download_dataset_response(
     repo_id = await asyncio.to_thread(resolve_cached_repo_id_case, repo_id, repo_type = "dataset")
     key = _download_job_key(repo_id)
 
-    transport = download_lifecycle.resolve_transport(body.use_xet)
+    use_xet = download_lifecycle.resolve_effective_use_xet(body.use_xet)
+    transport = download_lifecycle.resolve_transport(use_xet)
 
     claimed, claim_state = _registry.claim(
         key,
@@ -183,7 +184,7 @@ async def download_dataset_response(
         spawn = lambda: download_lifecycle.spawn_worker(
             ["--repo-id", repo_id, "--dataset"],
             hf_token,
-            use_xet = body.use_xet,
+            use_xet = use_xet,
         ),
         hf_token = hf_token,
         label = repo_id,

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -29,13 +29,8 @@ def backend_dir() -> Path:
 
 
 def resolve_effective_use_xet(use_xet: bool) -> bool:
-    """Downgrade an Xet request to HTTP when hf_xet is unavailable.
-
-    The default transport is Xet; this keeps a defaulted (or explicit) Xet
-    request from hard-failing on installs without the Xet extra, mirroring the
-    frontend's own downgrade. Callers feed the result to both resolve_transport
-    and spawn_worker so the chosen transport and the worker env never disagree.
-    """
+    """Downgrade an Xet request to HTTP when hf_xet is unavailable, so a defaulted
+    or explicit Xet request never hard-fails on installs without the Xet extra."""
     if not use_xet:
         return False
     reason = download_registry.download_transport_unavailable_reason(

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import subprocess
@@ -20,9 +21,30 @@ from hub.utils import inventory_scan as hf_cache_scan
 from hub.utils.hf_cache_state import EXIT_CANCELLED
 from hub.utils.state_dir import RepoType
 
+logger = logging.getLogger(__name__)
+
 
 def backend_dir() -> Path:
     return Path(__file__).resolve().parent.parent.parent
+
+
+def resolve_effective_use_xet(use_xet: bool) -> bool:
+    """Downgrade an Xet request to HTTP when hf_xet is unavailable.
+
+    The default transport is Xet; this keeps a defaulted (or explicit) Xet
+    request from hard-failing on installs without the Xet extra, mirroring the
+    frontend's own downgrade. Callers feed the result to both resolve_transport
+    and spawn_worker so the chosen transport and the worker env never disagree.
+    """
+    if not use_xet:
+        return False
+    reason = download_registry.download_transport_unavailable_reason(
+        download_registry.TRANSPORT_XET
+    )
+    if reason is None:
+        return True
+    logger.warning("Xet transport unavailable, falling back to HTTP: %s", reason)
+    return False
 
 
 def resolve_transport(use_xet: bool) -> str:

--- a/studio/backend/hub/services/models/downloads.py
+++ b/studio/backend/hub/services/models/downloads.py
@@ -64,7 +64,7 @@ def _spawn_download_worker(
     repo_id: str,
     variant: Optional[str],
     hf_token: Optional[str],
-    use_xet: bool = False,
+    use_xet: bool = True,
     protected_blob_hashes: Optional[frozenset[str]] = None,
 ) -> subprocess.Popen:
     args = ["--repo-id", repo_id]

--- a/studio/backend/hub/services/models/downloads.py
+++ b/studio/backend/hub/services/models/downloads.py
@@ -96,7 +96,8 @@ async def download_model_response(body: DownloadModelRequest, hf_token: Optional
             detail = f"Invalid gguf_variant: {variant!r}",
         )
     key = _download_job_key(repo_id, variant)
-    transport = download_lifecycle.resolve_transport(body.use_xet)
+    use_xet = download_lifecycle.resolve_effective_use_xet(body.use_xet)
+    transport = download_lifecycle.resolve_transport(use_xet)
     variant_blob_hashes = frozenset()
     variant_progress_blob_hashes = frozenset()
     completed_baseline_bytes = 0
@@ -171,7 +172,7 @@ async def download_model_response(body: DownloadModelRequest, hf_token: Optional
             repo_id,
             variant,
             hf_token,
-            use_xet = body.use_xet,
+            use_xet = use_xet,
             protected_blob_hashes = protected_blob_hashes,
         ),
         hf_token = hf_token,

--- a/studio/backend/hub/tests/test_download_lifecycle.py
+++ b/studio/backend/hub/tests/test_download_lifecycle.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from hub.services import download_lifecycle
+
+
+def _set_xet_reason(monkeypatch, reason):
+    # Drive resolve_effective_use_xet without needing hf_xet installed.
+    monkeypatch.setattr(
+        download_lifecycle.download_registry,
+        "download_transport_unavailable_reason",
+        lambda _transport: reason,
+    )
+
+
+def test_resolve_effective_use_xet_keeps_http_when_not_requested(monkeypatch):
+    _set_xet_reason(monkeypatch, "should not be consulted")
+    assert download_lifecycle.resolve_effective_use_xet(False) is False
+
+
+def test_resolve_effective_use_xet_keeps_xet_when_available(monkeypatch):
+    _set_xet_reason(monkeypatch, None)
+    assert download_lifecycle.resolve_effective_use_xet(True) is True
+
+
+def test_resolve_effective_use_xet_downgrades_when_xet_unavailable(monkeypatch):
+    # A defaulted/explicit Xet request must fall back to HTTP, not raise.
+    _set_xet_reason(monkeypatch, "Xet transport is unavailable because hf_xet is not installed.")
+    assert download_lifecycle.resolve_effective_use_xet(True) is False

--- a/studio/backend/hub/tests/test_download_lifecycle.py
+++ b/studio/backend/hub/tests/test_download_lifecycle.py
@@ -5,7 +5,6 @@ from hub.services import download_lifecycle
 
 
 def _set_xet_reason(monkeypatch, reason):
-    # Drive resolve_effective_use_xet without needing hf_xet installed.
     monkeypatch.setattr(
         download_lifecycle.download_registry,
         "download_transport_unavailable_reason",
@@ -24,6 +23,5 @@ def test_resolve_effective_use_xet_keeps_xet_when_available(monkeypatch):
 
 
 def test_resolve_effective_use_xet_downgrades_when_xet_unavailable(monkeypatch):
-    # A defaulted/explicit Xet request must fall back to HTTP, not raise.
     _set_xet_reason(monkeypatch, "Xet transport is unavailable because hf_xet is not installed.")
     assert download_lifecycle.resolve_effective_use_xet(True) is False

--- a/studio/frontend/src/features/hub/download-manager/constants.ts
+++ b/studio/frontend/src/features/hub/download-manager/constants.ts
@@ -8,7 +8,8 @@ export const TRANSPORT = {
 
 export const TRANSPORT_MODES = [TRANSPORT.HTTP, TRANSPORT.XET] as const;
 export type TransportMode = (typeof TRANSPORT_MODES)[number];
-export const DEFAULT_TRANSPORT_MODE: TransportMode = TRANSPORT.HTTP;
+// Xet by default; effectiveTransportMode() downgrades to HTTP if hf_xet is missing.
+export const DEFAULT_TRANSPORT_MODE: TransportMode = TRANSPORT.XET;
 
 export function isTransportMode(value: unknown): value is TransportMode {
   return (


### PR DESCRIPTION
### Summary

Make Hub downloads use the Xet transport by default instead of HTTP, so model and dataset pulls get faster parallel chunked transfers out of the box. Inference and training model loads were already Xet-first (with an HTTP fallback on stall); this brings explicit Hub downloads in line with the rest of Studio.

### Changes

- **Frontend:** `DEFAULT_TRANSPORT_MODE` is now `Xet`. A user with no saved transport preference starts on Xet, and the toggle still lets them switch to HTTP per repo. `effectiveTransportMode()` already downgrades to HTTP and shows a warning toast when `hf_xet` is unavailable, so machines without Xet keep working with no hard failure.
- **Backend:** `DownloadModelRequest.use_xet` and `DownloadDatasetRequest.use_xet` now default to `True`, keeping the API in step with the UI. Callers can still pass `use_xet=False` for sequential HTTP Range-resume.
- Aligned the internal `_spawn_download_worker` default to `True` so no path silently falls back to HTTP.

### Safety

- The Xet download path is already a first-class, tested transport (the toggle has shipped Xet as an option); this only changes the default starting preference.
- Graceful degradation is unchanged: if `hf_xet` is not installed, the start flow resolves to HTTP and warns, rather than erroring.
- Existing per-repo transport-conflict handling (a live HTTP partial is not discarded mid-transfer) is untouched.

### Verification

- `npm run typecheck` and `npm run build` pass.
- Backend schema check confirms `DownloadModelRequest(...).use_xet` and `DownloadDatasetRequest(...).use_xet` both resolve to `True`.
