### PR TITLE
Thread finetune_audio_layers through get_peft_model (Gemma 4 / Gemma 3N audio LoRA)

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2917,6 +2917,7 @@ class FastLlamaModel:
                 ("finetune_language_layers", True),
                 ("finetune_attention_modules", True),
                 ("finetune_mlp_modules", True),
+                ("finetune_audio_layers", False),
             ):
                 if peft_arg not in kwargs:
                     kwargs[peft_arg] = flag

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1367,7 +1367,6 @@ class FastBaseModel:
         finetune_language_layers = True,
         finetune_attention_modules = True,
         finetune_mlp_modules = True,
-        finetune_audio_layers = False,
         finetune_last_n_layers = None,
         layers_to_transform = None,
         layers_pattern = None,
@@ -1383,6 +1382,7 @@ class FastBaseModel:
         qat_scheme = None,
         target_parameters = None,  # For MoE expert layers (nn.Parameter)
         ensure_weight_tying = False,  # [TODO] Add `ensure_weight_tying` for `modules_to_save` for vision models
+        finetune_audio_layers = False,  # placed last to preserve existing positional argument order
         **kwargs,
     ):
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
@@ -1398,6 +1398,10 @@ class FastBaseModel:
         if isinstance(model, PeftModelForCausalLM):
             raise RuntimeError("Unsloth: You already added LoRA adapters to your model!")
 
+        # Remember whether the CALLER explicitly opted into audio. "all-linear" turns
+        # the flag on implicitly below, but an old unsloth_zoo that cannot do audio
+        # must not make a plain all-linear (text/vision) run fail.
+        _audio_explicitly_requested = bool(finetune_audio_layers)
         if target_modules == "all-linear":
             finetune_vision_layers = True
             finetune_language_layers = True
@@ -1405,12 +1409,13 @@ class FastBaseModel:
             finetune_mlp_modules = True
             finetune_audio_layers = True
         # Older unsloth_zoo (before get_peft_regex gained finetune_audio_layers) does
-        # not accept the kwarg. Pass it only when supported; if the caller explicitly
+        # not accept the kwarg. Pass it only when supported; if the caller EXPLICITLY
         # asked for audio but it is unsupported, fail loudly rather than silently
-        # training a language-only adapter.
+        # training a language-only adapter. (all-linear's implicit opt-in degrades
+        # gracefully instead of raising.)
         if "finetune_audio_layers" in inspect.signature(get_peft_regex).parameters:
             _audio_kwargs = {"finetune_audio_layers": finetune_audio_layers}
-        elif finetune_audio_layers:
+        elif _audio_explicitly_requested:
             raise RuntimeError(
                 "Unsloth: finetune_audio_layers=True requires a newer unsloth_zoo. "
                 "Please upgrade with `pip install --upgrade --no-deps unsloth_zoo`."

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1404,6 +1404,17 @@ class FastBaseModel:
             finetune_attention_modules = True
             finetune_mlp_modules = True
             finetune_audio_layers = True
+        # Older unsloth_zoo (before get_peft_regex gained finetune_audio_layers) does
+        # not accept the kwarg, so pass it only when supported to avoid a TypeError.
+        if "finetune_audio_layers" in inspect.signature(get_peft_regex).parameters:
+            _audio_kwargs = {"finetune_audio_layers": finetune_audio_layers}
+        else:
+            if finetune_audio_layers:
+                logger.warning(
+                    "Unsloth: finetune_audio_layers=True needs a newer unsloth_zoo; ignoring it. "
+                    "Please upgrade with `pip install --upgrade --no-deps unsloth_zoo`."
+                )
+            _audio_kwargs = {}
         if target_modules is None or target_modules == "all-linear":
             target_modules = get_peft_regex(
                 model,
@@ -1411,20 +1422,23 @@ class FastBaseModel:
                 finetune_language_layers = finetune_language_layers,
                 finetune_attention_modules = finetune_attention_modules,
                 finetune_mlp_modules = finetune_mlp_modules,
-                finetune_audio_layers = finetune_audio_layers,
+                **_audio_kwargs,
             )
         else:
             assert type(target_modules) in (list, tuple, str)
+            # finetune_audio_layers is deliberately NOT part of this condition: it
+            # defaults False, so including it would force every explicit target_modules
+            # list through get_peft_regex (and print the warning) even for text/vision
+            # models that never opted into layer-scope filtering.
             if type(target_modules) in (list, tuple) and (
                 not finetune_vision_layers
                 or not finetune_language_layers
                 or not finetune_attention_modules
                 or not finetune_mlp_modules
-                or not finetune_audio_layers
             ):
                 print(
                     "Unsloth: Explicit target_modules are constrained by the "
-                    "finetune_(vision|language|audio|attention|mlp) filters; adapters "
+                    "finetune_(vision|language|attention|mlp) filters; adapters "
                     "attach only where both select."
                 )
                 target_modules = get_peft_regex(
@@ -1433,8 +1447,8 @@ class FastBaseModel:
                     finetune_language_layers = finetune_language_layers,
                     finetune_attention_modules = finetune_attention_modules,
                     finetune_mlp_modules = finetune_mlp_modules,
-                    finetune_audio_layers = finetune_audio_layers,
                     target_modules = list(target_modules),
+                    **_audio_kwargs,
                 )
 
         if hasattr(model, "vllm_engine"):

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1405,15 +1405,17 @@ class FastBaseModel:
             finetune_mlp_modules = True
             finetune_audio_layers = True
         # Older unsloth_zoo (before get_peft_regex gained finetune_audio_layers) does
-        # not accept the kwarg, so pass it only when supported to avoid a TypeError.
+        # not accept the kwarg. Pass it only when supported; if the caller explicitly
+        # asked for audio but it is unsupported, fail loudly rather than silently
+        # training a language-only adapter.
         if "finetune_audio_layers" in inspect.signature(get_peft_regex).parameters:
             _audio_kwargs = {"finetune_audio_layers": finetune_audio_layers}
+        elif finetune_audio_layers:
+            raise RuntimeError(
+                "Unsloth: finetune_audio_layers=True requires a newer unsloth_zoo. "
+                "Please upgrade with `pip install --upgrade --no-deps unsloth_zoo`."
+            )
         else:
-            if finetune_audio_layers:
-                logger.warning(
-                    "Unsloth: finetune_audio_layers=True needs a newer unsloth_zoo; ignoring it. "
-                    "Please upgrade with `pip install --upgrade --no-deps unsloth_zoo`."
-                )
             _audio_kwargs = {}
         if target_modules is None or target_modules == "all-linear":
             target_modules = get_peft_regex(
@@ -1426,21 +1428,24 @@ class FastBaseModel:
             )
         else:
             assert type(target_modules) in (list, tuple, str)
-            # finetune_audio_layers is deliberately NOT part of this condition: it
-            # defaults False, so including it would force every explicit target_modules
-            # list through get_peft_regex (and print the warning) even for text/vision
-            # models that never opted into layer-scope filtering.
-            if type(target_modules) in (list, tuple) and (
+            # Route an explicit list through get_peft_regex when the caller scoped a
+            # layer family (one of the finetune_* below is off) OR opted into audio (so
+            # the new audio/embedder branches are considered). finetune_audio_layers is
+            # a POSITIVE term here: using `not finetune_audio_layers` would -- since it
+            # defaults False -- force every explicit list through the filter.
+            _scoping = (
                 not finetune_vision_layers
                 or not finetune_language_layers
                 or not finetune_attention_modules
                 or not finetune_mlp_modules
-            ):
-                print(
-                    "Unsloth: Explicit target_modules are constrained by the "
-                    "finetune_(vision|language|attention|mlp) filters; adapters "
-                    "attach only where both select."
-                )
+            )
+            if type(target_modules) in (list, tuple) and (_scoping or finetune_audio_layers):
+                if _scoping:
+                    print(
+                        "Unsloth: Explicit target_modules are constrained by the "
+                        "finetune_(vision|language|attention|mlp) filters; adapters "
+                        "attach only where both select."
+                    )
                 target_modules = get_peft_regex(
                     model,
                     finetune_vision_layers = finetune_vision_layers,

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1367,6 +1367,7 @@ class FastBaseModel:
         finetune_language_layers = True,
         finetune_attention_modules = True,
         finetune_mlp_modules = True,
+        finetune_audio_layers = False,
         finetune_last_n_layers = None,
         layers_to_transform = None,
         layers_pattern = None,
@@ -1402,6 +1403,7 @@ class FastBaseModel:
             finetune_language_layers = True
             finetune_attention_modules = True
             finetune_mlp_modules = True
+            finetune_audio_layers = True
         if target_modules is None or target_modules == "all-linear":
             target_modules = get_peft_regex(
                 model,
@@ -1409,6 +1411,7 @@ class FastBaseModel:
                 finetune_language_layers = finetune_language_layers,
                 finetune_attention_modules = finetune_attention_modules,
                 finetune_mlp_modules = finetune_mlp_modules,
+                finetune_audio_layers = finetune_audio_layers,
             )
         else:
             assert type(target_modules) in (list, tuple, str)
@@ -1417,10 +1420,11 @@ class FastBaseModel:
                 or not finetune_language_layers
                 or not finetune_attention_modules
                 or not finetune_mlp_modules
+                or not finetune_audio_layers
             ):
                 print(
                     "Unsloth: Explicit target_modules are constrained by the "
-                    "finetune_(vision|language|attention|mlp) filters; adapters "
+                    "finetune_(vision|language|audio|attention|mlp) filters; adapters "
                     "attach only where both select."
                 )
                 target_modules = get_peft_regex(
@@ -1429,6 +1433,7 @@ class FastBaseModel:
                     finetune_language_layers = finetune_language_layers,
                     finetune_attention_modules = finetune_attention_modules,
                     finetune_mlp_modules = finetune_mlp_modules,
+                    finetune_audio_layers = finetune_audio_layers,
                     target_modules = list(target_modules),
                 )
 


### PR DESCRIPTION
## Summary

Threads a new `finetune_audio_layers` flag through `FastBaseModel.get_peft_model` so `FastModel` / `FastVisionModel` can attach LoRA to the Gemma 4 / Gemma 3N audio encoder (`audio_tower`) and the audio/vision embedder projectors (`embed_audio.embedding_projection`, `embed_vision.embedding_projection`).

Today `get_peft_regex` requires an attention/mlp component token between the model-part tag and the leaf, which the flat embedder projections and the conformer `audio_tower` leaves do not have, so `finetune_vision_layers=True` never reaches the projector and nothing reaches the audio encoder.

## Change (`unsloth/models/vision.py`, `unsloth/models/llama.py`)

- Add `finetune_audio_layers = False` to `FastBaseModel.get_peft_model`.
- Set it `True` under `target_modules="all-linear"`.
- Include it in the explicit-`target_modules` layer-scope filter condition and the printed message.
- Pass it to both `get_peft_regex` calls.
- Add it to the `UNSLOTH_USE_NEW_MODEL` kwargs defaults in `llama.py` so the public entrypoint forwards it.

## Dependency

Requires unslothai/unsloth-zoo#814 (adds the `finetune_audio_layers` parameter and the audio/embedder branches to `get_peft_regex`). Merge that first.

## Usage

```python
model = FastModel.get_peft_model(
    model,
    finetune_language_layers = True,
    finetune_audio_layers    = True,   # adapts audio_tower + embed_audio projector
)
```

This restores audio fine-tuning in the Gemma audio notebooks, which previously passed an explicit `target_modules` list that (since the explicit-target layer-scope filter landed) attached zero audio modules.