### PR TITLE
Harden flaky Studio CI: retry VS-hide rename and tolerate same-URL nav interrupt

### DIFF
--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -185,13 +185,14 @@ jobs:
         # Retry up to 3 times to absorb known macos-14 free-runner
         # flakes: (1) Playwright Node 24 pipeTransport.js 'Unexpected
         # end of JSON input' crash when the Chromium browser process
-        # dies mid-test, and (2) Chromium net::ERR_NO_BUFFER_SPACE
-        # when the runner's kernel briefly runs out of socket buffers.
-        # The retry FULLY resets Studio (kill, reset-password, reboot,
-        # wait /api/health, re-export bootstrap pw) before re-running
-        # the script. A real test failure (assertion / timeout) does
-        # NOT match either pattern so it bypasses retry and surfaces
-        # immediately.
+        # dies mid-test, (2) Chromium net::ERR_NO_BUFFER_SPACE when the
+        # runner's kernel briefly runs out of socket buffers, and (3) a
+        # goto 'interrupted by another navigation' when the SPA auth
+        # guard redirects mid-navigation. The retry FULLY resets Studio
+        # (kill, reset-password, reboot, wait /api/health, re-export
+        # bootstrap pw) before re-running the script. A real test failure
+        # (assertion / timeout) does NOT match any pattern so it bypasses
+        # retry and surfaces immediately.
         run: |
           mkdir -p logs/playwright
           attempt=1
@@ -204,8 +205,9 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               break
             fi
-            if { grep -q "Unexpected end of JSON input" logs/playwright_attempt_${attempt}.log \
-                 || grep -q "ERR_NO_BUFFER_SPACE"        logs/playwright_attempt_${attempt}.log; } \
+            if { grep -q "Unexpected end of JSON input"       logs/playwright_attempt_${attempt}.log \
+                 || grep -q "ERR_NO_BUFFER_SPACE"             logs/playwright_attempt_${attempt}.log \
+                 || grep -q "interrupted by another navigation" logs/playwright_attempt_${attempt}.log; } \
                && [ "$attempt" -lt "$max_attempts" ]; then
               echo "::warning::Playwright flake on attempt ${attempt}; resetting Studio and retrying..."
               kill "${STUDIO_PID}" 2>/dev/null || true
@@ -280,8 +282,8 @@ jobs:
           STUDIO_UI_TURN_TIMEOUT_MS: '540000'
           GGUF_REPO: ${{ env.GGUF_REPO }}
           GGUF_VARIANT: ${{ env.GGUF_VARIANT }}
-        # Same flake-retry shape as "Drive the chat UI with Playwright"
-        # -- catches pipeTransport JSON crash and ERR_NO_BUFFER_SPACE.
+        # Same flake-retry shape as "Drive the chat UI with Playwright" -- catches
+        # pipeTransport JSON crash, ERR_NO_BUFFER_SPACE, and nav interrupts.
         run: |
           mkdir -p logs/playwright_extra
           attempt=1
@@ -294,8 +296,9 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               break
             fi
-            if { grep -q "Unexpected end of JSON input" logs/playwright_extra_attempt_${attempt}.log \
-                 || grep -q "ERR_NO_BUFFER_SPACE"        logs/playwright_extra_attempt_${attempt}.log; } \
+            if { grep -q "Unexpected end of JSON input"       logs/playwright_extra_attempt_${attempt}.log \
+                 || grep -q "ERR_NO_BUFFER_SPACE"             logs/playwright_extra_attempt_${attempt}.log \
+                 || grep -q "interrupted by another navigation" logs/playwright_extra_attempt_${attempt}.log; } \
                && [ "$attempt" -lt "$max_attempts" ]; then
               echo "::warning::Playwright flake on attempt ${attempt}; resetting Studio and retrying..."
               kill "${STUDIO_EXTRA_PID}" 2>/dev/null || true

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1338,11 +1338,19 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          # A Program Files dir can hold a transient handle (Defender / MSBuild node)
+          # so Rename-Item intermittently fails with "Access is denied"; retry to ride it out.
+          function Rename-WithRetry($Path, $NewName) {
+            for ($i = 1; $i -le 6; $i++) {
+              try { Rename-Item -LiteralPath $Path -NewName $NewName -ErrorAction Stop; return }
+              catch { if ($i -eq 6) { throw }; Start-Sleep -Seconds 3 }
+            }
+          }
           # Rename the Visual Studio install roots (incl. the Installer that holds
           # vswhere.exe) so Find-VsBuildTools' vswhere + filesystem scan both miss.
           foreach ($d in @("$env:ProgramFiles\Microsoft Visual Studio", "${env:ProgramFiles(x86)}\Microsoft Visual Studio")) {
             if (Test-Path -LiteralPath $d) {
-              Rename-Item -LiteralPath $d -NewName ((Split-Path $d -Leaf) + '.vsoff')
+              Rename-WithRetry $d ((Split-Path $d -Leaf) + '.vsoff')
               Write-Host "Hid VS: $d"
             }
           }
@@ -1351,7 +1359,7 @@ jobs:
           $hidden = @()
           foreach ($c in (Get-Command cmake -All -ErrorAction SilentlyContinue)) {
             if ($c.Source -and (Test-Path -LiteralPath $c.Source)) {
-              Rename-Item -LiteralPath $c.Source -NewName ((Split-Path $c.Source -Leaf) + '.off')
+              Rename-WithRetry $c.Source ((Split-Path $c.Source -Leaf) + '.off')
               $hidden += $c.Source
               Write-Host "Hid cmake: $($c.Source)"
             }
@@ -1536,8 +1544,16 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          # Retry the rename: a Program Files dir can hold a transient handle that
+          # makes Rename-Item intermittently fail with "Access is denied".
+          function Rename-WithRetry($Path, $NewName) {
+            for ($i = 1; $i -le 6; $i++) {
+              try { Rename-Item -LiteralPath $Path -NewName $NewName -ErrorAction Stop; return }
+              catch { if ($i -eq 6) { throw }; Start-Sleep -Seconds 3 }
+            }
+          }
           foreach ($d in @("$env:ProgramFiles\Microsoft Visual Studio", "${env:ProgramFiles(x86)}\Microsoft Visual Studio")) {
-            if (Test-Path -LiteralPath $d) { Rename-Item -LiteralPath $d -NewName ((Split-Path $d -Leaf) + '.vsoff'); Write-Host "Hid VS: $d" }
+            if (Test-Path -LiteralPath $d) { Rename-WithRetry $d ((Split-Path $d -Leaf) + '.vsoff'); Write-Host "Hid VS: $d" }
           }
 
       - name: Windows CUDA and ROCm prebuilts exist in unslothai/llama.cpp (what GPU users download, no VS)

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1225,15 +1225,17 @@ with sync_playwright() as p:
     # ─────────────────────────────────────────────────────
     step("Shutdown via account menu")
     # Re-login with NEW2 for a valid /api/shutdown token (CLI rotation
-    # invalidated the old one). The stale token can make the SPA auth
-    # guard abort this goto with ERR_ABORTED; resolve on
-    # domcontentloaded and tolerate it -- the pw-field wait confirms /login.
+    # invalidated the old one). The stale token can make the SPA auth guard
+    # abort this goto with ERR_ABORTED, or redirect to the same /login URL
+    # ("interrupted by another navigation"); resolve on domcontentloaded and
+    # tolerate either -- the pw-field wait below confirms we are on /login.
+    _tolerated_nav = ("ERR_ABORTED", "interrupted by another navigation")
     try:
         page.goto(f"{BASE}/login", wait_until = "domcontentloaded", timeout = 60_000)
     except Exception as exc:
-        if "ERR_ABORTED" not in str(exc):
+        if not any(t in str(exc) for t in _tolerated_nav):
             raise
-        info(f"goto /login aborted ({exc!r}); password-field wait will confirm /login")
+        info(f"goto /login interrupted ({exc!r}); password-field wait will confirm /login")
     pw_field = page.locator("#password")
     pw_field.wait_for(state = "visible", timeout = 60_000)
     pw_field.fill(NEW2)


### PR DESCRIPTION
### Summary

Hardens two intermittent Studio CI failures. Both are runner-environment flakes, not test-logic bugs, and they go red on unrelated PRs (for example they both flaked on #6712, whose only change is a logging filter).

### 1. Windows: "Studio install + inference without Visual Studio"

The `Hide Visual Studio + CMake` step renames `C:\Program Files\Microsoft Visual Studio` to simulate a host with no build tools. A background handle on a `Program Files` directory (Defender real-time scan or a lingering MSBuild node) makes `Rename-Item` intermittently fail with `Access to the path ... is denied`, and `$ErrorActionPreference = 'Stop'` turns that into a hard job failure:

```
Rename-Item: ... Access to the path 'C:\Program Files\Microsoft Visual Studio' is denied.
##[error]Process completed with exit code 1.
```

Fix: wrap the VS and cmake renames in both `Hide` steps in a short `Rename-WithRetry` (6 tries, 3s apart) so a transient lock is ridden out. A genuinely stuck rename still rethrows after the retries, so a real problem is not masked.

### 2. macOS: "Chat UI Tests"

The re-login `goto` to `/login` can be interrupted by the SPA auth guard redirecting to the same `/login` URL. Playwright reports this as:

```
playwright._impl._errors.Error: Page.goto: Navigation to "http://127.0.0.1:18896/login" is interrupted by another navigation to "http://127.0.0.1:18896/login"
```

The `goto` already tolerated `ERR_ABORTED`. This broadens it to also tolerate the same-URL `interrupted by another navigation` (the `#password` wait immediately after confirms we actually landed on `/login`, so tolerating the interrupt is safe). The same signature is also added to the two Playwright flake-retry harnesses as a safety net for any other navigation that hits the race.

### Testing

- `tests/studio/playwright_chat_ui.py` parses via `ast.parse` and byte-compiles via `py_compile`.
- Both workflow YAMLs parse via `yaml.safe_load`.
- `bash -n` on the two mac retry-harness shell blocks.
- PowerShell AST parse (`[System.Management.Automation.Language.Parser]`) on every `pwsh` step in the Windows workflow, including both edited `Hide` steps.
- Functional check of `Rename-WithRetry`: succeeds on a real rename, and rethrows after exhausting retries on a path that never renames.
- Confirmed the tolerance logic re-raises real failures (timeouts, assertions) while tolerating `ERR_ABORTED` and the nav interrupt.
