### PR TITLE
Route dense NemotronH models to the transformers 5.10 tier

### DIFF
--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -557,6 +557,76 @@ class TestConfigJsonHfCacheFallback:
         with patch("urllib.request.urlopen", return_value = _hf_response(fresh)):
             assert _load_config_json("org/model") == fresh
 
+    def test_auth_failure_does_not_serve_cache(self, tmp_path: Path, monkeypatch):
+        import urllib.error
+
+        # A repo whose config.json is in the hub cache from an earlier authorized session.
+        cfg = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
+        self._seed_cache(tmp_path, "private/model", cfg)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        # 401/403/404 is a definitive "no access": an unauthenticated caller must not be
+        # handed the cached private metadata.
+        for code in (401, 403, 404):
+            _config_json_cache.clear()
+            err = urllib.error.HTTPError("url", code, "denied", {}, None)
+            with patch("urllib.request.urlopen", side_effect = err):
+                assert _load_config_json("private/model") is None
+
+    def test_server_error_still_falls_back_to_cache(self, tmp_path: Path, monkeypatch):
+        import urllib.error
+
+        cfg = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
+        self._seed_cache(tmp_path, "org/model", cfg)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        # A 5xx is transient, not an access decision: keep serving the cache.
+        err = urllib.error.HTTPError("url", 503, "busy", {}, None)
+        with patch("urllib.request.urlopen", side_effect = err):
+            assert _load_config_json("org/model") == cfg
+
+
+class TestTierCheckTransientRetry:
+    """tier-needs checks must not memoize a transient fetch fallback."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _config_needs_510_cache.clear()
+        _config_needs_550_cache.clear()
+
+    @staticmethod
+    def _seed_cache(hub: Path, repo_id: str, cfg: dict, commit: str = "deadbeef"):
+        repo = hub / ("models--" + repo_id.replace("/", "--"))
+        snap = repo / "snapshots" / commit
+        snap.mkdir(parents = True)
+        (snap / "config.json").write_text(json.dumps(cfg))
+        (repo / "refs").mkdir(parents = True)
+        (repo / "refs" / "main").write_text(commit)
+
+    def test_transient_fallback_not_memoized_then_retries(self, tmp_path: Path, monkeypatch):
+        stale = {"model_type": "llama"}  # does not need 510
+        fresh = {"architectures": ["Gemma4UnifiedForConditionalGeneration"]}  # needs 510
+        self._seed_cache(tmp_path, "org/model", stale)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        # Network blip -> serve the cache, but do NOT pin the tier result.
+        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+            assert _check_config_needs_510("org/model") is False
+        assert "org/model" not in _config_needs_510_cache
+        # Connectivity returns: the next call re-fetches and sees the higher tier.
+        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)):
+            assert _check_config_needs_510("org/model") is True
+        assert _config_needs_510_cache["org/model"] is True  # definitive read is memoized
+
+    def test_definitive_network_read_is_memoized(self, tmp_path: Path, monkeypatch):
+        fresh = {"architectures": ["Gemma4ForConditionalGeneration"]}  # needs 550
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)) as mock_url:
+            assert _check_config_needs_550("org/model") is True
+            assert _check_config_needs_550("org/model") is True
+            assert mock_url.call_count == 1  # second call served from the tier cache
+
 
 class TestHigherTier:
     def test_picks_stronger_tier(self):

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -454,36 +454,75 @@ class TestNemotronHNeedsMlpSupport:
         assert _nemotron_h_needs_mlp_support({"model_type": "wrapper", "llm_config": None}) is False
 
 
+def _hf_response(cfg: dict):
+    """A urlopen() context-manager stand-in returning *cfg* as JSON bytes."""
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return json.dumps(cfg).encode()
+
+    return _Resp()
+
+
 class TestConfigJsonHfCacheFallback:
-    """_load_config_json reads the HF hub cache before any network (offline support)."""
+    """HF hub cache is consulted only offline or after a failed fetch (never stale online)."""
 
     def setup_method(self):
         _config_json_cache.clear()
 
-    def test_cache_hit_skips_network(self, tmp_path: Path, monkeypatch):
+    @staticmethod
+    def _seed_cache(hub: Path, repo_id: str, cfg: dict, commit: str = "deadbeef"):
+        repo = hub / ("models--" + repo_id.replace("/", "--"))
+        snap = repo / "snapshots" / commit
+        snap.mkdir(parents = True)
+        (snap / "config.json").write_text(json.dumps(cfg))
+        (repo / "refs").mkdir(parents = True)
+        (repo / "refs" / "main").write_text(commit)
+
+    def test_offline_reads_from_cache(self, tmp_path: Path, monkeypatch):
         cfg = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
-        cached = tmp_path / "config.json"
-        cached.write_text(json.dumps(cfg))
-        monkeypatch.setenv("HF_HUB_OFFLINE", "1")  # cache is consulted even offline
-        with (
-            patch("huggingface_hub.try_to_load_from_cache", return_value = str(cached)),
-            patch("urllib.request.urlopen") as mock_url,
-        ):
+        self._seed_cache(tmp_path, "unsloth/NVIDIA-Nemotron-3-Nano-4B", cfg)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        with patch("urllib.request.urlopen") as mock_url:
             assert _load_config_json("unsloth/NVIDIA-Nemotron-3-Nano-4B") == cfg
             mock_url.assert_not_called()
 
-    def test_offline_uncached_returns_none(self, monkeypatch):
+    def test_online_prefers_network_over_cache(self, tmp_path: Path, monkeypatch):
+        stale = {"model_type": "nemotron_h", "hybrid_override_pattern": "MMMM"}
+        fresh = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
+        self._seed_cache(tmp_path, "org/model", stale)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising = False)
+        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)):
+            assert _load_config_json("org/model") == fresh  # network wins, not stale cache
+
+    def test_network_failure_falls_back_to_cache(self, tmp_path: Path, monkeypatch):
+        cfg = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
+        self._seed_cache(tmp_path, "org/model", cfg)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+            assert _load_config_json("org/model") == cfg
+
+    def test_offline_uncached_returns_none(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-        with (
-            patch("huggingface_hub.try_to_load_from_cache", return_value = None),
-            patch("urllib.request.urlopen") as mock_url,
-        ):
+        with patch("urllib.request.urlopen") as mock_url:
             assert _load_config_json("private/unknown") is None
             mock_url.assert_not_called()
 
-    def test_helper_returns_none_when_missing(self):
-        with patch("huggingface_hub.try_to_load_from_cache", return_value = None):
-            assert _config_json_from_hf_cache("x/y") is None
+    def test_helper_ignores_local_paths(self, tmp_path: Path):
+        # A filesystem path is not a repo id; never treat it as one.
+        assert _config_json_from_hf_cache(str(tmp_path)) is None
+        assert _config_json_from_hf_cache("plainname") is None
 
 
 class TestHigherTier:
@@ -835,12 +874,14 @@ class TestActivateLoggingClarity:
             "sys.path" in text or "path only" in text
         ), f"early activation log does not clarify it is path-prepend only: {text!r}"
 
-    def test_activate_prefers_local_checkpoint_tier_over_resolved_base(self, caplog):
-        # A dense NemotronH checkpoint whose base resolves to an offline/private id: the
-        # base tier check yields default, but the local config wins via _higher_tier.
+    def test_activate_prefers_local_checkpoint_tier_over_resolved_base(self, caplog, tmp_path):
+        # A dense NemotronH checkpoint (real local config.json) whose base resolves to an
+        # offline/private id: the base check yields default, but the local config wins.
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        local = str(tmp_path)
         caplog.set_level(logging.INFO)
         snap = self._snapshot_env()
-        tiers = {"local/ckpt": "510", "private/base": "default"}
+        tiers = {local: "510", "private/base": "default"}
         try:
             with (
                 patch(
@@ -856,12 +897,45 @@ class TestActivateLoggingClarity:
                     return_value = True,
                 ),
             ):
-                activate_transformers_for_subprocess("local/ckpt")
+                activate_transformers_for_subprocess(local)
         finally:
             self._restore_env(snap)
 
         text = " ".join(r.getMessage() for r in caplog.records).lower()
         assert "5.10.2" in text, f"local checkpoint tier did not win: {text!r}"
+
+    def test_activate_adapter_without_config_skips_path_name_recheck(self, caplog, tmp_path):
+        # Adapter dir whose PATH contains 'gemma-4' but has no config.json: the local
+        # re-check must not run (would upgrade a default base from the directory name).
+        adapter = tmp_path / "gemma-4-experiment" / "llama-lora"
+        adapter.mkdir(parents = True)
+        local = str(adapter)
+        caplog.set_level(logging.INFO)
+        snap = self._snapshot_env()
+        seen = []
+
+        def fake_tier(m):
+            seen.append(m)
+            return "550" if "gemma-4" in m else "default"
+
+        try:
+            with (
+                patch(
+                    "utils.transformers_version._resolve_base_model",
+                    return_value = "meta/llama",
+                ),
+                patch(
+                    "utils.transformers_version.get_transformers_tier",
+                    side_effect = fake_tier,
+                ),
+            ):
+                activate_transformers_for_subprocess(local)
+        finally:
+            self._restore_env(snap)
+
+        assert seen == ["meta/llama"], f"adapter path was re-checked via substrings: {seen!r}"
+        text = " ".join(r.getMessage() for r in caplog.records).lower()
+        assert "default transformers" in text, f"adapter wrongly upgraded: {text!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -477,7 +477,12 @@ class TestConfigJsonHfCacheFallback:
         _config_json_cache.clear()
 
     @staticmethod
-    def _seed_cache(hub: Path, repo_id: str, cfg: dict, commit: str = "deadbeef"):
+    def _seed_cache(
+        hub: Path,
+        repo_id: str,
+        cfg: dict,
+        commit: str = "deadbeef",
+    ):
         repo = hub / ("models--" + repo_id.replace("/", "--"))
         snap = repo / "snapshots" / commit
         snap.mkdir(parents = True)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -595,7 +595,12 @@ class TestTierCheckTransientRetry:
         _config_needs_550_cache.clear()
 
     @staticmethod
-    def _seed_cache(hub: Path, repo_id: str, cfg: dict, commit: str = "deadbeef"):
+    def _seed_cache(
+        hub: Path,
+        repo_id: str,
+        cfg: dict,
+        commit: str = "deadbeef",
+    ):
         repo = hub / ("models--" + repo_id.replace("/", "--"))
         snap = repo / "snapshots" / commit
         snap.mkdir(parents = True)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -34,6 +34,8 @@ from utils.transformers_version import (
     _check_tokenizer_config_needs_v5,
     _check_config_needs_510,
     _check_config_needs_550,
+    _config_needs_510,
+    _nemotron_h_needs_mlp_support,
     _config_json_cache,
     _tokenizer_class_cache,
     _config_needs_510_cache,
@@ -383,6 +385,49 @@ class TestCheckConfigNeeds510:
 
 
 # ---------------------------------------------------------------------------
+# NemotronH dense (MLP) models need the 5.10 tier
+# ---------------------------------------------------------------------------
+
+
+class TestNemotronHNeedsMlpSupport:
+    """Dense NemotronH configs (MLP layers) require transformers >= 5.10."""
+
+    def test_hybrid_override_pattern_with_dash(self):
+        cfg = {
+            "model_type": "nemotron_h",
+            "hybrid_override_pattern": "M-M-M*-M-",
+        }
+        assert _nemotron_h_needs_mlp_support(cfg) is True
+
+    def test_layers_block_type_with_mlp(self):
+        cfg = {
+            "model_type": "nemotron_h",
+            "layers_block_type": ["mamba", "mlp", "attention", "mamba"],
+        }
+        assert _nemotron_h_needs_mlp_support(cfg) is True
+
+    def test_nemotron_h_moe_only_returns_false(self):
+        """A pure MoE NemotronH (no MLP) does not need the 5.10 tier."""
+        cfg = {
+            "model_type": "nemotron_h",
+            "hybrid_override_pattern": "MEME*MEM",
+        }
+        assert _nemotron_h_needs_mlp_support(cfg) is False
+
+    def test_non_nemotron_with_dash_returns_false(self):
+        """The dash heuristic only applies to nemotron_h configs."""
+        cfg = {"model_type": "llama", "hybrid_override_pattern": "M-M-"}
+        assert _nemotron_h_needs_mlp_support(cfg) is False
+
+    def test_config_needs_510_includes_dense_nemotron_h(self):
+        cfg = {
+            "model_type": "nemotron_h",
+            "hybrid_override_pattern": "M-M-M*-",
+        }
+        assert _config_needs_510(cfg) is True
+
+
+# ---------------------------------------------------------------------------
 # get_transformers_tier — tier detection
 # ---------------------------------------------------------------------------
 
@@ -437,6 +482,43 @@ class TestGetTransformersTier:
         (tmp_path / "config.json").write_text(json.dumps(cfg))
 
         assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_dense_nemotron_h_config_json_returns_510(self, tmp_path: Path):
+        """Local dense NemotronH checkpoint → 510 (MLP layers need >= 5.10)."""
+        cfg = {
+            "model_type": "nemotron_h",
+            "hybrid_override_pattern": "M-M-M*-M-",
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        # A v5 tokenizer would otherwise route this to 530; 510 must win.
+        (tmp_path / "tokenizer_config.json").write_text(
+            json.dumps({"tokenizer_class": "TokenizersBackend"})
+        )
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            assert get_transformers_tier(str(tmp_path)) == "510"
+            mock_urlopen.assert_not_called()
+
+    def test_dense_nemotron_h_remote_config_returns_510(self):
+        """Remote dense NemotronH (HF id) → 510 via config.json fetch, not 530."""
+
+        class _Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps(
+                    {
+                        "model_type": "nemotron_h",
+                        "hybrid_override_pattern": "M-M-M*-M-",
+                    }
+                ).encode()
+
+        with patch("urllib.request.urlopen", return_value = _Response()):
+            assert get_transformers_tier("unsloth/NVIDIA-Nemotron-3-Nano-4B") == "510"
 
     def test_local_config_json_short_circuits_path_substrings(self, tmp_path: Path):
         """Local config.json should prevent false matches from parent directory names."""

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -560,13 +560,12 @@ class TestConfigJsonHfCacheFallback:
     def test_auth_failure_does_not_serve_cache(self, tmp_path: Path, monkeypatch):
         import urllib.error
 
-        # A repo whose config.json is in the hub cache from an earlier authorized session.
+        # config.json cached from an earlier authorized session; an unauthenticated 4xx
+        # must not be handed that private metadata.
         cfg = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
         self._seed_cache(tmp_path, "private/model", cfg)
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
-        # 401/403/404 is a definitive "no access": an unauthenticated caller must not be
-        # handed the cached private metadata.
         for code in (401, 403, 404):
             _config_json_cache.clear()
             err = urllib.error.HTTPError("url", code, "denied", {}, None)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -880,8 +880,7 @@ class TestActivateLoggingClarity:
         ), f"early activation log does not clarify it is path-prepend only: {text!r}"
 
     def test_activate_prefers_local_checkpoint_tier_over_resolved_base(self, caplog, tmp_path):
-        # A dense NemotronH checkpoint (real local config.json) whose base resolves to an
-        # offline/private id: the base check yields default, but the local config wins.
+        # Base resolves to an offline/private id (default tier); the local config.json wins.
         (tmp_path / "config.json").write_text(json.dumps({"model_type": "llama"}))
         local = str(tmp_path)
         caplog.set_level(logging.INFO)
@@ -910,8 +909,7 @@ class TestActivateLoggingClarity:
         assert "5.10.2" in text, f"local checkpoint tier did not win: {text!r}"
 
     def test_activate_adapter_without_config_skips_path_name_recheck(self, caplog, tmp_path):
-        # Adapter dir whose PATH contains 'gemma-4' but has no config.json: the local
-        # re-check must not run (would upgrade a default base from the directory name).
+        # Adapter dir named 'gemma-4' but no config.json: the path-name re-check must not run.
         adapter = tmp_path / "gemma-4-experiment" / "llama-lora"
         adapter.mkdir(parents = True)
         local = str(adapter)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -529,6 +529,34 @@ class TestConfigJsonHfCacheFallback:
         assert _config_json_from_hf_cache(str(tmp_path)) is None
         assert _config_json_from_hf_cache("plainname") is None
 
+    def test_no_refs_main_picks_newest_snapshot(self, tmp_path: Path, monkeypatch):
+        # No refs/main (commit-pinned downloads): lexicographic order would pick the older
+        # SHA; selection must follow mtime so the newest snapshot wins.
+        repo = tmp_path / "models--org--model"
+        old = repo / "snapshots" / "0000old"
+        new = repo / "snapshots" / "ffffnew"
+        old.mkdir(parents = True)
+        new.mkdir(parents = True)
+        (old / "config.json").write_text(json.dumps({"model_type": "stale"}))
+        (new / "config.json").write_text(json.dumps({"model_type": "fresh"}))
+        os.utime(old / "config.json", (1000, 1000))
+        os.utime(new / "config.json", (2000, 2000))
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        assert _config_json_from_hf_cache("org/model") == {"model_type": "fresh"}
+
+    def test_transient_failure_does_not_cache_fallback(self, tmp_path: Path, monkeypatch):
+        stale = {"model_type": "nemotron_h", "hybrid_override_pattern": "MMMM"}
+        fresh = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
+        self._seed_cache(tmp_path, "org/model", stale)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        # Network fails -> serve the cached snapshot, but it must not be memoized.
+        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+            assert _load_config_json("org/model") == stale
+        # Connectivity returns: the next call must hit the network for the fresh config.
+        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)):
+            assert _load_config_json("org/model") == fresh
+
 
 class TestHigherTier:
     def test_picks_stronger_tier(self):

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -36,6 +36,9 @@ from utils.transformers_version import (
     _check_config_needs_550,
     _config_needs_510,
     _nemotron_h_needs_mlp_support,
+    _config_json_from_hf_cache,
+    _load_config_json,
+    _higher_tier,
     _config_json_cache,
     _tokenizer_class_cache,
     _config_needs_510_cache,
@@ -426,6 +429,70 @@ class TestNemotronHNeedsMlpSupport:
         }
         assert _config_needs_510(cfg) is True
 
+    def test_nested_llm_config_with_dash(self):
+        # VL wrapper (e.g. NemotronH_Nano_VL_V2): dense LM is under llm_config.
+        cfg = {
+            "model_type": "NemotronH_Nano_VL_V2",
+            "llm_config": {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"},
+        }
+        assert _nemotron_h_needs_mlp_support(cfg) is True
+        assert _config_needs_510(cfg) is True
+
+    def test_nested_text_config_with_mlp(self):
+        cfg = {
+            "model_type": "wrapper",
+            "text_config": {"model_type": "nemotron_h", "layers_block_type": ["mamba", "mlp"]},
+        }
+        assert _nemotron_h_needs_mlp_support(cfg) is True
+
+    def test_nested_non_nemotron_returns_false(self):
+        cfg = {"model_type": "wrapper", "llm_config": {"model_type": "llama"}}
+        assert _nemotron_h_needs_mlp_support(cfg) is False
+
+    def test_non_dict_and_missing_nested_do_not_raise(self):
+        assert _nemotron_h_needs_mlp_support(None) is False
+        assert _nemotron_h_needs_mlp_support({"model_type": "wrapper", "llm_config": None}) is False
+
+
+class TestConfigJsonHfCacheFallback:
+    """_load_config_json reads the HF hub cache before any network (offline support)."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+
+    def test_cache_hit_skips_network(self, tmp_path: Path, monkeypatch):
+        cfg = {"model_type": "nemotron_h", "hybrid_override_pattern": "M-M*-"}
+        cached = tmp_path / "config.json"
+        cached.write_text(json.dumps(cfg))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")  # cache is consulted even offline
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value = str(cached)),
+            patch("urllib.request.urlopen") as mock_url,
+        ):
+            assert _load_config_json("unsloth/NVIDIA-Nemotron-3-Nano-4B") == cfg
+            mock_url.assert_not_called()
+
+    def test_offline_uncached_returns_none(self, monkeypatch):
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        with (
+            patch("huggingface_hub.try_to_load_from_cache", return_value = None),
+            patch("urllib.request.urlopen") as mock_url,
+        ):
+            assert _load_config_json("private/unknown") is None
+            mock_url.assert_not_called()
+
+    def test_helper_returns_none_when_missing(self):
+        with patch("huggingface_hub.try_to_load_from_cache", return_value = None):
+            assert _config_json_from_hf_cache("x/y") is None
+
+
+class TestHigherTier:
+    def test_picks_stronger_tier(self):
+        assert _higher_tier("default", "510") == "510"
+        assert _higher_tier("530", "550") == "550"
+        assert _higher_tier("510", "default") == "510"
+        assert _higher_tier("default", "default") == "default"
+
 
 # ---------------------------------------------------------------------------
 # get_transformers_tier — tier detection
@@ -767,6 +834,34 @@ class TestActivateLoggingClarity:
         assert (
             "sys.path" in text or "path only" in text
         ), f"early activation log does not clarify it is path-prepend only: {text!r}"
+
+    def test_activate_prefers_local_checkpoint_tier_over_resolved_base(self, caplog):
+        # A dense NemotronH checkpoint whose base resolves to an offline/private id: the
+        # base tier check yields default, but the local config wins via _higher_tier.
+        caplog.set_level(logging.INFO)
+        snap = self._snapshot_env()
+        tiers = {"local/ckpt": "510", "private/base": "default"}
+        try:
+            with (
+                patch(
+                    "utils.transformers_version._resolve_base_model",
+                    return_value = "private/base",
+                ),
+                patch(
+                    "utils.transformers_version.get_transformers_tier",
+                    side_effect = lambda m: tiers[m],
+                ),
+                patch(
+                    "utils.transformers_version._ensure_venv_t5_510_exists",
+                    return_value = True,
+                ),
+            ):
+                activate_transformers_for_subprocess("local/ckpt")
+        finally:
+            self._restore_env(snap)
+
+        text = " ".join(r.getMessage() for r in caplog.records).lower()
+        assert "5.10.2" in text, f"local checkpoint tier did not win: {text!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -345,7 +345,6 @@ def _config_json_from_hf_cache(model_name: str) -> dict | None:
     """Parsed ``config.json`` from the local HF hub cache, or None if not cached."""
     try:
         from huggingface_hub import try_to_load_from_cache
-
         path = try_to_load_from_cache(model_name, "config.json")
         if isinstance(path, str) and path:
             with open(path) as f:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -417,6 +417,7 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         _config_json_cache[cache_key] = cfg
         return cfg
 
+    import urllib.error
     import urllib.request
 
     url = f"https://huggingface.co/{model_name}/raw/main/config.json"
@@ -429,11 +430,29 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
             cfg = json.loads(resp.read().decode())
         _config_json_cache[cache_key] = cfg
         return cfg
+    except urllib.error.HTTPError as exc:
+        # 401/403/404 is a definitive access answer, not a blip: do NOT fall back to the
+        # hub cache, or an unauthenticated/wrong-token request could read another caller's
+        # cached private metadata. Treat it as "no config".
+        if exc.code in (401, 403, 404):
+            logger.debug("config.json access denied for '%s': %s", model_name, exc)
+            return None
+        logger.debug("Could not fetch config.json for '%s': %s", model_name, exc)
+        return _config_json_from_hf_cache(model_name)
     except Exception as exc:
         logger.debug("Could not fetch config.json for '%s': %s", model_name, exc)
-        # Transient failure (rate limit, block): serve the hub cache but do NOT cache it,
-        # so a later call retries the network once connectivity returns.
+        # Transient failure (timeout, network blip): serve the hub cache but do NOT cache
+        # it, so a later call retries the network once connectivity returns.
         return _config_json_from_hf_cache(model_name)
+
+
+def _config_json_is_definitive(model_name: str) -> bool:
+    """True if the last unauthenticated ``_load_config_json`` read was definitive (local
+    file, offline hub cache, or a completed network fetch) rather than a transient
+    fallback. Transient reads are deliberately not stored, so a missing entry means
+    "retry next time" -- callers use this to avoid memoizing a network blip.
+    """
+    return (model_name, None) in _config_json_cache
 
 
 def _config_matches_tier(cfg: dict, architectures: set[str], model_types: set[str]) -> bool:
@@ -490,17 +509,15 @@ def _check_config_needs_550(model_name: str) -> bool:
     5.5.0 (e.g. Gemma 4).
 
     Checks locally first, else fetches from HuggingFace. Cached in
-    ``_config_needs_550_cache``. Returns False on any error (fail-open to lower tier).
+    ``_config_needs_550_cache`` only for a definitive read; a transient fetch failure
+    retries next call instead of pinning the wrong tier. Returns False on any error
+    (fail-open to lower tier).
     """
     if model_name in _config_needs_550_cache:
         return _config_needs_550_cache[model_name]
 
     cfg = _load_config_json(model_name)
-    if cfg is None:
-        _config_needs_550_cache[model_name] = False
-        return False
-
-    result = _config_needs_550(cfg)
+    result = bool(cfg) and _config_needs_550(cfg)
     if result:
         logger.info(
             "config.json check: %s needs transformers %s (architectures=%s, model_type=%s)",
@@ -509,7 +526,8 @@ def _check_config_needs_550(model_name: str) -> bool:
             cfg.get("architectures", []),
             cfg.get("model_type"),
         )
-    _config_needs_550_cache[model_name] = result
+    if _config_json_is_definitive(model_name):
+        _config_needs_550_cache[model_name] = result
     return result
 
 
@@ -519,11 +537,7 @@ def _check_config_needs_510(model_name: str) -> bool:
         return _config_needs_510_cache[model_name]
 
     cfg = _load_config_json(model_name)
-    if cfg is None:
-        _config_needs_510_cache[model_name] = False
-        return False
-
-    result = _config_needs_510(cfg)
+    result = bool(cfg) and _config_needs_510(cfg)
     if result:
         logger.info(
             "config.json check: %s needs transformers %s (architectures=%s, model_type=%s)",
@@ -532,7 +546,8 @@ def _check_config_needs_510(model_name: str) -> bool:
             cfg.get("architectures", []),
             cfg.get("model_type"),
         )
-    _config_needs_510_cache[model_name] = result
+    if _config_json_is_definitive(model_name):
+        _config_needs_510_cache[model_name] = result
     return result
 
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -341,6 +341,13 @@ def _check_tokenizer_config_needs_v5(model_name: str) -> bool:
         return False
 
 
+def _safe_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def _config_json_from_hf_cache(model_name: str) -> dict | None:
     """Parsed ``config.json`` from the local HF hub cache, or None.
 
@@ -363,7 +370,11 @@ def _config_json_from_hf_cache(model_name: str) -> dict | None:
     try:
         if ref_main.is_file():
             candidates.append(repo_dir / "snapshots" / ref_main.read_text().strip() / "config.json")
-        candidates += sorted(repo_dir.glob("snapshots/*/config.json"))
+        # No refs/main (e.g. commit-pinned downloads): newest snapshot by mtime, not a stale
+        # lexicographically-first SHA, matching what the Hub cache would actually load.
+        candidates += sorted(
+            repo_dir.glob("snapshots/*/config.json"), key = _safe_mtime, reverse = True
+        )
         for cfg_path in candidates:
             if cfg_path.is_file():
                 with open(cfg_path) as f:
@@ -420,10 +431,9 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         return cfg
     except Exception as exc:
         logger.debug("Could not fetch config.json for '%s': %s", model_name, exc)
-        # Fall back to the hub cache if the fetch failed (rate limit, transient block).
-        cfg = _config_json_from_hf_cache(model_name)
-        _config_json_cache[cache_key] = cfg
-        return cfg
+        # Transient failure (rate limit, block): serve the hub cache but do NOT cache it,
+        # so a later call retries the network once connectivity returns.
+        return _config_json_from_hf_cache(model_name)
 
 
 def _config_matches_tier(cfg: dict, architectures: set[str], model_types: set[str]) -> bool:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -431,9 +431,8 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         _config_json_cache[cache_key] = cfg
         return cfg
     except urllib.error.HTTPError as exc:
-        # 401/403/404 is a definitive access answer, not a blip: do NOT fall back to the
-        # hub cache, or an unauthenticated/wrong-token request could read another caller's
-        # cached private metadata. Treat it as "no config".
+        # 401/403/404 is a definitive access answer: never serve another caller's cached
+        # private metadata to an unauthenticated/wrong-token request.
         if exc.code in (401, 403, 404):
             logger.debug("config.json access denied for '%s': %s", model_name, exc)
             return None
@@ -441,17 +440,13 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         return _config_json_from_hf_cache(model_name)
     except Exception as exc:
         logger.debug("Could not fetch config.json for '%s': %s", model_name, exc)
-        # Transient failure (timeout, network blip): serve the hub cache but do NOT cache
-        # it, so a later call retries the network once connectivity returns.
+        # Transient: serve the hub cache uncached so the next call retries the network.
         return _config_json_from_hf_cache(model_name)
 
 
 def _config_json_is_definitive(model_name: str) -> bool:
-    """True if the last unauthenticated ``_load_config_json`` read was definitive (local
-    file, offline hub cache, or a completed network fetch) rather than a transient
-    fallback. Transient reads are deliberately not stored, so a missing entry means
-    "retry next time" -- callers use this to avoid memoizing a network blip.
-    """
+    """True if the last unauthenticated ``_load_config_json`` read was cached (definitive),
+    not a transient fallback (deliberately not stored, so callers re-check next call)."""
     return (model_name, None) in _config_json_cache
 
 
@@ -505,13 +500,8 @@ def _config_needs_510(cfg: dict) -> bool:
 
 
 def _check_config_needs_550(model_name: str) -> bool:
-    """True if ``config.json`` has architectures/model_type needing transformers
-    5.5.0 (e.g. Gemma 4).
-
-    Checks locally first, else fetches from HuggingFace. Cached in
-    ``_config_needs_550_cache`` only for a definitive read; a transient fetch failure
-    retries next call instead of pinning the wrong tier. Returns False on any error
-    (fail-open to lower tier).
+    """True if ``config.json`` needs transformers 5.5.0 (e.g. Gemma 4). Local first, else
+    fetched; cached only for a definitive read so a transient miss retries. False on error.
     """
     if model_name in _config_needs_550_cache:
         return _config_needs_550_cache[model_name]

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -398,14 +398,9 @@ def _config_needs_550(cfg: dict) -> bool:
 def _nemotron_h_needs_mlp_support(cfg: dict) -> bool:
     """True for a dense NemotronH config that uses MLP (``-``) layers.
 
-    NemotronH ``hybrid_override_pattern`` uses ``M`` (mamba), ``*`` (attention),
-    ``E`` (moe) and ``-`` (mlp). transformers only gained ``-`` -> ``mlp`` in its
-    ``pattern_mapping``/``valid_types``/``MIXER_TYPES`` in 5.10; 5.3 and 5.5 raise
-    ``KeyError: '-'`` (or reject the ``"mlp"`` block type) when parsing the config.
-    The model also ships ``auto_map`` remote code, but that only loads with
-    ``trust_remote_code=True`` -- a native (TRC=False) load such as export needs the
-    5.10 tier. Detected via the raw pattern or an already-expanded
-    ``layers_block_type`` list.
+    transformers only gained ``-`` -> ``mlp`` (pattern_mapping/valid_types/MIXER_TYPES)
+    in 5.10; 5.3/5.5 raise ``KeyError: '-'`` parsing the config. Detected from the raw
+    ``hybrid_override_pattern`` or an expanded ``layers_block_type``.
     """
     if cfg.get("model_type") != "nemotron_h":
         return False

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -137,6 +137,13 @@ _VENV_T5_510_DIR = str(_studio_root() / ".venv_t5_510")
 # Backwards-compat alias
 _VENV_T5_DIR = _VENV_T5_550_DIR
 
+# Tier precedence (higher 5.x tiers run first); used to pick the stronger of two tiers.
+_TIER_RANK = {"default": 0, "530": 1, "550": 2, "510": 3}
+
+
+def _higher_tier(a: str, b: str) -> str:
+    return a if _TIER_RANK.get(a, 0) >= _TIER_RANK.get(b, 0) else b
+
 
 def activate_transformers_for_subprocess(model_name: str) -> None:
     """Activate the correct transformers version in a subprocess worker.
@@ -148,6 +155,10 @@ def activate_transformers_for_subprocess(model_name: str) -> None:
     """
     resolved = _resolve_base_model(model_name)
     tier = get_transformers_tier(resolved)
+    if model_name != resolved:
+        # Prefer the higher tier: a local checkpoint's own config may reveal a dense
+        # NemotronH the (offline/private) base does not. Avoids KeyError: '-'.
+        tier = _higher_tier(tier, get_transformers_tier(model_name))
 
     if tier == "510":
         if not _ensure_venv_t5_510_exists():
@@ -330,6 +341,20 @@ def _check_tokenizer_config_needs_v5(model_name: str) -> bool:
         return False
 
 
+def _config_json_from_hf_cache(model_name: str) -> dict | None:
+    """Parsed ``config.json`` from the local HF hub cache, or None if not cached."""
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        path = try_to_load_from_cache(model_name, "config.json")
+        if isinstance(path, str) and path:
+            with open(path) as f:
+                return json.load(f)
+    except Exception as exc:
+        logger.debug("HF cache config.json lookup failed for '%s': %s", model_name, exc)
+    return None
+
+
 def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | None:
     """Return parsed ``config.json`` for *model_name*, checking local files first.
 
@@ -355,6 +380,13 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
             logger.debug("Could not read %s: %s", local_cfg, exc)
             _config_json_cache[cache_key] = None
             return None
+
+    # Already-downloaded repo: read config.json from the HF cache before any network,
+    # so offline/blocked fetches still tier correctly (e.g. a cached dense NemotronH).
+    cfg = _config_json_from_hf_cache(model_name)
+    if cfg is not None:
+        _config_json_cache[cache_key] = cfg
+        return cfg
 
     if _env_offline():
         _config_json_cache[cache_key] = None
@@ -395,22 +427,28 @@ def _config_needs_550(cfg: dict) -> bool:
     )
 
 
+_NESTED_CONFIG_KEYS = ("llm_config", "text_config", "language_config", "thinker_config")
+
+
 def _nemotron_h_needs_mlp_support(cfg: dict) -> bool:
     """True for a dense NemotronH config that uses MLP (``-``) layers.
 
     transformers only gained ``-`` -> ``mlp`` (pattern_mapping/valid_types/MIXER_TYPES)
     in 5.10; 5.3/5.5 raise ``KeyError: '-'`` parsing the config. Detected from the raw
-    ``hybrid_override_pattern`` or an expanded ``layers_block_type``.
+    ``hybrid_override_pattern`` or an expanded ``layers_block_type``, recursing into a
+    nested language config (VL wrappers like NemotronH_Nano_VL_V2 hold the dense LM
+    under ``llm_config``/``text_config``).
     """
-    if cfg.get("model_type") != "nemotron_h":
+    if not isinstance(cfg, dict):
         return False
-    pattern = cfg.get("hybrid_override_pattern")
-    if isinstance(pattern, str) and "-" in pattern:
-        return True
-    block_types = cfg.get("layers_block_type")
-    if isinstance(block_types, (list, tuple)) and "mlp" in block_types:
-        return True
-    return False
+    if cfg.get("model_type") == "nemotron_h":
+        pattern = cfg.get("hybrid_override_pattern")
+        if isinstance(pattern, str) and "-" in pattern:
+            return True
+        block_types = cfg.get("layers_block_type")
+        if isinstance(block_types, (list, tuple)) and "mlp" in block_types:
+            return True
+    return any(_nemotron_h_needs_mlp_support(cfg.get(key)) for key in _NESTED_CONFIG_KEYS)
 
 
 def _config_needs_510(cfg: dict) -> bool:
@@ -847,6 +885,10 @@ def ensure_transformers_version(model_name: str) -> None:
     # Resolve LoRA adapters to their base model for accurate detection.
     resolved = _resolve_base_model(model_name)
     tier = get_transformers_tier(resolved)
+    if model_name != resolved:
+        # Prefer the higher tier: a local checkpoint's own config may reveal a dense
+        # NemotronH the (offline/private) base does not. Avoids KeyError: '-'.
+        tier = _higher_tier(tier, get_transformers_tier(model_name))
 
     if tier == "510":
         target_version = TRANSFORMERS_510_VERSION

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -5,7 +5,9 @@
 
 Some newer model architectures (Ministral-3, GLM-4.7-Flash, Qwen3-30B-A3B MoE,
 tiny_qwen3_moe) require transformers>=5.3.0, while Gemma 4 models require a
-newer 5.x sidecar.  Everything else needs the default 4.57.x that ships with
+newer 5.x sidecar.  Dense NemotronH models (e.g. NVIDIA-Nemotron-3-Nano-4B) use
+MLP layers that only transformers>=5.10 can parse natively, so they go on the
+5.10 sidecar too.  Everything else needs the default 4.57.x that ships with
 Unsloth.
 
 Two separate target directories are maintained:
@@ -393,12 +395,38 @@ def _config_needs_550(cfg: dict) -> bool:
     )
 
 
+def _nemotron_h_needs_mlp_support(cfg: dict) -> bool:
+    """True for a dense NemotronH config that uses MLP (``-``) layers.
+
+    NemotronH ``hybrid_override_pattern`` uses ``M`` (mamba), ``*`` (attention),
+    ``E`` (moe) and ``-`` (mlp). transformers only gained ``-`` -> ``mlp`` in its
+    ``pattern_mapping``/``valid_types``/``MIXER_TYPES`` in 5.10; 5.3 and 5.5 raise
+    ``KeyError: '-'`` (or reject the ``"mlp"`` block type) when parsing the config.
+    The model also ships ``auto_map`` remote code, but that only loads with
+    ``trust_remote_code=True`` -- a native (TRC=False) load such as export needs the
+    5.10 tier. Detected via the raw pattern or an already-expanded
+    ``layers_block_type`` list.
+    """
+    if cfg.get("model_type") != "nemotron_h":
+        return False
+    pattern = cfg.get("hybrid_override_pattern")
+    if isinstance(pattern, str) and "-" in pattern:
+        return True
+    block_types = cfg.get("layers_block_type")
+    if isinstance(block_types, (list, tuple)) and "mlp" in block_types:
+        return True
+    return False
+
+
 def _config_needs_510(cfg: dict) -> bool:
-    return _config_matches_tier(
+    if _config_matches_tier(
         cfg,
         _TRANSFORMERS_510_ARCHITECTURES,
         _TRANSFORMERS_510_MODEL_TYPES,
-    )
+    ):
+        return True
+    # Dense NemotronH (e.g. NVIDIA-Nemotron-3-Nano-4B) needs 5.10 for MLP layers.
+    return _nemotron_h_needs_mlp_support(cfg)
 
 
 def _check_config_needs_550(model_name: str) -> bool:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -155,9 +155,11 @@ def activate_transformers_for_subprocess(model_name: str) -> None:
     """
     resolved = _resolve_base_model(model_name)
     tier = get_transformers_tier(resolved)
-    if model_name != resolved:
-        # Prefer the higher tier: a local checkpoint's own config may reveal a dense
-        # NemotronH the (offline/private) base does not. Avoids KeyError: '-'.
+    if model_name != resolved and (Path(model_name) / "config.json").is_file():
+        # A local checkpoint carries its own config the (offline/private) base may not
+        # surface. Gate on a real local config.json so this reads metadata, not path-name
+        # substrings (a /runs/gemma-4-x/llama-lora adapter must not upgrade). Avoids
+        # KeyError: '-' for dense NemotronH without misrouting plain adapters.
         tier = _higher_tier(tier, get_transformers_tier(model_name))
 
     if tier == "510":
@@ -342,13 +344,32 @@ def _check_tokenizer_config_needs_v5(model_name: str) -> bool:
 
 
 def _config_json_from_hf_cache(model_name: str) -> dict | None:
-    """Parsed ``config.json`` from the local HF hub cache, or None if not cached."""
+    """Parsed ``config.json`` from the local HF hub cache, or None if not cached.
+
+    Resolves the cache path with stdlib only (no ``huggingface_hub`` import) so tier
+    detection never loads the default-env hub before a sidecar venv is activated.
+    """
+    # Only a canonical ``owner/repo`` Hub id maps to a cache dir; reject local paths.
+    if not model_name or model_name.count("/") != 1 or model_name[0] in "/.~" or "\\" in model_name:
+        return None
+    hub = (
+        os.environ.get("HF_HUB_CACHE")
+        or os.environ.get("HUGGINGFACE_HUB_CACHE")
+        or os.path.join(
+            os.environ.get("HF_HOME") or os.path.expanduser("~/.cache/huggingface"), "hub"
+        )
+    )
+    repo_dir = Path(hub) / ("models--" + model_name.replace("/", "--"))
+    candidates = []
+    ref_main = repo_dir / "refs" / "main"
     try:
-        from huggingface_hub import try_to_load_from_cache
-        path = try_to_load_from_cache(model_name, "config.json")
-        if isinstance(path, str) and path:
-            with open(path) as f:
-                return json.load(f)
+        if ref_main.is_file():
+            candidates.append(repo_dir / "snapshots" / ref_main.read_text().strip() / "config.json")
+        candidates += sorted(repo_dir.glob("snapshots/*/config.json"))
+        for cfg_path in candidates:
+            if cfg_path.is_file():
+                with open(cfg_path) as f:
+                    return json.load(f)
     except Exception as exc:
         logger.debug("HF cache config.json lookup failed for '%s': %s", model_name, exc)
     return None
@@ -359,7 +380,8 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
 
     ``hf_token`` authenticates the raw fetch so gated/private repos resolve. The
     cache is keyed on the token so an unauthenticated miss never poisons a later
-    authenticated read.
+    authenticated read. The HF hub cache is consulted only offline or after a failed
+    network fetch, so an online read never serves stale metadata.
     """
     import hashlib
 
@@ -380,16 +402,11 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
             _config_json_cache[cache_key] = None
             return None
 
-    # Already-downloaded repo: read config.json from the HF cache before any network,
-    # so offline/blocked fetches still tier correctly (e.g. a cached dense NemotronH).
-    cfg = _config_json_from_hf_cache(model_name)
-    if cfg is not None:
+    if _env_offline():
+        # No network: a previously downloaded repo can still tier from the hub cache.
+        cfg = _config_json_from_hf_cache(model_name)
         _config_json_cache[cache_key] = cfg
         return cfg
-
-    if _env_offline():
-        _config_json_cache[cache_key] = None
-        return None
 
     import urllib.request
 
@@ -405,8 +422,10 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         return cfg
     except Exception as exc:
         logger.debug("Could not fetch config.json for '%s': %s", model_name, exc)
-        _config_json_cache[cache_key] = None
-        return None
+        # Fall back to the hub cache if the fetch failed (rate limit, transient block).
+        cfg = _config_json_from_hf_cache(model_name)
+        _config_json_cache[cache_key] = cfg
+        return cfg
 
 
 def _config_matches_tier(cfg: dict, architectures: set[str], model_types: set[str]) -> bool:
@@ -884,9 +903,11 @@ def ensure_transformers_version(model_name: str) -> None:
     # Resolve LoRA adapters to their base model for accurate detection.
     resolved = _resolve_base_model(model_name)
     tier = get_transformers_tier(resolved)
-    if model_name != resolved:
-        # Prefer the higher tier: a local checkpoint's own config may reveal a dense
-        # NemotronH the (offline/private) base does not. Avoids KeyError: '-'.
+    if model_name != resolved and (Path(model_name) / "config.json").is_file():
+        # A local checkpoint carries its own config the (offline/private) base may not
+        # surface. Gate on a real local config.json so this reads metadata, not path-name
+        # substrings (a /runs/gemma-4-x/llama-lora adapter must not upgrade). Avoids
+        # KeyError: '-' for dense NemotronH without misrouting plain adapters.
         tier = _higher_tier(tier, get_transformers_tier(model_name))
 
     if tier == "510":

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -137,7 +137,7 @@ _VENV_T5_510_DIR = str(_studio_root() / ".venv_t5_510")
 # Backwards-compat alias
 _VENV_T5_DIR = _VENV_T5_550_DIR
 
-# Tier precedence (higher 5.x tiers run first); used to pick the stronger of two tiers.
+# Tier precedence: higher rank wins in _higher_tier.
 _TIER_RANK = {"default": 0, "530": 1, "550": 2, "510": 3}
 
 
@@ -156,10 +156,8 @@ def activate_transformers_for_subprocess(model_name: str) -> None:
     resolved = _resolve_base_model(model_name)
     tier = get_transformers_tier(resolved)
     if model_name != resolved and (Path(model_name) / "config.json").is_file():
-        # A local checkpoint carries its own config the (offline/private) base may not
-        # surface. Gate on a real local config.json so this reads metadata, not path-name
-        # substrings (a /runs/gemma-4-x/llama-lora adapter must not upgrade). Avoids
-        # KeyError: '-' for dense NemotronH without misrouting plain adapters.
+        # Gate on a real local config.json: a checkpoint carries config the base may not
+        # surface, but path names alone must not upgrade a plain adapter.
         tier = _higher_tier(tier, get_transformers_tier(model_name))
 
     if tier == "510":
@@ -344,10 +342,10 @@ def _check_tokenizer_config_needs_v5(model_name: str) -> bool:
 
 
 def _config_json_from_hf_cache(model_name: str) -> dict | None:
-    """Parsed ``config.json`` from the local HF hub cache, or None if not cached.
+    """Parsed ``config.json`` from the local HF hub cache, or None.
 
-    Resolves the cache path with stdlib only (no ``huggingface_hub`` import) so tier
-    detection never loads the default-env hub before a sidecar venv is activated.
+    Stdlib-only path resolution (no ``huggingface_hub`` import) so tier detection never
+    loads the default-env hub before a sidecar venv is activated.
     """
     # Only a canonical ``owner/repo`` Hub id maps to a cache dir; reject local paths.
     if not model_name or model_name.count("/") != 1 or model_name[0] in "/.~" or "\\" in model_name:
@@ -449,13 +447,11 @@ _NESTED_CONFIG_KEYS = ("llm_config", "text_config", "language_config", "thinker_
 
 
 def _nemotron_h_needs_mlp_support(cfg: dict) -> bool:
-    """True for a dense NemotronH config that uses MLP (``-``) layers.
+    """True for a dense NemotronH config using MLP (``-``) layers.
 
-    transformers only gained ``-`` -> ``mlp`` (pattern_mapping/valid_types/MIXER_TYPES)
-    in 5.10; 5.3/5.5 raise ``KeyError: '-'`` parsing the config. Detected from the raw
-    ``hybrid_override_pattern`` or an expanded ``layers_block_type``, recursing into a
-    nested language config (VL wrappers like NemotronH_Nano_VL_V2 hold the dense LM
-    under ``llm_config``/``text_config``).
+    transformers only gained ``-`` -> ``mlp`` in 5.10; 5.3/5.5 raise ``KeyError: '-'``.
+    Read from ``hybrid_override_pattern`` or ``layers_block_type``, recursing into nested
+    language configs (VL wrappers hold the dense LM under ``llm_config``/``text_config``).
     """
     if not isinstance(cfg, dict):
         return False
@@ -476,7 +472,6 @@ def _config_needs_510(cfg: dict) -> bool:
         _TRANSFORMERS_510_MODEL_TYPES,
     ):
         return True
-    # Dense NemotronH (e.g. NVIDIA-Nemotron-3-Nano-4B) needs 5.10 for MLP layers.
     return _nemotron_h_needs_mlp_support(cfg)
 
 
@@ -904,10 +899,8 @@ def ensure_transformers_version(model_name: str) -> None:
     resolved = _resolve_base_model(model_name)
     tier = get_transformers_tier(resolved)
     if model_name != resolved and (Path(model_name) / "config.json").is_file():
-        # A local checkpoint carries its own config the (offline/private) base may not
-        # surface. Gate on a real local config.json so this reads metadata, not path-name
-        # substrings (a /runs/gemma-4-x/llama-lora adapter must not upgrade). Avoids
-        # KeyError: '-' for dense NemotronH without misrouting plain adapters.
+        # Gate on a real local config.json: a checkpoint carries config the base may not
+        # surface, but path names alone must not upgrade a plain adapter.
         tier = _higher_tier(tier, get_transformers_tier(model_name))
 
     if tier == "510":


### PR DESCRIPTION
## What

Fixes `Failed to load checkpoint: '-'` when loading or exporting a dense NemotronH
model (e.g. `unsloth/NVIDIA-Nemotron-3-Nano-4B`) in Studio.

## Root cause

Dense NemotronH models describe their layer stack with a `hybrid_override_pattern`
string that mixes `M` (mamba), `*` (attention), `E` (moe) and `-` (mlp), for example
`M-M-M-MM-M-M*-M-M*-...`. transformers only learned to parse the `-` (MLP) layer in
5.10: `pattern_mapping` gained `"-": "mlp"`, and `valid_types` / `MIXER_TYPES` gained
`"mlp"`. On 5.3 / 5.5 the config raises `KeyError: '-'` in `_pattern_to_list`.

Studio's tier selector routed this model to the 5.3 tier (530) via the
`TokenizersBackend` tokenizer check. The model also ships `auto_map` remote code, so
training and inference (which run with `trust_remote_code=True` after consent) load
through the model's own code and work. But a native load with `trust_remote_code=False`
(such as export loading a LoRA's base model) hits the built-in 5.3 parser and fails.

Reproduced: `AutoConfig.from_pretrained(<NemotronH>, trust_remote_code=False)` raises
`KeyError: '-'` on transformers 5.3.0, and loads cleanly on 5.10.2 (42 layers,
block types `{mamba, attention, mlp}`).

## Fix

Detect a dense NemotronH config (`model_type == "nemotron_h"` with a `-` in
`hybrid_override_pattern`, or `"mlp"` in an already-expanded `layers_block_type`) and
route it to the 5.10 tier, where it loads natively without remote code. Pure-MoE
NemotronH configs (no MLP layers) are unaffected and keep their existing tier.

Wired into `_config_needs_510`, so both the local-checkpoint and remote-HF-id paths
pick it up, and it takes precedence over the 530 tokenizer check.

## Tests

`tests/test_transformers_version.py`: detector unit tests (dash pattern, expanded
`mlp` block list, MoE-only negative, non-NemotronH negative) and tier-selection tests
for a local dense-NemotronH checkpoint (510 beats the 530 tokenizer signal) and a
remote HF id. Full file: 63 passed.
