### PR TITLE
fix(install): enable UV_NATIVE_TLS on macOS for corporate TLS-inspection proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_STUDIO_HOME=/abs/path sh
 $env:UNSLOTH_STUDIO_HOME='C:\path'; irm https://unsloth.ai/install.ps1 | iex
 ```
 
+Install behind a TLS-inspecting proxy (Cisco Umbrella, Zscaler, etc.) on macOS — enabled by default on macOS, set to `0` to opt out:
+```bash
+curl -fsSL https://unsloth.ai/install.sh | UV_NATIVE_TLS=1 sh
+```
+This switches uv to macOS SecureTransport so it reads your system Keychain. Your corporate CA must be trusted in the Keychain first (`sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ProxyCA.cer`).
+
 Point the frontend build at a corporate npm mirror/proxy with `UNSLOTH_NPM_REGISTRY` (for the developer install behind a firewall that blocks `registry.npmjs.org`):
 ```bash
 UNSLOTH_NPM_REGISTRY=https://artifactory.example.com/api/npm/npm/ ./install.sh --local

--- a/README.md
+++ b/README.md
@@ -246,11 +246,7 @@ curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_STUDIO_HOME=/abs/path sh
 $env:UNSLOTH_STUDIO_HOME='C:\path'; irm https://unsloth.ai/install.ps1 | iex
 ```
 
-On macOS, the installer defaults to using the system certificate store (`UV_SYSTEM_CERTS=1`) so uv reads your system Keychain. This is required behind TLS-inspecting proxies (Cisco Umbrella, Zscaler, etc.); your corporate CA must be trusted in the Keychain first:
-```bash
-sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ProxyCA.cer
-```
-To opt out of system certs on macOS:
+On macOS, the installer defaults to the system certificate store (`UV_SYSTEM_CERTS=1`) so uv trusts the CAs in your Keychain, needed behind TLS-inspecting proxies (Cisco Umbrella, Zscaler, etc.). Opt out with:
 ```bash
 curl -fsSL https://unsloth.ai/install.sh | UV_SYSTEM_CERTS=0 sh
 ```

--- a/README.md
+++ b/README.md
@@ -246,11 +246,14 @@ curl -fsSL https://unsloth.ai/install.sh | UNSLOTH_STUDIO_HOME=/abs/path sh
 $env:UNSLOTH_STUDIO_HOME='C:\path'; irm https://unsloth.ai/install.ps1 | iex
 ```
 
-Install behind a TLS-inspecting proxy (Cisco Umbrella, Zscaler, etc.) on macOS — enabled by default on macOS, set to `0` to opt out:
+On macOS, the installer defaults to using the system certificate store (`UV_SYSTEM_CERTS=1`) so uv reads your system Keychain. This is required behind TLS-inspecting proxies (Cisco Umbrella, Zscaler, etc.); your corporate CA must be trusted in the Keychain first:
 ```bash
-curl -fsSL https://unsloth.ai/install.sh | UV_NATIVE_TLS=1 sh
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ProxyCA.cer
 ```
-This switches uv to macOS SecureTransport so it reads your system Keychain. Your corporate CA must be trusted in the Keychain first (`sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ProxyCA.cer`).
+To opt out of system certs on macOS:
+```bash
+curl -fsSL https://unsloth.ai/install.sh | UV_SYSTEM_CERTS=0 sh
+```
 
 Point the frontend build at a corporate npm mirror/proxy with `UNSLOTH_NPM_REGISTRY` (for the developer install behind a firewall that blocks `registry.npmjs.org`):
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -1642,15 +1642,14 @@ export UV_HTTP_TIMEOUT
 # and rejects intercepted connections with "invalid peer certificate: UnknownIssuer".
 # Set both vars: UV_SYSTEM_CERTS is the modern one (uv >= 0.11), UV_NATIVE_TLS the
 # legacy one understood by uv 0.8.16-0.10.x, which the installer keeps if already
-# present (UV_MIN_VERSION) and which ignores UV_SYSTEM_CERTS. Opt out with UV_SYSTEM_CERTS=0.
-if [ "$OS" = "macos" ] && [ -z "${UV_SYSTEM_CERTS:-}" ] && [ -z "${UV_NATIVE_TLS:-}" ]; then
-    UV_SYSTEM_CERTS=1
-    UV_NATIVE_TLS=1
+# present (UV_MIN_VERSION) and which ignores UV_SYSTEM_CERTS. Mirror the choice onto
+# both so it works on either uv. Opt out with UV_SYSTEM_CERTS=0.
+if [ "$OS" = "macos" ]; then
+    : "${UV_SYSTEM_CERTS:=1}"
+    : "${UV_NATIVE_TLS:=$UV_SYSTEM_CERTS}"
 fi
-: "${UV_SYSTEM_CERTS:=}"
-: "${UV_NATIVE_TLS:=}"
-[ -n "$UV_SYSTEM_CERTS" ] && export UV_SYSTEM_CERTS
-[ -n "$UV_NATIVE_TLS" ] && export UV_NATIVE_TLS
+[ -n "${UV_SYSTEM_CERTS:-}" ] && export UV_SYSTEM_CERTS
+[ -n "${UV_NATIVE_TLS:-}" ] && export UV_NATIVE_TLS
 
 version_ge() {
     # returns 0 if $1 >= $2

--- a/install.sh
+++ b/install.sh
@@ -1636,16 +1636,21 @@ export UV_HTTP_RETRIES
 : "${UV_HTTP_TIMEOUT:=180}"
 export UV_HTTP_TIMEOUT
 
-# macOS: default to system certs so uv uses SecureTransport + the system Keychain.
+# macOS: trust the system Keychain so uv uses SecureTransport instead of rustls.
 # Required behind TLS-inspecting proxies (Cisco Umbrella, Zscaler, etc.) which
 # present their own CA certificate. rustls (uv's default) ignores the Keychain
 # and rejects intercepted connections with "invalid peer certificate: UnknownIssuer".
-# Users can opt out by setting UV_SYSTEM_CERTS=0 before running the installer.
-if [ "$OS" = "macos" ] && [ -z "${UV_SYSTEM_CERTS:-}" ]; then
+# Set both vars: UV_SYSTEM_CERTS is the modern one (uv >= 0.11), UV_NATIVE_TLS the
+# legacy one understood by uv 0.8.16-0.10.x, which the installer keeps if already
+# present (UV_MIN_VERSION) and which ignores UV_SYSTEM_CERTS. Opt out with UV_SYSTEM_CERTS=0.
+if [ "$OS" = "macos" ] && [ -z "${UV_SYSTEM_CERTS:-}" ] && [ -z "${UV_NATIVE_TLS:-}" ]; then
     UV_SYSTEM_CERTS=1
+    UV_NATIVE_TLS=1
 fi
 : "${UV_SYSTEM_CERTS:=}"
+: "${UV_NATIVE_TLS:=}"
 [ -n "$UV_SYSTEM_CERTS" ] && export UV_SYSTEM_CERTS
+[ -n "$UV_NATIVE_TLS" ] && export UV_NATIVE_TLS
 
 version_ge() {
     # returns 0 if $1 >= $2

--- a/install.sh
+++ b/install.sh
@@ -1641,7 +1641,7 @@ export UV_HTTP_TIMEOUT
 # present their own CA certificate. rustls (uv's default) ignores the Keychain
 # and rejects intercepted connections with "invalid peer certificate: UnknownIssuer".
 # Users can opt out by setting UV_NATIVE_TLS=0 before running the installer.
-if [ "$_PLATFORM" = "macos" ] && [ -z "${UV_NATIVE_TLS:-}" ]; then
+if [ "$OS" = "macos" ] && [ -z "${UV_NATIVE_TLS:-}" ]; then
     UV_NATIVE_TLS=1
 fi
 : "${UV_NATIVE_TLS:=}"

--- a/install.sh
+++ b/install.sh
@@ -1636,6 +1636,17 @@ export UV_HTTP_RETRIES
 : "${UV_HTTP_TIMEOUT:=180}"
 export UV_HTTP_TIMEOUT
 
+# macOS: default to native TLS so uv uses SecureTransport + the system Keychain.
+# Required behind TLS-inspecting proxies (Cisco Umbrella, Zscaler, etc.) which
+# present their own CA certificate. rustls (uv's default) ignores the Keychain
+# and rejects intercepted connections with "invalid peer certificate: UnknownIssuer".
+# Users can opt out by setting UV_NATIVE_TLS=0 before running the installer.
+if [ "$_PLATFORM" = "macos" ] && [ -z "${UV_NATIVE_TLS:-}" ]; then
+    UV_NATIVE_TLS=1
+fi
+: "${UV_NATIVE_TLS:=}"
+[ -n "$UV_NATIVE_TLS" ] && export UV_NATIVE_TLS
+
 version_ge() {
     # returns 0 if $1 >= $2
     _a=$1

--- a/install.sh
+++ b/install.sh
@@ -1636,16 +1636,16 @@ export UV_HTTP_RETRIES
 : "${UV_HTTP_TIMEOUT:=180}"
 export UV_HTTP_TIMEOUT
 
-# macOS: default to native TLS so uv uses SecureTransport + the system Keychain.
+# macOS: default to system certs so uv uses SecureTransport + the system Keychain.
 # Required behind TLS-inspecting proxies (Cisco Umbrella, Zscaler, etc.) which
 # present their own CA certificate. rustls (uv's default) ignores the Keychain
 # and rejects intercepted connections with "invalid peer certificate: UnknownIssuer".
-# Users can opt out by setting UV_NATIVE_TLS=0 before running the installer.
-if [ "$OS" = "macos" ] && [ -z "${UV_NATIVE_TLS:-}" ]; then
-    UV_NATIVE_TLS=1
+# Users can opt out by setting UV_SYSTEM_CERTS=0 before running the installer.
+if [ "$OS" = "macos" ] && [ -z "${UV_SYSTEM_CERTS:-}" ]; then
+    UV_SYSTEM_CERTS=1
 fi
-: "${UV_NATIVE_TLS:=}"
-[ -n "$UV_NATIVE_TLS" ] && export UV_NATIVE_TLS
+: "${UV_SYSTEM_CERTS:=}"
+[ -n "$UV_SYSTEM_CERTS" ] && export UV_SYSTEM_CERTS
 
 version_ge() {
     # returns 0 if $1 >= $2


### PR DESCRIPTION
## Problem

On macOS behind a TLS-inspecting proxy (Cisco Umbrella, Zscaler, etc.), the installer fails during PyTorch download with:

```
× Request failed after 5 retries
╰─▶ invalid peer certificate: UnknownIssuer
help: Consider enabling use of system TLS certificates with the
      `--system-certs` command-line flag
```

`uv` defaults to `rustls`, which uses its own bundled Mozilla CA store and **ignores the macOS Keychain**. Corporate proxies present their own CA-signed certificates (e.g. Cisco Umbrella Root CA), which rustls rejects.

This affects any macOS user on a COPE (Corporate-Owned, Personally-Enabled) device with TLS inspection enabled — a common enterprise security configuration.

## Fix

Export `UV_NATIVE_TLS=1` on macOS before any uv invocations. This switches uv to macOS SecureTransport, which reads the system Keychain and trusts whatever CA certs the org has installed.

The fix follows the same `:=` pattern already used for `UV_HTTP_RETRIES` and `UV_HTTP_TIMEOUT`, so any user override is respected.

## Why macOS only / why default-on

- SecureTransport is stable and always present on macOS — no downside to enabling it
- Corporate Mac fleets are the primary affected population
- Linux native TLS behaviour (OpenSSL vs. GnuTLS vs. distro cert bundles) is less uniform — better left opt-in
- Users can opt out with `UV_NATIVE_TLS=0` before running the installer

## Workaround (until merged)

```bash
UV_NATIVE_TLS=1 curl -fsSL https://unsloth.ai/install.sh | sh
```

The proxy CA cert must also be trusted in the macOS Keychain:
```bash
sudo security add-trusted-cert -d -r trustRoot \
  -k /Library/Keychains/System.keychain /path/to/ProxyCA.cer
```