### PR TITLE
Studio Playwright: snooze update banner before sending

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -569,6 +569,20 @@ with sync_playwright() as p:
         #    this at temp 0), and the old non-empty predicate got stuck
         #    on such bubbles.
         bubbles_before = _bubble_count()
+        # The llama.cpp update banner is a bottom-right toast that can overlap
+        # the composer's Send button and intercept the click. Snooze it if it
+        # is showing before sending.
+        snooze_btn = page.locator('[data-testid="llama-update-snooze-button"]')
+        if snooze_btn.count():
+            try:
+                snooze_btn.first.click(timeout = 2_000)
+                page.wait_for_selector(
+                    '[data-testid="llama-update-banner"]',
+                    state = "detached",
+                    timeout = 5_000,
+                )
+            except Exception:
+                pass
         composer.click()
         composer.fill(prompt)
         page.locator('button[aria-label="Send message"]').click()

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -569,20 +569,21 @@ with sync_playwright() as p:
         #    this at temp 0), and the old non-empty predicate got stuck
         #    on such bubbles.
         bubbles_before = _bubble_count()
-        # The llama.cpp update banner is a bottom-right toast that can overlap
-        # the composer's Send button and intercept the click. Snooze it if it
-        # is showing before sending.
-        snooze_btn = page.locator('[data-testid="llama-update-snooze-button"]')
-        if snooze_btn.count():
-            try:
-                snooze_btn.first.click(timeout = 2_000)
-                page.wait_for_selector(
-                    '[data-testid="llama-update-banner"]',
-                    state = "detached",
-                    timeout = 5_000,
-                )
-            except Exception:
-                pass
+        # The llama.cpp and web update banners are fixed bottom-right toasts
+        # (z-9998 / z-9999) that can overlap the composer's Send button and
+        # intercept the click. Snooze whichever is showing before sending.
+        for prefix in ("llama", "web"):
+            snooze_btn = page.locator(f'[data-testid="{prefix}-update-snooze-button"]')
+            if snooze_btn.count():
+                try:
+                    snooze_btn.first.click(timeout = 2_000)
+                    page.wait_for_selector(
+                        f'[data-testid="{prefix}-update-banner"]',
+                        state = "detached",
+                        timeout = 5_000,
+                    )
+                except Exception:
+                    pass
         composer.click()
         composer.fill(prompt)
         page.locator('button[aria-label="Send message"]').click()


### PR DESCRIPTION
## What
Dismiss the llama.cpp update banner before clicking Send in the chat UI Playwright smoke.

## Why
The update banner (`data-testid=llama-update-banner`) renders as a fixed bottom-right toast (`z-[9998]`). When an llama.cpp update is available it overlaps the composer's Send button, and its subtree intercepts the click, so `Locator.click("Send message")` times out. It is flaky: it fails only when the banner happens to be showing (e.g. the Windows studio UI smoke), and passes otherwise.

## Change
In `send_and_wait`, snooze the banner (click `data-testid=llama-update-snooze-button`) if present before each send, then wait for it to detach. No-op when no update banner is showing.