### PR TITLE
Studio: slim the GLM-5.2 thinking menu width

### DIFF
--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -612,6 +612,9 @@ export function SharedComposer({
   const isEffort =
     effectiveReasoningStyle === "reasoning_effort" ||
     effectiveReasoningStyle === "enable_thinking_effort";
+  // GLM-5.2's high|max effort menu has short labels, so it can sit slightly
+  // skinnier than the shared reasoning dropdown.
+  const isGlmEffort = effectiveReasoningStyle === "enable_thinking_effort";
   const thinkingActiveLook = isEffort
     ? reasoningLockedOn || (effectiveReasoningVisualEnabled && !reasoningDisabled)
     : reasoningLockedOn || (effectiveReasoningEnabled && !reasoningDisabled);
@@ -1785,7 +1788,10 @@ export function SharedComposer({
                 <DropdownMenuContent
                   side="top"
                   align="end"
-                  className="unsloth-plus-menu min-w-44"
+                  className={cn(
+                    "unsloth-plus-menu",
+                    isGlmEffort ? "min-w-40" : "min-w-44",
+                  )}
                 >
                   {isEffort ? (
                     <>

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -612,9 +612,12 @@ export function SharedComposer({
   const isEffort =
     effectiveReasoningStyle === "reasoning_effort" ||
     effectiveReasoningStyle === "enable_thinking_effort";
-  // GLM-5.2's high|max effort menu has short labels, so it can sit slightly
-  // skinnier than the shared reasoning dropdown.
-  const isGlmEffort = effectiveReasoningStyle === "enable_thinking_effort";
+  // GLM-5.2's effort menu (Off, high, max) has short rows, so it can sit a
+  // touch skinnier. Skip the narrower floor when a Preserve thinking row is
+  // present, since that longer label needs the wider width to stay one line.
+  const narrowEffortMenu =
+    effectiveReasoningStyle === "enable_thinking_effort" &&
+    !supportsPreserveThinking;
   const thinkingActiveLook = isEffort
     ? reasoningLockedOn || (effectiveReasoningVisualEnabled && !reasoningDisabled)
     : reasoningLockedOn || (effectiveReasoningEnabled && !reasoningDisabled);
@@ -1790,7 +1793,7 @@ export function SharedComposer({
                   align="end"
                   className={cn(
                     "unsloth-plus-menu",
-                    isGlmEffort ? "min-w-40" : "min-w-44",
+                    narrowEffortMenu ? "min-w-40" : "min-w-44",
                   )}
                 >
                   {isEffort ? (


### PR DESCRIPTION
## What

Makes the thinking dropdown a touch skinnier for GLM-5.2.

## Why

GLM-5.2 uses the high|max effort menu, whose rows are short ("high", "max", and the off row). At `min-w-44` the menu looks wider than its contents need.

## How

- Adds an `isGlmEffort` flag (`effectiveReasoningStyle === "enable_thinking_effort"`).
- Drops the menu to `min-w-40` only for GLM-5.2. Every other model keeps `min-w-44`, so the shared reasoning dropdown is unchanged.