### PR TITLE
Remove unused FalconH1RMSNormGated import

### DIFF
--- a/unsloth/models/falcon_h1.py
+++ b/unsloth/models/falcon_h1.py
@@ -38,7 +38,6 @@ try:
         FalconH1Model,
         FalconH1ForCausalLM,
         FalconH1RMSNorm,
-        FalconH1RMSNormGated,
         FalconHybridMambaAttentionDynamicCache,
     )
 except:


### PR DESCRIPTION
FalconH1RMSNormGated is imported from transformers in unsloth/models/falcon_h1.py but never referenced (the non-gated FalconH1RMSNorm and the other names in the same import are all used).

The unused hoist is flagged as a blocker by the import-hoist lint gate. That gate lints the PR merge commit (PR head merged into current main) against the merge-base, so this dead import on main surfaces as a blocker on every open PR even when the PR never touches this file (for example PR #6613). Removing it clears the lint failure across open PRs.

No behavior change: the symbol was never used.