### PR TITLE
Use uppercase -GGUF suffix for GGUF export default names

### DIFF
--- a/studio/frontend/src/features/export/components/export-run-panel.tsx
+++ b/studio/frontend/src/features/export/components/export-run-panel.tsx
@@ -320,7 +320,7 @@ export function ExportRunPanel(props: ExportRunPanelProps) {
                         Model Name
                       </label>
                       <Input
-                        placeholder="my-model-gguf"
+                        placeholder="my-model-GGUF"
                         value={modelName}
                         onChange={(e) => onModelNameChange(e.target.value)}
                       />

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -93,7 +93,12 @@ function siblingGgufDirectory(sourcePath: string): string | null {
   const trimmed = sourcePath.trim().replace(/[\\/]+$/, "");
   if (!trimmed) return null;
   const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  if (slash < 0) return `${trimmed}_GGUF`;
+  // Keep the lowercase ``_gguf`` token here: for a local-path source this is the
+  // exact intermediate dir the backend creates and then cleans up
+  // (core/export/export.py builds ``<checkpoint>_gguf``). Diverging to ``_GGUF``
+  // makes the backend treat the user's chosen dir as a separate location and
+  // relocate+delete the lowercase sibling, which can remove an existing export.
+  if (slash < 0) return `${trimmed}_gguf`;
   const parent =
     slash === 0 || (slash === 2 && /^[A-Za-z]:/.test(trimmed))
       ? trimmed.slice(0, slash + 1)
@@ -105,7 +110,7 @@ function siblingGgufDirectory(sourcePath: string): string | null {
     : trimmed.includes("\\")
       ? "\\"
       : "/";
-  return `${parent}${sep}${name}_GGUF`;
+  return `${parent}${sep}${name}_gguf`;
 }
 
 export function ExportPage() {

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -93,11 +93,8 @@ function siblingGgufDirectory(sourcePath: string): string | null {
   const trimmed = sourcePath.trim().replace(/[\\/]+$/, "");
   if (!trimmed) return null;
   const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  // Keep the lowercase ``_gguf`` token here: for a local-path source this is the
-  // exact intermediate dir the backend creates and then cleans up
-  // (core/export/export.py builds ``<checkpoint>_gguf``). Diverging to ``_GGUF``
-  // makes the backend treat the user's chosen dir as a separate location and
-  // relocate+delete the lowercase sibling, which can remove an existing export.
+  // Lowercase to match the backend's intermediate `<checkpoint>_gguf` dir
+  // (core/export/export.py); `_GGUF` would make it relocate+delete that sibling.
   if (slash < 0) return `${trimmed}_gguf`;
   const parent =
     slash === 0 || (slash === 2 && /^[A-Za-z]:/.test(trimmed))

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -84,7 +84,7 @@ function buildRelativeSaveDirectory(
 ): string {
   if (exportMethod === "gguf") {
     return `${(sourceBaseModelName.split("/").pop() ?? selectedModelIdx ?? "model")
-      .replace(/[^a-zA-Z0-9._-]/g, "-")}-gguf`;
+      .replace(/[^a-zA-Z0-9._-]/g, "-")}-GGUF`;
   }
   return `${selectedModelIdx ?? "model"}/${checkpoint}`;
 }
@@ -93,7 +93,7 @@ function siblingGgufDirectory(sourcePath: string): string | null {
   const trimmed = sourcePath.trim().replace(/[\\/]+$/, "");
   if (!trimmed) return null;
   const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  if (slash < 0) return `${trimmed}_gguf`;
+  if (slash < 0) return `${trimmed}_GGUF`;
   const parent =
     slash === 0 || (slash === 2 && /^[A-Za-z]:/.test(trimmed))
       ? trimmed.slice(0, slash + 1)
@@ -105,7 +105,7 @@ function siblingGgufDirectory(sourcePath: string): string | null {
     : trimmed.includes("\\")
       ? "\\"
       : "/";
-  return `${parent}${sep}${name}_gguf`;
+  return `${parent}${sep}${name}_GGUF`;
 }
 
 export function ExportPage() {

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -93,8 +93,8 @@ function siblingGgufDirectory(sourcePath: string): string | null {
   const trimmed = sourcePath.trim().replace(/[\\/]+$/, "");
   if (!trimmed) return null;
   const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  // Lowercase to match the backend's intermediate `<checkpoint>_gguf` dir
-  // (core/export/export.py); `_GGUF` would make it relocate+delete that sibling.
+  // Lowercase `_gguf` matches the backend's intermediate dir (core/export/export.py);
+  // `_GGUF` would relocate+delete that sibling.
   if (slash < 0) return `${trimmed}_gguf`;
   const parent =
     slash === 0 || (slash === 2 && /^[A-Za-z]:/.test(trimmed))


### PR DESCRIPTION
## What

Use an uppercase `GGUF` token in the default names Studio suggests for a GGUF export, matching the Hugging Face / Unsloth convention (`Model-GGUF`, e.g. `unsloth/Qwen3-1.7B-GGUF`).

Before: `NVIDIA-Nemotron-3-Nano-4B-gguf`
After: `NVIDIA-Nemotron-3-Nano-4B-GGUF`

## Changes (frontend, default names only)

- `export-page.tsx` `buildRelativeSaveDirectory`: GGUF save dir `…-gguf` -> `…-GGUF` (the default the user sees in the export form).
- `export-page.tsx` `siblingGgufDirectory`: local-path sibling dir `…_gguf` -> `…_GGUF` (kept the underscore separator, uppercased the token).
- `export-run-panel.tsx`: model-name input placeholder `my-model-gguf` -> `my-model-GGUF`.

These are only the pre-filled default strings; the user can still type anything. No backend or path-resolution logic changes.
