### PR TITLE
Polish the Hub card carousel: edge shadows, fades, and drag-to-scroll

### DIFF
--- a/studio/frontend/src/features/hub/catalog/card-carousel.tsx
+++ b/studio/frontend/src/features/hub/catalog/card-carousel.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils";
 import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -102,15 +104,67 @@ export function CardCarousel<T>({
     [stepPx],
   );
 
+  // Click-and-drag panning (mouse only; touch/pen keep native scrolling).
+  const drag = useRef<{ id: number; x: number; left: number; moved: boolean } | null>(
+    null,
+  );
+  const suppressClick = useRef(false);
+
+  const onPointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    suppressClick.current = false;
+    const el = scrollerRef.current;
+    if (!el || e.pointerType !== "mouse" || e.button !== 0) return;
+    drag.current = { id: e.pointerId, x: e.clientX, left: el.scrollLeft, moved: false };
+  }, []);
+
+  const onPointerMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current;
+    const el = scrollerRef.current;
+    if (!d || !el || e.pointerId !== d.id) return;
+    const dx = e.clientX - d.x;
+    // Ignore tiny moves so plain clicks still register.
+    if (!d.moved && Math.abs(dx) < 5) return;
+    if (!d.moved) {
+      d.moved = true;
+      el.setPointerCapture(d.id);
+    }
+    el.scrollLeft = d.left - dx;
+  }, []);
+
+  const endDrag = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = drag.current;
+    if (!d || e.pointerId !== d.id) return;
+    if (d.moved) {
+      // A drag just happened: swallow the click it would fire on a card.
+      suppressClick.current = true;
+      scrollerRef.current?.releasePointerCapture?.(d.id);
+    }
+    drag.current = null;
+  }, []);
+
+  const onClickCapture = useCallback((e: ReactMouseEvent<HTMLDivElement>) => {
+    if (!suppressClick.current) return;
+    suppressClick.current = false;
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
   return (
     <div className="relative">
       <div
         ref={scrollerRef}
         onScroll={updateArrows}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onClickCapture={onClickCapture}
+        // Stop the avatar image from starting a native drag during a pan.
+        onDragStart={(e) => e.preventDefault()}
         aria-label={ariaLabel}
         // px-2 + -mx-2 give card shadows room so the edge cards aren't clipped;
         // scroll-px-2 keeps snap-start aligned with the heading.
-        className="hub-carousel -mx-2 flex snap-x scroll-px-2 gap-4 overflow-x-auto px-2 pb-4 pt-2"
+        className="hub-carousel -mx-2 flex cursor-grab snap-x scroll-px-2 gap-4 overflow-x-auto px-2 pb-4 pt-2 select-none active:cursor-grabbing"
       >
         {items.map((item) => (
           <div

--- a/studio/frontend/src/features/hub/catalog/card-carousel.tsx
+++ b/studio/frontend/src/features/hub/catalog/card-carousel.tsx
@@ -121,6 +121,13 @@ export function CardCarousel<T>({
     const d = drag.current;
     const el = scrollerRef.current;
     if (!d || !el || e.pointerId !== d.id) return;
+    // Primary button no longer held: the press ended off the scroller, so no
+    // pointerup reached us. Drop the stale drag instead of scrolling on hover.
+    if ((e.buttons & 1) === 0) {
+      if (d.moved) el.style.scrollSnapType = "";
+      drag.current = null;
+      return;
+    }
     const dx = e.clientX - d.x;
     // Ignore tiny moves so plain clicks still register.
     if (!d.moved && Math.abs(dx) < 5) return;

--- a/studio/frontend/src/features/hub/catalog/card-carousel.tsx
+++ b/studio/frontend/src/features/hub/catalog/card-carousel.tsx
@@ -108,7 +108,9 @@ export function CardCarousel<T>({
         ref={scrollerRef}
         onScroll={updateArrows}
         aria-label={ariaLabel}
-        className="hub-carousel flex snap-x gap-4 overflow-x-auto pb-4 pt-2"
+        // px-2 + -mx-2 give card shadows room so the edge cards aren't clipped;
+        // scroll-px-2 keeps snap-start aligned with the heading.
+        className="hub-carousel -mx-2 flex snap-x scroll-px-2 gap-4 overflow-x-auto px-2 pb-4 pt-2"
       >
         {items.map((item) => (
           <div

--- a/studio/frontend/src/features/hub/catalog/card-carousel.tsx
+++ b/studio/frontend/src/features/hub/catalog/card-carousel.tsx
@@ -126,6 +126,8 @@ export function CardCarousel<T>({
     if (!d.moved && Math.abs(dx) < 5) return;
     if (!d.moved) {
       d.moved = true;
+      // Snap fights the per-frame scrollLeft writes; disable it while dragging.
+      el.style.scrollSnapType = "none";
       el.setPointerCapture(d.id);
     }
     el.scrollLeft = d.left - dx;
@@ -137,7 +139,10 @@ export function CardCarousel<T>({
     if (d.moved) {
       // A drag just happened: swallow the click it would fire on a card.
       suppressClick.current = true;
-      scrollerRef.current?.releasePointerCapture?.(d.id);
+      const el = scrollerRef.current;
+      // Restore snap so the row settles on a card after the drag.
+      if (el) el.style.scrollSnapType = "";
+      el?.releasePointerCapture?.(d.id);
     }
     drag.current = null;
   }, []);

--- a/studio/frontend/src/features/hub/hub.css
+++ b/studio/frontend/src/features/hub/hub.css
@@ -157,7 +157,9 @@
   }
 
   .hub-page .hub-carousel-fade-left {
-    left: 0;
+    /* -8px matches the scroller's -mx-2 bleed so the opaque edge sits on the
+       clip edge and no card peeks out beside the fade. */
+    left: -8px;
     background: linear-gradient(
       to right,
       var(--background),
@@ -167,7 +169,8 @@
   }
 
   .hub-page .hub-carousel-fade-right {
-    right: 0;
+    /* Mirror of fade-left: offset by the -mx-2 bleed to reach the clip edge. */
+    right: -8px;
     background: linear-gradient(
       to left,
       var(--background),

--- a/studio/frontend/src/features/hub/hub.css
+++ b/studio/frontend/src/features/hub/hub.css
@@ -147,7 +147,7 @@
     pointer-events: none;
     position: absolute;
     z-index: 5;
-    width: 56px;
+    width: 44px;
     opacity: 0;
     transition: opacity 240ms ease;
   }


### PR DESCRIPTION
## What

Three small fixes for the Hub card carousel (Trending Now and the other rows).

1. Edge card shadows were clipped. The scroll container only had vertical padding, so with `overflow-x-auto` the first and last cards had their drop shadow cut off on the left and right.
2. The left and right fades did not blend into the page background. After the shadow fix the scroller bleeds 8px past the wrapper (`-mx-2`), but the fade overlays stayed pinned to the wrapper edges, 8px inside the clip edge. That left a thin strip where a card showed beside the fade, so the fade looked like a separate block instead of melting into the background.
3. You could not drag the cards to move the row. The carousel only scrolled by wheel or trackpad, and grabbing a card started a native drag of its avatar image.

## Fix

`studio/frontend/src/features/hub/catalog/card-carousel.tsx`

- Add `px-2` for horizontal room and a matching `-mx-2` so the cards stay aligned with the section heading. Add `scroll-px-2` so `snap-start` does not scroll the padding away on load.
- Add mouse click-and-drag panning. Touch and pen keep native scrolling. A drag swallows the click it would otherwise fire on a card, plain clicks still select, and the avatar's native drag is blocked so it cannot hijack the gesture.

`studio/frontend/src/features/hub/hub.css`

- Offset both edge fades by the same 8px bleed (`left: -8px` / `right: -8px`) so their opaque edge sits exactly on the scroll clip edge and no card peeks out beside the fade.

## Testing

Verified in the running Studio frontend:

- At rest the first card sits 8px inside the clip edge so its shadow is fully shown, `scrollLeft` rests at 0, and the card left edge lines up with the heading text.
- When scrolled, both fades line up exactly with the scroll clip edges (0px gap measured each side), so the cards melt into the background with no detached strip.
- Dragging a card pans the row, the post-drag click is suppressed (no accidental navigation), a plain click still selects the model, and the avatar image no longer starts a native drag.
- No horizontal page overflow, scroll arrows unaffected. `npm run typecheck` and `npm run build` both pass.