### PR TITLE
Studio Colab: opt-in shareable Cloudflare tunnel link

### DIFF
--- a/studio/Unsloth_Studio_Colab.ipynb
+++ b/studio/Unsloth_Studio_Colab.ipynb
@@ -84,7 +84,7 @@
     "id": "277e431e"
    },
    "outputs": [],
-   "source": "import sys\nsys.path.insert(0, \"/content/unsloth/studio/backend\")\nfrom colab import start\nstart()"
+   "source": "import sys\nsys.path.insert(0, \"/content/unsloth/studio/backend\")\nfrom colab import start\n\nstart()                  # in-tab iframe only (default)\n# start(cloudflare=True) # uncomment to also get a shareable Cloudflare link"
   },
   {
    "cell_type": "markdown",

--- a/studio/Unsloth_Studio_Colab.ipynb
+++ b/studio/Unsloth_Studio_Colab.ipynb
@@ -84,7 +84,7 @@
     "id": "277e431e"
    },
    "outputs": [],
-   "source": "import sys\nsys.path.insert(0, \"/content/unsloth/studio/backend\")\nfrom colab import start\n\nstart()                  # in-tab iframe only (default)\n# start(cloudflare=True) # uncomment to also get a shareable Cloudflare link"
+   "source": "import sys\nsys.path.insert(0, \"/content/unsloth/studio/backend\")\nfrom colab import start\n\n# In-tab iframe only (default). start() blocks here keeping the kernel alive.\nstart()\n\n# For a shareable Cloudflare link, COMMENT OUT start() above and use this instead.\n# (Don't leave both: start() never returns, so the line below is never reached.)\n# start(cloudflare=True)"
   },
   {
    "cell_type": "markdown",

--- a/studio/Unsloth_Studio_Colab.ipynb
+++ b/studio/Unsloth_Studio_Colab.ipynb
@@ -84,7 +84,7 @@
     "id": "277e431e"
    },
    "outputs": [],
-   "source": "import sys\nsys.path.insert(0, \"/content/unsloth/studio/backend\")\nfrom colab import start\n\n# In-tab iframe only (default). start() blocks here keeping the kernel alive.\nstart()\n\n# For a shareable Cloudflare link, COMMENT OUT start() above and use this instead.\n# (Don't leave both: start() never returns, so the line below is never reached.)\n# start(cloudflare=True)"
+   "source": "import sys\nsys.path.insert(0, \"/content/unsloth/studio/backend\")\nfrom colab import start\n\n# Default: in-tab iframe only. start() blocks to keep the kernel alive.\nstart()\n\n# For a shareable Cloudflare link, replace start() above with:\n# start(cloudflare=True)"
   },
   {
    "cell_type": "markdown",

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -155,9 +155,8 @@ def start_cloudflare_tunnel(port: int) -> "str | None":
     except Exception as e:
         logger.info(f"Cloudflare tunnel failed to start ({e}); using Colab proxy only.")
         return None
-    if url:
-        logger.info(f"🔗 Shareable Cloudflare link: {url}")
-    else:
+    # The link is logged by _show_and_embed when the card renders; only note misses here.
+    if not url:
         logger.info("Cloudflare tunnel did not produce a URL; using Colab proxy only.")
     return url
 

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -104,14 +104,11 @@ def show_link(port: int = 8888, *, _url: "str | None" = None):
 
 
 def _bootstrap_password_pending() -> bool:
-    """True while the default admin still must change its seeded bootstrap password.
+    """True while the default admin still owes a bootstrap-password change.
 
-    While pending, the server injects that bootstrap admin password into the index
-    page for same-origin top-level GETs (``_inject_bootstrap`` in main.py) — and a
-    public Cloudflare tunnel request looks same-origin (no Origin header), so the
-    password would leak to anyone holding the link, handing them admin access. We
-    use this to refuse opening the tunnel until the admin password has been changed.
-    Fails safe: if we can't determine the state, treat it as pending (no tunnel).
+    While pending, main.py injects that password into same-origin GETs, and a public
+    tunnel GET (no Origin) reads as same-origin, so sharing the link would leak admin
+    access. Fails safe to pending if the state cannot be read.
     """
     try:
         from auth.storage import requires_password_change, DEFAULT_ADMIN_USERNAME
@@ -122,20 +119,11 @@ def _bootstrap_password_pending() -> bool:
 
 
 def start_cloudflare_tunnel(port: int) -> "str | None":
-    """Best-effort: open a free Cloudflare quick tunnel to localhost:*port* and
-    return its public ``https://*.trycloudflare.com`` URL, or None.
+    """Open a shareable Cloudflare quick tunnel to localhost:*port*, or None.
 
-    Colab's kernel-proxy iframe only works inside the single browser tab that
-    owns the runtime — it is not a link you can hand to someone else or open on
-    another device. The Cloudflare tunnel gives a shareable HTTPS URL anyone can
-    open. Studio's own ``run_server`` deliberately suppresses the tunnel on Colab
-    (see ``_cloudflare_tunnel_should_start`` in run.py), so we start it directly
-    here instead. Any failure collapses to None and the Colab proxy still works.
-
-    Refuses to open the tunnel while the admin account still holds its temporary
-    bootstrap password, since that password is exposed to any same-origin GET and
-    a public tunnel request counts as same-origin — sharing then would grant admin
-    access to anyone with the link.
+    run_server suppresses the tunnel on Colab by design, so we start it directly.
+    Refused while the bootstrap password is pending; any failure collapses to None
+    and the Colab proxy still works.
     """
     if _bootstrap_password_pending():
         logger.warning(
@@ -155,22 +143,18 @@ def start_cloudflare_tunnel(port: int) -> "str | None":
     except Exception as e:
         logger.info(f"Cloudflare tunnel failed to start ({e}); using Colab proxy only.")
         return None
-    # The link is logged by _show_and_embed when the card renders; only note misses here.
+    # Success is logged by _show_and_embed; note only misses here.
     if not url:
         logger.info("Cloudflare tunnel did not produce a URL; using Colab proxy only.")
     return url
 
 
 def _publish_cloudflare_url(cloudflare_url: "str | None") -> None:
-    """Mirror a directly-started tunnel URL onto the running app so /api/health
-    advertises it.
+    """Publish a directly-started tunnel URL onto app.state so /api/health advertises it.
 
-    ``run_server`` only sets ``app.state.cloudflare_url`` when it opens the tunnel
-    itself, but on Colab it suppresses the tunnel by design — so ``colab.start()``
-    opens it directly and must publish the URL here. Without this the frontend
-    reads ``cloudflare_url = None`` from /api/health and its API-key examples fall
-    back to the raw Colab/internal ``server_url``, which isn't reachable from
-    another device — defeating the point of the shareable link. Best-effort.
+    run_server only sets this when it opens the tunnel itself, which it skips on Colab,
+    so we set it here. Otherwise the frontend's API examples fall back to an
+    unreachable server_url. Best-effort.
     """
     if not cloudflare_url:
         return
@@ -188,7 +172,7 @@ def _stop_cloudflare_tunnel() -> None:
         stop_studio_tunnel()
     except Exception:
         pass
-    # Clear the published URL so /api/health stops advertising a dead tunnel.
+    # Stop /api/health advertising a dead tunnel.
     try:
         from main import app as _studio_app
         _studio_app.state.cloudflare_url = None
@@ -197,10 +181,10 @@ def _stop_cloudflare_tunnel() -> None:
 
 
 def _is_studio_healthy(port: int, timeout: float = 2.0) -> bool:
-    """Return True only if Unsloth Studio (not some other app on *port*) answers /api/health.
+    """True only if Unsloth Studio (not some other app) answers /api/health on *port*.
 
-    Validates the service marker so the reuse fast-path never reuses or tunnels
-    an unrelated process that merely happens to serve /api/health.
+    The service-marker check stops the reuse path reusing or tunneling a foreign
+    process that merely serves /api/health.
     """
     import json, urllib.request
     try:
@@ -211,14 +195,7 @@ def _is_studio_healthy(port: int, timeout: float = 2.0) -> bool:
 
 
 def _shareable_link_html(cloudflare_url: str) -> str:
-    """A branded card advertising the shareable Cloudflare HTTPS link.
-
-    Reuses the original Colab proxy banner skin (see ``show_link``) — white card,
-    black border, Unsloth gem, big black "Open" button — retrofitted for the
-    Cloudflare ``trycloudflare.com`` URL. Unlike the in-tab Colab proxy iframe
-    rendered below, this link can be opened from any device by anyone you share
-    it with, so it gets the same prominent treatment as the proxy "Ready!" banner.
-    """
+    """Branded card for the shareable Cloudflare link, styled like the show_link banner."""
     return f"""
     <div style="display: inline-block; padding: 20px; background: #ffffff; border: 2px solid #000000;
                 border-radius: 12px; margin: 10px 0; font-family: system-ui, -apple-system, sans-serif;">
@@ -246,12 +223,8 @@ def _shareable_link_html(cloudflare_url: str) -> str:
 
 
 def _show_and_embed(port: int, *, cloudflare_url: "str | None" = None):
-    """Embed the Studio inline for *port* with a branded header bar.
-
-    Fetches the proxy URL once (registering the port), then renders header bar +
-    iframe. Falls back to serve_kernel_port_as_iframe if IPython HTML is unavailable.
-    If *cloudflare_url* is given, a shareable-link card is rendered above the iframe.
-    """
+    """Render the Studio header + iframe for *port*, with a shareable-link card above
+    when *cloudflare_url* is set. Falls back to serve_kernel_port_as_iframe."""
     url = get_colab_url(port)
     logger.info(f"🌐 Unsloth Studio URL: {url}")
     if cloudflare_url:
@@ -303,20 +276,15 @@ def _show_and_embed(port: int, *, cloudflare_url: "str | None" = None):
 
 
 def start(port: int = 8888, *, cloudflare: bool = False):
-    """
-    Start Unsloth Studio server in Colab and display the URL.
+    """Start Unsloth Studio in Colab and display the URL.
 
     Args:
         port: Port to bind/serve on.
-        cloudflare: Opt in to a free Cloudflare HTTPS tunnel and show a
-            ``trycloudflare.com`` link reachable from any device (default OFF).
-            Off by default, Studio is shown only through the Colab-proxy iframe,
-            which works in the tab that owns the runtime. The tunnel exposes
-            Studio's login page beyond Colab, so enabling it is an explicit
-            opt-in; pass ``cloudflare=False`` (or omit it) to turn it back off.
+        cloudflare: Opt in to a shareable Cloudflare HTTPS link reachable from any
+            device (default OFF). It exposes Studio's login page beyond Colab, so it
+            stays an explicit opt-in; the default shows only the in-tab proxy iframe.
 
     Usage:
-        from colab import start
         start()                    # Colab-proxy iframe only (default)
         start(cloudflare=True)     # also open a shareable Cloudflare link
     """
@@ -328,8 +296,7 @@ def start(port: int = 8888, *, cloudflare: bool = False):
     # the port, so just re-show the link and iframe.
     if _is_studio_healthy(port):
         logger.info(f"   Studio is already running on port {port} — reusing existing server.")
-        # try/finally so an interrupt while the tunnel is starting or the iframe is
-        # rendering still tears the tunnel down instead of orphaning the process.
+        # try/finally: tear the tunnel down even if interrupted mid-start/render.
         try:
             cf_url = start_cloudflare_tunnel(port) if cloudflare else None
             _publish_cloudflare_url(cf_url)
@@ -356,10 +323,8 @@ def start(port: int = 8888, *, cloudflare: bool = False):
 
     logger.info("   Starting server...")
     try:
-        # cloudflare = False unconditionally: this helper owns the tunnel decision
-        # (started directly below only when the caller opts in). Leaving run_server's
-        # default True would start a tunnel on this 0.0.0.0 bind whenever Colab
-        # detection fails, defeating the documented cloudflare=False opt-out.
+        # cloudflare=False: this helper owns the tunnel. run_server's default True
+        # would tunnel this 0.0.0.0 bind if Colab detection fails, breaking the opt-out.
         app = run_server(
             host = "0.0.0.0",
             port = port,
@@ -400,12 +365,8 @@ def start(port: int = 8888, *, cloudflare: bool = False):
         )
         return
 
-    # Start the shareable Cloudflare tunnel now that the server is healthy. Studio's
-    # run_server suppresses the tunnel on Colab by design, so we open it directly,
-    # then publish the URL onto the app so /api/health (and the frontend) advertise it.
-    #
-    # try/finally so an interrupt while the tunnel is starting or the iframe is
-    # rendering still tears the tunnel down instead of orphaning the process.
+    # Open the tunnel now the server is healthy, publish its URL for /api/health, and
+    # tear it down on interrupt (try/finally) rather than orphan the process.
     try:
         cf_url = start_cloudflare_tunnel(actual_port) if cloudflare else None
         _publish_cloudflare_url(cf_url)

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -197,11 +197,15 @@ def _stop_cloudflare_tunnel() -> None:
 
 
 def _is_studio_healthy(port: int, timeout: float = 2.0) -> bool:
-    """Return True if a Studio backend is already answering health checks on *port*."""
-    import urllib.request
+    """Return True only if Unsloth Studio (not some other app on *port*) answers /api/health.
+
+    Validates the service marker so the reuse fast-path never reuses or tunnels
+    an unrelated process that merely happens to serve /api/health.
+    """
+    import json, urllib.request
     try:
-        with urllib.request.urlopen(f"http://localhost:{port}/api/health", timeout = timeout):
-            return True
+        with urllib.request.urlopen(f"http://localhost:{port}/api/health", timeout = timeout) as r:
+            return json.loads(r.read()).get("service") == "Unsloth UI Backend"
     except Exception:
         return False
 

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -151,26 +151,38 @@ def _is_studio_healthy(port: int, timeout: float = 2.0) -> bool:
 
 
 def _shareable_link_html(cloudflare_url: str) -> str:
-    """A small branded card advertising the shareable Cloudflare HTTPS link.
+    """A branded card advertising the shareable Cloudflare HTTPS link.
 
-    Rendered above the Colab-proxy iframe so the user can copy a URL that works
-    from any device, not just the tab that owns the runtime.
+    Reuses the original Colab proxy banner skin (see ``show_link``) — white card,
+    black border, Unsloth gem, big black "Open" button — retrofitted for the
+    Cloudflare ``trycloudflare.com`` URL. Unlike the in-tab Colab proxy iframe
+    rendered below, this link can be opened from any device by anyone you share
+    it with, so it gets the same prominent treatment as the proxy "Ready!" banner.
     """
     return f"""
-<div style="font-family:system-ui,-apple-system,sans-serif;margin:8px 0;padding:14px 16px;
-            background:#0b0b0b;border:2px solid #000;border-radius:12px;">
-  <div style="color:#fff;font-weight:800;font-size:15px;margin-bottom:6px;">
-    🔗 Shareable link (works from any device)
-  </div>
-  <a href="{cloudflare_url}" target="_blank"
-     style="color:#7fd1ff;font-family:monospace;font-size:14px;font-weight:700;word-break:break-all;">
-    {cloudflare_url}
-  </a>
-  <div style="color:#999;font-size:12px;margin-top:6px;">
-    Unlike the in-tab view below, this Cloudflare HTTPS link can be opened by anyone you share it with.
-  </div>
-</div>
-"""
+    <div style="display: inline-block; padding: 20px; background: #ffffff; border: 2px solid #000000;
+                border-radius: 12px; margin: 10px 0; font-family: system-ui, -apple-system, sans-serif;">
+        <h2 style="color: #000000; margin: 0 0 12px 0; font-size: 26px; font-weight: 800;
+                   display: flex; align-items: center; gap: 12px;">
+            <img src="https://github.com/unslothai/unsloth/raw/main/studio/frontend/public/unsloth-gem.png"
+                 height="48" style="display:block;">
+            Shareable Studio Link is Ready!
+        </h2>
+        <a href="{cloudflare_url}" onclick="var w=window.open(this.href,'_blank');if(!w){{return true;}}return false;"
+           style="display: inline-flex; align-items: center; gap: 10px; padding: 14px 28px;
+                  background: #000000; color: white; text-decoration: none; border-radius: 8px;
+                  font-weight: 800; font-size: 16px; cursor: pointer;">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="white"><polygon points="5,3 19,12 5,21"/></svg>
+            Open Unsloth Studio
+        </a>
+        <p style="color: #333333; margin: 12px 0 0 0; font-size: 14px; font-weight: bold;">
+            This Cloudflare HTTPS link works from any device — share it with anyone. The Colab view below only works in this tab.
+        </p>
+        <p style="color: #333333; margin: 16px 0 0 0; font-size: 13px; font-family: monospace; font-weight: bold;">
+            🔗 {cloudflare_url}
+        </p>
+    </div>
+    """
 
 
 def _show_and_embed(port: int, *, cloudflare_url: "str | None" = None):

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -103,6 +103,43 @@ def show_link(port: int = 8888, *, _url: "str | None" = None):
     display(HTML(html))
 
 
+def start_cloudflare_tunnel(port: int) -> "str | None":
+    """Best-effort: open a free Cloudflare quick tunnel to localhost:*port* and
+    return its public ``https://*.trycloudflare.com`` URL, or None.
+
+    Colab's kernel-proxy iframe only works inside the single browser tab that
+    owns the runtime — it is not a link you can hand to someone else or open on
+    another device. The Cloudflare tunnel gives a shareable HTTPS URL anyone can
+    open. Studio's own ``run_server`` deliberately suppresses the tunnel on Colab
+    (see ``_cloudflare_tunnel_should_start`` in run.py), so we start it directly
+    here instead. Any failure collapses to None and the Colab proxy still works.
+    """
+    try:
+        from cloudflare_tunnel import start_studio_tunnel
+    except Exception as e:
+        logger.info(f"Cloudflare tunnel unavailable ({e}); using Colab proxy only.")
+        return None
+    try:
+        url = start_studio_tunnel(port)
+    except Exception as e:
+        logger.info(f"Cloudflare tunnel failed to start ({e}); using Colab proxy only.")
+        return None
+    if url:
+        logger.info(f"🔗 Shareable Cloudflare link: {url}")
+    else:
+        logger.info("Cloudflare tunnel did not produce a URL; using Colab proxy only.")
+    return url
+
+
+def _stop_cloudflare_tunnel() -> None:
+    """Best-effort teardown of the Cloudflare tunnel started by start_cloudflare_tunnel."""
+    try:
+        from cloudflare_tunnel import stop_studio_tunnel
+        stop_studio_tunnel()
+    except Exception:
+        pass
+
+
 def _is_studio_healthy(port: int, timeout: float = 2.0) -> bool:
     """Return True if a Studio backend is already answering health checks on *port*."""
     import urllib.request
@@ -113,14 +150,40 @@ def _is_studio_healthy(port: int, timeout: float = 2.0) -> bool:
         return False
 
 
-def _show_and_embed(port: int):
+def _shareable_link_html(cloudflare_url: str) -> str:
+    """A small branded card advertising the shareable Cloudflare HTTPS link.
+
+    Rendered above the Colab-proxy iframe so the user can copy a URL that works
+    from any device, not just the tab that owns the runtime.
+    """
+    return f"""
+<div style="font-family:system-ui,-apple-system,sans-serif;margin:8px 0;padding:14px 16px;
+            background:#0b0b0b;border:2px solid #000;border-radius:12px;">
+  <div style="color:#fff;font-weight:800;font-size:15px;margin-bottom:6px;">
+    🔗 Shareable link (works from any device)
+  </div>
+  <a href="{cloudflare_url}" target="_blank"
+     style="color:#7fd1ff;font-family:monospace;font-size:14px;font-weight:700;word-break:break-all;">
+    {cloudflare_url}
+  </a>
+  <div style="color:#999;font-size:12px;margin-top:6px;">
+    Unlike the in-tab view below, this Cloudflare HTTPS link can be opened by anyone you share it with.
+  </div>
+</div>
+"""
+
+
+def _show_and_embed(port: int, *, cloudflare_url: "str | None" = None):
     """Embed the Studio inline for *port* with a branded header bar.
 
     Fetches the proxy URL once (registering the port), then renders header bar +
     iframe. Falls back to serve_kernel_port_as_iframe if IPython HTML is unavailable.
+    If *cloudflare_url* is given, a shareable-link card is rendered above the iframe.
     """
     url = get_colab_url(port)
     logger.info(f"🌐 Unsloth Studio URL: {url}")
+    if cloudflare_url:
+        logger.info(f"🔗 Shareable Cloudflare link: {cloudflare_url}")
 
     try:
         from IPython.display import HTML, display
@@ -135,6 +198,9 @@ def _show_and_embed(port: int):
             short_url = url[: next_dash + 1] + "..."
         except (ValueError, IndexError):
             short_url = url
+
+        if cloudflare_url:
+            display(HTML(_shareable_link_html(cloudflare_url)))
 
         display(
             HTML(f"""
@@ -164,13 +230,23 @@ def _show_and_embed(port: int):
             pass
 
 
-def start(port: int = 8888):
+def start(port: int = 8888, *, cloudflare: bool = False):
     """
     Start Unsloth Studio server in Colab and display the URL.
 
+    Args:
+        port: Port to bind/serve on.
+        cloudflare: Opt in to a free Cloudflare HTTPS tunnel and show a
+            ``trycloudflare.com`` link reachable from any device (default OFF).
+            Off by default, Studio is shown only through the Colab-proxy iframe,
+            which works in the tab that owns the runtime. The tunnel exposes
+            Studio's login page beyond Colab, so enabling it is an explicit
+            opt-in; pass ``cloudflare=False`` (or omit it) to turn it back off.
+
     Usage:
         from colab import start
-        start()
+        start()                    # Colab-proxy iframe only (default)
+        start(cloudflare=True)     # also open a shareable Cloudflare link
     """
     import time
 
@@ -180,13 +256,15 @@ def start(port: int = 8888):
     # the port, so just re-show the link and iframe.
     if _is_studio_healthy(port):
         logger.info(f"   Studio is already running on port {port} — reusing existing server.")
-        _show_and_embed(port)
+        cf_url = start_cloudflare_tunnel(port) if cloudflare else None
+        _show_and_embed(port, cloudflare_url = cf_url)
         try:
             for _ in range(10000):
                 time.sleep(300)
                 print("=", end = "", flush = True)
         except KeyboardInterrupt:
             logger.info("\nUnsloth Studio keepalive stopped.")
+            _stop_cloudflare_tunnel()
         return
 
     logger.info("   Loading backend...")
@@ -236,7 +314,11 @@ def start(port: int = 8888):
         )
         return
 
-    _show_and_embed(actual_port)
+    # Start the shareable Cloudflare tunnel now that the server is healthy. Studio's
+    # run_server suppresses the tunnel on Colab by design, so we open it directly.
+    cf_url = start_cloudflare_tunnel(actual_port) if cloudflare else None
+
+    _show_and_embed(actual_port, cloudflare_url = cf_url)
 
     # Keep kernel alive so the daemon server thread runs; handle KeyboardInterrupt
     # cleanly so interrupting the cell gives a readable message.
@@ -246,6 +328,7 @@ def start(port: int = 8888):
             print("=", end = "", flush = True)
     except KeyboardInterrupt:
         logger.info("\nUnsloth Studio keepalive stopped.")
+        _stop_cloudflare_tunnel()
 
 
 if __name__ == "__main__":

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -103,6 +103,24 @@ def show_link(port: int = 8888, *, _url: "str | None" = None):
     display(HTML(html))
 
 
+def _bootstrap_password_pending() -> bool:
+    """True while the default admin still must change its seeded bootstrap password.
+
+    While pending, the server injects that bootstrap admin password into the index
+    page for same-origin top-level GETs (``_inject_bootstrap`` in main.py) — and a
+    public Cloudflare tunnel request looks same-origin (no Origin header), so the
+    password would leak to anyone holding the link, handing them admin access. We
+    use this to refuse opening the tunnel until the admin password has been changed.
+    Fails safe: if we can't determine the state, treat it as pending (no tunnel).
+    """
+    try:
+        from auth.storage import requires_password_change, DEFAULT_ADMIN_USERNAME
+        return bool(requires_password_change(DEFAULT_ADMIN_USERNAME))
+    except Exception as e:
+        logger.info(f"Could not check admin password state ({e}); refusing tunnel to be safe.")
+        return True
+
+
 def start_cloudflare_tunnel(port: int) -> "str | None":
     """Best-effort: open a free Cloudflare quick tunnel to localhost:*port* and
     return its public ``https://*.trycloudflare.com`` URL, or None.
@@ -113,7 +131,20 @@ def start_cloudflare_tunnel(port: int) -> "str | None":
     open. Studio's own ``run_server`` deliberately suppresses the tunnel on Colab
     (see ``_cloudflare_tunnel_should_start`` in run.py), so we start it directly
     here instead. Any failure collapses to None and the Colab proxy still works.
+
+    Refuses to open the tunnel while the admin account still holds its temporary
+    bootstrap password, since that password is exposed to any same-origin GET and
+    a public tunnel request counts as same-origin — sharing then would grant admin
+    access to anyone with the link.
     """
+    if _bootstrap_password_pending():
+        logger.warning(
+            "Cloudflare link not started: the admin account still has its temporary "
+            "bootstrap password, which is exposed to anyone who can load the page. "
+            "Open Studio in this tab, log in and change the admin password, then re-run "
+            "start(cloudflare=True) to get the shareable link."
+        )
+        return None
     try:
         from cloudflare_tunnel import start_studio_tunnel
     except Exception as e:
@@ -322,7 +353,14 @@ def start(port: int = 8888, *, cloudflare: bool = False):
 
     logger.info("   Starting server...")
     try:
-        app = run_server(host = "0.0.0.0", port = port, frontend_path = frontend_path, silent = True)
+        # cloudflare = False unconditionally: this helper owns the tunnel decision
+        # (started directly below only when the caller opts in). Leaving run_server's
+        # default True would start a tunnel on this 0.0.0.0 bind whenever Colab
+        # detection fails, defeating the documented cloudflare=False opt-out.
+        app = run_server(
+            host = "0.0.0.0", port = port, frontend_path = frontend_path,
+            silent = True, cloudflare = False,
+        )
     except SystemExit as exc:
         logger.error(f"❌ Unsloth Studio failed to start: {exc}")
         return

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -358,8 +358,11 @@ def start(port: int = 8888, *, cloudflare: bool = False):
         # default True would start a tunnel on this 0.0.0.0 bind whenever Colab
         # detection fails, defeating the documented cloudflare=False opt-out.
         app = run_server(
-            host = "0.0.0.0", port = port, frontend_path = frontend_path,
-            silent = True, cloudflare = False,
+            host = "0.0.0.0",
+            port = port,
+            frontend_path = frontend_path,
+            silent = True,
+            cloudflare = False,
         )
     except SystemExit as exc:
         logger.error(f"❌ Unsloth Studio failed to start: {exc}")

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -131,11 +131,37 @@ def start_cloudflare_tunnel(port: int) -> "str | None":
     return url
 
 
+def _publish_cloudflare_url(cloudflare_url: "str | None") -> None:
+    """Mirror a directly-started tunnel URL onto the running app so /api/health
+    advertises it.
+
+    ``run_server`` only sets ``app.state.cloudflare_url`` when it opens the tunnel
+    itself, but on Colab it suppresses the tunnel by design — so ``colab.start()``
+    opens it directly and must publish the URL here. Without this the frontend
+    reads ``cloudflare_url = None`` from /api/health and its API-key examples fall
+    back to the raw Colab/internal ``server_url``, which isn't reachable from
+    another device — defeating the point of the shareable link. Best-effort.
+    """
+    if not cloudflare_url:
+        return
+    try:
+        from main import app as _studio_app
+        _studio_app.state.cloudflare_url = cloudflare_url
+    except Exception as e:
+        logger.info(f"Could not publish Cloudflare URL to /api/health ({e}).")
+
+
 def _stop_cloudflare_tunnel() -> None:
     """Best-effort teardown of the Cloudflare tunnel started by start_cloudflare_tunnel."""
     try:
         from cloudflare_tunnel import stop_studio_tunnel
         stop_studio_tunnel()
+    except Exception:
+        pass
+    # Clear the published URL so /api/health stops advertising a dead tunnel.
+    try:
+        from main import app as _studio_app
+        _studio_app.state.cloudflare_url = None
     except Exception:
         pass
 
@@ -268,14 +294,18 @@ def start(port: int = 8888, *, cloudflare: bool = False):
     # the port, so just re-show the link and iframe.
     if _is_studio_healthy(port):
         logger.info(f"   Studio is already running on port {port} — reusing existing server.")
-        cf_url = start_cloudflare_tunnel(port) if cloudflare else None
-        _show_and_embed(port, cloudflare_url = cf_url)
+        # try/finally so an interrupt while the tunnel is starting or the iframe is
+        # rendering still tears the tunnel down instead of orphaning the process.
         try:
+            cf_url = start_cloudflare_tunnel(port) if cloudflare else None
+            _publish_cloudflare_url(cf_url)
+            _show_and_embed(port, cloudflare_url = cf_url)
             for _ in range(10000):
                 time.sleep(300)
                 print("=", end = "", flush = True)
         except KeyboardInterrupt:
             logger.info("\nUnsloth Studio keepalive stopped.")
+        finally:
             _stop_cloudflare_tunnel()
         return
 
@@ -327,19 +357,23 @@ def start(port: int = 8888, *, cloudflare: bool = False):
         return
 
     # Start the shareable Cloudflare tunnel now that the server is healthy. Studio's
-    # run_server suppresses the tunnel on Colab by design, so we open it directly.
-    cf_url = start_cloudflare_tunnel(actual_port) if cloudflare else None
-
-    _show_and_embed(actual_port, cloudflare_url = cf_url)
-
-    # Keep kernel alive so the daemon server thread runs; handle KeyboardInterrupt
-    # cleanly so interrupting the cell gives a readable message.
+    # run_server suppresses the tunnel on Colab by design, so we open it directly,
+    # then publish the URL onto the app so /api/health (and the frontend) advertise it.
+    #
+    # try/finally so an interrupt while the tunnel is starting or the iframe is
+    # rendering still tears the tunnel down instead of orphaning the process.
     try:
+        cf_url = start_cloudflare_tunnel(actual_port) if cloudflare else None
+        _publish_cloudflare_url(cf_url)
+        _show_and_embed(actual_port, cloudflare_url = cf_url)
+
+        # Keep kernel alive so the daemon server thread runs.
         for _ in range(10000):
             time.sleep(300)
             print("=", end = "", flush = True)
     except KeyboardInterrupt:
         logger.info("\nUnsloth Studio keepalive stopped.")
+    finally:
         _stop_cloudflare_tunnel()
 
 


### PR DESCRIPTION
Adds an opt-in shareable Cloudflare link to Unsloth Studio on Colab, and surfaces it from the notebook.

Closes #6683

### What
- **Backend:** `start(port=8888, *, cloudflare=False)` in `studio/backend/colab.py`. When `cloudflare=True`, opens a free Cloudflare quick tunnel and renders a `https://*.trycloudflare.com` link card above the in-tab iframe. `run_server` deliberately suppresses the tunnel on Colab, so `colab.py` starts it directly via `cloudflare_tunnel.start_studio_tunnel()`; any failure degrades to the Colab proxy only.
- **Notebook:** the start cell in `studio/Unsloth_Studio_Colab.ipynb` now reads:
  ```python
  import sys
  sys.path.insert(0, "/content/unsloth/studio/backend")
  from colab import start

  start()                  # in-tab iframe only (default)
  # start(cloudflare=True) # uncomment to also get a shareable Cloudflare link
  ```

### Why
The Colab-proxy iframe only works in the tab that owns the runtime — it can't be shared or opened from another device. This gives users an explicit, discoverable way to get a shareable HTTPS URL.

### Behavior
- **Default unchanged:** bare `start()` keeps the in-tab Colab-proxy iframe.
- Cloudflare stays an explicit opt-in (the tunnel exposes Studio's login page beyond Colab).
