### PR TITLE
Show model provider/org in the trust_remote_code consent dialog

### DIFF
--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1582,6 +1582,19 @@ async def get_model_config(
         )
 
 
+def _consent_provider(model_name: str, scanned_targets: List[str]) -> Optional[str]:
+    """HF org for the consent dialog's `from "<provider>"` tag, or None.
+
+    Returns the owner only for a single, non-local, canonical ``owner/repo`` Hub id.
+    A LoRA's extra base target (len > 1) or a local/relative path yields None, so the
+    dialog never attributes the scanned code to the wrong publisher.
+    """
+    if len(scanned_targets) != 1 or is_local_path(model_name):
+        return None
+    parts = model_name.split("/")
+    return parts[0] if len(parts) == 2 and all(parts) else None
+
+
 @router.post("/remote-code-scan")
 async def scan_model_remote_code(
     model_name: str = Body(..., embed = True),
@@ -1658,6 +1671,9 @@ async def scan_model_remote_code(
         # created_by_scan = primary flag (older clients); scan_created_repos drives cleanup.
         payload["created_by_scan"] = model_name in scan_created_repos
         payload["scan_created_repos"] = scan_created_repos
+        # Provider (HF org) for the dialog's `from "<provider>"` tag, decided here where
+        # locality and scan scope are known (see _consent_provider).
+        payload["provider"] = _consent_provider(model_name, security_targets)
 
         # Malware gate (metadata-only): surface HF-flagged unsafe files so the dialog can
         # hard-block. Orthogonal to remote code -- a poisoned pickle needs no auto_map.

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1582,14 +1582,19 @@ async def get_model_config(
         )
 
 
-def _consent_provider(model_name: str, scanned_targets: List[str]) -> Optional[str]:
+def _consent_provider(
+    model_name: str,
+    scanned_targets: List[str],
+    external_refs: Optional[List[str]] = None,
+) -> Optional[str]:
     """HF org for the consent dialog's `from "<provider>"` tag, or None.
 
     Returns the owner only for a single, non-local, canonical ``owner/repo`` Hub id.
-    A LoRA's extra base target (len > 1) or a local/relative path yields None, so the
-    dialog never attributes the scanned code to the wrong publisher.
+    A LoRA's extra base target (len > 1), a local/relative path, or an external
+    ``auto_map`` ref (e.g. ``owner/other--mod.Class``, whose executable code lives in a
+    different repo) yields None, so the dialog never misattributes the scanned code.
     """
-    if len(scanned_targets) != 1 or is_local_path(model_name):
+    if len(scanned_targets) != 1 or external_refs or is_local_path(model_name):
         return None
     parts = model_name.split("/")
     return parts[0] if len(parts) == 2 and all(parts) else None
@@ -1658,12 +1663,14 @@ async def scan_model_remote_code(
             except Exception:
                 pass
 
+        external_refs: list = []
         for _target in security_targets:
             # Use the pre-base-resolution snapshot for the primary (see above).
             _mark_scan_created(
                 _target, preexisting = _primary_preexisting if _target == model_name else None
             )
             for _ext in external_auto_map_repos(_target, hf_token):
+                external_refs.append(_ext)
                 _mark_scan_created(_ext)
         decision = preflight_remote_code_consent_for_targets(security_targets, hf_token = hf_token)
         payload = decision.response_payload()
@@ -1672,8 +1679,8 @@ async def scan_model_remote_code(
         payload["created_by_scan"] = model_name in scan_created_repos
         payload["scan_created_repos"] = scan_created_repos
         # Provider (HF org) for the dialog's `from "<provider>"` tag, decided here where
-        # locality and scan scope are known (see _consent_provider).
-        payload["provider"] = _consent_provider(model_name, security_targets)
+        # locality, scan scope, and external auto_map refs are known (see _consent_provider).
+        payload["provider"] = _consent_provider(model_name, security_targets, external_refs)
 
         # Malware gate (metadata-only): surface HF-flagged unsafe files so the dialog can
         # hard-block. Orthogonal to remote code -- a poisoned pickle needs no auto_map.

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1589,10 +1589,9 @@ def _consent_provider(
 ) -> Optional[str]:
     """HF org for the consent dialog's `from "<provider>"` tag, or None.
 
-    Returns the owner only for a single, non-local, canonical ``owner/repo`` Hub id.
-    A LoRA's extra base target (len > 1), a local/relative path, or an external
-    ``auto_map`` ref (e.g. ``owner/other--mod.Class``, whose executable code lives in a
-    different repo) yields None, so the dialog never misattributes the scanned code.
+    Returns the owner only for a single, non-local, canonical ``owner/repo`` id; a LoRA's
+    extra base, a local path, or an external ``auto_map`` ref yields None so the dialog
+    never misattributes scanned code.
     """
     if len(scanned_targets) != 1 or external_refs or is_local_path(model_name):
         return None
@@ -1678,8 +1677,7 @@ async def scan_model_remote_code(
         # created_by_scan = primary flag (older clients); scan_created_repos drives cleanup.
         payload["created_by_scan"] = model_name in scan_created_repos
         payload["scan_created_repos"] = scan_created_repos
-        # Provider (HF org) for the dialog's `from "<provider>"` tag, decided here where
-        # locality, scan scope, and external auto_map refs are known (see _consent_provider).
+        # Provider tag decided here, where locality/scan scope/external refs are known.
         payload["provider"] = _consent_provider(model_name, security_targets, external_refs)
 
         # Malware gate (metadata-only): surface HF-flagged unsafe files so the dialog can

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -815,6 +815,35 @@ class TestRemoteCodeScan:
         assert not scan_remote_code_files({"modeling_x.py": _SCAN_MALICIOUS}).clean
 
 
+class TestConsentProvider:
+    """_consent_provider attributes the dialog's `from "<provider>"` tag only when safe."""
+
+    @staticmethod
+    def _fn():
+        from routes.models import _consent_provider
+
+        return _consent_provider
+
+    def test_single_hub_id_returns_owner(self):
+        assert self._fn()("NVIDIA/Nemotron", ["NVIDIA/Nemotron"]) == "NVIDIA"
+
+    def test_multi_target_lora_returns_none(self):
+        # A LoRA scans adapter + base; attributing to one would mislead.
+        assert self._fn()("user/adapter", ["user/adapter", "NVIDIA/base"]) is None
+
+    def test_local_path_returns_none(self, tmp_path):
+        d = tmp_path / "org" / "model"
+        d.mkdir(parents = True)
+        assert self._fn()(str(d), [str(d)]) is None
+        assert self._fn()("/home/me/model", ["/home/me/model"]) is None
+
+    def test_non_canonical_id_returns_none(self):
+        fn = self._fn()
+        assert fn("a/b/c", ["a/b/c"]) is None
+        assert fn("/repo", ["/repo"]) is None
+        assert fn("plainname", ["plainname"]) is None
+
+
 class TestScannerCoversAllExecutableCode:
     """repo_remote_code_files must collect every .py the loader could execute, so the fingerprint can't certify unscanned code."""
 

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -821,7 +821,6 @@ class TestConsentProvider:
     @staticmethod
     def _fn():
         from routes.models import _consent_provider
-
         return _consent_provider
 
     def test_single_hub_id_returns_owner(self):

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -825,10 +825,15 @@ class TestConsentProvider:
 
     def test_single_hub_id_returns_owner(self):
         assert self._fn()("NVIDIA/Nemotron", ["NVIDIA/Nemotron"]) == "NVIDIA"
+        assert self._fn()("NVIDIA/Nemotron", ["NVIDIA/Nemotron"], []) == "NVIDIA"
 
     def test_multi_target_lora_returns_none(self):
         # A LoRA scans adapter + base; attributing to one would mislead.
         assert self._fn()("user/adapter", ["user/adapter", "NVIDIA/base"]) is None
+
+    def test_external_auto_map_ref_returns_none(self):
+        # A single repo whose auto_map pulls code from another repo: don't attribute it.
+        assert self._fn()("owner/repo", ["owner/repo"], ["evilorg/evilrepo"]) is None
 
     def test_local_path_returns_none(self, tmp_path):
         d = tmp_path / "org" / "model"

--- a/studio/frontend/src/features/security/api/remote-code-api.ts
+++ b/studio/frontend/src/features/security/api/remote-code-api.ts
@@ -39,6 +39,7 @@ interface RemoteCodeScanResponse {
   scan_created_repos?: string[];
   unsafe_files?: Array<{ path?: string; level?: string }>;
   security_blocked?: boolean;
+  provider?: string | null;
 }
 
 /** Scan a model's auto_map code for the consent dialog (backend reads config + repo
@@ -93,6 +94,7 @@ export async function getRemoteCodeScan(
       (data.created_by_scan ? [data.model_name ?? modelName] : []),
     unsafeFiles,
     securityBlocked: Boolean(data.security_blocked),
+    provider: data.provider ?? null,
   };
 }
 

--- a/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
+++ b/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
@@ -23,6 +23,7 @@ import { severityTone } from "../lib/severity-tone";
 import { useRemoteCodeConsentDialogStore } from "../stores/remote-code-consent-dialog-store";
 import type {
   RemoteCodeFinding,
+  RemoteCodeScan,
   RemoteCodeSeverity,
   RemoteCodeSnippetRow,
   UnsafeFile,
@@ -163,11 +164,17 @@ function FindingCard({ finding }: { finding: RemoteCodeFinding }) {
 
 /** Split a model id into its display name and provider (the HF org/owner) so the
  *  consent dialog can say e.g. `Nemotron-3-Nano-4B from "unsloth"`. Returns a null
- *  provider for local paths (./, /, ~, C:\, backslashes) and bare names with no owner. */
-function parseModelDisplay(modelName?: string): {
+ *  provider unless the id is a canonical single Hub repo (`owner/repo`, exactly one
+ *  slash, both segments non-empty) that is not a local path. A deeper path
+ *  (`models/llama/7b`), a local path (./, /, ~, C:\, backslashes), or a multi-repo
+ *  scan (a LoRA adapter pulls its base too, so findings span repos) all yield a null
+ *  provider -- we must not present another repo's or a local directory's name as the
+ *  publisher in a trust decision. */
+function parseModelDisplay(scan?: RemoteCodeScan | null): {
   displayName: string;
   provider: string | null;
 } {
+  const modelName = scan?.modelName;
   if (!modelName) return { displayName: "This model", provider: null };
   const parts = modelName.split("/");
   const displayName = parts[parts.length - 1] || modelName;
@@ -177,8 +184,27 @@ function parseModelDisplay(modelName?: string): {
     modelName.startsWith("~") ||
     modelName.includes("\\") ||
     /^[A-Za-z]:/.test(modelName);
-  const provider = parts.length >= 2 && !looksLocal ? parts[0] : null;
+  const isCanonicalHubId =
+    parts.length === 2 && Boolean(parts[0]) && Boolean(parts[1]);
+  // A LoRA/adapter scan also pulls its base model and aggregates findings across
+  // both, so a single owner from modelName could misattribute the base's issue.
+  const multiRepoScan = (scan?.scanCreatedRepos?.length ?? 0) > 1;
+  const provider =
+    isCanonicalHubId && !looksLocal && !multiRepoScan ? parts[0] : null;
   return { displayName, provider };
+}
+
+/** ` from "<provider>"` clause, rendered only when a provider was confidently
+ *  resolved (see {@link parseModelDisplay}). */
+function ProviderSuffix({ provider }: { provider: string | null }) {
+  if (!provider) return null;
+  return (
+    <>
+      {" "}
+      from{" "}
+      <span className="font-medium text-foreground">"{provider}"</span>
+    </>
+  );
 }
 
 /** App-wide consent dialog for trust_remote_code loads: shows scan findings with the
@@ -188,7 +214,7 @@ export function RemoteCodeConsentDialog() {
   const scan = useRemoteCodeConsentDialogStore((s) => s.scan);
   const resolve = useRemoteCodeConsentDialogStore((s) => s.resolve);
 
-  const { displayName, provider } = parseModelDisplay(scan?.modelName);
+  const { displayName, provider } = parseModelDisplay(scan);
   const blocked = scan ? !scan.approvable : false;
   const findings = scan?.findings ?? [];
   const unsafeFiles = scan?.unsafeFiles ?? [];
@@ -239,15 +265,7 @@ export function RemoteCodeConsentDialog() {
                       <span className="font-medium text-foreground">
                         {displayName}
                       </span>
-                      {provider ? (
-                        <>
-                          {" "}
-                          from{" "}
-                          <span className="font-medium text-foreground">
-                            "{provider}"
-                          </span>
-                        </>
-                      ) : null}{" "}
+                      <ProviderSuffix provider={provider} />{" "}
                       contains files that Hugging Face's security scan flagged as
                       unsafe (for example, a malicious pickle that would run code
                       when the model loads). It cannot be loaded. The flagged
@@ -258,15 +276,7 @@ export function RemoteCodeConsentDialog() {
                       <span className="font-medium text-foreground">
                         {displayName}
                       </span>
-                      {provider ? (
-                        <>
-                          {" "}
-                          from{" "}
-                          <span className="font-medium text-foreground">
-                            "{provider}"
-                          </span>
-                        </>
-                      ) : null}{" "}
+                      <ProviderSuffix provider={provider} />{" "}
                       declares custom Python code in its repository.{" "}
                       {blocked
                         ? "A security scan flagged CRITICAL issues, so it cannot be enabled."

--- a/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
+++ b/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
@@ -23,7 +23,6 @@ import { severityTone } from "../lib/severity-tone";
 import { useRemoteCodeConsentDialogStore } from "../stores/remote-code-consent-dialog-store";
 import type {
   RemoteCodeFinding,
-  RemoteCodeScan,
   RemoteCodeSeverity,
   RemoteCodeSnippetRow,
   UnsafeFile,
@@ -162,30 +161,11 @@ function FindingCard({ finding }: { finding: RemoteCodeFinding }) {
   );
 }
 
-/** Display name + provider (HF org) for the consent dialog. Provider is null unless the
- *  id is a canonical `owner/repo` Hub id (not local, not a multi-repo/LoRA scan), so we
- *  never attribute a local dir or another repo's finding to the wrong publisher. */
-function parseModelDisplay(scan?: RemoteCodeScan | null): {
-  displayName: string;
-  provider: string | null;
-} {
-  const modelName = scan?.modelName;
-  if (!modelName) return { displayName: "This model", provider: null };
-  const parts = modelName.split("/");
-  const displayName = parts[parts.length - 1] || modelName;
-  const looksLocal =
-    modelName.startsWith(".") ||
-    modelName.startsWith("/") ||
-    modelName.startsWith("~") ||
-    modelName.includes("\\") ||
-    /^[A-Za-z]:/.test(modelName);
-  const isCanonicalHubId =
-    parts.length === 2 && Boolean(parts[0]) && Boolean(parts[1]);
-  // A LoRA scan also pulls its base, so a single owner could misattribute its finding.
-  const multiRepoScan = (scan?.scanCreatedRepos?.length ?? 0) > 1;
-  const provider =
-    isCanonicalHubId && !looksLocal && !multiRepoScan ? parts[0] : null;
-  return { displayName, provider };
+/** Last path segment of the model id for display. The provider (HF org) is decided
+ *  server-side (``scan.provider``), where locality and scan scope are known. */
+function modelDisplayName(modelName?: string): string {
+  if (!modelName) return "This model";
+  return modelName.split("/").pop() || modelName;
 }
 
 /** ` from "<provider>"` clause, rendered only when a provider was resolved. */
@@ -207,7 +187,8 @@ export function RemoteCodeConsentDialog() {
   const scan = useRemoteCodeConsentDialogStore((s) => s.scan);
   const resolve = useRemoteCodeConsentDialogStore((s) => s.resolve);
 
-  const { displayName, provider } = parseModelDisplay(scan);
+  const displayName = modelDisplayName(scan?.modelName);
+  const provider = scan?.provider ?? null;
   const blocked = scan ? !scan.approvable : false;
   const findings = scan?.findings ?? [];
   const unsafeFiles = scan?.unsafeFiles ?? [];

--- a/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
+++ b/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
@@ -161,8 +161,7 @@ function FindingCard({ finding }: { finding: RemoteCodeFinding }) {
   );
 }
 
-/** Last path segment of the model id for display. The provider (HF org) is decided
- *  server-side (``scan.provider``), where locality and scan scope are known. */
+/** Last path segment of the model id, for display. */
 function modelDisplayName(modelName?: string): string {
   if (!modelName) return "This model";
   return modelName.split("/").pop() || modelName;

--- a/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
+++ b/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
@@ -161,6 +161,26 @@ function FindingCard({ finding }: { finding: RemoteCodeFinding }) {
   );
 }
 
+/** Split a model id into its display name and provider (the HF org/owner) so the
+ *  consent dialog can say e.g. `Nemotron-3-Nano-4B from "unsloth"`. Returns a null
+ *  provider for local paths (./, /, ~, C:\, backslashes) and bare names with no owner. */
+function parseModelDisplay(modelName?: string): {
+  displayName: string;
+  provider: string | null;
+} {
+  if (!modelName) return { displayName: "This model", provider: null };
+  const parts = modelName.split("/");
+  const displayName = parts[parts.length - 1] || modelName;
+  const looksLocal =
+    modelName.startsWith(".") ||
+    modelName.startsWith("/") ||
+    modelName.startsWith("~") ||
+    modelName.includes("\\") ||
+    /^[A-Za-z]:/.test(modelName);
+  const provider = parts.length >= 2 && !looksLocal ? parts[0] : null;
+  return { displayName, provider };
+}
+
 /** App-wide consent dialog for trust_remote_code loads: shows scan findings with the
  *  flagged code in context; CRITICAL is a hard block. Mounted once in the root layout. */
 export function RemoteCodeConsentDialog() {
@@ -168,7 +188,7 @@ export function RemoteCodeConsentDialog() {
   const scan = useRemoteCodeConsentDialogStore((s) => s.scan);
   const resolve = useRemoteCodeConsentDialogStore((s) => s.resolve);
 
-  const displayName = scan?.modelName?.split("/").pop() || "This model";
+  const { displayName, provider } = parseModelDisplay(scan?.modelName);
   const blocked = scan ? !scan.approvable : false;
   const findings = scan?.findings ?? [];
   const unsafeFiles = scan?.unsafeFiles ?? [];
@@ -218,7 +238,16 @@ export function RemoteCodeConsentDialog() {
                     <>
                       <span className="font-medium text-foreground">
                         {displayName}
-                      </span>{" "}
+                      </span>
+                      {provider ? (
+                        <>
+                          {" "}
+                          from{" "}
+                          <span className="font-medium text-foreground">
+                            "{provider}"
+                          </span>
+                        </>
+                      ) : null}{" "}
                       contains files that Hugging Face's security scan flagged as
                       unsafe (for example, a malicious pickle that would run code
                       when the model loads). It cannot be loaded. The flagged
@@ -228,7 +257,16 @@ export function RemoteCodeConsentDialog() {
                     <>
                       <span className="font-medium text-foreground">
                         {displayName}
-                      </span>{" "}
+                      </span>
+                      {provider ? (
+                        <>
+                          {" "}
+                          from{" "}
+                          <span className="font-medium text-foreground">
+                            "{provider}"
+                          </span>
+                        </>
+                      ) : null}{" "}
                       declares custom Python code in its repository.{" "}
                       {blocked
                         ? "A security scan flagged CRITICAL issues, so it cannot be enabled."

--- a/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
+++ b/studio/frontend/src/features/security/components/remote-code-consent-dialog.tsx
@@ -162,14 +162,9 @@ function FindingCard({ finding }: { finding: RemoteCodeFinding }) {
   );
 }
 
-/** Split a model id into its display name and provider (the HF org/owner) so the
- *  consent dialog can say e.g. `Nemotron-3-Nano-4B from "unsloth"`. Returns a null
- *  provider unless the id is a canonical single Hub repo (`owner/repo`, exactly one
- *  slash, both segments non-empty) that is not a local path. A deeper path
- *  (`models/llama/7b`), a local path (./, /, ~, C:\, backslashes), or a multi-repo
- *  scan (a LoRA adapter pulls its base too, so findings span repos) all yield a null
- *  provider -- we must not present another repo's or a local directory's name as the
- *  publisher in a trust decision. */
+/** Display name + provider (HF org) for the consent dialog. Provider is null unless the
+ *  id is a canonical `owner/repo` Hub id (not local, not a multi-repo/LoRA scan), so we
+ *  never attribute a local dir or another repo's finding to the wrong publisher. */
 function parseModelDisplay(scan?: RemoteCodeScan | null): {
   displayName: string;
   provider: string | null;
@@ -186,16 +181,14 @@ function parseModelDisplay(scan?: RemoteCodeScan | null): {
     /^[A-Za-z]:/.test(modelName);
   const isCanonicalHubId =
     parts.length === 2 && Boolean(parts[0]) && Boolean(parts[1]);
-  // A LoRA/adapter scan also pulls its base model and aggregates findings across
-  // both, so a single owner from modelName could misattribute the base's issue.
+  // A LoRA scan also pulls its base, so a single owner could misattribute its finding.
   const multiRepoScan = (scan?.scanCreatedRepos?.length ?? 0) > 1;
   const provider =
     isCanonicalHubId && !looksLocal && !multiRepoScan ? parts[0] : null;
   return { displayName, provider };
 }
 
-/** ` from "<provider>"` clause, rendered only when a provider was confidently
- *  resolved (see {@link parseModelDisplay}). */
+/** ` from "<provider>"` clause, rendered only when a provider was resolved. */
 function ProviderSuffix({ provider }: { provider: string | null }) {
   if (!provider) return null;
   return (

--- a/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
+++ b/studio/frontend/src/features/security/hooks/use-remote-code-consent.ts
@@ -42,6 +42,7 @@ export async function confirmRemoteCodeIfNeeded({
       scanCreatedRepos: [],
       unsafeFiles: [],
       securityBlocked: false,
+      provider: null,
     };
   }
 

--- a/studio/frontend/src/features/security/types.ts
+++ b/studio/frontend/src/features/security/types.ts
@@ -43,7 +43,5 @@ export interface RemoteCodeScan {
   scanCreatedRepos: string[];
   unsafeFiles: UnsafeFile[]; // files HF flagged unsafe; non-empty => hard block
   securityBlocked: boolean; // blocked specifically by the malware gate
-  // HF org for the "from <provider>" tag, decided server-side (locality + scan scope);
-  // null for local paths and multi-repo/LoRA scans so we never misattribute.
-  provider: string | null;
+  provider: string | null; // HF org for the "from <provider>" tag; null when unattributable
 }

--- a/studio/frontend/src/features/security/types.ts
+++ b/studio/frontend/src/features/security/types.ts
@@ -43,4 +43,7 @@ export interface RemoteCodeScan {
   scanCreatedRepos: string[];
   unsafeFiles: UnsafeFile[]; // files HF flagged unsafe; non-empty => hard block
   securityBlocked: boolean; // blocked specifically by the malware gate
+  // HF org for the "from <provider>" tag, decided server-side (locality + scan scope);
+  // null for local paths and multi-repo/LoRA scans so we never misattribute.
+  provider: string | null;
 }


### PR DESCRIPTION
## What

Show the model's provider (the Hugging Face org/owner) in the `trust_remote_code` consent dialog, so the user can see at a glance who published the custom code they are about to enable.

Before:

> **NVIDIA-Nemotron-3-Nano-4B** declares custom Python code in its repository. Continue only if you trust the model source.

After:

> **NVIDIA-Nemotron-3-Nano-4B** from **"unsloth"** declares custom Python code in its repository. Continue only if you trust the model source.

## Why

The dialog only showed the trailing model name (`modelName.split("/").pop()`), dropping the owner. The owner is exactly the "who do I trust" signal the consent prompt is asking about (e.g. `unsloth/...` vs a random fork), so surfacing it makes the trust decision clearer.

## How

In `remote-code-consent-dialog.tsx`, a small `parseModelDisplay` helper splits the model id into `{ displayName, provider }`:

- `provider` is the first path segment (the HF org/owner) for hub repo ids like `owner/name`.
- It is `null` for local paths (`./`, `/`, `~`, `C:\`, backslashes) and bare names with no owner, so those loads render unchanged (no misleading `from "..."`).

The `from "<provider>"` tag is added to all three dialog variants (enable / blocked / malware) since they share the same description block. No behavior change beyond the displayed copy.
