### PR TITLE
Hub: restore Unsloth owner avatar to HF profile picture

### DIFF
--- a/studio/frontend/src/features/hub/catalog/owner-avatar.tsx
+++ b/studio/frontend/src/features/hub/catalog/owner-avatar.tsx
@@ -19,24 +19,6 @@ const SIZES: Record<AvatarSize, string> = {
   lg: "size-12 rounded-[15px] text-[16px]",
 };
 
-// Unsloth's own uploads (no upstream provider match) show the bundled Unsloth
-// brand avatar instead of a colored-initial tile, so they read as Unsloth even
-// in virtualized rows that never fetch the HF profile picture.
-const UNSLOTH_OWNER_LOGO: ProviderLogo = {
-  id: "unsloth",
-  name: "Unsloth",
-  logoPath: "/circle-logo-small.png",
-  treatment: "original",
-  background: "transparent",
-  fit: "cover",
-  // Used directly for the unsloth owner, never via prefix matching.
-  prefixes: [],
-};
-
-function isUnslothOwner(owner: string): boolean {
-  return owner.trim().toLowerCase() === "unsloth";
-}
-
 const AVATAR_IMAGE_RETRY_BASE_MS = 60_000;
 const AVATAR_IMAGE_RETRY_MAX_MS = 30 * 60_000;
 
@@ -86,15 +68,6 @@ export function OwnerAvatar({
       />
     );
   }
-  if (isUnslothOwner(owner)) {
-    return (
-      <ProviderLogoTile
-        provider={UNSLOTH_OWNER_LOGO}
-        size={size}
-        className={className}
-      />
-    );
-  }
   return (
     <DefaultAvatar
       owner={owner}
@@ -113,9 +86,6 @@ export function useAvatarImageUrl(
   const remoteUrl = useHfOwnerAvatar(owner.trim() || "?");
   if (provider) {
     return provider.treatment === "original" ? provider.logoPath : null;
-  }
-  if (isUnslothOwner(owner)) {
-    return UNSLOTH_OWNER_LOGO.logoPath;
   }
   return remoteUrl;
 }


### PR DESCRIPTION
## What

Removes the branch in `owner-avatar.tsx` that overrode the Unsloth owner avatar with the bundled `/circle-logo-small.png` sticker, restoring the behaviour we had before #6364.

## Why

#6364 added `UNSLOTH_OWNER_LOGO` so that Unsloth's own uploads (no upstream provider match) rendered the bundled sticker. Two problems with that:

1. It points at `circle-logo-small.png` (the green peeling-sticker circle), not the rounded tile icon we actually want on the cards.
2. It replaces the live Hugging Face org avatar, which is the source of truth for the Unsloth profile picture.

Rather than swap in another bundled asset, this reverts to the prior, simpler behaviour: Unsloth uploads use the live HF org avatar, with the colored initial tile as the fallback while the image loads or in virtualized rows.

## Scope

- Only touches the Unsloth owner fallback. Upstream re-uploads (Qwen, GLM, Gemma, and so on) are unaffected since they still resolve through `resolveOwnerProviderLogo` and `ProviderLogoTile`.
- No asset changes.