### PR TITLE
Studio: self-heal unsloth namespace shadows; clearer failed-load messages

### DIFF
--- a/studio/backend/core/export/worker.py
+++ b/studio/backend/core/export/worker.py
@@ -506,6 +506,13 @@ def run_export_process(*, cmd_queue: Any, resp_queue: Any, config: dict) -> None
         if backend_path not in sys.path:
             sys.path.insert(0, backend_path)
 
+        # Recover from any namespace-package shadow (a stray `unsloth/` dir on
+        # PYTHONPATH) before importing the Unsloth-backed export backend, which
+        # would otherwise fail with a cryptic "cannot import name ...".
+        from core.import_guards import ensure_real_packages
+
+        ensure_real_packages("unsloth_zoo", "unsloth")
+
         from core.export.export import ExportBackend
 
         import transformers

--- a/studio/backend/core/export/worker.py
+++ b/studio/backend/core/export/worker.py
@@ -506,9 +506,7 @@ def run_export_process(*, cmd_queue: Any, resp_queue: Any, config: dict) -> None
         if backend_path not in sys.path:
             sys.path.insert(0, backend_path)
 
-        # Recover from any namespace-package shadow (a stray `unsloth/` dir on
-        # PYTHONPATH) before importing the Unsloth-backed export backend, which
-        # would otherwise fail with a cryptic "cannot import name ...".
+        # Recover from any namespace-package shadow before importing Unsloth.
         from core.import_guards import ensure_real_packages
 
         ensure_real_packages("unsloth_zoo", "unsloth")

--- a/studio/backend/core/import_guards.py
+++ b/studio/backend/core/import_guards.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Shared guard against `unsloth` / `unsloth_zoo` namespace-package shadows.
+
+Dependency-free (stdlib only) so every subprocess entry point can call it
+before any heavy ML import. See `ensure_real_packages` for the full rationale.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def ensure_real_packages(*names: str) -> None:
+    """Stop `import <name>` from binding to a namespace-package shadow.
+
+    A directory named like the package but missing __init__.py on sys.path (a
+    stray checkout, a partial clone, or a polluted PYTHONPATH) makes the path
+    finder return a namespace package, so `from unsloth import FastLanguageModel`
+    dies with "cannot import name ... (unknown location)". A normal
+    site-packages install always wins, so only source/editable installs are
+    exposed. Drop the offending entries, import the real packages, then restore
+    sys.path so other modules on those entries keep importing.
+
+    Pass dependency-first (e.g. ``"unsloth_zoo", "unsloth"``); the real imports
+    are then performed dependency-last so each package's __init__ runs in order.
+    """
+    import importlib
+    import importlib.util
+
+    bad: set = set()
+    shadowed: list = []
+    for name in names:
+        try:
+            spec = importlib.util.find_spec(name)
+        except (ImportError, ValueError, AttributeError):
+            spec = None
+        # a real package exposes its __init__ via spec.origin; a namespace
+        # shadow has origin None/"namespace" and only search locations
+        if spec is None or spec.origin not in (None, "namespace"):
+            continue
+        dirs = {os.path.realpath(d) for d in (spec.submodule_search_locations or [])}
+        if not dirs:
+            continue
+        shadowed.append(name)
+        for entry in sys.path:
+            pkg = os.path.join(entry or os.getcwd(), name)
+            if os.path.realpath(pkg) in dirs and not os.path.isfile(
+                os.path.join(pkg, "__init__.py")
+            ):
+                bad.add(entry)
+    if not bad:
+        return
+    saved = list(sys.path)
+    sys.path[:] = [e for e in sys.path if e not in bad]
+    for name in shadowed:
+        for cached in [m for m in list(sys.modules) if m == name or m.startswith(name + ".")]:
+            del sys.modules[cached]
+    try:
+        importlib.invalidate_caches()
+        # Import unsloth before unsloth_zoo (names are dependency-first):
+        # unsloth.__init__ runs ROCm/Windows bnb fixes before it imports zoo,
+        # so importing zoo first here would skip them. Repeat import is a no-op.
+        for name in reversed(names):
+            importlib.import_module(name)
+    finally:
+        sys.path[:] = saved

--- a/studio/backend/core/import_guards.py
+++ b/studio/backend/core/import_guards.py
@@ -1,11 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Shared guard against `unsloth` / `unsloth_zoo` namespace-package shadows.
-
-Dependency-free (stdlib only) so every subprocess entry point can call it
-before any heavy ML import. See `ensure_real_packages` for the full rationale.
-"""
+"""Recover `unsloth`/`unsloth_zoo` from a namespace-package shadow. Stdlib-only."""
 
 from __future__ import annotations
 
@@ -14,19 +10,10 @@ import sys
 
 
 def ensure_real_packages(*names: str) -> None:
-    """Stop `import <name>` from binding to a namespace-package shadow.
-
-    A directory named like the package but missing __init__.py on sys.path (a
-    stray checkout, a partial clone, or a polluted PYTHONPATH) makes the path
-    finder return a namespace package, so `from unsloth import FastLanguageModel`
-    dies with "cannot import name ... (unknown location)". A normal
-    site-packages install always wins, so only source/editable installs are
-    exposed. Drop the offending entries, import the real packages, then restore
-    sys.path so other modules on those entries keep importing.
-
-    Pass dependency-first (e.g. ``"unsloth_zoo", "unsloth"``); the real imports
-    are then performed dependency-last so each package's __init__ runs in order.
-    """
+    """Drop sys.path entries where a bare `<name>/` dir (no __init__.py) shadows
+    the installed package as a namespace, import the real packages, restore
+    sys.path. No-op without a shadow. Pass dependency-first (e.g. "unsloth_zoo",
+    "unsloth"); imports run dependency-last."""
     import importlib
     import importlib.util
 
@@ -37,8 +24,7 @@ def ensure_real_packages(*names: str) -> None:
             spec = importlib.util.find_spec(name)
         except (ImportError, ValueError, AttributeError):
             spec = None
-        # a real package exposes its __init__ via spec.origin; a namespace
-        # shadow has origin None/"namespace" and only search locations
+        # real package -> spec.origin is its __init__; namespace shadow -> None/"namespace"
         if spec is None or spec.origin not in (None, "namespace"):
             continue
         dirs = {os.path.realpath(d) for d in (spec.submodule_search_locations or [])}
@@ -60,9 +46,7 @@ def ensure_real_packages(*names: str) -> None:
             del sys.modules[cached]
     try:
         importlib.invalidate_caches()
-        # Import unsloth before unsloth_zoo (names are dependency-first):
-        # unsloth.__init__ runs ROCm/Windows bnb fixes before it imports zoo,
-        # so importing zoo first here would skip them. Repeat import is a no-op.
+        # import unsloth before unsloth_zoo: unsloth.__init__ runs GPU/bnb fixes zoo relies on
         for name in reversed(names):
             importlib.import_module(name)
     finally:

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -716,6 +716,13 @@ def run_inference_process(*, cmd_queue: Any, resp_queue: Any, cancel_event, conf
 
         _ensure_backend_on_path()
 
+        # Recover from any namespace-package shadow (a stray `unsloth/` dir on
+        # PYTHONPATH) before importing the Unsloth-backed backend, which would
+        # otherwise fail with a cryptic "cannot import name ...".
+        from core.import_guards import ensure_real_packages
+
+        ensure_real_packages("unsloth_zoo", "unsloth")
+
         from core.inference.inference import InferenceBackend
 
         import transformers

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -716,9 +716,7 @@ def run_inference_process(*, cmd_queue: Any, resp_queue: Any, cancel_event, conf
 
         _ensure_backend_on_path()
 
-        # Recover from any namespace-package shadow (a stray `unsloth/` dir on
-        # PYTHONPATH) before importing the Unsloth-backed backend, which would
-        # otherwise fail with a cryptic "cannot import name ...".
+        # Recover from any namespace-package shadow before importing Unsloth.
         from core.import_guards import ensure_real_packages
 
         ensure_real_packages("unsloth_zoo", "unsloth")

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -46,58 +46,9 @@ if hasattr(torch._dynamo.config, "recompile_limit"):
     torch._dynamo.config.recompile_limit = 64
 
 
-def _ensure_real_packages(*names: str) -> None:
-    """Stop `import <name>` from binding to a namespace-package shadow.
-
-    A directory named like the package but missing __init__.py on sys.path (a
-    stray checkout, a partial clone, or a polluted PYTHONPATH) makes the path
-    finder return a namespace package, so `from unsloth import FastLanguageModel`
-    dies with "cannot import name ... (unknown location)". A normal
-    site-packages install always wins, so only source/editable installs are
-    exposed. Drop the offending entries, import the real packages, then restore
-    sys.path so other modules on those entries keep importing.
-    """
-    import importlib
-    import importlib.util
-
-    bad: set = set()
-    shadowed: list = []
-    for name in names:
-        try:
-            spec = importlib.util.find_spec(name)
-        except (ImportError, ValueError, AttributeError):
-            spec = None
-        # a real package exposes its __init__ via spec.origin; a namespace
-        # shadow has origin None/"namespace" and only search locations
-        if spec is None or spec.origin not in (None, "namespace"):
-            continue
-        dirs = {os.path.realpath(d) for d in (spec.submodule_search_locations or [])}
-        if not dirs:
-            continue
-        shadowed.append(name)
-        for entry in sys.path:
-            pkg = os.path.join(entry or os.getcwd(), name)
-            if os.path.realpath(pkg) in dirs and not os.path.isfile(
-                os.path.join(pkg, "__init__.py")
-            ):
-                bad.add(entry)
-    if not bad:
-        return
-    saved = list(sys.path)
-    sys.path[:] = [e for e in sys.path if e not in bad]
-    for name in shadowed:
-        for cached in [m for m in list(sys.modules) if m == name or m.startswith(name + ".")]:
-            del sys.modules[cached]
-    try:
-        importlib.invalidate_caches()
-        # Import unsloth before unsloth_zoo (names are dependency-first):
-        # unsloth.__init__ runs ROCm/Windows bnb fixes before it imports zoo,
-        # so importing zoo first here would skip them. Repeat import is a no-op.
-        for name in reversed(names):
-            importlib.import_module(name)
-    finally:
-        sys.path[:] = saved
-
+# Shared with the inference / export / embedding workers: drop any
+# namespace-package shadow for unsloth/unsloth_zoo before importing them.
+from core.import_guards import ensure_real_packages as _ensure_real_packages
 
 _ensure_real_packages("unsloth_zoo", "unsloth")
 from unsloth import FastLanguageModel, FastVisionModel, is_bfloat16_supported

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -46,8 +46,7 @@ if hasattr(torch._dynamo.config, "recompile_limit"):
     torch._dynamo.config.recompile_limit = 64
 
 
-# Shared with the inference / export / embedding workers: drop any
-# namespace-package shadow for unsloth/unsloth_zoo before importing them.
+# Drop any unsloth/unsloth_zoo namespace-package shadow before importing them.
 from core.import_guards import ensure_real_packages as _ensure_real_packages
 
 _ensure_real_packages("unsloth_zoo", "unsloth")

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -3156,9 +3156,7 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
     # ── 1. Import embedding-specific libraries ──
     _send_status(event_queue, "Importing embedding libraries...")
     try:
-        # Recover from any namespace-package shadow (a stray `unsloth/` dir on
-        # PYTHONPATH) before importing Unsloth; the LLM path gets this via
-        # trainer.py, but embedding training imports unsloth directly.
+        # Recover from a namespace-package shadow (embedding imports unsloth directly).
         from core.import_guards import ensure_real_packages
 
         ensure_real_packages("unsloth_zoo", "unsloth")

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -3156,6 +3156,12 @@ def _run_embedding_training(event_queue: Any, stop_queue: Any, config: dict) -> 
     # ── 1. Import embedding-specific libraries ──
     _send_status(event_queue, "Importing embedding libraries...")
     try:
+        # Recover from any namespace-package shadow (a stray `unsloth/` dir on
+        # PYTHONPATH) before importing Unsloth; the LLM path gets this via
+        # trainer.py, but embedding training imports unsloth directly.
+        from core.import_guards import ensure_real_packages
+
+        ensure_real_packages("unsloth_zoo", "unsloth")
         from unsloth import FastSentenceTransformer, is_bfloat16_supported
         from sentence_transformers import (
             SentenceTransformerTrainer,

--- a/studio/backend/tests/test_namespace_shadow_guard_pr6269.py
+++ b/studio/backend/tests/test_namespace_shadow_guard_pr6269.py
@@ -1,15 +1,18 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Verification tests for PR #6269 (training-worker namespace-shadow guard).
+"""Verification tests for PR #6269 (namespace-shadow guard).
 
-`_ensure_real_packages` (core/training/trainer.py) drops namespace-package
+`ensure_real_packages` (core/import_guards.py) drops namespace-package
 shadow dirs (a `unsloth`/`unsloth_zoo` dir with no __init__.py on sys.path)
 before `from unsloth import ...`. Order matters: `unsloth.__init__` runs its
 ROCm/Windows bnb fixes before importing unsloth_zoo, so the guard must import
 unsloth first. Each test runs the real guard (ast-extracted from source, no
 GPU/torch) in a subprocess, with fake packages reachable only via a meta path
 finder to mimic an editable/PEP 660 install where the shadow wins.
+
+Originally defined in core/training/trainer.py; extracted to the shared
+core/import_guards.py so the inference, export and embedding workers reuse it.
 """
 
 import json
@@ -21,7 +24,7 @@ from pathlib import Path
 
 import pytest
 
-TRAINER_PY = Path(__file__).resolve().parents[1] / "core" / "training" / "trainer.py"
+GUARD_PY = Path(__file__).resolve().parents[1] / "core" / "import_guards.py"
 
 
 # ── fake package bodies ──────────────────────────────────────────────
@@ -62,17 +65,17 @@ _DRIVER = textwrap.dedent(
 
     cfg = json.load(open(sys.argv[1]))
 
-    # Extract the real _ensure_real_packages from trainer.py source without
-    # importing the heavy module or its `from unsloth import ...` line.
-    src = open(cfg["trainer_py"]).read()
+    # Extract the real ensure_real_packages from import_guards.py source
+    # without importing the heavy module or its `from unsloth import ...` line.
+    src = open(cfg["guard_py"]).read()
     tree = ast.parse(src)
     fn = next(n for n in tree.body
-              if isinstance(n, ast.FunctionDef) and n.name == "_ensure_real_packages")
+              if isinstance(n, ast.FunctionDef) and n.name == "ensure_real_packages")
     mod = ast.Module(body=[fn], type_ignores=[])
     ast.fix_missing_locations(mod)
     ns = {"os": os, "sys": sys}
-    exec(compile(mod, cfg["trainer_py"], "exec"), ns)
-    _ensure_real_packages = ns["_ensure_real_packages"]
+    exec(compile(mod, cfg["guard_py"], "exec"), ns)
+    _ensure_real_packages = ns["ensure_real_packages"]
 
     # Under -S site-packages is off, so a shadow root placed first wins the
     # path finder; the real packages come only from the meta finder below.
@@ -148,7 +151,7 @@ def _run(
     shadow_roots,
     real: bool,
     names = ("unsloth_zoo", "unsloth"),
-    trainer_py: Path = TRAINER_PY,
+    guard_py: Path = GUARD_PY,
     raise_on_invalidate: bool = False,
 ):
     order_file = tmp_path / "order.txt"
@@ -159,7 +162,7 @@ def _run(
         _make_real_pkg(real_root)
 
     cfg = {
-        "trainer_py": str(trainer_py),
+        "guard_py": str(guard_py),
         "shadow_roots": [str(r) for r in shadow_roots],
         "real_root": str(real_root) if real else None,
         "names": list(names),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1926,6 +1926,7 @@ export function createOpenAIStreamAdapter(): ChatModelAdapter {
           externalModelLabel: externalSelection?.modelId ?? null,
           loadedIsMultimodal: runtime.loadedIsMultimodal,
           modelLoaded: !!params.checkpoint && !runtime.modelLoading,
+          loadError: runtime.lastModelLoadError,
         });
         if (imageGateReason) {
           toast.error(imageGateReason);

--- a/studio/frontend/src/features/chat/audio-attachment-adapter.ts
+++ b/studio/frontend/src/features/chat/audio-attachment-adapter.ts
@@ -39,8 +39,7 @@ export class AudioAttachmentAdapter implements AttachmentAdapter {
     const modelLoaded = !!checkpoint && !state.modelLoading;
     let unavailableReason: string | null = null;
     if (!modelLoaded) {
-      // Distinguish a failed load from "no model picked", matching the image
-      // attach gate.
+      // Mirror the image gate: flag a failed load vs "no model picked".
       unavailableReason = state.lastModelLoadError
         ? "The last model failed to load. Check the server logs, then load a model before adding audio files."
         : "Load a model before adding audio files.";

--- a/studio/frontend/src/features/chat/audio-attachment-adapter.ts
+++ b/studio/frontend/src/features/chat/audio-attachment-adapter.ts
@@ -39,7 +39,11 @@ export class AudioAttachmentAdapter implements AttachmentAdapter {
     const modelLoaded = !!checkpoint && !state.modelLoading;
     let unavailableReason: string | null = null;
     if (!modelLoaded) {
-      unavailableReason = "Load a model before adding audio files.";
+      // Distinguish a failed load from "no model picked", matching the image
+      // attach gate.
+      unavailableReason = state.lastModelLoadError
+        ? "The last model failed to load. Check the server logs, then load a model before adding audio files."
+        : "Load a model before adding audio files.";
     } else if (!activeModel?.hasAudioInput) {
       const label = activeModel?.name || checkpoint || "Current model";
       unavailableReason = `${label} cannot accept audio. Load an audio-input model before attaching audio files.`;

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -472,9 +472,7 @@ export function useChatModelRuntime() {
         .filter(Boolean)
         .join(" ");
       setModelsError(null);
-      // Starting a fresh load: clear any prior failed-load marker so the
-      // attach gates stop reporting it.
-      setLastModelLoadError(null);
+      setLastModelLoadError(null); // clear prior failed-load marker
       setLoadToastDismissedState(false);
       const loadInfo = {
         id: modelId,
@@ -1141,9 +1139,7 @@ export function useChatModelRuntime() {
         const message =
           error instanceof Error ? error.message : "Failed to load model";
         setModelsError(message);
-        // Record the load-specific failure so the attach gates can say "the
-        // last load failed" rather than the generic "no model picked".
-        setLastModelLoadError(message);
+        setLastModelLoadError(message); // load-specific failure for the attach gates
         if (throwOnError) {
           throw error instanceof Error ? error : new Error(message);
         }

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -245,6 +245,9 @@ export function useChatModelRuntime() {
   const setLoras = useChatRuntimeStore((state) => state.setLoras);
   const setParams = useChatRuntimeStore((state) => state.setParams);
   const setModelsError = useChatRuntimeStore((state) => state.setModelsError);
+  const setLastModelLoadError = useChatRuntimeStore(
+    (state) => state.setLastModelLoadError,
+  );
   const setCheckpoint = useChatRuntimeStore((state) => state.setCheckpoint);
   const clearCheckpoint = useChatRuntimeStore((state) => state.clearCheckpoint);
 
@@ -469,6 +472,9 @@ export function useChatModelRuntime() {
         .filter(Boolean)
         .join(" ");
       setModelsError(null);
+      // Starting a fresh load: clear any prior failed-load marker so the
+      // attach gates stop reporting it.
+      setLastModelLoadError(null);
       setLoadToastDismissedState(false);
       const loadInfo = {
         id: modelId,
@@ -1135,6 +1141,9 @@ export function useChatModelRuntime() {
         const message =
           error instanceof Error ? error.message : "Failed to load model";
         setModelsError(message);
+        // Record the load-specific failure so the attach gates can say "the
+        // last load failed" rather than the generic "no model picked".
+        setLastModelLoadError(message);
         if (throwOnError) {
           throw error instanceof Error ? error : new Error(message);
         }
@@ -1150,6 +1159,7 @@ export function useChatModelRuntime() {
       resetLoadingUi,
       setLoadToastDismissedState,
       setModelsError,
+      setLastModelLoadError,
       setParams,
     ],
   );

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -114,6 +114,7 @@ class VisionImageAdapter implements AttachmentAdapter {
       externalModelLabel,
       loadedIsMultimodal: state.loadedIsMultimodal,
       modelLoaded,
+      loadError: state.lastModelLoadError,
     });
     if (unavailableReason) {
       toast.error(unavailableReason);

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -485,6 +485,7 @@ export function SharedComposer({
   const modelLoaded = useChatRuntimeStore(
     (s) => !!s.params.checkpoint && !s.modelLoading,
   );
+  const lastModelLoadError = useChatRuntimeStore((s) => s.lastModelLoadError);
   const loadedIsMultimodal = useChatRuntimeStore((s) => s.loadedIsMultimodal);
   const supportsReasoning = useChatRuntimeStore((s) => s.supportsReasoning);
   const reasoningAlwaysOn = useChatRuntimeStore((s) => s.reasoningAlwaysOn);
@@ -566,6 +567,7 @@ export function SharedComposer({
     externalModelLabel: externalSelection?.modelId ?? null,
     loadedIsMultimodal,
     modelLoaded,
+    loadError: lastModelLoadError,
   });
   const isCompareMode = Boolean(model1?.id || model2?.id);
   // Attach-time gate. Compare mode defers to send: the catalog can lag a

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -466,6 +466,10 @@ type ChatRuntimeStore = {
   autoTitle: boolean;
   hfToken: string;
   modelsError: string | null;
+  // Set only when an actual model LOAD attempt fails (not on refresh/list/
+  // unload errors, which set modelsError). Lets the image/audio attach gates
+  // distinguish "the last load failed" from the generic "no model picked".
+  lastModelLoadError: string | null;
   activeGgufVariant: string | null;
   ggufContextLength: number | null;
   ggufMaxContextLength: number | null;
@@ -644,6 +648,7 @@ type ChatRuntimeStore = {
   setAutoTitle: (enabled: boolean) => void;
   setHfToken: (token: string) => void;
   setModelsError: (error: string | null) => void;
+  setLastModelLoadError: (error: string | null) => void;
   setCheckpoint: (modelId: string, ggufVariant?: string | null) => void;
   setActiveThreadId: (threadId: string | null) => void;
   setActiveProjectId: (projectId: string | null) => void;
@@ -948,6 +953,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   autoTitle: false,
   hfToken: loadString(HF_TOKEN_KEY, ""),
   modelsError: null,
+  lastModelLoadError: null,
   activeGgufVariant: null,
   ggufContextLength: null,
   ggufMaxContextLength: null,
@@ -1143,6 +1149,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     notifyHfTokenChanged(hfToken);
   },
   setModelsError: (modelsError) => set({ modelsError }),
+  setLastModelLoadError: (lastModelLoadError) => set({ lastModelLoadError }),
   setCheckpoint: (modelId, ggufVariant) =>
     set((state) => {
       // Persist external selections so they survive a refresh. Local ids are

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -466,9 +466,8 @@ type ChatRuntimeStore = {
   autoTitle: boolean;
   hfToken: string;
   modelsError: string | null;
-  // Set only when an actual model LOAD attempt fails (not on refresh/list/
-  // unload errors, which set modelsError). Lets the image/audio attach gates
-  // distinguish "the last load failed" from the generic "no model picked".
+  // Set only when a LOAD fails (not refresh/list/unload, which use modelsError);
+  // lets the attach gates flag a failed load vs "no model picked".
   lastModelLoadError: string | null;
   activeGgufVariant: string | null;
   ggufContextLength: number | null;

--- a/studio/frontend/src/features/chat/utils/image-input-support.ts
+++ b/studio/frontend/src/features/chat/utils/image-input-support.ts
@@ -22,9 +22,7 @@ export function getImageInputUnavailableReason({
   externalModelLabel?: string | null;
   loadedIsMultimodal: boolean;
   modelLoaded: boolean;
-  // The runtime `lastModelLoadError` (set only when an actual load attempt
-  // failed), if any. Lets the no-model branch distinguish a failed load from
-  // "no model picked".
+  // Runtime lastModelLoadError; lets the no-model branch flag a failed load.
   loadError?: string | null;
 }): string | null {
   if (isExternalModel) {
@@ -45,10 +43,7 @@ export function getImageInputUnavailableReason({
     return null;
   }
   if (!modelLoaded) {
-    // A failed load never sets the checkpoint, so modelLoaded stays false and
-    // the bare "Load a model" hint wrongly implies the user just forgot to
-    // pick one. When the last load actually errored, say so and point at the
-    // logs instead.
+    // Distinguish a failed load from "no model picked yet".
     if (loadError) {
       return "The last model failed to load. Check the server logs, then load a model before adding images.";
     }

--- a/studio/frontend/src/features/chat/utils/image-input-support.ts
+++ b/studio/frontend/src/features/chat/utils/image-input-support.ts
@@ -10,6 +10,7 @@ export function getImageInputUnavailableReason({
   externalModelLabel,
   loadedIsMultimodal,
   modelLoaded,
+  loadError,
 }: {
   activeModel?: ChatModelSummary;
   isExternalModel: boolean;
@@ -21,6 +22,10 @@ export function getImageInputUnavailableReason({
   externalModelLabel?: string | null;
   loadedIsMultimodal: boolean;
   modelLoaded: boolean;
+  // The runtime `lastModelLoadError` (set only when an actual load attempt
+  // failed), if any. Lets the no-model branch distinguish a failed load from
+  // "no model picked".
+  loadError?: string | null;
 }): string | null {
   if (isExternalModel) {
     const explicitlyNonVision =
@@ -39,7 +44,16 @@ export function getImageInputUnavailableReason({
     }
     return null;
   }
-  if (!modelLoaded) return "Load a model before adding images.";
+  if (!modelLoaded) {
+    // A failed load never sets the checkpoint, so modelLoaded stays false and
+    // the bare "Load a model" hint wrongly implies the user just forgot to
+    // pick one. When the last load actually errored, say so and point at the
+    // logs instead.
+    if (loadError) {
+      return "The last model failed to load. Check the server logs, then load a model before adding images.";
+    }
+    return "Load a model before adding images.";
+  }
   // loadedIsMultimodal is true for vision OR audio; that one flag can't tell
   // them apart, so only block when activeModel confirms audio-only (audio
   // capability set AND isVision === false). Otherwise trust the load


### PR DESCRIPTION
## Summary

Two independent Studio fixes that turn a failed model load from a confusing dead end into something the user can act on, hardened after an internal multi-reviewer pass. Both came out of a real case where loading a non-GGUF model failed and the only visible symptom was the chat composer saying "Load a model before adding images.", which looks like the user simply forgot to pick a model.

### 1. Backend: self-heal `unsloth` / `unsloth_zoo` namespace-package shadows

A directory named `unsloth` (or `unsloth_zoo`) without an `__init__.py` on `PYTHONPATH` / `sys.path` (a stray source checkout, or launching Studio from a directory that contains one) makes `import unsloth` resolve to an empty namespace package, so a worker's `from unsloth import FastLanguageModel` dies with a cryptic `cannot import name ... (unknown location)`.

The LLM training path already recovered from this via `_ensure_real_packages` in `trainer.py` (PR #6269), but the **inference**, **export**, and **embedding-training** subprocesses imported Unsloth directly with no guard. This extracts that helper into a shared, dependency-free `core/import_guards.py` and calls it before the Unsloth import in every subprocess. Rather than just raising a clearer error, it **recovers**: it drops the offending `sys.path` entries, imports the real packages (unsloth before unsloth_zoo so the pre-zoo GPU fixes run), then restores `sys.path`. `trainer.py` now imports the shared helper instead of keeping its own copy.

Covers both `unsloth` and `unsloth_zoo`, and both namespace origin forms (`None` and `"namespace"`).

### 2. Frontend: distinguish a failed load from "no model picked"

A failed load never sets the checkpoint, so the image and audio attach gates fell through to "Load a model before adding images/audio", which reads as if the user simply forgot to pick a model rather than that the load errored. This adds a dedicated `lastModelLoadError` to the chat runtime store, set **only** when an actual load attempt fails (not on refresh/list/status/unload errors, which keep using `modelsError`) and cleared when the next load starts. The image gate (all three call sites) and the audio gate now report a failed load and point at the server logs:

> The last model failed to load. Check the server logs, then load a model before adding images.

The gates still block in exactly the same cases.

## Testing

- Backend: the existing PR #6269 namespace-shadow test (`test_namespace_shadow_guard_pr6269.py`) now exercises the shared `ensure_real_packages` and passes (7 passed). It verifies recovery, unsloth-before-unsloth_zoo import order, `sys.path` restoration (even when `invalidate_caches` raises), and `ModuleNotFoundError` when the package is genuinely absent. `py_compile` passes on all changed backend files.
- Frontend: `tsc -b` typecheck and `vite build` pass. The eslint problem count on the changed files is unchanged before/after, so the diff adds no new lint issues.
