### PR TITLE
Studio: keep the sidebar bottom fade in sync when groups collapse

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -454,6 +454,7 @@ export function AppSidebar() {
     chatOpen,
     trainOpen,
     runsOpen,
+    pinnedOpen,
     isStudioRoute,
   ]);
 
@@ -1103,6 +1104,16 @@ export function AppSidebar() {
       <SidebarContent
         ref={scrollRef}
         onScroll={(e) => syncScrollState(e.currentTarget)}
+        // Collapsible groups animate their height; re-measure the fade once the
+        // open/close animation settles, not on the (still-animating) state flip.
+        onAnimationEnd={(e) => {
+          if (
+            e.animationName === "collapsible-down" ||
+            e.animationName === "collapsible-up"
+          ) {
+            syncScrollState(e.currentTarget);
+          }
+        }}
         className={cn(
           // pb-2 keeps the last row's rounded highlight clear of the
           // overflow clip edge so its bottom corners aren't shaved off.


### PR DESCRIPTION
## What

Fixes the sidebar bottom fade (above the profile) randomly disappearing when collapsing or expanding a group (Train, Pinned, etc.).

## Why

The fade is driven by `canScrollDown`, recomputed in an effect that runs the moment a group's open/closed state flips. But the groups animate their height (`animate-collapsible-up/down`), so the effect read `scrollHeight` while the row was still mid-collapse, producing a stale measurement. The Pinned section's `pinnedOpen` was also missing from that effect's dependencies, so toggling it never recomputed.

## How

- Re-measure when the collapse/expand animation actually finishes: an `onAnimationEnd` on the scroll container, filtered to the `collapsible-down` / `collapsible-up` keyframes. The event bubbles up from any group, so this covers every collapsible without enumerating them.
- Add the missing `pinnedOpen` to the recompute effect's deps for the synchronous path.

This reuses the existing guarded `syncScrollState` (it only updates state when the value changes), so there is no extra render churn and no risk of the ResizeObserver render loop the code was avoiding.