### PR TITLE
Fix Linux AppImage packaging

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -353,7 +353,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf
 
       # ── Node.js ──
       - name: Setup Node.js
@@ -406,8 +406,17 @@ jobs:
           if (config.bundle?.linux?.rpm) {
             throw new Error('bundle.linux.rpm must not be configured');
           }
+          if (config.bundle?.linux?.appimage?.bundleMediaFramework !== false) {
+            throw new Error('Linux AppImage bundleMediaFramework must stay false');
+          }
 
           const workflow = readFileSync('.github/workflows/release-desktop.yml', 'utf8');
+          if (workflow.includes('libayatana-appindicator3-dev')) {
+            throw new Error('Desktop Linux release must use libappindicator3-dev, not libayatana-appindicator3-dev');
+          }
+          if (!workflow.includes('linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage')) {
+            throw new Error('Desktop Linux release must pin linuxdeploy 1-alpha-20250213-2');
+          }
           const lines = workflow.split(/\r?\n/);
           const releaseBodies = [];
           for (let i = 0; i < lines.length; i += 1) {
@@ -568,6 +577,19 @@ jobs:
           Get-Command trusted-signing-cli -ErrorAction SilentlyContinue || Write-Output "trusted-signing-cli NOT in PATH"
           trusted-signing-cli --version || Write-Output "trusted-signing-cli failed to run"
 
+      # ── Linux: pin AppImage packaging toolchain ──
+      - name: Pin linuxdeploy for AppImage
+        if: matrix.platform == 'ubuntu-22.04'
+        shell: bash
+        run: |
+          set -euo pipefail
+          tools_dir="$RUNNER_TEMP/tauri-tools-cache/tauri"
+          mkdir -p "$tools_dir"
+          curl -fsSL \
+            "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage" \
+            -o "$tools_dir/linuxdeploy-x86_64.AppImage"
+          chmod +x "$tools_dir/linuxdeploy-x86_64.AppImage"
+
       # ── Linux: build + sign + upload ──
       - name: Build Linux app
         if: matrix.platform == 'ubuntu-22.04'
@@ -576,6 +598,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          XDG_CACHE_HOME: ${{ runner.temp }}/tauri-tools-cache
         with:
           projectPath: studio
           tauriScript: npx --prefix . tauri

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -411,13 +411,19 @@ jobs:
           }
 
           const workflow = readFileSync('.github/workflows/release-desktop.yml', 'utf8');
-          if (workflow.includes('libayatana-appindicator3-dev')) {
-            throw new Error('Desktop Linux release must use libappindicator3-dev, not libayatana-appindicator3-dev');
+          const lines = workflow.split(/\r?\n/);
+          const linuxInstallLines = lines.filter((line) => line.includes('sudo apt-get install'));
+          const ayatanaPackage = ['libayatana', 'appindicator3-dev'].join('-');
+          if (linuxInstallLines.some((line) => line.includes(ayatanaPackage))) {
+            throw new Error('Desktop Linux release must not install the Ayatana appindicator dev package');
           }
-          if (!workflow.includes('linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage')) {
+          if (!linuxInstallLines.some((line) => line.includes('libappindicator3-dev'))) {
+            throw new Error('Desktop Linux release must install libappindicator3-dev');
+          }
+          const linuxdeployLines = lines.filter((line) => line.includes('github.com/linuxdeploy/linuxdeploy/releases/download'));
+          if (!linuxdeployLines.some((line) => line.includes('1-alpha-20250213-2/linuxdeploy-x86_64.AppImage'))) {
             throw new Error('Desktop Linux release must pin linuxdeploy 1-alpha-20250213-2');
           }
-          const lines = workflow.split(/\r?\n/);
           const releaseBodies = [];
           for (let i = 0; i < lines.length; i += 1) {
             const match = lines[i].match(/^(\s*)releaseBody:\s*\|\s*$/);

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+            libwebkit2gtk-4.1-dev libappindicator3-dev \
             librsvg2-dev libxdo-dev libssl-dev patchelf
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -159,35 +159,11 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
-fn apply_linux_appimage_webkit_workarounds() {
-    if std::env::var_os("APPIMAGE").is_none() {
-        return;
-    }
-
-    // AppImage bundles WebKitGTK/GTK while still using host Mesa/EGL.
-    // On some rolling Linux stacks that mixed path leaves WebKit blank.
-    set_env_if_missing("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
-    set_env_if_missing("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-}
-
-#[cfg(target_os = "linux")]
-fn set_env_if_missing(key: &str, value: &str) {
-    if std::env::var_os(key).is_none() {
-        std::env::set_var(key, value);
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-fn apply_linux_appimage_webkit_workarounds() {}
-
 fn main() {
     // Fix PATH for GUI apps (macOS .app bundles, Linux AppImage, Windows)
     // GUI apps don't inherit shell dotfile PATH — this spawns the user's
     // login shell to source .zshrc/.bashrc/.profile and sets PATH properly.
     let _ = fix_path_env::fix();
-
-    apply_linux_appimage_webkit_workarounds();
 
     setup_logging();
     info!("Unsloth Studio desktop app starting");

--- a/studio/src-tauri/tauri.conf.json
+++ b/studio/src-tauri/tauri.conf.json
@@ -76,6 +76,9 @@
       }
     },
     "linux": {
+      "appimage": {
+        "bundleMediaFramework": false
+      },
       "deb": {
         "postRemoveScript": "./linux/postremove.sh"
       }


### PR DESCRIPTION
Summary

- Use libappindicator for Linux release builds
- Disable bundled media framework for AppImage
- Pin linuxdeploy for stable AppImage packaging
- Remove WebKit env workaround that did not fix the blank window

Validation

- Fork release workflow passed with this setup
- cargo check --manifest-path studio/src-tauri/Cargo.toml