### PR TITLE
CI: fix import-hoist false positive, vision-cache test cwd, and llama.cpp CLI smoke

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -2204,12 +2204,13 @@ jobs:
           pip install -e "$RUNNER_TEMP/unsloth-zoo" --no-deps
           pip show unsloth_zoo
 
-      - name: llama.cpp install via unsloth_zoo.llama_cpp + `llama-cli --help` smoke
+      - name: llama.cpp install via unsloth_zoo.llama_cpp + CLI `--help` smoke
         # Exercise the canonical `unsloth_zoo.llama_cpp.install_llama_cpp`
         # flow that GGUF export uses at runtime: clone ggml-org/llama.cpp
         # into ~/.unsloth/llama.cpp, build the LLAMA_CPP_TARGETS list
         # (llama-quantize, llama-cli, llama-mtmd-cli, llama-gguf-split,
-        # llama-server) via cmake, then run `llama-cli --help`.
+        # llama-server) via cmake, then run `--help` on whichever CLI
+        # inference binary the build actually produced.
         #
         # This replaces the previous "download upstream prebuilt zip"
         # approach, which silently exited 0 with the message
@@ -2217,6 +2218,18 @@ jobs:
         # naming drifted (the regex `bin-ubuntu-x64.*\.zip$` no longer
         # matched their current asset names). The build path is the same
         # one Unsloth users hit in production via `model.save_pretrained_gguf`.
+        #
+        # We do NOT hard-require `llama-cli` specifically: upstream
+        # ggml-org/llama.cpp moved the cli/server/ui targets behind the
+        # `LLAMA_BUILD_SERVER` cmake option (tools/CMakeLists.txt) and the
+        # set of binaries that survive a given checkout drifts over time
+        # (e.g. a recent build root shipped llama-server + llama-quantize
+        # + llama-diffusion-cli but no llama-cli). The durable contract is
+        # "install_llama_cpp produced a working CLI inference binary AND a
+        # working quantizer", so we --help-probe the first of
+        # llama-cli / llama-mtmd-cli / llama-server that exists. If a
+        # future llama.cpp restores llama-cli it is first in the list and
+        # is preferred, so this stays backwards compatible.
         #
         # Wall-time budget: ~3-5 min cold, dominated by cmake build of
         # 5 targets on the runner's 4 cores. Apt-package install is
@@ -2252,8 +2265,9 @@ jobs:
           print(f"Build targets: {LLAMA_CPP_TARGETS}")
           # install_llama_cpp returns (quantizer_path, converter_script_path).
           # The quantizer's directory is the `llama.cpp` install root, which
-          # also holds llama-cli after build/bin/llama-* gets copied up
-          # (llama_cpp.py:867-871).
+          # also holds the CLI inference binaries after build/bin/llama-* gets
+          # copied up (llama_cpp.py:1450-1454; on Windows they stay in
+          # build/bin/Release/).
           quantizer, converter = install_llama_cpp(print_output=True)
           assert quantizer and os.path.exists(quantizer), (
               f"install_llama_cpp returned quantizer={quantizer!r} but file missing"
@@ -2262,25 +2276,54 @@ jobs:
               f"install_llama_cpp returned converter={converter!r} but missing"
           )
           install_root = os.path.dirname(quantizer)
-          cli = os.path.join(install_root, "llama-cli")
-          assert os.path.exists(cli), (
-              f"llama-cli not found at {cli!r} after build. Build root contents: "
-              f"{sorted(p for p in os.listdir(install_root) if p.startswith('llama-'))[:20]}"
-          )
-          assert os.access(cli, os.X_OK), f"{cli!r} not executable"
-          # `llama-cli --help` exits non-zero on some builds; the contract
-          # is that recognizable help text appears on stdout/stderr.
+          is_windows = sys.platform == "win32"
+          exe = ".exe" if is_windows else ""
+          # Search both the copied-up root and the Windows build/bin/Release/
+          # location the quantizer might already live in.
+          search_dirs = [install_root]
+          win_release = os.path.join(install_root, "build", "bin", "Release")
+          if win_release not in search_dirs:
+              search_dirs.append(win_release)
+          # Any of these proves a working llama.cpp CLI inference binary was
+          # built. Order = preference: llama-cli is canonical (restored first
+          # if upstream brings it back), then the multimodal CLI, then the
+          # server (always built whenever cli would be, behind LLAMA_BUILD_SERVER).
+          cli_names = [f"llama-cli{exe}", f"llama-mtmd-cli{exe}", f"llama-server{exe}"]
+          cli = None
+          cli_name = None
+          for name in cli_names:
+              for d in search_dirs:
+                  candidate = os.path.join(d, name)
+                  if os.path.exists(candidate) and (is_windows or os.access(candidate, os.X_OK)):
+                      cli, cli_name = candidate, name
+                      break
+              if cli is not None:
+                  break
+          if cli is None:
+              found = []
+              for d in search_dirs:
+                  if os.path.isdir(d):
+                      found += [p for p in os.listdir(d) if p.startswith("llama-")]
+              raise AssertionError(
+                  f"No CLI inference binary ({', '.join(cli_names)}) found after "
+                  f"build in {search_dirs}. Build root contents: {sorted(set(found))[:20]}"
+              )
+          print(f"Using CLI inference binary: {cli_name} -> {cli}")
+          # `--help` exits non-zero on some builds; the contract is that
+          # recognizable help text appears on stdout/stderr. llama-server
+          # exposes a different flag set than llama-cli, so accept its
+          # tokens too (e.g. --host / --port / "server").
           proc = subprocess.run(
               [cli, "--help"], capture_output=True, text=True, timeout=30,
           )
           combined = (proc.stdout or "") + (proc.stderr or "")
-          print("--- llama-cli --help (first 30 lines) ---")
+          print(f"--- {cli_name} --help (first 30 lines) ---")
           print("\n".join(combined.splitlines()[:30]))
           assert any(
               tok in combined.lower()
-              for tok in ("usage", "--help", "--model", "-m,")
+              for tok in ("usage", "--help", "--model", "-m,", "--host", "--port", "server")
           ), (
-              f"llama-cli --help produced no recognizable help text. "
+              f"{cli_name} --help produced no recognizable help text. "
               f"exit={proc.returncode}\nstdout: {proc.stdout[:400]!r}\n"
               f"stderr: {proc.stderr[:400]!r}"
           )
@@ -2296,7 +2339,7 @@ jobs:
               f"stderr: {q.stderr[:400]!r}"
           )
           print(
-              f"\nOK: install_llama_cpp produced a working llama-cli at {cli} "
+              f"\nOK: install_llama_cpp produced a working {cli_name} at {cli} "
               f"and llama-quantize at {quantizer}."
           )
           PY

--- a/scripts/verify_import_hoist.py
+++ b/scripts/verify_import_hoist.py
@@ -581,9 +581,16 @@ def compare(before_src: str, after_src: str, path: str) -> list[tuple[str, str]]
             )
 
     # 3. TARGET-CHANGED (same scope+name resolves to a different import target)
+    #    Only a *swap* is dangerous: a BEFORE target that is no longer reachable in
+    #    AFTER means a reference was silently re-pointed. A pure superset growth
+    #    (tbefore <= tafter) is the benign `import pkg.subA` + `import pkg.subB`
+    #    case: both statements bind the same top-level name `pkg` to the same
+    #    package object and only *add* submodule attributes (e.g. adding
+    #    `import urllib.error` next to `import urllib.request`). Nothing the name
+    #    resolved to before is lost, so no reference is re-pointed -- skip it.
     for key, tafter in b["target_by_use"].items():
         tbefore = a["target_by_use"].get(key)
-        if tbefore and tbefore != tafter:
+        if tbefore and tbefore != tafter and (tbefore - tafter):
             findings.append(
                 (
                     "BLOCKER",

--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -41,8 +41,20 @@ from utils.models.model_config import (
 
 
 @pytest.fixture(autouse = True)
-def _clear_vision_cache():
-    """Ensure every test starts with a fresh cache."""
+def _clear_vision_cache(tmp_path, monkeypatch):
+    """Ensure every test starts with a fresh cache, from an empty working dir.
+
+    ``is_vision_model`` calls ``is_local_path`` first: any relative model id that
+    happens to exist on disk (``Path(name).exists()``) is treated as a local
+    model, short-circuiting before the mocked detection internals run. The CI cwd
+    (``studio/backend``) and the HF cache can contain dirs whose names collide
+    with the synthetic remote ids used here (``org/my-vlm``, ``model-a``,
+    ``broken/model`` ...), which made these tests fail with "called 0 times".
+    Running each test from a fresh empty ``tmp_path`` removes that collision
+    while leaving the real ``is_local_path`` logic intact (the local-GGUF tests
+    pass absolute ``tmp_path`` paths, unaffected by cwd).
+    """
+    monkeypatch.chdir(tmp_path)
     _vision_detection_cache.clear()
     yield
     _vision_detection_cache.clear()


### PR DESCRIPTION
Three independent CI fixes. Each currently fails on `main` and therefore on every open PR; none change runtime behavior of training/export code.

### 1. `verify_import_hoist.py` (Source lint) false positive
`TARGET-CHANGED` flagged `studio/backend/utils/transformers_version.py` because `_load_config_json` adds `import urllib.error` next to an existing `import urllib.request`. Both statements bind the same top-level package (`urllib`) and only add a submodule attribute, so nothing the name resolved to is lost. The check now only fires on a genuine swap (a BEFORE target no longer reachable in AFTER, i.e. `tbefore - tafter` non-empty). The self-test still passes, so real re-point/rename detection (`rename_clash`, `dangling_alias`) is unchanged.

### 2. `test_vision_cache.py` cwd isolation (Backend CI)
14 tests failed with "called 0 times". `is_vision_model()` calls `is_local_path()` first, which treats any relative model id that exists on disk (`Path(name).exists()`) as a local model and short-circuits before the mocked detection runs. The CI working dir (`studio/backend`) and the HF cache can contain dirs whose names collide with the synthetic remote ids (`org/my-vlm`, `model-a`, ...). Production code is correct; the autouse fixture now runs each test from a fresh empty `tmp_path`. The local-GGUF tests use absolute paths, so they are unaffected.

### 3. `llama.cpp` CLI smoke binary probe (Core)
The smoke step hard-required a binary named `llama-cli`, but upstream `ggml-org/llama.cpp` no longer always builds it (a recent build root had `llama-server` + `llama-quantize` + `llama-diffusion-cli`, no `llama-cli`). The step now `--help`-probes the first of `llama-cli` / `llama-mtmd-cli` / `llama-server` that exists. `llama-cli` stays first so it is preferred when present (backwards compatible); adds Windows `.exe` + `build/bin/Release/` handling. The `llama-quantize` round-trip is unchanged.

### Verification
- `verify_import_hoist.py --self-test`: ALL PASS; run on `transformers_version.py`: CLEAN / OVERALL PASS.
- `pytest studio/backend/tests/test_vision_cache.py`: 40 passed (also full backend suite green).
- Workflow YAML parses; embedded smoke script logic validated against the observed build output and Windows/Linux/macOS paths.
- ruff (0.6.9) format clean on both Python files.
