### PR TITLE
Studio: square off the sidebar profile button hover so it isn't a pill

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1286,7 +1286,7 @@ export function AppSidebar() {
                 <SidebarMenuButton
                   size="lg"
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
-                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-full group-data-[collapsible=icon]:!size-[34px] group-data-[collapsible=icon]:!p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
+                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-[5px] group-data-[collapsible=icon]:!size-[34px] group-data-[collapsible=icon]:!rounded-full group-data-[collapsible=icon]:!p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
                 >
                   <div className="flex shrink-0 items-center">
                     <UserAvatar


### PR DESCRIPTION
## What

The account/profile button at the bottom of the sidebar (avatar + name + settings cog) was using `rounded-full`, so its hover/open background rendered as a fully rounded pill. That looks off against the rest of the nav, which uses soft rounded rectangles.

This switches the expanded button to `rounded-[5px]` so the hover background is a clean rounded rectangle instead of a pill.

## Details

- `studio/frontend/src/components/app-sidebar.tsx`: profile `SidebarMenuButton` className `rounded-full` -> `rounded-[5px]`.
- Added `group-data-[collapsible=icon]:!rounded-full` so the collapsed icon-only state stays a circle around the round avatar, rather than becoming a squircle.

## Before / after

- Before: expanded profile button hover is a full pill.
- After: expanded profile button hover is a rounded rectangle; collapsed state is unchanged (still circular).

No behavior changes, styling only.