### PR TITLE
Studio: correct the anyio<4.14 pin rationale (mixed-install ImportError, not a 4.14 cancel-scope bug)

### DIFF
--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -56,7 +56,7 @@ httpx
 httpcore
 certifi
 idna
-anyio>=3.0,<4.14.0  # 4.14+ breaks cancel scope on Py3.13 (#6483)
+anyio>=3.0,<4.14.0  # one consistent <4.14: 4.14's TaskHandle importers over a stale 4.13 _core/_tasks -> ImportError (#6483)
 sniffio
 h11
 

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -13,8 +13,11 @@ fastmcp>=3.0.2
 mcp>=1.24,<2
 websockets>=15.0.1
 
-# anyio 4.14+ breaks cancel scope on Python 3.13 (#6483). Global cap so later
-# with-deps steps (studio.txt, data-designer-deps.txt) can't re-resolve it up.
+# Keep anyio on one consistent <4.14 line. anyio 4.14 added TaskHandle (imported
+# by __init__.py and the asyncio backend from _core/_tasks); a clean 4.14 is fine
+# on 3.13. The real failure (#6483) is a half-resolved install: a stale 4.13
+# _core/_tasks (no TaskHandle) under 4.14's importers raises ImportError and 500s
+# the server. Global cap so later with-deps steps can't re-resolve it up.
 anyio<4.14.0
 
 pandas==2.3.3

--- a/studio/backend/requirements/single-env/overrides-darwin-arm64.txt
+++ b/studio/backend/requirements/single-env/overrides-darwin-arm64.txt
@@ -4,8 +4,10 @@
 # happens at runtime via the side-car venvs.
 transformers>=4.57.6
 
-# mlx-vlm / mlx-lm pull anyio>=4.14, which conflicts with the constraints.txt
-# cap (anyio<4.14.0, #6483: 4.14+ breaks cancel scope on Python 3.13). A -c
-# constraint loses that conflict on macOS-arm and 4.14.0 gets installed; an
-# override wins it, so force anyio down here too.
+# mlx-vlm / mlx-lm pull anyio>=4.14, which fights the constraints.txt cap
+# (anyio<4.14.0). The -c constraint loses that fight on macOS-arm, leaving a
+# half-resolved anyio (4.14 importers over a stale 4.13 _core/_tasks with no
+# TaskHandle) that ImportErrors and 500s the server (#6483; clean 4.14 is fine,
+# it is the mix that breaks). An override wins the fight, so force one
+# consistent <4.14 here too.
 anyio<4.14.0


### PR DESCRIPTION
## Summary

Follow-up to #6546 / #6575. The `anyio<4.14.0` pin comments attribute the failure to "anyio 4.14+ breaks cancel scope on Python 3.13". That is not what happens. This PR corrects the rationale (comments only). The pin itself stays.

## What actually breaks

`anyio 4.14.0` added a new symbol, `TaskHandle`, in `anyio/_core/_tasks.py`. Both `anyio/__init__.py` (line 73) and the asyncio backend `anyio/_backends/_asyncio.py` (line 95) now do `from .._core._tasks import TaskHandle`. `4.13.0` has no `TaskHandle` and no such import.

A **clean** 4.14.0 is fine, including on Python 3.13. The CI 500 (`cannot import name 'TaskHandle' from anyio._core._tasks`) only happens with a **half-resolved install**: a stale `4.13 _core/_tasks.py` (no `TaskHandle`) sitting under 4.14's importers. That mix is produced on macOS-arm by the version fight between `mlx-vlm`/`mlx-lm` (which pull `anyio>=4.14`) and this `<4.14` cap.

## Reproduction (Python 3.13)

Clean installs, both versions:

| | TaskHandle in _core._tasks | import _backends._asyncio | move_on_after | Event |
|---|---|---|---|---|
| anyio 4.13.0 | absent | OK | cancelled_caught=True | OK |
| anyio 4.14.0 | present | OK | cancelled_caught=True | OK |

So neither clean version is broken on 3.13. Forcing the mix reproduces the exact CI error:

```
# overlay 4.13.0's _core/_tasks.py onto an otherwise-4.14.0 anyio, then:
python -c "import anyio"
ImportError: cannot import name 'TaskHandle' from 'anyio._core._tasks'
```

Restoring 4.14.0's `_core/_tasks.py` fixes it.

## Why the pin still stands

Keeping anyio on **one consistent** `<4.14` line avoids the mix. On macOS-arm the cap alone loses to mlx's `>=4.14`, so #6575 forces it via the uv override; Linux/Windows honor the constraint directly. (An alternative would be to allow a clean `>=4.14`, since clean 4.14 works - but the validated fix is the consistent `<4.14`.)

## Change

Comments only, in `constraints.txt` and `no-torch-runtime.txt`. No version changes.