### PR TITLE
Studio: set sidebar profile button radius to 14px

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1286,7 +1286,7 @@ export function AppSidebar() {
                 <SidebarMenuButton
                   size="lg"
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
-                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-[5px] group-data-[collapsible=icon]:!size-[34px] group-data-[collapsible=icon]:!rounded-full group-data-[collapsible=icon]:!p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
+                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-[14px] group-data-[collapsible=icon]:!size-[34px] group-data-[collapsible=icon]:!rounded-full group-data-[collapsible=icon]:!p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
                 >
                   <div className="flex shrink-0 items-center">
                     <UserAvatar


### PR DESCRIPTION
## What

Follow-up to #6443. The sidebar profile button was left at `rounded-[5px]`, which looked nearly square on its 44px-tall row. This sets it to `rounded-[14px]` so it matches the radius used by the other nav/chat rows while staying short of a full pill.

## Details

- `studio/frontend/src/components/app-sidebar.tsx`: profile `SidebarMenuButton` className `rounded-[5px]` -> `rounded-[14px]`.
- Collapsed icon-only state still pinned to `!rounded-full`, so the avatar stays circular when the sidebar is collapsed.

No behavior changes, styling only.