### PR TITLE
Studio: fall back to anonymous HF browsing on a malformed token

### DIFF
--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -14,7 +14,10 @@ import { useHubInfiniteScroll } from "@/features/hub/hooks/use-hub-infinite-scro
 import { ggufVariantsMatch, modelIdsMatch } from "@/features/hub/lib/model-identity";
 import { cn } from "@/lib/utils";
 import { usePlatformStore } from "@/config/env";
-import { useHfTokenStore } from "@/features/hub/stores/hf-token-store";
+import {
+  hfApiToken,
+  useHfTokenStore,
+} from "@/features/hub/stores/hf-token-store";
 import {
   getInferenceStatus,
   isExternalModelId,
@@ -551,6 +554,9 @@ export function ModelsPage() {
   const deferredDebouncedQuery = useDeferredValue(debouncedQuery);
   const hfToken = useHfTokenStore((s) => s.token);
   const debouncedHfToken = useDebouncedValue(hfToken, 500);
+  // Only forward a well-formed `hf_...` token to the Hugging Face client; a
+  // malformed value would otherwise throw and break anonymous browsing.
+  const apiHfToken = hfApiToken(debouncedHfToken);
   const deferredFormatFilter = useDeferredValue(formatFilter);
   const deferredCapabilityFilter = useDeferredValue(capabilityFilter);
 
@@ -605,7 +611,7 @@ export function ModelsPage() {
     handleRetrySearch,
   } = useDiscoverSearch({
     debouncedQuery,
-    accessToken: debouncedHfToken || undefined,
+    accessToken: apiHfToken,
     isDiscoverTab,
     isDatasetMode,
     sortBy: effectiveSort,
@@ -619,7 +625,7 @@ export function ModelsPage() {
     channelId: isChannelListMode ? activeChannelId : null,
     results,
     isLoading,
-    accessToken: debouncedHfToken || undefined,
+    accessToken: apiHfToken,
   });
 
   const {
@@ -702,7 +708,7 @@ export function ModelsPage() {
   const listRows = filteredDiscoverRows;
 
   const hubFeed = useHubFeed({
-    accessToken: debouncedHfToken || undefined,
+    accessToken: apiHfToken,
     online,
     enabled: isFeedMode,
     deviceType,
@@ -908,7 +914,7 @@ export function ModelsPage() {
     filteredCachedRows,
     filteredLocalRows,
     results: selectionResults,
-    accessToken: debouncedHfToken || undefined,
+    accessToken: apiHfToken,
     online,
   });
 

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -554,8 +554,6 @@ export function ModelsPage() {
   const deferredDebouncedQuery = useDeferredValue(debouncedQuery);
   const hfToken = useHfTokenStore((s) => s.token);
   const debouncedHfToken = useDebouncedValue(hfToken, 500);
-  // Only forward a well-formed `hf_...` token to the Hugging Face client; a
-  // malformed value would otherwise throw and break anonymous browsing.
   const apiHfToken = hfApiToken(debouncedHfToken);
   const deferredFormatFilter = useDeferredValue(formatFilter);
   const deferredCapabilityFilter = useDeferredValue(capabilityFilter);

--- a/studio/frontend/src/features/hub/stores/hf-token-store.ts
+++ b/studio/frontend/src/features/hub/stores/hf-token-store.ts
@@ -116,3 +116,20 @@ export const useHfTokenStore = create<HfTokenStore>((set) => {
 export function getHfToken(): string {
   return useHfTokenStore.getState().token;
 }
+
+/**
+ * Sanitize a stored token for use as a Hugging Face API credential.
+ *
+ * The Hugging Face JS client throws (`Your access token must start with
+ * 'hf_'`) when handed a non-empty token that isn't a well-formed HF token,
+ * rather than falling back to anonymous access. A single malformed value left
+ * in the token field (e.g. a placeholder someone typed) therefore takes down
+ * the entire Discover/Recommended feed, which otherwise works fine with no
+ * token at all. Treat anything that isn't an `hf_...` token as "no token" so
+ * those public-browsing flows degrade to anonymous access instead of erroring.
+ */
+export function hfApiToken(
+  token: string | undefined | null,
+): string | undefined {
+  return token && token.startsWith("hf_") ? token : undefined;
+}

--- a/studio/frontend/src/features/hub/stores/hf-token-store.ts
+++ b/studio/frontend/src/features/hub/stores/hf-token-store.ts
@@ -117,17 +117,8 @@ export function getHfToken(): string {
   return useHfTokenStore.getState().token;
 }
 
-/**
- * Sanitize a stored token for use as a Hugging Face API credential.
- *
- * The Hugging Face JS client throws (`Your access token must start with
- * 'hf_'`) when handed a non-empty token that isn't a well-formed HF token,
- * rather than falling back to anonymous access. A single malformed value left
- * in the token field (e.g. a placeholder someone typed) therefore takes down
- * the entire Discover/Recommended feed, which otherwise works fine with no
- * token at all. Treat anything that isn't an `hf_...` token as "no token" so
- * those public-browsing flows degrade to anonymous access instead of erroring.
- */
+// HF's JS client throws on a non-empty token that isn't `hf_...` instead of
+// browsing anonymously, so treat anything malformed as no token.
 export function hfApiToken(
   token: string | undefined | null,
 ): string | undefined {


### PR DESCRIPTION
## Problem

The Hub **Discover** and **Recommended** feeds call the Hugging Face JS client (`listModels` / `listDatasets`) **directly from the browser**. That client throws

> `Your access token must start with 'hf_'`

when handed a *non-empty* token that isn't a well-formed HF token, instead of falling back to anonymous access. So a single bad value left in the HF token field — e.g. a placeholder like `hellothere` someone typed once — takes down the **entire** discovery feed, surfacing as:

> Couldn't reach Hugging Face — The discovery feed couldn't load. … Your access token must start with 'hf_'

This is confusing because the feed works perfectly fine with **no** token (anonymous public browsing). It only breaks when a malformed token is present. The failure is purely client-side, so nothing shows up in the server logs.

## Fix

Add `hfApiToken()` to the HF token store. It returns the token only when it looks like a real `hf_...` credential, and `undefined` otherwise. `hub-page.tsx`'s four HF call sites (model search, feed write-back, model selection, dataset search) now route through it.

A malformed token therefore degrades to **anonymous** public browsing instead of erroring out. The raw token is still stored and shown unchanged in the settings field — this only sanitizes what gets handed to the HF client.

```ts
export function hfApiToken(
  token: string | undefined | null,
): string | undefined {
  return token && token.startsWith("hf_") ? token : undefined;
}
```

## Testing

- Repro: set `localStorage['unsloth_hf_token'] = 'hellothere'`, open `/hub?tab=discover` → feed errors. With this change the feed loads anonymously.
- Clearing the token (`localStorage.setItem('unsloth_hf_token','')`) and a valid `hf_...` token both continue to work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)