### PR TITLE
Fixes wrong negative argparse.BooleanOptionalAction argument name

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -921,7 +921,7 @@ def run_server(
     # port is never public (even with -H 0.0.0.0), and reject the contradictory combo.
     if secure and not cloudflare:
         raise SystemExit(
-            "A secure Cloudflare link is not allowed, use --not-secure which provides a 0.0.0.0 link"
+            "A secure Cloudflare link is not allowed, use --no-secure which provides a 0.0.0.0 link"
         )
     if secure:
         host = "127.0.0.1"
@@ -1161,7 +1161,7 @@ def run_server(
     # silently fall back to a raw port.
     if secure and not _cloudflare_url:
         print(
-            "A secure Cloudflare link is not allowed, use --not-secure which provides a 0.0.0.0 link",
+            "A secure Cloudflare link is not allowed, use --no-secure which provides a 0.0.0.0 link",
             file = sys.stderr,
             flush = True,
         )
@@ -1218,7 +1218,7 @@ if __name__ == "__main__":
         action = argparse.BooleanOptionalAction,
         default = False,
         help = "Expose ONLY a Cloudflare HTTPS link: bind localhost and fail closed "
-        "if the tunnel can't start. Without it, --not-secure also serves the raw "
+        "if the tunnel can't start. Without it, --no-secure also serves the raw "
         "0.0.0.0 port, which is reachable from anywhere on the network",
     )
     # Tri-state tool policy: no flag -> None (tools on, per-request honored);

--- a/studio/backend/tests/test_secure_tunnel_gate.py
+++ b/studio/backend/tests/test_secure_tunnel_gate.py
@@ -145,6 +145,6 @@ def test_failclosed_message_present_in_source():
     # The exact, user-facing fail-closed message must not drift.
     src = (_BACKEND / "run.py").read_text(encoding = "utf-8")
     assert (
-        "A secure Cloudflare link is not allowed, use --not-secure which provides a 0.0.0.0 link"
+        "A secure Cloudflare link is not allowed, use --no-secure which provides a 0.0.0.0 link"
         in src
     )

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -670,9 +670,9 @@ def studio_default(
     ),
     secure: bool = typer.Option(
         False,
-        "--secure/--not-secure",
+        "--secure/--no-secure",
         help = "Expose ONLY a Cloudflare HTTPS link: bind localhost and fail closed "
-        "if the tunnel can't start. Without it, --not-secure also serves the raw "
+        "if the tunnel can't start. Without it, --no-secure also serves the raw "
         "0.0.0.0 port, which is reachable from anywhere on the network.",
     ),
     verbose: bool = typer.Option(
@@ -798,7 +798,7 @@ def studio_default(
                 args.append("--api-only")
             # Forward the explicit polarity (matches run.py's BooleanOptionalAction).
             args.append("--cloudflare" if cloudflare else "--no-cloudflare")
-            args.append("--secure" if secure else "--not-secure")
+            args.append("--secure" if secure else "--no-secure")
             # Forward an explicit tool policy; None -> run.py leaves it unset (tools on).
             if enable_tools is True:
                 args.append("--enable-tools")
@@ -1034,9 +1034,9 @@ def run(
     ),
     secure: bool = typer.Option(
         False,
-        "--secure/--not-secure",
+        "--secure/--no-secure",
         help = "Expose ONLY a Cloudflare HTTPS link: bind localhost and fail closed "
-        "if the tunnel can't start. Without it, --not-secure also serves the raw "
+        "if the tunnel can't start. Without it, --no-secure also serves the raw "
         "0.0.0.0 port, which is reachable from anywhere on the network.",
     ),
     tensor_parallel: bool = typer.Option(
@@ -1189,7 +1189,7 @@ def run(
         args.extend(["--parallel", str(parallel)])
         # Forward the explicit polarity (same rationale as --load-in-4bit above).
         args.append("--cloudflare" if cloudflare else "--no-cloudflare")
-        args.append("--secure" if secure else "--not-secure")
+        args.append("--secure" if secure else "--no-secure")
         args.append("--tensor-parallel" if tensor_parallel else "--no-tensor-parallel")
         if verbose:
             args.append("--verbose")

--- a/unsloth_cli/tests/test_studio_secure_flag.py
+++ b/unsloth_cli/tests/test_studio_secure_flag.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Tests for the `--secure/--not-secure` Studio flag: option registration,
+"""Tests for the `--secure/--no-secure` Studio flag: option registration,
 re-exec/run_server forwarding, the forced 127.0.0.1 bind, and rejection
 alongside --no-cloudflare or before a subcommand. Modeled on
 test_studio_cloudflare_flag.py."""
@@ -35,7 +35,7 @@ def test_run_exposes_secure_option_default_off():
 
     opt = inspect.signature(_studio().run).parameters["secure"].default
     decls = set(getattr(opt, "param_decls", []) or [])
-    assert "--secure/--not-secure" in decls
+    assert "--secure/--no-secure" in decls
     assert getattr(opt, "default", None) is False
 
 
@@ -44,7 +44,7 @@ def test_studio_default_exposes_secure_option_default_off():
 
     opt = inspect.signature(_studio().studio_default).parameters["secure"].default
     decls = set(getattr(opt, "param_decls", []) or [])
-    assert "--secure/--not-secure" in decls
+    assert "--secure/--no-secure" in decls
     assert getattr(opt, "default", None) is False
 
 
@@ -129,9 +129,9 @@ def _invoke_studio_default(monkeypatch, args):
 @pytest.mark.parametrize(
     "user_flag,expected,unexpected",
     [
-        (None, "--not-secure", "--secure"),  # default off
-        ("--secure", "--secure", "--not-secure"),
-        ("--not-secure", "--not-secure", "--secure"),
+        (None, "--no-secure", "--secure"),  # default off
+        ("--secure", "--secure", "--no-secure"),
+        ("--no-secure", "--no-secure", "--secure"),
     ],
 )
 def test_run_reexec_forwards_secure_polarity(monkeypatch, user_flag, expected, unexpected):


### PR DESCRIPTION
studio.backend.run.__main__ adds "--secure" argument via argparse.BooleanOptionalAction, which automatically creates negative --no-secure, that is with **NO** prefix, instead of **NOT**.