### PR TITLE
Studio: keep the live progress stream alive during pre-first-step preparation

### DIFF
--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -68,6 +68,13 @@ class TrainingStopRequest(PydanticBaseModel):
 router = APIRouter()
 logger = get_logger(__name__)
 
+# Consecutive 1s polls without a step update that count as a stalled run. Applied
+# only once training is actually stepping: the pre-first-step phase (model load +
+# tokenizing a large dataset) can legitimately take far longer, and timing the
+# live stream out there is what made a healthy long-prep run look frozen and
+# disconnected from the UI.
+_PROGRESS_STALL_TIMEOUT_POLLS = 1800  # ~30 min at 1 poll/sec
+
 
 def _validate_local_dataset_paths(paths: list[str], label: str = "Local dataset") -> list[str]:
     """Resolve and validate a list of local dataset paths. Returns validated absolute paths."""
@@ -833,7 +840,11 @@ async def stream_training_progress(
         # ── Live polling loop ────────────────────────────────────
         last_step = resume_from_step if resume_from_step is not None else -1
         no_update_count = 0
-        max_no_updates = 1800  # Timeout after 30 min (large models need compile time)
+        # The stall timeout only applies once we have actually seen a live step in
+        # this stream; before the first step the run is still preparing and may
+        # legitimately emit no step for a long time (large model load / dataset
+        # tokenization), which must not be mistaken for a stall.
+        seen_live_step = False
 
         while backend.is_training_active():
             try:
@@ -871,6 +882,7 @@ async def stream_training_progress(
                         )
                         last_step = current_step
                         no_update_count = 0
+                        seen_live_step = True
                     else:
                         no_update_count += 1
                         # Heartbeat every 10 seconds.
@@ -913,8 +925,11 @@ async def stream_training_progress(
                             event_id = 0,
                         )
 
-                # Timeout check
-                if no_update_count > max_no_updates:
+                # Timeout check. Only fires once the run has started stepping: a
+                # long pre-first-step prep phase (e.g. tokenizing a large dataset)
+                # is not a stall, and ending the live stream there is what made a
+                # healthy background run look frozen in the UI.
+                if seen_live_step and no_update_count > _PROGRESS_STALL_TIMEOUT_POLLS:
                     logger.warning("Progress stream timeout - no updates received")
                     tp_timeout = getattr(
                         getattr(backend, "trainer", None), "training_progress", None

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -840,11 +840,16 @@ async def stream_training_progress(
         # ── Live polling loop ────────────────────────────────────
         last_step = resume_from_step if resume_from_step is not None else -1
         no_update_count = 0
-        # The stall timeout only applies once we have actually seen a live step in
-        # this stream; before the first step the run is still preparing and may
+        # The stall timeout only applies once the run has actually started
+        # stepping. Before the first step the run is still preparing and may
         # legitimately emit no step for a long time (large model load / dataset
-        # tokenization), which must not be mistaken for a stall.
-        seen_live_step = False
+        # tokenization), which must not be mistaken for a stall. On a reconnect to
+        # an already-stepping run, seed this from the resume point / existing
+        # history: otherwise a worker that hangs after step N would never time out
+        # for a client that reconnects past that step and only receives heartbeats.
+        seen_live_step = (resume_from_step is not None and resume_from_step > 0) or bool(
+            backend.step_history
+        )
 
         while backend.is_training_active():
             try:

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -68,11 +68,9 @@ class TrainingStopRequest(PydanticBaseModel):
 router = APIRouter()
 logger = get_logger(__name__)
 
-# Consecutive 1s polls without a step update that count as a stalled run. Applied
-# only once training is actually stepping: the pre-first-step phase (model load +
-# tokenizing a large dataset) can legitimately take far longer, and timing the
-# live stream out there is what made a healthy long-prep run look frozen and
-# disconnected from the UI.
+# Consecutive 1s polls without a step update that count as a stall. Applied only
+# once stepping: the pre-first-step phase (model load + tokenization) can take far
+# longer, and timing out there made a healthy long-prep run look frozen.
 _PROGRESS_STALL_TIMEOUT_POLLS = 1800  # ~30 min at 1 poll/sec
 
 
@@ -840,13 +838,10 @@ async def stream_training_progress(
         # ── Live polling loop ────────────────────────────────────
         last_step = resume_from_step if resume_from_step is not None else -1
         no_update_count = 0
-        # The stall timeout only applies once the run has actually started
-        # stepping. Before the first step the run is still preparing and may
-        # legitimately emit no step for a long time (large model load / dataset
-        # tokenization), which must not be mistaken for a stall. On a reconnect to
-        # an already-stepping run, seed this from the resume point / existing
-        # history: otherwise a worker that hangs after step N would never time out
-        # for a client that reconnects past that step and only receives heartbeats.
+        # The stall timeout applies only once the run is stepping (pre-step prep
+        # may legitimately emit no step for a long time). On reconnect to an
+        # already-stepping run, seed from the resume point / history, else a worker
+        # that hangs after step N never times out for a client that reconnects past it.
         seen_live_step = (resume_from_step is not None and resume_from_step > 0) or bool(
             backend.step_history
         )
@@ -930,10 +925,8 @@ async def stream_training_progress(
                             event_id = 0,
                         )
 
-                # Timeout check. Only fires once the run has started stepping: a
-                # long pre-first-step prep phase (e.g. tokenizing a large dataset)
-                # is not a stall, and ending the live stream there is what made a
-                # healthy background run look frozen in the UI.
+                # Fires only once stepping: a long pre-first-step prep phase is not
+                # a stall, and ending the stream there made a healthy run look frozen.
                 if seen_live_step and no_update_count > _PROGRESS_STALL_TIMEOUT_POLLS:
                     logger.warning("Progress stream timeout - no updates received")
                     tp_timeout = getattr(

--- a/studio/backend/tests/test_training_progress_prep_timeout.py
+++ b/studio/backend/tests/test_training_progress_prep_timeout.py
@@ -74,6 +74,11 @@ class _FakeRequest:
     headers = {}
 
 
+class _ReconnectRequest:
+    # Reconnect carrying the last step the client already received.
+    headers = {"last-event-id": "10"}
+
+
 def _raw(response):
     async def _drain():
         chunks = []
@@ -119,3 +124,18 @@ def test_stall_after_first_step_still_times_out(monkeypatch, _fast_short_timeout
     raw = _raw(asyncio.run(rt.stream_training_progress(_FakeRequest(), current_subject = "tester")))
 
     assert "event: error" in raw, "a real post-step stall should still time out"
+
+
+def test_reconnect_to_stepped_run_still_times_out(monkeypatch, _fast_short_timeout):
+    # Client reconnects at step 10 (Last-Event-ID) to a run that has already
+    # stepped and then hangs: no new step is emitted, only heartbeats, but the
+    # post-step stall timeout must still fire. Without seeding seen_live_step from
+    # the resume point it would reset to False and never time out for this client.
+    backend = _Backend(active_polls = 100, step_history = [10], live_step = 10)
+    monkeypatch.setattr(rt, "get_training_backend", lambda: backend)
+
+    raw = _raw(asyncio.run(rt.stream_training_progress(_ReconnectRequest(), current_subject = "tester")))
+
+    assert "event: error" in raw, (
+        "a reconnect to an already-stepped run that then stalls must still time out"
+    )

--- a/studio/backend/tests/test_training_progress_prep_timeout.py
+++ b/studio/backend/tests/test_training_progress_prep_timeout.py
@@ -134,8 +134,10 @@ def test_reconnect_to_stepped_run_still_times_out(monkeypatch, _fast_short_timeo
     backend = _Backend(active_polls = 100, step_history = [10], live_step = 10)
     monkeypatch.setattr(rt, "get_training_backend", lambda: backend)
 
-    raw = _raw(asyncio.run(rt.stream_training_progress(_ReconnectRequest(), current_subject = "tester")))
-
-    assert "event: error" in raw, (
-        "a reconnect to an already-stepped run that then stalls must still time out"
+    raw = _raw(
+        asyncio.run(rt.stream_training_progress(_ReconnectRequest(), current_subject = "tester"))
     )
+
+    assert (
+        "event: error" in raw
+    ), "a reconnect to an already-stepped run that then stalls must still time out"

--- a/studio/backend/tests/test_training_progress_prep_timeout.py
+++ b/studio/backend/tests/test_training_progress_prep_timeout.py
@@ -3,11 +3,9 @@
 
 """The live progress SSE must not time out during the pre-first-step phase.
 
-A large model load / dataset tokenization can keep a run at step 0 for far
-longer than the stall timeout. Treating that as a stall ends the live stream
-(emits an ``error`` event and breaks), which is what made a healthy background
-run look frozen and disconnected from the UI. The stall timeout must apply only
-once the run has actually started stepping.
+A large model load / dataset tokenization can keep a run at step 0 for longer
+than the stall timeout. Treating that as a stall ends the live stream and makes a
+healthy run look frozen, so the timeout must apply only once the run is stepping.
 """
 
 import asyncio
@@ -127,10 +125,10 @@ def test_stall_after_first_step_still_times_out(monkeypatch, _fast_short_timeout
 
 
 def test_reconnect_to_stepped_run_still_times_out(monkeypatch, _fast_short_timeout):
-    # Client reconnects at step 10 (Last-Event-ID) to a run that has already
-    # stepped and then hangs: no new step is emitted, only heartbeats, but the
-    # post-step stall timeout must still fire. Without seeding seen_live_step from
-    # the resume point it would reset to False and never time out for this client.
+    # Client reconnects at step 10 (Last-Event-ID) to a run that already stepped
+    # then hangs (only heartbeats): the post-step stall timeout must still fire.
+    # Without seeding seen_live_step from the resume point it resets to False and
+    # never times out for this client.
     backend = _Backend(active_polls = 100, step_history = [10], live_step = 10)
     monkeypatch.setattr(rt, "get_training_backend", lambda: backend)
 

--- a/studio/backend/tests/test_training_progress_prep_timeout.py
+++ b/studio/backend/tests/test_training_progress_prep_timeout.py
@@ -31,7 +31,11 @@ import routes.training as rt
 
 
 class _Progress:
-    def __init__(self, step = 0, total_steps = 1000):
+    def __init__(
+        self,
+        step = 0,
+        total_steps = 1000,
+    ):
         self.step = step
         self.total_steps = total_steps
         self.loss = None
@@ -45,7 +49,13 @@ class _Progress:
 
 
 class _Backend:
-    def __init__(self, *, active_polls, step_history = None, live_step = 0):
+    def __init__(
+        self,
+        *,
+        active_polls,
+        step_history = None,
+        live_step = 0,
+    ):
         self.current_job_id = "job-prep"
         self.step_history = list(step_history or [])
         self.loss_history = [1.0 for _ in self.step_history]
@@ -93,9 +103,9 @@ def test_prep_phase_does_not_time_out_before_first_step(monkeypatch, _fast_short
 
     raw = _raw(asyncio.run(rt.stream_training_progress(_FakeRequest(), current_subject = "tester")))
 
-    assert backend._active_calls > rt._PROGRESS_STALL_TIMEOUT_POLLS + 1, (
-        "the loop must have run past the stall threshold for this test to be meaningful"
-    )
+    assert (
+        backend._active_calls > rt._PROGRESS_STALL_TIMEOUT_POLLS + 1
+    ), "the loop must have run past the stall threshold for this test to be meaningful"
     assert "event: heartbeat" in raw, "prep heartbeats should still flow"
     assert "event: error" not in raw, "a still-preparing run must not be timed out as a stall"
 

--- a/studio/backend/tests/test_training_progress_prep_timeout.py
+++ b/studio/backend/tests/test_training_progress_prep_timeout.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The live progress SSE must not time out during the pre-first-step phase.
+
+A large model load / dataset tokenization can keep a run at step 0 for far
+longer than the stall timeout. Treating that as a stall ends the live stream
+(emits an ``error`` event and breaks), which is what made a healthy background
+run look frozen and disconnected from the UI. The stall timeout must apply only
+once the run has actually started stepping.
+"""
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+if "structlog" not in sys.modules:
+
+    class _DummyLogger:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+    sys.modules["structlog"] = types.SimpleNamespace(
+        BoundLogger = _DummyLogger,
+        get_logger = lambda *args, **kwargs: _DummyLogger(),
+    )
+
+import routes.training as rt
+
+
+class _Progress:
+    def __init__(self, step = 0, total_steps = 1000):
+        self.step = step
+        self.total_steps = total_steps
+        self.loss = None
+        self.learning_rate = None
+        self.epoch = None
+        self.grad_norm = None
+        self.num_tokens = None
+        self.eval_loss = None
+        self.elapsed_seconds = None
+        self.eta_seconds = None
+
+
+class _Backend:
+    def __init__(self, *, active_polls, step_history = None, live_step = 0):
+        self.current_job_id = "job-prep"
+        self.step_history = list(step_history or [])
+        self.loss_history = [1.0 for _ in self.step_history]
+        self.lr_history = [1e-4 for _ in self.step_history]
+        self.eval_enabled = False
+        self._active_calls = 0
+        self._active_polls = active_polls
+        self.trainer = types.SimpleNamespace(training_progress = _Progress(step = live_step))
+
+    def is_training_active(self):
+        self._active_calls += 1
+        return self._active_calls <= self._active_polls
+
+
+class _FakeRequest:
+    headers = {}
+
+
+def _raw(response):
+    async def _drain():
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+        return "".join(c.decode() if isinstance(c, bytes) else c for c in chunks)
+
+    return asyncio.run(asyncio.wait_for(_drain(), 15))
+
+
+@pytest.fixture
+def _fast_short_timeout(monkeypatch):
+    """Make the poll loop instant and the stall timeout tiny."""
+
+    async def _no_sleep(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(rt.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(rt, "_PROGRESS_STALL_TIMEOUT_POLLS", 3)
+
+
+def test_prep_phase_does_not_time_out_before_first_step(monkeypatch, _fast_short_timeout):
+    # Step 0 for many polls (far past the timeout), then the run ends. Pre-step
+    # this is preparation, not a stall: no error event may be emitted.
+    backend = _Backend(active_polls = 20, step_history = [], live_step = 0)
+    monkeypatch.setattr(rt, "get_training_backend", lambda: backend)
+
+    raw = _raw(asyncio.run(rt.stream_training_progress(_FakeRequest(), current_subject = "tester")))
+
+    assert backend._active_calls > rt._PROGRESS_STALL_TIMEOUT_POLLS + 1, (
+        "the loop must have run past the stall threshold for this test to be meaningful"
+    )
+    assert "event: heartbeat" in raw, "prep heartbeats should still flow"
+    assert "event: error" not in raw, "a still-preparing run must not be timed out as a stall"
+
+
+def test_stall_after_first_step_still_times_out(monkeypatch, _fast_short_timeout):
+    # Emits a live step (so seen_live_step becomes True) then stays put: a genuine
+    # post-step stall that must still trigger the timeout error.
+    backend = _Backend(active_polls = 100, step_history = [1, 2], live_step = 5)
+    monkeypatch.setattr(rt, "get_training_backend", lambda: backend)
+
+    raw = _raw(asyncio.run(rt.stream_training_progress(_FakeRequest(), current_subject = "tester")))
+
+    assert "event: error" in raw, "a real post-step stall should still time out"


### PR DESCRIPTION
## Problem

The live training progress SSE (`stream_training_progress`) increments `no_update_count` on every 1s poll that doesn't carry a new step, and after `max_no_updates = 1800` (about 30 minutes) it emits an `error` event and breaks the stream:

```python
no_update_count = 0
max_no_updates = 1800  # Timeout after 30 min
...
else:
    # No steps yet, but training is active (model loading, etc.).
    no_update_count += 1
    ...
if no_update_count > max_no_updates:
    ... yield ... event = "error" ...
    break
```

That counter is **also** driven by the pre-first-step phase (model load, then tokenizing the dataset), where it is never reset because no optimizer step has happened yet. On a large dataset that preparation can take well over 30 minutes, so the live view is torn down with an `error` while the run is healthy and still preparing. Training then continues in the background with the UI showing nothing, which is the "no progress for hours" decoupling users hit on big datasets.

## Fix

Apply the stall timeout only once the stream has actually seen a live step:

- Track `seen_live_step`, set it when a real step progress event is emitted.
- Gate the timeout on it: `if seen_live_step and no_update_count > _PROGRESS_STALL_TIMEOUT_POLLS`.

Before the first step the run is preparing and may legitimately emit no step for a long time. Heartbeats still flow (so the client stays connected and can show "Tokenizing..."), and the loop still exits when `is_training_active()` goes false, so a worker that actually dies during prep ends the stream cleanly. A genuine post-step stall still times out exactly as before. The 30-minute threshold is extracted to a module constant (`_PROGRESS_STALL_TIMEOUT_POLLS`) so it can be tuned and tested.

## Tests

`tests/test_training_progress_prep_timeout.py`:
- A run held at step 0 for far more polls than the timeout emits heartbeats and **no** error event.
- A run that emits a step and then stalls still emits the timeout error.
