### PR TITLE
Fix recent trainings section scope

### DIFF
--- a/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
+++ b/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
@@ -41,7 +41,6 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
-import { RecentTrainingsSection } from "@/features/studio/recent-trainings-section";
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 import {
@@ -529,8 +528,6 @@ export function DataRecipesPage(): ReactElement {
             ))}
           </div>
         )}
-
-        <RecentTrainingsSection />
       </main>
 
       <Dialog open={learningDialogOpen} onOpenChange={setLearningDialogOpen}>

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -2,7 +2,6 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { SectionCard } from "@/components/section-card";
-import { RecentTrainingsSection } from "@/features/studio/recent-trainings-section";
 import { Button } from "@/components/ui/button";
 import {
   Combobox,
@@ -1224,8 +1223,6 @@ export function ExportPage() {
             </>
           )}
         </SectionCard>
-
-        <RecentTrainingsSection />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove the Studio recent trainings section from Data Recipes.
- Remove the Studio recent trainings section from Export.

## Testing
- npm run typecheck
- npx biome check src/features/data-recipes/pages/data-recipes-page.tsx src/features/export/export-page.tsx (reports existing lint/format diagnostics outside this change)