### PR TITLE
Studio: keep code block scrollbars off one-line code

### DIFF
--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1644,6 +1644,11 @@
 		padding: 0 !important;
 	}
 
+	.aui-thread-root [data-streamdown="code-block-body"] {
+		/* Keep overlay scrollbars below one-line code. */
+		padding-bottom: 0.625rem !important;
+	}
+
 	[data-streamdown="code-block"] {
 		gap: 0.25rem;
 		padding: 0.75rem 1rem;


### PR DESCRIPTION
## Summary
- Add bottom clearance to chat code block bodies so horizontal scrollbars do not cover one-line commands.
- Keep the change scoped to Streamdown code blocks in the Studio chat thread.

Fixes #6469

## Testing
- npm run typecheck
- npm run build