### PR TITLE
README: document unsloth studio --secure (HTTPS) in the Launch section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ unsloth studio -p 8888
 ```
 For cloud or global access, add `-H 0.0.0.0`. By default, Unsloth is accessible only locally.
 
+For a secure HTTPS link instead of a raw network port, use `unsloth studio --secure`. Studio stays bound to localhost and is served only through a free Cloudflare HTTPS tunnel (it fails closed if the tunnel can't start, so the raw port is never exposed).
+
 #### Docker
 Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth``` container. Run:
 ```bash


### PR DESCRIPTION
Adds the `--secure` option to the Quickstart Launch section, alongside the existing `-H 0.0.0.0` note.

`unsloth studio --secure` serves Studio only through a free Cloudflare HTTPS tunnel: it stays bound to localhost and fails closed if the tunnel can't start, so the raw port is never exposed. This gives a secure HTTPS link without opening a raw network port.