### PR TITLE
studio/frontend: align custom titlebar sidebar surface with the real sidebar

### DIFF
--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { SIDEBAR_WIDTH, SIDEBAR_WIDTH_ICON } from "@/components/ui/sidebar";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
@@ -243,8 +244,11 @@ export function WindowTitlebar({
       >
         {showSidebarSurface && (
           <div
-            className="h-full shrink-0 border-r border-sidebar-border bg-sidebar"
-            style={{ width: pinned ? "16rem" : "3rem" }}
+            className={cn(
+              "h-full shrink-0 border-r border-sidebar-border dark:border-r-0",
+              pinned ? "bg-sidebar" : "bg-white dark:bg-background",
+            )}
+            style={{ width: pinned ? SIDEBAR_WIDTH : SIDEBAR_WIDTH_ICON }}
             onMouseDown={handleDragMouseDown}
             onDoubleClick={handleDragDoubleClick}
             aria-hidden="true"

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -766,4 +766,6 @@ export {
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_ICON,
 }


### PR DESCRIPTION
On Windows and Linux the desktop app draws its own titlebar (native decorations are off). The left part of that titlebar paints a "sidebar surface" strip so the sidebar appears to extend up into the titlebar. The strip didn't match the real sidebar below it, so the top of the sidebar was visibly offset.

## Before

<img width="1193" height="825" alt="image" src="https://github.com/user-attachments/assets/ba94224e-6192-4dbc-9906-abec6683892c" />

## After

<img width="1186" height="823" alt="image" src="https://github.com/user-attachments/assets/4a215590-0b6f-4492-8756-4744bcce1cda" />

## Problem

The strip was styled with hardcoded values that drifted from the real sidebar:

- Width was `16rem` while the sidebar is `17.5rem` (`SIDEBAR_WIDTH`), so the strip was 24px too narrow and the right edge didn't line up.
- The strip always drew a right border, but the sidebar drops it in dark mode (`dark:border-r-0`), leaving a stray vertical line at the top.
- When collapsed in dark mode the sidebar paints `bg-background`, but the strip stayed `bg-sidebar`, so the strip was a lighter gray than the sidebar below it.

## Fix

Source the strip's dimensions and styling from the sidebar instead of re-typing them:

- Import `SIDEBAR_WIDTH` / `SIDEBAR_WIDTH_ICON` for the width (the CSS vars aren't in scope here, since the titlebar renders above `SidebarProvider`).
- Add `dark:border-r-0` to match the sidebar's border in both themes.
- Match the background per state: `bg-sidebar` when expanded, `bg-white dark:bg-background` when collapsed.

The strip now matches the real sidebar across all four states (expanded/collapsed, light/dark).
