### PR TITLE
Match IGNORED_TOKENIZER_NAMES case-insensitively

### DIFF
--- a/tests/test_ignored_tokenizer_casing.py
+++ b/tests/test_ignored_tokenizer_casing.py
@@ -30,6 +30,7 @@ def _fake_auto_tokenizer():
     # return distinguishable stand-ins so we can see which one is returned.
     def from_pretrained(name, **kwargs):
         return _Tok("slow" if kwargs.get("from_slow") else "fast")
+
     return types.SimpleNamespace(from_pretrained = from_pretrained)
 
 
@@ -41,9 +42,11 @@ def test_ignored_tokenizer_name_matched_case_insensitively():
     name = "unsloth/Qwen2.5-Coder-7B-Instruct"  # name.lower() is in IGNORED_TOKENIZER_NAMES
     assert name.lower() in tu.IGNORED_TOKENIZER_NAMES  # guard the test's own premise
 
-    with patch.object(tu, "AutoTokenizer", _fake_auto_tokenizer()), \
-         patch.object(tu, "assert_same_tokenization", lambda a, b: False), \
-         patch.object(tu, "convert_to_fast_tokenizer", lambda slow, **k: _Tok("converted")):
+    with (
+        patch.object(tu, "AutoTokenizer", _fake_auto_tokenizer()),
+        patch.object(tu, "assert_same_tokenization", lambda a, b: False),
+        patch.object(tu, "convert_to_fast_tokenizer", lambda slow, **k: _Tok("converted")),
+    ):
         result = tu._load_correct_tokenizer(name, fix_tokenizer = True)
 
     assert result.kind == "fast", (

--- a/tests/test_ignored_tokenizer_casing.py
+++ b/tests/test_ignored_tokenizer_casing.py
@@ -1,0 +1,57 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: the IGNORED_TOKENIZER_NAMES guard must match case-insensitively."""
+
+import types
+from unittest.mock import patch
+
+import unsloth.tokenizer_utils as tu
+
+
+class _Tok:
+    def __init__(self, kind):
+        self.kind = kind
+
+
+def _fake_auto_tokenizer():
+    # _load_correct_tokenizer loads a slow tokenizer (from_slow = True) and a fast one;
+    # return distinguishable stand-ins so we can see which one is returned.
+    def from_pretrained(name, **kwargs):
+        return _Tok("slow" if kwargs.get("from_slow") else "fast")
+    return types.SimpleNamespace(from_pretrained = from_pretrained)
+
+
+def test_ignored_tokenizer_name_matched_case_insensitively():
+    # IGNORED_TOKENIZER_NAMES is stored fully lowercased, but users pass canonical
+    # mixed-case ids. The names in this list (e.g. the Qwen2.5-Coder tokenizers) must be
+    # returned untouched; before the fix the mixed-case name never matched, so it fell
+    # through into the slow/fast reconciliation + conversion path.
+    name = "unsloth/Qwen2.5-Coder-7B-Instruct"  # name.lower() is in IGNORED_TOKENIZER_NAMES
+    assert name.lower() in tu.IGNORED_TOKENIZER_NAMES  # guard the test's own premise
+
+    with patch.object(tu, "AutoTokenizer", _fake_auto_tokenizer()), \
+         patch.object(tu, "assert_same_tokenization", lambda a, b: False), \
+         patch.object(tu, "convert_to_fast_tokenizer", lambda slow, **k: _Tok("converted")):
+        result = tu._load_correct_tokenizer(name, fix_tokenizer = True)
+
+    assert result.kind == "fast", (
+        "an ignored tokenizer (matched case-insensitively) must be returned unchanged, "
+        f"but it fell through to conversion (got {result.kind!r})"
+    )
+
+
+if __name__ == "__main__":
+    test_ignored_tokenizer_name_matched_case_insensitively()
+    print("ok")

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -601,7 +601,7 @@ def _load_correct_tokenizer(
         cache_dir = cache_dir,
     )
 
-    if not fix_tokenizer or tokenizer_name in IGNORED_TOKENIZER_NAMES:
+    if not fix_tokenizer or tokenizer_name.lower() in IGNORED_TOKENIZER_NAMES:
         return fast_tokenizer
     # Ignore Mistral ones - they're a bit weird to handle!
     elif "mistral" in tokenizer_name.lower():


### PR DESCRIPTION
### What

`IGNORED_TOKENIZER_NAMES` is built fully lowercased:

```python
IGNORED_TOKENIZER_NAMES = frozenset(
    [x.lower() for x in IGNORED_TOKENIZER_NAMES]
    + [x.lower() + "-bnb-4bit" for x in IGNORED_TOKENIZER_NAMES]
)
```

but `_load_correct_tokenizer` checked membership against the raw, un-lowercased name:

```python
if not fix_tokenizer or tokenizer_name in IGNORED_TOKENIZER_NAMES:
    return fast_tokenizer
elif "mistral" in tokenizer_name.lower():   # sibling checks lowercase
    return fast_tokenizer
elif "phi-4" in tokenizer_name.lower():
    return fast_tokenizer
```

Users pass canonical mixed-case ids (e.g. `unsloth/Qwen2.5-Coder-7B-Instruct`), so the lookup was **always False** for exactly the names the list exists to catch. Those tokenizers (the Qwen2.5-Coder ones the list deliberately leaves alone, per the inline comment "Qwen Coder did not train on tool calling") then fell through into the slow/fast reconciliation and legacy-conversion path the guard was meant to skip.

### Fix

Lowercase `tokenizer_name` before the membership check, matching the adjacent `"mistral"`/`"phi-4"` checks. One-token change, no behavior change for any name not in the list.

### Test

Added `tests/test_ignored_tokenizer_casing.py`: with the vLLM/transformers calls stubbed (CPU-only, no download), it asserts a canonical mixed-case ignored name is returned untouched. Fails before this change (the name falls through to conversion), passes after.
