### PR TITLE
Studio: confirm saved Hugging Face token with a tick

### DIFF
--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -332,9 +332,11 @@ export function GeneralTab() {
               )}
             />
             {tokenSaved ? (
+              // Decorative: pointer-events-none lets clicks reach the input
+              // underneath so the field still focuses anywhere.
               <span
-                className="absolute right-7 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center text-emerald-600 duration-150 animate-in fade-in zoom-in dark:text-emerald-500"
-                title={t("settings.general.tokenSaved")}
+                className="pointer-events-none absolute right-7 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center text-emerald-600 duration-150 animate-in fade-in zoom-in dark:text-emerald-500"
+                role="img"
                 aria-label={t("settings.general.tokenSaved")}
               >
                 <Check className="size-4" strokeWidth={2.5} />

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -25,8 +25,9 @@ import {
   useShowLlamaUpdateBanner,
 } from "@/hooks/use-llama-update-pref";
 import { LOCALE_STORAGE_KEY, useT } from "@/i18n";
+import { cn } from "@/lib/utils";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { Eye, EyeOff } from "lucide-react";
+import { Check, Eye, EyeOff } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
   type HelperPrecacheSettings,
@@ -170,6 +171,12 @@ export function GeneralTab() {
     if (trimmed !== draftToken) setDraftToken(trimmed);
     if (trimmed !== hfToken) setHfToken(trimmed);
   };
+
+  // Show an "accepted" tick once a non-empty token has been committed to the
+  // store and the field still matches it (i.e. not mid-edit). Gives the user
+  // feedback that a pasted token was saved.
+  const tokenSaved =
+    draftToken.trim().length > 0 && draftToken.trim() === (hfToken ?? "");
 
   useEffect(() => {
     let cancelled = false;
@@ -319,8 +326,20 @@ export function GeneralTab() {
               value={draftToken}
               onChange={(e) => setDraftToken(e.target.value)}
               onBlur={commitToken}
-              className="h-8 w-full pr-8 font-mono text-xs"
+              className={cn(
+                "h-8 w-full font-mono text-xs",
+                tokenSaved ? "pr-14" : "pr-8",
+              )}
             />
+            {tokenSaved ? (
+              <span
+                className="absolute right-7 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center text-emerald-600 duration-150 animate-in fade-in zoom-in dark:text-emerald-500"
+                title={t("settings.general.tokenSaved")}
+                aria-label={t("settings.general.tokenSaved")}
+              >
+                <Check className="size-4" strokeWidth={2.5} />
+              </span>
+            ) : null}
             <button
               type="button"
               onClick={() => setShowToken((s) => !s)}

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -106,6 +106,7 @@ export const en = {
         "Used to load gated models and push artifacts.",
       hideToken: "Hide token",
       showToken: "Show token",
+      tokenSaved: "Token saved",
       password: "Password",
       passwordDescription: "Change the password for this Studio account.",
       passwordDialog: {

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -105,6 +105,7 @@ export const zhCN = {
       huggingFaceTokenDescription: "用于加载受限模型和推送产物。",
       hideToken: "隐藏 token",
       showToken: "显示 token",
+      tokenSaved: "Token 已保存",
       password: "密码",
       passwordDescription: "更改此 Studio 账号的密码。",
       passwordDialog: {


### PR DESCRIPTION
## What

Adds a small "saved" tick to the Hugging Face token field in Settings -> Account.

## Why

Right now you paste a token, click away, and nothing visibly changes. The value commits on blur but there is no confirmation, so it is easy to wonder whether the token was actually accepted.

## How

- Derives a `tokenSaved` boolean: true when the trimmed field is non-empty and matches the token already stored in the runtime store (so it only shows after a commit, not mid-edit).
- Renders a green tick inside the field, to the left of the show/hide eye, with a short fade and zoom in.
- Adds a `tokenSaved` string ("Token saved") to the `en` and `zh-CN` locales, used for the tick tooltip and aria-label.

The tick is purely a status indicator. It never renders, stores, logs, or transmits the token value, and the existing password masking is unchanged.

## Notes

The tick uses an emerald green to read as a clear confirmation. Happy to switch it to the app accent color if that is preferred.