### PR TITLE
Studio: cascade user message deletion to include assistant reply

### DIFF
--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -126,7 +126,7 @@ export async function deleteThreadMessage(args: {
           .map(({ message }) => message.id)
       : [];
 
-  // Delete the prompt first; that relinks its replies up to the prompt'sparent
+  // Delete the prompt first; that relinks its replies up to the prompt's parent
   repo.deleteMessage(messageId);
   for (const replyId of assistantReplyIds) {
     repo.deleteMessage(replyId);

--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -112,7 +112,26 @@ export async function deleteThreadMessage(args: {
   const exported = thread.export();
   const repo = new MessageRepository();
   repo.import(exported);
+
+  const target = exported.messages.find(
+    ({ message }) => message.id === messageId,
+  );
+  const assistantReplyIds =
+    target?.message.role === "user"
+      ? exported.messages
+          .filter(
+            ({ parentId, message }) =>
+              parentId === messageId && message.role === "assistant",
+          )
+          .map(({ message }) => message.id)
+      : [];
+
+  // Delete the prompt first; that relinks its replies up to the prompt'sparent
   repo.deleteMessage(messageId);
+  for (const replyId of assistantReplyIds) {
+    repo.deleteMessage(replyId);
+  }
+
   const next = repo.export();
   if (remoteId) {
     await syncExportedRepositoryToBackend(remoteId, next, {


### PR DESCRIPTION
Deleting a user prompt alone splices it out but relinks its assistant reply to the parent, leaving a floating response with no question above it. Fix by also deleting the assistant reply child when a user message is deleted, preserving proper alternating thread structure.