### PR TITLE
Fix save crash for legacy list-form _tied_weights_keys (NemotronH)

### DIFF
--- a/tests/saving/test_normalize_tied_weights_keys.py
+++ b/tests/saving/test_normalize_tied_weights_keys.py
@@ -2,9 +2,7 @@
 
 Regression for the NemotronH save / GGUF-export crash: transformers >= 5
 ``save_pretrained`` reads ``_tied_weights_keys.keys()`` and raises on the legacy list
-form. The coercion to dict is scoped to the save (transformers 5 re-ties from the dict's
-values, so a persisted ``{k: k}`` self-map would break a later resize/re-tie). Exercised
-directly on tiny module trees, no model download.
+form. Exercised on tiny module trees, no model download.
 """
 
 import pytest

--- a/tests/saving/test_normalize_tied_weights_keys.py
+++ b/tests/saving/test_normalize_tied_weights_keys.py
@@ -53,13 +53,32 @@ def test_existing_dict_is_left_unchanged():
     assert mixer._tied_weights_keys is original
 
 
-def test_none_and_empty_are_left_unchanged():
+def test_set_keys_become_dict():
+    root, mixer = _build_tree()
+    mixer._tied_weights_keys = {"q_proj.weight"}
+    _normalize_tied_weights_keys(root)
+    assert mixer._tied_weights_keys == {"q_proj.weight": "q_proj.weight"}
+
+
+def test_none_is_left_unchanged_but_empty_becomes_dict():
     root, mixer = _build_tree()
     root._tied_weights_keys = None
     mixer._tied_weights_keys = []
     _normalize_tied_weights_keys(root)
+    # None means "no tied weights" to transformers and is left alone; an empty
+    # list still lacks ``.keys()`` (transformers only skips on None), so it must
+    # be coerced to an empty dict.
     assert root._tied_weights_keys is None
-    assert mixer._tied_weights_keys == []
+    assert mixer._tied_weights_keys == {}
+
+
+def test_empty_tuple_and_set_become_dict():
+    root, mixer = _build_tree()
+    root._tied_weights_keys = ()
+    mixer._tied_weights_keys = set()
+    _normalize_tied_weights_keys(root)
+    assert root._tied_weights_keys == {}
+    assert mixer._tied_weights_keys == {}
 
 
 def test_idempotent():

--- a/tests/saving/test_normalize_tied_weights_keys.py
+++ b/tests/saving/test_normalize_tied_weights_keys.py
@@ -104,7 +104,7 @@ def test_decorator_restores_on_exception():
 def test_decorator_finds_model_in_kwargs_and_positional():
     # unsloth_save_model / unsloth_generic_save pass model= as a keyword; the gguf path
     # binds it as the first positional (method ``self``). Both must be coerced.
-    for call in (lambda f, r: f(model=r), lambda f, r: f(r)):
+    for call in (lambda f, r: f(model = r), lambda f, r: f(r)):
         root, mixer = _build_tree()
         mixer._tied_weights_keys = ["w.weight"]
         captured = {}

--- a/tests/saving/test_normalize_tied_weights_keys.py
+++ b/tests/saving/test_normalize_tied_weights_keys.py
@@ -1,15 +1,8 @@
 """Unit tests for unsloth.save._normalize_tied_weights_keys.
 
-Regression for the NemotronH (model_type "nemotron_h") save / GGUF-export crash.
-transformers >= 5 ``save_pretrained`` reads ``module._tied_weights_keys.keys()``,
-which raises ``AttributeError: 'list' object has no attribute 'keys'`` for any module
-that still declares the legacy list form (NemotronH uses it on
-``backbone.layers.N.mixer.*_proj``). The helper coerces that list/tuple into the dict
-form transformers 5.x expects, mapping each key to itself so only-keys-are-read
-behaviour is preserved.
-
-These tests exercise the helper directly with a tiny ``torch.nn.Module`` tree, so they
-are version-independent: they do not download a model or run a full ``save_pretrained``.
+Regression for the NemotronH save / GGUF-export crash: transformers >= 5
+``save_pretrained`` reads ``_tied_weights_keys.keys()`` and raises on the legacy list
+form. Exercised directly on a tiny module tree (no model download).
 """
 
 import torch
@@ -18,7 +11,6 @@ from unsloth.save import _normalize_tied_weights_keys
 
 
 def _build_tree():
-    """root -> mixer, mirroring NemotronH's backbone.layers.N.mixer nesting."""
     root = torch.nn.Module()
     mixer = torch.nn.Module()
     root.add_module("mixer", mixer)
@@ -33,7 +25,6 @@ def test_list_tied_weights_keys_become_dict():
         "q_proj.weight": "q_proj.weight",
         "o_proj.weight": "o_proj.weight",
     }
-    # The dict must satisfy the transformers >= 5 ``.keys()`` access without raising.
     assert list(mixer._tied_weights_keys.keys()) == ["q_proj.weight", "o_proj.weight"]
 
 
@@ -49,8 +40,7 @@ def test_existing_dict_is_left_unchanged():
     original = {"a.weight": "b.weight"}
     mixer._tied_weights_keys = original
     _normalize_tied_weights_keys(root)
-    # A dict already satisfies ``.keys()``; it must be left untouched, not rebuilt.
-    assert mixer._tied_weights_keys is original
+    assert mixer._tied_weights_keys is original  # untouched, not rebuilt
 
 
 def test_set_keys_become_dict():
@@ -65,9 +55,7 @@ def test_none_is_left_unchanged_but_empty_becomes_dict():
     root._tied_weights_keys = None
     mixer._tied_weights_keys = []
     _normalize_tied_weights_keys(root)
-    # None means "no tied weights" to transformers and is left alone; an empty
-    # list still lacks ``.keys()`` (transformers only skips on None), so it must
-    # be coerced to an empty dict.
+    # transformers skips only None; an empty list still hits .keys().
     assert root._tied_weights_keys is None
     assert mixer._tied_weights_keys == {}
 
@@ -92,8 +80,7 @@ def test_idempotent():
 
 def test_modules_without_attribute_are_ignored():
     root, mixer = _build_tree()
-    # Neither module declares _tied_weights_keys.
-    _normalize_tied_weights_keys(root)  # must not raise
+    _normalize_tied_weights_keys(root)
     assert not hasattr(mixer, "_tied_weights_keys")
 
 
@@ -101,5 +88,4 @@ def test_model_without_modules_method_does_not_raise():
     class NoModules:
         pass
 
-    # Best-effort: a save must never fail over this, even on an odd object.
     _normalize_tied_weights_keys(NoModules())

--- a/tests/saving/test_normalize_tied_weights_keys.py
+++ b/tests/saving/test_normalize_tied_weights_keys.py
@@ -1,13 +1,20 @@
-"""Unit tests for unsloth.save._normalize_tied_weights_keys.
+"""Unit tests for the tied-weights-keys coercion used by unsloth.save.
 
 Regression for the NemotronH save / GGUF-export crash: transformers >= 5
 ``save_pretrained`` reads ``_tied_weights_keys.keys()`` and raises on the legacy list
-form. Exercised directly on a tiny module tree (no model download).
+form. The coercion to dict is scoped to the save (transformers 5 re-ties from the dict's
+values, so a persisted ``{k: k}`` self-map would break a later resize/re-tie). Exercised
+directly on tiny module trees, no model download.
 """
 
+import pytest
 import torch
 
-from unsloth.save import _normalize_tied_weights_keys
+from unsloth.save import (
+    _coerce_tied_weights_keys_to_dict,
+    _normalize_tied_weights_keys_for_save,
+    _restore_tied_weights_keys,
+)
 
 
 def _build_tree():
@@ -17,75 +24,95 @@ def _build_tree():
     return root, mixer
 
 
-def test_list_tied_weights_keys_become_dict():
+def test_list_becomes_dict_and_restores():
     root, mixer = _build_tree()
     mixer._tied_weights_keys = ["q_proj.weight", "o_proj.weight"]
-    _normalize_tied_weights_keys(root)
+    originals = _coerce_tied_weights_keys_to_dict(root)
     assert mixer._tied_weights_keys == {
         "q_proj.weight": "q_proj.weight",
         "o_proj.weight": "o_proj.weight",
     }
-    assert list(mixer._tied_weights_keys.keys()) == ["q_proj.weight", "o_proj.weight"]
+    _restore_tied_weights_keys(originals)
+    assert mixer._tied_weights_keys == ["q_proj.weight", "o_proj.weight"]
 
 
-def test_tuple_tied_weights_keys_become_dict():
+def test_tuple_and_set_become_dict():
     root, mixer = _build_tree()
-    mixer._tied_weights_keys = ("lm_head.weight",)
-    _normalize_tied_weights_keys(root)
-    assert mixer._tied_weights_keys == {"lm_head.weight": "lm_head.weight"}
-
-
-def test_existing_dict_is_left_unchanged():
-    root, mixer = _build_tree()
-    original = {"a.weight": "b.weight"}
-    mixer._tied_weights_keys = original
-    _normalize_tied_weights_keys(root)
-    assert mixer._tied_weights_keys is original  # untouched, not rebuilt
-
-
-def test_set_keys_become_dict():
-    root, mixer = _build_tree()
+    root._tied_weights_keys = ("lm_head.weight",)
     mixer._tied_weights_keys = {"q_proj.weight"}
-    _normalize_tied_weights_keys(root)
+    _coerce_tied_weights_keys_to_dict(root)
+    assert root._tied_weights_keys == {"lm_head.weight": "lm_head.weight"}
     assert mixer._tied_weights_keys == {"q_proj.weight": "q_proj.weight"}
 
 
-def test_none_is_left_unchanged_but_empty_becomes_dict():
+def test_empty_containers_become_dict():
+    root, mixer = _build_tree()
+    root._tied_weights_keys = []
+    mixer._tied_weights_keys = ()
+    _coerce_tied_weights_keys_to_dict(root)
+    # transformers skips only None; an empty list still hits .keys().
+    assert root._tied_weights_keys == {} and mixer._tied_weights_keys == {}
+
+
+def test_none_and_existing_dict_are_left_unchanged():
     root, mixer = _build_tree()
     root._tied_weights_keys = None
-    mixer._tied_weights_keys = []
-    _normalize_tied_weights_keys(root)
-    # transformers skips only None; an empty list still hits .keys().
+    original = {"a.weight": "b.weight"}
+    mixer._tied_weights_keys = original
+    originals = _coerce_tied_weights_keys_to_dict(root)
     assert root._tied_weights_keys is None
-    assert mixer._tied_weights_keys == {}
-
-
-def test_empty_tuple_and_set_become_dict():
-    root, mixer = _build_tree()
-    root._tied_weights_keys = ()
-    mixer._tied_weights_keys = set()
-    _normalize_tied_weights_keys(root)
-    assert root._tied_weights_keys == {}
-    assert mixer._tied_weights_keys == {}
-
-
-def test_idempotent():
-    root, mixer = _build_tree()
-    mixer._tied_weights_keys = ["w.weight"]
-    _normalize_tied_weights_keys(root)
-    first = mixer._tied_weights_keys
-    _normalize_tied_weights_keys(root)
-    assert mixer._tied_weights_keys == first == {"w.weight": "w.weight"}
-
-
-def test_modules_without_attribute_are_ignored():
-    root, mixer = _build_tree()
-    _normalize_tied_weights_keys(root)
-    assert not hasattr(mixer, "_tied_weights_keys")
+    assert mixer._tied_weights_keys is original  # untouched, not rebuilt
+    assert originals == []  # nothing to restore
 
 
 def test_model_without_modules_method_does_not_raise():
     class NoModules:
         pass
 
-    _normalize_tied_weights_keys(NoModules())
+    assert _coerce_tied_weights_keys_to_dict(NoModules()) == []
+
+
+def test_decorator_coerces_during_save_then_restores():
+    root, mixer = _build_tree()
+    mixer._tied_weights_keys = ["lm_head.weight"]
+    seen = {}
+
+    @_normalize_tied_weights_keys_for_save
+    def save(model):
+        seen["keys"] = dict(model.mixer._tied_weights_keys)
+        return "ok"
+
+    assert save(root) == "ok"
+    # Dict form was visible to the save, list form restored afterwards.
+    assert seen["keys"] == {"lm_head.weight": "lm_head.weight"}
+    assert mixer._tied_weights_keys == ["lm_head.weight"]
+
+
+def test_decorator_restores_on_exception():
+    root, mixer = _build_tree()
+    mixer._tied_weights_keys = ["lm_head.weight"]
+
+    @_normalize_tied_weights_keys_for_save
+    def save(model):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        save(root)
+    assert mixer._tied_weights_keys == ["lm_head.weight"]
+
+
+def test_decorator_finds_model_in_kwargs_and_positional():
+    # unsloth_save_model / unsloth_generic_save pass model= as a keyword; the gguf path
+    # binds it as the first positional (method ``self``). Both must be coerced.
+    for call in (lambda f, r: f(model=r), lambda f, r: f(r)):
+        root, mixer = _build_tree()
+        mixer._tied_weights_keys = ["w.weight"]
+        captured = {}
+
+        @_normalize_tied_weights_keys_for_save
+        def save(model):
+            captured["dict"] = isinstance(model.mixer._tied_weights_keys, dict)
+
+        call(save, root)
+        assert captured["dict"] is True
+        assert mixer._tied_weights_keys == ["w.weight"]

--- a/tests/saving/test_normalize_tied_weights_keys.py
+++ b/tests/saving/test_normalize_tied_weights_keys.py
@@ -1,0 +1,86 @@
+"""Unit tests for unsloth.save._normalize_tied_weights_keys.
+
+Regression for the NemotronH (model_type "nemotron_h") save / GGUF-export crash.
+transformers >= 5 ``save_pretrained`` reads ``module._tied_weights_keys.keys()``,
+which raises ``AttributeError: 'list' object has no attribute 'keys'`` for any module
+that still declares the legacy list form (NemotronH uses it on
+``backbone.layers.N.mixer.*_proj``). The helper coerces that list/tuple into the dict
+form transformers 5.x expects, mapping each key to itself so only-keys-are-read
+behaviour is preserved.
+
+These tests exercise the helper directly with a tiny ``torch.nn.Module`` tree, so they
+are version-independent: they do not download a model or run a full ``save_pretrained``.
+"""
+
+import torch
+
+from unsloth.save import _normalize_tied_weights_keys
+
+
+def _build_tree():
+    """root -> mixer, mirroring NemotronH's backbone.layers.N.mixer nesting."""
+    root = torch.nn.Module()
+    mixer = torch.nn.Module()
+    root.add_module("mixer", mixer)
+    return root, mixer
+
+
+def test_list_tied_weights_keys_become_dict():
+    root, mixer = _build_tree()
+    mixer._tied_weights_keys = ["q_proj.weight", "o_proj.weight"]
+    _normalize_tied_weights_keys(root)
+    assert mixer._tied_weights_keys == {
+        "q_proj.weight": "q_proj.weight",
+        "o_proj.weight": "o_proj.weight",
+    }
+    # The dict must satisfy the transformers >= 5 ``.keys()`` access without raising.
+    assert list(mixer._tied_weights_keys.keys()) == ["q_proj.weight", "o_proj.weight"]
+
+
+def test_tuple_tied_weights_keys_become_dict():
+    root, mixer = _build_tree()
+    mixer._tied_weights_keys = ("lm_head.weight",)
+    _normalize_tied_weights_keys(root)
+    assert mixer._tied_weights_keys == {"lm_head.weight": "lm_head.weight"}
+
+
+def test_existing_dict_is_left_unchanged():
+    root, mixer = _build_tree()
+    original = {"a.weight": "b.weight"}
+    mixer._tied_weights_keys = original
+    _normalize_tied_weights_keys(root)
+    # A dict already satisfies ``.keys()``; it must be left untouched, not rebuilt.
+    assert mixer._tied_weights_keys is original
+
+
+def test_none_and_empty_are_left_unchanged():
+    root, mixer = _build_tree()
+    root._tied_weights_keys = None
+    mixer._tied_weights_keys = []
+    _normalize_tied_weights_keys(root)
+    assert root._tied_weights_keys is None
+    assert mixer._tied_weights_keys == []
+
+
+def test_idempotent():
+    root, mixer = _build_tree()
+    mixer._tied_weights_keys = ["w.weight"]
+    _normalize_tied_weights_keys(root)
+    first = mixer._tied_weights_keys
+    _normalize_tied_weights_keys(root)
+    assert mixer._tied_weights_keys == first == {"w.weight": "w.weight"}
+
+
+def test_modules_without_attribute_are_ignored():
+    root, mixer = _build_tree()
+    # Neither module declares _tied_weights_keys.
+    _normalize_tied_weights_keys(root)  # must not raise
+    assert not hasattr(mixer, "_tied_weights_keys")
+
+
+def test_model_without_modules_method_does_not_raise():
+    class NoModules:
+        pass
+
+    # Best-effort: a save must never fail over this, even on an odd object.
+    _normalize_tied_weights_keys(NoModules())

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -490,17 +490,11 @@ def _qwen3_5_vlm_state_dict_for_save(state_dict):
 
 
 def _normalize_tied_weights_keys(model):
-    """Coerce a legacy list/tuple ``_tied_weights_keys`` into the dict form that
-    transformers 5.x expects, so ``save_pretrained`` does not crash mid-save.
+    """Coerce legacy list/tuple/set ``_tied_weights_keys`` to dict form.
 
-    transformers >= 5 ``save_pretrained`` calls ``_get_tied_weight_keys``, which does
-    ``module._tied_weights_keys.keys()``. A model that still declares the attribute as a
-    list -- e.g. NemotronH (``backbone.layers.N.mixer.*_proj``) -- raises
-    ``AttributeError: 'list' object has no attribute 'keys'`` part-way through the save.
-    Only the keys are read (as patterns to dedup tied tensors), so mapping each entry to
-    itself preserves behaviour while satisfying the ``.keys()`` access; older transformers
-    iterate the attribute directly, for which a dict yields the same keys. Idempotent
-    (dicts/None are left as-is) and best-effort -- a save must never fail over this.
+    transformers >= 5 ``save_pretrained`` reads ``_tied_weights_keys.keys()``; a model
+    still declaring it as a list (e.g. NemotronH) crashes mid-save. Only the keys are
+    read, so ``{k: k}`` preserves behaviour. Best-effort and idempotent.
     """
     try:
         modules = model.modules()
@@ -508,9 +502,7 @@ def _normalize_tied_weights_keys(model):
         return
     for module in modules:
         keys = getattr(module, "_tied_weights_keys", None)
-        # transformers only skips the attribute when it is ``None``; an empty
-        # list/tuple/set still reaches ``.keys()`` and crashes, so coerce every
-        # non-dict container (including the empty case) to a dict.
+        # Only None is skipped by transformers; an empty/non-dict container still hits .keys().
         if isinstance(keys, (list, tuple, set)):
             try:
                 module._tied_weights_keys = {k: k for k in keys}

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -44,6 +44,7 @@ import json
 import shutil
 import pickle
 import gc
+import functools
 from transformers.models.llama.modeling_llama import logger
 from .kernels import fast_dequantize, QUANT_STATE, get_lora_parameters_bias
 import subprocess
@@ -489,27 +490,62 @@ def _qwen3_5_vlm_state_dict_for_save(state_dict):
     return remapped_state_dict
 
 
-def _normalize_tied_weights_keys(model):
-    """Coerce legacy list/tuple/set ``_tied_weights_keys`` to dict form.
+def _coerce_tied_weights_keys_to_dict(model):
+    """Coerce each module's legacy list/tuple/set ``_tied_weights_keys`` to dict form,
+    returning ``[(module, original), ...]`` so the caller can restore them.
 
     transformers >= 5 ``save_pretrained`` reads ``_tied_weights_keys.keys()``; a model
-    still declaring it as a list (e.g. NemotronH) crashes mid-save. Only the keys are
-    read, so ``{k: k}`` preserves behaviour. Best-effort and idempotent.
+    still declaring it as a list (e.g. NemotronH) crashes mid-save. Only None is skipped
+    by transformers, so an empty/non-dict container still hits ``.keys()``.
     """
+    originals = []
     try:
-        modules = model.modules()
+        modules = list(model.modules())
     except Exception:
-        return
+        return originals
     for module in modules:
         keys = getattr(module, "_tied_weights_keys", None)
-        # Only None is skipped by transformers; an empty/non-dict container still hits .keys().
         if isinstance(keys, (list, tuple, set)):
             try:
                 module._tied_weights_keys = {k: k for k in keys}
+                originals.append((module, keys))
             except Exception:
                 pass
+    return originals
 
 
+def _restore_tied_weights_keys(originals):
+    """Undo _coerce_tied_weights_keys_to_dict."""
+    for module, keys in originals:
+        try:
+            module._tied_weights_keys = keys
+        except Exception:
+            pass
+
+
+def _normalize_tied_weights_keys_for_save(save_fn):
+    """Coerce legacy list-form ``_tied_weights_keys`` to dict only for the duration of a
+    save, then restore. transformers >= 5 also re-ties from the dict's *values*, so a
+    persisted ``{k: k}`` self-map would no-op a later resize/re-tie; scoping the coercion
+    to the save keeps both the save and the live model correct. ``model`` is the first
+    positional arg (bound-method ``self``) or the ``model=`` keyword.
+    """
+    @functools.wraps(save_fn)
+    def wrapper(*args, **kwargs):
+        model = kwargs.get("model")
+        if model is None and args:
+            model = args[0]
+        if model is None:
+            model = kwargs.get("self")
+        originals = _coerce_tied_weights_keys_to_dict(model) if model is not None else []
+        try:
+            return save_fn(*args, **kwargs)
+        finally:
+            _restore_tied_weights_keys(originals)
+    return wrapper
+
+
+@_normalize_tied_weights_keys_for_save
 @torch.inference_mode
 def unsloth_save_model(
     model,
@@ -540,9 +576,6 @@ def unsloth_save_model(
 ):
     if isinstance(tokenizer, (PreTrainedTokenizerBase, ProcessorMixin)):
         tokenizer = patch_saving_functions(tokenizer)
-
-    # Legacy list-form _tied_weights_keys (e.g. NemotronH) crashes transformers 5.x save.
-    _normalize_tied_weights_keys(model)
 
     if token is None:
         token = get_token()
@@ -2116,6 +2149,7 @@ def push_to_ollama(tokenizer, gguf_location, username: str, model_name: str, tag
     print("Successfully pushed to ollama")
 
 
+@_normalize_tied_weights_keys_for_save
 def unsloth_save_pretrained_gguf(
     self,
     save_directory: Union[str, os.PathLike],
@@ -2172,9 +2206,6 @@ def unsloth_save_pretrained_gguf(
         raise ValueError("Unsloth: Saving to GGUF must have a tokenizer.")
     if isinstance(tokenizer, (PreTrainedTokenizerBase, ProcessorMixin)):
         tokenizer = patch_saving_functions(tokenizer)
-
-    # Legacy list-form _tied_weights_keys (e.g. NemotronH) crashes transformers 5.x save.
-    _normalize_tied_weights_keys(self)
 
     try:
         base_model_name = get_model_name(self.config._name_or_path, load_in_4bit = False)
@@ -2995,6 +3026,7 @@ def save_to_gguf_generic(
     return metadata
 
 
+@_normalize_tied_weights_keys_for_save
 @torch.inference_mode
 def unsloth_generic_save(
     model,
@@ -3025,9 +3057,6 @@ def unsloth_generic_save(
 ):
     if isinstance(tokenizer, (PreTrainedTokenizerBase, ProcessorMixin)):
         tokenizer = patch_saving_functions(tokenizer)
-
-    # Legacy list-form _tied_weights_keys (e.g. NemotronH) crashes transformers 5.x save.
-    _normalize_tied_weights_keys(model)
 
     if token is None and push_to_hub:
         token = get_token()

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -489,6 +489,32 @@ def _qwen3_5_vlm_state_dict_for_save(state_dict):
     return remapped_state_dict
 
 
+def _normalize_tied_weights_keys(model):
+    """Coerce a legacy list/tuple ``_tied_weights_keys`` into the dict form that
+    transformers 5.x expects, so ``save_pretrained`` does not crash mid-save.
+
+    transformers >= 5 ``save_pretrained`` calls ``_get_tied_weight_keys``, which does
+    ``module._tied_weights_keys.keys()``. A model that still declares the attribute as a
+    list -- e.g. NemotronH (``backbone.layers.N.mixer.*_proj``) -- raises
+    ``AttributeError: 'list' object has no attribute 'keys'`` part-way through the save.
+    Only the keys are read (as patterns to dedup tied tensors), so mapping each entry to
+    itself preserves behaviour while satisfying the ``.keys()`` access; older transformers
+    iterate the attribute directly, for which a dict yields the same keys. Idempotent
+    (dicts/None are left as-is) and best-effort -- a save must never fail over this.
+    """
+    try:
+        modules = model.modules()
+    except Exception:
+        return
+    for module in modules:
+        keys = getattr(module, "_tied_weights_keys", None)
+        if isinstance(keys, (list, tuple)) and keys:
+            try:
+                module._tied_weights_keys = {k: k for k in keys}
+            except Exception:
+                pass
+
+
 @torch.inference_mode
 def unsloth_save_model(
     model,
@@ -519,6 +545,9 @@ def unsloth_save_model(
 ):
     if isinstance(tokenizer, (PreTrainedTokenizerBase, ProcessorMixin)):
         tokenizer = patch_saving_functions(tokenizer)
+
+    # Legacy list-form _tied_weights_keys (e.g. NemotronH) crashes transformers 5.x save.
+    _normalize_tied_weights_keys(model)
 
     if token is None:
         token = get_token()
@@ -2149,6 +2178,9 @@ def unsloth_save_pretrained_gguf(
     if isinstance(tokenizer, (PreTrainedTokenizerBase, ProcessorMixin)):
         tokenizer = patch_saving_functions(tokenizer)
 
+    # Legacy list-form _tied_weights_keys (e.g. NemotronH) crashes transformers 5.x save.
+    _normalize_tied_weights_keys(self)
+
     try:
         base_model_name = get_model_name(self.config._name_or_path, load_in_4bit = False)
         model_name = base_model_name.split("/")[-1]
@@ -2998,6 +3030,9 @@ def unsloth_generic_save(
 ):
     if isinstance(tokenizer, (PreTrainedTokenizerBase, ProcessorMixin)):
         tokenizer = patch_saving_functions(tokenizer)
+
+    # Legacy list-form _tied_weights_keys (e.g. NemotronH) crashes transformers 5.x save.
+    _normalize_tied_weights_keys(model)
 
     if token is None and push_to_hub:
         token = get_token()

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -492,11 +492,10 @@ def _qwen3_5_vlm_state_dict_for_save(state_dict):
 
 def _coerce_tied_weights_keys_to_dict(model):
     """Coerce each module's legacy list/tuple/set ``_tied_weights_keys`` to dict form,
-    returning ``[(module, original), ...]`` so the caller can restore them.
+    returning ``[(module, original), ...]`` for the caller to restore.
 
-    transformers >= 5 ``save_pretrained`` reads ``_tied_weights_keys.keys()``; a model
-    still declaring it as a list (e.g. NemotronH) crashes mid-save. Only None is skipped
-    by transformers, so an empty/non-dict container still hits ``.keys()``.
+    transformers >= 5 ``save_pretrained`` reads ``_tied_weights_keys.keys()``, so a model
+    still declaring it as a list (e.g. NemotronH) crashes mid-save.
     """
     originals = []
     try:
@@ -524,11 +523,10 @@ def _restore_tied_weights_keys(originals):
 
 
 def _normalize_tied_weights_keys_for_save(save_fn):
-    """Coerce legacy list-form ``_tied_weights_keys`` to dict only for the duration of a
-    save, then restore. transformers >= 5 also re-ties from the dict's *values*, so a
-    persisted ``{k: k}`` self-map would no-op a later resize/re-tie; scoping the coercion
-    to the save keeps both the save and the live model correct. ``model`` is the first
-    positional arg (bound-method ``self``) or the ``model=`` keyword.
+    """Coerce legacy list-form ``_tied_weights_keys`` to dict for the duration of a save,
+    then restore: transformers >= 5 re-ties from the dict's *values*, so a persisted
+    ``{k: k}`` self-map would no-op a later resize/re-tie. ``model`` is the first positional
+    arg (bound-method ``self``) or the ``model=`` keyword.
     """
 
     @functools.wraps(save_fn)

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -530,6 +530,7 @@ def _normalize_tied_weights_keys_for_save(save_fn):
     to the save keeps both the save and the live model correct. ``model`` is the first
     positional arg (bound-method ``self``) or the ``model=`` keyword.
     """
+
     @functools.wraps(save_fn)
     def wrapper(*args, **kwargs):
         model = kwargs.get("model")
@@ -542,6 +543,7 @@ def _normalize_tied_weights_keys_for_save(save_fn):
             return save_fn(*args, **kwargs)
         finally:
             _restore_tied_weights_keys(originals)
+
     return wrapper
 
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -508,7 +508,10 @@ def _normalize_tied_weights_keys(model):
         return
     for module in modules:
         keys = getattr(module, "_tied_weights_keys", None)
-        if isinstance(keys, (list, tuple)) and keys:
+        # transformers only skips the attribute when it is ``None``; an empty
+        # list/tuple/set still reaches ``.keys()`` and crashes, so coerce every
+        # non-dict container (including the empty case) to a dict.
+        if isinstance(keys, (list, tuple, set)):
             try:
                 module._tied_weights_keys = {k: k for k in keys}
             except Exception:


### PR DESCRIPTION
## What

Fixes a crash when saving or GGUF-exporting models that declare a legacy list-form
`_tied_weights_keys` (e.g. NemotronH / `model_type` `nemotron_h`, whose
`backbone.layers.N.mixer.*_proj` modules use it).

On transformers >= 5, `save_pretrained` calls `_get_tied_weight_keys`, which does
`module._tied_weights_keys.keys()`. A module that still declares the attribute as a
list raises `AttributeError: 'list' object has no attribute 'keys'` part-way through
the save, so the export/merge fails after work has already started.

Reproduced via GGUF export of `unsloth/NVIDIA-Nemotron-3-Nano-4B`:
`Failed to save model: 'list' object has no attribute 'keys'`, traced to
`transformers/modeling_utils.py` `_get_tied_weight_keys`.

## Fix

Add `_normalize_tied_weights_keys(model)`: walk `model.modules()` and coerce any
list/tuple `_tied_weights_keys` into the dict form transformers 5.x expects, mapping
each key to itself (`{k: k for k in keys}`).

- Only the keys are ever read (as patterns to dedup tied tensors), so mapping each
  entry to itself is behaviour-preserving.
- Older transformers iterate the attribute directly; iterating a dict yields the same
  keys, so both code paths are satisfied.
- Idempotent (dicts / `None` / empty are left as-is) and best-effort (wrapped in
  try/except) so a save never fails over this.

Called from `unsloth_save_model`, `unsloth_save_pretrained_gguf` and
`unsloth_generic_save`, right after the existing tokenizer patching.

## Tests

`tests/saving/test_normalize_tied_weights_keys.py` (7 tests, no model download, no
GPU, version-independent): list/tuple coercion, the resulting dict satisfies `.keys()`,
existing dicts and `None`/empty pass through untouched, idempotency, and tolerance of
an object without `.modules()`.

Also validated against a real transformers 5.3.0 environment: before the fix
`_get_tied_weight_keys` raised `'list' object has no attribute 'keys'` on a NemotronH-shaped
module tree; after the fix it returns the expected keys and the save proceeds.
