### PR TITLE
Studio: apply an edited chat template on reload

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -546,6 +546,12 @@ export function ChatSettingsPanel({
   const loadedTensorParallel = useChatRuntimeStore(
     (s) => s.loadedTensorParallel,
   );
+  const chatTemplateOverride = useChatRuntimeStore(
+    (s) => s.chatTemplateOverride,
+  );
+  const loadedChatTemplateOverride = useChatRuntimeStore(
+    (s) => s.loadedChatTemplateOverride,
+  );
   const customContextLength = useChatRuntimeStore((s) => s.customContextLength);
   const setCustomContextLength = useChatRuntimeStore(
     (s) => s.setCustomContextLength,
@@ -584,8 +590,11 @@ export function ChatSettingsPanel({
   const specDirty = speculativeType !== loadedSpeculativeType;
   const specDraftDirty = specDraftNMax !== loadedSpecDraftNMax;
   const tpDirty = tensorParallel !== (loadedTensorParallel ?? false);
+  // A saved chat-template override is a reload-time setting too, so surface
+  // Apply for a template-only edit (otherwise it could never be applied).
+  const templateDirty = chatTemplateOverride !== loadedChatTemplateOverride;
   const modelSettingsDirty =
-    kvDirty || ctxDirty || specDirty || specDraftDirty || tpDirty;
+    kvDirty || ctxDirty || specDirty || specDraftDirty || tpDirty || templateDirty;
   const [presetNameInput, setPresetNameInput] = useState(activePreset);
   const [systemPromptEditorOpen, setSystemPromptEditorOpen] = useState(false);
   const [systemPromptDraft, setSystemPromptDraft] = useState("");


### PR DESCRIPTION
Fixes #6477

### Problem

The Chat Template editor lets you edit and save a Jinja template, and the toast says the change applies on the next model reload. But a template-only edit had no way to trigger that reload: the Apply button is gated on `modelSettingsDirty`, which only tracked KV cache, context length, speculative decoding, and tensor parallel, not the chat template override. So the saved override was never sent, and re-selecting the model from the sidebar staged it (resetting the override back to the loaded value), which is why it looked like the original template from the GGUF was restored.

### Fix

Include the chat template override in the dirty check so a template-only edit surfaces the Apply button. Apply already calls the reload path (`Reloading with updated chat template.`), which reads `chatTemplateOverride` from the store and sends it through to llama-server via `--chat-template-file`, so no other wiring was needed.

### Notes

Frontend-only change in `studio/frontend/src/features/chat/chat-settings-sheet.tsx`. The backend already applied the override correctly once a reload is triggered. Typecheck passes.