### PR TITLE
Harden trust_remote_code consent: scan GGUF-only auto_map and drop pre-set TRC defaults

### DIFF
--- a/studio/backend/assets/configs/model_defaults/default.yaml
+++ b/studio/backend/assets/configs/model_defaults/default.yaml
@@ -2,7 +2,6 @@
 # Used for models without specific configurations
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -48,7 +47,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.7
   top_p: 0.95
   top_k: -1

--- a/studio/backend/assets/configs/model_defaults/ernie/unsloth_ERNIE-4.5-21B-A3B-PT.yaml
+++ b/studio/backend/assets/configs/model_defaults/ernie/unsloth_ERNIE-4.5-21B-A3B-PT.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/ERNIE-4.5-21B-A3B-PT
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/ernie/unsloth_ERNIE-4.5-21B-A3B-PT.yaml
+++ b/studio/backend/assets/configs/model_defaults/ernie/unsloth_ERNIE-4.5-21B-A3B-PT.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/ernie/unsloth_ERNIE-4.5-VL-28B-A3B-PT.yaml
+++ b/studio/backend/assets/configs/model_defaults/ernie/unsloth_ERNIE-4.5-VL-28B-A3B-PT.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: true
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -49,7 +48,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: true
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/falcon/tiiuae_Falcon-H1-0.5B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/falcon/tiiuae_Falcon-H1-0.5B-Instruct.yaml
@@ -3,7 +3,6 @@
 # Also applies to: tiiuae/Falcon-H1-0.5B-Instruct, unsloth/Falcon-H1-0.5B-Instruct
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/falcon/tiiuae_Falcon-H1-0.5B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/falcon/tiiuae_Falcon-H1-0.5B-Instruct.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_codegemma-7b-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_codegemma-7b-bnb-4bit.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from Ollama
 
 training:
-  trust_remote_code: false
   max_seq_length: 4096
   # num_epochs: 4
   num_epochs: 0
@@ -45,6 +44,5 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0
   top_p: 0.9

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_functiongemma-270m-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_functiongemma-270m-it.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 4096
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_k: 64
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-27b-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-27b-bnb-4bit.yaml
@@ -40,5 +40,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-27b-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-27b-bnb-4bit.yaml
@@ -2,7 +2,6 @@
 # Based on Gemma2_(9B)-Alpaca.ipynb (same defaults for larger models)
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,4 +42,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-2b.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-2b.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-2b.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-2-2b.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/gemma-2-2b-bnb-4bit, google/gemma-2-2b
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-270m-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-270m-it.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_k: 64
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-27b-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-27b-it.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_k: 64
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-4b-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-4b-it.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_k: 64
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-4b-pt.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3-4b-pt.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 2
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_k: 64
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3n-E4B-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3n-E4B-it.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 1024
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
 audio_input: true
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_k: 64
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3n-E4B.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-3n-E4B.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 2
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
 audio_input: true
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_k: 64
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-26B-A4B-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-26B-A4B-it.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-26B-A4B-it, unsloth/gemma-4-26B-A4B-it-GGUF
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-26B-A4B.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-26B-A4B.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-26B-A4B
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-31B-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-31B-it.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-31B-it, unsloth/gemma-4-31B-it-GGUF
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-31B.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-31B.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-31B
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E2B-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E2B-it.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-E2B-it, unsloth/gemma-4-E2B-it-GGUF
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E2B.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E2B.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-E2B
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E4B-it.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E4B-it.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-E4B-it, unsloth/gemma-4-E4B-it-GGUF
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E4B.yaml
+++ b/studio/backend/assets/configs/model_defaults/gemma/unsloth_gemma-4-E4B.yaml
@@ -2,7 +2,6 @@
 # Also applies to: google/gemma-4-E4B
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   num_epochs: 0
   learning_rate: 2e-4
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 0.95
   top_k: 64

--- a/studio/backend/assets/configs/model_defaults/gpt-oss/unsloth_gpt-oss-120b.yaml
+++ b/studio/backend/assets/configs/model_defaults/gpt-oss/unsloth_gpt-oss-120b.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 4096
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 1.0
   top_k: 0

--- a/studio/backend/assets/configs/model_defaults/gpt-oss/unsloth_gpt-oss-20b.yaml
+++ b/studio/backend/assets/configs/model_defaults/gpt-oss/unsloth_gpt-oss-20b.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 1024
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.0
   top_p: 1.0
   top_k: 0

--- a/studio/backend/assets/configs/model_defaults/granite/unsloth_granite-4.0-350m-unsloth-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/granite/unsloth_granite-4.0-350m-unsloth-bnb-4bit.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -47,7 +46,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.0
   top_p: 1.0
   top_k: 0

--- a/studio/backend/assets/configs/model_defaults/granite/unsloth_granite-4.0-h-micro.yaml
+++ b/studio/backend/assets/configs/model_defaults/granite/unsloth_granite-4.0-h-micro.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -47,7 +46,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.0
   top_p: 1.0
   top_k: 0

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-11B-Vision-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-11B-Vision-Instruct.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-1B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-1B-Instruct.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-1B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-1B-Instruct.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Llama-3.2-1B-Instruct-unsloth-bnb-4bit, meta-llama/Llama-3.2-1B-Instruct, unsloth/Llama-3.2-1B-Instruct-bnb-4bit, RedHatAI/Llama-3.2-1B-Instruct-FP8, unsloth/Llama-3.2-1B-Instruct-FP8-Block, unsloth/Llama-3.2-1B-Instruct-FP8-Dynamic
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 5
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-3B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.2-3B-Instruct.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.3-70B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Llama-3.3-70B-Instruct.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-70B-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-70B-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-70B-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-70B-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Meta-Llama-3.1-8B-bnb-4bit, unsloth/Meta-Llama-3.1-8B-unsloth-bnb-4bit, meta-llama/Meta-Llama-3.1-8B, unsloth/Meta-Llama-3.1-8B, unsloth/Meta-Llama-3.1-70B, meta-llama/Meta-Llama-3.1-70B, unsloth/Meta-Llama-3.1-405B-bnb-4bit, meta-llama/Meta-Llama-3.1-405B
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-8B-Instruct-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-8B-Instruct-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to: "unsloth/Meta-Llama-3.1-8B-Instruct-unsloth-bnb-4bit", "meta-llama/Meta-Llama-3.1-8B-Instruct", "unsloth/Meta-Llama-3.1-8B-Instruct","RedHatAI/Llama-3.1-8B-Instruct-FP8","unsloth/Llama-3.1-8B-Instruct-FP8-Block","unsloth/Llama-3.1-8B-Instruct-FP8-Dynamic"
 
 training:
-  trust_remote_code: false
   max_seq_length: 8192
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-8B-Instruct-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_Meta-Llama-3.1-8B-Instruct-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-Instruct-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-Instruct-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/llama-3-8b-Instruct, meta-llama/Meta-Llama-3-8B-Instruct
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-Instruct-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-Instruct-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/llama/unsloth_llama-3-8b-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/llama-3-8b, meta-llama/Meta-Llama-3-8B
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/llasa/unsloth_Llasa-3B.yaml
+++ b/studio/backend/assets/configs/model_defaults/llasa/unsloth_Llasa-3B.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -40,7 +39,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.2
   top_p: 1.2
 

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_Magistral-Small-2509-unsloth-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_Magistral-Small-2509-unsloth-bnb-4bit.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -49,7 +48,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.7
   min_p: 0.01
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_Ministral-3-3B-Instruct-2512.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_Ministral-3-3B-Instruct-2512.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -49,7 +48,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.15
   top_p: 0.95
 

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Nemo-Base-2407-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Nemo-Base-2407-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Nemo-Base-2407-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Nemo-Base-2407-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to:  "unsloth/Mistral-Nemo-Base-2407",  "mistralai/Mistral-Nemo-Base-2407", "unsloth/Mistral-Nemo-Instruct-2407-bnb-4bit", "unsloth/Mistral-Nemo-Instruct-2407", "mistralai/Mistral-Nemo-Instruct-2407",
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Small-Instruct-2409.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Small-Instruct-2409.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Small-Instruct-2409.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_Mistral-Small-Instruct-2409.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Mistral-Small-Instruct-2409-bnb-4bit, mistralai/Mistral-Small-Instruct-2409
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_Pixtral-12B-2409.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_Pixtral-12B-2409.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-instruct-v0.3-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-instruct-v0.3-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/mistral-7b-instruct-v0.3, mistralai/Mistral-7B-Instruct-v0.3
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-instruct-v0.3-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-instruct-v0.3-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-v0.3-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-v0.3-bnb-4bit.yaml
@@ -40,5 +40,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-v0.3-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/mistral/unsloth_mistral-7b-v0.3-bnb-4bit.yaml
@@ -2,7 +2,6 @@
 # Based on Mistral_v0.3_(7B)-Alpaca.ipynb
 # Also applies to: "unsloth/mistral-7b-v0.3", "mistralai/Mistral-7B-v0.3",
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,4 +42,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/other/OuteAI_Llama-OuteTTS-1.0-1B.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/OuteAI_Llama-OuteTTS-1.0-1B.yaml
@@ -6,7 +6,6 @@
 audio_type: dac
 
 training:
-  trust_remote_code: false
   eval_steps: 0
   max_seq_length: 2048
   # num_epochs: 4
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.4
   top_k: 40
   top_p: 0.9

--- a/studio/backend/assets/configs/model_defaults/other/Spark-TTS-0.5B_LLM.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/Spark-TTS-0.5B_LLM.yaml
@@ -6,7 +6,6 @@
 audio_type: bicodec
 
 training:
-  trust_remote_code: false
   eval_steps: 0
   max_seq_length: 2048
   # num_epochs: 4
@@ -48,7 +47,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.8
   top_k: 50
   top_p: 1.0

--- a/studio/backend/assets/configs/model_defaults/other/sesame_csm-1b.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/sesame_csm-1b.yaml
@@ -44,5 +44,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/other/sesame_csm-1b.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/sesame_csm-1b.yaml
@@ -5,7 +5,6 @@
 audio_type: csm
 
 training:
-  trust_remote_code: false
   eval_steps: 0
   max_seq_length: 2048
   # num_epochs: 4
@@ -47,4 +46,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_GLM-4.7-Flash.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_GLM-4.7-Flash.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/GLM-4.7-Flash-unsloth-bnb-4bit, unsloth/GLM-4.7-Flash-bnb-4bit, THUDM/GLM-4.7-Flash
 
 training:
-  trust_remote_code: true
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: true
   temperature: 0.7
   top_p: 0.8
   top_k: 20

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_LFM2-1.2B.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_LFM2-1.2B.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -39,7 +38,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.3
   min_p: 0.15
 

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_Nemotron-3-Nano-30B-A3B.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_Nemotron-3-Nano-30B-A3B.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: true
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -47,7 +46,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: true
   temperature: 1.0
   top_p: 1.0
 

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_PaddleOCR-VL.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_PaddleOCR-VL.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: true
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -49,7 +48,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: true
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_answerdotai_ModernBERT-large.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_answerdotai_ModernBERT-large.yaml
@@ -40,5 +40,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_answerdotai_ModernBERT-large.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_answerdotai_ModernBERT-large.yaml
@@ -2,7 +2,6 @@
 # Based on bert_classification.ipynb
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 1
   num_epochs: 0
@@ -43,4 +42,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_orpheus-3b-0.1-ft.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_orpheus-3b-0.1-ft.yaml
@@ -6,7 +6,6 @@
 audio_type: snac
 
 training:
-  trust_remote_code: false
   eval_steps: 0
   max_seq_length: 2048
   # num_epochs: 4
@@ -48,7 +47,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_p: 0.95
 

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_tinyllama-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_tinyllama-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_tinyllama-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_tinyllama-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to: TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
 
 training:
-  trust_remote_code: false
   max_seq_length: 4096
   # num_epochs: 1
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_whisper-large-v3.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_whisper-large-v3.yaml
@@ -40,5 +40,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_whisper-large-v3.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_whisper-large-v3.yaml
@@ -6,7 +6,6 @@ audio_type: whisper
 audio_input: true
 
 training:
-  trust_remote_code: false
   eval_steps: 5
   max_seq_length: 448
   # num_epochs: 4
@@ -43,4 +42,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3-medium-4k-instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3-medium-4k-instruct.yaml
@@ -3,7 +3,6 @@
 # Also applies to: "unsloth/Phi-3-medium-4k-instruct-bnb-4bit", "microsoft/Phi-3-medium-4k-instruct",
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3-medium-4k-instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3-medium-4k-instruct.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3.5-mini-instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3.5-mini-instruct.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3.5-mini-instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-3.5-mini-instruct.yaml
@@ -3,7 +3,6 @@
 # Also applies to: "unsloth/Phi-3.5-mini-instruct-bnb-4bit", "microsoft/Phi-3.5-mini-instruct"
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-4.yaml
+++ b/studio/backend/assets/configs/model_defaults/phi/unsloth_Phi-4.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.8
   top_p: 0.95
 

--- a/studio/backend/assets/configs/model_defaults/qwen/imdatta0_tiny_qwen3_moe_2.8B_0.7B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/imdatta0_tiny_qwen3_moe_2.8B_0.7B.yaml
@@ -4,7 +4,6 @@
 # MoE model - includes gate_up_proj for MoE layers
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -46,7 +45,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_k: 20
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2-7B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2-7B.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2-7B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2-7B.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Qwen2-7B-bnb-4bit, Qwen/Qwen2-7B
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2-VL-7B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2-VL-7B-Instruct.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-1.5B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-1.5B-Instruct.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-1.5B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-1.5B-Instruct.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Qwen2.5-1.5B-Instruct-unsloth-bnb-4bit, Qwen/Qwen2.5-1.5B-Instruct, unsloth/Qwen2.5-1.5B-Instruct-bnb-4bit
 
 training:
-  trust_remote_code: false
   max_seq_length: 4096
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-7B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-7B.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-7B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-7B.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Qwen2.5-7B-unsloth-bnb-4bit, Qwen/Qwen2.5-7B, unsloth/Qwen2.5-7B-bnb-4bit
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-1.5B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-1.5B-Instruct.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-1.5B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-1.5B-Instruct.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Qwen2.5-Coder-1.5B-Instruct-bnb-4bit, Qwen/Qwen2.5-Coder-1.5B-Instruct
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-14B-Instruct.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-14B-Instruct.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-7B-Instruct-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-7B-Instruct-bnb-4bit.yaml
@@ -41,5 +41,3 @@ logging:
   enable_tensorboard: false
   tensorboard_dir: "runs"
   log_frequency: 10
-
-inference:

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-7B-Instruct-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-Coder-7B-Instruct-bnb-4bit.yaml
@@ -3,7 +3,6 @@
 # Also applies to: unsloth/Qwen2.5-Coder-7B-Instruct, Qwen/Qwen2.5-Coder-7B-Instruct
 
 training:
-  trust_remote_code: false
   max_seq_length: 32768
   # num_epochs: 4
   num_epochs: 0
@@ -44,4 +43,3 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-VL-7B-Instruct-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen2.5-VL-7B-Instruct-bnb-4bit.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth notebook
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 1.5
   min_p: 0.1
 

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-0.6B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-0.6B.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from Ollama
 
 training:
-  trust_remote_code: false
   max_seq_length: 1024
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_k: 20
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-14B-Base-unsloth-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-14B-Base-unsloth-bnb-4bit.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from Ollama
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_k: 20
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-14B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-14B.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from Ollama
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_k: 20
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-30B-A3B-Instruct-2507.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-30B-A3B-Instruct-2507.yaml
@@ -4,7 +4,6 @@
 # MoE model - includes gate_up_proj for MoE layers
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -46,7 +45,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_k: 20
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-32B.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-32B.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from Ollama
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_k: 20
   top_p: 0.95

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-4B-Instruct-2507.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-4B-Instruct-2507.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.7
   top_p: 0.80
   top_k: 20

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-4B-Thinking-2507.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-4B-Thinking-2507.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -45,7 +44,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.6
   top_p: 0.95
   top_k: 20

--- a/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-VL-8B-Instruct-unsloth-bnb-4bit.yaml
+++ b/studio/backend/assets/configs/model_defaults/qwen/unsloth_Qwen3-VL-8B-Instruct-unsloth-bnb-4bit.yaml
@@ -4,7 +4,6 @@
 # added inference parameters from unsloth guides
 
 training:
-  trust_remote_code: false
   max_seq_length: 2048
   # num_epochs: 4
   num_epochs: 0
@@ -43,7 +42,6 @@ logging:
   log_frequency: 10
 
 inference:
-  trust_remote_code: false
   temperature: 0.7
   top_p: 0.8
   top_k: 20

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -1235,7 +1235,6 @@ class TestScannerCoversAllExecutableCode:
             **kw,
         ):
             import json
-
             if filename == "config.json":
                 p = tmp_path / "config.json"
                 p.write_text(

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -1225,8 +1225,8 @@ class TestScannerCoversAllExecutableCode:
         assert configs is None
 
     def test_gguf_repo_auto_map_is_scanned_for_non_file_load_paths(self, tmp_path):
-        # A GGUF-only repo id still reaches non-llama.cpp paths (export), which run
-        # auto_map before failing on the weights; only a direct .gguf file is inert.
+        # A GGUF-only repo id still hits export paths that run auto_map; only a direct
+        # .gguf file is inert.
         def _dl(
             repo_id = None,
             filename = None,
@@ -1252,8 +1252,7 @@ class TestScannerCoversAllExecutableCode:
             assert consent._config_has_auto_map("unsloth/Some-Model-GGUF") is True
 
     def test_gguf_only_repo_with_python_is_scanned_and_blocked(self, tmp_path):
-        # Regression: the GGUF-only repo short-circuit must not skip scanning auto_map
-        # Python for export/non-GGUF loaders that pass trust_remote_code=True.
+        # Regression: the GGUF-only short-circuit must not skip auto_map Python for export loaders.
         def _dl(
             repo_id = None,
             filename = None,
@@ -1289,8 +1288,7 @@ class TestScannerCoversAllExecutableCode:
         assert d.fingerprint
 
     def test_transformers_style_repo_auto_map_is_scanned_and_blocked(self, tmp_path):
-        # A non-GGUF repo (safetensors, or MLX .npz) with auto_map is still scanned and
-        # blocked through the real consent gate.
+        # A non-GGUF repo (safetensors/MLX) with auto_map is still scanned and blocked.
         def _dl(
             repo_id = None,
             filename = None,

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -1224,9 +1224,10 @@ class TestScannerCoversAllExecutableCode:
             configs = consent._load_remote_code_configs("some/gated-repo")
         assert configs is None
 
-    def test_gguf_repo_auto_map_is_ignored(self):
-        # A GGUF repo with a vestigial auto_map loads via llama.cpp, which never runs it,
-        # so _config_has_auto_map must return False and skip the consent flow.
+    def test_gguf_repo_auto_map_is_scanned_for_non_file_load_paths(self, tmp_path):
+        # A GGUF-only repo id can still be passed to non-llama.cpp load paths (export uses
+        # transformers/Unsloth). Those paths can execute auto_map before failing on the
+        # weight shape, so only an explicit .gguf file reference is inert.
         def _dl(
             repo_id = None,
             filename = None,
@@ -1234,10 +1235,9 @@ class TestScannerCoversAllExecutableCode:
             **kw,
         ):
             import json
-            import tempfile
 
             if filename == "config.json":
-                p = Path(tempfile.mkdtemp()) / "config.json"
+                p = tmp_path / "config.json"
                 p.write_text(
                     json.dumps({"auto_map": {"AutoModelForCausalLM": "modeling_decilm.X"}})
                 )
@@ -1251,7 +1251,82 @@ class TestScannerCoversAllExecutableCode:
                 return_value = ["config.json", "model-00001-of-00097.gguf"],
             ),
         ):
-            assert consent._config_has_auto_map("unsloth/Some-Model-GGUF") is False
+            assert consent._config_has_auto_map("unsloth/Some-Model-GGUF") is True
+
+    def test_gguf_only_repo_with_python_is_scanned_and_blocked(self, tmp_path):
+        # Regression: the GGUF-only repo short-circuit must not skip scanning auto_map
+        # Python for export/non-GGUF loaders that pass trust_remote_code=True.
+        def _dl(
+            repo_id = None,
+            filename = None,
+            token = None,
+            **kw,
+        ):
+            import json
+
+            p = tmp_path / filename
+            if filename == "config.json":
+                p.write_text(json.dumps({"auto_map": {"AutoModel": "modeling_evil.X"}}))
+                return str(p)
+            if filename == "modeling_evil.py":
+                p.write_text("import subprocess\nsubprocess.Popen(['id'])\n")
+                return str(p)
+            raise EntryNotFoundError(filename)
+
+        with (
+            patch("huggingface_hub.hf_hub_download", side_effect = _dl),
+            patch(
+                "huggingface_hub.list_repo_files",
+                return_value = ["config.json", "modeling_evil.py", "model.Q4_K_M.gguf"],
+            ),
+        ):
+            d = evaluate_remote_code_consent_for_targets(
+                ["evil/GGUF-Only"],
+                trust_remote_code = True,
+            )
+
+        assert d.has_remote_code is True
+        assert d.blocked is True
+        assert d.max_severity == HIGH
+        assert d.fingerprint
+
+    def test_transformers_style_repo_auto_map_is_scanned_and_blocked(self, tmp_path):
+        # The GGUF change must not weaken transformers-style loads: a non-GGUF repo
+        # (safetensors, or MLX-style .npz with no .safetensors/.gguf) that declares an
+        # auto_map is still scanned and blocked through the real consent gate.
+        def _dl(
+            repo_id = None,
+            filename = None,
+            token = None,
+            **kw,
+        ):
+            import json
+
+            p = tmp_path / filename
+            if filename == "config.json":
+                p.write_text(json.dumps({"auto_map": {"AutoModel": "modeling_evil.X"}}))
+                return str(p)
+            if filename == "modeling_evil.py":
+                p.write_text("import subprocess\nsubprocess.Popen(['id'])\n")
+                return str(p)
+            raise EntryNotFoundError(filename)
+
+        for weights in (["model.safetensors"], ["weights.npz"]):
+            with (
+                patch("huggingface_hub.hf_hub_download", side_effect = _dl),
+                patch(
+                    "huggingface_hub.list_repo_files",
+                    return_value = ["config.json", "modeling_evil.py", *weights],
+                ),
+            ):
+                d = evaluate_remote_code_consent_for_targets(
+                    ["org/Transformers-Style"],
+                    trust_remote_code = True,
+                )
+            assert d.has_remote_code is True, weights
+            assert d.blocked is True, weights
+            assert d.max_severity == HIGH, weights
+            assert d.fingerprint, weights
 
     def test_direct_gguf_file_reference_has_no_auto_map(self):
         # A direct .gguf file reference (repo id + filename, >=3 segments) is a GGUF load: no remote code, no Hub call.

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -1225,9 +1225,8 @@ class TestScannerCoversAllExecutableCode:
         assert configs is None
 
     def test_gguf_repo_auto_map_is_scanned_for_non_file_load_paths(self, tmp_path):
-        # A GGUF-only repo id can still be passed to non-llama.cpp load paths (export uses
-        # transformers/Unsloth). Those paths can execute auto_map before failing on the
-        # weight shape, so only an explicit .gguf file reference is inert.
+        # A GGUF-only repo id still reaches non-llama.cpp paths (export), which run
+        # auto_map before failing on the weights; only a direct .gguf file is inert.
         def _dl(
             repo_id = None,
             filename = None,
@@ -1290,9 +1289,8 @@ class TestScannerCoversAllExecutableCode:
         assert d.fingerprint
 
     def test_transformers_style_repo_auto_map_is_scanned_and_blocked(self, tmp_path):
-        # The GGUF change must not weaken transformers-style loads: a non-GGUF repo
-        # (safetensors, or MLX-style .npz with no .safetensors/.gguf) that declares an
-        # auto_map is still scanned and blocked through the real consent gate.
+        # A non-GGUF repo (safetensors, or MLX .npz) with auto_map is still scanned and
+        # blocked through the real consent gate.
         def _dl(
             repo_id = None,
             filename = None,

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -36,6 +36,41 @@ def test_no_model_default_yaml_sets_trust_remote_code():
     )
 
 
+def test_no_model_default_yaml_has_empty_or_none_section():
+    # Removing a section's only key (trust_remote_code) must not leave a bare header
+    # like `inference:` -> PyYAML parses that as None and load_inference_config() does
+    # `model_config.get("inference", {}).get(...)`, which crashes on None. Every present
+    # top-level section must be a non-empty mapping.
+    offenders = []
+    for f in _MODEL_DEFAULTS.rglob("*.yaml"):
+        doc = yaml.safe_load(f.read_text())
+        if not isinstance(doc, dict):
+            offenders.append(f"{f.relative_to(_CONFIGS)} (not a mapping)")
+            continue
+        for section, body in doc.items():
+            if body is None or (isinstance(body, dict) and not body):
+                offenders.append(f"{f.relative_to(_CONFIGS)} [{section}]")
+    assert not offenders, (
+        "empty/None YAML section would crash the config loaders; drop the bare section "
+        f"header instead. Offending: {offenders}"
+    )
+
+
+def test_formerly_flagged_models_load_inference_config_without_crash():
+    # End-to-end: the models whose inference section was emptied by the TRC removal must
+    # still load their inference config (falling back to family/default params).
+    from utils.inference import load_inference_config
+
+    for model in (
+        "tiiuae/Falcon-H1-0.5B-Instruct",
+        "unsloth/Llama-3.2-1B-Instruct",
+        "unsloth/Qwen2.5-7B",
+    ):
+        cfg = load_inference_config(model)
+        assert isinstance(cfg, dict)
+        assert cfg.get("trust_remote_code", False) is False
+
+
 def test_base_templates_have_no_trust_remote_code():
     for name in ("full_finetune.yaml", "lora_text.yaml", "vision_lora.yaml"):
         doc = yaml.safe_load((_CONFIGS / name).read_text()) or {}

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -34,8 +34,7 @@ def test_no_model_default_yaml_sets_trust_remote_code():
 
 
 def test_no_model_default_yaml_has_empty_or_none_section():
-    # Dropping a section's only key must not leave a bare `inference:` header: PyYAML
-    # reads that as None and the .get(...).get(...) loaders crash on it.
+    # A bare `inference:` header (no keys) parses to None and crashes the .get() loaders.
     offenders = []
     for f in _MODEL_DEFAULTS.rglob("*.yaml"):
         doc = yaml.safe_load(f.read_text())
@@ -52,8 +51,7 @@ def test_no_model_default_yaml_has_empty_or_none_section():
 
 
 def test_formerly_flagged_models_load_inference_config_without_crash():
-    # End-to-end: the models whose inference section was emptied by the TRC removal must
-    # still load their inference config (falling back to family/default params).
+    # Models whose inference section was emptied by the TRC removal must still load.
     from utils.inference import load_inference_config
     for model in (
         "tiiuae/Falcon-H1-0.5B-Instruct",
@@ -66,8 +64,7 @@ def test_formerly_flagged_models_load_inference_config_without_crash():
 
 
 def test_all_model_yamls_load_for_training_and_inference():
-    # Every YAML must load through both config paths (training + inference) with the
-    # exact .get() patterns the routes use; the file stem resolves to that file.
+    # Every YAML must load through both config paths (training + inference) as the routes do.
     from utils.inference import load_inference_config
     from utils.models.model_config import load_model_defaults
 
@@ -105,8 +102,7 @@ def test_base_templates_have_no_trust_remote_code():
 
 
 def test_loader_defaults_trust_remote_code_off_for_formerly_flagged_models():
-    # The 4 models that used to ship trust_remote_code: true. The loader must now report
-    # no default (auto_map models get the dialog; GLM-4.7-Flash loads natively TRC=False).
+    # The 4 models that used to ship trust_remote_code: true must now report no default.
     from utils.models.model_config import load_model_defaults
     for model in (
         "unsloth/GLM-4.7-Flash",
@@ -122,9 +118,8 @@ def test_loader_defaults_trust_remote_code_off_for_formerly_flagged_models():
 
 
 def test_formerly_flagged_auto_map_models_still_require_consent_dialog():
-    # Crux of the change: an auto_map model must STILL surface the dialog -- it is driven
-    # by the repo's auto_map, not the YAML flag. Exercises the real backend path
-    # (preflight_remote_code_consent_for_targets), mocking only the Hub json + .py fetch.
+    # Crux: an auto_map model must STILL surface the dialog (driven by auto_map, not the
+    # YAML flag). Real backend path, mocking only the Hub json + .py fetch.
     from unittest.mock import patch
     from utils.security import consent, preflight_remote_code_consent_for_targets
 
@@ -155,8 +150,7 @@ def test_formerly_flagged_auto_map_models_still_require_consent_dialog():
 
 
 def test_no_auto_map_model_takes_no_dialog():
-    # Flip side: GLM-4.7-Flash ships no auto_map -> no dialog, loads natively (TRC=False).
-    # Its old YAML flag was a no-op, so removing it is safe.
+    # Flip side: GLM-4.7-Flash ships no auto_map -> no dialog; its old YAML flag was a no-op.
     from unittest.mock import patch
     from utils.security import consent, preflight_remote_code_consent_for_targets
 

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression: model-default YAMLs must not pre-set trust_remote_code.
+
+trust_remote_code is a per-load decision made through the remote-code consent dialog
+(which scans and pins the exact auto_map code), never a config default. A YAML that
+ships trust_remote_code: true would re-introduce a path to enabling remote code without
+the user reviewing it -- the bypass class fixed alongside this change. Models that
+genuinely run custom code ship auto_map, which the consent gate detects on its own, so
+the dialog still fires for them without a YAML flag.
+"""
+
+from pathlib import Path
+
+import yaml
+
+_CONFIGS = Path(__file__).resolve().parent.parent / "assets" / "configs"
+_MODEL_DEFAULTS = _CONFIGS / "model_defaults"
+
+
+def test_no_model_default_yaml_sets_trust_remote_code():
+    offenders = []
+    for f in _MODEL_DEFAULTS.rglob("*.yaml"):
+        doc = yaml.safe_load(f.read_text()) or {}
+        if not isinstance(doc, dict):
+            continue
+        for section, body in doc.items():
+            if isinstance(body, dict) and "trust_remote_code" in body:
+                offenders.append(f"{f.relative_to(_CONFIGS)} [{section}={body['trust_remote_code']}]")
+    assert not offenders, (
+        "trust_remote_code must not be pre-set in model defaults; it is enabled only via "
+        f"the consent dialog. Remove it from: {offenders}"
+    )
+
+
+def test_base_templates_have_no_trust_remote_code():
+    for name in ("full_finetune.yaml", "lora_text.yaml", "vision_lora.yaml"):
+        doc = yaml.safe_load((_CONFIGS / name).read_text()) or {}
+        flat = yaml.safe_dump(doc)
+        assert "trust_remote_code" not in flat, f"{name} should not set trust_remote_code"
+
+
+def test_loader_defaults_trust_remote_code_off_for_formerly_flagged_models():
+    # The 4 models that used to ship trust_remote_code: true. The loader must now report
+    # no default (auto_map models get the dialog; GLM-4.7-Flash loads natively TRC=False).
+    from utils.models.model_config import load_model_defaults
+
+    for model in (
+        "unsloth/GLM-4.7-Flash",
+        "unsloth/Nemotron-3-Nano-30B-A3B",
+        "unsloth/PaddleOCR-VL",
+        "unsloth/ERNIE-4.5-VL-28B-A3B-PT",
+    ):
+        d = load_model_defaults(model)
+        for section in ("training", "inference"):
+            assert not (d.get(section) or {}).get("trust_remote_code", False), (
+                f"{model} [{section}] still carries a trust_remote_code default"
+            )

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -60,7 +60,6 @@ def test_formerly_flagged_models_load_inference_config_without_crash():
     # End-to-end: the models whose inference section was emptied by the TRC removal must
     # still load their inference config (falling back to family/default params).
     from utils.inference import load_inference_config
-
     for model in (
         "tiiuae/Falcon-H1-0.5B-Instruct",
         "unsloth/Llama-3.2-1B-Instruct",

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -3,12 +3,9 @@
 
 """Regression: model-default YAMLs must not pre-set trust_remote_code.
 
-trust_remote_code is a per-load decision made through the remote-code consent dialog
-(which scans and pins the exact auto_map code), never a config default. A YAML that
-ships trust_remote_code: true would re-introduce a path to enabling remote code without
-the user reviewing it -- the bypass class fixed alongside this change. Models that
-genuinely run custom code ship auto_map, which the consent gate detects on its own, so
-the dialog still fires for them without a YAML flag.
+It is a per-load decision made through the consent dialog (which scans and pins the
+auto_map code), never a config default -- a YAML flag would re-open the no-review
+bypass. Models that run custom code ship auto_map, so the dialog still fires without it.
 """
 
 from pathlib import Path
@@ -37,10 +34,8 @@ def test_no_model_default_yaml_sets_trust_remote_code():
 
 
 def test_no_model_default_yaml_has_empty_or_none_section():
-    # Removing a section's only key (trust_remote_code) must not leave a bare header
-    # like `inference:` -> PyYAML parses that as None and load_inference_config() does
-    # `model_config.get("inference", {}).get(...)`, which crashes on None. Every present
-    # top-level section must be a non-empty mapping.
+    # Dropping a section's only key must not leave a bare `inference:` header: PyYAML
+    # reads that as None and the .get(...).get(...) loaders crash on it.
     offenders = []
     for f in _MODEL_DEFAULTS.rglob("*.yaml"):
         doc = yaml.safe_load(f.read_text())
@@ -71,10 +66,8 @@ def test_formerly_flagged_models_load_inference_config_without_crash():
 
 
 def test_all_model_yamls_load_for_training_and_inference():
-    # Every model default YAML must load through both Studio config paths without
-    # crashing: load_model_defaults (training) and load_inference_config (inference),
-    # including the exact .get() access patterns the routes use. Passing the file stem
-    # as the model name resolves to that exact file via the filename match.
+    # Every YAML must load through both config paths (training + inference) with the
+    # exact .get() patterns the routes use; the file stem resolves to that file.
     from utils.inference import load_inference_config
     from utils.models.model_config import load_model_defaults
 
@@ -129,12 +122,9 @@ def test_loader_defaults_trust_remote_code_off_for_formerly_flagged_models():
 
 
 def test_formerly_flagged_auto_map_models_still_require_consent_dialog():
-    # The crux of removing the YAML default: an auto_map model (Nemotron / PaddleOCR-VL /
-    # ERNIE-4.5-VL) must STILL surface the consent dialog. The dialog is driven by the
-    # repo's auto_map, not the YAML flag, so removing the flag cannot suppress it. This
-    # exercises the same backend path the training/inference/export flows call
-    # (preflight_remote_code_consent_for_targets -> the real _config_has_auto_map), mocking
-    # only the Hub config json + the .py downloader so no network/torch is needed.
+    # Crux of the change: an auto_map model must STILL surface the dialog -- it is driven
+    # by the repo's auto_map, not the YAML flag. Exercises the real backend path
+    # (preflight_remote_code_consent_for_targets), mocking only the Hub json + .py fetch.
     from unittest.mock import patch
     from utils.security import consent, preflight_remote_code_consent_for_targets
 
@@ -157,8 +147,7 @@ def test_formerly_flagged_auto_map_models_still_require_consent_dialog():
             patch.object(consent, "repo_remote_code_files", return_value = benign_py),
         ):
             decision = preflight_remote_code_consent_for_targets([model], hf_token = None)
-        # routes/models.py sets requires_trust_remote_code = decision.has_remote_code, which
-        # the frontend uses to open the dialog.
+        # routes/models.py opens the dialog from decision.has_remote_code.
         assert decision.has_remote_code is True, (
             f"{model} ships auto_map but the consent scan did not flag it -> dialog would "
             "not fire"
@@ -166,9 +155,8 @@ def test_formerly_flagged_auto_map_models_still_require_consent_dialog():
 
 
 def test_no_auto_map_model_takes_no_dialog():
-    # The flip side: GLM-4.7-Flash ships no auto_map, so the scan reports no remote code
-    # and no dialog fires -- it loads natively with trust_remote_code=False. Its old YAML
-    # flag was a no-op, which is why removing it is safe.
+    # Flip side: GLM-4.7-Flash ships no auto_map -> no dialog, loads natively (TRC=False).
+    # Its old YAML flag was a no-op, so removing it is safe.
     from unittest.mock import patch
     from utils.security import consent, preflight_remote_code_consent_for_targets
 

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -126,3 +126,49 @@ def test_loader_defaults_trust_remote_code_off_for_formerly_flagged_models():
             assert not (d.get(section) or {}).get(
                 "trust_remote_code", False
             ), f"{model} [{section}] still carries a trust_remote_code default"
+
+
+def test_formerly_flagged_auto_map_models_still_require_consent_dialog():
+    # The crux of removing the YAML default: an auto_map model (Nemotron / PaddleOCR-VL /
+    # ERNIE-4.5-VL) must STILL surface the consent dialog. The dialog is driven by the
+    # repo's auto_map, not the YAML flag, so removing the flag cannot suppress it. This
+    # exercises the same backend path the training/inference/export flows call
+    # (preflight_remote_code_consent_for_targets -> the real _config_has_auto_map), mocking
+    # only the Hub config json + the .py downloader so no network/torch is needed.
+    from unittest.mock import patch
+    from utils.security import consent, preflight_remote_code_consent_for_targets
+
+    auto_map_cfg = [{
+        "auto_map": {"AutoConfig": "configuration_x.XConfig",
+                     "AutoModelForCausalLM": "modeling_x.XForCausalLM"}
+    }]
+    benign_py = {"modeling_x.py": "class XForCausalLM:\n    pass\n"}
+    for model in (
+        "unsloth/Nemotron-3-Nano-30B-A3B",
+        "unsloth/PaddleOCR-VL",
+        "unsloth/ERNIE-4.5-VL-28B-A3B-PT",
+    ):
+        with patch.object(consent, "_load_remote_code_configs", return_value=auto_map_cfg), \
+             patch.object(consent, "repo_remote_code_files", return_value=benign_py):
+            decision = preflight_remote_code_consent_for_targets([model], hf_token=None)
+        # routes/models.py sets requires_trust_remote_code = decision.has_remote_code, which
+        # the frontend uses to open the dialog.
+        assert decision.has_remote_code is True, (
+            f"{model} ships auto_map but the consent scan did not flag it -> dialog would "
+            "not fire"
+        )
+
+
+def test_no_auto_map_model_takes_no_dialog():
+    # The flip side: GLM-4.7-Flash ships no auto_map, so the scan reports no remote code
+    # and no dialog fires -- it loads natively with trust_remote_code=False. Its old YAML
+    # flag was a no-op, which is why removing it is safe.
+    from unittest.mock import patch
+    from utils.security import consent, preflight_remote_code_consent_for_targets
+
+    with patch.object(consent, "_load_remote_code_configs",
+                      return_value=[{"model_type": "glm4_moe_lite"}]):
+        decision = preflight_remote_code_consent_for_targets(
+            ["unsloth/GLM-4.7-Flash"], hf_token=None
+        )
+    assert decision.has_remote_code is False

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -79,7 +79,12 @@ def test_all_model_yamls_load_for_training_and_inference():
     from utils.models.model_config import load_model_defaults
 
     infer_keys = {
-        "temperature", "top_p", "top_k", "min_p", "presence_penalty", "trust_remote_code",
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "presence_penalty",
+        "trust_remote_code",
     }
     failures = []
     for f in sorted(_MODEL_DEFAULTS.rglob("*.yaml")):

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -70,6 +70,35 @@ def test_formerly_flagged_models_load_inference_config_without_crash():
         assert cfg.get("trust_remote_code", False) is False
 
 
+def test_all_model_yamls_load_for_training_and_inference():
+    # Every model default YAML must load through both Studio config paths without
+    # crashing: load_model_defaults (training) and load_inference_config (inference),
+    # including the exact .get() access patterns the routes use. Passing the file stem
+    # as the model name resolves to that exact file via the filename match.
+    from utils.inference import load_inference_config
+    from utils.models.model_config import load_model_defaults
+
+    infer_keys = {
+        "temperature", "top_p", "top_k", "min_p", "presence_penalty", "trust_remote_code",
+    }
+    failures = []
+    for f in sorted(_MODEL_DEFAULTS.rglob("*.yaml")):
+        stem = f.stem
+        try:
+            md = load_model_defaults(stem)
+            assert isinstance(md, dict), f"load_model_defaults -> {type(md).__name__}"
+            assert not [k for k, v in md.items() if v is None], "has a None section"
+            # the dict sections the loaders read via .get('sect', {}).get(...)
+            for sect in ("training", "inference", "lora", "logging"):
+                assert isinstance(md.get(sect, {}), dict), f"{sect!r} is not a mapping"
+            md.get("training", {}).get("trust_remote_code", False)  # routes/training.py:263
+            cfg = load_inference_config(stem)
+            assert infer_keys <= set(cfg), f"inference config missing {infer_keys - set(cfg)}"
+        except Exception as e:  # noqa: BLE001 - aggregate so one failure does not hide others
+            failures.append(f"{f.relative_to(_CONFIGS)}: {type(e).__name__}: {e}")
+    assert not failures, "YAML config loaders crashed on: " + "; ".join(failures)
+
+
 def test_base_templates_have_no_trust_remote_code():
     for name in ("full_finetune.yaml", "lora_text.yaml", "vision_lora.yaml"):
         doc = yaml.safe_load((_CONFIGS / name).read_text()) or {}

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -138,19 +138,25 @@ def test_formerly_flagged_auto_map_models_still_require_consent_dialog():
     from unittest.mock import patch
     from utils.security import consent, preflight_remote_code_consent_for_targets
 
-    auto_map_cfg = [{
-        "auto_map": {"AutoConfig": "configuration_x.XConfig",
-                     "AutoModelForCausalLM": "modeling_x.XForCausalLM"}
-    }]
+    auto_map_cfg = [
+        {
+            "auto_map": {
+                "AutoConfig": "configuration_x.XConfig",
+                "AutoModelForCausalLM": "modeling_x.XForCausalLM",
+            }
+        }
+    ]
     benign_py = {"modeling_x.py": "class XForCausalLM:\n    pass\n"}
     for model in (
         "unsloth/Nemotron-3-Nano-30B-A3B",
         "unsloth/PaddleOCR-VL",
         "unsloth/ERNIE-4.5-VL-28B-A3B-PT",
     ):
-        with patch.object(consent, "_load_remote_code_configs", return_value=auto_map_cfg), \
-             patch.object(consent, "repo_remote_code_files", return_value=benign_py):
-            decision = preflight_remote_code_consent_for_targets([model], hf_token=None)
+        with (
+            patch.object(consent, "_load_remote_code_configs", return_value = auto_map_cfg),
+            patch.object(consent, "repo_remote_code_files", return_value = benign_py),
+        ):
+            decision = preflight_remote_code_consent_for_targets([model], hf_token = None)
         # routes/models.py sets requires_trust_remote_code = decision.has_remote_code, which
         # the frontend uses to open the dialog.
         assert decision.has_remote_code is True, (
@@ -166,9 +172,10 @@ def test_no_auto_map_model_takes_no_dialog():
     from unittest.mock import patch
     from utils.security import consent, preflight_remote_code_consent_for_targets
 
-    with patch.object(consent, "_load_remote_code_configs",
-                      return_value=[{"model_type": "glm4_moe_lite"}]):
+    with patch.object(
+        consent, "_load_remote_code_configs", return_value = [{"model_type": "glm4_moe_lite"}]
+    ):
         decision = preflight_remote_code_consent_for_targets(
-            ["unsloth/GLM-4.7-Flash"], hf_token=None
+            ["unsloth/GLM-4.7-Flash"], hf_token = None
         )
     assert decision.has_remote_code is False

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -27,7 +27,9 @@ def test_no_model_default_yaml_sets_trust_remote_code():
             continue
         for section, body in doc.items():
             if isinstance(body, dict) and "trust_remote_code" in body:
-                offenders.append(f"{f.relative_to(_CONFIGS)} [{section}={body['trust_remote_code']}]")
+                offenders.append(
+                    f"{f.relative_to(_CONFIGS)} [{section}={body['trust_remote_code']}]"
+                )
     assert not offenders, (
         "trust_remote_code must not be pre-set in model defaults; it is enabled only via "
         f"the consent dialog. Remove it from: {offenders}"
@@ -45,7 +47,6 @@ def test_loader_defaults_trust_remote_code_off_for_formerly_flagged_models():
     # The 4 models that used to ship trust_remote_code: true. The loader must now report
     # no default (auto_map models get the dialog; GLM-4.7-Flash loads natively TRC=False).
     from utils.models.model_config import load_model_defaults
-
     for model in (
         "unsloth/GLM-4.7-Flash",
         "unsloth/Nemotron-3-Nano-30B-A3B",
@@ -54,6 +55,6 @@ def test_loader_defaults_trust_remote_code_off_for_formerly_flagged_models():
     ):
         d = load_model_defaults(model)
         for section in ("training", "inference"):
-            assert not (d.get(section) or {}).get("trust_remote_code", False), (
-                f"{model} [{section}] still carries a trust_remote_code default"
-            )
+            assert not (d.get(section) or {}).get(
+                "trust_remote_code", False
+            ), f"{model} [{section}] still carries a trust_remote_code default"

--- a/studio/backend/utils/security/consent.py
+++ b/studio/backend/utils/security/consent.py
@@ -87,16 +87,11 @@ def _config_has_auto_map(model_name: str, hf_token: Optional[str] = None) -> Opt
     unreadable (transient/auth) so the caller treats it as "unknown" and scans, False
     when the repo genuinely ships none.
 
-    GGUF-inertness is a property of the LOADER, not the repo, so it is NOT decided here.
-    A GGUF *selection* loads via llama.cpp, which never reads config.json/auto_map; that
-    case is short-circuited upstream by the caller's ``is_gguf`` check (e.g. the inference
-    route skips the remote-code preflight entirely for a GGUF load). Every path that
-    reaches this helper -- export, training, non-GGUF inference -- loads through
-    transformers/Unsloth ``from_pretrained``, which DOES import ``auto_map`` even for a
-    repo that only ships ``.gguf`` weights (the import runs before it fails on the missing
-    transformers weights), so a GGUF-classified repo id MUST still be scanned. Only a
-    direct ``.gguf`` FILE reference is inert, since that is a genuine single-file
-    llama.cpp load.
+    GGUF-inertness is the LOADER's property, decided upstream by the caller's ``is_gguf``
+    check, not here. Every path that reaches this helper (export, training, non-GGUF
+    inference) loads via ``from_pretrained``, which imports ``auto_map`` even for a
+    ``.gguf``-only repo, so a GGUF-classified repo id MUST still be scanned. Only a direct
+    ``.gguf`` FILE reference is inert (a genuine single-file llama.cpp load).
     """
     # A direct .gguf FILE loads via llama.cpp (auto_map inert). A bare repo id ending in
     # .gguf can still ship safetensors + auto_map, so it falls through to the scan.

--- a/studio/backend/utils/security/consent.py
+++ b/studio/backend/utils/security/consent.py
@@ -264,8 +264,7 @@ def evaluate_remote_code_consent_for_targets(
         )
 
     if not combined:
-        # auto_map declared but no executable .py (e.g. a GGUF repo's vestigial
-        # auto_map) -> nothing to scan or run -> allow.
+        # auto_map declared but no executable .py (e.g. GGUF repo) -> nothing to scan -> allow.
         return RemoteCodeDecision(
             primary,
             False,

--- a/studio/backend/utils/security/consent.py
+++ b/studio/backend/utils/security/consent.py
@@ -85,8 +85,18 @@ def _config_has_auto_map(model_name: str, hf_token: Optional[str] = None) -> Opt
     """Whether any config (model/tokenizer/processor) declares an ``auto_map`` the load
     would execute. Reads raw JSON with ``hf_token``; returns None when a config is
     unreadable (transient/auth) so the caller treats it as "unknown" and scans, False
-    when the repo genuinely ships none. GGUF is False (llama.cpp never runs auto_map);
-    this is the single chokepoint for that rule, shared by validate / scan / worker.
+    when the repo genuinely ships none.
+
+    GGUF-inertness is a property of the LOADER, not the repo, so it is NOT decided here.
+    A GGUF *selection* loads via llama.cpp, which never reads config.json/auto_map; that
+    case is short-circuited upstream by the caller's ``is_gguf`` check (e.g. the inference
+    route skips the remote-code preflight entirely for a GGUF load). Every path that
+    reaches this helper -- export, training, non-GGUF inference -- loads through
+    transformers/Unsloth ``from_pretrained``, which DOES import ``auto_map`` even for a
+    repo that only ships ``.gguf`` weights (the import runs before it fails on the missing
+    transformers weights), so a GGUF-classified repo id MUST still be scanned. Only a
+    direct ``.gguf`` FILE reference is inert, since that is a genuine single-file
+    llama.cpp load.
     """
     # A direct .gguf FILE loads via llama.cpp (auto_map inert). A bare repo id ending in
     # .gguf can still ship safetensors + auto_map, so it falls through to the scan.
@@ -96,11 +106,6 @@ def _config_has_auto_map(model_name: str, hf_token: Optional[str] = None) -> Opt
     if configs is None:
         return None
     if not any(bool((cfg or {}).get("auto_map")) for cfg in configs):
-        return False
-    # auto_map present but a GGUF repo -> inert. Checked only when auto_map exists, so
-    # normal models skip the extra listing.
-    if _is_gguf_repo(model_name, hf_token):
-        logger.debug("Ignoring auto_map for GGUF repo '%s' (llama.cpp never runs it).", model_name)
         return False
     return True
 
@@ -122,42 +127,6 @@ def _is_direct_gguf_file_ref(model_name: str) -> bool:
         pass
     # Remote: a file reference is repo_id ("org/name") + filename => >= 2 slashes.
     return name.count("/") >= 2
-
-
-# Weight formats transformers can load (and thus run auto_map for). A repo shipping any
-# of these is not GGUF-only -- the user could load it through transformers -- so consent
-# still applies even if it also ships a .gguf.
-_TRANSFORMERS_WEIGHT_SUFFIXES = (
-    ".safetensors",
-    ".bin",
-    ".pt",
-    ".pth",
-    ".h5",
-    ".msgpack",
-    ".onnx",
-    ".ckpt",
-)
-
-
-def _is_gguf_repo(model_name: str, hf_token: Optional[str] = None) -> bool:
-    """Whether a remote repo loads only through llama.cpp (GGUF weights and NO
-    transformers-loadable weights), making its config inert. A repo that also ships
-    transformers weights is NOT GGUF (auto_map could run, so still gate). A listing
-    failure is treated as "not known-GGUF" (fall through to scan).
-    """
-    try:
-        from utils.paths import is_local_path
-
-        if is_local_path(model_name):
-            return False
-        from huggingface_hub import list_repo_files
-
-        files = [f.lower() for f in list_repo_files(model_name, token = hf_token)]
-        has_gguf = any(f.endswith(".gguf") for f in files)
-        has_transformers_weights = any(f.endswith(_TRANSFORMERS_WEIGHT_SUFFIXES) for f in files)
-        return has_gguf and not has_transformers_weights
-    except Exception:
-        return False
 
 
 def _load_remote_code_configs(model_name: str, hf_token: Optional[str] = None) -> Optional[list]:
@@ -301,7 +270,7 @@ def evaluate_remote_code_consent_for_targets(
 
     if not combined:
         # auto_map declared but no executable .py (e.g. a GGUF repo's vestigial
-        # auto_map) -> nothing to run -> allow.
+        # auto_map) -> nothing to scan or run -> allow.
         return RemoteCodeDecision(
             primary,
             False,

--- a/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
+++ b/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
@@ -45,9 +45,8 @@ export async function confirmRemoteCodeIfNeeded({
     };
   }
 
-  // No custom code and nothing unsafe: proceed without enabling trust_remote_code.
-  // A model that needs it ships auto_map and takes the dialog path below, so the flag
-  // is only ever enabled by explicit approval of scanned code.
+  // No custom code and nothing unsafe: proceed without trust_remote_code. Models needing
+  // it ship auto_map and hit the dialog below, so the flag is only enabled via approval.
   if (!scan.requiresTrustRemoteCode && scan.unsafeFiles.length === 0) {
     return true;
   }

--- a/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
+++ b/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
@@ -45,11 +45,11 @@ export async function confirmRemoteCodeIfNeeded({
     };
   }
 
-  // Open the dialog for custom-code consent OR flagged unsafe files. Otherwise a model
-  // can still need trust_remote_code via its YAML default (no auto_map, e.g. GLM-4.7-Flash):
-  // propagate the caller's requirement with an empty pin instead of sending false.
+  // No custom code to review and nothing flagged unsafe: proceed without enabling
+  // trust_remote_code. trust_remote_code is never turned on here -- a model that
+  // genuinely needs it ships auto_map (the scan reports it) and takes the dialog path
+  // below, so the flag is only ever enabled by an explicit approval of scanned code.
   if (!scan.requiresTrustRemoteCode && scan.unsafeFiles.length === 0) {
-    if (requiresTrustRemoteCode) onApprove(null);
     return true;
   }
 

--- a/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
+++ b/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
@@ -45,10 +45,9 @@ export async function confirmRemoteCodeIfNeeded({
     };
   }
 
-  // No custom code to review and nothing flagged unsafe: proceed without enabling
-  // trust_remote_code. trust_remote_code is never turned on here -- a model that
-  // genuinely needs it ships auto_map (the scan reports it) and takes the dialog path
-  // below, so the flag is only ever enabled by an explicit approval of scanned code.
+  // No custom code and nothing unsafe: proceed without enabling trust_remote_code.
+  // A model that needs it ships auto_map and takes the dialog path below, so the flag
+  // is only ever enabled by explicit approval of scanned code.
   if (!scan.requiresTrustRemoteCode && scan.unsafeFiles.length === 0) {
     return true;
   }


### PR DESCRIPTION
Two related hardenings to the `trust_remote_code` (TRC) consent flow. The consent dialog scans a repo's `auto_map` Python and pins the exact version before any TRC=True load; these changes make it the sole path to enabling TRC and close a way the scan was bypassed.

## 1. Scan auto_map for GGUF-only repo ids in the consent gate

`_config_has_auto_map` (the chokepoint shared by validate / scan / inference / training / export) returned `False` for any repo classified GGUF-only by `_is_gguf_repo` (ships `.gguf`, no transformers-loadable weight), even when a config declared an `auto_map` and the repo shipped the referenced `.py`. The evaluator then skipped the scan/fingerprint for that target.

GGUF-inertness is a property of the loader, not the repo: a GGUF selection loads via llama.cpp (which never reads `config.json`/`auto_map`) and is already short-circuited upstream by the caller's `is_gguf` check. Every path that reaches this helper (export, training, non-GGUF inference) loads through transformers/Unsloth `from_pretrained`, which DOES import `auto_map` even for a repo that only ships `.gguf` weights, before it fails on the missing transformers weights. I confirmed this directly: on transformers 4.40 through 5.12, the custom module is imported during class resolution, before the weight-load error.

Fix: drop the repo-level GGUF short-circuit (and the now-unused `_is_gguf_repo` helper). A direct `.gguf` file reference stays inert via `_is_direct_gguf_file_ref` (genuine single-file llama.cpp load); repo ids are always scanned. A GGUF repo whose `auto_map` ships no `.py` still allows via the existing empty-code path, so legitimate GGUF loads are unaffected, and GGUF inference never reaches this helper. Only a repo that actually contains a `.gguf` can change behavior; non-GGUF repos (safetensors, MLX) are byte-identical before and after.

## 2. Remove pre-set TRC config defaults; the consent dialog is the only enabler

TRC could still be turned on without the user reviewing any code, via two pre-set paths:

- 4 model_defaults YAMLs shipped `trust_remote_code: true` (GLM-4.7-Flash, Nemotron-3-Nano-30B-A3B, PaddleOCR-VL, ERNIE-4.5-VL).
- The frontend consent hook (`use-remote-code-consent.ts`) silently enabled TRC on a clean scan whenever the caller flagged the model as needing it.

Remove every `trust_remote_code` key from the model_defaults YAMLs (loaders already default to `False` when absent) and delete the frontend silent auto-enable, so TRC is only turned on after the user approves the scanned code in the dialog.

The three models that genuinely run custom code ship `auto_map`, which the consent gate detects on its own via `_config_has_auto_map`, so the dialog still fires for them in inference, training, and export (Nemotron is additionally re-granted by the trusted-org auto-enable in the workers). GLM-4.7-Flash has no `auto_map`: `glm4_moe_lite` is native in transformers 5.0+ and it loads with `trust_remote_code=False`, so its YAML flag was a no-op (verified `AutoConfig.from_pretrained(..., trust_remote_code=False)` on 5.0.0/5.1.0/5.5.0/5.10.0/5.12.1).

## Tests

- `test_consent_gate.py`: updated the GGUF auto_map test to expect a scan; added regression tests for a GGUF-only repo with `auto_map` Python (scanned and blocked) and a transformers-style repo (safetensors / MLX `.npz`) staying gated.
- `test_yaml_trust_remote_code_removed.py`: asserts no model-default YAML pre-sets `trust_remote_code` and the loader reports no default for the 4 formerly-flagged models.
- Backend security + config suites pass (`test_consent_gate`, `test_file_security`, `test_security_gate_consistency`, `test_validate_model_error`, `test_capability_detection`).
