### PR TITLE
Patch FalconH1RMSNorm to fix float64 compilation crash on Intel Arc DG2

### DIFF
--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -681,6 +681,7 @@ def fix_prepare_inputs_for_generation(module):
 
 class Unsloth_FalconH1RMSNorm(FalconH1RMSNorm):
     """fast_rms_layernorm (compiler-disabled, fp32 eps) avoids the float64 torch.compile RMSNorm kernel that fails on Intel Arc DG2 (issue #6555)."""
+
     def forward(self, hidden_states):
         return fast_rms_layernorm(self, hidden_states, gemma = False)
 

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -680,21 +680,7 @@ def fix_prepare_inputs_for_generation(module):
 
 
 class Unsloth_FalconH1RMSNorm(FalconH1RMSNorm):
-    """
-    Patched FalconH1RMSNorm that delegates to Unsloth's fast RMS layernorm kernel.
-    Fixes float64 type promotion on Intel Arc (DG2) when torch.compile generates
-    the auto-fused kernel triton_per_fused__to_copy_mean_mul_pow_rsqrt_*.
-
-    The stock FalconH1RMSNorm.forward() does:
-        hidden_states.pow(2).mean(-1, keepdim=True)
-        torch.rsqrt(variance + self.variance_epsilon)
-    where self.variance_epsilon is a Python float64. Under torch.compile the
-    fused Triton kernel promotes to double, which Intel Arc DG2 does not support.
-
-    Unsloth's fast_rms_layernorm is @torch.compiler.disable and handles the
-    epsilon as an explicit tl.float32 scalar, bypassing the compiler entirely.
-    """
-
+    """fast_rms_layernorm (compiler-disabled, fp32 eps) avoids the float64 torch.compile RMSNorm kernel that fails on Intel Arc DG2 (issue #6555)."""
     def forward(self, hidden_states):
         return fast_rms_layernorm(self, hidden_states, gemma = False)
 
@@ -735,10 +721,7 @@ class FastFalconH1Model(FastLlamaModel):
         transformers.models.falcon_h1.modeling_falcon_h1.FalconH1RotaryEmbedding = (
             LlamaRotaryEmbedding
         )
-        # Patch FalconH1RMSNorm to use Unsloth's fast RMS layernorm kernel.
-        # Fixes float64 type promotion on Intel Arc DG2 when torch.compile fuses
-        # the stock .pow(2).mean().rsqrt() pattern into a Triton kernel with
-        # double-precision operations (issue #6555).
+        # Avoids the float64 RMSNorm compile kernel that fails on Intel Arc DG2 (issue #6555).
         patch_falcon_h1_rms_layernorm()
         return
 

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -37,6 +37,8 @@ try:
         FalconH1DecoderLayer,
         FalconH1Model,
         FalconH1ForCausalLM,
+        FalconH1RMSNorm,
+        FalconH1RMSNormGated,
         FalconHybridMambaAttentionDynamicCache,
     )
 except:
@@ -677,6 +679,30 @@ def fix_prepare_inputs_for_generation(module):
         module.prepare_inputs_for_generation = _fast_prepare_inputs_for_generation
 
 
+class Unsloth_FalconH1RMSNorm(FalconH1RMSNorm):
+    """
+    Patched FalconH1RMSNorm that delegates to Unsloth's fast RMS layernorm kernel.
+    Fixes float64 type promotion on Intel Arc (DG2) when torch.compile generates
+    the auto-fused kernel triton_per_fused__to_copy_mean_mul_pow_rsqrt_*.
+
+    The stock FalconH1RMSNorm.forward() does:
+        hidden_states.pow(2).mean(-1, keepdim=True)
+        torch.rsqrt(variance + self.variance_epsilon)
+    where self.variance_epsilon is a Python float64. Under torch.compile the
+    fused Triton kernel promotes to double, which Intel Arc DG2 does not support.
+
+    Unsloth's fast_rms_layernorm is @torch.compiler.disable and handles the
+    epsilon as an explicit tl.float32 scalar, bypassing the compiler entirely.
+    """
+    def forward(self, hidden_states):
+        return fast_rms_layernorm(self, hidden_states, gemma=False)
+
+
+def patch_falcon_h1_rms_layernorm():
+    import transformers.models.falcon_h1.modeling_falcon_h1
+    transformers.models.falcon_h1.modeling_falcon_h1.FalconH1RMSNorm = Unsloth_FalconH1RMSNorm
+
+
 class FastFalconH1Model(FastLlamaModel):
     @staticmethod
     def pre_patch():
@@ -708,6 +734,11 @@ class FastFalconH1Model(FastLlamaModel):
         transformers.models.falcon_h1.modeling_falcon_h1.FalconH1RotaryEmbedding = (
             LlamaRotaryEmbedding
         )
+        # Patch FalconH1RMSNorm to use Unsloth's fast RMS layernorm kernel.
+        # Fixes float64 type promotion on Intel Arc DG2 when torch.compile fuses
+        # the stock .pow(2).mean().rsqrt() pattern into a Triton kernel with
+        # double-precision operations (issue #6555).
+        patch_falcon_h1_rms_layernorm()
         return
 
     @staticmethod

--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -694,8 +694,9 @@ class Unsloth_FalconH1RMSNorm(FalconH1RMSNorm):
     Unsloth's fast_rms_layernorm is @torch.compiler.disable and handles the
     epsilon as an explicit tl.float32 scalar, bypassing the compiler entirely.
     """
+
     def forward(self, hidden_states):
-        return fast_rms_layernorm(self, hidden_states, gemma=False)
+        return fast_rms_layernorm(self, hidden_states, gemma = False)
 
 
 def patch_falcon_h1_rms_layernorm():


### PR DESCRIPTION
## Description

Fixes #6555 — `RuntimeError: Double type is not supported on this platform` when training Falcon-H1-based models (e.g. MioTTS-0.1B) on Intel Arc A770 (DG2) with `torch.compile`.

## Root Cause

`FalconH1RMSNorm.forward()` does:
```python
variance = hidden_states.pow(2).mean(-1, keepdim=True)
hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
```
where `self.variance_epsilon` is a Python `float` (= float64). When `torch.compile` fuses this pattern into the auto-generated Triton kernel `triton_per_fused__to_copy_mean_mul_pow_rsqrt_*`, the float64 epsilon promotes the computation to double. Intel Arc DG2 GPUs do not support double precision — the Intel `ocloc` compiler rejects it with `Double type is not supported on this platform.`

The existing `patch_rms_layernorm()` only patches `LlamaRMSNorm`, not the separate `FalconH1RMSNorm` class in `transformers.models.falcon_h1`.

## Fix

1. **Import** `FalconH1RMSNorm` from transformers
2. **Add** `Unsloth_FalconH1RMSNorm` that delegates to `fast_rms_layernorm` — which is `@torch.compiler.disable` and handles epsilon as an explicit `tl.float32` scalar
3. **Call** `patch_falcon_h1_rms_layernorm()` in `FastFalconH1Model.pre_patch()`, before model creation, so every FalconH1RMSNorm instance uses the safe kernel

## Testing

- Verified the patching follows the same pattern as the existing `patch_rms_layernorm()` for `LlamaRMSNorm`
- The stk `FalconH1RMSNorm.forward()` is replaced before model creation, so decoder layer norms, final layernorm, and any internal norms all route through `fast_rms_layernorm`
- `FalconH1RMSNormGated` is imported for completeness (not used by MioTTS; `mamba_rms_norm: false` in config)