### PR TITLE
Studio: size separate-drafter MTP draft KV at full context (swa_full)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2907,7 +2907,11 @@ class LlamaCppBackend:
             # The drafter is served under the same --parallel slot count as the
             # main model, so price its KV per slot too: a sliding-window drafter
             # (Gemma) grows KV with slots and would otherwise be under-reserved.
-            kv = db._estimate_kv_cache_bytes(n_ctx, heavier, n_parallel = n_parallel)
+            # swa_full: the draft caches against the full target window, so its SWA
+            # layers are not window-capped and grow with n_ctx (safe upper bound).
+            kv = db._estimate_kv_cache_bytes(
+                n_ctx, heavier, n_parallel = n_parallel, swa_full = True
+            )
             return kv or None
         nextn = self._nextn_predict_layers or 0
         n_kv = self._n_kv_heads or self._n_heads

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2909,9 +2909,7 @@ class LlamaCppBackend:
             # (Gemma) grows KV with slots and would otherwise be under-reserved.
             # swa_full: the draft caches against the full target window, so its SWA
             # layers are not window-capped and grow with n_ctx (safe upper bound).
-            kv = db._estimate_kv_cache_bytes(
-                n_ctx, heavier, n_parallel = n_parallel, swa_full = True
-            )
+            kv = db._estimate_kv_cache_bytes(n_ctx, heavier, n_parallel = n_parallel, swa_full = True)
             return kv or None
         nextn = self._nextn_predict_layers or 0
         n_kv = self._n_kv_heads or self._n_heads


### PR DESCRIPTION
## Problem

For an MTP model served with a separate drafter (Gemma `mtp-*.gguf`), the draft model caches against the full target window, so its sliding-window-attention layers are not window-capped at runtime and the draft KV grows with `n_ctx`.

`_mtp_draft_kv_bytes` sized that draft KV through `_estimate_kv_cache_bytes`, which defaults to the SWA window cap. For the 12b drafter (4 layers, SWA pattern, shared KV layers) that produced a near-flat reservation of about 16 MiB at every context, so long contexts were under-reserved.

## Measurement

12b drafter, draft overhead measured as the GPU delta between spec and no-spec launches:

| ctx | real draft overhead |
|---|---|
| 32768 | 580 MiB |
| 131072 | 868 MiB |
| 262144 | 1252 MiB |

All under-reserved by the old flat estimate.

## Change

Pass `swa_full = True` when sizing the separate-drafter KV, so the draft is reserved as a safe upper bound that scales with context. Embedded MTP heads (Qwen `nextn_predict_layers`) take the other branch and are unaffected.

## Validation

- All fit, KV, MTP and context tests pass (618).
- gemma-12b predicted footprint moves from 10.6 to 12.5 GiB against a real 12.3 GiB; the gemma-31b 24GB pick tightens to a context that fits with margin on a real card.
