### PR TITLE
Studio: complete Visual Studio 2026 support for the CUDA llama.cpp build (v180 + CMake 4.2 guard)

### DIFF
--- a/.github/workflows/studio-setup-ps1-vs2026.yml
+++ b/.github/workflows/studio-setup-ps1-vs2026.yml
@@ -15,6 +15,10 @@
 #   - windows-2025-vs2026  -> real Visual Studio 2026 (toolset v180)
 # VS 2017/2019/2015 are retired from hosted images, so only 2022 and 2026 can be
 # exercised against a genuine install; the rest stay covered by job 1's mocks.
+#
+# Job 3 (vcredist-clean-box): exercises the VC++ runtime guard on a throwaway
+# runner - detection is present on the stock image, fires on a genuinely clean box
+# (signals removed restorably), and an uninstall/reinstall round trip restores it.
 
 name: Windows Studio setup.ps1 unit tests
 
@@ -152,3 +156,98 @@ jobs:
           }
 
           Write-Host "PASS: real $env:EXPECT_GEN detected correctly with toolset '$derived'."
+
+  vcredist-clean-box:
+    # Validate the VC++ runtime detection (Test-VCRedistInstalled) and the install
+    # path (Ensure-VCRedist) on a real, throwaway runner. Confirm present on the
+    # stock image, confirm detection FIRES on a genuinely clean box (registry +
+    # System32 signals removed, restorably), then run a literal uninstall/reinstall
+    # round trip. The runtime is always restored before the job ends.
+    name: VC++ runtime detect + install round-trip (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-2025-vs2026]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Detect present, fire on a clean box, and round-trip the install
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . (Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1/Get-FunctionSource.ps1')
+          $setup = Join-Path $env:GITHUB_WORKSPACE 'studio/setup.ps1'
+          foreach ($fn in @('step', 'substep', 'Invoke-SetupCommand', 'Refresh-Environment',
+                            'Test-VCRedistInstalled', 'Ensure-VCRedist')) {
+              $src = Get-FunctionSource -Path $setup -Name $fn
+              if (-not $src) { throw "Function '$fn' not found in setup.ps1" }
+              . ([scriptblock]::Create($src))
+          }
+
+          $regKeys = @(
+              'HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64',
+              'HKLM\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64'
+          )
+          function Show-GroundTruth {
+              $dll = Join-Path $env:SystemRoot 'System32\vcruntime140_1.dll'
+              Write-Host ("  System32\vcruntime140_1.dll present: {0}" -f (Test-Path $dll))
+              foreach ($k in $regKeys) {
+                  $r = Get-ItemProperty -Path "HKLM:\$($k.Substring(5))" -ErrorAction SilentlyContinue
+                  if ($r) { Write-Host ("  {0}: Installed={1} {2}.{3}" -f $k, $r.Installed, $r.Major, $r.Minor) }
+                  else    { Write-Host ("  {0}: (absent)" -f $k) }
+              }
+          }
+
+          Write-Host '== A. Detection on the stock runner (expect present) =='
+          Show-GroundTruth
+          if (-not (Test-VCRedistInstalled)) { throw 'Test-VCRedistInstalled reported ABSENT on a stock runner that ships the VC++ runtime (detection regression).' }
+          Write-Host '  Test-VCRedistInstalled -> present  OK'
+
+          Write-Host '== B. Genuinely clean box (restorable): detection must FIRE =='
+          $scratch = Join-Path $env:RUNNER_TEMP 'cleanwin'
+          New-Item -ItemType Directory -Force -Path (Join-Path $scratch 'System32') | Out-Null
+          $backup = Join-Path $env:RUNNER_TEMP 'vcreg_backup'
+          New-Item -ItemType Directory -Force -Path $backup | Out-Null
+          $origSysRoot = $env:SystemRoot
+          try {
+              for ($i = 0; $i -lt $regKeys.Count; $i++) {
+                  reg query $regKeys[$i] *> $null
+                  if ($LASTEXITCODE -eq 0) {
+                      reg export $regKeys[$i] (Join-Path $backup "$i.reg") /y *> $null
+                      reg delete $regKeys[$i] /f *> $null
+                  }
+              }
+              $env:SystemRoot = $scratch
+              if (Test-VCRedistInstalled) { throw 'Detection still PRESENT after both signals were removed (it would never trigger an install on a clean box).' }
+              Write-Host '  Test-VCRedistInstalled -> absent  OK (detection fires on a clean box)'
+          } finally {
+              $env:SystemRoot = $origSysRoot
+              for ($i = 0; $i -lt $regKeys.Count; $i++) {
+                  $f = Join-Path $backup "$i.reg"
+                  if (Test-Path $f) { reg import $f *> $null }
+              }
+          }
+          Show-GroundTruth
+          if (-not (Test-VCRedistInstalled)) { throw 'Detection did not recover after restoring the registry (test restore bug).' }
+
+          Write-Host '== C. Literal uninstall on this throwaway VM (official installer), observe detection =='
+          $exe = Join-Path $env:RUNNER_TEMP 'vc_redist.x64.exe'
+          Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile $exe
+          Start-Process -FilePath $exe -ArgumentList '/uninstall', '/quiet', '/norestart' -Wait
+          Show-GroundTruth
+          Write-Host ("  Test-VCRedistInstalled after uninstall -> {0}" -f (Test-VCRedistInstalled))
+
+          Write-Host '== D. Restore via Ensure-VCRedist (winget product path), installer fallback if needed =='
+          Ensure-VCRedist
+          if (-not (Test-VCRedistInstalled)) {
+              Write-Host '  winget path did not restore it; using the official installer to close the round trip.'
+              Start-Process -FilePath $exe -ArgumentList '/install', '/quiet', '/norestart' -Wait
+          }
+          Show-GroundTruth
+          if (-not (Test-VCRedistInstalled)) { throw 'VC++ runtime could not be restored after the uninstall round-trip.' }
+          Write-Host '  Test-VCRedistInstalled -> present  OK'
+          Write-Host 'PASS: detection is correct on a real install, fires on a clean box, and the install round-trip restores the runtime.'

--- a/.github/workflows/studio-setup-ps1-vs2026.yml
+++ b/.github/workflows/studio-setup-ps1-vs2026.yml
@@ -106,7 +106,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           . (Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1/Get-FunctionSource.ps1')
           $setup = Join-Path $env:GITHUB_WORKSPACE 'studio/setup.ps1'
-          foreach ($fn in @('Get-VcBuildCustomizationsDir', 'Find-VsBuildTools')) {
+          foreach ($fn in @('Resolve-VsGeneratorFromLabel', 'Get-VcBuildCustomizationsDir', 'Find-VsBuildTools')) {
               . ([scriptblock]::Create((Get-FunctionSource -Path $setup -Name $fn)))
           }
 

--- a/.github/workflows/studio-setup-ps1-vs2026.yml
+++ b/.github/workflows/studio-setup-ps1-vs2026.yml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Pure-logic unit tests for studio/setup.ps1 Visual Studio 2026 support on the
+# free windows-latest runner. No Visual Studio, CUDA, or GPU required - the
+# functions under test are pure:
+#   - Get-VcBuildCustomizationsDir : VC MSBuild folder derivation (v160/v170/v180)
+#   - Test-CmakeSupportsGenerator  : CMake >= 4.2 gate for the VS 2026 generator
+# Individual functions are extracted from setup.ps1 and dot-sourced (the script
+# is a top-level installer and cannot be loaded wholesale).
+
+name: Windows Studio setup.ps1 unit tests
+
+on:
+  pull_request:
+    paths:
+      - 'studio/setup.ps1'
+      - 'tests/studio_setup_ps1/**'
+      - '.github/workflows/studio-setup-ps1-vs2026.yml'
+  push:
+    branches: [main, pip]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pester:
+    name: setup.ps1 unit tests (VS 2026 / CMake guard)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Pester v5
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester -MinimumVersion 5.5.0
+          Get-Module Pester | Select-Object Name, Version | Format-Table
+
+      - name: Run Pester suite
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $testDir = Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1'
+          if (-not (Test-Path $testDir)) {
+              Write-Error "Test directory not found: $testDir"
+              exit 1
+          }
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path                = $testDir
+          $cfg.Run.Exit                = $true   # non-zero exit => job fails
+          $cfg.Run.Throw               = $true   # also throw on test failure / 0 tests
+          $cfg.TestResult.Enabled      = $true
+          $cfg.TestResult.OutputFormat = 'NUnitXml'
+          $cfg.TestResult.OutputPath   = Join-Path $env:GITHUB_WORKSPACE 'pester-results.xml'
+          $cfg.Output.Verbosity        = 'Detailed'
+          Invoke-Pester -Configuration $cfg
+
+      - name: Upload Pester results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: pester-results-setup-ps1
+          path: pester-results.xml
+          if-no-files-found: warn

--- a/.github/workflows/studio-setup-ps1-vs2026.yml
+++ b/.github/workflows/studio-setup-ps1-vs2026.yml
@@ -2,23 +2,12 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
 # Tests for studio/setup.ps1 Visual Studio detection + CUDA toolset support.
-#
-# Job 1 (pester): pure-logic unit tests on windows-latest. No real Visual Studio,
-# CUDA, or GPU required - functions are extracted from setup.ps1 and dot-sourced
-# (the script is a top-level installer, not importable wholesale), with
-# vswhere/cmake mocked and fake VS trees on disk. Covers all five versions
-# (2017/2019/2022/2026 + Preview) since those installs cannot be conjured in CI.
-#
-# Job 2 (vs-integration): runs the REAL detection against the actual Visual Studio
-# preinstalled on GitHub-hosted runners, in parallel:
-#   - windows-2022         -> real Visual Studio 2022 (toolset v170)
-#   - windows-2025-vs2026  -> real Visual Studio 2026 (toolset v180)
-# VS 2017/2019/2015 are retired from hosted images, so only 2022 and 2026 can be
-# exercised against a genuine install; the rest stay covered by job 1's mocks.
-#
-# Job 3 (vcredist-clean-box): exercises the VC++ runtime guard on a throwaway
-# runner - detection is present on the stock image, fires on a genuinely clean box
-# (signals removed restorably), and an uninstall/reinstall round trip restores it.
+# Job 1 (pester): mocked unit tests covering all VS versions (functions are
+#   dot-sourced from setup.ps1; the installs cannot be conjured in CI).
+# Job 2 (vs-integration): real detection against the VS preinstalled on the
+#   windows-2022 (v170) and windows-2025-vs2026 (v180) runners.
+# Job 3 (vcredist-clean-box): the VC++ runtime guard on a throwaway runner -
+#   present on the stock image, fires on a clean box, restored after a round trip.
 
 name: Windows Studio setup.ps1 unit tests
 
@@ -85,8 +74,7 @@ jobs:
           if-no-files-found: warn
 
   vs-integration:
-    # Exercise the real detection logic against the Visual Studio that is actually
-    # installed on the runner image - no mocks. Both versions run in parallel.
+    # Real detection against the VS installed on the runner image (no mocks).
     name: real-VS detection (${{ matrix.label }})
     strategy:
       fail-fast: false
@@ -141,8 +129,8 @@ jobs:
               throw "Toolset mismatch: derived '$derived', expected '$env:EXPECT_TOOLSET'"
           }
 
-          # ...and that v-number must be a real folder on the actual VS install
-          # (proves CUDA's BuildCustomizations would land in an existing toolset dir).
+          # ...and that v-number is a real folder on the VS install (where CUDA's
+          # BuildCustomizations would land).
           $vcRoot = Join-Path $r.InstallPath 'MSBuild\Microsoft\VC'
           if (Test-Path $vcRoot) {
               $realToolsets = @((Get-ChildItem -Path $vcRoot -Directory -ErrorAction SilentlyContinue).Name)
@@ -158,11 +146,9 @@ jobs:
           Write-Host "PASS: real $env:EXPECT_GEN detected correctly with toolset '$derived'."
 
   vcredist-clean-box:
-    # Validate the VC++ runtime detection (Test-VCRedistInstalled) and the install
-    # path (Ensure-VCRedist) on a real, throwaway runner. Confirm present on the
-    # stock image, confirm detection FIRES on a genuinely clean box (registry +
-    # System32 signals removed, restorably), then run a literal uninstall/reinstall
-    # round trip. The runtime is always restored before the job ends.
+    # Validate Test-VCRedistInstalled + Ensure-VCRedist on a throwaway runner:
+    # present on the stock image, fires on a clean box (signals removed restorably),
+    # then a literal uninstall/reinstall round trip. Always restored before the end.
     name: VC++ runtime detect + install round-trip (${{ matrix.os }})
     strategy:
       fail-fast: false
@@ -181,8 +167,8 @@ jobs:
           $ErrorActionPreference = 'Stop'
           . (Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1/Get-FunctionSource.ps1')
           $setup = Join-Path $env:GITHUB_WORKSPACE 'studio/setup.ps1'
-          # Dot-source the runtime guard plus the logging closure it reaches
-          # (Ensure-VCRedist -> step/substep -> Write-StudioStdoutMirror / Get-StudioAnsi).
+          # Dot-source the guard + the logging closure it reaches
+          # (step/substep -> Write-StudioStdoutMirror / Get-StudioAnsi).
           $script:StudioVtOk = $false
           $script:UnslothVerbose = $false
           foreach ($fn in @('Get-StudioAnsi', 'Write-StudioStdoutMirror', 'step', 'substep',

--- a/.github/workflows/studio-setup-ps1-vs2026.yml
+++ b/.github/workflows/studio-setup-ps1-vs2026.yml
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Pure-logic unit tests for studio/setup.ps1 Visual Studio 2026 support on the
-# free windows-latest runner. No Visual Studio, CUDA, or GPU required - the
-# functions under test are pure:
-#   - Get-VcBuildCustomizationsDir : VC MSBuild folder derivation (v160/v170/v180)
-#   - Test-CmakeSupportsGenerator  : CMake >= 4.2 gate for the VS 2026 generator
-# Individual functions are extracted from setup.ps1 and dot-sourced (the script
-# is a top-level installer and cannot be loaded wholesale).
+# Tests for studio/setup.ps1 Visual Studio detection + CUDA toolset support.
+#
+# Job 1 (pester): pure-logic unit tests on windows-latest. No real Visual Studio,
+# CUDA, or GPU required - functions are extracted from setup.ps1 and dot-sourced
+# (the script is a top-level installer, not importable wholesale), with
+# vswhere/cmake mocked and fake VS trees on disk. Covers all five versions
+# (2017/2019/2022/2026 + Preview) since those installs cannot be conjured in CI.
+#
+# Job 2 (vs-integration): runs the REAL detection against the actual Visual Studio
+# preinstalled on GitHub-hosted runners, in parallel:
+#   - windows-2022         -> real Visual Studio 2022 (toolset v170)
+#   - windows-2025-vs2026  -> real Visual Studio 2026 (toolset v180)
+# VS 2017/2019/2015 are retired from hosted images, so only 2022 and 2026 can be
+# exercised against a genuine install; the rest stay covered by job 1's mocks.
 
 name: Windows Studio setup.ps1 unit tests
 
@@ -72,3 +79,76 @@ jobs:
           name: pester-results-setup-ps1
           path: pester-results.xml
           if-no-files-found: warn
+
+  vs-integration:
+    # Exercise the real detection logic against the Visual Studio that is actually
+    # installed on the runner image - no mocks. Both versions run in parallel.
+    name: real-VS detection (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows-2022,        label: 'VS 2022', expectGen: 'Visual Studio 17 2022', expectToolset: 'v170' }
+          - { os: windows-2025-vs2026, label: 'VS 2026', expectGen: 'Visual Studio 18 2026', expectToolset: 'v180' }
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Detect the real Visual Studio with setup.ps1 functions
+        shell: pwsh
+        env:
+          EXPECT_GEN: ${{ matrix.expectGen }}
+          EXPECT_TOOLSET: ${{ matrix.expectToolset }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . (Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1/Get-FunctionSource.ps1')
+          $setup = Join-Path $env:GITHUB_WORKSPACE 'studio/setup.ps1'
+          foreach ($fn in @('Get-VcBuildCustomizationsDir', 'Find-VsBuildTools')) {
+              . ([scriptblock]::Create((Get-FunctionSource -Path $setup -Name $fn)))
+          }
+
+          # Ground truth from the real vswhere (independent of our code), for visibility.
+          $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (Test-Path $vsw) {
+              $year = (& $vsw -latest -property catalog_productLineVersion 2>$null | Select-Object -First 1)
+              $path = (& $vsw -latest -property installationPath 2>$null | Select-Object -First 1)
+              Write-Host "Real vswhere: productLineVersion='$year'  installPath='$path'"
+          } else {
+              Write-Host "vswhere not present at $vsw (relying on filesystem fallback)"
+          }
+
+          # Our detection must find the real VS and report the expected generator.
+          $r = Find-VsBuildTools
+          if (-not $r) { throw "Find-VsBuildTools returned null on a host with real $env:EXPECT_GEN" }
+          Write-Host "Find-VsBuildTools -> Generator='$($r.Generator)' Source='$($r.Source)' InstallPath='$($r.InstallPath)'"
+          if ($r.Generator -ne $env:EXPECT_GEN) {
+              throw "Detection mismatch: got '$($r.Generator)', expected '$env:EXPECT_GEN'"
+          }
+          if (-not (Test-Path $r.InstallPath)) { throw "Detected InstallPath does not exist: $($r.InstallPath)" }
+
+          # Toolset path derivation must match the expected v-number...
+          $bc = Get-VcBuildCustomizationsDir -VsInstallPath $r.InstallPath -Generator $r.Generator
+          $derived = Split-Path (Split-Path $bc -Parent) -Leaf   # e.g. v170 / v180
+          Write-Host "Get-VcBuildCustomizationsDir -> '$bc' (toolset='$derived')"
+          if ($derived -ne $env:EXPECT_TOOLSET) {
+              throw "Toolset mismatch: derived '$derived', expected '$env:EXPECT_TOOLSET'"
+          }
+
+          # ...and that v-number must be a real folder on the actual VS install
+          # (proves CUDA's BuildCustomizations would land in an existing toolset dir).
+          $vcRoot = Join-Path $r.InstallPath 'MSBuild\Microsoft\VC'
+          if (Test-Path $vcRoot) {
+              $realToolsets = @((Get-ChildItem -Path $vcRoot -Directory -ErrorAction SilentlyContinue).Name)
+              Write-Host "Real VC toolset dirs: $($realToolsets -join ', ')"
+              if ($realToolsets -notcontains $derived) {
+                  throw "Derived toolset '$derived' is not present on the real $env:EXPECT_GEN install (have: $($realToolsets -join ', '))"
+              }
+              Write-Host "OK: toolset '$derived' exists on the real VS install."
+          } else {
+              Write-Warning "VC MSBuild root absent ($vcRoot) - C++ workload not installed; skipping on-disk toolset check."
+          }
+
+          Write-Host "PASS: real $env:EXPECT_GEN detected correctly with toolset '$derived'."

--- a/.github/workflows/studio-setup-ps1-vs2026.yml
+++ b/.github/workflows/studio-setup-ps1-vs2026.yml
@@ -181,7 +181,12 @@ jobs:
           $ErrorActionPreference = 'Stop'
           . (Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1/Get-FunctionSource.ps1')
           $setup = Join-Path $env:GITHUB_WORKSPACE 'studio/setup.ps1'
-          foreach ($fn in @('step', 'substep', 'Invoke-SetupCommand', 'Refresh-Environment',
+          # Dot-source the runtime guard plus the logging closure it reaches
+          # (Ensure-VCRedist -> step/substep -> Write-StudioStdoutMirror / Get-StudioAnsi).
+          $script:StudioVtOk = $false
+          $script:UnslothVerbose = $false
+          foreach ($fn in @('Get-StudioAnsi', 'Write-StudioStdoutMirror', 'step', 'substep',
+                            'Invoke-SetupCommand', 'Refresh-Environment',
                             'Test-VCRedistInstalled', 'Ensure-VCRedist')) {
               $src = Get-FunctionSource -Path $setup -Name $fn
               if (-not $src) { throw "Function '$fn' not found in setup.ps1" }
@@ -240,6 +245,10 @@ jobs:
           Start-Process -FilePath $exe -ArgumentList '/uninstall', '/quiet', '/norestart' -Wait
           Show-GroundTruth
           Write-Host ("  Test-VCRedistInstalled after uninstall -> {0}" -f (Test-VCRedistInstalled))
+          if (Test-VCRedistInstalled) {
+              Write-Host '  Note: the Visual Studio on this image ref-counts the runtime, so the package'
+              Write-Host '        uninstall is a no-op here; section B already proved detection on a clean box.'
+          }
 
           Write-Host '== D. Restore via Ensure-VCRedist (winget product path), installer fallback if needed =='
           Ensure-VCRedist

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -510,36 +510,35 @@ function Get-FallbackVsGenerator {
     return $null
 }
 
+# Map a Visual Studio version label to its CMake generator. vswhere's
+# catalog_productLineVersion is the marketing YEAR for VS <= 2022 (e.g. "2022"),
+# but the internal MAJOR for VS 2026 (observed as "18" on the real VS 2026 runner
+# image), and install-dir names use either form. Accept both so detection works
+# from vswhere and from the filesystem scan regardless of which label a VS reports.
+# (VS 2026 detection adapted from @LeoBorcherding's #6038.)
+function Resolve-VsGeneratorFromLabel {
+    param([string]$Label)
+    if (-not $Label) { return $null }
+    $map = @{
+        '2026' = 'Visual Studio 18 2026'; '18' = 'Visual Studio 18 2026'
+        '2022' = 'Visual Studio 17 2022'; '17' = 'Visual Studio 17 2022'
+        '2019' = 'Visual Studio 16 2019'; '16' = 'Visual Studio 16 2019'
+        '2017' = 'Visual Studio 15 2017'; '15' = 'Visual Studio 15 2017'
+    }
+    return $map[$Label.Trim()]
+}
+
 # Find Visual Studio Build Tools for cmake -G flag.
 # Strategy: (1) vswhere, (2) scan filesystem (handles broken vswhere registration).
 # Returns @{ Generator = "Visual Studio 17 2022"; InstallPath = "C:\..."; Source = "..." } or $null.
 function Find-VsBuildTools {
-    # vswhere reports catalog_productLineVersion as the YEAR label (e.g. "2026").
-    $yearToGenerator = @{
-        '2026' = 'Visual Studio 18 2026'
-        '2022' = 'Visual Studio 17 2022'
-        '2019' = 'Visual Studio 16 2019'
-        '2017' = 'Visual Studio 15 2017'
-    }
-    # VS 2026 changed its install-dir convention to the internal major ("18");
-    # earlier versions use the year. Accept both so the filesystem fallback works
-    # regardless of which convention an install used. (VS 2026 detection adapted
-    # from @LeoBorcherding's #6038.)
-    $dirToGenerator = @{
-        '18'   = 'Visual Studio 18 2026'
-        '2026' = 'Visual Studio 18 2026'
-        '2022' = 'Visual Studio 17 2022'
-        '2019' = 'Visual Studio 16 2019'
-        '2017' = 'Visual Studio 15 2017'
-    }
-
     # --- Try vswhere first (works when VS is properly registered) ---
     $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $vsw) {
         $info = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion 2>$null
         $path = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
         if ($info -and $path) {
-            $gen = $yearToGenerator[$info.Trim()]
+            $gen = Resolve-VsGeneratorFromLabel $info
             if ($gen) {
                 return @{ Generator = $gen; InstallPath = $path.Trim(); Source = 'vswhere' }
             }
@@ -553,7 +552,7 @@ function Find-VsBuildTools {
     $dirs = @('18', '2026', '2022', '2019', '2017')
 
     foreach ($d in $dirs) {
-        $gen = $dirToGenerator[$d]
+        $gen = Resolve-VsGeneratorFromLabel $d
         if (-not $gen) { continue }
         foreach ($r in $roots) {
             $vsBase = Join-Path $r "Microsoft Visual Studio\$d"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -612,6 +612,45 @@ function Find-VsBuildTools {
     return $null
 }
 
+# Detect the Microsoft Visual C++ 2015-2022 Redistributable. The prebuilt
+# llama-server.exe and the PyTorch wheels dynamically link VCRUNTIME140.dll /
+# MSVCP140.dll / VCRUNTIME140_1.dll; the Universal CRT ships with Windows 10+ but
+# this redistributable does not. vcruntime140_1.dll (VS 2019+) is the newest of
+# those, so its presence is the signal; the registry is a fallback.
+function Test-VCRedistInstalled {
+    $sys = $env:SystemRoot
+    if ($sys -and (Test-Path (Join-Path $sys 'System32\vcruntime140_1.dll'))) { return $true }
+    foreach ($k in @(
+        'HKLM:\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64'
+    )) {
+        try {
+            $r = Get-ItemProperty -Path $k -ErrorAction Stop
+            if ($r.Installed -eq 1 -and [int]$r.Major -ge 14 -and [int]$r.Minor -ge 20) { return $true }
+        } catch { }
+    }
+    return $false
+}
+
+# Install the VC++ 2015-2022 runtime if missing (non-fatal). Both the prebuilt
+# llama-server and PyTorch need it; it is usually already present, so this no-ops.
+function Ensure-VCRedist {
+    if (Test-VCRedistInstalled) { step "vcredist" "present"; return }
+    Write-Host "Microsoft Visual C++ Redistributable (2015-2022) is missing; the prebuilt llama.cpp and PyTorch need it. Installing the runtime..." -ForegroundColor Yellow
+    if ($null -ne (Get-Command winget -ErrorAction SilentlyContinue)) {
+        try {
+            Invoke-SetupCommand { winget install --id Microsoft.VCRedist.2015+.x64 --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
+            Refresh-Environment
+        } catch { substep "VCRedist install failed: $($_.Exception.Message)" "Yellow" }
+    }
+    if (Test-VCRedistInstalled) { step "vcredist" "installed" }
+    else {
+        substep "Could not install the VC++ Redistributable automatically." "Yellow"
+        substep "If llama-server or torch reports a missing VCRUNTIME140.dll, install:" "Yellow"
+        substep "https://aka.ms/vs/17/release/vc_redist.x64.exe" "Yellow"
+    }
+}
+
 # ─────────────────────────────────────────────
 # Output style (aligned with studio/setup.sh: step / substep)
 # ─────────────────────────────────────────────
@@ -1282,6 +1321,13 @@ if (-not $HasGit) {
 } else {
     step "git" "$(git --version)"
 }
+
+# ============================================
+# 1b.5. Visual C++ Redistributable (runtime for the prebuilt llama.cpp + PyTorch)
+# ============================================
+# Not a build tool: the prebuilt llama-server and the pip/uv PyTorch wheels both
+# load the MSVC runtime DLLs at runtime, so ensure it even with no build tools.
+Ensure-VCRedist
 
 # ============================================
 # 1c. CMake (required for llama.cpp build)

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -436,7 +436,24 @@ function Test-CmakeSupportsGenerator {
 # Strategy: (1) vswhere, (2) scan filesystem (handles broken vswhere registration).
 # Returns @{ Generator = "Visual Studio 17 2022"; InstallPath = "C:\..."; Source = "..." } or $null.
 function Find-VsBuildTools {
-    $map = @{ '2022' = '17'; '2019' = '16'; '2017' = '15' }
+    # vswhere reports catalog_productLineVersion as the YEAR label (e.g. "2026").
+    $yearToGenerator = @{
+        '2026' = 'Visual Studio 18 2026'
+        '2022' = 'Visual Studio 17 2022'
+        '2019' = 'Visual Studio 16 2019'
+        '2017' = 'Visual Studio 15 2017'
+    }
+    # VS 2026 changed its install-dir convention to the internal major ("18");
+    # earlier versions use the year. Accept both so the filesystem fallback works
+    # regardless of which convention an install used. (VS 2026 detection adapted
+    # from @LeoBorcherding's #6038.)
+    $dirToGenerator = @{
+        '18'   = 'Visual Studio 18 2026'
+        '2026' = 'Visual Studio 18 2026'
+        '2022' = 'Visual Studio 17 2022'
+        '2019' = 'Visual Studio 16 2019'
+        '2017' = 'Visual Studio 15 2017'
+    }
 
     # --- Try vswhere first (works when VS is properly registered) ---
     $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -444,33 +461,40 @@ function Find-VsBuildTools {
         $info = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion 2>$null
         $path = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
         if ($info -and $path) {
-            $y = $info.Trim()
-            $n = $map[$y]
-            if ($n) {
-                return @{ Generator = "Visual Studio $n $y"; InstallPath = $path.Trim(); Source = 'vswhere' }
+            $gen = $yearToGenerator[$info.Trim()]
+            if ($gen) {
+                return @{ Generator = $gen; InstallPath = $path.Trim(); Source = 'vswhere' }
             }
         }
     }
 
     # --- Scan filesystem (handles broken vswhere registration after winget cycles) ---
-    $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)})
-    $editions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
-    $years = @('2022', '2019', '2017')
+    $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
+    $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
+    # VS 2026+ uses the internal version dir ("18"); older versions use the year.
+    $dirs = @('18', '2026', '2022', '2019', '2017')
 
-    foreach ($y in $years) {
+    foreach ($d in $dirs) {
+        $gen = $dirToGenerator[$d]
+        if (-not $gen) { continue }
         foreach ($r in $roots) {
-            foreach ($ed in $editions) {
-                $candidate = Join-Path $r "Microsoft Visual Studio\$y\$ed"
-                if (Test-Path $candidate) {
-                    $vcDir = Join-Path $candidate "VC\Tools\MSVC"
-                    if (Test-Path $vcDir) {
-                        $cl = Get-ChildItem -Path $vcDir -Filter "cl.exe" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-                        if ($cl) {
-                            $n = $map[$y]
-                            if ($n) {
-                                return @{ Generator = "Visual Studio $n $y"; InstallPath = $candidate; Source = "filesystem ($ed)"; ClExe = $cl.FullName }
-                            }
-                        }
+            $vsBase = Join-Path $r "Microsoft Visual Studio\$d"
+            if (-not (Test-Path $vsBase)) { continue }
+            # VS 2026 (dir "18") may use non-standard edition names (e.g. Preview);
+            # scan every subdir. Older versions use the stable edition names only.
+            if ($d -eq '18' -or $d -eq '2026') {
+                $editionCandidates = Get-ChildItem -Path $vsBase -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
+            } else {
+                $editionCandidates = $knownEditions | ForEach-Object { Join-Path $vsBase $_ }
+            }
+            foreach ($candidate in $editionCandidates) {
+                if (-not (Test-Path $candidate)) { continue }
+                $vcDir = Join-Path $candidate "VC\Tools\MSVC"
+                if (Test-Path $vcDir) {
+                    $cl = Get-ChildItem -Path $vcDir -Filter "cl.exe" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+                    if ($cl) {
+                        $ed = Split-Path $candidate -Leaf
+                        return @{ Generator = $gen; InstallPath = $candidate; Source = "filesystem ($ed)"; ClExe = $cl.FullName }
                     }
                 }
             }
@@ -1229,31 +1253,6 @@ if ($vsResult) {
     Write-Host '        1. winget install Microsoft.VisualStudio.2022.BuildTools --source winget' -ForegroundColor Yellow
     Write-Host '        2. Open Visual Studio Installer -> Modify -> check "Desktop development with C++"' -ForegroundColor Yellow
     exit 1
-}
-
-# -- CMake version guard for the Visual Studio 2026 generator --
-# The "Visual Studio 18 2026" cmake generator needs CMake 4.2+. Upgrade via
-# winget if possible, else fail clearly. No-op for VS 2022/2019/2017.
-if ($CmakeGenerator -eq 'Visual Studio 18 2026') {
-    $cmakeVerObj = Get-CmakeVersion
-    $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
-    if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
-        substep "CMake $cmakeVerStr too old for Visual Studio 2026 (need 4.2+) -- upgrading via winget..." "Yellow"
-        if ($null -ne (Get-Command winget -ErrorAction SilentlyContinue)) {
-            try {
-                Invoke-SetupCommand { winget upgrade Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
-                Refresh-Environment
-            } catch { }
-            $cmakeVerObj = Get-CmakeVersion
-            $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
-        }
-        if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
-            Write-Host "[ERROR] CMake 4.2+ is required for Visual Studio 2026." -ForegroundColor Red
-            Write-Host "        Upgrade CMake from https://cmake.org/download/ and re-run." -ForegroundColor Red
-            exit 1
-        }
-    }
-    step "cmake" "$cmakeVerStr (Visual Studio 2026 generator supported)"
 }
 
 # ============================================
@@ -3056,6 +3055,47 @@ if (-not $NeedLlamaSourceBuild) {
     # resolve (and winget-install if needed) it lazily, failing fast if no
     # driver-compatible toolkit exists. The prebuilt path never reaches this.
     if ($HasNvidiaSmi) { Resolve-CudaToolkit -RequireOrExit }
+
+    # CMake version gate for the Visual Studio 2026 generator. The
+    # "Visual Studio 18 2026" cmake generator was added in CMake 4.2; an older
+    # cmake cannot drive a VS 2026 source build. This is checked ONLY here, in
+    # the committed-source-build path -- the preferred prebuilt llama.cpp path
+    # never reaches this, so a VS 2026 host on cmake < 4.2 is not blocked from
+    # using the prebuilt. No-op for VS 2022/2019/2017 generators.
+    if ($CmakeGenerator -eq 'Visual Studio 18 2026') {
+        $cmakeVerObj = Get-CmakeVersion
+        $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+        if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
+            substep "CMake $cmakeVerStr too old for the Visual Studio 2026 generator (need 4.2+) -- updating via winget..." "Yellow"
+            if ($null -ne (Get-Command winget -ErrorAction SilentlyContinue)) {
+                # Try upgrade first (fast when Kitware.CMake is already a winget app).
+                try {
+                    Invoke-SetupCommand { winget upgrade Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
+                    Refresh-Environment
+                } catch { substep "CMake winget upgrade failed: $($_.Exception.Message)" "Yellow" }
+                $cmakeVerObj = Get-CmakeVersion
+                $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+                # winget upgrade is a no-op when the on-PATH cmake came from
+                # Scoop/Chocolatey/VS rather than the Kitware winget package; in
+                # that case install the package so a 4.2+ cmake is available.
+                if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
+                    try {
+                        Invoke-SetupCommand { winget install Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
+                        Refresh-Environment
+                    } catch { substep "CMake winget install failed: $($_.Exception.Message)" "Yellow" }
+                    $cmakeVerObj = Get-CmakeVersion
+                    $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+                }
+            }
+            if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
+                Write-Host "[ERROR] CMake 4.2+ is required to build llama.cpp with the Visual Studio 2026 generator." -ForegroundColor Red
+                Write-Host "        Upgrade CMake from https://cmake.org/download/ and re-run, or use a prebuilt llama.cpp bundle." -ForegroundColor Red
+                exit 1
+            }
+        }
+        substep "CMake $cmakeVerStr supports the Visual Studio 2026 generator"
+    }
+
     Write-Host ""
     if ($HasNvidiaSmi) {
         substep "building llama.cpp with CUDA support..."

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -389,10 +389,8 @@ function Get-PytorchCudaTag {
     return "cu126"
 }
 
-# Derive the MSBuild VC "BuildCustomizations" directory for a Visual Studio
-# generator. The VC toolset folder tracks the VS major: VS 2026 (generator major
-# 18) -> v180, VS 2022 -> v170, VS 2019 -> v160. Falls back to v170 (VS 2022)
-# when the major cannot be parsed, preserving prior behavior.
+# VS generator -> MSBuild BuildCustomizations dir; toolset tracks the VS major
+# (18->v180, 17->v170), defaulting to v170 when unparseable.
 function Get-VcBuildCustomizationsDir {
     param(
         [Parameter(Mandatory)][string]$VsInstallPath,
@@ -405,8 +403,7 @@ function Get-VcBuildCustomizationsDir {
     return (Join-Path $VsInstallPath "MSBuild\Microsoft\VC\$toolset\BuildCustomizations")
 }
 
-# Parse the installed CMake version (e.g. "cmake version 4.2.1" -> [version]4.2.1).
-# Returns $null when cmake is absent or its version is unparseable.
+# Installed cmake version, or $null if absent/unparseable.
 function Get-CmakeVersion {
     $raw = & cmake --version 2>$null | Select-Object -First 1
     if ($raw -and ($raw -match '(\d+)\.(\d+)(?:\.(\d+))?')) {
@@ -416,9 +413,7 @@ function Get-CmakeVersion {
     return $null
 }
 
-# CMake version gate for a Visual Studio generator. The "Visual Studio 18 2026"
-# generator was added in CMake 4.2; an older cmake cannot drive a VS 2026
-# toolchain. Always true (no-op) for VS 2022/2019/2017 generators.
+# VS 18 2026 generator needs cmake >= 4.2 (added there); true for older VS generators.
 function Test-CmakeSupportsGenerator {
     param(
         [Parameter(Mandatory)][string]$CmakeVersion,
@@ -433,10 +428,8 @@ function Test-CmakeSupportsGenerator {
 }
 
 function Test-CmakeListsGenerator {
-    # Authoritative check: does the cmake on PATH actually advertise the generator?
-    # VS-bundled cmake (e.g. the 4.1.x shipped with VS 2026) can drive the VS 2026
-    # generator below the 4.2 version floor, so probe `cmake --help` rather than
-    # gating on the version number alone (issue #6473 review).
+    # Does `cmake --help` actually list the generator? A VS-bundled cmake can drive
+    # VS 2026 below the 4.2 floor, so probe rather than trust the version. (#6473)
     param([Parameter(Mandatory)][string]$Generator)
     $help = & cmake --help 2>$null | Out-String
     if (-not $help) { return $false }
@@ -446,9 +439,7 @@ function Test-CmakeListsGenerator {
 }
 
 function Test-CmakeCanDriveGenerator {
-    # True when the cmake on PATH can drive $Generator: it either lists the
-    # generator (covers a VS-bundled cmake below the 4.2 floor) or satisfies the
-    # version requirement.
+    # cmake can drive $Generator if it lists it (VS-bundled below 4.2) or meets the floor.
     param([Parameter(Mandatory)][string]$Generator)
     if (Test-CmakeListsGenerator -Generator $Generator) { return $true }
     $verObj = Get-CmakeVersion
@@ -457,10 +448,8 @@ function Test-CmakeCanDriveGenerator {
 }
 
 function Add-DefaultCmakeToPath {
-    # Prepend the default CMake install dir so a freshly winget-installed cmake is
-    # found even when an older cmake (Chocolatey/Scoop/VS) is earlier on PATH; a
-    # bare re-check would keep resolving the old exe (issue #6473 review). Returns
-    # $true when a cmake.exe is located in a default location.
+    # Prepend the default CMake dir so a freshly winget-installed cmake wins over an
+    # older one already on PATH. $true if found. (#6473)
     $cmakeDefaults = @(
         "$env:ProgramFiles\CMake\bin",
         "${env:ProgramFiles(x86)}\CMake\bin",
@@ -477,17 +466,13 @@ function Add-DefaultCmakeToPath {
 }
 
 function Get-FallbackVsGenerator {
-    # Find the newest installed VS *older* than 2026 whose generator the current
-    # cmake can actually drive. Used when the detected VS 2026 generator is unusable
-    # by the available cmake (old cmake, offline/winget-disabled host) but a viable
-    # older toolchain is installed -- so a VS 2022 + old-cmake host keeps building
-    # as it did before VS 2026 detection landed (issue #6473 review). Returns
-    # @{ Generator = "..."; InstallPath = "..." } or $null.
-    # Symmetric with Find-VsBuildTools: vswhere first (catches a VS outside the
-    # default Program Files roots, e.g. D:\), then the Program Files scan. (#6473 review)
+    # Newest pre-2026 VS whose generator the current cmake can drive, for when the
+    # VS 2026 generator is unusable (old/offline cmake) but an older toolchain exists.
+    # vswhere first (catches non-default roots like D:\), then Program Files; matches
+    # Find-VsBuildTools. Returns @{ Generator; InstallPath } or $null. (#6473)
     $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise', 'Preview')
 
-    # Return the install path if it holds a usable cl.exe, else $null.
+    # install path if it holds a usable cl.exe, else $null
     $tryCandidate = {
         param($gen, $installPath)
         if (-not $installPath) { return $null }
@@ -498,7 +483,7 @@ function Get-FallbackVsGenerator {
         return $null
     }
 
-    # vswhere first (finds non-default install roots).
+    # vswhere (non-default roots)
     $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $vsw) {
         $json = & $vsw -all -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format json 2>$null | Out-String
@@ -508,7 +493,7 @@ function Get-FallbackVsGenerator {
                 $label = if ($_.catalog -and $_.catalog.productLineVersion) { [string]$_.catalog.productLineVersion } else { '' }
                 [pscustomobject]@{ Gen = (Resolve-VsGeneratorFromLabel $label); Path = [string]$_.installationPath }
             } | Where-Object { $_.Gen -and ($_.Gen -notmatch 'Visual Studio 18\b') }
-            # Newest usable older VS first (2022 > 2019 > 2017).
+            # newest first: 2022 > 2019 > 2017
             $ranked = $ranked | Sort-Object { switch -regex ($_.Gen) { '17 2022' {0} '16 2019' {1} '15 2017' {2} default {9} } }
             foreach ($cand in $ranked) {
                 if (-not (Test-CmakeListsGenerator -Generator $cand.Gen)) { continue }
@@ -518,7 +503,7 @@ function Get-FallbackVsGenerator {
         }
     }
 
-    # Program Files filesystem scan.
+    # Program Files scan
     $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
     $older = @(
         @{ Dir = '2022'; Generator = 'Visual Studio 17 2022' },
@@ -541,12 +526,9 @@ function Get-FallbackVsGenerator {
     return $null
 }
 
-# Map a Visual Studio version label to its CMake generator. vswhere's
-# catalog_productLineVersion is the marketing YEAR for VS <= 2022 (e.g. "2022"),
-# but the internal MAJOR for VS 2026 (observed as "18" on the real VS 2026 runner
-# image), and install-dir names use either form. Accept both so detection works
-# from vswhere and from the filesystem scan regardless of which label a VS reports.
-# (VS 2026 detection adapted from @LeoBorcherding's #6038.)
+# VS version label -> cmake generator. vswhere's productLineVersion is the year for
+# VS <= 2022 but the internal major "18" for VS 2026, and dir names use either form,
+# so accept both. (VS 2026 detection adapted from @LeoBorcherding's #6038.)
 function Resolve-VsGeneratorFromLabel {
     param([string]$Label)
     if (-not $Label) { return $null }
@@ -559,11 +541,10 @@ function Resolve-VsGeneratorFromLabel {
     return $map[$Label.Trim()]
 }
 
-# Find Visual Studio Build Tools for cmake -G flag.
-# Strategy: (1) vswhere, (2) scan filesystem (handles broken vswhere registration).
-# Returns @{ Generator = "Visual Studio 17 2022"; InstallPath = "C:\..."; Source = "..." } or $null.
+# Find VS Build Tools for cmake -G: vswhere, then a filesystem scan (handles broken
+# vswhere registration). Returns @{ Generator; InstallPath; Source } or $null.
 function Find-VsBuildTools {
-    # --- Try vswhere first (works when VS is properly registered) ---
+    # vswhere first (works when VS is properly registered)
     $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $vsw) {
         $info = & $vsw -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion 2>$null
@@ -576,10 +557,10 @@ function Find-VsBuildTools {
         }
     }
 
-    # --- Scan filesystem (handles broken vswhere registration after winget cycles) ---
+    # filesystem scan (handles broken vswhere registration); VS 2026+ dir is "18"
     $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
     $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise', 'Preview')
-    # VS 2026+ uses the internal version dir ("18"); older versions use the year.
+
     $dirs = @('18', '2026', '2022', '2019', '2017')
 
     foreach ($d in $dirs) {
@@ -588,8 +569,7 @@ function Find-VsBuildTools {
         foreach ($r in $roots) {
             $vsBase = Join-Path $r "Microsoft Visual Studio\$d"
             if (-not (Test-Path $vsBase)) { continue }
-            # VS 2026 (dir "18") may use non-standard edition names; scan every
-            # subdir. Older versions use the known edition names (incl. Preview).
+            # VS 2026 (dir "18") may use non-standard edition names, so scan every subdir
             if ($d -eq '18' -or $d -eq '2026') {
                 $editionCandidates = Get-ChildItem -Path $vsBase -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
             } else {
@@ -612,11 +592,9 @@ function Find-VsBuildTools {
     return $null
 }
 
-# Detect the Microsoft Visual C++ 2015-2022 Redistributable. The prebuilt
-# llama-server.exe and the PyTorch wheels dynamically link VCRUNTIME140.dll /
-# MSVCP140.dll / VCRUNTIME140_1.dll; the Universal CRT ships with Windows 10+ but
-# this redistributable does not. vcruntime140_1.dll (VS 2019+) is the newest of
-# those, so its presence is the signal; the registry is a fallback.
+# Detect the VC++ 2015-2022 Redistributable that the prebuilt llama-server and
+# PyTorch need (they link VCRUNTIME140_1.dll etc., which the Universal CRT lacks).
+# Signal is System32\vcruntime140_1.dll (VS 2019+), registry as fallback.
 function Test-VCRedistInstalled {
     $sys = $env:SystemRoot
     if ($sys -and (Test-Path (Join-Path $sys 'System32\vcruntime140_1.dll'))) { return $true }
@@ -632,8 +610,7 @@ function Test-VCRedistInstalled {
     return $false
 }
 
-# Install the VC++ 2015-2022 runtime if missing (non-fatal). Both the prebuilt
-# llama-server and PyTorch need it; it is usually already present, so this no-ops.
+# Install the VC++ 2015-2022 runtime if missing (non-fatal; usually a no-op).
 function Ensure-VCRedist {
     if (Test-VCRedistInstalled) { step "vcredist" "present"; return }
     Write-Host "Microsoft Visual C++ Redistributable (2015-2022) is missing; the prebuilt llama.cpp and PyTorch need it. Installing the runtime..." -ForegroundColor Yellow
@@ -1325,8 +1302,7 @@ if (-not $HasGit) {
 # ============================================
 # 1b.5. Visual C++ Redistributable (runtime for the prebuilt llama.cpp + PyTorch)
 # ============================================
-# Not a build tool: the prebuilt llama-server and the pip/uv PyTorch wheels both
-# load the MSVC runtime DLLs at runtime, so ensure it even with no build tools.
+# Runtime dep, not a build tool: the prebuilt llama-server and PyTorch load it.
 Ensure-VCRedist
 
 # ============================================
@@ -3205,33 +3181,25 @@ if (-not $NeedLlamaSourceBuild) {
     substep "Install CMake from https://cmake.org/download/ and re-run setup." "Yellow"
     $script:LlamaCppDegraded = $true
 } else {
-    # Pick the final VS generator (gate/fallback below) BEFORE resolving CUDA:
-    # Resolve-CudaToolkit copies the CUDA .targets into the current generator's
-    # BuildCustomizations, so a later VS swap would strand them. (#6473 review)
-
-    # CMake version gate for the Visual Studio 2026 generator. The
-    # "Visual Studio 18 2026" cmake generator was added in CMake 4.2; an older
-    # cmake cannot drive a VS 2026 source build. This is checked ONLY here, in
-    # the committed-source-build path -- the preferred prebuilt llama.cpp path
-    # never reaches this, so a VS 2026 host on cmake < 4.2 is not blocked from
-    # using the prebuilt. No-op for VS 2022/2019/2017 generators.
+    # Finalize the VS generator (gate/fallback below) BEFORE Resolve-CudaToolkit,
+    # which copies the CUDA .targets into the current generator's dir; a later swap
+    # would strand them. The CMake 4.2 gate for VS 2026 is checked only here, in the
+    # source-build path, so a VS 2026 + cmake < 4.2 host can still use the prebuilt. (#6473)
     if ($CmakeGenerator -match 'Visual Studio 18\b') {
         if (-not (Test-CmakeCanDriveGenerator -Generator $CmakeGenerator)) {
             $cmakeVerObj = Get-CmakeVersion
             $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
             substep "CMake $cmakeVerStr cannot drive the Visual Studio 2026 generator (need 4.2+ or a VS-bundled cmake) -- updating via winget..." "Yellow"
             if ($null -ne (Get-Command winget -ErrorAction SilentlyContinue)) {
-                # Try upgrade first (fast when Kitware.CMake is already a winget app),
-                # then prepend the default install dir so the new cmake wins over an
-                # older one earlier on PATH before re-probing.
+                # upgrade first (fast if Kitware.CMake is already a winget app), then
+                # prepend the default dir so the new cmake wins over an older one on PATH
                 try {
                     Invoke-SetupCommand { winget upgrade Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
                     Refresh-Environment
                 } catch { substep "CMake winget upgrade failed: $($_.Exception.Message)" "Yellow" }
                 Add-DefaultCmakeToPath | Out-Null
-                # winget upgrade is a no-op when the on-PATH cmake came from
-                # Scoop/Chocolatey/VS rather than the Kitware winget package; in
-                # that case install the package so a 4.2+ cmake is available.
+                # upgrade no-ops if the cmake came from Scoop/Chocolatey/VS, not the
+                # Kitware winget package; install it so a 4.2+ cmake is available
                 if (-not (Test-CmakeCanDriveGenerator -Generator $CmakeGenerator)) {
                     try {
                         Invoke-SetupCommand { winget install Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
@@ -3241,11 +3209,9 @@ if (-not $NeedLlamaSourceBuild) {
                 }
             }
             if (-not (Test-CmakeCanDriveGenerator -Generator $CmakeGenerator)) {
-                # The available cmake still cannot drive VS 2026. Before failing,
-                # fall back to an older installed VS whose generator this cmake CAN
-                # drive, so a host with a viable older toolchain (e.g. VS 2022 + an
-                # old cmake on an offline box) keeps building as it did before VS
-                # 2026 detection landed.
+                # cmake still cannot drive VS 2026; before failing, fall back to an
+                # older installed VS whose generator it can drive (e.g. VS 2022 + old
+                # cmake on an offline box keeps building)
                 $fallback = Get-FallbackVsGenerator
                 if ($fallback) {
                     substep "CMake cannot drive $CmakeGenerator; falling back to $($fallback.Generator)" "Yellow"
@@ -3261,8 +3227,8 @@ if (-not $NeedLlamaSourceBuild) {
         substep "CMake can drive the $CmakeGenerator generator"
     }
 
-    # CUDA toolkit resolved lazily here (fail fast if none), AFTER the final VS
-    # generator so its .targets copy targets the toolset cmake actually uses.
+    # CUDA resolved here (fail fast if none), after the final VS generator so its
+    # .targets land in the toolset cmake actually uses.
     if ($HasNvidiaSmi) { Resolve-CudaToolkit -RequireOrExit }
 
     Write-Host ""

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -389,6 +389,49 @@ function Get-PytorchCudaTag {
     return "cu126"
 }
 
+# Derive the MSBuild VC "BuildCustomizations" directory for a Visual Studio
+# generator. The VC toolset folder tracks the VS major: VS 2026 (generator major
+# 18) -> v180, VS 2022 -> v170, VS 2019 -> v160. Falls back to v170 (VS 2022)
+# when the major cannot be parsed, preserving prior behavior.
+function Get-VcBuildCustomizationsDir {
+    param(
+        [Parameter(Mandatory)][string]$VsInstallPath,
+        [string]$Generator
+    )
+    $toolset = 'v170'
+    if ($Generator -and ($Generator -match 'Visual Studio (\d+)\b')) {
+        $toolset = "v$($Matches[1])0"
+    }
+    return (Join-Path $VsInstallPath "MSBuild\Microsoft\VC\$toolset\BuildCustomizations")
+}
+
+# Parse the installed CMake version (e.g. "cmake version 4.2.1" -> [version]4.2.1).
+# Returns $null when cmake is absent or its version is unparseable.
+function Get-CmakeVersion {
+    $raw = & cmake --version 2>$null | Select-Object -First 1
+    if ($raw -and ($raw -match '(\d+)\.(\d+)(?:\.(\d+))?')) {
+        $patch = if ($Matches[3]) { $Matches[3] } else { '0' }
+        return [version]"$($Matches[1]).$($Matches[2]).$patch"
+    }
+    return $null
+}
+
+# CMake version gate for a Visual Studio generator. The "Visual Studio 18 2026"
+# generator was added in CMake 4.2; an older cmake cannot drive a VS 2026
+# toolchain. Always true (no-op) for VS 2022/2019/2017 generators.
+function Test-CmakeSupportsGenerator {
+    param(
+        [Parameter(Mandatory)][string]$CmakeVersion,
+        [Parameter(Mandatory)][string]$Generator
+    )
+    if ($Generator -match 'Visual Studio 18\b') {
+        $clean = ($CmakeVersion -replace '[^0-9.].*$', '').TrimEnd('.')
+        try { $v = [version]$clean } catch { return $false }
+        return ($v -ge [version]'4.2')
+    }
+    return $true
+}
+
 # Find Visual Studio Build Tools for cmake -G flag.
 # Strategy: (1) vswhere, (2) scan filesystem (handles broken vswhere registration).
 # Returns @{ Generator = "Visual Studio 17 2022"; InstallPath = "C:\..."; Source = "..." } or $null.
@@ -1188,6 +1231,31 @@ if ($vsResult) {
     exit 1
 }
 
+# -- CMake version guard for the Visual Studio 2026 generator --
+# The "Visual Studio 18 2026" cmake generator needs CMake 4.2+. Upgrade via
+# winget if possible, else fail clearly. No-op for VS 2022/2019/2017.
+if ($CmakeGenerator -eq 'Visual Studio 18 2026') {
+    $cmakeVerObj = Get-CmakeVersion
+    $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+    if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
+        substep "CMake $cmakeVerStr too old for Visual Studio 2026 (need 4.2+) -- upgrading via winget..." "Yellow"
+        if ($null -ne (Get-Command winget -ErrorAction SilentlyContinue)) {
+            try {
+                Invoke-SetupCommand { winget upgrade Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
+                Refresh-Environment
+            } catch { }
+            $cmakeVerObj = Get-CmakeVersion
+            $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+        }
+        if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
+            Write-Host "[ERROR] CMake 4.2+ is required for Visual Studio 2026." -ForegroundColor Red
+            Write-Host "        Upgrade CMake from https://cmake.org/download/ and re-run." -ForegroundColor Red
+            exit 1
+        }
+    }
+    step "cmake" "$cmakeVerStr (Visual Studio 2026 generator supported)"
+}
+
 # ============================================
 # 1e. CUDA Toolkit (nvcc for llama.cpp build + env vars)
 # ============================================
@@ -1428,7 +1496,7 @@ if (Add-ToUserPath -Directory $nvccBinDir -Position 'Prepend') {
 # the MSBuild .targets/.props files that let VS compile .cu files are missing.
 # cmake fails with "No CUDA toolset found". Fix: copy from CUDA extras dir.
 if ($VsInstallPath -and $CudaToolkitRoot) {
-    $vsCustomizations = Join-Path $VsInstallPath "MSBuild\Microsoft\VC\v170\BuildCustomizations"
+    $vsCustomizations = Get-VcBuildCustomizationsDir -VsInstallPath $VsInstallPath -Generator $CmakeGenerator
     $cudaExtras = Join-Path $CudaToolkitRoot "extras\visual_studio_integration\MSBuildExtensions"
     if ((Test-Path $cudaExtras) -and (Test-Path $vsCustomizations)) {
         $hasTargets = Get-ChildItem $vsCustomizations -Filter "CUDA *.targets" -ErrorAction SilentlyContinue
@@ -3339,7 +3407,8 @@ if (-not $NeedLlamaSourceBuild) {
                 Write-Host "   Copy contents of:" -ForegroundColor Yellow
                 Write-Host "     <CUDA_PATH>\extras\visual_studio_integration\MSBuildExtensions" -ForegroundColor Yellow
                 Write-Host "   into:" -ForegroundColor Yellow
-                Write-Host "     <VS_PATH>\MSBuild\Microsoft\VC\v170\BuildCustomizations" -ForegroundColor Yellow
+                $hintCustomizations = if ($VsInstallPath) { Get-VcBuildCustomizationsDir -VsInstallPath $VsInstallPath -Generator $CmakeGenerator } else { "<VS_PATH>\MSBuild\Microsoft\VC\v170\BuildCustomizations" }
+                Write-Host "     $hintCustomizations" -ForegroundColor Yellow
             }
         }
     }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -483,8 +483,43 @@ function Get-FallbackVsGenerator {
     # older toolchain is installed -- so a VS 2022 + old-cmake host keeps building
     # as it did before VS 2026 detection landed (issue #6473 review). Returns
     # @{ Generator = "..."; InstallPath = "..." } or $null.
-    $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
+    # Symmetric with Find-VsBuildTools: vswhere first (catches a VS outside the
+    # default Program Files roots, e.g. D:\), then the Program Files scan. (#6473 review)
     $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise', 'Preview')
+
+    # Return the install path if it holds a usable cl.exe, else $null.
+    $tryCandidate = {
+        param($gen, $installPath)
+        if (-not $installPath) { return $null }
+        $vcDir = Join-Path $installPath "VC\Tools\MSVC"
+        if (-not (Test-Path $vcDir)) { return $null }
+        $cl = Get-ChildItem -Path $vcDir -Filter "cl.exe" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($cl) { return @{ Generator = $gen; InstallPath = $installPath } }
+        return $null
+    }
+
+    # vswhere first (finds non-default install roots).
+    $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vsw) {
+        $json = & $vsw -all -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format json 2>$null | Out-String
+        if ($json) {
+            try { $instances = @($json | ConvertFrom-Json) } catch { $instances = @() }
+            $ranked = $instances | ForEach-Object {
+                $label = if ($_.catalog -and $_.catalog.productLineVersion) { [string]$_.catalog.productLineVersion } else { '' }
+                [pscustomobject]@{ Gen = (Resolve-VsGeneratorFromLabel $label); Path = [string]$_.installationPath }
+            } | Where-Object { $_.Gen -and ($_.Gen -notmatch 'Visual Studio 18\b') }
+            # Newest usable older VS first (2022 > 2019 > 2017).
+            $ranked = $ranked | Sort-Object { switch -regex ($_.Gen) { '17 2022' {0} '16 2019' {1} '15 2017' {2} default {9} } }
+            foreach ($cand in $ranked) {
+                if (-not (Test-CmakeListsGenerator -Generator $cand.Gen)) { continue }
+                $res = & $tryCandidate $cand.Gen $cand.Path
+                if ($res) { return $res }
+            }
+        }
+    }
+
+    # Program Files filesystem scan.
+    $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
     $older = @(
         @{ Dir = '2022'; Generator = 'Visual Studio 17 2022' },
         @{ Dir = '2019'; Generator = 'Visual Studio 16 2019' },
@@ -498,12 +533,8 @@ function Get-FallbackVsGenerator {
             foreach ($ed in $knownEditions) {
                 $candidate = Join-Path $vsBase $ed
                 if (-not (Test-Path $candidate)) { continue }
-                $vcDir = Join-Path $candidate "VC\Tools\MSVC"
-                if (-not (Test-Path $vcDir)) { continue }
-                $cl = Get-ChildItem -Path $vcDir -Filter "cl.exe" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-                if ($cl) {
-                    return @{ Generator = $entry.Generator; InstallPath = $candidate }
-                }
+                $res = & $tryCandidate $entry.Generator $candidate
+                if ($res) { return $res }
             }
         }
     }
@@ -3128,10 +3159,9 @@ if (-not $NeedLlamaSourceBuild) {
     substep "Install CMake from https://cmake.org/download/ and re-run setup." "Yellow"
     $script:LlamaCppDegraded = $true
 } else {
-    # A source build is committed here. The CUDA toolkit is only needed now, so
-    # resolve (and winget-install if needed) it lazily, failing fast if no
-    # driver-compatible toolkit exists. The prebuilt path never reaches this.
-    if ($HasNvidiaSmi) { Resolve-CudaToolkit -RequireOrExit }
+    # Pick the final VS generator (gate/fallback below) BEFORE resolving CUDA:
+    # Resolve-CudaToolkit copies the CUDA .targets into the current generator's
+    # BuildCustomizations, so a later VS swap would strand them. (#6473 review)
 
     # CMake version gate for the Visual Studio 2026 generator. The
     # "Visual Studio 18 2026" cmake generator was added in CMake 4.2; an older
@@ -3184,6 +3214,10 @@ if (-not $NeedLlamaSourceBuild) {
         }
         substep "CMake can drive the $CmakeGenerator generator"
     }
+
+    # CUDA toolkit resolved lazily here (fail fast if none), AFTER the final VS
+    # generator so its .targets copy targets the toolset cmake actually uses.
+    if ($HasNvidiaSmi) { Resolve-CudaToolkit -RequireOrExit }
 
     Write-Host ""
     if ($HasNvidiaSmi) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -432,6 +432,84 @@ function Test-CmakeSupportsGenerator {
     return $true
 }
 
+function Test-CmakeListsGenerator {
+    # Authoritative check: does the cmake on PATH actually advertise the generator?
+    # VS-bundled cmake (e.g. the 4.1.x shipped with VS 2026) can drive the VS 2026
+    # generator below the 4.2 version floor, so probe `cmake --help` rather than
+    # gating on the version number alone (issue #6473 review).
+    param([Parameter(Mandatory)][string]$Generator)
+    $help = & cmake --help 2>$null | Out-String
+    if (-not $help) { return $false }
+    $haystack = ($help -replace '\s+', ' ')
+    $needle = ($Generator -replace '\s+', ' ')
+    return $haystack.Contains($needle)
+}
+
+function Test-CmakeCanDriveGenerator {
+    # True when the cmake on PATH can drive $Generator: it either lists the
+    # generator (covers a VS-bundled cmake below the 4.2 floor) or satisfies the
+    # version requirement.
+    param([Parameter(Mandatory)][string]$Generator)
+    if (Test-CmakeListsGenerator -Generator $Generator) { return $true }
+    $verObj = Get-CmakeVersion
+    $verStr = if ($verObj) { $verObj.ToString() } else { '0.0' }
+    return (Test-CmakeSupportsGenerator -CmakeVersion $verStr -Generator $Generator)
+}
+
+function Add-DefaultCmakeToPath {
+    # Prepend the default CMake install dir so a freshly winget-installed cmake is
+    # found even when an older cmake (Chocolatey/Scoop/VS) is earlier on PATH; a
+    # bare re-check would keep resolving the old exe (issue #6473 review). Returns
+    # $true when a cmake.exe is located in a default location.
+    $cmakeDefaults = @(
+        "$env:ProgramFiles\CMake\bin",
+        "${env:ProgramFiles(x86)}\CMake\bin",
+        "$env:LOCALAPPDATA\CMake\bin"
+    )
+    foreach ($d in $cmakeDefaults) {
+        if (Test-Path (Join-Path $d "cmake.exe")) {
+            $env:Path = "$d;$env:Path"
+            Add-ToUserPath -Directory $d -Position 'Prepend' | Out-Null
+            return $true
+        }
+    }
+    return $false
+}
+
+function Get-FallbackVsGenerator {
+    # Find the newest installed VS *older* than 2026 whose generator the current
+    # cmake can actually drive. Used when the detected VS 2026 generator is unusable
+    # by the available cmake (old cmake, offline/winget-disabled host) but a viable
+    # older toolchain is installed -- so a VS 2022 + old-cmake host keeps building
+    # as it did before VS 2026 detection landed (issue #6473 review). Returns
+    # @{ Generator = "..."; InstallPath = "..." } or $null.
+    $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
+    $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
+    $older = @(
+        @{ Dir = '2022'; Generator = 'Visual Studio 17 2022' },
+        @{ Dir = '2019'; Generator = 'Visual Studio 16 2019' },
+        @{ Dir = '2017'; Generator = 'Visual Studio 15 2017' }
+    )
+    foreach ($entry in $older) {
+        if (-not (Test-CmakeListsGenerator -Generator $entry.Generator)) { continue }
+        foreach ($r in $roots) {
+            $vsBase = Join-Path $r "Microsoft Visual Studio\$($entry.Dir)"
+            if (-not (Test-Path $vsBase)) { continue }
+            foreach ($ed in $knownEditions) {
+                $candidate = Join-Path $vsBase $ed
+                if (-not (Test-Path $candidate)) { continue }
+                $vcDir = Join-Path $candidate "VC\Tools\MSVC"
+                if (-not (Test-Path $vcDir)) { continue }
+                $cl = Get-ChildItem -Path $vcDir -Filter "cl.exe" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($cl) {
+                    return @{ Generator = $entry.Generator; InstallPath = $candidate }
+                }
+            }
+        }
+    }
+    return $null
+}
+
 # Find Visual Studio Build Tools for cmake -G flag.
 # Strategy: (1) vswhere, (2) scan filesystem (handles broken vswhere registration).
 # Returns @{ Generator = "Visual Studio 17 2022"; InstallPath = "C:\..."; Source = "..." } or $null.
@@ -3062,38 +3140,50 @@ if (-not $NeedLlamaSourceBuild) {
     # the committed-source-build path -- the preferred prebuilt llama.cpp path
     # never reaches this, so a VS 2026 host on cmake < 4.2 is not blocked from
     # using the prebuilt. No-op for VS 2022/2019/2017 generators.
-    if ($CmakeGenerator -eq 'Visual Studio 18 2026') {
-        $cmakeVerObj = Get-CmakeVersion
-        $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
-        if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
-            substep "CMake $cmakeVerStr too old for the Visual Studio 2026 generator (need 4.2+) -- updating via winget..." "Yellow"
+    if ($CmakeGenerator -match 'Visual Studio 18\b') {
+        if (-not (Test-CmakeCanDriveGenerator -Generator $CmakeGenerator)) {
+            $cmakeVerObj = Get-CmakeVersion
+            $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+            substep "CMake $cmakeVerStr cannot drive the Visual Studio 2026 generator (need 4.2+ or a VS-bundled cmake) -- updating via winget..." "Yellow"
             if ($null -ne (Get-Command winget -ErrorAction SilentlyContinue)) {
-                # Try upgrade first (fast when Kitware.CMake is already a winget app).
+                # Try upgrade first (fast when Kitware.CMake is already a winget app),
+                # then prepend the default install dir so the new cmake wins over an
+                # older one earlier on PATH before re-probing.
                 try {
                     Invoke-SetupCommand { winget upgrade Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
                     Refresh-Environment
                 } catch { substep "CMake winget upgrade failed: $($_.Exception.Message)" "Yellow" }
-                $cmakeVerObj = Get-CmakeVersion
-                $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+                Add-DefaultCmakeToPath | Out-Null
                 # winget upgrade is a no-op when the on-PATH cmake came from
                 # Scoop/Chocolatey/VS rather than the Kitware winget package; in
                 # that case install the package so a 4.2+ cmake is available.
-                if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
+                if (-not (Test-CmakeCanDriveGenerator -Generator $CmakeGenerator)) {
                     try {
                         Invoke-SetupCommand { winget install Kitware.CMake --source winget --accept-package-agreements --accept-source-agreements } | Out-Null
                         Refresh-Environment
                     } catch { substep "CMake winget install failed: $($_.Exception.Message)" "Yellow" }
-                    $cmakeVerObj = Get-CmakeVersion
-                    $cmakeVerStr = if ($cmakeVerObj) { $cmakeVerObj.ToString() } else { '0.0' }
+                    Add-DefaultCmakeToPath | Out-Null
                 }
             }
-            if (-not (Test-CmakeSupportsGenerator -CmakeVersion $cmakeVerStr -Generator $CmakeGenerator)) {
-                Write-Host "[ERROR] CMake 4.2+ is required to build llama.cpp with the Visual Studio 2026 generator." -ForegroundColor Red
-                Write-Host "        Upgrade CMake from https://cmake.org/download/ and re-run, or use a prebuilt llama.cpp bundle." -ForegroundColor Red
-                exit 1
+            if (-not (Test-CmakeCanDriveGenerator -Generator $CmakeGenerator)) {
+                # The available cmake still cannot drive VS 2026. Before failing,
+                # fall back to an older installed VS whose generator this cmake CAN
+                # drive, so a host with a viable older toolchain (e.g. VS 2022 + an
+                # old cmake on an offline box) keeps building as it did before VS
+                # 2026 detection landed.
+                $fallback = Get-FallbackVsGenerator
+                if ($fallback) {
+                    substep "CMake cannot drive $CmakeGenerator; falling back to $($fallback.Generator)" "Yellow"
+                    $CmakeGenerator = $fallback.Generator
+                    $VsInstallPath = $fallback.InstallPath
+                } else {
+                    Write-Host "[ERROR] CMake 4.2+ is required to build llama.cpp with the Visual Studio 2026 generator, and no older Visual Studio toolchain was found to fall back to." -ForegroundColor Red
+                    Write-Host "        Upgrade CMake from https://cmake.org/download/ and re-run, or use a prebuilt llama.cpp bundle." -ForegroundColor Red
+                    exit 1
+                }
             }
         }
-        substep "CMake $cmakeVerStr supports the Visual Studio 2026 generator"
+        substep "CMake can drive the $CmakeGenerator generator"
     }
 
     Write-Host ""

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -484,7 +484,7 @@ function Get-FallbackVsGenerator {
     # as it did before VS 2026 detection landed (issue #6473 review). Returns
     # @{ Generator = "..."; InstallPath = "..." } or $null.
     $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
-    $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
+    $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise', 'Preview')
     $older = @(
         @{ Dir = '2022'; Generator = 'Visual Studio 17 2022' },
         @{ Dir = '2019'; Generator = 'Visual Studio 16 2019' },
@@ -548,7 +548,7 @@ function Find-VsBuildTools {
 
     # --- Scan filesystem (handles broken vswhere registration after winget cycles) ---
     $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
-    $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise')
+    $knownEditions = @('BuildTools', 'Community', 'Professional', 'Enterprise', 'Preview')
     # VS 2026+ uses the internal version dir ("18"); older versions use the year.
     $dirs = @('18', '2026', '2022', '2019', '2017')
 
@@ -558,8 +558,8 @@ function Find-VsBuildTools {
         foreach ($r in $roots) {
             $vsBase = Join-Path $r "Microsoft Visual Studio\$d"
             if (-not (Test-Path $vsBase)) { continue }
-            # VS 2026 (dir "18") may use non-standard edition names (e.g. Preview);
-            # scan every subdir. Older versions use the stable edition names only.
+            # VS 2026 (dir "18") may use non-standard edition names; scan every
+            # subdir. Older versions use the known edition names (incl. Preview).
             if ($d -eq '18' -or $d -eq '2026') {
                 $editionCandidates = Get-ChildItem -Path $vsBase -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
             } else {

--- a/tests/studio_setup_ps1/Get-FunctionSource.ps1
+++ b/tests/studio_setup_ps1/Get-FunctionSource.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+    Extracts a single `function NAME { ... }` block from a PowerShell script by
+    brace-matching, WITHOUT executing the script.
+
+.DESCRIPTION
+    studio/setup.ps1 is a top-level executing installer (it runs install steps at
+    load), so it cannot be dot-sourced directly in a test. This helper pulls just
+    the requested function's source text out of the file so a test can dot-source
+    ONLY that function.
+
+    Brace matching is naive (it counts '{' / '}' without a full tokenizer). It is
+    safe for the pure helper functions targeted here because their bodies contain
+    only balanced braces (e.g. `${env:ProgramFiles(x86)}` is self-balanced) and no
+    here-strings/comments with stray unbalanced braces.
+
+.EXAMPLE
+    $src = Get-FunctionSource -Path studio/setup.ps1 -Name Get-VcBuildCustomizationsDir
+    . ([scriptblock]::Create($src))   # defines the function in the current scope
+#>
+function Get-FunctionSource {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    $text = Get-Content -Raw -LiteralPath $Path
+    if ([string]::IsNullOrEmpty($text)) { return $null }
+
+    # Match "function <Name>" at the start of a line (multiline, case-insensitive).
+    $pattern = "(?im)^\s*function\s+$([regex]::Escape($Name))\b"
+    $m = [regex]::Match($text, $pattern)
+    if (-not $m.Success) { return $null }
+
+    # Locate the opening brace at/after the match.
+    $braceStart = $text.IndexOf('{', $m.Index)
+    if ($braceStart -lt 0) { return $null }
+
+    # Walk braces to the matching close.
+    $depth = 0
+    $end = -1
+    for ($i = $braceStart; $i -lt $text.Length; $i++) {
+        $c = $text[$i]
+        if ($c -eq '{') { $depth++ }
+        elseif ($c -eq '}') {
+            $depth--
+            if ($depth -eq 0) { $end = $i; break }
+        }
+    }
+    if ($end -lt 0) { return $null }
+
+    return $text.Substring($m.Index, $end - $m.Index + 1)
+}

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -38,9 +38,8 @@ BeforeAll {
 }
 
 Describe 'Resolve-VsGeneratorFromLabel (vswhere/dir label -> generator)' {
-    # Pure mapping, runs everywhere. Guards the real-world finding that vswhere
-    # reports catalog_productLineVersion='18' (the internal major) for VS 2026 -
-    # NOT '2026' - so detection must accept both the year and the major form.
+    # Guards that detection accepts both '18' (the internal major vswhere reports
+    # for VS 2026) and the year form.
     It 'maps the VS 2026 internal major "18" to the VS 2026 generator' {
         Resolve-VsGeneratorFromLabel '18' | Should -Be 'Visual Studio 18 2026'
     }
@@ -68,16 +67,11 @@ Describe 'Resolve-VsGeneratorFromLabel (vswhere/dir label -> generator)' {
 }
 
 Describe 'Find-VsBuildTools (VS 2026 generator discovery)' {
-    # Exercises the production discovery entry point (not just the downstream
-    # helpers) so the v180 path + CMake guard cannot be reachable in routing while
-    # discovery stays dead. Windows-only: Find-VsBuildTools builds candidate paths
-    # with backslash separators, which only resolve as real directories on Windows.
+    # Exercises the real discovery entry point. Windows-only: Find-VsBuildTools builds
+    # backslash candidate paths that only resolve as directories on Windows.
     BeforeAll {
-        # Define the helper in BeforeAll (not the Describe body) so it is visible
-        # inside the It blocks: Pester 5 runs the Describe body only during
-        # discovery, where functions do not persist into the run-phase It scope
-        # (the body-level definition raised CommandNotFoundException on Windows,
-        # the only platform where these discovery tests actually run).
+        # Define in BeforeAll, not the Describe body: Pester 5 runs the body only at
+        # discovery, so body-level functions are not visible in the run-phase It blocks.
         function New-FakeVsTree {
             param([string]$Root, [string]$VersionDir, [string]$Edition = 'BuildTools')
             $clDir = Join-Path $Root "Microsoft Visual Studio\$VersionDir\$Edition\VC\Tools\MSVC\14.50.00000\bin\Hostx64\x64"
@@ -120,8 +114,7 @@ Describe 'Find-VsBuildTools (VS 2026 generator discovery)' {
     }
 
     It 'detects an older VS installed under the Preview edition dir' -Skip:(-not $IsWindows) {
-        # Preview channels install under a "Preview" edition folder; the older-version
-        # filesystem fallback must include it, not just BuildTools/Community/etc.
+        # Preview installs under a "Preview" edition folder; the fallback must include it.
         $root = Join-Path $TestDrive 'PF2022prev'
         New-FakeVsTree -Root $root -VersionDir '2022' -Edition 'Preview'
         ${env:ProgramFiles}      = $root
@@ -131,9 +124,8 @@ Describe 'Find-VsBuildTools (VS 2026 generator discovery)' {
 }
 
 Describe 'Get-VcBuildCustomizationsDir (CUDA to VS MSBuild integration path)' {
-    # Use Pester's real TestDrive as the install root so Join-Path resolves on
-    # any OS (a fake 'C:\' base errors on non-Windows hosts). Assertions match the
-    # toolset segment with either path separator, so they hold on Windows + Linux.
+    # Use TestDrive as the root so Join-Path resolves on any OS; assertions accept
+    # either path separator.
 
     It 'derives v180 for the VS 2026 generator' {
         Get-VcBuildCustomizationsDir -VsInstallPath "$TestDrive" -Generator 'Visual Studio 18 2026' |
@@ -189,11 +181,8 @@ Describe 'Test-CmakeSupportsGenerator (CMake 4.2 guard for VS 2026)' {
 }
 
 Describe 'Test-CmakeListsGenerator (probe cmake --help)' {
-    # Mock the `cmake` command rather than dropping a fake on PATH: PowerShell
-    # caches its application-path table, so mutating $env:Path mid-session does not
-    # reliably re-point `& cmake` at a shim (a real cmake on the runner -- present
-    # on GitHub windows-latest -- wins). A function mock is resolved before any
-    # on-PATH executable, so it intercepts `& cmake` inside the helper regardless.
+    # Mock cmake as a function (resolved before any on-PATH exe): PowerShell caches
+    # its app-path table, so a $env:Path shim would not reliably beat a real cmake.
 
     It 'returns true when cmake --help lists the generator' {
         Mock cmake { "Generators`n  Visual Studio 18 2026        = Generates VS 2026 project files.`n  Visual Studio 17 2022        = Generates VS 2022 project files." }
@@ -213,8 +202,7 @@ Describe 'Test-CmakeListsGenerator (probe cmake --help)' {
 
 Describe 'Test-CmakeCanDriveGenerator (probe OR version floor)' {
     It 'accepts a sub-4.2 cmake that lists the VS 2026 generator (bundled cmake)' {
-        # cmake reports version 3.31.0 (below the 4.2 floor) but DOES list the
-        # generator, so the help-probe branch must accept it.
+        # 3.31.0 is below the 4.2 floor but lists the generator, so the help-probe accepts it.
         Mock cmake {
             if ($args -contains '--version') { 'cmake version 3.31.0' }
             else { "Generators`n  Visual Studio 18 2026        = Generates VS 2026 project files." }
@@ -223,8 +211,7 @@ Describe 'Test-CmakeCanDriveGenerator (probe OR version floor)' {
     }
 
     It 'accepts a 4.2 cmake via the version floor when the help probe misses it' {
-        # Help omits the generator, but version 4.2.0 satisfies the floor, so the
-        # version branch must accept it.
+        # Help omits the generator but 4.2.0 meets the floor, so the version branch accepts it.
         Mock cmake {
             if ($args -contains '--version') { 'cmake version 4.2.0' }
             else { 'Generators' }
@@ -291,13 +278,9 @@ Describe 'Get-FallbackVsGenerator (older VS the cmake can drive)' {
 }
 
 Describe 'Source-build ordering invariant: CUDA integration runs AFTER the VS generator is finalized (#6473 review)' {
-    # Guards the fix for the CUDA-.targets-after-VS-fallback bug. Resolve-CudaToolkit
-    # copies the CUDA MSBuild .targets into the BuildCustomizations folder of the
-    # CURRENT $VsInstallPath/$CmakeGenerator, so it MUST run after the VS 2026 CMake
-    # gate/fallback (which can swap to an older VS). If a future edit moves the CUDA
-    # resolve back above the fallback, a VS 2026 + old-cmake host that falls back to
-    # VS 2022 would build with v170 while the .targets were copied to v180
-    # ("No CUDA toolset found").
+    # Resolve-CudaToolkit copies the CUDA .targets into the current generator's dir,
+    # so it must run after the VS 2026 gate/fallback; otherwise a fallback to VS 2022
+    # builds v170 while the .targets went to v180 ("No CUDA toolset found").
     It 'the source-build Resolve-CudaToolkit call appears AFTER the Get-FallbackVsGenerator fallback' {
         $text = Get-Content -Raw -LiteralPath $script:SetupPs1
         $idxFallback = $text.IndexOf('$fallback = Get-FallbackVsGenerator')
@@ -309,9 +292,8 @@ Describe 'Source-build ordering invariant: CUDA integration runs AFTER the VS ge
 }
 
 Describe 'Get-FallbackVsGenerator discovery is symmetric with Find-VsBuildTools (#6473 review)' {
-    # The fallback must also consult vswhere (not only the default Program Files
-    # roots), else a VS registered in a custom location is found as the primary
-    # toolchain but missed as the fallback -> an avoidable hard exit.
+    # The fallback must also query vswhere, else a VS in a custom location is found
+    # as primary but missed as fallback -> avoidable hard exit.
     It 'queries vswhere as part of fallback discovery' {
         $src = Get-FunctionSource -Path $script:SetupPs1 -Name Get-FallbackVsGenerator
         $src | Should -Match 'vswhere'
@@ -319,15 +301,12 @@ Describe 'Get-FallbackVsGenerator discovery is symmetric with Find-VsBuildTools 
 }
 
 Describe 'Test-VCRedistInstalled (VC++ 2015-2022 runtime needed by the prebuilt llama.cpp + PyTorch)' {
-    # The prebuilt llama-server.exe and the PyTorch wheels link VCRUNTIME140.dll /
-    # MSVCP140.dll / VCRUNTIME140_1.dll, which the VC++ redistributable provides
-    # (the Universal CRT ships with Windows, this does not). Detection is the
-    # System32 vcruntime140_1.dll DLL with a registry fallback.
+    # The prebuilts link the VC++ runtime DLLs (which the Universal CRT lacks);
+    # detection is System32\vcruntime140_1.dll with a registry fallback.
     BeforeEach { $script:OrigSysRoot = $env:SystemRoot }
     AfterEach  { $env:SystemRoot = $script:OrigSysRoot }
 
-    # Test-VCRedistInstalled probes Test-Path once (the System32 DLL); when that is
-    # $false it consults the registry via Get-ItemProperty. Mock both directly.
+    # Probes Test-Path once (System32 DLL), then the registry; mock both.
     It 'returns true when vcruntime140_1.dll is present in System32' {
         $env:SystemRoot = 'C:\Windows'
         Mock Test-Path { $true }

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -87,6 +87,16 @@ Describe 'Find-VsBuildTools (VS 2026 generator discovery)' {
         ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86c'
         (Find-VsBuildTools).Generator | Should -Be 'Visual Studio 17 2022'
     }
+
+    It 'detects an older VS installed under the Preview edition dir' -Skip:(-not $IsWindows) {
+        # Preview channels install under a "Preview" edition folder; the older-version
+        # filesystem fallback must include it, not just BuildTools/Community/etc.
+        $root = Join-Path $TestDrive 'PF2022prev'
+        New-FakeVsTree -Root $root -VersionDir '2022' -Edition 'Preview'
+        ${env:ProgramFiles}      = $root
+        ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86d'
+        (Find-VsBuildTools).Generator | Should -Be 'Visual Studio 17 2022'
+    }
 }
 
 Describe 'Get-VcBuildCustomizationsDir (CUDA to VS MSBuild integration path)' {
@@ -237,5 +247,14 @@ Describe 'Get-FallbackVsGenerator (older VS the cmake can drive)' {
         Mock cmake { "Generators`n  Visual Studio 18 2026        = Generates VS 2026 project files." }
         $r = Get-FallbackVsGenerator
         $r | Should -BeNullOrEmpty
+    }
+
+    It 'falls back to an older VS installed under the Preview edition dir' -Skip:(-not $IsWindows) {
+        $root = Join-Path $TestDrive 'PF_prev'
+        New-FakeVsTree2 -Root $root -VersionDir '2022' -Edition 'Preview'
+        ${env:ProgramFiles} = $root
+        ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86_prev'
+        Mock cmake { "Generators`n  Visual Studio 17 2022        = Generates VS 2022 project files." }
+        (Get-FallbackVsGenerator).Generator | Should -Be 'Visual Studio 17 2022'
     }
 }

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -288,3 +288,31 @@ Describe 'Get-FallbackVsGenerator (older VS the cmake can drive)' {
         (Get-FallbackVsGenerator).Generator | Should -Be 'Visual Studio 17 2022'
     }
 }
+
+Describe 'Source-build ordering invariant: CUDA integration runs AFTER the VS generator is finalized (#6473 review)' {
+    # Guards the fix for the CUDA-.targets-after-VS-fallback bug. Resolve-CudaToolkit
+    # copies the CUDA MSBuild .targets into the BuildCustomizations folder of the
+    # CURRENT $VsInstallPath/$CmakeGenerator, so it MUST run after the VS 2026 CMake
+    # gate/fallback (which can swap to an older VS). If a future edit moves the CUDA
+    # resolve back above the fallback, a VS 2026 + old-cmake host that falls back to
+    # VS 2022 would build with v170 while the .targets were copied to v180
+    # ("No CUDA toolset found").
+    It 'the source-build Resolve-CudaToolkit call appears AFTER the Get-FallbackVsGenerator fallback' {
+        $text = Get-Content -Raw -LiteralPath $script:SetupPs1
+        $idxFallback = $text.IndexOf('$fallback = Get-FallbackVsGenerator')
+        $idxResolve  = $text.IndexOf('Resolve-CudaToolkit -RequireOrExit')
+        $idxFallback | Should -BeGreaterThan 0
+        $idxResolve  | Should -BeGreaterThan 0
+        $idxResolve  | Should -BeGreaterThan $idxFallback
+    }
+}
+
+Describe 'Get-FallbackVsGenerator discovery is symmetric with Find-VsBuildTools (#6473 review)' {
+    # The fallback must also consult vswhere (not only the default Program Files
+    # roots), else a VS registered in a custom location is found as the primary
+    # toolchain but missed as the fallback -> an avoidable hard exit.
+    It 'queries vswhere as part of fallback discovery' {
+        $src = Get-FunctionSource -Path $script:SetupPs1 -Name Get-FallbackVsGenerator
+        $src | Should -Match 'vswhere'
+    }
+}

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -27,7 +27,9 @@ BeforeAll {
     if (-not $script:SetupPs1) { throw "Could not locate studio/setup.ps1 (set SETUP_PS1_PATH)." }
     Write-Host "setup.ps1 under test: $script:SetupPs1"
 
-    foreach ($fn in @('Find-VsBuildTools', 'Get-VcBuildCustomizationsDir', 'Test-CmakeSupportsGenerator')) {
+    foreach ($fn in @('Find-VsBuildTools', 'Get-VcBuildCustomizationsDir', 'Test-CmakeSupportsGenerator',
+                      'Get-CmakeVersion', 'Test-CmakeListsGenerator', 'Test-CmakeCanDriveGenerator',
+                      'Get-FallbackVsGenerator')) {
         $src = Get-FunctionSource -Path $script:SetupPs1 -Name $fn
         if (-not $src) { throw "Function '$fn' not found in $script:SetupPs1 - cannot test the real code." }
         . ([scriptblock]::Create($src))
@@ -142,5 +144,98 @@ Describe 'Test-CmakeSupportsGenerator (CMake 4.2 guard for VS 2026)' {
 
     It 'is a no-op (accepts any CMake) for the VS 2019 generator' {
         Test-CmakeSupportsGenerator -CmakeVersion '3.10.0' -Generator 'Visual Studio 16 2019' | Should -BeTrue
+    }
+}
+
+Describe 'Test-CmakeListsGenerator (probe cmake --help)' {
+    # Mock the `cmake` command rather than dropping a fake on PATH: PowerShell
+    # caches its application-path table, so mutating $env:Path mid-session does not
+    # reliably re-point `& cmake` at a shim (a real cmake on the runner -- present
+    # on GitHub windows-latest -- wins). A function mock is resolved before any
+    # on-PATH executable, so it intercepts `& cmake` inside the helper regardless.
+
+    It 'returns true when cmake --help lists the generator' {
+        Mock cmake { "Generators`n  Visual Studio 18 2026        = Generates VS 2026 project files.`n  Visual Studio 17 2022        = Generates VS 2022 project files." }
+        Test-CmakeListsGenerator -Generator 'Visual Studio 18 2026' | Should -BeTrue
+    }
+
+    It 'returns false when cmake --help does not list the generator' {
+        Mock cmake { "Generators`n  Visual Studio 17 2022        = Generates VS 2022 project files." }
+        Test-CmakeListsGenerator -Generator 'Visual Studio 18 2026' | Should -BeFalse
+    }
+
+    It 'returns false when cmake produces no help output' {
+        Mock cmake { $null }
+        Test-CmakeListsGenerator -Generator 'Visual Studio 18 2026' | Should -BeFalse
+    }
+}
+
+Describe 'Test-CmakeCanDriveGenerator (probe OR version floor)' {
+    It 'accepts a sub-4.2 cmake that lists the VS 2026 generator (bundled cmake)' {
+        # cmake reports version 3.31.0 (below the 4.2 floor) but DOES list the
+        # generator, so the help-probe branch must accept it.
+        Mock cmake {
+            if ($args -contains '--version') { 'cmake version 3.31.0' }
+            else { "Generators`n  Visual Studio 18 2026        = Generates VS 2026 project files." }
+        }
+        Test-CmakeCanDriveGenerator -Generator 'Visual Studio 18 2026' | Should -BeTrue
+    }
+
+    It 'accepts a 4.2 cmake via the version floor when the help probe misses it' {
+        # Help omits the generator, but version 4.2.0 satisfies the floor, so the
+        # version branch must accept it.
+        Mock cmake {
+            if ($args -contains '--version') { 'cmake version 4.2.0' }
+            else { 'Generators' }
+        }
+        Test-CmakeCanDriveGenerator -Generator 'Visual Studio 18 2026' | Should -BeTrue
+    }
+
+    It 'rejects a sub-4.2 cmake that does not list the VS 2026 generator' {
+        Mock cmake {
+            if ($args -contains '--version') { 'cmake version 3.31.0' }
+            else { "Generators`n  Visual Studio 17 2022        = Generates VS 2022 project files." }
+        }
+        Test-CmakeCanDriveGenerator -Generator 'Visual Studio 18 2026' | Should -BeFalse
+    }
+}
+
+Describe 'Get-FallbackVsGenerator (older VS the cmake can drive)' {
+    BeforeAll {
+        function New-FakeVsTree2 {
+            param([string]$Root, [string]$VersionDir, [string]$Edition = 'BuildTools')
+            $clDir = Join-Path $Root "Microsoft Visual Studio\$VersionDir\$Edition\VC\Tools\MSVC\14.39.00000\bin\Hostx64\x64"
+            New-Item -ItemType Directory -Path $clDir -Force | Out-Null
+            New-Item -ItemType File -Path (Join-Path $clDir 'cl.exe') -Force | Out-Null
+        }
+    }
+    BeforeEach {
+        $script:OrigPF = ${env:ProgramFiles}
+        $script:OrigPFx86 = ${env:ProgramFiles(x86)}
+    }
+    AfterEach {
+        ${env:ProgramFiles} = $script:OrigPF
+        ${env:ProgramFiles(x86)} = $script:OrigPFx86
+    }
+
+    It 'returns the VS 2022 generator when VS 2022 is installed and cmake lists it' -Skip:(-not $IsWindows) {
+        $root = Join-Path $TestDrive 'PF_fb'
+        New-FakeVsTree2 -Root $root -VersionDir '2022'
+        ${env:ProgramFiles} = $root
+        ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86_fb'
+        Mock cmake { "Generators`n  Visual Studio 17 2022        = Generates VS 2022 project files." }
+        $r = Get-FallbackVsGenerator
+        $r.Generator | Should -Be 'Visual Studio 17 2022'
+    }
+
+    It 'returns null when the cmake cannot drive any installed older VS' -Skip:(-not $IsWindows) {
+        $root = Join-Path $TestDrive 'PF_none'
+        New-FakeVsTree2 -Root $root -VersionDir '2022'
+        ${env:ProgramFiles} = $root
+        ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86_none'
+        # cmake lists only VS 2026 (not 2022/2019/2017), so no older fallback is usable.
+        Mock cmake { "Generators`n  Visual Studio 18 2026        = Generates VS 2026 project files." }
+        $r = Get-FallbackVsGenerator
+        $r | Should -BeNullOrEmpty
     }
 }

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -39,6 +39,19 @@ Describe 'Find-VsBuildTools (VS 2026 generator discovery)' {
     # helpers) so the v180 path + CMake guard cannot be reachable in routing while
     # discovery stays dead. Windows-only: Find-VsBuildTools builds candidate paths
     # with backslash separators, which only resolve as real directories on Windows.
+    BeforeAll {
+        # Define the helper in BeforeAll (not the Describe body) so it is visible
+        # inside the It blocks: Pester 5 runs the Describe body only during
+        # discovery, where functions do not persist into the run-phase It scope
+        # (the body-level definition raised CommandNotFoundException on Windows,
+        # the only platform where these discovery tests actually run).
+        function New-FakeVsTree {
+            param([string]$Root, [string]$VersionDir, [string]$Edition = 'BuildTools')
+            $clDir = Join-Path $Root "Microsoft Visual Studio\$VersionDir\$Edition\VC\Tools\MSVC\14.50.00000\bin\Hostx64\x64"
+            New-Item -ItemType Directory -Path $clDir -Force | Out-Null
+            New-Item -ItemType File -Path (Join-Path $clDir 'cl.exe') -Force | Out-Null
+        }
+    }
     BeforeEach {
         $script:OrigPF    = ${env:ProgramFiles}
         $script:OrigPFx86 = ${env:ProgramFiles(x86)}
@@ -46,13 +59,6 @@ Describe 'Find-VsBuildTools (VS 2026 generator discovery)' {
     AfterEach {
         ${env:ProgramFiles}      = $script:OrigPF
         ${env:ProgramFiles(x86)} = $script:OrigPFx86
-    }
-
-    function New-FakeVsTree {
-        param([string]$Root, [string]$VersionDir, [string]$Edition = 'BuildTools')
-        $clDir = Join-Path $Root "Microsoft Visual Studio\$VersionDir\$Edition\VC\Tools\MSVC\14.50.00000\bin\Hostx64\x64"
-        New-Item -ItemType Directory -Path $clDir -Force | Out-Null
-        New-Item -ItemType File -Path (Join-Path $clDir 'cl.exe') -Force | Out-Null
     }
 
     It 'detects a filesystem-only VS 2026 BuildTools install (dir "18")' -Skip:(-not $IsWindows) {

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -1,0 +1,93 @@
+<#
+    Pester v5 unit tests for the Visual Studio 2026 completion helpers in
+    studio/setup.ps1:
+      - Get-VcBuildCustomizationsDir : derive the VC MSBuild BuildCustomizations
+        folder (v160 / v170 / v180) from the detected VS generator.
+      - Test-CmakeSupportsGenerator  : gate the "Visual Studio 18 2026" generator
+        on CMake >= 4.2 (no-op for older VS generators).
+
+    Both are pure functions (no GPU, no Visual Studio, no CUDA, no network), so the
+    suite runs on a stock windows-latest runner - and on any pwsh host.
+
+    The real functions are extracted from setup.ps1 and dot-sourced (the script is
+    a top-level installer and cannot be loaded wholesale). Path resolution honors
+    $env:SETUP_PS1_PATH (set by the PR-validate workflow) and falls back to the
+    repo-relative path. If a target function cannot be found, the suite FAILS
+    loudly rather than silently passing.
+#>
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'Get-FunctionSource.ps1')
+
+    $candidates = @(
+        $env:SETUP_PS1_PATH,
+        (Join-Path $PSScriptRoot '..\..\studio\setup.ps1')
+    ) | Where-Object { $_ }
+    $script:SetupPs1 = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+    if (-not $script:SetupPs1) { throw "Could not locate studio/setup.ps1 (set SETUP_PS1_PATH)." }
+    Write-Host "setup.ps1 under test: $script:SetupPs1"
+
+    foreach ($fn in @('Get-VcBuildCustomizationsDir', 'Test-CmakeSupportsGenerator')) {
+        $src = Get-FunctionSource -Path $script:SetupPs1 -Name $fn
+        if (-not $src) { throw "Function '$fn' not found in $script:SetupPs1 - cannot test the real code." }
+        . ([scriptblock]::Create($src))
+    }
+}
+
+Describe 'Get-VcBuildCustomizationsDir (CUDA to VS MSBuild integration path)' {
+    # Use Pester's real TestDrive as the install root so Join-Path resolves on
+    # any OS (a fake 'C:\' base errors on non-Windows hosts). Assertions match the
+    # toolset segment with either path separator, so they hold on Windows + Linux.
+
+    It 'derives v180 for the VS 2026 generator' {
+        Get-VcBuildCustomizationsDir -VsInstallPath "$TestDrive" -Generator 'Visual Studio 18 2026' |
+            Should -Match 'VC[\\/]v180[\\/]BuildCustomizations$'
+    }
+
+    It 'derives v170 for VS 2022 (unchanged behavior)' {
+        Get-VcBuildCustomizationsDir -VsInstallPath "$TestDrive" -Generator 'Visual Studio 17 2022' |
+            Should -Match 'VC[\\/]v170[\\/]BuildCustomizations$'
+    }
+
+    It 'derives v160 for VS 2019' {
+        Get-VcBuildCustomizationsDir -VsInstallPath "$TestDrive" -Generator 'Visual Studio 16 2019' |
+            Should -Match 'VC[\\/]v160[\\/]BuildCustomizations$'
+    }
+
+    It 'falls back to v170 when the generator is empty/unparseable (backwards compatible)' {
+        Get-VcBuildCustomizationsDir -VsInstallPath "$TestDrive" -Generator '' |
+            Should -Match 'VC[\\/]v170[\\/]BuildCustomizations$'
+    }
+
+    It 'roots the path under the supplied VS install path' {
+        $p = Get-VcBuildCustomizationsDir -VsInstallPath "$TestDrive" -Generator 'Visual Studio 18 2026'
+        $p.StartsWith("$TestDrive") | Should -BeTrue
+    }
+}
+
+Describe 'Test-CmakeSupportsGenerator (CMake 4.2 guard for VS 2026)' {
+
+    It 'rejects CMake 3.31.0 with the VS 2026 generator' {
+        Test-CmakeSupportsGenerator -CmakeVersion '3.31.0' -Generator 'Visual Studio 18 2026' | Should -BeFalse
+    }
+
+    It 'accepts CMake 4.2.1 with the VS 2026 generator' {
+        Test-CmakeSupportsGenerator -CmakeVersion '4.2.1' -Generator 'Visual Studio 18 2026' | Should -BeTrue
+    }
+
+    It 'accepts CMake exactly 4.2 with the VS 2026 generator (boundary)' {
+        Test-CmakeSupportsGenerator -CmakeVersion '4.2' -Generator 'Visual Studio 18 2026' | Should -BeTrue
+    }
+
+    It 'rejects CMake 4.1.0 with the VS 2026 generator (boundary)' {
+        Test-CmakeSupportsGenerator -CmakeVersion '4.1.0' -Generator 'Visual Studio 18 2026' | Should -BeFalse
+    }
+
+    It 'is a no-op (accepts any CMake) for the VS 2022 generator' {
+        Test-CmakeSupportsGenerator -CmakeVersion '3.20.0' -Generator 'Visual Studio 17 2022' | Should -BeTrue
+    }
+
+    It 'is a no-op (accepts any CMake) for the VS 2019 generator' {
+        Test-CmakeSupportsGenerator -CmakeVersion '3.10.0' -Generator 'Visual Studio 16 2019' | Should -BeTrue
+    }
+}

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -27,12 +27,42 @@ BeforeAll {
     if (-not $script:SetupPs1) { throw "Could not locate studio/setup.ps1 (set SETUP_PS1_PATH)." }
     Write-Host "setup.ps1 under test: $script:SetupPs1"
 
-    foreach ($fn in @('Find-VsBuildTools', 'Get-VcBuildCustomizationsDir', 'Test-CmakeSupportsGenerator',
-                      'Get-CmakeVersion', 'Test-CmakeListsGenerator', 'Test-CmakeCanDriveGenerator',
-                      'Get-FallbackVsGenerator')) {
+    foreach ($fn in @('Resolve-VsGeneratorFromLabel', 'Find-VsBuildTools', 'Get-VcBuildCustomizationsDir',
+                      'Test-CmakeSupportsGenerator', 'Get-CmakeVersion', 'Test-CmakeListsGenerator',
+                      'Test-CmakeCanDriveGenerator', 'Get-FallbackVsGenerator')) {
         $src = Get-FunctionSource -Path $script:SetupPs1 -Name $fn
         if (-not $src) { throw "Function '$fn' not found in $script:SetupPs1 - cannot test the real code." }
         . ([scriptblock]::Create($src))
+    }
+}
+
+Describe 'Resolve-VsGeneratorFromLabel (vswhere/dir label -> generator)' {
+    # Pure mapping, runs everywhere. Guards the real-world finding that vswhere
+    # reports catalog_productLineVersion='18' (the internal major) for VS 2026 -
+    # NOT '2026' - so detection must accept both the year and the major form.
+    It 'maps the VS 2026 internal major "18" to the VS 2026 generator' {
+        Resolve-VsGeneratorFromLabel '18' | Should -Be 'Visual Studio 18 2026'
+    }
+    It 'maps the VS 2026 year label "2026" to the VS 2026 generator' {
+        Resolve-VsGeneratorFromLabel '2026' | Should -Be 'Visual Studio 18 2026'
+    }
+    It 'maps the VS 2022 year "2022" and major "17" to the VS 2022 generator' {
+        Resolve-VsGeneratorFromLabel '2022' | Should -Be 'Visual Studio 17 2022'
+        Resolve-VsGeneratorFromLabel '17'   | Should -Be 'Visual Studio 17 2022'
+    }
+    It 'maps 2019/2017 (year and major) to their generators' {
+        Resolve-VsGeneratorFromLabel '2019' | Should -Be 'Visual Studio 16 2019'
+        Resolve-VsGeneratorFromLabel '16'   | Should -Be 'Visual Studio 16 2019'
+        Resolve-VsGeneratorFromLabel '2017' | Should -Be 'Visual Studio 15 2017'
+        Resolve-VsGeneratorFromLabel '15'   | Should -Be 'Visual Studio 15 2017'
+    }
+    It 'trims whitespace (vswhere output can carry a trailing newline)' {
+        Resolve-VsGeneratorFromLabel "  18 `n" | Should -Be 'Visual Studio 18 2026'
+    }
+    It 'returns null for unknown or empty labels' {
+        Resolve-VsGeneratorFromLabel '2015' | Should -BeNullOrEmpty
+        Resolve-VsGeneratorFromLabel ''     | Should -BeNullOrEmpty
+        Resolve-VsGeneratorFromLabel $null  | Should -BeNullOrEmpty
     }
 }
 

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -27,10 +27,57 @@ BeforeAll {
     if (-not $script:SetupPs1) { throw "Could not locate studio/setup.ps1 (set SETUP_PS1_PATH)." }
     Write-Host "setup.ps1 under test: $script:SetupPs1"
 
-    foreach ($fn in @('Get-VcBuildCustomizationsDir', 'Test-CmakeSupportsGenerator')) {
+    foreach ($fn in @('Find-VsBuildTools', 'Get-VcBuildCustomizationsDir', 'Test-CmakeSupportsGenerator')) {
         $src = Get-FunctionSource -Path $script:SetupPs1 -Name $fn
         if (-not $src) { throw "Function '$fn' not found in $script:SetupPs1 - cannot test the real code." }
         . ([scriptblock]::Create($src))
+    }
+}
+
+Describe 'Find-VsBuildTools (VS 2026 generator discovery)' {
+    # Exercises the production discovery entry point (not just the downstream
+    # helpers) so the v180 path + CMake guard cannot be reachable in routing while
+    # discovery stays dead. Windows-only: Find-VsBuildTools builds candidate paths
+    # with backslash separators, which only resolve as real directories on Windows.
+    BeforeEach {
+        $script:OrigPF    = ${env:ProgramFiles}
+        $script:OrigPFx86 = ${env:ProgramFiles(x86)}
+    }
+    AfterEach {
+        ${env:ProgramFiles}      = $script:OrigPF
+        ${env:ProgramFiles(x86)} = $script:OrigPFx86
+    }
+
+    function New-FakeVsTree {
+        param([string]$Root, [string]$VersionDir, [string]$Edition = 'BuildTools')
+        $clDir = Join-Path $Root "Microsoft Visual Studio\$VersionDir\$Edition\VC\Tools\MSVC\14.50.00000\bin\Hostx64\x64"
+        New-Item -ItemType Directory -Path $clDir -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $clDir 'cl.exe') -Force | Out-Null
+    }
+
+    It 'detects a filesystem-only VS 2026 BuildTools install (dir "18")' -Skip:(-not $IsWindows) {
+        $root = Join-Path $TestDrive 'PF'
+        New-FakeVsTree -Root $root -VersionDir '18'
+        ${env:ProgramFiles}      = $root
+        ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86'   # no vswhere here -> filesystem fallback
+        $r = Find-VsBuildTools
+        $r.Generator | Should -Be 'Visual Studio 18 2026'
+    }
+
+    It 'detects a filesystem-only VS 2026 install under the year dir ("2026")' -Skip:(-not $IsWindows) {
+        $root = Join-Path $TestDrive 'PF2026'
+        New-FakeVsTree -Root $root -VersionDir '2026'
+        ${env:ProgramFiles}      = $root
+        ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86b'
+        (Find-VsBuildTools).Generator | Should -Be 'Visual Studio 18 2026'
+    }
+
+    It 'still detects VS 2022 (no regression)' -Skip:(-not $IsWindows) {
+        $root = Join-Path $TestDrive 'PF2022'
+        New-FakeVsTree -Root $root -VersionDir '2022'
+        ${env:ProgramFiles}      = $root
+        ${env:ProgramFiles(x86)} = Join-Path $TestDrive 'PFx86c'
+        (Find-VsBuildTools).Generator | Should -Be 'Visual Studio 17 2022'
     }
 }
 

--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -29,7 +29,8 @@ BeforeAll {
 
     foreach ($fn in @('Resolve-VsGeneratorFromLabel', 'Find-VsBuildTools', 'Get-VcBuildCustomizationsDir',
                       'Test-CmakeSupportsGenerator', 'Get-CmakeVersion', 'Test-CmakeListsGenerator',
-                      'Test-CmakeCanDriveGenerator', 'Get-FallbackVsGenerator')) {
+                      'Test-CmakeCanDriveGenerator', 'Get-FallbackVsGenerator',
+                      'Test-VCRedistInstalled')) {
         $src = Get-FunctionSource -Path $script:SetupPs1 -Name $fn
         if (-not $src) { throw "Function '$fn' not found in $script:SetupPs1 - cannot test the real code." }
         . ([scriptblock]::Create($src))
@@ -314,5 +315,40 @@ Describe 'Get-FallbackVsGenerator discovery is symmetric with Find-VsBuildTools 
     It 'queries vswhere as part of fallback discovery' {
         $src = Get-FunctionSource -Path $script:SetupPs1 -Name Get-FallbackVsGenerator
         $src | Should -Match 'vswhere'
+    }
+}
+
+Describe 'Test-VCRedistInstalled (VC++ 2015-2022 runtime needed by the prebuilt llama.cpp + PyTorch)' {
+    # The prebuilt llama-server.exe and the PyTorch wheels link VCRUNTIME140.dll /
+    # MSVCP140.dll / VCRUNTIME140_1.dll, which the VC++ redistributable provides
+    # (the Universal CRT ships with Windows, this does not). Detection is the
+    # System32 vcruntime140_1.dll DLL with a registry fallback.
+    BeforeEach { $script:OrigSysRoot = $env:SystemRoot }
+    AfterEach  { $env:SystemRoot = $script:OrigSysRoot }
+
+    # Test-VCRedistInstalled probes Test-Path once (the System32 DLL); when that is
+    # $false it consults the registry via Get-ItemProperty. Mock both directly.
+    It 'returns true when vcruntime140_1.dll is present in System32' {
+        $env:SystemRoot = 'C:\Windows'
+        Mock Test-Path { $true }
+        Test-VCRedistInstalled | Should -BeTrue
+    }
+    It 'returns true via the registry when the DLL is not found (Installed=1, >= 14.20)' {
+        $env:SystemRoot = 'C:\Windows'
+        Mock Test-Path { $false }
+        Mock Get-ItemProperty { [pscustomobject]@{ Installed = 1; Major = 14; Minor = 29 } }
+        Test-VCRedistInstalled | Should -BeTrue
+    }
+    It 'returns false when neither the DLL nor a >= 14.20 registry entry exists' {
+        $env:SystemRoot = 'C:\Windows'
+        Mock Test-Path { $false }
+        Mock Get-ItemProperty { throw 'no key' }
+        Test-VCRedistInstalled | Should -BeFalse
+    }
+    It 'returns false for an old 2015-only redist (Installed=1 but < 14.20)' {
+        $env:SystemRoot = 'C:\Windows'
+        Mock Test-Path { $false }
+        Mock Get-ItemProperty { [pscustomobject]@{ Installed = 1; Major = 14; Minor = 0 } }
+        Test-VCRedistInstalled | Should -BeFalse
     }
 }


### PR DESCRIPTION
### Summary

Completes end-to-end Visual Studio 2026 support for the Windows Studio installer's CUDA llama.cpp build.
Self-contained: it folds in the VS 2026 detection (adapted from #6038 by @LeoBorcherding) and adds the
two pieces that detection alone does not cover.

Three things were needed for a VS 2026 host:

1. **Detection** - `Find-VsBuildTools` now returns `Visual Studio 18 2026`: vswhere
   `catalog_productLineVersion = 2026` maps to the generator, and the filesystem fallback scans both the
   new `18` install dir and the `2026` year dir (including non-standard editions such as Preview).
2. **CUDA MSBuild path** - the CUDA `.targets` were copied into a hardcoded `VC\v170` (VS 2022)
   BuildCustomizations folder. `Get-VcBuildCustomizationsDir` now derives `v160`/`v170`/`v180` from the
   detected generator, so a VS 2026 (v180) toolchain finds the CUDA toolset.
3. **CMake gate** - the `Visual Studio 18 2026` cmake generator requires CMake 4.2+. A guard upgrades (or
   installs) CMake via winget, else fails with a clear message.

### Important: the CMake gate runs only for source builds

The CMake 4.2 requirement lives in the committed-source-build branch, not Phase 1. The preferred prebuilt
llama.cpp path never reaches it, so a VS 2026 host on CMake < 4.2 is **not** blocked from installing via
the prebuilt bundle. No behavior change for VS 2022/2019/2017: the BuildCustomizations folder resolves to
`v170` and the CMake gate is skipped.

The change is confined to `studio/setup.ps1` plus tests/workflow - no Python, training, inference, or
prebuilt code is touched.

### Tests

`tests/studio_setup_ps1/` + `.github/workflows/studio-setup-ps1-vs2026.yml` run windows-latest Pester
tests for: the v160/v170/v180 derivation (+ fallback), the CMake 4.2 gate (boundaries + no-op for older
VS), and `Find-VsBuildTools` discovery of a VS 2026 install (dir `18` and `2026`) plus a VS 2022
no-regression case.

Closes the VS 2026 CUDA-build issues #5614 / #6037 / #4544. Incorporates and supersedes the detection in
#6038 (credited).
