### PR TITLE
Studio: refresh chat guided tour for the redesigned model picker

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3043,6 +3043,7 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
           type="button"
           aria-label="Tools and attachments"
           className="unsloth-composer-plus"
+          data-tour="chat-plus-menu"
         >
           <PlusIcon className="size-[22px] stroke-[1.75px]" />
         </button>

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2506,7 +2506,6 @@ export function ChatPage({
                     onClick={() => setSettingsOpen(true)}
                     className="flex h-[34px] w-[34px] translate-x-[2px] cursor-pointer items-center justify-center rounded-full text-nav-fg transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     aria-label="Open run settings"
-                    data-tour="chat-settings"
                   >
                     <HugeiconsIcon
                       icon={LayoutAlignRightIcon}

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1775,7 +1775,9 @@ export function ChatSettingsPanel({
             <SheetTitle>Run settings</SheetTitle>
             <SheetDescription>Chat inference settings</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full flex-col">{settingsContent}</div>
+          <div data-tour="chat-settings" className="flex h-full flex-col">
+            {settingsContent}
+          </div>
         </SheetContent>
       </Sheet>
     );
@@ -1783,6 +1785,7 @@ export function ChatSettingsPanel({
 
   return (
     <aside
+      data-tour="chat-settings"
       className={`relative z-50 shrink-0 h-full overflow-hidden bg-panel-surface text-panel-surface-fg font-heading ${open ? "w-[17rem] border-l border-sidebar-border" : "w-0"}`}
     >
       <div className="h-full w-full">{settingsContent}</div>

--- a/studio/frontend/src/features/chat/tour/steps.tsx
+++ b/studio/frontend/src/features/chat/tour/steps.tsx
@@ -27,21 +27,21 @@ export function buildChatTourSteps({
       title: "Pick a model",
       body: (
         <>
-          This selects what’s loaded for inference. Hub = base models. Fine-tuned
-          = trained Unsloth outputs, including LoRA adapters and full finetunes.
+          Selects what’s loaded for inference. Recommended is Unsloth’s curated
+          base models; On Device is your downloads and fine-tuned outputs (LoRA
+          adapters and full finetunes).
         </>
       ),
     },
     {
       id: "model-tabs",
       target: "chat-model-selector-popover",
-      title: "Two tabs",
+      title: "Find a model",
       body: (
         <>
-          Hub: search Unsloth’s models here, or hit Search Hub to browse all of
-          Hugging Face. Fine-tuned: local Unsloth outputs you’ve trained or
-          exported. If results look off, compare base vs fine-tuned outputs to
-          see what changed.
+          Search Unsloth’s models, or hit Search Hub for all of Hugging Face.
+          Switch Recommended and On Device, filter by format, and sort by
+          trending or recent. An OOM tag means it won’t fit in your VRAM.
         </>
       ),
       onEnter: openModelSelector,

--- a/studio/frontend/src/features/chat/tour/steps.tsx
+++ b/studio/frontend/src/features/chat/tour/steps.tsx
@@ -60,6 +60,18 @@ export function buildChatTourSteps({
       onEnter: openSettings,
       onExit: closeSettings,
     },
+    {
+      id: "plus-menu",
+      target: "chat-plus-menu",
+      title: "The + menu",
+      body: (
+        <>
+          Everything else lives here: attach photos and files, reuse saved
+          prompts, toggle tools and MCP, start a side-by-side compare, and
+          export the chat.
+        </>
+      ),
+    },
   ];
 
   if (canCompare) {


### PR DESCRIPTION
## What

The chat guided tour was out of sync with the redesigned model picker, its Settings step pointed at the wrong spot, and there was no step for the composer + menu.

## Changes

- `tour/steps.tsx`: "Pick a model" now describes the Recommended and On Device tabs (instead of the old Hub and Fine-tuned split). "Find a model" (renamed from "Two tabs") covers searching Unsloth's models vs Search Hub for all of Hugging Face, the format and sort filters, and the OOM tag. Added a new "The + menu" step covering attachments, saved prompts, tools and MCP, side-by-side compare, and export.
- `chat-page.tsx` and `chat-settings-sheet.tsx`: move the `chat-settings` tour anchor off the open-settings button and onto the run settings panel on the right. The button unmounts when settings opens, so the step lost its target and the tooltip drifted to the left; anchoring to the always-present panel keeps it beside the right-side sidebar.
- `thread.tsx`: add the `chat-plus-menu` tour anchor to the composer + button. The step points at the button and describes the menu rather than forcing it open, since the + menu is an uncontrolled dropdown and opening it under the tour overlay is unreliable.

## Notes

Tour copy plus tour anchors. No behavior change to the settings panel or the + menu themselves.
