### PR TITLE
Fix Studio shutdown logs appearing after terminal prompt

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -677,9 +677,38 @@ def _graceful_shutdown(server = None):
     logger.info("All subprocesses cleaned up")
 
 
+def _flush_standard_streams() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:
+            pass
+
+
+def _wait_for_server_shutdown(timeout: Optional[float] = None) -> None:
+    """Wait until the uvicorn thread has emitted its shutdown logs.
+
+    Terminal entrypoints call this after requesting shutdown so the shell prompt
+    cannot return while the background server thread still owns stdout/stderr.
+    Do not self-join when shutdown was triggered from a request handler running
+    on the server thread.
+    """
+    import threading
+
+    thread = _server_thread
+    if thread is None or thread is threading.current_thread():
+        _flush_standard_streams()
+        return
+    thread.join(timeout = timeout)
+    if thread.is_alive():
+        logger.warning("Timed out waiting for uvicorn server thread to stop")
+    _flush_standard_streams()
+
+
 # The uvicorn server instance -- set by run_server(), used by callers
 # that tell the server to exit (e.g. signal handlers).
 _server = None
+_server_thread = None
 
 # Shutdown event -- wakes the main loop on signal.
 _shutdown_event = None
@@ -909,7 +938,7 @@ def run_server(
         Signal handlers are NOT registered here so embedders (e.g. Colab) keep
         their own interrupt semantics; standalone callers register them after.
     """
-    global _server, _shutdown_event
+    global _server, _server_thread, _shutdown_event
 
     # Reap every child if the parent dies abnormally (terminal close, Task
     # Manager kill, SIGKILL); must run before any child can spawn.
@@ -1102,6 +1131,7 @@ def run_server(
                 startup_failed.set()
 
     thread = Thread(target = _run, daemon = True)
+    _server_thread = thread
     thread.start()
 
     # Wait until uvicorn finishes lifespan startup and binds sockets, or until it
@@ -1292,6 +1322,7 @@ if __name__ == "__main__":
     def _signal_handler(signum, frame):
         _graceful_shutdown(_server)
         _shutdown_event.set()
+        _wait_for_server_shutdown()
 
     signal.signal(signal.SIGINT, _signal_handler)
     signal.signal(signal.SIGTERM, _signal_handler)
@@ -1305,3 +1336,4 @@ if __name__ == "__main__":
     # lets the interpreter process pending signals.
     while not _shutdown_event.is_set():
         _shutdown_event.wait(timeout = 1)
+    _wait_for_server_shutdown()

--- a/tests/test_studio_shutdown_thread_wait.py
+++ b/tests/test_studio_shutdown_thread_wait.py
@@ -31,9 +31,7 @@ def _calls_name(tree: ast.AST, name: str) -> int:
     return sum(
         1
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == name
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == name
     )
 
 
@@ -73,9 +71,9 @@ def test_run_server_records_uvicorn_thread_for_terminal_shutdown_wait():
         for node in ast.walk(run_server)
     )
 
-    assert assigns_thread_global, (
-        "run_server must retain the uvicorn thread so terminal shutdown can join it"
-    )
+    assert (
+        assigns_thread_global
+    ), "run_server must retain the uvicorn thread so terminal shutdown can join it"
 
 
 def test_wait_for_server_shutdown_joins_uvicorn_thread():
@@ -89,22 +87,22 @@ def test_wait_for_server_shutdown_joins_uvicorn_thread():
         for node in ast.walk(wait_func)
     )
 
-    assert joins_thread, (
-        "_wait_for_server_shutdown must join the uvicorn thread before process exit"
-    )
+    assert (
+        joins_thread
+    ), "_wait_for_server_shutdown must join the uvicorn thread before process exit"
 
 
 def test_direct_backend_entrypoint_waits_before_returning_to_shell():
     tree = _parse(_RUN_PY)
 
-    assert _calls_name(tree, "_wait_for_server_shutdown") >= 2, (
-        "run.py must wait both from the signal path and after the main shutdown event loop"
-    )
+    assert (
+        _calls_name(tree, "_wait_for_server_shutdown") >= 2
+    ), "run.py must wait both from the signal path and after the main shutdown event loop"
 
 
 def test_cli_entrypoints_wait_before_returning_to_shell():
     tree = _parse(_STUDIO_CLI_PY)
 
-    assert _calls_shutdown_wait_getattr(tree) >= 4, (
-        "Studio CLI terminal paths must wait for the backend thread after requesting shutdown"
-    )
+    assert (
+        _calls_shutdown_wait_getattr(tree) >= 4
+    ), "Studio CLI terminal paths must wait for the backend thread after requesting shutdown"

--- a/tests/test_studio_shutdown_thread_wait.py
+++ b/tests/test_studio_shutdown_thread_wait.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for terminal shutdown ordering.
+
+These stay source-level so they do not need to import the full Studio backend.
+The shell prompt must not return while uvicorn's background thread can still
+write shutdown logs to stdout/stderr.
+"""
+
+import ast
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_RUN_PY = _ROOT / "studio" / "backend" / "run.py"
+_STUDIO_CLI_PY = _ROOT / "unsloth_cli" / "commands" / "studio.py"
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding = "utf-8"))
+
+
+def _function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"missing function {name}")
+
+
+def _calls_name(tree: ast.AST, name: str) -> int:
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    )
+
+
+def _calls_shutdown_wait_getattr(tree: ast.AST) -> int:
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Call):
+            continue
+        if not (isinstance(func.func, ast.Name) and func.func.id == "getattr"):
+            continue
+        if len(func.args) < 2:
+            continue
+        target, attr = func.args[:2]
+        if (
+            isinstance(target, ast.Name)
+            and target.id == "run_mod"
+            and isinstance(attr, ast.Constant)
+            and attr.value == "_wait_for_server_shutdown"
+        ):
+            count += 1
+    return count
+
+
+def test_run_server_records_uvicorn_thread_for_terminal_shutdown_wait():
+    tree = _parse(_RUN_PY)
+    run_server = _function(tree, "run_server")
+
+    assigns_thread_global = any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "_server_thread"
+            for target in node.targets
+        )
+        for node in ast.walk(run_server)
+    )
+
+    assert assigns_thread_global, (
+        "run_server must retain the uvicorn thread so terminal shutdown can join it"
+    )
+
+
+def test_wait_for_server_shutdown_joins_uvicorn_thread():
+    tree = _parse(_RUN_PY)
+    wait_func = _function(tree, "_wait_for_server_shutdown")
+
+    joins_thread = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "join"
+        for node in ast.walk(wait_func)
+    )
+
+    assert joins_thread, (
+        "_wait_for_server_shutdown must join the uvicorn thread before process exit"
+    )
+
+
+def test_direct_backend_entrypoint_waits_before_returning_to_shell():
+    tree = _parse(_RUN_PY)
+
+    assert _calls_name(tree, "_wait_for_server_shutdown") >= 2, (
+        "run.py must wait both from the signal path and after the main shutdown event loop"
+    )
+
+
+def test_cli_entrypoints_wait_before_returning_to_shell():
+    tree = _parse(_STUDIO_CLI_PY)
+
+    assert _calls_shutdown_wait_getattr(tree) >= 4, (
+        "Studio CLI terminal paths must wait for the backend thread after requesting shutdown"
+    )

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -862,9 +862,11 @@ def studio_default(
         else:
             while True:
                 time.sleep(1)
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
     except KeyboardInterrupt:
         run_mod._graceful_shutdown(run_mod._server)
         typer.echo("\nShutting down...")
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
 
 
 # ── unsloth studio run ───────────────────────────────────────────────
@@ -1266,6 +1268,7 @@ def run(
             raise typer.Exit(1)
     except BaseException:
         _graceful_shutdown(_server)
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
         raise
 
     loaded_model = result.get("model", model)
@@ -1369,9 +1372,11 @@ def run(
         else:
             while True:
                 time.sleep(1)
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
     except KeyboardInterrupt:
         run_mod._graceful_shutdown(run_mod._server)
         typer.echo("\nShutting down...")
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
 
 
 # ── unsloth studio stop ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

After:
<img width="944" height="193" alt="image" src="https://github.com/user-attachments/assets/e0573cbc-2532-4fec-bd39-9c2c8f662cb6" />


Fixes Studio terminal shutdown ordering so the shell prompt does not return while the backend server thread can still write shutdown logs to stdout/stderr.

- Retain the Uvicorn server thread created by `run_server`.
- Add `_wait_for_server_shutdown()` to join the server thread and flush stdout/stderr.
- Call the wait helper from direct backend shutdown and CLI shutdown paths.
- Add regression tests that assert terminal entrypoints wait for the backend thread before returning.

