### PR TITLE
Reset torch.compile cache poisoned by a stray forward before trainer.train()

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -62,6 +62,7 @@ __all__ = [
     "patch_unsloth_smart_gradient_checkpointing",
     "unpatch_unsloth_smart_gradient_checkpointing",
     "apply_unsloth_gradient_checkpointing",
+    "_unsloth_install_pretrain_detector",
     "patch_compiled_autograd",
     "process_vision_info",
     "unsloth_compile_transformers",
@@ -192,6 +193,33 @@ def resolve_hip_gpu_stats_name(gpu_stats):
 from unsloth_zoo.temporary_patches import (
     TEMPORARY_PATCHES,
 )
+
+
+def _unsloth_install_pretrain_detector(model):
+    """Attach a one-shot forward pre-hook that records whether a forward ran
+    before trainer.train(). Used by prepare_for_training_mode to drop a
+    torch.compile graph cache poisoned by a stray manual forward/backward.
+    Idempotent and a no-op if the model cannot take hooks."""
+    if model is None or not hasattr(model, "register_forward_pre_hook"):
+        return model
+    marker = getattr(model, "_unsloth_pretrain_marker", None)
+    if isinstance(marker, dict):
+        marker["seen"] = False
+        return model
+    marker = {"seen": False}
+    try:
+        model._unsloth_pretrain_marker = marker
+    except Exception:
+        return model
+
+    def _mark(_module, _inp):
+        marker["seen"] = True
+
+    try:
+        marker["hook"] = model.register_forward_pre_hook(_mark)
+    except Exception:
+        pass
+    return model
 
 
 def apply_unsloth_gradient_checkpointing(use_gradient_checkpointing, max_seq_length, dtype):

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -205,15 +205,25 @@ def _unsloth_install_pretrain_detector(model):
     marker = getattr(model, "_unsloth_pretrain_marker", None)
     if isinstance(marker, dict):
         marker["seen"] = False
-        return model
-    marker = {"seen": False}
-    try:
-        model._unsloth_pretrain_marker = marker
-    except Exception:
-        return model
+        # Re-register only if the previous hook was torn down (e.g. by an earlier
+        # train()); if the hook is still live this is a strict no-op so we never
+        # stack duplicate hooks.
+        if "hook" in marker:
+            return model
+    else:
+        marker = {"seen": False}
+        try:
+            model._unsloth_pretrain_marker = marker
+        except Exception:
+            return model
 
     def _mark(_module, _inp):
-        marker["seen"] = True
+        # Only a GRAD-ENABLED forward can poison the AOTAutograd/torch.compile
+        # backward-graph cache. A no-grad probe (`with torch.no_grad(): model(...)`,
+        # the sanity check the warning recommends) builds no backward graph, so
+        # treat it as clean and avoid a needless dynamo reset + recompile + warning.
+        if torch.is_grad_enabled():
+            marker["seen"] = True
 
     try:
         marker["hook"] = model.register_forward_pre_hook(_mark)

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -196,18 +196,15 @@ from unsloth_zoo.temporary_patches import (
 
 
 def _unsloth_install_pretrain_detector(model):
-    """Attach a one-shot forward pre-hook that records whether a forward ran
-    before trainer.train(). Used by prepare_for_training_mode to drop a
-    torch.compile graph cache poisoned by a stray manual forward/backward.
-    Idempotent and a no-op if the model cannot take hooks."""
+    """Attach a one-shot forward pre-hook recording whether a forward ran before
+    trainer.train(), so prepare_for_training_mode can drop a torch.compile graph cache poisoned
+    by a stray manual forward/backward. Idempotent; no-op if the model cannot take hooks."""
     if model is None or not hasattr(model, "register_forward_pre_hook"):
         return model
     marker = getattr(model, "_unsloth_pretrain_marker", None)
     if isinstance(marker, dict):
         marker["seen"] = False
-        # Re-register only if the previous hook was torn down (e.g. by an earlier
-        # train()); if the hook is still live this is a strict no-op so we never
-        # stack duplicate hooks.
+        # Re-register only if the previous hook was torn down; a live hook stays (no duplicates).
         if "hook" in marker:
             return model
     else:
@@ -218,10 +215,8 @@ def _unsloth_install_pretrain_detector(model):
             return model
 
     def _mark(_module, _inp):
-        # Only a GRAD-ENABLED forward can poison the AOTAutograd/torch.compile
-        # backward-graph cache. A no-grad probe (`with torch.no_grad(): model(...)`,
-        # the sanity check the warning recommends) builds no backward graph, so
-        # treat it as clean and avoid a needless dynamo reset + recompile + warning.
+        # Only a grad-enabled forward poisons the AOTAutograd backward-graph cache; a no-grad
+        # probe builds no backward graph, so treat it as clean (avoids a needless dynamo reset).
         if torch.is_grad_enabled():
             marker["seen"] = True
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -239,6 +239,7 @@ def _unsloth_reset_stray_compile_cache(self):
     # Module-level (not just inside the RL trainer template) so the SFT auto-packing wrapper and
     # the plain-Trainer loop can import and run it too.
     import os
+
     model = getattr(self, "model", None)
     if model is None:
         return
@@ -270,7 +271,9 @@ def _unsloth_reset_stray_compile_cache(self):
         except Exception:
             pass
         try:
-            from unsloth_zoo.gradient_checkpointing import reset_unsloth_gradient_checkpointing_buffers
+            from unsloth_zoo.gradient_checkpointing import (
+                reset_unsloth_gradient_checkpointing_buffers,
+            )
             reset_unsloth_gradient_checkpointing_buffers()
         except Exception:
             pass
@@ -279,6 +282,7 @@ def _unsloth_reset_stray_compile_cache(self):
         except Exception:
             pass
         import warnings
+
         warnings.warn(
             "Unsloth: detected a manual forward/backward run before trainer.train(); "
             "reset the torch.compile graph cache it poisoned so training starts clean. "
@@ -288,8 +292,10 @@ def _unsloth_reset_stray_compile_cache(self):
     for _m in markers:
         hook = _m.pop("hook", None)
         if hook is not None:
-            try: hook.remove()
-            except Exception: pass
+            try:
+                hook.remove()
+            except Exception:
+                pass
         _m["seen"] = False
 
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -203,10 +203,13 @@ def _unsloth_install_pretrain_detector(model):
         return model
     marker = getattr(model, "_unsloth_pretrain_marker", None)
     if isinstance(marker, dict):
-        marker["seen"] = False
-        # Re-register only if the previous hook was torn down; a live hook stays (no duplicates).
+        # A live hook is already recording: keep it (no duplicates) and DON'T clear seen -- a
+        # grad-enabled probe may have already flagged the poisoned cache, and a re-entrant
+        # get_peft_model/patch_peft_model call must not erase that before train() resets.
         if "hook" in marker:
             return model
+        # Marker exists but its hook was torn down -> reinstall fresh, so reset seen.
+        marker["seen"] = False
     else:
         marker = {"seen": False}
         try:

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -63,6 +63,7 @@ __all__ = [
     "unpatch_unsloth_smart_gradient_checkpointing",
     "apply_unsloth_gradient_checkpointing",
     "_unsloth_install_pretrain_detector",
+    "_unsloth_reset_stray_compile_cache",
     "patch_compiled_autograd",
     "process_vision_info",
     "unsloth_compile_transformers",
@@ -228,6 +229,68 @@ def _unsloth_install_pretrain_detector(model):
     except Exception:
         pass
     return model
+
+
+def _unsloth_reset_stray_compile_cache(self):
+    # A manual forward/backward under torch.compile BEFORE trainer.train() (e.g. a grad-norm
+    # probe) caches a forward + AOTAutograd backward graph in a one-off context; reusing it
+    # poisons training with NaN/zero gradients. If such a forward was seen and compile is on,
+    # drop the compiled-graph cache so training recompiles cleanly. No-op on the normal path.
+    # Module-level (not just inside the RL trainer template) so the SFT auto-packing wrapper and
+    # the plain-Trainer loop can import and run it too.
+    import os
+    model = getattr(self, "model", None)
+    if model is None:
+        return
+    # The detector hook can sit on any wrapper in the chain, and the probe may have run on a
+    # different one than self.model, so walk the chain: detect a "seen" marker anywhere and
+    # collect every marker to tear down below.
+    markers = []
+    seen = False
+    _curr = model
+    _visited = set()
+    while _curr is not None and id(_curr) not in _visited:
+        _visited.add(id(_curr))
+        _m = getattr(_curr, "_unsloth_pretrain_marker", None)
+        if isinstance(_m, dict):
+            markers.append(_m)
+            if _m.get("seen"):
+                seen = True
+        # Follow the wrapper chain: Unsloth/HF (.model), PEFT (.base_model), DDP/FSDP (.module).
+        _nxt = getattr(_curr, "model", None)
+        if _nxt is None:
+            _nxt = getattr(_curr, "base_model", None)
+        if _nxt is None:
+            _nxt = getattr(_curr, "module", None)
+        _curr = _nxt
+    if seen and os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") != "1":
+        try:
+            import torch._dynamo as _dynamo
+            _dynamo.reset()
+        except Exception:
+            pass
+        try:
+            from unsloth_zoo.gradient_checkpointing import reset_unsloth_gradient_checkpointing_buffers
+            reset_unsloth_gradient_checkpointing_buffers()
+        except Exception:
+            pass
+        try:
+            model.zero_grad(set_to_none = True)
+        except Exception:
+            pass
+        import warnings
+        warnings.warn(
+            "Unsloth: detected a manual forward/backward run before trainer.train(); "
+            "reset the torch.compile graph cache it poisoned so training starts clean. "
+            "To avoid this, run any pre-train probe under `with torch.no_grad():`."
+        )
+    # Tear down every one-shot detector hook in the chain so none adds per-step cost.
+    for _m in markers:
+        hook = _m.pop("hook", None)
+        if hook is not None:
+            try: hook.remove()
+            except Exception: pass
+        _m["seen"] = False
 
 
 def apply_unsloth_gradient_checkpointing(use_gradient_checkpointing, max_seq_length, dtype):

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3368,6 +3368,9 @@ class FastLlamaModel:
             m.for_training = functools.partial(FastBaseModel.for_training, m)
             m.for_inference = functools.partial(FastBaseModel.for_inference, m)
             m = m.model
+        # Detect a stray pre-train forward so train() can drop the torch.compile
+        # graph cache it would otherwise poison (see prepare_for_training_mode).
+        _unsloth_install_pretrain_detector(model)
         return model
 
     @staticmethod
@@ -3585,6 +3588,9 @@ class FastLlamaModel:
             m.for_training = functools.partial(FastBaseModel.for_training, m)
             m.for_inference = functools.partial(FastBaseModel.for_inference, m)
             m = m.model
+        # Detect a stray pre-train forward so train() can drop the torch.compile
+        # graph cache it would otherwise poison (see prepare_for_training_mode).
+        _unsloth_install_pretrain_detector(model)
         return model
 
     @staticmethod

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2765,7 +2765,7 @@ class FastLlamaModel:
             "self.accelerator.free_memory()",
             "self.accelerator.free_memory()\n"
             "    try:\n"
-            "        from unsloth.models.rl import _unsloth_reset_stray_compile_cache as _unsloth_reset_cc\n"
+            "        from unsloth.models._utils import _unsloth_reset_stray_compile_cache as _unsloth_reset_cc\n"
             "        _unsloth_reset_cc(self)\n"
             "    except Exception: pass",
             1,

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2756,6 +2756,20 @@ class FastLlamaModel:
             "is_torch_tpu_available()",
             "False",
         )
+        # Wire the stray-forward compile-cache reset into the plain Trainer path: get_peft_model
+        # arms the pre-train detector for every LoRA model, but only the TRL SFT/RL wrappers run
+        # the reset. A grad-enabled probe before a bare transformers.Trainer.train() would
+        # otherwise keep the poisoned Dynamo cache and leave the detector hook installed. Anchored
+        # on the first body statement; a no-op (and harmless) if upstream drops that line.
+        inner_training_loop = inner_training_loop.replace(
+            "self.accelerator.free_memory()",
+            "self.accelerator.free_memory()\n"
+            "    try:\n"
+            "        from unsloth.models.rl import _unsloth_reset_stray_compile_cache as _unsloth_reset_cc\n"
+            "        _unsloth_reset_cc(self)\n"
+            "    except Exception: pass",
+            1,
+        )
         exec(inner_training_loop, globals())
         Trainer._inner_training_loop = _fast_inner_training_loop
 

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3019,6 +3019,9 @@ class FastLlamaModel:
                         model.get_output_embeddings(), DEVICE_TYPE_TORCH
                     )
 
+                # Pre-wrapped PEFT model passes through here; still arm the detector so an RL
+                # trainer can reset a compile cache poisoned by a pre-train forward.
+                _unsloth_install_pretrain_detector(model)
                 return model
             else:
                 raise TypeError(

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2938,6 +2938,9 @@ class FastLlamaModel:
             )
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
             print("Unsloth: Full finetuning is enabled, so .get_peft_model has no effect")
+            # Full finetuning still compiles, so a stray pre-train forward can poison the
+            # cache; install the detector here too (it is idempotent).
+            _unsloth_install_pretrain_detector(model)
             return model
         transformers_set_seed(random_state)
 

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -402,8 +402,25 @@ def _unsloth_reset_stray_compile_cache(self):
     model = getattr(self, "model", None)
     if model is None:
         return
-    marker = getattr(model, "_unsloth_pretrain_marker", None)
-    seen = bool(marker.get("seen")) if isinstance(marker, dict) else False
+    # The detector hook may sit on any wrapper in the chain (PeftModel / DDP /
+    # the base model), and a pre-train probe could have run on a different
+    # wrapper than self.model. Walk the chain so a "seen" marker anywhere is
+    # detected, and collect every marker so all hooks are torn down below.
+    markers = []
+    seen = False
+    _curr = model
+    _visited = set()
+    while _curr is not None and id(_curr) not in _visited:
+        _visited.add(id(_curr))
+        _m = getattr(_curr, "_unsloth_pretrain_marker", None)
+        if isinstance(_m, dict):
+            markers.append(_m)
+            if _m.get("seen"):
+                seen = True
+        _nxt = getattr(_curr, "model", None)
+        if _nxt is None:
+            _nxt = getattr(_curr, "base_model", None)
+        _curr = _nxt
     if seen and os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") != "1":
         try:
             import torch._dynamo as _dynamo
@@ -424,13 +441,13 @@ def _unsloth_reset_stray_compile_cache(self):
             "reset the torch.compile graph cache it poisoned so training starts clean. "
             "To avoid this, run any pre-train probe under `with torch.no_grad():`."
         )
-    # Tear down the one-shot detector hook so it never adds per-step cost.
-    if isinstance(marker, dict):
-        hook = marker.pop("hook", None)
+    # Tear down every one-shot detector hook in the chain so none adds per-step cost.
+    for _m in markers:
+        hook = _m.pop("hook", None)
         if hook is not None:
             try: hook.remove()
             except Exception: pass
-        marker["seen"] = False
+        _m["seen"] = False
 def prepare_for_training_mode(f):
     @functools.wraps(f)
     def wrapper(self, *args, **kwargs):

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -390,63 +390,12 @@ try:
     from unsloth_zoo.gradient_checkpointing import reset_unsloth_gradient_checkpointing_buffers
 except:
     def reset_unsloth_gradient_checkpointing_buffers(): pass
-def _unsloth_reset_stray_compile_cache(self):
-    # A manual forward/backward under torch.compile BEFORE trainer.train() (e.g. a grad-norm
-    # probe) caches a forward + AOTAutograd backward graph in a one-off context; reusing it
-    # poisons training with NaN/zero gradients. If such a forward was seen and compile is on,
-    # drop the compiled-graph cache so training recompiles cleanly. No-op on the normal path.
-    import os
-    model = getattr(self, "model", None)
-    if model is None:
-        return
-    # The detector hook can sit on any wrapper in the chain, and the probe may have run on a
-    # different one than self.model, so walk the chain: detect a "seen" marker anywhere and
-    # collect every marker to tear down below.
-    markers = []
-    seen = False
-    _curr = model
-    _visited = set()
-    while _curr is not None and id(_curr) not in _visited:
-        _visited.add(id(_curr))
-        _m = getattr(_curr, "_unsloth_pretrain_marker", None)
-        if isinstance(_m, dict):
-            markers.append(_m)
-            if _m.get("seen"):
-                seen = True
-        # Follow the wrapper chain: Unsloth/HF (.model), PEFT (.base_model), DDP/FSDP (.module).
-        _nxt = getattr(_curr, "model", None)
-        if _nxt is None:
-            _nxt = getattr(_curr, "base_model", None)
-        if _nxt is None:
-            _nxt = getattr(_curr, "module", None)
-        _curr = _nxt
-    if seen and os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") != "1":
-        try:
-            import torch._dynamo as _dynamo
-            _dynamo.reset()
-        except Exception:
-            pass
-        try:
-            reset_unsloth_gradient_checkpointing_buffers()
-        except Exception:
-            pass
-        try:
-            model.zero_grad(set_to_none = True)
-        except Exception:
-            pass
-        import warnings
-        warnings.warn(
-            "Unsloth: detected a manual forward/backward run before trainer.train(); "
-            "reset the torch.compile graph cache it poisoned so training starts clean. "
-            "To avoid this, run any pre-train probe under `with torch.no_grad():`."
-        )
-    # Tear down every one-shot detector hook in the chain so none adds per-step cost.
-    for _m in markers:
-        hook = _m.pop("hook", None)
-        if hook is not None:
-            try: hook.remove()
-            except Exception: pass
-        _m["seen"] = False
+# Canonical reset lives in unsloth.models._utils so the SFT auto-packing wrapper and the plain
+# Trainer loop can import the same helper; fall back to a no-op only if it can't be imported.
+try:
+    from unsloth.models._utils import _unsloth_reset_stray_compile_cache
+except Exception:
+    def _unsloth_reset_stray_compile_cache(self): pass
 def prepare_for_training_mode(f):
     @functools.wraps(f)
     def wrapper(self, *args, **kwargs):

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -391,21 +391,17 @@ try:
 except:
     def reset_unsloth_gradient_checkpointing_buffers(): pass
 def _unsloth_reset_stray_compile_cache(self):
-    # A manual forward / forward+backward run under torch.compile BEFORE
-    # trainer.train() (e.g. a pre-train grad-norm probe) compiles and caches the
-    # model's forward and (via AOTAutograd) its backward graph in a one-off
-    # context that does not match the training loop. Reusing that cached graph
-    # poisons training with NaN/zero gradients (loss never moves). If a pre-train
-    # forward was seen and torch.compile is enabled, drop the compiled-graph cache
-    # so training recompiles cleanly. No-op on the normal path.
+    # A manual forward/backward under torch.compile BEFORE trainer.train() (e.g. a grad-norm
+    # probe) caches a forward + AOTAutograd backward graph in a one-off context; reusing it
+    # poisons training with NaN/zero gradients. If such a forward was seen and compile is on,
+    # drop the compiled-graph cache so training recompiles cleanly. No-op on the normal path.
     import os
     model = getattr(self, "model", None)
     if model is None:
         return
-    # The detector hook may sit on any wrapper in the chain (PeftModel / DDP /
-    # the base model), and a pre-train probe could have run on a different
-    # wrapper than self.model. Walk the chain so a "seen" marker anywhere is
-    # detected, and collect every marker so all hooks are torn down below.
+    # The detector hook can sit on any wrapper in the chain, and the probe may have run on a
+    # different one than self.model, so walk the chain: detect a "seen" marker anywhere and
+    # collect every marker to tear down below.
     markers = []
     seen = False
     _curr = model
@@ -417,9 +413,7 @@ def _unsloth_reset_stray_compile_cache(self):
             markers.append(_m)
             if _m.get("seen"):
                 seen = True
-        # Follow the wrapper chain: Unsloth/HF (.model), PEFT (.base_model) and
-        # DDP / FSDP (.module). A pre-train probe can fire on the model below a
-        # DDP wrapper, so .module must be walked too or the marker is missed.
+        # Follow the wrapper chain: Unsloth/HF (.model), PEFT (.base_model), DDP/FSDP (.module).
         _nxt = getattr(_curr, "model", None)
         if _nxt is None:
             _nxt = getattr(_curr, "base_model", None)

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -417,9 +417,14 @@ def _unsloth_reset_stray_compile_cache(self):
             markers.append(_m)
             if _m.get("seen"):
                 seen = True
+        # Follow the wrapper chain: Unsloth/HF (.model), PEFT (.base_model) and
+        # DDP / FSDP (.module). A pre-train probe can fire on the model below a
+        # DDP wrapper, so .module must be walked too or the marker is missed.
         _nxt = getattr(_curr, "model", None)
         if _nxt is None:
             _nxt = getattr(_curr, "base_model", None)
+        if _nxt is None:
+            _nxt = getattr(_curr, "module", None)
         _curr = _nxt
     if seen and os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") != "1":
         try:

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -390,9 +390,55 @@ try:
     from unsloth_zoo.gradient_checkpointing import reset_unsloth_gradient_checkpointing_buffers
 except:
     def reset_unsloth_gradient_checkpointing_buffers(): pass
+def _unsloth_reset_stray_compile_cache(self):
+    # A manual forward / forward+backward run under torch.compile BEFORE
+    # trainer.train() (e.g. a pre-train grad-norm probe) compiles and caches the
+    # model's forward and (via AOTAutograd) its backward graph in a one-off
+    # context that does not match the training loop. Reusing that cached graph
+    # poisons training with NaN/zero gradients (loss never moves). If a pre-train
+    # forward was seen and torch.compile is enabled, drop the compiled-graph cache
+    # so training recompiles cleanly. No-op on the normal path.
+    import os
+    model = getattr(self, "model", None)
+    if model is None:
+        return
+    marker = getattr(model, "_unsloth_pretrain_marker", None)
+    seen = bool(marker.get("seen")) if isinstance(marker, dict) else False
+    if seen and os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") != "1":
+        try:
+            import torch._dynamo as _dynamo
+            _dynamo.reset()
+        except Exception:
+            pass
+        try:
+            reset_unsloth_gradient_checkpointing_buffers()
+        except Exception:
+            pass
+        try:
+            model.zero_grad(set_to_none = True)
+        except Exception:
+            pass
+        import warnings
+        warnings.warn(
+            "Unsloth: detected a manual forward/backward run before trainer.train(); "
+            "reset the torch.compile graph cache it poisoned so training starts clean. "
+            "To avoid this, run any pre-train probe under `with torch.no_grad():`."
+        )
+    # Tear down the one-shot detector hook so it never adds per-step cost.
+    if isinstance(marker, dict):
+        hook = marker.pop("hook", None)
+        if hook is not None:
+            try: hook.remove()
+            except Exception: pass
+        marker["seen"] = False
 def prepare_for_training_mode(f):
     @functools.wraps(f)
     def wrapper(self, *args, **kwargs):
+        # Drop any torch.compile graph cache poisoned by a stray pre-train forward.
+        try:
+            _unsloth_reset_stray_compile_cache(self)
+        except Exception:
+            pass
         # Finish the previous W&B run if this is a subsequent train() call.
         # We do this at the START of train() (not the end) so that
         # evaluate() / log() still work after train() completes.

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1577,6 +1577,9 @@ class FastBaseModel:
             m.for_training = functools.partial(FastBaseModel.for_training, m)
             m.for_inference = functools.partial(FastBaseModel.for_inference, m)
             m = m.model
+        # Detect a stray pre-train forward so train() can drop the torch.compile
+        # graph cache it would otherwise poison (see prepare_for_training_mode).
+        _unsloth_install_pretrain_detector(model)
         return model
 
     @staticmethod

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1380,6 +1380,9 @@ class FastBaseModel:
     ):
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
             print("Unsloth: Full finetuning is enabled, so .get_peft_model has no effect")
+            # Full finetuning still compiles, so a stray pre-train forward can poison the
+            # cache; install the detector here too (it is idempotent).
+            _unsloth_install_pretrain_detector(model)
             return model
         transformers_set_seed(random_state)
 

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -604,7 +604,9 @@ def _patch_sft_trainer_auto_packing(trl_module):
         if not getattr(self, "_unsloth_train_reset_wrapped", False):
             try:
                 from unsloth.models.rl import _unsloth_reset_stray_compile_cache
+
                 _orig_train = self.train
+
                 @wraps(_orig_train)
                 def _train_with_reset(*train_args, **train_kwargs):
                     try:
@@ -612,6 +614,7 @@ def _patch_sft_trainer_auto_packing(trl_module):
                     except Exception:
                         pass
                     return _orig_train(*train_args, **train_kwargs)
+
                 self.train = _train_with_reset
                 self._unsloth_train_reset_wrapped = True
             except Exception:

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -596,6 +596,27 @@ def _patch_sft_trainer_auto_packing(trl_module):
             )
             print(message)
 
+        # get_peft_model installs a pre-train forward detector for plain LoRA/vision models,
+        # but only RL trainers run the reset via prepare_for_training_mode. Wire it into the
+        # SFT train() path too, else a grad-enabled probe before train() leaves the poisoned
+        # Dynamo cache in place and the detector hook installed on every training forward.
+        # (For UnslothSFTTrainer the later prepare_for_training_mode assignment supersedes this.)
+        if not getattr(self, "_unsloth_train_reset_wrapped", False):
+            try:
+                from unsloth.models.rl import _unsloth_reset_stray_compile_cache
+                _orig_train = self.train
+                @wraps(_orig_train)
+                def _train_with_reset(*train_args, **train_kwargs):
+                    try:
+                        _unsloth_reset_stray_compile_cache(self)
+                    except Exception:
+                        pass
+                    return _orig_train(*train_args, **train_kwargs)
+                self.train = _train_with_reset
+                self._unsloth_train_reset_wrapped = True
+            except Exception:
+                pass
+
     sft_trainer.__init__ = new_init
     sft_trainer._unsloth_auto_packing_wrapped = True
 

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -603,7 +603,7 @@ def _patch_sft_trainer_auto_packing(trl_module):
         # (For UnslothSFTTrainer the later prepare_for_training_mode assignment supersedes this.)
         if not getattr(self, "_unsloth_train_reset_wrapped", False):
             try:
-                from unsloth.models.rl import _unsloth_reset_stray_compile_cache
+                from unsloth.models._utils import _unsloth_reset_stray_compile_cache
 
                 _orig_train = self.train
 


### PR DESCRIPTION
A manual forward / forward+backward run under `model.train()` BEFORE `trainer.train()` (for example a pre-train grad-norm probe like `out = model(**batch); out.loss.backward()`) silently poisons training when torch.compile is enabled.

## Symptom

Loss stays flat and `grad_norm` is `NaN`/`Inf` from the first step, so the model never learns even though the run completes normally.

Observed on `unsloth/gpt-oss-20b-BF16`: loss frozen at ~4.25 with `grad_norm` `NaN` from step 1, with both `use_gradient_checkpointing="unsloth"` and `=True`.

## Root cause

The stray training-mode pass is the first one in the process, so torch.compile / `torch._dynamo` compiles and caches the model forward and, via AOTAutograd, its backward graph for the first time, in a one-off context that does not match the real training loop. When `trainer.train()` reuses that cached compiled graph the gradients come out `NaN`/`Inf`.

Evidence that pins it to the compile cache (single B200, transformers 4.57.6, TRL 0.25.1, torch 2.9.1):

| run | result |
| --- | --- |
| no probe (clean) | learns, loss 4.29 -> 0.0002 |
| probe + backward (current behaviour) | dead, loss frozen ~4.25, grad_norm NaN |
| probe under `UNSLOTH_COMPILE_DISABLE=1` | learns |
| probe + `torch._dynamo.reset()` before train | learns (4.29 -> 0.0002), identical to clean |
| probe + buffer reset / zero_grad / empty_cache / for_training (no dynamo reset) | still NaN |

So a single `torch._dynamo.reset()` before training fully cures it; resetting tensors, grads, or the gradient-checkpointing buffers does not.

## Fix

- `get_peft_model` attaches a one-shot forward pre-hook that records whether a forward ran before `train()` (model agnostic, works for `"unsloth"` and `True` gradient checkpointing).
- `prepare_for_training_mode` checks it at the start of `train()`. If a pre-train forward was seen and torch.compile is enabled, it calls `torch._dynamo.reset()` (plus a pristine gradient-checkpoint reset and `zero_grad`) and warns once, then removes the detection hook.

On the normal path (no pre-train forward) it is a strict no-op: no dynamo reset, no recompilation, and the loss curve is byte-identical to before. Verified that `probe + fix` reproduces the clean curve exactly and that a clean run with the fix installed is unchanged and emits no warning.

## Compatibility

- transformers 4.57.x and 5.x, TRL 0.22.x through 1.x: the change lives in `prepare_for_training_mode` and `get_peft_model`, no transformers/TRL internals touched.
- `torch._dynamo.reset()` is already used in unsloth_zoo (`cross_entropy_loss.py`) and is a no-op when nothing was compiled, so it is safe on eager / MLX / Mac and on NVIDIA / AMD / Intel backends.
- Skips entirely under `UNSLOTH_COMPILE_DISABLE=1`, where the bug cannot occur.