### PR TITLE
Studio: name the missing extractor when a Recipes file upload fails

### DIFF
--- a/studio/backend/routes/data_recipe/seed.py
+++ b/studio/backend/routes/data_recipe/seed.py
@@ -481,6 +481,24 @@ async def upload_unstructured_file(
                 error = "No extractable text found in file",
             )
         extracted_path.write_text(extracted_text, encoding = "utf-8")
+    except ImportError as e:
+        # Optional extractor missing (pymupdf4llm for PDF, mammoth for DOCX): name it.
+        raw_path.unlink(missing_ok = True)
+        extracted_path.unlink(missing_ok = True)
+        missing = getattr(e, "name", None) or "a required package"
+        logger.error(
+            "data_recipe.seed.text_extraction_dependency_missing",
+            error = str(e),
+            missing = missing,
+            exc_info = True,
+        )
+        return UnstructuredFileUploadResponse(
+            file_id = file_id,
+            filename = original_filename,
+            size_bytes = size_bytes,
+            status = "error",
+            error = f"Cannot read {ext} files: the '{missing}' package is not installed.",
+        )
     except Exception as e:
         raw_path.unlink(missing_ok = True)
         extracted_path.unlink(missing_ok = True)

--- a/studio/backend/routes/data_recipe/seed.py
+++ b/studio/backend/routes/data_recipe/seed.py
@@ -482,14 +482,27 @@ async def upload_unstructured_file(
             )
         extracted_path.write_text(extracted_text, encoding = "utf-8")
     except ImportError as e:
-        # Optional extractor missing (pymupdf4llm for PDF, mammoth for DOCX): name it.
         raw_path.unlink(missing_ok = True)
         extracted_path.unlink(missing_ok = True)
-        missing = getattr(e, "name", None) or "a required package"
+        missing = getattr(e, "name", None)
+        expected_missing = {".pdf": "pymupdf4llm", ".docx": "mammoth"}.get(ext)
+        if isinstance(e, ModuleNotFoundError) and missing == expected_missing:
+            logger.error(
+                "data_recipe.seed.text_extraction_dependency_missing",
+                error = str(e),
+                missing = missing,
+                exc_info = True,
+            )
+            return UnstructuredFileUploadResponse(
+                file_id = file_id,
+                filename = original_filename,
+                size_bytes = size_bytes,
+                status = "error",
+                error = f"Cannot read {ext} files: the '{missing}' package is not installed.",
+            )
         logger.error(
-            "data_recipe.seed.text_extraction_dependency_missing",
+            "data_recipe.seed.text_extraction_failed",
             error = str(e),
-            missing = missing,
             exc_info = True,
         )
         return UnstructuredFileUploadResponse(
@@ -497,7 +510,7 @@ async def upload_unstructured_file(
             filename = original_filename,
             size_bytes = size_bytes,
             status = "error",
-            error = f"Cannot read {ext} files: the '{missing}' package is not installed.",
+            error = "Text extraction failed.",
         )
     except Exception as e:
         raw_path.unlink(missing_ok = True)

--- a/studio/backend/tests/test_data_recipe_seed.py
+++ b/studio/backend/tests/test_data_recipe_seed.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import asyncio
+import importlib.util
 from pathlib import Path
+
+import pytest
 
 
 def _seed_route_source() -> str:
@@ -14,9 +18,104 @@ def test_seed_inspect_load_kwargs_disables_remote_code_execution():
     assert '"trust_remote_code": False' in _seed_route_source()
 
 
-def test_unstructured_upload_names_missing_extractor_dependency():
-    # A missing optional extractor (pymupdf4llm/mammoth) must name the package,
-    # not collapse into a generic "Text extraction failed".
-    source = _seed_route_source()
-    assert "except ImportError" in source
-    assert "is not installed" in source
+class _FakeUpload:
+    def __init__(self, filename: str, content: bytes):
+        self.filename = filename
+        self._content = content
+
+    async def read(self) -> bytes:
+        return self._content
+
+
+def _load_seed_route(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    pytest.importorskip("fastapi")
+    pytest.importorskip("multipart")
+    pytest.importorskip("structlog")
+
+    backend_root = Path(__file__).resolve().parent.parent
+    monkeypatch.syspath_prepend(str(backend_root))
+    route_path = backend_root / "routes" / "data_recipe" / "seed.py"
+    spec = importlib.util.spec_from_file_location("seed_under_test", route_path)
+    assert spec is not None and spec.loader is not None
+    seed_route = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(seed_route)
+    seed_route.UNSTRUCTURED_UPLOAD_ROOT = tmp_path / "unstructured-uploads"
+    return seed_route
+
+
+def _run_upload(seed_route, filename: str, content: bytes, block_id: str = "block"):
+    return asyncio.run(
+        seed_route.upload_unstructured_file(_FakeUpload(filename, content), block_id)
+    )
+
+
+def _block_files(seed_route, block_id: str = "block") -> list[str]:
+    block_dir = seed_route.UNSTRUCTURED_UPLOAD_ROOT / block_id
+    if not block_dir.exists():
+        return []
+    return sorted(path.name for path in block_dir.iterdir())
+
+
+def _raise(exc: BaseException):
+    def raise_exc(*args, **kwargs):
+        raise exc
+
+    return raise_exc
+
+
+@pytest.mark.parametrize(
+    ("filename", "package"),
+    [
+        ("paper.pdf", "pymupdf4llm"),
+        ("notes.docx", "mammoth"),
+    ],
+)
+def test_unstructured_upload_names_missing_extractor_dependency(
+    monkeypatch, tmp_path, filename, package
+):
+    seed_route = _load_seed_route(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        seed_route,
+        "_extract_text_from_file",
+        _raise(ModuleNotFoundError(f"No module named {package!r}", name=package)),
+    )
+
+    result = _run_upload(seed_route, filename, b"%PDF-1.7")
+
+    assert result.status == "error"
+    assert (
+        result.error
+        == f"Cannot read {Path(filename).suffix} files: the '{package}' package is not installed."
+    )
+    assert _block_files(seed_route) == []
+
+
+def test_unstructured_upload_keeps_txt_path_working(monkeypatch, tmp_path):
+    seed_route = _load_seed_route(monkeypatch, tmp_path)
+
+    result = _run_upload(seed_route, "notes.txt", b"hello")
+
+    assert result.status == "ok"
+    assert result.error is None
+    assert any(name.endswith(".txt") for name in _block_files(seed_route))
+    assert any(name.endswith(".extracted.txt") for name in _block_files(seed_route))
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ImportError("cannot import internal symbol"),
+        ModuleNotFoundError(
+            "No module named 'missing_transitive_pkg'",
+            name="missing_transitive_pkg",
+        ),
+    ],
+)
+def test_unstructured_upload_import_errors_stay_generic(monkeypatch, tmp_path, exc):
+    seed_route = _load_seed_route(monkeypatch, tmp_path)
+    monkeypatch.setattr(seed_route, "_extract_text_from_file", _raise(exc))
+    result = _run_upload(seed_route, "paper.pdf", b"%PDF-1.7")
+
+    assert result.status == "error"
+    assert result.error == "Text extraction failed."
+    assert _block_files(seed_route) == []

--- a/studio/backend/tests/test_data_recipe_seed.py
+++ b/studio/backend/tests/test_data_recipe_seed.py
@@ -4,9 +4,19 @@
 from pathlib import Path
 
 
-def test_seed_inspect_load_kwargs_disables_remote_code_execution():
-    seed_route = (
+def _seed_route_source() -> str:
+    return (
         Path(__file__).resolve().parent.parent / "routes" / "data_recipe" / "seed.py"
     ).read_text()
 
-    assert '"trust_remote_code": False' in seed_route
+
+def test_seed_inspect_load_kwargs_disables_remote_code_execution():
+    assert '"trust_remote_code": False' in _seed_route_source()
+
+
+def test_unstructured_upload_names_missing_extractor_dependency():
+    # A missing optional extractor (pymupdf4llm/mammoth) must name the package,
+    # not collapse into a generic "Text extraction failed".
+    source = _seed_route_source()
+    assert "except ImportError" in source
+    assert "is not installed" in source

--- a/studio/backend/tests/test_data_recipe_seed.py
+++ b/studio/backend/tests/test_data_recipe_seed.py
@@ -43,7 +43,12 @@ def _load_seed_route(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     return seed_route
 
 
-def _run_upload(seed_route, filename: str, content: bytes, block_id: str = "block"):
+def _run_upload(
+    seed_route,
+    filename: str,
+    content: bytes,
+    block_id: str = "block",
+):
     return asyncio.run(
         seed_route.upload_unstructured_file(_FakeUpload(filename, content), block_id)
     )
@@ -77,7 +82,7 @@ def test_unstructured_upload_names_missing_extractor_dependency(
     monkeypatch.setattr(
         seed_route,
         "_extract_text_from_file",
-        _raise(ModuleNotFoundError(f"No module named {package!r}", name=package)),
+        _raise(ModuleNotFoundError(f"No module named {package!r}", name = package)),
     )
 
     result = _run_upload(seed_route, filename, b"%PDF-1.7")
@@ -107,7 +112,7 @@ def test_unstructured_upload_keeps_txt_path_working(monkeypatch, tmp_path):
         ImportError("cannot import internal symbol"),
         ModuleNotFoundError(
             "No module named 'missing_transitive_pkg'",
-            name="missing_transitive_pkg",
+            name = "missing_transitive_pkg",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

When a file is uploaded to a Data Recipe, `upload_unstructured_file` extracts text via optional libraries: `pymupdf4llm` for PDF and `mammoth` for DOCX. These live in the data-designer dependency set, separate from the core requirements, so an install can be missing them while the rest of Recipes works.

If one is missing, the upload hits `import pymupdf4llm` (or `mammoth`), raises `ModuleNotFoundError`, and the broad `except Exception` reports a generic `Text extraction failed`. In the UI that surfaces as `Something went wrong`, with nothing telling the user a package is missing.

This catches `ImportError` before the generic handler and names the package, so the cause is obvious.

## Before / After

Before (PDF upload, `pymupdf4llm` not installed):

```
Text extraction failed.
```

After:

```
Cannot read .pdf files: the 'pymupdf4llm' package is not installed.
```

## Changes

- `upload_unstructured_file`: add an `except ImportError` branch that logs `data_recipe.seed.text_extraction_dependency_missing` and returns an error naming the missing package. The generic `except Exception` still covers real extraction failures.
- Add a regression test in the existing source-assertion style.

## Verification

- Reproduced both paths against a running Studio: a normal PDF still uploads and previews fine (`status: ok`), and with `pymupdf4llm` forced missing the response is `Cannot read .pdf files: the 'pymupdf4llm' package is not installed.`
- `ruff check` clean on both files; `pytest tests/test_data_recipe_seed.py` passes.

This improves the error message only. It does not change extraction behavior when the dependencies are present.
