### PR TITLE
Withhold HF_TOKEN from pull_request CI runs

### DIFF
--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -64,6 +64,25 @@ concurrency:
 permissions:
   contents: read
 
+# Secret exposure on pull_request
+# ===============================
+# This workflow is `pull_request`-triggered (incl. on `install.sh` and the
+# `.github/scripts/**` it runs), and the connection + prompt-cache jobs check
+# out and EXECUTE that PR-controlled code. HF_TOKEN is an external Hugging Face
+# credential, so it must never reach those steps on a PR run: a same-repo PR
+# could modify install.sh / a script to read and exfiltrate it (directly, or by
+# writing it into the uploaded logs/ artifact). It is therefore gated with
+# `github.event_name != 'pull_request' && secrets.HF_TOKEN || ''` so the real
+# token flows only on the trusted schedule/workflow_dispatch runs; on a PR the
+# step sees an empty string, and the public GGUF repos still download anonymously.
+#
+# GITHUB_TOKEN (passed as GH_TOKEN) is deliberately left ungated: it is the
+# auto-provisioned, job-scoped, `contents: read` token (negligible marginal
+# value to a same-repo PR author, who already has write access, and it expires
+# with the job), and install_llama_prebuilt.py needs it to authenticate GitHub's
+# releases API or the prebuilt llama.cpp download 403s on the shared-runner
+# anonymous rate-limit bucket.
+
 env:
   # Determinism precedent (studio-inference-smoke.yml): temp 0 + fixed seed.
   UNSLOTH_SEED: '3407'
@@ -134,7 +153,9 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Withheld on pull_request -- see the "Secret exposure" note below
+          # `permissions:`. Empty token still downloads the public GGUF.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p gguf-cache
@@ -150,7 +171,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Withheld on pull_request -- see the "Secret exposure" note below
+          # `permissions:`. Empty token still downloads the public GGUF.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -335,7 +358,9 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Withheld on pull_request -- see the "Secret exposure" note below
+          # `permissions:`. Empty token still downloads the public GGUF.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p gguf-cache
@@ -351,7 +376,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Withheld on pull_request -- see the "Secret exposure" note below
+          # `permissions:`. Empty token still downloads the public GGUF.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -508,7 +535,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Withheld on pull_request -- see the "Secret exposure" note below
+          # `permissions:`. Empty token still downloads the public GGUF.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -524,7 +553,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Withheld on pull_request -- see the "Secret exposure" note below
+          # `permissions:`. Empty token still downloads the public GGUF.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -64,24 +64,11 @@ concurrency:
 permissions:
   contents: read
 
-# Secret exposure on pull_request
-# ===============================
-# This workflow is `pull_request`-triggered (incl. on `install.sh` and the
-# `.github/scripts/**` it runs), and the connection + prompt-cache jobs check
-# out and EXECUTE that PR-controlled code. HF_TOKEN is an external Hugging Face
-# credential, so it must never reach those steps on a PR run: a same-repo PR
-# could modify install.sh / a script to read and exfiltrate it (directly, or by
-# writing it into the uploaded logs/ artifact). It is therefore gated with
-# `github.event_name != 'pull_request' && secrets.HF_TOKEN || ''` so the real
-# token flows only on the trusted schedule/workflow_dispatch runs; on a PR the
-# step sees an empty string, and the public GGUF repos still download anonymously.
-#
-# GITHUB_TOKEN (passed as GH_TOKEN) is deliberately left ungated: it is the
-# auto-provisioned, job-scoped, `contents: read` token (negligible marginal
-# value to a same-repo PR author, who already has write access, and it expires
-# with the job), and install_llama_prebuilt.py needs it to authenticate GitHub's
-# releases API or the prebuilt llama.cpp download 403s on the shared-runner
-# anonymous rate-limit bucket.
+# Secret handling on pull_request: these jobs check out and run PR-controlled code
+# (install.sh, .github/scripts/**), so HF_TOKEN (an external HF credential) is gated
+# off pull_request at each step below -- public GGUF repos still download anonymously.
+# GH_TOKEN (GITHUB_TOKEN) is kept: it is the job-scoped contents:read token and
+# install_llama_prebuilt.py needs it for the GitHub releases API (else 403s).
 
 env:
   # Determinism precedent (studio-inference-smoke.yml): temp 0 + fixed seed.
@@ -153,8 +140,7 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          # Withheld on pull_request -- see the "Secret exposure" note below
-          # `permissions:`. Empty token still downloads the public GGUF.
+          # Gated off PR (see note above); public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -171,8 +157,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on pull_request -- see the "Secret exposure" note below
-          # `permissions:`. Empty token still downloads the public GGUF.
+          # Gated off PR (see note above); public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -358,8 +343,7 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          # Withheld on pull_request -- see the "Secret exposure" note below
-          # `permissions:`. Empty token still downloads the public GGUF.
+          # Gated off PR (see note above); public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -376,8 +360,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on pull_request -- see the "Secret exposure" note below
-          # `permissions:`. Empty token still downloads the public GGUF.
+          # Gated off PR (see note above); public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -535,8 +518,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # Withheld on pull_request -- see the "Secret exposure" note below
-          # `permissions:`. Empty token still downloads the public GGUF.
+          # Gated off PR (see note above); public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -553,8 +535,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on pull_request -- see the "Secret exposure" note below
-          # `permissions:`. Empty token still downloads the public GGUF.
+          # Gated off PR (see note above); public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -241,8 +241,7 @@ jobs:
       # non-zero binary exit is an Unsloth/Studio bug.
       - name: Studio prebuilt llama.cpp install + GGUF inference (Mac M1)
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           # install_llama_prebuilt.py hits the GitHub releases API to
           # resolve the asset URL. Anonymous calls share the runner-IP
@@ -334,8 +333,7 @@ jobs:
       # train_metrics.json so we can detect regressions across CI runs.
       - name: MLX export round-trip — TRAIN + SAVE 3 formats
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           UNSLOTH_COMPILE_DISABLE: '1'
         run: |
@@ -352,8 +350,7 @@ jobs:
       # the saved dir.
       - name: MLX export round-trip — RELOAD LoRA (fresh process)
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           UNSLOTH_COMPILE_DISABLE: '1'
         run: |
@@ -363,8 +360,7 @@ jobs:
 
       - name: MLX export round-trip — RELOAD merged_16bit (fresh process)
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           UNSLOTH_COMPILE_DISABLE: '1'
         run: |
@@ -380,8 +376,7 @@ jobs:
       # LoRA + merged_16bit assertions remain the gating signal.
       - name: MLX export round-trip — RELOAD GGUF via llama-cli (fresh process)
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           if python -c "import json,sys; m=json.load(open('mlx_workdir/train_metrics.json')); sys.exit(0 if m.get('gguf_supported') else 1)"; then

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -241,7 +241,9 @@ jobs:
       # non-zero binary exit is an Unsloth/Studio bug.
       - name: Studio prebuilt llama.cpp install + GGUF inference (Mac M1)
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           # install_llama_prebuilt.py hits the GitHub releases API to
           # resolve the asset URL. Anonymous calls share the runner-IP
           # rate-limit bucket and 403 quickly -- pass the workflow's
@@ -332,7 +334,9 @@ jobs:
       # train_metrics.json so we can detect regressions across CI runs.
       - name: MLX export round-trip — TRAIN + SAVE 3 formats
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           UNSLOTH_COMPILE_DISABLE: '1'
         run: |
           mkdir -p mlx_workdir
@@ -348,7 +352,9 @@ jobs:
       # the saved dir.
       - name: MLX export round-trip — RELOAD LoRA (fresh process)
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           UNSLOTH_COMPILE_DISABLE: '1'
         run: |
           python tests/studio/run_real_mlx_smoke.py reload \
@@ -357,7 +363,9 @@ jobs:
 
       - name: MLX export round-trip — RELOAD merged_16bit (fresh process)
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
           UNSLOTH_COMPILE_DISABLE: '1'
         run: |
           python tests/studio/run_real_mlx_smoke.py reload \
@@ -372,7 +380,9 @@ jobs:
       # LoRA + merged_16bit assertions remain the gating signal.
       - name: MLX export round-trip — RELOAD GGUF via llama-cli (fresh process)
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           if python -c "import json,sys; m=json.load(open('mlx_workdir/train_metrics.json')); sys.exit(0 if m.get('gguf_supported') else 1)"; then
             python tests/studio/run_real_mlx_smoke.py reload \

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -83,8 +83,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -102,8 +101,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -83,7 +83,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -100,7 +102,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -97,7 +97,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -114,7 +116,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -364,7 +368,9 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p gguf-cache
@@ -380,7 +386,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -845,7 +853,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -863,7 +873,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -97,8 +97,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -116,8 +115,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -368,8 +366,7 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -386,8 +383,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -853,8 +849,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -873,8 +868,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/studio-mac-api-smoke.yml
+++ b/.github/workflows/studio-mac-api-smoke.yml
@@ -68,8 +68,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -87,8 +86,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/studio-mac-api-smoke.yml
+++ b/.github/workflows/studio-mac-api-smoke.yml
@@ -68,7 +68,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -85,7 +87,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -91,8 +91,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -112,8 +111,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -350,8 +348,7 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -369,8 +366,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -733,8 +729,7 @@ jobs:
         # Authenticated + parallel: shared macos-14 NAT egress stalls
         # multi-GB anonymous downloads.
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -762,8 +757,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -91,7 +91,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -110,7 +112,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -346,7 +350,9 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p gguf-cache
@@ -363,7 +369,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -725,7 +733,9 @@ jobs:
         # Authenticated + parallel: shared macos-14 NAT egress stalls
         # multi-GB anonymous downloads.
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p gguf-cache
@@ -752,7 +762,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -63,8 +63,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -68,8 +68,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -87,8 +86,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -68,7 +68,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -85,7 +87,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/studio-mac-update-smoke.yml
+++ b/.github/workflows/studio-mac-update-smoke.yml
@@ -62,7 +62,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -74,7 +76,9 @@ jobs:
       - name: First update should be a no-op (prebuilt already validated)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
           unsloth studio update --local 2>&1 | tee logs/update.log
@@ -93,7 +97,9 @@ jobs:
       - name: Second update must also be a no-op
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
           unsloth studio update --local 2>&1 | tee logs/update2.log

--- a/.github/workflows/studio-mac-update-smoke.yml
+++ b/.github/workflows/studio-mac-update-smoke.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -76,8 +75,7 @@ jobs:
       - name: First update should be a no-op (prebuilt already validated)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
@@ -97,8 +95,7 @@ jobs:
       - name: Second update must also be a no-op
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -82,8 +82,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -101,8 +100,7 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -82,7 +82,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -99,7 +101,9 @@ jobs:
       - name: Install Studio (--local, --no-torch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -71,8 +71,7 @@ jobs:
         # prebuilt path falls back to source build.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
@@ -88,8 +87,7 @@ jobs:
         # idempotency regressed.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
@@ -113,8 +111,7 @@ jobs:
         # the first one.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -71,7 +71,9 @@ jobs:
         # prebuilt path falls back to source build.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           mkdir -p logs
           set -o pipefail
@@ -86,7 +88,9 @@ jobs:
         # idempotency regressed.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
           unsloth studio update --local 2>&1 | tee logs/update.log
@@ -109,7 +113,9 @@ jobs:
         # the first one.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
           unsloth studio update --local 2>&1 | tee logs/update2.log

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -75,7 +75,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -124,7 +126,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           # *>&1 captures Write-Host (Information stream) output;

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -75,8 +75,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -126,8 +125,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -127,7 +127,9 @@ jobs:
         # described above (outcome != success).
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -179,7 +181,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           # *>&1 captures Write-Host (Information stream) output;
@@ -476,7 +480,9 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p gguf-cache
@@ -524,7 +530,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           # *>&1 captures Write-Host (Information stream) output;
@@ -906,7 +914,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -956,7 +966,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           # *>&1 captures Write-Host (Information stream) output;
@@ -1299,7 +1311,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -1376,7 +1390,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           $ProgressPreference = 'SilentlyContinue'

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -127,8 +127,7 @@ jobs:
         # described above (outcome != success).
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -181,8 +180,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
@@ -480,8 +478,7 @@ jobs:
         id: download-gguf
         if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -530,8 +527,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
@@ -914,8 +910,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -966,8 +961,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
@@ -1311,8 +1305,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -1390,8 +1383,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -91,7 +91,9 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
           mkdir -p hf-cache
@@ -155,7 +157,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           # *>&1 redirects ALL PowerShell streams (stdout, stderr,

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -91,8 +91,7 @@ jobs:
         id: prime-hf
         if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
         env:
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
@@ -157,8 +156,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -133,7 +133,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           # *>&1 captures Write-Host (Information stream) output;
@@ -180,7 +182,9 @@ jobs:
       - name: First update should be a no-op (prebuilt already validated)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
           unsloth studio update --local 2>&1 | tee logs/update.log
@@ -199,7 +203,9 @@ jobs:
       - name: Second update must also be a no-op
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
+          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
           unsloth studio update --local 2>&1 | tee logs/update2.log

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -133,8 +133,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
@@ -182,8 +181,7 @@ jobs:
       - name: First update should be a no-op (prebuilt already validated)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail
@@ -203,8 +201,7 @@ jobs:
       - name: Second update must also be a no-op
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HF_TOKEN withheld on pull_request: this step executes checked-out PR code,
-          # so a same-repo PR must not receive it; public GGUF repos download anonymously.
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           set -o pipefail


### PR DESCRIPTION
## Problem

Several `pull_request`-triggered CI workflows check out and execute PR-controlled code (`install.sh`, `.github/scripts/**`, `tests/**`) with `secrets.HF_TOKEN` in the step environment. For a same-repo PR, GitHub provides repository secrets to the run, so a malicious or compromised branch can modify a checked-out script to read and exfiltrate `HF_TOKEN`, including by writing it into the uploaded `logs/` artifact (the smoke workflows redact `UNSLOTH_API_KEY` from logs but not `HF_TOKEN`).

`HF_TOKEN` is an external Hugging Face credential of unknown scope, so it is the high-value exposure. This was flagged on `local-agent-guides-ci.yml` (added in 264f1a0), but the same shape is shared across the Studio smoke and MLX workflows, so this fixes the whole set.

Forked PRs do not normally receive repository secrets, so the realistic attacker is a same-repo branch / collaborator or a compromised trusted branch.

## Fix

Gate every `HF_TOKEN` reference in the affected `pull_request` workflows:

```yaml
HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
```

The real token now flows only on the trusted `schedule` / `push` / `workflow_dispatch` runs; on a PR the step sees an empty string. Every model repo these jobs use is public (`unsloth/*-GGUF`), so anonymous download still works on PRs, and `studio/install_llama_prebuilt.py` only attaches HF auth for Hugging Face hosts and tolerates an absent token. No PR functionality is lost.

## Why GITHUB_TOKEN is left as-is

`GITHUB_TOKEN` (passed as `GH_TOKEN`) is intentionally not gated:

- It is the auto-provisioned, job-scoped, `contents: read` token that expires with the job, so leaking it to a same-repo PR author gives them nothing they do not already have.
- `studio/install_llama_prebuilt.py` (`os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")`) needs it to authenticate the GitHub releases API; without it the prebuilt llama.cpp download falls back to the shared-runner anonymous rate-limit bucket and 403s.

`version-compat-ci.yml` (which only passes `GITHUB_TOKEN`) is unchanged for the same reasons.

## Scope

15 workflows, 53 `HF_TOKEN` sites gated. `local-agent-guides-ci.yml` carries a header note documenting the rule; the other files get a short inline comment at each site.

- local-agent-guides-ci.yml
- mlx-ci.yml
- studio-api-smoke.yml, studio-inference-smoke.yml, studio-ui-smoke.yml
- studio-mac-api-smoke.yml, studio-mac-inference-smoke.yml, studio-mac-ui-smoke.yml, studio-mac-install-matrix.yml, studio-mac-update-smoke.yml
- studio-update-smoke.yml
- studio-windows-api-smoke.yml, studio-windows-inference-smoke.yml, studio-windows-ui-smoke.yml, studio-windows-update-smoke.yml

## Validation

- All 30 workflow YAML files still parse.
- No raw `HF_TOKEN: ${{ secrets.HF_TOKEN }}` remains in any `pull_request` workflow.
- `GH_TOKEN` / `GITHUB_TOKEN` references are unchanged.
- `release-desktop.yml` (Apple/Azure/Tauri signing secrets) is not `pull_request`-triggered and is untouched; `studio-tauri-smoke.yml` references the signing env names but passes no real secrets.