### PR TITLE
fix: wrap unprotected evaluate() calls with robust_evaluate() to handle navigation context loss

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -494,12 +494,15 @@ with sync_playwright() as p:
             # typeahead actually filters (else an ignored-input regression
             # would silently pass).
             def picker_visible_text():
-                return robust_evaluate(page, """() => {
+                return robust_evaluate(
+                    page,
+                    """() => {
                     const el = document.querySelector(
                         '[role="dialog"], [role="listbox"], [role="menu"]'
                     );
                     return el ? (el.innerText || '').trim() : '';
-                }""")
+                }""",
+                )
 
             search.fill("qwen")
             page.wait_for_timeout(800)
@@ -535,9 +538,12 @@ with sync_playwright() as p:
 
     def _bubble_count():
         """Total [data-role='assistant'] elements (empty or not)."""
-        return robust_evaluate(page, """() => {
+        return robust_evaluate(
+            page,
+            """() => {
             return document.querySelectorAll('[data-role="assistant"]').length;
-        }""")
+        }""",
+        )
 
     def send_and_wait(prompt, idx):
         # 1. Wait until the previous turn fully stopped: Send attached
@@ -626,8 +632,11 @@ with sync_playwright() as p:
         send_and_wait(p_, i)
     shoot("04-after-five-turns")
 
-    texts = robust_evaluate(page, """() => Array.from(document.querySelectorAll('[data-role="assistant"]'))
-        .map(e => (e.innerText || '').trim())""")
+    texts = robust_evaluate(
+        page,
+        """() => Array.from(document.querySelectorAll('[data-role="assistant"]'))
+        .map(e => (e.innerText || '').trim())""",
+    )
     if len(texts) < len(prompts):
         fail(f"expected >= {len(prompts)} assistant bubbles, got {len(texts)}")
     info(f"five turn lengths = {[len(t) for t in texts[:5]]}")
@@ -840,7 +849,9 @@ with sync_playwright() as p:
             # Settle. The ".dark" class on <html> is the ground truth
             # (theme-store toggles only that); don't gate on ".light".
             page.wait_for_timeout(700)
-            bg = robust_evaluate(page, """() => {
+            bg = robust_evaluate(
+                page,
+                """() => {
                 const root = document.documentElement;
                 return {
                     cls:    root.className,
@@ -848,7 +859,8 @@ with sync_playwright() as p:
                     bg:     getComputedStyle(document.body).backgroundColor,
                     rbg:    getComputedStyle(root).backgroundColor,
                 };
-            }""")
+            }""",
+            )
             observed.append(bg)
             shoot(f"10-theme-cycle-{cycle + 1}")
             info(f"  cycle {cycle + 1}: dark={bg['isDark']} body bg={bg['bg']!r}")

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -494,7 +494,7 @@ with sync_playwright() as p:
             # typeahead actually filters (else an ignored-input regression
             # would silently pass).
             def picker_visible_text():
-                return page.evaluate("""() => {
+                return robust_evaluate(page, """() => {
                     const el = document.querySelector(
                         '[role="dialog"], [role="listbox"], [role="menu"]'
                     );
@@ -535,7 +535,7 @@ with sync_playwright() as p:
 
     def _bubble_count():
         """Total [data-role='assistant'] elements (empty or not)."""
-        return page.evaluate("""() => {
+        return robust_evaluate(page, """() => {
             return document.querySelectorAll('[data-role="assistant"]').length;
         }""")
 
@@ -626,7 +626,7 @@ with sync_playwright() as p:
         send_and_wait(p_, i)
     shoot("04-after-five-turns")
 
-    texts = page.evaluate("""() => Array.from(document.querySelectorAll('[data-role="assistant"]'))
+    texts = robust_evaluate(page, """() => Array.from(document.querySelectorAll('[data-role="assistant"]'))
         .map(e => (e.innerText || '').trim())""")
     if len(texts) < len(prompts):
         fail(f"expected >= {len(prompts)} assistant bubbles, got {len(texts)}")
@@ -827,7 +827,7 @@ with sync_playwright() as p:
                         theme_item.scroll_into_view_if_needed(timeout = 2_000)
                         theme_item.click(force = True, timeout = 3_000)
                     else:
-                        theme_item.evaluate("el => el.click()")
+                        robust_evaluate(theme_item, "el => el.click()")
                     click_err = None
                     break
                 except Exception as exc:
@@ -840,7 +840,7 @@ with sync_playwright() as p:
             # Settle. The ".dark" class on <html> is the ground truth
             # (theme-store toggles only that); don't gate on ".light".
             page.wait_for_timeout(700)
-            bg = page.evaluate("""() => {
+            bg = robust_evaluate(page, """() => {
                 const root = document.documentElement;
                 return {
                     cls:    root.className,

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -836,7 +836,7 @@ with sync_playwright() as p:
                         theme_item.scroll_into_view_if_needed(timeout = 2_000)
                         theme_item.click(force = True, timeout = 3_000)
                     else:
-                        robust_evaluate(theme_item, "el => el.click()")
+                        theme_item.evaluate("el => el.click()")
                     click_err = None
                     break
                 except Exception as exc:

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1062,7 +1062,8 @@ with sync_playwright() as p:
             shoot("15d-recent-clicked")
             info(f"OK clicked recent entry: {t[:60]!r}")
             # The landed thread must include at least one of our prompts.
-            turns_text = page.evaluate(
+            turns_text = robust_evaluate(
+                page,
                 """() => {
                 const els = document.querySelectorAll(
                     '[data-role="user"], [data-role="assistant"]'
@@ -1070,7 +1071,6 @@ with sync_playwright() as p:
                 return Array.from(els).map(e => (e.innerText || '')
                     .toLowerCase()).join(' ');
             }""",
-                None,
             )
             clicked_recent = True
             if any(k in turns_text for k in PROMPT_KEYWORDS):


### PR DESCRIPTION
## Issue

PR #5911 CI failure: `Page.evaluate: Execution context was destroyed` at `tests/studio/playwright_chat_ui.py` line 340.

This is a race condition — Playwright evaluates JS while the page navigates, destroying the execution context mid-call.

## Root Cause

The codebase has a `robust_evaluate()` helper in `_playwright_robust.py` that catches transient context-loss errors and retries with exponential backoff. However, 4 `evaluate()` calls in `playwright_chat_ui.py` were not using it:

- `picker_visible_text()` — model picker search
- `_bubble_count()` — assistant bubble count
- Assistant text extraction query
- Background/theme color query

Note: `theme_item.evaluate("el => el.click()")` is intentionally NOT wrapped because it is side-effecting. Retrying after a context loss could double-toggle the theme state. This call is already inside a 3-attempt try/except loop with graceful fallback (Escape + soft_fail).

## Fix

Wrap the 4 unprotected read-only `evaluate()` calls with the existing `robust_evaluate()` function (2 retries, 250ms-500ms backoff on context-loss errors).

## Changes

`tests/studio/playwright_chat_ui.py`: 4 lines changed — zero new dependencies, zero behavioral change for passing runs.
