### PR TITLE
Studio: model picker search placeholder, Search Hub tooltip, list polish

### DIFF
--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -2336,7 +2336,7 @@ export function HubModelPicker({
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search models"
+            placeholder="Search Unsloth models"
             data-model-picker-search-input={true}
             className="field-soft h-9 border-0 pl-8 pr-8"
           />
@@ -2345,15 +2345,20 @@ export function HubModelPicker({
           )}
         </div>
         {onBrowseHub ? (
-          <button
-            type="button"
-            onClick={onBrowseHub}
-            aria-label="Search more models on the Hub"
-            className="hub-tab-toggle-pill flex h-9 w-[110px] shrink-0 items-center justify-center gap-[5px] rounded-full border-0 text-xs text-foreground transition-colors"
-          >
-            <HugeiconsIcon icon={DashboardCircleIcon} className="size-4" />
-            Search Hub
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onBrowseHub}
+                aria-label="Search more models on the Hub"
+                className="hub-tab-toggle-pill flex h-9 w-[110px] shrink-0 items-center justify-center gap-[5px] rounded-full border-0 text-xs text-foreground transition-colors"
+              >
+                <HugeiconsIcon icon={DashboardCircleIcon} className="size-4" />
+                Search Hub
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Search all models</TooltipContent>
+          </Tooltip>
         ) : null}
       </div>
 
@@ -2386,7 +2391,7 @@ export function HubModelPicker({
           // Height tracks the content up to the cap, so short lists do not
           // leave white space. scroll-py + symmetric px keep the focus ring off
           // the overflow clip edges during keyboard nav.
-          "model-list-scroll max-h-[21rem] overflow-y-auto scroll-py-1.5 px-0.5 mr-1",
+          "model-list-scroll max-h-[335px] overflow-y-auto scroll-py-1.5 px-0.5 mr-1",
           listScrolled && "is-scrolled",
           listMoreBelow && "is-bottom-faded",
         )}
@@ -3362,7 +3367,7 @@ export function HubModelPicker({
       {/* Floating eject pill: overlaid on the list bottom, outside the scroll
           so the edge fade never touches it. Only the pill catches clicks. */}
       {onEject ? (
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-end pr-3.5 pb-5">
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-end pr-3.5 pb-[19px]">
           <button
             type="button"
             onClick={onEject}

--- a/studio/frontend/src/features/chat/tour/steps.tsx
+++ b/studio/frontend/src/features/chat/tour/steps.tsx
@@ -38,9 +38,10 @@ export function buildChatTourSteps({
       title: "Two tabs",
       body: (
         <>
-          Hub: search Hugging Face models. Fine-tuned: local Unsloth outputs you’ve
-          trained or exported. If results look off, compare base vs fine-tuned
-          outputs to see what changed.
+          Hub: search Unsloth’s models here, or hit Search Hub to browse all of
+          Hugging Face. Fine-tuned: local Unsloth outputs you’ve trained or
+          exported. If results look off, compare base vs fine-tuned outputs to
+          see what changed.
         </>
       ),
       onEnter: openModelSelector,


### PR DESCRIPTION
## What

Polish for the in-chat model picker popover and its guided-tour step.

- Search box placeholder now reads "Search Unsloth models", which matches the popover's Unsloth-only listing and makes it clear what is being searched.
- The "Search Hub" button gets a "Search all models" tooltip on hover, so it reads as the way to widen the search past Unsloth.
- The floating Eject pill moves 1px lower (pb-5 to pb-[19px]) so it sits a touch closer to the bottom edge.
- The results list max height drops by 1px (21rem to 335px), trimmed from the bottom only.
- The chat guided tour's "Two tabs" step is updated: the Hub tab now describes searching Unsloth's models in the popover, with Search Hub to browse all of Hugging Face. This matches the new search scoping above and the Hub Discover default-to-all change.

## Notes

Copy, a guided-tour wording update, and small sizing nudges. No behavior change.