### PR TITLE
Studio: quick eject from the model selector

### DIFF
--- a/studio/frontend/src/components/assistant-ui/model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector.tsx
@@ -189,7 +189,9 @@ function ModelSelectorTrigger({
             // content model, which forbids focusable descendants. Keyboard and
             // screen-reader users eject via the picker's "Eject model" button.
             // aria-hidden marks it decorative; stopPropagation stops the
-            // popover from toggling.
+            // popover from toggling. On touch (no hover) the eject icon and
+            // tooltip never reveal, so pointer-events-none disables the
+            // shortcut there and taps open the picker instead of ejecting.
             <span
               aria-hidden={true}
               title="Eject model"
@@ -201,7 +203,7 @@ function ModelSelectorTrigger({
               }}
               // Hit area larger than the icon, with a hover circle. Negative
               // margin keeps the icon in the dot's original spot.
-              className="-m-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-black/10 dark:hover:bg-white/10"
+              className="-m-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-black/10 dark:hover:bg-white/10 [@media(hover:none)]:pointer-events-none"
             >
               <HugeiconsIcon
                 icon={CheckmarkCircle02Icon}

--- a/studio/frontend/src/components/assistant-ui/model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector.tsx
@@ -8,12 +8,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { usePlatformStore } from "@/config/env";
 import { isCustomProviderType } from "@/features/chat/external-providers";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
@@ -188,50 +183,37 @@ function ModelSelectorTrigger({
       >
         {isLoaded &&
           (onEject ? (
-            // Loaded status doubles as the eject control: green checkmark at
-            // rest, red eject icon on pill hover, click to eject.
-            // stopPropagation keeps the popover from toggling; a span (not a
-            // nested button) keeps the trigger valid HTML.
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild={true}>
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    aria-label="Eject model"
-                    data-eject-hit={true}
-                    onPointerDown={(event) => event.stopPropagation()}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      onEject();
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        onEject();
-                      }
-                    }}
-                    // Hit area larger than the icon, with a hover circle.
-                    // Negative margin keeps the icon in the dot's original spot.
-                    className="-m-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-black/10 dark:hover:bg-white/10"
-                  >
-                    <HugeiconsIcon
-                      icon={CheckmarkCircle02Icon}
-                      strokeWidth={1.75}
-                      className="size-3.5 text-emerald-500 group-hover/trigger:hidden"
-                    />
-                    <HugeiconsIcon
-                      icon={RemoveCircleIcon}
-                      strokeWidth={1.75}
-                      className="hidden size-3.5 text-red-500 group-hover/trigger:block"
-                    />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>Eject model</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            // Loaded status doubles as a mouse eject shortcut: green checkmark
+            // at rest, red eject icon on pill hover, click to eject. A plain
+            // span (no role/tabIndex) keeps it out of the trigger button's
+            // content model, which forbids focusable descendants. Keyboard and
+            // screen-reader users eject via the picker's "Eject model" button.
+            // aria-hidden marks it decorative; stopPropagation stops the
+            // popover from toggling.
+            <span
+              aria-hidden={true}
+              title="Eject model"
+              data-eject-hit={true}
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onEject();
+              }}
+              // Hit area larger than the icon, with a hover circle. Negative
+              // margin keeps the icon in the dot's original spot.
+              className="-m-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-black/10 dark:hover:bg-white/10"
+            >
+              <HugeiconsIcon
+                icon={CheckmarkCircle02Icon}
+                strokeWidth={1.75}
+                className="size-3.5 text-emerald-500 group-hover/trigger:hidden"
+              />
+              <HugeiconsIcon
+                icon={RemoveCircleIcon}
+                strokeWidth={1.75}
+                className="hidden size-3.5 text-red-500 group-hover/trigger:block"
+              />
+            </span>
           ) : (
             <span className="size-2 shrink-0 rounded-full bg-emerald-500" />
           ))}

--- a/studio/frontend/src/components/assistant-ui/model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector.tsx
@@ -8,12 +8,18 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { usePlatformStore } from "@/config/env";
 import { isCustomProviderType } from "@/features/chat/external-providers";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
 import {
+  CheckmarkCircle02Icon,
   CloudIcon,
   DashboardSquare01Icon,
   Download01Icon,
@@ -146,6 +152,7 @@ function ModelSelectorTrigger({
   size = "default",
   className,
   dataTour,
+  onEject,
 }: {
   currentModel?: ModelOption;
   isLoaded: boolean;
@@ -154,6 +161,7 @@ function ModelSelectorTrigger({
   size?: "sm" | "default" | "lg";
   className?: string;
   dataTour?: string;
+  onEject?: () => void;
 }) {
   return (
     <PopoverTrigger asChild={true}>
@@ -161,12 +169,15 @@ function ModelSelectorTrigger({
         type="button"
         data-tour={dataTour}
         className={cn(
-          "unsloth-model-selector-trigger flex min-w-0 items-center gap-2 transition-colors",
+          "unsloth-model-selector-trigger group/trigger flex min-w-0 items-center gap-2 transition-colors",
+          // Suppress the pill's hover background while the eject hit area is
+          // hovered, so only the dot's own circle reacts.
           variant === "outline" &&
-            "rounded-full border border-border/60 hover:bg-[#ececec] dark:hover:bg-[#2d2e32]",
+            "rounded-full border border-border/60 hover:bg-[#ececec] has-[[data-eject-hit]:hover]:!bg-transparent dark:hover:bg-[#2d2e32]",
           variant === "ghost" &&
-            "rounded-full hover:bg-[#ececec] dark:hover:bg-[#2d2e32]",
-          variant === "muted" && "rounded-full bg-muted hover:bg-muted/80",
+            "rounded-full hover:bg-[#ececec] has-[[data-eject-hit]:hover]:!bg-transparent dark:hover:bg-[#2d2e32]",
+          variant === "muted" &&
+            "rounded-full bg-muted hover:bg-muted/80 has-[[data-eject-hit]:hover]:!bg-muted",
           // More left padding than right; the chevron is pulled close to the
           // label (below) so the trigger reads balanced around the text.
           size === "sm" && "h-8 pl-3 pr-1.5 text-xs",
@@ -175,9 +186,55 @@ function ModelSelectorTrigger({
           className,
         )}
       >
-        {isLoaded && (
-          <span className="size-2 shrink-0 rounded-full bg-emerald-500" />
-        )}
+        {isLoaded &&
+          (onEject ? (
+            // Loaded status doubles as the eject control: green checkmark at
+            // rest, red eject icon on pill hover, click to eject.
+            // stopPropagation keeps the popover from toggling; a span (not a
+            // nested button) keeps the trigger valid HTML.
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild={true}>
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Eject model"
+                    data-eject-hit={true}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onEject();
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onEject();
+                      }
+                    }}
+                    // Hit area larger than the icon, with a hover circle.
+                    // Negative margin keeps the icon in the dot's original spot.
+                    className="group/eject -m-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-black/10 dark:hover:bg-white/10"
+                  >
+                    <HugeiconsIcon
+                      icon={CheckmarkCircle02Icon}
+                      strokeWidth={1.75}
+                      className="size-3.5 text-emerald-500 group-hover/trigger:hidden"
+                    />
+                    <HugeiconsIcon
+                      icon={RemoveCircleIcon}
+                      strokeWidth={1.75}
+                      className="hidden size-3.5 text-red-500 group-hover/trigger:block"
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>Eject model</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <span className="size-2 shrink-0 rounded-full bg-emerald-500" />
+          ))}
         {currentModel?.icon ? (
           <span className="flex shrink-0 items-center">
             {currentModel.icon}
@@ -644,6 +701,7 @@ export function ModelSelector({
         size={size}
         className={className}
         dataTour={triggerDataTour}
+        onEject={onEject ? handleEject : undefined}
       />
       <ModelSelectorContent
         open={open}

--- a/studio/frontend/src/components/assistant-ui/model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector.tsx
@@ -215,7 +215,7 @@ function ModelSelectorTrigger({
                     }}
                     // Hit area larger than the icon, with a hover circle.
                     // Negative margin keeps the icon in the dot's original spot.
-                    className="group/eject -m-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-black/10 dark:hover:bg-white/10"
+                    className="-m-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-black/10 dark:hover:bg-white/10"
                   >
                     <HugeiconsIcon
                       icon={CheckmarkCircle02Icon}

--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -2389,7 +2389,11 @@ export function HubModelPicker({
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search Unsloth models"
+            placeholder={
+              section === "downloaded"
+                ? "Search local models"
+                : "Search Unsloth models"
+            }
             data-model-picker-search-input={true}
             className="field-soft h-9 border-0 pl-8 pr-8"
           />
@@ -3424,7 +3428,7 @@ export function HubModelPicker({
           <button
             type="button"
             onClick={onEject}
-            className="pointer-events-auto inline-flex items-center justify-center gap-2 rounded-md bg-popover px-3 py-2 text-[13px] text-destructive shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-[color-mix(in_srgb,var(--destructive)_12%,var(--popover))] dark:bg-[color-mix(in_srgb,var(--foreground)_10%,var(--sidebar))] dark:shadow-none dark:hover:bg-[color-mix(in_srgb,var(--destructive)_22%,var(--sidebar))]"
+            className="pointer-events-auto inline-flex items-center justify-center gap-2 rounded-md bg-popover px-3 py-2 text-[13px] font-medium text-destructive shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] transition-colors hover:bg-[color-mix(in_srgb,var(--destructive)_12%,var(--popover))] dark:bg-[color-mix(in_srgb,var(--foreground)_10%,var(--sidebar))] dark:shadow-none dark:hover:bg-[color-mix(in_srgb,var(--destructive)_22%,var(--sidebar))]"
             title="Eject model"
           >
             <HugeiconsIcon icon={RemoveCircleIcon} className="size-3.5" />


### PR DESCRIPTION
## Summary

Adds a one-click eject shortcut to the loaded-model pill in Studio's model selector, so you no longer need to open the picker and scroll to the "Eject model" button just to unload the current model.

## What changed

- The loaded-status indicator on the pill is now interactive. It shows a green checkmark at rest, and swaps to a red eject icon whenever you hover anywhere on the pill, with an "Eject model" tooltip. Clicking it ejects the model directly without opening the picker.
  - Hovering the icon itself shows a small circular hover background to mark the exact click target, and the rest of the pill stays unhighlighted in that case.
  - It is keyboard accessible (focus plus Enter/Space) and falls back to a plain green dot when no eject handler is available.
- On Device tab: the search placeholder now reads "Search local models" instead of "Search Unsloth models".
- The picker's existing "Eject model" button now uses medium font weight.

## Notes

The existing "Eject model" entries inside the picker are kept as-is. The pill shortcut is an addition, and the in-picker button remains the discoverable path.