### PR TITLE
Installer: add UNSLOTH_TORCH_INDEX_FAMILY override for torch wheel index

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1939,6 +1939,11 @@ exit 0
     # Mirrors Get-PytorchCudaTag in setup.ps1.
     function Get-TorchIndexUrl {
         $baseUrl = if ($env:UNSLOTH_PYTORCH_MIRROR) { $env:UNSLOTH_PYTORCH_MIRROR.TrimEnd('/') } else { "https://download.pytorch.org/whl" }
+        # Explicit override for hosts where GPU probing is impossible or must not
+        # happen (image builds, CI runners that build for a different target than
+        # they run on). Names the wheel index path leaf directly, e.g.
+        # UNSLOTH_TORCH_INDEX_FAMILY=cu128 | cu130 | cu126 | cpu | rocm6.4 | ...
+        if ($env:UNSLOTH_TORCH_INDEX_FAMILY) { return "$baseUrl/$($env:UNSLOTH_TORCH_INDEX_FAMILY)" }
         if (-not $NvidiaSmiExe) { return "$baseUrl/cpu" }
         try {
             $output = Invoke-NvidiaSmiBounded $NvidiaSmiExe

--- a/install.sh
+++ b/install.sh
@@ -1962,6 +1962,17 @@ _has_usable_nvidia_gpu() {
 get_torch_index_url() {
     _base="${UNSLOTH_PYTORCH_MIRROR:-https://download.pytorch.org/whl}"
     _base="${_base%/}"
+    # Explicit override for hosts where GPU probing is impossible or must not
+    # happen (Docker image builds, CI runners that build for a different
+    # target than they run on). Names the wheel index path leaf directly:
+    #   UNSLOTH_TORCH_INDEX_FAMILY=cu128 | cu130 | cu126 | cu124 | cu118 | cpu | rocm6.4 | ...
+    # Example: a Docker image that targets CUDA 12.8 is built on a host with no
+    # GPU and no nvidia-smi, so probing would otherwise fall back to cpu (or, on
+    # build hosts that leak /proc/driver/nvidia but cannot run nvidia-smi, cu126)
+    # and bake the wrong wheels. Setting this pins the index deterministically.
+    if [ -n "${UNSLOTH_TORCH_INDEX_FAMILY:-}" ]; then
+        echo "$_base/${UNSLOTH_TORCH_INDEX_FAMILY}"; return
+    fi
     # macOS: always CPU (no CUDA support)
     case "$(uname -s)" in Darwin) echo "$_base/cpu"; return ;; esac
     # Try nvidia-smi -- require the binary to actually list a usable GPU.


### PR DESCRIPTION
### What

Add an optional `UNSLOTH_TORCH_INDEX_FAMILY` environment variable that lets the installer pin the PyTorch wheel index family directly, instead of always probing the local GPU with `nvidia-smi`.

### Why

`get_torch_index_url()` in `install.sh` (and `Get-TorchIndexUrl` in `install.ps1`) choose the wheel index by reading the CUDA version from `nvidia-smi`. That is the right behaviour on a normal machine, but it has no good answer when there is no GPU to probe at the moment the index is selected:

- Inside a Docker image build, or
- on a CI runner that builds wheels for a different target than it runs on.

In those cases the bash path falls back to `cu126` (on build hosts that expose `/proc/driver/nvidia` but cannot actually run `nvidia-smi`) or to `cpu`. The image then bakes the wrong wheels, for example a `cu126` torch in an image that is meant to run CUDA 12.8. This is exactly what happens when building the Blackwell Studio Docker image: the build host has no usable `nvidia-smi`, so the installer silently picks `cu126`.

### How

`get_torch_index_url()` / `Get-TorchIndexUrl` now check `UNSLOTH_TORCH_INDEX_FAMILY` first. When set, they return `<mirror>/<value>` (for example `cu128`, `cu130`, `cu126`, `cpu`, `rocm6.4`) and skip probing. When unset or empty they behave exactly as before.

```sh
UNSLOTH_TORCH_INDEX_FAMILY=cu128 ./install.sh   # pin cu128 regardless of the build host
```

### Non-Docker safety

The override is purely additive and env-gated. With the variable unset or empty, `get_torch_index_url()` runs the same probing path it does today, so native installs are unchanged. Verified locally on a no-GPU host:

| `UNSLOTH_TORCH_INDEX_FAMILY` | result |
|---|---|
| unset | native probing, unchanged (cpu here) |
| empty string | native probing, unchanged (cpu here) |
| `cu128` | pins cu128 |
| `cu130` | pins cu130 |
| `cpu` | pins cpu |
| `cu126` with a custom `UNSLOTH_PYTORCH_MIRROR` | mirror base preserved, leaf cu126 |

`bash -n install.sh` and a PowerShell AST parse of `install.ps1` both pass.
