### PR TITLE
studio: persist personalization (profile, avatar, theme) server-side

### DIFF
--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -132,7 +132,7 @@ def _is_bundled_avatar_url(value: str) -> bool:
     marker = "Sloth emojis/"
     if marker not in path:
         return False
-    return path[path.index(marker):].lower().endswith(".png")
+    return path[path.index(marker) :].lower().endswith(".png")
 
 
 class PersonalizationProfile(BaseModel):

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -1,12 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+from typing import Literal, Optional
+
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from auth.authentication import get_current_subject
 from loggers import get_logger
 from utils.utils import safe_error_detail, log_and_http_error
+from utils.personalization_settings import (
+    MAX_AVATAR_DATA_URL_BYTES,
+    PERSONALIZATION_VERSION,
+    get_personalization,
+    set_personalization,
+)
 from utils.upload_limits import (
     MAX_UPLOAD_LIMIT_MB,
     MIN_UPLOAD_LIMIT_MB,
@@ -111,3 +119,80 @@ def update_helper_precache(
             log = logger,
         ) from exc
     return _helper_precache_response(enabled)
+
+
+# --- Personalization (profile + appearance), persisted server-side ----------
+# Field names are camelCase to match the frontend stores 1:1; extra keys are
+# ignored so the client can add prefs without a backend change.
+
+
+class PersonalizationProfile(BaseModel):
+    model_config = ConfigDict(extra = "ignore")
+
+    displayName: str = Field("", max_length = 200)
+    nickname: str = Field("", max_length = 200)
+    avatarDataUrl: Optional[str] = Field(None)
+    avatarShape: Literal["circle", "rounded"] = "circle"
+
+    @field_validator("avatarDataUrl")
+    @classmethod
+    def _validate_avatar(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return value
+        if not value.startswith("data:image/"):
+            raise ValueError("avatarDataUrl must be an image data URL.")
+        if len(value) > MAX_AVATAR_DATA_URL_BYTES:
+            raise ValueError("Avatar image is too large.")
+        return value
+
+
+class PersonalizationAppearance(BaseModel):
+    model_config = ConfigDict(extra = "ignore")
+
+    theme: Literal["light", "dark", "system"] = "system"
+    language: Optional[str] = Field(None, max_length = 20)
+
+
+class PersonalizationPayload(BaseModel):
+    model_config = ConfigDict(extra = "ignore")
+
+    version: int = PERSONALIZATION_VERSION
+    profile: PersonalizationProfile = Field(default_factory = PersonalizationProfile)
+    appearance: PersonalizationAppearance = Field(default_factory = PersonalizationAppearance)
+
+
+class PersonalizationResponse(PersonalizationPayload):
+    # Whether a blob was ever saved. The client uses this to decide between
+    # hydrating from the server and migrating existing local settings up, so a
+    # never-saved account does not overwrite the browser's values with defaults.
+    saved: bool = False
+
+
+@router.get("/personalization", response_model = PersonalizationResponse)
+def get_personalization_settings(
+    current_subject: str = Depends(get_current_subject),
+) -> PersonalizationResponse:
+    # Normalize the stored blob through the model so the client always gets a
+    # complete, validated shape (defaults fill any missing fields).
+    stored = get_personalization()
+    response = PersonalizationResponse.model_validate(stored or {})
+    response.saved = bool(stored)
+    return response
+
+
+@router.put("/personalization", response_model = PersonalizationPayload)
+def update_personalization_settings(
+    payload: PersonalizationPayload,
+    current_subject: str = Depends(get_current_subject),
+) -> PersonalizationPayload:
+    try:
+        set_personalization(payload.model_dump())
+    except ValueError as exc:
+        raise log_and_http_error(
+            exc,
+            400,
+            safe_error_detail(exc, fallback = "Invalid personalization settings."),
+            event = "settings.update_personalization_failed",
+            log = logger,
+        ) from exc
+    return payload

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -2,6 +2,7 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 from typing import Literal, Optional
+from urllib.parse import unquote, urlsplit
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -121,9 +122,17 @@ def update_helper_precache(
     return _helper_precache_response(enabled)
 
 
-# --- Personalization (profile + appearance), persisted server-side ----------
-# Field names are camelCase to match the frontend stores 1:1; extra keys are
-# ignored so the client can add prefs without a backend change.
+def _is_bundled_avatar_url(value: str) -> bool:
+    parsed = urlsplit(value)
+    if parsed.scheme or parsed.netloc:
+        return False
+    path = unquote(parsed.path).lstrip("/")
+    if ".." in path.split("/"):
+        return False
+    marker = "Sloth emojis/"
+    if marker not in path:
+        return False
+    return path[path.index(marker):].lower().endswith(".png")
 
 
 class PersonalizationProfile(BaseModel):
@@ -131,7 +140,7 @@ class PersonalizationProfile(BaseModel):
 
     displayName: str = Field("", max_length = 200)
     nickname: str = Field("", max_length = 200)
-    avatarDataUrl: Optional[str] = Field(None)
+    avatarDataUrl: Optional[str] = Field(None, max_length = MAX_AVATAR_DATA_URL_BYTES)
     avatarShape: Literal["circle", "rounded"] = "circle"
 
     @field_validator("avatarDataUrl")
@@ -139,10 +148,8 @@ class PersonalizationProfile(BaseModel):
     def _validate_avatar(cls, value: Optional[str]) -> Optional[str]:
         if not value:
             return value
-        if not value.startswith("data:image/"):
-            raise ValueError("avatarDataUrl must be an image data URL.")
-        if len(value) > MAX_AVATAR_DATA_URL_BYTES:
-            raise ValueError("Avatar image is too large.")
+        if not value.startswith("data:image/") and not _is_bundled_avatar_url(value):
+            raise ValueError("avatarDataUrl must be an image data URL or bundled avatar.")
         return value
 
 
@@ -162,9 +169,6 @@ class PersonalizationPayload(BaseModel):
 
 
 class PersonalizationResponse(PersonalizationPayload):
-    # Whether a blob was ever saved. The client uses this to decide between
-    # hydrating from the server and migrating existing local settings up, so a
-    # never-saved account does not overwrite the browser's values with defaults.
     saved: bool = False
 
 
@@ -172,8 +176,6 @@ class PersonalizationResponse(PersonalizationPayload):
 def get_personalization_settings(
     current_subject: str = Depends(get_current_subject),
 ) -> PersonalizationResponse:
-    # Normalize the stored blob through the model so the client always gets a
-    # complete, validated shape (defaults fill any missing fields).
     stored = get_personalization()
     response = PersonalizationResponse.model_validate(stored or {})
     response.saved = bool(stored)

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -182,8 +182,7 @@ def get_personalization_settings(
 
 @router.put("/personalization", response_model = PersonalizationPayload)
 def update_personalization_settings(
-    payload: PersonalizationPayload,
-    current_subject: str = Depends(get_current_subject),
+    payload: PersonalizationPayload, current_subject: str = Depends(get_current_subject)
 ) -> PersonalizationPayload:
     try:
         set_personalization(payload.model_dump())

--- a/studio/backend/tests/test_personalization_settings.py
+++ b/studio/backend/tests/test_personalization_settings.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Server-side personalization validation + persistence roundtrip."""
-
 import sys
 from pathlib import Path
 
@@ -60,6 +58,37 @@ def test_valid_avatar_and_shape():
         }
     )
     assert p.profile.avatarShape == "rounded"
+
+
+def test_bundled_avatar_url_allowed():
+    p = PersonalizationPayload.model_validate(
+        {"profile": {"avatarDataUrl": "/Sloth%20emojis/large%20sloth%20yay.png"}}
+    )
+    assert p.profile.avatarDataUrl == "/Sloth%20emojis/large%20sloth%20yay.png"
+
+
+def test_bundled_avatar_subpath_allowed():
+    p = PersonalizationPayload.model_validate(
+        {"profile": {"avatarDataUrl": "/studio/Sloth%20emojis/large%20sloth%20yay.png"}}
+    )
+    assert "Sloth%20emojis" in p.profile.avatarDataUrl
+
+
+def test_bundled_avatar_traversal_rejected():
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {"profile": {"avatarDataUrl": "/Sloth%20emojis/../secret.png"}}
+        )
+
+
+def test_get_read_errors_propagate(monkeypatch):
+    def fail(*args, **kwargs):
+        raise RuntimeError("read failed")
+
+    monkeypatch.setattr("storage.studio_db.get_app_setting", fail)
+
+    with pytest.raises(RuntimeError, match = "read failed"):
+        pers.get_personalization()
 
 
 def test_get_set_roundtrip(monkeypatch):

--- a/studio/backend/tests/test_personalization_settings.py
+++ b/studio/backend/tests/test_personalization_settings.py
@@ -64,7 +64,7 @@ def test_valid_avatar_and_shape():
 
 def test_get_set_roundtrip(monkeypatch):
     store: dict = {}
-    monkeypatch.setattr("storage.studio_db.get_app_setting", lambda k, d=None: store.get(k, d))
+    monkeypatch.setattr("storage.studio_db.get_app_setting", lambda k, d = None: store.get(k, d))
     monkeypatch.setattr("storage.studio_db.upsert_app_settings", lambda d: store.update(d))
 
     assert pers.get_personalization() == {}

--- a/studio/backend/tests/test_personalization_settings.py
+++ b/studio/backend/tests/test_personalization_settings.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 _BACKEND = Path(__file__).resolve().parents[1]
@@ -12,6 +14,8 @@ if str(_BACKEND) not in sys.path:
     sys.path.insert(0, str(_BACKEND))
 
 import utils.personalization_settings as pers  # noqa: E402
+from auth.authentication import get_current_subject  # noqa: E402
+from routes import settings as settings_routes  # noqa: E402
 from routes.settings import PersonalizationPayload  # noqa: E402
 
 
@@ -105,3 +109,38 @@ def test_get_set_roundtrip(monkeypatch):
     pers.set_personalization(data)
     assert store[pers.PERSONALIZATION_SETTING_KEY]["profile"]["displayName"] == "Mike"
     assert pers.get_personalization()["appearance"]["theme"] == "dark"
+
+
+def test_personalization_route_roundtrip_real_shape(monkeypatch):
+    store: dict = {}
+    monkeypatch.setattr("storage.studio_db.get_app_setting", lambda k, d = None: store.get(k, d))
+    monkeypatch.setattr("storage.studio_db.upsert_app_settings", lambda d: store.update(d))
+
+    app = FastAPI()
+    app.dependency_overrides[get_current_subject] = lambda: "unsloth"
+    app.include_router(settings_routes.router, prefix = "/api/settings")
+    client = TestClient(app)
+
+    initial = client.get("/api/settings/personalization")
+    assert initial.status_code == 200
+    assert initial.json()["saved"] is False
+
+    payload = {
+        "version": 1,
+        "profile": {
+            "displayName": "Mike",
+            "nickname": "M",
+            "avatarDataUrl": "/Sloth%20emojis/large%20sloth%20yay.png",
+            "avatarShape": "rounded",
+        },
+        "appearance": {"theme": "dark", "language": "en"},
+    }
+    put = client.put("/api/settings/personalization", json = payload)
+    assert put.status_code == 200
+
+    saved = client.get("/api/settings/personalization")
+    assert saved.status_code == 200
+    body = saved.json()
+    assert body["saved"] is True
+    assert body["profile"] == payload["profile"]
+    assert body["appearance"] == payload["appearance"]

--- a/studio/backend/tests/test_personalization_settings.py
+++ b/studio/backend/tests/test_personalization_settings.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Server-side personalization validation + persistence roundtrip."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import utils.personalization_settings as pers  # noqa: E402
+from routes.settings import PersonalizationPayload  # noqa: E402
+
+
+def test_defaults_fill_missing_fields():
+    p = PersonalizationPayload.model_validate({})
+    assert p.version == pers.PERSONALIZATION_VERSION
+    assert p.appearance.theme == "system"
+    assert p.profile.avatarShape == "circle"
+    assert p.profile.displayName == ""
+
+
+def test_unknown_keys_are_ignored():
+    p = PersonalizationPayload.model_validate(
+        {"profile": {"displayName": "Mike", "bogus": 1}, "extra": True}
+    )
+    assert p.profile.displayName == "Mike"
+
+
+def test_invalid_theme_rejected():
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate({"appearance": {"theme": "neon"}})
+
+
+def test_avatar_must_be_image_data_url():
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {"profile": {"avatarDataUrl": "http://example.com/a.png"}}
+        )
+
+
+def test_avatar_size_is_capped():
+    big = "data:image/png;base64," + "A" * (pers.MAX_AVATAR_DATA_URL_BYTES + 1)
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate({"profile": {"avatarDataUrl": big}})
+
+
+def test_valid_avatar_and_shape():
+    p = PersonalizationPayload.model_validate(
+        {
+            "profile": {
+                "avatarDataUrl": "data:image/png;base64,AAAA",
+                "avatarShape": "rounded",
+            }
+        }
+    )
+    assert p.profile.avatarShape == "rounded"
+
+
+def test_get_set_roundtrip(monkeypatch):
+    store: dict = {}
+    monkeypatch.setattr("storage.studio_db.get_app_setting", lambda k, d=None: store.get(k, d))
+    monkeypatch.setattr("storage.studio_db.upsert_app_settings", lambda d: store.update(d))
+
+    assert pers.get_personalization() == {}
+    data = {
+        "version": 1,
+        "profile": {"displayName": "Mike"},
+        "appearance": {"theme": "dark"},
+    }
+    pers.set_personalization(data)
+    assert store[pers.PERSONALIZATION_SETTING_KEY]["profile"]["displayName"] == "Mike"
+    assert pers.get_personalization()["appearance"]["theme"] == "dark"

--- a/studio/backend/utils/personalization_settings.py
+++ b/studio/backend/utils/personalization_settings.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Server-side personalization (profile + appearance).
+
+Profile name/avatar and appearance (theme, language) were stored only in the
+browser's localStorage, so every browser or device that connected started from
+defaults. Studio is single-account, so these are persisted as one JSON blob in
+the ``app_settings`` table; the value follows the account across browsers and
+devices. Validation of the blob shape lives in the route's pydantic model.
+"""
+
+from __future__ import annotations
+
+PERSONALIZATION_SETTING_KEY = "personalization"
+PERSONALIZATION_VERSION = 1
+# Avatar data URLs are stored inline in studio.db; cap to keep the row sane.
+MAX_AVATAR_DATA_URL_BYTES = 512 * 1024  # 512 KB
+
+
+def get_personalization() -> dict:
+    """The stored personalization blob, or an empty dict when none is saved."""
+    try:
+        from storage.studio_db import get_app_setting
+
+        stored = get_app_setting(PERSONALIZATION_SETTING_KEY, None)
+    except Exception:
+        stored = None
+    return stored if isinstance(stored, dict) else {}
+
+
+def set_personalization(data: dict) -> dict:
+    """Persist the (already validated) personalization blob."""
+    from storage.studio_db import upsert_app_settings
+
+    upsert_app_settings({PERSONALIZATION_SETTING_KEY: data})
+    return data

--- a/studio/backend/utils/personalization_settings.py
+++ b/studio/backend/utils/personalization_settings.py
@@ -10,13 +10,11 @@ MAX_AVATAR_DATA_URL_BYTES = 512 * 1024
 
 def get_personalization() -> dict:
     from storage.studio_db import get_app_setting
-
     stored = get_app_setting(PERSONALIZATION_SETTING_KEY, None)
     return stored if isinstance(stored, dict) else {}
 
 
 def set_personalization(data: dict) -> dict:
     from storage.studio_db import upsert_app_settings
-
     upsert_app_settings({PERSONALIZATION_SETTING_KEY: data})
     return data

--- a/studio/backend/utils/personalization_settings.py
+++ b/studio/backend/utils/personalization_settings.py
@@ -22,7 +22,6 @@ def get_personalization() -> dict:
     """The stored personalization blob, or an empty dict when none is saved."""
     try:
         from storage.studio_db import get_app_setting
-
         stored = get_app_setting(PERSONALIZATION_SETTING_KEY, None)
     except Exception:
         stored = None

--- a/studio/backend/utils/personalization_settings.py
+++ b/studio/backend/utils/personalization_settings.py
@@ -1,35 +1,25 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Server-side personalization (profile + appearance).
-
-Profile name/avatar and appearance (theme, language) were stored only in the
-browser's localStorage, so every browser or device that connected started from
-defaults. Studio is single-account, so these are persisted as one JSON blob in
-the ``app_settings`` table; the value follows the account across browsers and
-devices. Validation of the blob shape lives in the route's pydantic model.
-"""
+"""Server-side profile and appearance settings."""
 
 from __future__ import annotations
 
 PERSONALIZATION_SETTING_KEY = "personalization"
 PERSONALIZATION_VERSION = 1
-# Avatar data URLs are stored inline in studio.db; cap to keep the row sane.
 MAX_AVATAR_DATA_URL_BYTES = 512 * 1024  # 512 KB
 
 
 def get_personalization() -> dict:
-    """The stored personalization blob, or an empty dict when none is saved."""
-    try:
-        from storage.studio_db import get_app_setting
-        stored = get_app_setting(PERSONALIZATION_SETTING_KEY, None)
-    except Exception:
-        stored = None
+    """Return the saved blob, or empty when absent."""
+    from storage.studio_db import get_app_setting
+
+    stored = get_app_setting(PERSONALIZATION_SETTING_KEY, None)
     return stored if isinstance(stored, dict) else {}
 
 
 def set_personalization(data: dict) -> dict:
-    """Persist the (already validated) personalization blob."""
+    """Persist the validated blob."""
     from storage.studio_db import upsert_app_settings
 
     upsert_app_settings({PERSONALIZATION_SETTING_KEY: data})

--- a/studio/backend/utils/personalization_settings.py
+++ b/studio/backend/utils/personalization_settings.py
@@ -1,17 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Server-side profile and appearance settings."""
-
 from __future__ import annotations
 
 PERSONALIZATION_SETTING_KEY = "personalization"
 PERSONALIZATION_VERSION = 1
-MAX_AVATAR_DATA_URL_BYTES = 512 * 1024  # 512 KB
+MAX_AVATAR_DATA_URL_BYTES = 512 * 1024
 
 
 def get_personalization() -> dict:
-    """Return the saved blob, or empty when absent."""
     from storage.studio_db import get_app_setting
 
     stored = get_app_setting(PERSONALIZATION_SETTING_KEY, None)
@@ -19,7 +16,6 @@ def get_personalization() -> dict:
 
 
 def set_personalization(data: dict) -> dict:
-    """Persist the validated blob."""
     from storage.studio_db import upsert_app_settings
 
     upsert_app_settings({PERSONALIZATION_SETTING_KEY: data})

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -15,6 +15,8 @@ import {
 import { RemoteCodeConsentDialog } from "@/features/security";
 import { useTrainingUnloadGuard } from "@/features/training";
 import { useExportRuntimeLifecycle } from "@/features/export";
+import { hasAuthToken } from "@/features/auth";
+import { usePersonalizationSync } from "@/features/profile/hooks/use-personalization-sync";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { useT, type TranslationKey } from "@/i18n";
 import {
@@ -135,6 +137,10 @@ function RootLayout() {
   // Global export driver: streams worker logs and tracks status from any route
   // so an export keeps running and stays visible while training / chatting.
   useExportRuntimeLifecycle();
+  // Mirror profile + appearance to the server (when signed in) so they follow
+  // the account across browsers and devices instead of living only in this
+  // browser's localStorage.
+  usePersonalizationSync(hasAuthToken());
 
   const matchedTitle = useMatches({
     select: (matches) => {

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -5,7 +5,10 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { Navbar } from "@/components/navbar";
 import { fetchDeviceType, usePlatformStore } from "@/config/env";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
-import { SettingsDialog, useSettingsDialogStore } from "@/features/settings";
+import {
+  SettingsDialog,
+  useSettingsDialogStore,
+} from "@/features/settings";
 import {
   ChatPage,
   clearNewChatDraft,
@@ -16,7 +19,7 @@ import { RemoteCodeConsentDialog } from "@/features/security";
 import { useTrainingUnloadGuard } from "@/features/training";
 import { useExportRuntimeLifecycle } from "@/features/export";
 import { hasAuthToken } from "@/features/auth";
-import { usePersonalizationSync } from "@/features/profile/hooks/use-personalization-sync";
+import { usePersonalizationSync } from "@/features/profile";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { useT, type TranslationKey } from "@/i18n";
 import {
@@ -52,6 +55,11 @@ function RouteFallback() {
       {t("common.loading")}
     </div>
   );
+}
+
+function PersonalizationSyncMount() {
+  usePersonalizationSync(hasAuthToken());
+  return null;
 }
 
 const CHAT_ONLY_ALLOWED = new Set([
@@ -137,10 +145,6 @@ function RootLayout() {
   // Global export driver: streams worker logs and tracks status from any route
   // so an export keeps running and stays visible while training / chatting.
   useExportRuntimeLifecycle();
-  // Mirror profile + appearance to the server (when signed in) so they follow
-  // the account across browsers and devices instead of living only in this
-  // browser's localStorage.
-  usePersonalizationSync(hasAuthToken());
 
   const matchedTitle = useMatches({
     select: (matches) => {
@@ -206,6 +210,7 @@ function RootLayout() {
 
   return (
     <AppProvider>
+      <PersonalizationSyncMount />
       <SettingsDialog />
       <RemoteCodeConsentDialog />
       {hideNavbar ? (

--- a/studio/frontend/src/features/profile/components/profile-personalization-panel.tsx
+++ b/studio/frontend/src/features/profile/components/profile-personalization-panel.tsx
@@ -11,7 +11,7 @@ import { useT } from "@/i18n";
 import { toastError, toastSuccess } from "@/shared/toast";
 import { Camera01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { SLOTH_AVATARS } from "../sloth-avatars";
 import { decodeJwtSubject } from "../utils/jwt-subject";
 import { resizeImageFileToDataUrl } from "../utils/resize-image-file";
@@ -65,6 +65,8 @@ export function ProfilePersonalizationPanel() {
   const [draftName, setDraftName] = useState(displayName);
   const [draftNickname, setDraftNickname] = useState(nickname);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const lastDisplayNameRef = useRef(displayName);
+  const lastNicknameRef = useRef(nickname);
 
   const sessionSub = decodeJwtSubject(getAuthToken()) ?? "";
   const previewName = draftName.trim() || sessionSub || "Unsloth";
@@ -76,6 +78,18 @@ export function ProfilePersonalizationPanel() {
     () => draftNickname.trim() !== nickname.trim(),
     [draftNickname, nickname],
   );
+
+  useEffect(() => {
+    const previous = lastDisplayNameRef.current;
+    lastDisplayNameRef.current = displayName;
+    setDraftName((draft) => (draft === previous ? displayName : draft));
+  }, [displayName]);
+
+  useEffect(() => {
+    const previous = lastNicknameRef.current;
+    lastNicknameRef.current = nickname;
+    setDraftNickname((draft) => (draft === previous ? nickname : draft));
+  }, [nickname]);
 
   const saveName = () => {
     const trimmed = draftName.trim();
@@ -111,7 +125,6 @@ export function ProfilePersonalizationPanel() {
     }
   };
 
-  // Persist an avatar value (data URL or asset URL) and toast the result.
   const applyAvatar = (value: string) => {
     setAvatarDataUrl(value);
     const persisted = readPersistedProfile();

--- a/studio/frontend/src/features/profile/components/profile-personalization-panel.tsx
+++ b/studio/frontend/src/features/profile/components/profile-personalization-panel.tsx
@@ -15,7 +15,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { SLOTH_AVATARS } from "../sloth-avatars";
 import { decodeJwtSubject } from "../utils/jwt-subject";
 import { resizeImageFileToDataUrl } from "../utils/resize-image-file";
-import { useUserProfileStore } from "../stores/user-profile-store";
+import {
+  PROFILE_TEXT_MAX_LENGTH,
+  useUserProfileStore,
+} from "../stores/user-profile-store";
 import { UserAvatar } from "./user-avatar";
 
 const PROFILE_STORAGE_KEY = "unsloth_user_profile";
@@ -151,7 +154,6 @@ export function ProfilePersonalizationPanel() {
     }
   };
 
-  // Use a bundled sloth sticker as the avatar.
   const pickSloth = (path: string) => {
     setImageError(null);
     applyAvatar(publicAssetUrl(path));
@@ -195,6 +197,7 @@ export function ProfilePersonalizationPanel() {
             id="profile-display-name"
             type="text"
             value={draftName}
+            maxLength={PROFILE_TEXT_MAX_LENGTH}
             onChange={(e) => setDraftName(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
@@ -221,6 +224,7 @@ export function ProfilePersonalizationPanel() {
             id="profile-nickname"
             type="text"
             value={draftNickname}
+            maxLength={PROFILE_TEXT_MAX_LENGTH}
             onChange={(e) => setDraftNickname(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
@@ -272,7 +276,6 @@ export function ProfilePersonalizationPanel() {
           {SLOTH_AVATARS.map((path) => {
             const url = publicAssetUrl(path);
             const selected = avatarDataUrl === url;
-            // Readable accessible name from the filename, e.g. "sloth yay".
             const label =
               path.split("/").pop()?.replace(/\.png$/i, "").replace(/^large\s+/i, "").trim() ??
               "sloth";

--- a/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
+++ b/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
@@ -16,8 +16,11 @@ import {
   useLocale,
   type Locale,
 } from "@/i18n";
-import { useEffect, useRef, useState } from "react";
-import { useUserProfileStore } from "../stores/user-profile-store";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  PROFILE_TEXT_MAX_LENGTH,
+  useUserProfileStore,
+} from "../stores/user-profile-store";
 import type { AvatarShape } from "../stores/user-profile-store";
 
 const PUSH_DEBOUNCE_MS = 800;
@@ -30,6 +33,69 @@ type ProfileSnapshot = {
 };
 
 type PersonalizationWrite = Parameters<typeof savePersonalization>[0];
+type QueuedSave = {
+  data: PersonalizationWrite;
+  generation: number;
+  serialized: string;
+};
+type RefValue<T> = { current: T };
+
+function profileText(value: string): string {
+  return value.slice(0, PROFILE_TEXT_MAX_LENGTH);
+}
+
+function normalizeProfile(profile: ProfileSnapshot): ProfileSnapshot {
+  return {
+    ...profile,
+    displayName: profileText(profile.displayName),
+    nickname: profileText(profile.nickname),
+  };
+}
+
+function sameProfile(a: ProfileSnapshot, b: ProfileSnapshot): boolean {
+  return (
+    a.displayName === b.displayName &&
+    a.nickname === b.nickname &&
+    a.avatarDataUrl === b.avatarDataUrl &&
+    a.avatarShape === b.avatarShape
+  );
+}
+
+function drainQueuedSave(
+  saveInFlightRef: RefValue<boolean>,
+  queuedSaveRef: RefValue<QueuedSave | null>,
+  authGenerationRef: RefValue<number>,
+  lastSavedRef: RefValue<string>,
+): void {
+  if (saveInFlightRef.current) return;
+  const next = queuedSaveRef.current;
+  if (!next) return;
+  queuedSaveRef.current = null;
+  saveInFlightRef.current = true;
+  void savePersonalization(next.data)
+    .then(() => {
+      if (authGenerationRef.current === next.generation) {
+        lastSavedRef.current = next.serialized;
+      }
+    })
+    .catch(() => {
+      if (authGenerationRef.current === next.generation) {
+        lastSavedRef.current = "";
+      }
+    })
+    .finally(() => {
+      saveInFlightRef.current = false;
+      const queued = queuedSaveRef.current;
+      if (queued && authGenerationRef.current === queued.generation) {
+        drainQueuedSave(
+          saveInFlightRef,
+          queuedSaveRef,
+          authGenerationRef,
+          lastSavedRef,
+        );
+      }
+    });
+}
 
 function profileSnapshot(): ProfileSnapshot {
   const s = useUserProfileStore.getState();
@@ -48,7 +114,7 @@ function payload(
 ): PersonalizationWrite {
   return {
     version: 1,
-    profile,
+    profile: normalizeProfile(profile),
     appearance: { theme, language },
   };
 }
@@ -84,6 +150,17 @@ export function usePersonalizationSync(enabled: boolean): void {
   const latestThemeRef = useRef(theme);
   const latestLanguageRef = useRef(language);
   const lastSavedRef = useRef("");
+  const saveInFlightRef = useRef(false);
+  const queuedSaveRef = useRef<QueuedSave | null>(null);
+
+  const drainSaveQueue = useCallback(() => {
+    drainQueuedSave(
+      saveInFlightRef,
+      queuedSaveRef,
+      authGenerationRef,
+      lastSavedRef,
+    );
+  }, []);
 
   useEffect(() => {
     latestThemeRef.current = theme;
@@ -97,6 +174,7 @@ export function usePersonalizationSync(enabled: boolean): void {
     authGenerationRef.current += 1;
     const generation = authGenerationRef.current;
     lastSavedRef.current = "";
+    queuedSaveRef.current = null;
     if (!enabled) {
       return;
     }
@@ -123,14 +201,25 @@ export function usePersonalizationSync(enabled: boolean): void {
             payload(nextProfile, nextTheme, nextLanguage),
           );
         } else {
-          const nextProfile = profileSnapshot();
+          const rawProfile = profileSnapshot();
+          const nextProfile = normalizeProfile(rawProfile);
+          if (!sameProfile(rawProfile, nextProfile)) {
+            useUserProfileStore.setState(nextProfile);
+          }
           const nextTheme = latestThemeRef.current;
           const nextLanguage = getLocale();
           const nextPayload = payload(nextProfile, nextTheme, nextLanguage);
+          const nextSerialized = serialized(nextPayload);
           if (hasLocalSettings(nextProfile, nextTheme, nextLanguage)) {
-            await savePersonalization(nextPayload);
+            try {
+              await savePersonalization(nextPayload);
+              lastSavedRef.current = nextSerialized;
+            } catch {
+              lastSavedRef.current = "";
+            }
+          } else {
+            lastSavedRef.current = nextSerialized;
           }
-          lastSavedRef.current = serialized(nextPayload);
         }
         if (!cancelled && authGenerationRef.current === generation) {
           setHydratedGeneration(generation);
@@ -156,11 +245,12 @@ export function usePersonalizationSync(enabled: boolean): void {
     const currentSerialized = serialized(current);
     if (currentSerialized === lastSavedRef.current) return;
     const id = window.setTimeout(() => {
-      void savePersonalization(current)
-        .then(() => {
-          lastSavedRef.current = currentSerialized;
-        })
-        .catch(() => {});
+      queuedSaveRef.current = {
+        data: current,
+        generation: authGenerationRef.current,
+        serialized: currentSerialized,
+      };
+      drainSaveQueue();
     }, PUSH_DEBOUNCE_MS);
     return () => window.clearTimeout(id);
   }, [
@@ -172,5 +262,6 @@ export function usePersonalizationSync(enabled: boolean): void {
     avatarShape,
     theme,
     language,
+    drainSaveQueue,
   ]);
 }

--- a/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
+++ b/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  loadPersonalization,
+  savePersonalization,
+} from "@/features/settings/api/personalization";
+import { setTheme, useTheme } from "@/features/settings/stores/theme-store";
+import { useEffect, useRef } from "react";
+import { useUserProfileStore } from "../stores/user-profile-store";
+
+const PUSH_DEBOUNCE_MS = 800;
+
+/**
+ * Keep profile + appearance in sync with the server so personalization follows
+ * the account across browsers and devices (these were previously localStorage
+ * only). When the account has a saved blob the server is authoritative; when it
+ * does not, existing local settings are migrated up once so nothing is lost.
+ * Writers (the profile panel, theme toggles) keep using the local stores; this
+ * hook mirrors changes to the server, debounced.
+ */
+export function usePersonalizationSync(enabled: boolean): void {
+  const displayName = useUserProfileStore((s) => s.displayName);
+  const nickname = useUserProfileStore((s) => s.nickname);
+  const avatarDataUrl = useUserProfileStore((s) => s.avatarDataUrl);
+  const avatarShape = useUserProfileStore((s) => s.avatarShape);
+  const { theme } = useTheme();
+  const hydratedRef = useRef(false);
+
+  // Hydrate once when authenticated.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const remote = await loadPersonalization();
+        if (cancelled) return;
+        if (remote.saved) {
+          // Server is authoritative.
+          useUserProfileStore.setState({
+            displayName: remote.profile.displayName ?? "",
+            nickname: remote.profile.nickname ?? "",
+            avatarDataUrl: remote.profile.avatarDataUrl ?? null,
+            avatarShape: remote.profile.avatarShape === "rounded" ? "rounded" : "circle",
+          });
+          const t = remote.appearance.theme;
+          if (t === "light" || t === "dark" || t === "system") {
+            setTheme(t);
+          }
+        } else {
+          // Never saved: migrate the current local settings up once.
+          const s = useUserProfileStore.getState();
+          await savePersonalization({
+            version: 1,
+            profile: {
+              displayName: s.displayName,
+              nickname: s.nickname,
+              avatarDataUrl: s.avatarDataUrl,
+              avatarShape: s.avatarShape,
+            },
+            appearance: { theme, language: null },
+          });
+        }
+      } catch {
+        // Non-fatal: fall back to local-only behavior.
+      } finally {
+        if (!cancelled) hydratedRef.current = true;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // theme is intentionally excluded: hydration reads getState()/the current
+    // theme once and must not re-run on later theme changes (the write-through
+    // effect handles those).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  // Write through subsequent local changes to the server, debounced. Skipped
+  // until hydration completes so we never echo the just-hydrated values back.
+  useEffect(() => {
+    if (!enabled || !hydratedRef.current) return;
+    const id = window.setTimeout(() => {
+      void savePersonalization({
+        version: 1,
+        profile: { displayName, nickname, avatarDataUrl, avatarShape },
+        appearance: { theme, language: null },
+      }).catch(() => {});
+    }, PUSH_DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [enabled, displayName, nickname, avatarDataUrl, avatarShape, theme]);
+}

--- a/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
+++ b/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
@@ -4,89 +4,173 @@
 import {
   loadPersonalization,
   savePersonalization,
-} from "@/features/settings/api/personalization";
-import { setTheme, useTheme } from "@/features/settings/stores/theme-store";
-import { useEffect, useRef } from "react";
+  setTheme,
+  useTheme,
+  type Theme,
+} from "@/features/settings";
+import {
+  DEFAULT_LOCALE,
+  getLocale,
+  isSupportedLocale,
+  setLocale,
+  useLocale,
+  type Locale,
+} from "@/i18n";
+import { useEffect, useRef, useState } from "react";
 import { useUserProfileStore } from "../stores/user-profile-store";
+import type { AvatarShape } from "../stores/user-profile-store";
 
 const PUSH_DEBOUNCE_MS = 800;
 
-/**
- * Keep profile + appearance in sync with the server so personalization follows
- * the account across browsers and devices (these were previously localStorage
- * only). When the account has a saved blob the server is authoritative; when it
- * does not, existing local settings are migrated up once so nothing is lost.
- * Writers (the profile panel, theme toggles) keep using the local stores; this
- * hook mirrors changes to the server, debounced.
- */
+type ProfileSnapshot = {
+  displayName: string;
+  nickname: string;
+  avatarDataUrl: string | null;
+  avatarShape: AvatarShape;
+};
+
+type PersonalizationWrite = Parameters<typeof savePersonalization>[0];
+
+function profileSnapshot(): ProfileSnapshot {
+  const s = useUserProfileStore.getState();
+  return {
+    displayName: s.displayName,
+    nickname: s.nickname,
+    avatarDataUrl: s.avatarDataUrl,
+    avatarShape: s.avatarShape,
+  };
+}
+
+function payload(
+  profile: ProfileSnapshot,
+  theme: Theme,
+  language: Locale | null,
+): PersonalizationWrite {
+  return {
+    version: 1,
+    profile,
+    appearance: { theme, language },
+  };
+}
+
+function serialized(data: PersonalizationWrite): string {
+  return JSON.stringify(data);
+}
+
+function hasLocalSettings(
+  profile: ProfileSnapshot,
+  theme: Theme,
+  language: Locale,
+): boolean {
+  return Boolean(
+    profile.displayName ||
+      profile.nickname ||
+      profile.avatarDataUrl ||
+      profile.avatarShape !== "circle" ||
+      theme !== "system" ||
+      language !== DEFAULT_LOCALE,
+  );
+}
+
 export function usePersonalizationSync(enabled: boolean): void {
   const displayName = useUserProfileStore((s) => s.displayName);
   const nickname = useUserProfileStore((s) => s.nickname);
   const avatarDataUrl = useUserProfileStore((s) => s.avatarDataUrl);
   const avatarShape = useUserProfileStore((s) => s.avatarShape);
   const { theme } = useTheme();
-  const hydratedRef = useRef(false);
+  const language = useLocale();
+  const [hydratedGeneration, setHydratedGeneration] = useState(0);
+  const authGenerationRef = useRef(0);
+  const latestThemeRef = useRef(theme);
+  const latestLanguageRef = useRef(language);
+  const lastSavedRef = useRef("");
 
-  // Hydrate once when authenticated.
   useEffect(() => {
-    if (!enabled) return;
+    latestThemeRef.current = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    latestLanguageRef.current = language;
+  }, [language]);
+
+  useEffect(() => {
+    authGenerationRef.current += 1;
+    const generation = authGenerationRef.current;
+    lastSavedRef.current = "";
+    if (!enabled) {
+      return;
+    }
     let cancelled = false;
     void (async () => {
       try {
         const remote = await loadPersonalization();
         if (cancelled) return;
         if (remote.saved) {
-          // Server is authoritative.
-          useUserProfileStore.setState({
+          const nextProfile: ProfileSnapshot = {
             displayName: remote.profile.displayName ?? "",
             nickname: remote.profile.nickname ?? "",
             avatarDataUrl: remote.profile.avatarDataUrl ?? null,
             avatarShape: remote.profile.avatarShape === "rounded" ? "rounded" : "circle",
-          });
-          const t = remote.appearance.theme;
-          if (t === "light" || t === "dark" || t === "system") {
-            setTheme(t);
-          }
+          };
+          const nextTheme = remote.appearance.theme;
+          const nextLanguage = isSupportedLocale(remote.appearance.language)
+            ? remote.appearance.language
+            : latestLanguageRef.current;
+          useUserProfileStore.setState(nextProfile);
+          if (nextTheme !== latestThemeRef.current) setTheme(nextTheme);
+          if (nextLanguage !== latestLanguageRef.current) setLocale(nextLanguage);
+          lastSavedRef.current = serialized(
+            payload(nextProfile, nextTheme, nextLanguage),
+          );
         } else {
-          // Never saved: migrate the current local settings up once.
-          const s = useUserProfileStore.getState();
-          await savePersonalization({
-            version: 1,
-            profile: {
-              displayName: s.displayName,
-              nickname: s.nickname,
-              avatarDataUrl: s.avatarDataUrl,
-              avatarShape: s.avatarShape,
-            },
-            appearance: { theme, language: null },
-          });
+          const nextProfile = profileSnapshot();
+          const nextTheme = latestThemeRef.current;
+          const nextLanguage = getLocale();
+          const nextPayload = payload(nextProfile, nextTheme, nextLanguage);
+          if (hasLocalSettings(nextProfile, nextTheme, nextLanguage)) {
+            await savePersonalization(nextPayload);
+          }
+          lastSavedRef.current = serialized(nextPayload);
+        }
+        if (!cancelled && authGenerationRef.current === generation) {
+          setHydratedGeneration(generation);
         }
       } catch {
-        // Non-fatal: fall back to local-only behavior.
-      } finally {
-        if (!cancelled) hydratedRef.current = true;
+        if (!cancelled && authGenerationRef.current === generation) {
+          lastSavedRef.current = "";
+        }
       }
     })();
     return () => {
       cancelled = true;
     };
-    // theme is intentionally excluded: hydration reads getState()/the current
-    // theme once and must not re-run on later theme changes (the write-through
-    // effect handles those).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled]);
 
-  // Write through subsequent local changes to the server, debounced. Skipped
-  // until hydration completes so we never echo the just-hydrated values back.
   useEffect(() => {
-    if (!enabled || !hydratedRef.current) return;
+    if (!enabled || hydratedGeneration !== authGenerationRef.current) return;
+    const current = payload(
+      { displayName, nickname, avatarDataUrl, avatarShape },
+      theme,
+      language,
+    );
+    const currentSerialized = serialized(current);
+    if (currentSerialized === lastSavedRef.current) return;
     const id = window.setTimeout(() => {
-      void savePersonalization({
-        version: 1,
-        profile: { displayName, nickname, avatarDataUrl, avatarShape },
-        appearance: { theme, language: null },
-      }).catch(() => {});
+      void savePersonalization(current)
+        .then(() => {
+          lastSavedRef.current = currentSerialized;
+        })
+        .catch(() => {});
     }, PUSH_DEBOUNCE_MS);
     return () => window.clearTimeout(id);
-  }, [enabled, displayName, nickname, avatarDataUrl, avatarShape, theme]);
+  }, [
+    enabled,
+    hydratedGeneration,
+    displayName,
+    nickname,
+    avatarDataUrl,
+    avatarShape,
+    theme,
+    language,
+  ]);
 }

--- a/studio/frontend/src/features/profile/index.ts
+++ b/studio/frontend/src/features/profile/index.ts
@@ -4,3 +4,4 @@
 export { ProfilePersonalizationPanel } from "./components/profile-personalization-panel";
 export { UserAvatar } from "./components/user-avatar";
 export { useEffectiveProfile } from "./hooks/use-effective-profile";
+export { usePersonalizationSync } from "./hooks/use-personalization-sync";

--- a/studio/frontend/src/features/profile/stores/user-profile-store.ts
+++ b/studio/frontend/src/features/profile/stores/user-profile-store.ts
@@ -5,13 +5,12 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 export type AvatarShape = "circle" | "rounded";
+export const PROFILE_TEXT_MAX_LENGTH = 200;
 
 export interface UserProfileState {
   displayName: string;
-  // Preferred name used to address the user (greetings, etc.).
   nickname: string;
   avatarDataUrl: string | null;
-  // Avatar outline: full circle or rounded rectangle.
   avatarShape: AvatarShape;
   setDisplayName: (displayName: string) => void;
   setNickname: (nickname: string) => void;

--- a/studio/frontend/src/features/settings/api/personalization.ts
+++ b/studio/frontend/src/features/settings/api/personalization.ts
@@ -20,8 +20,7 @@ export type Personalization = {
   version: number;
   profile: PersonalizationProfile;
   appearance: PersonalizationAppearance;
-  // True once a blob has been saved server-side; lets the client decide between
-  // hydrating from the server and migrating existing local settings up.
+  // Distinguishes server hydrate from first local migration.
   saved: boolean;
 };
 

--- a/studio/frontend/src/features/settings/api/personalization.ts
+++ b/studio/frontend/src/features/settings/api/personalization.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
+
+export type PersonalizationProfile = {
+  displayName: string;
+  nickname: string;
+  avatarDataUrl: string | null;
+  avatarShape: "circle" | "rounded";
+};
+
+export type PersonalizationAppearance = {
+  theme: "light" | "dark" | "system";
+  language: string | null;
+};
+
+export type Personalization = {
+  version: number;
+  profile: PersonalizationProfile;
+  appearance: PersonalizationAppearance;
+  // True once a blob has been saved server-side; lets the client decide between
+  // hydrating from the server and migrating existing local settings up.
+  saved: boolean;
+};
+
+export async function loadPersonalization(): Promise<Personalization> {
+  const res = await authFetch("/api/settings/personalization");
+  if (!res.ok) {
+    throw new Error(await readFastApiError(res, "Failed to load personalization"));
+  }
+  return (await res.json()) as Personalization;
+}
+
+export async function savePersonalization(
+  data: Omit<Personalization, "saved">,
+): Promise<void> {
+  const res = await authFetch("/api/settings/personalization", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error(await readFastApiError(res, "Failed to save personalization"));
+  }
+}

--- a/studio/frontend/src/features/settings/index.ts
+++ b/studio/frontend/src/features/settings/index.ts
@@ -2,5 +2,16 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 export { SettingsDialog } from "./settings-dialog";
+export {
+  loadPersonalization,
+  savePersonalization,
+} from "./api/personalization";
+export { setTheme, useTheme } from "./stores/theme-store";
+export type {
+  Personalization,
+  PersonalizationAppearance,
+  PersonalizationProfile,
+} from "./api/personalization";
 export { useSettingsDialogStore } from "./stores/settings-dialog-store";
 export type { SettingsTab } from "./stores/settings-dialog-store";
+export type { ResolvedTheme, Theme } from "./stores/theme-store";


### PR DESCRIPTION
## Problem
Profile (display name, nickname, avatar, avatar shape), theme / dark mode, and related preferences were stored only in `localStorage`, so every browser or device started from defaults. Studio is single account, so these settings should follow the account, not the browser.

## Change
- New `utils/personalization_settings.py` stores one versioned JSON blob in the existing `app_settings` table.
- `GET` / `PUT /api/settings/personalization` with pydantic models (camelCase to match the frontend stores, theme validated, avatar must be an image data URL capped in size).
- Frontend: on authenticated boot, hydrate the profile and theme stores from the server. If the server blob is empty but `localStorage` has values, migrate once, then treat the server as the source of truth. Debounced write through on changes. The auth token is never moved into this blob.

## Validation
- `test_personalization_settings.py` (roundtrip, reject bad theme, reject oversized avatar).
- Live: set display name and dark theme in one browser, opened a fresh browser session, and confirmed they carried over.
