### PR TITLE
Installer: don't require cmake/Homebrew on macOS (prebuilt llama.cpp)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1534,13 +1534,10 @@ _maybe_reroute_strixhalo_to_2404() {
 _maybe_reroute_strixhalo_to_2404 || true
 
 # ── Check system dependencies ──
-# A *source* build of the GGUF inference engine (llama.cpp) needs git to clone it
-# and cmake to compile it. Studio downloads a prebuilt llama.cpp by default,
-# which needs neither: they're only used by the source-build fallback, which
-# studio/setup.sh self-skips (degrading gracefully) when they're absent. So on
-# macOS -- where requiring cmake otherwise forces a manual Homebrew install -- we
-# don't block on it; on Linux it's available through the system package manager,
-# so we keep requiring it there.
+# cmake/git are only needed to *build* llama.cpp from source. Studio downloads a
+# prebuilt by default, and setup.sh self-skips the source build when they're
+# absent -- so macOS doesn't block on cmake (requiring it would force a manual
+# Homebrew install). Linux keeps requiring them; its package manager has them.
 tauri_log "STEP" "Checking system dependencies"
 
 case "$OS" in

--- a/install.sh
+++ b/install.sh
@@ -1534,17 +1534,19 @@ _maybe_reroute_strixhalo_to_2404() {
 _maybe_reroute_strixhalo_to_2404 || true
 
 # ── Check system dependencies ──
-# cmake and git are needed by unsloth studio setup to build the GGUF inference
-# engine (llama.cpp). build-essential and libcurl-dev are also needed on Linux.
+# A *source* build of the GGUF inference engine (llama.cpp) needs git to clone it
+# and cmake to compile it. Studio downloads a prebuilt llama.cpp by default,
+# which needs neither: they're only used by the source-build fallback, which
+# studio/setup.sh self-skips (degrading gracefully) when they're absent. So on
+# macOS -- where requiring cmake otherwise forces a manual Homebrew install -- we
+# don't block on it; on Linux it installs painlessly via apt, so we keep
+# requiring it there.
 tauri_log "STEP" "Checking system dependencies"
 MISSING=""
 
-command -v cmake >/dev/null 2>&1 || MISSING="$MISSING cmake"
-command -v git   >/dev/null 2>&1 || MISSING="$MISSING git"
-
 case "$OS" in
     macos)
-        # Xcode Command Line Tools provide the C/C++ compiler
+        # Xcode Command Line Tools provide the C/C++ compiler and git.
         if ! xcode-select -p >/dev/null 2>&1; then
             echo ""
             echo "==> Xcode Command Line Tools are required."
@@ -1553,8 +1555,18 @@ case "$OS" in
             echo "    After the installation completes, please re-run this script."
             exit 1
         fi
+        # cmake is only needed for a source build; the default prebuilt path
+        # doesn't use it, so its absence is not fatal -- no Homebrew prerequisite.
+        if command -v cmake >/dev/null 2>&1; then
+            step "deps" "all system dependencies found"
+        else
+            step "deps" "using prebuilt llama.cpp (cmake not found)" "$C_WARN"
+            substep "Install cmake only if you want a source build: brew install cmake"
+        fi
         ;;
     linux|wsl)
+        command -v cmake >/dev/null 2>&1 || MISSING="$MISSING cmake"
+        command -v git   >/dev/null 2>&1 || MISSING="$MISSING git"
         # curl or wget is needed for downloads; check both
         if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
             MISSING="$MISSING curl"
@@ -1562,27 +1574,12 @@ case "$OS" in
         command -v gcc  >/dev/null 2>&1 || MISSING="$MISSING build-essential"
         # libcurl dev headers for llama.cpp HTTPS support
         command -v curl-config >/dev/null 2>&1 || MISSING="$MISSING libcurl4-openssl-dev"
-        ;;
-esac
 
-MISSING=$(echo "$MISSING" | sed 's/^ *//')
-
-if [ -n "$MISSING" ]; then
-    echo ""
-    step "deps" "missing: $MISSING" "$C_WARN"
-    substep "These are needed to build the GGUF inference engine."
-
-    case "$OS" in
-        macos)
-            if ! command -v brew >/dev/null 2>&1; then
-                echo ""
-                echo "    Homebrew is required to install them."
-                echo "    Install Homebrew from https://brew.sh then re-run this script."
-                exit 1
-            fi
-            brew install $MISSING </dev/null
-            ;;
-        linux|wsl)
+        MISSING=$(echo "$MISSING" | sed 's/^ *//')
+        if [ -n "$MISSING" ]; then
+            echo ""
+            step "deps" "missing: $MISSING" "$C_WARN"
+            substep "These are needed to build the GGUF inference engine."
             if command -v apt-get >/dev/null 2>&1; then
                 _smart_apt_install $MISSING
             else
@@ -1597,12 +1594,12 @@ if [ -n "$MISSING" ]; then
                 echo "      openSUSE:   sudo zypper install cmake git gcc gcc-c++ make libcurl-devel"
                 exit 1
             fi
-            ;;
-    esac
-    echo ""
-else
-    step "deps" "all system dependencies found"
-fi
+            echo ""
+        else
+            step "deps" "all system dependencies found"
+        fi
+        ;;
+esac
 
 # ── Install uv ──
 tauri_log "STEP" "Installing uv package manager"

--- a/install.sh
+++ b/install.sh
@@ -1539,10 +1539,9 @@ _maybe_reroute_strixhalo_to_2404 || true
 # which needs neither: they're only used by the source-build fallback, which
 # studio/setup.sh self-skips (degrading gracefully) when they're absent. So on
 # macOS -- where requiring cmake otherwise forces a manual Homebrew install -- we
-# don't block on it; on Linux it installs painlessly via apt, so we keep
-# requiring it there.
+# don't block on it; on Linux it's available through the system package manager,
+# so we keep requiring it there.
 tauri_log "STEP" "Checking system dependencies"
-MISSING=""
 
 case "$OS" in
     macos)
@@ -1565,6 +1564,7 @@ case "$OS" in
         fi
         ;;
     linux|wsl)
+        MISSING=""
         command -v cmake >/dev/null 2>&1 || MISSING="$MISSING cmake"
         command -v git   >/dev/null 2>&1 || MISSING="$MISSING git"
         # curl or wget is needed for downloads; check both


### PR DESCRIPTION
Installing on a clean Mac failed with "Homebrew is required to install them. Install Homebrew from https://brew.sh" because cmake was missing. 

## Problem

`install.sh` checks for `cmake` (and `git`) up front for all platforms, and on macOS a missing one is a hard `exit 1` telling the user to install Homebrew first. This runs before `studio/setup.sh`, so the user is blocked at the gate.

But cmake and git are only needed to build llama.cpp from source. Studio downloads a prebuilt llama.cpp by default (published for both Apple Silicon `bin-macos-arm64` and Intel `bin-macos-x64`), which needs neither. `setup.sh` already knows this: it tries the prebuilt first and only falls back to a source build when the prebuilt is unavailable, and that fallback self-skips (degrading gracefully) when cmake/git are absent.

So `install.sh`'s upfront gate is the inconsistency. `setup.sh` already treats these deps as optional, but the gate aborts on macOS before that logic ever runs, forcing Homebrew for a tool the common path never uses.

## Fix

Don't block the macOS install on cmake. The Xcode Command Line Tools check stays, since it provides the compiler and git. A missing cmake is now a non-fatal note ("using prebuilt llama.cpp"), with a hint to run `brew install cmake` only if you want a source build. Linux is unchanged: cmake, git, and build-essential still install via apt there, so they stay required.

## Verification

Validated with a throwaway CI run at https://github.com/oobabooga/unsloth/pull/1, which exercised arm64 and x86_64 installs, with or without cmake installed:

<img width="832" height="475" alt="image" src="https://github.com/user-attachments/assets/e2857fa6-ab28-4adf-87e3-8e66eb1bb644" />

Also:

- `sh -n install.sh` passes. Existing installer tests pass (`test_mac_intel_compat.sh` 56/56, `test_cross_platform_parity.py` 11/11). No test asserted the old "Homebrew is required" behavior.
- The macOS prebuilt bundle ships both `llama-server` and `llama-quantize` (verified against the latest release asset), and `install_llama_prebuilt.py` installs and smoke-tests them. So GGUF inference and GGUF export both work on the prebuilt path with no cmake. cmake was never what enabled them there; the source build only runs when the prebuilt fails.
- git stays available on macOS via Xcode CLT, so the later `unsloth-zoo @ git+...` overlay still works.
- `cmake` and `git` are only invoked by `setup.sh` on the source-build fallback, which sets `_LLAMA_CPP_DEGRADED` and warns rather than aborting when they're missing.
