### PR TITLE
(feat) Add a setting to toggle the chat model disclaimer

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -67,6 +67,7 @@ import {
   listPromptEntries,
   type PromptEntry,
 } from "@/features/chat/api/prompts-api";
+import { useChatPreferencesStore } from "@/features/chat/stores/chat-preferences-store";
 import { useChatProjects } from "@/features/chat/hooks/use-chat-projects";
 import { NewProjectDialog } from "@/features/chat/components/new-project-dialog";
 import { parseExternalModelId } from "@/features/chat/external-providers";
@@ -1177,6 +1178,9 @@ const ThreadComposerDock: FC<{
         promptQueueItemMatchesThreadIds(item, promptQueueThreadIds),
       ),
   );
+  const showModelDisclaimer = useChatPreferencesStore(
+    (s) => s.showModelDisclaimer,
+  );
 
   // Report dock height so the viewport reserves matching scroll space when
   // attachments or multiline input grow the composer.
@@ -1220,9 +1224,11 @@ const ThreadComposerDock: FC<{
             menuSide="top"
           />
         </div>
-        <p className="composer-footer-note">
-          LLMs can make mistakes. Double-check responses.
-        </p>
+        {showModelDisclaimer && (
+          <p className="composer-footer-note">
+            LLMs can make mistakes. Double-check responses.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -104,6 +104,7 @@ import {
   loadOptionalBool,
   useChatRuntimeStore,
 } from "./stores/chat-runtime-store";
+import { useChatPreferencesStore } from "./stores/chat-preferences-store";
 import { useExternalProvidersStore } from "./stores/external-providers-store";
 import { buildChatTourSteps } from "./tour";
 import { ArtifactSurface } from "./artifacts/artifact-surface";
@@ -492,6 +493,9 @@ function CompareShell({
   children: ReactElement;
   composer: ReactElement;
 }): ReactElement {
+  const showModelDisclaimer = useChatPreferencesStore(
+    (s) => s.showModelDisclaimer,
+  );
   return (
     <CompareHandlesProvider handlesRef={handlesRef}>
       <div className="flex min-h-0 min-w-0 flex-1 basis-0 flex-col">
@@ -503,9 +507,11 @@ function CompareShell({
         </div>
         <div className="shrink-0 bg-background pl-5 pr-5 md:pr-[30px] pb-2 pt-1">
           <div className="mx-auto w-full max-w-[48rem]">{composer}</div>
-          <p className="composer-footer-note">
-            LLMs can make mistakes. Double-check responses.
-          </p>
+          {showModelDisclaimer && (
+            <p className="composer-footer-note">
+              LLMs can make mistakes. Double-check responses.
+            </p>
+          )}
         </div>
       </div>
     </CompareHandlesProvider>

--- a/studio/frontend/src/features/chat/stores/chat-preferences-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-preferences-store.ts
@@ -6,9 +6,12 @@ import { persist } from "zustand/middleware";
 
 // Client-side chat UI prefs kept in localStorage, not the chat DB.
 // confirmDeleteChats: when off, deleting a chat skips the confirm dialog.
+// showModelDisclaimer: when off, hide the "LLMs can make mistakes" footer note.
 export interface ChatPreferencesState {
   confirmDeleteChats: boolean;
   setConfirmDeleteChats: (value: boolean) => void;
+  showModelDisclaimer: boolean;
+  setShowModelDisclaimer: (value: boolean) => void;
 }
 
 export const useChatPreferencesStore = create<ChatPreferencesState>()(
@@ -17,6 +20,9 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
       confirmDeleteChats: true,
       setConfirmDeleteChats: (confirmDeleteChats) =>
         set({ confirmDeleteChats }),
+      showModelDisclaimer: true,
+      setShowModelDisclaimer: (showModelDisclaimer) =>
+        set({ showModelDisclaimer }),
     }),
     {
       name: "unsloth_chat_preferences",
@@ -25,6 +31,7 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
         return {
           ...current,
           confirmDeleteChats: saved?.confirmDeleteChats ?? true,
+          showModelDisclaimer: saved?.showModelDisclaimer ?? true,
         };
       },
     },

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -316,12 +316,9 @@ export function ChatTab() {
             />
           </SettingsRow>
         ))}
-      </SettingsSection>
-
-      <SettingsSection title={t("settings.chat.composer.title")}>
         <SettingsRow
-          label={t("settings.chat.composer.modelDisclaimer")}
-          description={t("settings.chat.composer.modelDisclaimerDescription")}
+          label={t("settings.chat.modelDisclaimer")}
+          description={t("settings.chat.modelDisclaimerDescription")}
         >
           <Switch
             checked={showModelDisclaimer}

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -187,6 +187,12 @@ export function ChatTab() {
   const setConfirmDeleteChats = useChatPreferencesStore(
     (state) => state.setConfirmDeleteChats,
   );
+  const showModelDisclaimer = useChatPreferencesStore(
+    (state) => state.showModelDisclaimer,
+  );
+  const setShowModelDisclaimer = useChatPreferencesStore(
+    (state) => state.setShowModelDisclaimer,
+  );
 
   useEffect(() => {
     void countAllChats().then(setCount);
@@ -310,6 +316,18 @@ export function ChatTab() {
             />
           </SettingsRow>
         ))}
+      </SettingsSection>
+
+      <SettingsSection title={t("settings.chat.composer.title")}>
+        <SettingsRow
+          label={t("settings.chat.composer.modelDisclaimer")}
+          description={t("settings.chat.composer.modelDisclaimerDescription")}
+        >
+          <Switch
+            checked={showModelDisclaimer}
+            onCheckedChange={setShowModelDisclaimer}
+          />
+        </SettingsRow>
       </SettingsSection>
 
       <SettingsSection title={t("settings.chat.artifacts.title")}>

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -208,12 +208,9 @@ export const en = {
     chat: {
       title: "Chat",
       description: "Manage chat history stored on this device.",
-      composer: {
-        title: "Composer",
-        modelDisclaimer: "Show model disclaimer",
-        modelDisclaimerDescription:
-          'Show the "LLMs can make mistakes" note under the chat box.',
-      },
+      modelDisclaimer: "Show model disclaimer",
+      modelDisclaimerDescription:
+        'Show "LLMs can make mistakes" under the chat box.',
       artifacts: {
         title: "Canvas",
         collapseHtmlBlocks: "Collapse HTML blocks",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -208,6 +208,12 @@ export const en = {
     chat: {
       title: "Chat",
       description: "Manage chat history stored on this device.",
+      composer: {
+        title: "Composer",
+        modelDisclaimer: "Show model disclaimer",
+        modelDisclaimerDescription:
+          'Show the "LLMs can make mistakes" note under the chat box.',
+      },
       artifacts: {
         title: "Canvas",
         collapseHtmlBlocks: "Collapse HTML blocks",


### PR DESCRIPTION
## What this does

Adds a Settings toggle to hide the "LLMs can make mistakes. Double-check responses." note shown under the chat box.

The note is helpful by default, but some users run Studio in trusted or offline setups where it is just noise. This makes it optional without removing it for everyone.

## How it works

- New `showModelDisclaimer` preference in `chat-preferences-store` (localStorage, on by default). It sits next to the existing `confirmDeleteChats` pref and follows the same persist and merge pattern.
- Settings > Chat gets a "Show model disclaimer" row in the Chat menu section.
- Both places that render the note (the main thread composer dock in `assistant-ui/thread.tsx` and the compare view footer in `chat-page.tsx`) now render it only when the pref is on.
- Added the `settings.chat.modelDisclaimer` labels to `en`.

Default behavior is unchanged: the note still shows until a user turns it off.

## Verification

- frontend `typecheck` passes
- frontend `i18n:check` parity passes
