### PR TITLE
Studio: stop leaking the auth token through HTML canvas preview frames

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1235,17 +1235,12 @@ async def _authenticate_header_or_query(request: Request, token: Optional[str]) 
 
 @studio_router.get("/artifact-preview-frame", include_in_schema = False)
 async def artifact_preview_frame(allow_network: bool = False):
-    """Serve the opaque sandbox shell used for client-side HTML canvases.
+    """Serve the opaque sandbox shell for client-side HTML canvases.
 
-    No auth token is accepted here, by design. This shell is a static document
-    that only renders HTML posted to it via postMessage by its embedder, and the
-    CSP restricts embedding to Studio itself (frame-ancestors) inside a
-    no-same-origin sandbox. A bearer token in this frame's URL would be readable
-    by the untrusted canvas HTML through window.location.href, so the
-    network-mode CSP is chosen from allow_network alone and the frame never
-    receives a credential it could exfiltrate. Authenticating the request would
-    add no protection (the shell exposes no server resource) while reintroducing
-    that leak."""
+    No auth token by design: the URL is readable by the untrusted canvas via
+    location.href, and this static shell exposes no server resource (frame-ancestors
+    plus the sandbox already gate it), so the CSP is chosen from allow_network alone.
+    """
 
     csp = (
         _ARTIFACT_PREVIEW_FRAME_NETWORK_CSP if allow_network else _ARTIFACT_PREVIEW_FRAME_STRICT_CSP

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1234,15 +1234,18 @@ async def _authenticate_header_or_query(request: Request, token: Optional[str]) 
 
 
 @studio_router.get("/artifact-preview-frame", include_in_schema = False)
-async def artifact_preview_frame(
-    request: Request,
-    allow_network: bool = False,
-    token: Optional[str] = None,
-):
-    """Serve the opaque sandbox shell used for client-side HTML canvases."""
+async def artifact_preview_frame(allow_network: bool = False):
+    """Serve the opaque sandbox shell used for client-side HTML canvases.
 
-    if allow_network:
-        await _authenticate_header_or_query(request, token)
+    No auth token is accepted here, by design. This shell is a static document
+    that only renders HTML posted to it via postMessage by its embedder, and the
+    CSP restricts embedding to Studio itself (frame-ancestors) inside a
+    no-same-origin sandbox. A bearer token in this frame's URL would be readable
+    by the untrusted canvas HTML through window.location.href, so the
+    network-mode CSP is chosen from allow_network alone and the frame never
+    receives a credential it could exfiltrate. Authenticating the request would
+    add no protection (the shell exposes no server resource) while reintroducing
+    that leak."""
 
     csp = (
         _ARTIFACT_PREVIEW_FRAME_NETWORK_CSP if allow_network else _ARTIFACT_PREVIEW_FRAME_STRICT_CSP

--- a/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
+++ b/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
@@ -329,8 +329,7 @@ export function ArtifactSurface({
             code={artifact.code}
             title={artifact.title}
             fill={true}
-            // Only tool-rendered canvases may opt into network mode; fences
-            // auto-extracted from assistant text never get it.
+            // Network mode only for tool-rendered canvases, never fences.
             allowNetworkAccess={artifact.source === "tool"}
             className="h-full"
           />

--- a/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
+++ b/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
@@ -329,6 +329,9 @@ export function ArtifactSurface({
             code={artifact.code}
             title={artifact.title}
             fill={true}
+            // Only tool-rendered canvases may opt into network mode; fences
+            // auto-extracted from assistant text never get it.
+            allowNetworkAccess={artifact.source === "tool"}
             className="h-full"
           />
         ) : (

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -3,7 +3,6 @@
 
 "use client";
 
-import { getAuthToken } from "@/features/auth";
 import { apiUrl } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -36,29 +35,33 @@ export function ArtifactHtmlFrame({
   title = "HTML canvas preview",
   className,
   fill = false,
+  // Only artifacts the user explicitly rendered (the render_html tool) may opt
+  // into network mode. Auto-extracted fence cards default to no network so
+  // prompt-injected assistant text can never reach the network-enabled frame.
+  allowNetworkAccess = false,
 }: {
   code: string;
   title?: string;
   className?: string;
   fill?: boolean;
+  allowNetworkAccess?: boolean;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const allowNetworkAccess = useChatRuntimeStore(
+  const networkAccessEnabled = useChatRuntimeStore(
     (state) => state.allowArtifactNetworkAccess,
   );
   const [height, setHeight] = useState(HTML_FRAME_DEFAULT_HEIGHT);
   const artifactHtml = useMemo(() => buildArtifactSrcDoc(code), [code]);
   const src = useMemo(() => {
     const query = new URLSearchParams({ v: hashArtifactCode(code) });
-    if (allowNetworkAccess) {
-      const token = getAuthToken();
-      if (token) {
-        query.set("allow_network", "1");
-        query.set("token", token);
-      }
+    // No auth token is ever placed in the frame URL: untrusted canvas HTML runs
+    // in this frame and could read it back via window.location.href. The
+    // backend selects the network CSP from allow_network alone.
+    if (allowNetworkAccess && networkAccessEnabled) {
+      query.set("allow_network", "1");
     }
     return apiUrl(`/api/inference/artifact-preview-frame?${query.toString()}`);
-  }, [allowNetworkAccess, code]);
+  }, [allowNetworkAccess, networkAccessEnabled, code]);
   const postArtifactHtml = useCallback(() => {
     // Sandboxed frame has an opaque origin ("null"), so a wildcard target is
     // required; the payload only reaches this iframe's contentWindow.

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -35,9 +35,7 @@ export function ArtifactHtmlFrame({
   title = "HTML canvas preview",
   className,
   fill = false,
-  // Only artifacts the user explicitly rendered (the render_html tool) may opt
-  // into network mode. Auto-extracted fence cards default to no network so
-  // prompt-injected assistant text can never reach the network-enabled frame.
+  // Tool-rendered canvases only; default off so fences never get network.
   allowNetworkAccess = false,
 }: {
   code: string;
@@ -54,17 +52,13 @@ export function ArtifactHtmlFrame({
   const artifactHtml = useMemo(() => buildArtifactSrcDoc(code), [code]);
   const src = useMemo(() => {
     const query = new URLSearchParams({ v: hashArtifactCode(code) });
-    // No auth token is ever placed in the frame URL: untrusted canvas HTML runs
-    // in this frame and could read it back via window.location.href. The
-    // backend selects the network CSP from allow_network alone.
+    // Never put the auth token in the URL: in-frame code can read location.href.
     if (allowNetworkAccess && networkAccessEnabled) {
       query.set("allow_network", "1");
     }
     return apiUrl(`/api/inference/artifact-preview-frame?${query.toString()}`);
   }, [allowNetworkAccess, networkAccessEnabled, code]);
-  // Only feed loads WE initiated (mount or a src change). Untrusted canvas code
-  // can self-navigate the frame to ?allow_network=1, which also fires onLoad;
-  // reposting there would let a strict frame self-upgrade into a network one.
+  // Feed only parent-initiated loads, so a self-navigated frame can't self-upgrade.
   const pendingPostRef = useRef(false);
   useEffect(() => {
     pendingPostRef.current = true;

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -62,7 +62,16 @@ export function ArtifactHtmlFrame({
     }
     return apiUrl(`/api/inference/artifact-preview-frame?${query.toString()}`);
   }, [allowNetworkAccess, networkAccessEnabled, code]);
+  // Only feed loads WE initiated (mount or a src change). Untrusted canvas code
+  // can self-navigate the frame to ?allow_network=1, which also fires onLoad;
+  // reposting there would let a strict frame self-upgrade into a network one.
+  const pendingPostRef = useRef(false);
+  useEffect(() => {
+    pendingPostRef.current = true;
+  }, [src]);
   const postArtifactHtml = useCallback(() => {
+    if (!pendingPostRef.current) return;
+    pendingPostRef.current = false;
     // Sandboxed frame has an opaque origin ("null"), so a wildcard target is
     // required; the payload only reaches this iframe's contentWindow.
     iframeRef.current?.contentWindow?.postMessage(


### PR DESCRIPTION
## Summary

The HTML canvas preview frame placed the Studio bearer token in the iframe URL (`?token=`) whenever canvas network access was enabled. Untrusted canvas HTML executes inside that frame and can read its own `window.location.href`, and the network-mode CSP allows outbound `http:`/`https:`, so the token could be read back and exfiltrated, then replayed against authenticated Studio APIs.

The auto-render HTML cards widened the reach. `MessageHtmlArtifacts` is mounted on every assistant message and turns any visible ` ```html ` fence (ordinary, retrieved, or prompt-injected assistant output) into a Preview card that opens this same frame. The `render_html` tool path is worse still: it auto-opens the canvas with no click.

## Root cause and fix

The real problem is putting a reusable, full-scope credential where untrusted in-frame code can read it. So the token is no longer placed in the frame URL at all:

- `studio/backend/routes/inference.py` - `artifact_preview_frame` no longer accepts or validates `?token=`. The shell is a static document that only renders HTML posted to it by its embedder, and `frame-ancestors` plus the no-same-origin sandbox already restrict who can drive it, so the auth gate added no protection. The network vs strict CSP is now chosen from `allow_network` alone.
- `studio/frontend/src/features/chat/artifacts/html-frame.tsx` - removed `getAuthToken`; the frame `src` never carries a token. Added an `allowNetworkAccess` prop (default `false`); network mode requires both the prop and the user's existing network-access toggle.
- `studio/frontend/src/features/chat/artifacts/artifact-surface.tsx` - passes `allowNetworkAccess={artifact.source === "tool"}` so only explicitly tool-rendered canvases can request network mode.

The single backend change neutralizes token theft on every path, including the auto-open tool path. The source gating is layered defense so untrusted assistant text cannot reach network mode in the first place.

## Behavior after the change

| Artifact source | Network toggle | Frame URL |
| --- | --- | --- |
| fence (auto) | on | `?v=...` (no network, no token) |
| tool (render_html) | off | `?v=...` (no token) |
| tool (render_html) | on | `?v=...&allow_network=1` (no token) |

## Verification

- Backend `py_compile` clean; the shared `_authenticate_header_or_query` helper and `Request` are still used by `serve_sandbox_file` (unaffected).
- Frontend `tsc -b` typecheck passes.
- eslint and biome report identical findings to `main` on both touched files (all pre-existing, none on changed lines).
- The existing `test_artifact_preview_frame_omits_x_frame_options` test uses a stub endpoint and is unaffected.