### PR TITLE
studio/frontend: Prevent staged model's load settings from disappearing while it loads

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1607,6 +1607,17 @@ export function ChatPage({
         await selectModel(selection);
         return;
       }
+      // A load (or a cancel's background unload) is in flight. Staging a new
+      // pick now would queue it behind the active load, and the post-load
+      // cleanup would then silently drop it, so refuse and ask the user to
+      // wait. (The immediate-load branch above is already guarded inside
+      // selectModel; store.stageModel below also no-ops while loading.)
+      if (store.modelLoading) {
+        toast.info("Another model is already loading", {
+          description: "Wait for it to finish or cancel it first.",
+        });
+        return;
+      }
       // Tear down any existing staged pick first so its in-flight download is
       // cancelled, not left running after we rebind to the new pick.
       abandonStaged();

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2489,6 +2489,7 @@ export function ChatPage({
           );
         }}
         externalProviderType={activeExternalProviderType}
+        loadingModel={loadingModel}
         onReloadModel={() => {
           const state = useChatRuntimeStore.getState();
           if (state.params.checkpoint) {
@@ -2506,22 +2507,23 @@ export function ChatPage({
           if (!pending) return;
           const keyAtLoad = chatContextKey;
           // forceReload: the staged model isn't loaded yet, so bypass the
-          // same-checkpoint dedupe (and selectModel clears pendingSelection).
-          // keepSpeculative: honor the speculative mode set on the sidebar.
+          // same-checkpoint dedupe. keepSpeculative: honor the speculative mode
+          // set on the sidebar.
           void selectModel({
             ...pending,
             forceReload: true,
             keepSpeculative: true,
             throwOnError: true,
           }).catch(() => {
-            // Recoverable failure (expired token, gated repo, OOM…): selectModel
-            // cleared the pick but left the edited knobs intact.
+            // Recoverable failure (expired token, gated repo, OOM…): the pick is
+            // cleared only on success, so it normally stays staged with edited
+            // knobs intact — nothing to restore.
             const store = useChatRuntimeStore.getState();
-            // A pick staged meanwhile owns the knobs now; leave it untouched.
+            // Still staged (this pick, or a newer one queued meanwhile): leave it.
             if (store.pendingSelection) return;
-            // Restore (not re-stage, which would reset the knobs) only if the
-            // staged-load is still wanted: same chat context, sheet still open,
-            // page still mounted.
+            // Cleared mid-load (sheet closed / switched chats). Re-stage only if
+            // the staged-load is still wanted: same chat context, sheet still
+            // open, page still mounted.
             const stillWanted =
               mountedRef.current &&
               store.settingsPanelOpen &&

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1607,11 +1607,8 @@ export function ChatPage({
         await selectModel(selection);
         return;
       }
-      // A load (or a cancel's background unload) is in flight. Staging a new
-      // pick now would queue it behind the active load, and the post-load
-      // cleanup would then silently drop it, so refuse and ask the user to
-      // wait. (The immediate-load branch above is already guarded inside
-      // selectModel; store.stageModel below also no-ops while loading.)
+      // Refuse staging while a load is in flight (it would be silently dropped);
+      // the immediate-load branch above is already guarded in selectModel.
       if (store.modelLoading) {
         toast.info("Another model is already loading", {
           description: "Wait for it to finish or cancel it first.",

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -52,6 +52,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Slider } from "@/components/ui/slider";
+import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { InfoHint } from "@/components/ui/info-hint";
@@ -438,6 +439,10 @@ interface ChatSettingsPanelProps {
    */
   externalProviderType?: string | null;
   onReloadModel?: () => void;
+  /** The in-flight load (id + native path token), or null when idle. Used to
+   *  show a loading state for the staged pick only — not for an unrelated load
+   *  or a cancel's background unload. */
+  loadingModel?: { id: string; nativePathToken?: string | null } | null;
   /** Loads the staged `pendingSelection` (deferred "Load on selection" flow). */
   onLoadPendingModel?: () => void;
   /** Download progress (0–1) for a staged GGUF being fetched, or null when idle. */
@@ -457,6 +462,7 @@ export function ChatSettingsPanel({
   onExternalProviderChange,
   externalProviderType = null,
   onReloadModel,
+  loadingModel = null,
   onLoadPendingModel,
   stagedDownloadFraction,
   onCancelStagedDownload,
@@ -475,6 +481,17 @@ export function ChatSettingsPanel({
     !isExternalModel || Boolean(providerCapabilities?.presencePenalty);
   const isMobile = useIsMobile();
   const pendingSelection = useChatRuntimeStore((s) => s.pendingSelection);
+  // "Loading" only when the in-flight load IS this pick (not an unrelated load
+  // or a cancel's background unload). Matched on id + native token only:
+  // loadingModel carries no ggufVariant, but a variant mismatch would have
+  // abandoned the stage before load, so a surviving pendingSelection here always
+  // shares the loading pick's variant.
+  const stagedLoading =
+    pendingSelection != null &&
+    loadingModel != null &&
+    loadingModel.id === pendingSelection.id &&
+    (loadingModel.nativePathToken ?? null) ===
+      (pendingSelection.nativePathToken ?? null);
   const abandonStagedModel = useChatRuntimeStore((s) => s.abandonStagedModel);
   const resetModelSettingsToLoaded = useChatRuntimeStore(
     (s) => s.resetModelSettingsToLoaded,
@@ -856,10 +873,14 @@ export function ChatSettingsPanel({
             {pendingSelection && (
               <Alert className="rounded-[14px] border-primary/30 bg-primary/5 px-3 py-2">
                 <AlertTitle className="text-[12px] font-medium">
-                  {stagedLabel} is staged, not loaded yet
+                  {stagedLoading
+                    ? `Loading ${stagedLabel}…`
+                    : `${stagedLabel} is staged, not loaded yet`}
                 </AlertTitle>
                 <AlertDescription className="text-[11.5px] leading-[1.45] text-muted-foreground">
-                  Set the options below, then choose Load model to load it.
+                  {stagedLoading
+                    ? "Applying your settings."
+                    : "Set the options below, then choose Load model to load it."}
                 </AlertDescription>
               </Alert>
             )}
@@ -1103,31 +1124,44 @@ export function ChatSettingsPanel({
                     {Math.round((stagedDownloadFraction ?? 0) * 100)}%
                   </p>
                 )}
-                <div className="flex flex-wrap gap-1.5">
+                {stagedLoading ? (
+                  // Mid-load: nothing to load or abandon until it settles, so disable.
                   <Button
                     type="button"
-                    onClick={() => onLoadPendingModel?.()}
-                    disabled={stagedDownloading}
+                    disabled
                     size="sm"
-                    className="h-7 px-3 text-[12px] font-medium tracking-nav bg-primary/92 text-primary-foreground hover:bg-primary"
+                    className="h-7 w-fit px-3 text-[12px] font-medium tracking-nav bg-primary/92 text-primary-foreground hover:bg-primary"
                   >
-                    Load model
+                    <Spinner className="size-3.5" />
+                    Loading…
                   </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      // Cancel abandons the stage; if a download is mid-flight,
-                      // stop it too rather than leaving it running headless.
-                      if (stagedDownloading) onCancelStagedDownload?.();
-                      abandonStagedModel();
-                    }}
-                    className="h-7 px-3 text-[12px] font-medium tracking-nav text-muted-foreground"
-                  >
-                    Cancel
-                  </Button>
-                </div>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5">
+                    <Button
+                      type="button"
+                      onClick={() => onLoadPendingModel?.()}
+                      disabled={stagedDownloading}
+                      size="sm"
+                      className="h-7 px-3 text-[12px] font-medium tracking-nav bg-primary/92 text-primary-foreground hover:bg-primary"
+                    >
+                      Load model
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        // Cancel abandons the stage; if a download is mid-flight,
+                        // stop it too rather than leaving it running headless.
+                        if (stagedDownloading) onCancelStagedDownload?.();
+                        abandonStagedModel();
+                      }}
+                      className="h-7 px-3 text-[12px] font-medium tracking-nav text-muted-foreground"
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                )}
               </div>
             ) : modelSettingsDirty ? (
               <div className="flex flex-wrap gap-1.5">

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1147,11 +1147,11 @@ export function ChatSettingsPanel({
                       onClick={() => onLoadPendingModel?.()}
                       // A DIFFERENT model is mid-load (loadingModel is set but
                       // doesn't match this staged pick -- stagedLoading is false).
-                      // Block the click: selectModel's in-flight-load guard keys
-                      // on id + native token, so a different GGUF variant of the
-                      // same repo would be silently deduped to a no-op, leaving an
-                      // enabled button that does nothing. The stage stays put;
-                      // retry once the in-flight load settles.
+                      // Disable rather than leave an enabled button that can't act:
+                      // selectModel refuses to start a second concurrent load while
+                      // one is in flight, so the click would only surface a "wait
+                      // or cancel first" toast. The stage stays put; retry once the
+                      // in-flight load settles.
                       disabled={stagedDownloading || loadingModel != null}
                       size="sm"
                       className="h-7 px-3 text-[12px] font-medium tracking-nav bg-primary/92 text-primary-foreground hover:bg-primary"

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -100,6 +100,7 @@ import {
 } from "./provider-capabilities";
 import {
   isPendingGguf,
+  pendingSelectionMatches,
   useChatRuntimeStore,
 } from "./stores/chat-runtime-store";
 import { RetrievalSettingsSection } from "@/features/rag/components/retrieval-settings-section";
@@ -439,10 +440,14 @@ interface ChatSettingsPanelProps {
    */
   externalProviderType?: string | null;
   onReloadModel?: () => void;
-  /** The in-flight load (id + native path token), or null when idle. Used to
-   *  show a loading state for the staged pick only — not for an unrelated load
-   *  or a cancel's background unload. */
-  loadingModel?: { id: string; nativePathToken?: string | null } | null;
+  /** The in-flight load (id + GGUF variant + native path token), or null when
+   *  idle. Used to show a loading state for the staged pick only — not for an
+   *  unrelated load or a cancel's background unload. */
+  loadingModel?: {
+    id: string;
+    ggufVariant?: string | null;
+    nativePathToken?: string | null;
+  } | null;
   /** Loads the staged `pendingSelection` (deferred "Load on selection" flow). */
   onLoadPendingModel?: () => void;
   /** Download progress (0–1) for a staged GGUF being fetched, or null when idle. */
@@ -481,17 +486,17 @@ export function ChatSettingsPanel({
     !isExternalModel || Boolean(providerCapabilities?.presencePenalty);
   const isMobile = useIsMobile();
   const pendingSelection = useChatRuntimeStore((s) => s.pendingSelection);
-  // "Loading" only when the in-flight load IS this pick (not an unrelated load
-  // or a cancel's background unload). Matched on id + native token only:
-  // loadingModel carries no ggufVariant, but a variant mismatch would have
-  // abandoned the stage before load, so a surviving pendingSelection here always
-  // shares the loading pick's variant.
+  // "Loading" only when the in-flight load IS this staged pick (full id + GGUF
+  // variant + native token match), not an unrelated load or a cancel's
+  // background unload. The variant matters: a different quant of the same repo
+  // staged mid-load must not read as this one loading.
   const stagedLoading =
-    pendingSelection != null &&
     loadingModel != null &&
-    loadingModel.id === pendingSelection.id &&
-    (loadingModel.nativePathToken ?? null) ===
-      (pendingSelection.nativePathToken ?? null);
+    pendingSelectionMatches(pendingSelection, {
+      id: loadingModel.id,
+      ggufVariant: loadingModel.ggufVariant,
+      nativePathToken: loadingModel.nativePathToken,
+    });
   const abandonStagedModel = useChatRuntimeStore((s) => s.abandonStagedModel);
   const resetModelSettingsToLoaded = useChatRuntimeStore(
     (s) => s.resetModelSettingsToLoaded,

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -147,6 +147,7 @@ function NumericValueInput({
   className,
   ariaLabel,
   size: sizeAttr,
+  disabled = false,
 }: {
   value: number;
   min?: number;
@@ -157,6 +158,7 @@ function NumericValueInput({
   className?: string;
   ariaLabel?: string;
   size?: number;
+  disabled?: boolean;
 }) {
   const [focused, setFocused] = useState(false);
   const [draft, setDraft] = useState("");
@@ -179,6 +181,7 @@ function NumericValueInput({
     <input
       type="text"
       inputMode="decimal"
+      disabled={disabled}
       size={sizeAttr}
       /* Fixed 4ch pill; grows only when a longer value would clip. */
       style={{ width: `calc(${Math.max(displayed.length, 4)}ch + 18px)` }}
@@ -497,6 +500,10 @@ export function ChatSettingsPanel({
       ggufVariant: loadingModel.ggufVariant,
       nativePathToken: loadingModel.nativePathToken,
     });
+  // While the staged pick is loading, its load-time settings were already
+  // snapshotted at click time, so editing them now would be silently ignored
+  // and then overwritten by the load response. Lock them until the load settles.
+  const modelControlsDisabled = stagedLoading;
   const abandonStagedModel = useChatRuntimeStore((s) => s.abandonStagedModel);
   const resetModelSettingsToLoaded = useChatRuntimeStore(
     (s) => s.resetModelSettingsToLoaded,
@@ -924,6 +931,7 @@ export function ChatSettingsPanel({
                       }}
                       ariaLabel="Context Length"
                       size={8}
+                      disabled={modelControlsDisabled}
                     />
                   </div>
                   <Slider
@@ -945,6 +953,7 @@ export function ChatSettingsPanel({
                       );
                     }}
                     className="panel-slider"
+                    disabled={modelControlsDisabled}
                   />
                   {ggufMaxContextLength != null &&
                     typeof ctxDisplayValue === "number" &&
@@ -970,6 +979,7 @@ export function ChatSettingsPanel({
                   </div>
                   <div className="flex shrink-0 items-center gap-1.5">
                     <Select
+                      disabled={modelControlsDisabled}
                       value={kvCacheDtype ?? "f16"}
                       onValueChange={(v) => {
                         setKvCacheDtype(v === "f16" ? null : v);
@@ -1009,6 +1019,7 @@ export function ChatSettingsPanel({
                   </div>
                   <div className="flex shrink-0 items-center gap-1.5">
                     <Select
+                      disabled={modelControlsDisabled}
                       value={speculativeType ?? "auto"}
                       onValueChange={(v) => {
                         setSpeculativeType(v);
@@ -1083,6 +1094,7 @@ export function ChatSettingsPanel({
                     </div>
                     <input
                       type="number"
+                      disabled={modelControlsDisabled}
                       min={1}
                       max={16}
                       step={1}
@@ -1123,6 +1135,7 @@ export function ChatSettingsPanel({
                     className="panel-switch shrink-0"
                     checked={tensorParallel}
                     onCheckedChange={setTensorParallel}
+                    disabled={modelControlsDisabled}
                     data-test-id="tensor-parallel-switch"
                   />
                 </div>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -500,9 +500,7 @@ export function ChatSettingsPanel({
       ggufVariant: loadingModel.ggufVariant,
       nativePathToken: loadingModel.nativePathToken,
     });
-  // While the staged pick is loading, its load-time settings were already
-  // snapshotted at click time, so editing them now would be silently ignored
-  // and then overwritten by the load response. Lock them until the load settles.
+  // Load settings are snapshotted at click time; lock them while loading.
   const modelControlsDisabled = stagedLoading;
   const abandonStagedModel = useChatRuntimeStore((s) => s.abandonStagedModel);
   const resetModelSettingsToLoaded = useChatRuntimeStore(
@@ -1173,13 +1171,8 @@ export function ChatSettingsPanel({
                     <Button
                       type="button"
                       onClick={() => onLoadPendingModel?.()}
-                      // A DIFFERENT model is mid-load (loadingModel is set but
-                      // doesn't match this staged pick -- stagedLoading is false).
-                      // Disable rather than leave an enabled button that can't act:
-                      // selectModel refuses to start a second concurrent load while
-                      // one is in flight, so the click would only surface a "wait
-                      // or cancel first" toast. The stage stays put; retry once the
-                      // in-flight load settles.
+                      // Disabled while a different model is mid-load: selectModel
+                      // refuses a concurrent load, so the click could only toast.
                       disabled={stagedDownloading || loadingModel != null}
                       size="sm"
                       className="h-7 px-3 text-[12px] font-medium tracking-nav bg-primary/92 text-primary-foreground hover:bg-primary"

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1145,11 +1145,18 @@ export function ChatSettingsPanel({
                     <Button
                       type="button"
                       onClick={() => onLoadPendingModel?.()}
-                      disabled={stagedDownloading}
+                      // A DIFFERENT model is mid-load (loadingModel is set but
+                      // doesn't match this staged pick -- stagedLoading is false).
+                      // Block the click: selectModel's in-flight-load guard keys
+                      // on id + native token, so a different GGUF variant of the
+                      // same repo would be silently deduped to a no-op, leaving an
+                      // enabled button that does nothing. The stage stays put;
+                      // retry once the in-flight load settles.
+                      disabled={stagedDownloading || loadingModel != null}
                       size="sm"
                       className="h-7 px-3 text-[12px] font-medium tracking-nav bg-primary/92 text-primary-foreground hover:bg-primary"
                     >
-                      Load model
+                      {loadingModel != null ? "Another model loading…" : "Load model"}
                     </Button>
                     <Button
                       type="button"

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -254,6 +254,7 @@ export function useChatModelRuntime() {
     displayName: string;
     isDownloaded?: boolean;
     isCachedLora?: boolean;
+    ggufVariant?: string | null;
     nativePathToken?: string | null;
   } | null>(null);
   const [loadToastDismissed, setLoadToastDismissed] = useState(false);
@@ -480,6 +481,7 @@ export function useChatModelRuntime() {
         displayName,
         isDownloaded,
         isCachedLora,
+        ggufVariant: ggufVariant ?? null,
         nativePathToken: nativePathToken ?? null,
       };
       setLoadingModel(loadInfo);
@@ -514,6 +516,21 @@ export function useChatModelRuntime() {
             stateBeforeUnload.modelRequiresTrustRemoteCode;
           const previousActiveNativePathToken =
             stateBeforeUnload.activeNativePathToken;
+          // Snapshot the load settings at click time, before the awaits below
+          // (validation, the trust dialog, unload). For a staged Load these knobs
+          // stay editable and a sheet-close revert (abandonStagedModel) can fire
+          // mid-load; reading them live just before loadModel would let the load
+          // use post-click values. The model-switch speculative reset below
+          // updates this snapshot in lock-step so non-staged loads are unchanged.
+          const loadChatTemplateOverride = stateBeforeUnload.chatTemplateOverride;
+          const loadKvCacheDtype = stateBeforeUnload.kvCacheDtype;
+          const loadCustomContextLength = stateBeforeUnload.customContextLength;
+          const loadGgufContextLength = stateBeforeUnload.ggufContextLength;
+          const loadTensorParallel = stateBeforeUnload.tensorParallel;
+          const loadActivePresetSource = stateBeforeUnload.activePresetSource;
+          const loadActiveGgufVariant = stateBeforeUnload.activeGgufVariant;
+          let loadSpeculativeType = stateBeforeUnload.speculativeType;
+          let loadSpecDraftNMax = stateBeforeUnload.specDraftNMax;
           try {
             // Lightweight pre-flight validation: avoid unloading a working model
             // if the new identifier is clearly invalid (e.g. bad HF id / path).
@@ -522,18 +539,17 @@ export function useChatModelRuntime() {
               : undefined;
             // Validate with the same effective context /load uses: a GGUF native
             // context can exceed maxSeqLength, so sizing on raw maxSeqLength could
-            // pass, unload, then have /load refuse it. Read pre-unload state; load
-            // recomputes its own value, so this leaves loading untouched.
-            const preUnloadState = useChatRuntimeStore.getState();
+            // pass, unload, then have /load refuse it. Uses the click-time
+            // snapshot (same values loadModel uses below), so the two agree.
             const validateMaxSeqLength = resolveLoadMaxSeqLength({
               modelId,
               ggufVariant,
-              customContextLength: preUnloadState.customContextLength,
-              ggufContextLength: preUnloadState.ggufContextLength,
+              customContextLength: loadCustomContextLength,
+              ggufContextLength: loadGgufContextLength,
               currentCheckpoint,
-              activeGgufVariant: preUnloadState.activeGgufVariant,
+              activeGgufVariant: loadActiveGgufVariant,
               maxSeqLength,
-              presetSource: preUnloadState.activePresetSource,
+              presetSource: loadActivePresetSource,
             });
             const validation = await validateModel({
               model_path: modelId,
@@ -591,32 +607,23 @@ export function useChatModelRuntime() {
                 specDraftNMax: null,
                 loadedSpecDraftNMax: null,
               });
+              loadSpeculativeType = persistedSpeculativeType;
+              loadSpecDraftNMax = null;
             }
 
-            const {
-              chatTemplateOverride,
-              kvCacheDtype,
-              customContextLength,
-              ggufContextLength,
-              speculativeType,
-              specDraftNMax,
-              tensorParallel,
-              activePresetSource,
-              activeGgufVariant,
-            } = useChatRuntimeStore.getState();
             const effectiveMaxSeqLength = resolveLoadMaxSeqLength({
               modelId,
               ggufVariant,
               isGguf,
-              customContextLength,
-              ggufContextLength,
+              customContextLength: loadCustomContextLength,
+              ggufContextLength: loadGgufContextLength,
               currentCheckpoint,
-              activeGgufVariant,
+              activeGgufVariant: loadActiveGgufVariant,
               maxSeqLength,
-              presetSource: activePresetSource,
+              presetSource: loadActivePresetSource,
             });
             const effectiveChatTemplateOverride =
-              chatTemplateOverride?.trim() ? chatTemplateOverride : null;
+              loadChatTemplateOverride?.trim() ? loadChatTemplateOverride : null;
             const loadResponse = await loadModel({
               model_path: modelId,
               nativePathLease: loadNativePathLease,
@@ -628,10 +635,10 @@ export function useChatModelRuntime() {
               trust_remote_code: trustRemoteCode,
               approved_remote_code_fingerprint: approvedRemoteCodeFingerprint,
               chat_template_override: effectiveChatTemplateOverride,
-              cache_type_kv: kvCacheDtype,
-              speculative_type: speculativeType,
-              spec_draft_n_max: specDraftNMax,
-              tensor_parallel: tensorParallel,
+              cache_type_kv: loadKvCacheDtype,
+              speculative_type: loadSpeculativeType,
+              spec_draft_n_max: loadSpecDraftNMax,
+              tensor_parallel: loadTensorParallel,
             });
 
             // If cancelled while loading, don't update UI to show
@@ -641,7 +648,7 @@ export function useChatModelRuntime() {
             // The load applied this spec mode, so persist the user's standing
             // preference now (the requested intent, not the resolved echo;
             // saveSpeculativeType keeps only the universal auto/ngram/off).
-            saveSpeculativeType(speculativeType);
+            saveSpeculativeType(loadSpeculativeType);
 
             const currentParams = useChatRuntimeStore.getState().params;
             setParams(

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -25,6 +25,7 @@ import {
 } from "../api/chat-api";
 import { formatEta, formatRate } from "../utils/format-transfer";
 import {
+  pendingSelectionMatches,
   readPersistedSpeculativeType,
   resolveToolsEnabledOnLoad,
   saveSpeculativeType,
@@ -399,18 +400,22 @@ export function useChatModelRuntime() {
         typeof selection === "string" ? false : selection.keepSpeculative ?? false;
       // Picking/loading any model abandons a staged (deferred) selection.
       // Before the early-returns below so even a no-op re-select clears the
-      // stage, and so the Load button unmounts on first click (no double-load).
+      // stage.
       const staged = useChatRuntimeStore.getState().pendingSelection;
       if (staged) {
-        // Loading a DIFFERENT model abandons this stage, so cancel its in-flight
-        // download. Loading the staged pick itself keeps it (that download feeds
-        // this load).
-        const loadingStagedPick =
-          staged.id === modelId &&
-          (staged.ggufVariant ?? null) === (ggufVariant ?? null) &&
-          (staged.nativePathToken ?? null) === (nativePathToken ?? null);
-        if (!loadingStagedPick) cancelStagedModelDownload(staged);
-        useChatRuntimeStore.getState().setPendingSelection(null);
+        // Loading a DIFFERENT model abandons this stage. Loading the staged pick
+        // ITSELF keeps it so the sidebar can show its load settings (context, KV
+        // cache, …) during the load. Cleared on success below; on failure it's
+        // left staged so the user can retry (see onLoadPendingModel's catch).
+        const loadingStagedPick = pendingSelectionMatches(staged, {
+          id: modelId,
+          ggufVariant,
+          nativePathToken,
+        });
+        if (!loadingStagedPick) {
+          cancelStagedModelDownload(staged);
+          useChatRuntimeStore.getState().setPendingSelection(null);
+        }
       }
       const currentVariant = useChatRuntimeStore.getState().activeGgufVariant;
       if (!forceReload && (!modelId || (params.checkpoint === modelId && (ggufVariant ?? null) === (currentVariant ?? null)))) {
@@ -773,6 +778,18 @@ export function useChatModelRuntime() {
               }
             }
             await refresh({ signal: abortCtrl.signal });
+            // Cold start (nothing was loaded): refresh()'s setCheckpoint doesn't
+            // clear pendingSelection, so this pick would linger as a stale
+            // "staged" over the now-active model. Drop it. Scoped to this pick so
+            // a newer stage queued mid-load survives.
+            if (
+              pendingSelectionMatches(
+                useChatRuntimeStore.getState().pendingSelection,
+                { id: modelId, ggufVariant, nativePathToken },
+              )
+            ) {
+              useChatRuntimeStore.getState().setPendingSelection(null);
+            }
           } catch (error) {
             // Skip rollback if user cancelled -- model is already being unloaded.
             if (abortCtrl.signal.aborted) throw error;

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -422,12 +422,30 @@ export function useChatModelRuntime() {
       if (!forceReload && (!modelId || (params.checkpoint === modelId && (ggufVariant ?? null) === (currentVariant ?? null)))) {
         return;
       }
-      // Prevent duplicate loads if already loading this model
-      if (
-        loadingModelRef.current?.id === modelId &&
-        (loadingModelRef.current?.nativePathToken ?? null) === (nativePathToken ?? null)
-      )
+      // A load is already in flight. If it's this exact pick (id + GGUF variant +
+      // native path token), ignore the duplicate click. If it's a DIFFERENT model
+      // -- crucially including a different GGUF variant of the same repo, which the
+      // old id+token-only guard wrongly treated as a duplicate and silently
+      // no-op'd -- don't start a second concurrent load (the load path has no clean
+      // supersession) and don't silently swallow the request: surface it so the
+      // user knows to wait for, or cancel, the in-flight load. Centralized here so
+      // every entry point is covered, not just the staged Load button.
+      const inFlightLoad = loadingModelRef.current;
+      if (inFlightLoad) {
+        const loadingSamePick =
+          inFlightLoad.id === modelId &&
+          (inFlightLoad.ggufVariant ?? null) === (ggufVariant ?? null) &&
+          (inFlightLoad.nativePathToken ?? null) === (nativePathToken ?? null);
+        if (loadingSamePick) return;
+        const message =
+          "Another model is already loading. Wait for it to finish or cancel it first.";
+        setModelsError(message);
+        if (throwOnError) throw new Error(message);
+        toast.info("Another model is already loading", {
+          description: "Wait for it to finish or cancel it first.",
+        });
         return;
+      }
 
       const explicitIsLora =
         typeof selection === "string" ? undefined : selection.isLora;

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -785,16 +785,23 @@ export function useChatModelRuntime() {
               }
             }
             await refresh({ signal: abortCtrl.signal });
-            // Cold start (nothing was loaded): refresh()'s setCheckpoint doesn't
-            // clear pendingSelection, so this pick would linger as a stale
-            // "staged" over the now-active model. Drop it. Scoped to this pick so
-            // a newer stage queued mid-load survives.
-            if (
-              pendingSelectionMatches(
-                useChatRuntimeStore.getState().pendingSelection,
-                { id: modelId, ggufVariant, nativePathToken },
-              )
-            ) {
+            // A successful load owns the shared (pick-unscoped) settings fields,
+            // so any surviving stage is stale: the just-loaded pick itself, or a
+            // pick queued for a different model mid-load whose knobs this load
+            // overwrote. Drop it. Only a DIFFERENT pick's download needs
+            // cancelling; the loaded pick's is already consumed, and cancelling
+            // it inside its post-complete linger window would flicker its card.
+            const staleStage = useChatRuntimeStore.getState().pendingSelection;
+            if (staleStage) {
+              if (
+                !pendingSelectionMatches(staleStage, {
+                  id: modelId,
+                  ggufVariant,
+                  nativePathToken,
+                })
+              ) {
+                cancelStagedModelDownload(staleStage);
+              }
               useChatRuntimeStore.getState().setPendingSelection(null);
             }
           } catch (error) {

--- a/studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts
+++ b/studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts
@@ -10,6 +10,7 @@ import type { DownloadJob } from "@/features/hub/download-manager/use-repo-downl
 import { fetchGgufContextLength } from "../api/chat-api";
 import {
   isPendingGguf,
+  pendingSelectionMatches,
   useChatRuntimeStore,
 } from "../stores/chat-runtime-store";
 
@@ -54,15 +55,12 @@ export function useStagedModelPreparation(): DownloadJob {
         nativePathToken,
       });
       // Apply only if the same model is still staged (the user may have switched
-      // picks or loaded/cancelled while the request was in flight). Native ids
-      // are display labels, not paths, so two files can share an id -- compare
-      // the path token too, or a stale response could land on the wrong pick.
+      // picks or loaded/cancelled while the request was in flight).
       const latest = useChatRuntimeStore.getState().pendingSelection;
       if (
-        latest?.id === id &&
-        (latest.ggufVariant ?? null) === (ggufVariant ?? null) &&
-        (latest.nativePathToken ?? null) === (nativePathToken ?? null) &&
-        contextLength != null
+        latest &&
+        contextLength != null &&
+        pendingSelectionMatches(latest, { id, ggufVariant, nativePathToken })
       ) {
         setPendingSelection({ ...latest, contextLength });
       }

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1472,10 +1472,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   },
   setPendingSelection: (pendingSelection) => set({ pendingSelection }),
   stageModel: (selection) => {
-    // A model load (or a cancel's background unload) is in flight. Staging now
-    // would queue this pick behind the active load, and the post-load cleanup
-    // would then silently drop it -- so refuse. Callers that can surface UI
-    // feedback (chat-page's stageOrLoad) show a toast first.
+    // Refuse staging mid-load: post-load cleanup would silently drop the queued
+    // pick. stageOrLoad toasts first for callers that can.
     if (get().modelLoading) return;
     set((s) => {
       if (

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -453,6 +453,22 @@ export function isPendingGguf(pending: PendingModelSelection | null): boolean {
   return pending != null && hasGgufSource(pending);
 }
 
+/** Whether `pending` refers to the same model as `pick` (id + GGUF variant +
+ *  native path token, optionals null-normalized). Native ids are display labels
+ *  that can collide, so the token must match too — id alone can land on the
+ *  wrong file. */
+export function pendingSelectionMatches(
+  pending: PendingModelSelection | null,
+  pick: { id: string; ggufVariant?: string | null; nativePathToken?: string | null },
+): boolean {
+  return (
+    pending != null &&
+    pending.id === pick.id &&
+    (pending.ggufVariant ?? null) === (pick.ggufVariant ?? null) &&
+    (pending.nativePathToken ?? null) === (pick.nativePathToken ?? null)
+  );
+}
+
 type ChatRuntimeStore = {
   settingsHydrated: boolean;
   params: InferenceParams;

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1471,7 +1471,12 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     set({ loadOnSelection });
   },
   setPendingSelection: (pendingSelection) => set({ pendingSelection }),
-  stageModel: (selection) =>
+  stageModel: (selection) => {
+    // A model load (or a cancel's background unload) is in flight. Staging now
+    // would queue this pick behind the active load, and the post-load cleanup
+    // would then silently drop it -- so refuse. Callers that can surface UI
+    // feedback (chat-page's stageOrLoad) show a toast first.
+    if (get().modelLoading) return;
     set((s) => {
       if (
         s.pendingSelection &&
@@ -1491,7 +1496,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         speculativeType: readPersistedSpeculativeType(),
         specDraftNMax: null,
       };
-    }),
+    });
+  },
   abandonStagedModel: () => {
     const { pendingSelection } = get();
     if (!pendingSelection) return;


### PR DESCRIPTION
In chat with "Load on selection" off, picking a model stages it and shows its load settings (context length, KV cache, speculative decoding) plus a Load model button in the right sidebar. Clicking Load model made that whole section vanish for the entire load and reappear only once the model was active.

## Reproduction

1. Open Chat, open the model selector, toggle "Load on selection" off.
2. Select a GGUF model. The right sidebar shows the Model section (Context Length, KV Cache, Speculative Decoding) and a Load model button; the model is staged, not loaded.
3. Click Load model.
4. The entire Model section disappears for the whole load and only comes back after the model is active.

## Fix

`selectModel` cleared `pendingSelection` at the *start* of the load. But the Model section and its knobs are gated on `pendingSelection` / `pendingIsGguf`, and the loaded checkpoint isn't set until *after* the load finishes (in `refresh()`, via `setCheckpoint`). So for the whole load there was nothing keeping the section mounted.

The fix is to keep the staged pick alive through its own load instead of clearing it up front, and clear it once the load succeeds. While the staged pick is loading, the callout and button switch to a disabled "Loading..." state so the settings stay on screen.

The "loading" state is keyed to the identity of the model actually loading (`loadingModel`), not the shared `modelLoading` flag. That way an unrelated model's load, or a cancel's background unload, can't trigger it.

## Notes

- Frontend-only.
- Adds a small `pendingSelectionMatches` helper that dedupes the id + GGUF variant + native-token comparison (previously inlined in 3 places).
- No frontend test suite exists. Verified by hand on a real load, and by typecheck.
