### PR TITLE
Studio: correct anyio<4.14 comments to the real #6483 cause (4.14/Py3.13 streaming cancel-scope bug)

### DIFF
--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -56,7 +56,7 @@ httpx
 httpcore
 certifi
 idna
-anyio>=3.0,<4.14.0  # one consistent <4.14: 4.14's TaskHandle importers over a stale 4.13 _core/_tasks -> ImportError (#6483)
+anyio>=3.0,<4.14.0  # 4.14 asyncio cancel-scope RuntimeError on Py3.13 streaming (#6483); 4.13 unaffected
 sniffio
 h11
 

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -13,11 +13,11 @@ fastmcp>=3.0.2
 mcp>=1.24,<2
 websockets>=15.0.1
 
-# Keep anyio on one consistent <4.14 line. anyio 4.14 added TaskHandle (imported
-# by __init__.py and the asyncio backend from _core/_tasks); a clean 4.14 is fine
-# on 3.13. The real failure (#6483) is a half-resolved install: a stale 4.13
-# _core/_tasks (no TaskHandle) under 4.14's importers raises ImportError and 500s
-# the server. Global cap so later with-deps steps can't re-resolve it up.
+# Cap anyio <4.14: 4.14's new asyncio per-task cancel scope (TaskHandle/_run_coro)
+# gets exited in the wrong task on Python 3.13 under starlette's collapsing task
+# group, raising "RuntimeError: ... exit a cancel scope that isn't the current
+# task's" on streaming responses (#6483); 4.13 has no such code. Global cap so
+# later with-deps steps can't re-resolve it up.
 anyio<4.14.0
 
 pandas==2.3.3

--- a/studio/backend/requirements/single-env/overrides-darwin-arm64.txt
+++ b/studio/backend/requirements/single-env/overrides-darwin-arm64.txt
@@ -4,10 +4,9 @@
 # happens at runtime via the side-car venvs.
 transformers>=4.57.6
 
-# mlx-vlm / mlx-lm pull anyio>=4.14, which fights the constraints.txt cap
-# (anyio<4.14.0). The -c constraint loses that fight on macOS-arm, leaving a
-# half-resolved anyio (4.14 importers over a stale 4.13 _core/_tasks with no
-# TaskHandle) that ImportErrors and 500s the server (#6483; clean 4.14 is fine,
-# it is the mix that breaks). An override wins the fight, so force one
-# consistent <4.14 here too.
+# mlx-vlm / mlx-lm pull anyio>=4.14, which fights the constraints.txt cap (needed
+# for the 4.14 Python-3.13 streaming cancel-scope RuntimeError, #6483). The -c
+# constraint loses that fight on macOS-arm, leaving a half-resolved 4.14/4.13
+# anyio that also ImportErrors on TaskHandle and 500s the server. An override
+# wins the fight, so force one consistent <4.14 here too.
 anyio<4.14.0


### PR DESCRIPTION
Follow-up correcting comments merged in #6579. **Comments only, no version changes.**

#6579 reworded the `anyio<4.14` pin comments to say a clean 4.14 is fine on 3.13 and that the failure is just a half-resolved install. That is inaccurate. #6483 is a **genuine anyio 4.14 + Python 3.13 regression**, not an install artifact.

## What actually breaks (#6483)

From the reporter's crash log (clean 4.14.0, Python 3.13, Apple Silicon), a streaming `/v1/chat/completions` raises:

```
RuntimeError: Attempted to exit a cancel scope that isn't the current task's current cancel scope
  starlette/responses.py: async with create_collapsing_task_group()   # StreamingResponse
  anyio/_core/_tasks.py:276  _run_coro:  with self._cancel_scope:
  anyio/_backends/_asyncio.py:472  __exit__ -> RuntimeError
```

anyio 4.14 added `TaskHandle`, and `TaskHandle.__init__` creates a **per-task** `CancelScope` that `_run_coro` enters with `with self._cancel_scope:`. Under starlette's collapsing task group on the asyncio backend + Python 3.13, that scope is exited in a different task than it was entered, tripping anyio's host-task check. **4.13 has none of this code** (no `TaskHandle`/`_run_coro`), so it is unaffected - the reporter confirmed `anyio==4.13.0` fixes it. Same Py3.13 cancel-scope class seen upstream (e.g. encode/httpx#3728).

The `TaskHandle` ImportError seen in CI is a **separate, secondary** symptom: on macOS-arm the cap fights mlx's `anyio>=4.14`, leaving a half-resolved 4.14/4.13 anyio. That is real too, but it is not what #6483 is about.

## Why the pin stays

The `<4.14` cap is the correct mitigation for the real upstream bug; this PR only fixes the comments so the rationale is accurate (and so nobody un-pins thinking 4.14 is fine on 3.13). The actual fix belongs upstream in anyio.