### PR TITLE
Fix misleading 'only for image models' error for Qwen3-VL when torchvision is missing

### DIFF
--- a/tests/test_missing_torchvision_vlm.py
+++ b/tests/test_missing_torchvision_vlm.py
@@ -1,10 +1,5 @@
-"""Regression test for unsloth#4202.
-
-transformers >= 5.4 hard-requires torchvision for VLM image/video processors. When
-torchvision is missing the processor silently degrades to a text-only tokenizer and
-later trips the misleading "UnslothVisionDataCollator is only for image models!" error.
-`_missing_torchvision_error` lets the loader surface the real cause up front.
-"""
+"""Regression test for unsloth#4202: detect missing torchvision so the loader can
+surface the real cause instead of a misleading collator error."""
 
 import importlib.util
 from unittest import mock
@@ -30,6 +25,6 @@ def test_torchvision_present_unrelated_error_is_not_flagged():
 
 
 def test_matches_real_environment():
-    # find_spec is the source of truth when no torchvision-flavoured error is supplied.
+    # find_spec is the source of truth when no error is supplied.
     expected = importlib.util.find_spec("torchvision") is None
     assert _missing_torchvision_error(None) is expected

--- a/tests/test_missing_torchvision_vlm.py
+++ b/tests/test_missing_torchvision_vlm.py
@@ -5,6 +5,7 @@ torchvision is missing the processor silently degrades to a text-only tokenizer 
 later trips the misleading "UnslothVisionDataCollator is only for image models!" error.
 `_missing_torchvision_error` lets the loader surface the real cause up front.
 """
+
 import importlib.util
 from unittest import mock
 
@@ -17,13 +18,13 @@ def test_error_text_mentions_torchvision_is_detected():
 
 
 def test_torchvision_missing_is_detected_without_error():
-    with mock.patch.object(importlib.util, "find_spec", return_value=None):
+    with mock.patch.object(importlib.util, "find_spec", return_value = None):
         assert _missing_torchvision_error(None) is True
 
 
 def test_torchvision_present_unrelated_error_is_not_flagged():
     sentinel = object()
-    with mock.patch.object(importlib.util, "find_spec", return_value=sentinel):
+    with mock.patch.object(importlib.util, "find_spec", return_value = sentinel):
         assert _missing_torchvision_error(ValueError("unrelated")) is False
         assert _missing_torchvision_error(None) is False
 

--- a/tests/test_missing_torchvision_vlm.py
+++ b/tests/test_missing_torchvision_vlm.py
@@ -1,0 +1,34 @@
+"""Regression test for unsloth#4202.
+
+transformers >= 5.4 hard-requires torchvision for VLM image/video processors. When
+torchvision is missing the processor silently degrades to a text-only tokenizer and
+later trips the misleading "UnslothVisionDataCollator is only for image models!" error.
+`_missing_torchvision_error` lets the loader surface the real cause up front.
+"""
+import importlib.util
+from unittest import mock
+
+from unsloth.models.vision import _missing_torchvision_error
+
+
+def test_error_text_mentions_torchvision_is_detected():
+    err = ImportError("Qwen3VLVideoProcessor requires the Torchvision library but ...")
+    assert _missing_torchvision_error(err) is True
+
+
+def test_torchvision_missing_is_detected_without_error():
+    with mock.patch.object(importlib.util, "find_spec", return_value=None):
+        assert _missing_torchvision_error(None) is True
+
+
+def test_torchvision_present_unrelated_error_is_not_flagged():
+    sentinel = object()
+    with mock.patch.object(importlib.util, "find_spec", return_value=sentinel):
+        assert _missing_torchvision_error(ValueError("unrelated")) is False
+        assert _missing_torchvision_error(None) is False
+
+
+def test_matches_real_environment():
+    # find_spec is the source of truth when no torchvision-flavoured error is supplied.
+    expected = importlib.util.find_spec("torchvision") is None
+    assert _missing_torchvision_error(None) is expected

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -450,12 +450,10 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
 
 
 def _missing_torchvision_error(error = None):
-    """True if a VLM processor failed to load because torchvision is unavailable.
+    """True if a VLM processor failed to load due to missing torchvision (#4202).
 
-    transformers >= 5.4 hard-requires torchvision for image/video processors. Check
-    availability directly first; only trust the error text for the specific
-    torchvision-required message, not any incidental substring such as a model path
-    that contains "torchvision" (#4202)."""
+    Checks availability directly first, then only the specific torchvision-required
+    error text (not any incidental "torchvision" substring like a model path)."""
     import importlib.util
 
     if importlib.util.find_spec("torchvision") is None:
@@ -1216,11 +1214,8 @@ class FastBaseModel:
             )
             if _fallback is not None:
                 tokenizer = _fallback
-            # Still degraded: transformers >= 5.4 hard-requires torchvision for VLM
-            # image/video processors and no longer falls back to a slow processor, so a
-            # missing torchvision silently degrades the processor to a text-only tokenizer
-            # and later trips the misleading "only for image models" collator error (#4202).
-            # Surface the real cause up front instead.
+            # Missing torchvision silently degrades the VLM processor to a text-only
+            # tokenizer; surface the real cause instead of the later collator error (#4202).
             if tokenizer is None or not hasattr(tokenizer, "image_processor"):
                 if _missing_torchvision_error(_processor_load_error):
                     raise ImportError(

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -458,6 +458,7 @@ def _missing_torchvision_error(error = None):
     if error is not None and "torchvision" in str(error).lower():
         return True
     import importlib.util
+
     return importlib.util.find_spec("torchvision") is None
 
 

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -449,6 +449,18 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
     return output
 
 
+def _missing_torchvision_error(error = None):
+    """True if a VLM processor failed to load because torchvision is unavailable.
+
+    transformers >= 5.4 hard-requires torchvision for image/video processors. Check
+    both the captured exception text and torchvision availability directly, since the
+    inner fallbacks may swallow the original ImportError (#4202)."""
+    if error is not None and "torchvision" in str(error).lower():
+        return True
+    import importlib.util
+    return importlib.util.find_spec("torchvision") is None
+
+
 def _construct_vlm_processor_fallback(tokenizer_name, model_type, token, trust_remote_code):
     """Construct a VLM processor manually when AutoProcessor.from_pretrained fails.
 
@@ -1148,6 +1160,7 @@ class FastBaseModel:
                     except Exception:
                         pass
 
+        _processor_load_error = None
         if (whisper_language and whisper_task) or auto_model.__name__.endswith(
             "ForConditionalGeneration"
         ):
@@ -1160,7 +1173,8 @@ class FastBaseModel:
                     task = whisper_task,
                     trust_remote_code = trust_remote_code,
                 )
-            except Exception:
+            except Exception as e:
+                _processor_load_error = e
                 tokenizer = None
         else:
             try:
@@ -1170,7 +1184,8 @@ class FastBaseModel:
                     token = token,
                     trust_remote_code = trust_remote_code,
                 )
-            except:
+            except Exception as e:
+                _processor_load_error = e
                 tokenizer = get_auto_processor(
                     tokenizer_name,
                     padding_side = "left",
@@ -1194,7 +1209,19 @@ class FastBaseModel:
             )
             if _fallback is not None:
                 tokenizer = _fallback
-            if tokenizer is None:
+            # Still degraded: transformers >= 5.4 hard-requires torchvision for VLM
+            # image/video processors and no longer falls back to a slow processor, so a
+            # missing torchvision silently degrades the processor to a text-only tokenizer
+            # and later trips the misleading "only for image models" collator error (#4202).
+            # Surface the real cause up front instead.
+            if tokenizer is None or not hasattr(tokenizer, "image_processor"):
+                if _missing_torchvision_error(_processor_load_error):
+                    raise ImportError(
+                        f"Unsloth: Could not load the vision processor for `{tokenizer_name}` "
+                        "because torchvision is not installed. transformers >= 5.4 requires "
+                        "torchvision for vision (image/video) processors. Please install it, "
+                        "e.g. `pip install torchvision`."
+                    )
                 import sys
                 print(
                     f"Unsloth: Warning - VLM processor fallback returned None for model_type={model_type_arch}",

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1220,8 +1220,8 @@ class FastBaseModel:
                 if _missing_torchvision_error(_processor_load_error):
                     raise ImportError(
                         f"Unsloth: Could not load the vision processor for `{tokenizer_name}` "
-                        "because torchvision is not installed. transformers >= 5.4 requires "
-                        "torchvision for vision (image/video) processors. Please install it, "
+                        "because torchvision is not installed. transformers requires torchvision "
+                        "for this model's vision (image/video) processors. Please install it, "
                         "e.g. `pip install torchvision`."
                     )
                 import sys

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -453,13 +453,19 @@ def _missing_torchvision_error(error = None):
     """True if a VLM processor failed to load because torchvision is unavailable.
 
     transformers >= 5.4 hard-requires torchvision for image/video processors. Check
-    both the captured exception text and torchvision availability directly, since the
-    inner fallbacks may swallow the original ImportError (#4202)."""
-    if error is not None and "torchvision" in str(error).lower():
-        return True
+    availability directly first; only trust the error text for the specific
+    torchvision-required message, not any incidental substring such as a model path
+    that contains "torchvision" (#4202)."""
     import importlib.util
 
-    return importlib.util.find_spec("torchvision") is None
+    if importlib.util.find_spec("torchvision") is None:
+        return True
+    if error is not None:
+        error_str = str(error).lower()
+        return (
+            "requires the torchvision" in error_str or "no module named 'torchvision'" in error_str
+        )
+    return False
 
 
 def _construct_vlm_processor_fallback(tokenizer_name, model_type, token, trust_remote_code):


### PR DESCRIPTION
## Summary

Fixes the confusing `TypeError: Unsloth: UnslothVisionDataCollator is only for image models!` reported when fine-tuning Qwen3-VL / Qwen3.5 vision models (issue #4202).

## Root cause

The error is misleading. The model is a vision model, but the processor never loaded as one.

transformers `>= 5.4` made torchvision a hard requirement for VLM image and video processors and removed the old graceful fallback to the slow image processor. The behavior split is exactly what users reported (works on 5.3.0, fails on 5.4.0 / 5.5.0):

- `transformers 5.3.0`: `AutoImageProcessor.from_pretrained(...)` prints `Using use_fast=True but torchvision is not available. Falling back to the slow image processor.` and loads fine.
- `transformers 5.4.0 / 5.5.0`: the same call raises `ImportError: ... requires the Torchvision library` for both the image processor and `Qwen3VLVideoProcessor`, with no `use_fast=False` / `backend="pil"` escape hatch.

When torchvision is missing on 5.4+, the chain inside `FastBaseModel.from_pretrained` is:

1. `AutoProcessor.from_pretrained(...)` raises `ImportError` (torchvision required).
2. The `get_auto_processor` fallback hits the same `ImportError` and degrades to a plain `AutoTokenizer` (text only, no `image_processor`).
3. `_construct_vlm_processor_fallback` also fails (`AutoImageProcessor` needs torchvision too) and returns `None`.
4. Training proceeds with a text-only tokenizer, so `UnslothVisionDataCollator` later raises the cryptic "only for image models" error.

## Fix

Detect the degraded-VLM-processor case at load time and, when torchvision is the cause, raise a clear and actionable `ImportError` telling the user to install torchvision, instead of silently continuing with a text-only tokenizer.

The detection checks both the captured exception text and torchvision availability directly (the inner fallbacks swallow the original `ImportError`). Behavior is unchanged when torchvision is present, and the existing warning path is preserved for non-torchvision processor failures.

## Before / after

Repro: `FastVisionModel.from_pretrained("unsloth/Qwen3.5-2B")` on transformers 5.5.0 without torchvision, then build `UnslothVisionDataCollator`.

Before:
```
Unsloth: Warning - VLM processor fallback returned None for model_type=qwen3_5
TypeError: Unsloth: UnslothVisionDataCollator is only for image models!
```

After:
```
ImportError: Unsloth: Could not load the vision processor for `unsloth/Qwen3.5-2B`
because torchvision is not installed. transformers >= 5.4 requires torchvision for
vision (image/video) processors. Please install it, e.g. `pip install torchvision`.
```

With torchvision installed, loading and collator construction succeed as before (verified on transformers 5.5.0 and 5.10.4).

## Tests

Added `tests/test_missing_torchvision_vlm.py` covering `_missing_torchvision_error` (CPU only, no model download).
