### PR TITLE
Studio: label Apple Silicon as Metal/unified memory instead of CPU-only in installers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2460,6 +2460,9 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
     substep "ROCm: $_rocm_root"
     [ -n "$_gpu_rocm_ver" ] && substep "hipconfig: $_gpu_rocm_ver"
     [ -n "$_gpu_disp_mkt" ] && [ -n "$_gpu_disp_gfx" ] && substep "GPU: $_gpu_disp_mkt"
+elif [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
+    # Apple Silicon: PyTorch gets Metal (MPS) acceleration over unified memory, so not CPU-only.
+    step "gpu" "Apple Silicon (Metal, unified memory)"
 else
     step "gpu" "none (CPU-only)" "$C_WARN"
 fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -968,7 +968,7 @@ elif [ "$_setup_amd_detected" = true ]; then
     substep "ROCm: $_setup_rocm_root"
     [ -n "$_setup_rocm_ver" ] && substep "hipconfig: $_setup_rocm_ver"
     [ -n "$_setup_mkt" ] && [ -n "$_setup_gfx" ] && substep "GPU: $_setup_mkt"
-elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] && { [ "$(uname -m 2>/dev/null)" = "arm64" ] || [ "$(uname -m 2>/dev/null)" = "aarch64" ]; }; then
+elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] && [ "$(uname -m 2>/dev/null)" = "arm64" ]; then
     # Apple Silicon: llama.cpp builds with Metal over unified memory, so not a CPU-only host.
     step "gpu" "Apple Silicon (Metal, unified memory)"
 else

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -968,6 +968,9 @@ elif [ "$_setup_amd_detected" = true ]; then
     substep "ROCm: $_setup_rocm_root"
     [ -n "$_setup_rocm_ver" ] && substep "hipconfig: $_setup_rocm_ver"
     [ -n "$_setup_mkt" ] && [ -n "$_setup_gfx" ] && substep "GPU: $_setup_mkt"
+elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] && { [ "$(uname -m 2>/dev/null)" = "arm64" ] || [ "$(uname -m 2>/dev/null)" = "aarch64" ]; }; then
+    # Apple Silicon: llama.cpp builds with Metal over unified memory, so not a CPU-only host.
+    step "gpu" "Apple Silicon (Metal, unified memory)"
 else
     step "gpu" "none (chat-only / GGUF)" "$C_WARN"
     substep "Training and GPU inference require an NVIDIA or AMD ROCm GPU."


### PR DESCRIPTION
On Apple Silicon the installer reported the GPU as `none (CPU-only)`. That is confusing on a unified-memory Mac: PyTorch runs on Metal (MPS) and Studio's llama.cpp is built with Metal.

## Before / after

install.sh:

```diff
- gpu  none (CPU-only)
+ gpu  Apple Silicon (Metal, unified memory)
```

studio/setup.sh:

```diff
- gpu  none (chat-only / GGUF)
-      Training and GPU inference require an NVIDIA or AMD ROCm GPU.
+ gpu  Apple Silicon (Metal, unified memory)
```

A full Studio install runs both scripts, so a Mac user saw both wrong lines in one run.

## Detection

The GPU summary only special-cases NVIDIA and AMD/ROCm, then falls through to the CPU-only label. A Mac matches neither (no `nvidia-smi`; `TORCH_INDEX_URL` is the `/cpu` index on Darwin), so it hit the fallback. This adds an Apple-Silicon branch before that fallback:

- `install.sh` gates on `OS = macos && _ARCH = arm64` (the existing idiom in the file).
- `studio/setup.sh` uses an inline `uname` check (the `_HOST_*` vars aren't set yet there), mirroring the Metal-build detection at `setup.sh:1347`.

Intel/Rosetta Macs (`x86_64`) and aarch64 Linux are unaffected. Both branches require Darwin and Apple Silicon, so they keep the CPU-only label (Intel Macs have no MPS torch). `install.ps1` / `setup.ps1` need no change (Windows-only).

It's a status-line label only; nothing parses the text. Routing keys off `$OS` / `$TORCH_INDEX_URL` and the Tauri diag marker (already maps macOS to `mac`), all unchanged.
