### PR TITLE
Build UNSLOTH_MODEL_NAME fresh per load (fixes gpt-oss merged reload)

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1234,7 +1234,14 @@ class FastModel(FastBaseModel):
 
         # Save model types and loading method
         lowered_model_name = model_name.lower()
-        string = os.environ.get("UNSLOTH_MODEL_NAME", "") + model_types_all
+        # Build UNSLOTH_MODEL_NAME freshly from THIS load's model name + flags. Do not
+        # prepend the previous os.environ value: it persists in-process and is inherited
+        # across processes (e.g. a save->reload subprocess), so it accumulates stale load
+        # flags. A leftover "_load_in_4bit_" from an earlier bnb-4bit load would make
+        # gpt-oss wrongly take the BnB router patch (router.linear.weight) when later
+        # reloading a merged 16bit checkpoint (router.weight), raising
+        # "Unsloth: Critical error since some weights are not initialized".
+        string = lowered_model_name + "," + model_types_all
         if load_in_4bit:
             string += "_load_in_4bit_"
         if load_in_8bit:


### PR DESCRIPTION
## Problem

After fine-tuning a gpt-oss model loaded from the bnb-4bit repo and saving `merged_16bit`, reloading the merged checkpoint failed with:

```
Unsloth: Critical error since some weights are not initialized.
... were not used when initializing GptOssForCausalLM:
['model.layers.0.mlp.router.weight', 'model.layers.0.mlp.router.bias', ...]
```

The merged checkpoint is valid (plain `transformers` reloads it and reproduces the fine-tuned output). The failure came from gpt-oss keeping its BnB-4bit router patch (`router.linear.weight`) when it should have used the stock router (`router.weight`).

## Root cause

`UNSLOTH_MODEL_NAME` is built here by prepending its previous `os.environ` value:

```python
string = os.environ.get("UNSLOTH_MODEL_NAME", "") + model_types_all
if load_in_4bit:
    string += "_load_in_4bit_"
...
os.environ["UNSLOTH_MODEL_NAME"] = string
```

That env var persists for the process lifetime and is inherited by child processes (a save -> reload subprocess). So it accumulates load flags across loads. After a bnb-4bit gpt-oss load it contained `_load_in_4bit_`, and a later non-4bit load (reloading the `merged_16bit` checkpoint) still saw `_load_in_4bit_`. `unsloth_zoo`'s gpt-oss BnB auto-patch keys off exactly this flag, so it kept the BnB router and rejected the merged checkpoint's stock router keys.

## Fix

Build `UNSLOTH_MODEL_NAME` from THIS load's model name and flags instead of prepending the previous value, so each load is self-contained and does not carry stale flags from an unrelated earlier load. The model-type tag and the current load flags are still present, so all `UNSLOTH_MODEL_NAME` consumers keep working.

This is paired with `unslothai/unsloth-zoo` PR #802, which makes the gpt-oss BnB auto-patch restore the stock classes when the current load is not BnB-4bit.

## Evidence

Train one row for 30 steps to memorize "I WAS FINETUNED BY UNSLOTH", save `merged_16bit`, reload in a fresh process, and check reproduction.

Before: merged reload raised `Critical error since some weights are not initialized` (router keys).

After (both precisions, merge reloads and reproduces the phrase):

| repo | precision | train loss | LoRA reload | merged reload |
|---|---|---|---|---|
| `unsloth/gpt-oss-20b-unsloth-bnb-4bit` | 4bit | 4.37 -> 0.0001 | reproduces phrase | reproduces phrase |
| `unsloth/gpt-oss-20b-BF16` | 16bit | 4.29 -> 0.0001 | reproduces phrase | reproduces phrase |

Regression: a non-gpt-oss run (Llama-3.2-1B-Instruct, 4bit) keeps passing the full train -> merge -> reload path unchanged (LoRA and merged teacher-forced CE ~0.0002).
