### PR TITLE
Gemma 4 E-series: default generation to use_cache=False

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -3281,8 +3281,6 @@ def is_moe_model(model) -> bool:
     return num_experts is not None and num_experts > 0
 
 
-
-
 def is_gemma4_shared_kv_model(model) -> bool:
     """
     Detect Gemma 4 E-series models (E2B / E4B) that share KV across layers.
@@ -3305,8 +3303,6 @@ def is_gemma4_shared_kv_model(model) -> bool:
     ):
         return False
     return (_config_get(text_config, "num_kv_shared_layers", 0) or 0) > 0
-
-
 
 
 def _resolve_moe_parameter_name(model, default_name: str, alternate_name: str) -> str:

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -3294,15 +3294,17 @@ def is_gemma4_shared_kv_model(model) -> bool:
     26B-A4B have num_kv_shared_layers == 0 and are unaffected.
     """
     config = getattr(model, "config", model)
-    text_config = getattr(config, "text_config", None) or config
-    model_type = getattr(config, "model_type", "") or ""
-    text_model_type = getattr(text_config, "model_type", "") or ""
+    # Use _config_get so a dict config (some serialization / init paths) is read
+    # correctly; plain getattr would silently miss the field on a dict.
+    text_config = _config_get(config, "text_config", None) or config
+    model_type = _config_get(config, "model_type", "") or ""
+    text_model_type = _config_get(text_config, "model_type", "") or ""
     if not (
         (isinstance(model_type, str) and model_type.startswith("gemma4"))
         or (isinstance(text_model_type, str) and text_model_type.startswith("gemma4"))
     ):
         return False
-    return (getattr(text_config, "num_kv_shared_layers", 0) or 0) > 0
+    return (_config_get(text_config, "num_kv_shared_layers", 0) or 0) > 0
 
 
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -82,6 +82,7 @@ __all__ = [
     "_get_inference_mode_context_manager",
     "hf_login",
     "is_moe_model",
+    "is_gemma4_shared_kv_model",
     "get_moe_target_parameters",
     "make_fast_generate_wrapper",
 ]
@@ -3278,6 +3279,30 @@ def is_moe_model(model) -> bool:
                 break
 
     return num_experts is not None and num_experts > 0
+pass
+
+
+def is_gemma4_shared_kv_model(model) -> bool:
+    """
+    Detect Gemma 4 E-series models (E2B / E4B) that share KV across layers.
+
+    These have num_kv_shared_layers > 0, and in transformers 5.5.0 their
+    KV cache generation path is broken (huggingface/transformers#45242):
+    generating with a KV cache (use_cache=True / cache_implementation set)
+    yields different, garbled logits to the cache-free path. Gemma 4 31B /
+    26B-A4B have num_kv_shared_layers == 0 and are unaffected.
+    """
+    config = getattr(model, "config", model)
+    text_config = getattr(config, "text_config", None) or config
+    model_type = getattr(config, "model_type", "") or ""
+    text_model_type = getattr(text_config, "model_type", "") or ""
+    if not (
+        (isinstance(model_type, str) and model_type.startswith("gemma4")) or
+        (isinstance(text_model_type, str) and text_model_type.startswith("gemma4"))
+    ):
+        return False
+    return (getattr(text_config, "num_kv_shared_layers", 0) or 0) > 0
+pass
 
 
 def _resolve_moe_parameter_name(model, default_name: str, alternate_name: str) -> str:

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -3279,7 +3279,8 @@ def is_moe_model(model) -> bool:
                 break
 
     return num_experts is not None and num_experts > 0
-pass
+
+
 
 
 def is_gemma4_shared_kv_model(model) -> bool:
@@ -3297,12 +3298,13 @@ def is_gemma4_shared_kv_model(model) -> bool:
     model_type = getattr(config, "model_type", "") or ""
     text_model_type = getattr(text_config, "model_type", "") or ""
     if not (
-        (isinstance(model_type, str) and model_type.startswith("gemma4")) or
-        (isinstance(text_model_type, str) and text_model_type.startswith("gemma4"))
+        (isinstance(model_type, str) and model_type.startswith("gemma4"))
+        or (isinstance(text_model_type, str) and text_model_type.startswith("gemma4"))
     ):
         return False
     return (getattr(text_config, "num_kv_shared_layers", 0) or 0) > 0
-pass
+
+
 
 
 def _resolve_moe_parameter_name(model, default_name: str, alternate_name: str) -> str:

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2156,6 +2156,14 @@ def unsloth_fast_generate(self, *args, **kwargs):
 
     # For newer HF
     kwargs["cache_implementation"] = "dynamic"
+    # Gemma 4 E-series (E2B / E4B) share KV across layers and their KV cache
+    # generation path is broken in transformers 5.5.0
+    # (huggingface/transformers#45242): a cached forward diverges from the
+    # cache-free forward, so default greedy decode emits garbage. Default to the
+    # correct cache-free path unless the caller explicitly opts into a cache.
+    if "use_cache" not in kwargs and is_gemma4_shared_kv_model(self):
+        kwargs["use_cache"] = False
+        kwargs["cache_implementation"] = None
     # transformers 4.50 renamed num_logits_to_keep -> logits_to_keep; pop both,
     # re-emit under the spelling forward() accepts.
     _provided_num = kwargs.pop("num_logits_to_keep", None)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -405,6 +405,15 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
     if do_bfloat16_mixed_precision:
         cache_implementation = None
 
+    # Gemma 4 E-series (E2B / E4B) share KV across layers and their KV cache
+    # generation path is broken in transformers 5.5.0
+    # (huggingface/transformers#45242): a cached forward diverges from the
+    # cache-free forward, so default greedy decode emits garbage. Default to the
+    # correct cache-free path unless the caller explicitly opts into a cache.
+    if "use_cache" not in kwargs and is_gemma4_shared_kv_model(self):
+        kwargs["use_cache"] = False
+        cache_implementation = None
+
     if "generation_config" in kwargs:
         kwargs["generation_config"].cache_implementation = cache_implementation
         if cache_implementation is not None:


### PR DESCRIPTION
## Summary

Gemma 4 E-series models (E2B / E4B) share KV across their last layers (`num_kv_shared_layers > 0`). Under transformers 5.5.0 their KV-cache generation path is broken (huggingface/transformers#45242): a cached forward (`use_cache=True`) diverges from the cache-free forward (`use_cache=False`), so default greedy decode emits garbage even when the model has clearly learned the target.

Unsloth's fast-generate wrappers unconditionally set a cache implementation (`cache_implementation="dynamic"` for text, static / hybrid for vision), which routes Gemma 4 E-series default generation into the broken cached path.

This adds `is_gemma4_shared_kv_model` and, in both the text (`unsloth_fast_generate`) and vision (`unsloth_base_fast_generate`) generate wrappers, defaults these models to `use_cache=False` (and clears the forced `cache_implementation`) unless the caller passed `use_cache` explicitly. Users get correct output by default and can still opt into the cached path with `generate(..., use_cache=True)`.

This pairs with the unsloth-zoo PR that stops the `kv_shared_no_cache` forward wrapper from inverting the (already correct) cache-free path on the E-series.

## Gating

`is_gemma4_shared_kv_model` returns `True` only when `model_type` (or `text_config.model_type`) starts with `gemma4` and `num_kv_shared_layers > 0`:

```
gemma4-E2B (num_kv_shared=20):          True
gemma4 31B-like (num_kv_shared=0):      False
gemma3-270m:                            False
llama-3.2-1B:                           False
```

So Gemma 4 31B / 26B-A4B, Gemma 3, Gemma 3n, and every other model keep their existing generation behaviour.

## Evidence

`unsloth/gemma-4-E2B-it`, single-row overfit, generate after training (text and vision paths, both LoRA and merged_16bit):

```
teacher-forced / recompute loss = 0.00000
[use_cache=True ] garbage           (explicit override, the broken #45242 path)
[use_cache=False] correct target
[DEFAULT        ] correct target
```

Vision (response-only supervision, image + "##$$$ WHO AM I??? $$$###" -> "I am Unsloth!"):

```
[LoRA   DEFAULT] 'I am Unsloth!'
[merged DEFAULT] 'I am Unsloth!'
[*      use_cache=True] 'Based on the image, you are asking ...' (garbage)
```

Before this change, default generation on the same trained model emits repeated `### Answer:` / "Based on the image" garbage.
