### PR TITLE
Keep pad-named pad_tokens (e.g. <|vision_pad|>); fix Qwen3-Base load crash

### DIFF
--- a/tests/python/test_pad_token_fix.py
+++ b/tests/python/test_pad_token_fix.py
@@ -2,7 +2,7 @@
 
 It must delegate to unsloth_zoo's shared fix_pad_token when present (single
 source of truth), and fall back to a no-op against an older unsloth_zoo. Static
-+ CPU-only: the two helpers are exec'd in isolation so the test never imports
++ CPU-only: _fix_pad_token is exec'd in isolation so the test never imports
 torch / transformers / unsloth.
 """
 
@@ -15,7 +15,6 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 TOK_PATH = os.path.join(REPO_ROOT, "unsloth", "tokenizer_utils.py")
 
 WANTED = {
-    "_fix_vision_pad_token",
     "_fix_pad_token",
 }
 

--- a/tests/python/test_pad_token_fix.py
+++ b/tests/python/test_pad_token_fix.py
@@ -1,9 +1,9 @@
 """_fix_pad_token dispatch in unsloth/tokenizer_utils.py.
 
 It must delegate to unsloth_zoo's shared fix_pad_token when present (single
-source of truth), and fall back to the narrow vision-token swap against an
-older unsloth_zoo. Static + CPU-only: the two helpers are exec'd in isolation
-so the test never imports torch / transformers / unsloth.
+source of truth), and fall back to a no-op against an older unsloth_zoo. Static
++ CPU-only: the two helpers are exec'd in isolation so the test never imports
+torch / transformers / unsloth.
 """
 
 import ast
@@ -15,8 +15,6 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 TOK_PATH = os.path.join(REPO_ROOT, "unsloth", "tokenizer_utils.py")
 
 WANTED = {
-    "_VISION_PAD_TOKENS",
-    "_SAFE_TEXT_PAD_TOKENS",
     "_fix_vision_pad_token",
     "_fix_pad_token",
 }
@@ -69,17 +67,17 @@ def test_fix_pad_token_none_is_noop():
     assert ns["_fix_pad_token"](None) is None
 
 
-def test_fix_pad_token_falls_back_without_shared_module(monkeypatch):
+def test_fallback_keeps_pad_named_token(monkeypatch):
     ns = _load_pad_helpers()
     _block_shared_module(monkeypatch)
-    # Qwen3 text tokenizer shipping a vision pad_token -> narrow swap heals it.
+    # A pad-named token (e.g. <|vision_pad|>) is a valid pad -> fallback keeps it.
     tok = FakeTok(
         {"<|endoftext|>": 1, "<|im_end|>": 2, "<|vision_pad|>": 3},
         pad = "<|vision_pad|>",
         eos = "<|im_end|>",
     )
     ns["_fix_pad_token"](tok)
-    assert tok.pad_token == "<|endoftext|>"
+    assert tok.pad_token == "<|vision_pad|>"
     assert tok.pad_token != tok.eos_token
 
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -626,31 +626,22 @@ def _load_correct_tokenizer(
         return fast_tokenizer
 
 
-def _fix_vision_pad_token(tokenizer):
-    """No-op fallback: a pad-named token (e.g. <|vision_pad|>) is a valid pad, kept as-is.
-
-    Retained only for an older unsloth_zoo that lacks the shared pad_token module;
-    the active path heals missing / eos-collision / out-of-range pads via
-    unsloth_zoo.pad_token.fix_pad_token.
-    """
-    return tokenizer
-
-
 def _fix_pad_token(tokenizer):
     """Heal a bad/missing pad_token before chat-template repair.
 
-    Delegates to unsloth_zoo's shared fix_pad_token (single source of truth) when
-    available, falling back to a no-op against an older unsloth_zoo. allow_add=False
-    keeps this side-effect free: there is no model here to resize embeddings, so a
-    brand new pad token is never added - the later model-aware patch_tokenizer call
-    finishes the job and is idempotent.
+    Delegates to unsloth_zoo's shared fix_pad_token (single source of truth); against
+    an older unsloth_zoo without it, this is a no-op (a pad-named token like
+    <|vision_pad|> is already a valid pad). allow_add=False keeps this side-effect
+    free: there is no model here to resize embeddings, so a brand new pad token is
+    never added - the later model-aware patch_tokenizer call finishes the job and is
+    idempotent.
     """
     if tokenizer is None:
         return tokenizer
     try:
         from unsloth_zoo.pad_token import fix_pad_token
     except Exception:
-        return _fix_vision_pad_token(tokenizer)
+        return tokenizer
     fix_pad_token(tokenizer, allow_add = False)
     return tokenizer
 

--- a/unsloth/tokenizer_utils.py
+++ b/unsloth/tokenizer_utils.py
@@ -626,54 +626,13 @@ def _load_correct_tokenizer(
         return fast_tokenizer
 
 
-# Qwen3 text models share Qwen3-VL's vocab, so configs ship a vision pad_token;
-# padding text-only training with one yields NaN losses (#3155, #4104).
-_VISION_PAD_TOKENS = frozenset(
-    (
-        "<|vision_pad|>",
-        "<|image_pad|>",
-        "<|video_pad|>",
-        "<|audio_pad|>",
-    )
-)
-# Preference order; <unk> excluded since reusing it as pad masks real OOV tokens.
-_SAFE_TEXT_PAD_TOKENS = ("<|endoftext|>", "<pad>", "[PAD]")
-
-
 def _fix_vision_pad_token(tokenizer):
-    """Swap a vision pad_token on a text-only tokenizer for a safe text token (#3155)."""
-    if tokenizer is None:
-        return tokenizer
-    if hasattr(tokenizer, "image_processor"):
-        return tokenizer
-    pad_token = getattr(tokenizer, "pad_token", None)
-    if pad_token is None or pad_token not in _VISION_PAD_TOKENS:
-        return tokenizer
+    """No-op fallback: a pad-named token (e.g. <|vision_pad|>) is a valid pad, kept as-is.
 
-    get_vocab = getattr(tokenizer, "get_vocab", None)
-    if get_vocab is None:
-        return tokenizer
-    vocab = get_vocab()
-    if not isinstance(vocab, dict):
-        return tokenizer
-    new_pad_token = None
-    for candidate in _SAFE_TEXT_PAD_TOKENS:
-        if candidate in vocab and candidate != getattr(tokenizer, "eos_token", None):
-            new_pad_token = candidate
-            break
-    # Fall back to eos_token only if it is a distinct, non-vision token.
-    if new_pad_token is None:
-        eos_token = getattr(tokenizer, "eos_token", None)
-        if eos_token is not None and eos_token != pad_token and eos_token not in _VISION_PAD_TOKENS:
-            new_pad_token = eos_token
-    if new_pad_token is None:
-        return tokenizer
-
-    tokenizer.pad_token = new_pad_token
-    logger.warning(
-        f"Unsloth: pad_token was a vision token ({pad_token}) on a text-only "
-        f"model. Replaced with {new_pad_token} to avoid NaN losses."
-    )
+    Retained only for an older unsloth_zoo that lacks the shared pad_token module;
+    the active path heals missing / eos-collision / out-of-range pads via
+    unsloth_zoo.pad_token.fix_pad_token.
+    """
     return tokenizer
 
 
@@ -681,10 +640,10 @@ def _fix_pad_token(tokenizer):
     """Heal a bad/missing pad_token before chat-template repair.
 
     Delegates to unsloth_zoo's shared fix_pad_token (single source of truth) when
-    available, falling back to the narrow vision-token swap against an older
-    unsloth_zoo. allow_add=False keeps this side-effect free: there is no model
-    here to resize embeddings, so a brand new pad token is never added - the later
-    model-aware patch_tokenizer call finishes the job and is idempotent.
+    available, falling back to a no-op against an older unsloth_zoo. allow_add=False
+    keeps this side-effect free: there is no model here to resize embeddings, so a
+    brand new pad token is never added - the later model-aware patch_tokenizer call
+    finishes the job and is idempotent.
     """
     if tokenizer is None:
         return tokenizer


### PR DESCRIPTION
## What

A `pad_token` whose name contains "pad" (e.g. `<|vision_pad|>`) is a valid, dedicated padding token and is kept as-is. `load_correct_tokenizer` keeps delegating pad repair to the shared `fix_pad_token` in unsloth-zoo (single source of truth); the local `_fix_vision_pad_token` fallback, which used to strip vision pads on text-only models, is now a no-op.

## Why

`unsloth/Qwen3-4B-Base` ships `pad_token = <|vision_pad|>` (id 151654), a distinct, in-vocab token separate from eos `<|endoftext|>` (id 151643). That is a fine pad. Stripping it broke loading: there is no safe text pad to swap in (eos is `<|endoftext|>`, Qwen3 has no `unk_token`), so `FastLanguageModel.from_pretrained("unsloth/Qwen3-4B-Base")` ended up adding a junk token and raising `RuntimeError`, crashing the Qwen3 (4B) GRPO notebook.

The earlier NaN reports (#3155, #4104) were a masking artifact: collators set `labels = -100` on pad positions, so the pad token's identity does not affect the loss.

## Changes

- Remove `_fix_vision_pad_token` and the now-unused `_VISION_PAD_TOKENS` / `_SAFE_TEXT_PAD_TOKENS` sets. A pad-named token like `<|vision_pad|>` is already a valid pad, so the swap helper has no purpose.
- `_fix_pad_token` returns the tokenizer unchanged when the shared `unsloth_zoo.pad_token` module is unavailable (older unsloth-zoo), instead of routing through a no-op helper.
- Docstrings and the dispatch test updated.

## Testing

- `tests/python/test_pad_token_fix.py`: 4 passed (static, CPU only, no torch / transformers import).
- End to end: `FastLanguageModel.from_pretrained("unsloth/Qwen3-4B-Base", fast_inference = True)` loads with no crash and keeps `pad_token = <|vision_pad|>`.

## Depends on

unslothai/unsloth-zoo#831 (the shared `fix_pad_token` change). The fallback path makes this PR safe to land before the zoo release; the no-op simply keeps pad-named tokens either way.
