### PR TITLE
Installer: respect a declined Studio auto-start and order Ctrl+C shutdown logs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3126,10 +3126,13 @@ echo ""
 if [ -t 1 ]; then
     echo ""
     printf "  Start Unsloth Studio now? [Y/n] "
+    # Default to NOT starting when no answer can be read (closed/EOF tty) so a
+    # non-interactive caller is never trapped in a foreground server. A real
+    # Enter still counts as yes via ${_reply:-y} below.
     if [ -r /dev/tty ]; then
-        read -r _reply </dev/tty || _reply="y"
+        read -r _reply </dev/tty || _reply="n"
     else
-        _reply="y"
+        _reply="n"
     fi
     case "${_reply:-y}" in
         [Yy]*|"")
@@ -3137,6 +3140,9 @@ if [ -t 1 ]; then
             # Detach stdin from the `curl | sh` pipe: as a foreground server the
             # studio would otherwise drain the rest of this piped script, leaving
             # the shell to die parsing the now-truncated tail (`unexpected fi`).
+            # Ignore Ctrl+C so this shell waits for studio's own graceful
+            # shutdown instead of dying first and racing the prompt over its logs.
+            trap '' INT
             "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null
             _LAUNCH_EXIT=$?
             if [ "$_LAUNCH_EXIT" -ne 0 ] && [ "$_MIGRATED" = true ]; then


### PR DESCRIPTION
## Summary

Two fixes to the `curl | sh` Studio auto-start flow in `install.sh`, both on Linux / macOS / WSL. `install.ps1` already guards on input redirection, so Windows is not affected.

1. Declining the auto-start prompt (typing `n`) could still launch Studio.
2. On `Ctrl+C`, the shell prompt printed in the middle of Studio's shutdown logs.

## 1. Declining the prompt still launched Studio

The prompt read its answer with fallbacks that both defaulted to yes:

```sh
read -r _reply </dev/tty || _reply="y"   # read failure / EOF
else _reply="y"                          # no readable tty
case "${_reply:-y}" in [Yy]*|"") ...      # empty also yes
```

In a clean interactive terminal, typing `n` works. The problem is every path that is not a cleanly delivered `y`/`n` line falls back to yes and starts a blocking foreground server:

- A closed or EOF `/dev/tty` (semi-interactive sessions, automation, some cloud/web shells) makes `read` fail, so `|| _reply="y"` launches with no echoed answer.
- The install also has an earlier `read </dev/tty` (the package-accept prompt). If the user pre-types `n` during the multi-minute install, the earlier prompt consumes it and this one then sees EOF and launches.

### Fix

Default the unreadable cases to `n`, so a non-interactive caller is never trapped in a foreground server. A real Enter still counts as yes through `${_reply:-y}`:

```sh
read -r _reply </dev/tty || _reply="n"
else _reply="n"
```

Verified under a PTY that mimics `curl | sh`:

| input | before | after |
|---|---|---|
| type `n` / `N` | launches in EOF sessions | does not launch |
| press Enter | launches | launches (default yes preserved) |
| closed / EOF tty | launches | does not launch |

## 2. Ctrl+C printed the shell prompt in the middle of the shutdown logs

Reported output:

```
{"event": "Graceful shutdown initiated ..."}
ubuntu@host:~$ {"event": "All subprocesses cleaned up"}

Shutting down...
INFO:     Shutting down
```

When Studio is auto-started by the installer, the process tree is `interactive shell -> sh (install.sh) -> studio`. `Ctrl+C` sends `SIGINT` to the whole foreground process group. Studio catches it and runs its graceful shutdown, but the non-interactive installer shell takes the default `SIGINT` action and dies first, without waiting for the child. The interactive shell then sees the `curl | sh` pipeline finish and prints its prompt while the (now orphaned) Studio process is still writing its remaining shutdown logs.

This only happens through the installer auto-start path; a plain `unsloth studio` launch is a single process the shell waits on directly.

### Fix

Ignore `SIGINT` in the installer shell so it stays in `wait` until Studio finishes its own graceful shutdown, then proceeds:

```sh
trap '' INT
"$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null
```

The child still receives `SIGINT` from the terminal (the parent ignoring it does not stop delivery to the group), so Studio's handler runs normally. Verified under an interactive bash in a PTY: the prompt now prints after all shutdown logs.

## Validation

- `bash -n install.sh` and `dash -n install.sh` pass.
- `shellcheck 0.11.0` reports no findings in the changed region.
- PTY reproductions of both scenarios pass before/after.

## Notes

- `install.ps1` gates the prompt on `UserInteractive -and (-not [Console]::IsInputRedirected)` and runs Studio in process via `& $UnslothExe`, so neither issue applies there. No change needed.
