### PR TITLE
loader: gpt-oss MXFP4 with default load_in_4bit takes the MXFP4 dtype path

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -1367,7 +1367,11 @@ class FastModel(FastBaseModel):
             )
         elif "gpt_oss" in model_types_all:
             os.environ["UNSLOTH_DISABLE_STATIC_GENERATION"] = "1"
-            if not load_in_4bit:
+            # Use the EFFECTIVE bnb state, not the raw flag: a native MXFP4 checkpoint loaded
+            # with the default load_in_4bit=True (e.g. openai/gpt-oss-20b by exact name) has
+            # bnb disabled later by check_and_disable, so the raw flag would wrongly pick the
+            # BnB dtype path. Mirrors the _load_in_4bit_ token gate above.
+            if not (load_in_4bit and _bnb_compatible_quant):
                 # Only upcast MoE biases for MXFP4, not BnB
                 # Set norms to float32 since anyways they get upcasted to float32
                 os.environ["UNSLOTH_FORCE_CUSTOM_DTYPE"] = (


### PR DESCRIPTION
Follow-up to #6504. Codex flagged a remaining gpt-oss dtype-selection edge that the bnb-token sync in #6504 did not cover.

## Problem

The gpt-oss branch in `from_pretrained` selects the `UNSLOTH_FORCE_CUSTOM_DTYPE` recipe from the raw `load_in_4bit` flag:

```python
elif "gpt_oss" in model_types_all:
    if not load_in_4bit:
        # MXFP4 bias-upcast path
    else:
        # BnB down_proj/router compute-dtype path
```

A native MXFP4 checkpoint loaded by exact name with the default `load_in_4bit=True` (for example `FastLanguageModel.from_pretrained("openai/gpt-oss-20b")`) keeps `load_in_4bit` set here. bnb is only disabled later by `check_and_disable_bitsandbytes_loading` inside `FastBaseModel.from_pretrained`, which runs after this branch has already exported the env var. So a native MXFP4 gpt-oss takes the BnB path, which also calls `dequantize_module_weight` on a non-bnb module, instead of the MXFP4 bias-upcast path.

## Fix

Gate on the effective bnb state, `load_in_4bit and _bnb_compatible_quant`, the same value #6504 already computes for the `_load_in_4bit_` token. `_bnb_compatible_quant` is `get_quant_type(model_config) in (None, "bitsandbytes")`, so it is False for a native MXFP4 config.

Behavior:
- native MXFP4 gpt-oss, `load_in_4bit=True` (default): now takes the MXFP4 path (fixed)
- bnb-4bit gpt-oss QLoRA: `load_in_4bit and _bnb_compatible_quant` is True, takes the BnB path (unchanged)
- `-BF16` gpt-oss: `load_in_4bit` already False, takes the MXFP4 path (unchanged)

One-line condition change; no other behavior affected.