### PR TITLE
Studio: add Unsloth Docs to the MCP server presets

### DIFF
--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -61,6 +61,11 @@ type McpPreset = {
 // Hugging Face runs anonymously; add a token via "Manage MCP servers".
 const MCP_PRESETS: readonly McpPreset[] = [
   {
+    id: "unsloth-docs",
+    displayName: "Unsloth Docs",
+    url: "https://unsloth.ai/docs/~gitbook/mcp",
+  },
+  {
     id: "context7",
     displayName: "Context7",
     url: "https://mcp.context7.com/mcp",


### PR DESCRIPTION
## What

Adds an Unsloth Docs entry to the composer MCP servers dropdown, next to Context7, Exa, and Hugging Face.

## Why

Studio users asking about Unsloth itself should be able to point the model at the official docs in one click, without manually adding a server.

## How

- Adds a keyless preset to `MCP_PRESETS` in `mcp-composer-button.tsx` using the GitBook docs MCP endpoint `https://unsloth.ai/docs/~gitbook/mcp`.
- Placed first since it is Unsloth's own docs. It has no label override, so it renders as "Unsloth Docs" the same way the Hugging Face row does, and reuses the existing generic row rendering, toggle, and dedupe logic.