### PR TITLE
CI: add PyPI extra-index to CPU torch installs (fix sympy ResolutionImpossible)

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -209,7 +209,7 @@ jobs:
             'peft>=0.18,<0.20' 'accelerate>=0.34,<2' \
             ipython
           # torchvision: unsloth_zoo.vision_utils imports it at module scope.
-          pip install --index-url https://download.pytorch.org/whl/cpu \
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
             'torch>=2.4,<2.11' 'torchvision<0.26'
           # transformers + trl from the matrix combo.
           pip install "$RESOLVED_TRANSFORMERS_SPEC"
@@ -2166,7 +2166,7 @@ jobs:
           python -m pip install --upgrade pip
           # Match the matrix job's torch path so unsloth_zoo's
           # `import torch` resolves to the same CPU build.
-          pip install --index-url https://download.pytorch.org/whl/cpu \
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
             'torch>=2.4,<2.11' 'torchvision<0.26'
           pip install \
             'numpy<3' protobuf sentencepiece \

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -163,7 +163,7 @@ jobs:
             'pytest==9.0.3' \
             'pytest-asyncio==1.3.0' \
             'httpx==0.28.1'
-          pip install --index-url https://download.pytorch.org/whl/cpu \
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
             'torch==2.10.0'
           # github.com occasionally 500s on the git fetch; retry the
           # zoo install so a single upstream blip does not fail CI.

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -263,7 +263,7 @@ jobs:
           # unsloth_zoo.vision_utils imports PIL at module top, and the
           # easiest way to get a torch-compatible PIL on a CPU runner is
           # to let torchvision pull the right Pillow version.
-          pip install --index-url https://download.pytorch.org/whl/cpu \
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
                       'torch>=2.8,<2.11' 'torchvision<0.26'
           # Pin to the same versions update_all_notebooks.py installs in
           # generated notebooks. Keep these in lockstep with PIN_TRL /

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -76,7 +76,7 @@ jobs:
           # Torch CPU + transformers are required by a chunk of the backend test
           # suite (gpu_selection, kv_cache_estimation, utils). CPU-only torch
           # keeps the install ~250 MB / ~1 min on a clean runner.
-          pip install --index-url https://download.pytorch.org/whl/cpu 'torch>=2.4,<2.11'
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple 'torch>=2.4,<2.11'
           pip install 'transformers>=4.51,<5.5'
 
       - name: Backend tests
@@ -137,7 +137,7 @@ jobs:
             pyyaml jinja2 mammoth unpdf requests typer \
             'numpy<3' pytest pytest-asyncio httpx
           # torchvision: unsloth_zoo.vision_utils imports it at module scope.
-          pip install --index-url https://download.pytorch.org/whl/cpu \
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
             'torch>=2.4,<2.11' 'torchvision<0.26'
           pip install 'transformers>=4.51,<5.5'
           # bitsandbytes: hard import in unsloth/models/_utils.py. Recent

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1376,7 +1376,7 @@ jobs:
       - name: PyTorch CPU wheel installs and imports (no Visual Studio)
         run: |
           python -m pip install --upgrade pip
-          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
           python -c "import torch; print('torch', torch.__version__, 'cuda?', torch.cuda.is_available())"
 
       - name: Install Studio (--local, --no-torch) with no build tools present

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -242,7 +242,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # CPU torch (vllm/peft/st all depend on it).
-          pip install --index-url https://download.pytorch.org/whl/cpu \
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
             'torch>=2.4,<2.11' 'torchvision<0.26' 'torchcodec<0.10'
           # torchcodec is a hard requirement on transformers 5.x:
           # transformers/audio_utils.py:55 does


### PR DESCRIPTION
## Problem

Several workflows install CPU torch with:

```
pip install --index-url https://download.pytorch.org/whl/cpu 'torch>=2.4,<2.11'
```

`--index-url` replaces PyPI entirely, so torch's pure-Python dependencies (`sympy`, `networkx`, ...) have to be satisfied from the PyTorch wheel index. When pip selects a new torch (e.g. `2.10`, which requires `sympy>=1.13.3`) and no matching `sympy` is available from that index for the runner, pip backtracks through every torch version and fails:

```
ERROR: Cannot install torch==2.10.0+cpu ... conflicting dependencies.
  torch 2.10.0+cpu depends on sympy>=1.13.3
Additionally, some packages in these conflicts have no matching distributions
available for your environment: sympy
ERROR: ResolutionImpossible
```

This intermittently flaked the `Backend CI` Python 3.10 job (the dependency-install step, before any test ran), and the same latent pattern existed in several other CPU-torch installs. It only passed when a compatible `sympy` happened to be pre-installed by an earlier step.

## Fix

Add `--extra-index-url https://pypi.org/simple` to the CPU torch installs so torch's pure-Python deps resolve from PyPI, while the `+cpu` build is still preferred (its local version sorts above the bare PyPI build). This mirrors the pattern already used in `notebooks-ci.yml` (the per-spec pin loop).

Touched: `studio-backend-ci.yml`, `consolidated-tests-ci.yml`, `version-compat-ci.yml`, `mlx-ci.yml`, `notebooks-ci.yml`, `studio-windows-inference-smoke.yml`.

## Notes

- No code changes; CI configuration only. All workflow YAML validated locally.
- `notebooks-ci.yml` already used this pattern in one place; this brings the remaining CPU-torch installs in line.