### PR TITLE
Fix FlashAttention fp32 crash with DoRA (use_dora=True)

### DIFF
--- a/tests/utils/test_attention_dispatch_dora_dtype.py
+++ b/tests/utils/test_attention_dispatch_dora_dtype.py
@@ -1,0 +1,77 @@
+"""
+Regression test for unslothai/unsloth#1013.
+
+With DoRA (use_dora=True) the lora_magnitude_vector is upcast to fp32 for the
+optimizer, which promotes the q/k/v_proj output to fp32. FlashAttention only
+accepts fp16/bf16, so the fp32 q/k/v previously raised:
+    RuntimeError: FlashAttention only support fp16 and bf16 data type
+
+run_attention must downcast fp32 q/k/v before calling the flash kernels, and
+must leave already-16bit tensors untouched.
+"""
+import torch
+import unsloth  # noqa: F401
+
+from unsloth.utils import attention_dispatch as ad
+
+
+def _run(monkeypatch, qkv_dtype, backend):
+    captured = {}
+
+    def _check(Q):
+        captured["dtype"] = Q.dtype
+        # Mirror the real kernel constraint so an unfixed dispatch fails loudly.
+        if Q.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError("FlashAttention only support fp16 and bf16 data type")
+
+    def fake_flash_dense(Q, K, V, **kwargs):
+        _check(Q)
+        return torch.zeros_like(Q)
+
+    def fake_flash_varlen(Q, K, V, *args, **kwargs):
+        _check(Q)
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(ad, "flash_attn_func", fake_flash_dense, raising=False)
+    monkeypatch.setattr(ad, "flash_attn_varlen_func", fake_flash_varlen, raising=False)
+
+    bsz, n_heads, q_len, head_dim = 1, 2, 4, 8
+    Q = torch.randn(bsz, n_heads, q_len, head_dim, dtype=qkv_dtype)
+    K = torch.randn(bsz, n_heads, q_len, head_dim, dtype=qkv_dtype)
+    V = torch.randn(bsz, n_heads, q_len, head_dim, dtype=qkv_dtype)
+
+    seq_info = None
+    if backend == ad.FLASH_VARLEN:
+        cu = torch.tensor([0, q_len], dtype=torch.int32)
+        seq_info = (None, cu, q_len)
+
+    config = ad.AttentionConfig(
+        backend=backend, n_kv_heads=n_heads, n_groups=1,
+        flash_dense_kwargs={"causal": True},
+        flash_varlen_kwargs={"dropout_p": 0.0, "causal": True},
+    )
+    context = ad.AttentionContext(
+        bsz=bsz, q_len=q_len, kv_seq_len=q_len, n_heads=n_heads,
+        head_dim=head_dim, requires_grad=False, seq_info=seq_info,
+        attention_mask=None, causal_mask=None,
+    )
+    ad.run_attention(config=config, context=context, Q=Q, K=K, V=V)
+    return captured["dtype"]
+
+
+def test_dense_flash_downcasts_fp32_qkv(monkeypatch):
+    # fp32 DoRA output must be downcast to a flash-compatible dtype.
+    assert _run(monkeypatch, torch.float32, ad.FLASH_DENSE) in (
+        torch.bfloat16, torch.float16,
+    )
+
+
+def test_varlen_flash_downcasts_fp32_qkv(monkeypatch):
+    assert _run(monkeypatch, torch.float32, ad.FLASH_VARLEN) in (
+        torch.bfloat16, torch.float16,
+    )
+
+
+def test_bf16_qkv_left_untouched(monkeypatch):
+    # Standard LoRA path (already bf16) must not be altered.
+    assert _run(monkeypatch, torch.bfloat16, ad.FLASH_DENSE) == torch.bfloat16

--- a/tests/utils/test_attention_dispatch_dora_dtype.py
+++ b/tests/utils/test_attention_dispatch_dora_dtype.py
@@ -1,14 +1,5 @@
-"""
-Regression test for unslothai/unsloth#1013.
-
-With DoRA (use_dora=True) the lora_magnitude_vector is upcast to fp32 for the
-optimizer, which promotes the q/k/v_proj output to fp32. FlashAttention only
-accepts fp16/bf16, so the fp32 q/k/v previously raised:
-    RuntimeError: FlashAttention only support fp16 and bf16 data type
-
-run_attention must downcast fp32 q/k/v before calling the flash kernels, and
-must leave already-16bit tensors untouched.
-"""
+"""Regression test for unslothai/unsloth#1013: run_attention must downcast DoRA's
+fp32 q/k/v for FlashAttention while leaving already-16bit tensors untouched."""
 
 import torch
 import unsloth  # noqa: F401

--- a/tests/utils/test_attention_dispatch_dora_dtype.py
+++ b/tests/utils/test_attention_dispatch_dora_dtype.py
@@ -9,6 +9,7 @@ accepts fp16/bf16, so the fp32 q/k/v previously raised:
 run_attention must downcast fp32 q/k/v before calling the flash kernels, and
 must leave already-16bit tensors untouched.
 """
+
 import torch
 import unsloth  # noqa: F401
 
@@ -32,44 +33,48 @@ def _run(monkeypatch, qkv_dtype, backend):
         _check(Q)
         return torch.zeros_like(Q)
 
-    monkeypatch.setattr(ad, "flash_attn_func", fake_flash_dense, raising=False)
-    monkeypatch.setattr(ad, "flash_attn_varlen_func", fake_flash_varlen, raising=False)
+    monkeypatch.setattr(ad, "flash_attn_func", fake_flash_dense, raising = False)
+    monkeypatch.setattr(ad, "flash_attn_varlen_func", fake_flash_varlen, raising = False)
 
     bsz, n_heads, q_len, head_dim = 1, 2, 4, 8
-    Q = torch.randn(bsz, n_heads, q_len, head_dim, dtype=qkv_dtype)
-    K = torch.randn(bsz, n_heads, q_len, head_dim, dtype=qkv_dtype)
-    V = torch.randn(bsz, n_heads, q_len, head_dim, dtype=qkv_dtype)
+    Q = torch.randn(bsz, n_heads, q_len, head_dim, dtype = qkv_dtype)
+    K = torch.randn(bsz, n_heads, q_len, head_dim, dtype = qkv_dtype)
+    V = torch.randn(bsz, n_heads, q_len, head_dim, dtype = qkv_dtype)
 
     seq_info = None
     if backend == ad.FLASH_VARLEN:
-        cu = torch.tensor([0, q_len], dtype=torch.int32)
+        cu = torch.tensor([0, q_len], dtype = torch.int32)
         seq_info = (None, cu, q_len)
 
     config = ad.AttentionConfig(
-        backend=backend, n_kv_heads=n_heads, n_groups=1,
-        flash_dense_kwargs={"causal": True},
-        flash_varlen_kwargs={"dropout_p": 0.0, "causal": True},
+        backend = backend,
+        n_kv_heads = n_heads,
+        n_groups = 1,
+        flash_dense_kwargs = {"causal": True},
+        flash_varlen_kwargs = {"dropout_p": 0.0, "causal": True},
     )
     context = ad.AttentionContext(
-        bsz=bsz, q_len=q_len, kv_seq_len=q_len, n_heads=n_heads,
-        head_dim=head_dim, requires_grad=False, seq_info=seq_info,
-        attention_mask=None, causal_mask=None,
+        bsz = bsz,
+        q_len = q_len,
+        kv_seq_len = q_len,
+        n_heads = n_heads,
+        head_dim = head_dim,
+        requires_grad = False,
+        seq_info = seq_info,
+        attention_mask = None,
+        causal_mask = None,
     )
-    ad.run_attention(config=config, context=context, Q=Q, K=K, V=V)
+    ad.run_attention(config = config, context = context, Q = Q, K = K, V = V)
     return captured["dtype"]
 
 
 def test_dense_flash_downcasts_fp32_qkv(monkeypatch):
     # fp32 DoRA output must be downcast to a flash-compatible dtype.
-    assert _run(monkeypatch, torch.float32, ad.FLASH_DENSE) in (
-        torch.bfloat16, torch.float16,
-    )
+    assert _run(monkeypatch, torch.float32, ad.FLASH_DENSE) in (torch.bfloat16, torch.float16)
 
 
 def test_varlen_flash_downcasts_fp32_qkv(monkeypatch):
-    assert _run(monkeypatch, torch.float32, ad.FLASH_VARLEN) in (
-        torch.bfloat16, torch.float16,
-    )
+    assert _run(monkeypatch, torch.float32, ad.FLASH_VARLEN) in (torch.bfloat16, torch.float16)
 
 
 def test_bf16_qkv_left_untouched(monkeypatch):

--- a/unsloth/utils/attention_dispatch.py
+++ b/unsloth/utils/attention_dispatch.py
@@ -137,17 +137,14 @@ def run_attention(
     requires_grad = context.requires_grad
     sliding_window = context.sliding_window
 
-    # FlashAttention only supports fp16/bf16. DoRA upcasts its magnitude vector to
-    # fp32, promoting q/k/v_proj outputs to fp32 (any subset, depending on which
-    # modules DoRA targets) and would raise "FlashAttention only support fp16 and
-    # bf16 data type". Downcast whenever any of Q/K/V is fp32.
+    # DoRA promotes q/k/v_proj outputs to fp32, which FlashAttention rejects, so
+    # downcast any fp32 Q/K/V to a flash-supported dtype (#1013).
     if backend in (FLASH_DENSE, FLASH_VARLEN) and torch.float32 in (
         Q.dtype,
         K.dtype,
         V.dtype,
     ):
-        # Prefer the autocast dtype, else a non-fp32 input's dtype (the model compute
-        # dtype), then clamp to a flash-supported dtype.
+        # Prefer the autocast dtype, else a non-fp32 input's dtype, then clamp.
         if torch.is_autocast_enabled():
             try:
                 flash_dtype = torch.get_autocast_dtype("cuda")

--- a/unsloth/utils/attention_dispatch.py
+++ b/unsloth/utils/attention_dispatch.py
@@ -138,15 +138,25 @@ def run_attention(
     sliding_window = context.sliding_window
 
     # FlashAttention only supports fp16/bf16. DoRA upcasts its magnitude vector to
-    # fp32 for the optimizer, which promotes the q/k/v_proj output to fp32 and would
-    # raise "FlashAttention only support fp16 and bf16 data type". Downcast here.
-    if backend in (FLASH_DENSE, FLASH_VARLEN) and Q.dtype == torch.float32:
-        flash_dtype = torch.bfloat16 if SUPPORTS_BFLOAT16 else torch.float16
+    # fp32, promoting q/k/v_proj outputs to fp32 (any subset, depending on which
+    # modules DoRA targets) and would raise "FlashAttention only support fp16 and
+    # bf16 data type". Downcast whenever any of Q/K/V is fp32.
+    if backend in (FLASH_DENSE, FLASH_VARLEN) and torch.float32 in (
+        Q.dtype,
+        K.dtype,
+        V.dtype,
+    ):
+        # Prefer the autocast dtype, else a non-fp32 input's dtype (the model compute
+        # dtype), then clamp to a flash-supported dtype.
         if torch.is_autocast_enabled():
             try:
                 flash_dtype = torch.get_autocast_dtype("cuda")
             except (AttributeError, TypeError):
                 flash_dtype = torch.get_autocast_gpu_dtype()
+        else:
+            flash_dtype = next((d for d in (Q.dtype, K.dtype, V.dtype) if d != torch.float32), None)
+        if flash_dtype not in (torch.float16, torch.bfloat16):
+            flash_dtype = torch.bfloat16 if SUPPORTS_BFLOAT16 else torch.float16
         Q, K, V = Q.to(flash_dtype), K.to(flash_dtype), V.to(flash_dtype)
 
     if backend == FLASH_VARLEN:

--- a/unsloth/utils/attention_dispatch.py
+++ b/unsloth/utils/attention_dispatch.py
@@ -137,6 +137,18 @@ def run_attention(
     requires_grad = context.requires_grad
     sliding_window = context.sliding_window
 
+    # FlashAttention only supports fp16/bf16. DoRA upcasts its magnitude vector to
+    # fp32 for the optimizer, which promotes the q/k/v_proj output to fp32 and would
+    # raise "FlashAttention only support fp16 and bf16 data type". Downcast here.
+    if backend in (FLASH_DENSE, FLASH_VARLEN) and Q.dtype == torch.float32:
+        flash_dtype = torch.bfloat16 if SUPPORTS_BFLOAT16 else torch.float16
+        if torch.is_autocast_enabled():
+            try:
+                flash_dtype = torch.get_autocast_dtype("cuda")
+            except (AttributeError, TypeError):
+                flash_dtype = torch.get_autocast_gpu_dtype()
+        Q, K, V = Q.to(flash_dtype), K.to(flash_dtype), V.to(flash_dtype)
+
     if backend == FLASH_VARLEN:
         Q_f = Q.transpose(1, 2).reshape(bsz * q_len, n_heads, head_dim)
         K_f = K.transpose(1, 2).reshape(bsz * q_len, config.n_kv_heads, head_dim)


### PR DESCRIPTION
## Summary

Fixes the crash when combining FlashAttention 2 with DoRA (`use_dora=True`):

```
RuntimeError: FlashAttention only support fp16 and bf16 data type
```

## Root cause

For LoRA training we upcast the trainable adapter params (`lora_A`, `lora_B` and
`lora_magnitude_vector`) to fp32 so the optimizer has fp32 master weights. That is
correct and needed for DoRA.

The side effect is in PEFT's DoRA forward:

```python
mag_norm_scale = (magnitude / weight_norm).view(1, -1)
result_dora = (mag_norm_scale - 1) * base_result + mag_norm_scale * lora_result * scaling
```

`magnitude` is the fp32 magnitude vector, so type promotion makes `result_dora` fp32.
For the bnb 4bit/8bit layers PEFT only casts the variant output back to the compute
dtype when `requires_conversion = not torch.is_autocast_enabled()`, i.e. only when
autocast is off. During normal mixed precision training autocast is on, so the fp32
q/k/v_proj output is kept and flows into attention. FlashAttention only accepts
fp16/bf16, hence the error. Standard LoRA is unaffected because its output stays bf16.

This is why the only workarounds reported on the issue were "remove flash-attn" or
manually casting every fp32 param back to bf16 after `get_peft_model`.

## Fix

In `run_attention`, before dispatching to the flash kernels, downcast fp32 q/k/v to
the compute dtype (autocast dtype if active, else bf16/fp16 based on hardware support).
This is the natural choke point: flash literally cannot take fp32, so downcasting is the
only valid action. SDPA/eager paths are untouched, and already-16bit q/k/v are left as is,
so standard LoRA, rsLoRA and non-FA2 runs are unchanged. The change is model agnostic
since every model routes attention through this dispatch.

## Testing

Verified on a B200 with `unsloth/tinyllama-bnb-4bit`, all 7 LoRA target modules,
`use_dora=True`, `attn_implementation="flash_attention_2"`, fwd + bwd under autocast:

| Config | Before | After |
| --- | --- | --- |
| DoRA + FA2 | RuntimeError | PASS (loss 7.55) |
| standard LoRA + FA2 | PASS | PASS (loss 7.53) |
| DoRA + SDPA | PASS | PASS (loss 7.55) |

DoRA + FA2 and DoRA + SDPA give identical loss, confirming the downcast does not change
numerics.

Added `tests/utils/test_attention_dispatch_dora_dtype.py`. It monkeypatches the flash
functions so it runs on CPU without flash-attn, and fails on the unpatched dispatch
(2 failed) while passing with the fix (3 passed).

Fixes #1013