### PR TITLE
Fix _SameTaskStreamingResponse disconnect test bypassing __init__

### DIFF
--- a/tests/studio/test_stream_cancel_registration_timing.py
+++ b/tests/studio/test_stream_cancel_registration_timing.py
@@ -411,8 +411,7 @@ def test_same_task_response_closes_body_iterator_on_send_disconnect():
         response = m["_SameTaskStreamingResponse"].__new__(m["_SameTaskStreamingResponse"])
         response.body_iterator = agen
         response.background = None
-        # __new__ bypasses __init__, so set the attribute __init__ would: the
-        # disconnect-before-first-chunk branch of __call__ reads _unstarted_cleanup.
+        # __new__ bypasses __init__; __call__'s disconnect branch reads _unstarted_cleanup.
         response._unstarted_cleanup = None
 
         async def stream_response(_send):

--- a/tests/studio/test_stream_cancel_registration_timing.py
+++ b/tests/studio/test_stream_cancel_registration_timing.py
@@ -411,6 +411,9 @@ def test_same_task_response_closes_body_iterator_on_send_disconnect():
         response = m["_SameTaskStreamingResponse"].__new__(m["_SameTaskStreamingResponse"])
         response.body_iterator = agen
         response.background = None
+        # __new__ bypasses __init__, so set the attribute __init__ would: the
+        # disconnect-before-first-chunk branch of __call__ reads _unstarted_cleanup.
+        response._unstarted_cleanup = None
 
         async def stream_response(_send):
             raise OSError("client disconnected")


### PR DESCRIPTION
## Summary

The Backend CI "Repo tests (CPU)" job currently fails on `main` with:

```
FAILED tests/studio/test_stream_cancel_registration_timing.py::test_same_task_response_closes_body_iterator_on_send_disconnect - AttributeError: '_SameTaskStreamingResponse' object has no attribute '_unstarted_cleanup'
```

The test constructs `_SameTaskStreamingResponse` via `__new__` to bypass Starlette's `__init__`, then wires `body_iterator`, `background`, and `stream_response` by hand. It never sets `_unstarted_cleanup`, so when the simulated disconnect fires before the first body chunk, the unstarted-generator branch of `__call__` reads `self._unstarted_cleanup` and raises `AttributeError` instead of the expected `ClientDisconnect`.

The implementation is correct; the test was not updated to set the attribute when `_unstarted_cleanup` was added to `__init__`.

## Change

Set `response._unstarted_cleanup = None` in the manual construction, matching the default `__init__` assigns.

## Tests

`tests/studio/test_stream_cancel_registration_timing.py` passes (25 passed), including the previously failing case.
