### PR TITLE
Studio: gate the MTP target-KV reserve to MTP spec mode, not just MLA

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2840,12 +2840,16 @@ class LlamaCppBackend:
         drafter_path: Optional[str] = None,
         draft_weights_bytes: int = 0,
         n_parallel: int = 1,
+        mtp_keeps_target_ctx: bool = True,
     ) -> Optional[int]:
         """MTP draft reserve at ``n_ctx`` = draft KV (grows with ctx) + separate-
-        drafter weights + (MLA only) a duplicated target KV context. The verify
-        buffer rides in the ctx-fit headroom (no tuned constant). None when the
-        draft KV can't be sized (caller keeps the flat fallback).
-        ``draft_weights_bytes`` is the drafter file size (0 for embedded)."""
+        drafter weights + (MTP + MLA only) a duplicated target KV context. The
+        verify buffer rides in the ctx-fit headroom (no tuned constant). None when
+        the draft KV can't be sized (caller keeps the flat fallback).
+        ``draft_weights_bytes`` is the drafter file size (0 for embedded).
+        ``mtp_keeps_target_ctx`` is True for MTP draft modes (which keep the
+        duplicated target context) and False for separate-drafter spec modes
+        (draft-simple/draft-eagle3), which do not."""
         draft_kv = self._mtp_draft_kv_bytes(
             n_ctx,
             drafter_path = drafter_path,
@@ -2854,16 +2858,19 @@ class LlamaCppBackend:
             n_parallel = n_parallel,
         )
         weights = max(0, draft_weights_bytes)
-        # MLA models (GLM-5.x, DeepSeek, Kimi-K2) keep a *second* full copy of the
-        # target model's KV context for MTP draft verification -- llama.cpp's
+        # MLA models (GLM-5.x, DeepSeek, Kimi-K2) under MTP keep a *second* full copy
+        # of the target model's KV context for draft verification -- llama.cpp's
         # `ctx_tgt=yes` -- allocated at f16 regardless of the main cache type. It is
         # ~the main KV again and dwarfs the embedded draft head (GLM-5.2 @ 1M ctx:
         # a ~2 GiB head next to a ~89 GiB target copy), so omitting it lets auto-fit
         # pick a context that fits on paper but OOMs cublasCreate at the first
-        # decode. Non-MLA MTP (Qwen/Gemma) keeps no such copy, so this is gated
-        # strictly on MLA (kv_lora_rank present) and leaves those models unchanged.
+        # decode. Gated on both MLA (kv_lora_rank present) and the engaged mode
+        # actually being MTP: non-MLA MTP (Qwen/Gemma) keeps no such copy, and the
+        # separate-drafter spec modes (draft-simple/draft-eagle3) load a small
+        # distinct drafter with its own KV -- already counted in draft_kv/weights --
+        # rather than duplicating the target, so they must not be charged for it.
         target_ctx_copy = 0
-        if self._kv_lora_rank is not None:
+        if mtp_keeps_target_ctx and self._kv_lora_rank is not None:
             target_ctx_copy = self._estimate_kv_cache_bytes(n_ctx, "f16", n_parallel = n_parallel)
         if draft_kv is None:
             # KV unsized (exotic/remote drafter): still reserve known weights + any
@@ -4835,25 +4842,31 @@ class LlamaCppBackend:
                         except Exception:
                             _mtp_binary_ok = False
                             _mtp_probe_raised = True
-                    _mtp_will_engage = bool(
-                        _user_mtp_via_extras
-                        or _user_draft_via_extras
-                        or (
-                            not _extra_args_set_spec_type(extra_args)
-                            and _mtp_model_for_fit
-                            and (
-                                _mtp_effective in ("mtp", "mtp+ngram")
-                                or (_mtp_effective == "auto" and not _mtp_sub_3b_for_fit)
-                            )
-                            and (
-                                _mtp_binary_ok
-                                # Reserve on a raised (uncached) probe too: it re-probes in
-                                # _build_speculative_flags and may still engage MTP (embedded
-                                # head or separate drafter -- _mtp_model_for_fit covers both).
-                                or _mtp_probe_raised
-                            )
+                    _auto_studio_mtp = (
+                        not _extra_args_set_spec_type(extra_args)
+                        and _mtp_model_for_fit
+                        and (
+                            _mtp_effective in ("mtp", "mtp+ngram")
+                            or (_mtp_effective == "auto" and not _mtp_sub_3b_for_fit)
+                        )
+                        and (
+                            _mtp_binary_ok
+                            # Reserve on a raised (uncached) probe too: it re-probes in
+                            # _build_speculative_flags and may still engage MTP (embedded
+                            # head or separate drafter -- _mtp_model_for_fit covers both).
+                            or _mtp_probe_raised
                         )
                     )
+                    _mtp_will_engage = bool(
+                        _user_mtp_via_extras or _user_draft_via_extras or _auto_studio_mtp
+                    )
+                    # The duplicated full target-KV copy (ctx_tgt) is an MTP-only
+                    # cost: the MTP head runs a second context over the target
+                    # model's own KV geometry. The separate-drafter spec modes
+                    # (draft-simple/draft-eagle3, reached via _user_draft_via_extras)
+                    # load a small distinct drafter with its own KV and keep no such
+                    # copy, so only charge it when the engaged mode is truly MTP.
+                    _engaged_is_mtp = bool(_user_mtp_via_extras or _auto_studio_mtp)
 
                     # Effective draft depth: extras win (last-wins at launch), else
                     # the field, else the platform default (2 GPU / 3 CPU).
@@ -4922,6 +4935,7 @@ class LlamaCppBackend:
                                 drafter_path = _mtp_draft_for_budget,
                                 draft_weights_bytes = _mtp_draft_weights,
                                 n_parallel = n_parallel,
+                                mtp_keeps_target_ctx = _engaged_is_mtp,
                             )
                             is not None
                         ):
@@ -4937,6 +4951,7 @@ class LlamaCppBackend:
                                 _dp: Optional[str] = _mtp_draft_for_budget,
                                 _w: int = _mtp_draft_weights,
                                 _np: int = n_parallel,
+                                _mtp: bool = _engaged_is_mtp,
                             ) -> int:
                                 v = self._estimate_mtp_overhead_bytes(
                                     ctx,
@@ -4946,6 +4961,7 @@ class LlamaCppBackend:
                                     drafter_path = _dp,
                                     draft_weights_bytes = _w,
                                     n_parallel = _np,
+                                    mtp_keeps_target_ctx = _mtp,
                                 )
                                 return v if v is not None else 0
 

--- a/studio/backend/tests/test_mtp_mla_target_ctx.py
+++ b/studio/backend/tests/test_mtp_mla_target_ctx.py
@@ -172,6 +172,22 @@ class TestMlaTargetCtxReserve:
         ctx = 131072
         assert mla._estimate_mtp_overhead_bytes(ctx) > non._estimate_mtp_overhead_bytes(ctx)
 
+    def test_separate_drafter_mode_drops_target_copy(self):
+        # The duplicated target context is MTP-only. draft-simple / draft-eagle3
+        # load a small separate drafter with its own KV (counted in the draft KV)
+        # and keep no target copy, so even on an MLA model the reserve must drop
+        # the f16 copy when mtp_keeps_target_ctx=False -- which is what the loader
+        # threads for those modes. The default (True) keeps the MTP copy.
+        b = _make_mla_backend()
+        ctx = 262144
+        mtp = b._estimate_mtp_overhead_bytes(ctx)  # default True == MTP draft
+        separate = b._estimate_mtp_overhead_bytes(ctx, mtp_keeps_target_ctx = False)
+        # Separate-drafter overhead is exactly the draft KV (no target copy)...
+        assert separate == b._mtp_draft_kv_bytes(ctx)
+        # ...and the MTP reserve is that plus the full f16 target copy.
+        assert mtp == separate + b._estimate_kv_cache_bytes(ctx, "f16")
+        assert mtp > separate
+
 
 class TestMlaFitPreventsOom:
     """The corrected reserve must actually lower the auto-fit context so the
@@ -200,7 +216,7 @@ class TestMlaFitPreventsOom:
             self.MODEL_BYTES,
             mtp_engaged = True,
             total_mib = self.TOTAL_MIB,
-            mtp_overhead_fn = lambda c: (b._mtp_draft_kv_bytes(c) or 0),
+            mtp_overhead_fn = lambda c: b._mtp_draft_kv_bytes(c) or 0,
         )
         assert draft_only == self.REQ_CTX  # reproduces the over-advertised context
         assert with_copy < self.REQ_CTX  # corrected reserve backs the context off


### PR DESCRIPTION
## Summary

Follow-up to #6447. That PR reserves a duplicated f16 copy of the target model's KV context for MLA models under MTP speculative decoding (llama.cpp's `ctx_tgt`), which fixed the GLM-5.2 first-decode OOM. The reserve was gated only on MLA (`kv_lora_rank` present), but `_estimate_mtp_overhead_bytes` is also reached for the separate-drafter spec modes (`draft-simple` / `draft-eagle3`) via `_user_draft_via_extras`. Those modes load a small distinct drafter with its own KV (already counted in the draft KV + drafter weights) and keep no duplicated full target context; only MTP runs a second context over the target model's own KV geometry.

So on an MLA model, selecting `--spec-type draft-simple` or `draft-eagle3` through the extra-args field charged a full ~main-KV-sized f16 copy (tens of GiB) that those modes never allocate, needlessly backing off the advertised context. That is the same under-advertising #6312 set out to fix, just in the opposite direction. It is in the safe direction (over-reserve, never OOM) but a real regression for that configuration.

## Fix

Thread `mtp_keeps_target_ctx` through `_estimate_mtp_overhead_bytes` (True for MTP draft modes, False for the separate-drafter modes) and derive `_engaged_is_mtp` at the fit call site, so the target copy is added only when the engaged spec mode is actually MTP.

- MLA + MTP (GLM-5.2 / DeepSeek / Kimi) is unchanged: the GLM-5.2 OOM fix is preserved.
- Non-MLA MTP (Qwen / Gemma) was already unaffected (gated on `kv_lora_rank`) and stays so.
- MLA + `draft-simple` / `draft-eagle3` no longer pays the target copy.

## Test

`test_mtp_mla_target_ctx.py` adds `test_separate_drafter_mode_drops_target_copy`: on an MLA backend the separate-drafter reserve collapses to exactly the draft KV (no target copy), while the default MTP path keeps draft KV + the full f16 target copy.

Addresses the Codex review on #6447 (`r3437715720`). Existing MTP budget + MLA reserve suites pass (134 tests).
