### PR TITLE
Clarify Studio --secure hint exposes a public Cloudflare tunnel

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2595,7 +2595,7 @@ exit 0
             step "launch" "to start later, run:"
             substep "unsloth studio -p 8888"
             substep "(add -H 0.0.0.0 to allow network / cloud access)"
-            substep "(add --secure to allow HTTPS)"
+            substep "(add --secure for a public Cloudflare HTTPS link; anyone with the API key can run code)"
             Write-Host ""
         }
     } else {
@@ -2616,7 +2616,7 @@ exit 0
             substep "unsloth studio -p 8888"
         }
         substep "(add -H 0.0.0.0 to allow network / cloud access)"
-        substep "(add --secure to allow HTTPS)"
+        substep "(add --secure for a public Cloudflare HTTPS link; anyone with the API key can run code)"
         Write-Host ""
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -3160,7 +3160,7 @@ if [ -t 1 ]; then
             step "launch" "to start later, run:"
             substep "unsloth studio -p 8888"
             substep "(add -H 0.0.0.0 to allow network / cloud access)"
-            substep "(add --secure to allow HTTPS)"
+            substep "(add --secure for a public Cloudflare HTTPS link; anyone with the API key can run code)"
             echo ""
             ;;
     esac
@@ -3182,6 +3182,6 @@ else
         substep "unsloth studio -p 8888"
     fi
     substep "(add -H 0.0.0.0 to allow network / cloud access)"
-    substep "(add --secure to allow HTTPS)"
+    substep "(add --secure for a public Cloudflare HTTPS link; anyone with the API key can run code)"
     echo ""
 fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1822,7 +1822,7 @@ else
         printf "  ${C_DIM}%-15s${C_OK}%s${C_RST}\n" "launch" "unsloth studio -p 8888"
     fi
     printf "  ${C_DIM}%-15s%s${C_RST}\n" "" "(add -H 0.0.0.0 to allow network / cloud access)"
-    printf "  ${C_DIM}%-15s%s${C_RST}\n" "" "(add --secure to allow HTTPS)"
+    printf "  ${C_DIM}%-15s%s${C_RST}\n" "" "(add --secure for a public Cloudflare HTTPS link; anyone with the API key can run code)"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

The Studio launch hint printed by the installers and setup script described `--secure` as simply enabling HTTPS:

```
(add --secure to allow HTTPS)
```

That wording understates what the flag does. `--secure` does not just turn on local TLS: it forces a loopback bind and opens a public Cloudflare quick tunnel so Studio is reachable at a public `https://*.trycloudflare.com` URL. Studio serves Python and terminal tools by default, so the old hint could lead someone to publish a code-execution-capable service to the internet while thinking they only switched on HTTPS.

The runtime secure-mode banner already warns about this ("Anyone with the API key can run code on this machine"), and the `--secure` `--help` text is accurate. Only the post-install hint was out of step, so this PR brings it in line.

## Change

Updated the hint in `install.sh`, `install.ps1`, and `studio/setup.sh` (5 lines total):

```
(add --secure for a public Cloudflare HTTPS link; anyone with the API key can run code)
```

This matches the existing runtime banner language and makes the public exposure and code-execution context explicit at the point where users decide which flags to launch with.

## Why this is accurate

- `run_server` forces `host = "127.0.0.1"` when `--secure` is set and rejects `--secure --no-cloudflare` (`studio/backend/run.py`).
- `_cloudflare_tunnel_should_start` returns true whenever `secure` is set and Cloudflare is enabled, including loopback/api-only launches.
- The tunnel is started with `start_studio_tunnel(port)` and the public URL is stored on `app.state.cloudflare_url`.
- `cloudflare_tunnel.py` documents that the quick tunnel yields a free `https://*.trycloudflare.com` URL that works anywhere.

## Notes

No behavior change. This is launch-hint wording only. `bash -n` passes on `install.sh` and `studio/setup.sh`; the `install.ps1` edit is a plain string inside the existing `substep` call.
