### PR TITLE
Studio: default Hub Discover scope to all models

### DIFF
--- a/studio/frontend/src/features/hub/catalog/models-toolbar.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-toolbar.tsx
@@ -252,7 +252,7 @@ export const ModelsToolbar = memo(function ModelsToolbar({
                 ? `Search on-device ${isDataset ? "datasets" : "models"}`
                 : isDataset
                   ? "Search datasets"
-                  : "Search models"
+                  : "Search all models"
             }
             className={cn(
               "field-soft h-9 rounded-full !border-0 pl-10 text-[13px] placeholder:text-muted-foreground/80 focus-visible:!ring-0",

--- a/studio/frontend/src/features/hub/catalog/owner-scope-toggle.tsx
+++ b/studio/frontend/src/features/hub/catalog/owner-scope-toggle.tsx
@@ -28,8 +28,8 @@ export function OwnerScopeToggle({
       onValueChange={onChange}
       ariaLabel="Publisher scope"
       align="end"
-      // Extra gap so the chevron sits a touch further from the label.
-      className="h-8 gap-1.5 text-[11.5px]"
+      // Extra gap before the chevron; min-width keeps the pill readable.
+      className="h-8 min-w-[96px] gap-1.5 text-[11.5px]"
     />
   );
 }

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -90,18 +90,19 @@ const ALL_MODELS_VIEW_STORAGE_KEY = "unsloth.hub.allModelsView";
 const INVENTORY_SORT_STORAGE_KEY = "unsloth.hub.inventorySort";
 const OWNER_SCOPE_STORAGE_KEY = "unsloth.hub.ownerScope";
 
-/** Discover browsing scope: only the unsloth org (default) or the whole Hub. */
+/** Discover browsing scope: the whole Hub (default) or only the unsloth org. */
 export type OwnerScope = "unsloth" | "all";
 
 function readOwnerScopePreference(): OwnerScope {
   if (typeof window === "undefined") {
-    return "unsloth";
+    return "all";
   }
   try {
     const value = window.localStorage.getItem(OWNER_SCOPE_STORAGE_KEY);
-    return value === "all" ? "all" : "unsloth";
+    // Default to the whole Hub; only honor an explicit "unsloth" preference.
+    return value === "unsloth" ? "unsloth" : "all";
   } catch {
-    return "unsloth";
+    return "all";
   }
 }
 


### PR DESCRIPTION
## What

Make Hub Discover browse the full Hub by default.

- The Discover publisher scope now defaults to "All" instead of the unsloth org, so a fresh load shows the whole Hub. An explicit "Unsloth" choice is still saved in localStorage and honored on return.
- The Discover search placeholder now reads "Search all models" to match the wider default scope.
- The Unsloth/All scope pill gets a small min width so the label and chevron stay readable when toggling.

## Notes

The default only changes for users without a saved scope. Anyone who already picked Unsloth keeps it.