### PR TITLE
Fix gpt-oss detection in save: config.architectures is a list, not a string

### DIFF
--- a/tests/saving/test_is_gpt_oss_detection.py
+++ b/tests/saving/test_is_gpt_oss_detection.py
@@ -1,0 +1,52 @@
+import ast
+import types
+from pathlib import Path
+
+
+def _load_is_gpt_oss():
+    # Extract just the helper from save.py so the test runs without importing
+    # unsloth (which requires unsloth_zoo / a GPU), matching the pattern used by
+    # test_qwen3_5_vlm_full_finetune_key_remap.py.
+    source = Path(__file__).parents[2] / "unsloth" / "save.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+    helpers = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_is_gpt_oss"
+    ]
+    module = ast.Module(body = helpers, type_ignores = [])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(source), "exec"), namespace)
+    return namespace["_is_gpt_oss"]
+
+
+def _model(architectures = None, model_type = None):
+    config = types.SimpleNamespace()
+    if architectures is not None:
+        config.architectures = architectures
+    if model_type is not None:
+        config.model_type = model_type
+    return types.SimpleNamespace(config = config)
+
+
+def test_detects_gpt_oss_by_architecture():
+    # config.architectures is a list, so detection must use membership, not ==.
+    # A model that declares GptOssForCausalLM but has no matching model_type must
+    # still be routed to the mxfp4 save path.
+    is_gpt_oss = _load_is_gpt_oss()
+    assert is_gpt_oss(_model(architectures = ["GptOssForCausalLM"])) is True
+    assert is_gpt_oss(_model(architectures = ["GptOssForCausalLM"], model_type = "gpt_oss")) is True
+
+
+def test_detects_gpt_oss_by_model_type():
+    is_gpt_oss = _load_is_gpt_oss()
+    assert is_gpt_oss(_model(architectures = ["SomethingElse"], model_type = "gpt-oss")) is True
+    assert is_gpt_oss(_model(architectures = ["SomethingElse"], model_type = "gpt_oss")) is True
+
+
+def test_non_gpt_oss_is_false():
+    is_gpt_oss = _load_is_gpt_oss()
+    assert is_gpt_oss(_model(architectures = ["LlamaForCausalLM"], model_type = "llama")) is False
+    assert is_gpt_oss(_model()) is False
+    assert is_gpt_oss(types.SimpleNamespace()) is False

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -475,6 +475,14 @@ def _is_qwen3_5_vlm(model):
     ) or getattr(config, "model_type", None) in ("qwen3_5", "qwen3_5_moe")
 
 
+def _is_gpt_oss(model):
+    config = getattr(model, "config", None)
+    if config is None:
+        return False
+    architectures = getattr(config, "architectures", None) or ()
+    return "GptOssForCausalLM" in architectures or getattr(config, "model_type", None) in ("gpt-oss", "gpt_oss")
+
+
 def _qwen3_5_vlm_state_dict_for_save(state_dict):
     remapped_state_dict = {}
     for key, value in state_dict.items():
@@ -2231,15 +2239,7 @@ def unsloth_save_pretrained_gguf(
 
     is_processor = is_vlm and isinstance(tokenizer, ProcessorMixin)
 
-    is_gpt_oss = (
-        True
-        if (
-            hasattr(self.config, "architectures")
-            and self.config.architectures == "GptOssForCausalLM"
-        )
-        or (hasattr(self.config, "model_type") and self.config.model_type in ["gpt-oss", "gpt_oss"])
-        else False
-    )
+    is_gpt_oss = _is_gpt_oss(self)
     # Step 2: Prepare arguments for model saving
     arguments = dict(locals())
     arguments["model"] = self

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -480,7 +480,10 @@ def _is_gpt_oss(model):
     if config is None:
         return False
     architectures = getattr(config, "architectures", None) or ()
-    return "GptOssForCausalLM" in architectures or getattr(config, "model_type", None) in ("gpt-oss", "gpt_oss")
+    return "GptOssForCausalLM" in architectures or getattr(config, "model_type", None) in (
+        "gpt-oss",
+        "gpt_oss",
+    )
 
 
 def _qwen3_5_vlm_state_dict_for_save(state_dict):


### PR DESCRIPTION
## Summary

`unsloth_save_pretrained_gguf` decides whether a model needs the gpt-oss `mxfp4` save path with:

```python
self.config.architectures == "GptOssForCausalLM"
```

But `config.architectures` is a **list** (e.g. `["GptOssForCausalLM"]`), so comparing it to a string is always `False`. The architecture branch of the check never fires, leaving only the `model_type in ["gpt-oss", "gpt_oss"]` fallback. A model that declares `architectures=["GptOssForCausalLM"]` but does not have a matching `model_type` is therefore misrouted to `merged_16bit` instead of the required `mxfp4` path.

The same function already does this correctly a few lines above for the VLM check (`x.endswith(...) for x in self.config.architectures`), and `_is_qwen3_5_vlm` uses the same membership pattern.

## Fix

Extract the detection into an `_is_gpt_oss` helper that tests membership, mirroring `_is_qwen3_5_vlm`:

```python
def _is_gpt_oss(model):
    config = getattr(model, "config", None)
    if config is None:
        return False
    architectures = getattr(config, "architectures", None) or ()
    return "GptOssForCausalLM" in architectures or getattr(config, "model_type", None) in ("gpt-oss", "gpt_oss")
```

and call `is_gpt_oss = _is_gpt_oss(self)`.

## Test

`tests/saving/test_is_gpt_oss_detection.py` covers detection by architecture (the bug), by `model_type`, and the negative cases. It uses the same `ast`-based helper extraction as `test_qwen3_5_vlm_full_finetune_key_remap.py`, so it runs without a GPU or `unsloth_zoo`. The architecture case fails on `main` (the `==` returns `False`) and passes with this change; `ruff check` is clean and the existing qwen3_5 saving test still passes.
