### PR TITLE
Fix #6454: Patch StreamingResponse anyio scope leak on client disconnect

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -534,6 +534,25 @@ async def lifespan(app: FastAPI):
     )
 
 
+# --- Monkey-patch Starlette StreamingResponse to fix AnyIO scope leak (#6454) ---
+from starlette.responses import StreamingResponse as _StreamingResponse
+
+_original_stream_response = _StreamingResponse.stream_response
+
+async def _safe_stream_response(self: _StreamingResponse, send) -> None:
+    try:
+        await _original_stream_response(self, send)
+    finally:
+        if hasattr(self.body_iterator, "aclose"):
+            try:
+                await self.body_iterator.aclose()
+            except Exception:
+                pass
+
+_StreamingResponse.stream_response = _safe_stream_response
+# --------------------------------------------------------------------------------
+
+
 app = FastAPI(
     title = "Unsloth UI Backend",
     version = UNSLOTH_VERSION,

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -539,6 +539,7 @@ from starlette.responses import StreamingResponse as _StreamingResponse
 
 _original_stream_response = _StreamingResponse.stream_response
 
+
 async def _safe_stream_response(self: _StreamingResponse, send) -> None:
     try:
         await _original_stream_response(self, send)
@@ -548,6 +549,7 @@ async def _safe_stream_response(self: _StreamingResponse, send) -> None:
                 await self.body_iterator.aclose()
             except Exception:
                 pass
+
 
 _StreamingResponse.stream_response = _safe_stream_response
 # --------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #6454. 

When a client disconnects mid-stream from a `/v1/chat/completions` request, Starlette's `StreamingResponse` drops the async generator without closing it. Python's garbage collector later finalizes the generator in a background thread, triggering `__aexit__` for `anyio`'s CancelScope from the wrong context and raising `RuntimeError: Attempted to exit a cancel scope that isn't the current tasks's current cancel scope`. 

This PR monkey-patches `StreamingResponse` in `studio/backend/main.py` to guarantee `aclose()` is executed on the request task before the generator gets dropped to the background.