### PR TITLE
Respect requested 4bit/8bit for local '-bf16' directories

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -469,8 +469,10 @@ class FastLanguageModel(FastLlamaModel):
             ("-unsloth-bnb-4bit", "-bnb-4bit")
         ):
             model_name = _strip_unsloth_bnb_4bit_suffix(model_name)
-        # Change -BF16 to all False for 4bit, 8bit etc
-        if model_name.lower().endswith("-bf16"):
+        # '-bf16' hub repos load bf16; a local dir keeps the requested quant unless 16bit is set
+        if model_name.lower().endswith("-bf16") and (
+            load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
+        ):
             load_in_4bit = False
             load_in_8bit = False
             load_in_fp8 = False
@@ -628,8 +630,10 @@ class FastLanguageModel(FastLlamaModel):
                 ("-unsloth-bnb-4bit", "-bnb-4bit")
             ):
                 model_name = _strip_unsloth_bnb_4bit_suffix(model_name)
-            # Change -BF16 to all False for 4bit, 8bit etc
-            if model_name.lower().endswith("-bf16"):
+            # '-bf16' hub repos load bf16; a local dir keeps the requested quant unless 16bit is set
+            if model_name.lower().endswith("-bf16") and (
+                load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
+            ):
                 load_in_4bit = False
                 load_in_8bit = False
                 load_in_fp8 = False
@@ -1116,8 +1120,10 @@ class FastModel(FastBaseModel):
             ("-unsloth-bnb-4bit", "-bnb-4bit")
         ):
             model_name = _strip_unsloth_bnb_4bit_suffix(model_name)
-        # Change -BF16 to all False for 4bit, 8bit etc
-        if model_name.lower().endswith("-bf16"):
+        # '-bf16' hub repos load bf16; a local dir keeps the requested quant unless 16bit is set
+        if model_name.lower().endswith("-bf16") and (
+            load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
+        ):
             load_in_4bit = False
             load_in_8bit = False
             load_in_fp8 = False
@@ -1474,8 +1480,10 @@ class FastModel(FastBaseModel):
                 ("-unsloth-bnb-4bit", "-bnb-4bit")
             ):
                 model_name = _strip_unsloth_bnb_4bit_suffix(model_name)
-            # Change -BF16 to all False for 4bit, 8bit etc
-            if model_name.lower().endswith("-bf16"):
+            # '-bf16' hub repos load bf16; a local dir keeps the requested quant unless 16bit is set
+            if model_name.lower().endswith("-bf16") and (
+                load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
+            ):
                 load_in_4bit = False
                 load_in_8bit = False
                 load_in_fp8 = False


### PR DESCRIPTION
### Problem

The loader treats any `model_name` ending in `-bf16` as a request to load bf16 and force-disables 4bit/8bit. That suffix is our hub naming convention for bf16 weight repos, but it also fires for a local directory that just happens to be named `...-bf16`. Since `load_in_4bit` defaults to `True`, pointing at a local bf16 checkpoint dir named `-bf16` silently loads it in bf16 and uses roughly 4x the memory the user asked for.

### Fix

Only apply the `-bf16` suffix override for hub names, not local directories:

```python
if model_name.lower().endswith("-bf16") and not os.path.isdir(model_name):
```

- Hub repos ending in `-bf16` are unchanged (the convention still loads bf16).
- A local `-bf16` directory now honors the requested quantization (`load_in_4bit` / `load_in_8bit`). To force bf16 from a local dir, pass `load_in_16bit=True`.

Applied to all four `from_pretrained` paths in `loader.py`. `os.path.isdir` is cross platform.
