### PR TITLE
Studio: keep the training event pump alive so progress can't silently freeze

### DIFF
--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -645,20 +645,26 @@ class TrainingBackend:
             new_pump.start()
 
     def _ensure_pump_alive(self) -> bool:
-        """Restart the event pump if it crashed while the worker is still running.
+        """Restart the event pump if it crashed, even after the worker exited.
 
         Defence in depth behind _pump_loop's own guards, for an unforeseen
         thread death (e.g. MemoryError). _pump_running is left True only when a
         pump exited abnormally -- the loop clears it on every intended exit -- so
         a True flag plus a dead thread is an unambiguous crash, and the False
         flag during start_training setup keeps this from spawning a duplicate
-        before the first pump runs. A fresh pump drains the still-open queue so
-        the UI catches up. Returns True if a restart was performed.
+        before the first pump runs. The restart happens even when the worker has
+        already exited: the queue can still hold the terminal complete/error
+        events, and a fresh pump must drain them and finalize the run -- otherwise
+        progress.is_training stays True and the run looks stuck "running" forever
+        behind the dead pump. Returns True if a restart was performed.
         """
         with self._lock:
             if not self._pump_running:
                 return False
-            if self._proc is None or not self._proc.is_alive() or self._event_queue is None:
+            # A worker handle and queue are still required: a restarted pump
+            # dereferences both to drain and finalize. Their absence means there
+            # is nothing left to recover.
+            if self._proc is None or self._event_queue is None:
                 return False
             if self._pump_thread is not None and self._pump_thread.is_alive():
                 return False

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -478,6 +478,11 @@ class TrainingBackend:
         self._xet_fallback_used = False
         self._needs_xet_respawn = False
 
+        # Create the DB run row before the pump can consume events, so it appears
+        # in history during model loading and a fast terminal worker can't race the
+        # pump into a duplicate create/finalize. From here the pump only finalizes.
+        self._ensure_db_run_created()
+
         # Assign handles and start the pump together under the lock so a concurrent
         # poll can't see a live _proc with no pump and spawn a duplicate.
         new_pump = threading.Thread(target = self._pump_loop, daemon = True)
@@ -488,10 +493,6 @@ class TrainingBackend:
             self._proc = proc
             self._pump_thread = new_pump
             new_pump.start()
-
-        # Eagerly create DB run row so it appears in history during model loading.
-        # Done after the pump is live; the pump also creates it on the first event.
-        self._ensure_db_run_created()
 
         return True
 

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -216,6 +216,11 @@ class TrainingBackend:
         self._event_queue: Any = None
         self._stop_queue: Any = None
         self._pump_thread: Optional[threading.Thread] = None
+        # True only while a pump thread is meant to be running. Cleared on the
+        # pump's intended exits (worker gone, run finalized); left True if the
+        # pump ever dies abnormally, which is how _ensure_pump_alive tells a
+        # crash apart from a clean shutdown.
+        self._pump_running: bool = False
         self._lock = threading.Lock()
 
         # Progress state (updated by pump thread from subprocess events)
@@ -623,10 +628,44 @@ class TrainingBackend:
             self._stop_queue = stop_queue
             self._proc = new_proc
             self._pump_thread = new_pump
-        new_pump.start()
+            # Start under the lock so _ensure_pump_alive can never observe the
+            # new pump as a not-yet-started (dead) thread and spawn a duplicate.
+            new_pump.start()
+
+    def _ensure_pump_alive(self) -> bool:
+        """Restart the event pump if it crashed while the worker is still running.
+
+        Defence in depth behind _pump_loop's own guards, for an unforeseen
+        thread death (e.g. MemoryError). _pump_running is left True only when a
+        pump exited abnormally -- the loop clears it on every intended exit -- so
+        a True flag plus a dead thread is an unambiguous crash, and the False
+        flag during start_training setup keeps this from spawning a duplicate
+        before the first pump runs. A fresh pump drains the still-open queue so
+        the UI catches up. Returns True if a restart was performed.
+        """
+        with self._lock:
+            if not self._pump_running:
+                return False
+            if self._proc is None or not self._proc.is_alive() or self._event_queue is None:
+                return False
+            if self._pump_thread is not None and self._pump_thread.is_alive():
+                return False
+            logger.error(
+                "Training event pump thread died while the worker is still running; "
+                "restarting it so progress updates resume."
+            )
+            new_pump = threading.Thread(target = self._pump_loop, daemon = True)
+            self._pump_thread = new_pump
+            # Start under the lock so a concurrent _ensure_pump_alive can't see
+            # this thread as not-yet-started and spawn yet another pump.
+            new_pump.start()
+        return True
 
     def is_training_active(self) -> bool:
         """Check if training is currently active."""
+        # Self-heal a crashed pump first: a dead pump must never leave the worker
+        # training invisibly behind a frozen UI. Cheap enough for per-second polls.
+        self._ensure_pump_alive()
         with self._lock:
             if self._proc is not None and self._proc.is_alive():
                 return True
@@ -727,51 +766,91 @@ class TrainingBackend:
     # Event pump (background thread)
     # ------------------------------------------------------------------
 
+    def _safe_handle_event(self, event: dict) -> None:
+        """Apply one event, swallowing any handler error.
+
+        A malformed event must never propagate into _pump_loop: that thread is
+        the only writer of the in-memory progress state every status surface
+        reads, so if it died the worker would keep training while the UI froze.
+        """
+        try:
+            self._handle_event(event)
+        except Exception:
+            etype = event.get("type") if isinstance(event, dict) else type(event).__name__
+            logger.exception(
+                "Training event pump: failed to handle %s event; skipping", etype
+            )
+
     def _pump_loop(self) -> None:
-        """Background thread: consume events from subprocess → update state."""
+        """Background thread: consume events from subprocess → update state.
+
+        Resilience contract: this loop is the single writer of the in-memory
+        progress state that SSE /progress, /status, /metrics and the DB history
+        all read. If it exited while the worker subprocess was still running,
+        the run would keep burning GPU with events piling up in the (unbounded)
+        queue while every progress surface froze on the last step it saw -- the
+        worker and UI silently drift apart for the rest of the run. So no single
+        malformed event or transient queue/DB error may end it: every step is
+        guarded and the loop only returns through its intended exits (worker
+        handle gone, respawn handed off, or the run finalized).
+        """
+        self._pump_running = True
         while True:
             if self._proc is None or self._event_queue is None:
+                self._pump_running = False
                 return
 
-            event = self._read_queue(self._event_queue, timeout_sec = 0.25)
+            try:
+                event = self._read_queue(self._event_queue, timeout_sec = 0.25)
+            except Exception:
+                logger.exception("Training event pump: queue read failed; continuing")
+                time.sleep(0.1)
+                continue
+
             if event is not None:
-                self._handle_event(event)
+                self._safe_handle_event(event)
                 continue
 
             if self._proc.is_alive():
                 continue
 
-            # Process exited — drain remaining events.
-            for e in self._drain_queue(self._event_queue):
-                self._handle_event(e)
+            # Worker exited. Drain the backlog and finalize, guarded so a slow or
+            # failing DB write can't strand the thread; we return either way.
+            try:
+                for e in self._drain_queue(self._event_queue):
+                    self._safe_handle_event(e)
 
-            # Model-load stall: respawn over HTTP instead of finalizing as failure.
-            # Runs on THIS exiting pump thread and starts a fresh pump (never joins
-            # the current thread); DB run-state is preserved.
-            if self._needs_xet_respawn:
-                self._needs_xet_respawn = False
-                self._respawn_worker_disable_xet()
-                return
+                # Model-load stall: respawn over HTTP instead of finalizing as failure.
+                # Runs on THIS exiting pump thread and starts a fresh pump (never joins
+                # the current thread); DB run-state is preserved. The new pump takes
+                # over _pump_running, so this exit leaves the flag set.
+                if self._needs_xet_respawn:
+                    self._needs_xet_respawn = False
+                    self._respawn_worker_disable_xet()
+                    return
 
-            # Mark done if no explicit complete/error was received.
-            with self._lock:
-                if self._progress.is_training:
-                    if self._should_stop:
-                        self._progress.is_training = False
-                        self._progress.status_message = "Training stopped."
-                    else:
-                        self._progress.is_training = False
-                        self._progress.error = (
-                            self._progress.error or "Training process exited unexpectedly"
-                        )
+                # Mark done if no explicit complete/error was received.
+                with self._lock:
+                    if self._progress.is_training:
+                        if self._should_stop:
+                            self._progress.is_training = False
+                            self._progress.status_message = "Training stopped."
+                        else:
+                            self._progress.is_training = False
+                            self._progress.error = (
+                                self._progress.error or "Training process exited unexpectedly"
+                            )
 
-            self._ensure_db_run_created()
-            self._finalize_run_in_db(
-                status = "stopped" if self._should_stop else "error",
-                error_message = None
-                if self._should_stop
-                else "Training process terminated unexpectedly",
-            )
+                self._ensure_db_run_created()
+                self._finalize_run_in_db(
+                    status = "stopped" if self._should_stop else "error",
+                    error_message = None
+                    if self._should_stop
+                    else "Training process terminated unexpectedly",
+                )
+            except Exception:
+                logger.exception("Training event pump: finalization after worker exit failed")
+            self._pump_running = False
             return
 
     def _handle_event(self, event: dict) -> None:
@@ -1093,7 +1172,10 @@ class TrainingBackend:
             return q.get(timeout = timeout_sec)
         except queue.Empty:
             return None
-        except (EOFError, OSError, ValueError):
+        except Exception:
+            # A closed/broken queue (EOFError/OSError/ValueError) or an
+            # unpickleable payload from a crashing child must read as "no event"
+            # rather than propagating into the pump loop and killing it.
             return None
 
     @staticmethod

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -294,6 +294,9 @@ class TrainingBackend:
                 logger.warning("Previous pump thread did not exit within 5s — refusing to start")
                 return False
         self._pump_thread = None
+        # Clear any stale crash flag from a prior abnormally-died pump so the
+        # start-time watchdog can't treat this fresh setup as a recoverable death.
+        self._pump_running = False
 
         # Build config dict for the subprocess
         config = {
@@ -477,16 +480,21 @@ class TrainingBackend:
         self._xet_fallback_used = False
         self._needs_xet_respawn = False
 
-        # Assign subprocess handles after state reset.
-        self._event_queue = event_queue
-        self._stop_queue = stop_queue
-        self._proc = proc
+        # Assign subprocess handles and start the pump together under the lock, so
+        # a concurrent is_training_active()/_ensure_pump_alive() poll can never
+        # observe a live _proc with a not-yet-started pump and spawn a duplicate.
+        new_pump = threading.Thread(target = self._pump_loop, daemon = True)
+        with self._lock:
+            self._pump_running = False
+            self._event_queue = event_queue
+            self._stop_queue = stop_queue
+            self._proc = proc
+            self._pump_thread = new_pump
+            new_pump.start()
 
         # Eagerly create DB run row so it appears in history during model loading.
+        # Done after the pump is live; the pump also creates it on the first event.
         self._ensure_db_run_created()
-
-        self._pump_thread = threading.Thread(target = self._pump_loop, daemon = True)
-        self._pump_thread.start()
 
         return True
 
@@ -611,6 +619,10 @@ class TrainingBackend:
         except Exception:
             logger.error("Failed to respawn training subprocess", exc_info = True)
             with self._lock:
+                # No replacement pump will run; clear the liveness flag so a later
+                # run can't inherit a stale _pump_running=True (which would let the
+                # start-time watchdog spawn a duplicate pump).
+                self._pump_running = False
                 self._progress.is_training = False
                 self._progress.error = "Failed to recover stalled model download"
             self._ensure_db_run_created()
@@ -1172,10 +1184,11 @@ class TrainingBackend:
             return q.get(timeout = timeout_sec)
         except queue.Empty:
             return None
-        except Exception:
-            # A closed/broken queue (EOFError/OSError/ValueError) or an
-            # unpickleable payload from a crashing child must read as "no event"
-            # rather than propagating into the pump loop and killing it.
+        except (EOFError, OSError, ValueError):
+            # A closed/broken queue reads as "no event". Any *other* unexpected
+            # error is deliberately left to _pump_loop's guarded read block,
+            # which logs and backs off (time.sleep) so a persistently raising
+            # queue can't spin this into a hot loop.
             return None
 
     @staticmethod
@@ -1186,7 +1199,14 @@ class TrainingBackend:
                 events.append(q.get_nowait())
             except queue.Empty:
                 return events
-            except (EOFError, OSError, ValueError):
+            except Exception:
+                # Unlike the live read, a drain error must not abort the caller:
+                # _pump_loop drains here right before finalizing a worker exit, so
+                # return what we have and let finalization proceed rather than
+                # leaving the run wedged as "active" with a dead worker.
+                logger.exception(
+                    "Training event pump: queue drain failed; finalizing with drained events"
+                )
                 return events
 
     # ------------------------------------------------------------------

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -777,9 +777,7 @@ class TrainingBackend:
             self._handle_event(event)
         except Exception:
             etype = event.get("type") if isinstance(event, dict) else type(event).__name__
-            logger.exception(
-                "Training event pump: failed to handle %s event; skipping", etype
-            )
+            logger.exception("Training event pump: failed to handle %s event; skipping", etype)
 
     def _pump_loop(self) -> None:
         """Background thread: consume events from subprocess → update state.

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -819,9 +819,16 @@ class TrainingBackend:
             try:
                 event = self._read_queue(self._event_queue, timeout_sec = 0.25)
             except Exception:
+                # A read that keeps raising (e.g. a broken queue pipe after the
+                # child died) must not spin here forever: if the worker is gone,
+                # fall through to the finalize path below so the run can't stay
+                # "is_training" behind a dead worker. Only back off and retry
+                # while the worker is still alive.
                 logger.exception("Training event pump: queue read failed; continuing")
-                time.sleep(0.1)
-                continue
+                if self._proc is not None and self._proc.is_alive():
+                    time.sleep(0.1)
+                    continue
+                event = None
 
             if event is not None:
                 self._safe_handle_event(event)

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -216,10 +216,8 @@ class TrainingBackend:
         self._event_queue: Any = None
         self._stop_queue: Any = None
         self._pump_thread: Optional[threading.Thread] = None
-        # True only while a pump thread is meant to be running. Cleared on the
-        # pump's intended exits (worker gone, run finalized); left True if the
-        # pump ever dies abnormally, which is how _ensure_pump_alive tells a
-        # crash apart from a clean shutdown.
+        # True while a pump thread should be running; cleared on intended exits.
+        # Left True after an abnormal death so _ensure_pump_alive spots a crash.
         self._pump_running: bool = False
         self._lock = threading.Lock()
 
@@ -294,8 +292,8 @@ class TrainingBackend:
                 logger.warning("Previous pump thread did not exit within 5s — refusing to start")
                 return False
         self._pump_thread = None
-        # Clear any stale crash flag from a prior abnormally-died pump so the
-        # start-time watchdog can't treat this fresh setup as a recoverable death.
+        # Clear a stale crash flag from a prior died pump so the watchdog can't
+        # treat this fresh setup as a recoverable death.
         self._pump_running = False
 
         # Build config dict for the subprocess
@@ -480,9 +478,8 @@ class TrainingBackend:
         self._xet_fallback_used = False
         self._needs_xet_respawn = False
 
-        # Assign subprocess handles and start the pump together under the lock, so
-        # a concurrent is_training_active()/_ensure_pump_alive() poll can never
-        # observe a live _proc with a not-yet-started pump and spawn a duplicate.
+        # Assign handles and start the pump together under the lock so a concurrent
+        # poll can't see a live _proc with no pump and spawn a duplicate.
         new_pump = threading.Thread(target = self._pump_loop, daemon = True)
         with self._lock:
             self._pump_running = False
@@ -619,9 +616,8 @@ class TrainingBackend:
         except Exception:
             logger.error("Failed to respawn training subprocess", exc_info = True)
             with self._lock:
-                # No replacement pump will run; clear the liveness flag so a later
-                # run can't inherit a stale _pump_running=True (which would let the
-                # start-time watchdog spawn a duplicate pump).
+                # No replacement pump will run; clear the flag so a later run can't
+                # inherit a stale _pump_running=True and spawn a duplicate.
                 self._pump_running = False
                 self._progress.is_training = False
                 self._progress.error = "Failed to recover stalled model download"
@@ -647,23 +643,17 @@ class TrainingBackend:
     def _ensure_pump_alive(self) -> bool:
         """Restart the event pump if it crashed, even after the worker exited.
 
-        Defence in depth behind _pump_loop's own guards, for an unforeseen
-        thread death (e.g. MemoryError). _pump_running is left True only when a
-        pump exited abnormally -- the loop clears it on every intended exit -- so
-        a True flag plus a dead thread is an unambiguous crash, and the False
-        flag during start_training setup keeps this from spawning a duplicate
-        before the first pump runs. The restart happens even when the worker has
-        already exited: the queue can still hold the terminal complete/error
-        events, and a fresh pump must drain them and finalize the run -- otherwise
-        progress.is_training stays True and the run looks stuck "running" forever
-        behind the dead pump. Returns True if a restart was performed.
+        Defence in depth behind _pump_loop's guards. _pump_running stays True only
+        after an abnormal exit (the loop clears it on intended exits), so a True
+        flag plus a dead thread is an unambiguous crash. Restarts even after worker
+        exit so a fresh pump can drain the terminal events and finalize; otherwise
+        the run looks stuck "running" forever. Returns True if restarted.
         """
         with self._lock:
             if not self._pump_running:
                 return False
-            # A worker handle and queue are still required: a restarted pump
-            # dereferences both to drain and finalize. Their absence means there
-            # is nothing left to recover.
+            # A restarted pump needs the worker handle and queue to drain/finalize;
+            # their absence means nothing is left to recover.
             if self._proc is None or self._event_queue is None:
                 return False
             if self._pump_thread is not None and self._pump_thread.is_alive():
@@ -787,9 +777,8 @@ class TrainingBackend:
     def _safe_handle_event(self, event: dict) -> None:
         """Apply one event, swallowing any handler error.
 
-        A malformed event must never propagate into _pump_loop: that thread is
-        the only writer of the in-memory progress state every status surface
-        reads, so if it died the worker would keep training while the UI froze.
+        The pump is the only writer of the progress state every status surface
+        reads, so a malformed event must never propagate and kill it.
         """
         try:
             self._handle_event(event)
@@ -798,17 +787,13 @@ class TrainingBackend:
             logger.exception("Training event pump: failed to handle %s event; skipping", etype)
 
     def _pump_loop(self) -> None:
-        """Background thread: consume events from subprocess → update state.
+        """Background thread: consume subprocess events and update state.
 
-        Resilience contract: this loop is the single writer of the in-memory
-        progress state that SSE /progress, /status, /metrics and the DB history
-        all read. If it exited while the worker subprocess was still running,
-        the run would keep burning GPU with events piling up in the (unbounded)
-        queue while every progress surface froze on the last step it saw -- the
-        worker and UI silently drift apart for the rest of the run. So no single
-        malformed event or transient queue/DB error may end it: every step is
-        guarded and the loop only returns through its intended exits (worker
-        handle gone, respawn handed off, or the run finalized).
+        Sole writer of the in-memory progress state that /progress, /status,
+        /metrics and DB history read. If it exited while the worker still ran, the
+        run would burn GPU with events piling up while every surface froze. So no
+        single bad event or transient queue/DB error may end it; it returns only
+        through intended exits (worker gone, respawn handed off, finalized).
         """
         self._pump_running = True
         while True:
@@ -819,11 +804,8 @@ class TrainingBackend:
             try:
                 event = self._read_queue(self._event_queue, timeout_sec = 0.25)
             except Exception:
-                # A read that keeps raising (e.g. a broken queue pipe after the
-                # child died) must not spin here forever: if the worker is gone,
-                # fall through to the finalize path below so the run can't stay
-                # "is_training" behind a dead worker. Only back off and retry
-                # while the worker is still alive.
+                # If a read keeps raising after the worker died, fall through to
+                # finalize instead of spinning; only retry while the worker lives.
                 logger.exception("Training event pump: queue read failed; continuing")
                 if self._proc is not None and self._proc.is_alive():
                     time.sleep(0.1)
@@ -844,9 +826,8 @@ class TrainingBackend:
                     self._safe_handle_event(e)
 
                 # Model-load stall: respawn over HTTP instead of finalizing as failure.
-                # Runs on THIS exiting pump thread and starts a fresh pump (never joins
-                # the current thread); DB run-state is preserved. The new pump takes
-                # over _pump_running, so this exit leaves the flag set.
+                # Starts a fresh pump on this thread (no self-join); it takes over
+                # _pump_running, so this exit leaves the flag set.
                 if self._needs_xet_respawn:
                     self._needs_xet_respawn = False
                     self._respawn_worker_disable_xet()
@@ -1196,10 +1177,8 @@ class TrainingBackend:
         except queue.Empty:
             return None
         except (EOFError, OSError, ValueError):
-            # A closed/broken queue reads as "no event". Any *other* unexpected
-            # error is deliberately left to _pump_loop's guarded read block,
-            # which logs and backs off (time.sleep) so a persistently raising
-            # queue can't spin this into a hot loop.
+            # A closed/broken queue reads as "no event"; any other error is left to
+            # _pump_loop's guarded block, which logs and backs off.
             return None
 
     @staticmethod
@@ -1211,10 +1190,8 @@ class TrainingBackend:
             except queue.Empty:
                 return events
             except Exception:
-                # Unlike the live read, a drain error must not abort the caller:
-                # _pump_loop drains here right before finalizing a worker exit, so
-                # return what we have and let finalization proceed rather than
-                # leaving the run wedged as "active" with a dead worker.
+                # A drain error must not abort finalization: return what we have so
+                # the run finalizes rather than wedging "active" behind a dead worker.
                 logger.exception(
                     "Training event pump: queue drain failed; finalizing with drained events"
                 )

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -175,9 +175,9 @@ def test_pump_survives_handler_exception_and_keeps_processing(monkeypatch):
     pump = threading.Thread(target = b._pump_loop, daemon = True)
     pump.start()
     try:
-        assert _wait_until(lambda: handled.count("progress") == 2), (
-            "pump must keep processing good events after handler exceptions"
-        )
+        assert _wait_until(
+            lambda: handled.count("progress") == 2
+        ), "pump must keep processing good events after handler exceptions"
         assert pump.is_alive(), "pump thread must survive handler exceptions"
         assert b._pump_running is True
     finally:

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -9,8 +9,9 @@ the worker subprocess kept running, the run would continue (mp.Queue puts never
 block) while the UI froze on the last step it saw -- the long-standing "training
 is running in the background but no progress shows" symptom. These tests pin the
 two guarantees that prevent that: a single bad event/queue error can't kill the
-pump, and a pump that somehow does die is detected and restarted while the
-worker is alive. Driven with fakes; no GPU, no network, no real subprocess.
+pump, and a pump that somehow does die is detected and restarted -- even after
+the worker has exited, so the terminal events still get drained and the run is
+finalized. Driven with fakes; no GPU, no network, no real subprocess.
 """
 
 from __future__ import annotations
@@ -61,6 +62,10 @@ _pth = _types.ModuleType("utils.paths")
 _pth.outputs_root = lambda *a, **k: "/tmp/outputs"
 _stub("utils.paths", _pth)
 
+# Whether core.training.training was already imported before this file ran; only
+# evict it below if we were the one to create the (stub-bound) module instance.
+_TRAINING_PRE_IMPORTED = "core.training.training" in sys.modules
+
 from core.training.training import TrainingBackend
 
 # Restore every stubbed module so this file never pollutes the shared session.
@@ -78,6 +83,14 @@ for _name in (
         sys.modules.pop(_name, None)
     else:
         sys.modules[_name] = _prev
+
+# core.training.training imported its module-level helpers (prepare_gpu_selection,
+# etc.) while the stubs above were active, so those names stay bound to the stubs
+# in its globals. If we created that cached module, evict it (and its parent
+# package) so a later test re-imports the real module instead of the stubbed one.
+if not _TRAINING_PRE_IMPORTED:
+    sys.modules.pop("core.training.training", None)
+    sys.modules.pop("core.training", None)
 
 
 class _FakeProc:
@@ -331,14 +344,27 @@ def test_ensure_pump_alive_noop_when_pump_alive():
         alive.join(timeout = 5)
 
 
-def test_ensure_pump_alive_noop_when_worker_dead():
+def test_ensure_pump_alive_revives_crashed_pump_after_worker_exit(monkeypatch):
+    # A True _pump_running flag with a dead pump thread is a crash (the loop
+    # clears the flag on every intended exit). Even when the worker has already
+    # exited, the queue can still hold the terminal complete/error events, so the
+    # pump must be restarted to drain + finalize -- otherwise progress.is_training
+    # stays True and the run is stuck "running" forever behind the dead pump.
     b = TrainingBackend()
+    _silence_db(monkeypatch, b)
     b._proc = _FakeProc(alive = False)
     b._event_queue = _IdleQueue()
+    b._progress.is_training = True
     b._pump_running = True
     b._pump_thread = _dead_thread()
-    # Worker gone: the dead pump exited legitimately, nothing to revive.
-    assert b._ensure_pump_alive() is False
+
+    assert b._ensure_pump_alive() is True
+    assert _wait_until(
+        lambda: b._progress.is_training is False
+    ), "the restarted pump must drain + finalize the stranded run"
+    b._pump_thread.join(timeout = 5)
+    assert b._pump_running is False
+    assert b.is_training_active() is False
 
 
 def test_ensure_pump_alive_noop_during_setup():

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Parent-side training event-pump resilience.
+
+The pump thread is the only writer of the in-memory progress state that SSE
+/progress, /status, /metrics and the DB history all read. If it ever died while
+the worker subprocess kept running, the run would continue (mp.Queue puts never
+block) while the UI froze on the last step it saw -- the long-standing "training
+is running in the background but no progress shows" symptom. These tests pin the
+two guarantees that prevent that: a single bad event/queue error can't kill the
+pump, and a pump that somehow does die is detected and restarted while the
+worker is alive. Driven with fakes; no GPU, no network, no real subprocess.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import queue
+import sys
+import threading
+import time
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Stub the heavy module-level imports of core/training/training.py so it imports
+# under CPU-only/no-network, then restore them (see the restore loop below).
+_SAVED: dict = {}
+
+
+def _stub(name, mod):
+    _SAVED[name] = sys.modules.get(name)
+    sys.modules[name] = mod
+
+
+_lg = _types.ModuleType("loggers")
+_lg.get_logger = lambda name: logging.getLogger(name)
+_stub("loggers", _lg)
+_stub("structlog", _types.ModuleType("structlog"))
+_mpl = _types.ModuleType("matplotlib")
+_plt = _types.ModuleType("matplotlib.pyplot")
+_plt.Figure = type("Figure", (), {})  # referenced in a class-def annotation
+_mpl.pyplot = _plt
+_stub("matplotlib", _mpl)
+_stub("matplotlib.pyplot", _plt)
+_hw = _types.ModuleType("utils.hardware")
+_hw.prepare_gpu_selection = lambda *a, **k: (None, None)
+_stub("utils.hardware", _hw)
+_npl = _types.ModuleType("utils.native_path_leases")
+_npl.native_path_secret_removed_for_child_start = lambda: contextlib.nullcontext()
+_npl.run_without_native_path_secret = lambda fn: fn
+_stub("utils.native_path_leases", _npl)
+_pth = _types.ModuleType("utils.paths")
+_pth.outputs_root = lambda *a, **k: "/tmp/outputs"
+_stub("utils.paths", _pth)
+
+from core.training.training import TrainingBackend
+
+# Restore every stubbed module so this file never pollutes the shared session.
+for _name in (
+    "loggers",
+    "structlog",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "utils.hardware",
+    "utils.native_path_leases",
+    "utils.paths",
+):
+    _prev = _SAVED.get(_name)
+    if _prev is None:
+        sys.modules.pop(_name, None)
+    else:
+        sys.modules[_name] = _prev
+
+
+class _FakeProc:
+    """A subprocess handle whose liveness the test drives directly."""
+
+    def __init__(self, alive: bool = True):
+        self._alive = alive
+        self.pid = 4321
+
+    def is_alive(self):
+        return self._alive
+
+    def join(self, timeout = None):
+        self._alive = False
+
+
+class _IdleQueue:
+    """get()/get_nowait() always signal "no event" so the pump idles."""
+
+    def put(self, *a, **k):
+        pass
+
+    def get(self, *a, **k):
+        raise queue.Empty
+
+    def get_nowait(self, *a, **k):
+        raise queue.Empty
+
+
+class _ScriptedQueue:
+    """Yields queued events once, then signals empty forever."""
+
+    def __init__(self, events):
+        self._events = list(events)
+
+    def put(self, *a, **k):
+        pass
+
+    def get(self, *a, **k):
+        if self._events:
+            return self._events.pop(0)
+        raise queue.Empty
+
+    def get_nowait(self, *a, **k):
+        if self._events:
+            return self._events.pop(0)
+        raise queue.Empty
+
+
+def _dead_thread() -> threading.Thread:
+    t = threading.Thread(target = lambda: None)
+    t.start()
+    t.join()
+    return t
+
+
+def _silence_db(monkeypatch, b):
+    """Neutralize DB finalization so a started pump exits cleanly off-box."""
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **k: None)
+
+
+def _wait_until(predicate, timeout = 5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+# ----------------------------------------------------------------------------
+# Guarantee 1: a single bad event/queue error cannot kill the pump.
+# ----------------------------------------------------------------------------
+
+
+def test_pump_survives_handler_exception_and_keeps_processing(monkeypatch):
+    b = TrainingBackend()
+    _silence_db(monkeypatch, b)
+    handled: list = []
+
+    def fake_handle(ev):
+        if ev.get("type") == "boom":
+            raise RuntimeError("handler blew up")
+        handled.append(ev.get("type"))
+
+    monkeypatch.setattr(b, "_handle_event", fake_handle)
+
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    b._event_queue = _ScriptedQueue(
+        [{"type": "boom"}, {"type": "progress"}, {"type": "boom"}, {"type": "progress"}]
+    )
+
+    pump = threading.Thread(target = b._pump_loop, daemon = True)
+    pump.start()
+    try:
+        assert _wait_until(lambda: handled.count("progress") == 2), (
+            "pump must keep processing good events after handler exceptions"
+        )
+        assert pump.is_alive(), "pump thread must survive handler exceptions"
+        assert b._pump_running is True
+    finally:
+        proc._alive = False  # let the loop reach its clean exit
+        pump.join(timeout = 5)
+
+    assert not pump.is_alive()
+    assert b._pump_running is False, "clean exit must clear the running flag"
+
+
+def test_read_queue_swallows_arbitrary_exception():
+    class _ExplodingQueue:
+        def get(self, *a, **k):
+            raise RuntimeError("queue exploded")
+
+    # An unexpected error (not just Empty/EOFError/OSError/ValueError) must read
+    # as "no event", never bubble up to the pump loop.
+    assert TrainingBackend._read_queue(_ExplodingQueue(), 0.01) is None
+
+
+# ----------------------------------------------------------------------------
+# Guarantee 2: a pump that dies while the worker runs is detected + restarted.
+# ----------------------------------------------------------------------------
+
+
+def test_ensure_pump_alive_restarts_crashed_pump(monkeypatch):
+    b = TrainingBackend()
+    _silence_db(monkeypatch, b)
+    b._proc = _FakeProc(alive = True)
+    b._event_queue = _IdleQueue()
+    b._pump_running = True  # a pump started, then died abnormally
+    dead = _dead_thread()
+    b._pump_thread = dead
+
+    assert b._ensure_pump_alive() is True
+    try:
+        assert b._pump_thread is not dead
+        assert b._pump_thread.is_alive(), "a fresh pump must be running"
+    finally:
+        b._proc._alive = False
+        b._pump_thread.join(timeout = 5)
+
+
+def test_ensure_pump_alive_noop_when_pump_alive():
+    b = TrainingBackend()
+    b._proc = _FakeProc(alive = True)
+    b._event_queue = _IdleQueue()
+    b._pump_running = True
+    release = threading.Event()
+    alive = threading.Thread(target = release.wait, daemon = True)
+    alive.start()
+    b._pump_thread = alive
+    try:
+        assert b._ensure_pump_alive() is False
+        assert b._pump_thread is alive
+    finally:
+        release.set()
+        alive.join(timeout = 5)
+
+
+def test_ensure_pump_alive_noop_when_worker_dead():
+    b = TrainingBackend()
+    b._proc = _FakeProc(alive = False)
+    b._event_queue = _IdleQueue()
+    b._pump_running = True
+    b._pump_thread = _dead_thread()
+    # Worker gone: the dead pump exited legitimately, nothing to revive.
+    assert b._ensure_pump_alive() is False
+
+
+def test_ensure_pump_alive_noop_during_setup():
+    # _pump_running is False between state-reset and the first pump actually
+    # running; the watchdog must not race in and spawn a rogue pump.
+    b = TrainingBackend()
+    b._proc = _FakeProc(alive = True)
+    b._event_queue = _IdleQueue()
+    b._pump_running = False
+    b._pump_thread = None
+    assert b._ensure_pump_alive() is False
+    assert b._pump_thread is None
+
+
+def test_is_training_active_revives_dead_pump(monkeypatch):
+    b = TrainingBackend()
+    _silence_db(monkeypatch, b)
+    b._proc = _FakeProc(alive = True)
+    b._event_queue = _IdleQueue()
+    b._pump_running = True
+    dead = _dead_thread()
+    b._pump_thread = dead
+
+    # The status poll the SSE stream makes every second both reports activity
+    # and heals the dead pump as a side effect.
+    assert b.is_training_active() is True
+    try:
+        assert b._pump_thread is not dead
+        assert b._pump_thread.is_alive()
+    finally:
+        b._proc._alive = False
+        b._pump_thread.join(timeout = 5)

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -485,9 +485,9 @@ def test_db_run_created_before_pump_consumes_events(monkeypatch):
     monkeypatch.setattr(b, "_ensure_db_run_created", slow_create)
     monkeypatch.setattr(b, "_pump_loop", fake_pump)
 
-    assert b.start_training("job_db_order", model_name="m") is True
+    assert b.start_training("job_db_order", model_name = "m") is True
     if b._pump_thread is not None:
-        b._pump_thread.join(timeout=2.0)
+        b._pump_thread.join(timeout = 2.0)
 
     # The pump observed an already-created run; it would be False if the pump
     # were started before the eager create.

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -418,3 +418,77 @@ def test_is_training_active_revives_dead_pump(monkeypatch):
     finally:
         b._proc._alive = False
         b._pump_thread.join(timeout = 5)
+
+
+# ----------------------------------------------------------------------------
+# Guarantee 3: the DB run row exists before the pump consumes any event.
+# ----------------------------------------------------------------------------
+
+
+def _stub_spawn(monkeypatch):
+    """Stub start_training's spawn surface (GPU pick, mp context, worker)."""
+    g = TrainingBackend.start_training.__globals__
+
+    class _SpawnProc:
+        pid = 4321
+
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return True
+
+    class _Ctx:
+        def Queue(self):
+            return _IdleQueue()
+
+        def Process(self, **k):
+            return _SpawnProc()
+
+    # _CTX / prepare_gpu_selection resolve from the module globals; patch the
+    # function's own globals so the eviction of core.training.training (done at
+    # this test module's import for isolation) can't hand us a different copy.
+    monkeypatch.setitem(g, "_CTX", _Ctx())
+    monkeypatch.setitem(g, "prepare_gpu_selection", lambda *a, **k: (None, None))
+
+    hw = _types.ModuleType("utils.hardware")
+    hw.prepare_gpu_selection = lambda *a, **k: (None, None)
+    hw.hardware = type("HW", (), {"DEVICE": "cuda", "DeviceType": type("D", (), {"MLX": "mlx"})})()
+    monkeypatch.setitem(sys.modules, "utils.hardware", hw)
+
+    pl = _types.ModuleType("utils.process_lifetime")
+    pl.adopt_pid = lambda pid: None
+    monkeypatch.setitem(sys.modules, "utils.process_lifetime", pl)
+
+    worker = _types.ModuleType("core.training.worker")
+    worker.run_training_process = lambda **k: None
+    monkeypatch.setitem(sys.modules, "core.training.worker", worker)
+
+
+def test_db_run_created_before_pump_consumes_events(monkeypatch):
+    # A fast terminal worker must not race the pump into creating the DB row: by
+    # the time the pump runs, start_training has already created it. The create
+    # sleep widens the window so the ordering is observed, not luck.
+    b = TrainingBackend()
+    _stub_spawn(monkeypatch)
+
+    def slow_create():
+        time.sleep(0.05)
+        b._db_run_created = True
+
+    seen = {}
+
+    def fake_pump():
+        seen["db_created"] = b._db_run_created
+        b._pump_running = False
+
+    monkeypatch.setattr(b, "_ensure_db_run_created", slow_create)
+    monkeypatch.setattr(b, "_pump_loop", fake_pump)
+
+    assert b.start_training("job_db_order", model_name="m") is True
+    if b._pump_thread is not None:
+        b._pump_thread.join(timeout=2.0)
+
+    # The pump observed an already-created run; it would be False if the pump
+    # were started before the eager create.
+    assert seen["db_created"] is True

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -188,14 +188,107 @@ def test_pump_survives_handler_exception_and_keeps_processing(monkeypatch):
     assert b._pump_running is False, "clean exit must clear the running flag"
 
 
-def test_read_queue_swallows_arbitrary_exception():
-    class _ExplodingQueue:
-        def get(self, *a, **k):
-            raise RuntimeError("queue exploded")
+def test_read_queue_narrow_contract():
+    class _Q:
+        def __init__(self, exc):
+            self.exc = exc
 
-    # An unexpected error (not just Empty/EOFError/OSError/ValueError) must read
-    # as "no event", never bubble up to the pump loop.
-    assert TrainingBackend._read_queue(_ExplodingQueue(), 0.01) is None
+        def get(self, *a, **k):
+            raise self.exc
+
+    # Expected closed/broken-queue signals read as "no event".
+    for exc in (queue.Empty(), EOFError(), OSError(), ValueError()):
+        assert TrainingBackend._read_queue(_Q(exc), 0.01) is None
+
+    # Anything *unexpected* propagates on purpose, so _pump_loop's guarded read
+    # block can log and back off (time.sleep) instead of _read_queue swallowing
+    # it into a hot, frozen loop.
+    with pytest.raises(RuntimeError):
+        TrainingBackend._read_queue(_Q(RuntimeError("boom")), 0.01)
+
+
+def test_pump_survives_queue_read_exception_and_recovers(monkeypatch):
+    # _read_queue raising an unexpected error must be caught by the pump's outer
+    # guard (log + backoff), not kill the pump; once reads recover it processes.
+    b = TrainingBackend()
+    _silence_db(monkeypatch, b)
+    handled: list = []
+    monkeypatch.setattr(b, "_handle_event", lambda ev: handled.append(ev.get("type")))
+
+    class _FlakyQueue:
+        def __init__(self):
+            self.calls = 0
+
+        def get(self, *a, **k):
+            self.calls += 1
+            if self.calls <= 3:
+                raise RuntimeError("transient queue read error")
+            if self.calls == 4:
+                return {"type": "progress", "step": 1}
+            raise queue.Empty
+
+        def get_nowait(self, *a, **k):
+            raise queue.Empty
+
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    b._event_queue = _FlakyQueue()
+
+    pump = threading.Thread(target = b._pump_loop, daemon = True)
+    pump.start()
+    try:
+        assert _wait_until(lambda: handled == ["progress"]), (
+            "pump must recover after read errors and process the next event"
+        )
+        assert pump.is_alive()
+    finally:
+        proc._alive = False
+        pump.join(timeout = 5)
+
+
+def test_pump_finalizes_when_drain_queue_raises_unexpected_error(monkeypatch):
+    # Worker has exited; the final drain hits an unexpected error. The run must
+    # still be finalized (not wedged "active" with a dead worker).
+    b = TrainingBackend()
+    finalized: dict = {}
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.update(kw))
+
+    class _BadDrainQueue:
+        def get(self, *a, **k):
+            raise queue.Empty
+
+        def get_nowait(self, *a, **k):
+            raise RuntimeError("corrupt drain payload")
+
+    b._proc = _FakeProc(alive = False)
+    b._event_queue = _BadDrainQueue()
+    b._progress.is_training = True
+
+    b._pump_loop()  # returns once it sees the dead worker
+
+    assert b._progress.is_training is False
+    assert b._progress.error == "Training process exited unexpectedly"
+    assert finalized.get("status") == "error"
+    assert b._pump_running is False
+    assert b.is_training_active() is False
+
+
+def test_start_training_clears_stale_pump_running_flag():
+    # A prior pump that died abnormally leaves _pump_running True. The next
+    # start_training must clear it during reset so the start-time watchdog can't
+    # treat the fresh setup as a recoverable crash and spawn a duplicate pump.
+    b = TrainingBackend()
+    b._pump_running = True
+    b._pump_thread = None
+    b._proc = None
+
+    # No model_name -> start_training bails at kwargs["model_name"] (KeyError),
+    # but only AFTER the reset block that clears the stale flag.
+    with pytest.raises(KeyError):
+        b.start_training("job_stale_flag_test")
+
+    assert b._pump_running is False
 
 
 # ----------------------------------------------------------------------------

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -237,9 +237,9 @@ def test_pump_survives_queue_read_exception_and_recovers(monkeypatch):
     pump = threading.Thread(target = b._pump_loop, daemon = True)
     pump.start()
     try:
-        assert _wait_until(lambda: handled == ["progress"]), (
-            "pump must recover after read errors and process the next event"
-        )
+        assert _wait_until(
+            lambda: handled == ["progress"]
+        ), "pump must recover after read errors and process the next event"
         assert pump.is_alive()
     finally:
         proc._alive = False

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -287,6 +287,36 @@ def test_pump_finalizes_when_drain_queue_raises_unexpected_error(monkeypatch):
     assert b.is_training_active() is False
 
 
+def test_pump_finalizes_when_read_keeps_raising_on_dead_worker(monkeypatch):
+    # _read_queue only swallows EOFError/OSError/ValueError; an unexpected error
+    # escapes to the pump's outer guard. If it keeps raising after the worker has
+    # exited, the loop must still fall through to finalize -- not spin forever
+    # with a continue, leaving is_training True behind a dead worker.
+    b = TrainingBackend()
+    finalized: dict = {}
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.update(kw))
+
+    class _BrokenReadQueue:
+        def get(self, *a, **k):
+            raise RuntimeError("broken queue pipe")
+
+        def get_nowait(self, *a, **k):
+            raise queue.Empty
+
+    b._proc = _FakeProc(alive = False)
+    b._event_queue = _BrokenReadQueue()
+    b._progress.is_training = True
+
+    pump = threading.Thread(target = b._pump_loop, daemon = True)
+    pump.start()
+    pump.join(timeout = 5)
+    assert not pump.is_alive(), "pump must finalize a dead worker even when reads keep raising"
+    assert b._progress.is_training is False
+    assert finalized.get("status") == "error"
+    assert b._pump_running is False
+
+
 def test_start_training_clears_stale_pump_running_flag():
     # A prior pump that died abnormally leaves _pump_running True. The next
     # start_training must clear it during reset so the start-time watchdog can't

--- a/studio/backend/tests/test_training_pump_resilience.py
+++ b/studio/backend/tests/test_training_pump_resilience.py
@@ -3,15 +3,12 @@
 
 """Parent-side training event-pump resilience.
 
-The pump thread is the only writer of the in-memory progress state that SSE
-/progress, /status, /metrics and the DB history all read. If it ever died while
-the worker subprocess kept running, the run would continue (mp.Queue puts never
-block) while the UI froze on the last step it saw -- the long-standing "training
-is running in the background but no progress shows" symptom. These tests pin the
-two guarantees that prevent that: a single bad event/queue error can't kill the
-pump, and a pump that somehow does die is detected and restarted -- even after
-the worker has exited, so the terminal events still get drained and the run is
-finalized. Driven with fakes; no GPU, no network, no real subprocess.
+The pump is the only writer of the progress state /progress, /status, /metrics
+and DB history read. If it died while the worker ran, the run would continue while
+the UI froze -- the "training runs but no progress shows" symptom. These tests pin
+two guards: a bad event/queue error can't kill the pump, and a dead pump is
+detected and restarted (even after worker exit) so terminal events still finalize.
+Fakes only; no GPU, network, or subprocess.
 """
 
 from __future__ import annotations
@@ -84,10 +81,9 @@ for _name in (
     else:
         sys.modules[_name] = _prev
 
-# core.training.training imported its module-level helpers (prepare_gpu_selection,
-# etc.) while the stubs above were active, so those names stay bound to the stubs
-# in its globals. If we created that cached module, evict it (and its parent
-# package) so a later test re-imports the real module instead of the stubbed one.
+# training imported its helpers while the stubs were active, binding them to stubs.
+# If we created the cached module, evict it (and its parent) so a later test
+# re-imports the real one.
 if not _TRAINING_PRE_IMPORTED:
     sys.modules.pop("core.training.training", None)
     sys.modules.pop("core.training", None)
@@ -213,9 +209,8 @@ def test_read_queue_narrow_contract():
     for exc in (queue.Empty(), EOFError(), OSError(), ValueError()):
         assert TrainingBackend._read_queue(_Q(exc), 0.01) is None
 
-    # Anything *unexpected* propagates on purpose, so _pump_loop's guarded read
-    # block can log and back off (time.sleep) instead of _read_queue swallowing
-    # it into a hot, frozen loop.
+    # Anything unexpected propagates on purpose to _pump_loop's guarded block,
+    # which logs and backs off instead of swallowing it into a hot loop.
     with pytest.raises(RuntimeError):
         TrainingBackend._read_queue(_Q(RuntimeError("boom")), 0.01)
 
@@ -288,10 +283,8 @@ def test_pump_finalizes_when_drain_queue_raises_unexpected_error(monkeypatch):
 
 
 def test_pump_finalizes_when_read_keeps_raising_on_dead_worker(monkeypatch):
-    # _read_queue only swallows EOFError/OSError/ValueError; an unexpected error
-    # escapes to the pump's outer guard. If it keeps raising after the worker has
-    # exited, the loop must still fall through to finalize -- not spin forever
-    # with a continue, leaving is_training True behind a dead worker.
+    # An unexpected error escapes _read_queue to the pump's outer guard; if it
+    # keeps raising after worker exit, the loop must still finalize, not spin.
     b = TrainingBackend()
     finalized: dict = {}
     monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
@@ -375,11 +368,9 @@ def test_ensure_pump_alive_noop_when_pump_alive():
 
 
 def test_ensure_pump_alive_revives_crashed_pump_after_worker_exit(monkeypatch):
-    # A True _pump_running flag with a dead pump thread is a crash (the loop
-    # clears the flag on every intended exit). Even when the worker has already
-    # exited, the queue can still hold the terminal complete/error events, so the
-    # pump must be restarted to drain + finalize -- otherwise progress.is_training
-    # stays True and the run is stuck "running" forever behind the dead pump.
+    # True _pump_running + dead thread = a crash (the loop clears the flag on
+    # intended exits). The queue may still hold terminal events, so the pump must
+    # restart to drain and finalize, else the run is stuck "running" forever.
     b = TrainingBackend()
     _silence_db(monkeypatch, b)
     b._proc = _FakeProc(alive = False)


### PR DESCRIPTION
## Problem

Several users have hit a state where a training run is clearly still alive in the background (GPU busy, subprocess running) but Studio shows no progress at all, sometimes for many hours. The worker and the UI silently drift apart and never reconcile for the rest of the run.

## Root cause

In `studio/backend/core/training/training.py`, training runs in a child process that pushes `progress`/`status`/`complete` events onto an unbounded `multiprocessing.Queue`. Every progress surface the UI reads, the SSE `/progress` stream, `/status`, `/metrics`, and the persisted DB history, is derived from in-memory state (`step_history`, `_progress`, ...) that is written by exactly one place: the `_pump_loop` daemon thread.

That thread was unsupervised and unguarded:

- `_pump_loop` was `while True:` with no try/except around `_read_queue` / `_handle_event`. A single malformed event, or a transient error, would propagate out and end the thread permanently. There was no watchdog or restart.
- `_read_queue` only swallowed `Empty/EOFError/OSError/ValueError`, so anything else (for example an unpickleable payload from a child that crashed mid-write) killed the pump.
- `is_training_active()` keys liveness on `self._proc.is_alive()`, the child, never on the pump. So after the pump died, the SSE loop kept spinning, re-reading frozen state, emitting only stale heartbeats.

Because the queue is unbounded, `queue.put()` in the worker never blocks even with nobody draining, so the worker keeps training while the in-memory state, and therefore every UI surface and the DB history, freezes on the last step the pump saw.

## Fix

All in `studio/backend/core/training/training.py`:

1. Make `_pump_loop` unkillable. Each iteration is guarded: a bad event or queue-read error is logged and skipped via a new `_safe_handle_event`, and the post-exit drain/finalize is guarded too. The loop only returns through its intended exits.
2. Broaden `_read_queue` to treat any unexpected error as "no event" rather than letting it reach the loop.
3. Add a `_pump_running` flag plus an `_ensure_pump_alive()` watchdog wired into `is_training_active()`. If the pump ever dies while the worker is still running, the next status poll (the SSE stream polls every second) restarts it and the UI catches up from the still-open queue. The flag distinguishes an abnormal death from a clean shutdown, and from the brief setup window, so the watchdog never spawns a duplicate.
4. Start respawned and restarted pumps under the lock so a concurrent watchdog call can never observe a not-yet-started pump and spawn a second one.

No change to the queue being unbounded (a bounded queue could block the worker, which is worse), and no public API or schema change.

## Testing

Adds `studio/backend/tests/test_training_pump_resilience.py` (6 tests) pinning both guarantees: the pump keeps processing after a handler raises, `_read_queue` swallows arbitrary errors, and a pump that dies while the worker is alive is detected and restarted (including the no-op cases: pump alive, worker dead, and the setup window).

```
python -m pytest studio/backend/tests/test_training_pump_resilience.py \
  studio/backend/tests/test_training_xet_fallback.py \
  studio/backend/tests/test_training_nan_loss_handling.py \
  studio/backend/tests/test_training_progress_stream_nan.py \
  studio/backend/tests/test_chat_load_during_training.py -q
```

All pass, with no regressions in the existing training/pump tests.
