### PR TITLE
Studio: group the project export menu by Combined and Per chat

### DIFF
--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -300,15 +301,21 @@ export function ProjectsPage() {
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>Export All Projects</DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="w-52">
+                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
+                    Combined
+                  </DropdownMenuLabel>
                   {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                     <DropdownMenuItem key={`ap-m-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, true)}>
-                      {label} (combined)
+                      {label}
                     </DropdownMenuItem>
                   ))}
                   <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
+                    Per chat
+                  </DropdownMenuLabel>
                   {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                     <DropdownMenuItem key={`ap-s-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, false)}>
-                      {label} (per chat)
+                      {label}
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuSubContent>
@@ -316,15 +323,21 @@ export function ProjectsPage() {
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>Export Projects + Recents</DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="w-52">
+                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
+                    Combined
+                  </DropdownMenuLabel>
                   {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                     <DropdownMenuItem key={`all-m-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, true)}>
-                      {label} (combined)
+                      {label}
                     </DropdownMenuItem>
                   ))}
                   <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
+                    Per chat
+                  </DropdownMenuLabel>
                   {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
                     <DropdownMenuItem key={`all-s-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, false)}>
-                      {label} (per chat)
+                      {label}
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuSubContent>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -12,6 +12,7 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -301,45 +302,53 @@ export function ProjectsPage() {
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>Export All Projects</DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="w-52">
-                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
-                    Combined
-                  </DropdownMenuLabel>
-                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
-                    <DropdownMenuItem key={`ap-m-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, true)}>
-                      {label}
-                    </DropdownMenuItem>
-                  ))}
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel className="pb-1 pt-2 text-[11px] font-medium">
+                      Combined
+                    </DropdownMenuLabel>
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`ap-m-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, true)}>
+                        {label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
                   <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
-                    Per chat
-                  </DropdownMenuLabel>
-                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
-                    <DropdownMenuItem key={`ap-s-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, false)}>
-                      {label}
-                    </DropdownMenuItem>
-                  ))}
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel className="pb-1 pt-2 text-[11px] font-medium">
+                      Per chat
+                    </DropdownMenuLabel>
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`ap-s-${fmt}`} onSelect={() => void handleBulkProjectExport("projects", fmt, false)}>
+                        {label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>Export Projects + Recents</DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="w-52">
-                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
-                    Combined
-                  </DropdownMenuLabel>
-                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
-                    <DropdownMenuItem key={`all-m-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, true)}>
-                      {label}
-                    </DropdownMenuItem>
-                  ))}
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel className="pb-1 pt-2 text-[11px] font-medium">
+                      Combined
+                    </DropdownMenuLabel>
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`all-m-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, true)}>
+                        {label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
                   <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="px-3 pb-1 pt-2 text-[11px] font-medium">
-                    Per chat
-                  </DropdownMenuLabel>
-                  {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
-                    <DropdownMenuItem key={`all-s-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, false)}>
-                      {label}
-                    </DropdownMenuItem>
-                  ))}
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel className="pb-1 pt-2 text-[11px] font-medium">
+                      Per chat
+                    </DropdownMenuLabel>
+                    {EXPORT_FORMATS_LIST.map(({ fmt, label }) => (
+                      <DropdownMenuItem key={`all-s-${fmt}`} onSelect={() => void handleBulkProjectExport("all", fmt, false)}>
+                        {label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
             </DropdownMenuContent>


### PR DESCRIPTION
## Summary

The project export dropdown repeated the format on every row (`Raw JSONL (combined)`, `CSV (combined)`, and so on, then the same list with `(per chat)`). This swaps the per-row suffix for a section subheading, so each group is labelled once and the rows stay short.

## Before / After

Before:

```
Raw JSONL (combined)
CSV (combined)
ShareGPT JSONL (combined)
--------------------------
Raw JSONL (per chat)
CSV (per chat)
ShareGPT JSONL (per chat)
```

After:

```
Combined
  Raw JSONL
  CSV
  ShareGPT JSONL
--------------------------
Per chat
  Raw JSONL
  CSV
  ShareGPT JSONL
```

## Changes

- Add a `DropdownMenuLabel` subheading (`Combined`, `Per chat`) above each group in both the `Export All Projects` and `Export Projects + Recents` submenus.
- Drop the `(combined)` / `(per chat)` suffix from the row labels.

Labels only, no behavior change.

## Verification

- `tsc -b` clean and eslint clean on the changed file.
- Frontend builds; the served bundle shows the subheadings with no leftover suffixes.
