### PR TITLE
Studio: clean up empty leftover quant folders so they can be deleted

### DIFF
--- a/studio/backend/hub/services/models/deletion.py
+++ b/studio/backend/hub/services/models/deletion.py
@@ -107,14 +107,8 @@ def _has_remaining_main_gguf(target_repo) -> bool:
 
 
 def _remove_empty_variant_dirs(target_repos: list, variant: str) -> int:
-    """Remove snapshot subfolders for *variant* that are now empty.
-
-    HF lays out a split quant as one ``snapshots/<rev>/<quant>/`` directory, so
-    the folder name is the quant label. This reclaims both the folder left behind
-    by an interrupted/cancelled download (empty from the start) and the folder
-    emptied by unlinking this variant's shards above. Only genuinely empty
-    directories are removed, so a sibling quant's files are never touched.
-    """
+    """Remove now-empty ``snapshots/<rev>/<quant>/`` folders for *variant* (the
+    quant label names the folder); only empty dirs go, so siblings are safe."""
     variant_key = (extract_quant_token(variant) or variant).lower()
     removed = 0
     for target_repo in target_repos:
@@ -252,8 +246,7 @@ def _delete_gguf_variant_from_repos(
         )
 
     state_purged = download_manifest.purge_state("model", repo_id, variant)
-    # Reclaim the now-empty (or always-empty) quant subfolder so an interrupted
-    # download's leftover directory does not linger and 404 forever.
+    # Reclaim the empty quant folder so it stops 404ing on delete.
     removed_dirs = _remove_empty_variant_dirs(target_repos, variant)
     if (
         removed_snapshots == 0

--- a/studio/backend/hub/services/models/deletion.py
+++ b/studio/backend/hub/services/models/deletion.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 from pathlib import Path
 from typing import Optional
 
@@ -106,11 +107,13 @@ def _has_remaining_main_gguf(target_repo) -> bool:
     )
 
 
-def _remove_empty_variant_dirs(target_repos: list, variant: str) -> int:
+def _remove_empty_variant_dirs(target_repos: list, variant: str) -> tuple[int, list[str]]:
     """Remove now-empty ``snapshots/<rev>/<quant>/`` folders for *variant* (the
-    quant label names the folder); only empty dirs go, so siblings are safe."""
+    quant label names the folder); only empty dirs go, so siblings are safe.
+    Returns (count removed, removal failures other than a concurrent refill)."""
     variant_key = (extract_quant_token(variant) or variant).lower()
     removed = 0
+    failures: list[str] = []
     for target_repo in target_repos:
         repo_path = getattr(target_repo, "repo_path", None)
         if not repo_path:
@@ -135,15 +138,19 @@ def _remove_empty_variant_dirs(target_repos: list, variant: str) -> int:
                     matches = (
                         folder_quant is not None and folder_quant.lower() == variant_key
                     ) or sub.name.lower() == variant.lower()
-                    if not matches:
+                    if not matches or any(sub.iterdir()):
                         continue
-                    if any(sub.iterdir()):
-                        continue
-                    sub.rmdir()
-                    removed += 1
                 except OSError:
                     continue
-    return removed
+                try:
+                    sub.rmdir()
+                    removed += 1
+                except OSError as e:
+                    # A concurrent download refilling the dir (ENOTEMPTY) is not a
+                    # failure; a read-only cache or locked dir is, so surface it.
+                    if e.errno != errno.ENOTEMPTY:
+                        failures.append(f"{sub.name}: {e}")
+    return removed, failures
 
 
 def _delete_gguf_variant_from_repos(
@@ -247,7 +254,16 @@ def _delete_gguf_variant_from_repos(
 
     state_purged = download_manifest.purge_state("model", repo_id, variant)
     # Reclaim the empty quant folder so it stops 404ing on delete.
-    removed_dirs = _remove_empty_variant_dirs(target_repos, variant)
+    removed_dirs, dir_failures = _remove_empty_variant_dirs(target_repos, variant)
+    if dir_failures:
+        raise HTTPException(
+            status_code = 409,
+            detail = (
+                f"Couldn't fully delete {variant} for {repo_id}: "
+                f"{len(dir_failures)} folder(s) could not be removed "
+                "(read-only cache or in use). Try again."
+            ),
+        )
     if (
         removed_snapshots == 0
         and deleted_blobs == 0

--- a/studio/backend/hub/services/models/deletion.py
+++ b/studio/backend/hub/services/models/deletion.py
@@ -143,7 +143,7 @@ def _remove_empty_variant_dirs(target_repos: list, variant: str) -> int:
                     ) or sub.name.lower() == variant.lower()
                     if not matches:
                         continue
-                    if any(True for _ in sub.iterdir()):
+                    if any(sub.iterdir()):
                         continue
                     sub.rmdir()
                     removed += 1

--- a/studio/backend/hub/services/models/deletion.py
+++ b/studio/backend/hub/services/models/deletion.py
@@ -15,7 +15,7 @@ from loggers import get_logger
 from hub.utils import download_manifest
 from hub.utils import download_registry
 from hub.utils import inventory_scan as hf_cache_scan
-from hub.utils.gguf import extract_quant_label
+from hub.utils.gguf import extract_quant_label, extract_quant_token
 from hub.utils.hf_cache_state import (
     INCOMPLETE_SUFFIX,
     purge_partial_repo,
@@ -104,6 +104,52 @@ def _has_remaining_main_gguf(target_repo) -> bool:
             _is_main_gguf_filename,
         )
     )
+
+
+def _remove_empty_variant_dirs(target_repos: list, variant: str) -> int:
+    """Remove snapshot subfolders for *variant* that are now empty.
+
+    HF lays out a split quant as one ``snapshots/<rev>/<quant>/`` directory, so
+    the folder name is the quant label. This reclaims both the folder left behind
+    by an interrupted/cancelled download (empty from the start) and the folder
+    emptied by unlinking this variant's shards above. Only genuinely empty
+    directories are removed, so a sibling quant's files are never touched.
+    """
+    variant_key = (extract_quant_token(variant) or variant).lower()
+    removed = 0
+    for target_repo in target_repos:
+        repo_path = getattr(target_repo, "repo_path", None)
+        if not repo_path:
+            continue
+        snapshots = Path(repo_path) / "snapshots"
+        if not snapshots.is_dir():
+            continue
+        try:
+            snap_dirs = [s for s in snapshots.iterdir() if s.is_dir() and not s.is_symlink()]
+        except OSError:
+            continue
+        for snap in snap_dirs:
+            try:
+                subs = list(snap.iterdir())
+            except OSError:
+                continue
+            for sub in subs:
+                try:
+                    if sub.is_symlink() or not sub.is_dir():
+                        continue
+                    folder_quant = extract_quant_token(sub.name)
+                    matches = (
+                        folder_quant is not None and folder_quant.lower() == variant_key
+                    ) or sub.name.lower() == variant.lower()
+                    if not matches:
+                        continue
+                    if any(True for _ in sub.iterdir()):
+                        continue
+                    sub.rmdir()
+                    removed += 1
+                except OSError:
+                    continue
+    return removed
 
 
 def _delete_gguf_variant_from_repos(
@@ -206,11 +252,15 @@ def _delete_gguf_variant_from_repos(
         )
 
     state_purged = download_manifest.purge_state("model", repo_id, variant)
+    # Reclaim the now-empty (or always-empty) quant subfolder so an interrupted
+    # download's leftover directory does not linger and 404 forever.
+    removed_dirs = _remove_empty_variant_dirs(target_repos, variant)
     if (
         removed_snapshots == 0
         and deleted_blobs == 0
         and incomplete_result.deleted == 0
         and not state_purged
+        and removed_dirs == 0
     ):
         raise HTTPException(
             status_code = 404,

--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -27,6 +27,7 @@ from hub.utils.gguf import (
     extract_quant_label,
     iter_hf_cache_snapshots,
     is_big_endian_gguf_path,
+    list_empty_gguf_variant_dirs,
     list_gguf_variants,
     list_gguf_variants_from_hf_cache,
     list_local_gguf_variants,
@@ -629,6 +630,21 @@ async def get_gguf_variants_response(
                         variant.quant,
                         _partial_transport_for_variant(repo_id, variant.quant),
                     )
+
+        # An interrupted split download can leave an empty ``<quant>/`` folder
+        # with no shards: not downloaded, not a tracked partial, so otherwise
+        # invisible and unremovable. Surface it as cleanable so the UI exposes a
+        # delete affordance (deletion removes the empty folder).
+        try:
+            empty_dir_quants = {q.lower() for q in list_empty_gguf_variant_dirs(repo_id)}
+        except Exception as e:
+            logger.warning(f"Failed to scan empty GGUF variant folders for {repo_id}: {e}")
+            empty_dir_quants = set()
+        if empty_dir_quants:
+            for variant in variants:
+                if variant.quant.lower() in empty_dir_quants and not _is_fully_downloaded(variant):
+                    partial_quants.add(variant.quant)
+                    partial_quant_transports.setdefault(variant.quant, None)
 
         def _variant_detail(v) -> GgufVariantDetail:
             is_partial = v.quant in partial_quants

--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -335,7 +335,9 @@ def delete_variant_incomplete_blobs_result(
     return VariantIncompleteDeleteResult(deleted = deleted, unresolved = False)
 
 
-def _mark_empty_dir_cleanables(repo_id: str, response: GgufVariantsResponse) -> GgufVariantsResponse:
+def _mark_empty_dir_cleanables(
+    repo_id: str, response: GgufVariantsResponse
+) -> GgufVariantsResponse:
     """Surface empty leftover ``<quant>/`` folders (interrupted downloads) as
     partial so the UI can delete them -- on local/offline paths too, not just a
     remote listing. A listed quant is flipped to partial; an unlisted one is

--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -681,8 +681,22 @@ async def get_gguf_variants_response(
         )
 
     def _compute_with_cleanables() -> GgufVariantsResponse:
-        response = _compute()
-        if is_local_path(repo_id) or not _is_valid_repo_id(repo_id):
+        skip = is_local_path(repo_id) or not _is_valid_repo_id(repo_id)
+        try:
+            response = _compute()
+        except Exception:
+            # Offline / metadata fetch failed with only an empty leftover
+            # <quant>/ folder cached: still surface it so the UI can delete it,
+            # otherwise re-raise the original error.
+            if skip:
+                raise
+            enriched = _mark_empty_dir_cleanables(
+                repo_id, GgufVariantsResponse(repo_id = repo_id, variants = [])
+            )
+            if enriched.variants:
+                return enriched
+            raise
+        if skip:
             return response
         return _mark_empty_dir_cleanables(repo_id, response)
 

--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -631,10 +631,8 @@ async def get_gguf_variants_response(
                         _partial_transport_for_variant(repo_id, variant.quant),
                     )
 
-        # An interrupted split download can leave an empty ``<quant>/`` folder
-        # with no shards: not downloaded, not a tracked partial, so otherwise
-        # invisible and unremovable. Surface it as cleanable so the UI exposes a
-        # delete affordance (deletion removes the empty folder).
+        # Surface empty leftover ``<quant>/`` folders (interrupted downloads),
+        # otherwise invisible/unremovable, as cleanable so the UI can delete them.
         try:
             empty_dir_quants = {q.lower() for q in list_empty_gguf_variant_dirs(repo_id)}
         except Exception as e:

--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -335,6 +335,30 @@ def delete_variant_incomplete_blobs_result(
     return VariantIncompleteDeleteResult(deleted = deleted, unresolved = False)
 
 
+def _mark_empty_dir_cleanables(repo_id: str, response: GgufVariantsResponse) -> GgufVariantsResponse:
+    """Surface empty leftover ``<quant>/`` folders (interrupted downloads) as
+    partial so the UI can delete them -- on local/offline paths too, not just a
+    remote listing. A listed quant is flipped to partial; an unlisted one is
+    appended as a zero-byte cleanable entry."""
+    try:
+        empty_labels = list_empty_gguf_variant_dirs(repo_id)
+    except Exception as e:
+        logger.warning(f"Failed to scan empty GGUF variant folders for {repo_id}: {e}")
+        return response
+    if not empty_labels:
+        return response
+    empty_by_key = {label.lower(): label for label in empty_labels}
+    variants = list(response.variants)
+    listed = {v.quant.lower() for v in variants}
+    for i, v in enumerate(variants):
+        if v.quant.lower() in empty_by_key and not v.downloaded and not v.partial:
+            variants[i] = v.model_copy(update = {"partial": True})
+    for key, label in sorted(empty_by_key.items()):
+        if key not in listed:
+            variants.append(GgufVariantDetail(filename = f"{label}.gguf", quant = label, partial = True))
+    return response.model_copy(update = {"variants": variants})
+
+
 async def get_gguf_variants_response(
     repo_id: str,
     prefer_local_cache: bool = False,
@@ -631,19 +655,6 @@ async def get_gguf_variants_response(
                         _partial_transport_for_variant(repo_id, variant.quant),
                     )
 
-        # Surface empty leftover ``<quant>/`` folders (interrupted downloads),
-        # otherwise invisible/unremovable, as cleanable so the UI can delete them.
-        try:
-            empty_dir_quants = {q.lower() for q in list_empty_gguf_variant_dirs(repo_id)}
-        except Exception as e:
-            logger.warning(f"Failed to scan empty GGUF variant folders for {repo_id}: {e}")
-            empty_dir_quants = set()
-        if empty_dir_quants:
-            for variant in variants:
-                if variant.quant.lower() in empty_dir_quants and not _is_fully_downloaded(variant):
-                    partial_quants.add(variant.quant)
-                    partial_quant_transports.setdefault(variant.quant, None)
-
         def _variant_detail(v) -> GgufVariantDetail:
             is_partial = v.quant in partial_quants
             requirement = requirements_by_quant.get(v.quant.lower())
@@ -667,8 +678,14 @@ async def get_gguf_variants_response(
             default_variant = default_variant,
         )
 
+    def _compute_with_cleanables() -> GgufVariantsResponse:
+        response = _compute()
+        if is_local_path(repo_id) or not _is_valid_repo_id(repo_id):
+            return response
+        return _mark_empty_dir_cleanables(repo_id, response)
+
     try:
-        return await asyncio.to_thread(_compute)
+        return await asyncio.to_thread(_compute_with_cleanables)
     except HTTPException:
         raise
     except Exception as e:

--- a/studio/backend/hub/tests/test_empty_variant_folder.py
+++ b/studio/backend/hub/tests/test_empty_variant_folder.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Cleanup of empty leftover quant folders from interrupted split downloads.
-
-An interrupted/cancelled split download leaves ``snapshots/<rev>/<quant>/`` with
-no shards. Such a folder is neither downloaded nor a tracked partial, so before
-this it was invisible and a variant-delete 404'd, leaving it on disk forever.
-"""
+"""Cleanup of empty leftover quant folders from interrupted split downloads."""
 
 from pathlib import Path
 from types import SimpleNamespace
@@ -35,7 +30,7 @@ def test_list_empty_excludes_quant_with_files_in_another_snapshot(tmp_path, monk
     (snap1 / "UD-IQ1_S").mkdir(parents = True)  # empty here
     snap2 = tmp_path / "s2" / "snapshots" / "rev"
     (snap2 / "UD-IQ1_S").mkdir(parents = True)
-    (snap2 / "UD-IQ1_S" / "m-UD-IQ1_S-00001-of-00001.gguf").write_bytes(b"z")  # populated there
+    (snap2 / "UD-IQ1_S" / "m-UD-IQ1_S-00001-of-00001.gguf").write_bytes(b"z")  # has shards
     monkeypatch.setattr(gguf, "iter_hf_cache_snapshots", lambda repo_id: iter([snap1, snap2]))
     assert gguf.list_empty_gguf_variant_dirs("org/Repo-GGUF") == set()
 
@@ -53,13 +48,12 @@ def test_remove_empty_variant_dirs_removes_only_empty_match(tmp_path):
     removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_S")
     assert removed == 1
     assert not (snap / "UD-IQ1_S").exists()
-    assert (snap / "UD-IQ1_M").is_dir()  # sibling with files untouched
+    assert (snap / "UD-IQ1_M").is_dir()
 
 
 def test_remove_empty_variant_dirs_never_touches_populated_folder(tmp_path):
     snap = _make_snapshot(tmp_path)
     repo = SimpleNamespace(repo_path = str(tmp_path))
-    # Even when explicitly asked, a quant folder that still has shards stays.
     removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_M")
     assert removed == 0
     assert (snap / "UD-IQ1_M").is_dir()

--- a/studio/backend/hub/tests/test_empty_variant_folder.py
+++ b/studio/backend/hub/tests/test_empty_variant_folder.py
@@ -3,10 +3,12 @@
 
 """Cleanup of empty leftover quant folders from interrupted split downloads."""
 
+import errno
 from pathlib import Path
 from types import SimpleNamespace
 
-from hub.services.models import deletion
+from hub.schemas.inventory import GgufVariantDetail, GgufVariantsResponse
+from hub.services.models import deletion, gguf_variants
 from hub.utils import gguf
 
 
@@ -45,8 +47,9 @@ def test_list_empty_ignores_non_quant_dirs(tmp_path, monkeypatch):
 def test_remove_empty_variant_dirs_removes_only_empty_match(tmp_path):
     snap = _make_snapshot(tmp_path)
     repo = SimpleNamespace(repo_path = str(tmp_path))
-    removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_S")
+    removed, failures = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_S")
     assert removed == 1
+    assert failures == []
     assert not (snap / "UD-IQ1_S").exists()
     assert (snap / "UD-IQ1_M").is_dir()
 
@@ -54,7 +57,56 @@ def test_remove_empty_variant_dirs_removes_only_empty_match(tmp_path):
 def test_remove_empty_variant_dirs_never_touches_populated_folder(tmp_path):
     snap = _make_snapshot(tmp_path)
     repo = SimpleNamespace(repo_path = str(tmp_path))
-    removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_M")
+    removed, failures = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_M")
     assert removed == 0
-    assert (snap / "UD-IQ1_M").is_dir()
+    assert failures == []
     assert len(list((snap / "UD-IQ1_M").iterdir())) == 2
+
+
+def test_remove_empty_variant_dirs_surfaces_real_failure(tmp_path, monkeypatch):
+    _make_snapshot(tmp_path)
+    repo = SimpleNamespace(repo_path = str(tmp_path))
+
+    def _denied(self):
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(Path, "rmdir", _denied)
+    removed, failures = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_S")
+    assert removed == 0
+    assert len(failures) == 1
+
+
+def test_remove_empty_variant_dirs_ignores_concurrent_refill(tmp_path, monkeypatch):
+    _make_snapshot(tmp_path)
+    repo = SimpleNamespace(repo_path = str(tmp_path))
+
+    def _refilled(self):
+        raise OSError(errno.ENOTEMPTY, "directory not empty")
+
+    monkeypatch.setattr(Path, "rmdir", _refilled)
+    removed, failures = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_S")
+    assert removed == 0
+    assert failures == []
+
+
+def test_mark_empty_dir_cleanables_appends_unlisted(monkeypatch):
+    monkeypatch.setattr(gguf_variants, "list_empty_gguf_variant_dirs", lambda repo_id: {"UD-IQ1_S"})
+    resp = GgufVariantsResponse(
+        repo_id = "org/Repo-GGUF",
+        variants = [GgufVariantDetail(filename = "m-UD-IQ1_M.gguf", quant = "UD-IQ1_M", downloaded = True)],
+    )
+    out = gguf_variants._mark_empty_dir_cleanables("org/Repo-GGUF", resp)
+    by_q = {v.quant: v for v in out.variants}
+    assert by_q["UD-IQ1_M"].downloaded is True
+    assert by_q["UD-IQ1_S"].partial is True and by_q["UD-IQ1_S"].downloaded is False
+
+
+def test_mark_empty_dir_cleanables_flips_listed_variant(monkeypatch):
+    monkeypatch.setattr(gguf_variants, "list_empty_gguf_variant_dirs", lambda repo_id: {"UD-IQ1_S"})
+    resp = GgufVariantsResponse(
+        repo_id = "org/Repo-GGUF",
+        variants = [GgufVariantDetail(filename = "m-UD-IQ1_S.gguf", quant = "UD-IQ1_S")],
+    )
+    out = gguf_variants._mark_empty_dir_cleanables("org/Repo-GGUF", resp)
+    assert len(out.variants) == 1
+    assert out.variants[0].partial is True

--- a/studio/backend/hub/tests/test_empty_variant_folder.py
+++ b/studio/backend/hub/tests/test_empty_variant_folder.py
@@ -17,10 +17,10 @@ from hub.utils import gguf
 
 def _make_snapshot(root: Path) -> Path:
     snap = root / "snapshots" / "rev0"
-    (snap / "UD-IQ1_M").mkdir(parents=True)
+    (snap / "UD-IQ1_M").mkdir(parents = True)
     (snap / "UD-IQ1_M" / "GLM-UD-IQ1_M-00001-of-00002.gguf").write_bytes(b"x")
     (snap / "UD-IQ1_M" / "GLM-UD-IQ1_M-00002-of-00002.gguf").write_bytes(b"y")
-    (snap / "UD-IQ1_S").mkdir(parents=True)  # empty leftover
+    (snap / "UD-IQ1_S").mkdir(parents = True)  # empty leftover
     return snap
 
 
@@ -32,9 +32,9 @@ def test_list_empty_gguf_variant_dirs_finds_empty_leftover(tmp_path, monkeypatch
 
 def test_list_empty_excludes_quant_with_files_in_another_snapshot(tmp_path, monkeypatch):
     snap1 = tmp_path / "s1" / "snapshots" / "rev"
-    (snap1 / "UD-IQ1_S").mkdir(parents=True)  # empty here
+    (snap1 / "UD-IQ1_S").mkdir(parents = True)  # empty here
     snap2 = tmp_path / "s2" / "snapshots" / "rev"
-    (snap2 / "UD-IQ1_S").mkdir(parents=True)
+    (snap2 / "UD-IQ1_S").mkdir(parents = True)
     (snap2 / "UD-IQ1_S" / "m-UD-IQ1_S-00001-of-00001.gguf").write_bytes(b"z")  # populated there
     monkeypatch.setattr(gguf, "iter_hf_cache_snapshots", lambda repo_id: iter([snap1, snap2]))
     assert gguf.list_empty_gguf_variant_dirs("org/Repo-GGUF") == set()
@@ -42,14 +42,14 @@ def test_list_empty_excludes_quant_with_files_in_another_snapshot(tmp_path, monk
 
 def test_list_empty_ignores_non_quant_dirs(tmp_path, monkeypatch):
     snap = tmp_path / "snapshots" / "rev"
-    (snap / "not-a-quant").mkdir(parents=True)  # empty but not a quant label
+    (snap / "not-a-quant").mkdir(parents = True)  # empty but not a quant label
     monkeypatch.setattr(gguf, "iter_hf_cache_snapshots", lambda repo_id: iter([snap]))
     assert gguf.list_empty_gguf_variant_dirs("org/Repo-GGUF") == set()
 
 
 def test_remove_empty_variant_dirs_removes_only_empty_match(tmp_path):
     snap = _make_snapshot(tmp_path)
-    repo = SimpleNamespace(repo_path=str(tmp_path))
+    repo = SimpleNamespace(repo_path = str(tmp_path))
     removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_S")
     assert removed == 1
     assert not (snap / "UD-IQ1_S").exists()
@@ -58,7 +58,7 @@ def test_remove_empty_variant_dirs_removes_only_empty_match(tmp_path):
 
 def test_remove_empty_variant_dirs_never_touches_populated_folder(tmp_path):
     snap = _make_snapshot(tmp_path)
-    repo = SimpleNamespace(repo_path=str(tmp_path))
+    repo = SimpleNamespace(repo_path = str(tmp_path))
     # Even when explicitly asked, a quant folder that still has shards stays.
     removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_M")
     assert removed == 0

--- a/studio/backend/hub/tests/test_empty_variant_folder.py
+++ b/studio/backend/hub/tests/test_empty_variant_folder.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Cleanup of empty leftover quant folders from interrupted split downloads.
+
+An interrupted/cancelled split download leaves ``snapshots/<rev>/<quant>/`` with
+no shards. Such a folder is neither downloaded nor a tracked partial, so before
+this it was invisible and a variant-delete 404'd, leaving it on disk forever.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hub.services.models import deletion
+from hub.utils import gguf
+
+
+def _make_snapshot(root: Path) -> Path:
+    snap = root / "snapshots" / "rev0"
+    (snap / "UD-IQ1_M").mkdir(parents=True)
+    (snap / "UD-IQ1_M" / "GLM-UD-IQ1_M-00001-of-00002.gguf").write_bytes(b"x")
+    (snap / "UD-IQ1_M" / "GLM-UD-IQ1_M-00002-of-00002.gguf").write_bytes(b"y")
+    (snap / "UD-IQ1_S").mkdir(parents=True)  # empty leftover
+    return snap
+
+
+def test_list_empty_gguf_variant_dirs_finds_empty_leftover(tmp_path, monkeypatch):
+    snap = _make_snapshot(tmp_path)
+    monkeypatch.setattr(gguf, "iter_hf_cache_snapshots", lambda repo_id: iter([snap]))
+    assert gguf.list_empty_gguf_variant_dirs("org/Repo-GGUF") == {"UD-IQ1_S"}
+
+
+def test_list_empty_excludes_quant_with_files_in_another_snapshot(tmp_path, monkeypatch):
+    snap1 = tmp_path / "s1" / "snapshots" / "rev"
+    (snap1 / "UD-IQ1_S").mkdir(parents=True)  # empty here
+    snap2 = tmp_path / "s2" / "snapshots" / "rev"
+    (snap2 / "UD-IQ1_S").mkdir(parents=True)
+    (snap2 / "UD-IQ1_S" / "m-UD-IQ1_S-00001-of-00001.gguf").write_bytes(b"z")  # populated there
+    monkeypatch.setattr(gguf, "iter_hf_cache_snapshots", lambda repo_id: iter([snap1, snap2]))
+    assert gguf.list_empty_gguf_variant_dirs("org/Repo-GGUF") == set()
+
+
+def test_list_empty_ignores_non_quant_dirs(tmp_path, monkeypatch):
+    snap = tmp_path / "snapshots" / "rev"
+    (snap / "not-a-quant").mkdir(parents=True)  # empty but not a quant label
+    monkeypatch.setattr(gguf, "iter_hf_cache_snapshots", lambda repo_id: iter([snap]))
+    assert gguf.list_empty_gguf_variant_dirs("org/Repo-GGUF") == set()
+
+
+def test_remove_empty_variant_dirs_removes_only_empty_match(tmp_path):
+    snap = _make_snapshot(tmp_path)
+    repo = SimpleNamespace(repo_path=str(tmp_path))
+    removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_S")
+    assert removed == 1
+    assert not (snap / "UD-IQ1_S").exists()
+    assert (snap / "UD-IQ1_M").is_dir()  # sibling with files untouched
+
+
+def test_remove_empty_variant_dirs_never_touches_populated_folder(tmp_path):
+    snap = _make_snapshot(tmp_path)
+    repo = SimpleNamespace(repo_path=str(tmp_path))
+    # Even when explicitly asked, a quant folder that still has shards stays.
+    removed = deletion._remove_empty_variant_dirs([repo], "UD-IQ1_M")
+    assert removed == 0
+    assert (snap / "UD-IQ1_M").is_dir()
+    assert len(list((snap / "UD-IQ1_M").iterdir())) == 2

--- a/studio/backend/hub/tests/test_empty_variant_folder.py
+++ b/studio/backend/hub/tests/test_empty_variant_folder.py
@@ -110,3 +110,57 @@ def test_mark_empty_dir_cleanables_flips_listed_variant(monkeypatch):
     out = gguf_variants._mark_empty_dir_cleanables("org/Repo-GGUF", resp)
     assert len(out.variants) == 1
     assert out.variants[0].partial is True
+
+
+def _force_compute_to_raise(monkeypatch):
+    # Drive _compute() down its remote path, fail metadata, and have both cache
+    # fallbacks miss so the original error re-raises.
+    def _boom(*a, **k):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(gguf_variants, "list_gguf_variants", _boom, raising = False)
+    monkeypatch.setattr(
+        gguf_variants, "list_gguf_variants_from_hf_cache", lambda repo_id: None, raising = False
+    )
+    monkeypatch.setattr(
+        gguf_variants, "list_partial_gguf_variants_from_state", lambda repo_id: None, raising = False
+    )
+
+
+def test_get_variants_surfaces_cleanable_when_metadata_fails(monkeypatch):
+    # Offline / model_info fails and only an empty leftover folder is cached:
+    # the cleanable must still be returned instead of the error propagating.
+    import asyncio
+
+    _force_compute_to_raise(monkeypatch)
+    monkeypatch.setattr(gguf_variants, "list_empty_gguf_variant_dirs", lambda repo_id: {"UD-IQ1_S"})
+
+    resp = asyncio.run(
+        gguf_variants.get_gguf_variants_response(
+            "org/Repo-GGUF", prefer_local_cache = False, hf_token = None
+        )
+    )
+    by_q = {v.quant: v for v in resp.variants}
+    assert "UD-IQ1_S" in by_q
+    assert by_q["UD-IQ1_S"].partial is True and by_q["UD-IQ1_S"].downloaded is False
+
+
+def test_get_variants_reraises_when_no_cleanable(monkeypatch):
+    # Offline with nothing cleanable: original error must propagate (as HTTP).
+    import asyncio
+
+    from fastapi import HTTPException
+
+    _force_compute_to_raise(monkeypatch)
+    monkeypatch.setattr(gguf_variants, "list_empty_gguf_variant_dirs", lambda repo_id: set())
+
+    try:
+        asyncio.run(
+            gguf_variants.get_gguf_variants_response(
+                "org/Repo-GGUF", prefer_local_cache = False, hf_token = None
+            )
+        )
+        raised = False
+    except (HTTPException, RuntimeError):
+        raised = True
+    assert raised

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -300,7 +300,7 @@ def list_empty_gguf_variant_dirs(repo_id: str) -> set[str]:
                 quant = extract_quant_token(sub.name)
                 if not quant:
                     continue
-                has_child = any(True for _ in sub.iterdir())
+                has_child = any(sub.iterdir())
             except OSError:
                 continue
             if has_child:

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -276,6 +276,40 @@ def iter_hf_cache_snapshots(repo_id: str):
     yield from snapshots
 
 
+def list_empty_gguf_variant_dirs(repo_id: str) -> set[str]:
+    """Quant labels whose only on-disk presence is an EMPTY snapshot subfolder.
+
+    A cancelled or interrupted split download leaves the ``<quant>/`` directory
+    (e.g. ``UD-IQ1_S/``) behind with no shards. Such a folder is neither a
+    completed download nor a partial one (no ``.incomplete`` blobs, no manifest),
+    so it is otherwise invisible and cannot be removed from the UI. These labels
+    are surfaced as cleanable. A quant that has files in any snapshot is excluded
+    so a real download is never reported as an empty leftover.
+    """
+    empty: dict[str, str] = {}
+    nonempty: set[str] = set()
+    for snapshot in iter_hf_cache_snapshots(repo_id):
+        try:
+            entries = list(snapshot.iterdir())
+        except OSError:
+            continue
+        for sub in entries:
+            try:
+                if sub.is_symlink() or not sub.is_dir():
+                    continue
+                quant = extract_quant_token(sub.name)
+                if not quant:
+                    continue
+                has_child = any(True for _ in sub.iterdir())
+            except OSError:
+                continue
+            if has_child:
+                nonempty.add(quant.lower())
+            else:
+                empty.setdefault(quant.lower(), quant)
+    return {label for key, label in empty.items() if key not in nonempty}
+
+
 def list_gguf_variants_from_hf_cache(repo_id: str) -> Optional[tuple[list[GgufVariantInfo], bool]]:
     for snapshot in iter_hf_cache_snapshots(repo_id):
         variants, has_vision = list_local_gguf_variants(str(snapshot))

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -277,15 +277,8 @@ def iter_hf_cache_snapshots(repo_id: str):
 
 
 def list_empty_gguf_variant_dirs(repo_id: str) -> set[str]:
-    """Quant labels whose only on-disk presence is an EMPTY snapshot subfolder.
-
-    A cancelled or interrupted split download leaves the ``<quant>/`` directory
-    (e.g. ``UD-IQ1_S/``) behind with no shards. Such a folder is neither a
-    completed download nor a partial one (no ``.incomplete`` blobs, no manifest),
-    so it is otherwise invisible and cannot be removed from the UI. These labels
-    are surfaced as cleanable. A quant that has files in any snapshot is excluded
-    so a real download is never reported as an empty leftover.
-    """
+    """Quant labels present only as an EMPTY snapshot ``<quant>/`` folder (an
+    interrupted split download); a quant with shards in any snapshot is excluded."""
     empty: dict[str, str] = {}
     nonempty: set[str] = set()
     for snapshot in iter_hf_cache_snapshots(repo_id):


### PR DESCRIPTION
## Problem

An interrupted or cancelled split GGUF download leaves `snapshots/<rev>/<quant>/` behind with no shards (e.g. an empty `UD-IQ1_S/`). Such a folder is neither a completed download nor a tracked partial: there are no `.incomplete` blobs and no manifest. As a result:

- It does not appear in the variant list as downloaded or partial, so there is no delete affordance for it.
- A per-variant delete for that quant returns `404 Variant <q> not found in cache`, because nothing matched and no state was purged.

So the empty folder lingers on disk forever with no way to remove it from the UI. This is the real cause behind "I downloaded a quant, cancelled/interrupted it, and now I can't delete it."

Reproduced with `unsloth/GLM-5.2-GGUF`: `UD-IQ1_M` fully on disk and an empty `UD-IQ1_S/` left from a stopped download. The card showed every quant but `UD-IQ1_S` had no way to be cleared, and deleting it 404'd.

## Fix

- `list_empty_gguf_variant_dirs(repo_id)` (hub/utils/gguf.py): detect quant subfolders that are empty in every cache snapshot, excluding any quant that has shards in another snapshot so a real download is never reported as an empty leftover.
- `get_gguf_variants_response` (hub/services/models/gguf_variants.py): surface those quants as `partial` (cleanable) so the existing UI exposes a delete affordance.
- `_delete_gguf_variant_from_repos` (hub/services/models/deletion.py): after unlinking a variant's shards, remove the now-empty (or always-empty) quant subfolder and count it toward the result, so the delete succeeds instead of 404. Only genuinely empty directories are removed, so a sibling quant's files are never touched.

## Testing

- New `hub/tests/test_empty_variant_folder.py`: detection finds the empty leftover, excludes a quant populated in another snapshot, ignores non-quant dirs, and removal deletes only the empty match while leaving populated folders intact.
- Service-layer check against a fabricated cache (`UD-IQ1_M` full + empty `UD-IQ1_S`): the variant list marks `UD-IQ1_S` partial/cleanable, deleting it returns `{"status":"deleted"}` (no 404) and removes the folder with `UD-IQ1_M` untouched, and deleting a real variant also reclaims its now-empty folder.
- Full `hub/tests` suite passes (114).