### PR TITLE
Shim missing get_dummy_lora_warmup_rank for older unsloth-zoo (#6114)

### DIFF
--- a/tests/test_import_fixes_drift.py
+++ b/tests/test_import_fixes_drift.py
@@ -433,9 +433,7 @@ def test_vllm_lora_dummy_warmup_rank_hook_present():
     if not uses_hook:
         pytest.skip("this vllm's maybe_setup_dummy_loras doesn't use the hook")
     worker_mgr = getattr(worker_mgr_mod, "WorkerLoRAManager", None)
-    assert worker_mgr is not None and hasattr(
-        worker_mgr, "get_dummy_lora_warmup_rank"
-    ), (
+    assert worker_mgr is not None and hasattr(worker_mgr, "get_dummy_lora_warmup_rank"), (
         "DRIFT DETECTED: vLLM's maybe_setup_dummy_loras calls "
         "lora_manager.get_dummy_lora_warmup_rank but WorkerLoRAManager no longer "
         "defines it; fix_vllm_lora_warmup_rank backfills the wrong name -- "

--- a/tests/test_import_fixes_drift.py
+++ b/tests/test_import_fixes_drift.py
@@ -406,6 +406,43 @@ def test_vllm_aimv2_ovis_config_is_past_fix_version():
         )
 
 
+def test_vllm_lora_dummy_warmup_rank_hook_present():
+    """``fix_vllm_lora_warmup_rank``: vLLM's v1 engine (>= 0.21) added
+    ``LoRAModelRunnerMixin.maybe_setup_dummy_loras`` -> ``lora_manager
+    .get_dummy_lora_warmup_rank(default_rank)``; older unsloth_zoo LoRA-manager
+    ports don't implement it (#6114), so the shim backfills an identity default
+    on the live manager. If upstream drops the hook or renames the entry point,
+    the shim is mis-targeted -- fail so the maintainer re-points or removes it."""
+    pytest.importorskip("vllm")
+    try:
+        mixin_mod = importlib.import_module("vllm.v1.worker.lora_model_runner_mixin")
+        worker_mgr_mod = importlib.import_module("vllm.lora.worker_manager")
+    except Exception as exc:
+        pytest.skip(f"vllm LoRA worker modules unimportable: {exc!r}")
+    mixin = getattr(mixin_mod, "LoRAModelRunnerMixin", None)
+    entry = getattr(mixin, "maybe_setup_dummy_loras", None)
+    if entry is None:
+        pytest.skip("this vllm has no LoRAModelRunnerMixin.maybe_setup_dummy_loras")
+    # Gate on the call site actually using the hook, so the assertion can't
+    # false-fire on a vllm whose maybe_setup_dummy_loras predates it. (This
+    # test doesn't import unsloth, so the method is the genuine, un-wrapped one.)
+    try:
+        uses_hook = "get_dummy_lora_warmup_rank" in inspect.getsource(entry)
+    except (OSError, TypeError):
+        uses_hook = False
+    if not uses_hook:
+        pytest.skip("this vllm's maybe_setup_dummy_loras doesn't use the hook")
+    worker_mgr = getattr(worker_mgr_mod, "WorkerLoRAManager", None)
+    assert worker_mgr is not None and hasattr(
+        worker_mgr, "get_dummy_lora_warmup_rank"
+    ), (
+        "DRIFT DETECTED: vLLM's maybe_setup_dummy_loras calls "
+        "lora_manager.get_dummy_lora_warmup_rank but WorkerLoRAManager no longer "
+        "defines it; fix_vllm_lora_warmup_rank backfills the wrong name -- "
+        "re-point or remove it."
+    )
+
+
 # huggingface_hub
 
 

--- a/tests/test_vllm_lora_warmup_rank_shim.py
+++ b/tests/test_vllm_lora_warmup_rank_shim.py
@@ -1,0 +1,245 @@
+# Unsloth - 2x faster, 60% less VRAM LLM training and finetuning
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+"""Behavioural tests for ``fix_vllm_lora_warmup_rank`` (unsloth/import_fixes.py).
+
+vLLM's v1 ``LoRAModelRunnerMixin.maybe_setup_dummy_loras()`` calls
+``self.lora_manager.get_dummy_lora_warmup_rank(default_rank)``; older
+``unsloth_zoo`` LoRA-manager ports don't implement it, so ``fast_inference``
+LoRA warmup crashes with ``AttributeError`` (issue #6114). The shim wraps
+``maybe_setup_dummy_loras`` to backfill the identity default on the *live*
+manager class.
+
+These reproduce the crash and the fix against a synthetic mixin/manager that
+mirrors vLLM's exact call shape, so they exercise the shim's logic on the
+GPU-free harness without vLLM (or ``unsloth_zoo``) installed."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import pathlib
+import sys
+import types
+from contextlib import contextmanager
+
+import pytest
+
+
+def _load_import_fixes():
+    """Load ``unsloth/import_fixes.py`` standalone.
+
+    Importing ``unsloth.import_fixes`` the normal way executes the heavy
+    ``unsloth`` package ``__init__`` (which needs unsloth_zoo / a real
+    accelerator). The module itself is dependency-light and patches vLLM
+    lazily, so load it directly from source for a GPU-free unit test."""
+    path = pathlib.Path(__file__).resolve().parents[1] / "unsloth" / "import_fixes.py"
+    spec = importlib.util.spec_from_file_location(
+        "unsloth_import_fixes_under_test", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+IMPORT_FIXES = _load_import_fixes()
+
+
+def _make_classes():
+    """Fresh (Mixin, Manager, Cfg) classes per call so a backfilled method on
+    one test's manager class can't leak into another test."""
+
+    class PortManager:
+        """Mimics an older unsloth_zoo port: no ``get_dummy_lora_warmup_rank``."""
+
+        def __init__(self):
+            self.added_ranks = []
+            self.removed = False
+
+        @contextmanager
+        def dummy_lora_cache(self):
+            yield
+
+        def add_dummy_lora(self, lora_request, rank):
+            self.added_ranks.append(rank)
+
+        def remove_all_adapters(self):
+            self.removed = True
+
+    class Cfg:
+        def __init__(self, max_loras=1, max_lora_rank=16):
+            self.max_loras = max_loras
+            self.max_lora_rank = max_lora_rank
+
+    class LoRAModelRunnerMixin:
+        """Stand-in for vLLM's mixin with the real ``maybe_setup_dummy_loras``
+        call shape (the ``get_dummy_lora_warmup_rank`` hop is what breaks)."""
+
+        def __init__(self):
+            self.lora_manager = PortManager()
+
+        @contextmanager
+        def maybe_setup_dummy_loras(self, lora_config, remove_lora=True):
+            if lora_config is None:
+                yield
+                return
+            assert self.lora_manager is not None, "LoRA is not enabled"
+            warmup_rank = (
+                lora_config.max_lora_rank if lora_config.max_lora_rank < 8 else 8
+            )
+            # The call that AttributeErrors on older unsloth_zoo ports (#6114):
+            warmup_rank = self.lora_manager.get_dummy_lora_warmup_rank(warmup_rank)
+            with self.lora_manager.dummy_lora_cache():
+                for lora_id in range(1, lora_config.max_loras + 1):
+                    self.lora_manager.add_dummy_lora(lora_id, rank=warmup_rank)
+                yield
+            if remove_lora:
+                self.lora_manager.remove_all_adapters()
+
+    return LoRAModelRunnerMixin, PortManager, Cfg
+
+
+def _fake_module(mixin_cls):
+    module = types.ModuleType("unsloth_test_fake_vllm_lora_mixin")
+    module.LoRAModelRunnerMixin = mixin_cls
+    return module
+
+
+def test_unpatched_mixin_reproduces_issue_6114():
+    Mixin, _Manager, Cfg = _make_classes()
+    inst = Mixin()
+    with pytest.raises(AttributeError, match="get_dummy_lora_warmup_rank"):
+        with inst.maybe_setup_dummy_loras(Cfg(max_loras=2, max_lora_rank=16)):
+            pass
+
+
+def test_patch_backfills_identity_default_on_live_manager():
+    Mixin, Manager, Cfg = _make_classes()
+    IMPORT_FIXES._unsloth_patch_lora_model_runner_mixin(_fake_module(Mixin))
+
+    inst = Mixin()
+    with inst.maybe_setup_dummy_loras(Cfg(max_loras=2, max_lora_rank=16)):
+        pass
+
+    # min(max_lora_rank=16, 8) == 8, returned unchanged by the identity hook.
+    assert inst.lora_manager.added_ranks == [8, 8]
+    assert inst.lora_manager.removed is True
+    # The hook now lives on the manager class and is a pass-through.
+    assert hasattr(Manager, IMPORT_FIXES._VLLM_LORA_WARMUP_RANK_METHOD)
+    assert Manager().get_dummy_lora_warmup_rank(5) == 5
+
+
+def test_patch_preserves_a_manager_that_already_has_the_hook():
+    Mixin, Manager, Cfg = _make_classes()
+
+    def lowered(self, default_rank):
+        return min(default_rank, 4)
+
+    Manager.get_dummy_lora_warmup_rank = lowered
+    IMPORT_FIXES._unsloth_patch_lora_model_runner_mixin(_fake_module(Mixin))
+
+    inst = Mixin()
+    with inst.maybe_setup_dummy_loras(Cfg(max_loras=1, max_lora_rank=16)):
+        pass
+
+    # The shim must not clobber a manager that implements its own hook.
+    assert inst.lora_manager.added_ranks == [4]
+    assert Manager.get_dummy_lora_warmup_rank is lowered
+
+
+def test_patch_is_idempotent():
+    Mixin, _Manager, _Cfg = _make_classes()
+    module = _fake_module(Mixin)
+
+    IMPORT_FIXES._unsloth_patch_lora_model_runner_mixin(module)
+    first = Mixin.__dict__["maybe_setup_dummy_loras"]
+    IMPORT_FIXES._unsloth_patch_lora_model_runner_mixin(module)
+    second = Mixin.__dict__["maybe_setup_dummy_loras"]
+
+    assert first is second  # not double-wrapped
+    assert getattr(first, IMPORT_FIXES._VLLM_LORA_WARMUP_SHIM_SENTINEL, False)
+
+
+def test_lora_disabled_path_is_untouched():
+    Mixin, _Manager, _Cfg = _make_classes()
+    IMPORT_FIXES._unsloth_patch_lora_model_runner_mixin(_fake_module(Mixin))
+
+    inst = Mixin()
+    with inst.maybe_setup_dummy_loras(None):  # lora_config is None
+        pass
+    assert inst.lora_manager.added_ranks == []
+
+
+def _count_sentinel_finders():
+    return sum(
+        1
+        for f in sys.meta_path
+        if getattr(f, IMPORT_FIXES._VLLM_LORA_WARMUP_SHIM_SENTINEL, False)
+    )
+
+
+@contextmanager
+def _faked_vllm(extra_modules=()):
+    """Put a stand-in ``vllm`` (and optional submodules) in ``sys.modules`` so
+    the shim's ``find_spec("vllm")`` guard passes, then restore on exit."""
+    if importlib.util.find_spec("vllm") is not None:
+        pytest.skip("vllm present: exercise against the real module elsewhere")
+    names = ("vllm", *extra_modules)
+    saved = {name: sys.modules.get(name) for name in names}
+    meta_before = list(sys.meta_path)
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.__path__ = []  # mark as a package
+    # find_spec("vllm") reads __spec__ for an already-imported module.
+    fake_vllm.__spec__ = importlib.machinery.ModuleSpec(
+        "vllm", loader=None, is_package=True
+    )
+    sys.modules["vllm"] = fake_vllm
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+        sys.meta_path[:] = [
+            f
+            for f in sys.meta_path
+            if f in meta_before
+            or not getattr(f, IMPORT_FIXES._VLLM_LORA_WARMUP_SHIM_SENTINEL, False)
+        ]
+
+
+def test_fix_installs_one_post_import_finder_and_is_idempotent():
+    with _faked_vllm():
+        IMPORT_FIXES.fix_vllm_lora_warmup_rank()
+        assert _count_sentinel_finders() == 1
+        # Second call must not stack a second finder.
+        IMPORT_FIXES.fix_vllm_lora_warmup_rank()
+        assert _count_sentinel_finders() == 1
+
+
+def test_fix_patches_in_place_when_mixin_already_imported():
+    Mixin, _Manager, Cfg = _make_classes()
+    mod_name = IMPORT_FIXES._VLLM_LORA_MIXIN_MODULE
+    with _faked_vllm(extra_modules=(mod_name,)):
+        # vLLM (and the mixin module) already imported before us -> patch in
+        # place, no finder needed.
+        sys.modules[mod_name] = _fake_module(Mixin)
+        IMPORT_FIXES.fix_vllm_lora_warmup_rank()
+        assert _count_sentinel_finders() == 0
+
+        inst = Mixin()
+        with inst.maybe_setup_dummy_loras(Cfg(max_loras=1, max_lora_rank=4)):
+            pass
+        assert inst.lora_manager.added_ranks == [4]  # min(4, 8) == 4

--- a/tests/test_vllm_lora_warmup_rank_shim.py
+++ b/tests/test_vllm_lora_warmup_rank_shim.py
@@ -44,9 +44,7 @@ def _load_import_fixes():
     accelerator). The module itself is dependency-light and patches vLLM
     lazily, so load it directly from source for a GPU-free unit test."""
     path = pathlib.Path(__file__).resolve().parents[1] / "unsloth" / "import_fixes.py"
-    spec = importlib.util.spec_from_file_location(
-        "unsloth_import_fixes_under_test", path
-    )
+    spec = importlib.util.spec_from_file_location("unsloth_import_fixes_under_test", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -77,7 +75,11 @@ def _make_classes():
             self.removed = True
 
     class Cfg:
-        def __init__(self, max_loras=1, max_lora_rank=16):
+        def __init__(
+            self,
+            max_loras = 1,
+            max_lora_rank = 16,
+        ):
             self.max_loras = max_loras
             self.max_lora_rank = max_lora_rank
 
@@ -89,19 +91,21 @@ def _make_classes():
             self.lora_manager = PortManager()
 
         @contextmanager
-        def maybe_setup_dummy_loras(self, lora_config, remove_lora=True):
+        def maybe_setup_dummy_loras(
+            self,
+            lora_config,
+            remove_lora = True,
+        ):
             if lora_config is None:
                 yield
                 return
             assert self.lora_manager is not None, "LoRA is not enabled"
-            warmup_rank = (
-                lora_config.max_lora_rank if lora_config.max_lora_rank < 8 else 8
-            )
+            warmup_rank = lora_config.max_lora_rank if lora_config.max_lora_rank < 8 else 8
             # The call that AttributeErrors on older unsloth_zoo ports (#6114):
             warmup_rank = self.lora_manager.get_dummy_lora_warmup_rank(warmup_rank)
             with self.lora_manager.dummy_lora_cache():
                 for lora_id in range(1, lora_config.max_loras + 1):
-                    self.lora_manager.add_dummy_lora(lora_id, rank=warmup_rank)
+                    self.lora_manager.add_dummy_lora(lora_id, rank = warmup_rank)
                 yield
             if remove_lora:
                 self.lora_manager.remove_all_adapters()
@@ -118,8 +122,8 @@ def _fake_module(mixin_cls):
 def test_unpatched_mixin_reproduces_issue_6114():
     Mixin, _Manager, Cfg = _make_classes()
     inst = Mixin()
-    with pytest.raises(AttributeError, match="get_dummy_lora_warmup_rank"):
-        with inst.maybe_setup_dummy_loras(Cfg(max_loras=2, max_lora_rank=16)):
+    with pytest.raises(AttributeError, match = "get_dummy_lora_warmup_rank"):
+        with inst.maybe_setup_dummy_loras(Cfg(max_loras = 2, max_lora_rank = 16)):
             pass
 
 
@@ -128,7 +132,7 @@ def test_patch_backfills_identity_default_on_live_manager():
     IMPORT_FIXES._unsloth_patch_lora_model_runner_mixin(_fake_module(Mixin))
 
     inst = Mixin()
-    with inst.maybe_setup_dummy_loras(Cfg(max_loras=2, max_lora_rank=16)):
+    with inst.maybe_setup_dummy_loras(Cfg(max_loras = 2, max_lora_rank = 16)):
         pass
 
     # min(max_lora_rank=16, 8) == 8, returned unchanged by the identity hook.
@@ -149,7 +153,7 @@ def test_patch_preserves_a_manager_that_already_has_the_hook():
     IMPORT_FIXES._unsloth_patch_lora_model_runner_mixin(_fake_module(Mixin))
 
     inst = Mixin()
-    with inst.maybe_setup_dummy_loras(Cfg(max_loras=1, max_lora_rank=16)):
+    with inst.maybe_setup_dummy_loras(Cfg(max_loras = 1, max_lora_rank = 16)):
         pass
 
     # The shim must not clobber a manager that implements its own hook.
@@ -182,14 +186,12 @@ def test_lora_disabled_path_is_untouched():
 
 def _count_sentinel_finders():
     return sum(
-        1
-        for f in sys.meta_path
-        if getattr(f, IMPORT_FIXES._VLLM_LORA_WARMUP_SHIM_SENTINEL, False)
+        1 for f in sys.meta_path if getattr(f, IMPORT_FIXES._VLLM_LORA_WARMUP_SHIM_SENTINEL, False)
     )
 
 
 @contextmanager
-def _faked_vllm(extra_modules=()):
+def _faked_vllm(extra_modules = ()):
     """Put a stand-in ``vllm`` (and optional submodules) in ``sys.modules`` so
     the shim's ``find_spec("vllm")`` guard passes, then restore on exit."""
     if importlib.util.find_spec("vllm") is not None:
@@ -200,9 +202,7 @@ def _faked_vllm(extra_modules=()):
     fake_vllm = types.ModuleType("vllm")
     fake_vllm.__path__ = []  # mark as a package
     # find_spec("vllm") reads __spec__ for an already-imported module.
-    fake_vllm.__spec__ = importlib.machinery.ModuleSpec(
-        "vllm", loader=None, is_package=True
-    )
+    fake_vllm.__spec__ = importlib.machinery.ModuleSpec("vllm", loader = None, is_package = True)
     sys.modules["vllm"] = fake_vllm
     try:
         yield
@@ -232,7 +232,7 @@ def test_fix_installs_one_post_import_finder_and_is_idempotent():
 def test_fix_patches_in_place_when_mixin_already_imported():
     Mixin, _Manager, Cfg = _make_classes()
     mod_name = IMPORT_FIXES._VLLM_LORA_MIXIN_MODULE
-    with _faked_vllm(extra_modules=(mod_name,)):
+    with _faked_vllm(extra_modules = (mod_name,)):
         # vLLM (and the mixin module) already imported before us -> patch in
         # place, no finder needed.
         sys.modules[mod_name] = _fake_module(Mixin)
@@ -240,6 +240,6 @@ def test_fix_patches_in_place_when_mixin_already_imported():
         assert _count_sentinel_finders() == 0
 
         inst = Mixin()
-        with inst.maybe_setup_dummy_loras(Cfg(max_loras=1, max_lora_rank=4)):
+        with inst.maybe_setup_dummy_loras(Cfg(max_loras = 1, max_lora_rank = 4)):
             pass
         assert inst.lora_manager.added_ranks == [4]  # min(4, 8) == 4

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -170,6 +170,7 @@ from .import_fixes import (
     fix_xformers_performance_issue,
     fix_vllm_aimv2_issue,
     fix_vllm_lora_tokenizer_module,
+    fix_vllm_lora_warmup_rank,
     check_vllm_torch_sm100_compatibility,
     fix_vllm_guided_decoding_params,
     fix_vllm_pdl_blackwell,
@@ -197,6 +198,7 @@ from .import_fixes import (
 fix_xformers_performance_issue()
 fix_vllm_aimv2_issue()
 fix_vllm_lora_tokenizer_module()
+fix_vllm_lora_warmup_rank()
 # Check vLLM + torch < 2.9.0 + SM100 compatibility BEFORE importing vLLM
 check_vllm_torch_sm100_compatibility()
 fix_vllm_guided_decoding_params()
@@ -227,6 +229,7 @@ patch_accelerate_recursively_apply()
 del fix_xformers_performance_issue
 del fix_vllm_aimv2_issue
 del fix_vllm_lora_tokenizer_module
+del fix_vllm_lora_warmup_rank
 del check_vllm_torch_sm100_compatibility
 del fix_vllm_guided_decoding_params
 del fix_trl_vllm_ascend

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -488,6 +488,144 @@ def fix_vllm_lora_tokenizer_module():
     )
 
 
+# vLLM's v1 engine (>= 0.21) added a dummy-LoRA warmup hook:
+# `LoRAModelRunnerMixin.maybe_setup_dummy_loras()` now calls
+# `self.lora_manager.get_dummy_lora_warmup_rank(default_rank) -> int`, letting a
+# manager lower the warmup rank and otherwise returning vLLM's own default
+# (`min(max_lora_rank, 8)`). Older `unsloth_zoo.vllm_utils.patch_vllm()` swaps
+# vLLM's WorkerLoRAManager / LRUCacheWorkerLoRAManager for the ports in
+# `unsloth_zoo/vllm_lora_worker_manager.py`, which predate the hook and do not
+# implement it, so `fast_inference` LoRA warmup crashes with
+#   AttributeError: 'LRUCacheWorkerLoRAManager' object has no attribute
+#   'get_dummy_lora_warmup_rank'  (https://github.com/unslothai/unsloth/issues/6114).
+# The hook's no-op contract is "return default_rank unchanged" (i.e. the
+# pre-hook behaviour), so backfill exactly that. The ported manager is a
+# standalone class -- the crash proves it does not inherit vLLM's hook -- so we
+# patch the *live* `type(self.lora_manager)` from inside a wrapper around
+# `maybe_setup_dummy_loras`, which is robust to whichever manager the swap
+# installs. Installed via a one-shot post-import hook so vLLM is never imported
+# early (mirrors `fix_vllm_lora_tokenizer_module`'s deferral). Harmless once an
+# updated unsloth_zoo (or vLLM) ships the method: the `hasattr` guard no-ops.
+_VLLM_LORA_MIXIN_MODULE = "vllm.v1.worker.lora_model_runner_mixin"
+_VLLM_LORA_WARMUP_RANK_METHOD = "get_dummy_lora_warmup_rank"
+_VLLM_LORA_WARMUP_SHIM_SENTINEL = "__unsloth_vllm_lora_warmup_rank_shim__"
+
+
+def _unsloth_identity_lora_warmup_rank(self, default_rank):
+    # vLLM's no-op contract: keep the warmup rank vLLM already picked.
+    return default_rank
+
+
+def _unsloth_ensure_lora_warmup_rank(manager):
+    """Backfill the identity warmup-rank hook on ``manager``'s class if absent."""
+    if manager is None:
+        return
+    manager_cls = type(manager)
+    if not hasattr(manager_cls, _VLLM_LORA_WARMUP_RANK_METHOD):
+        try:
+            setattr(
+                manager_cls,
+                _VLLM_LORA_WARMUP_RANK_METHOD,
+                _unsloth_identity_lora_warmup_rank,
+            )
+        except Exception:
+            pass
+
+
+def _unsloth_wrap_maybe_setup_dummy_loras(original):
+    @functools.wraps(original)
+    def maybe_setup_dummy_loras(self, *args, **kwargs):
+        # Runs before the (contextmanager) body that calls
+        # get_dummy_lora_warmup_rank, so the live manager has it in time.
+        _unsloth_ensure_lora_warmup_rank(getattr(self, "lora_manager", None))
+        return original(self, *args, **kwargs)
+
+    setattr(maybe_setup_dummy_loras, _VLLM_LORA_WARMUP_SHIM_SENTINEL, True)
+    return maybe_setup_dummy_loras
+
+
+def _unsloth_patch_lora_model_runner_mixin(module):
+    mixin = getattr(module, "LoRAModelRunnerMixin", None)
+    if mixin is None:
+        return
+    # Only wrap a method defined directly on the mixin, and only once.
+    method = mixin.__dict__.get("maybe_setup_dummy_loras", None)
+    if method is None or getattr(method, _VLLM_LORA_WARMUP_SHIM_SENTINEL, False):
+        return
+    mixin.maybe_setup_dummy_loras = _unsloth_wrap_maybe_setup_dummy_loras(method)
+    logger.info(
+        "Unsloth: Backfilled vLLM dummy-LoRA warmup-rank hook for older "
+        "unsloth_zoo LoRA managers"
+    )
+
+
+class _VllmLoraWarmupPostImportLoader(importlib.abc.Loader):
+    """Delegates to the real loader, then patches the freshly-imported module.
+
+    Transparent for every other loader protocol method (``get_source``,
+    ``is_package``, ...) via ``__getattr__`` so module introspection still
+    resolves through the genuine loader.
+    """
+
+    __slots__ = ("_real_loader",)
+
+    def __init__(self, real_loader):
+        self._real_loader = real_loader
+
+    def create_module(self, spec):
+        return self._real_loader.create_module(spec)
+
+    def exec_module(self, module):
+        self._real_loader.exec_module(module)
+        try:
+            _unsloth_patch_lora_model_runner_mixin(module)
+        except Exception as e:
+            logger.info(f"Unsloth: Failed backfilling vLLM warmup-rank hook = {str(e)}")
+
+    def __getattr__(self, name):
+        return getattr(self._real_loader, name)
+
+
+class _VllmLoraWarmupPostImportFinder(importlib.abc.MetaPathFinder):
+    __slots__ = (_VLLM_LORA_WARMUP_SHIM_SENTINEL,)
+
+    def __init__(self):
+        setattr(self, _VLLM_LORA_WARMUP_SHIM_SENTINEL, True)
+
+    def find_spec(self, fullname, path = None, target = None):
+        if fullname != _VLLM_LORA_MIXIN_MODULE:
+            return None
+        # Resolve the real spec via the other finders (skipping ourselves to
+        # avoid recursion) and wrap its loader so we patch right after exec.
+        for finder in sys.meta_path:
+            if finder is self or getattr(finder, _VLLM_LORA_WARMUP_SHIM_SENTINEL, False):
+                continue
+            try:
+                spec = finder.find_spec(fullname, path, target)
+            except Exception:
+                spec = None
+            if spec is not None and spec.loader is not None:
+                spec.loader = _VllmLoraWarmupPostImportLoader(spec.loader)
+                return spec
+        return None
+
+
+def fix_vllm_lora_warmup_rank():
+    if importlib.util.find_spec("vllm") is None:
+        return
+    # vLLM already imported (loaded before us): patch the module in place.
+    existing = sys.modules.get(_VLLM_LORA_MIXIN_MODULE)
+    if existing is not None:
+        _unsloth_patch_lora_model_runner_mixin(existing)
+        return
+    for finder in sys.meta_path:
+        if getattr(finder, _VLLM_LORA_WARMUP_SHIM_SENTINEL, False):
+            return
+    # Inserted at the front so we intercept the import before the real finder
+    # loads it; we still delegate to the real finder for the actual load.
+    sys.meta_path.insert(0, _VllmLoraWarmupPostImportFinder())
+
+
 def fix_vllm_guided_decoding_params():
     def _maybe_raise_vllm_transformers_mismatch(error):
         error_text = str(error)

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -592,7 +592,12 @@ class _VllmLoraWarmupPostImportFinder(importlib.abc.MetaPathFinder):
     def __init__(self):
         setattr(self, _VLLM_LORA_WARMUP_SHIM_SENTINEL, True)
 
-    def find_spec(self, fullname, path = None, target = None):
+    def find_spec(
+        self,
+        fullname,
+        path = None,
+        target = None,
+    ):
         if fullname != _VLLM_LORA_MIXIN_MODULE:
             return None
         # Resolve the real spec via the other finders (skipping ourselves to


### PR DESCRIPTION
### Summary

Fixes the `fast_inference` LoRA warmup crash in #6114:

```
AttributeError: 'LRUCacheWorkerLoRAManager' object has no attribute
                'get_dummy_lora_warmup_rank'
```

### Root cause

vLLM's v1 engine (>= 0.21) added a dummy-LoRA warmup hook — `LoRAModelRunnerMixin.maybe_setup_dummy_loras()` now calls `self.lora_manager.get_dummy_lora_warmup_rank(default_rank) -> int`, letting a manager lower the warmup rank and otherwise returning vLLM's own default (`min(max_lora_rank, 8)`).

Older `unsloth_zoo.vllm_utils.patch_vllm()` swaps vLLM's `WorkerLoRAManager` / `LRUCacheWorkerLoRAManager` for the ports in `unsloth_zoo/vllm_lora_worker_manager.py`, which predate that hook and don't implement it. The ported manager is a standalone class (the crash itself proves it doesn't inherit vLLM's hook), so any `fast_inference` LoRA run on a recent vLLM + an older unsloth-zoo dies during dummy-LoRA warmup.

### Fix

`fix_vllm_lora_warmup_rank()` (in `import_fixes.py`, wired into `_gpu_init.py` next to the sibling `fix_vllm_lora_tokenizer_module`): a one-shot post-import hook that wraps `maybe_setup_dummy_loras` and backfills the **identity** default (`return default_rank`) on the *live* `type(self.lora_manager)`, right before the context-manager body runs. Identity == the exact pre-hook behaviour, so the warmup rank is unchanged.

This mirrors the recently-merged #6385 shim — it defends users who upgrade `unsloth` but keep an older `unsloth-zoo`, which a fix in `unsloth-zoo` alone can't reach. It is:

- **vLLM-side only** — no `unsloth-zoo` import; it patches whatever manager class is live, so it's robust to the swap.
- **deferred** — installed via a meta-path post-import hook so vLLM is never imported early (the SM100 compatibility check still runs first).
- **self-disabling** — the `hasattr` guard no-ops once `unsloth-zoo` (or vLLM) ships the method.

### Tests (GPU-free)

- `tests/test_vllm_lora_warmup_rank_shim.py` — reproduces the #6114 crash and the fix against a synthetic mixin/manager mirroring vLLM's exact call shape; covers the identity backfill, "don't clobber a manager that already implements the hook", idempotency, the LoRA-disabled path, and both entry-point branches (post-import-hook install vs. patch-in-place). 7 passing.
- `tests/test_import_fixes_drift.py` — a drift detector that fails if vLLM ever drops or renames the hook, so the shim gets revisited.

Both run on the existing GPU-free `tests/` harness (no vLLM / unsloth-zoo required).

