### PR TITLE
Studio: floor the GGUF VRAM fit reserve so tight cards keep KV on the GPU

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -816,7 +816,9 @@ _MAX_VRAM_RESERVE_FRAC = 0.125
 def _vram_reserve_mib(total_mib: float, frac: float) -> float:
     """Per-card VRAM reserve: ``(1 - frac) * total`` floored at _MIN_VRAM_RESERVE_MIB
     and capped at _MAX_VRAM_RESERVE_FRAC * total (see _MIN_VRAM_RESERVE_MIB for why)."""
-    return min(max((1.0 - frac) * total_mib, _MIN_VRAM_RESERVE_MIB), _MAX_VRAM_RESERVE_FRAC * total_mib)
+    return min(
+        max((1.0 - frac) * total_mib, _MIN_VRAM_RESERVE_MIB), _MAX_VRAM_RESERVE_FRAC * total_mib
+    )
 
 
 def _pooled_usable_mib(subset, frac, total_by_idx):
@@ -830,6 +832,7 @@ def _pooled_usable_mib(subset, frac, total_by_idx):
     if known_total > 0:
         budget += max(0.0, known_free - _vram_reserve_mib(known_total, frac))
     return budget
+
 
 # Apple unified memory is shared with the OS, so tighter than VRAM. Matches the
 # 0.85 MLX uses in mlx_inference.py (_configure_memory_limits); not kept in sync.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -807,21 +807,17 @@ _CTX_FIT_VRAM_FRACTION = 0.95
 # fraction dominates (5% of 80 GB = 4 GB); on consumer cards it is too thin (5% of
 # 24 GB = 1.2 GB) to cover what the byte estimate omits: CUDA context + compute
 # graph, the gap between nvidia-smi's reported free and the VRAM llama.cpp can
-# actually allocate, llama.cpp's own --fit margin (it keeps headroom and offloads
-# before the card is full), and a desktop compositor + browser sharing the card.
-# Too thin a cushion let auto-fit advertise a context that pinned -ngl -1 at load but
-# then offloaded layers to CPU at runtime (#6682). Measured on two 27Bs on a 24 GB
-# card (Qwen3.6-MTP, gemma-3): 5% advertised a context that spilled even on an idle
-# card -- ~35 of 60 tok/s -- and worse under a desktop. 3 GiB ~restores the headroom
-# #6312 removed (it cut the reserve from ~10% of free to 5% of total): it keeps both
-# fully on the GPU when idle and under a ~1 GB desktop, and sharply cuts the spill
-# under heavier ones. It is a fixed cushion, not a guarantee -- a ~2 GB+ desktop can
-# still drift past it. Capped at _MAX_VRAM_RESERVE_FRAC so a small card
-# isn't over-reserved (3 GiB would be 37% of an 8 GB card), and never below 5% so big
-# datacenter cards are unchanged. The cap is the floor's own fraction at its 24 GB
-# design point (3 GiB / 24 GB), so no card reserves a larger fraction than a 24 GB
-# card: the reserve is 12.5% up to 24 GB, then the flat 3 GiB (a shrinking fraction)
-# up to ~60 GB, then 5%.
+# actually allocate, llama.cpp's own --fit margin (it offloads before the card is
+# full), and a desktop compositor + browser sharing the card. Too thin a cushion let
+# auto-fit advertise a context that pinned -ngl -1 at load but then offloaded layers
+# to CPU at runtime, spilling even on an idle 24 GB card (#6682). 3 GiB ~restores the
+# headroom #6312 removed (it cut the reserve from ~10% of free to 5% of total): the
+# weights stay on the GPU when idle and under a ~1 GB desktop, with the spill sharply
+# cut under heavier ones -- though it is a fixed cushion, not a guarantee (a ~2 GB+
+# desktop can still drift past it). Capped at _MAX_VRAM_RESERVE_FRAC (the floor's own
+# fraction at its 24 GB design point, 3 GiB / 24 GB) so a small card isn't over-
+# reserved (3 GiB would be 37% of an 8 GB card), and never below 5% so datacenter
+# cards are unchanged.
 _MIN_VRAM_RESERVE_MIB = 3072
 _MAX_VRAM_RESERVE_FRAC = 0.125
 
@@ -829,10 +825,9 @@ _MAX_VRAM_RESERVE_FRAC = 0.125
 def _vram_reserve_mib(total_mib: float, frac: float) -> float:
     """VRAM to hold out of a card before sizing weights + KV: the fractional cushion
     ``(1 - frac) * total``, floored at ``_MIN_VRAM_RESERVE_MIB`` and capped at
-    ``_MAX_VRAM_RESERVE_FRAC * total`` (see _MIN_VRAM_RESERVE_MIB for why). Callers
-    subtract this from free and keep their own clamping (``_gpu_usable`` leaves the
-    result signed for ranking, the budget paths clamp at 0). Only used when total
-    VRAM is known; the unknown-total paths keep the legacy ``free * frac``."""
+    ``_MAX_VRAM_RESERVE_FRAC * total`` (see _MIN_VRAM_RESERVE_MIB for why). Only used
+    by _pooled_usable_mib, which subtracts it once from the pooled free of the
+    known-total GPUs; the unknown-total path keeps the legacy ``free * frac``."""
     return min(max((1.0 - frac) * total_mib, _MIN_VRAM_RESERVE_MIB), _MAX_VRAM_RESERVE_FRAC * total_mib)
 
 
@@ -2645,11 +2640,7 @@ class LlamaCppBackend:
             usable_fraction = LlamaCppBackend._GPU_PIN_VRAM_FRACTION
 
         # Per-GPU usable budget: free - (1-frac)*total when total is known, else
-        # the legacy free*frac (also covers a total-0 two-column probe). No absolute
-        # floor here: _select_gpus picks GPUs for a FIXED footprint (explicit ctx /
-        # file-size paths) and can't shrink it, so a bigger reserve would only deny
-        # the pin and fall to --fit (CPU offload) -- worse than pinning with a thin
-        # cushion. The floor lives in the auto-context paths that cap the KV instead.
+        # the legacy free*frac (also covers a total-0 two-column probe).
         def _usable(idx: int, free_mib: int) -> float:
             t = total_by_idx.get(idx, 0) if total_by_idx else 0
             if t > 0:
@@ -3066,7 +3057,7 @@ class LlamaCppBackend:
             budget_frac = _CTX_FIT_VRAM_FRACTION - (_MTP_VRAM_RESERVE_FRAC if flat_mtp else 0.0)
         # Absolute reserve off total when known, else fraction-of-free; clamp >=0.
         if total_mib is not None and total_mib > 0:
-            budget_mib = max(0.0, available_mib - _vram_reserve_mib(total_mib, budget_frac))
+            budget_mib = max(0.0, available_mib - (1.0 - budget_frac) * total_mib)
         else:
             budget_mib = available_mib * budget_frac
         budget_bytes = budget_mib * 1024 * 1024
@@ -4232,15 +4223,13 @@ class LlamaCppBackend:
         the compute buffer.
         """
 
-        # Per-GPU usable budget: free - reserve (floored, see _vram_reserve_mib),
-        # else (unknown total, e.g. a two-column probe) the legacy free*frac. Floored
-        # like the layer-split auto path (_gpu_usable): tensor mode also caps the KV
-        # context to this budget, so the cushion belongs here. (_select_gpus is the
-        # exception -- it sizes a fixed footprint and is left unfloored.)
+        # Per-GPU usable budget: free - (1-frac)*total, else (unknown total, e.g. a
+        # two-column probe) the legacy free*frac. Mirrors _select_gpus and
+        # _gpu_usable so the 5% cushion is kept on every path, not dropped here.
         def _usable(idx: int, free_mib: int) -> float:
             t = total_by_idx.get(idx, 0) if total_by_idx else 0
             if t > 0:
-                return max(0.0, free_mib - _vram_reserve_mib(t, _CTX_FIT_VRAM_FRACTION))
+                return max(0.0, free_mib - (1.0 - _CTX_FIT_VRAM_FRACTION) * t)
             return max(0.0, free_mib * _CTX_FIT_VRAM_FRACTION)
 
         # Drop GPUs whose usable budget can't hold the per-device compute-graph
@@ -4849,19 +4838,18 @@ class LlamaCppBackend:
                     total_by_idx = {idx: total for idx, _f, total in _gpu_mem}
 
                     def _gpu_usable(g, frac = _CTX_FIT_VRAM_FRACTION):
-                        # Per-GPU usable budget for ranking: free - reserve (floored,
-                        # see _vram_reserve_mib). Callers pass the ACTIVE fraction so
-                        # the ranking matches the budget the fit then tests (else mixed
-                        # totals mis-order). Left signed (no clamp) for ranking;
-                        # _pool_budget_mib clamps at 0.
+                        # Per-GPU usable budget for ranking: free - (1-frac)*total.
+                        # Callers pass the ACTIVE fraction so the ranking matches the
+                        # budget the fit then tests (else mixed totals mis-order).
                         idx, free = g
                         t = total_by_idx.get(idx, 0)
                         if t > 0:
-                            return free - _vram_reserve_mib(t, frac)
+                            return free - (1.0 - frac) * t
                         return free * frac
 
                     def _pool_budget_mib(subset, frac):
-                        # Floor applied once per pool, not per device; see _pooled_usable_mib.
+                        # Reserve the VRAM floor once across the pool (not per device);
+                        # this is the only place the auto-context budget applies it.
                         return _pooled_usable_mib(subset, frac, total_by_idx)
 
                     # Resolve effective context: 0 means let llama-server use

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -835,6 +835,24 @@ def _vram_reserve_mib(total_mib: float, frac: float) -> float:
     VRAM is known; the unknown-total paths keep the legacy ``free * frac``."""
     return min(max((1.0 - frac) * total_mib, _MIN_VRAM_RESERVE_MIB), _MAX_VRAM_RESERVE_FRAC * total_mib)
 
+
+def _pooled_usable_mib(subset, frac, total_by_idx):
+    """Pooled usable VRAM (MiB) for a GPU ``subset`` of (idx, free_mib) pairs.
+
+    The absolute floor in _vram_reserve_mib is a per-POOL cushion (the desktop drift
+    and the one-lump layer-split compute buffer it covers are not per-device), so it
+    is applied ONCE across the known-total GPUs via their pooled total -- a k-GPU
+    split must not reserve k x the floor or it under-advertises context (#6682).
+    Unknown-total GPUs (MIG/vGPU/N/A) keep their own ``free * frac`` cushion; pooling
+    their free with no total would add full free with no reserve. Single GPU is
+    unchanged (pool total == its own total)."""
+    known_free = sum(f for i, f in subset if total_by_idx.get(i, 0) > 0)
+    known_total = sum(total_by_idx.get(i, 0) for i, _ in subset if total_by_idx.get(i, 0) > 0)
+    budget = sum(f * frac for i, f in subset if total_by_idx.get(i, 0) <= 0)
+    if known_total > 0:
+        budget += max(0.0, known_free - _vram_reserve_mib(known_total, frac))
+    return budget
+
 # Apple unified memory is shared with the OS, so tighter than VRAM. Matches the
 # 0.85 MLX uses in mlx_inference.py (_configure_memory_limits); not kept in sync.
 _APPLE_UNIFIED_MEMORY_FRACTION = 0.85
@@ -4843,10 +4861,8 @@ class LlamaCppBackend:
                         return free * frac
 
                     def _pool_budget_mib(subset, frac):
-                        # Sum each GPU's own usable budget. Pooling free and total
-                        # separately would let an unknown-total GPU (MIG/vGPU/N/A)
-                        # add full free with no cushion among known-total GPUs.
-                        return sum(max(0.0, _gpu_usable(g, frac)) for g in subset)
+                        # Floor applied once per pool, not per device; see _pooled_usable_mib.
+                        return _pooled_usable_mib(subset, frac, total_by_idx)
 
                     # Resolve effective context: 0 means let llama-server use
                     # the model's native length. Only expand to a known native

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -803,6 +803,32 @@ _MTP_MIN_SIZE_B = 3.0
 # of free (see _fit_context_to_vram), plus a byte-accurate MTP draft reserve.
 _CTX_FIT_VRAM_FRACTION = 0.95
 
+# Floor under the absolute VRAM cushion (1 - frac) * total. On big cards the
+# fraction dominates (5% of 80 GB = 4 GB); on consumer cards it is too thin (5% of
+# 24 GB = 1.2 GB) to cover what the byte estimate omits: CUDA context + compute
+# graph, the gap between nvidia-smi's reported free and the VRAM llama.cpp can
+# actually allocate, and (the common case) a desktop compositor + browser sharing
+# the card whose usage drifts up after the fit reads `free`. Too thin a cushion let
+# auto-fit advertise a context that pinned -ngl -1 at load but then offloaded layers
+# to CPU at runtime, ~halving tok/s on a 24 GB desktop (#6682). 3 GiB ~restores the
+# headroom #6312 removed (it cut the reserve from ~10% of free to 5% of total); on a
+# 27B on a 24 GB card it keeps the load fully on the GPU under a light (~1.6 GB)
+# desktop where 5% spilled it. It is a fixed cushion, not a guarantee -- a heavier
+# desktop can still drift past it. Capped at _MAX_VRAM_RESERVE_FRAC so a small card
+# isn't over-reserved, and never below 5% so big datacenter cards are unchanged.
+_MIN_VRAM_RESERVE_MIB = 3072
+_MAX_VRAM_RESERVE_FRAC = 0.15
+
+
+def _vram_reserve_mib(total_mib: float, frac: float) -> float:
+    """VRAM to hold out of a card before sizing weights + KV: the fractional cushion
+    ``(1 - frac) * total``, floored at ``_MIN_VRAM_RESERVE_MIB`` and capped at
+    ``_MAX_VRAM_RESERVE_FRAC * total`` (see _MIN_VRAM_RESERVE_MIB for why). Callers
+    subtract this from free and keep their own clamping (``_gpu_usable`` leaves the
+    result signed for ranking, the budget paths clamp at 0). Only used when total
+    VRAM is known; the unknown-total paths keep the legacy ``free * frac``."""
+    return min(max((1.0 - frac) * total_mib, _MIN_VRAM_RESERVE_MIB), _MAX_VRAM_RESERVE_FRAC * total_mib)
+
 # Apple unified memory is shared with the OS, so tighter than VRAM. Matches the
 # 0.85 MLX uses in mlx_inference.py (_configure_memory_limits); not kept in sync.
 _APPLE_UNIFIED_MEMORY_FRACTION = 0.85
@@ -2595,7 +2621,11 @@ class LlamaCppBackend:
             usable_fraction = LlamaCppBackend._GPU_PIN_VRAM_FRACTION
 
         # Per-GPU usable budget: free - (1-frac)*total when total is known, else
-        # the legacy free*frac (also covers a total-0 two-column probe).
+        # the legacy free*frac (also covers a total-0 two-column probe). No absolute
+        # floor here: _select_gpus picks GPUs for a FIXED footprint (explicit ctx /
+        # file-size paths) and can't shrink it, so a bigger reserve would only deny
+        # the pin and fall to --fit (CPU offload) -- worse than pinning with a thin
+        # cushion. The floor lives in the auto-context paths that cap the KV instead.
         def _usable(idx: int, free_mib: int) -> float:
             t = total_by_idx.get(idx, 0) if total_by_idx else 0
             if t > 0:
@@ -3012,7 +3042,7 @@ class LlamaCppBackend:
             budget_frac = _CTX_FIT_VRAM_FRACTION - (_MTP_VRAM_RESERVE_FRAC if flat_mtp else 0.0)
         # Absolute reserve off total when known, else fraction-of-free; clamp >=0.
         if total_mib is not None and total_mib > 0:
-            budget_mib = max(0.0, available_mib - (1.0 - budget_frac) * total_mib)
+            budget_mib = max(0.0, available_mib - _vram_reserve_mib(total_mib, budget_frac))
         else:
             budget_mib = available_mib * budget_frac
         budget_bytes = budget_mib * 1024 * 1024
@@ -4178,13 +4208,15 @@ class LlamaCppBackend:
         the compute buffer.
         """
 
-        # Per-GPU usable budget: free - (1-frac)*total, else (unknown total, e.g. a
-        # two-column probe) the legacy free*frac. Mirrors _select_gpus and
-        # _gpu_usable so the 5% cushion is kept on every path, not dropped here.
+        # Per-GPU usable budget: free - reserve (floored, see _vram_reserve_mib),
+        # else (unknown total, e.g. a two-column probe) the legacy free*frac. Floored
+        # like the layer-split auto path (_gpu_usable): tensor mode also caps the KV
+        # context to this budget, so the cushion belongs here. (_select_gpus is the
+        # exception -- it sizes a fixed footprint and is left unfloored.)
         def _usable(idx: int, free_mib: int) -> float:
             t = total_by_idx.get(idx, 0) if total_by_idx else 0
             if t > 0:
-                return max(0.0, free_mib - (1.0 - _CTX_FIT_VRAM_FRACTION) * t)
+                return max(0.0, free_mib - _vram_reserve_mib(t, _CTX_FIT_VRAM_FRACTION))
             return max(0.0, free_mib * _CTX_FIT_VRAM_FRACTION)
 
         # Drop GPUs whose usable budget can't hold the per-device compute-graph
@@ -4793,13 +4825,15 @@ class LlamaCppBackend:
                     total_by_idx = {idx: total for idx, _f, total in _gpu_mem}
 
                     def _gpu_usable(g, frac = _CTX_FIT_VRAM_FRACTION):
-                        # Per-GPU usable budget for ranking: free - (1-frac)*total.
-                        # Callers pass the ACTIVE fraction so the ranking matches the
-                        # budget the fit then tests (else mixed totals mis-order).
+                        # Per-GPU usable budget for ranking: free - reserve (floored,
+                        # see _vram_reserve_mib). Callers pass the ACTIVE fraction so
+                        # the ranking matches the budget the fit then tests (else mixed
+                        # totals mis-order). Left signed (no clamp) for ranking;
+                        # _pool_budget_mib clamps at 0.
                         idx, free = g
                         t = total_by_idx.get(idx, 0)
                         if t > 0:
-                            return free - (1.0 - frac) * t
+                            return free - _vram_reserve_mib(t, frac)
                         return free * frac
 
                     def _pool_budget_mib(subset, frac):

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -815,9 +815,13 @@ _CTX_FIT_VRAM_FRACTION = 0.95
 # 27B on a 24 GB card it keeps the load fully on the GPU under a light (~1.6 GB)
 # desktop where 5% spilled it. It is a fixed cushion, not a guarantee -- a heavier
 # desktop can still drift past it. Capped at _MAX_VRAM_RESERVE_FRAC so a small card
-# isn't over-reserved, and never below 5% so big datacenter cards are unchanged.
+# isn't over-reserved (3 GiB would be 37% of an 8 GB card), and never below 5% so big
+# datacenter cards are unchanged. The cap is the floor's own fraction at its 24 GB
+# design point (3 GiB / 24 GB), so no card reserves a larger fraction than a 24 GB
+# card: the reserve is 12.5% up to 24 GB, then the flat 3 GiB (a shrinking fraction)
+# up to ~60 GB, then 5%.
 _MIN_VRAM_RESERVE_MIB = 3072
-_MAX_VRAM_RESERVE_FRAC = 0.15
+_MAX_VRAM_RESERVE_FRAC = 0.125
 
 
 def _vram_reserve_mib(total_mib: float, frac: float) -> float:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -807,14 +807,16 @@ _CTX_FIT_VRAM_FRACTION = 0.95
 # fraction dominates (5% of 80 GB = 4 GB); on consumer cards it is too thin (5% of
 # 24 GB = 1.2 GB) to cover what the byte estimate omits: CUDA context + compute
 # graph, the gap between nvidia-smi's reported free and the VRAM llama.cpp can
-# actually allocate, and (the common case) a desktop compositor + browser sharing
-# the card whose usage drifts up after the fit reads `free`. Too thin a cushion let
-# auto-fit advertise a context that pinned -ngl -1 at load but then offloaded layers
-# to CPU at runtime, ~halving tok/s on a 24 GB desktop (#6682). 3 GiB ~restores the
-# headroom #6312 removed (it cut the reserve from ~10% of free to 5% of total); on a
-# 27B on a 24 GB card it keeps the load fully on the GPU under a light (~1.6 GB)
-# desktop where 5% spilled it. It is a fixed cushion, not a guarantee -- a heavier
-# desktop can still drift past it. Capped at _MAX_VRAM_RESERVE_FRAC so a small card
+# actually allocate, llama.cpp's own --fit margin (it keeps headroom and offloads
+# before the card is full), and a desktop compositor + browser sharing the card.
+# Too thin a cushion let auto-fit advertise a context that pinned -ngl -1 at load but
+# then offloaded layers to CPU at runtime (#6682). Measured on two 27Bs on a 24 GB
+# card (Qwen3.6-MTP, gemma-3): 5% advertised a context that spilled even on an idle
+# card -- ~35 of 60 tok/s -- and worse under a desktop. 3 GiB ~restores the headroom
+# #6312 removed (it cut the reserve from ~10% of free to 5% of total): it keeps both
+# fully on the GPU when idle and under a ~1 GB desktop, and sharply cuts the spill
+# under heavier ones. It is a fixed cushion, not a guarantee -- a ~2 GB+ desktop can
+# still drift past it. Capped at _MAX_VRAM_RESERVE_FRAC so a small card
 # isn't over-reserved (3 GiB would be 37% of an 8 GB card), and never below 5% so big
 # datacenter cards are unchanged. The cap is the floor's own fraction at its 24 GB
 # design point (3 GiB / 24 GB), so no card reserves a larger fraction than a 24 GB

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -803,44 +803,27 @@ _MTP_MIN_SIZE_B = 3.0
 # of free (see _fit_context_to_vram), plus a byte-accurate MTP draft reserve.
 _CTX_FIT_VRAM_FRACTION = 0.95
 
-# Floor under the absolute VRAM cushion (1 - frac) * total. On big cards the
-# fraction dominates (5% of 80 GB = 4 GB); on consumer cards it is too thin (5% of
-# 24 GB = 1.2 GB) to cover what the byte estimate omits: CUDA context + compute
-# graph, the gap between nvidia-smi's reported free and the VRAM llama.cpp can
-# actually allocate, llama.cpp's own --fit margin (it offloads before the card is
-# full), and a desktop compositor + browser sharing the card. Too thin a cushion let
-# auto-fit advertise a context that pinned -ngl -1 at load but then offloaded layers
-# to CPU at runtime, spilling even on an idle 24 GB card (#6682). 3 GiB ~restores the
-# headroom #6312 removed (it cut the reserve from ~10% of free to 5% of total): the
-# weights stay on the GPU when idle and under a ~1 GB desktop, with the spill sharply
-# cut under heavier ones -- though it is a fixed cushion, not a guarantee (a ~2 GB+
-# desktop can still drift past it). Capped at _MAX_VRAM_RESERVE_FRAC (the floor's own
-# fraction at its 24 GB design point, 3 GiB / 24 GB) so a small card isn't over-
-# reserved (3 GiB would be 37% of an 8 GB card), and never below 5% so datacenter
-# cards are unchanged.
+# Floor under the absolute VRAM cushion (1 - frac) * total. On a 24 GB card 5% is
+# only ~1.2 GB, too thin for what the byte estimate misses (CUDA context, compute
+# buffers, the nvidia-smi-vs-CUDA free gap, a shared desktop); auto-fit then sized a
+# context that spilled to CPU and ~halved tok/s (#6682). 3 GiB ~restores the headroom
+# #6312 dropped (10%-of-free -> 5%-of-total). The cap (12.5% = 3 GiB / 24 GB) stops
+# small cards over-reserving; where 5% already tops 3 GiB (>= 60 GB) it's unchanged.
 _MIN_VRAM_RESERVE_MIB = 3072
 _MAX_VRAM_RESERVE_FRAC = 0.125
 
 
 def _vram_reserve_mib(total_mib: float, frac: float) -> float:
-    """VRAM to hold out of a card before sizing weights + KV: the fractional cushion
-    ``(1 - frac) * total``, floored at ``_MIN_VRAM_RESERVE_MIB`` and capped at
-    ``_MAX_VRAM_RESERVE_FRAC * total`` (see _MIN_VRAM_RESERVE_MIB for why). Only used
-    by _pooled_usable_mib, which subtracts it once from the pooled free of the
-    known-total GPUs; the unknown-total path keeps the legacy ``free * frac``."""
+    """Per-card VRAM reserve: ``(1 - frac) * total`` floored at _MIN_VRAM_RESERVE_MIB
+    and capped at _MAX_VRAM_RESERVE_FRAC * total (see _MIN_VRAM_RESERVE_MIB for why)."""
     return min(max((1.0 - frac) * total_mib, _MIN_VRAM_RESERVE_MIB), _MAX_VRAM_RESERVE_FRAC * total_mib)
 
 
 def _pooled_usable_mib(subset, frac, total_by_idx):
-    """Pooled usable VRAM (MiB) for a GPU ``subset`` of (idx, free_mib) pairs.
-
-    The absolute floor in _vram_reserve_mib is a per-POOL cushion (the desktop drift
-    and the one-lump layer-split compute buffer it covers are not per-device), so it
-    is applied ONCE across the known-total GPUs via their pooled total -- a k-GPU
-    split must not reserve k x the floor or it under-advertises context (#6682).
-    Unknown-total GPUs (MIG/vGPU/N/A) keep their own ``free * frac`` cushion; pooling
-    their free with no total would add full free with no reserve. Single GPU is
-    unchanged (pool total == its own total)."""
+    """Usable VRAM (MiB) over a GPU ``subset`` of (idx, free) pairs, reserving the
+    floor ONCE on the pooled total (a k-GPU split must not hold out k x the floor,
+    #6682). Unknown-total GPUs (MIG/vGPU) keep their own ``free * frac``; single GPU
+    is unchanged."""
     known_free = sum(f for i, f in subset if total_by_idx.get(i, 0) > 0)
     known_total = sum(total_by_idx.get(i, 0) for i, _ in subset if total_by_idx.get(i, 0) > 0)
     budget = sum(f * frac for i, f in subset if total_by_idx.get(i, 0) <= 0)

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -760,7 +760,9 @@ def test_vram_reserve_unchanged_on_datacenter_card():
     # 80 GB: 5% = 4096 MiB already exceeds the floor, so behaviour is unchanged
     # from #6312 (no over-reserving the big cards it was tuned for).
     total = 81920
-    assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == (1.0 - _CTX_FIT_VRAM_FRACTION) * total
+    assert (
+        _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == (1.0 - _CTX_FIT_VRAM_FRACTION) * total
+    )
 
 
 def test_vram_reserve_capped_on_small_card():

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -772,42 +772,6 @@ def test_vram_reserve_capped_on_small_card():
     assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == _MAX_VRAM_RESERVE_FRAC * total
 
 
-def test_fit_context_floor_caps_below_thin_fraction():
-    # Exercises _fit_context_to_vram's total-based reserve branch (the line the fix
-    # edits): on a 24 GB card the floor (3072) is reserved instead of the thin 5%
-    # (1229), so the capped context's footprint leaves >= the floor free and is
-    # strictly smaller than the 5% reserve would have advertised. A 27B-class model.
-    inst = _make_backend(native_ctx = 262144)
-    inst._can_estimate_kv = lambda: True
-    inst._estimate_kv_cache_bytes = lambda n, *a, **k: 0 if n <= 0 else int(n * 34_000)
-    model_size = int(17.5 * GIB)
-    total = 24576
-    free = 23700
-
-    def _cap_via_total_branch():
-        # total_mib set -> the fit applies _vram_reserve_mib internally (the floored
-        # branch), unlike the production load loop which pre-reserves and passes None.
-        return inst._fit_context_to_vram(
-            262144, free, model_size, None,
-            total_mib = total, budget_frac = _CTX_FIT_VRAM_FRACTION,
-        )
-
-    def _footprint_mib(ctx):
-        return (model_size + inst._estimate_kv_cache_bytes(ctx)) / (1024 * 1024)
-
-    floored_cap = _cap_via_total_branch()
-    # The floor (not the 5% fraction) is what bounds the footprint.
-    assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == _MIN_VRAM_RESERVE_MIB
-    assert _footprint_mib(floored_cap) <= free - _MIN_VRAM_RESERVE_MIB + 1
-    # Strictly tighter than #6312's thin 5% reserve: that budget would have fit a
-    # larger context (the over-advertisement #6682 reports).
-    thin_budget_mib = free - (1.0 - _CTX_FIT_VRAM_FRACTION) * total
-    thin_cap = inst._fit_context_to_vram(
-        262144, thin_budget_mib, model_size, None, budget_frac = 1.0,
-    )
-    assert floored_cap < thin_cap
-
-
 def test_pooled_usable_single_gpu_applies_floor():
     # Single GPU: pool budget == free - floor (unchanged by the per-pool refactor).
     frac = _CTX_FIT_VRAM_FRACTION
@@ -827,15 +791,6 @@ def test_pooled_usable_floor_applied_once_across_pool():
     assert pooled == 24000 - _vram_reserve_mib(2 * 24576, frac)  # one floor on the pool
     per_device = sum(max(0.0, f - _vram_reserve_mib(totals[i], frac)) for i, f in subset)
     assert pooled > per_device  # the refactor recovers ~one floor's worth of budget
-
-
-def test_pooled_usable_datacenter_unchanged():
-    # Two 80 GB cards: 5% of the 160 GB pool (8192) exceeds the floor, so the pool
-    # reserves the fraction -- datacenter behaviour is unchanged.
-    frac = _CTX_FIT_VRAM_FRACTION
-    subset = [(0, 70000), (1, 70000)]
-    totals = {0: 81920, 1: 81920}
-    assert _pooled_usable_mib(subset, frac, totals) == 140000 - (1.0 - frac) * (2 * 81920)
 
 
 def test_pooled_usable_unknown_total_keeps_per_device_cushion():

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -70,7 +70,10 @@ sys.modules.setdefault("httpx", _httpx_stub)
 from core.inference.llama_cpp import (
     _APPLE_UNIFIED_MEMORY_FRACTION,
     _CTX_FIT_VRAM_FRACTION,
+    _MAX_VRAM_RESERVE_FRAC,
+    _MIN_VRAM_RESERVE_MIB,
     LlamaCppBackend,
+    _vram_reserve_mib,
     classify_gpu_offload_lines,
 )
 from core.inference.llama_server_args import parse_ctx_override, resolve_requested_ctx
@@ -733,6 +736,74 @@ def test_select_gpus_reserves_per_device_overhead():
         small, gpus, total_by_idx = totals, per_device_overhead_bytes = gib
     )
     assert a == [0] and b == [0]
+
+
+# ---------------------------------------------------------------------------
+# VRAM reserve floor (#6682): 5% of total is too thin on consumer cards (1.2 GB
+# on 24 GB) to absorb CUDA context, the nvidia-smi vs CUDA free gap, and a shared
+# desktop's drift, so auto-fit advertised a context that pinned then offloaded to
+# CPU at runtime. The reserve is floored at _MIN_VRAM_RESERVE_MIB, capped at
+# _MAX_VRAM_RESERVE_FRAC, and unchanged where 5% already exceeds the floor.
+# ---------------------------------------------------------------------------
+
+
+def test_vram_reserve_floor_on_consumer_card():
+    # 24 GB: 5% = 1229 MiB is below the floor, so the floor wins (and is under the
+    # 15% cap = 3686), giving a real cushion instead of #6312's thin 5%.
+    total = 24576
+    assert (1.0 - _CTX_FIT_VRAM_FRACTION) * total < _MIN_VRAM_RESERVE_MIB
+    assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == _MIN_VRAM_RESERVE_MIB
+
+
+def test_vram_reserve_unchanged_on_datacenter_card():
+    # 80 GB: 5% = 4096 MiB already exceeds the floor, so behaviour is unchanged
+    # from #6312 (no over-reserving the big cards it was tuned for).
+    total = 81920
+    assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == (1.0 - _CTX_FIT_VRAM_FRACTION) * total
+
+
+def test_vram_reserve_capped_on_small_card():
+    # 8 GB: a flat floor would be 38% of the card; the cap holds it to 15% so a
+    # small card running a model that nearly fills it isn't pushed off the GPU.
+    total = 8192
+    assert _MIN_VRAM_RESERVE_MIB > _MAX_VRAM_RESERVE_FRAC * total
+    assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == _MAX_VRAM_RESERVE_FRAC * total
+
+
+def test_fit_context_floor_caps_below_thin_fraction():
+    # Exercises _fit_context_to_vram's total-based reserve branch (the line the fix
+    # edits): on a 24 GB card the floor (3072) is reserved instead of the thin 5%
+    # (1229), so the capped context's footprint leaves >= the floor free and is
+    # strictly smaller than the 5% reserve would have advertised. A 27B-class model.
+    inst = _make_backend(native_ctx = 262144)
+    inst._can_estimate_kv = lambda: True
+    inst._estimate_kv_cache_bytes = lambda n, *a, **k: 0 if n <= 0 else int(n * 34_000)
+    model_size = int(17.5 * GIB)
+    total = 24576
+    free = 23700
+
+    def _cap_via_total_branch():
+        # total_mib set -> the fit applies _vram_reserve_mib internally (the floored
+        # branch), unlike the production load loop which pre-reserves and passes None.
+        return inst._fit_context_to_vram(
+            262144, free, model_size, None,
+            total_mib = total, budget_frac = _CTX_FIT_VRAM_FRACTION,
+        )
+
+    def _footprint_mib(ctx):
+        return (model_size + inst._estimate_kv_cache_bytes(ctx)) / (1024 * 1024)
+
+    floored_cap = _cap_via_total_branch()
+    # The floor (not the 5% fraction) is what bounds the footprint.
+    assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == _MIN_VRAM_RESERVE_MIB
+    assert _footprint_mib(floored_cap) <= free - _MIN_VRAM_RESERVE_MIB + 1
+    # Strictly tighter than #6312's thin 5% reserve: that budget would have fit a
+    # larger context (the over-advertisement #6682 reports).
+    thin_budget_mib = free - (1.0 - _CTX_FIT_VRAM_FRACTION) * total
+    thin_cap = inst._fit_context_to_vram(
+        262144, thin_budget_mib, model_size, None, budget_frac = 1.0,
+    )
+    assert floored_cap < thin_cap
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -763,8 +763,9 @@ def test_vram_reserve_unchanged_on_datacenter_card():
 
 
 def test_vram_reserve_capped_on_small_card():
-    # 8 GB: a flat floor would be 38% of the card; the cap holds it to 15% so a
-    # small card running a model that nearly fills it isn't pushed off the GPU.
+    # 8 GB: a flat floor would be 37% of the card; the cap holds it to the 24 GB
+    # design fraction (12.5%) so a small card running a model that nearly fills it
+    # isn't pushed off the GPU, and never reserves a larger fraction than a 24 GB card.
     total = 8192
     assert _MIN_VRAM_RESERVE_MIB > _MAX_VRAM_RESERVE_FRAC * total
     assert _vram_reserve_mib(total, _CTX_FIT_VRAM_FRACTION) == _MAX_VRAM_RESERVE_FRAC * total

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -73,6 +73,7 @@ from core.inference.llama_cpp import (
     _MAX_VRAM_RESERVE_FRAC,
     _MIN_VRAM_RESERVE_MIB,
     LlamaCppBackend,
+    _pooled_usable_mib,
     _vram_reserve_mib,
     classify_gpu_offload_lines,
 )
@@ -805,6 +806,46 @@ def test_fit_context_floor_caps_below_thin_fraction():
         262144, thin_budget_mib, model_size, None, budget_frac = 1.0,
     )
     assert floored_cap < thin_cap
+
+
+def test_pooled_usable_single_gpu_applies_floor():
+    # Single GPU: pool budget == free - floor (unchanged by the per-pool refactor).
+    frac = _CTX_FIT_VRAM_FRACTION
+    subset = [(1, 23700)]
+    totals = {1: 24576}
+    assert _pooled_usable_mib(subset, frac, totals) == 23700 - _vram_reserve_mib(24576, frac)
+
+
+def test_pooled_usable_floor_applied_once_across_pool():
+    # Two 24 GB cards: the floor is reserved ONCE on the pooled total (3072), not
+    # 2x (6144). That is the #6682 multi-GPU fix -- the old per-device sum reserved
+    # 2x the floor and dropped tight pools to the 4096 fallback.
+    frac = _CTX_FIT_VRAM_FRACTION
+    subset = [(0, 12000), (1, 12000)]
+    totals = {0: 24576, 1: 24576}
+    pooled = _pooled_usable_mib(subset, frac, totals)
+    assert pooled == 24000 - _vram_reserve_mib(2 * 24576, frac)  # one floor on the pool
+    per_device = sum(max(0.0, f - _vram_reserve_mib(totals[i], frac)) for i, f in subset)
+    assert pooled > per_device  # the refactor recovers ~one floor's worth of budget
+
+
+def test_pooled_usable_datacenter_unchanged():
+    # Two 80 GB cards: 5% of the 160 GB pool (8192) exceeds the floor, so the pool
+    # reserves the fraction -- datacenter behaviour is unchanged.
+    frac = _CTX_FIT_VRAM_FRACTION
+    subset = [(0, 70000), (1, 70000)]
+    totals = {0: 81920, 1: 81920}
+    assert _pooled_usable_mib(subset, frac, totals) == 140000 - (1.0 - frac) * (2 * 81920)
+
+
+def test_pooled_usable_unknown_total_keeps_per_device_cushion():
+    # An unknown-total GPU (MIG/vGPU/N/A: total 0) keeps free*frac; the known card
+    # gets the pooled floor. The two contributions add, no full-free-no-reserve leak.
+    frac = _CTX_FIT_VRAM_FRACTION
+    subset = [(0, 24000), (1, 12000)]
+    totals = {0: 0, 1: 24576}  # GPU 0 total unknown
+    expected = 24000 * frac + max(0.0, 12000 - _vram_reserve_mib(24576, frac))
+    assert _pooled_usable_mib(subset, frac, totals) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/tests/test_mtp_vram_budget.py
+++ b/studio/backend/tests/test_mtp_vram_budget.py
@@ -966,17 +966,17 @@ class TestExtraArgsMtpDetection:
         assert "(_mtp_reserves_gpuand_mtp_kv_unsized)" in compact
         assert "mtp_flat_reserve_bytes=_tp_unsized_mtp_reserve" in compact
 
-    def test_pool_budget_sums_per_gpu_usable(self):
-        # Finding #1: the multi-GPU pooled budget must sum each GPU's own usable
-        # budget (so an unknown-total GPU gets the free*frac cushion) rather than
-        # pooling free and total separately. The fit calls pass the precomputed
-        # budget as an absolute (budget_frac=1.0, total_mib=None) so fit and check
-        # agree. Whitespace-stripped for formatter.
+    def test_pool_budget_delegates_to_pooled_usable(self):
+        # #6682: the multi-GPU pooled budget applies the absolute VRAM floor ONCE per
+        # pool (via _pooled_usable_mib), not a per-device floor summed k times -- the
+        # latter over-reserved k x the floor and dropped tight k-GPU pools to the 4096
+        # fallback. The unknown-total (MIG/vGPU) free*frac cushion is preserved inside
+        # the helper (behaviorally: test_pooled_usable_unknown_total_keeps_per_device_
+        # cushion). The fit calls still pass the precomputed budget as an absolute
+        # (budget_frac=1.0, total_mib=None) so fit and check agree.
         compact = "".join(inspect.getsource(LlamaCppBackend.load_model).split())
         assert "def_pool_budget_mib(subset,frac):" in compact
-        assert "sum(max(0.0,_gpu_usable(g,frac))forginsubset)" in compact
-        # No revert to the pooled free/total form.
-        assert "def_pool_total(" not in compact
+        assert "_pooled_usable_mib(subset,frac,total_by_idx)" in compact
         assert "budget_frac=1.0" in compact
 
 


### PR DESCRIPTION
On a 24 GB desktop card, loading a 27B GGUF would pin `-ngl -1`, then silently offload layers back to CPU at runtime and run at roughly half speed. Reported in #6682 (Qwen3.6-27B-MTP, ~14 tok/s instead of 30-35).

Closes #6682

## Problem

The GGUF auto-fit (#6312) reserves a flat 5% of total VRAM before sizing context. On a 24 GB card that is only ~1.2 GB, too thin to absorb what the byte estimate can't capture exactly: the CUDA context and compute buffers, and the gap between nvidia-smi's reported free and the VRAM CUDA actually exposes. So auto-fit sizes the context right up against the card's real usable limit. At that edge part of the load ends up on host RAM and generation roughly halves, even with nothing else on the card.

Clean-card context sweep for `Qwen3.6-27B-MTP` UD-Q4_K_XL, q8 KV, on an idle RTX 3090 (24 GB):

| context | tok/s |
|---|---|
| 32k-92k | 60 (full speed) |
| 102k | 47 |
| 113k (what #6312 picks) | ~35 |
| 131k | 27 |

At the ~113k that 5% advertises, the 27B is already down to ~35 of 60 tok/s with the GPU sitting ~1 GB short of full and host RAM climbing (the load is not staying fully on the device). Backing the context off restores full speed. A desktop or browser sharing the GPU makes it worse: at `-c 112128` with a 3.5 GB desktop held, it ran at 14.6 tok/s (reporter: 14.3).

## Fix

Floor the reserve: `min(max(0.05*total, 3072 MiB), 0.125*total)`. So the reserve is 5% base, floored at 3 GiB, capped at 12.5%:

- <= 24 GB: 12.5% (3 GiB on a 24 GB card)
- 24-60 GB: flat 3 GiB (a shrinking fraction)
- \>= 60 GB: 5% (datacenter cards unchanged)

The floor is a per-pool cushion. The desktop drift and the one-lump layer-split compute buffer it covers are not per-device, so it is applied once across the pool, not per GPU. It lives in one helper (`_pooled_usable_mib`) at the single place the auto-context budget is computed. Ranking and the tensor-parallel paths are untouched.

## Speed (RTX 3090, 24 GB)

Same model and card, measured idle and with a 1 GB desktop sharing the GPU:

| reserve | context | tok/s (idle) | tok/s (1 GB desktop) |
|---|---|---|---|
| 5% (#6312) | 113408 | ~35 (spilling) | ~23 |
| floored (this PR) | 66560 | 60 | 60 |

The fix holds full speed through a ~1 GB desktop. It is a fixed cushion, not a guarantee. A 27B with a ~3 GB desktop on 24 GB is at the card's edge (the fix gives 21.9 vs 14.6 there), and a steady desktop gets sized down to a smaller full-speed context instead.

Generalizes across architecture and cache type:
- `gemma-3-27b` (SWA): #6312 picks 122880 at 23 tok/s; fix picks 78592 at 40 tok/s (full speed).
- f16, q8, q4 KV all land at ~21 GB footprint and full speed (fix picks 33k, 66k, 98k for the same safe footprint).

## No context regression for models that already fit

Base (#6312) vs fix, same hardware. Only the two 27Bs that were spilling get reduced. Everything else is byte-identical:

| model | #6312 ctx | fix ctx |
|---|---|---|
| Qwen3-1.7B | 40960 | 40960 |
| gemma-4-12b | 262144 | 262144 |
| gemma-3-27b | 122880 (spilled) | 78592 |
| Qwen3.6-27B | 113408 (spilled) | 66560 |
| Qwen3.6-27B on a 49 GB card | 262144 | 262144 |

## Multi-GPU

The per-pool floor matters here. On a constrained 49+24 GB pool (neither card fits the model alone), a naive per-device floor would reserve 3 GiB per card and drop to the 4096 fallback with `--fit`. The per-pool floor pins both GPUs at 36352, 74 tok/s, no spill.

## Verification

- 6 new unit tests on the reserve helpers: floor, cap, and datacenter regimes, single-GPU pool, floor-applied-once-across-pool (the multi-GPU case), and the unknown-total (MIG/vGPU) carve-out.
- VRAM, fit, MTP, tensor-parallel, and datacenter suites green (666 passed).
- End-to-end through Studio on real hardware (RTX 3090 and RTX 6000 Ada): the loads in the tables above, plus the loaded 27B serves 102/102 spec-compliance tests at 67 tok/s with no spill.

Code change is ~50 lines (two helpers and one call-site swap). The rest is tests.
