### PR TITLE
Studio macOS: force anyio<4.14.0 via uv override

### DIFF
--- a/studio/backend/requirements/single-env/overrides-darwin-arm64.txt
+++ b/studio/backend/requirements/single-env/overrides-darwin-arm64.txt
@@ -3,3 +3,9 @@
 # backtrack unsloth. Relax to match the pin -- per-model 5.x routing
 # happens at runtime via the side-car venvs.
 transformers>=4.57.6
+
+# mlx-vlm / mlx-lm pull anyio>=4.14, which conflicts with the constraints.txt
+# cap (anyio<4.14.0, #6483: 4.14+ breaks cancel scope on Python 3.13). A -c
+# constraint loses that conflict on macOS-arm and 4.14.0 gets installed; an
+# override wins it, so force anyio down here too.
+anyio<4.14.0


### PR DESCRIPTION
## What
Force `anyio<4.14.0` on the macOS-arm studio venv by adding it to the uv override file.

## Why
#6546 pinned `anyio<4.14.0` in `constraints.txt` to avoid the Python 3.13 cancel-scope RuntimeError (#6483). On macOS-arm the pin is not taking effect: the studio venv still installs **anyio 4.14.0** and the server 500s on the first httpx-backed request (`cannot import name 'TaskHandle' from anyio._core._tasks`, surfaced via `routes/inference.py::_openai_passthrough_non_streaming`).

Root cause: `mlx-vlm` / `mlx-lm` pull `anyio>=4.14`, which conflicts with the `<4.14.0` cap. A uv `-c` constraint loses a hard-requirement conflict (it errors or yields 4.14.0), while a uv **override** wins it. `UV_OVERRIDE` is already applied on macOS-arm via `overrides-darwin-arm64.txt`, but it did not list anyio.

## Change
Add `anyio<4.14.0` to `single-env/overrides-darwin-arm64.txt`. macOS-arm now resolves **anyio 4.13.0**; Linux/Windows are unaffected (they already honor the constraints.txt cap). This does not change intent - it makes the existing `<4.14` pin actually stick on macOS-arm.

## Validation
Verified with uv that an override forces `anyio<4.14.0` even against an explicit `anyio==4.14.0` request (resolves to 4.13.0), whereas the same as a `-c` constraint is a hard conflict.