### PR TITLE
loader: build UNSLOTH_MODEL_NAME fresh per load (fixes gpt-oss merged_16bit reload)

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2460,7 +2460,7 @@ class FastLlamaModel:
             # Add to kwargs
             kwargs["rope_scaling"] = rope_scaling
 
-        from .loader_utils import check_and_disable_bitsandbytes_loading
+        from .loader_utils import check_and_disable_bitsandbytes_loading, sync_unsloth_model_name_bnb_flags
         from unsloth_zoo.utils import get_quant_type
 
         # Extract load_in_8bit from kwargs if provided
@@ -2470,6 +2470,9 @@ class FastLlamaModel:
         load_in_4bit, load_in_8bit, _ckpt_quant_method = check_and_disable_bitsandbytes_loading(
             model_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit
         )
+        # Correct UNSLOTH_MODEL_NAME's bnb tokens now that the effective bnb state is known
+        # (the per-load env was built before remap/disable). gpt-oss only; no-op otherwise.
+        sync_unsloth_model_name_bnb_flags(load_in_4bit, load_in_8bit)
 
         bnb_config = None
         _ckpt_qcfg = getattr(model_config, "quantization_config", None)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2460,7 +2460,10 @@ class FastLlamaModel:
             # Add to kwargs
             kwargs["rope_scaling"] = rope_scaling
 
-        from .loader_utils import check_and_disable_bitsandbytes_loading, sync_unsloth_model_name_bnb_flags
+        from .loader_utils import (
+            check_and_disable_bitsandbytes_loading,
+            sync_unsloth_model_name_bnb_flags,
+        )
         from unsloth_zoo.utils import get_quant_type
 
         # Extract load_in_8bit from kwargs if provided

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1234,7 +1234,13 @@ class FastModel(FastBaseModel):
 
         # Save model types and loading method
         lowered_model_name = model_name.lower()
-        string = os.environ.get("UNSLOTH_MODEL_NAME", "") + model_types_all
+        # Build UNSLOTH_MODEL_NAME freshly from THIS load's model name + flags. Do not
+        # prepend the previous os.environ value: it is inherited across processes (e.g. a
+        # save->reload subprocess) and accumulates stale load flags. A leftover
+        # "_load_in_4bit_" from an earlier bnb-4bit load would make gpt-oss wrongly take the
+        # BnB router patch (router.linear.weight) when later reloading a merged 16bit
+        # checkpoint (router.weight), raising "some weights are not initialized".
+        string = lowered_model_name + "," + model_types_all
         if load_in_4bit:
             string += "_load_in_4bit_"
         if load_in_8bit:

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1234,13 +1234,17 @@ class FastModel(FastBaseModel):
 
         # Save model types and loading method
         lowered_model_name = model_name.lower()
-        # Build UNSLOTH_MODEL_NAME freshly from THIS load's model name + flags. Do not
+        # Build UNSLOTH_MODEL_NAME freshly from THIS load's model types + flags. Do not
         # prepend the previous os.environ value: it is inherited across processes (e.g. a
         # save->reload subprocess) and accumulates stale load flags. A leftover
         # "_load_in_4bit_" from an earlier bnb-4bit load would make gpt-oss wrongly take the
         # BnB router patch (router.linear.weight) when later reloading a merged 16bit
         # checkpoint (router.weight), raising "some weights are not initialized".
-        string = lowered_model_name + "," + model_types_all
+        # Only the model TYPE tokens (model_types_all) and the load flags below are
+        # consumed downstream (e.g. `"gpt_oss" in`, `"_load_in_4bit_" in`); the raw model
+        # name/path is intentionally NOT included, so a local path that happens to contain
+        # a flag sentinel like "_load_in_4bit_" cannot be misread as that flag.
+        string = model_types_all
         if load_in_4bit:
             string += "_load_in_4bit_"
         if load_in_8bit:

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1244,10 +1244,23 @@ class FastModel(FastBaseModel):
         # consumed downstream (e.g. `"gpt_oss" in`, `"_load_in_4bit_" in`); the raw model
         # name/path is intentionally NOT included, so a local path that happens to contain
         # a flag sentinel like "_load_in_4bit_" cannot be misread as that flag.
+        #
+        # Encode the EFFECTIVE bnb state, not the requested one. A checkpoint already
+        # quantized with a non-bitsandbytes method (gpt-oss MXFP4, gptq, awq,
+        # compressed-tensors, ...) has load_in_4bit/8bit disabled later by
+        # check_and_disable_bitsandbytes_loading. Recording the requested `_load_in_4bit_`
+        # here would, for the public default load_in_4bit=True, route e.g. a native MXFP4
+        # gpt-oss (stock router.weight) onto the BnB router patch (router.linear.weight)
+        # and break the load. Mirror that normalization from the model's own config.
+        try:
+            from unsloth_zoo.utils import get_quant_type
+            _bnb_compatible_quant = get_quant_type(model_config) in (None, "bitsandbytes")
+        except Exception:
+            _bnb_compatible_quant = True
         string = model_types_all
-        if load_in_4bit:
+        if load_in_4bit and _bnb_compatible_quant:
             string += "_load_in_4bit_"
-        if load_in_8bit:
+        if load_in_8bit and _bnb_compatible_quant:
             string += "_load_in_8bit_"
         if load_in_16bit:
             string += "_load_in_16bit_"

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1252,26 +1252,14 @@ class FastModel(FastBaseModel):
         # here would, for the public default load_in_4bit=True, route e.g. a native MXFP4
         # gpt-oss (stock router.weight) onto the BnB router patch (router.linear.weight)
         # and break the load. Mirror that normalization from the model's own config.
+        # This is only an EARLY best-effort: for an adapter-only PEFT repo model_config is
+        # still None here, and the base may yet be remapped (get_model_name) to a different
+        # quant (e.g. an Unsloth `-bnb-4bit` build). The authoritative correction happens in
+        # the load path via sync_unsloth_model_name_bnb_flags(...) right after
+        # check_and_disable_bitsandbytes_loading, once the effective bnb state is known.
         try:
             from unsloth_zoo.utils import get_quant_type
-
-            # For an adapter-only PEFT repo, model_config is still None here (the base
-            # config is loaded later), so resolve the base checkpoint's config to detect
-            # a non-bnb-quantized base (e.g. a LoRA over gpt-oss MXFP4).
-            _quant_config = model_config
-            if _quant_config is None and peft_config is not None:
-                _base = getattr(peft_config, "base_model_name_or_path", None)
-                if _base:
-                    # No `revision` here: that is the adapter repo's revision, not the
-                    # base's. Honor `local_files_only` so offline loads still detect the
-                    # base quant method from cache.
-                    _quant_config = AutoConfig.from_pretrained(
-                        _base,
-                        token = token,
-                        trust_remote_code = trust_remote_code,
-                        local_files_only = local_files_only,
-                    )
-            _bnb_compatible_quant = get_quant_type(_quant_config) in (None, "bitsandbytes")
+            _bnb_compatible_quant = get_quant_type(model_config) in (None, "bitsandbytes")
         except Exception:
             _bnb_compatible_quant = True
         string = model_types_all

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -826,21 +826,34 @@ class FastLanguageModel(FastLlamaModel):
         if load_in_4bit:
             # Fix up bitsandbytes config, but respect user-provided quantization_config
             if quantization_config is None:
-                compute_dtype = dtype_from_config(model.config)
-                quantization_config = {
-                    # Sometimes compute_dtype is not a string!!
-                    "bnb_4bit_compute_dtype": compute_dtype,
-                    "bnb_4bit_quant_type": "nf4",
-                    "bnb_4bit_use_double_quant": True,
-                    "llm_int8_enable_fp32_cpu_offload": False,
-                    "llm_int8_has_fp16_weight": False,
-                    "llm_int8_skip_modules": None,
-                    "llm_int8_threshold": 6.0,
-                    "load_in_4bit": True,
-                    "load_in_8bit": False,
-                    "quant_method": "bitsandbytes",
-                }
-                model.config.update({"quantization_config": quantization_config})
+                # `load_in_4bit` here is the requested flag, not the effective one. A
+                # checkpoint already quantized with a non-bnb method (gpt-oss MXFP4, gptq,
+                # awq, compressed-tensors) had bnb disabled by
+                # check_and_disable_bitsandbytes_loading, so stamping a synthetic
+                # bitsandbytes quantization_config over its real one would be a lie and
+                # corrupt a saved config. Only stamp when the loaded model is bnb or
+                # unquantized.
+                try:
+                    from unsloth_zoo.utils import get_quant_type
+                    _stamp_bnb = get_quant_type(model.config) in (None, "bitsandbytes")
+                except Exception:
+                    _stamp_bnb = True
+                if _stamp_bnb:
+                    compute_dtype = dtype_from_config(model.config)
+                    quantization_config = {
+                        # Sometimes compute_dtype is not a string!!
+                        "bnb_4bit_compute_dtype": compute_dtype,
+                        "bnb_4bit_quant_type": "nf4",
+                        "bnb_4bit_use_double_quant": True,
+                        "llm_int8_enable_fp32_cpu_offload": False,
+                        "llm_int8_has_fp16_weight": False,
+                        "llm_int8_skip_modules": None,
+                        "llm_int8_threshold": 6.0,
+                        "load_in_4bit": True,
+                        "load_in_8bit": False,
+                        "quant_method": "bitsandbytes",
+                    }
+                    model.config.update({"quantization_config": quantization_config})
             else:
                 if hasattr(quantization_config, "to_dict"):
                     model.config.update({"quantization_config": quantization_config.to_dict()})
@@ -1687,21 +1700,34 @@ class FastModel(FastBaseModel):
         if load_in_4bit:
             # Fix up bitsandbytes config, but respect user-provided quantization_config
             if quantization_config is None:
-                compute_dtype = dtype_from_config(model.config)
-                quantization_config = {
-                    # Sometimes compute_dtype is not a string!!
-                    "bnb_4bit_compute_dtype": compute_dtype,
-                    "bnb_4bit_quant_type": "nf4",
-                    "bnb_4bit_use_double_quant": True,
-                    "llm_int8_enable_fp32_cpu_offload": False,
-                    "llm_int8_has_fp16_weight": False,
-                    "llm_int8_skip_modules": None,
-                    "llm_int8_threshold": 6.0,
-                    "load_in_4bit": True,
-                    "load_in_8bit": False,
-                    "quant_method": "bitsandbytes",
-                }
-                model.config.update({"quantization_config": quantization_config})
+                # `load_in_4bit` here is the requested flag, not the effective one. A
+                # checkpoint already quantized with a non-bnb method (gpt-oss MXFP4, gptq,
+                # awq, compressed-tensors) had bnb disabled by
+                # check_and_disable_bitsandbytes_loading, so stamping a synthetic
+                # bitsandbytes quantization_config over its real one would be a lie and
+                # corrupt a saved config. Only stamp when the loaded model is bnb or
+                # unquantized.
+                try:
+                    from unsloth_zoo.utils import get_quant_type
+                    _stamp_bnb = get_quant_type(model.config) in (None, "bitsandbytes")
+                except Exception:
+                    _stamp_bnb = True
+                if _stamp_bnb:
+                    compute_dtype = dtype_from_config(model.config)
+                    quantization_config = {
+                        # Sometimes compute_dtype is not a string!!
+                        "bnb_4bit_compute_dtype": compute_dtype,
+                        "bnb_4bit_quant_type": "nf4",
+                        "bnb_4bit_use_double_quant": True,
+                        "llm_int8_enable_fp32_cpu_offload": False,
+                        "llm_int8_has_fp16_weight": False,
+                        "llm_int8_skip_modules": None,
+                        "llm_int8_threshold": 6.0,
+                        "load_in_4bit": True,
+                        "load_in_8bit": False,
+                        "quant_method": "bitsandbytes",
+                    }
+                    model.config.update({"quantization_config": quantization_config})
             else:
                 if hasattr(quantization_config, "to_dict"):
                     model.config.update({"quantization_config": quantization_config.to_dict()})

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1254,7 +1254,23 @@ class FastModel(FastBaseModel):
         # and break the load. Mirror that normalization from the model's own config.
         try:
             from unsloth_zoo.utils import get_quant_type
-            _bnb_compatible_quant = get_quant_type(model_config) in (None, "bitsandbytes")
+            # For an adapter-only PEFT repo, model_config is still None here (the base
+            # config is loaded later), so resolve the base checkpoint's config to detect
+            # a non-bnb-quantized base (e.g. a LoRA over gpt-oss MXFP4).
+            _quant_config = model_config
+            if _quant_config is None and peft_config is not None:
+                _base = getattr(peft_config, "base_model_name_or_path", None)
+                if _base:
+                    # No `revision` here: that is the adapter repo's revision, not the
+                    # base's. Honor `local_files_only` so offline loads still detect the
+                    # base quant method from cache.
+                    _quant_config = AutoConfig.from_pretrained(
+                        _base,
+                        token = token,
+                        trust_remote_code = trust_remote_code,
+                        local_files_only = local_files_only,
+                    )
+            _bnb_compatible_quant = get_quant_type(_quant_config) in (None, "bitsandbytes")
         except Exception:
             _bnb_compatible_quant = True
         string = model_types_all

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1254,6 +1254,7 @@ class FastModel(FastBaseModel):
         # and break the load. Mirror that normalization from the model's own config.
         try:
             from unsloth_zoo.utils import get_quant_type
+
             # For an adapter-only PEFT repo, model_config is still None here (the base
             # config is loaded later), so resolve the base checkpoint's config to detect
             # a non-bnb-quantized base (e.g. a LoRA over gpt-oss MXFP4).

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -826,13 +826,9 @@ class FastLanguageModel(FastLlamaModel):
         if load_in_4bit:
             # Fix up bitsandbytes config, but respect user-provided quantization_config
             if quantization_config is None:
-                # `load_in_4bit` here is the requested flag, not the effective one. A
-                # checkpoint already quantized with a non-bnb method (gpt-oss MXFP4, gptq,
-                # awq, compressed-tensors) had bnb disabled by
-                # check_and_disable_bitsandbytes_loading, so stamping a synthetic
-                # bitsandbytes quantization_config over its real one would be a lie and
-                # corrupt a saved config. Only stamp when the loaded model is bnb or
-                # unquantized.
+                # `load_in_4bit` is the requested flag, not the effective one: a non-bnb
+                # checkpoint (MXFP4/gptq/awq) had bnb disabled by check_and_disable, so stamping a
+                # synthetic bnb config would corrupt its real one. Only stamp bnb/unquantized.
                 try:
                     from unsloth_zoo.utils import get_quant_type
                     _stamp_bnb = get_quant_type(model.config) in (None, "bitsandbytes")
@@ -1247,29 +1243,18 @@ class FastModel(FastBaseModel):
 
         # Save model types and loading method
         lowered_model_name = model_name.lower()
-        # Build UNSLOTH_MODEL_NAME freshly from THIS load's model types + flags. Do not
-        # prepend the previous os.environ value: it is inherited across processes (e.g. a
-        # save->reload subprocess) and accumulates stale load flags. A leftover
-        # "_load_in_4bit_" from an earlier bnb-4bit load would make gpt-oss wrongly take the
-        # BnB router patch (router.linear.weight) when later reloading a merged 16bit
-        # checkpoint (router.weight), raising "some weights are not initialized".
-        # Only the model TYPE tokens (model_types_all) and the load flags below are
-        # consumed downstream (e.g. `"gpt_oss" in`, `"_load_in_4bit_" in`); the raw model
-        # name/path is intentionally NOT included, so a local path that happens to contain
-        # a flag sentinel like "_load_in_4bit_" cannot be misread as that flag.
+        # Build UNSLOTH_MODEL_NAME fresh from THIS load's model types + flags; do not prepend the
+        # inherited os.environ value (a stale "_load_in_4bit_" from an earlier load, e.g. across a
+        # save->reload subprocess, would push gpt-oss onto the BnB router patch when later loading
+        # a 16bit checkpoint -> "weights not initialized"). Only the type tokens and the load flags
+        # below are consumed downstream; the raw model name/path is excluded so a path containing a
+        # flag sentinel cannot be misread.
         #
-        # Encode the EFFECTIVE bnb state, not the requested one. A checkpoint already
-        # quantized with a non-bitsandbytes method (gpt-oss MXFP4, gptq, awq,
-        # compressed-tensors, ...) has load_in_4bit/8bit disabled later by
-        # check_and_disable_bitsandbytes_loading. Recording the requested `_load_in_4bit_`
-        # here would, for the public default load_in_4bit=True, route e.g. a native MXFP4
-        # gpt-oss (stock router.weight) onto the BnB router patch (router.linear.weight)
-        # and break the load. Mirror that normalization from the model's own config.
-        # This is only an EARLY best-effort: for an adapter-only PEFT repo model_config is
-        # still None here, and the base may yet be remapped (get_model_name) to a different
-        # quant (e.g. an Unsloth `-bnb-4bit` build). The authoritative correction happens in
-        # the load path via sync_unsloth_model_name_bnb_flags(...) right after
-        # check_and_disable_bitsandbytes_loading, once the effective bnb state is known.
+        # Encode the EFFECTIVE bnb state: a non-bnb checkpoint (MXFP4/gptq/awq) has load_in_4bit
+        # disabled later by check_and_disable, so recording the requested flag here would route a
+        # native MXFP4 gpt-oss onto the BnB router patch. This is only an EARLY best-effort (an
+        # adapter-only PEFT repo has model_config=None here, and the base may be remapped); the
+        # authoritative correction is sync_unsloth_model_name_bnb_flags(...) after check_and_disable.
         try:
             from unsloth_zoo.utils import get_quant_type
             _bnb_compatible_quant = get_quant_type(model_config) in (None, "bitsandbytes")
@@ -1700,13 +1685,9 @@ class FastModel(FastBaseModel):
         if load_in_4bit:
             # Fix up bitsandbytes config, but respect user-provided quantization_config
             if quantization_config is None:
-                # `load_in_4bit` here is the requested flag, not the effective one. A
-                # checkpoint already quantized with a non-bnb method (gpt-oss MXFP4, gptq,
-                # awq, compressed-tensors) had bnb disabled by
-                # check_and_disable_bitsandbytes_loading, so stamping a synthetic
-                # bitsandbytes quantization_config over its real one would be a lie and
-                # corrupt a saved config. Only stamp when the loaded model is bnb or
-                # unquantized.
+                # `load_in_4bit` is the requested flag, not the effective one: a non-bnb
+                # checkpoint (MXFP4/gptq/awq) had bnb disabled by check_and_disable, so stamping a
+                # synthetic bnb config would corrupt its real one. Only stamp bnb/unquantized.
                 try:
                     from unsloth_zoo.utils import get_quant_type
                     _stamp_bnb = get_quant_type(model.config) in (None, "bitsandbytes")

--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -395,6 +395,32 @@ def check_and_disable_bitsandbytes_loading(
     return load_in_4bit, load_in_8bit, quant_method
 
 
+def sync_unsloth_model_name_bnb_flags(load_in_4bit, load_in_8bit):
+    """Make UNSLOTH_MODEL_NAME's `_load_in_4bit_` / `_load_in_8bit_` tokens match the
+    EFFECTIVE bitsandbytes load state, i.e. after `get_model_name` remapping and
+    `check_and_disable_bitsandbytes_loading` have run.
+
+    The per-load env built in `FastModel.from_pretrained` only sees the pre-remap config
+    (and for an adapter-only PEFT repo, `model_config` is still None there), so its bnb
+    tokens can be wrong once the base is resolved: a native MXFP4/GPTQ/AWQ base must NOT
+    carry `_load_in_4bit_`, while a base remapped to an Unsloth `-bnb-4bit` build must.
+    Only the gpt-oss patch reads these tokens (to choose BnB vs stock router/expert
+    classes), so this is gated to gpt-oss and is a strict no-op for every other model.
+    """
+    name = os.environ.get("UNSLOTH_MODEL_NAME", "")
+    if "gpt_oss" not in name.replace("-", "_"):
+        return
+    for flag, present in (
+        ("_load_in_4bit_", bool(load_in_4bit)),
+        ("_load_in_8bit_", bool(load_in_8bit)),
+    ):
+        if present and flag not in name:
+            name += flag
+        elif not present and flag in name:
+            name = name.replace(flag, "")
+    os.environ["UNSLOTH_MODEL_NAME"] = name
+
+
 def _get_fp8_mode_and_check_settings(
     load_in_fp8: Union[bool, str],
     fast_inference: bool,

--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -396,17 +396,10 @@ def check_and_disable_bitsandbytes_loading(
 
 
 def sync_unsloth_model_name_bnb_flags(load_in_4bit, load_in_8bit):
-    """Make UNSLOTH_MODEL_NAME's `_load_in_4bit_` / `_load_in_8bit_` tokens match the
-    EFFECTIVE bitsandbytes load state, i.e. after `get_model_name` remapping and
-    `check_and_disable_bitsandbytes_loading` have run.
-
-    The per-load env built in `FastModel.from_pretrained` only sees the pre-remap config
-    (and for an adapter-only PEFT repo, `model_config` is still None there), so its bnb
-    tokens can be wrong once the base is resolved: a native MXFP4/GPTQ/AWQ base must NOT
-    carry `_load_in_4bit_`, while a base remapped to an Unsloth `-bnb-4bit` build must.
-    Only the gpt-oss patch reads these tokens (to choose BnB vs stock router/expert
-    classes), so this is gated to gpt-oss and is a strict no-op for every other model.
-    """
+    """Make UNSLOTH_MODEL_NAME's `_load_in_4bit_`/`_load_in_8bit_` tokens match the EFFECTIVE bnb
+    state (after get_model_name remap + check_and_disable). The per-load env is built from the
+    pre-remap config (None for adapter-only PEFT repos), so its tokens can be wrong once the base
+    resolves. Only the gpt-oss patch reads them, so this is gated to gpt-oss; no-op otherwise."""
     name = os.environ.get("UNSLOTH_MODEL_NAME", "")
     if "gpt_oss" not in name.replace("-", "_"):
         return

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -812,7 +812,10 @@ class FastBaseModel:
         user_quantization_config = kwargs.get("quantization_config", None)
 
         # Check if model already has a non-bitsandbytes quantization config (e.g. compressed-tensors/NVFP4)
-        from .loader_utils import check_and_disable_bitsandbytes_loading, sync_unsloth_model_name_bnb_flags
+        from .loader_utils import (
+            check_and_disable_bitsandbytes_loading,
+            sync_unsloth_model_name_bnb_flags,
+        )
 
         load_in_4bit, load_in_8bit, _ = check_and_disable_bitsandbytes_loading(
             auto_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -812,11 +812,14 @@ class FastBaseModel:
         user_quantization_config = kwargs.get("quantization_config", None)
 
         # Check if model already has a non-bitsandbytes quantization config (e.g. compressed-tensors/NVFP4)
-        from .loader_utils import check_and_disable_bitsandbytes_loading
+        from .loader_utils import check_and_disable_bitsandbytes_loading, sync_unsloth_model_name_bnb_flags
 
         load_in_4bit, load_in_8bit, _ = check_and_disable_bitsandbytes_loading(
             auto_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit
         )
+        # Correct UNSLOTH_MODEL_NAME's bnb tokens now that the effective bnb state is known
+        # (the per-load env was built before remap/disable). gpt-oss only; no-op otherwise.
+        sync_unsloth_model_name_bnb_flags(load_in_4bit, load_in_8bit)
 
         if full_finetuning and (load_in_4bit or load_in_8bit):
             print(


### PR DESCRIPTION
## Problem

`UNSLOTH_MODEL_NAME` was built by **prepending the previous `os.environ` value**:

```python
string = os.environ.get("UNSLOTH_MODEL_NAME", "") + model_types_all
```

That value is inherited across processes (a save->reload subprocess) and accumulates stale load flags. A leftover `_load_in_4bit_` from an earlier bnb-4bit load made gpt-oss wrongly take the BnB router patch (`router.linear.weight`) when later reloading a merged 16-bit checkpoint (`router.weight`), raising:

```
Unsloth: Critical error since some weights are not initialized.
... ['model.layers.0.mlp.router.bias', 'model.layers.0.mlp.router.weight', ...]
```

## Fix

Build the string fresh from **this** load's model name + flags:

```python
string = lowered_model_name + "," + model_types_all
```

This is the loader-side half of the gpt-oss bnb-4bit / merged_16bit reload fix (the gpt_oss compiled-cache half is in unslothai/unsloth-zoo). All `UNSLOTH_MODEL_NAME` consumers use substring checks (`"gpt_oss" in ...`, `"_load_in_4bit_" in ...`), which the new format preserves; including `lowered_model_name` also makes those gates match the model name itself, not only `model_types_all`.

## Verification

With the paired unsloth-zoo change, gpt-oss-20b in both 4-bit and BF16 passes train -> save_lora + save_merged_16bit -> reload (fresh process), reproducing the fine-tuned phrase. The previously-failing merged_16bit reload now loads cleanly.
