### PR TITLE
Improve empty text dataset validation

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -75,6 +75,7 @@ from utils.datasets import format_and_template_dataset
 from utils.datasets.completion_masking import apply_completion_masking
 from utils.datasets.iterable import is_streaming_dataset as detect_streaming_dataset
 from utils.datasets.raw_text import prepare_raw_text_dataset, resolve_column_names
+from utils.datasets.text_validation import validate_text_sft_dataset
 from utils.paths import (
     ensure_dir,
     resolve_dataset_path,
@@ -2674,6 +2675,18 @@ class UnslothTrainer:
                 if split_result is not None:
                     train_portion, eval_dataset = split_result
                     dataset_info["dataset"] = train_portion
+
+            dataset_info["dataset"] = validate_text_sft_dataset(
+                dataset_info["dataset"],
+                split_name = "train",
+                is_vlm = self.is_vlm,
+            )
+            if eval_dataset is not None:
+                eval_dataset = validate_text_sft_dataset(
+                    eval_dataset,
+                    split_name = "eval",
+                    is_vlm = self.is_vlm,
+                )
 
             return (dataset_info, eval_dataset)
 

--- a/studio/backend/tests/test_text_dataset_validation.py
+++ b/studio/backend/tests/test_text_dataset_validation.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import pytest
+from datasets import Dataset, IterableDataset
+
+from utils.datasets.raw_text import prepare_raw_text_dataset
+from utils.datasets.text_validation import validate_text_sft_dataset
+
+
+def test_materialized_text_dataset_accepts_non_empty_rows():
+    dataset = [{"text": "hello"}, {"text": " world "}]
+
+    assert validate_text_sft_dataset(dataset, split_name = "train") is dataset
+
+
+def test_materialized_text_dataset_rejects_an_empty_split():
+    with pytest.raises(ValueError, match = "the train split is empty"):
+        validate_text_sft_dataset([], split_name = "train")
+
+
+def test_materialized_text_dataset_is_validated_completely():
+    dataset = Dataset.from_dict({"text": ["hello", "world", "   "]})
+
+    with pytest.raises(ValueError, match = r"train row 2 has an empty `text` field"):
+        validate_text_sft_dataset(dataset, split_name = "train")
+
+
+@pytest.mark.parametrize(
+    ("row", "message"),
+    [
+        ({"prompt": "missing"}, "eval row 0 is missing the `text` field"),
+        ({"text": None}, "eval row 0 has a non-string `text` field"),
+    ],
+)
+def test_materialized_text_dataset_reports_invalid_field(row, message):
+    with pytest.raises(ValueError, match = message):
+        validate_text_sft_dataset([row], split_name = "eval")
+
+
+def test_streaming_text_validation_is_lazy_and_rejects_a_later_blank():
+    visited: list[int] = []
+
+    def rows():
+        for index, text in enumerate(["first", "second", ""]):
+            visited.append(index)
+            yield {"text": text}
+
+    dataset = IterableDataset.from_generator(rows)
+    validated = validate_text_sft_dataset(dataset, split_name = "train")
+
+    assert visited == []
+    iterator = iter(validated)
+    assert next(iterator)["text"] == "first"
+    assert next(iterator)["text"] == "second"
+    with pytest.raises(ValueError, match = r"train row 2 has an empty `text` field"):
+        next(iterator)
+    assert visited == [0, 1, 2]
+
+
+def test_streaming_validation_does_not_scan_an_unbounded_invalid_prefix():
+    visited = 0
+
+    def rows():
+        nonlocal visited
+        while True:
+            visited += 1
+            yield {"text": None}
+
+    dataset = IterableDataset.from_generator(rows)
+    result = prepare_raw_text_dataset(
+        dataset,
+        mode_label = "CPT",
+        split_name = "train",
+        eos_token = "<eos>",
+        append_eos = True,
+    )
+
+    # Raw-text column discovery may perform its existing one-row schema probe,
+    # but validation must not continue through the unbounded invalid prefix.
+    assert visited == 1
+    assert result.dataset is not dataset
+
+
+def test_streaming_raw_text_drops_invalid_prefix_lazily_then_appends_eos():
+    visited: list[int] = []
+
+    def rows():
+        source = [None, 7, "valid"]
+        for index, text in enumerate(source):
+            visited.append(index)
+            yield {"text": text}
+
+    dataset = IterableDataset.from_generator(rows)
+    result = prepare_raw_text_dataset(
+        dataset,
+        mode_label = "CPT",
+        split_name = "train",
+        eos_token = "<eos>",
+        append_eos = True,
+    )
+
+    # Column discovery performs one bounded probe. HF IterableDataset starts a
+    # fresh generator when training later consumes the prepared pipeline.
+    assert visited == [0]
+    assert next(iter(result.dataset))["text"] == "valid<eos>"
+    assert visited == [0, 0, 1, 2]
+
+
+def test_raw_blank_is_rejected_before_eos_append():
+    dataset = Dataset.from_dict({"text": ["   "]})
+
+    with pytest.raises(ValueError, match = r"train row 0 has an empty `text` field"):
+        prepare_raw_text_dataset(
+            dataset,
+            mode_label = "CPT",
+            split_name = "train",
+            eos_token = "<eos>",
+            append_eos = True,
+        )
+
+
+def test_streaming_raw_blank_is_rejected_before_eos_append():
+    dataset = IterableDataset.from_generator(lambda: iter([{"text": " "}]))
+    result = prepare_raw_text_dataset(
+        dataset,
+        mode_label = "CPT",
+        split_name = "train",
+        eos_token = "<eos>",
+        append_eos = True,
+    )
+
+    with pytest.raises(ValueError, match = r"train row 0 has an empty `text` field"):
+        next(iter(result.dataset))
+
+
+def test_vlm_dataset_bypasses_text_validation_without_iteration():
+    iterated = False
+
+    def rows():
+        nonlocal iterated
+        iterated = True
+        yield {"image": "pixels", "messages": []}
+
+    dataset = IterableDataset.from_generator(rows)
+
+    assert validate_text_sft_dataset(dataset, is_vlm = True) is dataset
+    assert iterated is False

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -398,6 +398,18 @@ class TestTrainingRawSupport(unittest.TestCase):
             any("null or non-string 'text' values" in notice.message for notice in result.notices)
         )
 
+    def test_prepare_raw_text_dataset_rejects_blank_rows_before_appending_eos(self):
+        dataset = Dataset.from_dict({"text": ["", "   "]})
+
+        with self.assertRaisesRegex(ValueError, "empty `text` field"):
+            prepare_raw_text_dataset(
+                dataset,
+                mode_label = "CPT",
+                split_name = "train",
+                eos_token = "<eos>",
+                append_eos = True,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/studio/backend/utils/datasets/raw_text.py
+++ b/studio/backend/utils/datasets/raw_text.py
@@ -8,6 +8,9 @@ from typing import Literal
 
 from datasets import Dataset
 
+from .iterable import is_streaming_dataset
+from .text_validation import validate_text_sft_dataset
+
 
 @dataclass(frozen = True)
 class RawTextNotice:
@@ -117,6 +120,7 @@ def prepare_raw_text_dataset(
     notices: list[RawTextNotice] = []
     mode_title = mode_label.capitalize()
     split_scope = _split_scope(split_name)
+    validation_split_name = split_name or "raw text"
 
     col_names = resolve_column_names(dataset)
     if "text" not in col_names:
@@ -151,12 +155,30 @@ def prepare_raw_text_dataset(
         )
         dataset = dataset.rename_column(renamed_col, "text")
 
+    streaming = is_streaming_dataset(dataset) or not hasattr(dataset, "__len__")
+    if streaming:
+        # Validate raw strings lazily before the existing filter/EOS maps.
+        # Null/non-string rows remain eligible for the established lazy drop.
+        dataset = validate_text_sft_dataset(
+            dataset,
+            split_name = validation_split_name,
+            allow_non_string = True,
+        )
+
     dataset, invalid_row_notices = _drop_invalid_text_rows(
         dataset,
         mode_title = mode_title,
         split_scope = split_scope,
     )
     notices.extend(invalid_row_notices)
+
+    if not streaming:
+        # Materialized raw datasets can be checked completely before EOS
+        # mutation. Null/non-string rows have already been dropped above.
+        dataset = validate_text_sft_dataset(
+            dataset,
+            split_name = validation_split_name,
+        )
 
     if append_eos:
         if not eos_token:

--- a/studio/backend/utils/datasets/text_validation.py
+++ b/studio/backend/utils/datasets/text_validation.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Validation helpers for final text-SFT datasets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .iterable import is_streaming_dataset
+
+
+_MISSING = object()
+
+
+def _row_text_issue(row: Any, field_name: str, *, allow_non_string: bool) -> str | None:
+    if not isinstance(row, dict):
+        if allow_non_string:
+            return None
+        return f"is not a dictionary row (got {type(row).__name__})"
+
+    value = row.get(field_name, _MISSING)
+    if value is _MISSING:
+        if allow_non_string:
+            return None
+        return f"is missing the `{field_name}` field"
+    if not isinstance(value, str):
+        if allow_non_string:
+            return None
+        return f"has a non-string `{field_name}` field (got {type(value).__name__})"
+    if not value.strip():
+        return f"has an empty `{field_name}` field"
+    return None
+
+
+def _validation_error(*, split_name: str, row_index: int, issue: str) -> ValueError:
+    return ValueError(
+        f"Dataset validation failed: {split_name} row {row_index} {issue}. "
+        "Unsloth expects every row used for text SFT to contain non-empty text. "
+        "Remove blank rows or fix the dataset formatting/template so it produces "
+        "training text."
+    )
+
+
+def _validate_streaming_row(
+    row: Any, row_index: int, *, field_name: str, split_name: str, allow_non_string: bool
+) -> Any:
+    issue = _row_text_issue(
+        row,
+        field_name,
+        allow_non_string = allow_non_string,
+    )
+    if issue is not None:
+        raise _validation_error(
+            split_name = split_name,
+            row_index = row_index,
+            issue = issue,
+        )
+    return row
+
+
+def validate_text_sft_dataset(
+    dataset: Any,
+    *,
+    field_name: str = "text",
+    split_name: str = "train",
+    is_vlm: bool = False,
+    allow_non_string: bool = False,
+) -> Any:
+    """Return a dataset whose consumed text-SFT rows are guaranteed non-empty.
+
+    Materialized datasets are validated eagerly and completely. Streaming
+    datasets receive a lazy ``map`` validator so preparation never scans an
+    unbounded source merely to observe a target number of kept rows.
+
+    ``allow_non_string`` is used only by raw/CPT streaming preparation before
+    its existing lazy filter. It preserves the established behavior of dropping
+    null/non-string raw rows while still rejecting raw blank strings before EOS
+    is appended.
+    """
+
+    if is_vlm:
+        return dataset
+
+    if is_streaming_dataset(dataset) or not hasattr(dataset, "__len__"):
+        map_dataset = getattr(dataset, "map", None)
+        if not callable(map_dataset):
+            raise TypeError(
+                "Streaming text dataset validation requires a lazy `map` implementation."
+            )
+        return map_dataset(
+            _validate_streaming_row,
+            with_indices = True,
+            fn_kwargs = {
+                "field_name": field_name,
+                "split_name": split_name,
+                "allow_non_string": allow_non_string,
+            },
+        )
+
+    if len(dataset) == 0:
+        raise ValueError(
+            f"Dataset validation failed: the {split_name} split is empty. "
+            "Add at least one training example before starting text SFT."
+        )
+
+    for row_index, row in enumerate(dataset):
+        issue = _row_text_issue(
+            row,
+            field_name,
+            allow_non_string = allow_non_string,
+        )
+        if issue is not None:
+            raise _validation_error(
+                split_name = split_name,
+                row_index = row_index,
+                issue = issue,
+            )
+
+    return dataset


### PR DESCRIPTION
Summary
- Add validation for final text SFT train and eval datasets before trainer initialization.
- Report split and row context for empty, missing, or non-string text fields.
- Add focused coverage for the new text validation helper.

Root cause
Unsloth/TRL probes the dataset text field during SFTTrainer preparation. When the first formatted text value is empty, that probe can surface as a low-level string index out of range error instead of telling the user which dataset row is invalid.

User impact
Studio now fails earlier during dataset loading and formatting with an actionable dataset validation error. The existing progress error path can surface that message to the UI/toast instead of the raw trainer exception.

Validation
- python -m py_compile studio/backend/utils/datasets/text_validation.py studio/backend/tests/test_text_dataset_validation.py
- direct helper behavior script for valid, empty, missing, and streaming-style rows
- git diff --check

Full pytest was not run locally because this environment does not have pytest installed.