### PR TITLE
Studio: fix misleading max_seq_length advice for train-on-completions row drops

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3543,9 +3543,12 @@ class UnslothTrainer:
 
                     # ── Safety net: check if all samples were filtered out ──
                     # train_on_responses_only masks non-response tokens with -100;
-                    # if max_seq_length is too short the response is truncated away,
-                    # every sample becomes all -100, and Unsloth drops them, leaving
-                    # 0 usable samples. Skip this len()-based check for streaming.
+                    # a row becomes all -100 (and Unsloth drops it) when the response
+                    # template is not found in the formatted text. That is usually a
+                    # dataset/template mismatch (already-formatted data, or 'Train on
+                    # completions' applied to data that doesn't match the model's chat
+                    # template), and only sometimes max_seq_length truncating the
+                    # response away. Skip this len()-based check for streaming.
                     if detect_streaming_dataset(self.trainer.train_dataset):
                         logger.info("Skipping post-filter length check for streaming dataset\n")
                     else:
@@ -3560,13 +3563,18 @@ class UnslothTrainer:
                         if filtered_len == 0 or drop_pct > 30:
                             max_seq = training_args.get("max_seq_length", 2048)
                             error_msg = (
-                                f"{dropped}/{original_len} samples ({drop_pct}%) "
-                                f"were dropped after applying 'train on responses "
-                                f"only' — only {filtered_len} remain. This usually "
-                                f"means max_seq_length ({max_seq}) is too short "
-                                f"and the response portion is being truncated "
-                                f"away. Try increasing max_seq_length (e.g. 8192) "
-                                f"or disabling 'Train on completions'."
+                                f"{dropped}/{original_len} samples ({drop_pct}%) were "
+                                f"dropped after applying 'Train on completions': after "
+                                f"masking, those rows had no trainable response tokens "
+                                f"left. The usual cause is that this model's response "
+                                f"template was not found in the formatted samples, so "
+                                f"every token was masked out. That typically means the "
+                                f"dataset is already formatted, or its structure does "
+                                f"not match the model's chat template, so 'Train on "
+                                f"completions' should be turned off for this dataset. "
+                                f"Less commonly, a max_seq_length ({max_seq}) shorter "
+                                f"than the prompt can truncate the response away; only "
+                                f"raise it if your samples are actually longer than that."
                             )
                             logger.error(error_msg)
                             self._update_progress(error = error_msg, is_training = False)


### PR DESCRIPTION
## Problem

When 'Train on completions' is enabled, Studio applies `train_on_responses_only()` (which masks every non-response token to `-100`) and then runs a post-filter safety net: if too many rows were dropped (`filtered_len == 0 or drop_pct > 30`), it aborts with an error. The error text is misleading:

```
N/M samples (X%) were dropped after applying 'train on responses only' - only K remain.
This usually means max_seq_length (16384) is too short and the response portion is being
truncated away. Try increasing max_seq_length (e.g. 8192) or disabling 'Train on completions'.
```

Two problems:

1. The trigger is a **row-drop ratio**, not a token-length check. The `max_seq_length` value in the text is read only for display and is never compared to any measured sample length, so the "too short" narrative fires identically whether `max_seq_length` is 2048 or 16384.
2. The recommendation `8192` is a hardcoded literal. A user who already set 16384 is told to "increase" it to a smaller number.

The dominant real cause of every-row-masked is that the model's response template (for example `<|im_start|>assistant\n`) is **not found in the formatted samples**: the dataset is already formatted, or its structure does not match the model's chat template, so `train_on_responses_only` masks the whole row. This happens regardless of `max_seq_length`. The genuine fix is to turn off 'Train on completions' for that dataset, but the original message buried it behind the wrong context-length advice.

## Fix

Reword the error (and the comment above it) to lead with the actual most-likely cause and the actionable remedy (turn off 'Train on completions'), and mention `max_seq_length` only as a secondary possibility, without a hardcoded recommended value:

```
N/M samples (X%) were dropped after applying 'Train on completions': after masking, those
rows had no trainable response tokens left. The usual cause is that this model's response
template was not found in the formatted samples, so every token was masked out. That
typically means the dataset is already formatted, or its structure does not match the
model's chat template, so 'Train on completions' should be turned off for this dataset.
Less commonly, a max_seq_length (16384) shorter than the prompt can truncate the response
away; only raise it if your samples are actually longer than that.
```

No behavior change to the trigger or training; only the diagnostic text. One file, `studio/backend/core/training/trainer.py`.
