### PR TITLE
Studio: tighten the sidebar footer spacing and update-card fade

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1374,14 +1374,24 @@ export function AppSidebar() {
         )}
       </SidebarContent>
 
-      <SidebarFooter className="relative pt-3 pb-4 group-data-[collapsible=icon]:px-0">
+      <SidebarFooter
+        className={cn(
+          "relative pb-3 group-data-[collapsible=icon]:px-0",
+          // Tighter top with the update card so the fade hugs it; fuller top
+          // for the profile on its own.
+          showUpdateCard ? "pt-1.5" : "pt-2.5",
+        )}
+      >
         {/* Fade above the profile box, shown only when there's more list below
             the fold; at the bottom (or short lists) it fades so the last row
             shows fully (Gemini-style). right-2 keeps it clear of the 8px scrollbar gutter. */}
         <div
           aria-hidden="true"
           className={cn(
-            "pointer-events-none absolute left-0 right-2 bottom-full h-10 bg-gradient-to-t from-[var(--sidebar)] to-[rgb(from_var(--sidebar)_r_g_b/0)] transition-opacity duration-200",
+            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar)] to-[rgb(from_var(--sidebar)_r_g_b/0)] transition-opacity duration-200",
+            // Shorter fade when the update card sits above the profile so the
+            // list reads closer to it.
+            showUpdateCard ? "h-3" : "h-10",
             canScrollDown ? "opacity-100" : "opacity-0",
           )}
         />


### PR DESCRIPTION
## What

Small spacing adjustments to the sidebar footer (the profile and update-button area).

## Why

- #6545 added `pt-3 pb-4` to the footer, which lifted the bottom fade and left the profile sitting high off the bottom.
- When the update card is present the footer is taller, so the full-height fade left a wide gap above the update button.

## How

- Footer padding moves to `pb-3` with a conditional top:
  - `pt-1.5` when the update card is shown, so the fade hugs the card.
  - `pt-2.5` for the profile on its own, keeping a fuller top.
- When the update card is shown, shorten the fade above it from `h-10` to `h-3` so the list reads closer to the card. With no update card the fade stays `h-10`.

Pure presentation, no behavior change.