### PR TITLE
Fix fast_inference crash on ABI-broken vLLM: probe compiled extensions, not just import vllm

### DIFF
--- a/tests/test_vllm_broken_detection.py
+++ b/tests/test_vllm_broken_detection.py
@@ -11,14 +11,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 
-"""Regression test for issue #6590: ``fast_inference=True`` crashed with
-``ImportError: libcudart.so.13`` because modern vLLM loads its compiled
-extensions lazily. A bare ``import vllm`` succeeds even when ``vllm._C`` (or a
-sibling like ``vllm._C_stable_libtorch``) is ABI-broken, so
-``disable_broken_vllm`` never fired and the failure surfaced uncaught later
-inside ``fast_inference_setup``.
-
-Runs under the GPU-free ``tests/conftest.py`` with a synthetic vLLM."""
+"""Regression test for #6590: modern vLLM lazy-loads its compiled extensions, so
+a bare ``import vllm`` succeeds even when ``vllm._C`` (or a sibling) is ABI-broken
+and ``disable_broken_vllm`` missed it. GPU-free, via a synthetic vLLM."""
 
 from __future__ import annotations
 
@@ -36,7 +31,7 @@ _LIBCUDART_ERROR = "libcudart.so.13: cannot open shared object file: No such fil
 
 
 class _ExtensionLoader(importlib.abc.Loader):
-    """A compiled extension that either loads cleanly or fails on dlopen."""
+    """A compiled extension that loads cleanly or fails on dlopen."""
 
     def __init__(self, broken, error):
         self.broken = broken
@@ -51,14 +46,13 @@ class _ExtensionLoader(importlib.abc.Loader):
 
 
 class _FakeVllmFinder(importlib.abc.MetaPathFinder):
-    """A lazy-loading vLLM: ``import vllm`` is fine, and each ``vllm._*``
-    extension is present-and-healthy, present-but-ABI-broken, or absent —
-    mirroring how real vLLM only loads ``_C`` & friends when used."""
+    """Lazy vLLM: ``import vllm`` succeeds; each ``vllm._*`` ext is healthy,
+    ABI-broken, or absent, as real vLLM only loads ``_C`` & friends on use."""
 
     def __init__(self, present, broken, error):
-        self.present = present  # extensions this build ships
-        self.broken = broken  # subset of present that fails to dlopen
-        self.error = error  # dlopen message the broken ones raise
+        self.present = present
+        self.broken = broken
+        self.error = error
 
     def find_spec(
         self,
@@ -81,9 +75,8 @@ def _fake_vllm(
     broken,
     error = _LIBCUDART_ERROR,
 ):
-    """Install a synthetic lazy vLLM and restore every global the guard
-    touches (VLLM_BROKEN, the find_spec patch + meta-path blocker, and the
-    vllm* sys.modules entries) on exit."""
+    """Install a synthetic lazy vLLM, restoring VLLM_BROKEN, find_spec,
+    meta_path, and the vllm* sys.modules entries on exit."""
     from unsloth import import_fixes
 
     submodules = import_fixes._VLLM_COMPILED_EXTENSIONS
@@ -118,8 +111,7 @@ def _fake_vllm(
     ids = ["core_C", "sibling_C_stable_libtorch"],
 )
 def test_disable_broken_vllm_detects_lazy_loaded_broken_extension(broken_ext):
-    # A CUDA-major mismatch breaks every extension, but the break can surface
-    # through any one vLLM lazily loads — _C or a sibling. Either must be caught.
+    # A CUDA-major mismatch breaks every ext; whichever one loads first must trip detection.
     present = {"vllm._C", "vllm._C_stable_libtorch"}
     with _fake_vllm(present = present, broken = {broken_ext}) as import_fixes:
         detected = import_fixes.disable_broken_vllm()
@@ -142,10 +134,8 @@ def test_disable_broken_vllm_detects_lazy_loaded_broken_extension(broken_ext):
     ids = ["libnccl", "libcuda"],
 )
 def test_disable_broken_vllm_detects_non_cudart_so_failure(error):
-    # Force-loading vllm._C directly raises the bare loader error, without
-    # vLLM's "vllm._C" wrapper. A CUDA-major mismatch can surface through a
-    # linked .so other than libcudart (libnccl, libcuda, ...), which the old
-    # libcudart/libcublas/libnvrtc allow-list would have let slip through.
+    # A CUDA mismatch can surface through a non-libcudart .so (libnccl, libcuda),
+    # which the old libcudart/libcublas/libnvrtc allow-list let slip through.
     with _fake_vllm(present = {"vllm._C"}, broken = {"vllm._C"}, error = error) as import_fixes:
         detected = import_fixes.disable_broken_vllm()
 
@@ -162,10 +152,8 @@ def test_disable_broken_vllm_detects_non_cudart_so_failure(error):
     ids = ["core_only", "all_present"],
 )
 def test_disable_broken_vllm_keeps_healthy_vllm_enabled(present):
-    # A normal install: every extension that's present loads cleanly. Whether
-    # only _C is built or _C plus siblings are, the probe must not disable it —
-    # neither a ModuleNotFoundError on an absent sibling nor a clean load of an
-    # extra present one may be mistaken for an ABI break.
+    # Healthy install: an absent sibling (ModuleNotFoundError) or an extra present
+    # ext that loads cleanly must NOT be mistaken for an ABI break.
     with _fake_vllm(present = present, broken = set()) as import_fixes:
         detected = import_fixes.disable_broken_vllm()
 

--- a/tests/test_vllm_broken_detection.py
+++ b/tests/test_vllm_broken_detection.py
@@ -32,9 +32,7 @@ import types
 import pytest
 
 
-_LIBCUDART_ERROR = (
-    "libcudart.so.13: cannot open shared object file: No such file or directory"
-)
+_LIBCUDART_ERROR = "libcudart.so.13: cannot open shared object file: No such file or directory"
 
 
 class _ExtensionLoader(importlib.abc.Loader):
@@ -58,14 +56,19 @@ class _FakeVllmFinder(importlib.abc.MetaPathFinder):
 
     def __init__(self, present, broken):
         self.present = present  # extensions this build ships
-        self.broken = broken    # subset of present that fails to dlopen
+        self.broken = broken  # subset of present that fails to dlopen
 
-    def find_spec(self, fullname, path=None, target=None):
+    def find_spec(
+        self,
+        fullname,
+        path = None,
+        target = None,
+    ):
         if fullname in self.present:
             return importlib.machinery.ModuleSpec(
-                name=fullname,
-                loader=_ExtensionLoader(broken=fullname in self.broken),
-                is_package=False,
+                name = fullname,
+                loader = _ExtensionLoader(broken = fullname in self.broken),
+                is_package = False,
             )
         return None  # absent -> ModuleNotFoundError, which the guard ignores
 
@@ -86,9 +89,7 @@ def _fake_vllm(present, broken):
         import_fixes.VLLM_BROKEN = False
         fake_vllm = types.ModuleType("vllm")
         fake_vllm.__path__ = []
-        fake_vllm.__spec__ = importlib.machinery.ModuleSpec(
-            "vllm", loader=None, is_package=True
-        )
+        fake_vllm.__spec__ = importlib.machinery.ModuleSpec("vllm", loader = None, is_package = True)
         sys.modules["vllm"] = fake_vllm
         for name in submodules:
             sys.modules.pop(name, None)
@@ -108,13 +109,13 @@ def _fake_vllm(present, broken):
 @pytest.mark.parametrize(
     "broken_ext",
     ["vllm._C", "vllm._C_stable_libtorch"],
-    ids=["core_C", "sibling_C_stable_libtorch"],
+    ids = ["core_C", "sibling_C_stable_libtorch"],
 )
 def test_disable_broken_vllm_detects_lazy_loaded_broken_extension(broken_ext):
     # A CUDA-major mismatch breaks every extension, but the break can surface
     # through any one vLLM lazily loads — _C or a sibling. Either must be caught.
     present = {"vllm._C", "vllm._C_stable_libtorch"}
-    with _fake_vllm(present=present, broken={broken_ext}) as import_fixes:
+    with _fake_vllm(present = present, broken = {broken_ext}) as import_fixes:
         detected = import_fixes.disable_broken_vllm()
 
         assert detected is True, (
@@ -130,7 +131,7 @@ def test_disable_broken_vllm_keeps_healthy_vllm_enabled():
     # _C loads cleanly and the other extensions simply aren't built — a normal
     # install. The probe's ModuleNotFoundError on absent siblings must NOT be
     # mistaken for an ABI break.
-    with _fake_vllm(present={"vllm._C"}, broken=set()) as import_fixes:
+    with _fake_vllm(present = {"vllm._C"}, broken = set()) as import_fixes:
         detected = import_fixes.disable_broken_vllm()
 
         assert detected is False

--- a/tests/test_vllm_broken_detection.py
+++ b/tests/test_vllm_broken_detection.py
@@ -38,15 +38,16 @@ _LIBCUDART_ERROR = "libcudart.so.13: cannot open shared object file: No such fil
 class _ExtensionLoader(importlib.abc.Loader):
     """A compiled extension that either loads cleanly or fails on dlopen."""
 
-    def __init__(self, broken):
+    def __init__(self, broken, error):
         self.broken = broken
+        self.error = error
 
     def create_module(self, spec):
         return None
 
     def exec_module(self, module):
         if self.broken:
-            raise ImportError(_LIBCUDART_ERROR)
+            raise ImportError(self.error)
 
 
 class _FakeVllmFinder(importlib.abc.MetaPathFinder):
@@ -54,9 +55,10 @@ class _FakeVllmFinder(importlib.abc.MetaPathFinder):
     extension is present-and-healthy, present-but-ABI-broken, or absent —
     mirroring how real vLLM only loads ``_C`` & friends when used."""
 
-    def __init__(self, present, broken):
+    def __init__(self, present, broken, error):
         self.present = present  # extensions this build ships
         self.broken = broken  # subset of present that fails to dlopen
+        self.error = error  # dlopen message the broken ones raise
 
     def find_spec(
         self,
@@ -67,14 +69,18 @@ class _FakeVllmFinder(importlib.abc.MetaPathFinder):
         if fullname in self.present:
             return importlib.machinery.ModuleSpec(
                 name = fullname,
-                loader = _ExtensionLoader(broken = fullname in self.broken),
+                loader = _ExtensionLoader(broken = fullname in self.broken, error = self.error),
                 is_package = False,
             )
         return None  # absent -> ModuleNotFoundError, which the guard ignores
 
 
 @contextlib.contextmanager
-def _fake_vllm(present, broken):
+def _fake_vllm(
+    present,
+    broken,
+    error = _LIBCUDART_ERROR,
+):
     """Install a synthetic lazy vLLM and restore every global the guard
     touches (VLLM_BROKEN, the find_spec patch + meta-path blocker, and the
     vllm* sys.modules entries) on exit."""
@@ -93,7 +99,7 @@ def _fake_vllm(present, broken):
         sys.modules["vllm"] = fake_vllm
         for name in submodules:
             sys.modules.pop(name, None)
-        sys.meta_path.insert(0, _FakeVllmFinder(present, broken))
+        sys.meta_path.insert(0, _FakeVllmFinder(present, broken, error))
         yield import_fixes
     finally:
         import_fixes.VLLM_BROKEN = saved_broken
@@ -127,11 +133,40 @@ def test_disable_broken_vllm_detects_lazy_loaded_broken_extension(broken_ext):
         assert importlib.util.find_spec("vllm") is None
 
 
-def test_disable_broken_vllm_keeps_healthy_vllm_enabled():
-    # _C loads cleanly and the other extensions simply aren't built — a normal
-    # install. The probe's ModuleNotFoundError on absent siblings must NOT be
-    # mistaken for an ABI break.
-    with _fake_vllm(present = {"vllm._C"}, broken = set()) as import_fixes:
+@pytest.mark.parametrize(
+    "error",
+    [
+        "libnccl.so.2: cannot open shared object file: No such file or directory",
+        "libcuda.so.1: cannot open shared object file: No such file or directory",
+    ],
+    ids = ["libnccl", "libcuda"],
+)
+def test_disable_broken_vllm_detects_non_cudart_so_failure(error):
+    # Force-loading vllm._C directly raises the bare loader error, without
+    # vLLM's "vllm._C" wrapper. A CUDA-major mismatch can surface through a
+    # linked .so other than libcudart (libnccl, libcuda, ...), which the old
+    # libcudart/libcublas/libnvrtc allow-list would have let slip through.
+    with _fake_vllm(present = {"vllm._C"}, broken = {"vllm._C"}, error = error) as import_fixes:
+        detected = import_fixes.disable_broken_vllm()
+
+        assert detected is True, (
+            f"disable_broken_vllm missed a present-but-broken vllm._C raising "
+            f"{error!r} — vLLM would be left enabled and crash later."
+        )
+        assert import_fixes.VLLM_BROKEN is True
+
+
+@pytest.mark.parametrize(
+    "present",
+    [{"vllm._C"}, {"vllm._C", "vllm._C_stable_libtorch", "vllm._moe_C"}],
+    ids = ["core_only", "all_present"],
+)
+def test_disable_broken_vllm_keeps_healthy_vllm_enabled(present):
+    # A normal install: every extension that's present loads cleanly. Whether
+    # only _C is built or _C plus siblings are, the probe must not disable it —
+    # neither a ModuleNotFoundError on an absent sibling nor a clean load of an
+    # extra present one may be mistaken for an ABI break.
+    with _fake_vllm(present = present, broken = set()) as import_fixes:
         detected = import_fixes.disable_broken_vllm()
 
         assert detected is False

--- a/tests/test_vllm_broken_detection.py
+++ b/tests/test_vllm_broken_detection.py
@@ -1,0 +1,142 @@
+# Unsloth - 2x faster, 60% less VRAM LLM training and finetuning
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+"""Regression test for issue #6590: ``fast_inference=True`` crashed with
+``ImportError: libcudart.so.13`` because modern vLLM loads its compiled
+extensions lazily. A bare ``import vllm`` succeeds even when ``vllm._C`` (or a
+sibling like ``vllm._C_stable_libtorch``) is ABI-broken, so
+``disable_broken_vllm`` never fired and the failure surfaced uncaught later
+inside ``fast_inference_setup``.
+
+Runs under the GPU-free ``tests/conftest.py`` with a synthetic vLLM."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+import pytest
+
+
+_LIBCUDART_ERROR = (
+    "libcudart.so.13: cannot open shared object file: No such file or directory"
+)
+
+
+class _ExtensionLoader(importlib.abc.Loader):
+    """A compiled extension that either loads cleanly or fails on dlopen."""
+
+    def __init__(self, broken):
+        self.broken = broken
+
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        if self.broken:
+            raise ImportError(_LIBCUDART_ERROR)
+
+
+class _FakeVllmFinder(importlib.abc.MetaPathFinder):
+    """A lazy-loading vLLM: ``import vllm`` is fine, and each ``vllm._*``
+    extension is present-and-healthy, present-but-ABI-broken, or absent —
+    mirroring how real vLLM only loads ``_C`` & friends when used."""
+
+    def __init__(self, present, broken):
+        self.present = present  # extensions this build ships
+        self.broken = broken    # subset of present that fails to dlopen
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in self.present:
+            return importlib.machinery.ModuleSpec(
+                name=fullname,
+                loader=_ExtensionLoader(broken=fullname in self.broken),
+                is_package=False,
+            )
+        return None  # absent -> ModuleNotFoundError, which the guard ignores
+
+
+@contextlib.contextmanager
+def _fake_vllm(present, broken):
+    """Install a synthetic lazy vLLM and restore every global the guard
+    touches (VLLM_BROKEN, the find_spec patch + meta-path blocker, and the
+    vllm* sys.modules entries) on exit."""
+    from unsloth import import_fixes
+
+    submodules = import_fixes._VLLM_COMPILED_EXTENSIONS
+    saved_meta_path = list(sys.meta_path)
+    saved_find_spec = importlib.util.find_spec
+    saved_broken = import_fixes.VLLM_BROKEN
+    saved_modules = {n: sys.modules.get(n) for n in ("vllm", *submodules)}
+    try:
+        import_fixes.VLLM_BROKEN = False
+        fake_vllm = types.ModuleType("vllm")
+        fake_vllm.__path__ = []
+        fake_vllm.__spec__ = importlib.machinery.ModuleSpec(
+            "vllm", loader=None, is_package=True
+        )
+        sys.modules["vllm"] = fake_vllm
+        for name in submodules:
+            sys.modules.pop(name, None)
+        sys.meta_path.insert(0, _FakeVllmFinder(present, broken))
+        yield import_fixes
+    finally:
+        import_fixes.VLLM_BROKEN = saved_broken
+        sys.meta_path[:] = saved_meta_path
+        importlib.util.find_spec = saved_find_spec
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+@pytest.mark.parametrize(
+    "broken_ext",
+    ["vllm._C", "vllm._C_stable_libtorch"],
+    ids=["core_C", "sibling_C_stable_libtorch"],
+)
+def test_disable_broken_vllm_detects_lazy_loaded_broken_extension(broken_ext):
+    # A CUDA-major mismatch breaks every extension, but the break can surface
+    # through any one vLLM lazily loads — _C or a sibling. Either must be caught.
+    present = {"vllm._C", "vllm._C_stable_libtorch"}
+    with _fake_vllm(present=present, broken={broken_ext}) as import_fixes:
+        detected = import_fixes.disable_broken_vllm()
+
+        assert detected is True, (
+            f"disable_broken_vllm missed an ABI-broken {broken_ext} behind a "
+            "lazily-importable vllm package — issue #6590 would resurface."
+        )
+        assert import_fixes.VLLM_BROKEN is True
+        # Once disabled, vLLM must look absent so callers fall back cleanly.
+        assert importlib.util.find_spec("vllm") is None
+
+
+def test_disable_broken_vllm_keeps_healthy_vllm_enabled():
+    # _C loads cleanly and the other extensions simply aren't built — a normal
+    # install. The probe's ModuleNotFoundError on absent siblings must NOT be
+    # mistaken for an ABI break.
+    with _fake_vllm(present={"vllm._C"}, broken=set()) as import_fixes:
+        detected = import_fixes.disable_broken_vllm()
+
+        assert detected is False
+        assert import_fixes.VLLM_BROKEN is False
+        assert importlib.util.find_spec("vllm") is not None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -36,17 +36,15 @@ from .import_fixes import (
     fix_huggingface_hub,
 )
 
-# Redirect a read-only Hugging Face cache before anything below can import
-# huggingface_hub / transformers / vllm (disable_broken_vllm probes
-# `import vllm` and its compiled extensions, check_fbgemm_gpu_version
-# imports transformers, and fix_huggingface_hub imports huggingface_hub
-# itself), all of which can
-# freeze Hub's cache constants with the un-redirected paths. unsloth_zoo
-# runs the same redirect at import, but that happens after these probes.
-# hf_cache.py is stdlib-only, so load it straight from its file without
-# triggering the full unsloth_zoo package init this early; the zoo's own
-# call later is an idempotent no-op. Older unsloth_zoo without hf_cache.py
-# is skipped silently.
+# Redirect a read-only Hugging Face cache before anything below imports
+# huggingface_hub / transformers / vllm (disable_broken_vllm probes `import vllm`
+# and its compiled extensions, check_fbgemm_gpu_version imports transformers,
+# fix_huggingface_hub imports huggingface_hub) -- any of which would freeze Hub's
+# cache constants with the un-redirected paths. unsloth_zoo runs the same redirect
+# at import, but only after these probes. hf_cache.py is stdlib-only, so load it
+# straight from its file without triggering the full unsloth_zoo init this early;
+# the zoo's later call is an idempotent no-op. Older unsloth_zoo without it is
+# skipped silently.
 try:
     import importlib.util as _importlib_util
     from pathlib import Path as _Path

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -38,8 +38,9 @@ from .import_fixes import (
 
 # Redirect a read-only Hugging Face cache before anything below can import
 # huggingface_hub / transformers / vllm (disable_broken_vllm probes
-# `import vllm`, check_fbgemm_gpu_version imports transformers, and
-# fix_huggingface_hub imports huggingface_hub itself), all of which can
+# `import vllm` and its compiled extensions, check_fbgemm_gpu_version
+# imports transformers, and fix_huggingface_hub imports huggingface_hub
+# itself), all of which can
 # freeze Hub's cache constants with the un-redirected paths. unsloth_zoo
 # runs the same redirect at import, but that happens after these probes.
 # hf_cache.py is stdlib-only, so load it straight from its file without

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -2349,10 +2349,8 @@ def _is_broken_vllm_error(error) -> bool:
             )
         ) or ("vllm" in message and "undefined symbol" in message):
             return True
-        # Force-loading an extension raises the bare loader error (e.g.
-        # "libcudart.so.12: cannot open shared object file") without vLLM's
-        # "vllm._C" wrapper, and a CUDA mismatch can surface through any linked
-        # .so. Match generically; every caller feeds this only vLLM imports.
+        # Forced extension load raises the bare loader error (no "vllm._C"
+        # wrapper); match any .so failure as callers feed only vLLM imports.
         if "cannot open shared object file" in message:
             return True
         current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
@@ -2545,10 +2543,8 @@ def _clear_vllm_modules():
             sys.modules.pop(module_name, None)
 
 
-# vLLM's shipped compiled extensions. On CUDA, _C and _C_stable_libtorch are
-# imported eagerly at platform init, so an ABI break (e.g. a CUDA-major
-# mismatch) crashes there -- the reported failure -- and breaks the rest
-# uniformly, so probing _C and its siblings reliably trips it.
+# vLLM's compiled extensions. A CUDA-major ABI break hits all of them, so
+# probing the eagerly-loaded _C and its siblings reliably trips it.
 _VLLM_COMPILED_EXTENSIONS = (
     "vllm._C",
     "vllm._C_stable_libtorch",
@@ -2575,11 +2571,9 @@ def disable_broken_vllm(error = None):
         try:
             import vllm  # noqa: F401
 
-            # Modern vLLM loads its compiled extensions lazily, so a bare
-            # `import vllm` succeeds even when they're ABI-broken (e.g. built
-            # for another CUDA major). Force-load each so the .so failure
-            # surfaces here; a build that lacks one raises ModuleNotFoundError
-            # (skipped below).
+            # Lazy vLLM lets a bare `import vllm` succeed even when an extension
+            # is ABI-broken; force-load each to surface the .so failure here.
+            # A missing one raises ModuleNotFoundError (skipped below).
             for _ext in _VLLM_COMPILED_EXTENSIONS:
                 try:
                     importlib.import_module(_ext)

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -2545,15 +2545,14 @@ def _clear_vllm_modules():
             sys.modules.pop(module_name, None)
 
 
-# vLLM's main compiled extensions, eager-loaded when it initializes its kernels
-# (where an ABI break first surfaces). Not exhaustive: the set varies by
-# platform and vLLM version, but a CUDA/ROCm major mismatch breaks all of them,
-# so probing _C and its siblings reliably trips it.
+# vLLM's shipped compiled extensions. On CUDA, _C and _C_stable_libtorch are
+# imported eagerly at platform init, so an ABI break (e.g. a CUDA-major
+# mismatch) crashes there -- the reported failure -- and breaks the rest
+# uniformly, so probing _C and its siblings reliably trips it.
 _VLLM_COMPILED_EXTENSIONS = (
     "vllm._C",
     "vllm._C_stable_libtorch",
     "vllm._moe_C",
-    "vllm._moe_C_stable_libtorch",
     "vllm._rocm_C",
 )
 

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -2548,7 +2548,10 @@ def _clear_vllm_modules():
 # vLLM's compiled extensions, across the platforms its own init loads them on
 # (cuda/rocm: _C + _C_stable_libtorch; rocm also _rocm_C; xpu: _moe_C).
 _VLLM_COMPILED_EXTENSIONS = (
-    "vllm._C", "vllm._C_stable_libtorch", "vllm._rocm_C", "vllm._moe_C",
+    "vllm._C",
+    "vllm._C_stable_libtorch",
+    "vllm._rocm_C",
+    "vllm._moe_C",
 )
 
 
@@ -2569,6 +2572,7 @@ def disable_broken_vllm(error = None):
 
         try:
             import vllm  # noqa: F401
+
             # Modern vLLM loads its compiled extensions lazily, so a bare
             # `import vllm` succeeds even when they're ABI-broken (e.g. built
             # for another CUDA major). Force-load each so the .so failure

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1318,8 +1318,7 @@ def fix_vllm_pdl_blackwell():
 
     if patched:
         logger.info(
-            f"Unsloth: Applied PDL fix for SM100 ({sm100_gpu_name}) - "
-            f"patched: {', '.join(patched)}"
+            f"Unsloth: Applied PDL fix for SM100 ({sm100_gpu_name}) - patched: {', '.join(patched)}"
         )
     else:
         # Just set the env var - vLLM might be an older version without supports_pdl
@@ -2349,11 +2348,14 @@ def _is_broken_vllm_error(error) -> bool:
             )
         ) or ("vllm" in message and "undefined symbol" in message):
             return True
-        # Also catch CUDA shared library mismatches during vllm import
-        # e.g. "libcudart.so.12: cannot open shared object file"
-        if (
-            "libcudart" in message or "libcublas" in message or "libnvrtc" in message
-        ) and "cannot open shared object file" in message:
+        # A shared library failed to load while importing vLLM — a CUDA-major
+        # mismatch can surface through any linked .so (libcudart, libcublas,
+        # libnccl, libcuda, ...), and force-loading an extension directly raises
+        # the bare loader error ("libcudart.so.12: cannot open shared object
+        # file") without vLLM's own "vllm._C" wrapper. Every caller feeds this
+        # only vLLM-origin import errors, so any such failure here is a broken
+        # vLLM binary.
+        if "cannot open shared object file" in message:
             return True
         current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
     return False
@@ -2545,13 +2547,18 @@ def _clear_vllm_modules():
             sys.modules.pop(module_name, None)
 
 
-# vLLM's compiled extensions, across the platforms its own init loads them on
-# (cuda/rocm: _C + _C_stable_libtorch; rocm also _rocm_C; xpu: _moe_C).
+# vLLM's main compiled extensions, eager-loaded when it initializes its kernels
+# — the lazy step where an ABI break (e.g. a CUDA-major mismatch) first
+# surfaces. The exact set varies by platform and vLLM version, so this is the
+# common subset, not exhaustive; a CUDA/ROCm major mismatch breaks all of them,
+# so probing _C and its siblings reliably trips it. Names a build lacks raise
+# ModuleNotFoundError and are skipped (loop below).
 _VLLM_COMPILED_EXTENSIONS = (
     "vllm._C",
     "vllm._C_stable_libtorch",
-    "vllm._rocm_C",
     "vllm._moe_C",
+    "vllm._moe_C_stable_libtorch",
+    "vllm._rocm_C",
 )
 
 

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -2545,6 +2545,13 @@ def _clear_vllm_modules():
             sys.modules.pop(module_name, None)
 
 
+# vLLM's compiled extensions, across the platforms its own init loads them on
+# (cuda/rocm: _C + _C_stable_libtorch; rocm also _rocm_C; xpu: _moe_C).
+_VLLM_COMPILED_EXTENSIONS = (
+    "vllm._C", "vllm._C_stable_libtorch", "vllm._rocm_C", "vllm._moe_C",
+)
+
+
 def disable_broken_vllm(error = None):
     """Disable vLLM dynamically when its shared library is ABI-broken."""
     global VLLM_BROKEN
@@ -2562,6 +2569,17 @@ def disable_broken_vllm(error = None):
 
         try:
             import vllm  # noqa: F401
+            # Modern vLLM loads its compiled extensions lazily, so a bare
+            # `import vllm` succeeds even when they're ABI-broken (e.g. built
+            # for another CUDA major). Force-load each so the .so failure
+            # surfaces here: a build that lacks one raises ModuleNotFoundError
+            # (skipped), while a real ABI break raises ImportError/OSError and
+            # is classified by _is_broken_vllm_error below.
+            for _ext in _VLLM_COMPILED_EXTENSIONS:
+                try:
+                    importlib.import_module(_ext)
+                except ModuleNotFoundError:
+                    pass
             return False
         except Exception as import_error:
             failure = import_error

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -2349,13 +2349,10 @@ def _is_broken_vllm_error(error) -> bool:
             )
         ) or ("vllm" in message and "undefined symbol" in message):
             return True
-        # A shared library failed to load while importing vLLM — a CUDA-major
-        # mismatch can surface through any linked .so (libcudart, libcublas,
-        # libnccl, libcuda, ...), and force-loading an extension directly raises
-        # the bare loader error ("libcudart.so.12: cannot open shared object
-        # file") without vLLM's own "vllm._C" wrapper. Every caller feeds this
-        # only vLLM-origin import errors, so any such failure here is a broken
-        # vLLM binary.
+        # Force-loading an extension raises the bare loader error (e.g.
+        # "libcudart.so.12: cannot open shared object file") without vLLM's
+        # "vllm._C" wrapper, and a CUDA mismatch can surface through any linked
+        # .so. Match generically; every caller feeds this only vLLM imports.
         if "cannot open shared object file" in message:
             return True
         current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
@@ -2549,11 +2546,9 @@ def _clear_vllm_modules():
 
 
 # vLLM's main compiled extensions, eager-loaded when it initializes its kernels
-# — the lazy step where an ABI break (e.g. a CUDA-major mismatch) first
-# surfaces. The exact set varies by platform and vLLM version, so this is the
-# common subset, not exhaustive; a CUDA/ROCm major mismatch breaks all of them,
-# so probing _C and its siblings reliably trips it. Names a build lacks raise
-# ModuleNotFoundError and are skipped (loop below).
+# (where an ABI break first surfaces). Not exhaustive: the set varies by
+# platform and vLLM version, but a CUDA/ROCm major mismatch breaks all of them,
+# so probing _C and its siblings reliably trips it.
 _VLLM_COMPILED_EXTENSIONS = (
     "vllm._C",
     "vllm._C_stable_libtorch",
@@ -2584,9 +2579,8 @@ def disable_broken_vllm(error = None):
             # Modern vLLM loads its compiled extensions lazily, so a bare
             # `import vllm` succeeds even when they're ABI-broken (e.g. built
             # for another CUDA major). Force-load each so the .so failure
-            # surfaces here: a build that lacks one raises ModuleNotFoundError
-            # (skipped), while a real ABI break raises ImportError/OSError and
-            # is classified by _is_broken_vllm_error below.
+            # surfaces here; a build that lacks one raises ModuleNotFoundError
+            # (skipped below).
             for _ext in _VLLM_COMPILED_EXTENSIONS:
                 try:
                     importlib.import_module(_ext)

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1318,7 +1318,8 @@ def fix_vllm_pdl_blackwell():
 
     if patched:
         logger.info(
-            f"Unsloth: Applied PDL fix for SM100 ({sm100_gpu_name}) - patched: {', '.join(patched)}"
+            f"Unsloth: Applied PDL fix for SM100 ({sm100_gpu_name}) - "
+            f"patched: {', '.join(patched)}"
         )
     else:
         # Just set the env var - vLLM might be an older version without supports_pdl


### PR DESCRIPTION
`fast_inference=True` crashes at `from_pretrained` with `ImportError: libcudart.so.13: cannot open shared object file` when the installed vLLM was built for a different CUDA major than the runtime (reported on Colab/Kaggle with vLLM 0.23.0 and CUDA 12).

Closes #6590

## Problem

Unsloth ships a guard, `disable_broken_vllm()`, that runs at `import unsloth` and should catch this, disable vLLM, and print a reinstall hint. It never fired: it probes with a bare `import vllm`, but modern vLLM (0.23.0) loads its compiled extensions lazily, so `import vllm` never touches `vllm._C`. The probe passed against an ABI-broken install and the failure surfaced later inside `fast_inference_setup`.

## Fix

Force-load vLLM's compiled extensions in the probe (`_C`, `_C_stable_libtorch`, `_moe_C`, `_moe_C_stable_libtorch`, `_rocm_C`) instead of just `_C`, so the `.so` failure surfaces where the guard can handle it. Absent extensions raise `ModuleNotFoundError` (ignored), so a healthy install is never disabled.

Also broadened `_is_broken_vllm_error`: force-loading raises the bare loader error (e.g. `libnccl.so.2`, `libcuda.so.1`) without vLLM's `vllm._C` wrapper, so it now matches any `cannot open shared object file` rather than the old `libcudart`/`libcublas`/`libnvrtc` allowlist.

## Verification

Added `tests/test_vllm_broken_detection.py` (synthetic lazy-loading vLLM): the reported `_C` break, a sibling-only `_C_stable_libtorch` break, non-libcudart `.so` failures (`libnccl`, `libcuda`), and healthy installs. Each fails on the pre-fix code. `tests/test_import_fixes_drift.py` still passes (27 passed, 3 skipped).

## Note

Once disabled, a broken vLLM looks absent, so `from_pretrained(fast_inference=True)` raises `ImportError: Please install vLLM before enabling fast_inference!`, the existing behavior for missing vLLM. The message is imprecise (vLLM is installed, just broken), but the reinstall hint already printed at import time gives the real guidance. Tightening it is a follow-up, since it's shared with the genuinely-absent case.
