### PR TITLE
Studio: hide RAG embedder from the On Device list

### DIFF
--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -765,9 +765,12 @@ export function ModelsPage() {
       partitionByMatch(
         effectiveCachedRows.filter(
           (row) =>
-            (isDatasetMode ||
-              matchesFormat(row.modelFormat, deferredFormatFilter)) &&
-            isVisibleInventoryRow(row),
+            // Hidden-model filtering is model-only; datasets bypass it (and the
+            // format filter) the way Discover does, so a dataset whose
+            // id/title/path happens to contain an infra needle is not dropped.
+            isDatasetMode ||
+            (matchesFormat(row.modelFormat, deferredFormatFilter) &&
+              isVisibleInventoryRow(row)),
         ),
         inventoryTokens,
       ),
@@ -785,9 +788,12 @@ export function ModelsPage() {
       partitionByMatch(
         effectiveLocalRows.filter(
           (row) =>
-            (isDatasetMode ||
-              matchesFormat(row.modelFormat, deferredFormatFilter)) &&
-            isVisibleInventoryRow(row),
+            // Hidden-model filtering is model-only; datasets bypass it (and the
+            // format filter) the way Discover does, so a dataset whose
+            // id/title/path happens to contain an infra needle is not dropped.
+            isDatasetMode ||
+            (matchesFormat(row.modelFormat, deferredFormatFilter) &&
+              isVisibleInventoryRow(row)),
         ),
         inventoryTokens,
       ),
@@ -798,6 +804,27 @@ export function ModelsPage() {
       inventoryTokens,
       isVisibleInventoryRow,
     ],
+  );
+
+  // Header tallies exclude infra/hidden models so the count matches the On
+  // Device list (a fresh install with only the bge embedder cached reads 0,
+  // not 1 over an empty list). Datasets are never infra, so they keep their
+  // full count, mirroring the row filter above.
+  const visibleCachedCount = useMemo(
+    () =>
+      effectiveCachedRows.filter(
+        (row) => isDatasetMode || !isHiddenModelId(row.id, row.repoId),
+      ).length,
+    [effectiveCachedRows, isDatasetMode],
+  );
+  const visibleLocalCount = useMemo(
+    () =>
+      effectiveLocalRows.filter(
+        (row) =>
+          isDatasetMode ||
+          !isHiddenModelId(row.id, row.repoId, row.path, row.title),
+      ).length,
+    [effectiveLocalRows, isDatasetMode],
   );
 
   const filterResetSignature = useMemo(
@@ -1346,15 +1373,15 @@ export function ModelsPage() {
     return (
       <HubListHeader
         title="On device"
-        count={effectiveCachedRows.length + effectiveLocalRows.length}
+        count={visibleCachedCount + visibleLocalCount}
         view={allModelsView}
         onViewChange={setAllModelsView}
         actions={sortControl}
       />
     );
   }, [
-    effectiveCachedRows.length,
-    effectiveLocalRows.length,
+    visibleCachedCount,
+    visibleLocalCount,
     allModelsView,
     setAllModelsView,
     inventorySort,
@@ -1368,8 +1395,8 @@ export function ModelsPage() {
     <div className="hub-page flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden bg-background">
       <HubTopBar>
         <ModelsHeader
-          cachedCount={effectiveCachedRows.length}
-          localCount={effectiveLocalRows.length}
+          cachedCount={visibleCachedCount}
+          localCount={visibleLocalCount}
           isDataset={isDatasetMode}
           gpuLabel={gpuLabel}
           ramLabel={ramLabel}

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -740,6 +740,15 @@ export function ModelsPage() {
     () => (isDiscoverTab ? [] : tokenizeQuery(deferredDebouncedQuery)),
     [isDiscoverTab, deferredDebouncedQuery],
   );
+  // Hide infra models (e.g. the RAG embedder bge-small-en-v1.5) from the On
+  // Device list like Discover, but reveal a row when a query matches it so the
+  // user can confirm it is already downloaded.
+  const isVisibleInventoryRow = useCallback(
+    (row: CachedInventoryRow | LocalInventoryRow) =>
+      !isHiddenModelId(row.id, row.repoId) ||
+      (inventoryTokens.length > 0 && inventoryRowMatches(row, inventoryTokens)),
+    [inventoryTokens],
+  );
   // Format filter is a deliberate scope narrowing, so hard-filter it out. The
   // text query instead drives dim-not-filter on On Device (see ModelsCatalog) so
   // selection survives typing; matching rows are partitioned to the top.
@@ -748,12 +757,19 @@ export function ModelsPage() {
       partitionByMatch(
         effectiveCachedRows.filter(
           (row) =>
-            isDatasetMode ||
-            matchesFormat(row.modelFormat, deferredFormatFilter),
+            (isDatasetMode ||
+              matchesFormat(row.modelFormat, deferredFormatFilter)) &&
+            isVisibleInventoryRow(row),
         ),
         inventoryTokens,
       ),
-    [effectiveCachedRows, isDatasetMode, deferredFormatFilter, inventoryTokens],
+    [
+      effectiveCachedRows,
+      isDatasetMode,
+      deferredFormatFilter,
+      inventoryTokens,
+      isVisibleInventoryRow,
+    ],
   );
 
   const filteredLocalRows = useMemo(
@@ -761,12 +777,19 @@ export function ModelsPage() {
       partitionByMatch(
         effectiveLocalRows.filter(
           (row) =>
-            isDatasetMode ||
-            matchesFormat(row.modelFormat, deferredFormatFilter),
+            (isDatasetMode ||
+              matchesFormat(row.modelFormat, deferredFormatFilter)) &&
+            isVisibleInventoryRow(row),
         ),
         inventoryTokens,
       ),
-    [effectiveLocalRows, isDatasetMode, deferredFormatFilter, inventoryTokens],
+    [
+      effectiveLocalRows,
+      isDatasetMode,
+      deferredFormatFilter,
+      inventoryTokens,
+      isVisibleInventoryRow,
+    ],
   );
 
   const filterResetSignature = useMemo(

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -808,23 +808,22 @@ export function ModelsPage() {
 
   // Header tallies exclude infra/hidden models so the count matches the On
   // Device list (a fresh install with only the bge embedder cached reads 0,
-  // not 1 over an empty list). Datasets are never infra, so they keep their
-  // full count, mirroring the row filter above.
+  // not 1 over an empty list). Reuse isVisibleInventoryRow so a hidden row
+  // revealed by an active search is counted too, and datasets (never infra)
+  // keep their full count, mirroring the row filter above.
   const visibleCachedCount = useMemo(
     () =>
       effectiveCachedRows.filter(
-        (row) => isDatasetMode || !isHiddenModelId(row.id, row.repoId),
+        (row) => isDatasetMode || isVisibleInventoryRow(row),
       ).length,
-    [effectiveCachedRows, isDatasetMode],
+    [effectiveCachedRows, isDatasetMode, isVisibleInventoryRow],
   );
   const visibleLocalCount = useMemo(
     () =>
       effectiveLocalRows.filter(
-        (row) =>
-          isDatasetMode ||
-          !isHiddenModelId(row.id, row.repoId, row.path, row.title),
+        (row) => isDatasetMode || isVisibleInventoryRow(row),
       ).length,
-    [effectiveLocalRows, isDatasetMode],
+    [effectiveLocalRows, isDatasetMode, isVisibleInventoryRow],
   );
 
   const filterResetSignature = useMemo(

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -745,7 +745,15 @@ export function ModelsPage() {
   // user can confirm it is already downloaded.
   const isVisibleInventoryRow = useCallback(
     (row: CachedInventoryRow | LocalInventoryRow) =>
-      !isHiddenModelId(row.id, row.repoId) ||
+      // Local rows can have a null repoId and an id that is a hash rather than
+      // the file path/name, so also check path/title (the backend's
+      // _is_hidden_model checks the on-disk path for the same reason).
+      !isHiddenModelId(
+        row.id,
+        row.repoId,
+        row.kind !== "cache" ? row.path : undefined,
+        row.kind !== "cache" ? row.title : undefined,
+      ) ||
       (inventoryTokens.length > 0 && inventoryRowMatches(row, inventoryTokens)),
     [inventoryTokens],
   );


### PR DESCRIPTION
## What

The `bge-small-en-v1.5` RAG embedder (and the other infra models the app downloads, like the llama.cpp validation probe) were already hidden from the Hub Discover list via `isHiddenModelId`, but the same filter was never applied to the On Device list. As a result the embedder showed up as a normal downloaded model and cluttered the user's On Device view.

## Change

`hub-page.tsx` now applies the existing `isHiddenModelId` filter to the On Device inventory (`filteredCachedRows` and `filteredLocalRows`), with one nuance: a hidden row is revealed when the search query actually matches it. So by default infra models stay out of the list, but typing `bge` brings the row back, and since it lives in the On Device tab it reads as already downloaded.

## Behavior

- No search: infra models are dropped from the On Device list.
- Search matches the row: it reappears (already on device, so no re-download).
- Search does not match: it stays hidden.

This reuses the same needle list as Discover, so the llama.cpp probe gets the same treatment automatically.

## Testing

- `tsc -b` passes.
- `vite build` succeeds.
- Verified locally: the embedder no longer appears in On Device, and searching `bge` reveals it as downloaded.