### PR TITLE
Fix MTP detection bug in llama.cpp capability probe

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3841,6 +3841,7 @@ class LlamaCppBackend:
 
         target: Optional[str] = None
         from huggingface_hub import list_repo_files
+
         # Retry a transient listing blip (like the download step); a permanent
         # repo/auth error is not retried.
         for attempt in range(3):
@@ -3859,8 +3860,7 @@ class LlamaCppBackend:
                     logger.debug(f"Could not list repo files for {label}: {e}")
                     break
                 logger.debug(
-                    f"Could not list repo files for {label} "
-                    f"(attempt {attempt + 1}/3): {e}"
+                    f"Could not list repo files for {label} " f"(attempt {attempt + 1}/3): {e}"
                 )
                 if attempt < 2:
                     self._cancel_event.wait(2**attempt)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -657,10 +657,27 @@ def detect_reasoning_flags(
     return flags
 
 
+# Gemma model families known to ship separate MTP drafters.
+_GEMMA_MTP_FAMILY_RE = re.compile(
+    r"gemma[-_]?(?:3n|4)[-_]", re.IGNORECASE
+)
+
+
+def _is_gemma_mtp_family(name: str) -> bool:
+    """True if the name matches a Gemma family known to ship MTP drafters."""
+    return bool(_GEMMA_MTP_FAMILY_RE.search(name))
+
+
 def _is_mtp_model_name(model_identifier: Optional[str], gguf_path: Optional[str] = None) -> bool:
     """Name-based MTP detector. Fallback for the metadata signal."""
     for cand in (model_identifier, Path(gguf_path).name if gguf_path else None):
         if cand and "-mtp" in cand.lower():
+            return True
+        # Gemma 3n/4 families ship MTP via a separate drafter (mtp-*.gguf)
+        # and don't embed "-mtp" in the main model name. Recognise them so
+        # is_mtp_model stays True even when the drafter download fails,
+        # allowing the user to see a fallback reason instead of silent default.
+        if cand and _is_gemma_mtp_family(cand):
             return True
     return False
 
@@ -6313,13 +6330,54 @@ class LlamaCppBackend:
         # effective_mode == "auto": the promotion path. llama.cpp #22673:
         # MTP is compatible with mmproj, so there's no vision gate.
         if is_mtp_model and not _mtp_too_small:
-            # GPU: MTP-only. CPU/Mac: chain ngram-mod + MTP.
-            _emit_mtp(chain_ngram = not gpus)
+            # Can we actually emit MTP? Need either an embedded head or a
+            # separate drafter. A Gemma name match with no drafter means
+            # the download failed — fall back to ngram-mod with a reason.
+            _has_mtp_capability = True
+            if _is_gemma_mtp_family(model_identifier) and not mtp_draft_path:
+                _has_mtp_capability = False
+            
+            if _has_mtp_capability:
+                # GPU: MTP-only. CPU/Mac: chain ngram-mod + MTP.
+                _emit_mtp(chain_ngram = not gpus)
+            else:
+                # Name says MTP but no head/drafter resolved. The download
+                # silently failed or the repo lacks a root-level mtp-*.gguf.
+                logger.warning(
+                    "Model is recognised as MTP-capable (%s) but no MTP head "
+                    "or drafter was found; falling back to ngram-mod. Check "
+                    "network connectivity or run `unsloth studio update`.",
+                    model_identifier,
+                )
+                _small_caps = self.probe_server_capabilities(binary)
+                if _small_caps.get("supports_ngram_mod"):
+                    _emit_ngram_mod()
+                else:
+                    flags.append("--spec-default")
+                    self._speculative_type = "default"
+                self._spec_fallback_reason = "drafter_not_found"
         elif is_mtp_model and _mtp_too_small:
             # Sub-3B fallback: drop the MTP draft head, keep ngram-mod when
             # the binary supports it.
+            _has_mtp_capability = True
+            if _is_gemma_mtp_family(model_identifier) and not mtp_draft_path:
+                _has_mtp_capability = False
+            
             _small_caps = self.probe_server_capabilities(binary)
-            if _small_caps.get("supports_ngram_mod"):
+            if not _has_mtp_capability:
+                logger.warning(
+                    "Model is recognised as MTP-capable (%s) but no MTP head "
+                    "or drafter was found; falling back to ngram-mod. Check "
+                    "network connectivity or run `unsloth studio update`.",
+                    model_identifier,
+                )
+                if _small_caps.get("supports_ngram_mod"):
+                    _emit_ngram_mod()
+                else:
+                    flags.append("--spec-default")
+                    self._speculative_type = "default"
+                self._spec_fallback_reason = "drafter_not_found"
+            elif _small_caps.get("supports_ngram_mod"):
                 logger.info(
                     f"MTP GGUF detected but model size {_mtp_size_b:.1f}B "
                     "is below the 3B speedup threshold; using ngram-mod "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6544,6 +6544,19 @@ class LlamaCppBackend:
         if req_mode != backend_mode:
             return False
 
+        # A prior HF load fell back with drafter_not_found (the separate Gemma
+        # drafter did not resolve, e.g. a transient HF/network failure). The UI
+        # asks the user to fix access and reload, so a same-settings reload must
+        # retry the download in load_model instead of deduping to the stale
+        # fallback. HF loads resolve the drafter there (gguf_path is None here);
+        # req_mode already excludes the user-owns-spec-type case (None).
+        if (
+            self._spec_fallback_reason == "drafter_not_found"
+            and gguf_path is None
+            and req_mode in ("auto", "mtp", "mtp+ngram")
+        ):
+            return False
+
         # spec_draft_n_max only matters when an MTP variant is engaged. Compare
         # on the resolved spec so an Auto request promoted to draft-mtp still
         # bounces a reload when n_max changes.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -657,17 +657,17 @@ def detect_reasoning_flags(
     return flags
 
 
-# Gemma model families known to ship separate MTP drafters.
+# Gemma 3n/4 ship MTP as a separate drafter (no "-mtp" in the name).
 _GEMMA_MTP_FAMILY_RE = re.compile(r"gemma[-_]?(?:3n|4)[-_]", re.IGNORECASE)
 
 
 def _is_gemma_mtp_family(name: Optional[str]) -> bool:
-    """True if the name matches a Gemma family known to ship MTP drafters."""
+    """Match Gemma 3n/4 by name."""
     return bool(name) and bool(_GEMMA_MTP_FAMILY_RE.search(name))
 
 
 def _is_gemma_mtp_name(model_identifier: Optional[str], gguf_path: Optional[str] = None) -> bool:
-    """Gemma separate-drafter family via the model id or the GGUF filename."""
+    """Match Gemma 3n/4 by id or GGUF filename."""
     return _is_gemma_mtp_family(model_identifier) or _is_gemma_mtp_family(
         Path(gguf_path).name if gguf_path else None
     )
@@ -678,10 +678,8 @@ def _is_mtp_model_name(model_identifier: Optional[str], gguf_path: Optional[str]
     for cand in (model_identifier, Path(gguf_path).name if gguf_path else None):
         if cand and "-mtp" in cand.lower():
             return True
-        # Gemma 3n/4 families ship MTP via a separate drafter (mtp-*.gguf)
-        # and don't embed "-mtp" in the main model name. Recognise them so
-        # is_mtp_model stays True even when the drafter download fails,
-        # allowing the user to see a fallback reason instead of silent default.
+        # Recognise Gemma 3n/4 too, so a failed drafter download surfaces a
+        # fallback reason instead of silently defaulting.
         if cand and _is_gemma_mtp_family(cand):
             return True
     return False
@@ -3842,8 +3840,7 @@ class LlamaCppBackend:
         target: Optional[str] = None
         from huggingface_hub import list_repo_files
 
-        # Retry a transient listing blip (like the download step); a permanent
-        # repo/auth error is not retried.
+        # Retry a transient listing blip; permanent repo/auth errors are not.
         for attempt in range(3):
             if self._cancel_event.is_set():
                 return None
@@ -4878,9 +4875,8 @@ class LlamaCppBackend:
                         or _is_mtp_model_name(model_identifier, model_path)
                         or bool(mtp_draft_path)
                     ) and not (
-                        # Mirror the launch resolver: a Gemma recognised only by
-                        # name with no drafter/head falls back to ngram-mod, so
-                        # do not reserve drafter VRAM for it.
+                        # Drafterless Gemma falls back to ngram-mod; reserve no
+                        # drafter VRAM for it (mirrors the launch resolver).
                         _is_gemma_mtp_name(model_identifier, model_path)
                         and not mtp_draft_path
                         and not self._nextn_predict_layers
@@ -6255,10 +6251,8 @@ class LlamaCppBackend:
         _mtp_too_small = (
             _mtp_size_b is not None and _mtp_size_b < _MTP_MIN_SIZE_B and not bool(mtp_draft_path)
         )
-        # A Gemma 3n/4 recognised only by name (its MTP ships as a separate root
-        # mtp-*.gguf) with no resolved drafter and no embedded head cannot emit
-        # MTP -- llama-server would abort -- so every mode below treats it as
-        # "no usable MTP" and falls back with a drafter_not_found reason.
+        # Drafterless Gemma (name-only MTP, no embedded head): emitting MTP
+        # would abort llama-server, so every mode below falls back instead.
         _mtp_drafter_missing = (
             _is_gemma_mtp_name(model_identifier, model_path)
             and not mtp_draft_path
@@ -6370,8 +6364,7 @@ class LlamaCppBackend:
             return True
 
         def _fallback_drafter_not_found() -> None:
-            """Gemma MTP recognised by name but no drafter/head resolved: use
-            the zero-VRAM ngram-mod path (or spec-default) and record why."""
+            """Drafterless Gemma: use ngram-mod (or spec-default) and record why."""
             logger.warning(
                 "Model %s is MTP-capable but no drafter or head was found; "
                 "falling back. Check network or run `unsloth studio update`.",
@@ -6405,8 +6398,7 @@ class LlamaCppBackend:
                 self._speculative_type = "default"
                 return flags
             if _mtp_drafter_missing:
-                # Name says MTP but no head/drafter: emitting draft-mtp would
-                # abort the server, so fall back like the auto path.
+                # Drafterless: draft-mtp would abort llama-server, so fall back.
                 _fallback_drafter_not_found()
                 return flags
             if _mtp_too_small:
@@ -6467,8 +6459,7 @@ class LlamaCppBackend:
                 # spec-off: emit nothing, mirroring the sub-3B no-ngram path.
         elif is_mtp_model and not _mtp_too_small:
             if _mtp_drafter_missing:
-                # Name says MTP but no head/drafter resolved (download failed
-                # or the repo lacks a root mtp-*.gguf).
+                # Name-only MTP, drafter did not resolve (download failed/absent).
                 _fallback_drafter_not_found()
             else:
                 # GPU: MTP-only. CPU/Mac: chain ngram-mod + MTP.
@@ -6568,12 +6559,9 @@ class LlamaCppBackend:
         if req_mode != backend_mode:
             return False
 
-        # A prior HF load fell back with drafter_not_found (the separate Gemma
-        # drafter did not resolve, e.g. a transient HF/network failure). The UI
-        # asks the user to fix access and reload, so a same-settings reload must
-        # retry the download in load_model instead of deduping to the stale
-        # fallback. HF loads resolve the drafter there (gguf_path is None here);
-        # req_mode already excludes the user-owns-spec-type case (None).
+        # Prior HF load fell back with drafter_not_found; a same-settings reload
+        # must retry the download in load_model, not dedupe to the stale fallback
+        # (HF loads resolve the drafter there, so gguf_path is None here).
         if (
             self._spec_fallback_reason == "drafter_not_found"
             and gguf_path is None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -661,9 +661,16 @@ def detect_reasoning_flags(
 _GEMMA_MTP_FAMILY_RE = re.compile(r"gemma[-_]?(?:3n|4)[-_]", re.IGNORECASE)
 
 
-def _is_gemma_mtp_family(name: str) -> bool:
+def _is_gemma_mtp_family(name: Optional[str]) -> bool:
     """True if the name matches a Gemma family known to ship MTP drafters."""
-    return bool(_GEMMA_MTP_FAMILY_RE.search(name))
+    return bool(name) and bool(_GEMMA_MTP_FAMILY_RE.search(name))
+
+
+def _is_gemma_mtp_name(model_identifier: Optional[str], gguf_path: Optional[str] = None) -> bool:
+    """Gemma separate-drafter family via the model id or the GGUF filename."""
+    return _is_gemma_mtp_family(model_identifier) or _is_gemma_mtp_family(
+        Path(gguf_path).name if gguf_path else None
+    )
 
 
 def _is_mtp_model_name(model_identifier: Optional[str], gguf_path: Optional[str] = None) -> bool:
@@ -1883,7 +1890,7 @@ class LlamaCppBackend:
             # PR #22673 used draft-mtp; later renamed to mtp.
             if "draft-mtp" in spec_line:
                 mtp_token = "draft-mtp"
-            elif re.search(r"\bmtp\b", spec_line):
+            elif re.search(r"[|,\[]mtp[|,\]]", spec_line):
                 mtp_token = "mtp"
 
             # ngram-mod flag flavor. Post-rename builds advertise both new
@@ -4822,6 +4829,13 @@ class LlamaCppBackend:
                         self._nextn_predict_layers
                         or _is_mtp_model_name(model_identifier, model_path)
                         or bool(mtp_draft_path)
+                    ) and not (
+                        # Mirror the launch resolver: a Gemma recognised only by
+                        # name with no drafter/head falls back to ngram-mod, so
+                        # do not reserve drafter VRAM for it.
+                        _is_gemma_mtp_name(model_identifier, model_path)
+                        and not mtp_draft_path
+                        and not self._nextn_predict_layers
                     )
                     _mtp_binary_ok = True
                     _mtp_probe_raised = False
@@ -6184,6 +6198,15 @@ class LlamaCppBackend:
         _mtp_too_small = (
             _mtp_size_b is not None and _mtp_size_b < _MTP_MIN_SIZE_B and not bool(mtp_draft_path)
         )
+        # A Gemma 3n/4 recognised only by name (its MTP ships as a separate root
+        # mtp-*.gguf) with no resolved drafter and no embedded head cannot emit
+        # MTP -- llama-server would abort -- so every mode below treats it as
+        # "no usable MTP" and falls back with a drafter_not_found reason.
+        _mtp_drafter_missing = (
+            _is_gemma_mtp_name(model_identifier, model_path)
+            and not mtp_draft_path
+            and not self._nextn_predict_layers
+        )
 
         if user_owns_spec_type:
             # User --spec-type wins outright; suppress auto-emit to avoid a
@@ -6278,6 +6301,21 @@ class LlamaCppBackend:
             logger.info("Spec decoding: ngram-mod")
             return True
 
+        def _fallback_drafter_not_found() -> None:
+            """Gemma MTP recognised by name but no drafter/head resolved: use
+            the zero-VRAM ngram-mod path (or spec-default) and record why."""
+            logger.warning(
+                "Model %s is MTP-capable but no drafter or head was found; "
+                "falling back. Check network or run `unsloth studio update`.",
+                model_identifier,
+            )
+            if self.probe_server_capabilities(binary).get("supports_ngram_mod"):
+                _emit_ngram_mod()
+            else:
+                flags.append("--spec-default")
+                self._speculative_type = "default"
+            self._spec_fallback_reason = "drafter_not_found"
+
         if effective_mode == "off":
             return flags  # nothing to emit
         if effective_mode == "ngram-simple":
@@ -6298,6 +6336,11 @@ class LlamaCppBackend:
                 flags.append("--spec-default")
                 self._speculative_type = "default"
                 return flags
+            if _mtp_drafter_missing:
+                # Name says MTP but no head/drafter: emitting draft-mtp would
+                # abort the server, so fall back like the auto path.
+                _fallback_drafter_not_found()
+                return flags
             if _mtp_too_small:
                 logger.warning(
                     f"Forcing MTP on a {_mtp_size_b:.1f}B model; "
@@ -6316,6 +6359,10 @@ class LlamaCppBackend:
                 )
                 _emit_ngram_mod()
                 return flags
+            if _mtp_drafter_missing:
+                # No head/drafter: keep ngram-mod, drop the draft-mtp chain.
+                _fallback_drafter_not_found()
+                return flags
             if _mtp_too_small:
                 logger.warning(
                     f"Forcing MTP+Ngram on a {_mtp_size_b:.1f}B model; "
@@ -6328,54 +6375,19 @@ class LlamaCppBackend:
         # effective_mode == "auto": the promotion path. llama.cpp #22673:
         # MTP is compatible with mmproj, so there's no vision gate.
         if is_mtp_model and not _mtp_too_small:
-            # Can we actually emit MTP? Need either an embedded head or a
-            # separate drafter. A Gemma name match with no drafter means
-            # the download failed — fall back to ngram-mod with a reason.
-            _has_mtp_capability = True
-            if _is_gemma_mtp_family(model_identifier) and not mtp_draft_path:
-                _has_mtp_capability = False
-
-            if _has_mtp_capability:
+            if _mtp_drafter_missing:
+                # Name says MTP but no head/drafter resolved (download failed
+                # or the repo lacks a root mtp-*.gguf).
+                _fallback_drafter_not_found()
+            else:
                 # GPU: MTP-only. CPU/Mac: chain ngram-mod + MTP.
                 _emit_mtp(chain_ngram = not gpus)
-            else:
-                # Name says MTP but no head/drafter resolved. The download
-                # silently failed or the repo lacks a root-level mtp-*.gguf.
-                logger.warning(
-                    "Model is recognised as MTP-capable (%s) but no MTP head "
-                    "or drafter was found; falling back to ngram-mod. Check "
-                    "network connectivity or run `unsloth studio update`.",
-                    model_identifier,
-                )
-                _small_caps = self.probe_server_capabilities(binary)
-                if _small_caps.get("supports_ngram_mod"):
-                    _emit_ngram_mod()
-                else:
-                    flags.append("--spec-default")
-                    self._speculative_type = "default"
-                self._spec_fallback_reason = "drafter_not_found"
         elif is_mtp_model and _mtp_too_small:
             # Sub-3B fallback: drop the MTP draft head, keep ngram-mod when
             # the binary supports it.
-            _has_mtp_capability = True
-            if _is_gemma_mtp_family(model_identifier) and not mtp_draft_path:
-                _has_mtp_capability = False
-
-            _small_caps = self.probe_server_capabilities(binary)
-            if not _has_mtp_capability:
-                logger.warning(
-                    "Model is recognised as MTP-capable (%s) but no MTP head "
-                    "or drafter was found; falling back to ngram-mod. Check "
-                    "network connectivity or run `unsloth studio update`.",
-                    model_identifier,
-                )
-                if _small_caps.get("supports_ngram_mod"):
-                    _emit_ngram_mod()
-                else:
-                    flags.append("--spec-default")
-                    self._speculative_type = "default"
-                self._spec_fallback_reason = "drafter_not_found"
-            elif _small_caps.get("supports_ngram_mod"):
+            if _mtp_drafter_missing:
+                _fallback_drafter_not_found()
+            elif self.probe_server_capabilities(binary).get("supports_ngram_mod"):
                 logger.info(
                     f"MTP GGUF detected but model size {_mtp_size_b:.1f}B "
                     "is below the 3B speedup threshold; using ngram-mod "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1397,6 +1397,11 @@ class LlamaCppBackend:
         return self._gguf_path
 
     @property
+    def hf_repo(self) -> Optional[str]:
+        """HF repo of the loaded model, or None for local/native file loads."""
+        return self._hf_repo
+
+    @property
     def mtp_draft_path(self) -> Optional[str]:
         return self._mtp_draft_path
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -658,9 +658,7 @@ def detect_reasoning_flags(
 
 
 # Gemma model families known to ship separate MTP drafters.
-_GEMMA_MTP_FAMILY_RE = re.compile(
-    r"gemma[-_]?(?:3n|4)[-_]", re.IGNORECASE
-)
+_GEMMA_MTP_FAMILY_RE = re.compile(r"gemma[-_]?(?:3n|4)[-_]", re.IGNORECASE)
 
 
 def _is_gemma_mtp_family(name: str) -> bool:
@@ -6336,7 +6334,7 @@ class LlamaCppBackend:
             _has_mtp_capability = True
             if _is_gemma_mtp_family(model_identifier) and not mtp_draft_path:
                 _has_mtp_capability = False
-            
+
             if _has_mtp_capability:
                 # GPU: MTP-only. CPU/Mac: chain ngram-mod + MTP.
                 _emit_mtp(chain_ngram = not gpus)
@@ -6362,7 +6360,7 @@ class LlamaCppBackend:
             _has_mtp_capability = True
             if _is_gemma_mtp_family(model_identifier) and not mtp_draft_path:
                 _has_mtp_capability = False
-            
+
             _small_caps = self.probe_server_capabilities(binary)
             if not _has_mtp_capability:
                 logger.warning(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1868,7 +1868,7 @@ class LlamaCppBackend:
             # PR #22673 used draft-mtp; later renamed to mtp.
             if "draft-mtp" in spec_line:
                 mtp_token = "draft-mtp"
-            elif re.search(r"[|,\[]mtp[|,\]]", spec_line):
+            elif re.search(r"\bmtp\b", spec_line):
                 mtp_token = "mtp"
 
             # ngram-mod flag flavor. Post-rename builds advertise both new

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3840,11 +3840,30 @@ class LlamaCppBackend:
             return None
 
         target: Optional[str] = None
-        try:
-            from huggingface_hub import list_repo_files
-            target = pick(list_repo_files(hf_repo, token = hf_token))
-        except Exception as e:
-            logger.debug(f"Could not list repo files for {label}: {e}")
+        from huggingface_hub import list_repo_files
+        # Retry a transient listing blip (like the download step); a permanent
+        # repo/auth error is not retried.
+        for attempt in range(3):
+            if self._cancel_event.is_set():
+                return None
+            try:
+                target = pick(list_repo_files(hf_repo, token = hf_token))
+                break
+            except Exception as e:
+                if type(e).__name__ in (
+                    "RepositoryNotFoundError",
+                    "GatedRepoError",
+                    "RevisionNotFoundError",
+                    "EntryNotFoundError",
+                ):
+                    logger.debug(f"Could not list repo files for {label}: {e}")
+                    break
+                logger.debug(
+                    f"Could not list repo files for {label} "
+                    f"(attempt {attempt + 1}/3): {e}"
+                )
+                if attempt < 2:
+                    self._cancel_event.wait(2**attempt)
 
         if target is None:
             try:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -657,17 +657,18 @@ def detect_reasoning_flags(
     return flags
 
 
-# Gemma 3n/4 ship MTP as a separate drafter (no "-mtp" in the name).
-_GEMMA_MTP_FAMILY_RE = re.compile(r"gemma[-_]?(?:3n|4)[-_]", re.IGNORECASE)
+# Gemma 4 ships MTP as a separate drafter (no "-mtp" in the name). Gemma 3n
+# ships no drafter, so it is excluded -- it takes the normal non-MTP path.
+_GEMMA_MTP_FAMILY_RE = re.compile(r"gemma[-_]?4[-_]", re.IGNORECASE)
 
 
 def _is_gemma_mtp_family(name: Optional[str]) -> bool:
-    """Match Gemma 3n/4 by name."""
+    """Match Gemma 4 by name."""
     return bool(name) and bool(_GEMMA_MTP_FAMILY_RE.search(name))
 
 
 def _is_gemma_mtp_name(model_identifier: Optional[str], gguf_path: Optional[str] = None) -> bool:
-    """Match Gemma 3n/4 by id or GGUF filename."""
+    """Match Gemma 4 by id or GGUF filename."""
     return _is_gemma_mtp_family(model_identifier) or _is_gemma_mtp_family(
         Path(gguf_path).name if gguf_path else None
     )
@@ -678,7 +679,7 @@ def _is_mtp_model_name(model_identifier: Optional[str], gguf_path: Optional[str]
     for cand in (model_identifier, Path(gguf_path).name if gguf_path else None):
         if cand and "-mtp" in cand.lower():
             return True
-        # Recognise Gemma 3n/4 too, so a failed drafter download surfaces a
+        # Recognise Gemma 4 too, so a failed drafter download surfaces a
         # fallback reason instead of silently defaulting.
         if cand and _is_gemma_mtp_family(cand):
             return True
@@ -3840,7 +3841,8 @@ class LlamaCppBackend:
         target: Optional[str] = None
         from huggingface_hub import list_repo_files
 
-        # Retry a transient listing blip; permanent repo/auth errors are not.
+        # Retry a transient listing blip; permanent repo/auth errors and offline
+        # mode are not retried (offline raises at once -> fall through to cache).
         for attempt in range(3):
             if self._cancel_event.is_set():
                 return None
@@ -3853,6 +3855,7 @@ class LlamaCppBackend:
                     "GatedRepoError",
                     "RevisionNotFoundError",
                     "EntryNotFoundError",
+                    "OfflineModeIsEnabled",
                 ):
                     logger.debug(f"Could not list repo files for {label}: {e}")
                     break

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -412,8 +412,9 @@ class InferenceStatusResponse(BaseModel):
             "(auto on an MTP model, or forced mtp / mtp+ngram). "
             "'binary_no_mtp' / 'binary_outdated' -> a newer prebuilt would "
             "re-enable it (show the update affordance); 'runtime_error' -> the "
-            "current build could not run it. None when MTP engaged or was not "
-            "requested."
+            "current build could not run it; 'drafter_not_found' -> the model's "
+            "separate MTP drafter could not be resolved. None when MTP engaged "
+            "or was not requested."
         ),
     )
     llama_cpp_prebuilt_stale: bool = Field(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1787,6 +1787,7 @@ def _request_matches_loaded_settings(
     request: LoadRequest,
     llama_backend: LlamaCppBackend,
     effective_chat_template_override: Optional[str] = None,
+    is_direct_gguf_request: bool = False,
 ) -> bool:
     """True iff every runtime setting on the request matches the loaded server.
     Caller has already checked model+variant+is_loaded. See #5401.
@@ -1832,9 +1833,13 @@ def _request_matches_loaded_settings(
     # A prior HF load fell back with drafter_not_found (the separate Gemma
     # drafter did not resolve). The UI asks the user to fix access and reload,
     # so a same-settings reload must retry the download rather than dedupe to
-    # the stale fallback. Skipped when the request now owns --spec-type.
+    # the stale fallback. HF only (a direct .gguf has no download to retry and
+    # its companion change is handled by the drafter-path compare below);
+    # mirrors _already_in_target_state's gguf_path-is-None gate. Skipped when
+    # the request now owns --spec-type.
     if (
-        llama_backend.spec_fallback_reason == "drafter_not_found"
+        not is_direct_gguf_request
+        and llama_backend.spec_fallback_reason == "drafter_not_found"
         and req_mode in ("auto", "mtp", "mtp+ngram")
         and not _extra_args_set_spec_type(effective_extra)
     ):
@@ -2216,7 +2221,8 @@ async def load_model(
                 and llama_backend.model_identifier.lower() == model_identifier.lower()
                 # Match runtime settings so Apply isn't dropped (#5401).
                 and _request_matches_loaded_settings(
-                    request, llama_backend, effective_chat_template_override
+                    request, llama_backend, effective_chat_template_override,
+                    is_direct_gguf_request = is_direct_gguf_request,
                 )
                 # Skip if a prior audio probe failed -- let load_model retry.
                 and getattr(llama_backend, "_audio_probed", True)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2221,7 +2221,9 @@ async def load_model(
                 and llama_backend.model_identifier.lower() == model_identifier.lower()
                 # Match runtime settings so Apply isn't dropped (#5401).
                 and _request_matches_loaded_settings(
-                    request, llama_backend, effective_chat_template_override,
+                    request,
+                    llama_backend,
+                    effective_chat_template_override,
                     is_direct_gguf_request = is_direct_gguf_request,
                 )
                 # Skip if a prior audio probe failed -- let load_model retry.

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1787,7 +1787,6 @@ def _request_matches_loaded_settings(
     request: LoadRequest,
     llama_backend: LlamaCppBackend,
     effective_chat_template_override: Optional[str] = None,
-    is_direct_gguf_request: bool = False,
 ) -> bool:
     """True iff every runtime setting on the request matches the loaded server.
     Caller has already checked model+variant+is_loaded. See #5401.
@@ -1833,12 +1832,12 @@ def _request_matches_loaded_settings(
     # A prior HF load fell back with drafter_not_found (the separate Gemma
     # drafter did not resolve). The UI asks the user to fix access and reload,
     # so a same-settings reload must retry the download rather than dedupe to
-    # the stale fallback. HF only (a direct .gguf has no download to retry and
-    # its companion change is handled by the drafter-path compare below);
-    # mirrors _already_in_target_state's gguf_path-is-None gate. Skipped when
-    # the request now owns --spec-type.
+    # the stale fallback. HF only (`hf_repo` set): a local/native load has no
+    # download to retry -- including a local directory + gguf_variant whose
+    # identifier does not end in .gguf -- and its companion change is handled by
+    # the drafter-path compare below. Skipped when the request owns --spec-type.
     if (
-        not is_direct_gguf_request
+        llama_backend.hf_repo
         and llama_backend.spec_fallback_reason == "drafter_not_found"
         and req_mode in ("auto", "mtp", "mtp+ngram")
         and not _extra_args_set_spec_type(effective_extra)
@@ -2224,7 +2223,6 @@ async def load_model(
                     request,
                     llama_backend,
                     effective_chat_template_override,
-                    is_direct_gguf_request = is_direct_gguf_request,
                 )
                 # Skip if a prior audio probe failed -- let load_model retry.
                 and getattr(llama_backend, "_audio_probed", True)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1829,13 +1829,9 @@ def _request_matches_loaded_settings(
     backend_mode = llama_backend.requested_spec_mode or "auto"
     if req_mode != backend_mode:
         return False
-    # A prior HF load fell back with drafter_not_found (the separate Gemma
-    # drafter did not resolve). The UI asks the user to fix access and reload,
-    # so a same-settings reload must retry the download rather than dedupe to
-    # the stale fallback. HF only (`hf_repo` set): a local/native load has no
-    # download to retry -- including a local directory + gguf_variant whose
-    # identifier does not end in .gguf -- and its companion change is handled by
-    # the drafter-path compare below. Skipped when the request owns --spec-type.
+    # Prior HF load fell back with drafter_not_found: a same-settings reload must
+    # retry the download, not dedupe to the stale fallback. HF only (hf_repo set);
+    # local/native loads have no download to retry (handled by the path compare).
     if (
         llama_backend.hf_repo
         and llama_backend.spec_fallback_reason == "drafter_not_found"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1829,6 +1829,16 @@ def _request_matches_loaded_settings(
     backend_mode = llama_backend.requested_spec_mode or "auto"
     if req_mode != backend_mode:
         return False
+    # A prior HF load fell back with drafter_not_found (the separate Gemma
+    # drafter did not resolve). The UI asks the user to fix access and reload,
+    # so a same-settings reload must retry the download rather than dedupe to
+    # the stale fallback. Skipped when the request now owns --spec-type.
+    if (
+        llama_backend.spec_fallback_reason == "drafter_not_found"
+        and req_mode in ("auto", "mtp", "mtp+ngram")
+        and not _extra_args_set_spec_type(effective_extra)
+    ):
+        return False
     # spec_draft_n_max only matters with an MTP variant; None means "platform
     # default" and matches whatever the backend chose.
     if backend_mode in ("mtp", "mtp+ngram") and request.spec_draft_n_max is not None:

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -1857,8 +1857,7 @@ def test_is_gemma_mtp_family():
 
 
 def test_spec_fallback_reason_drafter_not_found(monkeypatch):
-    # A Gemma MTP model that fails to resolve its drafter should fall back
-    # to ngram-mod and set drafter_not_found.
+    # Drafterless Gemma should fall back to ngram-mod + drafter_not_found.
     backend = _resolver_backend(monkeypatch)
     flags = backend._build_speculative_flags(
         speculative_type = "auto",
@@ -1877,8 +1876,7 @@ def test_spec_fallback_reason_drafter_not_found(monkeypatch):
 
 
 def test_is_gemma_mtp_name_none_safe():
-    # Local GGUF loads pass model_identifier=None; must not raise, and the
-    # family must be recognised from the file name too.
+    # model_identifier=None (local load) must not raise; recognise via filename.
     from core.inference.llama_cpp import _is_gemma_mtp_family, _is_gemma_mtp_name
 
     assert _is_gemma_mtp_family(None) is False
@@ -1888,9 +1886,7 @@ def test_is_gemma_mtp_name_none_safe():
 
 @pytest.mark.parametrize("mode", ["mtp", "mtp+ngram"])
 def test_forced_mtp_gemma_without_drafter_falls_back(monkeypatch, mode):
-    # Forcing MTP on a Gemma whose drafter did not resolve must not emit
-    # draft-mtp without --model-draft (llama-server aborts); fall back to
-    # ngram-mod and record drafter_not_found.
+    # Forced MTP on a drafterless Gemma must fall back, not emit draft-mtp.
     backend = _resolver_backend(monkeypatch)
     flags = backend._build_speculative_flags(
         speculative_type = mode,
@@ -1909,8 +1905,7 @@ def test_forced_mtp_gemma_without_drafter_falls_back(monkeypatch, mode):
 
 
 def test_local_gemma_gguf_without_identifier_falls_back(monkeypatch):
-    # A local Gemma GGUF (no repo id, family only in the file name) must not
-    # crash and must fall back when no drafter resolved.
+    # Local Gemma GGUF (family only in filename) must not crash; falls back.
     backend = _resolver_backend(monkeypatch)
     flags = backend._build_speculative_flags(
         speculative_type = "auto",
@@ -1942,8 +1937,7 @@ def _drafter_not_found_kwargs():
 
 
 def test_already_in_target_state_retries_after_hf_drafter_not_found():
-    # A recoverable HF drafter_not_found fallback must NOT dedupe a reload;
-    # load_model has to re-attempt the separate-drafter download.
+    # Recoverable drafter_not_found must not dedupe; reload re-attempts download.
     backend = _mtp_backend(
         _model_identifier = "unsloth/gemma-4-E4B-it-GGUF",
         _speculative_type = "ngram-mod",

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -1851,9 +1851,28 @@ def test_is_gemma_mtp_family():
     from core.inference.llama_cpp import _is_gemma_mtp_family
 
     assert _is_gemma_mtp_family("unsloth/gemma-4-E4B-it-GGUF") is True
-    assert _is_gemma_mtp_family("unsloth/gemma-3n-E2B-it-GGUF") is True
+    assert _is_gemma_mtp_family("unsloth/gemma-4-12b-it-GGUF") is True
+    # gemma-3n ships no separate drafter, so it is not a drafter family.
+    assert _is_gemma_mtp_family("unsloth/gemma-3n-E2B-it-GGUF") is False
     assert _is_gemma_mtp_family("unsloth/Qwen3.5-35B-A3B-MTP-GGUF") is False
     assert _is_gemma_mtp_family("unsloth/llama-3-8b") is False
+
+
+def test_gemma_3n_without_drafter_is_not_mtp(monkeypatch):
+    # gemma-3n ships no drafter; it must take the normal non-MTP path, not
+    # drafter_not_found (which would make every reload retry a missing drafter).
+    backend = _resolver_backend(monkeypatch)
+    backend._build_speculative_flags(
+        speculative_type = "auto",
+        spec_draft_n_max = None,
+        extra_args = None,
+        model_identifier = "unsloth/gemma-3n-E4B-it-GGUF",
+        model_path = None,
+        gpus = True,
+        binary = "/fake/llama-server",
+        mtp_draft_path = None,
+    )
+    assert backend.spec_fallback_reason is None
 
 
 def test_spec_fallback_reason_drafter_not_found(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -1597,3 +1597,54 @@ def test_spec_fallback_reason_drafter_not_found(monkeypatch):
     assert parsed.get("--spec-type") == "ngram-mod"
     assert backend.speculative_type == "ngram-mod"
     assert backend.spec_fallback_reason == "drafter_not_found"
+
+
+def test_is_gemma_mtp_name_none_safe():
+    # Local GGUF loads pass model_identifier=None; must not raise, and the
+    # family must be recognised from the file name too.
+    from core.inference.llama_cpp import _is_gemma_mtp_family, _is_gemma_mtp_name
+
+    assert _is_gemma_mtp_family(None) is False
+    assert _is_gemma_mtp_name(None, "/models/gemma-4-E4B-it-Q4_K_M.gguf") is True
+    assert _is_gemma_mtp_name("unsloth/Qwen3.5-4B-MTP-GGUF", None) is False
+
+
+@pytest.mark.parametrize("mode", ["mtp", "mtp+ngram"])
+def test_forced_mtp_gemma_without_drafter_falls_back(monkeypatch, mode):
+    # Forcing MTP on a Gemma whose drafter did not resolve must not emit
+    # draft-mtp without --model-draft (llama-server aborts); fall back to
+    # ngram-mod and record drafter_not_found.
+    backend = _resolver_backend(monkeypatch)
+    flags = backend._build_speculative_flags(
+        speculative_type = mode,
+        spec_draft_n_max = None,
+        extra_args = None,
+        model_identifier = "unsloth/gemma-4-E4B-it-GGUF",
+        model_path = None,
+        gpus = True,
+        binary = "/fake/llama-server",
+        mtp_draft_path = None,
+    )
+    parsed = _flags_dict(flags)
+    assert parsed.get("--spec-type") == "ngram-mod"
+    assert "--model-draft" not in parsed
+    assert backend.spec_fallback_reason == "drafter_not_found"
+
+
+def test_local_gemma_gguf_without_identifier_falls_back(monkeypatch):
+    # A local Gemma GGUF (no repo id, family only in the file name) must not
+    # crash and must fall back when no drafter resolved.
+    backend = _resolver_backend(monkeypatch)
+    flags = backend._build_speculative_flags(
+        speculative_type = "auto",
+        spec_draft_n_max = None,
+        extra_args = None,
+        model_identifier = None,
+        model_path = "/models/gemma-4-E4B-it-Q4_K_M.gguf",
+        gpus = True,
+        binary = "/fake/llama-server",
+        mtp_draft_path = None,
+    )
+    parsed = _flags_dict(flags)
+    assert parsed.get("--spec-type") == "ngram-mod"
+    assert backend.spec_fallback_reason == "drafter_not_found"

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -1376,6 +1376,8 @@ _REAL_REPO_MATRIX = [
 
 def _resolve_real(monkeypatch, repo, drafter, mode):
     backend = _resolver_backend(monkeypatch)
+    if "qwen" in repo.lower() and "-mtp" in repo.lower():
+        backend._nextn_predict_layers = 1
     flags = backend._build_speculative_flags(
         speculative_type = mode,
         spec_draft_n_max = None,
@@ -1566,3 +1568,32 @@ def test_spec_fallback_reason_reset_on_off(monkeypatch):
         binary = "/fake/llama-server",
     )
     assert backend.spec_fallback_reason is None
+
+
+def test_is_gemma_mtp_family():
+    from core.inference.llama_cpp import _is_gemma_mtp_family
+
+    assert _is_gemma_mtp_family("unsloth/gemma-4-E4B-it-GGUF") is True
+    assert _is_gemma_mtp_family("unsloth/gemma-3n-E2B-it-GGUF") is True
+    assert _is_gemma_mtp_family("unsloth/Qwen3.5-35B-A3B-MTP-GGUF") is False
+    assert _is_gemma_mtp_family("unsloth/llama-3-8b") is False
+
+
+def test_spec_fallback_reason_drafter_not_found(monkeypatch):
+    # A Gemma MTP model that fails to resolve its drafter should fall back
+    # to ngram-mod and set drafter_not_found.
+    backend = _resolver_backend(monkeypatch)
+    flags = backend._build_speculative_flags(
+        speculative_type="auto",
+        spec_draft_n_max=None,
+        extra_args=None,
+        model_identifier="unsloth/gemma-4-E4B-it-GGUF",
+        model_path=None,
+        gpus=True,
+        binary="/fake/llama-server",
+        mtp_draft_path=None,  # Drafter download failed
+    )
+    parsed = _flags_dict(flags)
+    assert parsed.get("--spec-type") == "ngram-mod"
+    assert backend.speculative_type == "ngram-mod"
+    assert backend.spec_fallback_reason == "drafter_not_found"

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -1925,3 +1925,33 @@ def test_local_gemma_gguf_without_identifier_falls_back(monkeypatch):
     parsed = _flags_dict(flags)
     assert parsed.get("--spec-type") == "ngram-mod"
     assert backend.spec_fallback_reason == "drafter_not_found"
+
+
+def _drafter_not_found_kwargs():
+    return dict(
+        model_identifier = "unsloth/gemma-4-E4B-it-GGUF",
+        hf_variant = "Q4_K_M",
+        n_ctx = 8192,
+        cache_type_kv = None,
+        speculative_type = "auto",
+        chat_template_override = None,
+        extra_args = None,
+        is_vision = False,
+        gguf_path = None,  # HF load: drafter resolves inside load_model
+    )
+
+
+def test_already_in_target_state_retries_after_hf_drafter_not_found():
+    # A recoverable HF drafter_not_found fallback must NOT dedupe a reload;
+    # load_model has to re-attempt the separate-drafter download.
+    backend = _mtp_backend(
+        _model_identifier = "unsloth/gemma-4-E4B-it-GGUF",
+        _speculative_type = "ngram-mod",
+        _spec_fallback_reason = "drafter_not_found",
+        _mtp_draft_path = None,
+        _gguf_path = None,
+    )
+    assert backend._already_in_target_state(**_drafter_not_found_kwargs()) is False
+    # Sanity: with no fallback reason the same request still dedupes (matches).
+    ok = _mtp_backend(_model_identifier = "unsloth/gemma-4-E4B-it-GGUF", _gguf_path = None)
+    assert ok._already_in_target_state(**_drafter_not_found_kwargs()) is True

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -1584,14 +1584,14 @@ def test_spec_fallback_reason_drafter_not_found(monkeypatch):
     # to ngram-mod and set drafter_not_found.
     backend = _resolver_backend(monkeypatch)
     flags = backend._build_speculative_flags(
-        speculative_type="auto",
-        spec_draft_n_max=None,
-        extra_args=None,
-        model_identifier="unsloth/gemma-4-E4B-it-GGUF",
-        model_path=None,
-        gpus=True,
-        binary="/fake/llama-server",
-        mtp_draft_path=None,  # Drafter download failed
+        speculative_type = "auto",
+        spec_draft_n_max = None,
+        extra_args = None,
+        model_identifier = "unsloth/gemma-4-E4B-it-GGUF",
+        model_path = None,
+        gpus = True,
+        binary = "/fake/llama-server",
+        mtp_draft_path = None,  # Drafter download failed
     )
     parsed = _flags_dict(flags)
     assert parsed.get("--spec-type") == "ngram-mod"

--- a/studio/backend/tests/test_mtp_vram_budget.py
+++ b/studio/backend/tests/test_mtp_vram_budget.py
@@ -829,6 +829,20 @@ class TestExtraArgsMtpDetection:
             "request.tensor_parallel,llama_backend.tensor_parallel)" in body
         )
 
+    def test_route_matcher_retries_after_drafter_not_found(self):
+        # A recoverable HF drafter_not_found fallback must not be reported as
+        # already loaded, or the reload the UI asks for never retries the
+        # drafter download (#6459). Read from disk (importing routes.inference
+        # drags in heavy deps).
+        routes_src = (
+            Path(__file__).resolve().parent.parent / "routes" / "inference.py"
+        ).read_text()
+        start = routes_src.index("def _request_matches_loaded_settings")
+        end = routes_src.index("\ndef ", start + 1)
+        body = "".join(routes_src[start:end].split())
+        assert 'llama_backend.spec_fallback_reason=="drafter_not_found"' in body
+        assert "not_extra_args_set_spec_type(effective_extra)" in body
+
     def test_extra_args_main_cache_type_heavier_axis(self):
         # Asymmetric --cache-type-k/-v must budget the heavier axis (extras win
         # per axis at launch), not the last-wins single type that under-reserves.

--- a/studio/backend/tests/test_mtp_vram_budget.py
+++ b/studio/backend/tests/test_mtp_vram_budget.py
@@ -842,10 +842,10 @@ class TestExtraArgsMtpDetection:
         body = "".join(routes_src[start:end].split())
         assert 'llama_backend.spec_fallback_reason=="drafter_not_found"' in body
         assert "not_extra_args_set_spec_type(effective_extra)" in body
-        # HF-only: a direct .gguf load has no download to retry (mirrors the
-        # backend guard's gguf_path-is-None gate); local companion changes are
-        # handled by the drafter-path compare.
-        assert "notis_direct_gguf_request" in body
+        # HF-only: gated on hf_repo, so local/native loads (single file or a
+        # directory + gguf_variant) have no download to retry and fall through
+        # to the drafter-path compare instead of forcing a reload.
+        assert "llama_backend.hf_repo" in body
 
     def test_extra_args_main_cache_type_heavier_axis(self):
         # Asymmetric --cache-type-k/-v must budget the heavier axis (extras win

--- a/studio/backend/tests/test_mtp_vram_budget.py
+++ b/studio/backend/tests/test_mtp_vram_budget.py
@@ -830,10 +830,8 @@ class TestExtraArgsMtpDetection:
         )
 
     def test_route_matcher_retries_after_drafter_not_found(self):
-        # A recoverable HF drafter_not_found fallback must not be reported as
-        # already loaded, or the reload the UI asks for never retries the
-        # drafter download (#6459). Read from disk (importing routes.inference
-        # drags in heavy deps).
+        # drafter_not_found must not report "already loaded" or the reload never
+        # retries the download (#6459). Read source: importing routes pulls deps.
         routes_src = (
             Path(__file__).resolve().parent.parent / "routes" / "inference.py"
         ).read_text()
@@ -842,9 +840,7 @@ class TestExtraArgsMtpDetection:
         body = "".join(routes_src[start:end].split())
         assert 'llama_backend.spec_fallback_reason=="drafter_not_found"' in body
         assert "not_extra_args_set_spec_type(effective_extra)" in body
-        # HF-only: gated on hf_repo, so local/native loads (single file or a
-        # directory + gguf_variant) have no download to retry and fall through
-        # to the drafter-path compare instead of forcing a reload.
+        # HF-only (hf_repo): local/native loads have no download to retry.
         assert "llama_backend.hf_repo" in body
 
     def test_extra_args_main_cache_type_heavier_axis(self):

--- a/studio/backend/tests/test_mtp_vram_budget.py
+++ b/studio/backend/tests/test_mtp_vram_budget.py
@@ -842,6 +842,10 @@ class TestExtraArgsMtpDetection:
         body = "".join(routes_src[start:end].split())
         assert 'llama_backend.spec_fallback_reason=="drafter_not_found"' in body
         assert "not_extra_args_set_spec_type(effective_extra)" in body
+        # HF-only: a direct .gguf load has no download to retry (mirrors the
+        # backend guard's gguf_path-is-None gate); local companion changes are
+        # handled by the drafter-path compare.
+        assert "notis_direct_gguf_request" in body
 
     def test_extra_args_main_cache_type_heavier_axis(self):
         # Asymmetric --cache-type-k/-v must budget the heavier axis (extras win

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1008,7 +1008,7 @@ export function ChatSettingsPanel({
                         {specFallbackReason === "runtime_error"
                           ? "MTP could not start for this model on the installed llama.cpp build, so it is running without speculative decoding."
                           : specFallbackReason === "drafter_not_found"
-                            ? "This model supports MTP but the drafter file could not be downloaded. Running with ngram-mod fallback. Check your network connection and try reloading."
+                            ? "This model supports MTP but its drafter file could not be downloaded, so it is running without MTP. Check your network connection or Hugging Face access, then reload the model."
                             : "MTP is not available in the installed llama.cpp build, so this model is running without it." +
                               (llamaUpdateStatus?.update_available
                                 ? " Update llama.cpp to enable it."

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1010,7 +1010,7 @@ export function ChatSettingsPanel({
                           : specFallbackReason === "runtime_error"
                           ? "MTP could not start for this model on the installed llama.cpp build, so it is running without speculative decoding."
                           : specFallbackReason === "drafter_not_found"
-                            ? "This model supports MTP, but its drafter file could not be downloaded. MTP is off and it is running with n-gram speculative decoding instead. Check your network connection or Hugging Face access, then reload the model to retry the drafter."
+                            ? "This model supports MTP, but its drafter file could not be downloaded, so MTP is off and it falls back to n-gram speculative decoding where the llama.cpp build supports it. Check your network connection or Hugging Face access, then reload the model to retry the drafter."
                             : "MTP is not available in the installed llama.cpp build, so this model is running without it." +
                               (llamaUpdateStatus?.update_available
                                 ? " Update llama.cpp to enable it."

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1007,10 +1007,12 @@ export function ChatSettingsPanel({
                       <p>
                         {specFallbackReason === "runtime_error"
                           ? "MTP could not start for this model on the installed llama.cpp build, so it is running without speculative decoding."
-                          : "MTP is not available in the installed llama.cpp build, so this model is running without it." +
-                            (llamaUpdateStatus?.update_available
-                              ? " Update llama.cpp to enable it."
-                              : "")}
+                          : specFallbackReason === "drafter_not_found"
+                            ? "This model supports MTP but the drafter file could not be downloaded. Running with ngram-mod fallback. Check your network connection and try reloading."
+                            : "MTP is not available in the installed llama.cpp build, so this model is running without it." +
+                              (llamaUpdateStatus?.update_available
+                                ? " Update llama.cpp to enable it."
+                                : "")}
                       </p>
                       {mtpUpdatable && llamaUpdateStatus?.update_available && (
                         <Button

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1010,7 +1010,7 @@ export function ChatSettingsPanel({
                           : specFallbackReason === "runtime_error"
                           ? "MTP could not start for this model on the installed llama.cpp build, so it is running without speculative decoding."
                           : specFallbackReason === "drafter_not_found"
-                            ? "This model supports MTP but its drafter file could not be downloaded, so it is running without MTP. Check your network connection or Hugging Face access, then reload the model."
+                            ? "This model supports MTP, but its drafter file could not be downloaded. MTP is off and it is running with n-gram speculative decoding instead. Check your network connection or Hugging Face access, then reload the model to retry the drafter."
                             : "MTP is not available in the installed llama.cpp build, so this model is running without it." +
                               (llamaUpdateStatus?.update_available
                                 ? " Update llama.cpp to enable it."


### PR DESCRIPTION
Fixes #6406

## Problem

Loading `unsloth/gemma-4-E4B-it-GGUF` in Unsloth Studio ran without MTP speculative decoding and the UI blamed llama.cpp, even though the model supports MTP.

Unlike Qwen (which bakes the MTP head into the main GGUF), Gemma 4 ships its MTP head as a separate drafter file (a repo-root `mtp-*.gguf`). Studio did not recognise the Gemma 4 family as MTP-capable, so when that separate drafter was not resolved it silently fell back to standard decoding and mis-reported the cause as a llama.cpp limitation.

## Changes

- Recognise the Gemma 4 separate-drafter family by model id or GGUF filename, so a name-only Gemma 4 stays MTP-capable even before the drafter resolves. Gemma 3n is excluded since its GGUF repos ship no drafter; embedded-head models (Qwen) keep being detected via the GGUF metadata and are unaffected.
- Auto-download the separate drafter (repo-root `mtp-*.gguf`) when speculative decoding is auto/mtp/mtp+ngram and no drafter is already set. Transient HF listing/download failures retry with backoff; offline mode is non-retryable and falls through to the local cache.
- When the drafter cannot be resolved, surface a `drafter_not_found` state: warn, fall back to n-gram speculative decoding where the llama.cpp build supports it (instead of aborting), and re-attempt the drafter download on the next reload (self-heal) rather than deduping to the stale fallback.
- Forced `mtp` / `mtp+ngram` on a drafterless Gemma fall back instead of emitting `--spec-type draft-mtp` with no `--model-draft`, which would abort llama-server.
- The chat settings banner now distinguishes a missing drafter (check network or Hugging Face access, then reload to retry) from a llama.cpp build that lacks MTP (update llama.cpp).

The capability probe regex was investigated and left unchanged: real llama.cpp emits the `--spec-type` choices comma-joined (`...,draft-mtp,...`), so the existing `draft-mtp` branch already detects MTP. The substantive issue was the separate-drafter handling above, not the probe.

## Tests

- Backend MTP detection and VRAM budget suites pass (371), including a regression test that a drafterless Gemma 3n takes the normal non-MTP path.
- Embedded-MTP models (Qwen) and non-MTP models are unchanged (matrix tests).
