### PR TITLE
Studio: open a cached GGUF repo on the downloaded quant

### DIFF
--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -431,6 +431,12 @@ export function GgufDownloadCard({
           ggufVariantsMatch(v.quant, selectedQuantOverride),
         )?.quant
       : null) ??
+    // For a cached repo, open on a quant that is already on disk so the card
+    // shows "On device" / "Run" instead of defaulting to the recommended quant
+    // with a multi-hundred-GB "Download". The dropdown still lists every quant
+    // so other quantizations remain one click away to download.
+    sortedVariants?.find((v) => v.downloaded)?.quant ??
+    sortedVariants?.find((v) => v.partial)?.quant ??
     sortedVariants?.[0]?.quant ??
     null;
 


### PR DESCRIPTION
## Problem

The Hub download card picks its default selected quant as the first entry in the sorted variant list, which is the recommended quant for the user's hardware. For a repo that already has a quant on disk, the card therefore opens on a different, undownloaded quant and shows a large "Download" action instead of "Run". The downloaded quant is only reachable by opening the dropdown and scrolling, so a cached model looks like nothing was downloaded and like the only option is a fresh multi-hundred-GB download.

Example: with `unsloth/GLM-5.2-GGUF` and `UD-IQ1_M` on disk, the card opened on `UD-Q5_K_XL` with a 562 GB Download button.

## Fix

When no variant has been explicitly picked or adopted from an active download, prefer a downloaded (then partial) quant for the default selection, falling back to the recommended quant when nothing is on disk. The dropdown still lists every quant, so downloading other quantizations stays one click away.

```ts
selectedQuantOverride-resolved
  ?? sortedVariants?.find((v) => v.downloaded)?.quant
  ?? sortedVariants?.find((v) => v.partial)?.quant
  ?? sortedVariants?.[0]?.quant
  ?? null;
```

## Testing

- With `UD-IQ1_M` cached, the card now opens on `UD-IQ1_M` showing "On device" / "Run" instead of `UD-Q5_K_XL` / Download.
- With nothing cached, the default is unchanged (recommended quant).
- `tsc -b` and `vite build` pass.