### PR TITLE
Studio: fix Ctrl+C shutdown ordering (installer shell + uvicorn thread wait)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3126,10 +3126,13 @@ echo ""
 if [ -t 1 ]; then
     echo ""
     printf "  Start Unsloth Studio now? [Y/n] "
+    # Default to NOT starting when no answer can be read (closed/EOF tty) so a
+    # non-interactive caller is never trapped in a foreground server. A real
+    # Enter still counts as yes via ${_reply:-y} below.
     if [ -r /dev/tty ]; then
-        read -r _reply </dev/tty || _reply="y"
+        read -r _reply </dev/tty || _reply="n"
     else
-        _reply="y"
+        _reply="n"
     fi
     case "${_reply:-y}" in
         [Yy]*|"")
@@ -3137,6 +3140,9 @@ if [ -t 1 ]; then
             # Detach stdin from the `curl | sh` pipe: as a foreground server the
             # studio would otherwise drain the rest of this piped script, leaving
             # the shell to die parsing the now-truncated tail (`unexpected fi`).
+            # Ignore Ctrl+C so this shell waits for studio's own graceful
+            # shutdown instead of dying first and racing the prompt over its logs.
+            trap '' INT
             "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null
             _LAUNCH_EXIT=$?
             if [ "$_LAUNCH_EXIT" -ne 0 ] && [ "$_MIGRATED" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -3126,9 +3126,7 @@ echo ""
 if [ -t 1 ]; then
     echo ""
     printf "  Start Unsloth Studio now? [Y/n] "
-    # Default to NOT starting when no answer can be read (closed/EOF tty) so a
-    # non-interactive caller is never trapped in a foreground server. A real
-    # Enter still counts as yes via ${_reply:-y} below.
+    # No readable answer (closed/EOF tty) defaults to no; Enter is still yes.
     if [ -r /dev/tty ]; then
         read -r _reply </dev/tty || _reply="n"
     else
@@ -3140,13 +3138,10 @@ if [ -t 1 ]; then
             # Detach stdin from the `curl | sh` pipe: as a foreground server the
             # studio would otherwise drain the rest of this piped script, leaving
             # the shell to die parsing the now-truncated tail (`unexpected fi`).
-            # Ignore Ctrl+C so this shell waits for studio's own graceful
-            # shutdown instead of dying first and racing the prompt over its logs.
-            # Run studio in a subshell that resets INT to default, so the child
-            # does not inherit the ignore (which would swallow its own Ctrl+C).
+            # trap '' INT: wait for studio's shutdown instead of racing the prompt.
+            # Subshell resets INT so the child still gets Ctrl+C (no inherited ignore).
             trap '' INT
-            # `|| ...` keeps set -e from exiting on a non-zero studio, so the
-            # migration hint below still prints; captures the real exit code.
+            # `|| ...`: capture the exit code without set -e aborting first.
             _LAUNCH_EXIT=0
             (trap - INT; exec "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null) || _LAUNCH_EXIT=$?
             if [ "$_LAUNCH_EXIT" -ne 0 ] && [ "$_MIGRATED" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -3145,8 +3145,10 @@ if [ -t 1 ]; then
             # Run studio in a subshell that resets INT to default, so the child
             # does not inherit the ignore (which would swallow its own Ctrl+C).
             trap '' INT
-            (trap - INT; exec "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null)
-            _LAUNCH_EXIT=$?
+            # `|| ...` keeps set -e from exiting on a non-zero studio, so the
+            # migration hint below still prints; captures the real exit code.
+            _LAUNCH_EXIT=0
+            (trap - INT; exec "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null) || _LAUNCH_EXIT=$?
             if [ "$_LAUNCH_EXIT" -ne 0 ] && [ "$_MIGRATED" = true ]; then
                 echo ""
                 echo "⚠️  Unsloth Studio failed to start after migration."

--- a/install.sh
+++ b/install.sh
@@ -3142,8 +3142,10 @@ if [ -t 1 ]; then
             # the shell to die parsing the now-truncated tail (`unexpected fi`).
             # Ignore Ctrl+C so this shell waits for studio's own graceful
             # shutdown instead of dying first and racing the prompt over its logs.
+            # Run studio in a subshell that resets INT to default, so the child
+            # does not inherit the ignore (which would swallow its own Ctrl+C).
             trap '' INT
-            "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null
+            (trap - INT; exec "$VENV_DIR/bin/unsloth" studio -p 8888 </dev/null)
             _LAUNCH_EXIT=$?
             if [ "$_LAUNCH_EXIT" -ne 0 ] && [ "$_MIGRATED" = true ]; then
                 echo ""

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -677,9 +677,42 @@ def _graceful_shutdown(server = None):
     logger.info("All subprocesses cleaned up")
 
 
+# Bound the wait for uvicorn's thread like _graceful_shutdown bounds its
+# subprocess waits (5s), so a stuck shutdown can never hang the terminal.
+_SERVER_SHUTDOWN_JOIN_TIMEOUT = 5.0
+
+
+def _flush_standard_streams() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:
+            pass
+
+
+def _wait_for_server_shutdown(timeout: Optional[float] = _SERVER_SHUTDOWN_JOIN_TIMEOUT) -> None:
+    """Wait for the uvicorn thread to emit its shutdown logs before returning.
+
+    Terminal entrypoints call this after requesting shutdown so the shell prompt
+    cannot return while the background server thread still owns stdout/stderr.
+    Skip the join when called from the server thread itself (a request handler).
+    """
+    import threading
+
+    thread = _server_thread
+    if thread is None or thread is threading.current_thread():
+        _flush_standard_streams()
+        return
+    thread.join(timeout = timeout)
+    if thread.is_alive():
+        logger.warning("Timed out waiting for uvicorn server thread to stop")
+    _flush_standard_streams()
+
+
 # The uvicorn server instance -- set by run_server(), used by callers
 # that tell the server to exit (e.g. signal handlers).
 _server = None
+_server_thread = None
 
 # Shutdown event -- wakes the main loop on signal.
 _shutdown_event = None
@@ -909,7 +942,7 @@ def run_server(
         Signal handlers are NOT registered here so embedders (e.g. Colab) keep
         their own interrupt semantics; standalone callers register them after.
     """
-    global _server, _shutdown_event
+    global _server, _server_thread, _shutdown_event
 
     # Reap every child if the parent dies abnormally (terminal close, Task
     # Manager kill, SIGKILL); must run before any child can spawn.
@@ -1102,6 +1135,7 @@ def run_server(
                 startup_failed.set()
 
     thread = Thread(target = _run, daemon = True)
+    _server_thread = thread
     thread.start()
 
     # Wait until uvicorn finishes lifespan startup and binds sockets, or until it
@@ -1290,6 +1324,10 @@ if __name__ == "__main__":
 
     # Signal handler -- ensures subprocess cleanup on Ctrl+C.
     def _signal_handler(signum, frame):
+        # Restore defaults first so a second Ctrl+C / SIGTERM force-quits if the
+        # graceful shutdown below ever stalls.
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
         _graceful_shutdown(_server)
         _shutdown_event.set()
 
@@ -1305,3 +1343,5 @@ if __name__ == "__main__":
     # lets the interpreter process pending signals.
     while not _shutdown_event.is_set():
         _shutdown_event.wait(timeout = 1)
+    # Wait for uvicorn's thread to flush its shutdown logs before the prompt returns.
+    _wait_for_server_shutdown()

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -677,8 +677,7 @@ def _graceful_shutdown(server = None):
     logger.info("All subprocesses cleaned up")
 
 
-# Bound the wait for uvicorn's thread like _graceful_shutdown bounds its
-# subprocess waits (5s), so a stuck shutdown can never hang the terminal.
+# Bound the join so a stuck uvicorn shutdown cannot hang the terminal.
 _SERVER_SHUTDOWN_JOIN_TIMEOUT = 5.0
 
 
@@ -691,12 +690,8 @@ def _flush_standard_streams() -> None:
 
 
 def _wait_for_server_shutdown(timeout: Optional[float] = _SERVER_SHUTDOWN_JOIN_TIMEOUT) -> None:
-    """Wait for the uvicorn thread to emit its shutdown logs before returning.
-
-    Terminal entrypoints call this after requesting shutdown so the shell prompt
-    cannot return while the background server thread still owns stdout/stderr.
-    Skip the join when called from the server thread itself (a request handler).
-    """
+    """Join the uvicorn thread so the prompt returns only after its shutdown logs
+    flush. Skip the self-join when called from the server thread."""
     import threading
 
     thread = _server_thread
@@ -1324,8 +1319,7 @@ if __name__ == "__main__":
 
     # Signal handler -- ensures subprocess cleanup on Ctrl+C.
     def _signal_handler(signum, frame):
-        # Restore defaults first so a second Ctrl+C / SIGTERM (or SIGBREAK on
-        # Windows) force-quits if the graceful shutdown below ever stalls.
+        # Restore defaults so a second signal force-quits if shutdown stalls.
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
         if hasattr(signal, "SIGBREAK"):
@@ -1345,5 +1339,4 @@ if __name__ == "__main__":
     # lets the interpreter process pending signals.
     while not _shutdown_event.is_set():
         _shutdown_event.wait(timeout = 1)
-    # Wait for uvicorn's thread to flush its shutdown logs before the prompt returns.
     _wait_for_server_shutdown()

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1324,10 +1324,12 @@ if __name__ == "__main__":
 
     # Signal handler -- ensures subprocess cleanup on Ctrl+C.
     def _signal_handler(signum, frame):
-        # Restore defaults first so a second Ctrl+C / SIGTERM force-quits if the
-        # graceful shutdown below ever stalls.
+        # Restore defaults first so a second Ctrl+C / SIGTERM (or SIGBREAK on
+        # Windows) force-quits if the graceful shutdown below ever stalls.
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        if hasattr(signal, "SIGBREAK"):
+            signal.signal(signal.SIGBREAK, signal.SIG_DFL)
         _graceful_shutdown(_server)
         _shutdown_event.set()
 

--- a/tests/test_studio_shutdown_thread_wait.py
+++ b/tests/test_studio_shutdown_thread_wait.py
@@ -122,8 +122,7 @@ def test_signal_handler_restores_default_handlers_for_force_quit():
     handler = _function(tree, "_signal_handler")
 
     restores_default = any(
-        isinstance(node, ast.Attribute) and node.attr == "SIG_DFL"
-        for node in ast.walk(handler)
+        isinstance(node, ast.Attribute) and node.attr == "SIG_DFL" for node in ast.walk(handler)
     )
 
     assert (

--- a/tests/test_studio_shutdown_thread_wait.py
+++ b/tests/test_studio_shutdown_thread_wait.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Regression tests for terminal shutdown ordering.
-
-These stay source-level so they do not need to import the full Studio backend.
-The shell prompt must not return while uvicorn's background thread can still
-write shutdown logs to stdout/stderr.
-"""
+"""Source-level regression tests for terminal shutdown ordering (no backend import)."""
 
 import ast
 from pathlib import Path

--- a/tests/test_studio_shutdown_thread_wait.py
+++ b/tests/test_studio_shutdown_thread_wait.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for terminal shutdown ordering.
+
+These stay source-level so they do not need to import the full Studio backend.
+The shell prompt must not return while uvicorn's background thread can still
+write shutdown logs to stdout/stderr.
+"""
+
+import ast
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_RUN_PY = _ROOT / "studio" / "backend" / "run.py"
+_STUDIO_CLI_PY = _ROOT / "unsloth_cli" / "commands" / "studio.py"
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding = "utf-8"))
+
+
+def _function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"missing function {name}")
+
+
+def _calls_name(tree: ast.AST, name: str) -> int:
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == name
+    )
+
+
+def _calls_shutdown_wait_getattr(tree: ast.AST) -> int:
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Call):
+            continue
+        if not (isinstance(func.func, ast.Name) and func.func.id == "getattr"):
+            continue
+        if len(func.args) < 2:
+            continue
+        target, attr = func.args[:2]
+        if (
+            isinstance(target, ast.Name)
+            and target.id == "run_mod"
+            and isinstance(attr, ast.Constant)
+            and attr.value == "_wait_for_server_shutdown"
+        ):
+            count += 1
+    return count
+
+
+def test_run_server_records_uvicorn_thread_for_terminal_shutdown_wait():
+    tree = _parse(_RUN_PY)
+    run_server = _function(tree, "run_server")
+
+    assigns_thread_global = any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "_server_thread"
+            for target in node.targets
+        )
+        for node in ast.walk(run_server)
+    )
+
+    assert (
+        assigns_thread_global
+    ), "run_server must retain the uvicorn thread so terminal shutdown can join it"
+
+
+def test_wait_for_server_shutdown_joins_uvicorn_thread():
+    tree = _parse(_RUN_PY)
+    wait_func = _function(tree, "_wait_for_server_shutdown")
+
+    joins_thread = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "join"
+        for node in ast.walk(wait_func)
+    )
+
+    assert (
+        joins_thread
+    ), "_wait_for_server_shutdown must join the uvicorn thread before process exit"
+
+
+def test_wait_for_server_shutdown_join_is_bounded():
+    tree = _parse(_RUN_PY)
+    wait_func = _function(tree, "_wait_for_server_shutdown")
+
+    bounded_join = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "join"
+        and any(kw.arg == "timeout" for kw in node.keywords)
+        for node in ast.walk(wait_func)
+    )
+
+    assert (
+        bounded_join
+    ), "the join must pass a timeout so a stalled uvicorn shutdown cannot hang the terminal"
+
+
+def test_direct_backend_entrypoint_waits_before_returning_to_shell():
+    tree = _parse(_RUN_PY)
+
+    assert (
+        _calls_name(tree, "_wait_for_server_shutdown") >= 1
+    ), "run.py must wait after the main shutdown event loop before returning to the shell"
+
+
+def test_signal_handler_restores_default_handlers_for_force_quit():
+    tree = _parse(_RUN_PY)
+    handler = _function(tree, "_signal_handler")
+
+    restores_default = any(
+        isinstance(node, ast.Attribute) and node.attr == "SIG_DFL"
+        for node in ast.walk(handler)
+    )
+
+    assert (
+        restores_default
+    ), "the signal handler must restore SIG_DFL so a second Ctrl+C can force-quit"
+
+
+def test_cli_entrypoints_wait_before_returning_to_shell():
+    tree = _parse(_STUDIO_CLI_PY)
+
+    assert (
+        _calls_shutdown_wait_getattr(tree) >= 4
+    ), "Studio CLI terminal paths must wait for the backend thread after requesting shutdown"

--- a/tests/test_studio_shutdown_thread_wait.py
+++ b/tests/test_studio_shutdown_thread_wait.py
@@ -129,5 +129,5 @@ def test_cli_entrypoints_wait_before_returning_to_shell():
     tree = _parse(_STUDIO_CLI_PY)
 
     assert (
-        _calls_shutdown_wait_getattr(tree) >= 4
+        _calls_shutdown_wait_getattr(tree) >= 3
     ), "Studio CLI terminal paths must wait for the backend thread after requesting shutdown"

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -862,10 +862,10 @@ def studio_default(
         else:
             while True:
                 time.sleep(1)
-        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
     except KeyboardInterrupt:
         run_mod._graceful_shutdown(run_mod._server)
         typer.echo("\nShutting down...")
+    finally:
         getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
 
 
@@ -1372,10 +1372,10 @@ def run(
         else:
             while True:
                 time.sleep(1)
-        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
     except KeyboardInterrupt:
         run_mod._graceful_shutdown(run_mod._server)
         typer.echo("\nShutting down...")
+    finally:
         getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
 
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -862,9 +862,11 @@ def studio_default(
         else:
             while True:
                 time.sleep(1)
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
     except KeyboardInterrupt:
         run_mod._graceful_shutdown(run_mod._server)
         typer.echo("\nShutting down...")
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
 
 
 # ── unsloth studio run ───────────────────────────────────────────────
@@ -1266,6 +1268,7 @@ def run(
             raise typer.Exit(1)
     except BaseException:
         _graceful_shutdown(_server)
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
         raise
 
     loaded_model = result.get("model", model)
@@ -1369,9 +1372,11 @@ def run(
         else:
             while True:
                 time.sleep(1)
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
     except KeyboardInterrupt:
         run_mod._graceful_shutdown(run_mod._server)
         typer.echo("\nShutting down...")
+        getattr(run_mod, "_wait_for_server_shutdown", lambda: None)()
 
 
 # ── unsloth studio stop ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

On `Ctrl+C`, Studio's shutdown logs and the shell prompt interleave, and the auto-start prompt can launch even when declined. This consolidates the two halves of the fix. It supersedes #6564 (installer) and #6565 (server thread) and folds in the run.py-side work from #6565 by @Imagineer99 with two refinements.

There are two independent causes, on Linux / macOS / WSL:

1. The non-interactive installer shell (`curl | sh`) dies on `SIGINT` before the studio child finishes, so the outer shell prompt prints in the middle of the shutdown logs.
2. The studio process returns to the shell while its uvicorn daemon thread can still write shutdown logs, so they land after the prompt (or get cut off).

Both are needed for a clean shutdown.

## 1. Installer (`install.sh`)

The auto-start prompt also had a second bug: declining still launched. The read fallbacks defaulted to yes (`read ... || _reply="y"` and the no-tty branch), so any answer that was not a cleanly delivered `y`/`n` line auto-started a blocking foreground server (closed/EOF tty, or a `n` typed early and consumed by the earlier package-accept prompt).

- Default the unreadable cases to `n`; a real Enter still counts as yes via `${_reply:-y}`.
- `trap '' INT` before launching Studio so the installer shell waits for Studio's own graceful shutdown instead of dying first and racing the prompt over its logs. The child still receives `SIGINT` from the terminal.

## 2. Server thread (`studio/backend/run.py`, `unsloth_cli/commands/studio.py`)

From #6565 by @Imagineer99: retain the uvicorn thread (`_server_thread`) and add `_wait_for_server_shutdown()`, which joins it and flushes stdout/stderr. Terminal entrypoints call it after requesting shutdown (run.py's main shutdown path and the CLI shutdown/`KeyboardInterrupt`/`BaseException` paths) so the prompt cannot return while the thread still owns the streams.

Two refinements on top of #6565:

- Bound the join at 5s (`_SERVER_SHUTDOWN_JOIN_TIMEOUT`, matching the per-subprocess timeouts in `_graceful_shutdown`). The original joined with `timeout=None` at every call site, which could hang the terminal forever if uvicorn shutdown stalled and left the existing `is_alive()` warning branch unreachable.
- Restore `SIG_DFL` for `SIGINT`/`SIGTERM` at the start of the signal handler so a second `Ctrl+C` force-quits, and drop the redundant in-handler wait (the post-loop wait already covers the signal path). This also keeps the wait out of the signal handler.

## Validation

- `bash -n`, `dash -n`, `shellcheck` clean on `install.sh`.
- `python -m py_compile` and `ast.parse` clean on `run.py`, `studio.py`, the test.
- `pytest tests/test_studio_shutdown_thread_wait.py` passes (6 source-level AST tests, including new ones for the bounded join and the `SIG_DFL` restore).
- PTY reproductions under a real interactive bash:
  - Installer: declining (`n`/`N`/EOF) no longer launches; Enter still launches; the prompt prints after all shutdown logs.
  - Server: with the wait, uvicorn's `INFO: Shutting down` prints before the prompt (without it, the line is lost). A stalled uvicorn thread exits via the 5s bound (no infinite hang); a second `Ctrl+C` force-quits in ~0.2s.

## Notes

`install.ps1` gates the prompt on `UserInteractive -and (-not [Console]::IsInputRedirected)` and runs Studio in process via `& $UnslothExe`, so neither issue applies on Windows. No change there.
