### PR TITLE
studio: fix two backend CI test failures (capability dict + MTP recovery race)

### DIFF
--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -107,6 +107,7 @@ def test_detect_safetensors_features_none_template_returns_all_false():
         "supports_reasoning": False,
         "reasoning_style": "enable_thinking",
         "reasoning_always_on": False,
+        "reasoning_effort_levels": [],
         "supports_preserve_thinking": False,
         "supports_tools": False,
     }

--- a/studio/backend/tests/test_tensor_parallel.py
+++ b/studio/backend/tests/test_tensor_parallel.py
@@ -365,6 +365,11 @@ def test_runtime_recovery_reloads_without_mtp(monkeypatch):
     while b._spec_fallback_reason != "runtime_error" and time.monotonic() < deadline:
         time.sleep(0.02)
     assert b._spec_fallback_reason == "runtime_error"
+    # The reload thread clears the single-flight flag in its finally, a beat after
+    # it sets the fallback reason -- wait for that instead of racing the thread.
+    deadline = time.monotonic() + 2
+    while b._mtp_runtime_fallback_in_progress and time.monotonic() < deadline:
+        time.sleep(0.02)
     assert b._mtp_runtime_fallback_in_progress is False
 
 


### PR DESCRIPTION
## Summary

The Studio backend test matrix (`(Python 3.10)` through `(Python 3.13)`) has been red on every open PR regardless of what the PR touches (e.g. frontend-only #6458, CLI-only #6453, and #6459). Two unrelated tests on `main` are responsible. Both are test-side issues; the production code is correct.

### 1. `test_safetensors_capability_advertise.py::test_detect_safetensors_features_none_template_returns_all_false`

`detect_reasoning_flags()` now returns a `reasoning_effort_levels` key (added alongside the GLM-5.2 high/max/disabled thinking work in #6444), so the route helper emits six keys. The none-template expectation still listed only five and failed the exact-equality assert:

```
Left contains 1 more item:
{'reasoning_effort_levels': []}
```

Fix: add `"reasoning_effort_levels": []` to the expected dict.

### 2. `test_tensor_parallel.py::test_runtime_recovery_reloads_without_mtp`

The recovery thread sets `_spec_fallback_reason = "runtime_error"` and then, a couple of statements later in its `finally`, clears the single-flight flag `_mtp_runtime_fallback_in_progress`. The test waited on `_spec_fallback_reason` and then immediately asserted the flag was `False`, so on a loaded runner it observed the flag still `True`:

```
assert b._mtp_runtime_fallback_in_progress is False
E   assert True is False
```

Fix: wait for the flag to clear (bounded poll) before asserting, matching how the test already waits for the fallback reason. The production lifecycle (flag cleared in `finally`) is unchanged.

## Validation

- `test_safetensors_capability_advertise.py`: 16 passed.
- `test_tensor_parallel.py`: 77 passed; the recovery test passed 12/12 in a loop (was an intermittent race).

Unblocks CI on #6459, #6458, #6453 (and other open PRs) once they pick up `main`. The `Core (HF=default + TRL=default)` cell fails for a separate reason that lives in unsloth-zoo and is handled in a companion PR there.