### PR TITLE
Studio: UNSLOTH_NPM_REGISTRY opt-in for corporate npm mirrors (#6491)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,15 @@ curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_STUDIO_HOME=/abs/path sh
 $env:UNSLOTH_STUDIO_HOME='C:\path'; irm https://unsloth.ai/install.ps1 | iex
 ```
 
+Point the frontend build at a corporate npm mirror/proxy with `UNSLOTH_NPM_REGISTRY` (for the developer install behind a firewall that blocks `registry.npmjs.org`):
+```bash
+UNSLOTH_NPM_REGISTRY=https://artifactory.example.com/api/npm/npm/ ./install.sh --local
+```
+```powershell
+$env:UNSLOTH_NPM_REGISTRY='https://artifactory.example.com/api/npm/npm/'; .\install.ps1 --local
+```
+It is threaded as `--registry` into the Studio frontend `npm`/`bun` installs; the supply-chain locks (7-day `min-release-age`, exact version pins) stay in force.
+
 Cap Studio's native CPU thread pools on high-core hosts: `UNSLOTH_CPU_THREADS=8 unsloth studio -p 8888`.
 
 #### Uninstall

--- a/build.sh
+++ b/build.sh
@@ -35,10 +35,19 @@ _restore_gitignores() {
 }
 trap _restore_gitignores EXIT
 
+# Corporate-mirror / proxy escape hatch (#6491). When UNSLOTH_NPM_REGISTRY is set we
+# thread it as `--registry <url>` into the installs (overrides frontend/.npmrc's pinned
+# registry for both bun and npm; min-release-age / save-exact stay in force). Empty
+# array (the default) expands to nothing under `set -u`.
+_NPM_REGISTRY_ARGS=()
+if [ -n "${UNSLOTH_NPM_REGISTRY:-}" ]; then
+    _NPM_REGISTRY_ARGS=(--registry "$UNSLOTH_NPM_REGISTRY")
+fi
+
 # Use bun for install if available (faster), fall back to npm.
 _install_ok=false
 if command -v bun &>/dev/null; then
-    if bun install; then
+    if bun install "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}"; then
         _install_ok=true
     else
         echo "⚠ bun install failed, falling back to npm"
@@ -46,8 +55,10 @@ if command -v bun &>/dev/null; then
     fi
 fi
 if [ "$_install_ok" != "true" ]; then
-    if ! npm install; then
+    if ! npm install "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}"; then
         echo "❌ ERROR: package install failed" >&2
+        echo "   If you are behind a corporate firewall/proxy, set UNSLOTH_NPM_REGISTRY to your mirror and retry, e.g.:" >&2
+        echo "   UNSLOTH_NPM_REGISTRY=https://your-mirror.example/api/npm/ ./build.sh" >&2
         exit 1
     fi
 fi

--- a/studio/frontend/.npmrc
+++ b/studio/frontend/.npmrc
@@ -14,9 +14,18 @@ min-release-age=7
 # `npm install <name>@<version> --save-exact` pass) but it stops new
 # carets from creeping into the manifest as patch-version footguns.
 save-exact=true
-# Lock the registry. A user-set PIP_INDEX_URL-style override (here:
-# NPM_CONFIG_REGISTRY env var or a stale ~/.npmrc) shouldn't redirect
-# our installs to an attacker registry.
+# Pin the default registry so a stale or hostile *lower-precedence* ~/.npmrc
+# can't silently redirect our installs to an attacker registry. Note this does
+# NOT block an ambient NPM_CONFIG_REGISTRY env var: npm and bun honor that at a
+# higher precedence than this project file. That is exactly why Unsloth does not
+# read NPM_CONFIG_REGISTRY and instead exposes one deliberate, explicit opt-in.
+#
+# Corporate mirror / proxy (issue #6491): if your firewall blocks
+# registry.npmjs.org, set UNSLOTH_NPM_REGISTRY=<your-mirror-url> when running
+# ./install.sh (or setup.sh / setup.ps1). The installer threads it as
+# `--registry <url>`, which overrides this line for both npm and bun while
+# leaving the min-release-age and save-exact locks above in force. Do not edit
+# this line for that -- the env var keeps the default pinned for everyone else.
 registry=https://registry.npmjs.org/
 audit-level=high
 fund=false

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -897,7 +897,14 @@ function Show-NpmRegistryHint {
     if ($env:UNSLOTH_NPM_REGISTRY) { return }
     $mirror = $env:NPM_CONFIG_REGISTRY
     if (-not $mirror) {
-        try { $mirror = (& npm config get registry 2>$null | Out-String).Trim() } catch { $mirror = "" }
+        # Read npm config from a dir with no project .npmrc so the frontend's pinned
+        # registry= does not mask the user's ~/.npmrc / global mirror.
+        $pushed = $false
+        try {
+            Push-Location ([System.IO.Path]::GetTempPath()) -ErrorAction Stop
+            $pushed = $true
+            $mirror = (& npm config get registry 2>$null | Out-String).Trim()
+        } catch { $mirror = "" } finally { if ($pushed) { Pop-Location } }
     }
     if ($mirror -in @("", "undefined", "null", "https://registry.npmjs.org", "https://registry.npmjs.org/")) {
         $mirror = ""

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -37,6 +37,18 @@ $DefaultLlamaSource = "https://github.com/ggml-org/llama.cpp"
 $DefaultLlamaTag = "latest"
 $DefaultLlamaForceCompileRef = "master"
 
+# Corporate-mirror / proxy escape hatch for the frontend npm/bun install (#6491).
+# studio/frontend/.npmrc pins registry=https://registry.npmjs.org/ as a supply-chain
+# lock, which overrides a corporate user's ~/.npmrc proxy and causes 403s behind a
+# firewall. UNSLOTH_NPM_REGISTRY is a deliberate opt-in: when set we splat it as
+# `--registry <url>` into every npm/bun install. `--registry` is the highest-precedence
+# override for BOTH tools and leaves min-release-age / save-exact in force. Empty array
+# (the default) splats to nothing, so normal installs are unchanged.
+$NpmRegistryArgs = @()
+if ($env:UNSLOTH_NPM_REGISTRY) {
+    $NpmRegistryArgs = @('--registry', $env:UNSLOTH_NPM_REGISTRY)
+}
+
 # Verbose can be enabled either by CLI flag or by UNSLOTH_VERBOSE=1.
 $script:UnslothVerbose = ($env:UNSLOTH_VERBOSE -eq '1')
 foreach ($a in $args) {
@@ -875,6 +887,34 @@ function substep {
         Write-Host ("  {0,-15}{1}" -f "", $Message) -ForegroundColor $fc
     }
     Write-StudioStdoutMirror ("  {0,-15}{1}" -f "", $Message)
+}
+
+function Show-NpmRegistryHint {
+    # Print actionable guidance when a frontend/OXC npm/bun install fails and the
+    # registry lock is the likely cause (corporate firewall/proxy). No-op once the
+    # user has opted in via UNSLOTH_NPM_REGISTRY. We never switch registries
+    # automatically -- we only guide.
+    if ($env:UNSLOTH_NPM_REGISTRY) { return }
+    $mirror = $env:NPM_CONFIG_REGISTRY
+    if (-not $mirror) {
+        try { $mirror = (& npm config get registry 2>$null | Out-String).Trim() } catch { $mirror = "" }
+    }
+    if ($mirror -in @("", "undefined", "null", "https://registry.npmjs.org", "https://registry.npmjs.org/")) {
+        $mirror = ""
+    }
+    Write-Host ""
+    step "frontend" "registry.npmjs.org looks blocked (corporate firewall/proxy?)" "Yellow"
+    if ($mirror) {
+        substep "Studio pins the public npm registry; your mirror is being ignored."
+        substep "Detected a registry in your npm config:"
+        substep "  $mirror"
+        substep "Re-run pointing Studio at it:"
+        substep "  `$env:UNSLOTH_NPM_REGISTRY='$mirror'; .\install.ps1 --local"
+    } else {
+        substep "If you use a private mirror/proxy, point Studio at it and re-run:"
+        substep "  `$env:UNSLOTH_NPM_REGISTRY='https://your-mirror.example/api/npm/'; .\install.ps1 --local"
+    }
+    substep "(min-release-age and save-exact stay enforced.)"
 }
 
 # ─────────────────────────────────────────────
@@ -2113,7 +2153,7 @@ if ($NeedNodeForSetup) {
             substep "installing bun (faster frontend package installs)..."
             $prevEAP_bun = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
-            Invoke-SetupCommand { npm install -g bun --allow-scripts=bun } | Out-Null
+            Invoke-SetupCommand { npm install -g bun --allow-scripts=bun @NpmRegistryArgs } | Out-Null
             $ErrorActionPreference = $prevEAP_bun
             Refresh-Environment
             # Refresh-Environment rebuilds PATH (Machine;User;current), demoting the
@@ -2173,7 +2213,7 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
     # the cache + retry once before falling back to npm.
     if ($UseBun) {
         Write-Host "   Using bun for package install (faster)" -ForegroundColor DarkGray
-        $bunExit = Invoke-SetupCommand { bun install }
+        $bunExit = Invoke-SetupCommand { bun install @NpmRegistryArgs }
         # On Windows, .bin/ entries vary by package manager:
         #   npm  → tsc, tsc.cmd, tsc.ps1
         #   bun  → tsc.exe, tsc.bunx
@@ -2187,7 +2227,7 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
                 Remove-Item "node_modules" -Recurse -Force -ErrorAction SilentlyContinue
             }
             Invoke-SetupCommand { bun pm cache rm } | Out-Null
-            $bunExit = Invoke-SetupCommand { bun install }
+            $bunExit = Invoke-SetupCommand { bun install @NpmRegistryArgs }
             $hasTsc = (Test-Path "node_modules\.bin\tsc") -or (Test-Path "node_modules\.bin\tsc.cmd") -or (Test-Path "node_modules\.bin\tsc.exe") -or (Test-Path "node_modules\.bin\tsc.bunx")
             $hasVite = (Test-Path "node_modules\.bin\vite") -or (Test-Path "node_modules\.bin\vite.cmd") -or (Test-Path "node_modules\.bin\vite.exe") -or (Test-Path "node_modules\.bin\vite.bunx")
             if ($bunExit -ne 0 -or -not $hasTsc -or -not $hasVite) {
@@ -2206,13 +2246,14 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
         }
     }
     if (-not $UseBun) {
-        $npmExit = Invoke-SetupCommand { npm install }
+        $npmExit = Invoke-SetupCommand { npm install @NpmRegistryArgs }
         if ($npmExit -ne 0) {
             Pop-Location
             $ErrorActionPreference = $prevEAP_npm
             foreach ($gi in $HiddenGitignores) { Rename-Item -Path "$gi._twbuild" -NewName (Split-Path $gi -Leaf) -Force -ErrorAction SilentlyContinue }
             Write-Host "[ERROR] npm install failed (exit code $npmExit)" -ForegroundColor Red
             Write-Host "   Try running 'npm install' manually in frontend/ to see errors" -ForegroundColor Yellow
+            Show-NpmRegistryHint
             exit 1
         }
     }
@@ -2249,11 +2290,12 @@ if ((Test-Path $OxcValidatorDir) -and $NodeSource -ne "skip" -and (Get-Command n
     $prevEAP_oxc = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     Push-Location $OxcValidatorDir
-    $oxcInstallExit = Invoke-SetupCommand { npm install }
+    $oxcInstallExit = Invoke-SetupCommand { npm install @NpmRegistryArgs }
     if ($oxcInstallExit -ne 0) {
         Pop-Location
         $ErrorActionPreference = $prevEAP_oxc
         Write-Host "[ERROR] OXC validator npm install failed (exit code $oxcInstallExit)" -ForegroundColor Red
+        Show-NpmRegistryHint
         exit 1
     }
     Pop-Location

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -74,6 +74,59 @@ verbose_substep() {
     return 0
 }
 
+# ── Corporate-mirror / proxy escape hatch for the frontend npm/bun install (#6491) ──
+# studio/frontend/.npmrc pins registry=https://registry.npmjs.org/ as a supply-chain
+# lock. A project-level pin overrides a corporate user's ~/.npmrc proxy, so the install
+# hits npmjs.org directly and a firewall returns 403. UNSLOTH_NPM_REGISTRY is a
+# deliberate opt-in: when set we thread it as `--registry <url>` into every npm/bun
+# install. `--registry` is the highest-precedence override for BOTH tools and leaves
+# min-release-age / save-exact in force. Empty array (the default) expands to nothing
+# under `set -u`, so normal installs are unchanged.
+_NPM_REGISTRY_ARGS=()
+if [ -n "${UNSLOTH_NPM_REGISTRY:-}" ]; then
+    _NPM_REGISTRY_ARGS=(--registry "$UNSLOTH_NPM_REGISTRY")
+fi
+# Failure-path capture log consumed by _suggest_npm_registry. Set to a temp file
+# around the npm/bun installs; "" elsewhere so unrelated run_quiet calls don't capture.
+_CAPTURE_LOG=""
+
+# Print actionable guidance when a frontend/OXC npm/bun install fails and the registry
+# lock is the likely cause (corporate firewall/proxy). No-op once the user has opted in
+# via UNSLOTH_NPM_REGISTRY. We never switch registries automatically -- we only guide.
+# $1 = path to a captured install log (may be empty/missing).
+_suggest_npm_registry() {
+    [ -n "${UNSLOTH_NPM_REGISTRY:-}" ] && return 0
+    local _log="${1:-}"
+    # If we captured output and it does NOT look like a registry/network problem, stay
+    # quiet -- the raw error already shown is more useful than a misleading hint.
+    if [ -n "$_log" ] && [ -s "$_log" ] \
+        && ! grep -Eqi '40[13]|ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ConnectionRefused|failed to resolve|registry\.npmjs\.org|getaddrinfo|tunneling socket|network|proxy|self.?signed|unable to (get|verify)' "$_log"; then
+        return 0
+    fi
+    # Best-effort: surface a mirror the user already configured (env or ~/.npmrc).
+    local _mirror="${NPM_CONFIG_REGISTRY:-${npm_config_registry:-}}"
+    if [ -z "$_mirror" ] && command -v npm >/dev/null 2>&1; then
+        _mirror="$(npm config get registry 2>/dev/null || true)"
+    fi
+    case "$_mirror" in
+        ""|undefined|null|https://registry.npmjs.org|https://registry.npmjs.org/) _mirror="" ;;
+    esac
+    printf '\n' >&2
+    step "frontend" "registry.npmjs.org looks blocked (corporate firewall/proxy?)" "$C_WARN" >&2
+    if [ -n "$_mirror" ]; then
+        substep "Studio pins the public npm registry; your mirror is being ignored." >&2
+        substep "Detected a registry in your npm config:" >&2
+        substep "  $_mirror" >&2
+        substep "Re-run pointing Studio at it:" >&2
+        substep "  UNSLOTH_NPM_REGISTRY=$_mirror ./install.sh --local" >&2
+    else
+        substep "If you use a private mirror/proxy, point Studio at it and re-run:" >&2
+        substep "  UNSLOTH_NPM_REGISTRY=https://your-mirror.example/api/npm/ ./install.sh --local" >&2
+    fi
+    substep "(min-release-age and save-exact stay enforced.)" >&2
+    return 0
+}
+
 run_maybe_quiet() {
     if _is_verbose; then
         "$@"
@@ -113,6 +166,7 @@ _run_quiet() {
         local exit_code=$?
         step "error" "$label failed (exit code $exit_code)" "$C_ERR" >&2
         cat "$tmplog" >&2
+        if [ -n "${_CAPTURE_LOG:-}" ]; then cat "$tmplog" >> "$_CAPTURE_LOG" 2>/dev/null || true; fi
         rm -f "$tmplog"
 
         if [ "$on_fail" = "exit" ]; then
@@ -647,7 +701,7 @@ elif [ "$NODE_SOURCE" = bundled ]; then
     substep "installing bun..."
     # --allow-scripts=bun: npm >=11.16 gates install scripts and bun's
     # postinstall fetches its binary; without it the install is a broken stub.
-    if run_maybe_quiet npm install -g bun --allow-scripts=bun && command -v bun &>/dev/null; then
+    if run_maybe_quiet npm install -g bun --allow-scripts=bun "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}" && command -v bun &>/dev/null; then
         substep "bun installed ($(bun --version))"
     else
         substep "bun install skipped (npm will be used instead)"
@@ -690,7 +744,7 @@ trap _restore_gitignores EXIT
 _try_bun_install() {
     local _log _exit_code=0
     _log=$(mktemp)
-    bun install >"$_log" 2>&1 || _exit_code=$?
+    bun install "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}" >"$_log" 2>&1 || _exit_code=$?
 
     # bun may create .exe shims on Windows (Git Bash / MSYS2) instead of plain scripts
     if [ "$_exit_code" -eq 0 ] \
@@ -707,11 +761,15 @@ _try_bun_install() {
         echo "   bun install exited 0 but critical binaries are missing:"
     fi
     sed 's/^/   | /' "$_log" >&2
+    if [ -n "${_CAPTURE_LOG:-}" ]; then cat "$_log" >> "$_CAPTURE_LOG" 2>/dev/null || true; fi
     rm -f "$_log"
     rm -rf node_modules
     return 1
 }
 
+# Capture install output (bun + npm fallback) so we can detect a registry block.
+_FRONTEND_INSTALL_LOG=$(mktemp)
+_CAPTURE_LOG="$_FRONTEND_INSTALL_LOG"
 _bun_install_ok=false
 if command -v bun &>/dev/null; then
     substep "using bun for package install (faster)"
@@ -728,12 +786,15 @@ if command -v bun &>/dev/null; then
     fi
 fi
 if [ "$_bun_install_ok" = false ]; then
-    run_quiet_no_exit "npm install" npm install --no-fund --no-audit --loglevel=error
+    run_quiet_no_exit "npm install" npm install --no-fund --no-audit --loglevel=error "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}"
     _npm_install_rc=$?
     if [ "$_npm_install_rc" -ne 0 ]; then
+        _suggest_npm_registry "$_FRONTEND_INSTALL_LOG"
         exit "$_npm_install_rc"
     fi
 fi
+_CAPTURE_LOG=""
+rm -f "$_FRONTEND_INSTALL_LOG"
 run_quiet "npm run build" npm run build
 
 _restore_gitignores
@@ -759,11 +820,17 @@ fi  # end frontend build check
 # Node, so do not run npm install against an unsuitable/absent system Node.
 if [ -d "$_OXC_DIR" ] && [ "${NODE_SOURCE:-}" != skip ] && command -v npm &>/dev/null; then
     cd "$_OXC_DIR"
-    run_quiet_no_exit "npm install (oxc validator runtime)" npm install --no-fund --no-audit --loglevel=error
+    _OXC_INSTALL_LOG=$(mktemp)
+    _CAPTURE_LOG="$_OXC_INSTALL_LOG"
+    run_quiet_no_exit "npm install (oxc validator runtime)" npm install --no-fund --no-audit --loglevel=error "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}"
     _oxc_install_rc=$?
+    _CAPTURE_LOG=""
     if [ "$_oxc_install_rc" -ne 0 ]; then
+        _suggest_npm_registry "$_OXC_INSTALL_LOG"
+        rm -f "$_OXC_INSTALL_LOG"
         exit "$_oxc_install_rc"
     fi
+    rm -f "$_OXC_INSTALL_LOG"
     cd "$SCRIPT_DIR"
 elif [ -d "$_OXC_DIR" ] && [ "${NODE_SOURCE:-}" != skip ]; then
     # No npm on PATH: skip rather than abort; the backend Node resolver degrades

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -104,9 +104,12 @@ _suggest_npm_registry() {
         return 0
     fi
     # Best-effort: surface a mirror the user already configured (env or ~/.npmrc).
+    # Read npm config from / (a dir with no project .npmrc) so the frontend's pinned
+    # registry= does not mask the user's ~/.npmrc / global mirror -- the caller is
+    # still inside studio/frontend when this runs.
     local _mirror="${NPM_CONFIG_REGISTRY:-${npm_config_registry:-}}"
     if [ -z "$_mirror" ] && command -v npm >/dev/null 2>&1; then
-        _mirror="$(npm config get registry 2>/dev/null || true)"
+        _mirror="$( (cd / 2>/dev/null && npm config get registry) 2>/dev/null || true )"
     fi
     case "$_mirror" in
         ""|undefined|null|https://registry.npmjs.org|https://registry.npmjs.org/) _mirror="" ;;

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -786,10 +786,14 @@ if command -v bun &>/dev/null; then
     fi
 fi
 if [ "$_bun_install_ok" = false ]; then
-    run_quiet_no_exit "npm install" npm install --no-fund --no-audit --loglevel=error "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}"
-    _npm_install_rc=$?
+    # `|| _npm_install_rc=$?` keeps this off `set -e`'s exit path (run_quiet_no_exit
+    # returns non-zero on failure) so the hint branch is reachable; it also captures
+    # the exact exit code. Mirrors the `|| BUILD_OK=false` idiom used below.
+    _npm_install_rc=0
+    run_quiet_no_exit "npm install" npm install --no-fund --no-audit --loglevel=error "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}" || _npm_install_rc=$?
     if [ "$_npm_install_rc" -ne 0 ]; then
         _suggest_npm_registry "$_FRONTEND_INSTALL_LOG"
+        rm -f "$_FRONTEND_INSTALL_LOG"
         exit "$_npm_install_rc"
     fi
 fi
@@ -822,8 +826,10 @@ if [ -d "$_OXC_DIR" ] && [ "${NODE_SOURCE:-}" != skip ] && command -v npm &>/dev
     cd "$_OXC_DIR"
     _OXC_INSTALL_LOG=$(mktemp)
     _CAPTURE_LOG="$_OXC_INSTALL_LOG"
-    run_quiet_no_exit "npm install (oxc validator runtime)" npm install --no-fund --no-audit --loglevel=error "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}"
-    _oxc_install_rc=$?
+    # `|| _oxc_install_rc=$?` keeps this off `set -e`'s exit path so the hint branch
+    # below is reachable; it also captures the exact exit code.
+    _oxc_install_rc=0
+    run_quiet_no_exit "npm install (oxc validator runtime)" npm install --no-fund --no-audit --loglevel=error "${_NPM_REGISTRY_ARGS[@]+"${_NPM_REGISTRY_ARGS[@]}"}" || _oxc_install_rc=$?
     _CAPTURE_LOG=""
     if [ "$_oxc_install_rc" -ne 0 ]; then
         _suggest_npm_registry "$_OXC_INSTALL_LOG"


### PR DESCRIPTION
Fixes #6491.

## Problem
The Studio developer/advanced install (`./install.sh --local` -> `studio/setup.sh`, and the Windows `setup.ps1`) builds the frontend with `bun install` / `npm install` inside `studio/frontend/`. That directory ships a committed `.npmrc` that pins:

```
registry=https://registry.npmjs.org/
```

A project-level `.npmrc` `registry=` takes precedence over the user's `~/.npmrc`. So a user behind a corporate firewall who points npm/bun at their Artifactory/proxy in `~/.npmrc` (because the firewall blocks direct access to npmjs.org) is ignored, the install fetches straight from `registry.npmjs.org`, and the firewall returns HTTP 403:

```
error: GET https://registry.npmjs.org/ip-address - 403
error: GET https://registry.npmjs.org/mermaid - 403
```

That `registry=` line is a deliberate supply-chain lock (it sits with `min-release-age=7` and `save-exact=true`), so removing it is not an option. The goal is to keep the lock as the default and add a deliberate, opt-in escape hatch for corporate mirrors without changing behavior for everyone else.

## Change
Add an opt-in env var `UNSLOTH_NPM_REGISTRY` (off by default). When set, it is threaded as `--registry <url>` into every registry-touching install:

- `setup.sh` and `setup.ps1`: bun bootstrap (`npm install -g bun`), `bun install` (+ cache-clear retry), npm frontend fallback, and the OXC validator runtime install.
- `build.sh`: the frontend `bun install` / `npm install`.

`--registry` is the highest-precedence override for both tools (bun's own docs: it overrides `.npmrc`, `bunfig.toml` and environment variables) and leaves `min-release-age` / `save-exact` in force. When the env var is unset the args array is empty, so normal installs are byte-for-byte unchanged.

On an install failure that looks like a blocked registry (403/connection/DNS errors against the registry), the installer now prints a short, actionable message pointing at `UNSLOTH_NPM_REGISTRY` and auto-suggests the mirror already configured in the user's `~/.npmrc` / `NPM_CONFIG_REGISTRY`. It never switches registries automatically.

The `.npmrc` comment is also corrected: the pin does not block an ambient `NPM_CONFIG_REGISTRY` env var (npm and bun honor that at a higher precedence than the project file); it only guards against a lower-precedence stale `~/.npmrc`. That is why we expose the explicit `UNSLOTH_NPM_REGISTRY` opt-in rather than reading `NPM_CONFIG_REGISTRY`.

## Usage
```bash
UNSLOTH_NPM_REGISTRY=https://artifactory.example.com/api/npm/npm/ ./install.sh --local
```
```powershell
$env:UNSLOTH_NPM_REGISTRY='https://artifactory.example.com/api/npm/npm/'; .\install.ps1 --local
```

## Validation
Tested locally with bun 1.3.11 and npm 11.11.1 against the real `studio/frontend` (committed `package-lock.json` + `.npmrc`):

- Unset (default lock): `bun install` succeeds, `npm run build` produces a 175 KB CSS asset. No regression.
- `UNSLOTH_NPM_REGISTRY=https://registry.npmjs.org/` (explicit default): clean no-op, install succeeds.
- `UNSLOTH_NPM_REGISTRY=http://127.0.0.1:9/` (unreachable): both `bun install --registry ...` and `npm install --registry ...` fail to reach npmjs.org and hit the override host instead. For npm, the lockfile's pinned `resolved` URLs are rewritten to the override host, confirming a corporate mirror would receive both metadata and tarballs.
- `bash -n` on `setup.sh` / `build.sh` and a PowerShell parser pass on `setup.ps1` are clean.
- The failure-hint helpers were unit tested in both shells: silent when the user has opted in or when the failure is not registry-related, and they surface the detected mirror with the correct re-run command on a real block.

## Scope
No change to the desktop installers (`install.sh` / `install.ps1` bundle a prebuilt frontend and never hit the registry), the Tauri config, CI/release workflows (intentionally stay on the public registry), or the supply-chain audit scripts (they read only the committed lockfile, which this does not modify).