### PR TITLE
CLI: verify Studio server identity 

### DIFF
--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -281,12 +281,23 @@ def _is_studio_health(body) -> bool:
     )
 
 
+def _is_loopback(host: str) -> bool:
+    import ipaddress
+
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def find_studio_server(timeout: float = 3.0) -> Optional[str]:
     import json
     import urllib.request
+    from urllib.parse import urlparse
 
-    url_override = os.environ.get("UNSLOTH_STUDIO_URL")
-    base = (url_override or "http://127.0.0.1:8888").rstrip("/")
+    base = (os.environ.get("UNSLOTH_STUDIO_URL") or "http://127.0.0.1:8888").rstrip("/")
     request = urllib.request.Request(f"{base}/api/health", headers = {"User-Agent": _USER_AGENT})
     try:
         with urllib.request.urlopen(request, timeout = timeout) as response:
@@ -295,7 +306,7 @@ def find_studio_server(timeout: float = 3.0) -> Optional[str]:
         return None
     if not _is_studio_health(body):
         return None
-    if url_override is None:
+    if _is_loopback(urlparse(base).hostname or ""):
         install_id = _local_studio_install_id()
         if install_id is not None and body.get("studio_root_id") != install_id:
             return None

--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -258,16 +258,49 @@ def load_chat_backend(
     return ChatBackend("unsloth", backend)
 
 
+_STUDIO_INSTALL_ID_RE = re.compile(r"^[0-9a-f]{64}$")
+_HEALTH_BODY_LIMIT = 64 * 1024
+
+
+def _local_studio_install_id() -> Optional[str]:
+    try:
+        ensure_studio_backend_path()
+        from utils.paths import studio_root
+
+        token = (studio_root() / "share" / "studio_install_id").read_text().strip()
+    except (OSError, ValueError, ImportError):
+        return None
+    return token if _STUDIO_INSTALL_ID_RE.fullmatch(token) else None
+
+
+def _is_studio_health(body) -> bool:
+    return (
+        isinstance(body, dict)
+        and body.get("status") == "healthy"
+        and body.get("service") == "Unsloth UI Backend"
+        and body.get("supports_desktop_auth") is True
+    )
+
+
 def find_studio_server(timeout: float = 3.0) -> Optional[str]:
+    import json
     import urllib.request
 
-    base = os.environ.get("UNSLOTH_STUDIO_URL", "http://127.0.0.1:8888").rstrip("/")
+    url_override = os.environ.get("UNSLOTH_STUDIO_URL")
+    base = (url_override or "http://127.0.0.1:8888").rstrip("/")
     request = urllib.request.Request(f"{base}/api/health", headers = {"User-Agent": _USER_AGENT})
     try:
-        with urllib.request.urlopen(request, timeout = timeout):
-            return base
+        with urllib.request.urlopen(request, timeout = timeout) as response:
+            body = json.loads(response.read(_HEALTH_BODY_LIMIT).decode("utf-8", "replace"))
     except Exception:
         return None
+    if not _is_studio_health(body):
+        return None
+    if url_override is None:
+        install_id = _local_studio_install_id()
+        if install_id is not None and body.get("studio_root_id") != install_id:
+            return None
+    return base
 
 
 def _studio_token() -> Optional[str]:

--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -266,7 +266,6 @@ def _local_studio_install_id() -> Optional[str]:
     try:
         ensure_studio_backend_path()
         from utils.paths import studio_root
-
         token = (studio_root() / "share" / "studio_install_id").read_text().strip()
     except (OSError, ValueError, ImportError):
         return None

--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -283,7 +283,6 @@ def _is_studio_health(body) -> bool:
 
 def _is_loopback(host: str) -> bool:
     import ipaddress
-
     if host == "localhost":
         return True
     try:
@@ -294,7 +293,6 @@ def _is_loopback(host: str) -> bool:
 
 def _same_origin(a: str, b: str) -> bool:
     from urllib.parse import urlparse
-
     pa, pb = urlparse(a), urlparse(b)
     return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
 

--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -266,8 +266,8 @@ def _local_studio_install_id() -> Optional[str]:
     try:
         ensure_studio_backend_path()
         from utils.paths import studio_root
-        token = (studio_root() / "share" / "studio_install_id").read_text().strip()
-    except (OSError, ValueError, ImportError):
+        token = (studio_root() / "share" / "studio_install_id").read_text(encoding = "utf-8").strip()
+    except Exception:
         return None
     return token if _STUDIO_INSTALL_ID_RE.fullmatch(token) else None
 
@@ -292,6 +292,13 @@ def _is_loopback(host: str) -> bool:
         return False
 
 
+def _same_origin(a: str, b: str) -> bool:
+    from urllib.parse import urlparse
+
+    pa, pb = urlparse(a), urlparse(b)
+    return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
+
+
 def find_studio_server(timeout: float = 3.0) -> Optional[str]:
     import json
     import urllib.request
@@ -301,12 +308,17 @@ def find_studio_server(timeout: float = 3.0) -> Optional[str]:
     request = urllib.request.Request(f"{base}/api/health", headers = {"User-Agent": _USER_AGENT})
     try:
         with urllib.request.urlopen(request, timeout = timeout) as response:
+            final_url = response.geturl()
             body = json.loads(response.read(_HEALTH_BODY_LIMIT).decode("utf-8", "replace"))
     except Exception:
         return None
     if not _is_studio_health(body):
         return None
     if _is_loopback(urlparse(base).hostname or ""):
+        # A squatter on this port could 302 the probe to the real Studio so the
+        # id check passes, yet we'd still send credentials back to the squatter.
+        if not _same_origin(final_url, base):
+            return None
         install_id = _local_studio_install_id()
         if install_id is not None and body.get("studio_root_id") != install_id:
             return None

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -263,7 +263,11 @@ def test_find_studio_server_none_when_not_running(monkeypatch):
 class _FakeHealth:
     """Minimal urlopen() return value carrying a canned /api/health body."""
 
-    def __init__(self, body: bytes, final_url: str = "http://127.0.0.1:8888"):
+    def __init__(
+        self,
+        body: bytes,
+        final_url: str = "http://127.0.0.1:8888",
+    ):
         self._body = body
         self._final_url = final_url
 

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -260,6 +260,131 @@ def test_find_studio_server_none_when_not_running(monkeypatch):
     assert _inference.find_studio_server() is None
 
 
+class _FakeHealth:
+    """Minimal urlopen() return value carrying a canned /api/health body."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, limit = None):
+        return self._body if limit is None else self._body[:limit]
+
+
+def _healthy_body(root_id = None) -> bytes:
+    import json
+
+    body = {
+        "status": "healthy",
+        "service": "Unsloth UI Backend",
+        "supports_desktop_auth": True,
+    }
+    if root_id is not None:
+        body["studio_root_id"] = root_id
+    return json.dumps(body).encode()
+
+
+def test_find_studio_server_matches_local_install_id(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    root_id = "a" * 64
+    monkeypatch.delenv("UNSLOTH_STUDIO_URL", raising = False)
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: root_id)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body(root_id))
+    )
+    assert _inference.find_studio_server() == "http://127.0.0.1:8888"
+
+
+def test_find_studio_server_rejects_mismatched_install_id(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    monkeypatch.delenv("UNSLOTH_STUDIO_URL", raising = False)
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("b" * 64))
+    )
+    assert _inference.find_studio_server() is None
+
+
+def test_find_studio_server_rejects_non_studio_responder(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    monkeypatch.delenv("UNSLOTH_STUDIO_URL", raising = False)
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: None)
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *a, **k: _FakeHealth(b'{"status":"evil","studio_root_id":"spoof"}'),
+    )
+    assert _inference.find_studio_server() is None
+
+
+def test_find_studio_server_dev_install_accepts_loopback_studio(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    # No installer id to match against: a real loopback Studio is still adopted.
+    monkeypatch.delenv("UNSLOTH_STUDIO_URL", raising = False)
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: None)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("c" * 64))
+    )
+    assert _inference.find_studio_server() == "http://127.0.0.1:8888"
+
+
+def test_find_studio_server_honors_explicit_remote_url(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    # Explicit URL = user intent (e.g. RunPod proxy); a remote id won't match a
+    # local one, so the install-id gate must not apply.
+    monkeypatch.setenv("UNSLOTH_STUDIO_URL", "https://studio.example.com")
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("b" * 64))
+    )
+    assert _inference.find_studio_server() == "https://studio.example.com"
+
+
+def test_connect_studio_server_does_not_issue_token_for_unverified_health(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    monkeypatch.delenv("UNSLOTH_STUDIO_URL", raising = False)
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *a, **k: _FakeHealth(_healthy_body("b" * 64)),
+    )
+
+    def boom():
+        raise AssertionError("must not self-issue a token for an unverified backend")
+
+    monkeypatch.setattr(_inference, "_studio_token", boom)
+    assert (
+        _inference.connect_studio_server(
+            "model", hf_token = "hf_secret", max_seq_length = 2048, load_in_4bit = True
+        )
+        is None
+    )
+
+
 class _FakeSSEResponse:
     def __init__(self, lines):
         self._lines = lines

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -263,8 +263,9 @@ def test_find_studio_server_none_when_not_running(monkeypatch):
 class _FakeHealth:
     """Minimal urlopen() return value carrying a canned /api/health body."""
 
-    def __init__(self, body: bytes):
+    def __init__(self, body: bytes, final_url: str = "http://127.0.0.1:8888"):
         self._body = body
+        self._final_url = final_url
 
     def __enter__(self):
         return self
@@ -274,6 +275,9 @@ class _FakeHealth:
 
     def read(self, limit = None):
         return self._body if limit is None else self._body[:limit]
+
+    def geturl(self):
+        return self._final_url
 
 
 def _healthy_body(root_id = None) -> bytes:
@@ -367,18 +371,56 @@ def test_find_studio_server_checks_id_on_explicit_loopback_port(monkeypatch):
 
     # A custom *local* port still gets the id check: a squatter on 127.0.0.1:9000
     # must not receive credentials just because UNSLOTH_STUDIO_URL is set.
-    monkeypatch.setenv("UNSLOTH_STUDIO_URL", "http://127.0.0.1:9000")
+    port = "http://127.0.0.1:9000"
+    monkeypatch.setenv("UNSLOTH_STUDIO_URL", port)
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("b" * 64), port)
+    )
+    assert _inference.find_studio_server() is None
+
+    # The real local Studio on that port (matching id) is still adopted.
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("a" * 64), port)
+    )
+    assert _inference.find_studio_server() == port
+
+
+def test_find_studio_server_rejects_redirected_health(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    # A squatter on 8888 redirects the probe to the real Studio on 9000, so the
+    # body + id check pass — but credentials would still go to 8888. Reject it.
+    monkeypatch.delenv("UNSLOTH_STUDIO_URL", raising = False)
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *a, **k: _FakeHealth(_healthy_body("a" * 64), "http://127.0.0.1:9000/api/health"),
+    )
+    assert _inference.find_studio_server() is None
+
+
+def test_find_studio_server_empty_url_is_treated_as_default(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    # An empty UNSLOTH_STUDIO_URL must fall back to the loopback default *and*
+    # still be id-checked, not silently skip verification.
+    monkeypatch.setenv("UNSLOTH_STUDIO_URL", "")
     monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
     monkeypatch.setattr(
         urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("b" * 64))
     )
     assert _inference.find_studio_server() is None
 
-    # The real local Studio on that port (matching id) is still adopted.
     monkeypatch.setattr(
         urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("a" * 64))
     )
-    assert _inference.find_studio_server() == "http://127.0.0.1:9000"
+    assert _inference.find_studio_server() == "http://127.0.0.1:8888"
 
 
 def test_connect_studio_server_does_not_issue_token_for_unverified_health(monkeypatch):

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -350,14 +350,35 @@ def test_find_studio_server_honors_explicit_remote_url(monkeypatch):
 
     from unsloth_cli import _inference
 
-    # Explicit URL = user intent (e.g. RunPod proxy); a remote id won't match a
-    # local one, so the install-id gate must not apply.
+    # Remote (non-loopback) Studio, e.g. a RunPod proxy: its install id won't
+    # match a local one, so the id gate must not apply to remote hosts.
     monkeypatch.setenv("UNSLOTH_STUDIO_URL", "https://studio.example.com")
     monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
     monkeypatch.setattr(
         urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("b" * 64))
     )
     assert _inference.find_studio_server() == "https://studio.example.com"
+
+
+def test_find_studio_server_checks_id_on_explicit_loopback_port(monkeypatch):
+    import urllib.request
+
+    from unsloth_cli import _inference
+
+    # A custom *local* port still gets the id check: a squatter on 127.0.0.1:9000
+    # must not receive credentials just because UNSLOTH_STUDIO_URL is set.
+    monkeypatch.setenv("UNSLOTH_STUDIO_URL", "http://127.0.0.1:9000")
+    monkeypatch.setattr(_inference, "_local_studio_install_id", lambda: "a" * 64)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("b" * 64))
+    )
+    assert _inference.find_studio_server() is None
+
+    # The real local Studio on that port (matching id) is still adopted.
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: _FakeHealth(_healthy_body("a" * 64))
+    )
+    assert _inference.find_studio_server() == "http://127.0.0.1:9000"
 
 
 def test_connect_studio_server_does_not_issue_token_for_unverified_health(monkeypatch):


### PR DESCRIPTION
The CLI sent a Studio token and hf_token to anything answering on 127.0.0.1:8888. Now it checks the server is really this install's Studio (matching studio_install_id) before sending anything; otherwise it loads the model locally.