### PR TITLE
Suppress only torchao's cosmetic cpp-extensions warning

### DIFF
--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -152,10 +152,15 @@ if not UNSLOTH_ENABLE_LOGGING:
     sys.stderr.add_filter("CUTE_INVALID_CONTROL_PATH")
     # CUTLASS TMA-related errors when not targeting correct architecture
     sys.stderr.add_filter("Trying to use tma without CUTE_ARCH_TMA")
-    # Skipping import of cpp extensions due to incompatible torch version 2.9.0+cu128 for torchao version 0.15.0
-    logging.getLogger("torchao").setLevel(logging.ERROR)
-    # Also filter torchao print to stderr about cpp extensions
-    sys.stderr.add_filter("Skipping import of cpp extensions")
+    # torchao logs a cosmetic WARNING on torch < 2.11 (torchao/__init__.py:
+    # `logger.warning("Skipping import of cpp extensions due to incompatible
+    # torch version. Please upgrade to torch >= 2.11.0 (found ...).")`). The
+    # bnb-4bit / Unsloth paths do not use torchao's cpp kernels, so drop only
+    # this record and keep every other torchao log instead of raising the whole
+    # logger to ERROR.
+    logging.getLogger("torchao").addFilter(
+        HideLoggingMessage("Skipping import of cpp extensions due to incompatible torch version")
+    )
     # SyntaxWarning: invalid escape sequence '\.'
     warnings.filterwarnings("ignore", message = "invalid escape sequence", category = SyntaxWarning)
     # PYTORCH_CUDA_ALLOC_CONF is deprecated warning from torch

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -152,12 +152,9 @@ if not UNSLOTH_ENABLE_LOGGING:
     sys.stderr.add_filter("CUTE_INVALID_CONTROL_PATH")
     # CUTLASS TMA-related errors when not targeting correct architecture
     sys.stderr.add_filter("Trying to use tma without CUTE_ARCH_TMA")
-    # torchao logs a cosmetic WARNING on torch < 2.11 (torchao/__init__.py:
-    # `logger.warning("Skipping import of cpp extensions due to incompatible
-    # torch version. Please upgrade to torch >= 2.11.0 (found ...).")`). The
-    # bnb-4bit / Unsloth paths do not use torchao's cpp kernels, so drop only
-    # this record and keep every other torchao log instead of raising the whole
-    # logger to ERROR.
+    # torchao logs a cosmetic "Skipping import of cpp extensions" WARNING on torch < 2.11. The
+    # bnb-4bit / Unsloth paths don't use torchao's cpp kernels, so drop only that record rather
+    # than raising the whole torchao logger to ERROR.
     logging.getLogger("torchao").addFilter(
         HideLoggingMessage("Skipping import of cpp extensions due to incompatible torch version")
     )


### PR DESCRIPTION
On torch < 2.11, importing torchao prints a cosmetic WARNING:

```
Skipping import of cpp extensions due to incompatible torch version. Please upgrade to torch >= 2.11.0 (found 2.9.1+cu128).
```

It is emitted from `torchao/__init__.py` via `logging.getLogger("torchao").warning(...)`. The bnb-4bit and Unsloth paths do not use torchao's cpp kernels, so this is just log noise.

The quiet block in `unsloth/import_fixes.py` already targeted this message, but did so with:

```python
logging.getLogger("torchao").setLevel(logging.ERROR)
sys.stderr.add_filter("Skipping import of cpp extensions")
```

`setLevel(logging.ERROR)` is a blanket suppressor: it also hides any genuine torchao WARNING (for example a real kernel-load failure), and the stderr substring filter is a redundant second channel that would also match the unrelated `TORCHAO_FORCE_SKIP_LOADING_SO_FILES` message.

This swaps both for a single `HideLoggingMessage` logging filter (the same helper already used for the `HF_TOKEN` message) scoped to the torchao logger, dropping only this one record while every other torchao log passes through.

### Verified

- torch 2.9.1 + torchao 0.17.0: message gone; torchao still imports and works; an unrelated torchao warning still appears.
- torch >= 2.11: no-op (torchao never emits the message).
- torchao not installed: no-op (filter registered on an unused logger; nothing imported).
- Idempotent and platform independent (pure `logging`).