### PR TITLE
Studio: cap GGUF context to unified memory on Apple Silicon

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -804,9 +804,9 @@ _MTP_MIN_SIZE_B = 3.0
 _CTX_FIT_VRAM_FRACTION = 0.95
 
 # Fraction of Apple Silicon's recommended Metal working-set to budget for a GGUF
-# load. Unified memory is shared with the OS and other apps, so this is tighter
-# than the dedicated-VRAM fraction above; it matches MLX's own 0.85 cap
-# (mlx_inference.py _configure_memory_limits).
+# load: unified memory is shared with the OS, so it's tighter than the
+# dedicated-VRAM fraction above. Set independently to match the 0.85 MLX uses
+# in mlx_inference.py (_configure_memory_limits); the two are not kept in sync.
 _APPLE_UNIFIED_MEMORY_FRACTION = 0.85
 
 # Flat MTP reserve, used only when GGUF dims are too sparse for the byte-accurate
@@ -5358,18 +5358,14 @@ class LlamaCppBackend:
                         and self._can_estimate_kv()
                         and effective_ctx > 0
                     ):
-                        # Apple Silicon: no discrete GPU is enumerated, so the
-                        # VRAM-fit branches above are skipped and effective_ctx is
-                        # still the model's full native length -- which over-commits
-                        # unified memory and makes llama-server fail with "Compute
-                        # error." at decode (#5118, #6529). Cap against the unified-
-                        # memory budget with the same fit math; leave gpu_indices=None
-                        # / use_fit=True untouched (Metal has no CUDA device plumbing
-                        # to pin, and --fit on still ships as a backstop alongside the
-                        # reduced -c). Mirror the discrete-GPU branch: derive the UI
-                        # ceiling from native for both explicit and auto, but shrink
-                        # the launch context only when it's auto -- an explicit user
-                        # context is honored verbatim.
+                        # Apple Silicon enumerates no GPU, so the branches above are
+                        # skipped and the context stays at full native length, which
+                        # over-commits unified memory -> llama-server "Compute error."
+                        # at decode (#5118, #6529). Budget it with the same fit math.
+                        # gpu_indices/use_fit stay at their defaults (nothing to pin on
+                        # Metal; --fit on rides along as a backstop). Like the discrete
+                        # branch, the UI ceiling comes from native for both modes but
+                        # only the auto context is shrunk; an explicit one is honored.
                         native_ctx_for_cap = self._context_length or effective_ctx
                         cap = self._fit_context_to_vram(
                             native_ctx_for_cap,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5351,7 +5351,7 @@ class LlamaCppBackend:
                             # so the slider isn't on an unusable native ctx.
                             effective_ctx = min(4096, effective_ctx) if effective_ctx > 0 else 4096
 
-                    elif _apple_budget_mib > 0 and self._can_estimate_kv() and effective_ctx > 0:
+                    elif _apple_budget_mib > 0 and effective_ctx > 0:
                         # Apple Silicon enumerates no GPU, so the branches above are
                         # skipped and the context stays at full native length, which
                         # over-commits unified memory -> llama-server "Compute error."
@@ -5361,32 +5361,48 @@ class LlamaCppBackend:
                         # branch, the UI ceiling comes from native for both modes but
                         # only the auto context is shrunk; an explicit one is honored.
                         native_ctx_for_cap = self._context_length or effective_ctx
-                        cap = self._fit_context_to_vram(
-                            native_ctx_for_cap,
-                            _apple_budget_mib,
-                            model_size_fit,
-                            cache_type_kv,
-                            n_parallel = n_parallel,
-                            mtp_engaged = _mtp_reserves_gpu,
-                            mtp_overhead_fn = mtp_overhead_fn,
-                            budget_frac = 1.0,
-                            total_mib = None,
+                        # Mirror the discrete path's _pin_fraction: reserve the flat MTP
+                        # fraction up front when the draft KV can't be byte-sized, so an
+                        # MTP draft (e.g. Qwen3.6-MTP, #6529) can't push the unified
+                        # footprint over budget. No-op (== _apple_budget_mib) when MTP is
+                        # not engaged, since _flat_mtp_reserve is 0 then; mutually
+                        # exclusive with the byte-accurate _mtp_bytes reserve below.
+                        _apple_fit_budget_mib = int(
+                            _apple_budget_mib * max(0.0, 1.0 - _flat_mtp_reserve)
                         )
-                        _cap_footprint_mib = (
-                            model_size_fit
-                            + self._estimate_kv_cache_bytes(
-                                cap, cache_type_kv, n_parallel = n_parallel
+                        if self._can_estimate_kv():
+                            cap = self._fit_context_to_vram(
+                                native_ctx_for_cap,
+                                _apple_fit_budget_mib,
+                                model_size_fit,
+                                cache_type_kv,
+                                n_parallel = n_parallel,
+                                mtp_engaged = _mtp_reserves_gpu,
+                                mtp_overhead_fn = mtp_overhead_fn,
+                                budget_frac = 1.0,
+                                total_mib = None,
                             )
-                            + _mtp_bytes(cap)
-                        ) / (1024 * 1024)
-                        # _fit_context_to_vram returns the request unchanged when it
-                        # already fits OR when weights alone exceed the budget; only
-                        # the latter still over-commits, so floor to 4096 then.
-                        max_available_ctx = (
-                            cap
-                            if _cap_footprint_mib <= _apple_budget_mib
-                            else min(4096, native_ctx_for_cap)
-                        )
+                            _cap_footprint_mib = (
+                                model_size_fit
+                                + self._estimate_kv_cache_bytes(
+                                    cap, cache_type_kv, n_parallel = n_parallel
+                                )
+                                + _mtp_bytes(cap)
+                            ) / (1024 * 1024)
+                            # _fit_context_to_vram returns the request unchanged when it
+                            # already fits OR when weights alone exceed the budget; only
+                            # the latter still over-commits, so floor to 4096 then.
+                            max_available_ctx = (
+                                cap
+                                if _cap_footprint_mib <= _apple_fit_budget_mib
+                                else min(4096, native_ctx_for_cap)
+                            )
+                        else:
+                            # KV metadata too sparse to size the cache: mirror the
+                            # discrete file-size-only fallback (elif gpus above). Native
+                            # is not a safe auto default on unified memory, so floor to
+                            # 4096 instead of launching at full native and over-committing.
+                            max_available_ctx = min(4096, native_ctx_for_cap)
                         if not explicit_ctx:
                             effective_ctx = max_available_ctx
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2190,7 +2190,6 @@ class LlamaCppBackend:
         rec_bytes = 0
         try:
             import mlx.core as mx
-
             if mx.metal.is_available():
                 rec_bytes = int(mx.device_info().get("max_recommended_working_set_size") or 0)
         except Exception:
@@ -2198,7 +2197,6 @@ class LlamaCppBackend:
         if rec_bytes <= 0:
             try:
                 import psutil
-
                 rec_bytes = int(psutil.virtual_memory().total)
             except Exception:
                 return 0
@@ -5353,11 +5351,7 @@ class LlamaCppBackend:
                             # so the slider isn't on an unusable native ctx.
                             effective_ctx = min(4096, effective_ctx) if effective_ctx > 0 else 4096
 
-                    elif (
-                        _apple_budget_mib > 0
-                        and self._can_estimate_kv()
-                        and effective_ctx > 0
-                    ):
+                    elif _apple_budget_mib > 0 and self._can_estimate_kv() and effective_ctx > 0:
                         # Apple Silicon enumerates no GPU, so the branches above are
                         # skipped and the context stays at full native length, which
                         # over-commits unified memory -> llama-server "Compute error."

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -803,10 +803,8 @@ _MTP_MIN_SIZE_B = 3.0
 # of free (see _fit_context_to_vram), plus a byte-accurate MTP draft reserve.
 _CTX_FIT_VRAM_FRACTION = 0.95
 
-# Fraction of Apple Silicon's recommended Metal working-set to budget for a GGUF
-# load: unified memory is shared with the OS, so it's tighter than the
-# dedicated-VRAM fraction above. Set independently to match the 0.85 MLX uses
-# in mlx_inference.py (_configure_memory_limits); the two are not kept in sync.
+# Apple unified memory is shared with the OS, so tighter than VRAM. Matches the
+# 0.85 MLX uses in mlx_inference.py (_configure_memory_limits); not kept in sync.
 _APPLE_UNIFIED_MEMORY_FRACTION = 0.85
 
 # Flat MTP reserve, used only when GGUF dims are too sparse for the byte-accurate
@@ -2175,13 +2173,10 @@ class LlamaCppBackend:
     def _apple_metal_memory_budget_bytes() -> int:
         """Unified-memory budget for GGUF context fitting on Apple Silicon.
 
-        llama.cpp's discrete-GPU VRAM fit never runs on Metal -- no GPU is
-        enumerated (_get_gpu_memory returns []) -- so the context would default
-        to the model's full native length and over-commit unified memory,
-        making llama-server fail with "Compute error." at decode (#5118, #6529).
-        Mirror MLX's own budget: a fraction of Metal's recommended working-set
-        size, falling back to total system RAM. Returns 0 off Apple Silicon or
-        when no budget is resolvable (so callers can skip the cap).
+        No GPU is enumerated on Metal, so the context would default to native and
+        over-commit unified memory ("Compute error." at decode, #5118/#6529). Use a
+        fraction of MLX's Metal working-set, else total RAM; 0 off Apple Silicon or
+        when unresolvable, so callers skip the cap.
         """
         from utils.hardware import is_apple_silicon
 
@@ -5064,9 +5059,7 @@ class LlamaCppBackend:
                         else 0.0
                     )
                     _pin_fraction = self._GPU_PIN_VRAM_FRACTION - _flat_mtp_reserve
-                    # Apple Silicon enumerates no discrete GPU, so none of the
-                    # VRAM-fit branches below run; this unified-memory budget (0
-                    # off Apple Silicon) drives a context cap in their place.
+                    # Unified-memory budget (0 off Apple Silicon) for the no-GPU Metal cap below.
                     _apple_budget_mib = self._apple_metal_memory_budget_bytes() // (1024 * 1024)
 
                     def _restore_after_tensor_downgrade():
@@ -5352,21 +5345,15 @@ class LlamaCppBackend:
                             effective_ctx = min(4096, effective_ctx) if effective_ctx > 0 else 4096
 
                     elif _apple_budget_mib > 0 and effective_ctx > 0:
-                        # Apple Silicon enumerates no GPU, so the branches above are
-                        # skipped and the context stays at full native length, which
-                        # over-commits unified memory -> llama-server "Compute error."
-                        # at decode (#5118, #6529). Budget it with the same fit math.
-                        # gpu_indices/use_fit stay at their defaults (nothing to pin on
-                        # Metal; --fit on rides along as a backstop). Like the discrete
-                        # branch, the UI ceiling comes from native for both modes but
-                        # only the auto context is shrunk; an explicit one is honored.
+                        # No GPU on Metal: the branches above are skipped and the context
+                        # stays at native, over-committing unified memory (#5118, #6529).
+                        # Cap with the same fit math (--fit on stays as a backstop); only
+                        # auto context shrinks, explicit is honored.
                         native_ctx_for_cap = self._context_length or effective_ctx
-                        # Mirror the discrete path's _pin_fraction: reserve the flat MTP
-                        # fraction up front when the draft KV can't be byte-sized, so an
-                        # MTP draft (e.g. Qwen3.6-MTP, #6529) can't push the unified
-                        # footprint over budget. No-op (== _apple_budget_mib) when MTP is
-                        # not engaged, since _flat_mtp_reserve is 0 then; mutually
-                        # exclusive with the byte-accurate _mtp_bytes reserve below.
+                        # Reserve the flat MTP fraction up front like the discrete
+                        # _pin_fraction, so an unsized MTP draft (e.g. Qwen3.6-MTP, #6529)
+                        # can't over-commit. No-op when MTP is off; exclusive with the
+                        # byte-accurate _mtp_bytes reserve.
                         _apple_fit_budget_mib = int(
                             _apple_budget_mib * max(0.0, 1.0 - _flat_mtp_reserve)
                         )
@@ -5389,19 +5376,16 @@ class LlamaCppBackend:
                                 )
                                 + _mtp_bytes(cap)
                             ) / (1024 * 1024)
-                            # _fit_context_to_vram returns the request unchanged when it
-                            # already fits OR when weights alone exceed the budget; only
-                            # the latter still over-commits, so floor to 4096 then.
+                            # Fit returns the request unchanged when it fits OR weights
+                            # exceed budget; only the latter over-commits, so floor to 4096.
                             max_available_ctx = (
                                 cap
                                 if _cap_footprint_mib <= _apple_fit_budget_mib
                                 else min(4096, native_ctx_for_cap)
                             )
                         else:
-                            # KV metadata too sparse to size the cache: mirror the
-                            # discrete file-size-only fallback (elif gpus above). Native
-                            # is not a safe auto default on unified memory, so floor to
-                            # 4096 instead of launching at full native and over-committing.
+                            # No KV estimate: mirror the discrete file-size-only fallback
+                            # and floor to 4096 rather than launch at native and over-commit.
                             max_available_ctx = min(4096, native_ctx_for_cap)
                         if not explicit_ctx:
                             effective_ctx = max_available_ctx

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -803,6 +803,12 @@ _MTP_MIN_SIZE_B = 3.0
 # of free (see _fit_context_to_vram), plus a byte-accurate MTP draft reserve.
 _CTX_FIT_VRAM_FRACTION = 0.95
 
+# Fraction of Apple Silicon's recommended Metal working-set to budget for a GGUF
+# load. Unified memory is shared with the OS and other apps, so this is tighter
+# than the dedicated-VRAM fraction above; it matches MLX's own 0.85 cap
+# (mlx_inference.py _configure_memory_limits).
+_APPLE_UNIFIED_MEMORY_FRACTION = 0.85
+
 # Flat MTP reserve, used only when GGUF dims are too sparse for the byte-accurate
 # reserve (_estimate_mtp_overhead_bytes). Applied to both the fit budget and pin.
 _MTP_VRAM_RESERVE_FRAC = 0.05
@@ -2164,6 +2170,39 @@ class LlamaCppBackend:
         index; empty if no supported GPU is reachable. Thin wrapper over
         ``_get_gpu_memory`` for callers that only need free VRAM."""
         return [(idx, free) for idx, free, _total in LlamaCppBackend._get_gpu_memory()]
+
+    @staticmethod
+    def _apple_metal_memory_budget_bytes() -> int:
+        """Unified-memory budget for GGUF context fitting on Apple Silicon.
+
+        llama.cpp's discrete-GPU VRAM fit never runs on Metal -- no GPU is
+        enumerated (_get_gpu_memory returns []) -- so the context would default
+        to the model's full native length and over-commit unified memory,
+        making llama-server fail with "Compute error." at decode (#5118, #6529).
+        Mirror MLX's own budget: a fraction of Metal's recommended working-set
+        size, falling back to total system RAM. Returns 0 off Apple Silicon or
+        when no budget is resolvable (so callers can skip the cap).
+        """
+        from utils.hardware import is_apple_silicon
+
+        if not is_apple_silicon():
+            return 0
+        rec_bytes = 0
+        try:
+            import mlx.core as mx
+
+            if mx.metal.is_available():
+                rec_bytes = int(mx.device_info().get("max_recommended_working_set_size") or 0)
+        except Exception:
+            rec_bytes = 0
+        if rec_bytes <= 0:
+            try:
+                import psutil
+
+                rec_bytes = int(psutil.virtual_memory().total)
+            except Exception:
+                return 0
+        return int(rec_bytes * _APPLE_UNIFIED_MEMORY_FRACTION)
 
     @staticmethod
     def _get_gpu_memory() -> list[tuple[int, int, int]]:
@@ -5027,6 +5066,10 @@ class LlamaCppBackend:
                         else 0.0
                     )
                     _pin_fraction = self._GPU_PIN_VRAM_FRACTION - _flat_mtp_reserve
+                    # Apple Silicon enumerates no discrete GPU, so none of the
+                    # VRAM-fit branches below run; this unified-memory budget (0
+                    # off Apple Silicon) drives a context cap in their place.
+                    _apple_budget_mib = self._apple_metal_memory_budget_bytes() // (1024 * 1024)
 
                     def _restore_after_tensor_downgrade():
                         # Tensor mode dropped a quantized KV and stripped the cache
@@ -5309,6 +5352,53 @@ class LlamaCppBackend:
                             # Weights don't fit on any subset; default UI to 4096
                             # so the slider isn't on an unusable native ctx.
                             effective_ctx = min(4096, effective_ctx) if effective_ctx > 0 else 4096
+
+                    elif (
+                        _apple_budget_mib > 0
+                        and self._can_estimate_kv()
+                        and effective_ctx > 0
+                    ):
+                        # Apple Silicon: no discrete GPU is enumerated, so the
+                        # VRAM-fit branches above are skipped and effective_ctx is
+                        # still the model's full native length -- which over-commits
+                        # unified memory and makes llama-server fail with "Compute
+                        # error." at decode (#5118, #6529). Cap against the unified-
+                        # memory budget with the same fit math; leave gpu_indices=None
+                        # / use_fit=True untouched (Metal has no CUDA device plumbing
+                        # to pin, and --fit on still ships as a backstop alongside the
+                        # reduced -c). Mirror the discrete-GPU branch: derive the UI
+                        # ceiling from native for both explicit and auto, but shrink
+                        # the launch context only when it's auto -- an explicit user
+                        # context is honored verbatim.
+                        native_ctx_for_cap = self._context_length or effective_ctx
+                        cap = self._fit_context_to_vram(
+                            native_ctx_for_cap,
+                            _apple_budget_mib,
+                            model_size_fit,
+                            cache_type_kv,
+                            n_parallel = n_parallel,
+                            mtp_engaged = _mtp_reserves_gpu,
+                            mtp_overhead_fn = mtp_overhead_fn,
+                            budget_frac = 1.0,
+                            total_mib = None,
+                        )
+                        _cap_footprint_mib = (
+                            model_size_fit
+                            + self._estimate_kv_cache_bytes(
+                                cap, cache_type_kv, n_parallel = n_parallel
+                            )
+                            + _mtp_bytes(cap)
+                        ) / (1024 * 1024)
+                        # _fit_context_to_vram returns the request unchanged when it
+                        # already fits OR when weights alone exceed the budget; only
+                        # the latter still over-commits, so floor to 4096 then.
+                        max_available_ctx = (
+                            cap
+                            if _cap_footprint_mib <= _apple_budget_mib
+                            else min(4096, native_ctx_for_cap)
+                        )
+                        if not explicit_ctx:
+                            effective_ctx = max_available_ctx
 
                     # MTP reserve at the final context, for the logs below.
                     _mtp_reserve_bytes = _mtp_bytes(effective_ctx) if _mtp_will_engage else 0

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -892,8 +892,12 @@ class TestAppleMtpFlatReserve:
         # Without the reserve the cap fills the whole budget with weights+main KV,
         # leaving nothing for the ~5% flat MTP draft reserve -> over-commit.
         kw = dict(
-            n_ctx = 0, model_gib = 15.7, gpus = [], native_ctx = 262144,
-            kv_per_token_bytes = 64_000, apple_budget_mib = 23_000,
+            n_ctx = 0,
+            model_gib = 15.7,
+            gpus = [],
+            native_ctx = 262144,
+            kv_per_token_bytes = 64_000,
+            apple_budget_mib = 23_000,
         )
         no_reserve = _drive(**kw, flat_mtp_reserve = 0.0)
         with_reserve = _drive(**kw, flat_mtp_reserve = 0.05)
@@ -910,8 +914,12 @@ class TestAppleMtpFlatReserve:
     def test_no_reserve_is_a_noop_when_mtp_absent(self):
         # flat_mtp_reserve == 0 (the common, non-MTP case) must not change the cap.
         kw = dict(
-            n_ctx = 0, model_gib = 15.7, gpus = [], native_ctx = 262144,
-            kv_per_token_bytes = 64_000, apple_budget_mib = 23_000,
+            n_ctx = 0,
+            model_gib = 15.7,
+            gpus = [],
+            native_ctx = 262144,
+            kv_per_token_bytes = 64_000,
+            apple_budget_mib = 23_000,
         )
         assert _drive(**kw, flat_mtp_reserve = 0.0) == _drive(**kw)
 

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -227,12 +227,9 @@ def _drive(
         if use_fit and not explicit_ctx:
             effective_ctx = min(FALLBACK_CTX, effective_ctx) if effective_ctx > 0 else FALLBACK_CTX
     elif apple_budget_mib > 0 and effective_ctx > 0:
-        # Mirrors the Apple-Silicon unified-memory branch in load_model: the
-        # budget already carries the fraction, so budget_frac = 1.0; the UI
-        # ceiling comes from native for both explicit and auto, but only auto
-        # shrinks the launch context. A flat MTP reserve is taken off the budget
-        # up front (no-op when flat_mtp_reserve == 0), and sparse-KV metadata
-        # floors to FALLBACK_CTX like the discrete file-size-only fallback.
+        # Mirrors the Apple unified-memory branch in load_model: flat MTP reserve
+        # off the budget up front (no-op at 0), sparse-KV floors to FALLBACK_CTX,
+        # only auto context shrinks.
         native_ctx_for_cap = context_length or effective_ctx
         apple_fit_budget_mib = int(apple_budget_mib * max(0.0, 1.0 - flat_mtp_reserve))
         if inst._can_estimate_kv():
@@ -739,13 +736,9 @@ def test_select_gpus_reserves_per_device_overhead():
 
 
 # ---------------------------------------------------------------------------
-# Apple Silicon unified-memory context cap (#5118, #6529).
-#
-# llama.cpp enumerates no discrete GPU on Metal, so the VRAM-fit branches never
-# run and the context defaulted to the model's full native length, over-
-# committing unified memory -> llama-server "Compute error." at decode. The fix
-# resolves a unified-memory budget and caps the *auto* context with the same fit
-# math used for discrete GPUs (explicit user contexts stay honored verbatim).
+# Apple Silicon unified-memory context cap (#5118, #6529): no discrete GPU on
+# Metal, so the auto context defaulted to native and over-committed unified
+# memory. The fix budgets and caps the auto context (explicit stays verbatim).
 # ---------------------------------------------------------------------------
 
 
@@ -803,9 +796,8 @@ class TestAppleContextCap:
     """The real ``_fit_context_to_vram`` against the reporter's M3 Pro case."""
 
     def test_caps_native_context_into_unified_budget(self):
-        # Qwen3.6-27B Q4 (~15.7 GB) at native 262144 ctx with ~16 GB KV -> ~32 GB
-        # footprint on a 36 GB M3 Pro (~27 GB Metal working set, ~23 GB budget at
-        # 0.85). The fit must reduce the context so the footprint fits.
+        # ~15.7 GB weights at native 262144 (~16 GB KV) -> ~32 GB on a 36 GB M3
+        # Pro (~23 GB budget); the fit must reduce the context to fit.
         inst = _make_backend(native_ctx = 262144)
         inst._can_estimate_kv = lambda: True
         inst._estimate_kv_cache_bytes = (
@@ -831,11 +823,7 @@ class TestAppleContextCap:
 
 
 class TestAppleBranchEndToEnd:
-    """Drive the new Apple ``elif`` glue (cap / floor / explicit) via _drive.
-
-    No GPU is present, so only the Apple branch can fire; covers the
-    footprint-fits vs weights-exceed-budget decision the inline fit can't.
-    """
+    """Drive the Apple elif glue (cap / floor / explicit) via _drive, no GPU."""
 
     def test_auto_context_capped_below_native(self):
         plan = _drive(
@@ -852,8 +840,7 @@ class TestAppleBranchEndToEnd:
         assert plan["max_available_ctx"] == plan["c_arg"]
 
     def test_floors_to_fallback_when_weights_exceed_budget(self):
-        # Model weights alone blow the budget: the fit can't shrink ctx to help,
-        # so the auto context must floor to 4096 rather than stay at native.
+        # Weights alone exceed budget: ctx can't help, so floor to 4096.
         plan = _drive(
             n_ctx = 0,
             model_gib = 100,
@@ -866,9 +853,7 @@ class TestAppleBranchEndToEnd:
         assert plan["gpu_indices"] is None
 
     def test_explicit_context_honored_verbatim(self):
-        # An explicit user context must never be silently shrunk on Apple, but
-        # the UI ceiling still tightens to the budget (mirrors the GPU branch,
-        # which computes max_available_ctx regardless of explicit_ctx).
+        # Explicit context is never shrunk, but the UI ceiling still tightens.
         plan = _drive(
             n_ctx = 200_000,
             model_gib = 15.7,
@@ -884,13 +869,11 @@ class TestAppleBranchEndToEnd:
 
 
 class TestAppleMtpFlatReserve:
-    """The Apple cap must reserve the flat MTP fraction up front, like the
-    discrete path's _pin_fraction, so an MTP draft whose KV can't be byte-sized
-    (e.g. Qwen3.6-MTP, #6529) can't push the unified footprint over budget."""
+    """Apple cap reserves the flat MTP fraction up front (like _pin_fraction) so
+    an unsized MTP draft (Qwen3.6-MTP, #6529) can't over-commit."""
 
     def test_flat_reserve_keeps_draft_within_budget(self):
-        # Without the reserve the cap fills the whole budget with weights+main KV,
-        # leaving nothing for the ~5% flat MTP draft reserve -> over-commit.
+        # No reserve -> cap fills the budget, leaving nothing for the ~5% draft.
         kw = dict(
             n_ctx = 0,
             model_gib = 15.7,
@@ -925,9 +908,8 @@ class TestAppleMtpFlatReserve:
 
 
 class TestAppleNoKvMetadataFloor:
-    """When KV metadata is too sparse to size the cache, the Apple branch must
-    floor the auto context to FALLBACK_CTX (mirroring the discrete file-size-only
-    fallback) instead of launching at full native and over-committing."""
+    """Sparse KV metadata floors the auto context to FALLBACK_CTX (like the
+    discrete file-size-only fallback) instead of launching at native."""
 
     def test_sparse_kv_floors_auto_context(self):
         plan = _drive(

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -225,26 +225,24 @@ def _drive(
         gpu_indices, use_fit = inst._select_gpus(model_size, gpus)
         if use_fit and not explicit_ctx:
             effective_ctx = min(FALLBACK_CTX, effective_ctx) if effective_ctx > 0 else FALLBACK_CTX
-    elif (
-        apple_budget_mib > 0
-        and inst._can_estimate_kv()
-        and effective_ctx > 0
-    ):
+    elif apple_budget_mib > 0 and inst._can_estimate_kv() and effective_ctx > 0:
         # Mirrors the Apple-Silicon unified-memory branch in load_model: the
         # budget already carries the fraction, so budget_frac = 1.0; the UI
         # ceiling comes from native for both explicit and auto, but only auto
         # shrinks the launch context.
         native_ctx_for_cap = context_length or effective_ctx
         cap = inst._fit_context_to_vram(
-            native_ctx_for_cap, apple_budget_mib, model_size, cache_type_kv, budget_frac = 1.0,
+            native_ctx_for_cap,
+            apple_budget_mib,
+            model_size,
+            cache_type_kv,
+            budget_frac = 1.0,
         )
-        cap_footprint_mib = (
-            model_size + inst._estimate_kv_cache_bytes(cap, cache_type_kv)
-        ) / (1024 * 1024)
+        cap_footprint_mib = (model_size + inst._estimate_kv_cache_bytes(cap, cache_type_kv)) / (
+            1024 * 1024
+        )
         max_available_ctx = (
-            cap
-            if cap_footprint_mib <= apple_budget_mib
-            else min(FALLBACK_CTX, native_ctx_for_cap)
+            cap if cap_footprint_mib <= apple_budget_mib else min(FALLBACK_CTX, native_ctx_for_cap)
         )
         if not explicit_ctx:
             effective_ctx = max_available_ctx
@@ -744,7 +742,6 @@ def test_select_gpus_reserves_per_device_overhead():
 
 def _force_apple(monkeypatch):
     import platform as _platform
-
     monkeypatch.setattr(_platform, "system", lambda: "Darwin")
     monkeypatch.setattr(_platform, "machine", lambda: "arm64")
 
@@ -754,9 +751,7 @@ def _install_fake_mlx(monkeypatch, working_set_bytes):
     mlx = _types.ModuleType("mlx")
     mlx_core = _types.ModuleType("mlx.core")
     mlx_core.metal = _types.SimpleNamespace(is_available = lambda: True)
-    mlx_core.device_info = lambda: {
-        "max_recommended_working_set_size": working_set_bytes
-    }
+    mlx_core.device_info = lambda: {"max_recommended_working_set_size": working_set_bytes}
     mlx.core = mlx_core
     monkeypatch.setitem(sys.modules, "mlx", mlx)
     monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
@@ -811,18 +806,18 @@ class TestAppleContextCap:
         budget_mib = int(27 * GIB * _APPLE_UNIFIED_MEMORY_FRACTION) // (1024 * 1024)
 
         # The native footprint over-commits the budget -- this is the bug.
-        native_footprint_mib = (
-            model_size_fit + inst._estimate_kv_cache_bytes(262144)
-        ) // (1024 * 1024)
+        native_footprint_mib = (model_size_fit + inst._estimate_kv_cache_bytes(262144)) // (
+            1024 * 1024
+        )
         assert native_footprint_mib > budget_mib
 
         capped = inst._fit_context_to_vram(
             262144, budget_mib, model_size_fit, None, budget_frac = 1.0
         )
         assert capped < 262144
-        capped_footprint_mib = (
-            model_size_fit + inst._estimate_kv_cache_bytes(capped)
-        ) // (1024 * 1024)
+        capped_footprint_mib = (model_size_fit + inst._estimate_kv_cache_bytes(capped)) // (
+            1024 * 1024
+        )
         assert capped_footprint_mib <= budget_mib
 
 

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -68,6 +68,7 @@ _httpx_stub.Client = type(
 sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import (
+    _APPLE_UNIFIED_MEMORY_FRACTION,
     _CTX_FIT_VRAM_FRACTION,
     LlamaCppBackend,
     classify_gpu_offload_lines,
@@ -120,6 +121,7 @@ def _drive(
     kv_per_token_bytes = 325_000,
     can_estimate_kv = True,
     extra_args = None,
+    apple_budget_mib = 0,
 ):
     """Drive the post-metadata portion of load_model with stubbed inputs.
 
@@ -223,6 +225,29 @@ def _drive(
         gpu_indices, use_fit = inst._select_gpus(model_size, gpus)
         if use_fit and not explicit_ctx:
             effective_ctx = min(FALLBACK_CTX, effective_ctx) if effective_ctx > 0 else FALLBACK_CTX
+    elif (
+        apple_budget_mib > 0
+        and inst._can_estimate_kv()
+        and effective_ctx > 0
+    ):
+        # Mirrors the Apple-Silicon unified-memory branch in load_model: the
+        # budget already carries the fraction, so budget_frac = 1.0; the UI
+        # ceiling comes from native for both explicit and auto, but only auto
+        # shrinks the launch context.
+        native_ctx_for_cap = context_length or effective_ctx
+        cap = inst._fit_context_to_vram(
+            native_ctx_for_cap, apple_budget_mib, model_size, cache_type_kv, budget_frac = 1.0,
+        )
+        cap_footprint_mib = (
+            model_size + inst._estimate_kv_cache_bytes(cap, cache_type_kv)
+        ) / (1024 * 1024)
+        max_available_ctx = (
+            cap
+            if cap_footprint_mib <= apple_budget_mib
+            else min(FALLBACK_CTX, native_ctx_for_cap)
+        )
+        if not explicit_ctx:
+            effective_ctx = max_available_ctx
 
     return {
         "c_arg": effective_ctx if effective_ctx > 0 else 0,
@@ -704,3 +729,151 @@ def test_select_gpus_reserves_per_device_overhead():
         small, gpus, total_by_idx = totals, per_device_overhead_bytes = gib
     )
     assert a == [0] and b == [0]
+
+
+# ---------------------------------------------------------------------------
+# Apple Silicon unified-memory context cap (#5118, #6529).
+#
+# llama.cpp enumerates no discrete GPU on Metal, so the VRAM-fit branches never
+# run and the context defaulted to the model's full native length, over-
+# committing unified memory -> llama-server "Compute error." at decode. The fix
+# resolves a unified-memory budget and caps the *auto* context with the same fit
+# math used for discrete GPUs (explicit user contexts stay honored verbatim).
+# ---------------------------------------------------------------------------
+
+
+def _force_apple(monkeypatch):
+    import platform as _platform
+
+    monkeypatch.setattr(_platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(_platform, "machine", lambda: "arm64")
+
+
+def _install_fake_mlx(monkeypatch, working_set_bytes):
+    """Minimal mlx.core stub exposing metal.is_available() and device_info()."""
+    mlx = _types.ModuleType("mlx")
+    mlx_core = _types.ModuleType("mlx.core")
+    mlx_core.metal = _types.SimpleNamespace(is_available = lambda: True)
+    mlx_core.device_info = lambda: {
+        "max_recommended_working_set_size": working_set_bytes
+    }
+    mlx.core = mlx_core
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+
+
+class TestAppleUnifiedMemoryBudget:
+    def test_zero_off_apple_silicon(self, monkeypatch):
+        import platform as _platform
+
+        monkeypatch.setattr(_platform, "system", lambda: "Linux")
+        monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+        assert LlamaCppBackend._apple_metal_memory_budget_bytes() == 0
+
+    def test_uses_metal_working_set(self, monkeypatch):
+        _force_apple(monkeypatch)
+        ws = 27 * GIB  # ~recommended working set on a 36 GB Mac
+        _install_fake_mlx(monkeypatch, ws)
+        assert LlamaCppBackend._apple_metal_memory_budget_bytes() == int(
+            ws * _APPLE_UNIFIED_MEMORY_FRACTION
+        )
+
+    def test_falls_back_to_total_ram_without_mlx(self, monkeypatch):
+        _force_apple(monkeypatch)
+        monkeypatch.setitem(sys.modules, "mlx", None)  # import mlx.core -> ImportError
+        fake_psutil = _types.ModuleType("psutil")
+        fake_psutil.virtual_memory = lambda: _types.SimpleNamespace(total = 36 * GIB)
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+        assert LlamaCppBackend._apple_metal_memory_budget_bytes() == int(
+            36 * GIB * _APPLE_UNIFIED_MEMORY_FRACTION
+        )
+
+    def test_zero_when_no_budget_resolvable(self, monkeypatch):
+        _force_apple(monkeypatch)
+        monkeypatch.setitem(sys.modules, "mlx", None)
+        monkeypatch.setitem(sys.modules, "psutil", None)
+        assert LlamaCppBackend._apple_metal_memory_budget_bytes() == 0
+
+
+class TestAppleContextCap:
+    """The real ``_fit_context_to_vram`` against the reporter's M3 Pro case."""
+
+    def test_caps_native_context_into_unified_budget(self):
+        # Qwen3.6-27B Q4 (~15.7 GB) at native 262144 ctx with ~16 GB KV -> ~32 GB
+        # footprint on a 36 GB M3 Pro (~27 GB Metal working set, ~23 GB budget at
+        # 0.85). The fit must reduce the context so the footprint fits.
+        inst = _make_backend(native_ctx = 262144)
+        inst._can_estimate_kv = lambda: True
+        inst._estimate_kv_cache_bytes = (
+            lambda n, *a, **k: 0 if n <= 0 else int(n * 64_000)  # ~16 GB @ 262144
+        )
+        model_size_fit = int(15.7 * GIB)
+        budget_mib = int(27 * GIB * _APPLE_UNIFIED_MEMORY_FRACTION) // (1024 * 1024)
+
+        # The native footprint over-commits the budget -- this is the bug.
+        native_footprint_mib = (
+            model_size_fit + inst._estimate_kv_cache_bytes(262144)
+        ) // (1024 * 1024)
+        assert native_footprint_mib > budget_mib
+
+        capped = inst._fit_context_to_vram(
+            262144, budget_mib, model_size_fit, None, budget_frac = 1.0
+        )
+        assert capped < 262144
+        capped_footprint_mib = (
+            model_size_fit + inst._estimate_kv_cache_bytes(capped)
+        ) // (1024 * 1024)
+        assert capped_footprint_mib <= budget_mib
+
+
+class TestAppleBranchEndToEnd:
+    """Drive the new Apple ``elif`` glue (cap / floor / explicit) via _drive.
+
+    No GPU is present, so only the Apple branch can fire; covers the
+    footprint-fits vs weights-exceed-budget decision the inline fit can't.
+    """
+
+    def test_auto_context_capped_below_native(self):
+        plan = _drive(
+            n_ctx = 0,
+            model_gib = 15.7,
+            gpus = [],
+            native_ctx = 262144,
+            kv_per_token_bytes = 64_000,
+            apple_budget_mib = 23_000,  # ~22 GB: weights fit, native KV doesn't
+        )
+        assert 0 < plan["c_arg"] < 262144
+        assert plan["use_fit"] is True  # --fit on still ships as a backstop
+        assert plan["gpu_indices"] is None  # no CUDA device pinning on Metal
+        assert plan["max_available_ctx"] == plan["c_arg"]
+
+    def test_floors_to_fallback_when_weights_exceed_budget(self):
+        # Model weights alone blow the budget: the fit can't shrink ctx to help,
+        # so the auto context must floor to 4096 rather than stay at native.
+        plan = _drive(
+            n_ctx = 0,
+            model_gib = 100,
+            gpus = [],
+            native_ctx = 262144,
+            apple_budget_mib = 20_000,
+        )
+        assert plan["c_arg"] == FALLBACK_CTX
+        assert plan["use_fit"] is True
+        assert plan["gpu_indices"] is None
+
+    def test_explicit_context_honored_verbatim(self):
+        # An explicit user context must never be silently shrunk on Apple, but
+        # the UI ceiling still tightens to the budget (mirrors the GPU branch,
+        # which computes max_available_ctx regardless of explicit_ctx).
+        plan = _drive(
+            n_ctx = 200_000,
+            model_gib = 15.7,
+            gpus = [],
+            native_ctx = 262144,
+            kv_per_token_bytes = 64_000,
+            apple_budget_mib = 23_000,
+        )
+        assert plan["c_arg"] == 200_000  # launch context honored verbatim
+        assert plan["use_fit"] is True
+        # Ceiling reflects the budget so the over-budget warning still fires.
+        assert plan["max_available_ctx"] < 262144

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -122,6 +122,7 @@ def _drive(
     can_estimate_kv = True,
     extra_args = None,
     apple_budget_mib = 0,
+    flat_mtp_reserve = 0.0,
 ):
     """Drive the post-metadata portion of load_model with stubbed inputs.
 
@@ -225,25 +226,33 @@ def _drive(
         gpu_indices, use_fit = inst._select_gpus(model_size, gpus)
         if use_fit and not explicit_ctx:
             effective_ctx = min(FALLBACK_CTX, effective_ctx) if effective_ctx > 0 else FALLBACK_CTX
-    elif apple_budget_mib > 0 and inst._can_estimate_kv() and effective_ctx > 0:
+    elif apple_budget_mib > 0 and effective_ctx > 0:
         # Mirrors the Apple-Silicon unified-memory branch in load_model: the
         # budget already carries the fraction, so budget_frac = 1.0; the UI
         # ceiling comes from native for both explicit and auto, but only auto
-        # shrinks the launch context.
+        # shrinks the launch context. A flat MTP reserve is taken off the budget
+        # up front (no-op when flat_mtp_reserve == 0), and sparse-KV metadata
+        # floors to FALLBACK_CTX like the discrete file-size-only fallback.
         native_ctx_for_cap = context_length or effective_ctx
-        cap = inst._fit_context_to_vram(
-            native_ctx_for_cap,
-            apple_budget_mib,
-            model_size,
-            cache_type_kv,
-            budget_frac = 1.0,
-        )
-        cap_footprint_mib = (model_size + inst._estimate_kv_cache_bytes(cap, cache_type_kv)) / (
-            1024 * 1024
-        )
-        max_available_ctx = (
-            cap if cap_footprint_mib <= apple_budget_mib else min(FALLBACK_CTX, native_ctx_for_cap)
-        )
+        apple_fit_budget_mib = int(apple_budget_mib * max(0.0, 1.0 - flat_mtp_reserve))
+        if inst._can_estimate_kv():
+            cap = inst._fit_context_to_vram(
+                native_ctx_for_cap,
+                apple_fit_budget_mib,
+                model_size,
+                cache_type_kv,
+                budget_frac = 1.0,
+            )
+            cap_footprint_mib = (model_size + inst._estimate_kv_cache_bytes(cap, cache_type_kv)) / (
+                1024 * 1024
+            )
+            max_available_ctx = (
+                cap
+                if cap_footprint_mib <= apple_fit_budget_mib
+                else min(FALLBACK_CTX, native_ctx_for_cap)
+            )
+        else:
+            max_available_ctx = min(FALLBACK_CTX, native_ctx_for_cap)
         if not explicit_ctx:
             effective_ctx = max_available_ctx
 
@@ -872,3 +881,66 @@ class TestAppleBranchEndToEnd:
         assert plan["use_fit"] is True
         # Ceiling reflects the budget so the over-budget warning still fires.
         assert plan["max_available_ctx"] < 262144
+
+
+class TestAppleMtpFlatReserve:
+    """The Apple cap must reserve the flat MTP fraction up front, like the
+    discrete path's _pin_fraction, so an MTP draft whose KV can't be byte-sized
+    (e.g. Qwen3.6-MTP, #6529) can't push the unified footprint over budget."""
+
+    def test_flat_reserve_keeps_draft_within_budget(self):
+        # Without the reserve the cap fills the whole budget with weights+main KV,
+        # leaving nothing for the ~5% flat MTP draft reserve -> over-commit.
+        kw = dict(
+            n_ctx = 0, model_gib = 15.7, gpus = [], native_ctx = 262144,
+            kv_per_token_bytes = 64_000, apple_budget_mib = 23_000,
+        )
+        no_reserve = _drive(**kw, flat_mtp_reserve = 0.0)
+        with_reserve = _drive(**kw, flat_mtp_reserve = 0.05)
+
+        def footprint_mib(ctx):
+            return (15.7 * GIB + ctx * 64_000) / (1024 * 1024)
+
+        # No reserve: main footprint + 5% draft exceeds the budget.
+        assert footprint_mib(no_reserve["c_arg"]) + 0.05 * 23_000 > 23_000
+        # With reserve: the cap is smaller and the full footprint fits.
+        assert with_reserve["c_arg"] < no_reserve["c_arg"]
+        assert footprint_mib(with_reserve["c_arg"]) + 0.05 * 23_000 <= 23_000
+
+    def test_no_reserve_is_a_noop_when_mtp_absent(self):
+        # flat_mtp_reserve == 0 (the common, non-MTP case) must not change the cap.
+        kw = dict(
+            n_ctx = 0, model_gib = 15.7, gpus = [], native_ctx = 262144,
+            kv_per_token_bytes = 64_000, apple_budget_mib = 23_000,
+        )
+        assert _drive(**kw, flat_mtp_reserve = 0.0) == _drive(**kw)
+
+
+class TestAppleNoKvMetadataFloor:
+    """When KV metadata is too sparse to size the cache, the Apple branch must
+    floor the auto context to FALLBACK_CTX (mirroring the discrete file-size-only
+    fallback) instead of launching at full native and over-committing."""
+
+    def test_sparse_kv_floors_auto_context(self):
+        plan = _drive(
+            n_ctx = 0,
+            model_gib = 15.7,
+            gpus = [],
+            native_ctx = 262144,
+            can_estimate_kv = False,
+            apple_budget_mib = 23_000,
+        )
+        assert plan["c_arg"] == FALLBACK_CTX  # not native 262144
+        assert plan["use_fit"] is True
+        assert plan["gpu_indices"] is None
+
+    def test_sparse_kv_still_honors_explicit_context(self):
+        plan = _drive(
+            n_ctx = 100_000,
+            model_gib = 15.7,
+            gpus = [],
+            native_ctx = 262144,
+            can_estimate_kv = False,
+            apple_budget_mib = 23_000,
+        )
+        assert plan["c_arg"] == 100_000  # explicit honored even without KV sizing


### PR DESCRIPTION
Closes #5118
Closes #6529

## Problem

On Apple Silicon, Studio does no context-length capping. It always launches with the model's full native context (e.g. `-c 262144`), regardless of available memory. On CUDA/ROCm it shrinks the context to fit VRAM; on Metal it skips that, because `_get_gpu_memory()` returns `[]` (it only knows nvidia-smi / `torch.cuda`).

So a GGUF load over-commits unified memory and dies on the first decode with `Error: Compute error.` (llama-server failing to build the Metal compute graph), even though the same model runs fine in a standalone llama.cpp Mac app. Reported on an M3 Pro / 36 GB: ~15.7 GB weights + ~16 GB KV at full context. `--fit on` doesn't save it (llama.cpp only shrinks context at `-c 0`, and layer offload can't free unified RAM).

## Fix

Give the fit path a memory budget on Apple Silicon: Metal's recommended working-set (via mlx, falling back to total RAM) at 0.85, run through the same `_fit_context_to_vram` that CUDA and ROCm already use.

`gpu_indices=None` / `use_fit=True` stay untouched (nothing to pin on Metal), so it just ships a reduced `-c` with `--fit on` as a backstop. Explicit user contexts are honored verbatim; only the auto context is shrunk. Off Apple Silicon the budget is 0 and behavior is unchanged.

## Verification

Tests in `test_llama_cpp_context_fit.py` cover the budget helper and the cap/floor/explicit paths; full file and the broad VRAM-fit suites pass.

Also run on real Mac runners ([CI](https://github.com/oobabooga/unsloth/actions/runs/28061214791)): on `macos-26-arm64` the helper reads a 5.01 GB Metal working-set, budgets 4.26 GB, and caps `262144` to `39680`; on `macos-15-intel` it returns 0 (no-op). A full model decode wasn't exercised (runner RAM too small).
