### PR TITLE
fix: CLI emits "--no-secure" to match run.py argparse

### DIFF
--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -798,7 +798,7 @@ def studio_default(
                 args.append("--api-only")
             # Forward the explicit polarity (matches run.py's BooleanOptionalAction).
             args.append("--cloudflare" if cloudflare else "--no-cloudflare")
-            args.append("--secure" if secure else "--not-secure")
+            args.append("--secure" if secure else "--no-secure")
             # Forward an explicit tool policy; None -> run.py leaves it unset (tools on).
             if enable_tools is True:
                 args.append("--enable-tools")
@@ -1189,7 +1189,7 @@ def run(
         args.extend(["--parallel", str(parallel)])
         # Forward the explicit polarity (same rationale as --load-in-4bit above).
         args.append("--cloudflare" if cloudflare else "--no-cloudflare")
-        args.append("--secure" if secure else "--not-secure")
+        args.append("--secure" if secure else "--no-secure")
         args.append("--tensor-parallel" if tensor_parallel else "--no-tensor-parallel")
         if verbose:
             args.append("--verbose")

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1189,7 +1189,7 @@ def run(
         args.extend(["--parallel", str(parallel)])
         # Forward the explicit polarity (same rationale as --load-in-4bit above).
         args.append("--cloudflare" if cloudflare else "--no-cloudflare")
-        args.append("--secure" if secure else "--no-secure")
+        args.append("--secure" if secure else "--not-secure")
         args.append("--tensor-parallel" if tensor_parallel else "--no-tensor-parallel")
         if verbose:
             args.append("--verbose")


### PR DESCRIPTION
## Summary
 
`unsloth studio` fails to launch on a default invocation, dying at argument parsing:
 
```
run.py: error: unrecognized arguments: --not-secure
```
 
The CLI (`unsloth_cli/commands/studio.py`) forwards `--not-secure` to the backend in two places, but `studio/backend/run.py`'s argparse only registers `--secure | --no-secure` (`BooleanOptionalAction`). Any launch without `--secure` takes the `else` branch, emits `--not-secure`, and the backend rejects it.
 
This aligns the CLI with the backend flag name. It also matches the adjacent `--cloudflare`/`--no-cloudflare` forwarding right above it, which already uses the `--no-` polarity.
 
## Changes
 
`unsloth_cli/commands/studio.py`, lines 801 and 1192:
 
```diff
-args.append("--secure" if secure else "--not-secure")
+args.append("--secure" if secure else "--no-secure")
```
 
## Reproduction
 
On a clean `pip install unsloth` (2026.6.8), macOS / Apple Silicon:
 
```
unsloth studio -p 9999
# -> run.py: error: unrecognized arguments: --not-secure
```
 
## Verification
 
With the patch applied, `unsloth studio -p 9999` launches fully — server starts, frontend loads, `/api/health` returns 200, model list and endpoints all respond. Observed working on 2026.6.8; the same default launch works on my older 2026.6.2 global install, so this appears to have regressed between those versions.
 
## Notes
 
- If `--not-secure` was ever a documented/user-facing flag, happy to also add it as a back-compat alias in `run.py` so existing invocations keep working — let me know which you'd prefer.
- Possibly worth a small integration test that feeds the CLI's forwarded args through the backend parser; the existing `test_studio_secure_flag.py` only checks the CLI side, which is why this stayed green.
 